### PR TITLE
c262 parity: parse sloppy JS arrow cases

### DIFF
--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -3,10 +3,18 @@ use perry_hir::{lower_module, ArrayElement, BinaryOp, Expr, Stmt};
 use perry_parser::parse_typescript_with_cache;
 
 fn lower_src(src: &str) -> perry_hir::Module {
+    lower_src_with_filename(src, "c262_parity.ts")
+}
+
+fn lower_js_src(src: &str) -> perry_hir::Module {
+    lower_src_with_filename(src, "c262_parity.js")
+}
+
+fn lower_src_with_filename(src: &str, filename: &str) -> perry_hir::Module {
     let mut cache = SourceCache::new();
-    let parsed = parse_typescript_with_cache(src, "c262_parity.ts", &mut cache)
-        .expect("parse should succeed");
-    lower_module(&parsed.module, "test", "c262_parity.ts").expect("lower should succeed")
+    let parsed =
+        parse_typescript_with_cache(src, filename, &mut cache).expect("parse should succeed");
+    lower_module(&parsed.module, "test", filename).expect("lower should succeed")
 }
 
 fn top_level_init<'a>(module: &'a perry_hir::Module, name: &str) -> &'a Expr {
@@ -92,4 +100,20 @@ fn sloppy_assignment_expression_creates_storage_before_following_getvalue() {
         "{left:?}"
     );
     assert!(matches!(right.as_ref(), Expr::LocalGet(id) if *id == y_id));
+}
+
+#[test]
+fn sloppy_js_yield_identifier_arrow_parameters_lower() {
+    let module = lower_js_src(
+        r#"
+        var yield = 23;
+        var f = (x = yield) => x;
+        var g = yield => yield;
+        var h = (yield) => yield;
+        "#,
+    );
+
+    assert!(matches!(top_level_init(&module, "f"), Expr::Closure { .. }));
+    assert!(matches!(top_level_init(&module, "g"), Expr::Closure { .. }));
+    assert!(matches!(top_level_init(&module, "h"), Expr::Closure { .. }));
 }

--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -6,8 +6,8 @@
 use anyhow::Result;
 use perry_diagnostics::{Diagnostic, DiagnosticCode, Diagnostics, FileId, SourceCache, Span};
 use swc_common::{input::StringInput, sync::Lrc, FileName, SourceMap};
-use swc_ecma_ast::Module;
-use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsSyntax};
+use swc_ecma_ast::{Module, ModuleItem, Script};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsSyntax};
 
 // Re-export AST types for consumers that need to inspect the AST
 pub use swc_ecma_ast;
@@ -56,26 +56,10 @@ pub fn parse_typescript_with_cache(
         parse_source.clone(),
     );
 
-    // Enable TSX parsing for .tsx files
-    let is_tsx = filename.ends_with(".tsx");
-
-    let lexer = Lexer::new(
-        Syntax::Typescript(TsSyntax {
-            tsx: is_tsx,
-            decorators: true,
-            dts: false,
-            no_early_errors: false,
-            disallow_ambiguous_jsx_like: false,
-        }),
-        swc_ecma_ast::EsVersion::Es2022,
-        StringInput::from(&*source_file),
-        None,
-    );
-
-    let mut parser = Parser::new_from(lexer);
+    let mut parser = parser_for_source_file(&source_file, filename);
     let mut diagnostics = Diagnostics::new();
 
-    let module = parser.parse_module().map_err(|e| {
+    let module = parse_module_or_script(&mut parser, filename, &parse_source).map_err(|e| {
         // Convert SWC error to our diagnostic
         let span = Span::new(file_id, e.span().lo.0, e.span().hi.0);
         let diag = Diagnostic::error(DiagnosticCode::ParseError, format!("{}", e.kind().msg()))
@@ -117,25 +101,9 @@ pub fn parse_typescript(source: &str, filename: &str) -> Result<Module> {
         parse_source,
     );
 
-    let is_tsx = filename.ends_with(".tsx");
+    let mut parser = parser_for_source_file(&source_file, filename);
 
-    let lexer = Lexer::new(
-        Syntax::Typescript(TsSyntax {
-            tsx: is_tsx,
-            decorators: true,
-            dts: false,
-            no_early_errors: false,
-            disallow_ambiguous_jsx_like: false,
-        }),
-        swc_ecma_ast::EsVersion::Es2022,
-        StringInput::from(&*source_file),
-        None,
-    );
-
-    let mut parser = Parser::new_from(lexer);
-
-    let module = parser
-        .parse_module()
+    let module = parse_module_or_script(&mut parser, filename, &source_file.src)
         .map_err(|e| anyhow::anyhow!("Parse error: {:?}", e))?;
 
     // Check for recoverable errors
@@ -144,6 +112,82 @@ pub fn parse_typescript(source: &str, filename: &str) -> Result<Module> {
     }
 
     Ok(module)
+}
+
+fn parser_for_source_file<'a>(
+    source_file: &'a swc_common::SourceFile,
+    filename: &str,
+) -> Parser<Lexer<'a>> {
+    let lexer = Lexer::new(
+        syntax_for_filename(filename),
+        swc_ecma_ast::EsVersion::Es2022,
+        StringInput::from(source_file),
+        None,
+    );
+    Parser::new_from(lexer)
+}
+
+fn syntax_for_filename(filename: &str) -> Syntax {
+    let path = filename.split(['?', '#']).next().unwrap_or(filename);
+    if path.ends_with(".ts")
+        || path.ends_with(".tsx")
+        || path.ends_with(".mts")
+        || path.ends_with(".cts")
+    {
+        Syntax::Typescript(TsSyntax {
+            tsx: path.ends_with(".tsx"),
+            decorators: true,
+            dts: false,
+            no_early_errors: false,
+            disallow_ambiguous_jsx_like: false,
+        })
+    } else {
+        Syntax::Es(EsSyntax {
+            jsx: path.ends_with(".jsx"),
+            decorators: true,
+            decorators_before_export: true,
+            export_default_from: true,
+            import_attributes: true,
+            ..Default::default()
+        })
+    }
+}
+
+fn parse_module_or_script(
+    parser: &mut Parser<Lexer<'_>>,
+    filename: &str,
+    source: &str,
+) -> swc_ecma_parser::PResult<Module> {
+    if should_parse_as_script(filename, source) {
+        parser.parse_script().map(script_to_module)
+    } else {
+        parser.parse_module()
+    }
+}
+
+fn should_parse_as_script(filename: &str, source: &str) -> bool {
+    let path = filename.split(['?', '#']).next().unwrap_or(filename);
+    (path.ends_with(".js") || path.ends_with(".cjs") || path.ends_with(".jsx"))
+        && !looks_like_es_module(source)
+}
+
+fn looks_like_es_module(source: &str) -> bool {
+    source.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("import ")
+            || trimmed.starts_with("import{")
+            || trimmed.starts_with("export ")
+            || trimmed.starts_with("export{")
+            || trimmed.starts_with("export*")
+    })
+}
+
+fn script_to_module(script: Script) -> Module {
+    Module {
+        span: script.span,
+        body: script.body.into_iter().map(ModuleItem::Stmt).collect(),
+        shebang: script.shebang,
+    }
 }
 
 fn normalize_unicode_identifier_escapes(source: &str) -> String {
@@ -328,5 +372,59 @@ mod tests {
         let result = parse_typescript_with_cache(source, "test.ts", &mut cache);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_js_sloppy_with_without_ts_warning() {
+        let source = r#"
+            function foo() {
+                var a = { a: 10 };
+                with (a) {
+                    return () => a;
+                }
+            }
+        "#;
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(source, "test.js", &mut cache).unwrap();
+
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_parse_js_sloppy_yield_arrow_parameter() {
+        let source = r#"
+            var yield = 23;
+            var f = (x = yield) => x;
+            var g = yield => yield;
+            var h = (yield) => yield;
+        "#;
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(source, "test.js", &mut cache).unwrap();
+
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_parse_ts_still_rejects_ts_syntax_errors() {
+        let source = "let x: number = ;";
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(source, "test.ts", &mut cache);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_js_module_syntax_still_uses_module_parser() {
+        let source = r#"
+            export const value = 1;
+        "#;
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(source, "test.js", &mut cache).unwrap();
+
+        assert!(result.diagnostics.is_empty());
     }
 }


### PR DESCRIPTION
## What changed

- Parse non-TypeScript source files with SWC `EsSyntax` instead of the TypeScript parser.
- Treat `.js`, `.cjs`, and `.jsx` as sloppy scripts unless the source visibly uses ESM import/export syntax, converting parsed scripts back into the existing `Module` shape for downstream lowering.
- Keep TypeScript/TSX parsing on the existing TypeScript syntax path.
- Add parser and HIR regressions for sloppy JS `yield` as an arrow parameter/default binding, plus a parser regression for sloppy `with` no longer surfacing a TypeScript parse warning.

## Why

The arrow-function Test262 slice includes sloppy JavaScript cases that Node accepts but Perry parsed as strict TypeScript modules. That caused TS-only diagnostics for valid sloppy JS, notably `yield` binding positions and `with`.

## Validation

- `cargo fmt -p perry-parser -p perry-hir`
- `cargo check -p perry-parser -p perry-hir`
- `cargo test -p perry-parser`
- `cargo test -p perry-hir`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- Exact Test262 files at pinned `4249661388e5d3f92a85186213da140a6481490f`:
  - `language/expressions/arrow-function/param-dflt-yield-id-non-strict.js`: Node 0, Perry compile 0, Perry run 0
  - `language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-yield.js`: Node 0, Perry compile 0, Perry run 0
  - `language/expressions/arrow-function/syntax/arrowparameters-cover-formalparameters-yield.js`: Node 0, Perry compile 0, Perry run 0
  - `language/expressions/arrow-function/arrow/capturing-closure-variables-2.js`: Node 0, Perry compile 1; residual is HIR `with` unsupported semantics, not SWC TS2410 parsing
- Arrow-function Test262 slice:
  - `scripts/test262_subset.py --root vendor/test262 --dir language/expressions/arrow-function --perry-bin "$PWD/target/release/perry" --timeout 20 --sample-cap 20 --report /tmp/c262-arrow-followup-e.json`
  - Result: pass 141, diff 0, runtime-fail 13, compile-fail 1, skip 0, judged 155, parity 91.0%

## Residual

`language/expressions/arrow-function/arrow/capturing-closure-variables-2.js` still fails at compile time because Perry does not implement ECMAScript `with` object-environment dynamic scope chains. This PR intentionally avoids a narrow fake lowering for `with` because it would pass one fixture while being semantically incorrect for general sloppy JS.
