### PR TITLE
[codex] Fix primitive prototype reflective brand checks

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -107,6 +107,46 @@ fn lower_runtime_property_get_by_name(
     ))
 }
 
+fn is_primitive_builtin_proto_method(builtin_name: &str, method_name: &str) -> bool {
+    match builtin_name {
+        "Number" => matches!(
+            method_name,
+            "toExponential" | "toFixed" | "toLocaleString" | "toPrecision" | "toString" | "valueOf"
+        ),
+        "Boolean" | "Symbol" => matches!(method_name, "toString" | "valueOf"),
+        "BigInt" => matches!(method_name, "toString" | "valueOf"),
+        _ => false,
+    }
+}
+
+fn builtin_prototype_method_read<'a>(
+    object: &'a Expr,
+    property: &'a str,
+) -> Option<(&'a str, &'a str)> {
+    let Expr::PropertyGet {
+        object: ctor_object,
+        property: proto_property,
+    } = object
+    else {
+        return None;
+    };
+    if proto_property != "prototype" {
+        return None;
+    }
+    let Expr::PropertyGet {
+        object: global_object,
+        property: builtin_name,
+    } = ctor_object.as_ref()
+    else {
+        return None;
+    };
+    if !matches!(global_object.as_ref(), Expr::GlobalGet(_)) {
+        return None;
+    }
+    is_primitive_builtin_proto_method(builtin_name, property)
+        .then_some((builtin_name.as_str(), property))
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::PropertyGet { object, property }
@@ -429,6 +469,28 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // `js_array_set_f64` (no return value, no realloc) since there's
         // no local to write a possibly-realloc'd pointer back to.
         Expr::PropertyGet { object, property } => {
+            if let Some((builtin_name, method_name)) =
+                builtin_prototype_method_read(object, property)
+            {
+                let builtin_idx = ctx.strings.intern(builtin_name);
+                let builtin_bytes_global =
+                    format!("@{}", ctx.strings.entry(builtin_idx).bytes_global);
+                let builtin_len = builtin_name.len().to_string();
+                let method_idx = ctx.strings.intern(method_name);
+                let method_bytes_global =
+                    format!("@{}", ctx.strings.entry(method_idx).bytes_global);
+                let method_len = method_name.len().to_string();
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_builtin_prototype_method_value",
+                    &[
+                        (PTR, &builtin_bytes_global),
+                        (I64, &builtin_len),
+                        (PTR, &method_bytes_global),
+                        (I64, &method_len),
+                    ],
+                ));
+            }
             // date-fns `constructFrom(date, value)` reads `date.constructor`
             // to clone Dates without naming Date directly. Perry stores
             // Date as a raw f64 timestamp (no ObjectHeader), so the

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1023,6 +1023,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // so `inst.constructor === Date` (date-fns / drizzle / lodash duck
     // checks) holds.
     module.declare_function("js_get_global_this_builtin_value", DOUBLE, &[PTR, I64]);
+    module.declare_function(
+        "js_builtin_prototype_method_value",
+        DOUBLE,
+        &[PTR, I64, PTR, I64],
+    );
     // Inline-allocator class registration: emitted once per class
     // with a parent in the entry-block init prelude. The runtime
     // allocators register on every alloc; the inline allocator skips

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1299,7 +1299,9 @@ fn is_builtin_prototype_receiver(ctx: &LoweringContext, recv: &ast::Expr) -> boo
                 return false;
             };
             let name = base.sym.as_ref();
-            matches!(name, "Array" | "String" | "Number" | "Boolean" | "Function")
+            // Number/Boolean primitive methods need to stay reflective so
+            // their prototype thunks brand-check `this` (#4100).
+            matches!(name, "Array" | "String" | "Function")
                 && ctx.lookup_local(name).is_none()
                 && ctx.lookup_func(name).is_none()
         }

--- a/crates/perry-runtime/src/collection_iter.rs
+++ b/crates/perry-runtime/src/collection_iter.rs
@@ -179,6 +179,25 @@ pub(crate) fn builtin_prototype_method(builtin_name: &str, method_name: &str) ->
     }
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn js_builtin_prototype_method_value(
+    builtin_ptr: *const u8,
+    builtin_len: usize,
+    method_ptr: *const u8,
+    method_len: usize,
+) -> f64 {
+    let builtin = match std::str::from_utf8(std::slice::from_raw_parts(builtin_ptr, builtin_len)) {
+        Ok(value) => value,
+        Err(_) => return f64::from_bits(TAG_UNDEFINED),
+    };
+    let method = match std::str::from_utf8(std::slice::from_raw_parts(method_ptr, method_len)) {
+        Ok(value) => value,
+        Err(_) => return f64::from_bits(TAG_UNDEFINED),
+    };
+    crate::object::primitive_proto_method_value(builtin, method)
+        .unwrap_or_else(|| builtin_prototype_method(builtin, method))
+}
+
 pub(crate) enum ConstructorIter {
     Empty,
     Array(f64),

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2710,6 +2710,23 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
         install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         return;
     }
+    // #4100: primitive wrapper prototypes need real thunks for their own
+    // methods so reflective calls brand-check `this` instead of hitting the
+    // generic Object no-op/valueOf fallbacks.
+    if primitive_proto_thunks::install_primitive_proto_methods(builtin_name, proto_obj) {
+        install_noop_proto_methods(
+            proto_obj,
+            &[
+                ("hasOwnProperty", 1),
+                ("isPrototypeOf", 1),
+                ("propertyIsEnumerable", 1),
+            ],
+        );
+        if !matches!(builtin_name, "Number") {
+            install_noop_proto_methods(proto_obj, &[("toLocaleString", 0)]);
+        }
+        return;
+    }
     match builtin_name {
         "Array" => {
             install_proto_method(

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -89,6 +89,7 @@ pub use object_literal_ops::*;
 pub use object_ops::*;
 pub use object_ops_frozen::*;
 pub use polymorphic_index::*;
+pub(crate) use primitive_proto_thunks::primitive_proto_method_value;
 pub use property_key::*;
 pub(crate) use prototype_helpers::*;
 pub(crate) use reflect_support::*;

--- a/crates/perry-runtime/src/object/primitive_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/primitive_proto_thunks.rs
@@ -1,160 +1,322 @@
-//! Primitive-wrapper prototype-method thunks (#4100, part of the #3662 cluster).
+//! Primitive wrapper prototype-method thunks.
 //!
-//! `Number.prototype.valueOf` & friends are reachable as plain values (e.g.
-//! `Number.prototype.valueOf.call(x)`, `Reflect.apply`, method extraction).
-//! The fast path `n.valueOf()` is lowered directly by codegen and never touches
-//! these thunks, so they only fire on the reflective path — which previously
-//! resolved to `global_this_builtin_noop_thunk` (Number/Boolean) or fell back
-//! to `Object.prototype.toString` (Symbol/BigInt, whose prototypes had no own
-//! methods). Both produced `"[object Object]"`/`"[object Symbol]"` instead of
-//! the spec behaviour.
-//!
-//! Per spec these methods must perform a `this` brand check and throw a
-//! `TypeError` when called on an incompatible receiver. The thunks below read
-//! the `IMPLICIT_THIS` receiver (set by the `.call`/`.apply` dispatch),
-//! brand-check it against the matching primitive (or its boxed wrapper), throw
-//! on mismatch, and otherwise re-dispatch to the canonical per-type logic via
-//! `js_native_call_method` — which also returns the correct value, fixing the
-//! wrong-value reflective `toString` (`Symbol("x").toString()` → `"Symbol(x)"`,
-//! `(5n).toString(2)` → `"101"`).
-//!
-//! Installed onto each wrapper's `.prototype` by
-//! `global_this::populate_builtin_prototype_methods`.
+//! These methods are observable as function values
+//! (`Number.prototype.valueOf.call(x)`, `Symbol.prototype.toString.call(x)`)
+//! and must brand-check their `this` receiver instead of falling through to
+//! Object defaults.
 
 use super::*;
 
-/// Throw `TypeError: Method <proto>.<method> called on incompatible receiver`.
-/// Mirrors the collection-thunk wording; Test262's brand-check tests assert
-/// only the error *type*, so the exact message is informational. Never returns.
-fn throw_incompatible_receiver(proto: &str, method: &str) -> ! {
-    let msg = format!("Method {proto}.{method} called on incompatible receiver");
-    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    let err = crate::error::js_typeerror_new(s);
-    crate::exception::js_throw(f64::from_bits(
-        crate::value::JSValue::pointer(err as *const u8).bits(),
+const CLASS_ID_BOXED_NUMBER: u32 = 0xFFFF_0060;
+const CLASS_ID_BOXED_BOOLEAN: u32 = 0xFFFF_0062;
+const CLASS_ID_BOXED_BIGINT: u32 = 0xFFFF_0063;
+const CLASS_ID_BOXED_SYMBOL: u32 = 0xFFFF_0064;
+
+pub(super) fn install_primitive_proto_methods(
+    builtin_name: &str,
+    proto_obj: *mut ObjectHeader,
+) -> bool {
+    use super::global_this::install_proto_method as ipm;
+
+    match builtin_name {
+        "Number" => {
+            ipm(
+                proto_obj,
+                "toExponential",
+                number_proto_to_exponential_thunk as *const u8,
+                1,
+            );
+            ipm(
+                proto_obj,
+                "toFixed",
+                number_proto_to_fixed_thunk as *const u8,
+                1,
+            );
+            ipm(
+                proto_obj,
+                "toLocaleString",
+                number_proto_to_locale_string_thunk as *const u8,
+                0,
+            );
+            ipm(
+                proto_obj,
+                "toPrecision",
+                number_proto_to_precision_thunk as *const u8,
+                1,
+            );
+            ipm(
+                proto_obj,
+                "toString",
+                number_proto_to_string_thunk as *const u8,
+                1,
+            );
+            ipm(
+                proto_obj,
+                "valueOf",
+                number_proto_value_of_thunk as *const u8,
+                0,
+            );
+        }
+        "Boolean" => {
+            ipm(
+                proto_obj,
+                "toString",
+                boolean_proto_to_string_thunk as *const u8,
+                0,
+            );
+            ipm(
+                proto_obj,
+                "valueOf",
+                boolean_proto_value_of_thunk as *const u8,
+                0,
+            );
+        }
+        "Symbol" => {
+            ipm(
+                proto_obj,
+                "toString",
+                symbol_proto_to_string_thunk as *const u8,
+                0,
+            );
+            ipm(
+                proto_obj,
+                "valueOf",
+                symbol_proto_value_of_thunk as *const u8,
+                0,
+            );
+        }
+        "BigInt" => {
+            ipm(
+                proto_obj,
+                "toString",
+                bigint_proto_to_string_thunk as *const u8,
+                1,
+            );
+            ipm(
+                proto_obj,
+                "valueOf",
+                bigint_proto_value_of_thunk as *const u8,
+                0,
+            );
+        }
+        _ => return false,
+    }
+    true
+}
+
+pub(crate) fn primitive_proto_method_value(builtin_name: &str, method_name: &str) -> Option<f64> {
+    let (func_ptr, arity) = match (builtin_name, method_name) {
+        ("Number", "toExponential") => (number_proto_to_exponential_thunk as *const u8, 1),
+        ("Number", "toFixed") => (number_proto_to_fixed_thunk as *const u8, 1),
+        ("Number", "toLocaleString") => (number_proto_to_locale_string_thunk as *const u8, 0),
+        ("Number", "toPrecision") => (number_proto_to_precision_thunk as *const u8, 1),
+        ("Number", "toString") => (number_proto_to_string_thunk as *const u8, 1),
+        ("Number", "valueOf") => (number_proto_value_of_thunk as *const u8, 0),
+        ("Boolean", "toString") => (boolean_proto_to_string_thunk as *const u8, 0),
+        ("Boolean", "valueOf") => (boolean_proto_value_of_thunk as *const u8, 0),
+        ("Symbol", "toString") => (symbol_proto_to_string_thunk as *const u8, 0),
+        ("Symbol", "valueOf") => (symbol_proto_value_of_thunk as *const u8, 0),
+        ("BigInt", "toString") => (bigint_proto_to_string_thunk as *const u8, 1),
+        ("BigInt", "valueOf") => (bigint_proto_value_of_thunk as *const u8, 0),
+        _ => return None,
+    };
+    Some(primitive_proto_method_closure_value(
+        method_name,
+        func_ptr,
+        arity,
     ))
 }
 
-fn receiver_bits() -> f64 {
+fn primitive_proto_method_closure_value(method_name: &str, func_ptr: *const u8, arity: u32) -> f64 {
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    crate::closure::js_register_closure_arity(func_ptr, arity);
+    super::native_module::set_bound_native_closure_name(closure, method_name);
+    super::native_module::set_builtin_closure_length(closure as usize, arity);
+    super::set_builtin_property_attrs(
+        closure as usize,
+        "name".to_string(),
+        super::PropertyAttrs::new(false, false, true),
+    );
+    super::set_builtin_property_attrs(
+        closure as usize,
+        "length".to_string(),
+        super::PropertyAttrs::new(false, false, true),
+    );
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
+fn receiver_value() -> f64 {
     f64::from_bits(IMPLICIT_THIS.with(|c| c.get()))
 }
 
-#[inline]
+fn throw_incompatible_receiver(proto: &str, method: &str) -> ! {
+    let msg = format!("{proto}.{method} called on incompatible receiver");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn boxed_payload(receiver: f64, expected_class_id: u32) -> Option<f64> {
+    let (class_id, payload) = crate::builtins::boxed_primitive_payload(receiver)?;
+    (class_id == expected_class_id).then_some(payload)
+}
+
 fn number_receiver_or_throw(method: &str) -> f64 {
-    let this = receiver_bits();
-    let jsv = crate::value::JSValue::from_bits(this.to_bits());
-    if jsv.is_number()
-        || jsv.is_int32()
-        || crate::builtins::boxed_primitive_to_string_tag(this) == Some("Number")
-    {
-        this
-    } else {
-        throw_incompatible_receiver("Number.prototype", method)
+    let receiver = receiver_value();
+    if let Some(payload) = boxed_payload(receiver, CLASS_ID_BOXED_NUMBER) {
+        return payload;
     }
+    let jv = crate::value::JSValue::from_bits(receiver.to_bits());
+    if jv.is_int32() {
+        return jv.as_int32() as f64;
+    }
+    if jv.is_number() {
+        return receiver;
+    }
+    throw_incompatible_receiver("Number.prototype", method)
 }
 
-#[inline]
 fn boolean_receiver_or_throw(method: &str) -> f64 {
-    let this = receiver_bits();
-    let jsv = crate::value::JSValue::from_bits(this.to_bits());
-    if jsv.is_bool() || crate::builtins::boxed_primitive_to_string_tag(this) == Some("Boolean") {
-        this
-    } else {
-        throw_incompatible_receiver("Boolean.prototype", method)
+    let receiver = receiver_value();
+    if let Some(payload) = boxed_payload(receiver, CLASS_ID_BOXED_BOOLEAN) {
+        return payload;
     }
+    let jv = crate::value::JSValue::from_bits(receiver.to_bits());
+    if jv.is_bool() {
+        return receiver;
+    }
+    throw_incompatible_receiver("Boolean.prototype", method)
 }
 
-#[inline]
 fn symbol_receiver_or_throw(method: &str) -> f64 {
-    let this = receiver_bits();
-    let is_symbol = unsafe { crate::symbol::js_is_symbol(this) != 0 };
-    if is_symbol || crate::builtins::boxed_primitive_to_string_tag(this) == Some("Symbol") {
-        this
-    } else {
-        throw_incompatible_receiver("Symbol.prototype", method)
+    let receiver = receiver_value();
+    if let Some(payload) = boxed_payload(receiver, CLASS_ID_BOXED_SYMBOL) {
+        return payload;
     }
+    if unsafe { crate::symbol::js_is_symbol(receiver) } != 0 {
+        return receiver;
+    }
+    throw_incompatible_receiver("Symbol.prototype", method)
 }
 
-#[inline]
 fn bigint_receiver_or_throw(method: &str) -> f64 {
-    let this = receiver_bits();
-    let jsv = crate::value::JSValue::from_bits(this.to_bits());
-    if jsv.is_bigint() || crate::builtins::boxed_primitive_to_string_tag(this) == Some("BigInt") {
-        this
-    } else {
-        throw_incompatible_receiver("BigInt.prototype", method)
+    let receiver = receiver_value();
+    if let Some(payload) = boxed_payload(receiver, CLASS_ID_BOXED_BIGINT) {
+        return payload;
     }
+    if crate::value::JSValue::from_bits(receiver.to_bits()).is_bigint() {
+        return receiver;
+    }
+    throw_incompatible_receiver("BigInt.prototype", method)
 }
 
-/// Re-dispatch the brand-checked receiver to the canonical method logic, which
-/// also produces the correct value for the wrong-value reflective `toString`.
-fn redispatch(this: f64, method: &str, args: &[f64]) -> f64 {
-    unsafe {
-        super::js_native_call_method(
-            this,
-            method.as_ptr() as *const i8,
-            method.len(),
-            args.as_ptr(),
-            args.len(),
-        )
-    }
+fn string_value(ptr: *mut crate::string::StringHeader) -> f64 {
+    f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits())
 }
 
 pub(super) extern "C" fn number_proto_value_of_thunk(
-    _c: *const crate::closure::ClosureHeader,
+    _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
-    let this = number_receiver_or_throw("valueOf");
-    redispatch(this, "valueOf", &[])
+    number_receiver_or_throw("valueOf")
+}
+
+pub(super) extern "C" fn number_proto_to_string_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    radix: f64,
+) -> f64 {
+    string_value(crate::value::js_jsvalue_to_string_radix(
+        number_receiver_or_throw("toString"),
+        radix,
+    ))
+}
+
+pub(super) extern "C" fn number_proto_to_fixed_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    decimals: f64,
+) -> f64 {
+    string_value(crate::string::js_number_to_fixed(
+        number_receiver_or_throw("toFixed"),
+        decimals,
+    ))
+}
+
+pub(super) extern "C" fn number_proto_to_precision_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    precision: f64,
+) -> f64 {
+    string_value(crate::string::js_number_to_precision(
+        number_receiver_or_throw("toPrecision"),
+        precision,
+    ))
+}
+
+pub(super) extern "C" fn number_proto_to_exponential_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    decimals: f64,
+) -> f64 {
+    string_value(crate::string::js_number_to_exponential(
+        number_receiver_or_throw("toExponential"),
+        decimals,
+    ))
 }
 
 pub(super) extern "C" fn number_proto_to_locale_string_thunk(
-    _c: *const crate::closure::ClosureHeader,
+    _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
-    let this = number_receiver_or_throw("toLocaleString");
-    redispatch(this, "toLocaleString", &[])
-}
-
-pub(super) extern "C" fn boolean_proto_to_string_thunk(
-    _c: *const crate::closure::ClosureHeader,
-) -> f64 {
-    let this = boolean_receiver_or_throw("toString");
-    redispatch(this, "toString", &[])
+    let n = number_receiver_or_throw("toLocaleString");
+    let s = crate::date::js_number_to_locale_string(n);
+    string_value(s)
 }
 
 pub(super) extern "C" fn boolean_proto_value_of_thunk(
-    _c: *const crate::closure::ClosureHeader,
+    _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
-    let this = boolean_receiver_or_throw("valueOf");
-    redispatch(this, "valueOf", &[])
+    boolean_receiver_or_throw("valueOf")
 }
 
-pub(super) extern "C" fn symbol_proto_to_string_thunk(
-    _c: *const crate::closure::ClosureHeader,
+pub(super) extern "C" fn boolean_proto_to_string_thunk(
+    _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
-    let this = symbol_receiver_or_throw("toString");
-    redispatch(this, "toString", &[])
+    let value = boolean_receiver_or_throw("toString");
+    let bytes = if crate::value::JSValue::from_bits(value.to_bits()).as_bool() {
+        b"true".as_slice()
+    } else {
+        b"false".as_slice()
+    };
+    let s = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    string_value(s)
 }
 
 pub(super) extern "C" fn symbol_proto_value_of_thunk(
-    _c: *const crate::closure::ClosureHeader,
+    _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
-    let this = symbol_receiver_or_throw("valueOf");
-    redispatch(this, "valueOf", &[])
+    symbol_receiver_or_throw("valueOf")
 }
 
-pub(super) extern "C" fn bigint_proto_to_string_thunk(
-    _c: *const crate::closure::ClosureHeader,
-    radix: f64,
+pub(super) extern "C" fn symbol_proto_to_string_thunk(
+    _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
-    let this = bigint_receiver_or_throw("toString");
-    // Forward an explicit radix; a missing arg arrives as `undefined`, which the
-    // canonical BigInt `toString` arm treats as decimal.
-    redispatch(this, "toString", &[radix])
+    let symbol = symbol_receiver_or_throw("toString");
+    let s =
+        unsafe { crate::symbol::js_symbol_to_string(symbol) } as *mut crate::string::StringHeader;
+    string_value(s)
 }
 
 pub(super) extern "C" fn bigint_proto_value_of_thunk(
-    _c: *const crate::closure::ClosureHeader,
+    _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
-    let this = bigint_receiver_or_throw("valueOf");
-    redispatch(this, "valueOf", &[])
+    bigint_receiver_or_throw("valueOf")
+}
+
+pub(super) extern "C" fn bigint_proto_to_string_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    radix: f64,
+) -> f64 {
+    string_value(crate::value::js_jsvalue_to_string_radix(
+        bigint_receiver_or_throw("toString"),
+        radix,
+    ))
 }

--- a/test-parity/node-suite/globals/reflective-builtins.ts
+++ b/test-parity/node-suite/globals/reflective-builtins.ts
@@ -1,0 +1,64 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label, "ok", String(fn()));
+  } catch (err: any) {
+    console.log(label, "throw", err?.constructor?.name ?? err?.name);
+  }
+}
+
+const map = new Map();
+show("Map.set invalid receiver", () => Map.prototype.set.call(null, "k", "v"));
+show("Map.set valid receiver", () => {
+  Map.prototype.set.call(map, "k", "v");
+  return map.get("k");
+});
+
+const weakMap = new WeakMap();
+const weakKey = {};
+show("WeakMap.set invalid receiver", () => WeakMap.prototype.set.call(undefined, weakKey, 1));
+show("WeakMap.set valid receiver", () => {
+  WeakMap.prototype.set.call(weakMap, weakKey, 2);
+  return weakMap.get(weakKey);
+});
+
+show("Number.valueOf invalid receiver", () => Number.prototype.valueOf.call({}));
+show("Number.valueOf primitive receiver", () => Number.prototype.valueOf.call(12));
+show("Number.toFixed invalid receiver", () => Number.prototype.toFixed.call({}, 1));
+show("Number.toFixed primitive receiver", () => Number.prototype.toFixed.call(1.23, 1));
+show("Number.toPrecision invalid receiver", () => Number.prototype.toPrecision.call({}, 2));
+show("Number.toPrecision primitive receiver", () => Number.prototype.toPrecision.call(1.23, 2));
+show("Number.toExponential invalid receiver", () => Number.prototype.toExponential.call({}, 1));
+show("Number.toExponential primitive receiver", () => Number.prototype.toExponential.call(1.23, 1));
+show("Number.toString invalid receiver", () => Number.prototype.toString.call({}));
+show("Number.toString primitive receiver", () => Number.prototype.toString.call(31, 16));
+show("Number.toLocaleString invalid receiver", () => Number.prototype.toLocaleString.call({}));
+
+show("Boolean.toString invalid receiver", () => Boolean.prototype.toString.call({}));
+show("Boolean.toString primitive receiver", () => Boolean.prototype.toString.call(false));
+show("Boolean.valueOf invalid receiver", () => Boolean.prototype.valueOf.call({}));
+show("Boolean.valueOf primitive receiver", () => Boolean.prototype.valueOf.call(true));
+
+const symbolValue = Symbol("x");
+show("Symbol.toString invalid receiver", () => Symbol.prototype.toString.call({}));
+show("Symbol.toString primitive receiver", () => Symbol.prototype.toString.call(symbolValue));
+show("Symbol.valueOf invalid receiver", () => Symbol.prototype.valueOf.call({}));
+show("Symbol.valueOf primitive receiver", () => Symbol.prototype.valueOf.call(symbolValue) === symbolValue);
+
+const bigintValue = BigInt("31");
+show("BigInt.toString invalid receiver", () => BigInt.prototype.toString.call({}));
+show("BigInt.toString primitive receiver", () => BigInt.prototype.toString.call(bigintValue, 16));
+show("BigInt.valueOf invalid receiver", () => BigInt.prototype.valueOf.call({}));
+show("BigInt.valueOf primitive receiver", () => BigInt.prototype.valueOf.call(BigInt("5")) === BigInt("5"));
+
+const ArrayCtor: any = Array;
+const ObjectCtor: any = Object;
+const DateCtor: any = Date;
+
+show("Array dynamic instanceof", () => [] instanceof ArrayCtor);
+show("Object dynamic instanceof", () => ({}) instanceof ObjectCtor);
+show("Date dynamic instanceof", () => new Date(0) instanceof DateCtor);
+
+show("Array Symbol.hasInstance", () => ArrayCtor[Symbol.hasInstance]([]));
+show("Object Symbol.hasInstance", () => ObjectCtor[Symbol.hasInstance]({}));
+show("Date Symbol.hasInstance", () => DateCtor[Symbol.hasInstance](new Date(0)));
+show("Function hasInstance inherited", () => typeof ArrayCtor[Symbol.hasInstance]);


### PR DESCRIPTION
## Summary
- #2545 is already closed, so this PR targets the still-open #4100.
- Install brand-checking thunks for Number, Boolean, Symbol, and BigInt prototype methods when reached through reflective call paths.
- Expose static `Ctor.prototype.method` value reads through a runtime FFI helper so those reads return callable thunks instead of generic fallbacks.
- Keep Number/Boolean `.prototype.*.call(...)` reflective in HIR so invalid receivers throw instead of being rewritten to ordinary object method calls.
- Add a globals parity fixture covering primitive prototype brand checks, plus related reflective regression surfaces already resolved on main.

Closes #4100.

## Validation
- `cargo fmt`
- `cargo check -p perry-runtime -p perry-codegen -p perry-hir`
- `cargo build --release -p perry-runtime -p perry`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 target/release/perry compile --no-cache test-parity/node-suite/globals/reflective-builtins.ts && ./reflective-builtins`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") && PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter reflective-builtins`\n- `cargo test -p perry-codegen --test manifest_consistency`