### PR TITLE
[codex] Load real TLS CA certificate inventory

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -5281,17 +5281,6 @@ pub(crate) unsafe fn get_native_module_constant(
     let cjs_default_base = cjs_default_base_module(module_name);
     let is_cjs_default_object = cjs_default_base.is_some();
     let module_name = cjs_default_base.unwrap_or(module_name);
-    let tls_dispatch_noargs = |method: &str| -> Option<f64> {
-        let ptr = crate::value::JS_NATIVE_TLS_DISPATCH.load(Ordering::SeqCst);
-        if ptr.is_null() {
-            None
-        } else {
-            let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
-                std::mem::transmute(ptr);
-            Some(dispatch(method.as_ptr(), method.len(), std::ptr::null(), 0))
-        }
-    };
-
     if module_name == "process.namespace" && property == "default" {
         return cjs_default_export_value("process");
     }
@@ -6444,8 +6433,7 @@ pub(crate) unsafe fn get_native_module_constant(
             "DEFAULT_CIPHERS" => Some(str_val(crate::tls::DEFAULT_CIPHERS)),
             "CLIENT_RENEG_LIMIT" => Some(3.0),
             "CLIENT_RENEG_WINDOW" => Some(600.0),
-            "rootCertificates" => tls_dispatch_noargs("rootCertificates")
-                .or_else(|| Some(crate::tls::js_tls_root_certificates())),
+            "rootCertificates" => Some(crate::tls::js_tls_root_certificates()),
             _ => None,
         },
         "events" => match property {

--- a/crates/perry-runtime/src/tls.rs
+++ b/crates/perry-runtime/src/tls.rs
@@ -3,6 +3,8 @@
 //! Live TLS sockets are implemented in the net/stdlib path. This module covers
 //! Node-compatible helper APIs and SecureContext shape used for feature checks.
 
+mod roots;
+
 use crate::array::ArrayHeader;
 use crate::object::ObjectHeader;
 use crate::string::StringHeader;
@@ -83,8 +85,6 @@ const TLS_CIPHERS: &[&str] = &[
     "tls_aes_256_gcm_sha384",
     "tls_chacha20_poly1305_sha256",
 ];
-
-const SAMPLE_ROOT_CERT: &str = "-----BEGIN CERTIFICATE-----\nMIIDdzCCAl+gAwIBAgIEbmhJVTANBgkqhkiG9w0BAQsFADBvMQswCQYDVQQGEwJVUzETMBEGA1UEChMKUGVycnkgVGVzdDEUMBIGA1UECxMLTm9kZSBQYXJpdHkxHzAdBgNVBAMTFlBlcnJ5IFJ1bnRpbWUgUm9vdCBDQTEUMBIGA1UEBRMLMDAwMDAwMDAwMDAwHhcNMjAwMTAxMDAwMDAwWhcNMzAwMTAxMDAwMDAwWjBvMQswCQYDVQQGEwJVUzETMBEGA1UEChMKUGVycnkgVGVzdDEUMBIGA1UECxMLTm9kZSBQYXJpdHkxHzAdBgNVBAMTFlBlcnJ5IFJ1bnRpbWUgUm9vdCBDQTEUMBIGA1UEBRMLMDAwMDAwMDAwMDAwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7V8v2F7GQ0Hf4dYhH2NQ+0VvYk3+K3q3q4r1KjC8a6Q0jL8q7cF2c9eQ6x2Yq8Q+Jc7T6Z6bYx7k9X2J3K1M8n9Q4Y5z3b6d8n1p0f3h5j7k9l2m4n6p8r0t2v4x6z8A0B2C4D6E8F1G3H5J7K9L2M4N6P8R0T2V4X6Z8A1B3C5D7E9F0G2H4J6K8L0M2N4P6R8T1V3X5Z7A9B0C2D4E6F8G1H3J5K7L9M0N2P4R6T8V0X2Z4A6B8C1D3E5F7G9H0J2K4L6M8N0P2R4T6V8X0Z2A4B6C8D0E2F4G6H8J0K2L4M6N8P0R2T4V6X8Z0AgMBAAGjITAfMB0GA1UdDgQWBBS5cGVycnktbm9kZS10bHMtcm9vdDANBgkqhkiG9w0BAQsFAAOCAQEAK7rY5nXl9T0s5T8w7Q9z2P4m6N8r0T2v4X6z8A0B2C4D6E8F1G3H5J7K9L2M4N6P8R0T2V4X6Z8A1B3C5D7E9F0G2H4J6K8L0M2N4P6R8T1V3X5Z7A9B0C2D4E6F8G1H3J5K7L9M0N2P4R6T8V0X2Z4A6B8C1D3E5F7G9H0J2K4L6M8N0P2R4T6V8X0Z2A4B6C8D0E2F4G6H8J0K2L4M6N8P0R2T4V6X8Z0\n-----END CERTIFICATE-----";
 
 fn string_value(s: &str) -> f64 {
     let ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
@@ -196,12 +196,12 @@ fn owned_string_array(items: &[String]) -> f64 {
     ptr_value(arr)
 }
 
-fn cached_cert_array(cache: &AtomicU64, certs: &[&str]) -> f64 {
+fn cached_owned_cert_array(cache: &AtomicU64, certs: &[String]) -> f64 {
     let cached = cache.load(Ordering::Relaxed);
     if cached != 0 {
         return f64::from_bits(cached);
     }
-    let arr = freeze_heap_value(string_array(certs));
+    let arr = freeze_heap_value(owned_string_array(certs));
     crate::gc::runtime_store_root_atomic_nanbox_u64(cache, arr.to_bits(), Ordering::Relaxed);
     arr
 }
@@ -214,7 +214,7 @@ pub fn scan_tls_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
 }
 
 pub fn js_tls_root_certificates() -> f64 {
-    cached_cert_array(&ROOT_CERTS_CACHE, &[SAMPLE_ROOT_CERT])
+    cached_owned_cert_array(&ROOT_CERTS_CACHE, roots::bundled_certificates())
 }
 
 #[no_mangle]
@@ -237,10 +237,10 @@ pub extern "C" fn js_tls_get_ca_certificates(ca_type: f64) -> f64 {
         crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
     };
     match ca_type.as_str() {
-        "default" => cached_cert_array(&DEFAULT_CA_CACHE, &[SAMPLE_ROOT_CERT]),
-        "system" => cached_cert_array(&SYSTEM_CA_CACHE, &[SAMPLE_ROOT_CERT]),
+        "default" => cached_owned_cert_array(&DEFAULT_CA_CACHE, roots::bundled_certificates()),
+        "system" => cached_owned_cert_array(&SYSTEM_CA_CACHE, roots::system_certificates()),
         "bundled" => js_tls_root_certificates(),
-        "extra" => cached_cert_array(&EXTRA_CA_CACHE, &[]),
+        "extra" => cached_owned_cert_array(&EXTRA_CA_CACHE, roots::extra_certificates()),
         _ => {
             let message = format!("The argument 'type' is invalid. Received '{}'", ca_type);
             crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE");

--- a/crates/perry-runtime/src/tls/roots.rs
+++ b/crates/perry-runtime/src/tls/roots.rs
@@ -1,0 +1,165 @@
+use std::path::Path;
+use std::sync::OnceLock;
+
+const CA_BUNDLE_PATHS: &[&str] = &[
+    "/etc/ssl/certs/ca-certificates.crt",
+    "/etc/pki/tls/certs/ca-bundle.crt",
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+    "/etc/ssl/cert.pem",
+];
+
+const FALLBACK_ROOT_CERTS: &[&str] = &[
+    r#"-----BEGIN CERTIFICATE-----
+MIIFgzCCA2ugAwIBAgIPXZONMGc2yAYdGsdUhGkHMA0GCSqGSIb3DQEBCwUAMDsx
+CzAJBgNVBAYTAkVTMREwDwYDVQQKDAhGTk1ULVJDTTEZMBcGA1UECwwQQUMgUkFJ
+WiBGTk1ULVJDTTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALpxgHpM
+hm5/yBNtwMZ9HACXjywMI7sQmkCpGreHiPibVmr75nuOi5KOpyVdWRHbNi63URcfq
+QgfBBckWKo3Shjf5TnUV/3XwSyRAZHiItQDwFj8d0fsjz50Q7qsNI1NOHZnjrDIb
+zAzWHFctPVrbtQBULgTfmxKo0nRIBnuvMApGGWn3v7v3QqQIecaZ5JCEJhfTzC8P
+hxFtBDXaEAUwED653cXeuYLj2VbPNmaUtu1vZ5Gzz3rkQUCwJaydkxNEJY7kvqcf
+w+Z374jNUUeAlz+taibmSXaXvMiwzn15Cou08YfxGyqxRxqAQVKL9LFwag0Jl1mp
+dICIfkYtwb1TplvqKtMUejPUBjFd8g5CSxJkjKZqLsXF3mwWsXmo8RZZUc1g16p6
+DULmbvkzSDGm0oGObVo/CK67lWMK07q87Hj/LaZmtVC+nFNCM+HHmpxffnTtOmlc
+YF7wk5HlqX2doWjKI/pgG6BU6VtX7hI+cL5NqYuSf+4lsKMB7ObiFj86xsc3i1w
+4peSMKGJ47xVqCfWS+2QrYv6YyVZLag13cqXM7zlzced0ezvXg5KkAYmY6252TUt
+B7p2ZSysV4999AeU14ECll2jB0nVetBX+RvnU0Z1qrB5QstocQjpYL05ac70r8NW
+QMetUqIJ5G+GR4of6ygnXYMgrwTJbFaai0b1AgMBAAGjgYMwgYAwDwYDVR0TAQH/
+BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFPd9xf3E6Jobd2Sn9R2g
+zL+HYJptMD4GA1UdIAQ3MDUwMwYEVR0gADArMCkGCCsGAQUFBwIBFh1odHRwOi8v
+d3d3LmNlcnQuZm5tdC5lcy9kcGNzLzANBgkqhkiG9w0BAQsFAAOCAgEAB5BK3/Mj
+TvDDnFFlm5wioooMhfNzKWtN/gHiqQxjAb8EZ6WdmF/9ARP67Jpi6Yb+tmLSbkyU
++8B1RXxlDPiyN8+sD8+Nb/kZ94/sHvJwnvDKuO+3/3Y3dlv2bojzr2IyIpMNOmq
+OFGYMLVN0V2Ue1bLdI4E7pWYjJ2cJj+F3qkPNZVEI7VFY/uY5+ctHhKQV8Xa7pO6
+kO8Rf77IzlhEYt8llvhjho6Tc+hj507wTmzl6NLrTQfv6MooqtyuGC2mDOL7Nii4
+LcK2NJpLuHvUBKwrZ1pebbuCoGRw6IYsMHkCtA+fdZn71uSANA+iW+YJF1DngoAB
+d15jmfZ5nc8OaKveri6E6FO80vFIOiZiaBECEHX5FaZNXzuvO+FB8TxxuBEOb+dY
+7Ixjp6o7RTUaN8Tvkasq6+yO3m/qZASlaWFot4/nUbQ4mrcFuNLwy+AwF+mWj2zs
+3gyLp1txyM/1d8iC9djwj2ij3+RvrWWTV3F9yfiD8zYm1kGdNYno/Tq0dwzn+ev
+QoFt9B9kiABdcPUXmsEKvU7ANm5mqwujGSQkBqvjrTcuFqN1W8rB2Vt2lh8kORdO
+ag0wokRqEIr9baRRmW1FMdW4R58MD3R++Lj8UGrp1MYp3/RgT408m2ECVAdf4Wqs
+lKYIYvuu8wd+RU4riEmViAqhOLUTpPSPaLtrM=
+-----END CERTIFICATE-----"#,
+    r#"-----BEGIN CERTIFICATE-----
+MIICbjCCAfOgAwIBAgIQYvYybOXE42hcG2LdnC6dlTAKBggqhkjOPQQDAzB4MQsw
+CQYDVQQGEwJFUzERMA8GA1UECgwIRk5NVC1SQ00xDjAMBgNVBAsMBUNlcmVzMRgw
+FgYDVQRhDA9WQVRFUy1RMjgyNjAwNEoxLDAqBgNVBAMMI0FDIFJBSVogRk5NVC1S
+Q00gU0VSVklET1JFUyBTRUdVUk9TMB4XDTE4MTIyMDA5MzczM1oXDTQzMTIyMDA5
+MzczM1oweDELMAkGA1UEBhMCRVMxETAPBgNVBAoMCEZOTVQtUkNNMQ4wDAYDVQQL
+DAVDZXJlczEYMBYGA1UEYQwPVkFURVMtUTI4MjYwMDRKMSwwKgYDVQQDDCNBQyBS
+QUlaIEZOTVQtUkNNIFNFUlZJRE9SRVMgU0VHVVJPUzB2MBAGByqGSM49AgEGBSuB
+BAAiA2IABPa6V1PIyqvfNkpSIeSX0oNnnvBlUdBeh8dHsVnyV0ebAAKTRBdp20LH
+sbI6GA60XYyzZl2hNPk2LEnb80b8s0RpRBNm/dfF/a82Tc4DTQdxz69qBdKiQ1oK
+Um8BA06Oi6NCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYD
+VR0OBBYEFAG5L++/EYZg8k/QQW6rcx/n0m5JMAoGCCqGSM49BAMDA2kAMGYCMQCu
+SuMrQMN0EfKVrRYj3k4MGuZdpSRea0R7/DjiT8ucRRcRTBQnJlU5dUoDzBOQn5IC
+MQD6SmxgiHPz7riYYqnOK8LZiqZwMR2vsJRM60/G49HzYqc8/5MuB1xJAWdpEgJy
+v+c=
+-----END CERTIFICATE-----"#,
+];
+
+static BUNDLED_CERTS: OnceLock<Vec<String>> = OnceLock::new();
+static SYSTEM_CERTS: OnceLock<Vec<String>> = OnceLock::new();
+static EXTRA_CERTS: OnceLock<Vec<String>> = OnceLock::new();
+
+pub(crate) fn bundled_certificates() -> &'static [String] {
+    BUNDLED_CERTS
+        .get_or_init(|| multi_cert_or_fallback(load_first_existing_bundle()))
+        .as_slice()
+}
+
+pub(crate) fn system_certificates() -> &'static [String] {
+    SYSTEM_CERTS
+        .get_or_init(|| multi_cert_or_fallback(load_first_existing_bundle()))
+        .as_slice()
+}
+
+pub(crate) fn extra_certificates() -> &'static [String] {
+    EXTRA_CERTS
+        .get_or_init(|| {
+            std::env::var_os("NODE_EXTRA_CA_CERTS")
+                .and_then(|path| load_pem_file(Path::new(&path)))
+                .unwrap_or_default()
+        })
+        .as_slice()
+}
+
+fn load_first_existing_bundle() -> Vec<String> {
+    std::env::var_os("SSL_CERT_FILE")
+        .and_then(|path| load_pem_file(Path::new(&path)))
+        .filter(|certs| certs.len() > 1)
+        .or_else(|| {
+            CA_BUNDLE_PATHS
+                .iter()
+                .find_map(|path| load_pem_file(Path::new(path)).filter(|certs| certs.len() > 1))
+        })
+        .unwrap_or_default()
+}
+
+fn load_pem_file(path: &Path) -> Option<Vec<String>> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let certs = split_pem_certificates(&contents);
+    if certs.is_empty() {
+        None
+    } else {
+        Some(certs)
+    }
+}
+
+fn multi_cert_or_fallback(certs: Vec<String>) -> Vec<String> {
+    if certs.len() > 1 {
+        return certs;
+    }
+    FALLBACK_ROOT_CERTS
+        .iter()
+        .map(|cert| format!("{}\n", cert.trim_end()))
+        .collect()
+}
+
+pub(crate) fn split_pem_certificates(contents: &str) -> Vec<String> {
+    let mut certs = Vec::new();
+    let mut current = String::new();
+    let mut in_cert = false;
+
+    for line in contents.lines() {
+        if line.contains("-----BEGIN CERTIFICATE-----") {
+            current.clear();
+            in_cert = true;
+        }
+        if in_cert {
+            current.push_str(line.trim_end());
+            current.push('\n');
+        }
+        if line.contains("-----END CERTIFICATE-----") && in_cert {
+            certs.push(std::mem::take(&mut current));
+            in_cert = false;
+        }
+    }
+
+    certs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_multiple_pem_blocks() {
+        let joined = format!("{}\n{}\n", FALLBACK_ROOT_CERTS[0], FALLBACK_ROOT_CERTS[1]);
+        let certs = split_pem_certificates(&joined);
+        assert_eq!(certs.len(), 2);
+        assert!(certs[0].starts_with("-----BEGIN CERTIFICATE-----"));
+        assert!(certs[1].ends_with("-----END CERTIFICATE-----\n"));
+    }
+
+    #[test]
+    fn fallback_is_real_multi_cert_inventory() {
+        let certs = multi_cert_or_fallback(Vec::new());
+        assert!(certs.len() > 1);
+        assert!(certs.iter().all(|cert| {
+            cert.starts_with("-----BEGIN CERTIFICATE-----")
+                && cert.contains("-----END CERTIFICATE-----")
+                && !cert.contains("Perry Runtime Root CA")
+                && !cert.contains("Perry Test")
+        }));
+    }
+}

--- a/test-parity/node-suite/tls/helpers/inventory-and-ca.ts
+++ b/test-parity/node-suite/tls/helpers/inventory-and-ca.ts
@@ -1,5 +1,18 @@
 import tls from "node:tls";
 
+function hasSyntheticMarker(cert: string): boolean {
+  return cert.indexOf("Perry Runtime Root CA") !== -1 || cert.indexOf("Perry Test") !== -1;
+}
+
+function allCertsAreNonSynthetic(certs: readonly string[]): boolean {
+  for (let i = 0; i < certs.length; i++) {
+    if (hasSyntheticMarker(certs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 const ciphers = tls.getCiphers();
 console.log("getCiphers function:", typeof tls.getCiphers === "function");
 console.log("ciphers array:", Array.isArray(ciphers) && ciphers.length >= 10);
@@ -18,17 +31,23 @@ console.log("default constants:", tls.DEFAULT_ECDH_CURVE === "auto" &&
 
 console.log("root certs:", Array.isArray(tls.rootCertificates) &&
   Object.isFrozen(tls.rootCertificates) &&
-  tls.rootCertificates.length > 0 &&
+  tls.rootCertificates.length > 1 &&
   typeof tls.rootCertificates[0] === "string" &&
-  tls.rootCertificates[0].startsWith("-----BEGIN CERTIFICATE-----"));
+  tls.rootCertificates[0].startsWith("-----BEGIN CERTIFICATE-----") &&
+  allCertsAreNonSynthetic(tls.rootCertificates));
 
 for (const type of ["default", "system", "bundled", "extra"] as const) {
   const certs = tls.getCACertificates(type);
-  const markerOk = type === "extra" || certs[0]?.startsWith("-----BEGIN CERTIFICATE-----") === true;
-  console.log(`ca ${type}:`, Array.isArray(certs) && Object.isFrozen(certs) && markerOk);
+  const markerOk = type === "extra" || certs.length === 0 ||
+    certs[0]?.startsWith("-----BEGIN CERTIFICATE-----") === true;
+  const sizeOk = type === "extra" || (type === "system" ? certs.length !== 1 : certs.length > 1);
+  const noSynthetic = allCertsAreNonSynthetic(certs);
+  console.log(`ca ${type}:`, Array.isArray(certs) && Object.isFrozen(certs) &&
+    markerOk && sizeOk && noSynthetic);
 }
 
 console.log("ca default arg:", tls.getCACertificates().length === tls.getCACertificates("default").length);
+console.log("ca bundled root identity:", tls.getCACertificates("bundled").length === tls.rootCertificates.length);
 
 try {
   tls.getCACertificates("invalid" as any);


### PR DESCRIPTION
## Linked Issues

Fixes #3860.
Addresses the CA-bundle fidelity portion of #3848.

## Behavior Cluster

This PR replaces the one-entry synthetic TLS CA placeholder with a real multi-certificate PEM inventory for the `node:tls` helper surface. It keeps the values frozen/cached like Node's helper arrays and routes `tls.rootCertificates` through the same runtime-backed cache as `tls.getCACertificates("bundled")`.

The updated fixture now rejects the old synthetic Perry certificate marker and requires the default/bundled root inventory to be multi-cert PEM data.

## Why These Were Batched

#3848 and #3860 share the same TLS helper implementation path and the same `inventory-and-ca` parity fixture. Keeping them together makes the observable `rootCertificates`, `getCACertificates("default")`, `getCACertificates("system")`, and `getCACertificates("bundled")` behavior consistent in one runtime cut.

## Tests Added

- Strengthened `test-parity/node-suite/tls/helpers/inventory-and-ca.ts` so a one-entry synthetic placeholder cannot pass.
- Added runtime unit coverage for PEM splitting and the fallback multi-cert inventory.

## Commands Run

```console
$ NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" node test-parity/node-suite/tls/helpers/inventory-and-ca.ts
$ PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 target/release/perry test-parity/node-suite/tls/helpers/inventory-and-ca.ts -o /tmp/perry_tls_inventory_ca_noopt && /tmp/perry_tls_inventory_ca_noopt
$ cargo test -p perry-runtime tls
$ cargo fmt --all -- --check
$ git diff --check
$ ./scripts/check_file_size.sh
$ NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module tls --filter inventory-and-ca
$ NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module tls
```

## Known Limitations And Non-Goals

- This does not implement `tls.createServer`, `TLSSocket`, or TLS server/socket lifecycle behavior.
- This does not rewrite live socket certificate verification or handshake behavior.
- This does not attempt byte-for-byte identity with Node's bundled Mozilla/OpenSSL CA list; it removes the synthetic placeholder and provides Node-shaped frozen multi-cert PEM helper arrays.
