### PR TITLE
fix(runtime): validate typed-array constructor length (#3662)

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -854,9 +854,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     Ok(ctx.block().bitcast_i64_to_double(&p))
                 }
                 Some(arg_expr) => match arg_expr.as_ref() {
-                    // Literal integer length: `new Int32Array(3)`.
+                    // Literal integer length: `new Int32Array(3)`. A negative
+                    // literal (`new Int32Array(-1)`) is passed through verbatim
+                    // so the runtime throws the spec RangeError (#3662).
                     Expr::Integer(n) => {
-                        let len_str = (*n as i32).max(0).to_string();
+                        let len_str = (*n as i32).to_string();
                         let p = ctx.block().call(
                             I64,
                             "js_typed_array_new_empty",

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -461,10 +461,31 @@ pub extern "C" fn js_uint8array_from_array(arr_ptr: *const ArrayHeader) -> *mut 
     buf
 }
 
+/// Validate a `new Uint8Array(length)` argument with `ToIndex` semantics and
+/// throw the spec `RangeError: Invalid typed array length: <n>` on a negative
+/// or out-of-range length, matching Node (#3662). `Uint8Array` is backed by a
+/// `BufferHeader` in Perry, so this lives here rather than in `typedarray.rs`.
+#[inline]
+fn uint8array_length_or_throw(val: f64) -> u32 {
+    let integer = if val.is_nan() { 0.0 } else { val.trunc() };
+    if integer < 0.0 || integer > 9_007_199_254_740_991.0 {
+        let shown = if val.is_infinite() {
+            if val > 0.0 { "Infinity" } else { "-Infinity" }.to_string()
+        } else {
+            format!("{}", integer as i64)
+        };
+        let msg = format!("Invalid typed array length: {shown}");
+        let m = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err = crate::error::js_rangeerror_new(m);
+        crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+    }
+    integer as u32
+}
+
 /// `new Uint8Array(length)` — zero-filled buffer marked as Uint8Array.
 #[no_mangle]
 pub extern "C" fn js_uint8array_alloc(length: i32) -> *mut BufferHeader {
-    let length = length.max(0) as u32;
+    let length = uint8array_length_or_throw(length as f64);
     let buf = buffer_alloc(length);
     unsafe {
         (*buf).length = length;
@@ -524,13 +545,11 @@ pub extern "C" fn js_uint8array_new(val: f64) -> *mut BufferHeader {
         return js_uint8array_from_array(raw as *const ArrayHeader);
     }
     // Plain IEEE double (upper16 < 0x7FFC or > 0x7FFF) — numeric length.
+    // Node applies ToIndex (NaN → 0, truncate toward zero) and throws a
+    // RangeError on a negative / out-of-range length (#3662).
     if !(0x7FFC..=0x7FFF).contains(&top16) {
-        let len = if val.is_finite() && val >= 0.0 {
-            val as i32
-        } else {
-            0
-        };
-        return js_uint8array_alloc(len);
+        let len = uint8array_length_or_throw(val);
+        return js_uint8array_alloc(len.min(i32::MAX as u32) as i32);
     }
     // Any other tag (undefined/null/bool/string/bigint) → empty buffer,
     // matching the JS semantics of `new Uint8Array(undefined)` et al.

--- a/crates/perry-runtime/src/typedarray.rs
+++ b/crates/perry-runtime/src/typedarray.rs
@@ -293,6 +293,25 @@ fn throw_range_error(message: &[u8]) -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+/// Validate a typed-array constructor length argument with `ToIndex`
+/// semantics (#3662). Node truncates toward zero (`NaN` → 0, `2.5` → 2) and
+/// throws a plain `RangeError: Invalid typed array length: <n>` when the
+/// resulting integer is negative or exceeds `2**53 - 1` (`Infinity` included).
+/// Returns the validated element count.
+#[inline]
+fn typed_array_length_or_throw(val: f64) -> u32 {
+    let integer = if val.is_nan() { 0.0 } else { val.trunc() };
+    if integer < 0.0 || integer > 9_007_199_254_740_991.0 {
+        let shown = if val.is_infinite() {
+            if val > 0.0 { "Infinity" } else { "-Infinity" }.to_string()
+        } else {
+            format!("{}", integer as i64)
+        };
+        throw_range_error(format!("Invalid typed array length: {shown}").as_bytes());
+    }
+    integer as u32
+}
+
 #[inline]
 fn is_arena_backed_addr(addr: usize) -> bool {
     !matches!(
@@ -673,7 +692,8 @@ pub extern "C" fn js_native_memory_copy(dst_raw: u64, src_raw: u64) {
 /// Allocate a typed array of `length` elements, all zero.
 #[no_mangle]
 pub extern "C" fn js_typed_array_new_empty(kind: i32, length: i32) -> *mut TypedArrayHeader {
-    typed_array_alloc(kind as u8, length.max(0) as u32)
+    let len = typed_array_length_or_throw(length as f64);
+    typed_array_alloc(kind as u8, len)
 }
 
 /// Allocate a typed array from a NaN-boxed JS value. Dispatches at runtime:
@@ -709,7 +729,8 @@ pub extern "C" fn js_typed_array_new(kind: i32, val: f64) -> *mut TypedArrayHead
     if top16 == 0x7FFE {
         // INT32_TAG — lower 32 bits are the signed length.
         let n = (bits & 0xFFFF_FFFF) as i32;
-        return typed_array_alloc(kind as u8, n.max(0) as u32);
+        let len = typed_array_length_or_throw(n as f64);
+        return typed_array_alloc(kind as u8, len);
     }
     if !(0x7FFC..=0x7FFF).contains(&top16) {
         // Issue #654: typed-array sources (`new Float64Array(otherTA)`)
@@ -727,13 +748,11 @@ pub extern "C" fn js_typed_array_new(kind: i32, val: f64) -> *mut TypedArrayHead
                 );
             }
         }
-        // Plain IEEE double (including negative, NaN, ±Inf).
-        let len = if val.is_finite() && val >= 0.0 {
-            val as i32
-        } else {
-            0
-        };
-        return typed_array_alloc(kind as u8, len.max(0) as u32);
+        // Plain IEEE double (including negative, NaN, ±Inf). Node applies
+        // ToIndex: NaN → 0, truncate toward zero, and throw a RangeError on a
+        // negative / out-of-range length (#3662).
+        let len = typed_array_length_or_throw(val);
+        return typed_array_alloc(kind as u8, len);
     }
     // Undefined / null / bool / string → empty typed array.
     typed_array_alloc(kind as u8, 0)

--- a/test-files/test_gap_3662_typedarray_length.ts
+++ b/test-files/test_gap_3662_typedarray_length.ts
@@ -1,0 +1,38 @@
+// #3662 — typed-array constructors must validate their length argument with
+// ToIndex semantics and throw a `RangeError: Invalid typed array length: <n>`
+// on a negative / out-of-range length, instead of silently clamping to 0.
+//
+// Node truncates toward zero (`NaN` -> 0, `2.5` -> 2, no throw) and throws a
+// plain RangeError (no `.code`) on a negative, `Infinity`, or `>= 2**53`
+// length. We print the error message so the output is byte-identical to Node.
+
+function r(fn: () => void): string {
+    try {
+        fn();
+        return "NO_THROW";
+    } catch (e: any) {
+        return `${e.constructor.name}: ${e.message}`;
+    }
+}
+
+// Negative literal lengths across the typed-array family.
+console.log("Uint8Array(-1):", r(() => new Uint8Array(-1)));
+console.log("Int8Array(-5):", r(() => new Int8Array(-5)));
+console.log("Uint16Array(-2):", r(() => new Uint16Array(-2)));
+console.log("Int32Array(-1):", r(() => new Int32Array(-1)));
+console.log("Float32Array(-3):", r(() => new Float32Array(-3)));
+console.log("Float64Array(-4):", r(() => new Float64Array(-4)));
+console.log("Uint8ClampedArray(-1):", r(() => new Uint8ClampedArray(-1)));
+
+// Non-finite / too-large lengths.
+console.log("Float64Array(Inf):", r(() => new Float64Array(Infinity)));
+console.log("Uint8Array(2**53):", r(() => new Uint8Array(2 ** 53)));
+
+// Negative via a variable (runtime-dispatched path).
+const neg = -3;
+console.log("Uint8Array(neg):", r(() => new Uint8Array(neg)));
+console.log("Int16Array(neg):", r(() => new Int16Array(neg)));
+
+// Valid lengths still allocate; NaN -> 0 and fractional truncates (no throw).
+console.log("ok:", new Uint8Array(4).length, new Int32Array(3).length, new Float64Array(0).length);
+console.log("NaN->", new Uint8Array(NaN).length, "2.5->", new Uint8Array(2.5).length);


### PR DESCRIPTION
## Summary

Typed-array constructors silently clamped a negative or out-of-range length argument to `0` instead of throwing the spec-mandated `RangeError`. This is the **ECMAScript-constructor slice** of the #3662 "builtins must throw the spec error on invalid args" cluster.

Prior #3662 sub-clusters already merged:
- collection prototype brand checks — #3739
- `Function.prototype.{apply,call,bind}` not-callable `this` — #4073
- node-core `fs`/`zlib`/`process` arg validation — #4082

### Before
```ts
new Uint8Array(-1)        // -> length-0 Uint8Array (no throw)
new Float64Array(Infinity) // -> length-0 (no throw)
```
### After (byte-identical to `node --experimental-strip-types`)
```
RangeError: Invalid typed array length: -1
RangeError: Invalid typed array length: Infinity
```

## What changed

A shared `ToIndex`-style length validator: truncate toward zero (`NaN` → 0, `2.5` → 2, **no throw**) and throw a plain `RangeError: Invalid typed array length: <n>` (no `.code`, matching Node) when the resulting integer is negative, `Infinity`, or `>= 2**53`.

- **`typedarray.rs`** — `typed_array_length_or_throw`, wired into `js_typed_array_new_empty` (literal-length path) and `js_typed_array_new` (INT32-tagged and plain-double runtime-dispatch paths). Covers `Int8/16/32`, `Uint16/32`, `Float32/64`, `Uint8ClampedArray`.
- **`buffer/from.rs`** — `uint8array_length_or_throw`, wired into `js_uint8array_alloc` (literal path) and `js_uint8array_new` (runtime path). `Uint8Array` is backed by a `BufferHeader` in Perry, so it has its own path.
- **`codegen/expr/arrays_finds.rs`** — stop clamping the literal integer length with `.max(0)` so a negative literal reaches the runtime validator.

## Testing

New gap test `test-files/test_gap_3662_typedarray_length.ts` is byte-identical to `node --experimental-strip-types` in **both** the default auto-optimize and `PERRY_NO_AUTO_OPTIMIZE=1` builds (covers literal + variable negative lengths, `Infinity`, `2**53`, and the non-throwing `NaN`/fractional truncation cases).

## Out of scope

The 3-arg buffer-view form `new Uint8Array(buffer, byteOffset, length)` offset/length bounds validation is a deeper feature gap (Perry does not yet model real views — the `byteOffset` getter is hardcoded to 0), tracked separately.
