### PR TITLE
fix(check): reconcile stale Node builtin table with modern builtins (#3744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1100 — fix(check): reconcile stale Node builtin table with modern builtins (#3744)
+
+`perry check --check-deps` reported a clean build for unsupported modern `node:*` imports that `perry compile` rejects. The cause: the hand-maintained `is_node_builtin` table in `crates/perry/src/commands/deps.rs` predated Node's newer builtins, so names like `node:sea` and `node:inspector` were not recognized as builtins at all — and the U-006 dependency diagnostic only fires for recognized-but-unsupported builtins, so they fell through to a clean result.
+
+Reconciled the table against Node v25's builtin set: added `async_hooks`, `diagnostics_channel`, `http2`, `inspector`, `sea`, `sqlite`, `test`, `trace_events`, and `wasi` to `is_node_builtin`. Each was classified by the real gate (`perry compile` of `import * as m from "node:<name>"`): the compile-accepted ones (`async_hooks`, `diagnostics_channel`, `http2`, `sqlite`, `test`/`test/reporters`, `trace_events`, `wasi`) were also added to `is_supported_node_builtin` so check does not false-positive on them, while the compile-rejected ones (`inspector`, `inspector/promises`, `sea`) are intentionally left out of the allowlist so `check --check-deps` now surfaces the `U006` diagnostic instead of a false clean bill. Added three regression tests asserting the contract (unsupported→flagged, supported→recognized+allowed, supported⊆recognized). CLI-only change; no runtime/manifest/docs impact.
+
 ## v0.5.1099 — fix(crypto): unblock crypto.getCipherInfo (manifest gate)
 
 `crypto.getCipherInfo(name[, options])` threw the #463 "not implemented in Perry" error, even though its runtime (`js_crypto_get_cipher_info`) and native-module dispatch (`object/native_module.rs`) were already complete — the manifest just lacked the method row, so the U-006 import/dispatch gate rejected the call. Added `method("crypto", "getCipherInfo", false, None)` to the API manifest (`entries.rs`), beside `getCiphers`. `crypto.getCipherInfo("aes-128-cbc")` now returns `{ name, nid, blockSize, ivLength, keyLength, mode }` matching Node across the standard AES cbc/gcm/ecb/wrap ciphers (by name and by NID). Advances the crypto argument/surface parity work (#3955). Same shape as the v0.5.1063 `generateKeySync` fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1099
+**Current Version:** 0.5.1100
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1099"
+version = "0.5.1100"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry/src/commands/deps.rs
+++ b/crates/perry/src/commands/deps.rs
@@ -221,6 +221,7 @@ impl DependencyResolver {
 fn is_node_builtin(name: &str) -> bool {
     let builtins = [
         "assert",
+        "async_hooks",
         "buffer",
         "child_process",
         "cluster",
@@ -228,12 +229,15 @@ fn is_node_builtin(name: &str) -> bool {
         "constants",
         "crypto",
         "dgram",
+        "diagnostics_channel",
         "dns",
         "domain",
         "events",
         "fs",
         "http",
+        "http2",
         "https",
+        "inspector",
         "module",
         "net",
         "os",
@@ -244,16 +248,21 @@ fn is_node_builtin(name: &str) -> bool {
         "querystring",
         "readline",
         "repl",
+        "sea",
+        "sqlite",
         "stream",
         "string_decoder",
         "sys",
+        "test",
         "timers",
         "tls",
+        "trace_events",
         "tty",
         "url",
         "util",
         "v8",
         "vm",
+        "wasi",
         "worker_threads",
         "zlib",
     ];
@@ -296,15 +305,18 @@ fn is_supported_node_builtin(name: &str) -> bool {
     matches!(
         base,
         // Real implementations
-        "crypto" | "events" | "http" | "https" | "net" | "readline"
+        "crypto" | "events" | "http" | "http2" | "https" | "net" | "readline"
         | "stream" | "streams" | "worker_threads" | "zlib"
         | "fs" | "path" | "os" | "util" | "process" | "buffer"
         | "console" | "perf_hooks" | "timers" | "url" | "querystring"
-        | "tls" | "tty" | "assert"
+        | "tls" | "tty" | "assert" | "diagnostics_channel" | "sqlite"
         // Stubs (compile + import but functionality limited)
         | "cluster" | "child_process" | "dgram" | "dns" | "domain"
         | "repl" | "punycode" | "string_decoder" | "sys" | "v8" | "vm"
-        | "constants" | "module"
+        | "constants" | "module" | "async_hooks" | "test" | "trace_events"
+        | "wasi" // NOTE: `inspector`/`inspector/promises` and `sea` are intentionally
+                 // absent — `perry compile` rejects them, so `perry check` must surface
+                 // the U006 diagnostic rather than report a clean build (#3744).
     )
 }
 
@@ -612,4 +624,107 @@ pub fn compatibility_to_diagnostics(packages: &[PackageCompatibility]) -> Diagno
     }
 
     diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #3744: `perry check` must not report a clean build for modern Node
+    /// builtins that `perry compile` rejects. The builtin table feeds the
+    /// U006 diagnostic only when a name is recognized as a Node builtin AND
+    /// is not in the supported allowlist — so an unsupported builtin missing
+    /// from `is_node_builtin` silently passes check.
+    #[test]
+    fn modern_unsupported_builtins_are_flagged() {
+        // Compile-rejected modules: recognized as builtins, NOT supported, so
+        // `check_node_builtin_imports` surfaces the diagnostic.
+        for m in ["sea", "inspector", "node:inspector/promises", "node:sea"] {
+            assert!(is_node_builtin(m), "{m} should be a recognized builtin");
+            assert!(
+                !is_supported_node_builtin(m),
+                "{m} is not compile-supported and must be flagged by check"
+            );
+        }
+    }
+
+    /// Modern builtins that `perry compile` accepts must be in BOTH tables so
+    /// check neither false-negatives (silently passes an unsupported import)
+    /// nor false-positives (flags a working import).
+    #[test]
+    fn modern_supported_builtins_are_recognized_and_allowed() {
+        for m in [
+            "async_hooks",
+            "diagnostics_channel",
+            "http2",
+            "sqlite",
+            "test",
+            "node:test/reporters",
+            "trace_events",
+            "wasi",
+        ] {
+            assert!(is_node_builtin(m), "{m} should be a recognized builtin");
+            assert!(
+                is_supported_node_builtin(m),
+                "{m} compiles and must not be flagged by check"
+            );
+        }
+    }
+
+    /// Every compile-supported builtin must also be a recognized builtin —
+    /// otherwise the allowlist arm is dead (the gate short-circuits on
+    /// `is_node_builtin` first).
+    #[test]
+    fn supported_implies_recognized() {
+        for base in [
+            "crypto",
+            "events",
+            "http",
+            "http2",
+            "https",
+            "net",
+            "readline",
+            "stream",
+            "worker_threads",
+            "zlib",
+            "fs",
+            "path",
+            "os",
+            "util",
+            "process",
+            "buffer",
+            "console",
+            "perf_hooks",
+            "timers",
+            "url",
+            "querystring",
+            "tls",
+            "tty",
+            "assert",
+            "diagnostics_channel",
+            "sqlite",
+            "cluster",
+            "child_process",
+            "dgram",
+            "dns",
+            "domain",
+            "repl",
+            "punycode",
+            "string_decoder",
+            "sys",
+            "v8",
+            "vm",
+            "constants",
+            "module",
+            "async_hooks",
+            "test",
+            "trace_events",
+            "wasi",
+        ] {
+            assert!(
+                is_node_builtin(base),
+                "{base} is in the supported allowlist but not the builtin table"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
`perry check --check-deps` reported a clean build for unsupported modern `node:*` imports that `perry compile` rejects. The hand-maintained `is_node_builtin` table in `crates/perry/src/commands/deps.rs` predated Node's newer builtins, so names like `node:sea` and `node:inspector` were never recognized as builtins — and the U006 dependency diagnostic only fires for *recognized-but-unsupported* builtins, so they fell through to a clean result.

Fixes #3744.

## Fix
Reconciled the table against Node v25's builtin set. Each newly-added name was classified by the **real gate** — compiling `import * as m from "node:<name>"`:

| module | `perry compile` | added to |
|--------|-----------------|----------|
| `async_hooks`, `diagnostics_channel`, `http2`, `sqlite`, `test`/`test/reporters`, `trace_events`, `wasi` | OK | both tables (recognized + allowed) |
| `inspector`, `inspector/promises`, `sea` | FAIL | `is_node_builtin` only → now flagged with U006 |

So check no longer false-negatives on `node:sea`/`node:inspector`, and does not false-positive on the supported modern builtins.

## Validation
- `cargo test -p perry deps::` — 3 new regression tests pass (unsupported→flagged, supported→recognized+allowed, supported⊆recognized).
- End-to-end `perry check --check-deps` in isolated dirs: `node:sea`/`node:inspector` → `error[U006]`; `node:sqlite`/`node:http2`/`node:async_hooks` → clean.
- `cargo fmt --all -- --check` clean. CLI-only change; no runtime/manifest/docs impact.
