### PR TITLE
Fix worker postMessageToThread delivery

### DIFF
--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -21,6 +21,7 @@ use perry_runtime::thread::{
 };
 use perry_runtime::value::JSValue;
 
+mod direct_message;
 mod parent_port;
 mod worker_options;
 mod worker_surface;
@@ -143,6 +144,11 @@ type WorkerEntry = extern "C" fn();
 
 enum WorkerCommand {
     Message(SerializedValue),
+    DirectMessage {
+        message: SerializedValue,
+        source_thread_id: u64,
+        ack: Sender<direct_message::DirectMessageResult>,
+    },
     Terminate,
 }
 
@@ -1122,17 +1128,6 @@ fn object_u64_field(value: f64, field_name: &str) -> Option<u64> {
     Some(field.to_bits())
 }
 
-/// worker_threads.postMessageToThread(threadId, value[, transferList][, timeout])
-#[no_mangle]
-pub extern "C" fn js_worker_threads_post_message_to_thread(
-    _thread_id: f64,
-    _value: f64,
-    _transfer_list: f64,
-    _timeout: f64,
-) -> f64 {
-    js_undefined()
-}
-
 /// new worker_threads.MessageChannel()
 ///
 /// Allocates two paired same-process ports and returns `{ port1, port2 }`.
@@ -1601,6 +1596,15 @@ pub extern "C" fn js_worker_threads_worker_new(entry_ptr: i64, options: f64) -> 
                             let closure = callback_ptr as *const ClosureHeader;
                             perry_runtime::closure::js_closure_call1(closure, f64::from_bits(bits));
                         }
+                    }
+                    Ok(WorkerCommand::DirectMessage {
+                        message,
+                        source_thread_id,
+                        ack,
+                    }) => {
+                        let result =
+                            direct_message::deliver_worker_message(&message, source_thread_id);
+                        let _ = ack.send(result);
                     }
                     Ok(WorkerCommand::Terminate) => {
                         exit_code = 1;

--- a/crates/perry-stdlib/src/worker_threads/direct_message.rs
+++ b/crates/perry-stdlib/src/worker_threads/direct_message.rs
@@ -1,0 +1,177 @@
+use std::sync::mpsc::{self, Receiver};
+use std::time::Duration;
+
+use perry_runtime::string::js_string_from_bytes;
+use perry_runtime::thread::{
+    deserialize_nanbox_on_current_thread, serialize_nanbox_for_thread, SerializedValue,
+};
+use perry_runtime::value::JSValue;
+
+use super::{is_undefined, js_bool, WorkerCommand, CURRENT_WORKER_ID, WORKERS};
+
+pub(super) enum DirectMessageResult {
+    Delivered,
+    Failed,
+}
+
+#[derive(Clone, Copy)]
+enum WorkerMessagingError {
+    Failed,
+    SameThread,
+    Timeout,
+}
+
+impl WorkerMessagingError {
+    fn code(self) -> &'static str {
+        match self {
+            WorkerMessagingError::Failed => "ERR_WORKER_MESSAGING_FAILED",
+            WorkerMessagingError::SameThread => "ERR_WORKER_MESSAGING_SAME_THREAD",
+            WorkerMessagingError::Timeout => "ERR_WORKER_MESSAGING_TIMEOUT",
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            WorkerMessagingError::Failed => "Cannot find the destination thread or listener",
+            WorkerMessagingError::SameThread => "Cannot sent a message to the same thread",
+            WorkerMessagingError::Timeout => "Sending a message to another thread timed out",
+        }
+    }
+}
+
+/// worker_threads.postMessageToThread(threadId, value[, transferList][, timeout])
+#[no_mangle]
+pub extern "C" fn js_worker_threads_post_message_to_thread(
+    thread_id: f64,
+    value: f64,
+    _transfer_list: f64,
+    timeout: f64,
+) -> f64 {
+    let Some(target_thread_id) = thread_id_from_value(thread_id) else {
+        return rejected_worker_messaging_promise(WorkerMessagingError::Failed);
+    };
+    let source_thread_id = CURRENT_WORKER_ID.with(|id| id.get());
+    if target_thread_id == source_thread_id {
+        return rejected_worker_messaging_promise(WorkerMessagingError::SameThread);
+    }
+
+    let message = unsafe { serialize_nanbox_for_thread(value.to_bits()) };
+    let (ack_tx, ack_rx) = mpsc::channel::<DirectMessageResult>();
+    let sender = WORKERS
+        .lock()
+        .unwrap()
+        .get(&target_thread_id)
+        .and_then(|worker| worker.alive.then(|| worker.sender.clone()));
+    let Some(sender) = sender else {
+        return rejected_worker_messaging_promise(WorkerMessagingError::Failed);
+    };
+
+    let promise = unsafe { crate::common::async_bridge::js_promise_new_for_native_resolution() };
+    let promise_ptr = promise as usize;
+    let timeout = timeout_duration(timeout);
+    if sender
+        .send(WorkerCommand::DirectMessage {
+            message,
+            source_thread_id,
+            ack: ack_tx,
+        })
+        .is_err()
+    {
+        queue_worker_messaging_rejection(promise_ptr, WorkerMessagingError::Failed);
+    } else {
+        std::thread::spawn(move || wait_for_direct_message_ack(promise_ptr, ack_rx, timeout));
+    }
+
+    perry_runtime::value::js_nanbox_pointer(promise as i64)
+}
+
+#[used]
+static KEEP_WT_POST_MESSAGE_TO_THREAD: extern "C" fn(f64, f64, f64, f64) -> f64 =
+    js_worker_threads_post_message_to_thread;
+
+pub(super) fn deliver_worker_message(
+    message: &SerializedValue,
+    source_thread_id: u64,
+) -> DirectMessageResult {
+    let bits = unsafe { deserialize_nanbox_on_current_thread(message) };
+    let event = b"workerMessage";
+    let event_ptr = js_string_from_bytes(event.as_ptr(), event.len() as u32);
+    let event_bits = JSValue::string_ptr(event_ptr).bits() as i64;
+    let mut args = perry_runtime::js_array_alloc(0);
+    args = perry_runtime::js_array_push(args, JSValue::from_bits(bits));
+    args = perry_runtime::js_array_push(args, JSValue::number(source_thread_id as f64));
+    let delivered = perry_runtime::os::js_process_emit(event_bits, args);
+    if delivered.to_bits() == js_bool(true).to_bits() {
+        DirectMessageResult::Delivered
+    } else {
+        DirectMessageResult::Failed
+    }
+}
+
+fn js_undefined_bits() -> u64 {
+    JSValue::undefined().bits()
+}
+
+fn worker_messaging_error_value(error: WorkerMessagingError) -> f64 {
+    let message = error.message();
+    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    perry_runtime::node_submodules::register_error_code_pub(msg_ptr, error.code());
+    let err = perry_runtime::error::js_error_new_with_message(msg_ptr);
+    perry_runtime::value::js_nanbox_pointer(err as i64)
+}
+
+fn rejected_worker_messaging_promise(error: WorkerMessagingError) -> f64 {
+    let err = worker_messaging_error_value(error);
+    let promise = perry_runtime::js_promise_rejected(err);
+    perry_runtime::value::js_nanbox_pointer(promise as i64)
+}
+
+fn thread_id_from_value(value: f64) -> Option<u64> {
+    if value.is_finite() && value >= 0.0 {
+        Some(value as u64)
+    } else {
+        None
+    }
+}
+
+fn timeout_duration(timeout: f64) -> Option<Duration> {
+    if is_undefined(timeout) || !timeout.is_finite() || timeout < 0.0 {
+        return None;
+    }
+    Some(Duration::from_millis(timeout as u64))
+}
+
+fn wait_for_direct_message_ack(
+    promise_ptr: usize,
+    ack_rx: Receiver<DirectMessageResult>,
+    timeout: Option<Duration>,
+) {
+    let result = match timeout {
+        Some(timeout) => match ack_rx.recv_timeout(timeout) {
+            Ok(result) => Ok(result),
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(WorkerMessagingError::Timeout),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(WorkerMessagingError::Failed),
+        },
+        None => ack_rx.recv().map_err(|_| WorkerMessagingError::Failed),
+    };
+
+    match result {
+        Ok(DirectMessageResult::Delivered) => {
+            crate::common::async_bridge::queue_promise_resolution(
+                promise_ptr,
+                true,
+                js_undefined_bits(),
+            );
+        }
+        Ok(DirectMessageResult::Failed) => {
+            queue_worker_messaging_rejection(promise_ptr, WorkerMessagingError::Failed);
+        }
+        Err(error) => queue_worker_messaging_rejection(promise_ptr, error),
+    }
+}
+
+fn queue_worker_messaging_rejection(promise_ptr: usize, error: WorkerMessagingError) {
+    crate::common::async_bridge::queue_deferred_resolution(promise_ptr, false, move || {
+        worker_messaging_error_value(error).to_bits()
+    });
+}

--- a/reference/deepwiki/nodejs-node-worker-post-message-to-thread.md
+++ b/reference/deepwiki/nodejs-node-worker-post-message-to-thread.md
@@ -1,0 +1,208 @@
+# DeepWiki Response
+
+Repository: `nodejs/node`
+Question: How does node:worker_threads postMessageToThread deliver process workerMessage events and reject same-thread or timeout cases?
+Search: https://deepwiki.com/search/how-does-nodeworkerthreads-pos_f36a0adf-2459-4416-ad5e-d206656740ce
+
+**Question**: How does node:worker_threads postMessageToThread deliver process workerMessage events and reject same-thread or timeout cases?
+
+The user is asking about how `node:worker_threads.postMessageToThread()` delivers `process.workerMessage` events and handles same-thread or timeout scenarios.
+
+`node:worker_threads.postMessageToThread()` is a function that sends a value to another worker thread identified by its thread ID [1](#ref-q1-1) . This function returns a Promise that is fulfilled if the message is successfully processed by the destination thread [2](#ref-q1-2) .
+
+### Delivery of `process.workerMessage` events
+
+When `postMessageToThread()` is called, the message is delivered to the target thread, which then emits a `'workerMessage'` event on the `process` object [3](#ref-q1-3) . The event listener for `'workerMessage'` receives the `value` sent and the `source` thread ID [4](#ref-q1-4) .
+
+An example of this can be seen in the Node.js documentation, where a main thread sets up a listener for `'workerMessage'` and then uses `postMessageToThread` to communicate with other workers [5](#ref-q1-5) .
+
+### Rejection Cases
+
+`postMessageToThread()` handles several error conditions by throwing specific errors:
+
+*   **Same-thread messaging**: If the `threadId` provided to `postMessageToThread()` is the same as the current thread's ID, an `ERR_WORKER_MESSAGING_SAME_THREAD` error is thrown [6](#ref-q1-6) . This error is defined as "Cannot sent a message to the same thread" [7](#ref-q1-7) .
+*   **Timeout**: If a `timeout` is specified and the message delivery times out, an `ERR_WORKER_MESSAGING_TIMEOUT` error is thrown [8](#ref-q1-8) . This error is defined as "Sending a message to another thread timed out" [9](#ref-q1-9) .
+*   **Invalid thread or no listener**: If the target `threadId` is invalid or the target thread does not have a listener for the `workerMessage` event, an `ERR_WORKER_MESSAGING_FAILED` error is thrown [10](#ref-q1-10) . This error is defined as "Cannot find the destination thread or listener" [11](#ref-q1-11) .
+*   **Error during processing**: If the destination thread throws an error while processing the `workerMessage` event, an `ERR_WORKER_MESSAGING_ERRORED` error is thrown [12](#ref-q1-12) . This error is defined as "The destination thread threw an error while processing the message" [13](#ref-q1-13) .
+
+## Notes
+
+The `postMessageToThread` function is exposed through `lib/worker_threads.js` [14](#ref-q1-14)  which imports it from `internal/worker/messaging` [14](#ref-q1-14) . The `process.on('workerMessage')` event is a relatively new addition, introduced in Node.js v22.5.0 and v20.19.0 [15](#ref-q1-15) . Previously, communication between non-parent/child worker threads typically involved `MessageChannel` and `MessagePort` objects [16](#ref-q1-16) .
+
+Wiki pages you might want to explore:
+- [Core Runtime Architecture (nodejs/node)](/wiki/nodejs/node#2)
+- [Module System Architecture (nodejs/node)](/wiki/nodejs/node#2.4)
+
+View this search on DeepWiki: https://deepwiki.com/search/how-does-nodeworkerthreads-pos_f36a0adf-2459-4416-ad5e-d206656740ce
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `doc/api/worker_threads.md:479-500`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L479-L500)
+
+```markdown
+## `worker_threads.postMessageToThread(threadId, value[, transferList][, timeout])`
+
+<!-- YAML
+added:
+- v22.5.0
+- v20.19.0
+-->
+
+> Stability: 1.1 - Active development
+
+* `threadId` {number} The target thread ID. If the thread ID is invalid, a
+  [`ERR_WORKER_MESSAGING_FAILED`][] error will be thrown. If the target thread ID is the current thread ID,
+  a [`ERR_WORKER_MESSAGING_SAME_THREAD`][] error will be thrown.
+* `value` {any} The value to send.
+* `transferList` {Object\[]} If one or more `MessagePort`-like objects are passed in `value`,
+  a `transferList` is required for those items or [`ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`][] is thrown.
+  See [`port.postMessage()`][] for more information.
+* `timeout` {number} Time to wait for the message to be delivered in milliseconds.
+  By default it's `undefined`, which means wait forever. If the operation times out,
+  a [`ERR_WORKER_MESSAGING_TIMEOUT`][] error is thrown.
+* Returns: {Promise} A promise which is fulfilled if the message was successfully processed by destination thread.
+```
+
+<a id="ref-q1-2"></a>
+### [2] `doc/api/worker_threads.md:499`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L499)
+
+```markdown
+* Returns: {Promise} A promise which is fulfilled if the message was successfully processed by destination thread.
+```
+
+<a id="ref-q1-3"></a>
+### [3] `doc/api/process.md:249-254`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/process.md#L249-L254)
+
+```markdown
+* `value` {any} A value transmitted using [`postMessageToThread()`][].
+* `source` {number} The transmitting worker thread ID or `0` for the main thread.
+
+The `'workerMessage'` event is emitted for any incoming message send by the other
+party by using [`postMessageToThread()`][].
+```
+
+<a id="ref-q1-4"></a>
+### [4] `doc/api/process.md:249-250`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/process.md#L249-L250)
+
+```markdown
+* `value` {any} A value transmitted using [`postMessageToThread()`][].
+* `source` {number} The transmitting worker thread ID or `0` for the main thread.
+```
+
+<a id="ref-q1-5"></a>
+### [5] `doc/api/worker_threads.md:536-539`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L536-L539)
+
+```markdown
+  process.on('workerMessage', (value, source) => {
+    console.log(`${source} -> ${threadId}:`, value);
+    postMessageToThread(source, { message: 'pong' });
+  });
+```
+
+<a id="ref-q1-6"></a>
+### [6] `doc/api/worker_threads.md:490-492`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L490-L492)
+
+```markdown
+  [`ERR_WORKER_MESSAGING_FAILED`][] error will be thrown. If the target thread ID is the current thread ID,
+  a [`ERR_WORKER_MESSAGING_SAME_THREAD`][] error will be thrown.
+* `value` {any} The value to send.
+```
+
+<a id="ref-q1-7"></a>
+### [7] `lib/internal/errors.js:1918`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/lib/internal/errors.js#L1918)
+
+```javascript
+E('ERR_WORKER_MESSAGING_SAME_THREAD', 'Cannot sent a message to the same thread', Error);
+```
+
+<a id="ref-q1-8"></a>
+### [8] `doc/api/worker_threads.md:496-498`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L496-L498)
+
+```markdown
+* `timeout` {number} Time to wait for the message to be delivered in milliseconds.
+  By default it's `undefined`, which means wait forever. If the operation times out,
+  a [`ERR_WORKER_MESSAGING_TIMEOUT`][] error is thrown.
+```
+
+<a id="ref-q1-9"></a>
+### [9] `lib/internal/errors.js:1919`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/lib/internal/errors.js#L1919)
+
+```javascript
+E('ERR_WORKER_MESSAGING_TIMEOUT', 'Sending a message to another thread timed out', Error);
+```
+
+<a id="ref-q1-10"></a>
+### [10] `doc/api/worker_threads.md:503-505`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L503-L505)
+
+```markdown
+If the target thread has no listener for the `workerMessage` event, then the operation will throw
+a [`ERR_WORKER_MESSAGING_FAILED`][] error.
+```
+
+<a id="ref-q1-11"></a>
+### [11] `lib/internal/errors.js:1917`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/lib/internal/errors.js#L1917)
+
+```javascript
+E('ERR_WORKER_MESSAGING_FAILED', 'Cannot find the destination thread or listener', Error);
+```
+
+<a id="ref-q1-12"></a>
+### [12] `doc/api/worker_threads.md:506-508`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L506-L508)
+
+```markdown
+If the target thread threw an error while processing the `workerMessage` event, then the operation will throw
+a [`ERR_WORKER_MESSAGING_ERRORED`][] error.
+```
+
+<a id="ref-q1-13"></a>
+### [13] `lib/internal/errors.js:1916`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/lib/internal/errors.js#L1916)
+
+```javascript
+E('ERR_WORKER_MESSAGING_ERRORED', 'The destination thread threw an error while processing the message', Error);
+```
+
+<a id="ref-q1-14"></a>
+### [14] `lib/worker_threads.js:25-26`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/lib/worker_threads.js#L25-L26)
+
+```javascript
+  postMessageToThread,
+} = require('internal/worker/messaging');
+```
+
+<a id="ref-q1-15"></a>
+### [15] `doc/api/process.md:244-247`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/process.md#L244-L247)
+
+```markdown
+added:
+- v22.5.0
+- v20.19.0
+-->
+```
+
+<a id="ref-q1-16"></a>
+### [16] `doc/api/worker_threads.md:1538-1542`
+Source: [nodejs/node @ 159ae48f](https://github.com/nodejs/node/blob/159ae48f/doc/api/worker_threads.md#L1538-L1542)
+
+```markdown
+To create custom messaging channels (which is encouraged over using the default
+global channel because it facilitates separation of concerns), users can create
+a `MessageChannel` object on either thread and pass one of the
+`MessagePort`s on that `MessageChannel` to the other thread through a
+pre-existing channel, such as the global one.
+```

--- a/test-parity/node-suite/worker_threads/direct-message/delivery.ts
+++ b/test-parity/node-suite/worker_threads/direct-message/delivery.ts
@@ -1,0 +1,49 @@
+import { Worker, postMessageToThread } from "node:worker_threads";
+
+process.chdir("test-parity/node-suite/worker_threads/direct-message");
+
+const worker = new Worker("./worker.cjs");
+let directMessage: any;
+let resolved = false;
+
+function maybeFinish() {
+  if (!directMessage || !resolved) {
+    return;
+  }
+
+  console.log(
+    "direct:",
+    directMessage.text,
+    directMessage.count,
+    directMessage.nestedOk,
+    directMessage.source,
+  );
+  console.log("resolved:", resolved);
+  worker.terminate().then((code) => {
+    console.log("terminate:", code);
+  });
+}
+
+worker.on("message", async (message: any) => {
+  if (message.phase === "ready") {
+    try {
+      await postMessageToThread(
+        worker.threadId,
+        { text: "hello", count: 2, nested: { ok: true } },
+        undefined,
+        1000,
+      );
+      resolved = true;
+      maybeFinish();
+    } catch (err: any) {
+      console.log("direct error:", err.code, err.message);
+      worker.terminate();
+    }
+    return;
+  }
+
+  if (message.phase === "direct") {
+    directMessage = message;
+    maybeFinish();
+  }
+});

--- a/test-parity/node-suite/worker_threads/direct-message/errors.ts
+++ b/test-parity/node-suite/worker_threads/direct-message/errors.ts
@@ -1,0 +1,37 @@
+import {
+  Worker,
+  postMessageToThread,
+  threadId,
+} from "node:worker_threads";
+
+process.chdir("test-parity/node-suite/worker_threads/direct-message");
+
+async function logRejection(label: string, promise: Promise<any>) {
+  try {
+    await promise;
+    console.log(label, "resolved");
+  } catch (err: any) {
+    console.log(label, err.name, err.code, err.message);
+  }
+}
+
+async function run() {
+  await logRejection("same-thread:", postMessageToThread(threadId, "self"));
+
+  const worker = new Worker("./no-listener-worker.cjs");
+  worker.on("message", async (message: any) => {
+    if (message.phase !== "ready") {
+      return;
+    }
+
+    await logRejection(
+      "no-listener:",
+      postMessageToThread(worker.threadId, "direct", undefined, 1000),
+    );
+    worker.terminate().then((code) => {
+      console.log("terminate:", code);
+    });
+  });
+}
+
+run();

--- a/test-parity/node-suite/worker_threads/direct-message/no-listener-worker.cjs
+++ b/test-parity/node-suite/worker_threads/direct-message/no-listener-worker.cjs
@@ -1,0 +1,4 @@
+const { parentPort } = require("node:worker_threads");
+
+parentPort.on("message", () => {});
+parentPort.postMessage({ phase: "ready" });

--- a/test-parity/node-suite/worker_threads/direct-message/timeout-worker.cjs
+++ b/test-parity/node-suite/worker_threads/direct-message/timeout-worker.cjs
@@ -1,0 +1,8 @@
+const { parentPort } = require("node:worker_threads");
+
+process.on("workerMessage", () => {});
+parentPort.on("message", () => {});
+parentPort.postMessage({ phase: "ready" });
+
+const start = Date.now();
+while (Date.now() - start < 100) {}

--- a/test-parity/node-suite/worker_threads/direct-message/timeout.ts
+++ b/test-parity/node-suite/worker_threads/direct-message/timeout.ts
@@ -1,0 +1,22 @@
+import { Worker, postMessageToThread } from "node:worker_threads";
+
+process.chdir("test-parity/node-suite/worker_threads/direct-message");
+
+const worker = new Worker("./timeout-worker.cjs");
+
+worker.on("message", async (message: any) => {
+  if (message.phase !== "ready") {
+    return;
+  }
+
+  try {
+    await postMessageToThread(worker.threadId, "slow", undefined, 1);
+    console.log("timeout: resolved");
+  } catch (err: any) {
+    console.log("timeout:", err.name, err.code, err.message);
+  }
+
+  worker.terminate().then((code) => {
+    console.log("terminate:", code);
+  });
+});

--- a/test-parity/node-suite/worker_threads/direct-message/worker.cjs
+++ b/test-parity/node-suite/worker_threads/direct-message/worker.cjs
@@ -1,0 +1,14 @@
+const { parentPort } = require("node:worker_threads");
+
+process.on("workerMessage", (value, source) => {
+  parentPort.postMessage({
+    phase: "direct",
+    text: value.text,
+    count: value.count,
+    nestedOk: value.nested.ok,
+    source,
+  });
+});
+
+parentPort.on("message", () => {});
+parentPort.postMessage({ phase: "ready" });


### PR DESCRIPTION
## Summary
- Implement `node:worker_threads` `postMessageToThread(threadId, value[, transferList][, timeout])` direct delivery through the existing worker registry and command loop.
- Emit `process` `workerMessage` in the target worker with the delivered value and source thread id, and reject covered same-thread/failed/timeout cases with Node-compatible error codes.
- Split direct-message logic into `worker_threads/direct_message.rs` so `worker_threads.rs` stays under the CI file-size limit.
- Add focused direct-message parity fixtures plus the DeepWiki reference used for Node behavior.

Fixes #3326

## Verification
- `./scripts/check_file_size.sh` — PASS (`worker_threads.rs` 1990 lines; no Rust source files exceed 2000 lines)
- `cargo fmt --all -- --check` — PASS
- `./run_parity_tests.sh --suite node-suite --module worker_threads` — PASS (16 pass, 0 fail, 0 compile fail); report `test-parity/reports/parity_report_20260602_005141.json`
- `cargo test -p perry-api-manifest` — PASS (31 passed; doc-tests 0)
- `cargo test -p perry-codegen --test manifest_consistency` — PASS (5 passed)
- `cargo test -p perry --bin perry hosted_builtin_default_import_collects_querystring_source -- --exact` — PASS (0 matched, 429 filtered; exit 0)