### PR TITLE
fix(runtime): #4004 — small-handle fetch ids must not be dereferenced as heap pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1096 — fix(runtime): #4004 — small-handle fetch ids must not be dereferenced as heap pointers
+
+**Root cause.** #4018 disambiguated the Web Fetch and node:http handle id-spaces by
+moving fetch `Request`/`Headers`/`Response` handles into a high band (`0x40000+`),
+disjoint from node:http/perry-ffi handles (`< 0x40000`). That fixed the dispatch-site
+collision in #4004 — but surfaced a latent crash. The runtime's type-identity probes
+(`date::is_date_cell_addr` → `is_date_value`, `map::is_registered_map`,
+`set::is_registered_set`, `weakref::weak_class_id_from_receiver`) read a `GcHeader` at
+`addr - GC_HEADER_SIZE` after only rejecting addresses below `0x1000 + GC_HEADER_SIZE`.
+Small-handle registry ids are NaN-boxed as `POINTER_TAG` values but are not heap
+addresses; while fetch handles started at `1` they fell below that floor and were
+skipped, but at `0x40000+` they sailed past it. Any **untyped** method/property dispatch
+on a fetch handle — exactly the shape a Hono `node:http` adapter takes, where
+`request.headers.get(...)` has an `any`-typed receiver — then dereferenced `id - 8`,
+reading unmapped memory and segfaulting (`EXC_BAD_ACCESS` at `0x3fff8` for handle
+`0x40000`).
+
+**Fix.** Raise the floor in those four probes to the canonical `< 0x100000` small-handle
+cutoff used throughout the runtime. Real `Date`/`Map`/`Set`/`WeakMap`/`WeakSet` cells are
+arena-allocated above the cutoff, so each remains an exact heap-pointer identity check
+with no behavior change for genuine heap objects; the whole small-handle band (Web Fetch,
+node:http/perry-ffi, timers, …) is now rejected before any GC-header deref.
+
+Also: `Headers.get` on the untyped dispatch path (`fetch/dispatch.rs`) now returns `null`
+for an absent header instead of the empty string, matching WHATWG/Node — `js_headers_get`
+signals absence with a null `StringHeader` pointer that was previously wrapped as `""`,
+which would have broken `headers.get(x) === null` checks in the same Hono path.
+
+Adds `test-parity/node-suite/http/server/request-handle-no-collision.ts`, a deterministic
+regression test that allocates a live node:http server handle (low band) alongside a fetch
+`Request` (high band) and drives the untyped `request.headers.get`/`.has` access that
+crashed. Output is byte-identical to Node. Validated: perry-runtime 962/962 and
+perry-stdlib 87/87 unit tests pass.
+
 ## v0.5.1095 — fix(runtime): Object.prototype.toString brands for Map/Set/WeakMap/WeakSet/Promise/RegExp
 
 `Object.prototype.toString.call(x)` returned `"[object Object]"` for `Map`, `Set`, `WeakMap`, `WeakSet`, `Promise`, and `RegExp` instead of Node's `"[object Map]"`, `"[object Set]"`, `"[object WeakMap]"`, `"[object WeakSet]"`, `"[object Promise]"`, and `"[object RegExp]"`. `js_object_to_string` (`object/mod.rs`) discriminated only Array/Error/Date/buffer brands and let these fall through to the generic object tag. Added per-type detection before the GC-header object discrimination: Map/Set via their registries (`is_registered_map`/`is_registered_set` — they're raw-alloc'd with no GcHeader), RegExp via `is_regex_pointer`, WeakMap/WeakSet via `weak_class_id_from_receiver`, and Promise via `js_value_is_promise`. (The RegExp *brand* is distinct from `RegExp.prototype.toString` → `/source/flags`, fixed separately in v0.5.1094.) Advances the collections / object-model / RegExp conformance issues (#3989, #3986, #4035).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1095
+**Current Version:** 0.5.1096
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1095"
+version = "0.5.1096"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1095"
+version = "0.5.1096"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1095"
+version = "0.5.1096"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1095"
+version = "0.5.1096"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1095"
+version = "0.5.1096"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -58,7 +58,16 @@ pub fn date_invalid() -> f64 {
 /// with no side-table registry to keep in sync.
 #[inline]
 pub fn is_date_cell_addr(addr: usize) -> bool {
-    if addr < 0x1000 + crate::gc::GC_HEADER_SIZE {
+    // #4004: small-handle registry ids (Web Fetch Request/Headers/Response,
+    // perry-ffi/node:http handles, timer ids, …) are NaN-boxed as POINTER_TAG
+    // values but are NOT real heap addresses — they live in the `< 0x100000`
+    // small-handle band. Real `DateCell`s are arena-allocated, always at or
+    // above the small-handle cutoff. Dereferencing `addr - GC_HEADER_SIZE` on a
+    // small handle reads unmapped memory: once #4018 moved fetch handles up to
+    // 0x40000 (past the old 0x1000 floor), any untyped `request.headers.get()`
+    // dispatch routed its receiver through `is_date_value` here and segfaulted.
+    // Reject the whole small-handle band so this is an exact heap-pointer check.
+    if addr < 0x100000 {
         return false;
     }
     unsafe {

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -85,7 +85,13 @@ pub fn is_registered_map(addr: usize) -> bool {
     // Profile (samply, perf-comprehensive): ~5.7% inclusive samples
     // were attributed to is_registered_map's HashSet lookup before
     // this fast path landed.
-    if addr < 0x1000 + crate::gc::GC_HEADER_SIZE {
+    // #4004: small-handle registry ids (Web Fetch, perry-ffi/node:http, timers,
+    // …) are NaN-boxed POINTER_TAG values living below the `0x100000`
+    // small-handle cutoff; they are not heap addresses. Managed Maps are
+    // arena-allocated above it, so reject the whole small-handle band before
+    // dereferencing `addr - GC_HEADER_SIZE` (deref'ing e.g. a 0x40000 fetch
+    // handle reads unmapped memory and segfaults — see is_date_cell_addr).
+    if addr < 0x100000 {
         return false;
     }
     unsafe {

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -109,7 +109,11 @@ fn register_set(ptr: *mut SetHeader) {
 }
 
 pub fn is_registered_set(addr: usize) -> bool {
-    if addr < 0x1000 + crate::gc::GC_HEADER_SIZE {
+    // #4004: reject the `< 0x100000` small-handle band (Web Fetch / node:http /
+    // timer ids are NaN-boxed POINTER_TAG values, not heap addresses) before
+    // dereferencing the GC header. Managed Sets are arena-allocated above the
+    // cutoff. See map::is_registered_map / date::is_date_cell_addr.
+    if addr < 0x100000 {
         return false;
     }
     unsafe {

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -347,7 +347,11 @@ pub unsafe fn try_weak_method_dispatch(
 /// (`js_nanbox_get_pointer` yields 0) safely resolves to `None`.
 pub fn weak_class_id_from_receiver(receiver: f64) -> Option<u32> {
     let addr = js_nanbox_get_pointer(receiver) as usize;
-    if addr < 0x1000 + crate::gc::GC_HEADER_SIZE {
+    // #4004: reject the `< 0x100000` small-handle band (Web Fetch / node:http /
+    // timer ids are NaN-boxed POINTER_TAG values, not heap addresses) before
+    // dereferencing the GC header. WeakMap/WeakSet are ObjectHeader-backed
+    // allocations above the cutoff. See map::is_registered_map.
+    if addr < 0x100000 {
         return None;
     }
     unsafe {

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -597,9 +597,19 @@ pub fn dispatch_headers_method(headers_id: usize, method: &str, args: &[f64]) ->
     };
     unsafe {
         match method {
-            "get" => Some(f64::from_bits(
-                JSValue::string_ptr(js_headers_get(h_f64, str_arg(0))).bits(),
-            )),
+            // WHATWG `Headers.get` returns `null` for an absent header, not the
+            // empty string. `js_headers_get` signals absence with a null
+            // `StringHeader` pointer; wrapping that in `string_ptr` would render
+            // as `""` and break `headers.get(x) === null` checks (the Hono
+            // adapter path behind #4004).
+            "get" => {
+                let p = js_headers_get(h_f64, str_arg(0));
+                if p.is_null() {
+                    Some(f64::from_bits(TAG_NULL))
+                } else {
+                    Some(f64::from_bits(JSValue::string_ptr(p).bits()))
+                }
+            }
             "set" => Some(js_headers_set(h_f64, str_arg(0), str_arg(1))),
             "append" => Some(js_headers_append(h_f64, str_arg(0), str_arg(1))),
             "has" => Some(js_headers_has(h_f64, str_arg(0))),

--- a/test-parity/node-suite/http/server/request-handle-no-collision.ts
+++ b/test-parity/node-suite/http/server/request-handle-no-collision.ts
@@ -1,0 +1,45 @@
+import http from "node:http";
+
+// Regression test for #4004.
+//
+// A node:http server allocates handles in the low small-handle band
+// (< 0x40000); WHATWG fetch `Request` / `Headers` handles were moved into a
+// disjoint high band (0x40000+) by #4018 so the two can no longer share an id.
+// But that move surfaced a latent crash: the runtime's small-handle type
+// probes (`is_date_value`, `is_registered_map`, …) only skipped addresses
+// below ~0x1000, so a 0x40000+ fetch handle reached an untyped method/property
+// dispatch was dereferenced as a heap pointer (reading a GC header at id-8) and
+// segfaulted. This is exactly the access shape a Hono "node:http adapter"
+// takes — `request.headers.get(...)` on an `any`-typed request — which is why
+// it forced a startup-warmup workaround.
+//
+// Allocate a live server handle (low band), then build a fetch Request (high
+// band) and exercise it through an `any`-typed receiver so the call routes
+// through the runtime handle-dispatch tower rather than the statically-typed
+// fast path.
+const server = http.createServer(() => {});
+console.log("server typeof:", typeof server);
+
+const request = new Request("http://localhost/path", {
+  method: "POST",
+  headers: { "x-test": "perry", "content-type": "application/json" },
+}) as any;
+
+console.log("is Request:", request instanceof Request);
+console.log("method:", request.method);
+console.log("url:", request.url);
+
+const headers = request.headers;
+console.log("headers typeof:", typeof headers);
+console.log("get is function:", typeof headers.get === "function");
+console.log("x-test:", headers.get("x-test"));
+console.log("content-type:", headers.get("content-type"));
+console.log("missing:", headers.get("nope"));
+console.log("has x-test:", headers.has("x-test"));
+console.log("has nope:", headers.has("nope"));
+
+// A standalone Headers reached through an `any` receiver hits the same path.
+const h = new Headers({ a: "1", b: "2" }) as any;
+console.log("untyped Headers get:", h.get("a"));
+console.log("untyped Headers has:", h.has("b"));
+console.log("untyped Headers missing:", h.get("z"));


### PR DESCRIPTION
## Summary

Fixes #4004.

PR #4018 disambiguated the Web Fetch and node:http handle id-spaces by moving fetch `Request`/`Headers`/`Response` handles into a high band (`0x40000+`), disjoint from node:http/perry-ffi handles (`< 0x40000`). That removed the dispatch-site collision described in #4004 — but surfaced a **latent segfault** that still broke the exact Hono `node:http` adapter path the issue is about.

### Root cause

The runtime's type-identity probes read a `GcHeader` at `addr - GC_HEADER_SIZE` after only rejecting addresses below `0x1000 + GC_HEADER_SIZE`:

- `date::is_date_cell_addr` (via `is_date_value`)
- `map::is_registered_map`
- `set::is_registered_set`
- `weakref::weak_class_id_from_receiver`

Small-handle registry ids are NaN-boxed as `POINTER_TAG` values but are **not** heap addresses. While fetch handles started at `1` they fell below that `~0x1008` floor and were safely skipped; at `0x40000+` they sail past it. Any **untyped** method/property dispatch on a fetch handle — e.g. Hono's `request.headers.get(...)` where the receiver is `any` — then dereferenced `id - 8`, reading unmapped memory and segfaulting (`EXC_BAD_ACCESS` at `0x3fff8` for handle `0x40000`).

### Fix

- Raise the floor in those four probes to the canonical `< 0x100000` small-handle cutoff used throughout the runtime. Real `Date`/`Map`/`Set`/`WeakMap`/`WeakSet` cells are arena-allocated above the cutoff, so each stays an exact heap-pointer identity check with no behavior change for genuine heap objects.
- `Headers.get` on the untyped dispatch path now returns `null` for an absent header instead of `""`, matching WHATWG/Node (`js_headers_get` signals absence with a null pointer that was previously wrapped as an empty string — which would break `headers.get(x) === null` in the same Hono path).

### Test

Adds `test-parity/node-suite/http/server/request-handle-no-collision.ts`: allocates a live node:http server handle (low band) alongside a fetch `Request` (high band) and drives the untyped `request.headers.get`/`.has` access that crashed. Output is **byte-identical to Node**.

### Validation

- `perry-runtime` unit tests: 962/962 pass
- `perry-stdlib` unit tests: 87/87 pass
- New regression test: byte-identical to `node --experimental-strip-types`
