### PR TITLE
node: expose stream helper exports

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4070,6 +4070,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "isErrored", false, None),
     method("stream", "isReadable", false, None),
     method("stream", "isWritable", false, None),
+    // #2685: Node exposes these byte-view helpers and destroyed-state
+    // predicate directly from `node:stream`.
+    method("stream", "_isArrayBufferView", false, None),
+    method("stream", "_isUint8Array", false, None),
+    method("stream", "_uint8ArrayToBuffer", false, None),
+    method("stream", "isDestroyed", false, None),
     // #1537: `stream.getDefaultHighWaterMark(objectMode)` /
     // `setDefaultHighWaterMark(objectMode, value)` — the per-mode platform
     // default highWaterMark (65536 byte / 16 objectMode), mutable at runtime.

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -987,6 +987,43 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // #2685: top-level stream byte-view helpers and destroyed-state predicate.
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "_isArrayBufferView",
+        class_filter: None,
+        runtime: "js_node_stream_is_array_buffer_view",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "_isUint8Array",
+        class_filter: None,
+        runtime: "js_node_stream_is_uint8_array",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "_uint8ArrayToBuffer",
+        class_filter: None,
+        runtime: "js_node_stream_uint8_array_to_buffer",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "stream",
+        has_receiver: false,
+        method: "isDestroyed",
+        class_filter: None,
+        runtime: "js_node_stream_is_destroyed",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // #1537: `stream.getDefaultHighWaterMark(objectMode)` /
     // `setDefaultHighWaterMark(objectMode, value)` — the per-mode platform
     // default highWaterMark (65536 byte / 16 objectMode), mutable at runtime.

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1203,6 +1203,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_stream_is_errored", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_is_readable", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_is_writable", DOUBLE, &[DOUBLE]);
+    // #2685: top-level stream helpers.
+    module.declare_function("js_node_stream_is_array_buffer_view", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_is_uint8_array", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_is_destroyed", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_node_stream_uint8_array_to_buffer", DOUBLE, &[DOUBLE]);
     // #1537: getDefaultHighWaterMark(objectMode) / setDefaultHighWaterMark(objectMode, value).
     module.declare_function("js_node_stream_get_default_hwm", DOUBLE, &[DOUBLE]);
     module.declare_function("js_node_stream_set_default_hwm", DOUBLE, &[DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -800,6 +800,104 @@ pub extern "C" fn js_node_stream_is_writable(stream: f64) -> f64 {
     }
 }
 
+/// #2685: `stream.isDestroyed(s)`. Node returns `null` for non-streams and a
+/// boolean for real stream instances.
+#[no_mangle]
+pub extern "C" fn js_node_stream_is_destroyed(stream: f64) -> f64 {
+    if !is_classic_stream_instance_value(stream) {
+        return f64::from_bits(TAG_NULL);
+    }
+    f64::from_bits(if stream_destroyed(stream) {
+        TAG_TRUE
+    } else {
+        TAG_FALSE
+    })
+}
+
+fn bool_value(value: bool) -> f64 {
+    f64::from_bits(if value { TAG_TRUE } else { TAG_FALSE })
+}
+
+fn stream_value_addr(value: f64) -> Option<usize> {
+    let jsv = JSValue::from_bits(value.to_bits());
+    if !jsv.is_pointer() {
+        return None;
+    }
+    let addr = (value.to_bits() & crate::value::POINTER_MASK) as usize;
+    if addr < 0x10000 {
+        None
+    } else {
+        Some(addr)
+    }
+}
+
+/// #2685: `stream._isArrayBufferView(value)` aliases Node's stream-local
+/// helper semantics, where Buffer counts as an ArrayBuffer view.
+#[no_mangle]
+pub extern "C" fn js_node_stream_is_array_buffer_view(value: f64) -> f64 {
+    let Some(addr) = stream_value_addr(value) else {
+        return f64::from_bits(TAG_FALSE);
+    };
+    let registered_view = crate::buffer::is_registered_buffer(addr)
+        && (!crate::buffer::is_any_array_buffer(addr)
+            || crate::buffer::is_uint8array_buffer(addr)
+            || crate::buffer::is_data_view(addr));
+    bool_value(registered_view || crate::typedarray::lookup_typed_array_kind(addr).is_some())
+}
+
+/// #2685: `stream._isUint8Array(value)` returns true for Buffer as well as
+/// Uint8Array instances, matching Node's internal type predicate.
+#[no_mangle]
+pub extern "C" fn js_node_stream_is_uint8_array(value: f64) -> f64 {
+    let Some(addr) = stream_value_addr(value) else {
+        return f64::from_bits(TAG_FALSE);
+    };
+    let registered_uint8 = crate::buffer::is_registered_buffer(addr)
+        && (crate::buffer::is_uint8array_buffer(addr)
+            || (!crate::buffer::is_any_array_buffer(addr) && !crate::buffer::is_data_view(addr)));
+    bool_value(
+        registered_uint8
+            || crate::typedarray::lookup_typed_array_kind(addr)
+                == Some(crate::typedarray::KIND_UINT8),
+    )
+}
+
+fn stream_byte_view_bytes(value: f64) -> Vec<u8> {
+    let Some(addr) = stream_value_addr(value) else {
+        return Vec::new();
+    };
+    if crate::buffer::is_any_array_buffer(addr)
+        && !crate::buffer::is_uint8array_buffer(addr)
+        && !crate::buffer::is_data_view(addr)
+    {
+        return Vec::new();
+    }
+    if crate::buffer::is_registered_buffer(addr) {
+        let data = crate::buffer::js_native_buffer_data_ptr(value);
+        let len = crate::buffer::js_native_buffer_byte_len(value);
+        if data.is_null() || len == 0 {
+            return Vec::new();
+        }
+        return unsafe { std::slice::from_raw_parts(data, len).to_vec() };
+    }
+    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let ta = addr as *const crate::typedarray::TypedArrayHeader;
+        return unsafe {
+            crate::typedarray::typed_array_bytes(ta)
+                .map(|bytes| bytes.to_vec())
+                .unwrap_or_default()
+        };
+    }
+    Vec::new()
+}
+
+/// #2685: `stream._uint8ArrayToBuffer(view)` returns a Buffer containing the
+/// bytes visible through the passed ArrayBuffer view.
+#[no_mangle]
+pub extern "C" fn js_node_stream_uint8_array_to_buffer(value: f64) -> f64 {
+    buffer_value_from_bytes(&stream_byte_view_bytes(value))
+}
+
 /// #1537: `stream.getDefaultHighWaterMark(objectMode)` returns the current
 /// platform-default highWaterMark — 65536 for byte streams, 16 for
 /// objectMode (both settable via `setDefaultHighWaterMark`).

--- a/crates/perry-runtime/src/node_stream_keepalive.rs
+++ b/crates/perry-runtime/src/node_stream_keepalive.rs
@@ -156,6 +156,16 @@ static KEEP_NS_IS_READABLE: extern "C" fn(f64) -> f64 = super::js_node_stream_is
 #[used]
 static KEEP_NS_IS_WRITABLE: extern "C" fn(f64) -> f64 = super::js_node_stream_is_writable;
 #[used]
+static KEEP_NS_IS_ARRAY_BUFFER_VIEW: extern "C" fn(f64) -> f64 =
+    super::js_node_stream_is_array_buffer_view;
+#[used]
+static KEEP_NS_IS_UINT8_ARRAY: extern "C" fn(f64) -> f64 = super::js_node_stream_is_uint8_array;
+#[used]
+static KEEP_NS_IS_DESTROYED: extern "C" fn(f64) -> f64 = super::js_node_stream_is_destroyed;
+#[used]
+static KEEP_NS_UINT8_ARRAY_TO_BUFFER: extern "C" fn(f64) -> f64 =
+    super::js_node_stream_uint8_array_to_buffer;
+#[used]
 static KEEP_NS_GET_DEFAULT_HWM: extern "C" fn(f64) -> f64 = super::js_node_stream_get_default_hwm;
 #[used]
 static KEEP_NS_SET_DEFAULT_HWM: extern "C" fn(f64, f64) -> f64 =

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1383,6 +1383,32 @@ const ASYNC_HOOKS_NAMESPACE_KEYS: &[&[u8]] = &[
     b"triggerAsyncId",
 ];
 
+const STREAM_NAMESPACE_KEYS: &[&[u8]] = &[
+    b"Duplex",
+    b"PassThrough",
+    b"Readable",
+    b"Stream",
+    b"Transform",
+    b"Writable",
+    b"_isArrayBufferView",
+    b"_isUint8Array",
+    b"_uint8ArrayToBuffer",
+    b"addAbortSignal",
+    b"compose",
+    b"default",
+    b"duplexPair",
+    b"finished",
+    b"getDefaultHighWaterMark",
+    b"isDestroyed",
+    b"isDisturbed",
+    b"isErrored",
+    b"isReadable",
+    b"isWritable",
+    b"pipeline",
+    b"promises",
+    b"setDefaultHighWaterMark",
+];
+
 const DNS_DEFAULT_KEYS: &[&[u8]] = &[
     b"lookup",
     b"lookupService",
@@ -2486,6 +2512,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
         "url.default" => Some(URL_DEFAULT_KEYS),
         "util" => Some(UTIL_NAMESPACE_KEYS),
         "util.default" => Some(UTIL_DEFAULT_KEYS),
+        "stream" => Some(STREAM_NAMESPACE_KEYS),
         "net" => Some(&[
             b"BlockList",
             b"_createServerHandle",
@@ -3320,6 +3347,22 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("util", "debug" | "debuglog" | "inherits") => Some(2),
         ("util", "MIMEParams") => Some(0),
         ("util", "MIMEType") => Some(1),
+        ("stream", "pipeline" | "compose") => Some(0),
+        ("stream", "finished") => Some(3),
+        (
+            "stream",
+            "duplexPair"
+            | "isDisturbed"
+            | "isErrored"
+            | "isReadable"
+            | "isWritable"
+            | "getDefaultHighWaterMark"
+            | "_isArrayBufferView"
+            | "_isUint8Array"
+            | "_uint8ArrayToBuffer"
+            | "isDestroyed",
+        ) => Some(1),
+        ("stream", "setDefaultHighWaterMark" | "addAbortSignal") => Some(2),
         ("net", "createServer" | "Server") => Some(2),
         ("net", "Socket") => Some(1),
         ("net", "BlockList" | "SocketAddress") => Some(0),
@@ -4367,6 +4410,18 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("stream", "compose")
             | ("stream", "duplexPair")
             | ("stream", "pipeline")
+            | ("stream", "finished")
+            | ("stream", "isDisturbed")
+            | ("stream", "isErrored")
+            | ("stream", "isReadable")
+            | ("stream", "isWritable")
+            | ("stream", "getDefaultHighWaterMark")
+            | ("stream", "setDefaultHighWaterMark")
+            | ("stream", "addAbortSignal")
+            | ("stream", "_isArrayBufferView")
+            | ("stream", "_isUint8Array")
+            | ("stream", "_uint8ArrayToBuffer")
+            | ("stream", "isDestroyed")
             | ("stream", "Readable")
             | ("stream", "Writable")
             | ("stream", "Duplex")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1639,16 +1639,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("console", "profile") | ("console", "profileEnd") | ("console", "timeStamp") => {
             f64::from_bits(JSValue::undefined().bits())
         }
-        ("stream", "compose") => crate::node_stream::js_node_stream_compose_args(pack_args()),
-        ("stream", "duplexPair") => crate::node_stream::js_node_stream_duplex_pair(arg(0)),
-        ("stream", "pipeline") => crate::node_stream::js_node_stream_pipeline(pack_args()),
-        // Classic stream constructors are legacy-callable in Node:
-        // `PassThrough()` behaves like `new PassThrough()`.
-        ("stream", "Readable") => crate::node_stream::js_node_stream_readable_new(arg(0)),
-        ("stream", "Writable") => crate::node_stream::js_node_stream_writable_new(arg(0)),
-        ("stream", "Duplex") => crate::node_stream::js_node_stream_duplex_new(arg(0)),
-        ("stream", "Transform") => crate::node_stream::js_node_stream_transform_new(arg(0)),
-        ("stream", "PassThrough") => crate::node_stream::js_node_stream_passthrough_new(arg(0)),
+        ("stream", _) => dispatch_stream_native_module_method(method_name, args_ptr, args_len)
+            .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits())),
         ("readline", "clearLine") => {
             crate::readline_helpers::js_readline_clear_line_args(pack_args())
         }

--- a/crates/perry-runtime/src/object/native_module_stream.rs
+++ b/crates/perry-runtime/src/object/native_module_stream.rs
@@ -37,6 +37,19 @@ pub(crate) fn attach_stream_legacy_prototype(constructor_value: f64) {
         "prototype",
         proto_value,
     );
+    let closure = (constructor_value.to_bits() & crate::value::POINTER_MASK) as usize;
+    for name in [
+        "_isArrayBufferView",
+        "_isUint8Array",
+        "_uint8ArrayToBuffer",
+        "isDestroyed",
+    ] {
+        crate::closure::closure_set_dynamic_prop(
+            closure,
+            name,
+            bound_native_callable_export_value("stream", name),
+        );
+    }
 }
 
 pub(crate) fn attach_stream_constructor_prototype(constructor_value: f64, name: &str) {
@@ -76,6 +89,53 @@ pub(crate) fn is_stream_event_emitter_prototype_value(value: f64) -> bool {
         return false;
     }
     STREAM_EVENT_EMITTER_PROTOTYPES.with(|protos| protos.borrow().contains(&bits))
+}
+
+pub(crate) unsafe fn dispatch_stream_native_module_method(
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    let arg = |n: usize| -> f64 {
+        if n < args_len && !args_ptr.is_null() {
+            *args_ptr.add(n)
+        } else {
+            f64::from_bits(JSValue::undefined().bits())
+        }
+    };
+    let pack_args = || -> *mut crate::array::ArrayHeader {
+        let mut arr = crate::array::js_array_alloc(args_len as u32);
+        for i in 0..args_len {
+            arr = crate::array::js_array_push_f64(arr, arg(i));
+        }
+        arr
+    };
+
+    Some(match method_name {
+        "compose" => crate::node_stream::js_node_stream_compose_args(pack_args()),
+        "duplexPair" => crate::node_stream::js_node_stream_duplex_pair(arg(0)),
+        "pipeline" => crate::node_stream::js_node_stream_pipeline(pack_args()),
+        "finished" => crate::node_stream::js_node_stream_finished(pack_args()),
+        "isDisturbed" => crate::node_stream::js_node_stream_is_disturbed(arg(0)),
+        "isErrored" => crate::node_stream::js_node_stream_is_errored(arg(0)),
+        "isReadable" => crate::node_stream::js_node_stream_is_readable(arg(0)),
+        "isWritable" => crate::node_stream::js_node_stream_is_writable(arg(0)),
+        "getDefaultHighWaterMark" => crate::node_stream::js_node_stream_get_default_hwm(arg(0)),
+        "setDefaultHighWaterMark" => {
+            crate::node_stream::js_node_stream_set_default_hwm(arg(0), arg(1))
+        }
+        "addAbortSignal" => crate::node_stream::js_node_stream_add_abort_signal(arg(0), arg(1)),
+        "_isArrayBufferView" => crate::node_stream::js_node_stream_is_array_buffer_view(arg(0)),
+        "_isUint8Array" => crate::node_stream::js_node_stream_is_uint8_array(arg(0)),
+        "_uint8ArrayToBuffer" => crate::node_stream::js_node_stream_uint8_array_to_buffer(arg(0)),
+        "isDestroyed" => crate::node_stream::js_node_stream_is_destroyed(arg(0)),
+        "Readable" => crate::node_stream::js_node_stream_readable_new(arg(0)),
+        "Writable" => crate::node_stream::js_node_stream_writable_new(arg(0)),
+        "Duplex" => crate::node_stream::js_node_stream_duplex_new(arg(0)),
+        "Transform" => crate::node_stream::js_node_stream_transform_new(arg(0)),
+        "PassThrough" => crate::node_stream::js_node_stream_passthrough_new(arg(0)),
+        _ => return None,
+    })
 }
 
 #[cfg(test)]

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1798 entries across 106 modules
+// Coverage: 1802 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -3149,6 +3149,12 @@ declare module "stream" {
   /** stdlib */
   export const promises: any;
   /** stdlib */
+  export function _isArrayBufferView(...args: any[]): any;
+  /** stdlib */
+  export function _isUint8Array(...args: any[]): any;
+  /** stdlib */
+  export function _uint8ArrayToBuffer(...args: any[]): any;
+  /** stdlib */
   export function addAbortSignal(...args: any[]): any;
   /** stdlib */
   export function compose(...args: any[]): any;
@@ -3160,6 +3166,8 @@ declare module "stream" {
   export function finished(...args: any[]): any;
   /** stdlib */
   export function getDefaultHighWaterMark(...args: any[]): any;
+  /** stdlib */
+  export function isDestroyed(...args: any[]): any;
   /** stdlib */
   export function isDisturbed(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2616 entries across 109 modules.
+Total: 2620 entries across 109 modules.
 
 ## Modules
 
@@ -2812,6 +2812,9 @@ Total: 2616 entries across 109 modules.
 
 ### Methods
 
+- `_isArrayBufferView` — module
+- `_isUint8Array` — module
+- `_uint8ArrayToBuffer` — module
 - `addAbortSignal` — module
 - `addListener` — instance
 - `allowHalfOpen` — instance
@@ -2829,6 +2832,7 @@ Total: 2616 entries across 109 modules.
 - `finished` — module
 - `getDefaultHighWaterMark` — module
 - `getMaxListeners` — instance
+- `isDestroyed` — module
 - `isDisturbed` — module
 - `isErrored` — module
 - `isPaused` — instance

--- a/test-parity/node-suite/stream/static/helper-exports.ts
+++ b/test-parity/node-suite/stream/static/helper-exports.ts
@@ -1,0 +1,53 @@
+import stream from "node:stream";
+import * as streamNs from "node:stream";
+
+const helpers = [
+  ["_isArrayBufferView", (stream as any)._isArrayBufferView],
+  ["_isUint8Array", (stream as any)._isUint8Array],
+  ["_uint8ArrayToBuffer", (stream as any)._uint8ArrayToBuffer],
+  ["isDestroyed", (stream as any).isDestroyed],
+] as const;
+
+for (const [name, fn] of helpers) {
+  console.log(
+    "helper:",
+    name,
+    Object.keys(stream as any).includes(name),
+    Object.keys(streamNs as any).includes(name),
+    typeof fn,
+    fn.length,
+  );
+}
+
+const u8 = new Uint8Array([1, 2, 3]);
+const buffer = Buffer.from([4, 5]);
+const dataView = new DataView(new ArrayBuffer(2));
+
+console.log(
+  "isUint8Array:",
+  (stream as any)._isUint8Array(u8),
+  (stream as any)._isUint8Array(buffer),
+  (stream as any)._isUint8Array(dataView),
+);
+console.log(
+  "isArrayBufferView:",
+  (stream as any)._isArrayBufferView(u8),
+  (stream as any)._isArrayBufferView(buffer),
+  (stream as any)._isArrayBufferView(dataView),
+  (stream as any)._isArrayBufferView(new ArrayBuffer(1)),
+);
+
+const fromU8 = (stream as any)._uint8ArrayToBuffer(u8);
+const fromDataView = (stream as any)._uint8ArrayToBuffer(dataView);
+console.log("toBuffer u8:", Buffer.isBuffer(fromU8), fromU8.toString("hex"));
+console.log(
+  "toBuffer dataview:",
+  Buffer.isBuffer(fromDataView),
+  fromDataView.length,
+);
+
+const readable = stream.Readable.from(["x"]);
+console.log("destroyed before:", (stream as any).isDestroyed(readable));
+readable.destroy();
+console.log("destroyed after:", (stream as any).isDestroyed(readable));
+console.log("destroyed plain:", (stream as any).isDestroyed({ destroyed: true }));


### PR DESCRIPTION
Fixes #2685

## Summary
- expose node:stream _isArrayBufferView, _isUint8Array, _uint8ArrayToBuffer, and isDestroyed through the manifest, default export, namespace export, and dynamic dispatch
- add runtime stream helper implementations for Buffer/Uint8Array/DataView predicates, byte-view Buffer conversion, and destroyed-state checks
- add parity coverage for helper export shape and byte-view/destroyed behavior; regenerate API docs

## Tests
- NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module stream/static --filter helper-exports\n- NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module stream/static\n- NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module stream/imports\n- cargo fmt --all -- --check\n- git diff --check origin/main\n- ./scripts/check_file_size.sh\n- cargo check -p perry-runtime -p perry-codegen -p perry-api-manifest