### PR TITLE
fix(runtime): brand-check Function.prototype apply/call/bind this (#3662)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -648,6 +648,43 @@ pub(crate) unsafe fn try_dispatch_value_called_proto_method(
     ))
 }
 
+/// #3662: classify a `Function.prototype.{apply,call,bind}` receiver. Returns
+/// `true` when the receiver is *definitively not callable* — any primitive
+/// (`undefined`/`null`/number/bool/string/bigint/symbol) or a recognized
+/// ordinary heap object — so the spec brand check must throw a `TypeError`.
+/// An *ambiguous* pointer (e.g. a native-callable value that isn't a real
+/// closure) returns `false` so the caller keeps its prior conservative
+/// behavior, mirroring the additive collection-thunk approach in #3662.
+unsafe fn fn_proto_receiver_not_callable(object: f64) -> bool {
+    let jsval = JSValue::from_bits(object.to_bits());
+    if !jsval.is_pointer() {
+        return true; // primitive — never callable
+    }
+    let raw = (object.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if crate::closure::is_closure_ptr(raw) {
+        return false; // a real closure is callable
+    }
+    // A recognized ordinary object (plain object, array, Map, …) is not
+    // callable. Unrecognized pointers stay ambiguous (return false).
+    is_valid_obj_ptr(raw as *const u8)
+}
+
+/// #3662: throw the spec `TypeError` for a `Function.prototype.{apply,call,
+/// bind}` invoked on a non-callable `this`. Test262's brand-check tests assert
+/// only the error *type*; the wording mirrors V8/Node (`bind` has its own
+/// distinct message). Never returns.
+#[cold]
+fn throw_fn_proto_not_callable(method: &str) -> ! {
+    let message = if method == "bind" {
+        "Bind must be called on a function".to_string()
+    } else {
+        format!("Function.prototype.{method} was called on a value that is not a function")
+    };
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_native_call_method(
     object: f64,
@@ -2712,6 +2749,13 @@ pub unsafe extern "C" fn js_native_call_method(
             if jsval.is_pointer() && crate::closure::is_closure_ptr(raw_ptr) {
                 return crate::closure::js_function_bind(object, args_ptr, args_len);
             }
+            // #3662: a non-callable `this` (primitive or recognized plain
+            // object) is a spec `TypeError` — `Function.prototype.bind.call(x)`.
+            // Ambiguous pointers (possible native callables) keep the prior
+            // conservative return-unchanged behavior.
+            if fn_proto_receiver_not_callable(object) {
+                throw_fn_proto_not_callable("bind");
+            }
             return object;
         }
 
@@ -2931,7 +2975,7 @@ pub unsafe extern "C" fn js_native_call_method(
         // `_curry3`) build their dispatch chain around
         // `fn.apply(this, arguments)` / `fn.call(this, x)`, so without these
         // arms ramda fails immediately on the first curried export.
-        "call" if jsval.is_pointer() => {
+        "call" => {
             // Proxy receiver (#3656): `p.call(thisArg, ...args)` routes through
             // the proxy `apply` trap (or, absent a trap, forwards to the target).
             if crate::proxy::js_proxy_is_proxy(object) == 1 {
@@ -2968,6 +3012,11 @@ pub unsafe extern "C" fn js_native_call_method(
                 IMPLICIT_THIS.with(|c| c.set(prev_this));
                 return result;
             }
+            // #3662: `Function.prototype.call.call(x, …)` on a non-callable
+            // `this` throws a `TypeError`; ambiguous pointers fall through.
+            if fn_proto_receiver_not_callable(object) {
+                throw_fn_proto_not_callable("call");
+            }
         }
 
         // Function.prototype.apply(thisArg, argsArray) — invoke the receiver
@@ -2976,7 +3025,7 @@ pub unsafe extern "C" fn js_native_call_method(
         // null / undefined (treat as no args). Mirrors `js_native_call_method_apply`
         // but for the `Function.prototype.apply` path rather than the
         // dynamic-spread method-call codegen path.
-        "apply" if jsval.is_pointer() => {
+        "apply" => {
             // Proxy receiver (#3656): `p.apply(thisArg, argsArray)` routes
             // through the proxy `apply` trap (or forwards to the target).
             if crate::proxy::js_proxy_is_proxy(object) == 1 {
@@ -3037,6 +3086,11 @@ pub unsafe extern "C" fn js_native_call_method(
                     crate::closure::js_native_call_value(object, call_args_ptr, call_args_len);
                 IMPLICIT_THIS.with(|c| c.set(prev_this));
                 return result;
+            }
+            // #3662: `Function.prototype.apply.call(x, …)` on a non-callable
+            // `this` throws a `TypeError`; ambiguous pointers fall through.
+            if fn_proto_receiver_not_callable(object) {
+                throw_fn_proto_not_callable("apply");
             }
         }
 

--- a/test-files/test_gap_3662_function_proto_brand_check.ts
+++ b/test-files/test_gap_3662_function_proto_brand_check.ts
@@ -1,0 +1,42 @@
+// #3662: Function.prototype.{apply,call,bind} must brand-check `this` and throw
+// a TypeError when invoked (reflectively) on a non-callable receiver — mirrors
+// test262 built-ins/Function/prototype/{apply,bind}/this-not-callable*.js, which
+// are plain `Function.prototype.apply.call(thisValue, ...)` forms. The direct
+// fast path and reflective calls on a real function must still work.
+function name(e: unknown): string {
+  return (e as any)?.constructor?.name ?? String(e);
+}
+function expectThrow(label: string, fn: () => void) {
+  try {
+    fn();
+    console.log(label + ": NO THROW");
+  } catch (e) {
+    console.log(label + ": " + name(e));
+  }
+}
+const f = function (a: number, b: number) {
+  return a + b;
+};
+const apply = Function.prototype.apply;
+const call = Function.prototype.call;
+const bind = Function.prototype.bind;
+
+// Non-callable `this` → TypeError.
+expectThrow("apply/undefined", () => apply.call(undefined, null, []));
+expectThrow("apply/null", () => apply.call(null, null, []));
+expectThrow("apply/object", () => apply.call({}, null, []));
+expectThrow("apply/number", () => apply.call(42, null, []));
+expectThrow("call/undefined", () => call.call(undefined));
+expectThrow("call/null", () => call.call(null));
+expectThrow("call/object", () => call.call({}));
+expectThrow("bind/undefined", () => bind.call(undefined));
+expectThrow("bind/null", () => bind.call(null));
+expectThrow("bind/object", () => bind.call({}));
+
+// Positive: direct + reflective calls on a real function still work.
+console.log("apply-direct:", f.apply(null, [2, 3]));
+console.log("call-direct:", f.call(null, 4, 5));
+console.log("bind-direct:", f.bind(null, 10)(20));
+console.log("apply-reflect:", apply.call(f, null, [6, 7]));
+console.log("call-reflect:", call.call(f, null, 8, 9));
+console.log("bind-reflect:", bind.call(f, null, 100)(200));


### PR DESCRIPTION
## Summary

Advances #3662 (the "builtins must throw spec TypeError/RangeError" cluster) by adding the **`Function.prototype.{apply,call,bind}` not-callable brand check**: invoking these reflectively on a non-callable `this` now throws a `TypeError`, matching Node/test262 (`built-ins/Function/prototype/{apply,bind}/this-not-callable*.js`).

```js
const apply = Function.prototype.apply;
apply.call(undefined, null, []);  // before: silently no-op'd → now: TypeError
Function.prototype.bind.call({});  // before: returned {} → now: TypeError
```

## What changed

`crates/perry-runtime/src/object/native_call_method.rs` — the reflective dispatch chokepoint:

- The `apply` / `call` / `bind` arms now brand-check the receiver. When `this` is **definitively not callable** (a primitive, or a recognized ordinary heap object), they throw the spec `TypeError` instead of silently returning the receiver / no-op'ing.
- New `fn_proto_receiver_not_callable(object)` classifier: primitives and recognized plain objects → not callable (throw); a real closure → callable (proceed); an *ambiguous* pointer (e.g. a native-callable value that isn't a real closure) stays conservative and falls through unchanged, so no working idiom regresses.
- `throw_fn_proto_not_callable(method)` raises the `TypeError` (`bind` keeps Node's distinct "Bind must be called on a function" wording; test262 asserts only the error *type*).

This mirrors the merged collection-brand-check PR (#3739): the fast direct path (`f.apply(...)`, `f.call(...)`, `f.bind(...)`) is lowered straight to closure dispatch and never touches these arms — only the reflective / method-extraction path does, which previously no-op'd. (Under the auto-optimize build the HIR folds `m.call(thisArg, …)` to a `thisArg.m(…)` method call, which lowers to the same `js_native_call_method` arms — so the check fires identically there.)

## Verification

New `test-files/test_gap_3662_function_proto_brand_check.ts` (method-extraction form, mirroring test262). **Byte-identical to Node in BOTH the non-optimized and auto-optimize builds**: all 10 non-callable receivers (apply/call/bind × undefined/null/object/number) throw `TypeError`, and all 6 positives (direct + reflective on a real function) still work.

- `cargo test -p perry-runtime` → **962 passed** (single-threaded; the parallel run hits a pre-existing flaky SIGBUS unrelated to this change).
- 7 directly-relevant apply/call/bind/uncurry idiom gap tests (`test_function_apply_call`, `test_gap_3716_uncurry_this`, `test_gap_3828_function_method_values`, `test_gap_bind_replace_2840_2867`, `test_issue_3585_bindings`, `test_method_bind_any_receiver`, `test_issue_711_function_prototype`) all still match Node.
- `cargo fmt --all --check` clean.

## Scope / follow-up

The rest of #3662 remains open: `Function.prototype[Symbol.hasInstance]` reflective form, and the node-core `ERR_INVALID_ARG_TYPE`/`ERR_OUT_OF_RANGE` arg-validation cases (fs/buffer/process/zlib/ArrayBuffer/TypedArray).

Refs #3662.
