### PR TITLE
fix(runtime): throw TypeError for non-callable array/TypedArray callbacks (#4091)

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -257,7 +257,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             Ok(blk.call(
                 DOUBLE,
                 "js_array_find",
@@ -269,7 +270,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let i32_v = blk.call(
                 I32,
                 "js_array_findIndex",
@@ -282,7 +284,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             Ok(blk.call(
                 DOUBLE,
                 "js_array_find_last",
@@ -294,7 +297,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let i32_v = blk.call(
                 I32,
                 "js_array_find_last_index",

--- a/crates/perry-codegen/src/expr/bigint_set.rs
+++ b/crates/perry-codegen/src/expr/bigint_set.rs
@@ -164,7 +164,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             };
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             // Convert literal NaN bits to a double via bitcast — but the
             // string above isn't valid LLVM. Use a real NaN literal instead.
             let init_use = if has_init == "1" {

--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -58,7 +58,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let result = blk.call(
                 I64,
                 "js_array_filter",
@@ -141,7 +142,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             Ok(blk.call(
                 DOUBLE,
                 "js_array_some",
@@ -155,7 +157,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             Ok(blk.call(
                 DOUBLE,
                 "js_array_every",

--- a/crates/perry-codegen/src/expr/math_simple.rs
+++ b/crates/perry-codegen/src/expr/math_simple.rs
@@ -125,7 +125,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            // `map` uses a receiver-aware validator (TypedArray.map renders its
+            // non-callable message differently than Array.prototype.map).
+            let cb_handle = blk.call(
+                I64,
+                "js_validate_array_map_callback",
+                &[(I64, &arr_handle), (DOUBLE, &cb_box)],
+            );
             let result = blk.call(
                 I64,
                 "js_array_map",

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -537,7 +537,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating
+            // (validated up front so even an empty array throws, per spec).
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             // Load length (null-guarded).
             let len_i32 = blk.safe_load_i32_from_ptr(&arr_handle);
             // Loop: for i = 0; i < len; i++

--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -336,7 +336,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = unbox_to_i64(blk, &arr_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let result = blk.call(
                 I64,
                 "js_array_flatMap",

--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -63,7 +63,8 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let runtime_fn = if property == "some" {
                 "js_array_some"
             } else {
@@ -236,7 +237,8 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let result = blk.call(
                 I64,
                 "js_array_flatMap",
@@ -257,7 +259,8 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             Ok(blk.call(
                 DOUBLE,
                 "js_array_find",
@@ -274,7 +277,8 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let i32_v = blk.call(
                 I32,
                 "js_array_findIndex",
@@ -292,7 +296,8 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             Ok(blk.call(
                 DOUBLE,
                 "js_array_find_last",
@@ -309,7 +314,8 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let i32_v = blk.call(
                 I32,
                 "js_array_find_last_index",
@@ -333,7 +339,8 @@ pub(crate) fn lower_array_method(
             };
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let has_init_str = format!("{}", has_initial);
             Ok(blk.call(
                 DOUBLE,
@@ -362,7 +369,8 @@ pub(crate) fn lower_array_method(
             };
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let has_init_str = format!("{}", has_initial);
             Ok(blk.call(
                 DOUBLE,
@@ -382,7 +390,14 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            // `map` uses a receiver-aware validator (TypedArray.map renders its
+            // non-callable message differently than Array.prototype.map).
+            let cb_handle = blk.call(
+                I64,
+                "js_validate_array_map_callback",
+                &[(I64, &recv_handle), (DOUBLE, &cb_box)],
+            );
             let result = blk.call(
                 I64,
                 "js_array_map",
@@ -400,7 +415,8 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             let result = blk.call(
                 I64,
                 "js_array_filter",
@@ -418,7 +434,8 @@ pub(crate) fn lower_array_method(
             let cb_box = lower_expr(ctx, &args[0])?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
-            let cb_handle = unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating.
+            let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
             blk.call_void(
                 "js_array_forEach",
                 &[(I64, &recv_handle), (I64, &cb_handle)],

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -924,6 +924,12 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_array_sort_with_comparator", I64, &[I64, I64]);
     // #2796: validate sort/toSorted comparator (function | undefined) before sorting.
     module.declare_function("js_validate_array_comparator", I64, &[DOUBLE]);
+    // #4091: non-callable callback validators for higher-order array /
+    // TypedArray methods. Standard form takes the boxed callback; the `map`
+    // form also takes the receiver handle so it can pick the typed-array
+    // message format.
+    module.declare_function("js_validate_array_callback", I64, &[DOUBLE]);
+    module.declare_function("js_validate_array_map_callback", I64, &[I64, DOUBLE]);
     // ES2023 immutable array methods
     module.declare_function("js_array_to_reversed", I64, &[I64]);
     module.declare_function("js_array_to_sorted_default", I64, &[I64]);

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -8,7 +8,7 @@ use crate::native_value::{
     LoweredValue, MaterializationReason, NativeOwnedViewSlot, NativeRep, PodLayoutDecision,
     PodLocal, SemanticKind,
 };
-use crate::types::{I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I32, I64, I8, PTR};
 
 fn is_global_this_value(expr: &perry_hir::Expr) -> bool {
     matches!(expr, perry_hir::Expr::GlobalGet(_))
@@ -1436,7 +1436,13 @@ fn lower_unused_expr(ctx: &mut FnCtx<'_>, expr: &perry_hir::Expr) -> Result<bool
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
             let arr_handle = crate::expr::unbox_to_i64(blk, &arr_box);
-            let cb_handle = crate::expr::unbox_to_i64(blk, &cb_box);
+            // #4091: throw TypeError for a non-callable callback before iterating
+            // (the discarded-result path still validates per spec).
+            let cb_handle = blk.call(
+                I64,
+                "js_validate_array_map_callback",
+                &[(I64, &arr_handle), (DOUBLE, &cb_box)],
+            );
             blk.call_void(
                 "js_array_map_discard",
                 &[(I64, &arr_handle), (I64, &cb_handle)],

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -787,3 +787,144 @@ static KEEP_ARRAY_TO_LOCALE_STRING: extern "C" fn(
     f64,
     f64,
 ) -> *mut crate::string::StringHeader = js_array_to_locale_string;
+
+// ---------------------------------------------------------------------------
+// #4091: non-callable callback validation for higher-order array / TypedArray
+// methods (map/forEach/filter/reduce/find*/some/every/flatMap). Per ECMA-262
+// these throw a `TypeError` *before* iterating when the callback is not
+// callable. Codegen has already unboxed the closure pointer by the time the
+// runtime entry runs, so — mirroring `js_validate_array_comparator` (sort,
+// #2796) — the boxed value is threaded into a validator that returns the
+// resolved `ClosureHeader*` (as `i64`) or throws.
+// ---------------------------------------------------------------------------
+
+/// Read a runtime `StringHeader*` into an owned Rust `String`.
+fn header_to_owned_string(sp: *const crate::string::StringHeader) -> String {
+    if sp.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let header = &*sp;
+        let bytes_ptr = (sp as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        let slice = std::slice::from_raw_parts(bytes_ptr, header.byte_len as usize);
+        std::str::from_utf8(slice).unwrap_or("").to_string()
+    }
+}
+
+#[inline]
+fn jsvalue_to_owned_string(v: f64) -> String {
+    header_to_owned_string(crate::value::js_jsvalue_to_string(v))
+}
+
+#[inline]
+fn typeof_owned_string(v: f64) -> String {
+    header_to_owned_string(crate::builtins::js_value_typeof(v))
+}
+
+/// Resolve a higher-order callback argument to its `ClosureHeader*` (as
+/// `i64`). Returns `Some(ptr)` only for values the runtime can actually
+/// invoke (real closures, bound methods/functions); `None` for any
+/// non-callable so the caller can throw the spec `TypeError`.
+#[inline]
+fn resolve_callback_ptr(cb_boxed: f64) -> Option<i64> {
+    use crate::value::JSValue;
+    let jv = JSValue::from_bits(cb_boxed.to_bits());
+    if jv.is_pointer() {
+        let ptr = jv.as_pointer::<ClosureHeader>();
+        if !crate::closure::get_valid_func_ptr(ptr).is_null() {
+            return Some(ptr as i64);
+        }
+    }
+    None
+}
+
+/// Render a non-callable value for the *standard* V8 message used by every
+/// `Array.prototype` iteration method and all `%TypedArray%.prototype`
+/// methods except `map`: `<typeof> <value>` (e.g. `number 5`, `string "x"`,
+/// `object null`, `undefined`, `boolean true`, `object`, `bigint`, `symbol`).
+fn render_callback_typeof(cb_boxed: f64) -> String {
+    use crate::value::JSValue;
+    let jv = JSValue::from_bits(cb_boxed.to_bits());
+    let ty = typeof_owned_string(cb_boxed);
+    match ty.as_str() {
+        "undefined" => "undefined".to_string(),
+        "object" if jv.is_null() => "object null".to_string(),
+        // Plain objects/arrays render as just the type — no value.
+        "object" => "object".to_string(),
+        "number" | "boolean" => format!("{} {}", ty, jsvalue_to_owned_string(cb_boxed)),
+        "string" => format!("{} \"{}\"", ty, jsvalue_to_owned_string(cb_boxed)),
+        // bigint / symbol render as just the type — no value.
+        _ => ty,
+    }
+}
+
+/// Render a non-callable value for `%TypedArray%.prototype.map`, which uses a
+/// distinct rendering with no `typeof` prefix (e.g. `5`, `x`, `null`, `true`,
+/// `undefined`). Object receivers fall back to V8's `#<Object>`.
+fn render_callback_plain(cb_boxed: f64) -> String {
+    use crate::value::JSValue;
+    let jv = JSValue::from_bits(cb_boxed.to_bits());
+    if jv.is_undefined()
+        || jv.is_null()
+        || jv.is_bool()
+        || jv.is_number()
+        || jv.is_int32()
+        || jv.is_any_string()
+        || jv.is_bigint()
+    {
+        return jsvalue_to_owned_string(cb_boxed);
+    }
+    if jv.is_pointer() {
+        let ptr = jv.as_pointer::<u8>();
+        if crate::symbol::is_registered_symbol(ptr as usize) {
+            return jsvalue_to_owned_string(cb_boxed);
+        }
+        return "#<Object>".to_string();
+    }
+    jsvalue_to_owned_string(cb_boxed)
+}
+
+#[cold]
+fn throw_not_a_function(rendered: String) -> ! {
+    let message = format!("{} is not a function", rendered);
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+}
+
+/// Validate a higher-order array/TypedArray callback (#4091). Returns the
+/// resolved `ClosureHeader*` (as `i64`) for callable values, or throws a
+/// `TypeError` with V8's standard `<typeof> <value> is not a function`
+/// message. Used by every iteration method except `map`.
+#[no_mangle]
+pub extern "C" fn js_validate_array_callback(cb_boxed: f64) -> i64 {
+    if let Some(p) = resolve_callback_ptr(cb_boxed) {
+        return p;
+    }
+    throw_not_a_function(render_callback_typeof(cb_boxed));
+}
+
+#[used]
+static KEEP_VALIDATE_ARRAY_CALLBACK: extern "C" fn(f64) -> i64 = js_validate_array_callback;
+
+/// Validate a `map` callback (#4091). Identical to
+/// [`js_validate_array_callback`] except that, for a typed-array receiver, the
+/// non-callable message uses `%TypedArray%.prototype.map`'s distinct rendering
+/// (no `typeof` prefix). Takes the receiver handle so it can pick the format.
+#[no_mangle]
+pub extern "C" fn js_validate_array_map_callback(arr: i64, cb_boxed: f64) -> i64 {
+    if let Some(p) = resolve_callback_ptr(cb_boxed) {
+        return p;
+    }
+    let is_typed_array = crate::typedarray::lookup_typed_array_kind(arr as usize).is_some();
+    let rendered = if is_typed_array {
+        render_callback_plain(cb_boxed)
+    } else {
+        render_callback_typeof(cb_boxed)
+    };
+    throw_not_a_function(rendered);
+}
+
+#[used]
+static KEEP_VALIDATE_ARRAY_MAP_CALLBACK: extern "C" fn(i64, f64) -> i64 =
+    js_validate_array_map_callback;

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -55,7 +55,8 @@ pub use self::iter_methods::{
     js_array_at, js_array_every, js_array_filter, js_array_find, js_array_findIndex,
     js_array_find_last, js_array_find_last_index, js_array_flatMap, js_array_forEach,
     js_array_join, js_array_join_value, js_array_map, js_array_map_discard, js_array_reduce,
-    js_array_some, js_array_to_locale_string,
+    js_array_some, js_array_to_locale_string, js_validate_array_callback,
+    js_validate_array_map_callback,
 };
 pub use self::iter_object::{
     array_entries_iter, array_keys_iter, array_values_iter, dispatch_array_iterator_method,

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -438,19 +438,22 @@ unsafe fn dispatch_typed_array_method(
             f64::NAN
         }
     };
-    let arg_closure = |i: usize| -> *const crate::closure::ClosureHeader {
-        if i < args_len && !args_ptr.is_null() {
-            let v = *args_ptr.add(i);
-            let bits = v.to_bits();
-            let tag = (bits >> 48) as u16;
-            if tag == 0x7FFD {
-                (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::closure::ClosureHeader
-            } else {
-                std::ptr::null()
-            }
+    // #4091: validate the 1st argument is callable, throwing a spec `TypeError`
+    // otherwise (this dynamic dispatch tower is the inline-`new` /
+    // `Uint8Array`-local path, where the boxed callback is still available).
+    // `map` uses %TypedArray%.prototype.map's distinct non-callable rendering.
+    let validate_cb = |map_form: bool| -> *const crate::closure::ClosureHeader {
+        let boxed = if args_len >= 1 && !args_ptr.is_null() {
+            *args_ptr
         } else {
-            std::ptr::null()
-        }
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        };
+        let p = if map_form {
+            crate::array::js_validate_array_map_callback(ta as i64, boxed)
+        } else {
+            crate::array::js_validate_array_callback(boxed)
+        };
+        p as *const crate::closure::ClosureHeader
     };
     let r = match method_name {
         "length" => crate::typedarray::js_typed_array_length(ta) as f64,
@@ -520,21 +523,9 @@ unsafe fn dispatch_typed_array_method(
             };
             f64::from_bits(crate::typedarray::js_typed_array_with(ta, idx, val) as u64)
         }
-        "findLast" => {
-            let cb = arg_closure(0);
-            if cb.is_null() {
-                f64::from_bits(crate::value::TAG_UNDEFINED)
-            } else {
-                crate::typedarray::js_typed_array_find_last(ta, cb)
-            }
-        }
+        "findLast" => crate::typedarray::js_typed_array_find_last(ta, validate_cb(false)),
         "findLastIndex" => {
-            let cb = arg_closure(0);
-            if cb.is_null() {
-                -1.0
-            } else {
-                crate::typedarray::js_typed_array_find_last_index(ta, cb)
-            }
+            crate::typedarray::js_typed_array_find_last_index(ta, validate_cb(false))
         }
         // #2797/#2798/#2799: callback-bearing %TypedArray% methods. The codegen
         // lowerers only fire for receivers it can statically prove are plain
@@ -542,18 +533,18 @@ unsafe fn dispatch_typed_array_method(
         // where these arms previously fell through to the undefined catch-all
         // (so `ta.map`/`ta.reduce`/`ta.find` silently no-op'd).
         "map" => {
-            let result = crate::typedarray::js_typed_array_map(ta, arg_closure(0));
+            let result = crate::typedarray::js_typed_array_map(ta, validate_cb(true));
             f64::from_bits(JSValue::pointer(result as *mut u8).bits())
         }
         "filter" => {
-            let result = crate::typedarray::js_typed_array_filter(ta, arg_closure(0));
+            let result = crate::typedarray::js_typed_array_filter(ta, validate_cb(false));
             f64::from_bits(JSValue::pointer(result as *mut u8).bits())
         }
-        "forEach" => crate::typedarray::js_typed_array_for_each(ta, arg_closure(0)),
-        "some" => crate::typedarray::js_typed_array_some(ta, arg_closure(0)),
-        "every" => crate::typedarray::js_typed_array_every(ta, arg_closure(0)),
-        "find" => crate::typedarray::js_typed_array_find(ta, arg_closure(0)),
-        "findIndex" => crate::typedarray::js_typed_array_find_index(ta, arg_closure(0)),
+        "forEach" => crate::typedarray::js_typed_array_for_each(ta, validate_cb(false)),
+        "some" => crate::typedarray::js_typed_array_some(ta, validate_cb(false)),
+        "every" => crate::typedarray::js_typed_array_every(ta, validate_cb(false)),
+        "find" => crate::typedarray::js_typed_array_find(ta, validate_cb(false)),
+        "findIndex" => crate::typedarray::js_typed_array_find_index(ta, validate_cb(false)),
         "values" | "Symbol.iterator" | "@@iterator" => {
             let iter =
                 crate::array::js_array_values_iter_obj(ta as *const crate::array::ArrayHeader);
@@ -581,7 +572,7 @@ unsafe fn dispatch_typed_array_method(
             }
         }
         "reduce" | "reduceRight" => {
-            let cb = arg_closure(0);
+            let cb = validate_cb(false);
             // initial value present only when a 2nd arg was passed.
             let (has_init, init) = if args_len >= 2 && !args_ptr.is_null() {
                 (1, *args_ptr.add(1))
@@ -1664,15 +1655,18 @@ pub unsafe extern "C" fn js_native_call_method(
                     }
                     "map" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr =
+                            crate::array::js_validate_array_map_callback(arr as i64, *args_ptr)
+                                as *const crate::closure::ClosureHeader;
                         let result = crate::array::js_array_map(arr, cb_ptr);
                         return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
                     }
                     "filter" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         let result = crate::array::js_array_filter(arr, cb_ptr);
                         return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
                     }
@@ -1689,8 +1683,9 @@ pub unsafe extern "C" fn js_native_call_method(
                     // pattern.
                     "forEach" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         crate::array::js_array_forEach(arr, cb_ptr);
                         return f64::from_bits(crate::value::TAG_UNDEFINED);
                     }
@@ -1812,39 +1807,45 @@ pub unsafe extern "C" fn js_native_call_method(
                     // `triggerMultiComponentHooks`, so on_set never fired.
                     "some" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         return crate::array::js_array_some(arr, cb_ptr);
                     }
                     "every" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         return crate::array::js_array_every(arr, cb_ptr);
                     }
                     "find" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         return crate::array::js_array_find(arr, cb_ptr);
                     }
                     "findIndex" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         let idx = crate::array::js_array_findIndex(arr, cb_ptr);
                         return idx as f64;
                     }
                     "findLast" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         return crate::array::js_array_find_last(arr, cb_ptr);
                     }
                     "findLastIndex" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         let idx = crate::array::js_array_find_last_index(arr, cb_ptr);
                         return idx as f64;
                     }
@@ -1882,8 +1883,9 @@ pub unsafe extern "C" fn js_native_call_method(
                     }
                     "reduce" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         let (has_init, init) = if args_len >= 2 {
                             (1i32, *args_ptr.add(1))
                         } else {
@@ -1893,8 +1895,9 @@ pub unsafe extern "C" fn js_native_call_method(
                     }
                     "reduceRight" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         let (has_init, init) = if args_len >= 2 {
                             (1i32, *args_ptr.add(1))
                         } else {
@@ -1917,8 +1920,9 @@ pub unsafe extern "C" fn js_native_call_method(
                     }
                     "flatMap" if args_len >= 1 && !args_ptr.is_null() => {
                         let arr = raw_ptr as *const crate::array::ArrayHeader;
-                        let cb_bits = (*args_ptr).to_bits() & 0x0000_FFFF_FFFF_FFFF;
-                        let cb_ptr = cb_bits as *const crate::closure::ClosureHeader;
+                        // #4091: throw TypeError for a non-callable callback.
+                        let cb_ptr = crate::array::js_validate_array_callback(*args_ptr)
+                            as *const crate::closure::ClosureHeader;
                         let result = crate::array::js_array_flatMap(arr, cb_ptr);
                         return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
                     }

--- a/test-parity/node-suite/object/array-noncallable-callback.ts
+++ b/test-parity/node-suite/object/array-noncallable-callback.ts
@@ -1,0 +1,52 @@
+// #4091: array / TypedArray iteration methods must throw a `TypeError` when
+// handed a non-callable callback, *before* any iteration. The message matches
+// V8 byte-for-byte: `<typeof> <value> is not a function` for Array.prototype
+// (and most %TypedArray% methods), with `%TypedArray%.prototype.map` using its
+// distinct no-typeof rendering, and `sort` keeping its comparator wording.
+function log(label: string, fn: () => unknown) {
+  try {
+    console.log(label, JSON.stringify(fn()));
+  } catch (err: any) {
+    console.log(label, "throw", err.name, err.message);
+  }
+}
+
+// --- Array.prototype: non-callable callbacks throw ---
+log("array map number", () => [1, 2, 3].map(5 as any));
+log("array forEach undefined", () => [1, 2, 3].forEach(undefined as any));
+log("array filter string", () => [1, 2, 3].filter("x" as any));
+log("array reduce number", () => [1, 2, 3].reduce(5 as any));
+log("array reduceRight number", () => [1, 2, 3].reduceRight(5 as any));
+log("array some number", () => [1, 2, 3].some(5 as any));
+log("array every number", () => [1, 2, 3].every(5 as any));
+log("array find number", () => [1, 2, 3].find(5 as any));
+log("array findIndex number", () => [1, 2, 3].findIndex(5 as any));
+log("array findLast number", () => [1, 2, 3].findLast(5 as any));
+log("array findLastIndex number", () => [1, 2, 3].findLastIndex(5 as any));
+log("array flatMap number", () => [1, 2, 3].flatMap(5 as any));
+log("array map null", () => [1, 2, 3].map(null as any));
+log("array map boolean", () => [1, 2, 3].map(true as any));
+log("array map object", () => [1, 2, 3].map({} as any));
+log("array sort string", () => [3, 1, 2].sort("x" as any));
+log("array sort number", () => [3, 1, 2].sort(5 as any));
+
+// --- %TypedArray%: most methods share Array's message; map differs ---
+log("typedarray map number", () => new Int32Array([1]).map(7 as any));
+log("typedarray forEach string", () => new Int32Array([1]).forEach("x" as any));
+log("typedarray filter undefined", () => new Float64Array([1]).filter(undefined as any));
+log("typedarray reduce number", () => new Int32Array([1]).reduce(5 as any));
+log("typedarray some number", () => new Int32Array([1]).some(5 as any));
+log("typedarray sort string", () => new Int32Array([3, 1, 2]).sort("x" as any));
+
+// --- Valid callbacks must NOT throw ---
+log("array map valid", () => [1, 2, 3].map((x) => x * 2));
+log("array filter valid", () => [1, 2, 3].filter((x) => x > 1));
+log("array reduce valid", () => [1, 2, 3].reduce((a, b) => a + b, 0));
+log("array forEach valid", () => {
+  let sum = 0;
+  [1, 2, 3].forEach((x) => {
+    sum += x;
+  });
+  return sum;
+});
+log("array sort valid", () => [3, 1, 2].sort((a, b) => a - b));


### PR DESCRIPTION
## Summary

Closes #4091 (the remaining #3146 sub-case). Array / TypedArray iteration methods now throw a `TypeError` **before** iterating when handed a non-callable callback, with messages byte-identical to `node --experimental-strip-types`. Previously Perry passed the non-closure straight to the runtime iterator, which produced the generic `value is not a function` or no-op'd.

## Approach

Mirrors the existing `js_validate_array_comparator` (sort, #2796) pattern: the **boxed** callback is threaded into a validator that returns the resolved `ClosureHeader*` or throws. Two new runtime helpers in `array/iter_methods.rs`:

- `js_validate_array_callback(cb)` — standard V8 message `<typeof> <value> is not a function` (e.g. `number 5`, `string "x"`, `object null`, `boolean true`, `object`, `bigint`, `undefined`). Used by every method except `map`.
- `js_validate_array_map_callback(arr, cb)` — same, but for a typed-array receiver uses `%TypedArray%.prototype.map`'s distinct no-`typeof` rendering (`7 is not a function`). Takes the receiver handle to pick the format.

The "is callable" gate uses `get_valid_func_ptr` — the same predicate the runtime uses to decide whether to actually invoke a closure — so it accepts every callable form that works today (closures, bound methods, bound functions) and only rejects genuine non-callables. **No false throws on valid callbacks.**

Validation is wired in at every lowering path that reaches these methods:
- Codegen HIR fast-path variants: `ArrayMap`/`ArrayForEach`/`ArrayFilter`/`ArraySome`/`ArrayEvery`/`ArrayFind*`/`ArrayReduce*`/`ArrayFlatMap` (math_simple, misc_methods, logical_collections, arrays_finds, bigint_set, string_regex_proc, let_stmt discard-map).
- Codegen generic `Call → lower_array_method` safety-net arms.
- Runtime dynamic dispatch (`js_native_call_method`) for inline-`new` typed arrays and `as any` arrays — the `new Int32Array([1]).map(7)` path.

## Verification

`test-parity/node-suite/object/array-noncallable-callback.ts` (new) is byte-identical to Node, covering every acceptance-criteria case (per-type messages, the TypedArray.map special form, `sort`'s distinct wording) plus valid callbacks that must not throw. Additionally verified byte-identical against Node for valid callbacks across forms (named fn, `.bind()`, method ref, arrow, `as any` arrays, typed arrays). `cargo fmt --all --check` clean; `perry-runtime` suite green (the lone `navigator_global_constructor_identity_shape` failure is a pre-existing parallelism flake — passes in isolation, unrelated to this change).

## Out of scope

`new Int32Array(...).map(fn)` returning the wrong **value** (renders `[object Object]`) is a separate, pre-existing TypedArray.map gap — this change is transparent to valid callbacks (the validator returns the identical closure pointer), so it neither causes nor fixes it.
