### PR TITLE
fix(runtime): Object.prototype.toString brands for Map/Set/WeakMap/WeakSet/Promise/RegExp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1095 — fix(runtime): Object.prototype.toString brands for Map/Set/WeakMap/WeakSet/Promise/RegExp
+
+`Object.prototype.toString.call(x)` returned `"[object Object]"` for `Map`, `Set`, `WeakMap`, `WeakSet`, `Promise`, and `RegExp` instead of Node's `"[object Map]"`, `"[object Set]"`, `"[object WeakMap]"`, `"[object WeakSet]"`, `"[object Promise]"`, and `"[object RegExp]"`. `js_object_to_string` (`object/mod.rs`) discriminated only Array/Error/Date/buffer brands and let these fall through to the generic object tag. Added per-type detection before the GC-header object discrimination: Map/Set via their registries (`is_registered_map`/`is_registered_set` — they're raw-alloc'd with no GcHeader), RegExp via `is_regex_pointer`, WeakMap/WeakSet via `weak_class_id_from_receiver`, and Promise via `js_value_is_promise`. (The RegExp *brand* is distinct from `RegExp.prototype.toString` → `/source/flags`, fixed separately in v0.5.1094.) Advances the collections / object-model / RegExp conformance issues (#3989, #3986, #4035).
+
 ## v0.5.1094 — fix(regexp): RegExp.prototype.toString returns /source/flags
 
 `/a/gi.toString()`, `String(/a/gi)`, and `` `${/a/gi}` `` all returned `"[object Object]"` instead of `"/a/gi"` — a RegExp fell through to `Object.prototype.toString` for both the explicit method call and ToString coercion. Added a shared `js_regexp_to_string(re)` helper (`/{source}/{flags}`, reusing the existing `source`/`flags` accessors) and wired it through three paths: the `regex.toString()` method dispatch (`dispatch_regex_receiver_method` + the `native_call_method` receiver gate, now `test|exec|toString`) and the ToString coercion in `js_jsvalue_to_string` (covers `String()` / template literals). Advances the RegExp conformance issue (#4035).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1094
+**Current Version:** 0.5.1095
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1094"
+version = "0.5.1095"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1094"
+version = "0.5.1095"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1094"
+version = "0.5.1095"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1094"
+version = "0.5.1095"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1094"
+version = "0.5.1095"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1683,6 +1683,45 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
     }
+    // Map / Set / WeakMap / WeakSet / Promise brands. Node tags these
+    // `[object Map]` / `[object Set]` / `[object WeakMap]` / `[object WeakSet]`
+    // / `[object Promise]`; without per-type detection they fall through to the
+    // generic `[object Object]`. Map/Set are raw-alloc'd (no GcHeader) so detect
+    // via their registries before the GC-header object discrimination below.
+    if raw_addr >= 0x1000 {
+        let tag = if crate::map::is_registered_map(raw_addr) {
+            Some("Map")
+        } else if crate::set::is_registered_set(raw_addr) {
+            Some("Set")
+        } else if crate::regex::is_regex_pointer(raw_addr as *const u8) {
+            // `Object.prototype.toString.call(/a/)` is `[object RegExp]` (the
+            // brand) — distinct from `/a/.toString()` which is `/a/` (the value).
+            Some("RegExp")
+        } else {
+            None
+        };
+        if let Some(tag) = tag {
+            let formatted = format!("[object {}]", tag);
+            let str_ptr =
+                crate::string::js_string_from_bytes(formatted.as_ptr(), formatted.len() as u32);
+            return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+        }
+    }
+    if let Some(cid) = crate::weakref::weak_class_id_from_receiver(value) {
+        let tag = if cid == crate::weakref::CLASS_ID_WEAKSET {
+            "WeakSet"
+        } else {
+            "WeakMap"
+        };
+        let formatted = format!("[object {}]", tag);
+        let str_ptr =
+            crate::string::js_string_from_bytes(formatted.as_ptr(), formatted.len() as u32);
+        return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    }
+    if crate::promise::js_value_is_promise(value) != 0 {
+        let str_ptr = crate::string::js_string_from_bytes(b"[object Promise]".as_ptr(), 16);
+        return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    }
     if let Some(tag) = web_stream_to_string_tag(value) {
         let formatted = format!("[object {}]", tag);
         let bytes = formatted.as_bytes();


### PR DESCRIPTION
## Summary

`Object.prototype.toString.call(x)` returned `"[object Object]"` for `Map`, `Set`, `WeakMap`, `WeakSet`, `Promise`, and `RegExp` instead of Node's `"[object Map]"`, `"[object Set]"`, `"[object WeakMap]"`, `"[object WeakSet]"`, `"[object Promise]"`, and `"[object RegExp]"`.

## Fix

`js_object_to_string` (`object/mod.rs`) discriminated only Array/Error/Date/buffer brands and let these fall through to the generic object tag. Added per-type detection before the GC-header object discrimination:
- **Map/Set** via their registries (`is_registered_map`/`is_registered_set`) — they're raw-alloc'd with no GcHeader, so detected by address before any GC-header read;
- **RegExp** via `is_regex_pointer`;
- **WeakMap/WeakSet** via `weak_class_id_from_receiver`;
- **Promise** via `js_value_is_promise`.

The RegExp *brand* is distinct from `RegExp.prototype.toString` (`/source/flags`, fixed in v0.5.1094).

## Verification

- All 14 probed brands match Node: the six fixed types plus `Array`/`Object`/`Date`/`Error`/`ArrayBuffer`/`Uint8Array`/`null`/number are unchanged (no false brands on plain objects/arrays).

Advances the collections / object-model / RegExp conformance issues (#3989, #3986, #4035).
