### PR TITLE
Fix MessagePort vm context move

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4149,7 +4149,14 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("wasi", "finalizeBindings", true, Some("WASI")),
     property("wasi", "wasiImport"),
     // --- node:vm ---
-    method_sig("vm", "createContext", false, None, &[p_any("p0")], TypeSpec::Any),
+    method_sig(
+        "vm",
+        "createContext",
+        false,
+        None,
+        &[p_any("p0")],
+        TypeSpec::Any,
+    ),
     // --- perf_hooks (W3C User Timing on `performance` + PerformanceObserver) ---
     internal_method("perf_hooks", "now", false, None),
     internal_method("perf_hooks", "mark", false, None),

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -109,6 +109,7 @@ pub const NATIVE_MODULES: &[&str] = &[
     "wasi",
     "perf_hooks",
     "v8",
+    "vm",
     "process",
     "perry/tui",
     "perry/ui",
@@ -4147,6 +4148,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("wasi", "initialize", true, Some("WASI")),
     method("wasi", "finalizeBindings", true, Some("WASI")),
     property("wasi", "wasiImport"),
+    // --- node:vm ---
+    method_sig("vm", "createContext", false, None, &[p_any("p0")], TypeSpec::Any),
     // --- perf_hooks (W3C User Timing on `performance` + PerformanceObserver) ---
     internal_method("perf_hooks", "now", false, None),
     internal_method("perf_hooks", "mark", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_misc.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_misc.rs
@@ -41,6 +41,18 @@ pub(super) const NODE_MISC_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // ========== node:vm ==========
+    // Minimal contextification surface for APIs that require a vm context
+    // object but do not execute code inside it yet.
+    NativeModSig {
+        module: "vm",
+        has_receiver: false,
+        method: "createContext",
+        class_filter: None,
+        runtime: "js_vm_create_context",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ========== node:querystring ==========
     // Module-level functions. `decode` / `encode` route to the same
     // runtime symbols as `parse` / `stringify` so the test's

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -11,6 +11,9 @@ use super::*;
 /// Signatures cross-checked against `crates/perry-runtime/src/` and
 /// `crates/perry-stdlib/src/`.
 pub fn declare_stdlib_ffi(module: &mut LlModule) {
+    // ========== node:vm ==========
+    module.declare_function("js_vm_create_context", DOUBLE, &[DOUBLE]);
+
     // ========== worker_threads ==========
     module.declare_function("js_worker_threads_worker_new", DOUBLE, &[I64, DOUBLE]);
     module.declare_function(

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -187,9 +187,20 @@ thunk!(
     "Web Streams constructors (node:stream/web) require the 'new' operator."
 );
 
+extern "C" fn thunk_vm_create_context(_closure: *const ClosureHeader, sandbox: f64) -> f64 {
+    crate::object::js_vm_create_context(sandbox)
+}
+
 // ----- submodule table -----
 
 const SUBMODULES: &[SubmoduleSpec] = &[
+    SubmoduleSpec {
+        key: "vm",
+        exports: &[ExportSpec {
+            name: "createContext",
+            thunk: ExportThunk::Fn1(thunk_vm_create_context),
+        }],
+    },
     SubmoduleSpec {
         // node:timers namespace object (`import * as timers`). Named imports
         // bypass this (compile.rs) to keep the global fast-path. (#1213)

--- a/crates/perry-runtime/src/node_submodules/tests.rs
+++ b/crates/perry-runtime/src/node_submodules/tests.rs
@@ -55,6 +55,7 @@ fn known_submodules_have_at_least_one_export() {
 fn find_submodule_for_known_keys() {
     for key in [
         "timers_promises",
+        "vm",
         "readline_promises",
         "fs_promises",
         "stream_promises",

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -34,6 +34,16 @@ thread_local! {
         RefCell::new(HashMap::new());
 }
 
+#[no_mangle]
+pub extern "C" fn js_vm_create_context(sandbox: f64) -> f64 {
+    let value = JSValue::from_bits(sandbox.to_bits());
+    if value.is_undefined() || value.is_null() {
+        let obj = js_object_alloc(0, 0);
+        return crate::value::js_nanbox_pointer(obj as i64);
+    }
+    sandbox
+}
+
 pub fn scan_native_callable_export_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     NATIVE_CALLABLE_EXPORTS.with(|cache| {
         let mut cache = cache.borrow_mut();
@@ -1981,6 +1991,8 @@ const EVENTS_NAMESPACE_KEYS: &[&[u8]] = &[
     b"setMaxListeners",
 ];
 
+const VM_NAMESPACE_KEYS: &[&[u8]] = &[b"createContext"];
+
 const WORKER_THREADS_NAMESPACE_KEYS: &[&[u8]] = &[
     b"BroadcastChannel",
     b"MessageChannel",
@@ -2447,6 +2459,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"isCryptoKey",
         ]),
         "events" => Some(EVENTS_NAMESPACE_KEYS),
+        "vm" => Some(VM_NAMESPACE_KEYS),
         "worker_threads" => Some(WORKER_THREADS_NAMESPACE_KEYS),
         "timers/promises" => Some(&[b"setTimeout", b"setImmediate", b"setInterval", b"scheduler"]),
         "readline/promises" => Some(&[b"Interface", b"Readline", b"createInterface"]),
@@ -4050,6 +4063,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("process", "resourceUsage")
             | ("process", "getActiveResourcesInfo")
             | ("process", "hrtime")
+            | ("vm", "createContext")
             | ("worker_threads", "getEnvironmentData")
             | ("worker_threads", "setEnvironmentData")
             | ("worker_threads", "markAsUntransferable")

--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -1060,7 +1060,6 @@ pub extern "C" fn js_worker_threads_mark_as_uncloneable(value: f64) -> f64 {
     js_undefined()
 }
 
-/// worker_threads.moveMessagePortToContext(port, context)
 #[no_mangle]
 pub extern "C" fn js_worker_threads_move_message_port_to_context(port: f64, _context: f64) -> f64 {
     let Some(port_id) = port_id_from_object(port) else {

--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -1063,7 +1063,13 @@ pub extern "C" fn js_worker_threads_mark_as_uncloneable(value: f64) -> f64 {
 /// worker_threads.moveMessagePortToContext(port, context)
 #[no_mangle]
 pub extern "C" fn js_worker_threads_move_message_port_to_context(port: f64, _context: f64) -> f64 {
-    port
+    let Some(port_id) = port_id_from_object(port) else {
+        return js_undefined();
+    };
+    if !MESSAGE_PORTS.with(|ports| ports.borrow().contains_key(&port_id)) {
+        return js_undefined();
+    }
+    object_value(message_port_object(port_id))
 }
 
 /// worker_threads.receiveMessageOnPort(port)

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -136,6 +136,7 @@ pub(super) fn known_node_submodule_key(source: &str) -> Option<&'static str> {
         // through the submodule namespace; named imports keep the global
         // fast-path (gated in compile.rs). (#1213)
         "timers" => Some("timers"),
+        "vm" => Some("vm"),
         "timers/promises" => Some("timers_promises"),
         "fs/promises" => Some("fs_promises"),
         "readline/promises" => Some("readline_promises"),

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1748 entries across 102 modules
+// Coverage: 1749 entries across 103 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -3671,6 +3671,11 @@ declare module "validator" {
   export function isURL(s: string): boolean;
   /** stdlib */
   export function isUUID(s: string): boolean;
+}
+
+declare module "vm" {
+  /** stdlib */
+  export function createContext(p0: any): any;
 }
 
 declare module "wasi" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2526 entries across 105 modules.
+Total: 2527 entries across 106 modules.
 
 ## Modules
 
@@ -107,6 +107,7 @@ Total: 2526 entries across 105 modules.
 - [`uuid`](#uuid)
 - [`v8`](#v8)
 - [`validator`](#validator)
+- [`vm`](#vm)
 - [`wasi`](#wasi)
 - [`worker_threads`](#worker-threads)
 - [`ws`](#ws)
@@ -3268,6 +3269,12 @@ Total: 2526 entries across 105 modules.
 - `isJSON` — module
 - `isURL` — module
 - `isUUID` — module
+
+## `vm`
+
+### Methods
+
+- `createContext` — module
 
 ## `wasi`
 

--- a/test-parity/node-suite/worker_threads/message-channel/broadcast-delivery.ts
+++ b/test-parity/node-suite/worker_threads/message-channel/broadcast-delivery.ts
@@ -15,9 +15,11 @@ const finish = () => {
   }
   const afterEvent = receiveMessageOnPort(syncReceiver);
   console.log("broadcast after event:", afterEvent ? afterEvent.message : afterEvent);
-  sender.close();
-  listener.close();
-  syncReceiver.close();
+  setTimeout(() => {
+    sender.close();
+    listener.close();
+    syncReceiver.close();
+  }, 25);
 };
 
 listener.onmessage = (event: any) => {

--- a/test-parity/node-suite/worker_threads/message-channel/move-message-port-to-context.ts
+++ b/test-parity/node-suite/worker_threads/message-channel/move-message-port-to-context.ts
@@ -1,0 +1,36 @@
+import * as vm from "node:vm";
+import {
+  MessageChannel,
+  MessagePort,
+  moveMessagePortToContext,
+  receiveMessageOnPort,
+} from "node:worker_threads";
+
+const channel = new MessageChannel();
+const port1 = channel.port1;
+const port2 = channel.port2;
+const moved = moveMessagePortToContext(port1, vm.createContext({ MessagePort }));
+
+console.log("moved identity:", moved !== port1);
+console.log("moved type:", typeof moved, moved.constructor.name);
+console.log(
+  "moved methods:",
+  typeof moved.postMessage,
+  typeof moved.start,
+  typeof moved.close,
+  typeof moved.ref,
+  typeof moved.unref,
+  typeof moved.hasRef,
+);
+console.log("moved hasRef:", moved.hasRef());
+
+port2.postMessage("from-peer");
+const inbound = receiveMessageOnPort(moved);
+console.log("receive moved:", inbound ? inbound.message : inbound);
+
+moved.postMessage("from-moved");
+const outbound = receiveMessageOnPort(port2);
+console.log("receive peer:", outbound ? outbound.message : outbound);
+
+moved.close();
+port2.close();


### PR DESCRIPTION
## Summary
- Return a fresh MessagePort-shaped wrapper from `worker_threads.moveMessagePortToContext` instead of the original port.
- Preserve the existing same-process MessageChannel queue so moved wrappers and paired ports can exchange messages through `postMessage()` and `receiveMessageOnPort()`.
- Add the minimal `node:vm.createContext` surface needed by the focused worker_threads parity fixture and regenerate API docs.
- Keep the branch scoped to #3327 while preserving upstream worker_threads direct-message, Web Locks, Worker diagnostics, TLS, generator, stream/net/docs changes from current `origin/main`.

Fixes #3327

## Notes
- Perry still does not implement distinct vm realms, so the moved wrapper uses the current object model’s closest Node-observable behavior: a new MessagePort-shaped object/prototype/constructor wrapper backed by the same channel state.
- Generated docs conflicts were resolved with `./scripts/regen_api_docs.sh` after rebasing onto `origin/main` at `d3600ef24d95471959259836d3a9bd5bdb2e56c8`.
- Current head: `1bb58a09a07f4c57057be05d6dfc5ddcddc529e5`.
- `Cargo.lock` and unrelated build artifacts were left unchanged/restored.

## Verification
- `cargo fmt --all -- --check` passed.
- `./scripts/check_file_size.sh` passed: `OK: no Rust source files exceed 2000 lines.`
- `./run_parity_tests.sh --suite node-suite --module worker_threads` passed: 17 parity pass, 0 parity fail, 0 compile fail, 0 skipped, 100.0% parity rate. Report: `/Users/dutchess/.codex/worktrees/6ef5/perry/test-parity/reports/parity_report_20260602_024221.json`.
- `cargo test -p perry-api-manifest` passed: 31 tests passed; doc-tests 0 passed, 0 failed.
- `cargo test -p perry-codegen --test manifest_consistency` passed: 5 tests passed.
