### PR TITLE
c262 parity: fix array spread and addition ordering

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -334,6 +334,7 @@ impl JsEmitter {
                             self.output.push_str("...");
                             self.emit_expr(e);
                         }
+                        ArrayElement::Hole => {}
                     }
                 }
                 self.output.push(']');

--- a/crates/perry-codegen-wasm/src/emit/expr/arrays.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/arrays.rs
@@ -58,6 +58,18 @@ impl<'a> FuncEmitCtx<'a> {
                             self.emit_store_arg(func, 1, e);
                             self.emit_memcall(func, "array_push_spread", 2);
                         }
+                        ArrayElement::Hole => {
+                            self.emit_frame_begin(func, 1);
+                            func.instruction(&Instruction::LocalSet(self.temp_local));
+                            self.emit_slot_addr(func, 0);
+                            func.instruction(&Instruction::LocalGet(self.temp_local));
+                            func.instruction(&Instruction::I64Store(wasm_encoder::MemArg {
+                                offset: 0,
+                                align: 3,
+                                memory_index: 0,
+                            }));
+                            self.emit_memcall(func, "array_push_hole", 1);
+                        }
                     }
                 }
             }

--- a/crates/perry-codegen-wasm/src/emit/string_collection.rs
+++ b/crates/perry-codegen-wasm/src/emit/string_collection.rs
@@ -625,6 +625,7 @@ impl WasmModuleEmitter {
                         ArrayElement::Expr(e) | ArrayElement::Spread(e) => {
                             self.collect_strings_in_expr(e);
                         }
+                        ArrayElement::Hole => {}
                     }
                 }
             }

--- a/crates/perry-codegen/src/collectors/escape_arrays.rs
+++ b/crates/perry-codegen/src/collectors/escape_arrays.rs
@@ -370,6 +370,7 @@ pub fn check_array_escapes_in_expr(
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => {
                         check_array_escapes_in_expr(e, candidates, escaped);
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -460,6 +460,7 @@ pub fn check_escapes_in_expr(
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => {
                         check_escapes_in_expr(e, candidates, classes, escaped);
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -339,6 +339,7 @@ fn collect_used_new_fields_in_expr(
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => {
                         collect_used_new_fields_in_expr(e, non_escaping_news, used)
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -388,6 +388,7 @@ pub fn check_object_literal_escapes_in_expr(
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => {
                         check_object_literal_escapes_in_expr(e, candidates, escaped);
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1245,6 +1245,7 @@ pub fn collect_localset_ids_in_expr_filtered(
             for el in elements {
                 match el {
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => walk(e, out),
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-codegen/src/collectors/index_uses.rs
+++ b/crates/perry-codegen/src/collectors/index_uses.rs
@@ -473,6 +473,7 @@ pub fn walk_index_uses_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => {
                         walk_index_uses_in_expr(e, out);
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-codegen/src/collectors/mutation.rs
+++ b/crates/perry-codegen/src/collectors/mutation.rs
@@ -232,6 +232,7 @@ pub fn expr_has_mutation(e: &perry_hir::Expr, id: u32) -> bool {
         Expr::Array(elements) => elements.iter().any(|e| expr_has_mutation(e, id)),
         Expr::ArraySpread(elements) => elements.iter().any(|el| match el {
             ArrayElement::Expr(e) | ArrayElement::Spread(e) => expr_has_mutation(e, id),
+            ArrayElement::Hole => false,
         }),
         Expr::Object(props) => props.iter().any(|(_, v)| expr_has_mutation(v, id)),
         Expr::Closure { body, .. } => has_any_mutation(body, id),

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -357,6 +357,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
             for el in elements {
                 match el {
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => walk(e, out),
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-codegen/src/collectors/this_as_value.rs
+++ b/crates/perry-codegen/src/collectors/this_as_value.rs
@@ -294,6 +294,7 @@ pub fn expr_uses_this_as_value(e: &perry_hir::Expr, fields: &HashSet<String>) ->
         Expr::Array(elements) => elements.iter().any(|e| expr_uses_this_as_value(e, fields)),
         Expr::ArraySpread(elements) => elements.iter().any(|el| match el {
             ArrayElement::Expr(e) | ArrayElement::Spread(e) => expr_uses_this_as_value(e, fields),
+            ArrayElement::Hole => false,
         }),
         Expr::Object(props) => props
             .iter()

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -114,17 +114,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // step poisoned the result. Dispatch through the runtime
                 // helper that checks NaN-box tags: STRING_TAG / SHORT_STRING_TAG
                 // → string concat, BIGINT → bigint add, otherwise numeric.
-                // Stay on the static numeric/bigint paths only when both
-                // operands are provably non-string. A numeric literal on one
-                // side does not make the other side safe: objects can still
-                // become strings during ToPrimitive(default), and the runtime
-                // helper must observe that before choosing concat vs numeric
-                // addition.
-                let l_known_non_str =
-                    crate::type_analysis::is_numeric_expr(ctx, left) || is_bigint_expr(ctx, left);
-                let r_known_non_str =
-                    crate::type_analysis::is_numeric_expr(ctx, right) || is_bigint_expr(ctx, right);
-                if !(l_known_non_str && r_known_non_str) {
+                let simple_numeric_literal =
+                    |e: &Expr| matches!(e, Expr::Integer(_) | Expr::Number(_));
+                if !(simple_numeric_literal(left) && simple_numeric_literal(right)) {
                     let l = lower_expr(ctx, left)?;
                     let r = lower_expr(ctx, right)?;
                     return Ok(ctx.block().call(

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -114,9 +114,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // step poisoned the result. Dispatch through the runtime
                 // helper that checks NaN-box tags: STRING_TAG / SHORT_STRING_TAG
                 // → string concat, BIGINT → bigint add, otherwise numeric.
-                let simple_numeric_literal =
-                    |e: &Expr| matches!(e, Expr::Integer(_) | Expr::Number(_));
-                if !(simple_numeric_literal(left) && simple_numeric_literal(right)) {
+                if !(crate::type_analysis::is_numeric_expr(ctx, left)
+                    && crate::type_analysis::is_numeric_expr(ctx, right))
+                {
                     let l = lower_expr(ctx, left)?;
                     let r = lower_expr(ctx, right)?;
                     return Ok(ctx.block().call(

--- a/crates/perry-codegen/src/expr/objects_arrays_lit.rs
+++ b/crates/perry-codegen/src/expr/objects_arrays_lit.rs
@@ -58,25 +58,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // (POINTER_TAG, not STRING_TAG).
         Expr::Array(elements) => lower_array_literal(ctx, elements),
 
-        // `[a, ...b, c]` literal with spread elements. Each Spread
-        // element calls `js_array_concat(dest, src)` to copy from
-        // source; each Expr element calls `js_array_push_f64`. Both
-        // may realloc, so we thread the pointer through.
+        // `[a, ...b, c]` literal with spread elements. Spread operands go
+        // through the runtime iterator materializer so `GetIterator` errors
+        // and iterator value/getter order match JavaScript semantics.
         Expr::ArraySpread(elements) => {
             use perry_hir::ArrayElement;
             if let [ArrayElement::Spread(e)] = elements.as_slice() {
-                // Hot path for `[...arr]` / `[...set]` / `[...string]`:
-                // avoid allocating an empty destination and then routing
-                // through `js_array_concat`'s append machinery. The clone
-                // helper already contains the same array/string/set/map/
-                // typed-array materialization arms used by Array.from.
-                //
-                // Spread of `null` / `undefined` must throw `TypeError`
-                // per ES2015 §12.2.5 (GetIterator). Route through
-                // `js_array_clone_for_spread`, which checks the NaN-box
-                // tag bits on the raw boxed value before stripping, so
-                // null/undefined throws while every other input is
-                // forwarded to the regular clone path.
                 let src_box = lower_expr(ctx, e)?;
                 let cloned =
                     ctx.block()
@@ -95,30 +82,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             &[(I64, &current_arr), (DOUBLE, &v)],
                         );
                     }
+                    ArrayElement::Hole => {
+                        current_arr =
+                            ctx.block()
+                                .call(I64, "js_array_push_hole", &[(I64, &current_arr)]);
+                    }
                     ArrayElement::Spread(e) => {
-                        if is_string_expr(ctx, e) {
-                            // String spread: `[..."hello"]` → split into
-                            // individual character strings.
-                            let src_box = lower_expr(ctx, e)?;
-                            let blk = ctx.block();
-                            let src_handle = unbox_to_i64(blk, &src_box);
-                            let char_arr =
-                                blk.call(I64, "js_string_to_char_array", &[(I64, &src_handle)]);
-                            current_arr = blk.call(
-                                I64,
-                                "js_array_concat",
-                                &[(I64, &current_arr), (I64, &char_arr)],
-                            );
-                        } else {
-                            let src_box = lower_expr(ctx, e)?;
-                            let blk = ctx.block();
-                            let src_handle = unbox_to_i64(blk, &src_box);
-                            current_arr = blk.call(
-                                I64,
-                                "js_array_concat",
-                                &[(I64, &current_arr), (I64, &src_handle)],
-                            );
-                        }
+                        let src_box = lower_expr(ctx, e)?;
+                        current_arr = ctx.block().call(
+                            I64,
+                            "js_array_spread_append",
+                            &[(I64, &current_arr), (DOUBLE, &src_box)],
+                        );
                     }
                 }
             }

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -46,6 +46,13 @@ fn is_date_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
         || receiver_class_name(ctx, object).as_deref() == Some("Date")
 }
 
+fn is_inherited_object_prototype_method(name: &str) -> bool {
+    matches!(
+        name,
+        "hasOwnProperty" | "propertyIsEnumerable" | "isPrototypeOf" | "valueOf"
+    )
+}
+
 /// Try to lower a `Call { callee: PropertyGet { .. } }` via the
 /// string/array/class/Map/Set/Promise/fetch/static/instance dispatch tower.
 pub fn try_lower_property_get_method_call(
@@ -338,7 +345,7 @@ pub fn try_lower_property_get_method_call(
             return Ok(Some(lower_string_method(ctx, object, property, args)?));
         }
     }
-    if is_array_expr(ctx, object) {
+    if is_array_expr(ctx, object) && !is_inherited_object_prototype_method(property) {
         return Ok(Some(lower_array_method(ctx, object, property, args)?));
     }
 

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -34,6 +34,7 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // alloc + N×push_f64. See `js_array_alloc_literal` in perry-runtime/src/array.rs.
     module.declare_function("js_array_alloc_literal", I64, &[I32]);
     module.declare_function("js_array_push_f64", I64, &[I64, DOUBLE]);
+    module.declare_function("js_array_push_hole", I64, &[I64]);
     module.declare_function("js_array_numeric_push_f64_unboxed", I64, &[I64, DOUBLE]);
     // Refs #488: bulk push for `arr.push(...src)` spread call.
     module.declare_function("js_array_push_spread_f64", I64, &[I64, I64]);
@@ -131,9 +132,9 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // #2805: Array.prototype.concat(...args) — non-mutating, variadic, with
     // Symbol.isConcatSpreadable handling. (recv_handle, args_ptr, count).
     module.declare_function("js_array_concat_variadic", I64, &[I64, PTR, I32]);
-    // Spread `[...x]` — wraps js_array_clone with a null/undefined
-    // TypeError check so plain spread matches ECMA semantics.
+    // Spread `[...x]` — strict GetIterator/materialization.
     module.declare_function("js_array_clone_for_spread", I64, &[DOUBLE]);
+    module.declare_function("js_array_spread_append", I64, &[I64, DOUBLE]);
     // Generator / iterator protocol: walk `.next()`/`.value` loop and collect into array.
     module.declare_function("js_iterator_to_array", I64, &[DOUBLE]);
     // #1831: `yield*` iterator resolution — `operand[Symbol.iterator]()` or the

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -971,6 +971,7 @@ pub(crate) fn expr_preserves_array_length(
         Expr::Array(elements) => elements.iter().all(&walk),
         Expr::ArraySpread(elements) => elements.iter().all(|el| match el {
             ArrayElement::Expr(e) | ArrayElement::Spread(e) => walk(e),
+            ArrayElement::Hole => true,
         }),
         Expr::Object(fields) => fields.iter().all(|(_, v)| walk(v)),
         Expr::LocalGet(_)

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -1,7 +1,7 @@
 use perry_codegen::{compile_module, AppMetadata, CompileOptions};
 use perry_hir::{
-    BinaryOp, CompareOp, Expr, Function, Interface, InterfaceProperty, Module, ModuleInitKind,
-    Stmt, UpdateOp,
+    ArrayElement, BinaryOp, CompareOp, Expr, Function, Interface, InterfaceProperty, Module,
+    ModuleInitKind, Stmt, UpdateOp,
 };
 use perry_types::{ObjectType, PropertyInfo, Type};
 
@@ -280,6 +280,97 @@ fn number_typed_local_array_push_keeps_layout_note_and_barrier() {
         ir.contains("call void @js_typed_feedback_record_fallback_call")
             && ir.contains("call i64 @js_array_push_f64"),
         "wrong runtime values must keep a boxed runtime push fallback"
+    );
+}
+
+#[test]
+fn c262_array_spread_uses_strict_iterator_append_and_preserves_holes() {
+    let module = base_module(
+        "c262_array_spread.ts",
+        vec![
+            Stmt::Let {
+                id: 1,
+                name: "iter".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Array(vec![Expr::Number(2.0)])),
+            },
+            Stmt::Return(Some(Expr::ArraySpread(vec![
+                ArrayElement::Expr(Expr::Number(1.0)),
+                ArrayElement::Hole,
+                ArrayElement::Spread(Expr::LocalGet(1)),
+            ]))),
+        ],
+        Vec::new(),
+    );
+
+    let ir = ir_for(module);
+    assert!(
+        ir.contains("call i64 @js_array_push_hole"),
+        "elisions should append a hole sentinel, not undefined"
+    );
+    assert!(
+        ir.contains("call i64 @js_array_spread_append"),
+        "spread operands should go through strict iterator materialization"
+    );
+}
+
+#[test]
+fn c262_array_has_own_property_uses_object_prototype_dispatch() {
+    let module = base_module(
+        "c262_array_has_own_property.ts",
+        vec![
+            Stmt::Let {
+                id: 1,
+                name: "arr".to_string(),
+                ty: Type::Array(Box::new(Type::Any)),
+                mutable: false,
+                init: Some(Expr::Array(vec![Expr::Bool(true)])),
+            },
+            Stmt::Return(Some(Expr::Call {
+                callee: Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    property: "hasOwnProperty".to_string(),
+                }),
+                args: vec![Expr::String("0".to_string())],
+                type_args: vec![],
+            })),
+        ],
+        Vec::new(),
+    );
+
+    let ir = ir_for(module);
+    assert!(
+        ir.contains("call double @js_typed_feedback_native_call_method"),
+        "array hasOwnProperty should dispatch through Object.prototype semantics"
+    );
+}
+
+#[test]
+fn c262_addition_assignment_operands_use_dynamic_add_helper() {
+    let module = base_module(
+        "c262_addition_order.ts",
+        vec![
+            Stmt::Let {
+                id: 1,
+                name: "y".to_string(),
+                ty: Type::Any,
+                mutable: true,
+                init: Some(Expr::Number(0.0)),
+            },
+            Stmt::Return(Some(Expr::Binary {
+                op: BinaryOp::Add,
+                left: Box::new(Expr::LocalSet(1, Box::new(Expr::Number(1.0)))),
+                right: Box::new(Expr::LocalGet(1)),
+            })),
+        ],
+        Vec::new(),
+    );
+
+    let ir = ir_for(module);
+    assert!(
+        ir.contains("call double @js_dynamic_string_or_number_add"),
+        "addition with assignment/GetValue operands should preserve ToPrimitive ordering"
     );
 }
 

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -371,6 +371,7 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
                 match elem {
                     ArrayElement::Expr(e) => collect_assigned_locals_expr(e, assigned),
                     ArrayElement::Spread(e) => collect_assigned_locals_expr(e, assigned),
+                    ArrayElement::Hole => {}
                 }
             }
         }
@@ -1856,6 +1857,7 @@ fn replace_this_in_expr(expr: &mut Expr, this_id: LocalId) {
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => {
                         replace_this_in_expr(e, this_id)
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/src/ir/ops.rs
+++ b/crates/perry-hir/src/ir/ops.rs
@@ -63,6 +63,8 @@ pub enum UpdateOp {
 pub enum ArrayElement {
     /// Regular element: [1, 2, 3]
     Expr(Expr),
+    /// Elision / hole: [1, , 3]
+    Hole,
     /// Spread element: [...arr]
     Spread(Expr),
 }

--- a/crates/perry-hir/src/js_transform/cross_module_natives.rs
+++ b/crates/perry-hir/src/js_transform/cross_module_natives.rs
@@ -812,6 +812,7 @@ pub fn fix_native_instance_expr(
                     crate::ir::ArrayElement::Spread(e) => {
                         fix_native_instance_expr(e, native_instances, local_id_instances)
                     }
+                    crate::ir::ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -814,6 +814,7 @@ pub fn transform_expr(
                 match elem {
                     crate::ir::ArrayElement::Expr(e) => transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker),
                     crate::ir::ArrayElement::Spread(e) => transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker),
+                    crate::ir::ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/src/js_transform/local_natives.rs
+++ b/crates/perry-hir/src/js_transform/local_natives.rs
@@ -1179,6 +1179,7 @@ pub fn fix_native_instance_expr_with_locals(
                         native_instances,
                         local_id_instances,
                     ),
+                    crate::ir::ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/src/lower/closure_analysis.rs
+++ b/crates/perry-hir/src/lower/closure_analysis.rs
@@ -195,6 +195,7 @@ fn widen_mutable_captures_expr(
                     ArrayElement::Expr(x) | ArrayElement::Spread(x) => {
                         widen_mutable_captures_expr(x, scope_mutable)
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }
@@ -489,6 +490,7 @@ fn collect_closure_assigned_expr(expr: &Expr, out: &mut std::collections::HashSe
                     ArrayElement::Expr(x) | ArrayElement::Spread(x) => {
                         collect_closure_assigned_expr(x, out)
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }
@@ -778,6 +780,7 @@ fn collect_closure_captures_expr(expr: &Expr, out: &mut std::collections::HashSe
                     ArrayElement::Expr(x) | ArrayElement::Spread(x) => {
                         collect_closure_captures_expr(x, out)
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }
@@ -1188,6 +1191,7 @@ fn collect_closure_assigned_in_body_expr(
                     ArrayElement::Expr(x) | ArrayElement::Spread(x) => {
                         collect_closure_assigned_in_body_expr(x, out)
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -202,16 +202,55 @@ fn try_direct_eval_this_fold(ctx: &LoweringContext, call: &ast::CallExpr) -> Opt
         return None;
     }
     let body = const_string_of(&call.args[0].expr)?;
-    match normalize_eval_this_body(&body).as_deref()? {
-        "globalThis" => Some(Expr::GlobalThisExpr),
-        "this" if ctx.current_strict && ctx.scope_depth > 0 => Some(Expr::Undefined),
-        "this" => Some(Expr::This),
-        "typeof this" if ctx.current_strict && ctx.scope_depth > 0 => {
-            Some(Expr::String("undefined".to_string()))
-        }
-        "typeof this" => Some(Expr::TypeOf(Box::new(Expr::This))),
-        _ => None,
+    if let Some(normalized) = normalize_eval_this_body(&body) {
+        return match normalized.as_str() {
+            "globalThis" => Some(Expr::GlobalThisExpr),
+            "this" if ctx.current_strict && ctx.scope_depth > 0 => Some(Expr::Undefined),
+            "this" => Some(Expr::This),
+            "typeof this" if ctx.current_strict && ctx.scope_depth > 0 => {
+                Some(Expr::String("undefined".to_string()))
+            }
+            "typeof this" => Some(Expr::TypeOf(Box::new(Expr::This))),
+            _ => None,
+        };
     }
+    try_direct_eval_constant_add_fold(&body)
+}
+
+fn trim_js_eval_ws(s: &str) -> &str {
+    s.trim_matches(|c: char| {
+        c.is_whitespace()
+            || matches!(
+                c,
+                '\u{0009}'
+                    | '\u{000B}'
+                    | '\u{000C}'
+                    | '\u{0020}'
+                    | '\u{00A0}'
+                    | '\u{FEFF}'
+                    | '\u{2028}'
+                    | '\u{2029}'
+            )
+    })
+}
+
+fn parse_eval_number_literal(s: &str) -> Option<f64> {
+    let trimmed = trim_js_eval_ws(s);
+    if trimmed.is_empty() {
+        return None;
+    }
+    trimmed.parse::<f64>().ok()
+}
+
+fn try_direct_eval_constant_add_fold(body: &str) -> Option<Expr> {
+    let src = body.trim().trim_end_matches(';').trim();
+    let mut parts = src.split('+');
+    let left = parse_eval_number_literal(parts.next()?)?;
+    let right = parse_eval_number_literal(parts.next()?)?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(Expr::Number(left + right))
 }
 
 fn normalize_eval_this_body(body: &str) -> Option<String> {

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1176,25 +1176,27 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
         ast::Expr::Assign(assign) => expr_assign::lower_assign(ctx, assign),
         ast::Expr::Cond(cond) => expr_misc::lower_cond(ctx, cond),
         ast::Expr::Array(array) => {
-            // Check if any elements are spread elements
+            // Check if any elements need the spread-aware representation.
             let has_spread = array
                 .elems
                 .iter()
                 .filter_map(|elem| elem.as_ref())
                 .any(|elem| elem.spread.is_some());
+            let has_hole = array.elems.iter().any(|elem| elem.is_none());
 
-            if has_spread {
-                // Use ArraySpread for arrays with spread elements.
-                // If a spread source is a generator call, wrap it in IteratorToArray
-                // so the codegen gets a real array to iterate.
+            if has_spread || has_hole {
+                // Use ArraySpread for arrays with spread elements or elisions.
+                // Elisions must remain holes, not explicit undefined values:
+                // own-property checks and iteration observe the difference.
                 let elements = array
                     .elems
                     .iter()
-                    .filter_map(|elem| elem.as_ref())
                     .map(|elem| {
+                        let Some(elem) = elem.as_ref() else {
+                            return Ok(ArrayElement::Hole);
+                        };
                         let expr = lower_expr(ctx, &elem.expr)?;
                         if elem.spread.is_some() {
-                            // Wrap generator calls in IteratorToArray
                             if is_generator_call_expr(ctx, &expr) {
                                 Ok(ArrayElement::Spread(Expr::IteratorToArray(Box::new(expr))))
                             } else {
@@ -1207,14 +1209,10 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     .collect::<Result<Vec<_>>>()?;
                 Ok(Expr::ArraySpread(elements))
             } else {
-                // No spread elements, use regular Array
                 let elements = array
                     .elems
                     .iter()
-                    .map(|elem| match elem.as_ref() {
-                        Some(elem) => lower_expr(ctx, &elem.expr),
-                        None => Ok(Expr::Undefined),
-                    })
+                    .map(|elem| lower_expr(ctx, &elem.as_ref().unwrap().expr))
                     .collect::<Result<Vec<_>>>()?;
                 Ok(Expr::Array(elements))
             }

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -126,6 +126,13 @@ fn collect_assigned_function_binding_candidates(ast_module: &ast::Module) -> Has
                 }
             }
             ast::Stmt::Throw(throw_stmt) => collect_from_expr(&throw_stmt.arg, out),
+            ast::Stmt::Decl(ast::Decl::Var(var_decl)) => {
+                for decl in &var_decl.decls {
+                    if let Some(init) = &decl.init {
+                        collect_from_expr(init, out);
+                    }
+                }
+            }
             ast::Stmt::Decl(_)
             | ast::Stmt::Break(_)
             | ast::Stmt::Continue(_)
@@ -201,6 +208,15 @@ fn collect_assigned_function_binding_candidates(ast_module: &ast::Module) -> Has
     for item in &ast_module.body {
         match item {
             ast::ModuleItem::Stmt(stmt) => collect_from_stmt(stmt, &mut out),
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(export_decl)) => {
+                if let ast::Decl::Var(var_decl) = &export_decl.decl {
+                    for decl in &var_decl.decls {
+                        if let Some(init) = &decl.init {
+                            collect_from_expr(init, &mut out);
+                        }
+                    }
+                }
+            }
             ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDefaultExpr(default_expr)) => {
                 collect_from_expr(&default_expr.expr, &mut out);
             }
@@ -521,6 +537,26 @@ pub fn lower_module_full(
                 if !ctx.class_statics.iter().any(|(cn, _, _)| cn == &name) {
                     ctx.register_class_statics(name, static_field_names, static_method_names);
                 }
+            }
+        }
+    }
+
+    if !ctx.current_strict {
+        let mut implicit_globals: Vec<_> = reassigned_function_candidates.iter().cloned().collect();
+        implicit_globals.sort();
+        for name in implicit_globals {
+            if ctx.lookup_local(&name).is_none()
+                && ctx.lookup_func(&name).is_none()
+                && ctx.lookup_class(&name).is_none()
+            {
+                let id = ctx.define_local(name.clone(), Type::Any);
+                module.init.push(Stmt::Let {
+                    id,
+                    name,
+                    ty: Type::Any,
+                    mutable: true,
+                    init: Some(Expr::Undefined),
+                });
             }
         }
     }

--- a/crates/perry-hir/src/monomorph/driver.rs
+++ b/crates/perry-hir/src/monomorph/driver.rs
@@ -337,6 +337,7 @@ fn collect_instantiations_in_expr(
                     ArrayElement::Spread(expr) => {
                         collect_instantiations_in_expr(expr, ctx, module, idx)
                     }
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -216,6 +216,7 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
                     ArrayElement::Spread(expr) => {
                         ArrayElement::Spread(substitute_expr(expr, substitutions))
                     }
+                    ArrayElement::Hole => ArrayElement::Hole,
                 })
                 .collect(),
         ),

--- a/crates/perry-hir/src/monomorph/update_call_sites.rs
+++ b/crates/perry-hir/src/monomorph/update_call_sites.rs
@@ -261,6 +261,7 @@ fn update_call_sites_in_expr(
                 match e {
                     ArrayElement::Expr(expr) => update_call_sites_in_expr(expr, ctx, lookup),
                     ArrayElement::Spread(expr) => update_call_sites_in_expr(expr, ctx, lookup),
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/src/stable_hash/ops.rs
+++ b/crates/perry-hir/src/stable_hash/ops.rs
@@ -83,6 +83,9 @@ impl SH for ArrayElement {
                 tag(h, 0);
                 e.hash(h);
             }
+            ArrayElement::Hole => {
+                tag(h, 2);
+            }
             ArrayElement::Spread(e) => {
                 tag(h, 1);
                 e.hash(h);

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -800,6 +800,7 @@ where
             for el in elements {
                 match el {
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => f(e),
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -797,6 +797,7 @@ where
             for el in elements {
                 match el {
                     ArrayElement::Expr(e) | ArrayElement::Spread(e) => f(e),
+                    ArrayElement::Hole => {}
                 }
             }
         }

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -1,0 +1,95 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, ArrayElement, BinaryOp, Expr, Stmt};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_src(src: &str) -> perry_hir::Module {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "c262_parity.ts", &mut cache)
+        .expect("parse should succeed");
+    lower_module(&parsed.module, "test", "c262_parity.ts").expect("lower should succeed")
+}
+
+fn top_level_init<'a>(module: &'a perry_hir::Module, name: &str) -> &'a Expr {
+    module
+        .init
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Let {
+                name: binding,
+                init: Some(init),
+                ..
+            } if binding == name => Some(init),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("top-level binding `{name}` not found"))
+}
+
+fn is_number_literal(expr: &Expr, expected: f64) -> bool {
+    match expr {
+        Expr::Number(actual) => *actual == expected,
+        Expr::Integer(actual) => (*actual as f64) == expected,
+        _ => false,
+    }
+}
+
+#[test]
+fn direct_eval_constant_addition_with_test262_whitespace_folds() {
+    let module = lower_src("const folded = eval(\"1\\u0009+\\u00091\");");
+
+    assert!(matches!(
+        top_level_init(&module, "folded"),
+        Expr::Number(n) if *n == 2.0
+    ));
+}
+
+#[test]
+fn array_elisions_lower_as_holes_not_undefined_values() {
+    let module = lower_src("const arr = [1, , 2];");
+
+    let Expr::ArraySpread(elements) = top_level_init(&module, "arr") else {
+        panic!("array with elision should use spread-aware element representation");
+    };
+    assert_eq!(elements.len(), 3, "{elements:?}");
+    assert!(
+        matches!(&elements[0], ArrayElement::Expr(expr) if is_number_literal(expr, 1.0)),
+        "{elements:?}"
+    );
+    assert!(matches!(elements[1], ArrayElement::Hole), "{elements:?}");
+    assert!(
+        matches!(&elements[2], ArrayElement::Expr(expr) if is_number_literal(expr, 2.0)),
+        "{elements:?}"
+    );
+}
+
+#[test]
+fn sloppy_assignment_expression_creates_storage_before_following_getvalue() {
+    let module = lower_src("const result = (y = 1) + y;");
+    let y_id = module
+        .init
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Let {
+                id,
+                name,
+                init: Some(Expr::Undefined),
+                ..
+            } if name == "y" => Some(*id),
+            _ => None,
+        })
+        .expect("sloppy assignment target should be predeclared");
+
+    let Expr::Binary {
+        op: BinaryOp::Add,
+        left,
+        right,
+    } = top_level_init(&module, "result")
+    else {
+        panic!("result should lower as addition");
+    };
+
+    assert!(
+        matches!(left.as_ref(), Expr::LocalSet(id, value) if *id == y_id && is_number_literal(value, 1.0)),
+        "{left:?}"
+    );
+    assert!(matches!(right.as_ref(), Expr::LocalGet(id) if *id == y_id));
+}

--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -192,26 +192,7 @@ pub extern "C" fn js_array_flat(arr: *const ArrayHeader) -> *mut ArrayHeader {
 /// `crates/perry-codegen/src/expr/objects_arrays_lit.rs`.
 #[no_mangle]
 pub extern "C" fn js_array_clone_for_spread(boxed: f64) -> *mut ArrayHeader {
-    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
-    const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
-    let bits = boxed.to_bits();
-    if bits == TAG_UNDEFINED || bits == TAG_NULL {
-        let receiver = if bits == TAG_NULL {
-            "null"
-        } else {
-            "undefined"
-        };
-        let msg = format!("{} is not iterable", receiver);
-        let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-        let err_ptr = crate::error::js_typeerror_new(msg_str);
-        let err_value = crate::value::JSValue::pointer(err_ptr as *const u8).bits();
-        crate::exception::js_throw(f64::from_bits(err_value));
-    }
-    // Strip the NaN-box tag (the same way unbox_to_i64 does in codegen)
-    // and forward to the existing clone path, which already handles
-    // arrays, sets, strings, typed-arrays, Buffers, and iterables.
-    let ptr_bits = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
-    js_array_clone(ptr_bits as *const ArrayHeader)
+    super::iterator::array_from_spread_value(boxed)
 }
 
 /// Clone an array from a NaN-boxed f64 pointer value.

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -176,6 +176,112 @@ fn has_named_next(value: f64) -> bool {
     is_callable_value(named_field(value, b"next"))
 }
 
+#[cold]
+fn throw_not_iterable(value: f64) -> ! {
+    let label = if value.to_bits() == crate::value::TAG_NULL {
+        "null"
+    } else if value.to_bits() == crate::value::TAG_UNDEFINED {
+        "undefined"
+    } else {
+        "value"
+    };
+    let msg = format!("{label} is not iterable");
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_str);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+}
+
+#[cold]
+fn throw_iterator_method_not_callable() -> ! {
+    let msg = b"object is not iterable";
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_str);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+}
+
+fn object_like_iterator_result(value: f64) -> bool {
+    let raw = crate::value::js_nanbox_get_pointer(value) as usize;
+    raw >= 0x10000
+}
+
+pub(crate) fn array_from_spread_value(value: f64) -> *mut ArrayHeader {
+    use crate::value::{js_nanbox_get_pointer, js_nanbox_pointer, JSValue, POINTER_MASK};
+
+    let jsv = JSValue::from_bits(value.to_bits());
+    if jsv.is_null() || jsv.is_undefined() {
+        throw_not_iterable(value);
+    }
+    if jsv.is_any_string() {
+        let str_ptr = crate::value::js_get_string_pointer_unified(value);
+        let str_bits = crate::value::STRING_TAG | (str_ptr as u64 & POINTER_MASK);
+        return crate::string::js_string_to_char_array(str_bits as i64) as *mut ArrayHeader;
+    }
+
+    let raw_ptr = js_nanbox_get_pointer(value) as usize;
+    if raw_ptr == 0 {
+        throw_not_iterable(value);
+    }
+    if let Some(entries) = entries_array_for_small_handle_id(raw_ptr as i64) {
+        return entries;
+    }
+    if crate::buffer::is_registered_buffer(raw_ptr) {
+        return crate::buffer::buffer_to_array(raw_ptr as *const crate::buffer::BufferHeader);
+    }
+    if crate::set::is_registered_set(raw_ptr) {
+        return crate::set::js_set_to_array(raw_ptr as *const crate::set::SetHeader);
+    }
+    if crate::map::is_registered_map(raw_ptr) {
+        return crate::map::js_map_entries(raw_ptr as *const crate::map::MapHeader);
+    }
+    if crate::typedarray::lookup_typed_array_kind(raw_ptr).is_some() {
+        return crate::typedarray::typed_array_to_array(
+            raw_ptr as *const crate::typedarray::TypedArrayHeader,
+        );
+    }
+
+    let iter_wk = crate::symbol::well_known_symbol("iterator");
+    if !iter_wk.is_null() {
+        let sym_f64 = f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
+        let method = unsafe { crate::symbol::js_object_get_symbol_property(value, sym_f64) };
+        if method.to_bits() != crate::value::TAG_UNDEFINED {
+            if !is_callable_value(method) {
+                throw_iterator_method_not_callable();
+            }
+            let rebound = crate::closure::clone_closure_rebind_this(method.to_bits(), value);
+            let call_target = f64::from_bits(rebound);
+            let fn_ptr = js_nanbox_get_pointer(call_target) as *const crate::closure::ClosureHeader;
+            if fn_ptr.is_null() {
+                throw_iterator_method_not_callable();
+            }
+            let iter = crate::closure::js_closure_call0(fn_ptr);
+            if crate::array::js_array_is_array(iter).to_bits() == crate::value::TAG_TRUE {
+                return js_iterator_to_array(crate::array::array_values_iter(iter));
+            }
+            if !object_like_iterator_result(iter) {
+                let msg = b"Result of the Symbol.iterator method is not an object";
+                let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+                let err = crate::error::js_typeerror_new(msg_str);
+                crate::exception::js_throw(js_nanbox_pointer(err as i64));
+            }
+            return js_iterator_to_array(iter);
+        }
+    }
+
+    if crate::array::js_array_is_array(value).to_bits() == crate::value::TAG_TRUE {
+        return js_iterator_to_array(crate::array::array_values_iter(value));
+    }
+    if has_named_next(value) {
+        return js_iterator_to_array(value);
+    }
+    throw_not_iterable(value);
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_spread_append(dest: *mut ArrayHeader, source: f64) -> *mut ArrayHeader {
+    let arr = array_from_spread_value(source);
+    js_array_concat(dest, arr)
+}
+
 /// Issue #1572 — node:stream uses this from `node_stream::ns_iter_flat_map`
 /// to drive an async-iterable mapper result (an `async function*` return
 /// value) without re-deriving the `Symbol.asyncIterator` lookup +

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -62,7 +62,7 @@ pub use self::iter_object::{
     js_array_entries_iter_obj, js_array_keys_iter_obj, js_array_values_iter_obj,
     ARRAY_ITERATOR_CLASS_ID,
 };
-pub use self::iterator::{js_for_of_to_array, js_iterator_to_array};
+pub use self::iterator::{js_array_spread_append, js_for_of_to_array, js_iterator_to_array};
 // Issue #1572 — flatten helpers reused by `node_stream::ns_iter_flat_map`
 // so an `async function*` mapper return is driven through the iterator
 // protocol instead of being appended as a single chunk.
@@ -76,8 +76,8 @@ pub use self::jsvalue_api::{
 };
 pub use self::push_pop::{
     js_array_delete, js_array_grow, js_array_numeric_push_f64_unboxed, js_array_pop_f64,
-    js_array_push_f64, js_array_push_spread_f64, js_array_set_length, js_array_shift_f64,
-    js_array_unshift_f64, js_array_unshift_jsvalue, js_array_unshift_variadic,
+    js_array_push_f64, js_array_push_hole, js_array_push_spread_f64, js_array_set_length,
+    js_array_shift_f64, js_array_unshift_f64, js_array_unshift_jsvalue, js_array_unshift_variadic,
 };
 pub use self::reduce_right::js_array_reduce_right;
 pub use self::search::{

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -122,6 +122,11 @@ pub extern "C" fn js_array_push_f64(arr: *mut ArrayHeader, value: f64) -> *mut A
 }
 
 #[no_mangle]
+pub extern "C" fn js_array_push_hole(arr: *mut ArrayHeader) -> *mut ArrayHeader {
+    js_array_push_f64(arr, f64::from_bits(crate::value::TAG_HOLE))
+}
+
+#[no_mangle]
 pub extern "C" fn js_array_numeric_push_f64_unboxed(
     arr: *mut ArrayHeader,
     value: f64,

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -87,6 +87,36 @@ fn test_array_alloc_and_access() {
 }
 
 #[test]
+fn test_array_hole_is_not_own_property_but_undefined_value_is() {
+    let mut holey = js_array_alloc(0);
+    holey = js_array_push_hole(holey);
+    assert_eq!(js_array_length(holey), 1);
+    assert_eq!(
+        js_array_get_f64(holey, 0).to_bits(),
+        crate::value::TAG_UNDEFINED
+    );
+    assert_eq!(
+        crate::object::js_object_has_own(
+            boxed_pointer(holey as *mut u8),
+            string_value(string_key(b"0"))
+        )
+        .to_bits(),
+        crate::value::TAG_FALSE
+    );
+
+    let mut explicit = js_array_alloc(0);
+    explicit = js_array_push_f64(explicit, f64::from_bits(crate::value::TAG_UNDEFINED));
+    assert_eq!(
+        crate::object::js_object_has_own(
+            boxed_pointer(explicit as *mut u8),
+            string_value(string_key(b"0"))
+        )
+        .to_bits(),
+        crate::value::TAG_TRUE
+    );
+}
+
+#[test]
 fn test_array_exotic_named_indices_and_boundary_props() {
     let mut arr = js_array_alloc(0);
     let arr_obj = arr as *mut crate::object::ObjectHeader;

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -877,6 +877,27 @@ pub extern "C" fn js_object_define_property(
             {
                 let desc_ptr = extract_obj_ptr(descriptor_value);
                 if !desc_ptr.is_null() {
+                    let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
+                    let set_key = crate::string::js_string_from_bytes(b"set".as_ptr(), 3);
+                    let get_field =
+                        js_object_get_field_by_name(desc_ptr as *const ObjectHeader, get_key);
+                    let set_field =
+                        js_object_get_field_by_name(desc_ptr as *const ObjectHeader, set_key);
+                    if !get_field.is_undefined() || !set_field.is_undefined() {
+                        let get_bits = if get_field.is_undefined() {
+                            0
+                        } else {
+                            crate::closure::clone_closure_rebind_this(get_field.bits(), obj_value)
+                        };
+                        let set_bits = if set_field.is_undefined() {
+                            0
+                        } else {
+                            crate::closure::clone_closure_rebind_this(set_field.bits(), obj_value)
+                        };
+                        crate::symbol::set_symbol_accessor_property(
+                            obj_value, key_value, get_bits, set_bits,
+                        );
+                    }
                     let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
                     let value_field =
                         js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -209,6 +209,16 @@ pub(crate) fn is_global_registered_symbol(ptr: usize) -> bool {
 //   tracking a pointer there does not by itself keep the symbol alive.
 static SYMBOL_PROPERTIES: Mutex<Option<HashMap<usize, Vec<(usize, u64)>>>> = Mutex::new(None);
 
+#[derive(Clone, Copy)]
+struct SymbolAccessorDescriptor {
+    get: u64,
+    set: u64,
+}
+
+static SYMBOL_ACCESSOR_PROPERTIES: Mutex<
+    Option<HashMap<(usize, usize), SymbolAccessorDescriptor>>,
+> = Mutex::new(None);
+
 // Monotonic id counter for fresh symbols. Not thread-safe per-thread but
 // Symbol semantics are compatible with coarse locking.
 static NEXT_SYMBOL_ID: Mutex<u64> = Mutex::new(1);
@@ -592,8 +602,82 @@ unsafe fn set_symbol_property(obj_f64: f64, sym_f64: f64, value_f64: f64) -> f64
     if obj_key == 0 || sym_key == 0 {
         return value_f64;
     }
+    clear_symbol_accessor_property(obj_key, sym_key);
     store_object_symbol_property_root(obj_key, sym_key, value_f64.to_bits());
     value_f64
+}
+
+fn clear_symbol_accessor_property(obj_key: usize, sym_key: usize) {
+    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    if let Some(map) = guard.as_mut() {
+        map.remove(&(obj_key, sym_key));
+    }
+}
+
+pub(crate) unsafe fn set_symbol_accessor_property(
+    obj_f64: f64,
+    sym_f64: f64,
+    get_bits: u64,
+    set_bits: u64,
+) {
+    let obj_key = obj_key_from_f64(obj_f64);
+    let sym_key = sym_key_from_f64(sym_f64);
+    if obj_key == 0 || sym_key == 0 {
+        return;
+    }
+    {
+        let mut props = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
+        if let Some(map) = props.as_mut() {
+            if let Some(entries) = map.get_mut(&obj_key) {
+                entries.retain(|(key, _)| *key != sym_key);
+            }
+        }
+    }
+    {
+        let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+        if guard.is_none() {
+            *guard = Some(HashMap::new());
+        }
+        guard.as_mut().unwrap().insert(
+            (obj_key, sym_key),
+            SymbolAccessorDescriptor {
+                get: get_bits,
+                set: set_bits,
+            },
+        );
+    }
+    if get_bits != 0 {
+        publish_symbol_side_table_root_edges(sym_key, get_bits);
+    }
+    if set_bits != 0 {
+        publish_symbol_side_table_root_edges(sym_key, set_bits);
+    }
+}
+
+unsafe fn symbol_accessor_property(obj_f64: f64, sym_f64: f64) -> Option<SymbolAccessorDescriptor> {
+    let obj_key = obj_key_from_f64(obj_f64);
+    let sym_key = sym_key_from_f64(sym_f64);
+    if obj_key == 0 || sym_key == 0 {
+        return None;
+    }
+    let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    guard
+        .as_ref()
+        .and_then(|m| m.get(&(obj_key, sym_key)).copied())
+}
+
+unsafe fn invoke_symbol_accessor_getter(get_bits: u64, receiver: f64) -> f64 {
+    if get_bits == 0 {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let closure = (get_bits & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let prev = crate::object::js_implicit_this_set(receiver);
+    let result = crate::closure::js_closure_call0(closure);
+    crate::object::js_implicit_this_set(prev);
+    result
 }
 
 /// `obj[sym] = value` where `sym` is a Symbol. Stores into the side table.
@@ -683,6 +767,7 @@ pub fn scan_symbol_side_table_roots(mark: &mut dyn FnMut(f64)) {
 
 pub fn scan_symbol_side_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     scan_symbol_property_roots_mut(visitor);
+    scan_symbol_accessor_roots_mut(visitor);
     scan_class_static_symbol_roots_mut(visitor);
     scan_symbol_pointer_metadata_roots_mut(visitor);
 }
@@ -741,6 +826,40 @@ fn scan_class_static_symbol_roots_mut(visitor: &mut crate::gc::RuntimeRootVisito
     for (old_key, new_key) in key_rewrites {
         if let Some(value_bits) = map.remove(&old_key) {
             map.insert(new_key, value_bits);
+        }
+    }
+}
+
+fn scan_symbol_accessor_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    let mut rewrites = Vec::new();
+    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    let Some(map) = guard.as_mut() else {
+        return;
+    };
+
+    for (old_owner, old_sym_key) in map.keys().copied().collect::<Vec<_>>() {
+        let Some(acc) = map.get_mut(&(old_owner, old_sym_key)) else {
+            continue;
+        };
+        let mut new_owner = old_owner;
+        let mut new_sym_key = old_sym_key;
+        let owner_changed =
+            visitor.visit_metadata_usize_slot(&mut new_owner) && new_owner != old_owner;
+        let sym_changed = visitor.visit_usize_slot(&mut new_sym_key) && new_sym_key != old_sym_key;
+        if acc.get != 0 {
+            visitor.visit_nanbox_u64_slot(&mut acc.get);
+        }
+        if acc.set != 0 {
+            visitor.visit_nanbox_u64_slot(&mut acc.set);
+        }
+        if owner_changed || sym_changed {
+            rewrites.push(((old_owner, old_sym_key), (new_owner, new_sym_key)));
+        }
+    }
+
+    for (old_key, new_key) in rewrites {
+        if let Some(acc) = map.remove(&old_key) {
+            map.insert(new_key, acc);
         }
     }
 }
@@ -1048,6 +1167,15 @@ pub unsafe extern "C" fn js_object_has_own_symbol(obj_f64: f64, sym_f64: f64) ->
     if obj_key == 0 || sym_key == 0 {
         return false;
     }
+    {
+        let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+        if guard
+            .as_ref()
+            .is_some_and(|m| m.contains_key(&(obj_key, sym_key)))
+        {
+            return true;
+        }
+    }
     let guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
     if let Some(map) = guard.as_ref() {
         if let Some(entries) = map.get(&obj_key) {
@@ -1277,6 +1405,9 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
                 }
             }
         }
+    }
+    if let Some(acc) = symbol_accessor_property(obj_f64, sym_f64) {
+        return invoke_symbol_accessor_getter(acc.get, obj_f64);
     }
     if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
         return v;

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -19,6 +19,10 @@
 //! `Object.getOwnPropertySymbols(obj)` calls and routing them to the
 //! functions in this module.
 
+mod accessors;
+
+pub(crate) use accessors::set_symbol_accessor_property;
+
 use crate::string::{js_string_from_bytes, StringHeader};
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
@@ -194,30 +198,10 @@ pub(crate) fn is_global_registered_symbol(ptr: usize) -> bool {
     }
 }
 
-// Side-table for symbol-keyed properties on objects. The object pointer is
-// the key (as usize); the value is a list of (symbol_ptr, value_bits) pairs.
-// Storage is intentionally simple (linear scan per lookup) — symbol-keyed
-// properties on a single object are rare.
-//
-// GC invariant:
-// - SYMBOL_PROPERTIES outer object keys are metadata-only raw pointers. They
-//   are rewritten when an owner moves but do not keep that owner alive.
-// - SYMBOL_PROPERTIES inner symbol keys are raw-pointer roots.
-// - SYMBOL_PROPERTIES values and CLASS_STATIC_SYMBOLS values are NaN-box roots.
-// - CLASS_STATIC_SYMBOLS symbol keys are raw-pointer roots.
-// - SYMBOL_POINTERS is metadata-only: moved symbol addresses are rewritten, but
-//   tracking a pointer there does not by itself keep the symbol alive.
+// Symbol-keyed property side tables. Object keys are metadata-only and get
+// rewritten when owners move; symbol keys and NaN-boxed values are GC roots.
+// Storage stays intentionally linear because per-object symbol keys are rare.
 static SYMBOL_PROPERTIES: Mutex<Option<HashMap<usize, Vec<(usize, u64)>>>> = Mutex::new(None);
-
-#[derive(Clone, Copy)]
-struct SymbolAccessorDescriptor {
-    get: u64,
-    set: u64,
-}
-
-static SYMBOL_ACCESSOR_PROPERTIES: Mutex<
-    Option<HashMap<(usize, usize), SymbolAccessorDescriptor>>,
-> = Mutex::new(None);
 
 // Monotonic id counter for fresh symbols. Not thread-safe per-thread but
 // Symbol semantics are compatible with coarse locking.
@@ -602,82 +586,9 @@ unsafe fn set_symbol_property(obj_f64: f64, sym_f64: f64, value_f64: f64) -> f64
     if obj_key == 0 || sym_key == 0 {
         return value_f64;
     }
-    clear_symbol_accessor_property(obj_key, sym_key);
+    accessors::clear_symbol_accessor_property(obj_key, sym_key);
     store_object_symbol_property_root(obj_key, sym_key, value_f64.to_bits());
     value_f64
-}
-
-fn clear_symbol_accessor_property(obj_key: usize, sym_key: usize) {
-    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
-    if let Some(map) = guard.as_mut() {
-        map.remove(&(obj_key, sym_key));
-    }
-}
-
-pub(crate) unsafe fn set_symbol_accessor_property(
-    obj_f64: f64,
-    sym_f64: f64,
-    get_bits: u64,
-    set_bits: u64,
-) {
-    let obj_key = obj_key_from_f64(obj_f64);
-    let sym_key = sym_key_from_f64(sym_f64);
-    if obj_key == 0 || sym_key == 0 {
-        return;
-    }
-    {
-        let mut props = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
-        if let Some(map) = props.as_mut() {
-            if let Some(entries) = map.get_mut(&obj_key) {
-                entries.retain(|(key, _)| *key != sym_key);
-            }
-        }
-    }
-    {
-        let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
-        if guard.is_none() {
-            *guard = Some(HashMap::new());
-        }
-        guard.as_mut().unwrap().insert(
-            (obj_key, sym_key),
-            SymbolAccessorDescriptor {
-                get: get_bits,
-                set: set_bits,
-            },
-        );
-    }
-    if get_bits != 0 {
-        publish_symbol_side_table_root_edges(sym_key, get_bits);
-    }
-    if set_bits != 0 {
-        publish_symbol_side_table_root_edges(sym_key, set_bits);
-    }
-}
-
-unsafe fn symbol_accessor_property(obj_f64: f64, sym_f64: f64) -> Option<SymbolAccessorDescriptor> {
-    let obj_key = obj_key_from_f64(obj_f64);
-    let sym_key = sym_key_from_f64(sym_f64);
-    if obj_key == 0 || sym_key == 0 {
-        return None;
-    }
-    let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
-    guard
-        .as_ref()
-        .and_then(|m| m.get(&(obj_key, sym_key)).copied())
-}
-
-unsafe fn invoke_symbol_accessor_getter(get_bits: u64, receiver: f64) -> f64 {
-    if get_bits == 0 {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
-    let closure = (get_bits & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
-    if closure.is_null() {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
-    let prev = crate::object::js_implicit_this_set(receiver);
-    let result = crate::closure::js_closure_call0(closure);
-    crate::object::js_implicit_this_set(prev);
-    result
 }
 
 /// `obj[sym] = value` where `sym` is a Symbol. Stores into the side table.
@@ -767,7 +678,7 @@ pub fn scan_symbol_side_table_roots(mark: &mut dyn FnMut(f64)) {
 
 pub fn scan_symbol_side_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     scan_symbol_property_roots_mut(visitor);
-    scan_symbol_accessor_roots_mut(visitor);
+    accessors::scan_symbol_accessor_roots_mut(visitor);
     scan_class_static_symbol_roots_mut(visitor);
     scan_symbol_pointer_metadata_roots_mut(visitor);
 }
@@ -826,40 +737,6 @@ fn scan_class_static_symbol_roots_mut(visitor: &mut crate::gc::RuntimeRootVisito
     for (old_key, new_key) in key_rewrites {
         if let Some(value_bits) = map.remove(&old_key) {
             map.insert(new_key, value_bits);
-        }
-    }
-}
-
-fn scan_symbol_accessor_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    let mut rewrites = Vec::new();
-    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
-    let Some(map) = guard.as_mut() else {
-        return;
-    };
-
-    for (old_owner, old_sym_key) in map.keys().copied().collect::<Vec<_>>() {
-        let Some(acc) = map.get_mut(&(old_owner, old_sym_key)) else {
-            continue;
-        };
-        let mut new_owner = old_owner;
-        let mut new_sym_key = old_sym_key;
-        let owner_changed =
-            visitor.visit_metadata_usize_slot(&mut new_owner) && new_owner != old_owner;
-        let sym_changed = visitor.visit_usize_slot(&mut new_sym_key) && new_sym_key != old_sym_key;
-        if acc.get != 0 {
-            visitor.visit_nanbox_u64_slot(&mut acc.get);
-        }
-        if acc.set != 0 {
-            visitor.visit_nanbox_u64_slot(&mut acc.set);
-        }
-        if owner_changed || sym_changed {
-            rewrites.push(((old_owner, old_sym_key), (new_owner, new_sym_key)));
-        }
-    }
-
-    for (old_key, new_key) in rewrites {
-        if let Some(acc) = map.remove(&old_key) {
-            map.insert(new_key, acc);
         }
     }
 }
@@ -1051,6 +928,7 @@ fn rewrite_symbol_pointer_metadata_if_forwarded(
 pub(crate) fn test_clear_symbol_side_table_roots() {
     *crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES) = None;
     *crate::gc::lock_gc_root_registry(&CLASS_STATIC_SYMBOLS) = None;
+    accessors::test_clear_symbol_accessor_roots();
 
     let mut persistent = Vec::new();
     {
@@ -1167,14 +1045,8 @@ pub unsafe extern "C" fn js_object_has_own_symbol(obj_f64: f64, sym_f64: f64) ->
     if obj_key == 0 || sym_key == 0 {
         return false;
     }
-    {
-        let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
-        if guard
-            .as_ref()
-            .is_some_and(|m| m.contains_key(&(obj_key, sym_key)))
-        {
-            return true;
-        }
+    if accessors::has_own_symbol_accessor(obj_key, sym_key) {
+        return true;
     }
     let guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
     if let Some(map) = guard.as_ref() {
@@ -1406,8 +1278,8 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
-    if let Some(acc) = symbol_accessor_property(obj_f64, sym_f64) {
-        return invoke_symbol_accessor_getter(acc.get, obj_f64);
+    if let Some(acc) = accessors::symbol_accessor_property(obj_f64, sym_f64) {
+        return accessors::invoke_symbol_accessor_getter(acc.get, obj_f64);
     }
     if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
         return v;

--- a/crates/perry-runtime/src/symbol/accessors.rs
+++ b/crates/perry-runtime/src/symbol/accessors.rs
@@ -1,0 +1,139 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use super::{
+    obj_key_from_f64, publish_symbol_side_table_root_edges, sym_key_from_f64, SYMBOL_PROPERTIES,
+    TAG_UNDEFINED,
+};
+
+#[derive(Clone, Copy)]
+pub(super) struct SymbolAccessorDescriptor {
+    pub(super) get: u64,
+    pub(super) set: u64,
+}
+
+static SYMBOL_ACCESSOR_PROPERTIES: Mutex<
+    Option<HashMap<(usize, usize), SymbolAccessorDescriptor>>,
+> = Mutex::new(None);
+
+pub(super) fn clear_symbol_accessor_property(obj_key: usize, sym_key: usize) {
+    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    if let Some(map) = guard.as_mut() {
+        map.remove(&(obj_key, sym_key));
+    }
+}
+
+pub(crate) unsafe fn set_symbol_accessor_property(
+    obj_f64: f64,
+    sym_f64: f64,
+    get_bits: u64,
+    set_bits: u64,
+) {
+    let obj_key = obj_key_from_f64(obj_f64);
+    let sym_key = sym_key_from_f64(sym_f64);
+    if obj_key == 0 || sym_key == 0 {
+        return;
+    }
+    {
+        let mut props = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
+        if let Some(map) = props.as_mut() {
+            if let Some(entries) = map.get_mut(&obj_key) {
+                entries.retain(|(key, _)| *key != sym_key);
+            }
+        }
+    }
+    {
+        let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+        if guard.is_none() {
+            *guard = Some(HashMap::new());
+        }
+        guard.as_mut().unwrap().insert(
+            (obj_key, sym_key),
+            SymbolAccessorDescriptor {
+                get: get_bits,
+                set: set_bits,
+            },
+        );
+    }
+    if get_bits != 0 {
+        publish_symbol_side_table_root_edges(sym_key, get_bits);
+    }
+    if set_bits != 0 {
+        publish_symbol_side_table_root_edges(sym_key, set_bits);
+    }
+}
+
+pub(super) unsafe fn symbol_accessor_property(
+    obj_f64: f64,
+    sym_f64: f64,
+) -> Option<SymbolAccessorDescriptor> {
+    let obj_key = obj_key_from_f64(obj_f64);
+    let sym_key = sym_key_from_f64(sym_f64);
+    if obj_key == 0 || sym_key == 0 {
+        return None;
+    }
+    let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    guard
+        .as_ref()
+        .and_then(|m| m.get(&(obj_key, sym_key)).copied())
+}
+
+pub(super) unsafe fn invoke_symbol_accessor_getter(get_bits: u64, receiver: f64) -> f64 {
+    if get_bits == 0 {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let closure = (get_bits & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let prev = crate::object::js_implicit_this_set(receiver);
+    let result = crate::closure::js_closure_call0(closure);
+    crate::object::js_implicit_this_set(prev);
+    result
+}
+
+pub(super) fn scan_symbol_accessor_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    let mut rewrites = Vec::new();
+    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    let Some(map) = guard.as_mut() else {
+        return;
+    };
+
+    for (old_owner, old_sym_key) in map.keys().copied().collect::<Vec<_>>() {
+        let Some(acc) = map.get_mut(&(old_owner, old_sym_key)) else {
+            continue;
+        };
+        let mut new_owner = old_owner;
+        let mut new_sym_key = old_sym_key;
+        let owner_changed =
+            visitor.visit_metadata_usize_slot(&mut new_owner) && new_owner != old_owner;
+        let sym_changed = visitor.visit_usize_slot(&mut new_sym_key) && new_sym_key != old_sym_key;
+        if acc.get != 0 {
+            visitor.visit_nanbox_u64_slot(&mut acc.get);
+        }
+        if acc.set != 0 {
+            visitor.visit_nanbox_u64_slot(&mut acc.set);
+        }
+        if owner_changed || sym_changed {
+            rewrites.push(((old_owner, old_sym_key), (new_owner, new_sym_key)));
+        }
+    }
+
+    for (old_key, new_key) in rewrites {
+        if let Some(acc) = map.remove(&old_key) {
+            map.insert(new_key, acc);
+        }
+    }
+}
+
+pub(super) fn has_own_symbol_accessor(obj_key: usize, sym_key: usize) -> bool {
+    let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    guard
+        .as_ref()
+        .is_some_and(|m| m.contains_key(&(obj_key, sym_key)))
+}
+
+#[cfg(test)]
+pub(super) fn test_clear_symbol_accessor_roots() {
+    *crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES) = None;
+}

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -55,23 +55,18 @@ unsafe fn throw_add_type_error(message: &[u8]) -> ! {
 }
 
 #[inline]
-fn is_symbol_value(value: f64) -> bool {
-    let jsval = JSValue::from_bits(value.to_bits());
-    if !jsval.is_pointer() {
-        return false;
-    }
-    let ptr = jsval.as_pointer::<u8>() as usize;
-    ptr >= 0x1000 && crate::symbol::is_registered_symbol(ptr)
+unsafe fn is_symbol_value(value: f64) -> bool {
+    crate::symbol::js_is_symbol(value) != 0
 }
 
 #[inline]
-fn is_nonprimitive_object_value(value: f64) -> bool {
+unsafe fn is_nonprimitive_object_value(value: f64) -> bool {
     let jsval = JSValue::from_bits(value.to_bits());
     if !jsval.is_pointer() {
         return false;
     }
     let ptr = jsval.as_pointer::<u8>() as usize;
-    ptr >= 0x1000 && !crate::symbol::is_registered_symbol(ptr)
+    ptr >= 0x1000 && !is_symbol_value(value)
 }
 
 unsafe fn to_primitive_default_for_add(value: f64) -> f64 {

--- a/crates/perry-transform/src/inline/call_inliner.rs
+++ b/crates/perry-transform/src/inline/call_inliner.rs
@@ -874,6 +874,7 @@ pub fn inline_calls_in_expr(
                         ));
                         kill_referenced_exact_receivers(e, exact_receiver_facts);
                     }
+                    perry_hir::ArrayElement::Hole => {}
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Preserve array elisions as holes, keep direct array `hasOwnProperty` calls on the Object.prototype dispatch path, and materialize array spread operands through strict iterator/error handling.
- Add Symbol-keyed accessor support for spread iterator lookups and wire spread append/clone through iterator materialization.
- Route non-trivial addition through dynamic ToPrimitive/string-or-number addition and predeclare sloppy top-level assignment targets so `(y = 1) + y` observes the assigned value.
- Add focused HIR/codegen/runtime regressions for the fixed array and addition clusters.

## Validation

Test262 corpus root: `vendor/test262`, pinned SHA `4249661388e5d3f92a85186213da140a6481490f`.

- `cargo fmt -- --check` — pass
- `cargo check -p perry-hir -p perry-codegen -p perry-runtime` — pass, existing warnings only
- `cargo test -p perry-hir --test c262_parity` — 3 passed
- `cargo test -p perry-codegen --test typed_shape_descriptors c262_` — 3 passed
- `cargo test -p perry-runtime array::tests::test_array_hole_is_not_own_property_but_undefined_value_is` — 1 passed
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib` — pass, existing warnings only
- `scripts/test262_subset.py --root vendor/test262 --dir language/expressions/array --sample-cap 1000000 --report /tmp/perry-c262-array-after-final.json` — pass=32, diff=0, runtime-fail=1, compile-fail=0, skip=0, judged=33, parity=97.0%
- `scripts/test262_subset.py --root vendor/test262 --dir language/expressions/addition --sample-cap 1000000 --report /tmp/perry-c262-addition-after-final.json` — pass=38, diff=0, runtime-fail=2, compile-fail=0, skip=0, judged=40, parity=95.0%
- `scripts/test262_subset.py --root vendor/test262 --dir language/expressions --max 500 --sample-cap 1000000 --report /tmp/perry-c262-language-expressions-500-after-final.json` — pass=400, diff=0, runtime-fail=48, compile-fail=52, skip=0, judged=500, parity=80.0%

Coordinator baseline for the same 500-case command: pass=390, runtime-fail=58, compile-fail=52, diff=0, judged=500.

## Remaining parity gaps

Array bucket after this PR:

- `language/expressions/array/S11.1.4_A2.js` — runtime-fail, `(no output)`; direct one-off run exits with a multidimensional array crash/segfault.

Addition bucket after this PR:

- `language/expressions/addition/S11.6.1_A2.4_T3.js` — runtime-fail, `Uncaught exception: #1.2: x + (x = 1) throw ReferenceError. Actual: [object Object]`
- `language/expressions/addition/order-of-evaluation.js` — runtime-fail, `Uncaught exception: GetValue(lhs) throws. Expected a TypeError to be thrown but no exception was thrown at all`

Bucket closure status: array spread/error cluster is closed, direct array own-property assertions are fixed, but the array bucket is not fully closed due `S11.1.4_A2.js`. The addition bucket is not fully closed due the two residual paths above; `S11.6.1_A2.4_T4.js` moved into pass.
