### PR TITLE
fix(thread): type perry/thread spawn() as Promise<any> (#4022)

### DIFF
--- a/crates/perry-api-manifest/src/emit.rs
+++ b/crates/perry-api-manifest/src/emit.rs
@@ -539,6 +539,7 @@ fn render_type(ty: &TypeSpec) -> &'static str {
         TypeSpec::Handle => "any",
         TypeSpec::Void => "void",
         TypeSpec::Any => "any",
+        TypeSpec::Promise => "Promise<any>",
     }
 }
 

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1516,13 +1516,16 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         &[p_any("p0"), p_any("p1")],
         TypeSpec::Any,
     ),
+    // `spawn(fn)` runs `fn` on a background OS thread and hands back a
+    // Promise that resolves to the closure's return value (#4022). The
+    // resolved value's type isn't statically known, so `Promise<any>`.
     method_sig(
         "perry/thread",
         "spawn",
         false,
         None,
         &[p_any("p0")],
-        TypeSpec::Any,
+        TypeSpec::Promise,
     ),
     method_sig(
         "lodash",

--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -140,6 +140,11 @@ pub enum TypeSpec {
     /// returns a NaN-boxed JSValue whose user-side type isn't fixed
     /// (`F64` returns can be `Promise<T>`, mixed strings/numbers, etc.).
     Any,
+    /// `Promise<any>`. The call returns a runtime Promise whose resolved
+    /// value isn't statically known (e.g. `perry/thread`'s `spawn`, whose
+    /// resolution is the background closure's return value). Distinguishes
+    /// "this is awaitable" from the opaque [`TypeSpec::Any`] fallback.
+    Promise,
 }
 
 /// What shape of symbol this entry describes.

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -2437,7 +2437,7 @@ declare module "perry/thread" {
   /** stdlib */
   export function parallelMap(p0: any, p1: any): any;
   /** stdlib */
-  export function spawn(p0: any): any;
+  export function spawn(p0: any): Promise<any>;
 }
 
 declare module "perry/tui" {


### PR DESCRIPTION
## What

Fixes #4022. `spawn()` from `perry/thread` hovered as `const handle: any` in editors because the API manifest declared its return as `TypeSpec::Any`, which the generated `.d.ts` renders as `any`.

At runtime `spawn(fn)` runs `fn` on a background OS thread and hands back a real `Promise` that resolves to the closure's return value (verified: `handle instanceof Promise === true`, `handle.then(v => ...)` resolves to the returned number). The type now matches that behavior.

## Change

- Add a `TypeSpec::Promise` variant to the API manifest (renders `Promise<any>`), distinguishing "awaitable" from the opaque `Any` fallback.
- Point `perry/thread` `spawn`'s return type at it.
- Regenerate `docs/api/perry.d.ts` via `scripts/regen_api_docs.sh`:

```diff
-  export function spawn(p0: any): any;
+  export function spawn(p0: any): Promise<any>;
```

The resolved value's type isn't statically knowable from the manifest (it's the closure's return), so `Promise<any>` is the honest declaration rather than `Promise<void>`.

## Test

- `cargo test --release -p perry-api-manifest` — 31 passed.
- Compiled + ran the issue's repro: `handle instanceof Promise` is `true` and the promise resolves to the closure's value.
- `cargo fmt --all -- --check` clean; docs regenerated (no drift).
