### PR TITLE
[codex] fix child_process lifecycle exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1106 — fix(child_process): fork lifecycle exports (#4110)
+
+Folds in external contributor PR #4110: rounds out the `child_process` fork lifecycle surface — `subprocess[Symbol.dispose]`, the `fork(...).send(...)` callback firing once the IPC channel has closed, and the forked-child object shape. Adds the supporting runtime wiring in `crates/perry-runtime/src/child_process/` plus node-suite parity fixtures. Merged on top of current `main`; only the auto-generated doc count/coverage lines conflicted and were regenerated from the manifest.
+
 ## v0.5.1105 — fix(stream/web): ReadableStream.from sources (#4106)
 
 Folds in external contributor PR #4106: lowers `ReadableStream.from(...)` (and the `node:stream/web` alias) to the `readable_stream` native `from` constructor so building a web `ReadableStream` from an iterable/async-iterable source works. Merged on top of current `main`; the only conflict was in `crates/perry-hir/src/lower/expr_call/native_module.rs`, where this PR's `ReadableStream.from` static-call block and main's broadened `is_process_ref` gate (#process namespace/default-import) landed in the same region — both were kept.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1105
+**Current Version:** 0.5.1106
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1105"
+version = "0.5.1106"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "bytes",
  "h2",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5316,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "bson",
  "futures-util",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "image",
@@ -5419,14 +5419,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "brotli",
  "flate2",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "base64",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5638,14 +5638,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "itoa",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "block2",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "block2",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1105"
+version = "0.5.1106"
 
 [[package]]
 name = "perry-ui-test"
@@ -5734,11 +5734,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1105"
+version = "0.5.1106"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "block2",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "block2",
@@ -5770,7 +5770,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "block2",
  "libc",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "libc",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1105"
+version = "0.5.1106"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1105"
+version = "0.5.1106"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4200,6 +4200,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("stream", "destroyed", true, None),
     // --- child_process (synchronous + async exec surface;
     //     spawn/fork are documented but not yet codegen'd) ---
+    method("child_process", "_forkChild", false, None),
     method("child_process", "exec", false, None),
     method("child_process", "execSync", false, None),
     method("child_process", "execFile", false, None),

--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -98,6 +98,7 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     // Distinct shape band from spawn's ChildProcess (which carries no send/disconnect).
     let cp_obj = cp_build_object(&cp_methods, CP_SHAPE_ID + 0x20 + cp_methods.len() as u32);
     let cp = cp_box_ptr(cp_obj as *const u8);
+    cp_install_dispose(cp);
 
     cp_set_field(cp, b"stdout", stdout_obj);
     cp_set_field(cp, b"stderr", stderr_obj);

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -826,6 +826,21 @@ extern "C" fn cp_method_kill(closure: *const ClosureHeader, signal: f64) -> f64 
     }
     TAG_TRUE_F64
 }
+/// `child[Symbol.dispose]()` — Node aliases this to `kill()` and returns
+/// `undefined`, so `using child = spawn(...)` terminates the subprocess on
+/// scope exit. #2556.
+extern "C" fn cp_method_dispose(closure: *const ClosureHeader) -> f64 {
+    let _ = cp_method_kill(closure, cp_undefined());
+    cp_undefined()
+}
+pub(crate) fn js_fork_child(args_len: usize) -> f64 {
+    if args_len < 2 {
+        crate::node_submodules::diagnostics::throw_type_error_no_code(
+            b"Cannot destructure property 'initMessageChannel' of 'serialization[serializationMode]' as it is undefined.",
+        );
+    }
+    f64::from_bits(JSValue::undefined().bits())
+}
 /// `removeListener(event, cb)` / `off(event, cb)` — rebuild the `event`
 /// listener array without the matching closure (compared by NaN-boxed bits).
 /// #1780.
@@ -1091,6 +1106,8 @@ fn cp_register_arities() {
     js_register_closure_arity(cp_method_remove_listener as *const u8, 2);
     js_register_closure_arity(cp_method_remove_all_listeners as *const u8, 1);
     js_register_closure_arity(cp_method_kill as *const u8, 1);
+    js_register_closure_arity(cp_method_dispose as *const u8, 0);
+    crate::closure::js_register_closure_length(cp_method_dispose as *const u8, 0);
     js_register_closure_arity(cp_method_read as *const u8, 1);
     js_register_closure_arity(cp_method_pipe as *const u8, 1);
     js_register_closure_arity(cp_method_write2 as *const u8, 2);
@@ -1126,6 +1143,35 @@ fn cp_build_object(methods: &[(&str, CpFn)], shape_id: u32) -> *mut ObjectHeader
         js_object_set_field(obj, i as u32, JSValue::pointer(closure as *const u8));
     }
     obj
+}
+
+fn cp_install_dispose(cp: f64) {
+    let Some(obj) = cp_object_ptr(cp) else {
+        return;
+    };
+
+    let closure = js_closure_alloc(cp_method_dispose as *const u8, 1);
+    if closure.is_null() {
+        return;
+    }
+    js_closure_set_capture_ptr(closure, 0, cp.to_bits() as i64);
+    crate::object::set_bound_native_closure_name(closure, "");
+    crate::object::set_builtin_closure_length(closure as usize, 0);
+    let dispose_value = cp_box_ptr(closure as *const u8);
+
+    let hidden_attrs = crate::object::PropertyAttrs::new(true, false, true);
+    for key in ["__perry_dispose__", "@@__perry_wk_dispose"] {
+        cp_set_field(cp, key.as_bytes(), dispose_value);
+        crate::object::set_builtin_property_attrs(obj as usize, key.to_string(), hidden_attrs);
+    }
+
+    let dispose_sym = crate::symbol::well_known_symbol("dispose");
+    if !dispose_sym.is_null() {
+        let dispose_sym_value = cp_box_ptr(dispose_sym as *const u8);
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(cp, dispose_sym_value, dispose_value);
+        }
+    }
 }
 
 /// Build a stdout/stderr Readable-shaped EventEmitter.

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -463,6 +463,7 @@ pub extern "C" fn js_child_process_spawn_streams(
     ];
     let cp_obj = cp_build_object(&cp_methods, CP_SHAPE_ID + cp_methods.len() as u32);
     let cp = cp_box_ptr(cp_obj as *const u8);
+    cp_install_dispose(cp);
 
     cp_set_field(cp, b"stdout", stdout_obj);
     cp_set_field(cp, b"stderr", stderr_obj);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1617,6 +1617,7 @@ const DNS_PROMISES_NAMESPACE_KEYS: &[&[u8]] = &[
 
 const CHILD_PROCESS_DEFAULT_KEYS: &[&[u8]] = &[
     b"ChildProcess",
+    b"_forkChild",
     b"exec",
     b"execFile",
     b"execFileSync",
@@ -1628,6 +1629,7 @@ const CHILD_PROCESS_DEFAULT_KEYS: &[&[u8]] = &[
 
 const CHILD_PROCESS_NAMESPACE_KEYS: &[&[u8]] = &[
     b"ChildProcess",
+    b"_forkChild",
     b"default",
     b"exec",
     b"execFile",
@@ -3439,6 +3441,7 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("tls", "connect") => Some(4),
         ("tls", "createServer" | "Server") => Some(2),
         ("tls", "TLSSocket") => Some(2),
+        ("child_process", "_forkChild") => Some(2),
         _ => None,
     }
 }
@@ -4383,6 +4386,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             // (`cp.spawn(...)`) already lowers through a dedicated codegen path;
             // this just keeps the value-read form coherent so it dispatches
             // through dispatch_native_module_method.
+            | ("child_process", "_forkChild")
             | ("child_process", "exec")
             | ("child_process", "execFile")
             | ("child_process", "execSync")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1678,8 +1678,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         // codegen arms (`expr/child_proc.rs`); this arm mirrors them for the
         // value-call form. `cmd` / `file` / `module` strings come in NaN-boxed
         // (SSO-safe via `js_string_materialize_to_heap`); `args` is the array
-        // pointer (or null); `opts` is the options-object pointer (or 0 →
-        // undefined inside the impls).
+        // pointer (or null); `opts` is the options-object pointer (or 0).
         ("child_process", "spawn") => {
             let cmd = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
             let args_p = optional_ptr_addr(arg(1)) as i64;
@@ -1710,6 +1709,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
             let file = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
             crate::child_process::js_child_process_exec_file_sync(file, arg(1), arg(2))
         }
+        ("child_process", "_forkChild") => crate::child_process::js_fork_child(args_len),
         ("child_process", "fork") => {
             let module = crate::string::js_string_materialize_to_heap(arg(0)) as i64;
             let args_p = optional_ptr_addr(arg(1)) as i64;

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1802 entries across 106 modules
+// Coverage: 1799 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -274,6 +274,8 @@ declare module "child_process" {
   /** stdlib */
   const _default: any;
   export default _default;
+  /** stdlib */
+  export function _forkChild(...args: any[]): any;
   /** stdlib */
   export function exec(...args: any[]): any;
   /** stdlib */
@@ -3149,12 +3151,6 @@ declare module "stream" {
   /** stdlib */
   export const promises: any;
   /** stdlib */
-  export function _isArrayBufferView(...args: any[]): any;
-  /** stdlib */
-  export function _isUint8Array(...args: any[]): any;
-  /** stdlib */
-  export function _uint8ArrayToBuffer(...args: any[]): any;
-  /** stdlib */
   export function addAbortSignal(...args: any[]): any;
   /** stdlib */
   export function compose(...args: any[]): any;
@@ -3166,8 +3162,6 @@ declare module "stream" {
   export function finished(...args: any[]): any;
   /** stdlib */
   export function getDefaultHighWaterMark(...args: any[]): any;
-  /** stdlib */
-  export function isDestroyed(...args: any[]): any;
   /** stdlib */
   export function isDisturbed(...args: any[]): any;
   /** stdlib */
@@ -3977,12 +3971,4 @@ declare module "zlib" {
   export function unzip(buffer: any, callback: any): void;
   /** stdlib */
   export function unzipSync(p0: string): any;
-  /** stdlib */
-  export function zstdCompress(buffer: any, callback: any): void;
-  /** stdlib */
-  export function zstdCompressSync(p0: any, options?: any): string;
-  /** stdlib */
-  export function zstdDecompress(buffer: any, callback: any): void;
-  /** stdlib */
-  export function zstdDecompressSync(p0: any, options?: any): string;
 }

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2620 entries across 109 modules.
+Total: 2603 entries across 109 modules.
 
 ## Modules
 
@@ -345,6 +345,7 @@ Total: 2620 entries across 109 modules.
 
 ### Methods
 
+- `_forkChild` — module
 - `exec` — module
 - `execFile` — module
 - `execFileSync` — module
@@ -2812,9 +2813,6 @@ Total: 2620 entries across 109 modules.
 
 ### Methods
 
-- `_isArrayBufferView` — module
-- `_isUint8Array` — module
-- `_uint8ArrayToBuffer` — module
 - `addAbortSignal` — module
 - `addListener` — instance
 - `allowHalfOpen` — instance
@@ -2832,7 +2830,6 @@ Total: 2620 entries across 109 modules.
 - `finished` — module
 - `getDefaultHighWaterMark` — module
 - `getMaxListeners` — instance
-- `isDestroyed` — module
 - `isDisturbed` — module
 - `isErrored` — module
 - `isPaused` — instance
@@ -3380,27 +3377,13 @@ Total: 2620 entries across 109 modules.
 ### Methods
 
 - `compileFunction` — module
-- `createCachedData` — instance
 - `createContext` — module
 - `createScript` — module
-- `dependencySpecifiers` — instance
-- `error` — instance
-- `evaluate` — instance
-- `hasAsyncGraph` — instance
-- `hasTopLevelAwait` — instance
-- `identifier` — instance
-- `instantiate` — instance
 - `isContext` — module
-- `link` — instance
-- `linkRequests` — instance
 - `measureMemory` — module
-- `moduleRequests` — instance
-- `namespace` — instance
 - `runInContext` — module
 - `runInNewContext` — module
 - `runInThisContext` — module
-- `setExport` — instance
-- `status` — instance
 
 ### Properties
 
@@ -3557,10 +3540,6 @@ Total: 2620 entries across 109 modules.
 - `inflateSync` — module
 - `unzip` — module
 - `unzipSync` — module
-- `zstdCompress` — module
-- `zstdCompressSync` — module
-- `zstdDecompress` — module
-- `zstdDecompressSync` — module
 
 ### Properties
 

--- a/test-parity/node-suite/child_process/async/fork-send-callback-closed.ts
+++ b/test-parity/node-suite/child_process/async/fork-send-callback-closed.ts
@@ -1,0 +1,30 @@
+import { fork } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const childFile = join(tmpdir(), `perry-fork-send-${process.pid}.js`);
+writeFileSync(
+  childFile,
+  "process.on('message', () => {}); setInterval(() => {}, 1000);",
+);
+
+const child = fork(childFile, [], { stdio: ["ignore", "ignore", "ignore", "ipc"] });
+
+console.log("send length:", child.send.length);
+const successReturn = child.send({ ok: true }, (err: any) => {
+  console.log("send callback success err:", err === null ? "null" : err?.code ?? err?.name);
+  child.disconnect();
+  setTimeout(() => {
+    const closedReturn = child.send({ afterDisconnect: true }, (closedErr: any) => {
+      console.log("send callback closed err:", closedErr?.name, closedErr?.code);
+      child.kill();
+      try {
+        unlinkSync(childFile);
+      } catch {}
+    });
+    console.log("send return closed:", closedReturn);
+  }, 25);
+});
+
+console.log("send return success:", successReturn);

--- a/test-parity/node-suite/child_process/async/subprocess-dispose.ts
+++ b/test-parity/node-suite/child_process/async/subprocess-dispose.ts
@@ -1,0 +1,18 @@
+import { spawn } from "node:child_process";
+
+const command = process.platform === "win32" ? "cmd" : "sleep";
+const args =
+  process.platform === "win32"
+    ? ["/c", "ping -n 60 127.0.0.1 >NUL"]
+    : ["60"];
+const child = spawn(command, args);
+const dispose = (child as any)[Symbol.dispose];
+
+child.on("exit", (code, signal) => {
+  console.log("dispose exit:", code, signal);
+});
+
+console.log("dispose type:", typeof dispose);
+console.log("dispose length:", dispose?.length);
+console.log("dispose name:", dispose?.name);
+console.log("dispose return undefined:", dispose.call(child) === undefined);

--- a/test-parity/node-suite/child_process/imports/fork-child-shape.ts
+++ b/test-parity/node-suite/child_process/imports/fork-child-shape.ts
@@ -1,0 +1,24 @@
+import childProcessDefault from "node:child_process";
+import * as childProcessNs from "node:child_process";
+
+const key = "_forkChild";
+const nsHelper = (childProcessNs as any)._forkChild;
+const defaultHelper = (childProcessDefault as any)._forkChild;
+
+console.log("namespace keys include _forkChild:", Object.keys(childProcessNs).includes(key));
+console.log(
+  "namespace enumerable _forkChild:",
+  Object.prototype.propertyIsEnumerable.call(childProcessNs, key),
+);
+console.log("namespace _forkChild type:", typeof nsHelper);
+console.log("namespace _forkChild length:", nsHelper?.length);
+console.log("namespace _forkChild name:", nsHelper?.name);
+console.log("default keys include _forkChild:", Object.keys(childProcessDefault).includes(key));
+console.log(
+  "default enumerable _forkChild:",
+  Object.prototype.propertyIsEnumerable.call(childProcessDefault, key),
+);
+console.log("default _forkChild type:", typeof defaultHelper);
+console.log("default _forkChild length:", defaultHelper?.length);
+console.log("default _forkChild name:", defaultHelper?.name);
+console.log("namespace/default identity:", nsHelper === defaultHelper);


### PR DESCRIPTION
## Issues

Fixes PerryTS/perry#2556.
Fixes PerryTS/perry#2717.
Fixes PerryTS/perry#3316.

## Summary

- Adds `subprocess[Symbol.dispose]` on `spawn()` and `fork()` ChildProcess objects, implemented as the Node-compatible `kill()` lifecycle alias returning `undefined`.
- Exposes `child_process._forkChild` on namespace/default imports, API manifest, generated docs, and captured-call dispatch with Node's observable name/length/key shape.
- Adds child_process parity coverage for `_forkChild` shape, subprocess disposal, and the existing `send(..., callback)` closed-channel semantics.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `cargo check -p perry-runtime -p perry-stdlib -p perry-api-manifest`
- `cargo test -p perry-api-manifest`
- `./scripts/regen_api_docs.sh`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module child_process`

## Non-goals

- This does not implement full child-side `_forkChild` IPC bootstrap/process mutation; the export is surfaced and dispatches conservatively for bootstrap-shaped calls.
- Broader `spawn`/`exec` option semantics and child-side `process.send` work remain separate issues.
