### PR TITLE
[codex] Fix tty WriteStream pipe fd handling

### DIFF
--- a/crates/perry-runtime/src/tty.rs
+++ b/crates/perry-runtime/src/tty.rs
@@ -94,12 +94,45 @@ pub(crate) fn is_tty_fd(fd: i32) -> bool {
     isatty_impl(fd)
 }
 
-fn validate_tty_fd(fd: f64) -> i32 {
+fn validate_fd_number(fd: f64) -> i32 {
     if !fd.is_finite() || fd < 0.0 || fd.fract() != 0.0 {
         throw_invalid_fd(fd);
     }
-    let fd_i = fd as i32;
+    fd as i32
+}
+
+#[cfg(unix)]
+fn write_stream_fd_type_supported(fd: i32) -> bool {
+    unsafe {
+        let mut stat: libc::stat = std::mem::zeroed();
+        if libc::fstat(fd, &mut stat) != 0 {
+            return false;
+        }
+        let file_type = stat.st_mode & libc::S_IFMT;
+        file_type == libc::S_IFIFO || file_type == libc::S_IFSOCK
+    }
+}
+
+#[cfg(not(unix))]
+fn write_stream_fd_type_supported(_fd: i32) -> bool {
+    false
+}
+
+fn can_init_write_stream_fd(fd: i32) -> bool {
+    is_tty_fd(fd) || write_stream_fd_type_supported(fd)
+}
+
+fn validate_tty_read_fd(fd: f64) -> i32 {
+    let fd_i = validate_fd_number(fd);
     if !is_tty_fd(fd_i) {
+        throw_tty_init_failed();
+    }
+    fd_i
+}
+
+fn validate_tty_write_fd(fd: f64) -> i32 {
+    let fd_i = validate_fd_number(fd);
+    if !can_init_write_stream_fd(fd_i) {
         throw_tty_init_failed();
     }
     fd_i
@@ -772,7 +805,7 @@ pub(crate) fn tty_listener_remove_all_value() -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_tty_read_stream_new(fd: f64) -> f64 {
-    validate_tty_fd(fd);
+    validate_tty_read_fd(fd);
     ensure_tty_prototypes();
     let keys = b"isRaw\0isTTY\0";
     let obj = crate::object::js_object_alloc_class_with_keys(
@@ -791,7 +824,7 @@ pub extern "C" fn js_tty_read_stream_new(fd: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_tty_write_stream_new(fd: f64) -> f64 {
-    validate_tty_fd(fd);
+    validate_tty_write_fd(fd);
     ensure_tty_prototypes();
     let obj = crate::object::js_object_alloc_class_with_keys(
         CLASS_ID_TTY_WRITE_STREAM,
@@ -1054,7 +1087,7 @@ pub fn throw_invalid_fd(fd: f64) -> ! {
 }
 
 pub fn throw_tty_init_failed() -> ! {
-    let message = "TTY initialization failed";
+    let message = "TTY initialization failed: uv_tty_init returned EINVAL (invalid argument)";
     let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
     crate::node_submodules::register_error_code_pub(msg, "ERR_TTY_INIT_FAILED");
     let err = crate::error::js_error_new_with_name_message(b"SystemError", msg);
@@ -1170,6 +1203,18 @@ pub extern "C" fn js_tty_resize_drain() -> i32 {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    struct FdGuard(i32);
+
+    #[cfg(unix)]
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            unsafe {
+                libc::close(self.0);
+            }
+        }
+    }
+
     #[test]
     fn isatty_zero_for_pipe() {
         // In test runner stdin is not a TTY (cargo test pipes stdin).
@@ -1209,6 +1254,40 @@ mod tests {
             "expected TAG_FALSE or TAG_TRUE, got {:#x}",
             bits
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_stream_init_accepts_pipe_fd() {
+        let mut fds = [0; 2];
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(rc, 0);
+        let _read_guard = FdGuard(fds[0]);
+        let write_guard = FdGuard(fds[1]);
+
+        assert!(!is_tty_fd(write_guard.0));
+        assert!(can_init_write_stream_fd(write_guard.0));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_stream_init_rejects_regular_file_fd() {
+        use std::os::unix::io::AsRawFd;
+
+        let path =
+            std::env::temp_dir().join(format!("perry-tty-regular-file-{}", std::process::id()));
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+
+        assert!(!is_tty_fd(file.as_raw_fd()));
+        assert!(!can_init_write_stream_fd(file.as_raw_fd()));
+
+        drop(file);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/tests/issue_3908_tty_write_stream_pipe.js
+++ b/tests/issue_3908_tty_write_stream_pipe.js
@@ -1,0 +1,20 @@
+import tty from "node:tty";
+
+function firstLine(err) {
+  return String(err?.message || "").split("\n")[0];
+}
+
+function check(label, fn) {
+  try {
+    const value = fn();
+    console.log(label + " OK:", value === undefined ? "undefined" : String(value));
+  } catch (err) {
+    console.log(label + " THROW:", err?.name, err?.code || "no-code", firstLine(err));
+  }
+}
+
+check("WriteStream fd1 fd", () => new tty.WriteStream(1).fd);
+check("WriteStream fd2 fd", () => new tty.WriteStream(2).fd);
+check("ReadStream fd0 fd", () => new tty.ReadStream(0).fd);
+check("WriteStream invalid -1", () => new tty.WriteStream(-1).fd);
+check("ReadStream invalid -1", () => new tty.ReadStream(-1).fd);

--- a/tests/test_issue_3908_tty_write_stream_pipe.sh
+++ b/tests/test_issue_3908_tty_write_stream_pipe.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$ROOT/target/release/perry}}"
+FIXTURE="$ROOT/tests/issue_3908_tty_write_stream_pipe.js"
+WORKDIR="${TMPDIR:-/tmp}/perry-issue-3908-$$"
+BIN="$WORKDIR/perry-tty-pipe"
+NODE_OUT="$WORKDIR/node.out"
+PERRY_OUT="$WORKDIR/perry.out"
+COMPILE_LOG="$WORKDIR/compile.log"
+
+mkdir -p "$WORKDIR"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if [[ ! -x "$PERRY" ]]; then
+  PERRY="$ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+  echo "Perry binary not found; build target/release/perry or target/debug/perry first" >&2
+  exit 1
+fi
+
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+    return $?
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+    return $?
+  fi
+  "$@" &
+  local pid=$!
+  (sleep "$secs" && kill -TERM "$pid" 2>/dev/null && sleep 1 && kill -KILL "$pid" 2>/dev/null) &
+  local watcher=$!
+  if wait "$pid" 2>/dev/null; then
+    kill -TERM "$watcher" 2>/dev/null || true
+    wait "$watcher" 2>/dev/null || true
+    return 0
+  fi
+  local rc=$?
+  kill -TERM "$watcher" 2>/dev/null || true
+  wait "$watcher" 2>/dev/null || true
+  [[ "$rc" == "143" ]] && return 124
+  return "$rc"
+}
+
+set +e
+run_with_timeout 10 node "$FIXTURE" 2>&1 | cat >"$NODE_OUT"
+node_rc=${PIPESTATUS[0]}
+set -e
+if [[ "$node_rc" -ne 0 ]]; then
+  echo "Node reference run failed" >&2
+  cat "$NODE_OUT" >&2
+  exit 1
+fi
+
+env PERRY_ALLOW_UNIMPLEMENTED=1 "$PERRY" compile --no-cache "$FIXTURE" -o "$BIN" \
+  >"$COMPILE_LOG" 2>&1 || {
+  cat "$COMPILE_LOG" >&2
+  exit 1
+}
+set +e
+run_with_timeout 10 "$BIN" 2>&1 | cat >"$PERRY_OUT"
+perry_rc=${PIPESTATUS[0]}
+set -e
+if [[ "$perry_rc" -ne 0 ]]; then
+  echo "Perry fixture run failed" >&2
+  cat "$PERRY_OUT" >&2
+  exit 1
+fi
+
+if ! diff -u "$NODE_OUT" "$PERRY_OUT"; then
+  echo "Perry output differed from Node under pipe-backed stdout/stderr" >&2
+  exit 1
+fi


### PR DESCRIPTION
Fixes #3908

## Summary
- split tty fd validation so ReadStream keeps tty-only behavior while WriteStream accepts Unix FIFO/socket fds in addition to TTYs
- keep regular files and invalid fds rejected, and align ERR_TTY_INIT_FAILED text with Node for constructor failures
- add a pipe-backed stdout/stderr regression harness that compares Perry output to Node

## Non-goals
- PTY harness coverage and resize behavior remain out of scope for this focused fd-type cut

## Tests
- cargo test -p perry-runtime tty
- cargo build --release -p perry
- tests/test_issue_3908_tty_write_stream_pipe.sh
- cargo check -p perry-runtime
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh