### PR TITLE
[codex] Add Node module require bridge

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3338,6 +3338,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("module", "constants"),
     property("module", "wrap"),
     property("module", "wrapper"),
+    class("module", "Module"),
+    method("module", "Module", false, None),
     method("module", "createRequire", false, None),
     method("module", "findPackageJSON", false, None),
     method("module", "findSourceMap", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -578,6 +578,15 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "module",
         has_receiver: false,
+        method: "createRequire",
+        class_filter: None,
+        runtime: "js_module_create_require",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "module",
+        has_receiver: false,
         method: "enableCompileCache",
         class_filter: None,
         runtime: "js_module_enable_compile_cache",

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -58,6 +58,7 @@ fn is_cjs_style_native_default_import(module_name: &str) -> bool {
             | "events"
             | "inspector"
             | "inspector/promises"
+            | "module"
             | "os"
             | "path"
             | "path/posix"

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -55,6 +55,7 @@ pub mod iterator_helpers;
 pub mod map;
 pub mod math;
 pub mod messaging;
+pub mod module_require;
 pub mod native_abi;
 pub mod native_arena;
 pub mod native_handle;

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -1,0 +1,211 @@
+//! Minimal `node:module.createRequire` / CommonJS `require` bridge.
+//!
+//! This intentionally covers Perry's deterministic native-builtin path and the
+//! public function shape. Full CommonJS file/package resolution remains in the
+//! compiler-side CJS wrapper and future `Module._*` work.
+
+use crate::closure::{js_closure_alloc, js_register_closure_arity, ClosureHeader};
+use crate::object::{js_object_alloc, js_object_set_field_by_name};
+use crate::string::js_string_from_bytes;
+use crate::value::{js_nanbox_pointer, JSValue, TAG_NULL, TAG_UNDEFINED};
+
+fn undefined() -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+fn null() -> f64 {
+    f64::from_bits(TAG_NULL)
+}
+
+fn string_value(value: &str) -> f64 {
+    let ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+fn object_value(obj: *mut crate::object::ObjectHeader) -> f64 {
+    f64::from_bits(JSValue::object_ptr(obj as *mut u8).bits())
+}
+
+fn set_field(obj: *mut crate::object::ObjectHeader, name: &str, value: f64) {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(obj, key, value);
+}
+
+fn set_closure_prop(closure: *mut ClosureHeader, name: &str, value: f64) {
+    crate::closure::closure_set_dynamic_prop(closure as usize, name, value);
+}
+
+fn named_closure(
+    func: *const u8,
+    arity: u32,
+    length: u32,
+    name: &str,
+) -> (*mut ClosureHeader, f64) {
+    js_register_closure_arity(func, arity);
+    crate::closure::js_register_closure_length(func, length);
+    let closure = js_closure_alloc(func, 0);
+    crate::object::set_bound_native_closure_name(closure, name);
+    crate::object::set_builtin_closure_length(closure as usize, length);
+    (closure, js_nanbox_pointer(closure as i64))
+}
+
+fn value_to_string(value: f64, arg_name: &str) -> String {
+    let jv = JSValue::from_bits(value.to_bits());
+    let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some(bytes) = (unsafe { crate::string::js_string_key_bytes(jv, &mut sso) }) else {
+        let message = format!(
+            "The \"{}\" argument must be of type string. Received {}",
+            arg_name,
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    };
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn throw_invalid_value(arg_name: &str, value: f64) -> ! {
+    let message = format!(
+        "The argument '{}' is invalid. Received {}",
+        arg_name,
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE")
+}
+
+fn validate_create_require_base(filename_or_url: f64) {
+    let jv = JSValue::from_bits(filename_or_url.to_bits());
+    if jv.is_any_string() {
+        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let Some(bytes) = (unsafe { crate::string::js_string_key_bytes(jv, &mut sso) }) else {
+            throw_invalid_value("filename", filename_or_url);
+        };
+        let s = String::from_utf8_lossy(bytes);
+        if s.starts_with("file:") || std::path::Path::new(s.as_ref()).is_absolute() {
+            return;
+        }
+        throw_invalid_value("filename", filename_or_url);
+    }
+    if crate::url::node_compat::module_base_to_path(filename_or_url).is_some() {
+        return;
+    }
+    throw_invalid_value("filename", filename_or_url);
+}
+
+fn supported_require_builtin(specifier: &str) -> Option<&str> {
+    let name = specifier.strip_prefix("node:").unwrap_or(specifier);
+    match name {
+        "assert" | "assert/strict" | "async_hooks" | "buffer" | "child_process" | "cluster"
+        | "console" | "constants" | "crypto" | "dns" | "dns/promises" | "events" | "fs"
+        | "http" | "http2" | "https" | "module" | "net" | "os" | "path" | "path/posix"
+        | "path/win32" | "perf_hooks" | "process" | "punycode" | "querystring" | "readline"
+        | "readline/promises" | "stream" | "stream/promises" | "string_decoder" | "sys"
+        | "test" | "test/reporters" | "timers" | "timers/promises" | "tty" | "url" | "util"
+        | "util/types" | "worker_threads" | "zlib" => Some(name),
+        _ => None,
+    }
+}
+
+fn resolve_builtin(specifier: &str) -> Option<&str> {
+    supported_require_builtin(specifier).map(|_| specifier)
+}
+
+fn require_builtin_value(module_name: &str) -> f64 {
+    if module_name == "timers/promises" {
+        return unsafe {
+            crate::node_submodules::js_node_submodule_namespace(
+                b"timers_promises".as_ptr(),
+                "timers_promises".len() as u32,
+            )
+        };
+    }
+    crate::object::native_module_get_builtin_module_value(module_name)
+}
+
+fn throw_module_not_found(specifier: &str) -> ! {
+    let message = format!("Cannot find module '{}'", specifier);
+    crate::fs::validate::throw_error_with_code(&message, "MODULE_NOT_FOUND")
+}
+
+extern "C" fn require_thunk(_closure: *const ClosureHeader, id: f64) -> f64 {
+    let specifier = value_to_string(id, "id");
+    if specifier.is_empty() {
+        let message = "The argument 'id' must be a non-empty string";
+        crate::fs::validate::throw_type_error_with_code(message, "ERR_INVALID_ARG_VALUE");
+    }
+    let Some(module_name) = supported_require_builtin(&specifier) else {
+        throw_module_not_found(&specifier);
+    };
+    require_builtin_value(module_name)
+}
+
+extern "C" fn resolve_thunk(_closure: *const ClosureHeader, request: f64, _options: f64) -> f64 {
+    let specifier = value_to_string(request, "request");
+    if let Some(resolved) = resolve_builtin(&specifier) {
+        return string_value(resolved);
+    }
+    throw_module_not_found(&specifier)
+}
+
+extern "C" fn resolve_paths_thunk(_closure: *const ClosureHeader, request: f64) -> f64 {
+    let specifier = value_to_string(request, "request");
+    if supported_require_builtin(&specifier).is_some() {
+        return null();
+    }
+    null()
+}
+
+extern "C" fn extension_noop_thunk(
+    _closure: *const ClosureHeader,
+    _module: f64,
+    _filename: f64,
+) -> f64 {
+    undefined()
+}
+
+fn extensions_object() -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj = js_object_alloc(0, 3);
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    for name in [".js", ".json", ".node"] {
+        let (_, value) = named_closure(extension_noop_thunk as *const u8, 2, 2, name);
+        let value_handle = scope.root_nanbox_f64(value);
+        set_field(
+            obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+            name,
+            value_handle.get_nanbox_f64(),
+        );
+    }
+    object_value(obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>())
+}
+
+fn make_require(main_value: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let (_, paths_value) = named_closure(resolve_paths_thunk as *const u8, 1, 1, "paths");
+    let paths_handle = scope.root_nanbox_f64(paths_value);
+    let (resolve_closure, resolve_value) =
+        named_closure(resolve_thunk as *const u8, 2, 2, "resolve");
+    let resolve_handle = scope.root_nanbox_f64(resolve_value);
+    set_closure_prop(resolve_closure, "paths", paths_handle.get_nanbox_f64());
+
+    let cache_handle = scope.root_nanbox_f64(object_value(js_object_alloc(0, 0)));
+    let extensions_handle = scope.root_nanbox_f64(extensions_object());
+
+    let (require_closure, require_value) =
+        named_closure(require_thunk as *const u8, 1, 1, "require");
+    let require_handle = scope.root_nanbox_f64(require_value);
+    set_closure_prop(require_closure, "resolve", resolve_handle.get_nanbox_f64());
+    set_closure_prop(require_closure, "cache", cache_handle.get_nanbox_f64());
+    set_closure_prop(
+        require_closure,
+        "extensions",
+        extensions_handle.get_nanbox_f64(),
+    );
+    set_closure_prop(require_closure, "main", main_value);
+    require_handle.get_nanbox_f64()
+}
+
+#[no_mangle]
+pub extern "C" fn js_module_create_require(filename_or_url: f64) -> f64 {
+    validate_create_require_base(filename_or_url);
+    make_require(undefined())
+}

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -2815,6 +2815,7 @@ fn cjs_default_base_module(module_name: &str) -> Option<&'static str> {
         "dns/promises.default" => Some("dns/promises"),
         "inspector.default" => Some("inspector"),
         "inspector/promises.default" => Some("inspector/promises"),
+        "module.default" => Some("module"),
         "os.default" => Some("os"),
         "path.default" => Some("path"),
         "path.posix.default" => Some("path.posix"),
@@ -2839,6 +2840,7 @@ fn cjs_default_namespace_name(module_name: &str) -> Option<&'static str> {
         "dns/promises" => Some("dns/promises.default"),
         "inspector" => Some("inspector.default"),
         "inspector/promises" => Some("inspector/promises.default"),
+        "module" => Some("module.default"),
         "os" => Some("os.default"),
         "path" => Some("path.default"),
         "path.posix" => Some("path.posix.default"),
@@ -2875,6 +2877,7 @@ fn cjs_default_export_value(module_name: &str) -> Option<f64> {
             b"process".as_ptr(),
             "process".len(),
         )),
+        "module" => Some(bound_native_callable_export_value("module", "Module")),
         "async_hooks" | "child_process" | "constants" | "dns" | "dns/promises" | "os" | "path"
         | "path.posix" | "path.win32" | "punycode" | "querystring" | "repl" | "url" | "util"
         | "inspector" | "inspector/promises" => create_cjs_default_namespace(module_name),
@@ -3607,6 +3610,7 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("perf_hooks", "PerformanceResourceTiming") => Some(0),
         // #3119/#3126/#3263 node:module helpers.
         ("module", "createRequire") => Some(1),
+        ("module", "Module") => Some(0),
         ("module", "enableCompileCache") => Some(1),
         ("module", "flushCompileCache") => Some(0),
         ("module", "getCompileCacheDir") => Some(0),
@@ -4495,6 +4499,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("http", "setGlobalProxyFromEnv")
             | ("http", "_connectionListener")
             | ("module", "createRequire")
+            | ("module", "Module")
             | ("module", "findPackageJSON")
             | ("module", "findSourceMap")
             | ("module", "flushCompileCache")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -510,6 +510,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         }
         ("process", "getBuiltinModule") => crate::process::js_process_get_builtin_module(arg(0)),
         ("process", "execve") => crate::process::js_process_execve(arg(0), arg(1), arg(2)),
+        ("module", "createRequire") => crate::module_require::js_module_create_require(arg(0)),
         ("module", "enableCompileCache") => crate::process::js_module_enable_compile_cache(arg(0)),
         ("module", "flushCompileCache") => crate::process::js_module_flush_compile_cache(),
         ("module", "getCompileCacheDir") => crate::process::js_module_get_compile_cache_dir(),

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -136,6 +136,11 @@ pub(in crate::commands::compile) fn wrap_commonjs(source: &str, source_path: &Pa
         .map(|(spec, local)| format!("        if (specifier === '{}') return {};", spec, local))
         .collect::<Vec<_>>()
         .join("\n");
+    let require_resolve_cases = require_specs
+        .iter()
+        .map(|spec| format!("        if (specifier === '{}') return '{}';", spec, spec))
+        .collect::<Vec<_>>()
+        .join("\n");
 
     let mut named_exports = extract_exports_from_source(source);
 
@@ -347,10 +352,85 @@ const _cjs = (function() {{
     const __cjs_module = {{ exports: {{}} }};
     var module = __cjs_module;
     var exports = __cjs_module.exports;
+    function __perry_cjs_require_error(kind, code, message) {{
+        const err = kind === 'type' ? new TypeError(message) : new Error(message);
+        err.code = code;
+        return err;
+    }}
+    function __perry_cjs_require_is_builtin(specifier) {{
+        switch (specifier) {{
+            case 'assert': case 'node:assert':
+            case 'assert/strict': case 'node:assert/strict':
+            case 'async_hooks': case 'node:async_hooks':
+            case 'buffer': case 'node:buffer':
+            case 'child_process': case 'node:child_process':
+            case 'cluster': case 'node:cluster':
+            case 'console': case 'node:console':
+            case 'constants': case 'node:constants':
+            case 'crypto': case 'node:crypto':
+            case 'dns': case 'node:dns':
+            case 'dns/promises': case 'node:dns/promises':
+            case 'events': case 'node:events':
+            case 'fs': case 'node:fs':
+            case 'http': case 'node:http':
+            case 'http2': case 'node:http2':
+            case 'https': case 'node:https':
+            case 'module': case 'node:module':
+            case 'net': case 'node:net':
+            case 'os': case 'node:os':
+            case 'path': case 'node:path':
+            case 'path/posix': case 'node:path/posix':
+            case 'path/win32': case 'node:path/win32':
+            case 'perf_hooks': case 'node:perf_hooks':
+            case 'process': case 'node:process':
+            case 'punycode': case 'node:punycode':
+            case 'querystring': case 'node:querystring':
+            case 'readline': case 'node:readline':
+            case 'readline/promises': case 'node:readline/promises':
+            case 'stream': case 'node:stream':
+            case 'stream/promises': case 'node:stream/promises':
+            case 'string_decoder': case 'node:string_decoder':
+            case 'sys': case 'node:sys':
+            case 'test': case 'node:test':
+            case 'test/reporters': case 'node:test/reporters':
+            case 'timers': case 'node:timers':
+            case 'timers/promises': case 'node:timers/promises':
+            case 'tty': case 'node:tty':
+            case 'url': case 'node:url':
+            case 'util': case 'node:util':
+            case 'util/types': case 'node:util/types':
+            case 'worker_threads': case 'node:worker_threads':
+            case 'zlib': case 'node:zlib':
+                return true;
+            default:
+                return false;
+        }}
+    }}
     function require(specifier) {{
+        if (typeof specifier !== 'string') throw __perry_cjs_require_error('type', 'ERR_INVALID_ARG_TYPE', 'The "id" argument must be of type string.');
+        if (specifier === '') throw __perry_cjs_require_error('type', 'ERR_INVALID_ARG_VALUE', 'The argument "id" must be a non-empty string.');
 {require_cases}
         throw new Error('require() is not supported: ' + specifier);
     }}
+    require.name = 'require';
+    require.resolve = function resolve(specifier, options) {{
+        if (typeof specifier !== 'string') throw __perry_cjs_require_error('type', 'ERR_INVALID_ARG_TYPE', 'The "request" argument must be of type string.');
+{require_resolve_cases}
+        if (__perry_cjs_require_is_builtin(specifier)) return specifier;
+        throw __perry_cjs_require_error('error', 'MODULE_NOT_FOUND', 'Cannot find module ' + specifier);
+    }};
+    require.resolve.name = 'resolve';
+    require.resolve.paths = function paths(specifier) {{
+        if (typeof specifier !== 'string') throw __perry_cjs_require_error('type', 'ERR_INVALID_ARG_TYPE', 'The "request" argument must be of type string.');
+        return null;
+    }};
+    require.cache = {{}};
+    require.extensions = {{
+        '.js': function(module, filename) {{}},
+        '.json': function(module, filename) {{}},
+        '.node': function(module, filename) {{}},
+    }};
+    require.main = module;
 
     {body_for_iife}
 

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1846 entries across 106 modules
+// Coverage: 1848 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -1921,11 +1921,15 @@ declare module "lru-cache" {
 
 declare module "module" {
   /** stdlib */
+  export class Module { [key: string]: any; }
+  /** stdlib */
   export class SourceMap { [key: string]: any; }
   /** stdlib */
   export const builtinModules: any;
   /** stdlib */
   export const constants: any;
+  /** stdlib */
+  export function Module(...args: any[]): any;
   /** stdlib */
   export function SourceMap(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2664 entries across 109 modules.
+Total: 2666 entries across 109 modules.
 
 ## Modules
 
@@ -1771,10 +1771,12 @@ Total: 2664 entries across 109 modules.
 
 ### Classes
 
+- `Module`
 - `SourceMap`
 
 ### Methods
 
+- `Module` — module
 - `SourceMap` — module
 - `createRequire` — module
 - `enableCompileCache` — module

--- a/test-parity/node-suite/module/require/cjs-package/commonjs-require-shape.ts
+++ b/test-parity/node-suite/module/require/cjs-package/commonjs-require-shape.ts
@@ -1,0 +1,44 @@
+function line(name, value) {
+  console.log(name + ": " + String(value));
+}
+
+line("require-type", typeof require);
+line("require-name", require.name);
+line("require-length", require.length);
+line("resolve-type", typeof require.resolve);
+line("resolve-name", require.resolve.name);
+line("resolve-length", require.resolve.length);
+line("resolve-paths-type", typeof require.resolve.paths);
+line("resolve-fs", require.resolve("fs"));
+line("resolve-node-fs", require.resolve("node:fs"));
+line("paths-fs", require.resolve.paths("fs"));
+line("cache-type", typeof require.cache);
+line("cache-same", require.cache === require.cache);
+line("extensions-type", typeof require.extensions);
+line("extensions-keys", Object.keys(require.extensions).sort().join(","));
+line("ext-js-type", typeof require.extensions[".js"]);
+line("main-in", Object.prototype.hasOwnProperty.call(require, "main"));
+line("main-type", typeof require.main);
+line("fs-readFileSync-type", typeof require("node:fs").readFileSync);
+line("path-sep", require("node:path").sep);
+
+try {
+  require(123);
+} catch (err) {
+  line("bad-require-code", err.code);
+  line("bad-require-name", err.name);
+}
+
+try {
+  require("");
+} catch (err) {
+  line("empty-require-code", err.code);
+  line("empty-require-name", err.name);
+}
+
+try {
+  require.resolve(123);
+} catch (err) {
+  line("bad-resolve-code", err.code);
+  line("bad-resolve-name", err.name);
+}

--- a/test-parity/node-suite/module/require/cjs-package/package.json
+++ b/test-parity/node-suite/module/require/cjs-package/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test-parity/node-suite/module/require/create-require-shape.ts
+++ b/test-parity/node-suite/module/require/create-require-shape.ts
@@ -1,0 +1,63 @@
+import ModuleDefault, * as ModuleNS from "node:module";
+import { createRequire } from "node:module";
+
+function line(name, value) {
+  console.log(name + ": " + String(value));
+}
+
+line("default-type", typeof ModuleDefault);
+line("namespace-default-type", typeof ModuleNS.default);
+line("default-eq-namespace-default", ModuleDefault === ModuleNS.default);
+line("createRequire-type", typeof createRequire);
+line("createRequire-length", createRequire.length);
+
+const req = createRequire(import.meta.url);
+
+line("require-type", typeof req);
+line("require-name", req.name);
+line("require-length", req.length);
+line("resolve-type", typeof req.resolve);
+line("resolve-name", req.resolve.name);
+line("resolve-length", req.resolve.length);
+line("resolve-paths-type", typeof req.resolve.paths);
+line("resolve-fs", req.resolve("fs"));
+line("resolve-node-fs", req.resolve("node:fs"));
+line("paths-fs", req.resolve.paths("fs"));
+line("cache-type", typeof req.cache);
+line("cache-same", req.cache === req.cache);
+line("cache-keys-len", Object.keys(req.cache).length);
+line("extensions-type", typeof req.extensions);
+line("extensions-keys", Object.keys(req.extensions).sort().join(","));
+line("ext-js-type", typeof req.extensions[".js"]);
+line("main-in", Object.prototype.hasOwnProperty.call(req, "main"));
+line("main-value", req.main);
+line("fs-readFileSync-type", typeof req("node:fs").readFileSync);
+line("path-sep", req("node:path").sep);
+
+try {
+  createRequire(123);
+} catch (err) {
+  line("bad-create-code", err.code);
+  line("bad-create-name", err.name);
+}
+
+try {
+  req(123);
+} catch (err) {
+  line("bad-require-code", err.code);
+  line("bad-require-name", err.name);
+}
+
+try {
+  req("");
+} catch (err) {
+  line("empty-require-code", err.code);
+  line("empty-require-name", err.name);
+}
+
+try {
+  req.resolve(123);
+} catch (err) {
+  line("bad-resolve-code", err.code);
+  line("bad-resolve-name", err.name);
+}


### PR DESCRIPTION
## Summary

Adds a narrow Node compatibility bridge for the related `node:module` and CommonJS `require` surfaces covered by #3671, #2616, and #3707.

- Implements `module.createRequire()` as a callable `require` with `resolve`, `resolve.paths`, `cache`, `extensions`, and `main` shape.
- Exposes the same `require` shape in generated CommonJS wrappers.
- Makes `node:module` default import / namespace `.default` resolve to the `Module` callable stub with stable identity.
- Adds parity fixtures for ESM `createRequire()` and CommonJS wrapper `require` shape.

This intentionally does not implement the broader CommonJS `Module._*` resolver/cache internals; it only bridges the callable and metadata surfaces needed by these issues.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-runtime -p perry-hir -p perry-codegen -p perry-api-manifest`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") && PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module module`

Parity result: 8 pass, 0 fail, 0 compile fail.
