### PR TITLE
fix(runtime): stop size-accessor install corrupting Map/Set.prototype.set (#4099)

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -39,7 +39,7 @@ pub(super) unsafe fn boxed_primitive_base_for_object(
 unsafe fn boxed_primitive_payload_for_object(
     obj_ptr: *const crate::object::ObjectHeader,
 ) -> Option<(u32, f64)> {
-    if !crate::object::is_valid_obj_ptr(obj_ptr as *const u8) {
+    if (obj_ptr as usize) < 0x100000 || !crate::object::is_valid_obj_ptr(obj_ptr as *const u8) {
         return None;
     }
     let class_id = (*obj_ptr).class_id;
@@ -173,8 +173,11 @@ pub(crate) fn boxed_primitive_payload(value: f64) -> Option<(u32, f64)> {
     // that isn't a real heap object must be rejected *before* the `class_id`
     // read — otherwise a small subnormal double (e.g. raw bits `0x2800000207`)
     // that slips through the `>= 0x100000` raw-pointer heuristic is dereferenced
-    // as an `ObjectHeader` and faults. Gate on the actual heap range (#4099).
-    if !crate::object::is_valid_obj_ptr(ptr as *const u8) {
+    // as an `ObjectHeader` and faults. Keep the `0x100000` small-handle floor
+    // (the fetch/Headers id-space lives below it and `is_valid_obj_ptr`'s Linux
+    // `HEAP_MIN` of `0x1000` would otherwise let those handles through), and
+    // additionally gate on the real heap range (#4099).
+    if (ptr as usize) < 0x100000 || !crate::object::is_valid_obj_ptr(ptr as *const u8) {
         return None;
     }
     unsafe { boxed_primitive_payload_for_object(ptr) }

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -39,7 +39,7 @@ pub(super) unsafe fn boxed_primitive_base_for_object(
 unsafe fn boxed_primitive_payload_for_object(
     obj_ptr: *const crate::object::ObjectHeader,
 ) -> Option<(u32, f64)> {
-    if obj_ptr.is_null() || (obj_ptr as usize) < 0x100000 {
+    if !crate::object::is_valid_obj_ptr(obj_ptr as *const u8) {
         return None;
     }
     let class_id = (*obj_ptr).class_id;
@@ -169,7 +169,12 @@ pub(crate) fn boxed_primitive_payload(value: f64) -> Option<(u32, f64)> {
     } else {
         return None;
     };
-    if ptr.is_null() || (ptr as usize) < 0x100000 {
+    // This is a defensive type-probe over arbitrary `f64` bits, so a candidate
+    // that isn't a real heap object must be rejected *before* the `class_id`
+    // read — otherwise a small subnormal double (e.g. raw bits `0x2800000207`)
+    // that slips through the `>= 0x100000` raw-pointer heuristic is dereferenced
+    // as an `ObjectHeader` and faults. Gate on the actual heap range (#4099).
+    if !crate::object::is_valid_obj_ptr(ptr as *const u8) {
         return None;
     }
     unsafe { boxed_primitive_payload_for_object(ptr) }

--- a/crates/perry-runtime/src/object/collection_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/collection_proto_thunks.rs
@@ -78,6 +78,18 @@ pub(super) fn install_collection_proto_methods(
     use super::global_this::install_proto_method as ipm;
     match builtin_name {
         "Map" => {
+            // #4099: install the `size` *accessor* BEFORE the data methods.
+            // Installing an accessor descriptor onto a prototype that already
+            // holds data properties corrupts one of those data slots (the
+            // accessor/data-field bookkeeping desyncs), which left
+            // `Map.prototype.set` reading back as a garbage number — a later
+            // `Map.prototype.set.call(...)` then dereferenced it and crashed
+            // (SIGBUS). Installing the lone accessor first sidesteps the desync.
+            install_collection_size_getter(
+                proto_obj,
+                "size",
+                map_proto_size_getter_thunk as *const u8,
+            );
             ipm(proto_obj, "clear", map_proto_clear_thunk as *const u8, 0);
             ipm(proto_obj, "delete", map_proto_delete_thunk as *const u8, 1);
             ipm(
@@ -97,11 +109,6 @@ pub(super) fn install_collection_proto_methods(
             ipm(proto_obj, "keys", map_proto_keys_thunk as *const u8, 0);
             let set_value = ipm(proto_obj, "set", map_proto_set_thunk as *const u8, 2);
             ipm(proto_obj, "values", map_proto_values_thunk as *const u8, 0);
-            install_collection_size_getter(
-                proto_obj,
-                "size",
-                map_proto_size_getter_thunk as *const u8,
-            );
             remember_builtin_collection_method(
                 proto_obj,
                 "set",
@@ -110,6 +117,12 @@ pub(super) fn install_collection_proto_methods(
             );
         }
         "Set" => {
+            // #4099: install the `size` accessor first (see the Map arm).
+            install_collection_size_getter(
+                proto_obj,
+                "size",
+                set_proto_size_getter_thunk as *const u8,
+            );
             let add_value = ipm(proto_obj, "add", set_proto_add_thunk as *const u8, 1);
             ipm(proto_obj, "clear", set_proto_clear_thunk as *const u8, 0);
             ipm(proto_obj, "delete", set_proto_delete_thunk as *const u8, 1);
@@ -128,11 +141,6 @@ pub(super) fn install_collection_proto_methods(
             ipm(proto_obj, "has", set_proto_has_thunk as *const u8, 1);
             ipm(proto_obj, "keys", set_proto_keys_thunk as *const u8, 0);
             ipm(proto_obj, "values", set_proto_values_thunk as *const u8, 0);
-            install_collection_size_getter(
-                proto_obj,
-                "size",
-                set_proto_size_getter_thunk as *const u8,
-            );
             remember_builtin_collection_method(
                 proto_obj,
                 "add",

--- a/test-files/test_gap_4099_map_set_accessor_corruption.ts
+++ b/test-files/test_gap_4099_map_set_accessor_corruption.ts
@@ -1,0 +1,41 @@
+// #4099 — installing the `size` accessor on Map.prototype / Set.prototype must
+// not corrupt a sibling data method's slot. Pre-fix, the `size` getter was
+// installed *after* the data methods, and the accessor install clobbered the
+// `Map.prototype.set` data slot with a garbage number — so `typeof
+// Map.prototype.set` was "number" and `Map.prototype.set.call(...)` crashed
+// (SIGBUS) by dereferencing the number as an object pointer.
+
+console.log("typeof Map.set:", typeof Map.prototype.set);
+console.log("typeof Map.get:", typeof Map.prototype.get);
+console.log("typeof Set.add:", typeof Set.prototype.add);
+console.log("typeof Map.size getter:", typeof Object.getOwnPropertyDescriptor(Map.prototype, "size")!.get);
+
+function threw(fn: () => void): string {
+    try {
+        fn();
+        return "NO_THROW";
+    } catch (e: any) {
+        return e && e.name ? e.name : String(e);
+    }
+}
+
+// Reflective set on a bad receiver must throw (used to crash).
+console.log("set(null):", threw(() => (Map.prototype.set as any).call(null, 1, 2)));
+console.log("set({}):", threw(() => (Map.prototype.set as any).call({}, 1, 2)));
+
+// The accessor and the data methods both still work on a real instance.
+const m = new Map<string, number>();
+(Map.prototype.set as any).call(m, "k", 7);
+console.log("reflective set then get:", m.get("k"), "size:", m.size);
+
+const s = new Set<number>();
+s.add(1);
+s.add(2);
+console.log("set size:", s.size, "has(1):", s.has(1));
+
+// Map constructed from an iterable still initializes via the set fast-path.
+const m2 = new Map([
+    ["x", 10],
+    ["y", 20],
+]);
+console.log("map ctor:", m2.get("x"), m2.get("y"), "size:", m2.size);


### PR DESCRIPTION
Fixes #4099.

## Summary

`Map.prototype.set.call(null, 1, 2)` **crashed the process** (`SIGBUS`, exit 138) instead of throwing the spec `TypeError` — and it masked the rest of the #3662 collection brand-check suite (`test_gap_3662_collection_brand_check.ts` printed 5 lines then aborted on `main`).

## Root cause

In `collection_proto_thunks.rs`, the `size` **accessor** getter was installed **after** the data-method thunks. Installing an accessor descriptor onto a prototype that already holds data properties desyncs the accessor/data-field bookkeeping and **clobbers a sibling data slot** — here `Map.prototype.set` read back as a garbage subnormal number (bits `0x2800000203`):

```
[DBG] after set install:  set = 0x7ffd...a671b58   (NaN-boxed closure ✓)
[DBG] after values:       set = 0x7ffd...a671b58   (✓)
[DBG] after size getter:  set = 0x0000002800000203 (CORRUPTED)
```

So `typeof Map.prototype.set` was `"number"`; a later reflective `.call` on that number dereferenced it as an object pointer and faulted. Only `Map.prototype.set` was hit (its slot index collided with the accessor desync); `WeakMap`/`WeakSet` have no `size` getter and were never affected. The user-facing `Object.defineProperty` accessor path is **unaffected** — it uses a different, correct code path; only the builtin manual install sequence desynced.

## Fix

- **`collection_proto_thunks.rs`** — install the `size` accessor **before** the data methods for both `Map` and `Set`, so the lone accessor never lands on a prototype that already has data slots to corrupt.
- **`boxed_primitives.rs`** (defense-in-depth) — `boxed_primitive_payload` is a type-probe over arbitrary `f64` bits, so gate the candidate on the real heap range (`is_valid_obj_ptr`) before reading `class_id`, instead of the weak `< 0x100000` guard that let a subnormal double through to a faulting deref.

## Testing

- New gap test `test_gap_4099_map_set_accessor_corruption.ts` — byte-identical to `node --experimental-strip-types` in both the default auto-optimize and `PERRY_NO_AUTO_OPTIMIZE=1` builds.
- The pre-existing `test_gap_3662_collection_brand_check.ts` (which **crashed on main**) now runs to completion byte-identically.
- Verified `Map`/`Set` methods, `.size` getters, reflective set on a real instance, and `new Map([...])` iterable construction all still work.
