### PR TITLE
fix(runtime): brand-check primitive-wrapper prototype methods (#4100)

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2830,17 +2830,86 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                 &[
                     ("toExponential", 1),
                     ("toFixed", 1),
-                    ("toLocaleString", 0),
                     ("toPrecision", 1),
                     ("toString", 1),
-                    ("valueOf", 0),
                 ],
             );
+            // OBJECT_PROTO_METHODS installs noop `valueOf`/`toLocaleString`, so
+            // it must run BEFORE the brand thunks below — otherwise it clobbers
+            // them back to no-ops.
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            // #4100: `valueOf`/`toLocaleString` brand-check `this` and throw a
+            // `TypeError` on an incompatible reflective receiver instead of
+            // falling back to `Object.prototype` (`"[object Object]"`).
+            install_proto_method(
+                proto_obj,
+                "valueOf",
+                primitive_proto_thunks::number_proto_value_of_thunk as *const u8,
+                0,
+            );
+            install_proto_method(
+                proto_obj,
+                "toLocaleString",
+                primitive_proto_thunks::number_proto_to_locale_string_thunk as *const u8,
+                0,
+            );
         }
         "Boolean" => {
-            install_noop_proto_methods(proto_obj, &[("toString", 0), ("valueOf", 0)]);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            // #4100: brand-checking `toString`/`valueOf` (mirror `Number`).
+            // Installed after OBJECT_PROTO_METHODS so the brand `valueOf` wins.
+            install_proto_method(
+                proto_obj,
+                "toString",
+                primitive_proto_thunks::boolean_proto_to_string_thunk as *const u8,
+                0,
+            );
+            install_proto_method(
+                proto_obj,
+                "valueOf",
+                primitive_proto_thunks::boolean_proto_value_of_thunk as *const u8,
+                0,
+            );
+        }
+        "Symbol" => {
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            // #4100: Symbol.prototype previously had no own methods, so
+            // reflective `Symbol.prototype.toString.call(sym)` resolved to
+            // `Object.prototype.toString` (`"[object Symbol]"`) and an
+            // incompatible receiver returned `"[object Object]"` instead of
+            // throwing. Install brand-checking thunks that re-dispatch to the
+            // canonical symbol logic (`"Symbol(x)"`). After OBJECT_PROTO_METHODS
+            // so the brand `valueOf` wins.
+            install_proto_method(
+                proto_obj,
+                "toString",
+                primitive_proto_thunks::symbol_proto_to_string_thunk as *const u8,
+                0,
+            );
+            install_proto_method(
+                proto_obj,
+                "valueOf",
+                primitive_proto_thunks::symbol_proto_value_of_thunk as *const u8,
+                0,
+            );
+        }
+        "BigInt" => {
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            // #4100: mirror `Symbol` — brand-checking `toString`(radix)/`valueOf`
+            // re-dispatched to the canonical BigInt logic (`(5n).toString(2)`
+            // → `"101"`). After OBJECT_PROTO_METHODS so the brand `valueOf` wins.
+            install_proto_method(
+                proto_obj,
+                "toString",
+                primitive_proto_thunks::bigint_proto_to_string_thunk as *const u8,
+                1,
+            );
+            install_proto_method(
+                proto_obj,
+                "valueOf",
+                primitive_proto_thunks::bigint_proto_value_of_thunk as *const u8,
+                0,
+            );
         }
         "Date" => {
             install_noop_proto_methods(

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -47,6 +47,7 @@ mod object_literal_ops;
 mod object_ops;
 mod object_ops_frozen;
 mod polymorphic_index;
+mod primitive_proto_thunks;
 mod property_key;
 pub(crate) mod prototype_chain;
 mod prototype_helpers;

--- a/crates/perry-runtime/src/object/primitive_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/primitive_proto_thunks.rs
@@ -1,0 +1,160 @@
+//! Primitive-wrapper prototype-method thunks (#4100, part of the #3662 cluster).
+//!
+//! `Number.prototype.valueOf` & friends are reachable as plain values (e.g.
+//! `Number.prototype.valueOf.call(x)`, `Reflect.apply`, method extraction).
+//! The fast path `n.valueOf()` is lowered directly by codegen and never touches
+//! these thunks, so they only fire on the reflective path — which previously
+//! resolved to `global_this_builtin_noop_thunk` (Number/Boolean) or fell back
+//! to `Object.prototype.toString` (Symbol/BigInt, whose prototypes had no own
+//! methods). Both produced `"[object Object]"`/`"[object Symbol]"` instead of
+//! the spec behaviour.
+//!
+//! Per spec these methods must perform a `this` brand check and throw a
+//! `TypeError` when called on an incompatible receiver. The thunks below read
+//! the `IMPLICIT_THIS` receiver (set by the `.call`/`.apply` dispatch),
+//! brand-check it against the matching primitive (or its boxed wrapper), throw
+//! on mismatch, and otherwise re-dispatch to the canonical per-type logic via
+//! `js_native_call_method` — which also returns the correct value, fixing the
+//! wrong-value reflective `toString` (`Symbol("x").toString()` → `"Symbol(x)"`,
+//! `(5n).toString(2)` → `"101"`).
+//!
+//! Installed onto each wrapper's `.prototype` by
+//! `global_this::populate_builtin_prototype_methods`.
+
+use super::*;
+
+/// Throw `TypeError: Method <proto>.<method> called on incompatible receiver`.
+/// Mirrors the collection-thunk wording; Test262's brand-check tests assert
+/// only the error *type*, so the exact message is informational. Never returns.
+fn throw_incompatible_receiver(proto: &str, method: &str) -> ! {
+    let msg = format!("Method {proto}.{method} called on incompatible receiver");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(f64::from_bits(
+        crate::value::JSValue::pointer(err as *const u8).bits(),
+    ))
+}
+
+fn receiver_bits() -> f64 {
+    f64::from_bits(IMPLICIT_THIS.with(|c| c.get()))
+}
+
+#[inline]
+fn number_receiver_or_throw(method: &str) -> f64 {
+    let this = receiver_bits();
+    let jsv = crate::value::JSValue::from_bits(this.to_bits());
+    if jsv.is_number()
+        || jsv.is_int32()
+        || crate::builtins::boxed_primitive_to_string_tag(this) == Some("Number")
+    {
+        this
+    } else {
+        throw_incompatible_receiver("Number.prototype", method)
+    }
+}
+
+#[inline]
+fn boolean_receiver_or_throw(method: &str) -> f64 {
+    let this = receiver_bits();
+    let jsv = crate::value::JSValue::from_bits(this.to_bits());
+    if jsv.is_bool() || crate::builtins::boxed_primitive_to_string_tag(this) == Some("Boolean") {
+        this
+    } else {
+        throw_incompatible_receiver("Boolean.prototype", method)
+    }
+}
+
+#[inline]
+fn symbol_receiver_or_throw(method: &str) -> f64 {
+    let this = receiver_bits();
+    let is_symbol = unsafe { crate::symbol::js_is_symbol(this) != 0 };
+    if is_symbol || crate::builtins::boxed_primitive_to_string_tag(this) == Some("Symbol") {
+        this
+    } else {
+        throw_incompatible_receiver("Symbol.prototype", method)
+    }
+}
+
+#[inline]
+fn bigint_receiver_or_throw(method: &str) -> f64 {
+    let this = receiver_bits();
+    let jsv = crate::value::JSValue::from_bits(this.to_bits());
+    if jsv.is_bigint() || crate::builtins::boxed_primitive_to_string_tag(this) == Some("BigInt") {
+        this
+    } else {
+        throw_incompatible_receiver("BigInt.prototype", method)
+    }
+}
+
+/// Re-dispatch the brand-checked receiver to the canonical method logic, which
+/// also produces the correct value for the wrong-value reflective `toString`.
+fn redispatch(this: f64, method: &str, args: &[f64]) -> f64 {
+    unsafe {
+        super::js_native_call_method(
+            this,
+            method.as_ptr() as *const i8,
+            method.len(),
+            args.as_ptr(),
+            args.len(),
+        )
+    }
+}
+
+pub(super) extern "C" fn number_proto_value_of_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = number_receiver_or_throw("valueOf");
+    redispatch(this, "valueOf", &[])
+}
+
+pub(super) extern "C" fn number_proto_to_locale_string_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = number_receiver_or_throw("toLocaleString");
+    redispatch(this, "toLocaleString", &[])
+}
+
+pub(super) extern "C" fn boolean_proto_to_string_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = boolean_receiver_or_throw("toString");
+    redispatch(this, "toString", &[])
+}
+
+pub(super) extern "C" fn boolean_proto_value_of_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = boolean_receiver_or_throw("valueOf");
+    redispatch(this, "valueOf", &[])
+}
+
+pub(super) extern "C" fn symbol_proto_to_string_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = symbol_receiver_or_throw("toString");
+    redispatch(this, "toString", &[])
+}
+
+pub(super) extern "C" fn symbol_proto_value_of_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = symbol_receiver_or_throw("valueOf");
+    redispatch(this, "valueOf", &[])
+}
+
+pub(super) extern "C" fn bigint_proto_to_string_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    radix: f64,
+) -> f64 {
+    let this = bigint_receiver_or_throw("toString");
+    // Forward an explicit radix; a missing arg arrives as `undefined`, which the
+    // canonical BigInt `toString` arm treats as decimal.
+    redispatch(this, "toString", &[radix])
+}
+
+pub(super) extern "C" fn bigint_proto_value_of_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = bigint_receiver_or_throw("valueOf");
+    redispatch(this, "valueOf", &[])
+}

--- a/test-files/test_gap_4100_primitive_proto_brand_check.ts
+++ b/test-files/test_gap_4100_primitive_proto_brand_check.ts
@@ -1,0 +1,44 @@
+// #4100 (part of #3662) — primitive-wrapper prototype methods must perform the
+// spec `this` brand check and throw a TypeError on an incompatible receiver,
+// and must return the correct value when invoked reflectively on a real
+// primitive. Pre-fix these resolved to `Object.prototype` and returned
+// "[object Object]"/"[object Symbol]" instead of throwing / the right value.
+// We print only error *types* / values so output is byte-identical to Node.
+
+function threw(fn: () => void): string {
+    try {
+        fn();
+        return "NO_THROW";
+    } catch (e: any) {
+        return e && e.name ? e.name : String(e);
+    }
+}
+
+// --- Brand check: wrong / primitive receiver must throw TypeError. ---
+console.log("Number.valueOf{}:", threw(() => (Number.prototype.valueOf as any).call({})));
+console.log("Number.toLocaleString{}:", threw(() => (Number.prototype.toLocaleString as any).call({})));
+console.log("Boolean.toString{}:", threw(() => (Boolean.prototype.toString as any).call({})));
+console.log("Boolean.valueOf{}:", threw(() => (Boolean.prototype.valueOf as any).call({})));
+console.log("Symbol.toString{}:", threw(() => (Symbol.prototype.toString as any).call({})));
+console.log("Symbol.valueOf{}:", threw(() => (Symbol.prototype.valueOf as any).call({})));
+console.log("BigInt.toString{}:", threw(() => (BigInt.prototype.toString as any).call({})));
+console.log("BigInt.valueOf{}:", threw(() => (BigInt.prototype.valueOf as any).call({})));
+
+// Cross-brand: a Number is not a BigInt etc.
+console.log("Number.valueOf on sym:", threw(() => (Number.prototype.valueOf as any).call(Symbol("x"))));
+console.log("BigInt.valueOf on 5:", threw(() => (BigInt.prototype.valueOf as any).call(5)));
+
+// --- Correct receiver: reflective dispatch returns the right value. ---
+console.log("Number.valueOf(5):", (Number.prototype.valueOf as any).call(5));
+console.log("Number.toLocaleString(5):", (Number.prototype.toLocaleString as any).call(5));
+console.log("Boolean.toString(true):", (Boolean.prototype.toString as any).call(true));
+console.log("Boolean.valueOf(false):", (Boolean.prototype.valueOf as any).call(false));
+console.log("Symbol.toString:", (Symbol.prototype.toString as any).call(Symbol("x")));
+const sy = Symbol("y");
+console.log("Symbol.valueOf identity:", (Symbol.prototype.valueOf as any).call(sy) === sy);
+console.log("BigInt.toString(5n,2):", (BigInt.prototype.toString as any).call(5n, 2));
+console.log("BigInt.toString(255n):", (BigInt.prototype.toString as any).call(255n));
+console.log("BigInt.valueOf(5n):", (BigInt.prototype.valueOf as any).call(5n) === 5n);
+
+// --- Sanity: the fast direct-call path is unchanged. ---
+console.log("direct:", (5).valueOf(), true.toString(), (255n).toString(16), Symbol("z").toString());


### PR DESCRIPTION
## Summary

Fixes #4100 (part of the #3662 brand-check cluster).

The primitive-wrapper prototype methods did **not** perform the spec `this`
brand check when invoked reflectively on an incompatible receiver — they fell
back to `Object.prototype` and returned `"[object Object]"` instead of throwing
a `TypeError`. On a *valid* receiver the reflective `toString` also returned the
wrong value (the generic `Object.prototype.toString`, e.g. `"[object Symbol]"`
instead of `"Symbol(x)"`).

Methods fixed (each now throws `TypeError` on a non-matching receiver and
returns the correct value on a valid one):

- `Number.prototype.valueOf`, `Number.prototype.toLocaleString`
- `Boolean.prototype.toString`, `Boolean.prototype.valueOf`
- `Symbol.prototype.toString`, `Symbol.prototype.valueOf`
- `BigInt.prototype.toString` (incl. radix), `BigInt.prototype.valueOf`

## Approach

New `object/primitive_proto_thunks.rs` module (mirroring
`collection_proto_thunks.rs`): each thunk reads the `IMPLICIT_THIS` receiver,
brand-checks it against the matching primitive **or its boxed wrapper**, throws
`TypeError` on mismatch, and otherwise re-dispatches to `js_native_call_method`
— which produces the canonical value, fixing the wrong-value reflective
`toString` too.

`Symbol`/`BigInt` prototypes previously had no own `valueOf`/`toString` (they
resolved up to `Object.prototype`); they now get brand-checking thunks. For
`Number`/`Boolean`, `OBJECT_PROTO_METHODS` (which installs no-op
`valueOf`/`toLocaleString`) is now installed **before** the brand thunks so it
no longer clobbers them.

The fast direct path (`(5).valueOf()`, `sym.toString()`, …) is lowered by
codegen and never touches these thunks, so the change is additive.

## Testing

- New gap test `test-files/test_gap_4100_primitive_proto_brand_check.ts`.
- Verified **byte-identical** to `node --experimental-strip-types` in both
  no-opt and auto-optimize modes (brand-check throws, cross-brand throws, valid
  receivers return correct values incl. `BigInt.prototype.toString.call(5n, 2)`
  → `"101"`).
- Regression spot-check of direct + boxed-wrapper primitive methods: unchanged.
- `cargo fmt --all -- --check` clean; `cargo test -p perry-runtime` green (two
  unrelated parallelism/CWD-dependent flakes in `gc::`/`url::` pass in
  isolation).
