### PR TITLE
fix(stream): #3663 — wire on/write/pipe + data pump on all stream construction paths

### DIFF
--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -222,6 +222,31 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 }
             }
 
+            // `new stream.Readable(opts)` / `new stream.Writable(opts)` /
+            // `new stream.Duplex(...)` / `.Transform` / `.PassThrough` (#3663).
+            // The namespace-member form (`import * as stream` /
+            // `const stream = require('stream')`) arrives here as
+            // `NewDynamic { callee: PropertyGet { NativeModuleRef("stream"),
+            // "Readable" } }` instead of the bare-identifier `Expr::New`
+            // produced by a named ESM import. Without this arm it would fall
+            // through to the empty-object placeholder below, so the resulting
+            // object carries no EventEmitter/Writable methods and
+            // `.on()`/`.write()`/`.pipe()` throw "is not a function". Route to
+            // the same `lower_builtin_new` stream handler the named-import path
+            // uses so the runtime allocates the fully-methoded stream object.
+            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
+                    if mod_name == "stream"
+                        && matches!(
+                            property.as_str(),
+                            "Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough"
+                        )
+                    {
+                        return lower_new(ctx, property, args);
+                    }
+                }
+            }
+
             // `new v8.Serializer()` / `new v8.Deserializer(buf)` (and the
             // `Default*` subclasses) (#3680) — route to the runtime
             // constructors that allocate a codec-backed instance object whose

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -16,12 +16,39 @@ fn is_global_this_value(expr: &Expr) -> bool {
 const STREAM_CTOR_NAMES: [&str; 5] =
     ["Readable", "Writable", "Duplex", "Transform", "PassThrough"];
 
+/// #3663: the string argument of a `require("<literal>")` call, if any. Unlike
+/// `is_require_builtin_module` (whose allowlist is just fs/path/crypto), this
+/// returns the specifier verbatim so the caller can match the module it cares
+/// about (`"stream"`).
+fn require_literal_specifier(init: &ast::Expr) -> Option<String> {
+    let ast::Expr::Call(call) = init else {
+        return None;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let ast::Expr::Ident(ident) = callee.as_ref() else {
+        return None;
+    };
+    if ident.sym.as_ref() != "require" {
+        return None;
+    }
+    let arg = call.args.first()?;
+    if arg.spread.is_some() {
+        return None;
+    }
+    let ast::Expr::Lit(ast::Lit::Str(s)) = arg.expr.as_ref() else {
+        return None;
+    };
+    s.value.as_str().map(|s| s.to_string())
+}
+
 /// #3663: resolve the builtin module that a destructuring RHS reads from.
 /// Handles `const { Readable } = require('stream')` (CJS), and the namespace
 /// forms `const { Readable } = stream` where `stream` is an `import * as` /
 /// `const stream = require('stream')` alias. Returns the canonical module name.
 fn destructure_builtin_module_source(ctx: &LoweringContext, init: &ast::Expr) -> Option<String> {
-    if let Some(module) = is_require_builtin_module(init) {
+    if let Some(module) = require_literal_specifier(init) {
         return Some(module);
     }
     if let ast::Expr::Ident(ident) = init {

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -12,6 +12,75 @@ fn is_global_this_value(expr: &Expr) -> bool {
         )
 }
 
+/// #3663: classic-stream constructor export names from `node:stream`.
+const STREAM_CTOR_NAMES: [&str; 5] =
+    ["Readable", "Writable", "Duplex", "Transform", "PassThrough"];
+
+/// #3663: resolve the builtin module that a destructuring RHS reads from.
+/// Handles `const { Readable } = require('stream')` (CJS), and the namespace
+/// forms `const { Readable } = stream` where `stream` is an `import * as` /
+/// `const stream = require('stream')` alias. Returns the canonical module name.
+fn destructure_builtin_module_source(ctx: &LoweringContext, init: &ast::Expr) -> Option<String> {
+    if let Some(module) = is_require_builtin_module(init) {
+        return Some(module);
+    }
+    if let ast::Expr::Ident(ident) = init {
+        let name = ident.sym.as_ref();
+        if let Some(module) = ctx.lookup_builtin_module_alias(name) {
+            return Some(module.to_string());
+        }
+        if let Some((module, None)) = ctx.lookup_native_module(name) {
+            return Some(module.to_string());
+        }
+    }
+    None
+}
+
+/// #3663: register destructured `node:stream` constructor bindings as
+/// native-module member aliases, mirroring `import { Readable } from 'stream'`.
+/// Without this, `const { Readable } = require('stream')` leaves `Readable` as a
+/// plain local, so the later `const r = new Readable(...)` binding is never
+/// tagged as a stream instance — and `r.on()/.write()/.pipe()` then fall through
+/// to no-op stub closures instead of routing to the real stream pump (the
+/// `NativeMethodCall` path the named-import form already takes).
+fn register_destructured_stream_ctors(ctx: &mut LoweringContext, decl: &ast::VarDeclarator) {
+    let ast::Pat::Object(obj_pat) = &decl.name else {
+        return;
+    };
+    let Some(init) = decl.init.as_deref() else {
+        return;
+    };
+    let Some(module) = destructure_builtin_module_source(ctx, init) else {
+        return;
+    };
+    if module != "stream" {
+        return;
+    }
+    for prop in &obj_pat.props {
+        let (key, binding) = match prop {
+            ast::ObjectPatProp::Assign(assign) => {
+                let name = assign.key.sym.to_string();
+                (name.clone(), name)
+            }
+            ast::ObjectPatProp::KeyValue(kv) => {
+                let key = match &kv.key {
+                    ast::PropName::Ident(i) => i.sym.to_string(),
+                    ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
+                    _ => continue,
+                };
+                let ast::Pat::Ident(binding) = kv.value.as_ref() else {
+                    continue;
+                };
+                (key, binding.id.sym.to_string())
+            }
+            _ => continue,
+        };
+        if STREAM_CTOR_NAMES.contains(&key.as_str()) {
+            ctx.register_native_module(binding, "stream".to_string(), Some(key));
+        }
+    }
+}
+
 /// Lower a variable declaration, handling array destructuring patterns.
 /// Returns a vector of statements (multiple for destructuring, single for simple bindings).
 pub(crate) fn lower_var_decl_with_destructuring(
@@ -314,7 +383,8 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                         | ("https", "Agent")
                                         | ("dns" | "dns/promises", "Resolver")
                                         | ("sqlite", "DatabaseSync")
-                                );
+                                ) || (module_name == "stream"
+                                    && STREAM_CTOR_NAMES.contains(&class_name));
                                 if is_known_native_class {
                                     let (mod_for_class, cls_for_class) = if class_name == "Agent" {
                                         ("http", "Agent")
@@ -1698,6 +1768,11 @@ pub(crate) fn lower_var_decl_with_destructuring(
             });
         }
         ast::Pat::Array(_) | ast::Pat::Object(_) => {
+            // #3663: tag destructured `node:stream` constructors as native-module
+            // aliases so subsequent `new Readable(...)` bindings register as
+            // stream instances and their methods route to the real pump.
+            register_destructured_stream_ctors(ctx, decl);
+
             // Delegate to the recursive pattern binding helper so that all
             // destructuring features (nested patterns, defaults, rest, computed
             // keys) work consistently across all call sites.

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -13,8 +13,7 @@ fn is_global_this_value(expr: &Expr) -> bool {
 }
 
 /// #3663: classic-stream constructor export names from `node:stream`.
-const STREAM_CTOR_NAMES: [&str; 5] =
-    ["Readable", "Writable", "Duplex", "Transform", "PassThrough"];
+const STREAM_CTOR_NAMES: [&str; 5] = ["Readable", "Writable", "Duplex", "Transform", "PassThrough"];
 
 /// #3663: the string argument of a `require("<literal>")` call, if any. Unlike
 /// `is_require_builtin_module` (whose allowlist is just fs/path/crypto), this

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1134,6 +1134,36 @@ pub unsafe extern "C" fn js_new_function_construct(
             };
             return crate::wasi::js_wasi_new(options);
         }
+        // #3663: `new Readable(opts)` (and Writable/Duplex/Transform/PassThrough)
+        // where the constructor binding came through any aliasing path the
+        // compiler can't resolve to a bare `Expr::New` — `const { Readable } =
+        // require('stream')`, `const s = require('stream'); new s.Readable()`,
+        // or `const R = stream.Readable; new R()`. In each case the callee
+        // value is the `stream.<Ctor>` bound-method closure, so dispatch to the
+        // same runtime constructors the named-import path uses. Without this the
+        // call falls through to the empty-object baseline and the resulting
+        // object has no EventEmitter/Writable methods, so `.on()`/`.write()`/
+        // `.pipe()` throw "is not a function".
+        if module == "stream"
+            && matches!(
+                method.as_str(),
+                "Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough"
+            )
+        {
+            let opts = if !args_ptr.is_null() && args_len > 0 {
+                *args_ptr
+            } else {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            };
+            return match method.as_str() {
+                "Readable" => crate::node_stream::js_node_stream_readable_new(opts),
+                "Writable" => crate::node_stream::js_node_stream_writable_new(opts),
+                "Duplex" => crate::node_stream::js_node_stream_duplex_new(opts),
+                "Transform" => crate::node_stream::js_node_stream_transform_new(opts),
+                "PassThrough" => crate::node_stream::js_node_stream_passthrough_new(opts),
+                _ => unreachable!(),
+            };
+        }
     }
 
     // date-fns `constructFrom` clones a Date via

--- a/test-parity/node-suite/stream/construct-paths/namespace-member-new.ts
+++ b/test-parity/node-suite/stream/construct-paths/namespace-member-new.ts
@@ -1,0 +1,10 @@
+// #3663: `new stream.Readable(...)` via a namespace import must pump too.
+import * as stream from "node:stream";
+const seen: string[] = [];
+const r = new stream.Readable({ read() {} });
+const w = new stream.Writable({
+  write(c: any, _e: any, cb: any) { seen.push(String(c)); cb(); },
+});
+w.on("finish", () => console.log("finish:", seen.join("|")));
+r.pipe(w);
+r.push("x"); r.push("y"); r.push(null);


### PR DESCRIPTION
## Summary

Fixes #3663 — classic `node:stream` objects (`Readable`/`Writable`/`Duplex`/`Transform`/`PassThrough`) missing `on`/`write`/`pipe` on some construction paths.

The methods only worked on the **direct ESM named-import** path (`import { Readable } from "stream"; new Readable(...)`). Every other construction form failed:

| Construction | Before | After |
|---|---|---|
| `import { Readable } from "stream"` | works | works |
| `const { Readable } = require("stream")` | **`TypeError: on is not a function`** | works + pumps |
| `import * as s; new s.Readable()` | **`TypeError`** | works + pumps |
| `const s = require("stream"); const { Readable } = s` | **`TypeError`** | works + pumps |

The reported 65 parity failures concentrate here because Node's own stream test files use `const { Readable } = require("stream")`.

## Root cause

Two independent gaps, both keyed off how the binding is introduced:

1. **Construction.** A named ESM import lowers `new Readable()` to `Expr::New { class_name: "Readable" }` → the existing `lower_builtin_new` stream handler builds a fully-methoded object. CJS-destructured / namespace-member bindings instead lower to `Expr::NewDynamic`, which fell through to an **empty-object placeholder** — no EventEmitter/Writable methods.

2. **Data pump.** The classic-stream method routing (`.pipe`/`.on`/`.write` → real `NativeMethodCall` pump) fires during lowering only when the receiver local is tagged as a `("stream", Ctor)` native instance. That tagging keys off `lookup_native_module`, which ESM named imports populate but CJS require-destructure does not — so even once methods existed they were no-op stubs.

## Fix (4 files)

- **`runtime/object/class_registry.rs`** — `js_new_function_construct` already resolves a callee value to `(module, method)` and dispatches `tty`/`fs`/`tls` stream-likes; add a `stream` arm so any aliasing shape that reaches it builds the real object via `js_node_stream_*_new`.
- **`codegen/expr/new_dynamic.rs`** — route `NewDynamic { callee: PropertyGet { NativeModuleRef("stream"), Ctor } }` (the `import * as stream` member form) straight to `lower_builtin_new`.
- **`hir/destructuring/var_decl.rs`** — register destructured / namespaced stream constructors as native-module member aliases (mirroring `import { Readable }`), so the existing instance-tagging + method-routing machinery treats them identically. `is_require_builtin_module`'s allowlist is only `fs/path/crypto`, so a dedicated `require_literal_specifier` recognizes `require("stream")`.
- **`test-parity/node-suite/stream/construct-paths/namespace-member-new.ts`** — parity fixture for the `new stream.Readable()` construct-and-pump path.

## Verification

- All four construction forms now produce **byte-identical** output to `node --experimental-strip-types` for a full pipe/push/`'end'`/`'finish'` pump, plus `Readable.from`, `r.constructor.name`, and Transform/Duplex/PassThrough method presence.
- Stream parity sweep over the affected fixtures (`pipe`/`write`/`push`/`flow`/`events`/`duplex`/`transform`): **172/175 match Node**. The 3 mismatches are all ESM-path fixtures untouched by this change (pre-existing fidelity gaps: repipe double-pump, default-`_transform` throw, sync-throw stack trace).
- Non-stream sweep (events/fs/path/crypto/buffer/util): no regressions; the only mismatches are pre-existing `buffer/byte-length` gaps unrelated to this change.
- The destructure hook is gated to `module == "stream"` + the five constructor names, so non-stream destructures are unaffected.
- Default auto-optimize build verified (not just `PERRY_NO_AUTO_OPTIMIZE`). `cargo fmt --all --check` clean; `perry-hir` tests pass.

### Known follow-ups (out of scope, pre-existing)
Data-pump *fidelity* gaps that also affect the ESM path: repipe-after-unpipe double-pump, `new Transform()` with no `_transform` should throw `ERR_METHOD_NOT_IMPLEMENTED`, and sync-throw stack-trace depth.
