### PR TITLE
fix(runtime): implement Function.prototype[Symbol.hasInstance] (#3662)

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1093,6 +1093,36 @@ fn install_typed_array_proto_accessors(proto_obj: *mut ObjectHeader) {
     }
 }
 
+/// Install `%Function.prototype% [ @@hasInstance ]` (#3662). Pre-fix this was
+/// `undefined` — `typeof Function.prototype[Symbol.hasInstance]` reported
+/// "undefined", a reflective `.call` threw, and a class with a custom
+/// `static [Symbol.hasInstance]` was the only way to reach the protocol. The
+/// method is keyed by the real well-known `Symbol.hasInstance` (not an
+/// `@@`-string own property, which would leak into `getOwnPropertyNames`).
+fn install_function_has_instance_symbol(proto_obj: *mut ObjectHeader) {
+    if proto_obj.is_null() {
+        return;
+    }
+    unsafe {
+        let func_ptr = super::instanceof::function_prototype_has_instance_thunk as *const u8;
+        crate::closure::js_register_closure_arity(func_ptr, 1);
+        let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+        if closure.is_null() {
+            return;
+        }
+        super::native_module::set_bound_native_closure_name(closure, "[Symbol.hasInstance]");
+        super::native_module::set_builtin_closure_length(closure as usize, 1);
+        let sym = crate::symbol::well_known_symbol("hasInstance");
+        if sym.is_null() {
+            return;
+        }
+        let proto_value = crate::value::js_nanbox_pointer(proto_obj as i64);
+        let sym_value = f64::from_bits(crate::value::JSValue::pointer(sym as *const u8).bits());
+        let fn_value = f64::from_bits(crate::value::js_nanbox_pointer(closure as i64).to_bits());
+        crate::symbol::js_object_set_symbol_property(proto_value, sym_value, fn_value);
+    }
+}
+
 fn install_typed_array_iterator_symbol(proto_obj: *mut ObjectHeader) {
     if proto_obj.is_null() {
         return;
@@ -2712,6 +2742,7 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                 1,
             );
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            install_function_has_instance_symbol(proto_obj);
         }
         "String" => {
             install_noop_proto_methods(

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -197,6 +197,19 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             _ => {}
         }
         let class_id = match name {
+            // Reference-type global constructors used as runtime *values*
+            // (e.g. `Function.prototype[Symbol.hasInstance].call(Map, m)`, or a
+            // dynamic `x instanceof ctorVar`). These mirror the synthetic ids
+            // the compile-time `instanceof` operator emits — see
+            // perry-codegen/src/expr/instance_misc1.rs — which `js_instanceof`
+            // resolves via the per-type registries (#3662). `Array`/`Object`/
+            // `Date` constructor *values* aren't identified here (they are not
+            // noop-thunk closures), so they stay a known gap for the dynamic
+            // path; the literal-RHS operator handles them at compile time.
+            "Map" => 0xFFFF0022,
+            "Set" => 0xFFFF0023,
+            "RegExp" => 0xFFFF0021,
+            "ArrayBuffer" => 0xFFFF0025,
             "Error" => crate::error::CLASS_ID_ERROR,
             "TypeError" => crate::error::CLASS_ID_TYPE_ERROR,
             "RangeError" => crate::error::CLASS_ID_RANGE_ERROR,
@@ -255,6 +268,12 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
     // (Callable RHS values never reach here — they resolve to a synthetic
     // class id above — so we don't need to model the arrow-`.prototype`
     // case at this site.)
+    //
+    // #3662: `OrdinaryHasInstance` (the `@@hasInstance` reflective path) wants
+    // `false` here, not a `TypeError`; it sets this flag for the call.
+    if SUPPRESS_INSTANCEOF_RHS_THROW.with(|c| c.get()) {
+        return f64::from_bits(TAG_FALSE);
+    }
     throw_invalid_instanceof_rhs(type_ref)
 }
 
@@ -264,6 +283,49 @@ fn throw_invalid_instanceof_rhs(type_ref: f64) -> ! {
         throw_type_error(b"Right-hand side of 'instanceof' is not callable");
     }
     throw_type_error(b"Right-hand side of 'instanceof' is not an object");
+}
+
+/// `%Function.prototype% [ @@hasInstance ]` (#3662). Spec: return
+/// `OrdinaryHasInstance(this, V)`. Unlike the `instanceof` *operator* — which
+/// throws a `TypeError` on a non-callable right-hand side — `OrdinaryHasInstance`
+/// returns `false` when `this` is not callable, so `Function.prototype[Symbol
+/// .hasInstance].call(undefined, {})` is `false` (not a throw). Installed on
+/// `Function.prototype` under the `@@hasInstance` key; the receiver flows in
+/// through `IMPLICIT_THIS` set by the `.call`/member dispatch.
+pub(crate) extern "C" fn function_prototype_has_instance_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let constructor = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let result = ordinary_has_instance(constructor, value);
+    f64::from_bits(if result {
+        crate::value::TAG_TRUE
+    } else {
+        crate::value::TAG_FALSE
+    })
+}
+
+/// `OrdinaryHasInstance(C, O)` without the throwing semantics of the operator:
+/// a non-callable `C` (or one whose constructor identity Perry cannot resolve)
+/// yields `false` rather than a `TypeError`. Delegates to the operator's full
+/// constructor-resolution path (`js_instanceof_dynamic`) with the unresolved-RHS
+/// throw suppressed for the duration of the call, so every constructor shape the
+/// operator understands (class objects, bound natives like `Array`/`Map`,
+/// INT32 class-refs, synthetic function class ids, …) resolves identically.
+fn ordinary_has_instance(constructor: f64, value: f64) -> bool {
+    let prev = SUPPRESS_INSTANCEOF_RHS_THROW.with(|c| c.replace(true));
+    let result = js_instanceof_dynamic(value, constructor);
+    SUPPRESS_INSTANCEOF_RHS_THROW.with(|c| c.set(prev));
+    result.to_bits() == crate::value::TAG_TRUE
+}
+
+thread_local! {
+    /// When set, `js_instanceof_dynamic` returns `false` instead of throwing on
+    /// an unresolved / non-callable right-hand side. Used by
+    /// `OrdinaryHasInstance` (#3662), whose spec returns `false` there rather
+    /// than the `TypeError` the `instanceof` operator raises.
+    static SUPPRESS_INSTANCEOF_RHS_THROW: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
 }
 
 /// Whether `value` is a (non-callable) object for the purposes of the

--- a/test-files/test_gap_3662_function_hasinstance.ts
+++ b/test-files/test_gap_3662_function_hasinstance.ts
@@ -1,0 +1,42 @@
+// #3662 — `Function.prototype[Symbol.hasInstance]` must exist and implement
+// `OrdinaryHasInstance`. Pre-fix it was `undefined`: `typeof` reported
+// "undefined" and any reflective use threw. Unlike the `instanceof` operator
+// (which throws a TypeError on a non-callable RHS), `OrdinaryHasInstance`
+// returns `false` for a non-callable `this`. We print booleans / error *types*
+// so the output is byte-identical to Node.
+
+function r(fn: () => unknown): string {
+    try {
+        return String(fn());
+    } catch (e: any) {
+        return "throw:" + e.constructor.name;
+    }
+}
+
+const hi = Function.prototype[Symbol.hasInstance];
+console.log("typeof:", typeof hi);
+
+// Non-callable `this` -> false (not a TypeError).
+console.log("undefined:", r(() => hi.call(undefined, {})));
+console.log("number:", r(() => hi.call(5, {})));
+console.log("plainobj:", r(() => hi.call({}, [])));
+
+// Non-object value with a callable `this` -> false.
+console.log("value-prim:", r(() => hi.call(Array, 5)));
+
+// User classes resolve through the normal prototype-chain walk.
+class Animal {}
+class Dog extends Animal {}
+const d = new Dog();
+console.log("Dog d:", r(() => hi.call(Dog, d)));
+console.log("Animal d:", r(() => hi.call(Animal, d)));
+console.log("Dog {}:", r(() => hi.call(Dog, {})));
+
+// Built-in reference constructors used as runtime values.
+console.log("Map m:", r(() => hi.call(Map, new Map())));
+console.log("Set s:", r(() => hi.call(Set, new Set())));
+console.log("RegExp re:", r(() => hi.call(RegExp, /x/)));
+console.log("Set m:", r(() => hi.call(Set, new Map())));
+
+// The `instanceof` operator itself is unchanged.
+console.log("operator:", d instanceof Dog, d instanceof Animal, ({}) instanceof Dog, [] instanceof Array);


### PR DESCRIPTION
## Summary

`Function.prototype[Symbol.hasInstance]` was **undefined** in Perry — `typeof Function.prototype[Symbol.hasInstance]` reported `"undefined"`, any reflective use threw, and a class with a custom `static [Symbol.hasInstance]` was the only way to reach the protocol. This is the **missing-method slice** of the #3662 "builtins must throw / behave per spec" cluster (the `Function.prototype.{apply,call,bind}` not-callable checks landed in #4073).

### Before
```ts
typeof Function.prototype[Symbol.hasInstance]              // "undefined"
Function.prototype[Symbol.hasInstance].call(undefined, {}) // threw TypeError
```
### After (byte-identical to `node --experimental-strip-types`)
```ts
typeof Function.prototype[Symbol.hasInstance]              // "function"
Function.prototype[Symbol.hasInstance].call(undefined, {}) // false
Function.prototype[Symbol.hasInstance].call(Dog, new Dog()) // true
```

## What changed

- **`global_this.rs`** — `install_function_has_instance_symbol` installs the method on `Function.prototype`, keyed by the real well-known `Symbol.hasInstance` (via `js_object_set_symbol_property`, not an `@@`-string own property that would leak into `getOwnPropertyNames`).
- **`instanceof.rs`** — `function_prototype_has_instance_thunk` + `ordinary_has_instance`. `OrdinaryHasInstance` differs from the `instanceof` *operator*: a non-callable `this` yields `false`, **not** a `TypeError`. It reuses the operator's full constructor-resolution path (`js_instanceof_dynamic`) with a thread-local flag (`SUPPRESS_INSTANCEOF_RHS_THROW`) that makes the unresolved-RHS tail return `false` instead of throwing — for this path only.
- `js_instanceof_dynamic` now also resolves the `Map`/`Set`/`RegExp`/`ArrayBuffer` global constructor **values** (mirroring the synthetic class ids the compile-time operator emits), so reflective `hasInstance` **and** a dynamic `x instanceof ctorVar` work for them.

## Testing

New gap test `test-files/test_gap_3662_function_hasinstance.ts` is byte-identical to Node in both the default auto-optimize and `PERRY_NO_AUTO_OPTIMIZE=1` builds. Existing `instanceof` gap tests still pass; the `instanceof` operator is unchanged.

## Known gap (follow-up)

`Array`/`Object`/`Date` constructor *values* are not yet identified on the dynamic path (they aren't noop-thunk closures, so `identify_global_builtin_constructor` returns `None`), so `hi.call(Array, [])` and `x instanceof ArrayVar` stay `false`. The literal-RHS `instanceof` operator handles them at compile time; this pre-existing dynamic-path gap is left for a separate change.
