### PR TITLE
fix(node): throw spec arg-validation errors for fs/process/zlib (#3662)

### DIFF
--- a/crates/perry-ext-zlib/src/lib.rs
+++ b/crates/perry-ext-zlib/src/lib.rs
@@ -84,6 +84,8 @@ fn inflate_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
 /// `{ level }` throws `RangeError` before any compression runs (#2935).
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut StringHeader {
+    stream::js_zlib_validate_options(opts, 9); // gzip needs windowBits >= 9 (#3662)
+    stream::js_zlib_validate_buffer_arg(data_bits); // options validate before the buffer
     let level = stream::compression_from_opts(opts);
     match stream::read_input_from_bits(data_bits).map(|d| gzip_bytes_with(&d, level)) {
         Some(Ok(out)) => alloc_bytes(&out).as_raw(),
@@ -98,6 +100,7 @@ pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut St
 /// `data_bits` is the raw NaN-box bit pattern of the data argument (#2935).
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut StringHeader {
+    stream::js_zlib_validate_buffer_arg(data_bits); // #3662
     match stream::read_input_from_bits(data_bits).map(|d| gunzip_bytes(&d)) {
         Some(Ok(out)) => alloc_bytes(&out).as_raw(),
         _ => std::ptr::null_mut(),
@@ -113,6 +116,8 @@ pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut StringHeade
 /// `RangeError` before any compression runs (#2935).
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut StringHeader {
+    stream::js_zlib_validate_options(opts, 8); // deflate accepts windowBits >= 8 (#3662)
+    stream::js_zlib_validate_buffer_arg(data_bits);
     let level = stream::compression_from_opts(opts);
     match stream::read_input_from_bits(data_bits).map(|d| deflate_bytes_with(&d, level)) {
         Some(Ok(out)) => alloc_bytes(&out).as_raw(),
@@ -127,6 +132,7 @@ pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut
 /// `data_bits` is the raw NaN-box bit pattern of the data argument (#2935).
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_inflate_sync(data_bits: i64) -> *mut StringHeader {
+    stream::js_zlib_validate_buffer_arg(data_bits); // #3662
     match stream::read_input_from_bits(data_bits).map(|d| inflate_bytes(&d)) {
         Some(Ok(out)) => alloc_bytes(&out).as_raw(),
         _ => std::ptr::null_mut(),

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -52,6 +52,16 @@ extern "C" {
     // non-numeric arg and `RangeError [ERR_OUT_OF_RANGE]` for an out-of-range
     // level/strategy, matching Node — the throwing path lives in perry-runtime.
     pub(crate) fn js_zlib_validate_params(level: f64, strategy: f64) -> i32;
+    // #3662: validate the full options object (windowBits/level/memLevel/
+    // strategy/chunkSize/flush) the way Node's Zlib constructor does, throwing
+    // the spec `TypeError`/`RangeError` before any compression runs.
+    // `min_window_bits` is 9 for gzip compression, 8 for every other codec.
+    pub(crate) fn js_zlib_validate_options(opts: f64, min_window_bits: i32);
+    // #3662: reject a non-string/non-Buffer/TypedArray/DataView/ArrayBuffer
+    // `buffer` argument with `TypeError [ERR_INVALID_ARG_TYPE]` before reading
+    // any bytes. The in-tree codecs validate inline; this shared helper gives
+    // the ext crate the same rejection without the runtime's value typing.
+    pub(crate) fn js_zlib_validate_buffer_arg(data_bits: i64);
     fn js_native_call_method_str_key(
         object: f64,
         name_handle: i64,
@@ -449,27 +459,34 @@ fn create_stream(codec: Codec, level: Compression) -> i64 {
 // ── factories ────────────────────────────────────────────────────────────────
 
 macro_rules! factory {
-    ($name:ident, $codec:expr) => {
+    // `$min_wb` is the lower `windowBits` bound for option validation (#3662):
+    // 9 for gzip compression, 8 for every other deflate-family codec, and 0 to
+    // skip zlib option validation entirely (brotli has its own option shape).
+    ($name:ident, $codec:expr, $min_wb:expr) => {
         /// # Safety
-        /// FFI entry; `opts` is the NaN-boxed options object. Its `{ level }`
-        /// (if present) sets the initial compression level for deflate-family
-        /// encoders; an out-of-range `level` throws via `js_zlib_resolve_level`.
+        /// FFI entry; `opts` is the NaN-boxed options object. It is validated
+        /// the way Node's constructor does (#3662), then its `{ level }` (if
+        /// present) sets the initial compression level for deflate-family
+        /// encoders.
         #[no_mangle]
         pub unsafe extern "C" fn $name(opts: f64) -> i64 {
+            if $min_wb != 0 {
+                js_zlib_validate_options(opts, $min_wb);
+            }
             let level = Compression::new(js_zlib_resolve_level(opts) as u32);
             create_stream($codec, level)
         }
     };
 }
-factory!(js_zlib_create_gzip, Codec::Gzip);
-factory!(js_zlib_create_gunzip, Codec::Gunzip);
-factory!(js_zlib_create_deflate, Codec::Deflate);
-factory!(js_zlib_create_inflate, Codec::Inflate);
-factory!(js_zlib_create_deflate_raw, Codec::DeflateRaw);
-factory!(js_zlib_create_inflate_raw, Codec::InflateRaw);
-factory!(js_zlib_create_unzip, Codec::Unzip);
-factory!(js_zlib_create_brotli_compress, Codec::BrotliCompress);
-factory!(js_zlib_create_brotli_decompress, Codec::BrotliDecompress);
+factory!(js_zlib_create_gzip, Codec::Gzip, 9);
+factory!(js_zlib_create_gunzip, Codec::Gunzip, 8);
+factory!(js_zlib_create_deflate, Codec::Deflate, 8);
+factory!(js_zlib_create_inflate, Codec::Inflate, 8);
+factory!(js_zlib_create_deflate_raw, Codec::DeflateRaw, 8);
+factory!(js_zlib_create_inflate_raw, Codec::InflateRaw, 8);
+factory!(js_zlib_create_unzip, Codec::Unzip, 8);
+factory!(js_zlib_create_brotli_compress, Codec::BrotliCompress, 0);
+factory!(js_zlib_create_brotli_decompress, Codec::BrotliDecompress, 0);
 
 // ── chunk / buffer helpers ─────────────────────────────────────────────────────
 

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -567,6 +567,7 @@ pub extern "C" fn js_fs_mkdir_sync(path_value: f64) -> i32 {
 
 pub(crate) unsafe fn js_fs_mkdir_result(path_value: f64, options_value: f64) -> Result<(), f64> {
     validate::validate_path("path", path_value);
+    validate::validate_mkdir_options(options_value);
     let path_str = match decode_path_value(path_value) {
         Some(s) => s,
         None => validate::throw_invalid_path_arg("path", path_value),

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -546,6 +546,42 @@ pub(crate) fn validate_object_options(arg_name: &str, value: f64) {
     throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
 }
 
+/// Validate the options object passed to `fs.mkdir*` (#3662). Node accepts an
+/// omitted value or a numeric/string `mode` shorthand without inspecting it;
+/// when an options *object* is supplied it requires `recursive` to be a boolean
+/// and `mode` to be a number or string, throwing
+/// `TypeError [ERR_INVALID_ARG_TYPE]` otherwise. `recursive` is checked first,
+/// matching Node's `validateBoolean(recursive, 'options.recursive')` ordering.
+pub(crate) fn validate_mkdir_options(options_value: f64) {
+    if !is_plain_options_object(options_value) {
+        return;
+    }
+    let obj =
+        JSValue::from_bits(options_value.to_bits()).as_pointer::<crate::object::ObjectHeader>();
+
+    let recursive_key = js_string_from_bytes(b"recursive".as_ptr(), 9);
+    let recursive = crate::object::js_object_get_field_by_name_f64(obj, recursive_key);
+    let recursive_jv = JSValue::from_bits(recursive.to_bits());
+    if !is_nullish(recursive_jv) && !recursive_jv.is_bool() {
+        let message = format!(
+            "The \"options.recursive\" property must be of type boolean. Received {}",
+            describe_received(recursive)
+        );
+        throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+
+    let mode_key = js_string_from_bytes(b"mode".as_ptr(), 4);
+    let mode = crate::object::js_object_get_field_by_name_f64(obj, mode_key);
+    let mode_jv = JSValue::from_bits(mode.to_bits());
+    if !is_nullish(mode_jv) && !is_numeric(mode_jv) && !mode_jv.is_any_string() {
+        let message = format!(
+            "The \"options.mode\" property must be of type number. Received {}",
+            describe_received(mode)
+        );
+        throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+}
+
 /// Validate the `mode` bitmask used by `fs.access*` and `fs.copyFile*`.
 /// Node treats `null`/`undefined` as the default, rejects non-numbers with a
 /// short `ERR_INVALID_ARG_TYPE` message, and rejects values whose integer part

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -68,7 +68,9 @@ pub mod node_test;
 pub mod node_v8;
 // #2935: surface the zlib option-level resolver at the crate root so
 // perry-stdlib's bundled codecs (and the `perry-ext-zlib` extern) can reach it.
-pub use node_submodules::js_zlib_resolve_level;
+pub use node_submodules::{
+    js_zlib_resolve_level, js_zlib_validate_buffer_arg, js_zlib_validate_options,
+};
 pub mod object;
 pub mod os;
 pub mod path;

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -115,7 +115,7 @@ mod test;
 mod timers;
 mod trace_events;
 mod zlib;
-pub use zlib::js_zlib_resolve_level;
+pub use zlib::{js_zlib_resolve_level, js_zlib_validate_buffer_arg, js_zlib_validate_options};
 
 // #1671: hono/jsx/server + hono/jsx/streaming. Re-export the stream-creation
 // registration so perry-stdlib's `bundled-streams` init can wire it up.

--- a/crates/perry-runtime/src/node_submodules/zlib.rs
+++ b/crates/perry-runtime/src/node_submodules/zlib.rs
@@ -119,6 +119,151 @@ pub extern "C" fn js_zlib_validate_params(level: f64, strategy: f64) -> i32 {
     }
 }
 
+/// Read an options-object field by name as a raw NaN-boxed `f64`. Returns the
+/// `undefined` sentinel when `ptr` carries no such property.
+fn read_option_field(ptr: *const crate::object::ObjectHeader, name: &[u8]) -> f64 {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::object::js_object_get_field_by_name_f64(ptr, key)
+}
+
+/// Decode an options field to its numeric `f64`, validating Node's type
+/// contract: an absent/`undefined`/`null` value is skipped (`None`), a numeric
+/// value is returned, and anything else throws `TypeError [ERR_INVALID_ARG_TYPE]`
+/// with Node's `The "<name>" property must be of type number. Received …` shape.
+fn option_number(value: f64, name: &str) -> Option<f64> {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() || jv.is_null() {
+        return None;
+    }
+    if jv.is_int32() {
+        return Some(jv.as_int32() as f64);
+    }
+    if jv.is_number() {
+        return Some(f64::from_bits(value.to_bits()));
+    }
+    let received = crate::fs::validate::describe_received(value);
+    let message = format!("The \"{name}\" property must be of type number. Received {received}");
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+/// Validate a `>= min && <= max` zlib option (`level`/`memLevel`/`strategy`/
+/// `windowBits`/`flush`). Mirrors Node's `checkRangesOrGetDefault`: a present
+/// numeric value outside `[min, max]` throws `RangeError [ERR_OUT_OF_RANGE]`.
+fn validate_option_range(
+    ptr: *const crate::object::ObjectHeader,
+    name: &[u8],
+    display: &str,
+    min: i64,
+    max: i64,
+) {
+    let Some(n) = option_number(read_option_field(ptr, name), display) else {
+        return;
+    };
+    if n < min as f64 || n > max as f64 {
+        let received = crate::fs::validate::format_received_number(n);
+        let message = format!(
+            "The value of \"{display}\" is out of range. It must be >= {min} and <= {max}. Received {received}"
+        );
+        crate::fs::validate::throw_range_error_with_code(&message);
+    }
+}
+
+/// Validate the `chunkSize` option. Node only enforces a lower bound
+/// (`Z_MIN_CHUNK` = 64) and rejects `NaN`, with a `It must be >= 64` message
+/// that omits the upper bound the ranged options carry.
+fn validate_option_chunk_size(ptr: *const crate::object::ObjectHeader) {
+    let Some(n) = option_number(read_option_field(ptr, b"chunkSize"), "options.chunkSize") else {
+        return;
+    };
+    if n < 64.0 || n.is_nan() {
+        let received = crate::fs::validate::format_received_number(n);
+        let message = format!(
+            "The value of \"options.chunkSize\" is out of range. It must be >= 64. Received {received}"
+        );
+        crate::fs::validate::throw_range_error_with_code(&message);
+    }
+}
+
+/// Validate a `node:zlib` options object the way Node's `Zlib`/`ZlibBase`
+/// constructors do, throwing the spec-mandated `TypeError`/`RangeError` before
+/// any compression runs (#3662). Shared by the one-shot sync codecs and the
+/// `createGzip`/`createDeflate`/… stream factories, and by both the in-tree
+/// (`perry-stdlib`) and out-of-tree (`perry-ext-zlib`) codec crates.
+///
+/// `min_window_bits` is the lower `windowBits` bound, which differs by codec:
+/// gzip compression requires `>= 9`, every other codec accepts `>= 8`.
+///
+/// The field order matches Node exactly (`windowBits`, `level`, `memLevel`,
+/// `strategy`, `chunkSize`, `flush`) so that an object with several bad options
+/// reports the same first offender Node does.
+#[no_mangle]
+pub extern "C" fn js_zlib_validate_options(opts: f64, min_window_bits: i32) {
+    let jv = crate::value::JSValue::from_bits(opts.to_bits());
+    if !jv.is_pointer() {
+        return;
+    }
+    let ptr = jv.as_pointer::<crate::object::ObjectHeader>();
+    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return;
+    }
+
+    validate_option_range(
+        ptr,
+        b"windowBits",
+        "options.windowBits",
+        min_window_bits as i64,
+        15,
+    );
+    validate_option_range(ptr, b"level", "options.level", -1, 9);
+    validate_option_range(ptr, b"memLevel", "options.memLevel", 1, 9);
+    validate_option_range(ptr, b"strategy", "options.strategy", 0, 4);
+    validate_option_chunk_size(ptr);
+    validate_option_range(ptr, b"flush", "options.flush", 0, 5);
+}
+
+/// Validate the `buffer` argument to a one-shot zlib codec (`gzipSync`,
+/// `deflateSync`, `gunzipSync`, `inflateSync`, …) the way Node does (#3662):
+/// the value must be a string or an instance of Buffer/TypedArray/DataView/
+/// ArrayBuffer, otherwise `TypeError [ERR_INVALID_ARG_TYPE]` is thrown.
+///
+/// `data_bits` is the raw NaN-box bit pattern of the data argument (the codecs
+/// receive it as a full value via `NA_F64`). The in-tree `perry-stdlib` codecs
+/// already perform this check inside `codec_bytes`; this shared helper lets the
+/// out-of-tree `perry-ext-zlib` codecs (used by the auto-optimize build) reject
+/// the same inputs without duplicating the runtime's value typing.
+#[no_mangle]
+pub extern "C" fn js_zlib_validate_buffer_arg(data_bits: i64) {
+    let value = f64::from_bits(data_bits as u64);
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_any_string() {
+        return;
+    }
+    // Buffer / TypedArray / DataView / ArrayBuffer all live behind a heap
+    // pointer; recover the raw address (pointer/string-tagged values mask off
+    // the tag, a bare small pointer is used as-is) and probe the registries.
+    let bits = value.to_bits();
+    let raw = if jv.is_pointer() || jv.is_string() {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if !value.is_nan() && bits >= 0x1000 && bits < 0x0001_0000_0000_0000 {
+        bits as usize
+    } else {
+        0
+    };
+    if raw >= 0x1000 {
+        if crate::typedarray::lookup_typed_array_kind(raw).is_some() {
+            return;
+        }
+        if crate::buffer::is_registered_buffer(raw) {
+            return;
+        }
+    }
+    let received = crate::fs::validate::describe_received(value);
+    let message = format!(
+        "The \"buffer\" argument must be of type string or an instance of Buffer, TypedArray, DataView, or ArrayBuffer. Received {received}"
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
 /// Keep the codegen-emitted symbol alive through the whole-program LLVM
 /// bitcode rebuild performed by auto-optimize (see
 /// `project_auto_optimize_keepalive_3320`). Called only from generated `.o` /
@@ -127,3 +272,7 @@ pub extern "C" fn js_zlib_validate_params(level: f64, strategy: f64) -> i32 {
 static KEEP_JS_ZLIB_RESOLVE_LEVEL: extern "C" fn(f64) -> i32 = js_zlib_resolve_level;
 #[used]
 static KEEP_JS_ZLIB_VALIDATE_PARAMS: extern "C" fn(f64, f64) -> i32 = js_zlib_validate_params;
+#[used]
+static KEEP_JS_ZLIB_VALIDATE_OPTIONS: extern "C" fn(f64, i32) = js_zlib_validate_options;
+#[used]
+static KEEP_JS_ZLIB_VALIDATE_BUFFER_ARG: extern "C" fn(i64) = js_zlib_validate_buffer_arg;

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -1038,6 +1038,23 @@ fn warning_value_to_string(v: f64) -> String {
     }
 }
 
+/// Validate the optional `type` positional of `process.emitWarning` (#3662).
+///
+/// Node only type-checks `type` when it is supplied as a non-object value:
+/// `undefined`/`null`, a string, an object (the `{ type, code, detail }`
+/// overload), or a function (custom error ctor) are all accepted. A non-string
+/// *primitive* (number/boolean/bigint/symbol) throws
+/// `TypeError [ERR_INVALID_ARG_TYPE]` with the `"type"` argument message.
+fn validate_emit_warning_type(type_name: f64) {
+    let jv = JSValue::from_bits(type_name.to_bits());
+    if jv.is_undefined() || jv.is_null() || jv.is_any_string() || jv.is_pointer() {
+        return;
+    }
+    let received = crate::fs::validate::describe_received(type_name);
+    let message = format!("The \"type\" argument must be of type string. Received {received}");
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
 fn object_from_value(value: f64) -> Option<*mut crate::object::ObjectHeader> {
     let jv = JSValue::from_bits(value.to_bits());
     if !jv.is_pointer() {
@@ -1163,6 +1180,23 @@ fn schedule_warning(warning: f64, label: &str, code: &str, msg: &str, detail: &s
 /// after the current synchronous frame.
 #[no_mangle]
 pub extern "C" fn js_process_emit_warning(warning: f64, type_name: f64, code: f64) {
+    // #3662 — Node validates the optional `type` (when supplied as a non-object
+    // positional) and then the `warning` argument before building the warning,
+    // throwing `TypeError [ERR_INVALID_ARG_TYPE]`. The object overload (where
+    // `type_name` carries `{ type, code, detail }`) is exempt, as is the
+    // function (custom ctor) form — both are valid Node usages.
+    validate_emit_warning_type(type_name);
+    let warning_jv = JSValue::from_bits(warning.to_bits());
+    let warning_is_valid = warning_jv.is_any_string()
+        || crate::error::js_error_is_error(warning).to_bits() == crate::value::TAG_TRUE;
+    if !warning_is_valid {
+        let received = crate::fs::validate::describe_received(warning);
+        let message = format!(
+            "The \"warning\" argument must be of type string or an instance of Error. Received {received}"
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+
     let msg = warning_value_to_string(warning);
 
     let (raw_type, raw_code, detail) = if let Some(options) = object_from_value(type_name) {

--- a/crates/perry-stdlib/src/zlib.rs
+++ b/crates/perry-stdlib/src/zlib.rs
@@ -149,6 +149,9 @@ unsafe fn crc32_bytes(value: f64) -> Vec<u8> {
 /// out-of-range throws `RangeError [ERR_OUT_OF_RANGE]` before compression).
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut BufferHeader {
+    // Gzip compression requires `windowBits >= 9`; option validation runs
+    // before the buffer is touched so a bad option reports Node's error first.
+    perry_runtime::js_zlib_validate_options(opts, 9);
     let level = Compression::new(perry_runtime::js_zlib_resolve_level(opts) as u32);
     let data = codec_bytes(f64::from_bits(data_bits as u64));
 
@@ -185,6 +188,8 @@ pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut BufferHeade
 /// #2935: honor `options.level` (see `js_zlib_gzip_sync`).
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut BufferHeader {
+    // Raw/zlib deflate accepts `windowBits >= 8` (only gzip needs 9).
+    perry_runtime::js_zlib_validate_options(opts, 8);
     let level = Compression::new(perry_runtime::js_zlib_resolve_level(opts) as u32);
     let data = codec_bytes(f64::from_bits(data_bits as u64));
 
@@ -587,43 +592,52 @@ pub fn is_zlib_stream_handle(handle: i64) -> bool {
 /// # Safety
 /// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_gzip(_opts: f64) -> i64 {
+pub unsafe extern "C" fn js_zlib_create_gzip(opts: f64) -> i64 {
+    // Node validates the options object in the stream constructor, before any
+    // data flows. Gzip compression needs `windowBits >= 9` (#3662).
+    perry_runtime::js_zlib_validate_options(opts, 9);
     create_zlib_stream(Codec::Gzip)
 }
 /// # Safety
-/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+/// FFI entry; `opts` is the NaN-boxed options object (validated, then ignored).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_gunzip(_opts: f64) -> i64 {
+pub unsafe extern "C" fn js_zlib_create_gunzip(opts: f64) -> i64 {
+    perry_runtime::js_zlib_validate_options(opts, 8);
     create_zlib_stream(Codec::Gunzip)
 }
 /// # Safety
-/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+/// FFI entry; `opts` is the NaN-boxed options object (validated, then ignored).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_deflate(_opts: f64) -> i64 {
+pub unsafe extern "C" fn js_zlib_create_deflate(opts: f64) -> i64 {
+    perry_runtime::js_zlib_validate_options(opts, 8);
     create_zlib_stream(Codec::Deflate)
 }
 /// # Safety
-/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+/// FFI entry; `opts` is the NaN-boxed options object (validated, then ignored).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_inflate(_opts: f64) -> i64 {
+pub unsafe extern "C" fn js_zlib_create_inflate(opts: f64) -> i64 {
+    perry_runtime::js_zlib_validate_options(opts, 8);
     create_zlib_stream(Codec::Inflate)
 }
 /// # Safety
-/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+/// FFI entry; `opts` is the NaN-boxed options object (validated, then ignored).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_deflate_raw(_opts: f64) -> i64 {
+pub unsafe extern "C" fn js_zlib_create_deflate_raw(opts: f64) -> i64 {
+    perry_runtime::js_zlib_validate_options(opts, 8);
     create_zlib_stream(Codec::DeflateRaw)
 }
 /// # Safety
-/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+/// FFI entry; `opts` is the NaN-boxed options object (validated, then ignored).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_inflate_raw(_opts: f64) -> i64 {
+pub unsafe extern "C" fn js_zlib_create_inflate_raw(opts: f64) -> i64 {
+    perry_runtime::js_zlib_validate_options(opts, 8);
     create_zlib_stream(Codec::InflateRaw)
 }
 /// # Safety
-/// FFI entry; `_opts` is the (ignored) NaN-boxed options object.
+/// FFI entry; `opts` is the NaN-boxed options object (validated, then ignored).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_create_unzip(_opts: f64) -> i64 {
+pub unsafe extern "C" fn js_zlib_create_unzip(opts: f64) -> i64 {
+    perry_runtime::js_zlib_validate_options(opts, 8);
     create_zlib_stream(Codec::Unzip)
 }
 /// # Safety

--- a/test-files/test_gap_3662_node_argvalidation.ts
+++ b/test-files/test_gap_3662_node_argvalidation.ts
@@ -1,0 +1,86 @@
+// #3662 — node-core argument validation (fs / process / zlib sub-cluster).
+//
+// Where the spec/Node require a built-in to reject bad input, Perry must throw
+// the same `TypeError [ERR_INVALID_ARG_TYPE]` / `RangeError [ERR_OUT_OF_RANGE]`
+// rather than silently proceeding. Each probe prints the thrown error's `.name`
+// and `.code` (and, for the cases that pin message parity, the full `.message`)
+// so the output is compared byte-for-byte against
+// `node --experimental-strip-types`.
+//
+// Scope note: this covers the zlib option/buffer validation, `process.emitWarning`
+// argument validation, and `fs.mkdirSync` option validation. The collection
+// brand checks (#3739) and `Function.prototype` not-callable checks (PR #4073)
+// live in their own changes.
+import * as fs from "node:fs";
+import * as zlib from "node:zlib";
+
+function probe(label: string, fn: () => any) {
+  try {
+    fn();
+    console.log(label, "no-throw");
+  } catch (e: any) {
+    console.log(label, e.name, e.code);
+  }
+}
+function probeMsg(label: string, fn: () => any) {
+  try {
+    fn();
+    console.log(label, "no-throw");
+  } catch (e: any) {
+    console.log(label, e.name, e.code, "|", e.message);
+  }
+}
+
+console.log("=== zlib: input buffer arg type ===");
+probe("gzipSync(123)", () => zlib.gzipSync(123 as any));
+probe("gzipSync(null)", () => zlib.gzipSync(null as any));
+probe("gzipSync(undefined)", () => zlib.gzipSync(undefined as any));
+probe("gzipSync(true)", () => zlib.gzipSync(true as any));
+probe("gzipSync({})", () => zlib.gzipSync({} as any));
+probe("deflateSync(123)", () => zlib.deflateSync(123 as any));
+probe("gunzipSync(123)", () => zlib.gunzipSync(123 as any));
+probe("inflateSync(null)", () => zlib.inflateSync(null as any));
+
+console.log("=== zlib: gzipSync option validation ===");
+probeMsg("level:'a'", () => zlib.gzipSync("x", { level: "a" } as any));
+probeMsg("level:99", () => zlib.gzipSync("x", { level: 99 } as any));
+probeMsg("level:-5", () => zlib.gzipSync("x", { level: -5 } as any));
+probe("level:5.5 (ok)", () => zlib.gzipSync("x", { level: 5.5 } as any));
+probeMsg("windowBits:8", () => zlib.gzipSync("x", { windowBits: 8 } as any));
+probeMsg("windowBits:99", () => zlib.gzipSync("x", { windowBits: 99 } as any));
+probeMsg("memLevel:0", () => zlib.gzipSync("x", { memLevel: 0 } as any));
+probeMsg("memLevel:99", () => zlib.gzipSync("x", { memLevel: 99 } as any));
+probeMsg("strategy:99", () => zlib.gzipSync("x", { strategy: 99 } as any));
+probeMsg("strategy:'a'", () => zlib.gzipSync("x", { strategy: "a" } as any));
+probeMsg("chunkSize:0", () => zlib.gzipSync("x", { chunkSize: 0 } as any));
+probeMsg("chunkSize:-1", () => zlib.gzipSync("x", { chunkSize: -1 } as any));
+probeMsg("chunkSize:'a'", () => zlib.gzipSync("x", { chunkSize: "a" } as any));
+probeMsg("flush:'a'", () => zlib.gzipSync("x", { flush: "a" } as any));
+probeMsg("flush:99", () => zlib.gzipSync("x", { flush: 99 } as any));
+
+console.log("=== zlib: deflateSync windowBits (min 8, not 9) ===");
+probe("deflate windowBits:8 (ok)", () => zlib.deflateSync("x", { windowBits: 8 } as any));
+probeMsg("deflate windowBits:7", () => zlib.deflateSync("x", { windowBits: 7 } as any));
+
+console.log("=== zlib: option order (first offender) ===");
+probeMsg("chunkSize+level", () => zlib.gzipSync("x", { chunkSize: 0, level: 99 } as any));
+probeMsg("level+windowBits", () => zlib.gzipSync("x", { level: 99, windowBits: 99 } as any));
+probeMsg("bad-buffer+bad-opt", () => zlib.gzipSync(123 as any, { level: 99 } as any));
+
+console.log("=== zlib: createGzip / createDeflate factory option validation ===");
+probeMsg("createGzip level:99", () => zlib.createGzip({ level: 99 } as any));
+probeMsg("createGzip windowBits:8", () => zlib.createGzip({ windowBits: 8 } as any));
+probeMsg("createDeflate windowBits:7", () => zlib.createDeflate({ windowBits: 7 } as any));
+probe("createDeflate windowBits:8 (ok)", () => zlib.createDeflate({ windowBits: 8 } as any));
+probe("createGzip valid (ok)", () => zlib.createGzip({ level: 6 } as any));
+
+console.log("=== process.emitWarning ===");
+probeMsg("emitWarning(5)", () => (process as any).emitWarning(5));
+probeMsg("emitWarning(true)", () => (process as any).emitWarning(true));
+probeMsg("emitWarning(null)", () => (process as any).emitWarning(null));
+probeMsg("emitWarning('ok', 5)", () => (process as any).emitWarning("ok", 5));
+
+console.log("=== fs.mkdirSync option validation ===");
+probeMsg("mkdirSync recursive:5", () => fs.mkdirSync("/tmp/perry-3662-x", { recursive: 5 } as any));
+probeMsg("mkdirSync recursive:'x'", () => fs.mkdirSync("/tmp/perry-3662-x", { recursive: "x" } as any));
+probeMsg("mkdirSync mode:{}", () => fs.mkdirSync("/tmp/perry-3662-x", { mode: {} } as any));


### PR DESCRIPTION
## Summary

Node-core argument-validation sub-cluster of #3662: make `zlib`, `process`, and `fs` builtins throw the spec-mandated `TypeError [ERR_INVALID_ARG_TYPE]` / `RangeError [ERR_OUT_OF_RANGE]` on invalid arguments instead of silently proceeding.

Scope boundary: the `Function.prototype` not-callable checks landed in #4073 and the collection (Set/Map/Weak*) brand checks in #3739 — this PR is the remaining node-core piece (fs / process / zlib).

## What changed

**zlib option validation** — new shared `js_zlib_validate_options(opts, min_window_bits)` in `perry-runtime`, called from both the in-tree (`perry-stdlib`) and out-of-tree (`perry-ext-zlib`, used by the auto-optimize build) codecs: from `gzipSync` / `deflateSync` and every `create*` stream factory. Validates `windowBits`, `level`, `memLevel`, `strategy`, `chunkSize`, and `flush` in **Node's exact field order** so the first-offender message matches Node when several options are bad. `windowBits` lower bound is 9 for gzip compression and 8 for every other codec (mirrors Node's `Z_MIN_WINDOWBITS`). A non-numeric option throws the `"options.<name>" property must be of type number` TypeError; an out-of-range one throws the matching `ERR_OUT_OF_RANGE` RangeError.

**zlib buffer-arg validation** — new `js_zlib_validate_buffer_arg` rejects a non-string/Buffer/TypedArray/DataView/ArrayBuffer first argument to the `gzip`/`gunzip`/`deflate`/`inflate` sync codecs in the ext path (the stdlib path already validated this inline via `codec_bytes`). brotli's ext codec takes a pre-unboxed pointer (calling-convention quirk) and is left as a follow-up — the stdlib path already validates it.

**process.emitWarning** — validates the `warning` argument (must be a string or `Error`) and the `type` positional (must be a string), in Node's order (type before warning).

**fs.mkdirSync** — validates the options object's `recursive` (boolean) and `mode` (number/string) properties.

## Testing

New gap test `test-files/test_gap_3662_node_argvalidation.ts` is **byte-for-byte identical** to `node --experimental-strip-types` in **both** the default auto-optimize build and `PERRY_NO_AUTO_OPTIMIZE=1`:

```
=== NO-OPT diff vs Node ===   ✅ MATCH
=== AUTO-OPT diff vs Node === ✅ MATCH
```

- `cargo test --release -p perry-runtime` → 964 passed, 0 failed
- `cargo fmt --all -- --check` → clean
- Regression-checked valid round trips (gzip/deflate/inflate with options, `createGzip`, recursive `mkdirSync`, string `emitWarning`) stay working.

## Follow-ups (not in scope here)

- brotli buffer-arg validation in the ext (pointer-based) codec path.
- Scattered fs gaps surfaced while probing (`writeFileSync` bad-encoding `ERR_INVALID_ARG_VALUE`, `readSync` buffer-before-fd order) — separate, riskier touches to hot paths.

Closes part of #3662.
