### PR TITLE
chore(parity): resolve v8 skiplist/manifest triage ambiguity (#3700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1102 — chore(parity): resolve v8 skiplist/manifest triage ambiguity (#3700)
+
+`scripts/parity-skiplist.toml` skiplisted `node:v8` while the API manifest still claimed v8 entries, making compatibility triage ambiguous (a v8 failure could be bucketed as both `Skip` and a manifest/runtime gap). Documented the rule that resolves it: the skiplist and the manifest measure **different axes** — the manifest records whether an API exists and is callable; the skiplist records whether it is a byte-for-byte parity target. A skiplisted-but-manifest-claimed API is not a conflict.
+
+Verified that v8's manifest surface is genuinely callable and matches Node's *shapes* (`serialize`/`deserialize` roundtrip, `getHeapStatistics`/`getHeapSpaceStatistics`/`getHeapCodeStatistics`, `cachedDataVersionTag`, `GCProfiler`), but is not byte-parity-testable: `serialize`/`deserialize` use the JSC wire format (Perry isn't V8, so the bytes differ from Node's V8 format) and the heap-introspection/`cachedDataVersionTag` values are runtime-specific (skip categories 2 + 3). Corrected v8's skiplist reason accordingly and added a header note documenting the skiplist-vs-manifest distinction and the triage rule. `punycode` (the other module named in #3700) was already removed from the skiplist on an earlier change. Config-only; no runtime/manifest/docs impact (the parity sweep is tag-gated).
+
 ## v0.5.1101 — fix(module): implement SourceMap.findEntry / findOrigin (#3675)
 
 `new module.SourceMap(payload)` constructed an instance but `findEntry`/`findOrigin` were noop stubs that returned `undefined`. Implemented both against the Source Map v3 mappings grammar (`crates/perry-runtime/src/process.rs`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1101
+**Current Version:** 0.5.1102
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1101"
+version = "0.5.1102"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "bson",
  "futures-util",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "image",
@@ -5418,14 +5418,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "brotli",
  "flate2",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "base64",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5635,14 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "itoa",
@@ -5659,7 +5659,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "block2",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "block2",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1101"
+version = "0.5.1102"
 
 [[package]]
 name = "perry-ui-test"
@@ -5731,11 +5731,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1101"
+version = "0.5.1102"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "block2",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "block2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "block2",
  "libc",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1101"
+version = "0.5.1102"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1101"
+version = "0.5.1102"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/scripts/parity-skiplist.toml
+++ b/scripts/parity-skiplist.toml
@@ -26,6 +26,17 @@
 #    values that legitimately differ between runs (process.pid,
 #    Date.now standalone, fs.watch event timing) so byte-for-byte
 #    parity comparison is not the right test shape.
+#
+# NOTE on skiplist vs API manifest (#3700): a skiplisted module/API can
+# still appear in `--print-api-manifest`, and that is NOT a conflict.
+# The two sources measure different axes: the manifest records whether an
+# API *exists and is callable* in Perry; this skiplist records whether the
+# API is a *byte-for-byte parity target*. A module is correctly skiplisted
+# (one of the three categories above) even while the manifest claims it —
+# e.g. `v8` is implemented and callable, but its surface is not
+# byte-matchable against Node (see its reason below). Triage rule: a
+# failure on a skiplisted-but-manifest-claimed API is bucketed as `Skip`,
+# not as a manifest/runtime gap.
 
 [skip-modules]
 # Architectural — require a JS interpreter at runtime.
@@ -36,7 +47,12 @@
 "inspector" = "V8 inspector protocol; Perry is not V8."
 "inspector/promises" = "V8 inspector protocol; Perry is not V8."
 "trace_events" = "V8 trace events; not applicable to native binaries."
-"v8" = "V8-specific introspection (heap snapshots, cached data, serialization). Inapplicable."
+# Implemented and manifest-claimed, but not byte-parity-testable: serialize/
+# deserialize use the JSC wire format (Perry isn't V8, so the bytes differ from
+# Node's V8 format), and getHeapStatistics/getHeapSpaceStatistics/
+# getHeapCodeStatistics/cachedDataVersionTag return runtime-specific values
+# (categories 2 + 3). Roundtrips and shapes work; byte-for-byte diffing does not.
+"v8" = "V8-specific introspection + JSC-format serialization; callable but not byte-parity-testable (see #3700)."
 "domain" = "Deprecated since Node 4; not implementing legacy error-routing system."
 
 # Out-of-scope test surface.


### PR DESCRIPTION
## Summary
`scripts/parity-skiplist.toml` skiplisted `node:v8` while the API manifest still claimed v8 entries, so a v8 failure could be bucketed as both `Skip` and a manifest/runtime gap — the triage ambiguity #3700 reports.

Fixes #3700.

## Resolution
The skiplist and the manifest measure **different axes**, and a skiplisted-but-manifest-claimed API is *not* a conflict:
- **manifest** — whether an API exists and is callable in Perry
- **skiplist** — whether the API is a byte-for-byte parity target

I verified v8's manifest surface is genuinely callable and shape-correct vs Node (`serialize`/`deserialize` roundtrip, `getHeapStatistics`/`getHeapSpaceStatistics`/`getHeapCodeStatistics`, `cachedDataVersionTag`, `GCProfiler.start/stop`) — but it is **not byte-parity-testable**: `serialize`/`deserialize` use the JSC wire format (Perry isn't V8, so the bytes differ from Node's V8 format), and the heap-introspection values + `cachedDataVersionTag` are runtime-specific (skip categories 2 + 3). So the blanket module skip is correct.

Changes (config-only):
- Corrected v8's skiplist reason to state *why* it's skipped (callable but not byte-matchable), instead of the misleading "Inapplicable".
- Added a header note documenting the skiplist-vs-manifest distinction and the triage rule (a skiplisted-but-manifest-claimed API is bucketed as `Skip`).

`punycode` (the other module named in #3700) was already removed from the skiplist on an earlier change.

## Validation
`gen_parity_tests.py --dry-run` still parses the skiplist and skips v8 (behavior unchanged, clarity improved); `tomllib` parse confirms the entry. No runtime/manifest/docs impact — the parity sweep is tag-gated, not run on PRs.
