### PR TITLE
node:dgram + node:cluster default-import shape parity (#3693, #3687)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -837,6 +837,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("dns/promises", "setLocalAddress", true, Some("Resolver")),
     // node:dgram has deterministic in-process loopback coverage for the
     // unicast subset; multicast/queue option methods remain shape-compatible.
+    // #3693: default import (`import dgram from "node:dgram"`) === the module
+    // namespace (CJS `module.exports`).
+    property("dgram", "default"),
     method("dgram", "createSocket", false, None),
     class("dgram", "Socket"),
     method("dgram", "Socket", false, None),
@@ -854,6 +857,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("dgram", "removeListener", true, Some("Socket")),
     method("dgram", "emit", true, Some("Socket")),
     method("dgram", "listenerCount", true, Some("Socket")),
+    method("dgram", "eventNames", true, Some("Socket")),
     method("dgram", "addMembership", true, Some("Socket")),
     method("dgram", "dropMembership", true, Some("Socket")),
     method("dgram", "addSourceSpecificMembership", true, Some("Socket")),
@@ -3307,6 +3311,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // `setupMaster`, `fork`, and `disconnect` route through the native
     // module bound-method path; handle sharing/listening distribution is
     // outside this manifest entry.
+    // #3687: default import (`import cluster from "node:cluster"`) is the
+    // EventEmitter-shaped `cluster.default` namespace; the `import * as`
+    // namespace keeps the shape-only surface.
+    property("cluster", "default"),
     method("cluster", "fork", false, None),
     method("cluster", "disconnect", false, None),
     method("cluster", "setupPrimary", false, None),
@@ -3329,8 +3337,21 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // as properties so the #463 strict gate doesn't bail out at compile
     // time; `get_native_module_constant` returns `undefined` at
     // runtime.
+    // #3687: the EventEmitter method surface. On the `import * as` namespace
+    // these all read `undefined` (they are not named exports); on the default
+    // import they resolve to bound methods. Registered so the #463 strict gate
+    // accepts reads/calls at compile time.
     internal_property("cluster", "on"),
     internal_property("cluster", "addListener"),
+    internal_property("cluster", "once"),
+    internal_property("cluster", "prependListener"),
+    internal_property("cluster", "prependOnceListener"),
+    internal_property("cluster", "off"),
+    internal_property("cluster", "removeListener"),
+    internal_property("cluster", "removeAllListeners"),
+    internal_property("cluster", "emit"),
+    internal_property("cluster", "eventNames"),
+    internal_property("cluster", "listenerCount"),
     // ===========================================================
     // #513 Phase A: backfill receiver-less surface for modules that
     // previously had zero entries. Without these, `module_has_any_entries`

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -534,6 +534,15 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "dgram",
         has_receiver: true,
+        method: "eventNames",
+        class_filter: Some("Socket"),
+        runtime: "js_dgram_socket_event_names",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "dgram",
+        has_receiver: true,
         method: "addMembership",
         class_filter: Some("Socket"),
         runtime: "js_dgram_socket_add_membership",

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -106,6 +106,7 @@ fn is_cjs_style_native_default_import(module_name: &str) -> bool {
         module_name,
         "async_hooks"
             | "child_process"
+            | "cluster"
             | "constants"
             | "dns"
             | "dns/promises"

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -19,6 +19,7 @@ fn is_cjs_style_native_default_import(module_name: &str) -> bool {
         module_name,
         "async_hooks"
             | "child_process"
+            | "cluster"
             | "constants"
             | "dns"
             | "dns/promises"

--- a/crates/perry-runtime/src/cluster.rs
+++ b/crates/perry-runtime/src/cluster.rs
@@ -5,6 +5,7 @@
 //! implement socket/listening handle distribution.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::sync::Once;
 
 use crate::array::ArrayHeader;
@@ -78,6 +79,255 @@ pub fn cluster_property(property: &str) -> Option<f64> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// node:cluster default-import EventEmitter (#3687)
+//
+// In Node, `node:cluster` is a singleton EventEmitter, so the *default* import
+// (`import cluster from "node:cluster"`) exposes `on`/`once`/`emit`/… while the
+// *namespace* import (`import * as cluster`) does not (those live on
+// EventEmitter.prototype, not as named module exports). Perry models the
+// default import as a distinct `cluster.default` native-module namespace whose
+// EventEmitter method reads resolve here; the namespace import keeps the
+// `undefined` shape via `cluster_property`. Real worker-lifecycle events are
+// still deferred (closed umbrella #3605) — this is module-level listener
+// bookkeeping plus a synchronous `fork` emit so feature-detection and manual
+// `emit()` round-trips match Node.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+struct ClusterListener {
+    callback_bits: u64,
+    once: bool,
+}
+
+#[derive(Default)]
+struct ClusterEmitter {
+    events: HashMap<String, Vec<ClusterListener>>,
+    order: Vec<String>,
+}
+
+thread_local! {
+    static CLUSTER_EMITTER: RefCell<ClusterEmitter> = RefCell::new(ClusterEmitter::default());
+}
+
+/// The `cluster.default` namespace object — the value bound by
+/// `import cluster from "node:cluster"`. Cached (see
+/// `should_cache_native_module_namespace`), so EventEmitter methods can return
+/// it for `cluster.on(...) === cluster` chaining.
+fn cluster_default_value() -> f64 {
+    crate::object::js_create_native_module_namespace(
+        b"cluster.default".as_ptr(),
+        "cluster.default".len(),
+    )
+}
+
+fn cluster_emitter_event_name(event: f64) -> Option<String> {
+    let jv = JSValue::from_bits(event.to_bits());
+    if jv.is_string() || jv.is_short_string() {
+        return value_to_string(event);
+    }
+    // Non-string event names follow EventEmitter ToString semantics.
+    let coerced = crate::value::js_jsvalue_to_string(event);
+    if coerced.is_null() {
+        return None;
+    }
+    value_to_string(f64::from_bits(JSValue::string_ptr(coerced).bits()))
+}
+
+fn cluster_register_listener(event: f64, listener: f64, once: bool, prepend: bool) -> f64 {
+    if !is_closure_value(listener) {
+        return cluster_default_value();
+    }
+    if let Some(name) = cluster_emitter_event_name(event) {
+        CLUSTER_EMITTER.with(|emitter| {
+            let mut emitter = emitter.borrow_mut();
+            if !emitter.order.iter().any(|n| n == &name) {
+                emitter.order.push(name.clone());
+            }
+            let entry = ClusterListener {
+                callback_bits: listener.to_bits(),
+                once,
+            };
+            let listeners = emitter.events.entry(name).or_default();
+            if prepend {
+                listeners.insert(0, entry);
+            } else {
+                listeners.push(entry);
+            }
+        });
+    }
+    cluster_default_value()
+}
+
+pub(crate) fn cluster_emit_event(event: &str, args: &[f64]) -> bool {
+    let listeners = CLUSTER_EMITTER.with(|emitter| {
+        let mut emitter = emitter.borrow_mut();
+        let Some(listeners) = emitter.events.get_mut(event) else {
+            return Vec::new();
+        };
+        let snapshot = listeners.clone();
+        if snapshot.iter().any(|l| l.once) {
+            listeners.retain(|l| !l.once);
+            if listeners.is_empty() {
+                emitter.events.remove(event);
+                emitter.order.retain(|n| n != event);
+            }
+        }
+        snapshot
+    });
+    if listeners.is_empty() {
+        return false;
+    }
+    for listener in listeners {
+        let cb = f64::from_bits(listener.callback_bits);
+        let prev = js_implicit_this_set(cluster_default_value());
+        unsafe {
+            let _ = crate::closure::js_native_call_value(cb, args.as_ptr(), args.len());
+        }
+        js_implicit_this_set(prev);
+    }
+    true
+}
+
+fn cluster_emitter_scan(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    CLUSTER_EMITTER.with(|emitter| {
+        let mut emitter = emitter.borrow_mut();
+        for listeners in emitter.events.values_mut() {
+            for listener in listeners {
+                visitor.visit_nanbox_u64_slot(&mut listener.callback_bits);
+            }
+        }
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_on(event: f64, listener: f64) -> f64 {
+    ensure_cluster_runtime();
+    cluster_register_listener(event, listener, false, false)
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_once(event: f64, listener: f64) -> f64 {
+    ensure_cluster_runtime();
+    cluster_register_listener(event, listener, true, false)
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_prepend_listener(event: f64, listener: f64) -> f64 {
+    ensure_cluster_runtime();
+    cluster_register_listener(event, listener, false, true)
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_prepend_once_listener(event: f64, listener: f64) -> f64 {
+    ensure_cluster_runtime();
+    cluster_register_listener(event, listener, true, true)
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_emit(event: f64, args: *const ArrayHeader) -> f64 {
+    ensure_cluster_runtime();
+    let Some(name) = cluster_emitter_event_name(event) else {
+        return TAG_FALSE_F64;
+    };
+    let values = if args.is_null() {
+        Vec::new()
+    } else {
+        let len = crate::array::js_array_length(args);
+        let mut out = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            out.push(crate::array::js_array_get_f64(args, i));
+        }
+        out
+    };
+    if cluster_emit_event(&name, &values) {
+        TAG_TRUE_F64
+    } else {
+        TAG_FALSE_F64
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_event_names() -> f64 {
+    ensure_cluster_runtime();
+    let names = CLUSTER_EMITTER.with(|emitter| {
+        let emitter = emitter.borrow();
+        emitter
+            .order
+            .iter()
+            .filter(|n| emitter.events.get(*n).is_some_and(|l| !l.is_empty()))
+            .cloned()
+            .collect::<Vec<_>>()
+    });
+    let mut arr = crate::array::js_array_alloc(names.len() as u32);
+    for name in names {
+        arr = crate::array::js_array_push(arr, JSValue::string_ptr(str_key(name.as_bytes())));
+    }
+    box_ptr(arr as *const u8)
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_listener_count(event: f64) -> f64 {
+    ensure_cluster_runtime();
+    let Some(name) = cluster_emitter_event_name(event) else {
+        return 0.0;
+    };
+    CLUSTER_EMITTER.with(|emitter| {
+        emitter
+            .borrow()
+            .events
+            .get(&name)
+            .map(|l| l.len() as f64)
+            .unwrap_or(0.0)
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_remove_listener(event: f64, listener: f64) -> f64 {
+    ensure_cluster_runtime();
+    if let Some(name) = cluster_emitter_event_name(event) {
+        let bits = listener.to_bits();
+        CLUSTER_EMITTER.with(|emitter| {
+            let mut emitter = emitter.borrow_mut();
+            if let Some(listeners) = emitter.events.get_mut(&name) {
+                if let Some(pos) = listeners.iter().rposition(|l| l.callback_bits == bits) {
+                    listeners.remove(pos);
+                }
+                if listeners.is_empty() {
+                    emitter.events.remove(&name);
+                    emitter.order.retain(|n| n != &name);
+                }
+            }
+        });
+    }
+    cluster_default_value()
+}
+
+#[no_mangle]
+pub extern "C" fn js_cluster_remove_all_listeners(event: f64) -> f64 {
+    ensure_cluster_runtime();
+    let jv = JSValue::from_bits(event.to_bits());
+    let target = if jv.is_undefined() || jv.is_null() {
+        None
+    } else {
+        cluster_emitter_event_name(event)
+    };
+    CLUSTER_EMITTER.with(|emitter| {
+        let mut emitter = emitter.borrow_mut();
+        match target {
+            Some(name) => {
+                emitter.events.remove(&name);
+                emitter.order.retain(|n| n != &name);
+            }
+            None => {
+                emitter.events.clear();
+                emitter.order.clear();
+            }
+        }
+    });
+    cluster_default_value()
+}
+
 #[no_mangle]
 pub extern "C" fn js_cluster_setup_primary(settings: f64) -> f64 {
     ensure_cluster_runtime();
@@ -119,6 +369,9 @@ pub extern "C" fn js_cluster_fork(env: f64) -> f64 {
 
     decorate_worker(worker, id);
     register_worker(id, worker);
+    // Node fires the cluster-level `fork` event synchronously when the worker
+    // object is created (`online`/`exit`/etc. remain deferred — #3605).
+    cluster_emit_event("fork", &[worker]);
     worker
 }
 
@@ -170,6 +423,7 @@ fn cluster_root_scanner(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
             visitor.visit_nanbox_u64_slot(bits);
         }
     });
+    cluster_emitter_scan(visitor);
 }
 
 fn register_cluster_arities() {

--- a/crates/perry-runtime/src/dgram.rs
+++ b/crates/perry-runtime/src/dgram.rs
@@ -13,7 +13,8 @@ use crate::closure::{
     js_closure_alloc, js_closure_set_capture_ptr, js_register_closure_rest, ClosureHeader,
 };
 use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name, ObjectHeader,
+    js_object_alloc, js_object_get_field_by_name_f64, js_object_keys, js_object_set_field_by_name,
+    ObjectHeader,
 };
 use crate::value::{
     js_nanbox_pointer, JSValue, POINTER_MASK, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
@@ -98,6 +99,10 @@ const SOCKET_METHODS: &[MethodSpec] = &[
     MethodSpec {
         name: "listenerCount",
         thunk: dgram_listener_count_thunk,
+    },
+    MethodSpec {
+        name: "eventNames",
+        thunk: dgram_event_names_thunk,
     },
     MethodSpec {
         name: "addMembership",
@@ -830,6 +835,39 @@ fn emit_event(socket: f64, event: &str, args: &[f64]) -> bool {
     emit_event_value(socket, str_value(event), args)
 }
 
+/// `socket.eventNames()` — the list of events with at least one registered
+/// listener, in registration order. Recomputed from the socket's hidden
+/// listener-storage fields (keyed by `EVENT_LISTENERS_PREFIX`) so it self-
+/// corrects when `once` listeners fire or listeners are removed, matching
+/// Node's EventEmitter.eventNames().
+fn event_names_impl(socket: f64) -> f64 {
+    let Some(obj) = object_ptr_from_value(socket) else {
+        return boxed_pointer(crate::array::js_array_alloc(0) as *const u8);
+    };
+    let keys = js_object_keys(obj);
+    let mut out = crate::array::js_array_alloc(0);
+    if !keys.is_null() {
+        let len = crate::array::js_array_length(keys);
+        for i in 0..len {
+            let Some(key_name) = string_to_rust(crate::array::js_array_get_f64(keys, i)) else {
+                continue;
+            };
+            let Some(event) = key_name
+                .as_bytes()
+                .strip_prefix(EVENT_LISTENERS_PREFIX)
+                .map(|rest| String::from_utf8_lossy(rest).into_owned())
+            else {
+                continue;
+            };
+            let event_value = str_value(&event);
+            if !listener_snapshot(socket, event_value).is_empty() {
+                out = crate::array::js_array_push_f64(out, event_value);
+            }
+        }
+    }
+    boxed_pointer(out as *const u8)
+}
+
 fn allocate_port(registry: &mut DgramRegistry, address: &str) -> u16 {
     for _ in 0..16384 {
         let port = registry.next_port;
@@ -1308,6 +1346,10 @@ extern "C" fn dgram_listener_count_thunk(closure: *const ClosureHeader, rest: f6
     listener_snapshot(this_value(closure), event).len() as f64
 }
 
+extern "C" fn dgram_event_names_thunk(closure: *const ClosureHeader, _rest: f64) -> f64 {
+    event_names_impl(this_value(closure))
+}
+
 extern "C" fn dgram_add_membership_thunk(closure: *const ClosureHeader, rest: f64) -> f64 {
     membership_impl(
         this_value(closure),
@@ -1497,6 +1539,11 @@ pub extern "C" fn js_dgram_socket_listener_count(handle: i64, args: *const Array
         args.first().copied().unwrap_or_else(undefined_value),
     )
     .len() as f64
+}
+
+#[no_mangle]
+pub extern "C" fn js_dgram_socket_event_names(handle: i64, _args: *const ArrayHeader) -> f64 {
+    event_names_impl(socket_value_from_handle(handle))
 }
 
 #[no_mangle]

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2738,6 +2738,20 @@ pub extern "C" fn js_object_get_field_by_name(
                 if let Some(value) = native_module_own_field_by_key(obj, key) {
                     return value;
                 }
+                // #3687: node:cluster default-import EventEmitter methods on the
+                // distinct `cluster.default` namespace. Mirror the
+                // NativeModuleRef fast path (`js_native_module_property_by_name`)
+                // — this dynamic `obj[key]` read must resolve `on`/`emit`/… to
+                // bound methods *before* `get_native_module_constant` (which
+                // normalizes to `cluster` and returns `undefined` for `on`).
+                if module_name == "cluster.default"
+                    && super::is_cluster_emitter_method(property_name)
+                {
+                    return JSValue::from_bits(
+                        super::bound_native_callable_export_value(module_name, property_name)
+                            .to_bits(),
+                    );
+                }
                 if let Some(val) = get_native_module_constant(module_name, property_name, nb_ptr) {
                     return JSValue::from_bits(val.to_bits());
                 }

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1775,6 +1775,7 @@ fn cjs_default_base_module(module_name: &str) -> Option<&'static str> {
     match module_name {
         "async_hooks.default" => Some("async_hooks"),
         "child_process.default" => Some("child_process"),
+        "cluster.default" => Some("cluster"),
         "constants.default" => Some("constants"),
         "dns.default" => Some("dns"),
         "dns/promises.default" => Some("dns/promises"),
@@ -1794,6 +1795,7 @@ fn cjs_default_namespace_name(module_name: &str) -> Option<&'static str> {
     match module_name {
         "async_hooks" => Some("async_hooks.default"),
         "child_process" => Some("child_process.default"),
+        "cluster" => Some("cluster.default"),
         "constants" => Some("constants.default"),
         "dns" => Some("dns.default"),
         "dns/promises" => Some("dns/promises.default"),
@@ -1817,6 +1819,16 @@ fn create_cjs_default_namespace(module_name: &str) -> Option<f64> {
 fn cjs_default_export_value(module_name: &str) -> Option<f64> {
     match module_name {
         "events" => Some(bound_native_callable_export_value("events", "EventEmitter")),
+        // #3687: `node:cluster` default import is a distinct EventEmitter-shaped
+        // `cluster.default` namespace (its `on`/`emit`/… reads diverge from the
+        // bare `import * as` namespace).
+        "cluster" => create_cjs_default_namespace("cluster"),
+        // #3693: `node:dgram` default === the module namespace (CJS
+        // `module.exports`); a cached singleton makes `dgram === ns.default`.
+        "dgram" => Some(js_create_native_module_namespace(
+            b"dgram".as_ptr(),
+            "dgram".len(),
+        )),
         "async_hooks" | "child_process" | "constants" | "dns" | "dns/promises" | "os" | "path"
         | "path.posix" | "path.win32" | "punycode" | "querystring" | "url" | "util" => {
             create_cjs_default_namespace(module_name)
@@ -1861,6 +1873,9 @@ fn should_cache_native_module_namespace(module_name: &str) -> bool {
             | "dns.default"
             | "dns/promises.default"
             | "child_process.default"
+            | "cluster"
+            | "cluster.default"
+            | "dgram"
             | "events"
             | "fs.constants"
             | "os"
@@ -1990,6 +2005,17 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
         if let Some(value) = super::global_this::webcrypto_method_value(property_name) {
             return value;
         }
+    }
+
+    // #3687: `node:cluster` is a singleton EventEmitter. Its EventEmitter
+    // method surface is exposed ONLY on the default import (the distinct
+    // `cluster.default` namespace) — `import * as cluster` reads these as
+    // `undefined` (they live on EventEmitter.prototype, not as named exports).
+    // Resolve them to bound methods here, before the generic
+    // `get_native_module_constant` path (where `cluster_property` would return
+    // `undefined` for `on`/`addListener`).
+    if module_name == "cluster.default" && is_cluster_emitter_method(property_name) {
+        return bound_native_callable_export_value("cluster.default", property_name);
     }
 
     if let Some(val) = get_native_module_constant(module_name, property_name, 0.0) {
@@ -2234,8 +2260,42 @@ pub(crate) fn fs_namespace_descriptor_setter_value(property_name: &str) -> f64 {
     value
 }
 
+/// The EventEmitter method names `node:cluster`'s default import exposes
+/// (#3687). Kept narrow so a typo'd `cluster.foo` still reads `undefined`.
+pub(crate) fn is_cluster_emitter_method(prop: &str) -> bool {
+    matches!(
+        prop,
+        "on" | "addListener"
+            | "once"
+            | "prependListener"
+            | "prependOnceListener"
+            | "off"
+            | "removeListener"
+            | "removeAllListeners"
+            | "emit"
+            | "eventNames"
+            | "listenerCount"
+    )
+}
+
 fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
     match (module, prop) {
+        // #3687: node:cluster — module-method `.length` matches Node.
+        ("cluster", "fork" | "disconnect" | "setupPrimary" | "setupMaster" | "Worker") => Some(1),
+        ("cluster", "emit") => Some(1),
+        ("cluster", "eventNames") => Some(0),
+        (
+            "cluster",
+            "on"
+            | "addListener"
+            | "once"
+            | "prependListener"
+            | "prependOnceListener"
+            | "removeListener"
+            | "off"
+            | "listenerCount",
+        ) => Some(2),
+        ("cluster", "removeAllListeners") => Some(1),
         ("events", "EventEmitter") => Some(1),
         ("events", "EventEmitterAsyncResource") => Some(0),
         ("events", "addAbortListener") => Some(2),

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -246,6 +246,9 @@ pub(crate) unsafe fn dispatch_native_module_method(
         "path/posix" => ("path.posix", false),
         "path/win32" => ("path.win32", false),
         "async_hooks.default" => ("async_hooks", false),
+        // #3687: cluster default-import method calls (`cluster.fork()`,
+        // `cluster.emit(...)`) dispatch against the base `cluster` arms.
+        "cluster.default" => ("cluster", false),
         "os.default" => ("os", false),
         "path.default" => ("path", false),
         "path.posix.default" => ("path.posix", false),
@@ -1695,6 +1698,26 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("cluster", "fork") => crate::cluster::js_cluster_fork(arg(0)),
         ("cluster", "disconnect") => crate::cluster::js_cluster_disconnect(arg(0)),
         ("cluster", "Worker") => f64::from_bits(JSValue::undefined().bits()),
+        // #3687: node:cluster default-import EventEmitter surface.
+        ("cluster", "on") | ("cluster", "addListener") => {
+            crate::cluster::js_cluster_on(arg(0), arg(1))
+        }
+        ("cluster", "once") => crate::cluster::js_cluster_once(arg(0), arg(1)),
+        ("cluster", "prependListener") => {
+            crate::cluster::js_cluster_prepend_listener(arg(0), arg(1))
+        }
+        ("cluster", "prependOnceListener") => {
+            crate::cluster::js_cluster_prepend_once_listener(arg(0), arg(1))
+        }
+        ("cluster", "emit") => crate::cluster::js_cluster_emit(arg(0), pack_args_from(1)),
+        ("cluster", "eventNames") => crate::cluster::js_cluster_event_names(),
+        ("cluster", "listenerCount") => crate::cluster::js_cluster_listener_count(arg(0)),
+        ("cluster", "removeListener") | ("cluster", "off") => {
+            crate::cluster::js_cluster_remove_listener(arg(0), arg(1))
+        }
+        ("cluster", "removeAllListeners") => {
+            crate::cluster::js_cluster_remove_all_listeners(arg(0))
+        }
 
         // #1577: captured-then-called crypto methods (`const f =
         // crypto.createHash; f(...)`). The impls live in perry-stdlib (which

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1736 entries across 102 modules
+// Coverage: 1738 entries across 102 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -293,6 +293,9 @@ declare module "cluster" {
   export const SCHED_NONE: any;
   /** stdlib */
   export const SCHED_RR: any;
+  /** stdlib */
+  const _default: any;
+  export default _default;
   /** stdlib */
   export const isMaster: any;
   /** stdlib */
@@ -989,6 +992,9 @@ declare module "dayjs" {
 declare module "dgram" {
   /** stdlib */
   export class Socket { [key: string]: any; }
+  /** stdlib */
+  const _default: any;
+  export default _default;
   /** stdlib */
   export function Socket(...args: any[]): any;
   /** stdlib */

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -100,7 +100,15 @@ Selected highlights (full list in `runtime-parity.md`):
 
 ### node:cluster
 
-**Total APIs: 35** · Perry covers: primary lifecycle subset · Gap: worker handle distribution and remaining events
+**Total APIs: 35** · Perry covers: primary lifecycle subset + default-import EventEmitter surface · Gap: worker handle distribution and remaining lifecycle events
+
+The default import (`import cluster from "node:cluster"`) is an EventEmitter:
+`on`/`addListener`/`once`/`off`/`removeListener`/`removeAllListeners`/`emit`/
+`eventNames`/`listenerCount` register and fire module-level listeners (a
+synchronous `fork` event is emitted when a worker object is created). The
+`import * as cluster` namespace keeps the shape-only surface and reads those
+EventEmitter names as `undefined`, matching Node. Real worker `online`/`exit`/
+`listening`/`disconnect` events remain deferred (#3605).
 
 Selected highlights (full list in `runtime-parity.md`):
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2456 entries across 105 modules.
+Total: 2459 entries across 105 modules.
 
 ## Modules
 
@@ -365,6 +365,7 @@ Total: 2456 entries across 105 modules.
 
 - `SCHED_NONE`
 - `SCHED_RR`
+- `default`
 - `isMaster`
 - `isPrimary`
 - `isWorker`
@@ -832,6 +833,7 @@ Total: 2456 entries across 105 modules.
 - `dropMembership` — instance *(class: `Socket`)*
 - `dropSourceSpecificMembership` — instance *(class: `Socket`)*
 - `emit` — instance *(class: `Socket`)*
+- `eventNames` — instance *(class: `Socket`)*
 - `getRecvBufferSize` — instance *(class: `Socket`)*
 - `getSendBufferSize` — instance *(class: `Socket`)*
 - `getSendQueueCount` — instance *(class: `Socket`)*
@@ -852,6 +854,10 @@ Total: 2456 entries across 105 modules.
 - `setSendBufferSize` — instance *(class: `Socket`)*
 - `setTTL` — instance *(class: `Socket`)*
 - `unref` — instance *(class: `Socket`)*
+
+### Properties
+
+- `default`
 
 ## `diagnostics_channel`
 

--- a/test-parity/node-suite/cluster/default-import-shape.ts
+++ b/test-parity/node-suite/cluster/default-import-shape.ts
@@ -1,0 +1,49 @@
+// #3687: node:cluster default-import EventEmitter + primary setup state.
+//
+// Deterministic primary-process parity (no real worker forking): the default
+// import (an EventEmitter) and the `import * as` namespace diverge for the
+// EventEmitter method surface, callable arity matches Node, setupPrimary()
+// updates cluster.settings, and default-import listener bookkeeping
+// (on/emit/eventNames/listenerCount/removeListener) round-trips.
+import clusterDefault from "node:cluster";
+import * as clusterNamespace from "node:cluster";
+
+const def = clusterDefault as Record<string, any>;
+const ns = clusterNamespace as Record<string, any>;
+
+console.log("typeof default:", typeof clusterDefault);
+console.log("isPrimary:", def.isPrimary, "isMaster:", def.isMaster, "isWorker:", def.isWorker);
+console.log("schedulingPolicy:", def.schedulingPolicy, "SCHED_RR:", def.SCHED_RR, "SCHED_NONE:", def.SCHED_NONE);
+
+// Default import exposes the EventEmitter surface; the namespace import does not.
+for (const name of [
+  "fork", "disconnect", "setupPrimary", "setupMaster", "Worker",
+  "on", "addListener", "once", "emit", "eventNames", "listenerCount",
+]) {
+  console.log(
+    `default ${name}: ${typeof def[name]}/${def[name]?.length} | namespace ${name}: ${typeof ns[name]}`,
+  );
+}
+
+// setupPrimary() updates cluster.settings with Node-compatible keys.
+def.setupPrimary({ execArgv: ["--probe-flag"] });
+console.log("settings.execArgv isArray:", Array.isArray(def.settings?.execArgv));
+console.log("settings.execArgv:", JSON.stringify(def.settings?.execArgv));
+
+// Default-import EventEmitter registration / bookkeeping.
+let fired = 0;
+const listener = (n: number) => {
+  fired += n;
+};
+const onResult = def.on("custom", listener);
+console.log("on returns self:", onResult === clusterDefault);
+console.log("eventNames after on:", def.eventNames().map(String).join(","));
+console.log("listenerCount(custom):", def.listenerCount("custom"));
+console.log("emit returns:", def.emit("custom", 41));
+console.log("fired:", fired);
+def.removeListener("custom", listener);
+console.log("listenerCount after remove:", def.listenerCount("custom"));
+def.once("once-evt", () => {});
+console.log("eventNames before removeAll:", def.eventNames().map(String).sort().join(","));
+def.removeAllListeners();
+console.log("eventNames after removeAll:", def.eventNames().join(","));

--- a/test-parity/node-suite/dgram/default-import-shape.ts
+++ b/test-parity/node-suite/dgram/default-import-shape.ts
@@ -1,0 +1,47 @@
+// #3693: node:dgram default import + Socket EventEmitter/error shape.
+//
+// Deterministic shape/validation parity (no real ports printed): the default
+// import resolves and equals the namespace default, createSocket validates the
+// socket type, the stub Socket carries the EventEmitter surface (including
+// eventNames), pre-bind / pre-connect calls raise Node error codes, and
+// ref()/unref() return the socket.
+import dgram from "node:dgram";
+import * as dgramNs from "node:dgram";
+
+function codeOf(fn: () => unknown): string {
+  try {
+    const value = fn();
+    if (value === undefined) return "undefined";
+    if (value === null) return "null";
+    return typeof value;
+  } catch (err: unknown) {
+    const e = err as { code?: string; name?: string };
+    return e.code ?? e.name ?? "Error";
+  }
+}
+
+console.log("default type:", typeof dgram);
+console.log("namespace createSocket:", typeof dgramNs.createSocket);
+console.log("default identity:", dgram === (dgramNs as { default?: unknown }).default);
+console.log("bad type:", codeOf(() => dgram.createSocket("udp5" as never)));
+
+const socket = dgram.createSocket("udp4");
+for (const name of [
+  "send", "bind", "close", "address", "connect", "disconnect",
+  "addMembership", "dropMembership", "setBroadcast", "setTTL",
+  "getSendQueueSize", "getSendQueueCount", "ref", "unref",
+  "on", "once", "emit", "eventNames",
+]) {
+  console.log(`${name}:`, typeof (socket as Record<string, unknown>)[name]);
+}
+
+console.log("address before bind:", codeOf(() => socket.address()));
+console.log("disconnect before connect:", codeOf(() => socket.disconnect()));
+console.log("ref returns self:", socket.ref() === socket);
+console.log("unref returns self:", socket.unref() === socket);
+
+socket.on("message", () => {});
+socket.once("error", () => {});
+console.log("eventNames:", socket.eventNames().map(String).sort().join(","));
+
+socket.close();


### PR DESCRIPTION
Fixes #3693 and #3687 — `node:dgram` and `node:cluster` default-import shape parity.

Both issues were filed at 0.5.1044 and are partly stale; I probed current behavior first. The dgram stub described in #3693 is long gone (type validation, `EBADF`, `ERR_SOCKET_DGRAM_NOT_CONNECTED`, `ref()/unref()` self-return, `getSendQueue*` already worked). Remaining genuine gaps in both modules are fixed here.

## #3693 — node:dgram
- Add `dgram.default` to the manifest so `import dgram from "node:dgram"` compiles without `PERRY_ALLOW_UNIMPLEMENTED`.
- Make `dgram === ns.default` true: cache the dgram namespace singleton and resolve the CJS default export to it (`NativeModuleRef` already lowers to `js_create_native_module_namespace`, so the cached singleton makes both sides identical).
- Add `Socket.eventNames()` — runtime impl (enumerates the socket's hidden listener-storage keys), native-table row, FFI, and manifest entry.

## #3687 — node:cluster
- Model the default import as a distinct `cluster.default` EventEmitter namespace: `on`/`addListener`/`once`/`off`/`removeListener`/`removeAllListeners`/`emit`/`eventNames`/`listenerCount` register and fire module-level listeners; `fork()` emits a synchronous `fork` event. The `import * as cluster` namespace keeps the shape-only surface and reads those names as `undefined`, matching Node's default-vs-namespace divergence.
- Fix callable arity to match Node `.length`: `fork`/`disconnect`/`setupPrimary`/`setupMaster`/`Worker` = 1, `on`/`addListener`/`once`/`listenerCount`/`removeListener` = 2, `emit` = 1, `eventNames` = 0.
- The default-only EventEmitter methods resolve in both property-read paths (the `NativeModuleRef` static path and the dynamic `obj[key]` field-get path), before the generic constant resolver normalizes `cluster.default` → `cluster` and short-circuits.

`setupPrimary()`/`setupMaster()` already updated `cluster.settings`; that path is unchanged.

## Tests / docs
- New deterministic fixtures `test-parity/node-suite/{dgram,cluster}/default-import-shape.ts`, both **byte-for-byte parity vs Node** in opt + no-opt.
- Parity suite: `dgram` 4/4 (existing fixtures unchanged), `cluster` 0 → 1 (was "No tests matched").
- 962 perry-runtime unit tests pass; other CJS default imports (`path`/`events`/`child_process`) unaffected.
- Regenerated `docs/api/perry.d.ts` + `docs/src/api/reference.md`; updated `docs/runtime-parity-gaps.md`.

## Out of scope (still deferred)
Real UDP packet I/O (#3175–#3179) and real worker forking / `online`/`exit`/`listening`/`disconnect` lifecycle events (#3605). Typed direct `cluster.on(...)` calls (no native-table row) remain undefined; the EventEmitter surface works via property-read/value dispatch, which is what feature-detection and the issue probes use.

Version bump + CHANGELOG intentionally omitted (fold in at merge).
