### PR TITLE
fix(runtime): dynamic instanceof Array/Object/Date + typed-array view validation (#4102, #4103)

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -151,6 +151,36 @@ pub(super) fn lower_builtin_new(
             );
             Ok(Some(nanbox_pointer_inline(ctx.block(), &handle)))
         }
+        // #4103: `new TA(buffer, byteOffset, length?)` view constructor for the
+        // non-`Uint8Array` kinds. The runtime applies the spec offset/length
+        // bounds + alignment checks (RangeError) — Uint8Array piggybacks on the
+        // BufferHeader path above. Pass the raw NaN-boxed offset/length so
+        // ToIndex (and the `undefined` length default) is honored in the runtime.
+        name @ ("Int8Array" | "Uint16Array" | "Int16Array" | "Uint32Array" | "Int32Array"
+        | "Float32Array" | "Float64Array" | "Uint8ClampedArray" | "BigInt64Array"
+        | "BigUint64Array" | "Float16Array")
+            if args.len() >= 2 =>
+        {
+            let kind = typed_array_view_kind(name);
+            let source = lower_expr(ctx, &args[0])?;
+            let offset_box = lower_expr(ctx, &args[1])?;
+            let length_box = if args.len() >= 3 {
+                lower_expr(ctx, &args[2])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            let handle = ctx.block().call(
+                I64,
+                "js_typed_array_view",
+                &[
+                    (I32, &kind.to_string()),
+                    (DOUBLE, &source),
+                    (DOUBLE, &offset_box),
+                    (DOUBLE, &length_box),
+                ],
+            );
+            Ok(Some(nanbox_pointer_inline(ctx.block(), &handle)))
+        }
         // Minimal DataView support for BufferSource consumers such as
         // StringDecoder: Perry models ArrayBuffer/Uint8Array storage as a
         // BufferHeader, so `new DataView(buffer)` can create a registered view
@@ -1460,5 +1490,26 @@ pub(super) fn lower_builtin_new(
         }
 
         _ => Ok(None),
+    }
+}
+
+/// Map a typed-array constructor name to its runtime `KIND_*` integer (mirrors
+/// `perry_runtime::typedarray::KIND_*`). Used by the `#4103` view-constructor
+/// arm to tell `js_typed_array_view` which element type to build.
+fn typed_array_view_kind(name: &str) -> i32 {
+    match name {
+        "Int8Array" => 0,
+        "Uint8Array" => 1,
+        "Int16Array" => 2,
+        "Uint16Array" => 3,
+        "Int32Array" => 4,
+        "Uint32Array" => 5,
+        "Float32Array" => 6,
+        "Float64Array" => 7,
+        "Uint8ClampedArray" => 8,
+        "BigInt64Array" => 9,
+        "BigUint64Array" => 10,
+        "Float16Array" => 11,
+        _ => 7,
     }
 }

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -95,6 +95,9 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_typed_array_new_from_array", I64, &[I32, I64]);
     // Runtime-dispatched constructor: handles numeric length OR source-array arg.
     module.declare_function("js_typed_array_new", I64, &[I32, DOUBLE]);
+    // #4103: `new TA(buffer, byteOffset, length?)` view constructor with spec
+    // offset/length validation (kind, source, offset_value, length_value).
+    module.declare_function("js_typed_array_view", I64, &[I32, DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_typed_array_length", I32, &[I64]);
     module.declare_function("js_typed_array_get", DOUBLE, &[I64, I32]);
     // #2063: string / dynamic-key `ta[key]` [[Get]] dispatcher (canonical

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -581,6 +581,19 @@ pub extern "C" fn js_uint8array_view(
     let src = raw as *const BufferHeader;
     unsafe {
         let total_len = (*src).length as i32;
+        // #4103: spec `RangeError` for an out-of-range view. `BYTES_PER_ELEMENT`
+        // is 1 for `Uint8Array`, so there is no alignment constraint — only the
+        // offset and (offset + length) bounds against the backing buffer.
+        if byte_offset < 0 || byte_offset > total_len {
+            crate::fs::validate::throw_range_error_with_code(&format!(
+                "Start offset {byte_offset} is outside the bounds of the buffer"
+            ));
+        }
+        if requested_length >= 0 && byte_offset.saturating_add(requested_length) > total_len {
+            crate::fs::validate::throw_range_error_with_code(&format!(
+                "Invalid typed array length: {requested_length}"
+            ));
+        }
         let start = byte_offset.clamp(0, total_len);
         let len = if requested_length < 0 {
             total_len.saturating_sub(start)

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -90,6 +90,7 @@ pub mod timer;
 pub mod typed_feedback;
 pub mod typedarray;
 pub mod typedarray_half;
+pub mod typedarray_view;
 pub mod url;
 pub mod value;
 pub mod wasi;

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -641,6 +641,14 @@ pub(super) fn identify_global_builtin_constructor(func_value: f64) -> Option<&'s
         let is_global_builtin_func = func_ptr
             == global_this_builtin_noop_thunk as *const u8 as usize
             || func_ptr == typed_array_constructor_call_thunk as *const u8 as usize
+            // #4102: `Array`/`Object`/`Date` constructor *values* carry their own
+            // coercion thunks (not the shared noop thunk), so the dynamic
+            // `instanceof` / reflective `@@hasInstance` path could not recover
+            // their name. Accept those thunks too; the singleton walk below maps
+            // each back to "Array"/"Object"/"Date".
+            || func_ptr == global_this_array_thunk as *const u8 as usize
+            || func_ptr == global_this_object_thunk as *const u8 as usize
+            || func_ptr == global_this_date_thunk as *const u8 as usize
             || func_ptr == webcrypto_illegal_constructor_thunk as *const u8 as usize
             || func_ptr
                 == crate::messaging::js_message_channel_constructor_call_error as *const u8

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -94,7 +94,7 @@ pub(crate) extern "C" fn global_this_builtin_noop_thunk(
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
-extern "C" fn global_this_date_thunk(
+pub(crate) extern "C" fn global_this_date_thunk(
     _closure: *const crate::closure::ClosureHeader,
     _arg: f64,
 ) -> f64 {
@@ -347,7 +347,7 @@ extern "C" fn global_this_string_thunk(
     crate::value::js_nanbox_string(string_ptr as i64)
 }
 
-extern "C" fn global_this_object_thunk(
+pub(crate) extern "C" fn global_this_object_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
 ) -> f64 {

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -203,13 +203,18 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             // the compile-time `instanceof` operator emits — see
             // perry-codegen/src/expr/instance_misc1.rs — which `js_instanceof`
             // resolves via the per-type registries (#3662). `Array`/`Object`/
-            // `Date` constructor *values* aren't identified here (they are not
-            // noop-thunk closures), so they stay a known gap for the dynamic
-            // path; the literal-RHS operator handles them at compile time.
+            // `Date` carry their own coercion thunks rather than the shared
+            // noop thunk; #4102 added those thunks to the
+            // `identify_global_builtin_constructor` allow-list so the dynamic /
+            // reflective path now resolves them here just like the literal-RHS
+            // operator does at compile time.
             "Map" => 0xFFFF0022,
             "Set" => 0xFFFF0023,
             "RegExp" => 0xFFFF0021,
             "ArrayBuffer" => 0xFFFF0025,
+            "Array" => 0xFFFF0024,
+            "Object" => 0xFFFF0050,
+            "Date" => 0xFFFF0020,
             "Error" => crate::error::CLASS_ID_ERROR,
             "TypeError" => crate::error::CLASS_ID_TYPE_ERROR,
             "RangeError" => crate::error::CLASS_ID_RANGE_ERROR,

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1346,6 +1346,25 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
+    // #4102: every function value inherits `%Function.prototype%`, so reading a
+    // well-known symbol off a constructor *value* whose own / explicit-prototype
+    // lookups missed must fall back to Function.prototype's own symbols. Most
+    // importantly this exposes `@@hasInstance` (#4098), so
+    // `(Array as any)[Symbol.hasInstance]([])` resolves the installed
+    // `OrdinaryHasInstance` thunk instead of `undefined`. Perry does not link a
+    // closure's static prototype to Function.prototype, so this is the hop that
+    // models that inheritance for the symbol-read path.
+    if (bits >> 48) == 0x7FFD {
+        let ptr = crate::value::js_nanbox_get_pointer(obj_f64) as usize;
+        if ptr != 0 && crate::closure::is_closure_ptr(ptr) {
+            let func_proto = crate::object::builtin_prototype_value("Function");
+            if (func_proto.to_bits() >> 48) == 0x7FFD {
+                if let Some(v) = own_symbol_property(func_proto, sym_f64) {
+                    return v;
+                }
+            }
+        }
+    }
     // #1545: Web ReadableStream handles are normal finite numbers, not
     // heap objects. Expose `rs[Symbol.asyncIterator]` as the same bound method
     // as `rs.values`, matching Node's Web Streams surface while leaving

--- a/crates/perry-runtime/src/typedarray.rs
+++ b/crates/perry-runtime/src/typedarray.rs
@@ -763,6 +763,111 @@ pub extern "C" fn js_typed_array_new(kind: i32, val: f64) -> *mut TypedArrayHead
     typed_array_alloc(kind as u8, 0)
 }
 
+/// `ToIndex(value)` for a typed-array view's `byteOffset` / `length`
+/// arguments (#4103): `undefined` / `NaN` → 0, otherwise `ToIntegerOrInfinity`
+/// truncated toward zero, with a `RangeError` for a negative or
+/// out-of-`[[0, 2^53-1]]` result.
+fn typed_array_view_to_index(value: f64) -> i64 {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() {
+        return 0;
+    }
+    let n = jv.to_number();
+    if n.is_nan() {
+        return 0;
+    }
+    if n < 0.0 || n > 9_007_199_254_740_991.0 {
+        throw_range_error(b"Invalid typed array length");
+    }
+    n.trunc() as i64
+}
+
+/// `new TA(buffer, byteOffset, length?)` for the non-`Uint8Array` typed-array
+/// kinds — create a view over an `ArrayBuffer` with the spec's offset/length
+/// validation (#4103). Perry still models the result as an owning
+/// `TypedArrayHeader` (the `byteOffset` getter reports 0), but the bounds
+/// checks match Node and throw `RangeError` on violation:
+///   - `byteOffset % BYTES_PER_ELEMENT == 0` (alignment),
+///   - `byteOffset <= buffer.byteLength`,
+///   - when `length` is omitted, the remaining bytes are a whole multiple of
+///     `BYTES_PER_ELEMENT`,
+///   - `byteOffset + length * BYTES_PER_ELEMENT <= buffer.byteLength`.
+/// `offset_value` / `length_value` are the raw NaN-boxed arguments
+/// (`undefined` when absent) so `ToIndex` runs here. A non-`ArrayBuffer`
+/// source routes to the normal `js_typed_array_new` constructor.
+#[no_mangle]
+pub extern "C" fn js_typed_array_view(
+    kind: i32,
+    source: f64,
+    offset_value: f64,
+    length_value: f64,
+) -> *mut TypedArrayHeader {
+    let kind = kind as u8;
+    let bits = source.to_bits();
+    if (bits >> 48) != 0x7FFD {
+        return js_typed_array_new(kind as i32, source);
+    }
+    let addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if !crate::buffer::is_registered_buffer(addr) || !crate::buffer::is_any_array_buffer(addr) {
+        return js_typed_array_new(kind as i32, source);
+    }
+    let bpe = elem_size_for_kind(kind) as i64;
+    let src = addr as *const crate::buffer::BufferHeader;
+    let total_len = unsafe { (*src).length as i64 };
+
+    let offset = typed_array_view_to_index(offset_value);
+    if bpe > 1 && offset % bpe != 0 {
+        throw_range_error(
+            format!(
+                "start offset of {} should be a multiple of {}",
+                name_for_kind(kind),
+                bpe
+            )
+            .as_bytes(),
+        );
+    }
+    if offset > total_len {
+        throw_range_error(
+            format!("Start offset {offset} is outside the bounds of the buffer").as_bytes(),
+        );
+    }
+
+    let length_jv = crate::value::JSValue::from_bits(length_value.to_bits());
+    let elem_count = if length_jv.is_undefined() {
+        let remaining = total_len - offset;
+        if bpe > 1 && remaining % bpe != 0 {
+            throw_range_error(
+                format!(
+                    "byte length of {} should be a multiple of {}",
+                    name_for_kind(kind),
+                    bpe
+                )
+                .as_bytes(),
+            );
+        }
+        remaining / bpe
+    } else {
+        let requested = typed_array_view_to_index(length_value);
+        if offset + requested * bpe > total_len {
+            throw_range_error(format!("Invalid typed array length: {requested}").as_bytes());
+        }
+        requested
+    };
+
+    // The native byte layout matches between BufferHeader and TypedArrayHeader,
+    // so copy the backing bytes at `offset` directly to preserve element values.
+    let count = elem_count.max(0) as u32;
+    let ta = typed_array_alloc(kind, count);
+    if count > 0 {
+        unsafe {
+            let src_data = crate::buffer::buffer_data(src).add(offset as usize);
+            let dst = data_ptr_mut(ta);
+            ptr::copy_nonoverlapping(src_data, dst, (count as i64 * bpe) as usize);
+        }
+    }
+    ta
+}
+
 /// Copy elements from one typed array into a new typed array of `dst_kind`,
 /// reading via `load_at` (so source-element semantics stay correct) and
 /// writing via `store_at` (which clamps / truncates / sign-extends per

--- a/crates/perry-runtime/src/typedarray.rs
+++ b/crates/perry-runtime/src/typedarray.rs
@@ -191,7 +191,7 @@ fn data_ptr(ta: *const TypedArrayHeader) -> *const u8 {
 }
 
 #[inline]
-fn data_ptr_mut(ta: *mut TypedArrayHeader) -> *mut u8 {
+pub(crate) fn data_ptr_mut(ta: *mut TypedArrayHeader) -> *mut u8 {
     unsafe {
         if crate::native_arena::is_native_typed_view(ta as *const TypedArrayHeader) {
             crate::native_arena::native_view_data_ptr_mut(ta)
@@ -287,7 +287,7 @@ fn throw_type_error(message: &[u8]) -> ! {
 }
 
 #[cold]
-fn throw_range_error(message: &[u8]) -> ! {
+pub(crate) fn throw_range_error(message: &[u8]) -> ! {
     let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = crate::error::js_rangeerror_new(msg);
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
@@ -761,111 +761,6 @@ pub extern "C" fn js_typed_array_new(kind: i32, val: f64) -> *mut TypedArrayHead
     }
     // Undefined / null / bool / string → empty typed array.
     typed_array_alloc(kind as u8, 0)
-}
-
-/// `ToIndex(value)` for a typed-array view's `byteOffset` / `length`
-/// arguments (#4103): `undefined` / `NaN` → 0, otherwise `ToIntegerOrInfinity`
-/// truncated toward zero, with a `RangeError` for a negative or
-/// out-of-`[[0, 2^53-1]]` result.
-fn typed_array_view_to_index(value: f64) -> i64 {
-    let jv = crate::value::JSValue::from_bits(value.to_bits());
-    if jv.is_undefined() {
-        return 0;
-    }
-    let n = jv.to_number();
-    if n.is_nan() {
-        return 0;
-    }
-    if n < 0.0 || n > 9_007_199_254_740_991.0 {
-        throw_range_error(b"Invalid typed array length");
-    }
-    n.trunc() as i64
-}
-
-/// `new TA(buffer, byteOffset, length?)` for the non-`Uint8Array` typed-array
-/// kinds — create a view over an `ArrayBuffer` with the spec's offset/length
-/// validation (#4103). Perry still models the result as an owning
-/// `TypedArrayHeader` (the `byteOffset` getter reports 0), but the bounds
-/// checks match Node and throw `RangeError` on violation:
-///   - `byteOffset % BYTES_PER_ELEMENT == 0` (alignment),
-///   - `byteOffset <= buffer.byteLength`,
-///   - when `length` is omitted, the remaining bytes are a whole multiple of
-///     `BYTES_PER_ELEMENT`,
-///   - `byteOffset + length * BYTES_PER_ELEMENT <= buffer.byteLength`.
-/// `offset_value` / `length_value` are the raw NaN-boxed arguments
-/// (`undefined` when absent) so `ToIndex` runs here. A non-`ArrayBuffer`
-/// source routes to the normal `js_typed_array_new` constructor.
-#[no_mangle]
-pub extern "C" fn js_typed_array_view(
-    kind: i32,
-    source: f64,
-    offset_value: f64,
-    length_value: f64,
-) -> *mut TypedArrayHeader {
-    let kind = kind as u8;
-    let bits = source.to_bits();
-    if (bits >> 48) != 0x7FFD {
-        return js_typed_array_new(kind as i32, source);
-    }
-    let addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
-    if !crate::buffer::is_registered_buffer(addr) || !crate::buffer::is_any_array_buffer(addr) {
-        return js_typed_array_new(kind as i32, source);
-    }
-    let bpe = elem_size_for_kind(kind) as i64;
-    let src = addr as *const crate::buffer::BufferHeader;
-    let total_len = unsafe { (*src).length as i64 };
-
-    let offset = typed_array_view_to_index(offset_value);
-    if bpe > 1 && offset % bpe != 0 {
-        throw_range_error(
-            format!(
-                "start offset of {} should be a multiple of {}",
-                name_for_kind(kind),
-                bpe
-            )
-            .as_bytes(),
-        );
-    }
-    if offset > total_len {
-        throw_range_error(
-            format!("Start offset {offset} is outside the bounds of the buffer").as_bytes(),
-        );
-    }
-
-    let length_jv = crate::value::JSValue::from_bits(length_value.to_bits());
-    let elem_count = if length_jv.is_undefined() {
-        let remaining = total_len - offset;
-        if bpe > 1 && remaining % bpe != 0 {
-            throw_range_error(
-                format!(
-                    "byte length of {} should be a multiple of {}",
-                    name_for_kind(kind),
-                    bpe
-                )
-                .as_bytes(),
-            );
-        }
-        remaining / bpe
-    } else {
-        let requested = typed_array_view_to_index(length_value);
-        if offset + requested * bpe > total_len {
-            throw_range_error(format!("Invalid typed array length: {requested}").as_bytes());
-        }
-        requested
-    };
-
-    // The native byte layout matches between BufferHeader and TypedArrayHeader,
-    // so copy the backing bytes at `offset` directly to preserve element values.
-    let count = elem_count.max(0) as u32;
-    let ta = typed_array_alloc(kind, count);
-    if count > 0 {
-        unsafe {
-            let src_data = crate::buffer::buffer_data(src).add(offset as usize);
-            let dst = data_ptr_mut(ta);
-            ptr::copy_nonoverlapping(src_data, dst, (count as i64 * bpe) as usize);
-        }
-    }
-    ta
 }
 
 /// Copy elements from one typed array into a new typed array of `dst_kind`,

--- a/crates/perry-runtime/src/typedarray_view.rs
+++ b/crates/perry-runtime/src/typedarray_view.rs
@@ -1,0 +1,120 @@
+//! `new TA(buffer, byteOffset, length?)` view-constructor validation (#4103).
+//!
+//! Split out of `typedarray.rs` to keep that file under the 2000-line gate.
+//! Perry does not yet model real offset-honoring views (the `byteOffset`
+//! getter still reports 0 and the view copies rather than aliases the backing
+//! store — the broader gap #4103 calls out); this module adds the spec
+//! `RangeError` bounds/alignment validation and copies the correct bytes at
+//! the requested offset so the multi-arg form matches Node.
+
+use std::ptr;
+
+use crate::typedarray::{
+    data_ptr_mut, elem_size_for_kind, js_typed_array_new, name_for_kind, throw_range_error,
+    typed_array_alloc, TypedArrayHeader,
+};
+
+/// `ToIndex(value)` for a typed-array view's `byteOffset` / `length`
+/// arguments (#4103): `undefined` / `NaN` → 0, otherwise `ToIntegerOrInfinity`
+/// truncated toward zero, with a `RangeError` for a negative or
+/// out-of-`[[0, 2^53-1]]` result.
+fn typed_array_view_to_index(value: f64) -> i64 {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() {
+        return 0;
+    }
+    let n = jv.to_number();
+    if n.is_nan() {
+        return 0;
+    }
+    if n < 0.0 || n > 9_007_199_254_740_991.0 {
+        throw_range_error(b"Invalid typed array length");
+    }
+    n.trunc() as i64
+}
+
+/// `new TA(buffer, byteOffset, length?)` for the non-`Uint8Array` typed-array
+/// kinds — create a view over an `ArrayBuffer` with the spec's offset/length
+/// validation (#4103). Perry still models the result as an owning
+/// `TypedArrayHeader` (the `byteOffset` getter reports 0), but the bounds
+/// checks match Node and throw `RangeError` on violation:
+///   - `byteOffset % BYTES_PER_ELEMENT == 0` (alignment),
+///   - `byteOffset <= buffer.byteLength`,
+///   - when `length` is omitted, the remaining bytes are a whole multiple of
+///     `BYTES_PER_ELEMENT`,
+///   - `byteOffset + length * BYTES_PER_ELEMENT <= buffer.byteLength`.
+/// `offset_value` / `length_value` are the raw NaN-boxed arguments
+/// (`undefined` when absent) so `ToIndex` runs here. A non-`ArrayBuffer`
+/// source routes to the normal `js_typed_array_new` constructor.
+#[no_mangle]
+pub extern "C" fn js_typed_array_view(
+    kind: i32,
+    source: f64,
+    offset_value: f64,
+    length_value: f64,
+) -> *mut TypedArrayHeader {
+    let kind = kind as u8;
+    let bits = source.to_bits();
+    if (bits >> 48) != 0x7FFD {
+        return js_typed_array_new(kind as i32, source);
+    }
+    let addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if !crate::buffer::is_registered_buffer(addr) || !crate::buffer::is_any_array_buffer(addr) {
+        return js_typed_array_new(kind as i32, source);
+    }
+    let bpe = elem_size_for_kind(kind) as i64;
+    let src = addr as *const crate::buffer::BufferHeader;
+    let total_len = unsafe { (*src).length as i64 };
+
+    let offset = typed_array_view_to_index(offset_value);
+    if bpe > 1 && offset % bpe != 0 {
+        throw_range_error(
+            format!(
+                "start offset of {} should be a multiple of {}",
+                name_for_kind(kind),
+                bpe
+            )
+            .as_bytes(),
+        );
+    }
+    if offset > total_len {
+        throw_range_error(
+            format!("Start offset {offset} is outside the bounds of the buffer").as_bytes(),
+        );
+    }
+
+    let length_jv = crate::value::JSValue::from_bits(length_value.to_bits());
+    let elem_count = if length_jv.is_undefined() {
+        let remaining = total_len - offset;
+        if bpe > 1 && remaining % bpe != 0 {
+            throw_range_error(
+                format!(
+                    "byte length of {} should be a multiple of {}",
+                    name_for_kind(kind),
+                    bpe
+                )
+                .as_bytes(),
+            );
+        }
+        remaining / bpe
+    } else {
+        let requested = typed_array_view_to_index(length_value);
+        if offset + requested * bpe > total_len {
+            throw_range_error(format!("Invalid typed array length: {requested}").as_bytes());
+        }
+        requested
+    };
+
+    // The native byte layout matches between BufferHeader and TypedArrayHeader,
+    // so copy the backing bytes at `offset` directly to preserve element values.
+    let count = elem_count.max(0) as u32;
+    let ta = typed_array_alloc(kind, count);
+    if count > 0 {
+        unsafe {
+            let src_data = crate::buffer::buffer_data(src).add(offset as usize);
+            let dst = data_ptr_mut(ta);
+            ptr::copy_nonoverlapping(src_data, dst, (count as i64 * bpe) as usize);
+        }
+    }
+    ta
+}

--- a/test-files/test_gap_4102_dynamic_instanceof.ts
+++ b/test-files/test_gap_4102_dynamic_instanceof.ts
@@ -1,0 +1,33 @@
+// #4102 — dynamic `instanceof` and reflective `@@hasInstance` with the
+// `Array` / `Object` / `Date` constructor *values*. The literal-RHS operator
+// (`[] instanceof Array`) already resolves these at compile time; the dynamic
+// form (`[] instanceof A` where `A = Array`) and the reflective
+// `C[Symbol.hasInstance](v)` form previously returned `false` / `undefined`.
+// Output is booleans so it is byte-identical to Node.
+
+const A = Array;
+const O = Object;
+const D = Date;
+
+// Dynamic `instanceof` against a constructor held in a variable.
+console.log("arr A:", ([] as any) instanceof A); // true
+console.log("obj O:", ({} as any) instanceof O); // true
+console.log("date D:", (new Date() as any) instanceof D); // true
+
+// Cross checks: arrays/dates are objects; plain objects are not arrays.
+console.log("arr O:", ([] as any) instanceof O); // true
+console.log("date O:", (new Date() as any) instanceof O); // true
+console.log("obj A:", ({} as any) instanceof A); // false
+console.log("date A:", (new Date() as any) instanceof A); // false
+
+// Direct `C[Symbol.hasInstance](v)` for the built-in constructor values.
+console.log("Array hi:", (Array as any)[Symbol.hasInstance]([])); // true
+console.log("Object hi:", (Object as any)[Symbol.hasInstance]({})); // true
+console.log("Date hi:", (Date as any)[Symbol.hasInstance](new Date())); // true
+console.log("Array hi obj:", (Array as any)[Symbol.hasInstance]({})); // false
+
+// The `Function.prototype[Symbol.hasInstance].call(C, v)` form (already worked
+// via #4098) stays consistent with the direct read above.
+const hi = Function.prototype[Symbol.hasInstance];
+console.log("call Array:", hi.call(Array, [])); // true
+console.log("call Date:", hi.call(Date, new Date())); // true

--- a/test-files/test_gap_4103_typedarray_view_validation.ts
+++ b/test-files/test_gap_4103_typedarray_view_validation.ts
@@ -1,0 +1,34 @@
+// #4103 — `new TA(buffer, byteOffset, length)` must validate `byteOffset` /
+// `length` against the backing `ArrayBuffer` and throw a `RangeError` for an
+// out-of-range / misaligned view (it previously succeeded silently). We print
+// the error *type* (or the resulting length for the valid cases) so the output
+// is byte-identical to Node.
+
+function r(fn: () => unknown): string {
+    try {
+        return "ok:" + String(fn());
+    } catch (e: any) {
+        return "throw:" + e.constructor.name;
+    }
+}
+
+// Out-of-range / misaligned → RangeError.
+console.log("u8 7,4:", r(() => new Uint8Array(new ArrayBuffer(8), 7, 4))); // offset+len > buffer
+console.log("u32 3:", r(() => new Uint32Array(new ArrayBuffer(8), 3))); // offset % 4 != 0
+console.log("u8 16:", r(() => new Uint8Array(new ArrayBuffer(8), 16))); // offset > byteLength
+console.log("u32 6,1:", r(() => new Uint32Array(new ArrayBuffer(8), 6, 1))); // offset misaligned
+console.log("u16 7:", r(() => new Uint16Array(new ArrayBuffer(8), 7))); // odd offset for 2-byte
+
+// Valid views → length of the view.
+console.log("u8 4,4:", r(() => new Uint8Array(new ArrayBuffer(8), 4, 4).length)); // 4
+console.log("u32 4:", r(() => new Uint32Array(new ArrayBuffer(8), 4).length)); // 1
+console.log("u32 0:", r(() => new Uint32Array(new ArrayBuffer(8), 0).length)); // 2
+console.log("u16 2,2:", r(() => new Uint16Array(new ArrayBuffer(8), 2, 2).length)); // 2
+
+// Data is read from the byte offset.
+const ab = new ArrayBuffer(8);
+const bytes = new Uint8Array(ab);
+bytes[4] = 0xaa;
+bytes[5] = 0xbb;
+const view = new Uint8Array(ab, 4, 2);
+console.log("data:", view[0], view[1]); // 170 187


### PR DESCRIPTION
Fixes #4102 and #4103 — two follow-ups in the #3662 cluster. Both are validated byte-for-byte against `node --experimental-strip-types`.

## #4102 — dynamic `instanceof` / reflective `@@hasInstance` with `Array`/`Object`/`Date` constructor values

PR #4098 wired up `Function.prototype[Symbol.hasInstance]` and the dynamic path for `Map`/`Set`/`RegExp`/`ArrayBuffer`, but explicitly left `Array`/`Object`/`Date` as a gap because those constructor **values** carry their own coercion thunks (`global_this_array_thunk` / `global_this_object_thunk` / `global_this_date_thunk`) rather than the shared noop thunk, so `identify_global_builtin_constructor` returned `None`.

- `class_registry.rs`: add the three coercion thunks to the `identify_global_builtin_constructor` allow-list (and make the object/date thunks `pub(crate)`). The existing globalThis-singleton walk then recovers `"Array"`/`"Object"`/`"Date"`.
- `instanceof.rs`: map those names to the synthetic class ids `0xFFFF0024`/`0xFFFF0050`/`0xFFFF0020` that `js_instanceof` already resolves.
- `symbol.rs`: when a symbol read on a **closure** value misses its own + explicit-prototype lookups, fall back to `%Function.prototype%`'s own symbols. This models the inheritance Perry doesn't otherwise link, so `(Array as any)[Symbol.hasInstance]([])` resolves the installed `OrdinaryHasInstance` thunk instead of `undefined`.

```ts
const A = Array, O = Object, D = Date;
[] instanceof A;                          // true  (was false)
({}) instanceof O;                        // true  (was false)
new Date() instanceof D;                  // true  (was false)
(Array as any)[Symbol.hasInstance]([]);   // true  (was undefined)
```

## #4103 — `new TA(buffer, byteOffset, length)` offset/length validation

The 3-argument typed-array view constructor did not validate `byteOffset`/`length` against the backing `ArrayBuffer`, so out-of-range / misaligned views silently succeeded instead of throwing the spec `RangeError`.

- `buffer/from.rs`: `js_uint8array_view` (the `Uint8Array` path, `BYTES_PER_ELEMENT == 1`) now throws on `offset > byteLength` and `offset + length > byteLength`.
- `typedarray.rs`: new `js_typed_array_view(kind, source, offset, length)` for the other kinds — applies `ToIndex`, alignment (`offset % BPE == 0`), `offset <= byteLength`, whole-multiple-remainder, and `offset + length*BPE <= byteLength` checks, then copies the backing bytes at the offset (native layout matches, so element values are preserved).
- `lower_call/builtin.rs` + `runtime_decls`: route multi-arg non-`Uint8Array` typed arrays through the new helper (they previously fell through to the empty-object `Expr::New` placeholder).

```ts
new Uint8Array(new ArrayBuffer(8), 7, 4);   // RangeError (offset+len > buffer)
new Uint32Array(new ArrayBuffer(8), 3);     // RangeError (offset % 4 != 0)
new Uint8Array(new ArrayBuffer(8), 16);     // RangeError (offset > byteLength)
new Uint8Array(new ArrayBuffer(8), 4, 4);   // ok, length 4
```

Note: Perry still does not model real offset-honoring views (the `byteOffset` getter stays `0`, and views copy rather than alias the backing store — the broader gap the issue calls out). This PR is scoped to the spec validation + correct length/data-at-offset for the multi-arg form.

## Tests
- `test-files/test_gap_4102_dynamic_instanceof.ts` — byte-identical to Node.
- `test-files/test_gap_4103_typedarray_view_validation.ts` — byte-identical to Node.
- Existing `test_gap_3662_function_hasinstance.ts` / `test_gap_3662_typedarray_length.ts` still pass; `perry-runtime` lib tests pass (965/965).
