### PR TITLE
Implement vm.measureMemory shape validation

### DIFF
--- a/crates/perry-runtime/src/node_vm.rs
+++ b/crates/perry-runtime/src/node_vm.rs
@@ -4,13 +4,32 @@
 //! model without a runtime JavaScript interpreter: function-valued exports,
 //! the `Script` constructor value, `isContext({}) === false`, and the
 //! `vm.constants` symbol namespace. Script execution, contextification,
-//! compileFunction, measureMemory, cached data, source maps, and VM modules
-//! remain tracked by the VM issues referenced from the parity fixtures.
+//! compileFunction, cached data, source maps, and VM modules remain tracked by
+//! the VM issues referenced from the parity fixtures.
 
+use crate::gc::{RuntimeHandle, RuntimeHandleScope};
+use crate::object::ObjectHeader;
+use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static MEASURE_MEMORY_WARNING_EMITTED: AtomicBool = AtomicBool::new(false);
 
 fn bool_value(value: bool) -> f64 {
     f64::from_bits(JSValue::bool(value).bits())
+}
+
+fn undefined_value() -> f64 {
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+fn string_value(value: &str) -> f64 {
+    let ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+fn boxed_ptr(ptr: *const u8) -> f64 {
+    f64::from_bits(JSValue::pointer(ptr).bits())
 }
 
 fn throw_vm_unimplemented(api: &str, issue: &str) -> f64 {
@@ -20,6 +39,274 @@ fn throw_vm_unimplemented(api: &str, issue: &str) -> f64 {
 
 // `createContext` is handled by the working implementation in
 // `object::native_module.rs` (#4050); routed there from dispatch.
+
+fn object_ptr_from_value(value: f64) -> Option<*const ObjectHeader> {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let ptr = jv.as_pointer::<u8>();
+    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    let gc_header = unsafe { &*(ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader) };
+    if gc_header.obj_type != crate::gc::GC_TYPE_OBJECT {
+        return None;
+    }
+    Some(ptr as *const ObjectHeader)
+}
+
+fn validate_options_object(options: f64) {
+    let jv = JSValue::from_bits(options.to_bits());
+    if jv.is_undefined() || object_ptr_from_value(options).is_some() {
+        return;
+    }
+    let message = format!(
+        "The \"options\" argument must be of type object. Received {}",
+        crate::fs::validate::describe_received(options)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+fn object_property<'scope>(
+    scope: &'scope RuntimeHandleScope,
+    options_handle: &RuntimeHandle<'scope>,
+    name: &[u8],
+) -> f64 {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let key_handle = scope.root_string_ptr(key);
+    let Some(obj) = object_ptr_from_value(options_handle.get_nanbox_f64()) else {
+        return undefined_value();
+    };
+    crate::object::js_object_get_field_by_name_f64(
+        obj,
+        key_handle.get_raw_const_ptr::<StringHeader>(),
+    )
+}
+
+fn string_from_value(value: f64) -> Option<String> {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if !js_value.is_any_string() {
+        return None;
+    }
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const StringHeader;
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return Some(String::new());
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+        let bytes = std::slice::from_raw_parts(data, len);
+        Some(String::from_utf8_lossy(bytes).into_owned())
+    }
+}
+
+fn string_value_is(value: f64, expected: &str) -> bool {
+    string_from_value(value).is_some_and(|actual| actual == expected)
+}
+
+fn format_number_for_received(value: f64) -> String {
+    if value.is_nan() {
+        return "NaN".to_string();
+    }
+    if value.is_infinite() {
+        return if value.is_sign_positive() {
+            "Infinity".to_string()
+        } else {
+            "-Infinity".to_string()
+        };
+    }
+    if value.fract() == 0.0 && value.abs() < 1e21 {
+        format!("{}", value as i64)
+    } else {
+        format!("{value}")
+    }
+}
+
+fn format_validate_one_of_received(value: f64) -> String {
+    let jv = JSValue::from_bits(value.to_bits());
+    if let Some(value) = string_from_value(value) {
+        return format!("'{value}'");
+    }
+    if jv.is_null() {
+        return "null".to_string();
+    }
+    if jv.is_undefined() {
+        return "undefined".to_string();
+    }
+    if jv.is_bool() {
+        return format!("{}", jv.as_bool());
+    }
+    if jv.is_int32() {
+        return format!("{}", jv.as_int32());
+    }
+    if jv.is_number() {
+        return format_number_for_received(jv.as_number());
+    }
+    crate::fs::validate::describe_received(value)
+}
+
+fn throw_invalid_one_of(property: &str, allowed: &[&str], value: f64) -> ! {
+    let allowed = allowed
+        .iter()
+        .map(|entry| format!("'{entry}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let message = format!(
+        "The property '{property}' must be one of: {allowed}. Received {}",
+        format_validate_one_of_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE")
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MeasureMemoryMode {
+    Summary,
+    Detailed,
+}
+
+fn validate_measure_memory_options(options: f64) -> MeasureMemoryMode {
+    validate_options_object(options);
+    if JSValue::from_bits(options.to_bits()).is_undefined() {
+        return MeasureMemoryMode::Summary;
+    }
+
+    let scope = RuntimeHandleScope::new();
+    let options_handle = scope.root_nanbox_f64(options);
+    let mode = object_property(&scope, &options_handle, b"mode");
+    let execution = object_property(&scope, &options_handle, b"execution");
+
+    let mode =
+        if JSValue::from_bits(mode.to_bits()).is_undefined() || string_value_is(mode, "summary") {
+            MeasureMemoryMode::Summary
+        } else if string_value_is(mode, "detailed") {
+            MeasureMemoryMode::Detailed
+        } else {
+            throw_invalid_one_of("options.mode", &["summary", "detailed"], mode);
+        };
+
+    if !JSValue::from_bits(execution.to_bits()).is_undefined()
+        && !string_value_is(execution, "default")
+        && !string_value_is(execution, "eager")
+    {
+        throw_invalid_one_of("options.execution", &["default", "eager"], execution);
+    }
+
+    mode
+}
+
+fn emit_measure_memory_warning_once() {
+    if MEASURE_MEMORY_WARNING_EMITTED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    let scope = RuntimeHandleScope::new();
+    let message = scope.root_nanbox_f64(string_value(
+        "vm.measureMemory is an experimental feature and might change at any time",
+    ));
+    let warning_type = scope.root_nanbox_f64(string_value("ExperimentalWarning"));
+    crate::process::js_process_emit_warning(
+        message.get_nanbox_f64(),
+        warning_type.get_nanbox_f64(),
+        undefined_value(),
+    );
+}
+
+fn set_object_field<'scope>(
+    scope: &'scope RuntimeHandleScope,
+    obj_handle: &RuntimeHandle<'scope>,
+    name: &str,
+    value: f64,
+) {
+    let value_handle = scope.root_nanbox_f64(value);
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let key_handle = scope.root_string_ptr(key);
+    crate::object::js_object_set_field_by_name(
+        obj_handle.get_raw_mut_ptr::<ObjectHeader>(),
+        key_handle.get_raw_const_ptr::<StringHeader>() as *mut StringHeader,
+        value_handle.get_nanbox_f64(),
+    );
+}
+
+fn memory_entry<'scope>(scope: &'scope RuntimeHandleScope, estimate: f64, upper: f64) -> f64 {
+    let range = crate::array::js_array_alloc(2);
+    let range_handle = scope.root_raw_mut_ptr(range);
+    let range = crate::array::js_array_push_f64(
+        range_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
+        estimate,
+    );
+    range_handle.set_raw_mut_ptr::<crate::array::ArrayHeader>(range);
+    let range = crate::array::js_array_push_f64(
+        range_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
+        upper,
+    );
+    range_handle.set_raw_mut_ptr::<crate::array::ArrayHeader>(range);
+
+    let entry = crate::object::js_object_alloc(0, 2);
+    let entry_handle = scope.root_raw_mut_ptr(entry);
+    set_object_field(scope, &entry_handle, "jsMemoryEstimate", estimate);
+    set_object_field(
+        scope,
+        &entry_handle,
+        "jsMemoryRange",
+        boxed_ptr(range_handle.get_raw_const_ptr::<crate::array::ArrayHeader>() as *const u8),
+    );
+    boxed_ptr(entry_handle.get_raw_const_ptr::<ObjectHeader>() as *const u8)
+}
+
+fn wasm_memory_entry<'scope>(scope: &'scope RuntimeHandleScope) -> f64 {
+    let entry = crate::object::js_object_alloc(0, 2);
+    let entry_handle = scope.root_raw_mut_ptr(entry);
+    set_object_field(scope, &entry_handle, "code", 0.0);
+    set_object_field(scope, &entry_handle, "metadata", 0.0);
+    boxed_ptr(entry_handle.get_raw_const_ptr::<ObjectHeader>() as *const u8)
+}
+
+fn measure_memory_result(mode: MeasureMemoryMode) -> f64 {
+    let mut heap_used = 0_u64;
+    let mut heap_total = 0_u64;
+    crate::arena::js_arena_stats(&mut heap_used, &mut heap_total);
+    let estimate = heap_used as f64;
+    let upper = heap_total.max(heap_used) as f64;
+
+    let scope = RuntimeHandleScope::new();
+    let total = scope.root_nanbox_f64(memory_entry(&scope, estimate, upper));
+    let wasm = scope.root_nanbox_f64(wasm_memory_entry(&scope));
+
+    let result = crate::object::js_object_alloc(
+        0,
+        if mode == MeasureMemoryMode::Detailed {
+            4
+        } else {
+            2
+        },
+    );
+    let result_handle = scope.root_raw_mut_ptr(result);
+    set_object_field(&scope, &result_handle, "total", total.get_nanbox_f64());
+    set_object_field(&scope, &result_handle, "WebAssembly", wasm.get_nanbox_f64());
+
+    if mode == MeasureMemoryMode::Detailed {
+        let current = scope.root_nanbox_f64(memory_entry(&scope, estimate, upper));
+        let other = crate::array::js_array_alloc(0);
+        let other_handle = scope.root_raw_mut_ptr(other);
+        set_object_field(&scope, &result_handle, "current", current.get_nanbox_f64());
+        set_object_field(
+            &scope,
+            &result_handle,
+            "other",
+            boxed_ptr(other_handle.get_raw_const_ptr::<crate::array::ArrayHeader>() as *const u8),
+        );
+    }
+
+    boxed_ptr(result_handle.get_raw_const_ptr::<ObjectHeader>() as *const u8)
+}
+
+fn resolved_promise(value: f64) -> f64 {
+    let scope = RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+    crate::value::js_nanbox_pointer(crate::promise::js_promise_resolved(
+        value_handle.get_nanbox_f64(),
+    ) as i64)
+}
 
 pub extern "C" fn js_vm_create_script(_code: f64, _options: f64) -> f64 {
     throw_vm_unimplemented("createScript/Script compilation", "3127")
@@ -49,8 +336,10 @@ pub extern "C" fn js_vm_compile_function(_code: f64, _params: f64, _options: f64
     throw_vm_unimplemented("compileFunction runtime function construction", "3130")
 }
 
-pub extern "C" fn js_vm_measure_memory(_options: f64) -> f64 {
-    throw_vm_unimplemented("measureMemory", "3284")
+pub extern "C" fn js_vm_measure_memory(options: f64) -> f64 {
+    emit_measure_memory_warning_once();
+    let mode = validate_measure_memory_options(options);
+    resolved_promise(measure_memory_result(mode))
 }
 
 pub extern "C" fn js_vm_script_call(_code: f64, _options: f64) -> f64 {

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -132,9 +132,9 @@ Selected highlights (full list in `runtime-parity.md`):
 
 **Total APIs: 32** · Perry covers: import/require namespace shape, callable
 export metadata, `vm.constants`, `process.getBuiltinModule("vm")`, and
-`vm.isContext({})` · Gap: runtime VM execution, contextification, VM modules,
-context-loader constant behavior, cached data, source-map metadata, and heap
-measurement
+`vm.isContext({})`, plus `vm.measureMemory()` result shape and validation ·
+Gap: runtime VM execution, contextification, VM modules, context-loader
+constant behavior, cached data, and source-map metadata
 
 Shape coverage is fixture-backed in `test-parity/node-suite/vm`; the generated
 `test_parity_vm` inventory now skip-lists only the still-open behavior leaves.

--- a/scripts/parity-skiplist.toml
+++ b/scripts/parity-skiplist.toml
@@ -86,7 +86,6 @@
 "vm.runInNewContext(code[, contextObject[, options]])" = "Runtime eval in a new context remains open (#3128)."
 "vm.compileFunction(code[, params[, options]])" = "Runtime function construction remains open (#3130)."
 "vm.createContext([contextObject[, options]])" = "Runtime contextification remains open (#3128)."
-"vm.measureMemory([options])" = "V8 heap measurement remains open/inapplicable (#3284)."
 "util.compileFunction(...)" = "Same as vm.compileFunction — needs JS interpreter."
 
 # Out-of-scope — native addons / V8 internals.

--- a/test-files/test_parity_vm.ts
+++ b/test-files/test_parity_vm.ts
@@ -45,10 +45,10 @@ import * as vm from "node:vm";
 // SKIP: vm.runInNewContext(code[, contextObject[, options]]) — Runtime eval in a new context remains open (#3128).
 // SKIP: vm.runInThisContext(code[, options]) — Runtime eval remains open (#3127).
 // SKIP: vm.compileFunction(code[, params[, options]]) — Runtime function construction remains open (#3130).
-// SKIP: vm.measureMemory([options]) — V8 heap measurement remains open/inapplicable (#3284).
+// TODO(call): vm.measureMemory([options])
 
 // ── Constants ──
 console.log("vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER:", vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER);
 console.log("vm.constants.DONT_CONTEXTIFY:", vm.constants.DONT_CONTEXTIFY);
 
-// Coverage: 2 auto-emitted, 1 TODO, 29 skip-listed.
+// Coverage: 2 auto-emitted, 2 TODO, 28 skip-listed.

--- a/test-parity/node-suite/vm/README.md
+++ b/test-parity/node-suite/vm/README.md
@@ -3,7 +3,9 @@
 This directory covers the default Node `node:vm` surface that is visible
 without `--experimental-vm-modules`: import and require shapes, callable export
 metadata, `vm.constants`, `process.getBuiltinModule("vm")`, and
-`vm.isContext({})`.
+`vm.isContext({})`. `measureMemory` is covered for Node-shaped eager summary
+and detailed results, option validation, and experimental-warning delivery;
+the exact byte estimates remain Perry-specific.
 
 Intentionally open leaves:
 
@@ -12,7 +14,6 @@ Intentionally open leaves:
 - compileFunction: #3130
 - VM module classes and evaluation: #3132, #3133
 - vm.constants deeper context-loader behavior: #3283
-- measureMemory: #3284
 - Script sourceMapURL metadata: #3321
 - SourceTextModule module request helpers: #3322
 - SourceTextModule cached data: #3323

--- a/test-parity/node-suite/vm/measure-memory.ts
+++ b/test-parity/node-suite/vm/measure-memory.ts
@@ -1,0 +1,80 @@
+// node:vm measureMemory result shape, validation, and warning behavior.
+import * as vm from "node:vm";
+
+const warnings: string[] = [];
+process.on("warning", (warning: any) => {
+  warnings.push(`${warning.name}:${warning.message}`);
+});
+
+function showMemoryEntry(label: string, entry: any): void {
+  console.log(`${label} keys:`, Object.keys(entry).join(","));
+  console.log(`${label} estimate type:`, typeof entry.jsMemoryEstimate);
+  console.log(
+    `${label} range shape:`,
+    Array.isArray(entry.jsMemoryRange),
+    entry.jsMemoryRange.length,
+    entry.jsMemoryRange.every((value: unknown) => typeof value === "number"),
+  );
+}
+
+function showWasm(label: string, wasm: any): void {
+  console.log(`${label} wasm keys:`, Object.keys(wasm).join(","));
+  console.log(`${label} wasm types:`, typeof wasm.code, typeof wasm.metadata);
+}
+
+function expectThrow(label: string, expectedCode: string, expectedMessage: string, fn: () => unknown): void {
+  try {
+    fn();
+    console.log(`${label}:`, "no throw");
+  } catch (err: any) {
+    console.log(
+      `${label}:`,
+      err?.name,
+      err?.code === expectedCode,
+      err?.message === expectedMessage,
+    );
+    console.log(`${label} message:`, err?.message);
+  }
+}
+
+const promise = vm.measureMemory({ execution: "eager" });
+console.log("promise shape:", promise instanceof Promise, typeof (promise as any).then);
+
+const summary = await promise;
+console.log("summary keys:", Object.keys(summary).join(","));
+showMemoryEntry("summary total", summary.total);
+showWasm("summary", (summary as any).WebAssembly);
+
+const detailed = await vm.measureMemory({ mode: "detailed", execution: "eager" });
+console.log("detailed keys:", Object.keys(detailed).join(","));
+showMemoryEntry("detailed total", detailed.total);
+showMemoryEntry("detailed current", (detailed as any).current);
+console.log(
+  "detailed other:",
+  Array.isArray((detailed as any).other),
+  (detailed as any).other.length,
+);
+showWasm("detailed", (detailed as any).WebAssembly);
+
+expectThrow(
+  "invalid mode",
+  "ERR_INVALID_ARG_VALUE",
+  "The property 'options.mode' must be one of: 'summary', 'detailed'. Received 'bad'",
+  () => vm.measureMemory({ mode: "bad" } as any),
+);
+expectThrow(
+  "invalid execution",
+  "ERR_INVALID_ARG_VALUE",
+  "The property 'options.execution' must be one of: 'default', 'eager'. Received 'bad'",
+  () => vm.measureMemory({ execution: "bad" } as any),
+);
+expectThrow(
+  "null options",
+  "ERR_INVALID_ARG_TYPE",
+  'The "options" argument must be of type object. Received null',
+  () => vm.measureMemory(null as any),
+);
+
+setImmediate(() => {
+  console.log("warnings:", warnings.length, warnings.join("|"));
+});


### PR DESCRIPTION
## Summary
- Implements `vm.measureMemory([options])` as a Promise-returning API with Node-shaped summary and detailed result objects.
- Adds Node-compatible validation for `options`, `options.mode`, and `options.execution`, including `ERR_INVALID_ARG_TYPE` / `ERR_INVALID_ARG_VALUE` codes.
- Emits the experimental `vm.measureMemory` warning once and adds focused VM parity coverage for eager summary/detailed mode, invalid options, and warning delivery.
- Updates VM parity inventory/docs to move `vm.measureMemory([options])` out of the skiplist while leaving exact memory byte values Perry-specific.

## Stacking / dependency
This branch is stacked on and depends on #4079 (`andrewtdiz:codex/vm-parity-scaffold`), which is still open.

## Validation
- Validated PerryTS/perry#3284 and checked Node behavior with the requested DeepWiki query against `nodejs/node`.
- `python3.11 scripts/gen_parity_tests.py --module vm --force`
- `cargo fmt -p perry-runtime`
- `node --experimental-strip-types test-parity/node-suite/vm/measure-memory.ts`
- `cargo check -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --module vm --filter measure-memory`
- `./run_parity_tests.sh --suite parity --filter test_parity_vm`
- `git diff --check`
- `cargo check -p perry -p perry-stdlib`

## Not run
- Full release build or exhaustive parity suite; this PR only ran the focused VM parity and cargo checks above.
