### PR TITLE
[codex] crypto WebCrypto key metadata parity

### DIFF
--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -41,7 +41,7 @@ use std::sync::{Mutex, OnceLock};
 
 static EXTERNAL_BUFFER_REGISTRY: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
 static EXTERNAL_UINT8ARRAY_REGISTRY: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
-static EXTERNAL_CRYPTO_KEY_META_REGISTRY: OnceLock<Mutex<HashMap<usize, (u8, u8, u8)>>> =
+static EXTERNAL_CRYPTO_KEY_META_REGISTRY: OnceLock<Mutex<HashMap<usize, CryptoKeyMeta>>> =
     OnceLock::new();
 
 fn external_buffers() -> &'static Mutex<HashSet<usize>> {
@@ -52,9 +52,11 @@ fn external_uint8arrays() -> &'static Mutex<HashSet<usize>> {
     EXTERNAL_UINT8ARRAY_REGISTRY.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
-fn external_crypto_keys() -> &'static Mutex<HashMap<usize, (u8, u8, u8)>> {
+fn external_crypto_keys() -> &'static Mutex<HashMap<usize, CryptoKeyMeta>> {
     EXTERNAL_CRYPTO_KEY_META_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
+
+pub type CryptoKeyMeta = (u8, u8, u8, bool, u32);
 
 thread_local! {
     static BUFFER_REGISTRY: RefCell<PtrHashSet<usize>> = RefCell::new(new_ptr_hash_set());
@@ -99,7 +101,9 @@ thread_local! {
     /// algo: 1 HMAC, 2 AES-GCM, 3 AES-KW, 4 AES-CBC, 5 AES-CTR, 6 HKDF, 7 PBKDF2
     /// hash: 1 SHA-1, 2 SHA-256, 3 SHA-384, 4 SHA-512
     /// kind: 1 secret, 2 private, 3 public
-    static CRYPTO_KEY_META_REGISTRY: RefCell<PtrHashMap<usize, (u8, u8, u8)>> =
+    /// extractable: WebCrypto CryptoKey.extractable
+    /// usages: bitset matching WebCrypto usage names
+    static CRYPTO_KEY_META_REGISTRY: RefCell<PtrHashMap<usize, CryptoKeyMeta>> =
         RefCell::new(new_ptr_hash_map());
     /// String-backed asymmetric KeyObject surrogates returned by crypto
     /// helpers. They intentionally keep PEM/internal-string storage so the
@@ -291,16 +295,42 @@ pub fn is_secret_key(addr: usize) -> bool {
 }
 
 pub fn mark_as_crypto_key(addr: usize, algo: u8, hash: u8, kind: u8) {
+    mark_as_crypto_key_with_flags(
+        addr,
+        algo,
+        hash,
+        kind,
+        true,
+        default_crypto_key_usages(algo, kind),
+    );
+}
+
+pub fn mark_as_crypto_key_with_flags(
+    addr: usize,
+    algo: u8,
+    hash: u8,
+    kind: u8,
+    extractable: bool,
+    usages: u32,
+) {
     CRYPTO_KEY_META_REGISTRY.with(|r| {
-        r.borrow_mut().insert(addr, (algo, hash, kind));
+        r.borrow_mut()
+            .insert(addr, (algo, hash, kind, extractable, usages));
     });
 }
 
 #[no_mangle]
-pub extern "C" fn js_buffer_mark_as_crypto_key_external(addr: usize, algo: u8, hash: u8, kind: u8) {
+pub extern "C" fn js_buffer_mark_as_crypto_key_external(
+    addr: usize,
+    algo: u8,
+    hash: u8,
+    kind: u8,
+    extractable: u8,
+    usages: u32,
+) {
     register_buffer(addr as *const BufferHeader);
     mark_as_uint8array(addr);
-    mark_as_crypto_key(addr, algo, hash, kind);
+    mark_as_crypto_key_with_flags(addr, algo, hash, kind, extractable != 0, usages);
     if let Ok(mut r) = external_buffers().lock() {
         r.insert(addr);
     }
@@ -308,11 +338,11 @@ pub extern "C" fn js_buffer_mark_as_crypto_key_external(addr: usize, algo: u8, h
         r.insert(addr);
     }
     if let Ok(mut r) = external_crypto_keys().lock() {
-        r.insert(addr, (algo, hash, kind));
+        r.insert(addr, (algo, hash, kind, extractable != 0, usages));
     }
 }
 
-pub fn crypto_key_meta(addr: usize) -> Option<(u8, u8, u8)> {
+pub fn crypto_key_meta(addr: usize) -> Option<CryptoKeyMeta> {
     CRYPTO_KEY_META_REGISTRY
         .with(|r| r.borrow().get(&addr).copied())
         .or_else(|| {
@@ -321,6 +351,30 @@ pub fn crypto_key_meta(addr: usize) -> Option<(u8, u8, u8)> {
                 .ok()
                 .and_then(|r| r.get(&addr).copied())
         })
+}
+
+fn default_crypto_key_usages(algo: u8, kind: u8) -> u32 {
+    const ENCRYPT: u32 = 1 << 0;
+    const DECRYPT: u32 = 1 << 1;
+    const SIGN: u32 = 1 << 2;
+    const VERIFY: u32 = 1 << 3;
+    const DERIVE_KEY: u32 = 1 << 4;
+    const DERIVE_BITS: u32 = 1 << 5;
+    const WRAP_KEY: u32 = 1 << 6;
+    const UNWRAP_KEY: u32 = 1 << 7;
+
+    match (algo, kind) {
+        (1, 1) => SIGN | VERIFY,
+        (2 | 4 | 5, 1) => ENCRYPT | DECRYPT | WRAP_KEY | UNWRAP_KEY,
+        (3, 1) => WRAP_KEY | UNWRAP_KEY,
+        (6 | 7, 1) => DERIVE_KEY | DERIVE_BITS,
+        (8 | 10 | 12 | 14, 2) => SIGN,
+        (8 | 10 | 12 | 14, 3) => VERIFY,
+        (9 | 11, 2) => DERIVE_KEY | DERIVE_BITS,
+        (13, 2) => DECRYPT | UNWRAP_KEY,
+        (13, 3) => ENCRYPT | WRAP_KEY,
+        _ => 0,
+    }
 }
 
 /// `kind`: 1 public, 2 private. `asym_type`: 1 rsa, 2 ec, 3 ed25519, 4 x25519.

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -14,6 +14,143 @@ const CLASS_ID_BOXED_BOOLEAN: u32 = 0xFFFF_0062;
 const CLASS_ID_BOXED_BIGINT: u32 = 0xFFFF_0063;
 const CLASS_ID_BOXED_SYMBOL: u32 = 0xFFFF_0064;
 
+const CRYPTO_USAGE_ENCRYPT: u32 = 1 << 0;
+const CRYPTO_USAGE_DECRYPT: u32 = 1 << 1;
+const CRYPTO_USAGE_SIGN: u32 = 1 << 2;
+const CRYPTO_USAGE_VERIFY: u32 = 1 << 3;
+const CRYPTO_USAGE_DERIVE_KEY: u32 = 1 << 4;
+const CRYPTO_USAGE_DERIVE_BITS: u32 = 1 << 5;
+const CRYPTO_USAGE_WRAP_KEY: u32 = 1 << 6;
+const CRYPTO_USAGE_UNWRAP_KEY: u32 = 1 << 7;
+
+unsafe fn crypto_key_property_value(addr: usize, key_bytes: &[u8]) -> Option<JSValue> {
+    let (algo, hash, kind, extractable, usages) = crate::buffer::crypto_key_meta(addr)?;
+    match key_bytes {
+        b"algorithm" => Some(crypto_key_algorithm_value(addr, algo, hash)),
+        b"extractable" => Some(JSValue::bool(extractable)),
+        b"type" => Some(string_value(match kind {
+            2 => "private",
+            3 => "public",
+            _ => "secret",
+        })),
+        b"usages" => Some(crypto_key_usages_value(usages)),
+        _ => None,
+    }
+}
+
+unsafe fn crypto_key_algorithm_value(addr: usize, algo: u8, hash: u8) -> JSValue {
+    let obj = js_object_alloc(0, 3);
+    if obj.is_null() {
+        return JSValue::undefined();
+    }
+    set_string_field(obj, b"name", crypto_key_algorithm_name(algo));
+    if crypto_key_algorithm_has_hash(algo) {
+        let hash_obj = js_object_alloc(0, 1);
+        if !hash_obj.is_null() {
+            set_string_field(hash_obj, b"name", crypto_key_hash_name(hash));
+            set_value_field(obj, b"hash", JSValue::pointer(hash_obj as *const u8));
+        }
+    }
+    if crypto_key_algorithm_has_length(algo) {
+        let key = addr as *const crate::buffer::BufferHeader;
+        let bits = if key.is_null() {
+            0.0
+        } else {
+            crate::buffer::js_buffer_length(key) as f64 * 8.0
+        };
+        set_value_field(obj, b"length", JSValue::number(bits));
+    }
+    if let Some(curve) = crypto_key_named_curve(algo) {
+        set_string_field(obj, b"namedCurve", curve);
+    }
+    JSValue::pointer(obj as *const u8)
+}
+
+fn crypto_key_algorithm_name(algo: u8) -> &'static str {
+    match algo {
+        1 => "HMAC",
+        2 => "AES-GCM",
+        3 => "AES-KW",
+        4 => "AES-CBC",
+        5 => "AES-CTR",
+        6 => "HKDF",
+        7 => "PBKDF2",
+        8 => "ECDSA",
+        9 => "ECDH",
+        10 => "Ed25519",
+        11 => "X25519",
+        12 => "RSASSA-PKCS1-v1_5",
+        13 => "RSA-OAEP",
+        14 => "RSA-PSS",
+        _ => "",
+    }
+}
+
+fn crypto_key_hash_name(hash: u8) -> &'static str {
+    match hash {
+        1 => "SHA-1",
+        3 => "SHA-384",
+        4 => "SHA-512",
+        _ => "SHA-256",
+    }
+}
+
+fn crypto_key_algorithm_has_hash(algo: u8) -> bool {
+    matches!(algo, 1 | 12 | 13 | 14)
+}
+
+fn crypto_key_algorithm_has_length(algo: u8) -> bool {
+    matches!(algo, 1 | 2 | 3 | 4 | 5)
+}
+
+fn crypto_key_named_curve(algo: u8) -> Option<&'static str> {
+    match algo {
+        8 | 9 => Some("P-256"),
+        10 => Some("Ed25519"),
+        11 => Some("X25519"),
+        _ => None,
+    }
+}
+
+unsafe fn crypto_key_usages_value(usages: u32) -> JSValue {
+    let entries = [
+        (CRYPTO_USAGE_ENCRYPT, "encrypt"),
+        (CRYPTO_USAGE_DECRYPT, "decrypt"),
+        (CRYPTO_USAGE_SIGN, "sign"),
+        (CRYPTO_USAGE_VERIFY, "verify"),
+        (CRYPTO_USAGE_DERIVE_KEY, "deriveKey"),
+        (CRYPTO_USAGE_DERIVE_BITS, "deriveBits"),
+        (CRYPTO_USAGE_WRAP_KEY, "wrapKey"),
+        (CRYPTO_USAGE_UNWRAP_KEY, "unwrapKey"),
+    ];
+    let count = entries.iter().filter(|(bit, _)| usages & *bit != 0).count();
+    let mut arr = crate::array::js_array_alloc(count as u32);
+    for (bit, name) in entries {
+        if usages & bit == 0 {
+            continue;
+        }
+        let s = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        arr = crate::array::js_array_push(arr, JSValue::string_ptr(s));
+    }
+    JSValue::array_ptr(arr)
+}
+
+unsafe fn set_string_field(obj: *mut ObjectHeader, key: &[u8], value: &str) {
+    let key = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    let value = crate::string::js_string_from_bytes(value.as_ptr(), value.len() as u32);
+    js_object_set_field_by_name(obj, key, f64::from_bits(JSValue::string_ptr(value).bits()));
+}
+
+unsafe fn set_value_field(obj: *mut ObjectHeader, key: &[u8], value: JSValue) {
+    let key = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    js_object_set_field_by_name(obj, key, f64::from_bits(value.bits()));
+}
+
+unsafe fn string_value(value: &str) -> JSValue {
+    let s = crate::string::js_string_from_bytes(value.as_ptr(), value.len() as u32);
+    JSValue::string_ptr(s)
+}
+
 /// Get a field from an object by index
 ///
 /// #1129/#1136: the small-pointer guard below previously used a 16 MB
@@ -2098,6 +2235,9 @@ pub extern "C" fn js_object_get_field_by_name(
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let key_len = (*key).byte_len as usize;
                 let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+                if let Some(value) = crypto_key_property_value(obj as usize, key_bytes) {
+                    return value;
+                }
                 if key_bytes == b"length" || key_bytes == b"byteLength" {
                     let b = obj as *const crate::buffer::BufferHeader;
                     return JSValue::number(crate::buffer::js_buffer_length(b) as f64);

--- a/crates/perry-stdlib/src/webcrypto/aes.rs
+++ b/crates/perry-stdlib/src/webcrypto/aes.rs
@@ -337,6 +337,13 @@ pub unsafe extern "C" fn js_webcrypto_encrypt(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            mat,
+            USAGE_ENCRYPT,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         let key_bytes = bytes_from_jsvalue(key_bits.to_bits());
         let public_key = match RsaPublicKey::from_public_key_der(&key_bytes) {
             Ok(k) => k,
@@ -365,6 +372,13 @@ pub unsafe extern "C" fn js_webcrypto_encrypt(
                 "InvalidAccessError",
                 "The requested operation is not valid for the provided key",
             );
+        }
+        if let Err((name, message)) = require_usage(
+            mat,
+            USAGE_ENCRYPT,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
         }
         let (key, iv, data) = match extract_aes_cbc_args(
             algo_bits.to_bits(),
@@ -397,6 +411,13 @@ pub unsafe extern "C" fn js_webcrypto_encrypt(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            mat,
+            USAGE_ENCRYPT,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         let (key, counter, length, data) = match extract_aes_ctr_args(
             algo_bits.to_bits(),
             key_bits.to_bits(),
@@ -426,6 +447,13 @@ pub unsafe extern "C" fn js_webcrypto_encrypt(
             "InvalidAccessError",
             "The requested operation is not valid for the provided key",
         );
+    }
+    if let Err((name, message)) = require_usage(
+        mat,
+        USAGE_ENCRYPT,
+        "The requested operation is not valid for the provided key",
+    ) {
+        return reject_with_dom_exception(name, message);
     }
     let (key, iv, aad, data) =
         match extract_aes_gcm_args(algo_bits.to_bits(), key_bits.to_bits(), data_bits.to_bits()) {
@@ -470,6 +498,13 @@ pub unsafe extern "C" fn js_webcrypto_decrypt(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            mat,
+            USAGE_DECRYPT,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         let key_bytes = bytes_from_jsvalue(key_bits.to_bits());
         let private_key = match RsaPrivateKey::from_pkcs8_der(&key_bytes) {
             Ok(k) => k,
@@ -498,6 +533,13 @@ pub unsafe extern "C" fn js_webcrypto_decrypt(
                 "InvalidAccessError",
                 "The requested operation is not valid for the provided key",
             );
+        }
+        if let Err((name, message)) = require_usage(
+            mat,
+            USAGE_DECRYPT,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
         }
         let (key, iv, data) = match extract_aes_cbc_args(
             algo_bits.to_bits(),
@@ -530,6 +572,13 @@ pub unsafe extern "C" fn js_webcrypto_decrypt(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            mat,
+            USAGE_DECRYPT,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         let (key, counter, length, data) = match extract_aes_ctr_args(
             algo_bits.to_bits(),
             key_bits.to_bits(),
@@ -559,6 +608,13 @@ pub unsafe extern "C" fn js_webcrypto_decrypt(
             "InvalidAccessError",
             "The requested operation is not valid for the provided key",
         );
+    }
+    if let Err((name, message)) = require_usage(
+        mat,
+        USAGE_DECRYPT,
+        "The requested operation is not valid for the provided key",
+    ) {
+        return reject_with_dom_exception(name, message);
     }
     let (key, iv, aad, data) =
         match extract_aes_gcm_args(algo_bits.to_bits(), key_bits.to_bits(), data_bits.to_bits()) {

--- a/crates/perry-stdlib/src/webcrypto/hmac.rs
+++ b/crates/perry-stdlib/src/webcrypto/hmac.rs
@@ -34,6 +34,11 @@ pub unsafe extern "C" fn js_webcrypto_sign(
                 "Unable to use this key to sign",
             );
         }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_SIGN, "Unable to use this key to sign")
+        {
+            return reject_with_dom_exception(name, message);
+        }
         match compute_hmac(mat.hash, &key_bytes, &data_bytes) {
             Some(s) => s,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -44,6 +49,11 @@ pub unsafe extern "C" fn js_webcrypto_sign(
                 "InvalidAccessError",
                 "Unable to use this key to sign",
             );
+        }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_SIGN, "Unable to use this key to sign")
+        {
+            return reject_with_dom_exception(name, message);
         }
         let signing_key = match P256EcdsaSigningKey::from_slice(&key_bytes) {
             Ok(k) => k,
@@ -57,6 +67,11 @@ pub unsafe extern "C" fn js_webcrypto_sign(
                 "InvalidAccessError",
                 "Unable to use this key to sign",
             );
+        }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_SIGN, "Unable to use this key to sign")
+        {
+            return reject_with_dom_exception(name, message);
         }
         let secret: [u8; 32] = match key_bytes.as_slice().try_into() {
             Ok(s) => s,
@@ -72,6 +87,11 @@ pub unsafe extern "C" fn js_webcrypto_sign(
                 "Unable to use this key to sign",
             );
         }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_SIGN, "Unable to use this key to sign")
+        {
+            return reject_with_dom_exception(name, message);
+        }
         let private_key = match RsaPrivateKey::from_pkcs8_der(&key_bytes) {
             Ok(k) => k,
             Err(_) => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -86,6 +106,11 @@ pub unsafe extern "C" fn js_webcrypto_sign(
                 "InvalidAccessError",
                 "Unable to use this key to sign",
             );
+        }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_SIGN, "Unable to use this key to sign")
+        {
+            return reject_with_dom_exception(name, message);
         }
         let salt_len = object_field_bits(algo_bits.to_bits(), b"saltLength")
             .and_then(number_from_bits)
@@ -136,6 +161,11 @@ pub unsafe extern "C" fn js_webcrypto_verify(
                 "Unable to use this key to verify",
             );
         }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_VERIFY, "Unable to use this key to verify")
+        {
+            return reject_with_dom_exception(name, message);
+        }
         let expected_sig = match compute_hmac(mat.hash, &key_bytes, &data_bytes) {
             Some(s) => s,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -147,6 +177,11 @@ pub unsafe extern "C" fn js_webcrypto_verify(
                 "InvalidAccessError",
                 "Unable to use this key to verify",
             );
+        }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_VERIFY, "Unable to use this key to verify")
+        {
+            return reject_with_dom_exception(name, message);
         }
         let verifying_key = match P256EcdsaVerifyingKey::from_sec1_bytes(&key_bytes) {
             Ok(k) => k,
@@ -163,6 +198,11 @@ pub unsafe extern "C" fn js_webcrypto_verify(
                 "InvalidAccessError",
                 "Unable to use this key to verify",
             );
+        }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_VERIFY, "Unable to use this key to verify")
+        {
+            return reject_with_dom_exception(name, message);
         }
         let public: [u8; 32] = match key_bytes.as_slice().try_into() {
             Ok(p) => p,
@@ -185,6 +225,11 @@ pub unsafe extern "C" fn js_webcrypto_verify(
                 "Unable to use this key to verify",
             );
         }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_VERIFY, "Unable to use this key to verify")
+        {
+            return reject_with_dom_exception(name, message);
+        }
         let public_key = match RsaPublicKey::from_public_key_der(&key_bytes) {
             Ok(k) => k,
             Err(_) => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -196,6 +241,11 @@ pub unsafe extern "C" fn js_webcrypto_verify(
                 "InvalidAccessError",
                 "Unable to use this key to verify",
             );
+        }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_VERIFY, "Unable to use this key to verify")
+        {
+            return reject_with_dom_exception(name, message);
         }
         let salt_len = object_field_bits(algo_bits.to_bits(), b"saltLength")
             .and_then(number_from_bits)

--- a/crates/perry-stdlib/src/webcrypto/jwk.rs
+++ b/crates/perry-stdlib/src/webcrypto/jwk.rs
@@ -8,18 +8,17 @@ use super::*;
 /// - `"AES-GCM"` or `{ name: "AES-GCM" }` — keyed by 128/192/256-bit
 ///   bytes; the IV / additionalData come in at encrypt/decrypt time.
 ///
-/// `extractable` and `keyUsages` are accepted but not enforced —
-/// perry's threat model treats them as documentation. Unsupported
-/// shapes resolve to undefined (callers that then pass that into
-/// `sign`/`encrypt` will reject there with a clear error).
+/// `extractable` and `keyUsages` are stored on the returned key and
+/// enforced by later WebCrypto operations.
 #[no_mangle]
 pub unsafe extern "C" fn js_webcrypto_import_key(
     format_bits: f64,
     key_bits: f64,
     algo_bits: f64,
-    _extractable_bits: f64,
-    _usages_bits: f64,
+    extractable_bits: f64,
+    usages_bits: f64,
 ) -> *mut Promise {
+    let extractable = bool_from_jsvalue(extractable_bits.to_bits());
     let format = match string_from_jsvalue(format_bits.to_bits()) {
         Some(s) => s,
         None => {
@@ -150,6 +149,29 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
         );
     };
 
+    let empty_allowed = kind == KeyKind::Public;
+    let empty_message = if kind == KeyKind::Secret {
+        "Usages cannot be empty when importing a secret key."
+    } else {
+        "Usages cannot be empty when importing a private key."
+    };
+    let bad_message = if key_algo == KeyAlgo::Hmac {
+        "Unsupported key usage for HMAC key"
+    } else {
+        "Unsupported key usage for the requested algorithm"
+    };
+    let usages = match validate_key_usages(
+        key_algo,
+        kind,
+        usages_bits.to_bits(),
+        empty_allowed,
+        empty_message,
+        bad_message,
+    ) {
+        Ok(u) => u,
+        Err((name, message)) => return reject_with_dom_exception(name, message),
+    };
+
     let key_bytes = if format_lower == "jwk" {
         jwk_import_key_bytes(key_bits.to_bits(), key_algo, kind).unwrap_or_else(|| Vec::new())
     } else {
@@ -208,11 +230,7 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     }
     register_crypto_key(
         buf as usize,
-        CryptoKeyMaterial {
-            algo: key_algo,
-            hash,
-            kind,
-        },
+        CryptoKeyMaterial::new(key_algo, hash, kind, extractable, usages),
     );
     let val = JSValue::pointer(buf as *const u8).bits();
     resolve_with_bits(val)
@@ -242,6 +260,9 @@ pub unsafe extern "C" fn js_webcrypto_export_key(format_bits: f64, key_bits: f64
             return reject_with_dom_exception("InvalidAccessError", "Key is not a valid CryptoKey")
         }
     };
+    if !mat.extractable {
+        return reject_with_dom_exception("InvalidAccessException", "key is not extractable");
+    }
     if format_lower == "raw" && mat.kind == KeyKind::Private {
         return reject_with_dom_exception("OperationError", "The operation failed");
     }

--- a/crates/perry-stdlib/src/webcrypto/kdf.rs
+++ b/crates/perry-stdlib/src/webcrypto/kdf.rs
@@ -9,6 +9,20 @@ pub unsafe extern "C" fn js_webcrypto_derive_bits(
     base_key_bits: f64,
     length_bits: f64,
 ) -> *mut Promise {
+    let base_addr = strip_ptr(base_key_bits.to_bits());
+    let base_mat = match lookup_crypto_key(base_addr) {
+        Some(m) => m,
+        None => {
+            return reject_with_dom_exception("InvalidAccessError", "Key is not a valid CryptoKey")
+        }
+    };
+    if let Err((name, message)) = require_usage(
+        base_mat,
+        USAGE_DERIVE_BITS,
+        "The requested operation is not valid for the provided key",
+    ) {
+        return reject_with_dom_exception(name, message);
+    }
     let bit_len = match number_from_bits(length_bits.to_bits()) {
         Some(n) => n,
         None => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -35,9 +49,24 @@ pub unsafe extern "C" fn js_webcrypto_derive_key(
     algo_bits: f64,
     base_key_bits: f64,
     derived_algo_bits: f64,
-    _extractable_bits: f64,
-    _usages_bits: f64,
+    extractable_bits: f64,
+    usages_bits: f64,
 ) -> *mut Promise {
+    let base_addr = strip_ptr(base_key_bits.to_bits());
+    let base_mat = match lookup_crypto_key(base_addr) {
+        Some(m) => m,
+        None => {
+            return reject_with_dom_exception("InvalidAccessError", "Key is not a valid CryptoKey")
+        }
+    };
+    if let Err((name, message)) = require_usage(
+        base_mat,
+        USAGE_DERIVE_KEY,
+        "The requested operation is not valid for the provided key",
+    ) {
+        return reject_with_dom_exception(name, message);
+    }
+    let extractable = bool_from_jsvalue(extractable_bits.to_bits());
     let derived_name = match extract_algo_name(derived_algo_bits.to_bits()) {
         Some(s) => s,
         None => {
@@ -73,6 +102,17 @@ pub unsafe extern "C" fn js_webcrypto_derive_key(
     if bit_len % 8 != 0 || bit_len == 0 || bit_len > 256 {
         return reject_with_dom_exception("OperationError", "The operation failed");
     }
+    let usages = match validate_key_usages(
+        key_algo,
+        KeyKind::Secret,
+        usages_bits.to_bits(),
+        false,
+        "Usages cannot be empty when creating a key.",
+        "Unsupported key usage for the requested algorithm",
+    ) {
+        Ok(u) => u,
+        Err((name, message)) => return reject_with_dom_exception(name, message),
+    };
     let byte_len = (bit_len / 8) as usize;
     let key_bytes = if let Some(bytes) =
         kdf_derive_bytes(algo_bits.to_bits(), base_key_bits.to_bits(), byte_len)
@@ -94,11 +134,7 @@ pub unsafe extern "C" fn js_webcrypto_derive_key(
     }
     register_crypto_key(
         buf as usize,
-        CryptoKeyMaterial {
-            algo: key_algo,
-            hash,
-            kind: KeyKind::Secret,
-        },
+        CryptoKeyMaterial::new(key_algo, hash, KeyKind::Secret, extractable, usages),
     );
     resolve_with_bits(JSValue::pointer(buf as *const u8).bits())
 }

--- a/crates/perry-stdlib/src/webcrypto/keys.rs
+++ b/crates/perry-stdlib/src/webcrypto/keys.rs
@@ -12,16 +12,15 @@ use super::*;
 ///   `{ publicKey, privateKey }` CryptoKeyPair that can be used by
 ///   `subtle.sign` / `subtle.verify`.
 ///
-/// Other asymmetric algorithms (RSA-OAEP, RSA-PSS, ECDH) and HMAC
-/// keygen are TODO follow-ups — `extractable` and `keyUsages` are
-/// accepted but not enforced (perry's threat model treats them as
-/// documentation, matching `importKey`).
+/// `extractable` and `keyUsages` are preserved on the returned
+/// CryptoKey metadata and enforced by later WebCrypto operations.
 #[no_mangle]
 pub unsafe extern "C" fn js_webcrypto_generate_key(
     algo_bits: f64,
-    _extractable_bits: f64,
-    _usages_bits: f64,
+    extractable_bits: f64,
+    usages_bits: f64,
 ) -> *mut Promise {
+    let extractable = bool_from_jsvalue(extractable_bits.to_bits());
     let algo_name = match extract_algo_name(algo_bits.to_bits()) {
         Some(s) => s,
         None => {
@@ -36,6 +35,15 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
             "RSASSA-PKCS1-V1_5" => KeyAlgo::RsassaPkcs1,
             "RSA-PSS" => KeyAlgo::RsaPss,
             _ => unreachable!(),
+        };
+        let (private_usages, public_usages) = match validate_key_pair_usages(
+            key_algo,
+            usages_bits.to_bits(),
+            "Usages cannot be empty when creating a key.",
+            "Unsupported key usage for the requested algorithm",
+        ) {
+            Ok(u) => u,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
         };
         let mut rng = rand::rngs::OsRng;
         let private_key = match RsaPrivateKey::new(&mut rng, 2048) {
@@ -59,19 +67,17 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         }
         register_crypto_key(
             private_buf as usize,
-            CryptoKeyMaterial {
-                algo: key_algo,
+            CryptoKeyMaterial::new(
+                key_algo,
                 hash,
-                kind: KeyKind::Private,
-            },
+                KeyKind::Private,
+                extractable,
+                private_usages,
+            ),
         );
         register_crypto_key(
             public_buf as usize,
-            CryptoKeyMaterial {
-                algo: key_algo,
-                hash,
-                kind: KeyKind::Public,
-            },
+            CryptoKeyMaterial::new(key_algo, hash, KeyKind::Public, true, public_usages),
         );
 
         let obj = js_object_alloc(0, 2);
@@ -93,6 +99,15 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         return resolve_with_bits(JSValue::pointer(obj as *const u8).bits());
     }
     if algo_upper == "ED25519" {
+        let (private_usages, public_usages) = match validate_key_pair_usages(
+            KeyAlgo::Ed25519,
+            usages_bits.to_bits(),
+            "Usages cannot be empty when creating a key.",
+            "Unsupported key usage for the requested algorithm",
+        ) {
+            Ok(u) => u,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
         let mut seed = [0u8; 32];
         rand::rngs::OsRng.fill_bytes(&mut seed);
         let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
@@ -105,19 +120,23 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         }
         register_crypto_key(
             private_buf as usize,
-            CryptoKeyMaterial {
-                algo: KeyAlgo::Ed25519,
-                hash: HashAlgo::Sha256,
-                kind: KeyKind::Private,
-            },
+            CryptoKeyMaterial::new(
+                KeyAlgo::Ed25519,
+                HashAlgo::Sha256,
+                KeyKind::Private,
+                extractable,
+                private_usages,
+            ),
         );
         register_crypto_key(
             public_buf as usize,
-            CryptoKeyMaterial {
-                algo: KeyAlgo::Ed25519,
-                hash: HashAlgo::Sha256,
-                kind: KeyKind::Public,
-            },
+            CryptoKeyMaterial::new(
+                KeyAlgo::Ed25519,
+                HashAlgo::Sha256,
+                KeyKind::Public,
+                true,
+                public_usages,
+            ),
         );
 
         let obj = js_object_alloc(0, 2);
@@ -139,6 +158,15 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         return resolve_with_bits(JSValue::pointer(obj as *const u8).bits());
     }
     if algo_upper == "X25519" {
+        let (private_usages, public_usages) = match validate_key_pair_usages(
+            KeyAlgo::X25519,
+            usages_bits.to_bits(),
+            "Usages cannot be empty when creating a key.",
+            "Unsupported key usage for the requested algorithm",
+        ) {
+            Ok(u) => u,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
         let mut seed = [0u8; 32];
         rand::rngs::OsRng.fill_bytes(&mut seed);
         let private_key = x25519_dalek::StaticSecret::from(seed);
@@ -153,19 +181,23 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         }
         register_crypto_key(
             private_buf as usize,
-            CryptoKeyMaterial {
-                algo: KeyAlgo::X25519,
-                hash: HashAlgo::Sha256,
-                kind: KeyKind::Private,
-            },
+            CryptoKeyMaterial::new(
+                KeyAlgo::X25519,
+                HashAlgo::Sha256,
+                KeyKind::Private,
+                extractable,
+                private_usages,
+            ),
         );
         register_crypto_key(
             public_buf as usize,
-            CryptoKeyMaterial {
-                algo: KeyAlgo::X25519,
-                hash: HashAlgo::Sha256,
-                kind: KeyKind::Public,
-            },
+            CryptoKeyMaterial::new(
+                KeyAlgo::X25519,
+                HashAlgo::Sha256,
+                KeyKind::Public,
+                true,
+                public_usages,
+            ),
         );
 
         let obj = js_object_alloc(0, 2);
@@ -187,6 +219,15 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         return resolve_with_bits(JSValue::pointer(obj as *const u8).bits());
     }
     if algo_upper == "ECDH" {
+        let (private_usages, public_usages) = match validate_key_pair_usages(
+            KeyAlgo::EcdhP256,
+            usages_bits.to_bits(),
+            "Usages cannot be empty when creating a key.",
+            "Unsupported key usage for the requested algorithm",
+        ) {
+            Ok(u) => u,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
         let curve = match object_field_string(algo_bits.to_bits(), b"namedCurve") {
             Some(c) => c,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -213,19 +254,23 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         }
         register_crypto_key(
             private_buf as usize,
-            CryptoKeyMaterial {
-                algo: KeyAlgo::EcdhP256,
-                hash: HashAlgo::Sha256,
-                kind: KeyKind::Private,
-            },
+            CryptoKeyMaterial::new(
+                KeyAlgo::EcdhP256,
+                HashAlgo::Sha256,
+                KeyKind::Private,
+                extractable,
+                private_usages,
+            ),
         );
         register_crypto_key(
             public_buf as usize,
-            CryptoKeyMaterial {
-                algo: KeyAlgo::EcdhP256,
-                hash: HashAlgo::Sha256,
-                kind: KeyKind::Public,
-            },
+            CryptoKeyMaterial::new(
+                KeyAlgo::EcdhP256,
+                HashAlgo::Sha256,
+                KeyKind::Public,
+                true,
+                public_usages,
+            ),
         );
 
         let obj = js_object_alloc(0, 2);
@@ -247,6 +292,15 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         return resolve_with_bits(JSValue::pointer(obj as *const u8).bits());
     }
     if algo_upper == "ECDSA" {
+        let (private_usages, public_usages) = match validate_key_pair_usages(
+            KeyAlgo::EcdsaP256,
+            usages_bits.to_bits(),
+            "Usages cannot be empty when creating a key.",
+            "Unsupported key usage for the requested algorithm",
+        ) {
+            Ok(u) => u,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
         let curve = match object_field_string(algo_bits.to_bits(), b"namedCurve") {
             Some(c) => c,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -273,19 +327,23 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         }
         register_crypto_key(
             private_buf as usize,
-            CryptoKeyMaterial {
-                algo: KeyAlgo::EcdsaP256,
-                hash: HashAlgo::Sha256,
-                kind: KeyKind::Private,
-            },
+            CryptoKeyMaterial::new(
+                KeyAlgo::EcdsaP256,
+                HashAlgo::Sha256,
+                KeyKind::Private,
+                extractable,
+                private_usages,
+            ),
         );
         register_crypto_key(
             public_buf as usize,
-            CryptoKeyMaterial {
-                algo: KeyAlgo::EcdsaP256,
-                hash: HashAlgo::Sha256,
-                kind: KeyKind::Public,
-            },
+            CryptoKeyMaterial::new(
+                KeyAlgo::EcdsaP256,
+                HashAlgo::Sha256,
+                KeyKind::Public,
+                true,
+                public_usages,
+            ),
         );
 
         let obj = js_object_alloc(0, 2);
@@ -307,6 +365,44 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         return resolve_with_bits(JSValue::pointer(obj as *const u8).bits());
     }
 
+    if algo_upper == "HMAC" {
+        let hash = match extract_hmac_hash(algo_bits.to_bits()) {
+            Some(h) => h,
+            None => return reject_with_dom_exception("OperationError", "The operation failed"),
+        };
+        let usages = match validate_key_usages(
+            KeyAlgo::Hmac,
+            KeyKind::Secret,
+            usages_bits.to_bits(),
+            false,
+            "Usages cannot be empty when creating a key.",
+            "Unsupported key usage for an HMAC key",
+        ) {
+            Ok(u) => u,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
+        let bit_len = object_field_number(algo_bits.to_bits(), b"length").unwrap_or(match hash {
+            HashAlgo::Sha1 | HashAlgo::Sha256 => 512,
+            HashAlgo::Sha384 | HashAlgo::Sha512 => 1024,
+        });
+        if bit_len == 0 {
+            return reject_with_dom_exception("OperationError", "The operation failed");
+        }
+        let byte_len = ((bit_len + 7) / 8) as usize;
+        let mut key_bytes = vec![0u8; byte_len];
+        use rand::RngCore;
+        rand::rngs::OsRng.fill_bytes(&mut key_bytes);
+        let buf = alloc_uint8array_from_slice(&key_bytes);
+        if buf.is_null() {
+            return reject_with_dom_exception("OperationError", "The operation failed");
+        }
+        register_crypto_key(
+            buf as usize,
+            CryptoKeyMaterial::new(KeyAlgo::Hmac, hash, KeyKind::Secret, extractable, usages),
+        );
+        return resolve_with_bits(JSValue::pointer(buf as *const u8).bits());
+    }
+
     if algo_upper != "AES-GCM"
         && algo_upper != "AES-KW"
         && algo_upper != "AES-CBC"
@@ -316,6 +412,26 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
     }
     // Read `length` from the algorithm object; default to 256 for the
     // string-shorthand form.
+    let key_algo = if algo_upper == "AES-CBC" {
+        KeyAlgo::AesCbc
+    } else if algo_upper == "AES-CTR" {
+        KeyAlgo::AesCtr
+    } else if algo_upper == "AES-KW" {
+        KeyAlgo::AesKw
+    } else {
+        KeyAlgo::AesGcm
+    };
+    let usages = match validate_key_usages(
+        key_algo,
+        KeyKind::Secret,
+        usages_bits.to_bits(),
+        false,
+        "Usages cannot be empty when creating a key.",
+        "Unsupported key usage for the requested algorithm",
+    ) {
+        Ok(u) => u,
+        Err((name, message)) => return reject_with_dom_exception(name, message),
+    };
     let length = object_field_number(algo_bits.to_bits(), b"length").unwrap_or(256);
     let byte_len = match (algo_upper.as_str(), length) {
         (_, 128) => 16,
@@ -336,19 +452,13 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
     }
     register_crypto_key(
         buf as usize,
-        CryptoKeyMaterial {
-            algo: if algo_upper == "AES-CBC" {
-                KeyAlgo::AesCbc
-            } else if algo_upper == "AES-CTR" {
-                KeyAlgo::AesCtr
-            } else if algo_upper == "AES-KW" {
-                KeyAlgo::AesKw
-            } else {
-                KeyAlgo::AesGcm
-            },
-            hash: HashAlgo::Sha256,
-            kind: KeyKind::Secret,
-        },
+        CryptoKeyMaterial::new(
+            key_algo,
+            HashAlgo::Sha256,
+            KeyKind::Secret,
+            extractable,
+            usages,
+        ),
     );
     let val = JSValue::pointer(buf as *const u8).bits();
     resolve_with_bits(val)

--- a/crates/perry-stdlib/src/webcrypto/util.rs
+++ b/crates/perry-stdlib/src/webcrypto/util.rs
@@ -47,7 +47,14 @@ pub(super) use perry_runtime::{
 extern "C" {
     fn js_buffer_register_external(addr: usize);
     fn js_buffer_mark_as_uint8array_external(addr: usize);
-    fn js_buffer_mark_as_crypto_key_external(addr: usize, algo: u8, hash: u8, kind: u8);
+    fn js_buffer_mark_as_crypto_key_external(
+        addr: usize,
+        algo: u8,
+        hash: u8,
+        kind: u8,
+        extractable: u8,
+        usages: u32,
+    );
 }
 
 /// `buffer_data` is private to perry-runtime — open-code the same offset.
@@ -105,6 +112,15 @@ pub(super) enum KeyKind {
     Public,
 }
 
+pub(super) const USAGE_ENCRYPT: u32 = 1 << 0;
+pub(super) const USAGE_DECRYPT: u32 = 1 << 1;
+pub(super) const USAGE_SIGN: u32 = 1 << 2;
+pub(super) const USAGE_VERIFY: u32 = 1 << 3;
+pub(super) const USAGE_DERIVE_KEY: u32 = 1 << 4;
+pub(super) const USAGE_DERIVE_BITS: u32 = 1 << 5;
+pub(super) const USAGE_WRAP_KEY: u32 = 1 << 6;
+pub(super) const USAGE_UNWRAP_KEY: u32 = 1 << 7;
+
 #[derive(Copy, Clone, Debug)]
 pub(super) struct CryptoKeyMaterial {
     pub(super) algo: KeyAlgo,
@@ -113,6 +129,26 @@ pub(super) struct CryptoKeyMaterial {
     /// the struct stays `Copy`).
     pub(super) hash: HashAlgo,
     pub(super) kind: KeyKind,
+    pub(super) extractable: bool,
+    pub(super) usages: u32,
+}
+
+impl CryptoKeyMaterial {
+    pub(super) fn new(
+        algo: KeyAlgo,
+        hash: HashAlgo,
+        kind: KeyKind,
+        extractable: bool,
+        usages: u32,
+    ) -> Self {
+        Self {
+            algo,
+            hash,
+            kind,
+            extractable,
+            usages,
+        }
+    }
 }
 
 pub(super) static CRYPTO_KEY_REGISTRY: Lazy<Mutex<HashMap<usize, CryptoKeyMaterial>>> =
@@ -126,6 +162,8 @@ pub(super) fn register_crypto_key(buf_addr: usize, mat: CryptoKeyMaterial) {
             runtime_algo_id(mat.algo),
             runtime_hash_id(mat.hash),
             runtime_key_kind_id(mat.kind),
+            u8::from(mat.extractable),
+            mat.usages,
         );
     }
 }
@@ -139,7 +177,13 @@ fn runtime_algo_id(algo: KeyAlgo) -> u8 {
         KeyAlgo::AesCtr => 5,
         KeyAlgo::Hkdf => 6,
         KeyAlgo::Pbkdf2 => 7,
-        _ => 0,
+        KeyAlgo::EcdsaP256 => 8,
+        KeyAlgo::EcdhP256 => 9,
+        KeyAlgo::Ed25519 => 10,
+        KeyAlgo::X25519 => 11,
+        KeyAlgo::RsassaPkcs1 => 12,
+        KeyAlgo::RsaOaep => 13,
+        KeyAlgo::RsaPss => 14,
     }
 }
 
@@ -167,7 +211,8 @@ pub(super) fn lookup_crypto_key(buf_addr: usize) -> Option<CryptoKeyMaterial> {
         .get(&buf_addr)
         .copied()
         .or_else(|| {
-            let (algo, hash, kind) = perry_runtime::buffer::crypto_key_meta(buf_addr)?;
+            let (algo, hash, kind, extractable, usages) =
+                perry_runtime::buffer::crypto_key_meta(buf_addr)?;
             let algo = match algo {
                 1 => KeyAlgo::Hmac,
                 2 => KeyAlgo::AesGcm,
@@ -176,6 +221,13 @@ pub(super) fn lookup_crypto_key(buf_addr: usize) -> Option<CryptoKeyMaterial> {
                 5 => KeyAlgo::AesCtr,
                 6 => KeyAlgo::Hkdf,
                 7 => KeyAlgo::Pbkdf2,
+                8 => KeyAlgo::EcdsaP256,
+                9 => KeyAlgo::EcdhP256,
+                10 => KeyAlgo::Ed25519,
+                11 => KeyAlgo::X25519,
+                12 => KeyAlgo::RsassaPkcs1,
+                13 => KeyAlgo::RsaOaep,
+                14 => KeyAlgo::RsaPss,
                 _ => return None,
             };
             let hash = match hash {
@@ -191,7 +243,13 @@ pub(super) fn lookup_crypto_key(buf_addr: usize) -> Option<CryptoKeyMaterial> {
                 3 => KeyKind::Public,
                 _ => KeyKind::Secret,
             };
-            Some(CryptoKeyMaterial { algo, hash, kind })
+            Some(CryptoKeyMaterial {
+                algo,
+                hash,
+                kind,
+                extractable,
+                usages,
+            })
         })
 }
 
@@ -324,6 +382,128 @@ pub(super) unsafe fn extract_algorithm_hash(algo_bits: u64, default: HashAlgo) -
     let key_ptr = perry_runtime::js_string_from_bytes(key.as_ptr(), key.len() as u32);
     let hash_val = perry_runtime::js_object_get_field_by_name(obj_ptr, key_ptr);
     extract_hash_algo(hash_val.bits()).unwrap_or(default)
+}
+
+pub(super) fn bool_from_jsvalue(bits: u64) -> bool {
+    matches!(bits, TAG_TRUE)
+}
+
+pub(super) unsafe fn key_usages_from_jsvalue(bits: u64) -> Option<u32> {
+    let is_array =
+        JSValue::from_bits(perry_runtime::array::js_array_is_array(f64::from_bits(bits)).to_bits());
+    if !is_array.is_bool() || !is_array.as_bool() {
+        return Some(0);
+    }
+    let arr = strip_ptr(bits) as *const perry_runtime::ArrayHeader;
+    if (arr as usize) < 0x1000 {
+        return Some(0);
+    }
+    let len = perry_runtime::array::js_array_length(arr);
+    let mut usages = 0u32;
+    for i in 0..len {
+        let item = perry_runtime::array::js_array_get(arr, i);
+        let name = string_from_jsvalue(item.bits())?;
+        let bit = usage_bit(&name)?;
+        usages |= bit;
+    }
+    Some(usages)
+}
+
+pub(super) fn usage_bit(name: &str) -> Option<u32> {
+    match name {
+        "encrypt" => Some(USAGE_ENCRYPT),
+        "decrypt" => Some(USAGE_DECRYPT),
+        "sign" => Some(USAGE_SIGN),
+        "verify" => Some(USAGE_VERIFY),
+        "deriveKey" => Some(USAGE_DERIVE_KEY),
+        "deriveBits" => Some(USAGE_DERIVE_BITS),
+        "wrapKey" => Some(USAGE_WRAP_KEY),
+        "unwrapKey" => Some(USAGE_UNWRAP_KEY),
+        _ => None,
+    }
+}
+
+pub(super) fn supported_usages(algo: KeyAlgo, kind: KeyKind) -> u32 {
+    match (algo, kind) {
+        (KeyAlgo::Hmac, KeyKind::Secret) => USAGE_SIGN | USAGE_VERIFY,
+        (KeyAlgo::AesGcm | KeyAlgo::AesCbc | KeyAlgo::AesCtr, KeyKind::Secret) => {
+            USAGE_ENCRYPT | USAGE_DECRYPT | USAGE_WRAP_KEY | USAGE_UNWRAP_KEY
+        }
+        (KeyAlgo::AesKw, KeyKind::Secret) => USAGE_WRAP_KEY | USAGE_UNWRAP_KEY,
+        (KeyAlgo::Hkdf | KeyAlgo::Pbkdf2, KeyKind::Secret) => USAGE_DERIVE_KEY | USAGE_DERIVE_BITS,
+        (
+            KeyAlgo::EcdsaP256 | KeyAlgo::Ed25519 | KeyAlgo::RsassaPkcs1 | KeyAlgo::RsaPss,
+            KeyKind::Private,
+        ) => USAGE_SIGN,
+        (
+            KeyAlgo::EcdsaP256 | KeyAlgo::Ed25519 | KeyAlgo::RsassaPkcs1 | KeyAlgo::RsaPss,
+            KeyKind::Public,
+        ) => USAGE_VERIFY,
+        (KeyAlgo::EcdhP256 | KeyAlgo::X25519, KeyKind::Private) => {
+            USAGE_DERIVE_KEY | USAGE_DERIVE_BITS
+        }
+        (KeyAlgo::EcdhP256 | KeyAlgo::X25519, KeyKind::Public) => 0,
+        (KeyAlgo::RsaOaep, KeyKind::Public) => USAGE_ENCRYPT | USAGE_WRAP_KEY,
+        (KeyAlgo::RsaOaep, KeyKind::Private) => USAGE_DECRYPT | USAGE_UNWRAP_KEY,
+        _ => 0,
+    }
+}
+
+pub(super) unsafe fn validate_key_usages(
+    algo: KeyAlgo,
+    kind: KeyKind,
+    usages_bits: u64,
+    empty_allowed: bool,
+    empty_message: &'static str,
+    bad_message: &'static str,
+) -> Result<u32, (&'static str, &'static str)> {
+    let usages = match key_usages_from_jsvalue(usages_bits) {
+        Some(u) => u,
+        None => return Err(("SyntaxError", bad_message)),
+    };
+    let supported = supported_usages(algo, kind);
+    if usages & !supported != 0 {
+        return Err(("SyntaxError", bad_message));
+    }
+    if usages == 0 && !empty_allowed {
+        return Err(("SyntaxError", empty_message));
+    }
+    Ok(usages)
+}
+
+pub(super) unsafe fn validate_key_pair_usages(
+    algo: KeyAlgo,
+    usages_bits: u64,
+    empty_message: &'static str,
+    bad_message: &'static str,
+) -> Result<(u32, u32), (&'static str, &'static str)> {
+    let requested = match key_usages_from_jsvalue(usages_bits) {
+        Some(u) => u,
+        None => return Err(("SyntaxError", bad_message)),
+    };
+    let private_supported = supported_usages(algo, KeyKind::Private);
+    let public_supported = supported_usages(algo, KeyKind::Public);
+    if requested & !(private_supported | public_supported) != 0 {
+        return Err(("SyntaxError", bad_message));
+    }
+    let private_usages = requested & private_supported;
+    let public_usages = requested & public_supported;
+    if private_usages == 0 && public_usages == 0 {
+        return Err(("SyntaxError", empty_message));
+    }
+    Ok((private_usages, public_usages))
+}
+
+pub(super) fn require_usage(
+    mat: CryptoKeyMaterial,
+    usage: u32,
+    message: &'static str,
+) -> Result<(), (&'static str, &'static str)> {
+    if mat.usages & usage == 0 {
+        Err(("InvalidAccessError", message))
+    } else {
+        Ok(())
+    }
 }
 
 /// Allocate a fresh Buffer marked as Uint8Array (so `instanceof Uint8Array`

--- a/crates/perry-stdlib/src/webcrypto/wrap.rs
+++ b/crates/perry-stdlib/src/webcrypto/wrap.rs
@@ -13,10 +13,38 @@ use super::*;
 //     existing encrypt/decrypt path takes; wrapped output is
 //     `ciphertext || tag`.
 //
-// `format` is currently restricted to `"raw"` — the only format
-// jose uses for symmetric keys. JWK / spki / pkcs8 are TODO follow-
-// ups (they require an asymmetric algorithm we haven't wired yet).
+// `format` supports `"raw"` plus secret-key `"jwk"` serialization for
+// the AES/HMAC key-management paths Perry already implements. SPKI/PKCS8
+// wrapping remains scoped to future asymmetric work.
 // =====================================================================
+
+fn secret_jwk_bytes(mat: CryptoKeyMaterial, key_bytes: &[u8]) -> Option<Vec<u8>> {
+    if mat.kind != KeyKind::Secret {
+        return None;
+    }
+    let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key_bytes);
+    let json = serde_json::json!({
+        "kty": "oct",
+        "k": encoded,
+    });
+    let mut bytes = serde_json::to_vec(&json).ok()?;
+    while bytes.len() % 8 != 0 {
+        bytes.push(b' ');
+    }
+    Some(bytes)
+}
+
+fn secret_jwk_key_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let obj = value.as_object()?;
+    if obj.get("kty")?.as_str()? != "oct" {
+        return None;
+    }
+    let k = obj.get("k")?.as_str()?;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(k.as_bytes())
+        .ok()
+}
 
 /// AES-KW wrap — RFC 3394. Returns the wrapped key (8 bytes longer
 /// than `plaintext_key`). `aes-kw` 0.3 ships
@@ -115,14 +143,31 @@ pub unsafe extern "C" fn js_webcrypto_wrap_key(
             )
         }
     };
-    if format != "raw" {
+    let format_lower = format.to_ascii_lowercase();
+    if format_lower != "raw" && format_lower != "jwk" {
         return reject_with_dom_exception("NotSupportedError", "Unsupported key format");
     }
     let key_addr = strip_ptr(key_bits.to_bits());
-    if lookup_crypto_key(key_addr).is_none() {
-        return reject_with_dom_exception("InvalidAccessError", "Key is not a valid CryptoKey");
+    let key_mat = match lookup_crypto_key(key_addr) {
+        Some(m) => m,
+        None => {
+            return reject_with_dom_exception("InvalidAccessError", "Key is not a valid CryptoKey")
+        }
+    };
+    if !key_mat.extractable {
+        return reject_with_dom_exception("InvalidAccessException", "key is not extractable");
     }
-    let key_bytes = bytes_from_jsvalue(key_bits.to_bits());
+    let raw_key_bytes = bytes_from_jsvalue(key_bits.to_bits());
+    let key_bytes = if format_lower == "jwk" {
+        match secret_jwk_bytes(key_mat, &raw_key_bytes) {
+            Some(bytes) => bytes,
+            None => {
+                return reject_with_dom_exception("NotSupportedError", "Unsupported key format")
+            }
+        }
+    } else {
+        raw_key_bytes
+    };
     let wrapping_key_addr = strip_ptr(wrapping_key_bits.to_bits());
     let wrapping_mat = match lookup_crypto_key(wrapping_key_addr) {
         Some(m) => m,
@@ -151,6 +196,13 @@ pub unsafe extern "C" fn js_webcrypto_wrap_key(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            wrapping_mat,
+            USAGE_WRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         match aes_kw_wrap(&wrapping_key_bytes, &key_bytes) {
             Some(w) => w,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -161,6 +213,13 @@ pub unsafe extern "C" fn js_webcrypto_wrap_key(
                 "InvalidAccessError",
                 "The requested operation is not valid for the provided key",
             );
+        }
+        if let Err((name, message)) = require_usage(
+            wrapping_mat,
+            USAGE_WRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
         }
         let (iv, aad) = match resolve_aes_gcm_iv_aad(wrap_algo_bits.to_bits()) {
             Some(t) => t,
@@ -182,6 +241,13 @@ pub unsafe extern "C" fn js_webcrypto_wrap_key(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            wrapping_mat,
+            USAGE_WRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         let iv = match object_field_bytes(wrap_algo_bits.to_bits(), b"iv") {
             Some(v) => v,
             None => {
@@ -201,6 +267,13 @@ pub unsafe extern "C" fn js_webcrypto_wrap_key(
                 "InvalidAccessError",
                 "The requested operation is not valid for the provided key",
             );
+        }
+        if let Err((name, message)) = require_usage(
+            wrapping_mat,
+            USAGE_WRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
         }
         let counter = match object_field_bytes(wrap_algo_bits.to_bits(), b"counter") {
             Some(v) => v,
@@ -231,6 +304,13 @@ pub unsafe extern "C" fn js_webcrypto_wrap_key(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            wrapping_mat,
+            USAGE_WRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         let public_key = match RsaPublicKey::from_public_key_der(&wrapping_key_bytes) {
             Ok(k) => k,
             Err(_) => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -260,9 +340,10 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
     unwrapping_key_bits: f64,
     unwrap_algo_bits: f64,
     unwrapped_algo_bits: f64,
-    _extractable_bits: f64,
-    _usages_bits: f64,
+    extractable_bits: f64,
+    usages_bits: f64,
 ) -> *mut Promise {
+    let extractable = bool_from_jsvalue(extractable_bits.to_bits());
     let format = match string_from_jsvalue(format_bits.to_bits()) {
         Some(s) => s,
         None => {
@@ -272,7 +353,8 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
             )
         }
     };
-    if format != "raw" {
+    let format_lower = format.to_ascii_lowercase();
+    if format_lower != "raw" && format_lower != "jwk" {
         return reject_with_dom_exception("NotSupportedError", "Unsupported key format");
     }
     let wrapped_bytes = bytes_from_jsvalue(wrapped_key_bits.to_bits());
@@ -304,6 +386,13 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            unwrapping_mat,
+            USAGE_UNWRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         match aes_kw_unwrap(&unwrapping_key_bytes, &wrapped_bytes) {
             Some(r) => r,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -314,6 +403,13 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
                 "InvalidAccessError",
                 "The requested operation is not valid for the provided key",
             );
+        }
+        if let Err((name, message)) = require_usage(
+            unwrapping_mat,
+            USAGE_UNWRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
         }
         let (iv, aad) = match resolve_aes_gcm_iv_aad(unwrap_algo_bits.to_bits()) {
             Some(t) => t,
@@ -335,6 +431,13 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            unwrapping_mat,
+            USAGE_UNWRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         let iv = match object_field_bytes(unwrap_algo_bits.to_bits(), b"iv") {
             Some(v) => v,
             None => {
@@ -354,6 +457,13 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
                 "InvalidAccessError",
                 "The requested operation is not valid for the provided key",
             );
+        }
+        if let Err((name, message)) = require_usage(
+            unwrapping_mat,
+            USAGE_UNWRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
         }
         let counter = match object_field_bytes(unwrap_algo_bits.to_bits(), b"counter") {
             Some(v) => v,
@@ -384,6 +494,13 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
                 "The requested operation is not valid for the provided key",
             );
         }
+        if let Err((name, message)) = require_usage(
+            unwrapping_mat,
+            USAGE_UNWRAP_KEY,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
         let private_key = match RsaPrivateKey::from_pkcs8_der(&unwrapping_key_bytes) {
             Ok(k) => k,
             Err(_) => return reject_with_dom_exception("OperationError", "The operation failed"),
@@ -399,6 +516,15 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
         );
     };
 
+    let recovered = if format_lower == "jwk" {
+        match secret_jwk_key_bytes(&recovered) {
+            Some(bytes) => bytes,
+            None => return reject_with_dom_exception("DataError", "Key data is invalid"),
+        }
+    } else {
+        recovered
+    };
+
     // Register the recovered bytes as a CryptoKey under the requested
     // unwrappedKeyAlgorithm.
     let unwrapped_name = match wrap_algo_name(unwrapped_algo_bits.to_bits()) {
@@ -410,12 +536,30 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
             )
         }
     };
-    let key_algo = match unwrapped_name.as_str() {
-        "AES-GCM" => KeyAlgo::AesGcm,
-        "AES-KW" => KeyAlgo::AesKw,
-        "AES-CBC" => KeyAlgo::AesCbc,
-        "AES-CTR" => KeyAlgo::AesCtr,
+    let (key_algo, hash) = match unwrapped_name.as_str() {
+        "HMAC" => {
+            let hash = match extract_hmac_hash(unwrapped_algo_bits.to_bits()) {
+                Some(h) => h,
+                None => return reject_with_dom_exception("OperationError", "The operation failed"),
+            };
+            (KeyAlgo::Hmac, hash)
+        }
+        "AES-GCM" => (KeyAlgo::AesGcm, HashAlgo::Sha256),
+        "AES-KW" => (KeyAlgo::AesKw, HashAlgo::Sha256),
+        "AES-CBC" => (KeyAlgo::AesCbc, HashAlgo::Sha256),
+        "AES-CTR" => (KeyAlgo::AesCtr, HashAlgo::Sha256),
         _ => return reject_with_dom_exception("OperationError", "The operation failed"),
+    };
+    let usages = match validate_key_usages(
+        key_algo,
+        KeyKind::Secret,
+        usages_bits.to_bits(),
+        false,
+        "Usages cannot be empty when importing a secret key.",
+        "Unsupported key usage for the requested algorithm",
+    ) {
+        Ok(u) => u,
+        Err((name, message)) => return reject_with_dom_exception(name, message),
     };
     let buf = alloc_uint8array_from_slice(&recovered);
     if buf.is_null() {
@@ -423,11 +567,7 @@ pub unsafe extern "C" fn js_webcrypto_unwrap_key(
     }
     register_crypto_key(
         buf as usize,
-        CryptoKeyMaterial {
-            algo: key_algo,
-            hash: HashAlgo::Sha256,
-            kind: KeyKind::Secret,
-        },
+        CryptoKeyMaterial::new(key_algo, hash, KeyKind::Secret, extractable, usages),
     );
     let val = JSValue::pointer(buf as *const u8).bits();
     resolve_with_bits(val)

--- a/test-parity/node-suite/crypto/webcrypto/cryptokey-usages-extractable.ts
+++ b/test-parity/node-suite/crypto/webcrypto/cryptokey-usages-extractable.ts
@@ -1,0 +1,64 @@
+import * as crypto from "node:crypto";
+
+async function logReject(label: string, promise: Promise<unknown>) {
+  let rejected = false;
+  let name = "";
+  try {
+    await promise;
+  } catch (e: any) {
+    rejected = true;
+    name = e?.name ?? "";
+  }
+  console.log(`${label}:`, rejected, name);
+}
+
+async function main() {
+  const limited = await crypto.subtle.generateKey(
+    { name: "AES-GCM", length: 128 },
+    false,
+    ["encrypt"],
+  );
+  console.log("limited aes:", limited.type, limited.algorithm.name, limited.extractable, limited.usages.join(","));
+  await logReject("limited export", crypto.subtle.exportKey("raw", limited));
+  await logReject(
+    "limited decrypt",
+    crypto.subtle.decrypt({ name: "AES-GCM", iv: new Uint8Array(12) }, limited, new Uint8Array(16)),
+  );
+  await logReject(
+    "aes empty usages",
+    crypto.subtle.generateKey({ name: "AES-GCM", length: 128 }, true, []),
+  );
+
+  const imported = await crypto.subtle.importKey("raw", new Uint8Array(16), "AES-GCM", false, ["encrypt"]);
+  console.log("imported aes:", imported.type, imported.algorithm.name, imported.extractable, imported.usages.join(","));
+  await logReject("imported export", crypto.subtle.exportKey("raw", imported));
+  await logReject("import aes empty usages", crypto.subtle.importKey("raw", new Uint8Array(16), "AES-GCM", true, []));
+
+  const signOnly = await crypto.subtle.generateKey(
+    { name: "HMAC", hash: "SHA-256", length: 256 },
+    true,
+    ["sign"],
+  );
+  const verifyOnly = await crypto.subtle.generateKey(
+    { name: "HMAC", hash: "SHA-256", length: 256 },
+    true,
+    ["verify"],
+  );
+  const data = new TextEncoder().encode("usage check");
+  const sig = await crypto.subtle.sign("HMAC", signOnly, data);
+  console.log("hmac sign-only usages:", signOnly.usages.join(","));
+  await logReject("hmac sign with verify-only", crypto.subtle.sign("HMAC", verifyOnly, data));
+  await logReject("hmac verify with sign-only", crypto.subtle.verify("HMAC", signOnly, sig, data));
+  await logReject(
+    "import hmac bad usage",
+    crypto.subtle.importKey(
+      "raw",
+      new Uint8Array(32),
+      { name: "HMAC", hash: "SHA-256" },
+      true,
+      ["encrypt" as any],
+    ),
+  );
+}
+
+await main();

--- a/test-parity/node-suite/crypto/webcrypto/hmac-generate-key.ts
+++ b/test-parity/node-suite/crypto/webcrypto/hmac-generate-key.ts
@@ -1,0 +1,45 @@
+import * as crypto from "node:crypto";
+
+async function logReject(label: string, promise: Promise<unknown>) {
+  let rejected = false;
+  let name = "";
+  try {
+    await promise;
+  } catch (e: any) {
+    rejected = true;
+    name = e?.name ?? "";
+  }
+  console.log(`${label}:`, rejected, name);
+}
+
+async function main() {
+  const data = new TextEncoder().encode("generated hmac");
+  const key = await crypto.subtle.generateKey(
+    { name: "HMAC", hash: "SHA-256", length: 256 },
+    true,
+    ["sign", "verify"],
+  );
+  console.log(
+    "hmac generated key:",
+    key.type,
+    key.algorithm.name,
+    key.algorithm.hash.name,
+    key.algorithm.length,
+    key.extractable,
+    key.usages.join(","),
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, data);
+  console.log("hmac generated sig:", sig.byteLength > 0);
+  console.log("hmac generated verify:", await crypto.subtle.verify("HMAC", key, sig, data));
+
+  await logReject(
+    "hmac empty usages",
+    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-256", length: 256 }, true, []),
+  );
+  await logReject(
+    "hmac bad usage",
+    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-256", length: 256 }, true, ["encrypt" as any]),
+  );
+}
+
+await main();

--- a/test-parity/node-suite/crypto/webcrypto/jwk-wrap-unwrap.ts
+++ b/test-parity/node-suite/crypto/webcrypto/jwk-wrap-unwrap.ts
@@ -1,0 +1,52 @@
+import * as crypto from "node:crypto";
+
+async function logReject(label: string, promise: Promise<unknown>) {
+  let rejected = false;
+  let name = "";
+  try {
+    await promise;
+  } catch (e: any) {
+    rejected = true;
+    name = e?.name ?? "";
+  }
+  console.log(`${label}:`, rejected, name);
+}
+
+async function main() {
+  const kek = await crypto.subtle.generateKey(
+    { name: "AES-KW", length: 256 },
+    true,
+    ["wrapKey", "unwrapKey"],
+  );
+  const target = await crypto.subtle.generateKey(
+    { name: "AES-GCM", length: 128 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+  const wrapped = await crypto.subtle.wrapKey("jwk", target, kek, "AES-KW");
+  console.log("wrap jwk:", wrapped.byteLength > 0);
+  const unwrapped = await crypto.subtle.unwrapKey(
+    "jwk",
+    wrapped,
+    kek,
+    "AES-KW",
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+  console.log("unwrap jwk:", unwrapped.type, unwrapped.algorithm.name, unwrapped.extractable, unwrapped.usages.join(","));
+  await logReject("unwrap jwk export", crypto.subtle.exportKey("raw", unwrapped));
+
+  const wrapOnly = await crypto.subtle.generateKey({ name: "AES-KW", length: 256 }, true, ["wrapKey"]);
+  const unwrapOnly = await crypto.subtle.generateKey({ name: "AES-KW", length: 256 }, true, ["unwrapKey"]);
+  await logReject("wrap with unwrap-only kek", crypto.subtle.wrapKey("raw", target, unwrapOnly, "AES-KW"));
+  await logReject(
+    "unwrap with wrap-only kek",
+    crypto.subtle.unwrapKey("raw", await crypto.subtle.wrapKey("raw", target, wrapOnly, "AES-KW"), wrapOnly, "AES-KW", { name: "AES-GCM" }, true, ["encrypt"]),
+  );
+  const nonExtractableTarget = await crypto.subtle.generateKey({ name: "AES-GCM", length: 128 }, false, ["encrypt"]);
+  await logReject("wrap nonextractable target", crypto.subtle.wrapKey("raw", nonExtractableTarget, wrapOnly, "AES-KW"));
+  await logReject("wrap spki aes", crypto.subtle.wrapKey("spki", target, kek, "AES-KW"));
+}
+
+await main();


### PR DESCRIPTION
## Summary

Closes #2929, #2930, #2931.

This PR fills a coherent WebCrypto key-management parity gap for `node:crypto`:

- stores CryptoKey `type`, `algorithm`, `extractable`, and `usages` metadata in runtime/stdlib key registration
- enforces key usages for encrypt/decrypt, sign/verify, deriveKey/deriveBits, and wrapKey/unwrapKey
- implements HMAC `subtle.generateKey()` with Node-shaped validation and metadata
- rejects export/wrap of non-extractable keys with Node-matching DOMException names
- supports secret-key JWK wrap/unwrap round-trips for AES/HMAC key-management paths

## Why Batched

These issues share the same implementation path: WebCrypto CryptoKey metadata needs to survive generation/import/unwrap and then be consulted by operation dispatch. Fixing them separately would duplicate registry, validation, and parity-test work.

## Tests Added

- `test-parity/node-suite/crypto/webcrypto/hmac-generate-key.ts`
- `test-parity/node-suite/crypto/webcrypto/cryptokey-usages-extractable.ts`
- `test-parity/node-suite/crypto/webcrypto/jwk-wrap-unwrap.ts`

## Validation

- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter hmac-generate-key`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter cryptokey-usages-extractable`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter jwk-wrap-unwrap`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter webcrypto` (54 pass, 0 fail)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_TERM_COLOR=never cargo check -p perry-runtime -p perry-stdlib`

## Known Limitations / Non-Goals

- JWK wrap/unwrap support in this cut is scoped to secret-key AES/HMAC paths.
- Asymmetric SPKI/PKCS8/JWK wrapping is left for separate asymmetric key-management work.
- This does not add new WebCrypto algorithms or change the broader WebCrypto byte-result return-type model.
- This does not address stream-backed crypto transforms or AES-GCM `createCipheriv` state handling.
