### PR TITLE
[codex] Fix fluent chain lowering cliff

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -896,10 +896,9 @@ pub(super) fn try_global_builtins(
         }
     }
 
-    // #854: lower the callee for its side effects (registration/tagging done
-    // inside `lower_expr`) even though the resulting value is unused on the
-    // fall-through path that hands the args back to the generic dispatcher.
-    let _callee_expr = lower_expr(ctx, expr)?;
-
+    // Fall through to the shared call tail. It owns lowering the callee for
+    // the generic dispatcher; doing it speculatively here relowers every
+    // receiver in a fluent generic chain and turns `a.b().c().d()` into an
+    // exponential lowering walk.
     Ok(Err(args))
 }

--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -235,6 +235,9 @@ pub(super) fn try_static_method_and_instance(
         // The inner call might lower to a NativeMethodCall, and we need to chain properly
         if let ast::MemberProp::Ident(method_ident) = &member.prop {
             let method_name = method_ident.sym.to_string();
+            if !may_lower_to_native_method_call(ctx, &member.obj) {
+                return Ok(Err(args));
+            }
             // Lower the object expression first
             let object_expr = lower_expr(ctx, &member.obj)?;
             // Check if it's a NativeMethodCall for a fluent-API native module
@@ -380,6 +383,58 @@ pub(super) fn try_static_method_and_instance(
     }
 
     Ok(Err(args))
+}
+
+fn may_lower_to_native_method_call(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    match expr {
+        ast::Expr::Ident(ident) => ident_may_start_native_method_call(ctx, ident.sym.as_ref()),
+        ast::Expr::New(_) => detect_native_instance_expr(ctx, expr).is_some(),
+        ast::Expr::Paren(paren) => may_lower_to_native_method_call(ctx, &paren.expr),
+        ast::Expr::TsAs(ts_as) => may_lower_to_native_method_call(ctx, &ts_as.expr),
+        ast::Expr::TsNonNull(ts_nn) => may_lower_to_native_method_call(ctx, &ts_nn.expr),
+        ast::Expr::TsSatisfies(ts_sat) => may_lower_to_native_method_call(ctx, &ts_sat.expr),
+        ast::Expr::TsTypeAssertion(ts_ta) => may_lower_to_native_method_call(ctx, &ts_ta.expr),
+        ast::Expr::TsConstAssertion(ts_const) => {
+            may_lower_to_native_method_call(ctx, &ts_const.expr)
+        }
+        ast::Expr::Call(call) => {
+            if native_class_from_factory_call(ctx, call).is_some() {
+                return true;
+            }
+
+            let ast::Callee::Expr(callee_expr) = &call.callee else {
+                return false;
+            };
+            let ast::Expr::Member(member) = callee_expr.as_ref() else {
+                return false;
+            };
+
+            match member.obj.as_ref() {
+                ast::Expr::Ident(ident) => {
+                    ident_may_start_native_method_call(ctx, ident.sym.as_ref())
+                }
+                object => {
+                    detect_native_instance_expr(ctx, object).is_some()
+                        || may_lower_to_native_method_call(ctx, object)
+                }
+            }
+        }
+        _ => false,
+    }
+}
+
+fn ident_may_start_native_method_call(ctx: &LoweringContext, name: &str) -> bool {
+    if ctx.lookup_native_instance(name).is_some() || ctx.lookup_native_module(name).is_some() {
+        return true;
+    }
+
+    ctx.lookup_imported_func(name).is_some()
+        && !ctx.namespace_import_locals.contains(name)
+        && name
+            .chars()
+            .next()
+            .map(|c| c.is_uppercase())
+            .unwrap_or(false)
 }
 
 /// Resolve the native `(module, class)` produced by an inline factory call

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -47,6 +47,55 @@ fn native_arena_owner_type(ty: &Type) -> bool {
     matches!(ty, Type::Named(name) if name == "NativeArena" || name == "NativeArenaOwner")
 }
 
+fn expr_may_infer_to_native_arena_owner(expr: &ast::Expr, ctx: &LoweringContext) -> bool {
+    match expr {
+        ast::Expr::Ident(ident) => {
+            let name = ident.sym.as_ref();
+            if name == "NativeArena" && !native_arena_global_is_shadowed(ctx) {
+                return true;
+            }
+            ctx.lookup_local_type(name)
+                .is_some_and(native_arena_owner_type)
+        }
+        ast::Expr::Call(call) => {
+            let ast::Callee::Expr(callee) = &call.callee else {
+                return false;
+            };
+            let ast::Expr::Member(member) = callee.as_ref() else {
+                return false;
+            };
+            let ast::MemberProp::Ident(method) = &member.prop else {
+                return false;
+            };
+            matches!(
+                (member.obj.as_ref(), method.sym.as_ref()),
+                (ast::Expr::Ident(obj), "alloc")
+                    if obj.sym.as_ref() == "NativeArena" && !native_arena_global_is_shadowed(ctx)
+            )
+        }
+        ast::Expr::Member(member) if matches!(member.obj.as_ref(), ast::Expr::This(_)) => {
+            let ast::MemberProp::Ident(prop) = &member.prop else {
+                return false;
+            };
+            let Some(class_name) = &ctx.current_class else {
+                return false;
+            };
+            ctx.lookup_class_field_type(class_name, prop.sym.as_ref())
+                .is_some_and(native_arena_owner_type)
+        }
+        ast::Expr::Paren(paren) => expr_may_infer_to_native_arena_owner(&paren.expr, ctx),
+        ast::Expr::TsAs(ts_as) => expr_may_infer_to_native_arena_owner(&ts_as.expr, ctx),
+        ast::Expr::TsTypeAssertion(ts_assert) => {
+            expr_may_infer_to_native_arena_owner(&ts_assert.expr, ctx)
+        }
+        ast::Expr::TsNonNull(non_null) => expr_may_infer_to_native_arena_owner(&non_null.expr, ctx),
+        ast::Expr::TsConstAssertion(const_assert) => {
+            expr_may_infer_to_native_arena_owner(&const_assert.expr, ctx)
+        }
+        _ => false,
+    }
+}
+
 fn native_arena_view_type_from_kind(ctx: &LoweringContext, expr: &ast::Expr) -> Option<Type> {
     match expr {
         ast::Expr::Lit(ast::Lit::Str(s)) => {
@@ -98,7 +147,9 @@ fn infer_native_arena_call_return_type(
         return Some(Type::Named("NativeArena".to_string()));
     }
 
-    if !native_arena_owner_type(&infer_type_from_expr(&member.obj, ctx)) {
+    if !expr_may_infer_to_native_arena_owner(&member.obj, ctx)
+        || !native_arena_owner_type(&infer_type_from_expr(&member.obj, ctx))
+    {
         return None;
     }
 
@@ -734,6 +785,110 @@ fn infer_set_elements_type(new_expr: &ast::NewExpr, ctx: &LoweringContext) -> Ve
     Vec::new()
 }
 
+fn known_receiver_method_name(method_name: &str) -> bool {
+    matches!(
+        method_name,
+        // Map / Set / WeakMap / WeakSet
+        "get" | "has" | "delete" | "set" | "add"
+        // TypedArray / String / Array
+        | "slice" | "subarray" | "trim" | "trimStart" | "trimEnd" | "toLowerCase"
+        | "toUpperCase" | "substring" | "substr" | "replace" | "replaceAll"
+        | "padStart" | "padEnd" | "repeat" | "charAt" | "concat" | "normalize"
+        | "toLocaleLowerCase" | "toLocaleUpperCase" | "indexOf" | "lastIndexOf"
+        | "search" | "charCodeAt" | "codePointAt" | "localeCompare" | "startsWith"
+        | "endsWith" | "includes" | "split" | "match" | "matchAll" | "push"
+        | "unshift" | "findIndex" | "join" | "pop" | "shift" | "find" | "at"
+        | "map" | "filter" | "flat" | "flatMap" | "reverse" | "sort" | "splice"
+        | "reduce" | "fill" | "forEach"
+        // Number / object-ish builtins
+        | "toFixed" | "toPrecision" | "toExponential" | "toString" | "valueOf"
+        // Known userland-native instance return tables.
+        | "encode" | "encodeInto" | "decode" | "readLines" | "readableWebStream"
+        | "take" | "drop" | "compose"
+    )
+}
+
+fn ident_has_known_static_method_return(
+    ctx: &LoweringContext,
+    name: &str,
+    method_name: &str,
+) -> bool {
+    if matches!(
+        name,
+        "Math"
+            | "Number"
+            | "JSON"
+            | "Object"
+            | "Date"
+            | "Buffer"
+            | "Readable"
+            | "crypto"
+            | "console"
+    ) {
+        return true;
+    }
+    if name != "Uint8Array" && crate::ir::typed_array_kind_for_name(name).is_some() {
+        return matches!(method_name, "from" | "of");
+    }
+    if ctx.lookup_builtin_module_alias(name).is_some()
+        || matches!(ctx.lookup_native_module(name), Some((_, None)))
+    {
+        return true;
+    }
+    false
+}
+
+fn expr_may_have_typed_receiver(expr: &ast::Expr, ctx: &LoweringContext) -> bool {
+    match expr {
+        ast::Expr::Lit(ast::Lit::Str(_)) => true,
+        ast::Expr::Array(_) => true,
+        ast::Expr::Ident(ident) => ctx
+            .lookup_local_type(ident.sym.as_ref())
+            .is_some_and(|ty| !matches!(ty, Type::Any | Type::Unknown)),
+        ast::Expr::This(_) => true,
+        ast::Expr::New(_) => true,
+        ast::Expr::Member(member) => {
+            if matches!(member.obj.as_ref(), ast::Expr::This(_)) {
+                return true;
+            }
+            expr_may_have_typed_receiver(&member.obj, ctx)
+        }
+        ast::Expr::Call(call) => {
+            let ast::Callee::Expr(callee) = &call.callee else {
+                return false;
+            };
+            let ast::Expr::Member(member) = callee.as_ref() else {
+                return false;
+            };
+            expr_may_have_typed_receiver(&member.obj, ctx)
+        }
+        ast::Expr::Paren(paren) => expr_may_have_typed_receiver(&paren.expr, ctx),
+        ast::Expr::TsAs(ts_as) => expr_may_have_typed_receiver(&ts_as.expr, ctx),
+        ast::Expr::TsTypeAssertion(ts_assert) => expr_may_have_typed_receiver(&ts_assert.expr, ctx),
+        ast::Expr::TsNonNull(non_null) => expr_may_have_typed_receiver(&non_null.expr, ctx),
+        ast::Expr::TsConstAssertion(const_assert) => {
+            expr_may_have_typed_receiver(&const_assert.expr, ctx)
+        }
+        _ => false,
+    }
+}
+
+fn method_return_may_depend_on_receiver_type(
+    ctx: &LoweringContext,
+    receiver: &ast::Expr,
+    method_name: &str,
+) -> bool {
+    if known_receiver_method_name(method_name) {
+        return true;
+    }
+    if let ast::Expr::Ident(ident) = receiver {
+        if ident_has_known_static_method_return(ctx, ident.sym.as_ref(), method_name) {
+            return true;
+        }
+    }
+    expr_may_have_typed_receiver(receiver, ctx)
+}
+
 pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) -> Type {
     match callee {
         // Direct function call: foo()
@@ -775,6 +930,12 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                             return Type::Promise(Box::new(filehandle_type()));
                         }
                     }
+                }
+                if method_name == "toString" {
+                    return Type::String;
+                }
+                if !method_return_may_depend_on_receiver_type(ctx, &member.obj, method_name) {
+                    return Type::Any;
                 }
                 let obj_ty = infer_type_from_expr(&member.obj, ctx);
 
@@ -1008,11 +1169,6 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                     if obj_name == "console" {
                         return Type::Void;
                     }
-                }
-
-                // Generic .toString() on any object → String
-                if method_name == "toString" {
-                    return Type::String;
                 }
             }
             Type::Any

--- a/crates/perry-hir/tests/fluent_chain_lowering.rs
+++ b/crates/perry-hir/tests/fluent_chain_lowering.rs
@@ -1,0 +1,101 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::lower_module;
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_result(src: &str) -> Result<perry_hir::Module, String> {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = parse_typescript_with_cache(&src, "fluent_chain_lowering.ts", &mut cache)
+                .expect("parse should succeed");
+            lower_module(&parsed.module, "test", "fluent_chain_lowering.ts")
+                .map_err(|e| e.to_string())
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+fn chain_source(routes: &[(&str, &str)]) -> String {
+    let chain = routes
+        .iter()
+        .map(|(method, name)| format!("  .{method}(\"{name}\", 0)"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"
+        declare const handlers: any;
+
+        export const out = handlers
+        {chain}
+        "#
+    )
+}
+
+#[test]
+fn opencode_session_route_chain_lowers_without_exponential_receiver_relowering() {
+    let routes = [
+        ("handle", "list"),
+        ("handle", "status"),
+        ("handle", "get"),
+        ("handle", "children"),
+        ("handle", "todo"),
+        ("handle", "diff"),
+        ("handle", "messages"),
+        ("handle", "message"),
+        ("handleRaw", "create"),
+        ("handle", "remove"),
+        ("handle", "update"),
+        ("handleRaw", "fork"),
+        ("handle", "abort"),
+        ("handle", "init"),
+        ("handle", "share"),
+        ("handle", "unshare"),
+        ("handle", "summarize"),
+        ("handle", "prompt"),
+        ("handle", "promptAsync"),
+        ("handle", "command"),
+        ("handle", "shell"),
+        ("handle", "revert"),
+        ("handle", "unrevert"),
+        ("handle", "permissionRespond"),
+        ("handle", "deleteMessage"),
+        ("handle", "deletePart"),
+        ("handle", "updatePart"),
+    ];
+
+    let module = lower_result(&chain_source(&routes)).expect("fluent route chain should lower");
+    let debug = format!("{module:#?}");
+    assert!(
+        debug.contains("property: \"handle\"") && debug.contains("property: \"handleRaw\""),
+        "route builder calls should remain generic property calls: {debug}"
+    );
+    assert!(
+        !debug.contains("NativeMethodCall"),
+        "generic route builder calls must not be classified as native methods: {debug}"
+    );
+}
+
+#[test]
+fn native_fluent_chain_still_dispatches_through_native_methods() {
+    let module = lower_result(
+        r#"
+        export const out = new Decimal(1).plus(2).times(3).toString();
+        "#,
+    )
+    .expect("native fluent chain should lower");
+    let debug = format!("{module:#?}");
+    assert!(
+        debug.contains("module: \"decimal.js\""),
+        "Decimal chain should dispatch through decimal.js native methods: {debug}"
+    );
+    for method in ["plus", "times", "toString"] {
+        assert!(
+            debug.contains(&format!("method: \"{method}\"")),
+            "Decimal chain should preserve native method {method}: {debug}"
+        );
+    }
+}


### PR DESCRIPTION
## What changed

This avoids repeated lowering/type inference over generic fluent receiver chains such as OpenCode's yargs command builder in `src/index.ts`.

The patch:
- lets the shared generic call tail own callee lowering instead of speculatively lowering fallthrough global calls
- only attempts native fluent method dispatch when the receiver can plausibly lower to a native method call
- short-circuits method return inference for arbitrary untyped builder chains that cannot hit Perry's known typed/native receiver tables
- adds a focused HIR regression covering an OpenCode-shaped generic fluent chain and preserving `Decimal` native fluent dispatch

## Why

OpenCode-shaped fluent yargs chains could hit a lowering/type-inference complexity cliff. Staged assignment forms passed, but inline receiver chains could become dramatically slower or hang because nested receivers were walked/lowered repeatedly.

This PR fixes that compiler blocker without broad OpenTUI/OpenCode refactors and without claiming OpenCode native completion.

## Validation

From this PR branch (`perry 0.5.1094`):

```sh
cargo test -p perry-hir --test fluent_chain_lowering -- --nocapture
```

Result: passed, 2 tests.

```sh
cargo build -p perry
```

Result: passed.

Manual OpenCode-shaped reducer checks with `target/debug/perry`:

```sh
target/debug/perry check -v /tmp/perry-yargs-fixed-gate-tYNVQC/inline-23/entry.ts
```

Result: passed, `elapsed=0.893`.

```sh
target/debug/perry check -v /var/folders/8q/vx4z9tqd08jd1b5_bykzbdkr0000gn/T/opentui-perry-opencode-index-yargs-Vx2YwM/staged-23/entry.ts
```

Result: passed, `elapsed=0.895`.

The OpenTUI yargs helper currently encodes the old expected failure, so it exits once `inline-2` passes and reports `expected inline-2 to time out during Perry check`. That is stale script expectation, not the current compiler behavior.

## Not covered

This does not claim actual OpenCode native completion. After this blocker, the next observed native OpenCode gate failure is a separate `--check-deps` resolver/import graph issue with many `R003` package/import resolution misses for OpenCode aliases/subpaths such as `@/...`, `@opencode-ai/core/...`, and `@opentui/keymap/runtime-modules`.

The OpenTUI `renderer.intermediateRender()` runtime abort is also separate and not addressed here.
