### PR TITLE
Generator/async-generator intrinsics + prototype chains (#3664)

### DIFF
--- a/crates/perry-codegen-arkts/src/tests.rs
+++ b/crates/perry-codegen-arkts/src/tests.rs
@@ -29,6 +29,7 @@ fn empty_module() -> Module {
         init_kind: perry_hir::ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
+++ b/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
@@ -53,6 +53,7 @@ fn empty_module() -> Module {
         init_kind: perry_hir::ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1265,6 +1265,28 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             }
         }
     }
+    // #3664: async-generator wrapper symbols, identified by the func_ids the
+    // generator transform recorded (it cleared `is_async` before we get here,
+    // so the body shape alone can't tell async generators from sync ones).
+    // Named declarations use the `__perry_wrap_<name>` singleton symbol;
+    // generator EXPRESSIONS use the inline `perry_closure_<modprefix>__<id>`
+    // symbol — the same two symbol forms as `user_fn_wrapper_generator`.
+    let mut user_fn_wrapper_async_generator: std::collections::HashSet<String> = hir
+        .functions
+        .iter()
+        .filter(|f| hir.async_generator_funcs.contains(&f.id))
+        .filter_map(|f| {
+            func_names
+                .get(&f.id)
+                .map(|name| format!("__perry_wrap_{}", name))
+        })
+        .collect();
+    for (func_id, _expr) in closures {
+        if hir.async_generator_funcs.contains(func_id) {
+            user_fn_wrapper_async_generator
+                .insert(format!("perry_closure_{}__{}", module_prefix, func_id));
+        }
+    }
 
     // Display names so `console.log` / `util.inspect` print `[Function:
     // <name>]` instead of `[Function (anonymous)]` (#1202). Two kinds:
@@ -1372,6 +1394,7 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
         &user_fn_wrapper_length,
         &user_fn_wrapper_async,
         &user_fn_wrapper_generator,
+        &user_fn_wrapper_async_generator,
         &user_fn_display_names,
     );
 

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -64,6 +64,11 @@ pub(super) fn emit_string_pool(
     // function. Registered so util.types.isGeneratorFunction can distinguish
     // lowered generator state-machine closures from ordinary functions.
     user_fn_wrapper_generator: &std::collections::HashSet<String>,
+    // #3664: wrapper/closure symbols whose source form was `async function*`.
+    // Registered in the runtime's async-generator registry so the
+    // `%AsyncGeneratorFunction%`/`%AsyncGenerator%` intrinsic chain (and
+    // `util.types.isAsyncFunction`) resolve correctly for them.
+    user_fn_wrapper_async_generator: &std::collections::HashSet<String>,
     // `(wrapper_symbol, display_name)` for every top-level user function
     // we want `console.log` / `util.inspect` to label with the original
     // JS name. Each entry produces one `js_register_function_name` call
@@ -811,6 +816,21 @@ pub(super) fn emit_string_pool(
         let func_ref = format!("@{}", wrap_sym);
         blk.call_void(
             "js_register_closure_generator_function",
+            &[(PTR, &func_ref)],
+        );
+    }
+
+    // #3664: async-generator wrappers. These are ALSO in
+    // `user_fn_wrapper_generator` above (they share the sync generator
+    // lowering); this extra registration is what lets the runtime tell an
+    // `async function*` apart from a `function*`.
+    let mut sorted_async_generator_wrappers: Vec<String> =
+        user_fn_wrapper_async_generator.iter().cloned().collect();
+    sorted_async_generator_wrappers.sort();
+    for wrap_sym in sorted_async_generator_wrappers {
+        let func_ref = format!("@{}", wrap_sym);
+        blk.call_void(
+            "js_register_closure_async_generator_function",
             &[(PTR, &func_ref)],
         );
     }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -167,6 +167,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_register_closure_length", VOID, &[PTR, I32]);
     module.declare_function("js_register_closure_async_function", VOID, &[PTR]);
     module.declare_function("js_register_closure_generator_function", VOID, &[PTR]);
+    module.declare_function(
+        "js_register_closure_async_generator_function",
+        VOID,
+        &[PTR],
+    );
     module.declare_function("js_closure_call0", DOUBLE, &[I64]);
     module.declare_function("js_closure_call1", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_closure_call2", DOUBLE, &[I64, DOUBLE, DOUBLE]);

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -167,11 +167,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_register_closure_length", VOID, &[PTR, I32]);
     module.declare_function("js_register_closure_async_function", VOID, &[PTR]);
     module.declare_function("js_register_closure_generator_function", VOID, &[PTR]);
-    module.declare_function(
-        "js_register_closure_async_generator_function",
-        VOID,
-        &[PTR],
-    );
+    module.declare_function("js_register_closure_async_generator_function", VOID, &[PTR]);
     module.declare_function("js_closure_call0", DOUBLE, &[I64]);
     module.declare_function("js_closure_call1", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_closure_call2", DOUBLE, &[I64, DOUBLE, DOUBLE]);

--- a/crates/perry-codegen/tests/large_object_barriers.rs
+++ b/crates/perry-codegen/tests/large_object_barriers.rs
@@ -127,6 +127,7 @@ fn module_with_large_pointer_array_literal(element_count: usize) -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 
@@ -190,6 +191,7 @@ fn module_with_large_local_array_push(element_count: usize) -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/native_proof_buffer_views.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views.rs
@@ -105,6 +105,7 @@ fn module_with_classes_and_params(
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -105,6 +105,7 @@ fn module_with_classes_and_params(
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/shadow_slot_hygiene.rs
+++ b/crates/perry-codegen/tests/shadow_slot_hygiene.rs
@@ -120,6 +120,7 @@ fn shadow_hygiene_module() -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 
@@ -171,6 +172,7 @@ fn top_level_shadow_module(name: &str) -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 
@@ -251,6 +253,7 @@ fn flat_const_row_alias_shadow_module() -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 
@@ -304,6 +307,7 @@ fn reassigned_any_shadow_module() -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 
@@ -372,6 +376,7 @@ fn mixed_any_alias_shadow_module() -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 
@@ -446,6 +451,7 @@ fn closure_captured_write_shadow_module() -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -145,6 +145,7 @@ fn module_with_classes(
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_shape_descriptor.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptor.rs
@@ -129,6 +129,7 @@ fn module_with_new(class: Class) -> Module {
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -143,6 +143,7 @@ fn base_module(name: &str, body: Vec<Stmt>, interfaces: Vec<Interface>) -> Modul
         init_kind: ModuleInitKind::Eager,
         async_step_closures: std::collections::HashSet::new(),
         closure_display_names: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
     }
 }
 

--- a/crates/perry-hir/src/ir/module.rs
+++ b/crates/perry-hir/src/ir/module.rs
@@ -83,6 +83,14 @@ pub struct Module {
     /// Keyed by the closure/function's HIR FuncId; consumed by codegen
     /// when emitting `js_register_function_name` calls.
     pub closure_display_names: std::collections::HashMap<perry_types::FuncId, String>,
+    /// #3664: func_ids of `async function*` declarations and `async function*(){}`
+    /// expressions. The generator transform clears `is_async`/`is_generator`
+    /// before codegen, erasing the async-vs-sync distinction (both lower to a
+    /// `{next,return,throw}` wrapper). This set preserves it so codegen can
+    /// register async-generator closures in the runtime's dedicated async-
+    /// generator registry, which drives `%AsyncGeneratorFunction%` / `%Async
+    /// Generator%` intrinsic resolution. Populated by `transform_generators`.
+    pub async_generator_funcs: std::collections::HashSet<perry_types::FuncId>,
 }
 
 impl Module {
@@ -111,6 +119,7 @@ impl Module {
             init_kind: ModuleInitKind::Eager,
             async_step_closures: std::collections::HashSet::new(),
             closure_display_names: std::collections::HashMap::new(),
+            async_generator_funcs: std::collections::HashSet::new(),
         }
     }
 }

--- a/crates/perry-hir/src/stable_hash/module.rs
+++ b/crates/perry-hir/src/stable_hash/module.rs
@@ -33,6 +33,7 @@ impl SH for Module {
             init_kind,
             async_step_closures,
             closure_display_names,
+            async_generator_funcs,
         } = self;
         name.hash(h);
         imports.hash(h);
@@ -59,6 +60,11 @@ impl SH for Module {
         let mut ids: Vec<u32> = async_step_closures.iter().copied().collect();
         ids.sort_unstable();
         ids.hash(h);
+        // #3664: async-generator func_ids participate in codegen (drive the
+        // async-generator registry calls), so they're part of the stable hash.
+        let mut async_gen_ids: Vec<u32> = async_generator_funcs.iter().copied().collect();
+        async_gen_ids.sort_unstable();
+        async_gen_ids.hash(h);
         // HashMap has nondeterministic iteration order; sort by key.
         let mut display_pairs: Vec<(u32, &String)> =
             closure_display_names.iter().map(|(k, v)| (*k, v)).collect();

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -29,11 +29,11 @@ pub use registry::{
     is_registered_async_function, is_registered_async_generator_function,
     is_registered_generator_function, js_register_closure_arity,
     js_register_closure_async_function, js_register_closure_async_generator_function,
-    js_register_closure_generator_function,
-    js_register_closure_length, js_register_closure_rest, js_register_closure_synthetic_arguments,
-    lookup_closure_arity, lookup_closure_length, lookup_closure_rest, lookup_closure_rest_full,
-    real_capture_count, resolve_strategy, DispatchStrategy, BOUND_FUNCTION_FUNC_PTR,
-    BOUND_METHOD_FUNC_PTR, CAPTURES_THIS_FLAG, CLOSURE_MAGIC,
+    js_register_closure_generator_function, js_register_closure_length, js_register_closure_rest,
+    js_register_closure_synthetic_arguments, lookup_closure_arity, lookup_closure_length,
+    lookup_closure_rest, lookup_closure_rest_full, real_capture_count, resolve_strategy,
+    DispatchStrategy, BOUND_FUNCTION_FUNC_PTR, BOUND_METHOD_FUNC_PTR, CAPTURES_THIS_FLAG,
+    CLOSURE_MAGIC,
 };
 
 pub use dispatch::{

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -26,8 +26,10 @@ pub use alloc::{
 
 pub use registry::{
     build_rest_array, closure_arity, closure_length, dispatch_rest_bundled, dispatch_with_arity,
-    is_registered_async_function, is_registered_generator_function, js_register_closure_arity,
-    js_register_closure_async_function, js_register_closure_generator_function,
+    is_registered_async_function, is_registered_async_generator_function,
+    is_registered_generator_function, js_register_closure_arity,
+    js_register_closure_async_function, js_register_closure_async_generator_function,
+    js_register_closure_generator_function,
     js_register_closure_length, js_register_closure_rest, js_register_closure_synthetic_arguments,
     lookup_closure_arity, lookup_closure_length, lookup_closure_rest, lookup_closure_rest_full,
     real_capture_count, resolve_strategy, DispatchStrategy, BOUND_FUNCTION_FUNC_PTR,

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -70,6 +70,16 @@ thread_local! {
     static CLOSURE_GENERATOR_FUNCTION_REGISTRY: RefCell<crate::fast_hash::PtrHashMap<usize, bool>> =
         RefCell::new(crate::fast_hash::new_ptr_hash_map());
 
+    /// #3664: side-table marking closure body `func_ptr`s that came from an
+    /// `async function*`. Async generators also live in
+    /// `CLOSURE_GENERATOR_FUNCTION_REGISTRY` (they lower to the same
+    /// `{next,return,throw}` wrapper as sync generators), so this registry is
+    /// what distinguishes the two — it drives `%AsyncGeneratorFunction%` vs
+    /// `%GeneratorFunction%` intrinsic resolution.
+    static CLOSURE_ASYNC_GENERATOR_FUNCTION_REGISTRY:
+        RefCell<crate::fast_hash::PtrHashMap<usize, ()>> =
+        RefCell::new(crate::fast_hash::new_ptr_hash_map());
+
     /// Unified dispatch lookup, populated lazily on first call to a func_ptr.
     /// Cuts the per-call cost from TWO RefCell::borrow + HashMap::get
     /// (one each for rest and arity) down to ONE — material on hot paths
@@ -288,6 +298,31 @@ pub fn is_registered_generator_function(func_ptr: *const u8) -> bool {
     CLOSURE_GENERATOR_FUNCTION_REGISTRY
         .with(|r| r.borrow().get(&(func_ptr as usize)).copied())
         .unwrap_or(false)
+}
+
+/// #3664: register a closure body `func_ptr` as an `async function*`. Also
+/// marks it in the async-function registry so `util.types.isAsyncFunction`
+/// reports `true` for async generators (matching Node).
+#[no_mangle]
+pub extern "C" fn js_register_closure_async_generator_function(func_ptr: *const u8) {
+    if func_ptr.is_null() {
+        return;
+    }
+    CLOSURE_ASYNC_GENERATOR_FUNCTION_REGISTRY.with(|r| {
+        r.borrow_mut().insert(func_ptr as usize, ());
+    });
+    CLOSURE_ASYNC_FUNCTION_REGISTRY.with(|r| {
+        r.borrow_mut().insert(func_ptr as usize, ());
+    });
+}
+
+#[inline(always)]
+pub fn is_registered_async_generator_function(func_ptr: *const u8) -> bool {
+    if func_ptr.is_null() {
+        return false;
+    }
+    CLOSURE_ASYNC_GENERATOR_FUNCTION_REGISTRY
+        .with(|r| r.borrow().contains_key(&(func_ptr as usize)))
 }
 
 /// Public helper: given a `*const ClosureHeader` pointer, return the

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2257,6 +2257,18 @@ pub extern "C" fn js_object_get_field_by_name(
                     if val.to_bits() != crate::value::TAG_UNDEFINED {
                         return JSValue::from_bits(val.to_bits());
                     }
+                    // #3664: `g.constructor` for a generator/async-generator
+                    // function resolves through its [[Prototype]] (`%Generator%`)
+                    // to `%GeneratorFunction%` / `%AsyncGeneratorFunction%`.
+                    // Other functions have no `constructor` own-prop in Perry's
+                    // model (they fall through to `undefined`, as before).
+                    if name_str == "constructor" {
+                        if let Some(ctor) =
+                            crate::object::generator_function_constructor_of(obj as usize)
+                        {
+                            return JSValue::from_bits(ctor.to_bits());
+                        }
+                    }
                     // #2059: `fn.name` — every function carries a built-in own
                     // `name` data property. Resolve the codegen-registered name
                     // (keyed by the wrapper func_ptr, the same registry the

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2269,6 +2269,18 @@ pub extern "C" fn js_object_get_field_by_name(
                             return JSValue::from_bits(ctor.to_bits());
                         }
                     }
+                    // #3664: `g.prototype` for a generator/async-generator
+                    // function is a lazily-created object whose [[Prototype]] is
+                    // `%Generator.prototype%`. Non-generator functions fall
+                    // through (unchanged). The dynamic-prop check above already
+                    // returned any cached/user-assigned `prototype`.
+                    if name_str == "prototype" {
+                        if let Some(proto) =
+                            crate::object::generator_function_prototype_of(obj as usize)
+                        {
+                            return JSValue::from_bits(proto.to_bits());
+                        }
+                    }
                     // #2059: `fn.name` — every function carries a built-in own
                     // `name` data property. Resolve the codegen-registered name
                     // (keyed by the wrapper func_ptr, the same registry the

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1206,6 +1206,221 @@ pub(crate) fn typed_array_intrinsic_proto_ptr() -> *mut ObjectHeader {
     crate::object::TYPED_ARRAY_INTRINSIC_PROTO_PTR.load(Ordering::Acquire) as *mut ObjectHeader
 }
 
+// ---------------------------------------------------------------------------
+// #3664: generator / async-generator intrinsic prototype towers.
+// ---------------------------------------------------------------------------
+
+/// Distinguishes plain vs async generator closures for the intrinsic-tower
+/// lookups.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GeneratorKind {
+    Sync,
+    Async,
+}
+
+/// Classify a `GC_TYPE_CLOSURE` pointer as a (plain | async) generator
+/// function, or `None` for any other closure. Async generators register in
+/// BOTH the generator and async registries (the lowering carries `is_async &&
+/// is_generator`), so async-registry membership disambiguates the two.
+fn closure_generator_kind(closure_ptr: usize) -> Option<GeneratorKind> {
+    let closure = closure_ptr as *const crate::closure::ClosureHeader;
+    let func_ptr = crate::closure::get_valid_func_ptr(closure);
+    if func_ptr.is_null() || !crate::closure::is_registered_generator_function(func_ptr) {
+        return None;
+    }
+    if crate::closure::is_registered_async_function(func_ptr) {
+        Some(GeneratorKind::Async)
+    } else {
+        Some(GeneratorKind::Sync)
+    }
+}
+
+fn intrinsic_pointer_value(slot: i64) -> Option<f64> {
+    if slot != 0 {
+        Some(crate::value::js_nanbox_pointer(slot))
+    } else {
+        None
+    }
+}
+
+/// `Object.getPrototypeOf(g)` for a generator-function closure `g` →
+/// `%Generator%` / `%AsyncGenerator%` (a.k.a. `<Ctor>.prototype`). Returns
+/// `None` for non-generator closures so the caller keeps its existing
+/// `closure_static_prototype` / null resolution. (#3664)
+pub(crate) fn generator_function_proto_of(closure_ptr: usize) -> Option<f64> {
+    let slot = match closure_generator_kind(closure_ptr)? {
+        GeneratorKind::Sync => crate::object::GENERATOR_INTRINSIC_PROTO_PTR.load(Ordering::Acquire),
+        GeneratorKind::Async => {
+            crate::object::ASYNC_GENERATOR_INTRINSIC_PROTO_PTR.load(Ordering::Acquire)
+        }
+    };
+    intrinsic_pointer_value(slot)
+}
+
+/// `g.constructor` for a generator-function closure `g` → `%GeneratorFunction%`
+/// / `%AsyncGeneratorFunction%`. `None` for non-generator closures. (#3664)
+pub(crate) fn generator_function_constructor_of(closure_ptr: usize) -> Option<f64> {
+    let slot = match closure_generator_kind(closure_ptr)? {
+        GeneratorKind::Sync => {
+            crate::object::GENERATOR_FUNCTION_INTRINSIC_PTR.load(Ordering::Acquire)
+        }
+        GeneratorKind::Async => {
+            crate::object::ASYNC_GENERATOR_FUNCTION_INTRINSIC_PTR.load(Ordering::Acquire)
+        }
+    };
+    intrinsic_pointer_value(slot)
+}
+
+/// `%Generator.prototype%` / `%AsyncGenerator.prototype%` pointer (the object
+/// carrying `next`/`return`/`throw`). Used by Phase 2/3 to wire `g.prototype`'s
+/// `[[Prototype]]` and the live generator-object chain. Null until
+/// `populate_global_this_builtins` has run. (#3664)
+pub(crate) fn generator_prototype_ptr(is_async: bool) -> *mut ObjectHeader {
+    let slot = if is_async {
+        crate::object::ASYNC_GENERATOR_PROTOTYPE_PTR.load(Ordering::Acquire)
+    } else {
+        crate::object::GENERATOR_PROTOTYPE_PTR.load(Ordering::Acquire)
+    };
+    slot as *mut ObjectHeader
+}
+
+/// Set a data property on an intrinsic object and record its descriptor attrs
+/// for `Object.getOwnPropertyDescriptor` reflection. (#3664)
+fn set_intrinsic_data_prop(
+    obj: *mut ObjectHeader,
+    name: &str,
+    value: f64,
+    attrs: super::PropertyAttrs,
+) {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(obj, key, value);
+    super::set_builtin_property_attrs(obj as usize, name.to_string(), attrs);
+}
+
+/// Set `obj[Symbol.toStringTag] = tag` (the descriptor is the spec default
+/// `{ writable:false, enumerable:false, configurable:true }`). (#3664)
+fn set_intrinsic_to_string_tag(obj: *mut ObjectHeader, tag: &str) {
+    let sym = crate::symbol::well_known_symbol("toStringTag");
+    if sym.is_null() {
+        return;
+    }
+    let tag_str = crate::string::js_string_from_bytes(tag.as_ptr(), tag.len() as u32);
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            crate::value::js_nanbox_pointer(obj as i64),
+            f64::from_bits(crate::value::JSValue::pointer(sym as *const u8).bits()),
+            f64::from_bits(crate::js_nanbox_string(tag_str as i64).to_bits()),
+        );
+    }
+}
+
+/// Build one generator-intrinsic tower (sync or async) and store its three
+/// objects in the GC-rooted atomics declared in `object/mod.rs`.
+///
+/// Spec chain (sync names; async mirrors with the `Async` prefix):
+/// ```text
+/// %GeneratorFunction%             ctor closure, name "GeneratorFunction", length 1
+///   .prototype = %Generator%      (non-writable, non-enumerable, non-configurable)
+/// %Generator%  (= %GeneratorFunction.prototype%)
+///   .constructor = %GeneratorFunction%      (non-writable, non-enum, configurable)
+///   .prototype   = %Generator.prototype%    (non-writable, non-enum, configurable)
+///   [Symbol.toStringTag] = "GeneratorFunction"
+/// %Generator.prototype%  (= %GeneratorFunction.prototype.prototype%)
+///   .constructor = %Generator%              (non-writable, non-enum, configurable)
+///   .next / .return / .throw                (Phase 1: noop-backed for descriptor tests)
+///   [Symbol.toStringTag] = "Generator"
+/// ```
+fn build_generator_tower(
+    is_async: bool,
+    ctor_slot: &std::sync::atomic::AtomicI64,
+    proto_slot: &std::sync::atomic::AtomicI64,
+    gen_proto_slot: &std::sync::atomic::AtomicI64,
+) {
+    let (ctor_name, ctor_tag, inst_tag) = if is_async {
+        (
+            "AsyncGeneratorFunction",
+            "AsyncGeneratorFunction",
+            "AsyncGenerator",
+        )
+    } else {
+        ("GeneratorFunction", "GeneratorFunction", "Generator")
+    };
+    let noop = global_this_builtin_noop_thunk as *const u8;
+    let ctor = crate::closure::js_closure_alloc(noop, 0);
+    let proto = js_object_alloc(0, 0); // %Generator% / %AsyncGenerator%
+    let gen_proto = js_object_alloc(0, 0); // %Generator.prototype%
+    if ctor.is_null() || proto.is_null() || gen_proto.is_null() {
+        return;
+    }
+    let non_writable = super::PropertyAttrs::new(false, false, false);
+    let configurable = super::PropertyAttrs::new(false, false, true);
+
+    // --- %GeneratorFunction% constructor ---
+    crate::closure::js_register_closure_arity(noop, 1);
+    super::native_module::set_bound_native_closure_name(ctor, ctor_name);
+    super::native_module::set_builtin_closure_length(ctor as usize, 1);
+    super::set_builtin_property_attrs(ctor as usize, "name".to_string(), configurable);
+    super::set_builtin_property_attrs(ctor as usize, "length".to_string(), configurable);
+    set_intrinsic_data_prop(
+        ctor as *mut ObjectHeader,
+        "prototype",
+        crate::value::js_nanbox_pointer(proto as i64),
+        non_writable,
+    );
+
+    // --- %Generator% (= %GeneratorFunction.prototype%) ---
+    set_intrinsic_data_prop(
+        proto,
+        "constructor",
+        crate::value::js_nanbox_pointer(ctor as i64),
+        configurable,
+    );
+    set_intrinsic_data_prop(
+        proto,
+        "prototype",
+        crate::value::js_nanbox_pointer(gen_proto as i64),
+        configurable,
+    );
+    set_intrinsic_to_string_tag(proto, ctor_tag);
+
+    // --- %Generator.prototype% ---
+    set_intrinsic_data_prop(
+        gen_proto,
+        "constructor",
+        crate::value::js_nanbox_pointer(proto as i64),
+        configurable,
+    );
+    install_proto_method(gen_proto, "next", noop, 1);
+    install_proto_method(gen_proto, "return", noop, 1);
+    install_proto_method(gen_proto, "throw", noop, 1);
+    set_intrinsic_to_string_tag(gen_proto, inst_tag);
+
+    ctor_slot.store(ctor as i64, Ordering::Release);
+    proto_slot.store(proto as i64, Ordering::Release);
+    gen_proto_slot.store(gen_proto as i64, Ordering::Release);
+}
+
+/// Build both generator intrinsic towers. Idempotent; called once from
+/// `populate_global_this_builtins` under the globalThis singleton CAS. (#3664)
+fn ensure_generator_intrinsics() {
+    if crate::object::GENERATOR_FUNCTION_INTRINSIC_PTR.load(Ordering::Acquire) == 0 {
+        build_generator_tower(
+            false,
+            &crate::object::GENERATOR_FUNCTION_INTRINSIC_PTR,
+            &crate::object::GENERATOR_INTRINSIC_PROTO_PTR,
+            &crate::object::GENERATOR_PROTOTYPE_PTR,
+        );
+    }
+    if crate::object::ASYNC_GENERATOR_FUNCTION_INTRINSIC_PTR.load(Ordering::Acquire) == 0 {
+        build_generator_tower(
+            true,
+            &crate::object::ASYNC_GENERATOR_FUNCTION_INTRINSIC_PTR,
+            &crate::object::ASYNC_GENERATOR_INTRINSIC_PROTO_PTR,
+            &crate::object::ASYNC_GENERATOR_PROTOTYPE_PTR,
+        );
+    }
+}
+
 /// Populate the freshly-allocated globalThis singleton with built-in
 /// constructor / namespace properties. Called exactly once from the CAS
 /// winner in `js_get_global_this`. Constructors get a ClosureHeader-
@@ -1234,6 +1449,10 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     // built below, and the per-kind `.prototype` objects can be flagged with
     // `OBJ_FLAG_TYPED_ARRAY_PROTO` for `Object.getPrototypeOf` resolution.
     let (typed_array_intrinsic_ctor, _) = ensure_typed_array_intrinsic();
+    // #3664: build the generator / async-generator intrinsic prototype towers
+    // so `Object.getPrototypeOf(function*(){})`, `g.constructor`, and the
+    // `%Generator(.prototype)%` chains resolve to real objects.
+    ensure_generator_intrinsics();
     // Constructors: ClosureHeader-backed so typeof is "function".
     for name in GLOBAL_THIS_BUILTIN_CONSTRUCTORS.iter().copied() {
         if name == "Buffer" {

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1283,6 +1283,36 @@ pub(crate) fn generator_function_constructor_of(closure_ptr: usize) -> Option<f6
     intrinsic_pointer_value(slot)
 }
 
+/// `g.prototype` for a generator-function closure `g`: a lazily-created object
+/// whose `[[Prototype]]` is `%Generator.prototype%` / `%AsyncGenerator.prototype%`,
+/// cached as the closure's own `prototype` dynamic-prop so the identity is
+/// stable across reads (`g.prototype === g.prototype`). Returns `None` for
+/// non-generator closures (their `.prototype` keeps its existing behaviour).
+/// A live generator instance's `[[Prototype]]` is set to this object (Phase 3b),
+/// completing the spec chain `g() → g.prototype → %Generator.prototype%`. (#3664)
+pub(crate) fn generator_function_prototype_of(closure_ptr: usize) -> Option<f64> {
+    let kind = closure_generator_kind(closure_ptr)?;
+    // A previously-created (or user-assigned) `prototype` wins — preserves
+    // identity and lets `g.prototype = X` overrides stick.
+    let existing = crate::closure::closure_get_dynamic_prop(closure_ptr, "prototype");
+    if existing.to_bits() != crate::value::TAG_UNDEFINED {
+        return Some(f64::from_bits(existing.to_bits()));
+    }
+    ensure_generator_intrinsics();
+    let gen_proto = generator_prototype_ptr(matches!(kind, GeneratorKind::Async));
+    let obj = js_object_alloc(0, 0);
+    if obj.is_null() {
+        return None;
+    }
+    if !gen_proto.is_null() {
+        let proto_bits = crate::value::js_nanbox_pointer(gen_proto as i64).to_bits();
+        super::prototype_chain::object_set_static_prototype(obj as usize, proto_bits);
+    }
+    let obj_value = crate::value::js_nanbox_pointer(obj as i64);
+    crate::closure::closure_set_dynamic_prop(closure_ptr, "prototype", obj_value);
+    Some(obj_value)
+}
+
 /// `%Generator.prototype%` / `%AsyncGenerator.prototype%` pointer (the object
 /// carrying `next`/`return`/`throw`). Used by Phase 2/3 to wire `g.prototype`'s
 /// `[[Prototype]]` and the live generator-object chain. Null until
@@ -1325,6 +1355,91 @@ fn set_intrinsic_to_string_tag(obj: *mut ObjectHeader, tag: &str) {
             f64::from_bits(crate::js_nanbox_string(tag_str as i64).to_bits()),
         );
     }
+}
+
+/// Build a `TypeError` value for a `%Generator.prototype%` method invoked on a
+/// receiver that isn't a generator object (NaN-boxed pointer, not thrown). (#3664)
+fn generator_receiver_type_error_value(method: &[u8]) -> f64 {
+    let mut msg = b"Generator.prototype.".to_vec();
+    msg.extend_from_slice(method);
+    msg.extend_from_slice(b" called on incompatible receiver");
+    let h = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(h);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+/// Shared body for `%Generator.prototype%`/`%AsyncGenerator.prototype%`'s
+/// `next`/`return`/`throw`. These prototype methods exist so test262's
+/// brand-check cases (`GeneratorPrototype.next.call(nonGenerator)`) and method-
+/// identity reads resolve. The real state machine lives in each generator
+/// instance's OWN `next`/`return`/`throw` closures (Perry lowers a generator
+/// call to a `{next,return,throw}` object), so for a valid receiver we delegate
+/// to the instance's own same-named method. Normal `iter.next()` reads the own
+/// property directly and never reaches here, so generator execution is
+/// unaffected.
+///
+/// `is_async` selects the spec's incompatible-receiver behaviour: sync
+/// generators throw a `TypeError` synchronously, async generators return a
+/// rejected promise (their methods always return promises). (#3664)
+fn generator_proto_method(method: &[u8], arg: f64, is_async: bool) -> f64 {
+    let bad_receiver = |method: &[u8]| -> f64 {
+        let errv = generator_receiver_type_error_value(method);
+        if is_async {
+            let promise = crate::promise::js_promise_rejected(errv);
+            crate::value::js_nanbox_pointer(promise as i64)
+        } else {
+            crate::exception::js_throw(errv)
+        }
+    };
+    let this = crate::object::js_implicit_this_get();
+    if crate::object::js_util_types_is_generator_object(this).to_bits() != crate::value::TAG_TRUE {
+        return bad_receiver(method);
+    }
+    let this_obj = JSValue::from_bits(this.to_bits()).as_pointer::<ObjectHeader>();
+    let key = crate::string::js_string_from_bytes(method.as_ptr(), method.len() as u32);
+    let own = js_object_get_field_by_name(this_obj, key);
+    if !own.is_pointer() {
+        return bad_receiver(method);
+    }
+    let own_closure = own.as_pointer::<crate::closure::ClosureHeader>();
+    crate::closure::js_closure_call1(own_closure, arg)
+}
+
+extern "C" fn generator_proto_next_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    generator_proto_method(b"next", arg, false)
+}
+extern "C" fn generator_proto_return_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    generator_proto_method(b"return", arg, false)
+}
+extern "C" fn generator_proto_throw_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    generator_proto_method(b"throw", arg, false)
+}
+extern "C" fn async_generator_proto_next_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    generator_proto_method(b"next", arg, true)
+}
+extern "C" fn async_generator_proto_return_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    generator_proto_method(b"return", arg, true)
+}
+extern "C" fn async_generator_proto_throw_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    generator_proto_method(b"throw", arg, true)
 }
 
 /// Build one generator-intrinsic tower (sync or async) and store its three
@@ -1403,9 +1518,22 @@ fn build_generator_tower(
         crate::value::js_nanbox_pointer(proto as i64),
         configurable,
     );
-    install_proto_method(gen_proto, "next", noop, 1);
-    install_proto_method(gen_proto, "return", noop, 1);
-    install_proto_method(gen_proto, "throw", noop, 1);
+    let (next_thunk, return_thunk, throw_thunk) = if is_async {
+        (
+            async_generator_proto_next_thunk as *const u8,
+            async_generator_proto_return_thunk as *const u8,
+            async_generator_proto_throw_thunk as *const u8,
+        )
+    } else {
+        (
+            generator_proto_next_thunk as *const u8,
+            generator_proto_return_thunk as *const u8,
+            generator_proto_throw_thunk as *const u8,
+        )
+    };
+    install_proto_method(gen_proto, "next", next_thunk, 1);
+    install_proto_method(gen_proto, "return", return_thunk, 1);
+    install_proto_method(gen_proto, "throw", throw_thunk, 1);
     set_intrinsic_to_string_tag(gen_proto, inst_tag);
 
     ctor_slot.store(ctor as i64, Ordering::Release);

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1392,17 +1392,41 @@ fn generator_proto_method(method: &[u8], arg: f64, is_async: bool) -> f64 {
         }
     };
     let this = crate::object::js_implicit_this_get();
-    if crate::object::js_util_types_is_generator_object(this).to_bits() != crate::value::TAG_TRUE {
+    let jv = JSValue::from_bits(this.to_bits());
+    if !jv.is_pointer() {
         return bad_receiver(method);
     }
-    let this_obj = JSValue::from_bits(this.to_bits()).as_pointer::<ObjectHeader>();
-    let key = crate::string::js_string_from_bytes(method.as_ptr(), method.len() as u32);
-    let own = js_object_get_field_by_name(this_obj, key);
-    if !own.is_pointer() {
+    let this_obj = jv.as_pointer::<ObjectHeader>();
+    // Reject the prototype singletons themselves: they carry these methods as
+    // OWN thunks, so delegating below would re-enter this thunk forever. A real
+    // generator instance is never the prototype object.
+    if this_obj == generator_prototype_ptr(false) || this_obj == generator_prototype_ptr(true) {
         return bad_receiver(method);
     }
-    let own_closure = own.as_pointer::<crate::closure::ClosureHeader>();
-    crate::closure::js_closure_call1(own_closure, arg)
+    // Brand-check + delegation use OWN properties only. A generator instance
+    // (Perry's `{next,return,throw}` object) owns all three state-machine
+    // closures; an object that merely INHERITS them (e.g. `g.prototype`, whose
+    // [[Prototype]] is `%Generator.prototype%`) is not a generator — and reading
+    // the inherited method would resolve back to this very thunk and recurse.
+    let own_method = |name: &[u8]| -> Option<*const crate::closure::ClosureHeader> {
+        let v = crate::object::js_object_get_own_field_or_undef(this, name.as_ptr(), name.len());
+        let vv = JSValue::from_bits(v.to_bits());
+        if vv.is_pointer() && crate::closure::is_closure_ptr(vv.as_pointer::<u8>() as usize) {
+            Some(vv.as_pointer::<crate::closure::ClosureHeader>())
+        } else {
+            None
+        }
+    };
+    if own_method(b"next").is_none()
+        || own_method(b"return").is_none()
+        || own_method(b"throw").is_none()
+    {
+        return bad_receiver(method);
+    }
+    match own_method(method) {
+        Some(own_closure) => crate::closure::js_closure_call1(own_closure, arg),
+        None => bad_receiver(method),
+    }
 }
 
 extern "C" fn generator_proto_next_thunk(

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1225,13 +1225,18 @@ enum GeneratorKind {
 fn closure_generator_kind(closure_ptr: usize) -> Option<GeneratorKind> {
     let closure = closure_ptr as *const crate::closure::ClosureHeader;
     let func_ptr = crate::closure::get_valid_func_ptr(closure);
-    if func_ptr.is_null() || !crate::closure::is_registered_generator_function(func_ptr) {
+    if func_ptr.is_null() {
         return None;
     }
-    if crate::closure::is_registered_async_function(func_ptr) {
+    // Async generators are registered in BOTH registries (they share the sync
+    // generator's `{next,return,throw}` lowering), so check the async-generator
+    // registry first — it's the only signal that disambiguates the two.
+    if crate::closure::is_registered_async_generator_function(func_ptr) {
         Some(GeneratorKind::Async)
-    } else {
+    } else if crate::closure::is_registered_generator_function(func_ptr) {
         Some(GeneratorKind::Sync)
+    } else {
+        None
     }
 }
 
@@ -1248,7 +1253,12 @@ fn intrinsic_pointer_value(slot: i64) -> Option<f64> {
 /// `None` for non-generator closures so the caller keeps its existing
 /// `closure_static_prototype` / null resolution. (#3664)
 pub(crate) fn generator_function_proto_of(closure_ptr: usize) -> Option<f64> {
-    let slot = match closure_generator_kind(closure_ptr)? {
+    let kind = closure_generator_kind(closure_ptr)?;
+    // The towers are normally built in `populate_global_this_builtins`, but a
+    // program that reflects on a generator without ever touching `globalThis`
+    // would otherwise see null. Build lazily (idempotent) on first use.
+    ensure_generator_intrinsics();
+    let slot = match kind {
         GeneratorKind::Sync => crate::object::GENERATOR_INTRINSIC_PROTO_PTR.load(Ordering::Acquire),
         GeneratorKind::Async => {
             crate::object::ASYNC_GENERATOR_INTRINSIC_PROTO_PTR.load(Ordering::Acquire)
@@ -1260,7 +1270,9 @@ pub(crate) fn generator_function_proto_of(closure_ptr: usize) -> Option<f64> {
 /// `g.constructor` for a generator-function closure `g` → `%GeneratorFunction%`
 /// / `%AsyncGeneratorFunction%`. `None` for non-generator closures. (#3664)
 pub(crate) fn generator_function_constructor_of(closure_ptr: usize) -> Option<f64> {
-    let slot = match closure_generator_kind(closure_ptr)? {
+    let kind = closure_generator_kind(closure_ptr)?;
+    ensure_generator_intrinsics();
+    let slot = match kind {
         GeneratorKind::Sync => {
             crate::object::GENERATOR_FUNCTION_INTRINSIC_PTR.load(Ordering::Acquire)
         }
@@ -1276,6 +1288,7 @@ pub(crate) fn generator_function_constructor_of(closure_ptr: usize) -> Option<f6
 /// `[[Prototype]]` and the live generator-object chain. Null until
 /// `populate_global_this_builtins` has run. (#3664)
 pub(crate) fn generator_prototype_ptr(is_async: bool) -> *mut ObjectHeader {
+    ensure_generator_intrinsics();
     let slot = if is_async {
         crate::object::ASYNC_GENERATOR_PROTOTYPE_PTR.load(Ordering::Acquire)
     } else {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1319,7 +1319,11 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
         Ordering::Acquire,
         Ordering::Release,
     );
-    visitor.visit_atomic_i64_slot(&GENERATOR_PROTOTYPE_PTR, Ordering::Acquire, Ordering::Release);
+    visitor.visit_atomic_i64_slot(
+        &GENERATOR_PROTOTYPE_PTR,
+        Ordering::Acquire,
+        Ordering::Release,
+    );
     visitor.visit_atomic_i64_slot(
         &ASYNC_GENERATOR_FUNCTION_INTRINSIC_PTR,
         Ordering::Acquire,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -100,6 +100,20 @@ static GLOBAL_THIS_READY: AtomicBool = AtomicBool::new(false);
 // array constructors and scanned by `scan_object_cache_roots_mut`.
 pub(crate) static TYPED_ARRAY_INTRINSIC_PTR: AtomicI64 = AtomicI64::new(0);
 pub(crate) static TYPED_ARRAY_INTRINSIC_PROTO_PTR: AtomicI64 = AtomicI64::new(0);
+// #3664: the generator / async-generator intrinsic prototype towers.
+// `*_FUNCTION_INTRINSIC_PTR` = `%GeneratorFunction%` / `%AsyncGeneratorFunction%`
+// (the constructor closures); `*_INTRINSIC_PROTO_PTR` = `%Generator%` /
+// `%AsyncGenerator%` (a.k.a. `<Ctor>.prototype`), the object
+// `Object.getPrototypeOf(function*(){})` resolves to; `*_PROTOTYPE_PTR` =
+// `%Generator.prototype%` / `%AsyncGenerator.prototype%` (a.k.a.
+// `<Ctor>.prototype.prototype`), carrying `next`/`return`/`throw`. All six are
+// GC roots scanned by `scan_object_cache_roots_mut`.
+pub(crate) static GENERATOR_FUNCTION_INTRINSIC_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static GENERATOR_INTRINSIC_PROTO_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static GENERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static ASYNC_GENERATOR_FUNCTION_INTRINSIC_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static ASYNC_GENERATOR_INTRINSIC_PROTO_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static ASYNC_GENERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
 pub(crate) static LOCAL_STORAGE_PTR: AtomicI64 = AtomicI64::new(0);
 pub(crate) static SESSION_STORAGE_PTR: AtomicI64 = AtomicI64::new(0);
 
@@ -1291,6 +1305,33 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
     );
     visitor.visit_atomic_i64_slot(
         &TYPED_ARRAY_INTRINSIC_PROTO_PTR,
+        Ordering::Acquire,
+        Ordering::Release,
+    );
+    // #3664: generator / async-generator intrinsic tower roots.
+    visitor.visit_atomic_i64_slot(
+        &GENERATOR_FUNCTION_INTRINSIC_PTR,
+        Ordering::Acquire,
+        Ordering::Release,
+    );
+    visitor.visit_atomic_i64_slot(
+        &GENERATOR_INTRINSIC_PROTO_PTR,
+        Ordering::Acquire,
+        Ordering::Release,
+    );
+    visitor.visit_atomic_i64_slot(&GENERATOR_PROTOTYPE_PTR, Ordering::Acquire, Ordering::Release);
+    visitor.visit_atomic_i64_slot(
+        &ASYNC_GENERATOR_FUNCTION_INTRINSIC_PTR,
+        Ordering::Acquire,
+        Ordering::Release,
+    );
+    visitor.visit_atomic_i64_slot(
+        &ASYNC_GENERATOR_INTRINSIC_PROTO_PTR,
+        Ordering::Acquire,
+        Ordering::Release,
+    );
+    visitor.visit_atomic_i64_slot(
+        &ASYNC_GENERATOR_PROTOTYPE_PTR,
         Ordering::Acquire,
         Ordering::Release,
     );

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1503,6 +1503,13 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                     {
                         return f64::from_bits(proto_bits);
                     }
+                    // #3664: a generator/async-generator function's
+                    // [[Prototype]] is `%Generator%` / `%AsyncGenerator%`.
+                    if let Some(proto) =
+                        crate::object::generator_function_proto_of(raw_addr as usize)
+                    {
+                        return proto;
+                    }
                     return f64::from_bits(TAG_NULL);
                 }
                 if let Some(proto) = constructor_dynamic_prototype(obj) {
@@ -1566,6 +1573,10 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                         crate::closure::closure_static_prototype(bits as usize)
                     {
                         return f64::from_bits(proto_bits);
+                    }
+                    // #3664: generator/async-generator [[Prototype]] resolution.
+                    if let Some(proto) = crate::object::generator_function_proto_of(bits as usize) {
+                        return proto;
                     }
                     return f64::from_bits(TAG_NULL);
                 }

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -54,14 +54,44 @@ pub(crate) use rewrite_returns::{
     rewrite_yield_to_await_in_stmts,
 };
 
+// #3664: per-thread accumulator for async-generator func_ids discovered while
+// transforming a module. The generator transform clears `is_async`/
+// `is_generator` (both async and sync generators lower to an identical
+// `{next,return,throw}` wrapper), so we record the async ones here BEFORE the
+// flags are cleared, then drain into `module.async_generator_funcs` at the end
+// of `transform_generators`. A thread_local keeps this isolated when modules
+// are transformed in parallel; `transform_generators` clears it on entry so a
+// reused worker thread never leaks IDs across modules.
+thread_local! {
+    static ASYNC_GENERATOR_FUNC_IDS: std::cell::RefCell<std::collections::HashSet<FuncId>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// Record a func_id as belonging to an `async function*` (declaration or
+/// expression). Called from the generator transform while the original
+/// `is_async` flag is still observable. (#3664)
+fn record_async_generator_func(id: FuncId) {
+    ASYNC_GENERATOR_FUNC_IDS.with(|s| {
+        s.borrow_mut().insert(id);
+    });
+}
+
 /// Transform all generator functions in a module into state machine form.
 pub fn transform_generators(module: &mut Module) {
+    // #3664: reset the per-thread async-generator accumulator for this module.
+    ASYNC_GENERATOR_FUNC_IDS.with(|s| s.borrow_mut().clear());
+
     // Compute the next available local and func IDs by scanning the module
     let mut next_local_id = compute_max_local_id(module) + 1;
     let mut next_func_id = compute_max_func_id(module) + 1;
 
     for func in &mut module.functions {
         if func.is_generator {
+            // #3664: `async function* name(){}` — record before the transform
+            // clears `is_async`.
+            if func.is_async {
+                record_async_generator_func(func.id);
+            }
             transform_generator_function(func, &mut next_local_id, &mut next_func_id);
         }
     }
@@ -106,6 +136,13 @@ pub fn transform_generators(module: &mut Module) {
             m.body = b;
         }
     }
+
+    // #3664: drain the async-generator func_ids collected above (named + closure
+    // expressions) into the module so codegen can register them.
+    ASYNC_GENERATOR_FUNC_IDS.with(|s| {
+        let collected = std::mem::take(&mut *s.borrow_mut());
+        module.async_generator_funcs.extend(collected);
+    });
 }
 
 fn transform_generator_closures_in_stmts(
@@ -214,6 +251,7 @@ fn transform_generator_closures_in_expr(
 
     // Now transform THIS closure if it's a generator expression.
     if let Expr::Closure {
+        func_id,
         is_generator,
         params,
         body,
@@ -227,6 +265,11 @@ fn transform_generator_closures_in_expr(
     } = expr
     {
         if *is_generator {
+            // #3664: `async function*(){}` expression — record its func_id (the
+            // symbol codegen registers) before `is_async` is cleared below.
+            if *is_async {
+                record_async_generator_func(*func_id);
+            }
             let synth_id = {
                 let id = *next_func_id;
                 *next_func_id += 1;

--- a/test-parity/node-suite/globals/generator-intrinsics.ts
+++ b/test-parity/node-suite/globals/generator-intrinsics.ts
@@ -1,0 +1,61 @@
+// #3664: generator / async-generator intrinsic objects + prototype chains.
+// Exercises the function-side intrinsics, the %Generator(.prototype)% chain,
+// the lazy per-function `.prototype`, and the brand-checked prototype methods
+// (sync throws, async rejects).
+
+function* g() {
+  yield 1;
+}
+async function* ag() {
+  yield 1;
+}
+
+// --- function-side intrinsics ---
+const GenProto = Object.getPrototypeOf(g); // %Generator%
+const GeneratorFunction = GenProto.constructor; // %GeneratorFunction%
+console.log("g.constructor.name:", g.constructor.name);
+console.log("GeneratorFunction.name:", GeneratorFunction.name);
+console.log("GeneratorFunction.length:", GeneratorFunction.length);
+console.log("GenProto.constructor === GeneratorFunction:", GenProto.constructor === GeneratorFunction);
+console.log("GeneratorFunction.prototype === GenProto:", GeneratorFunction.prototype === GenProto);
+console.log("GenProto[toStringTag]:", GenProto[Symbol.toStringTag]);
+
+// --- %Generator.prototype% ---
+const GeneratorPrototype = GenProto.prototype; // %Generator.prototype%
+console.log("GeneratorPrototype.constructor === GenProto:", GeneratorPrototype.constructor === GenProto);
+console.log("GeneratorPrototype[toStringTag]:", GeneratorPrototype[Symbol.toStringTag]);
+console.log("typeof GeneratorPrototype.next:", typeof GeneratorPrototype.next);
+
+// --- per-function g.prototype (lazy) ---
+console.log("typeof g.prototype:", typeof g.prototype);
+console.log("g.prototype identity stable:", g.prototype === g.prototype);
+console.log("getPrototypeOf(g.prototype) === GeneratorPrototype:", Object.getPrototypeOf(g.prototype) === GeneratorPrototype);
+
+// --- async tower is distinct ---
+const AGenProto = Object.getPrototypeOf(ag);
+const AsyncGeneratorFunction = AGenProto.constructor;
+console.log("AsyncGeneratorFunction.name:", AsyncGeneratorFunction.name);
+console.log("AGenProto[toStringTag]:", AGenProto[Symbol.toStringTag]);
+console.log("AGenProto.prototype[toStringTag]:", AGenProto.prototype[Symbol.toStringTag]);
+console.log("sync !== async ctor:", GeneratorFunction !== AsyncGeneratorFunction);
+
+// --- brand-check: sync prototype method throws on bad receiver ---
+for (const bad of [undefined, null, {}, function () {}, g.prototype]) {
+  try {
+    GeneratorPrototype.next.call(bad as any);
+    console.log("sync brand NO THROW");
+  } catch (e) {
+    console.log("sync brand throws:", (e as any) instanceof TypeError);
+  }
+}
+
+// --- delegation: prototype method drives a real instance ---
+const it = g();
+console.log("delegated next:", JSON.stringify(GeneratorPrototype.next.call(it)));
+
+// --- brand-check: async prototype method rejects on bad receiver ---
+const AGP = AGenProto.prototype;
+AGP.next.call(undefined as any).then(
+  () => console.log("async brand NO REJECT"),
+  (e: any) => console.log("async brand rejects:", e instanceof TypeError),
+);


### PR DESCRIPTION
## Summary

Fixes the core of #3664: generator / async-generator **intrinsic objects and prototype chains** were missing, so reflective access threw `TypeError: Cannot read properties of null`. This builds the `%GeneratorFunction%` / `%Generator%` / `%Generator.prototype%` towers (and the async trio), wires the function-side chains, and makes the prototype `next`/`return`/`throw` methods brand-checked + functional.

### What now works (all byte-identical to `node --experimental-strip-types`)

```js
function* g() {}
g.constructor.name                         // "GeneratorFunction"
Object.getPrototypeOf(g).constructor.name  // "GeneratorFunction"
Object.getPrototypeOf(g).prototype         // %Generator.prototype% (constructor back-link, toStringTag "Generator")
g.prototype                                // object; getPrototypeOf(g.prototype) === %Generator.prototype%
async function* ag() {}
ag.constructor.name                        // "AsyncGeneratorFunction"  (distinct tower)

GeneratorPrototype.next.call({})           // throws TypeError (brand check, own-property based)
GeneratorPrototype.next.call(realGen)      // delegates to the instance's own state machine
AsyncGeneratorPrototype.next.call(x)       // returns a rejected promise (not a throw)
```

## Implementation

- **Intrinsic towers** (`object/global_this.rs`): six GC-rooted singletons built (lazily + during `populate_global_this_builtins`) mirroring the existing `%TypedArray%` pattern — `name`/`length`, `constructor`/`prototype` back-links, `Symbol.toStringTag`.
- **Function-side resolution**: `Object.getPrototypeOf(g)` (`object_ops.rs`) and `g.constructor` / lazy `g.prototype` (`field_get_set.rs`), all gated on `get_valid_func_ptr` → generator-registry membership, so non-generators are untouched.
- **Async vs sync disambiguation**: Perry registered async generators only in the *generator* registry. Added `Module.async_generator_funcs` (populated by the generator transform before it clears `is_async`), a dedicated `CLOSURE_ASYNC_GENERATOR_FUNCTION_REGISTRY`, and codegen registration for both named declarations and `async function*(){}` expressions. Also fixes `util.types.isAsyncFunction(asyncGen)` → `true`.
- **Prototype methods**: `next`/`return`/`throw` brand-check the receiver using **own** properties (an object that merely *inherits* them, like `g.prototype`, is rejected — this avoids an infinite-recursion stack overflow), then delegate to the instance's own state-machine closure. Sync throws `TypeError`; async returns `Promise.reject(TypeError)`.

## Test262 impact

Radar (`scripts/test262_subset.py`, four generator categories), vs `main` baseline:

| | pass |
|---|---|
| main baseline | 26 |
| this PR | **39** (+13) |

The remaining failures in these categories are **out of scope** for generator intrinsics and tracked separately:
- ~34 — `verifyProperty` → `Function.prototype.call.bind(...)` "uncurry-this" idiom (a general harness gap that fails on plain objects too).
- ~11 — dynamic `GeneratorFunction()` / `new GeneratorFunction()` construction (runtime eval, #1677).
- ~12 — pre-existing `try/finally`/`throw()` generator **execution** bugs.
- ~5 — parser-strictness `SyntaxError` negatives (yield/await in params).

**Deferred follow-up:** the live-instance two-level chain (`getPrototypeOf(getPrototypeOf(g())) === %Generator.prototype%`, ~2–4 tests) needs the transform/codegen to record each instance's owning function — deeper work for a small tail; left for a separate PR.

## Validation

- New parity fixture `test-parity/node-suite/globals/generator-intrinsics.ts` — byte-identical to Node in **both** optimize modes.
- Generator execution regression smoke (for-of, spread, `yield*`, return values, for-await) unchanged. (`Math.max(...gen())` empty-spread is a pre-existing, unrelated gap on `main`.)
- `cargo test` green for perry-runtime (962), perry-hir, perry-transform, perry-codegen; `cargo fmt --all --check` clean.

Closes #3664 (core null-deref / intrinsic-chain gap).
