### PR TITLE
c262 parity: narrow arrow eval/default runtime gaps

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -180,7 +180,7 @@ pub(crate) fn try_indirect_eval_globalthis(
 /// strict function that binding can be `undefined`, while global direct eval
 /// still sees global `this`. The indirect/global case is handled separately by
 /// [`try_indirect_eval_globalthis`] and the callable global eval thunk.
-fn try_direct_eval_this_fold(ctx: &LoweringContext, call: &ast::CallExpr) -> Option<Expr> {
+fn try_direct_eval_this_fold(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Option<Expr> {
     if call.args.len() != 1 || call.args[0].spread.is_some() {
         return None;
     }
@@ -214,7 +214,65 @@ fn try_direct_eval_this_fold(ctx: &LoweringContext, call: &ast::CallExpr) -> Opt
             _ => None,
         };
     }
+    if let Some(expr) = try_direct_eval_simple_assignment_fold(ctx, &body) {
+        return Some(expr);
+    }
     try_direct_eval_constant_add_fold(&body)
+}
+
+fn parse_eval_ident_name(src: &str) -> Option<&str> {
+    let mut chars = src.chars();
+    let first = chars.next()?;
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        return None;
+    }
+    if chars.all(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric()) {
+        Some(src)
+    } else {
+        None
+    }
+}
+
+fn parse_eval_literal(src: &str) -> Option<Expr> {
+    let s = trim_js_eval_ws(src);
+    if let Some(inner) = s.strip_prefix('"').and_then(|rest| rest.strip_suffix('"')) {
+        return Some(Expr::String(inner.to_string()));
+    }
+    if let Some(inner) = s
+        .strip_prefix('\'')
+        .and_then(|rest| rest.strip_suffix('\''))
+    {
+        return Some(Expr::String(inner.to_string()));
+    }
+    if s == "undefined" {
+        return Some(Expr::Undefined);
+    }
+    parse_eval_number_literal(s).map(Expr::Number)
+}
+
+fn try_direct_eval_simple_assignment_fold(ctx: &mut LoweringContext, body: &str) -> Option<Expr> {
+    let src = body.trim().trim_end_matches(';').trim();
+    let is_var_assignment = src.starts_with("var ");
+    let assignment = src.strip_prefix("var ").unwrap_or(src);
+    let (name_raw, value_raw) = assignment.split_once('=')?;
+    let name = parse_eval_ident_name(trim_js_eval_ws(name_raw))?;
+    let value = parse_eval_literal(value_raw)?;
+    if let Some(id) = ctx.lookup_local(name) {
+        if is_var_assignment && !ctx.var_hoisted_ids.contains(&id) {
+            return Some(Expr::SyntaxErrorNew(Box::new(Expr::String(format!(
+                "eval var declaration conflicts with lexical binding `{name}`"
+            )))));
+        }
+        Some(Expr::LocalSet(id, Box::new(value)))
+    } else if ctx.current_strict {
+        Some(super::throw_reference_error_expr(&format!(
+            "eval assignment to undeclared identifier `{name}`"
+        )))
+    } else {
+        let id = ctx.define_local(name.to_string(), perry_types::Type::Any);
+        ctx.var_hoisted_ids.insert(id);
+        Some(Expr::LocalSet(id, Box::new(value)))
+    }
 }
 
 fn trim_js_eval_ws(s: &str) -> &str {

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -125,10 +125,10 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
     for param in &arrow.params {
         let param_name = get_pat_name(param)?;
-        let param_default = get_param_default(ctx, param)?;
         let is_rest = is_rest_param(param);
         let param_ty = get_pat_type(param, ctx);
         let param_id = ctx.define_local(param_name.clone(), param_ty.clone());
+        let param_default = get_param_default(ctx, param)?;
         params.push(Param {
             id: param_id,
             name: param_name,

--- a/crates/perry-hir/src/lower_decl/helpers.rs
+++ b/crates/perry-hir/src/lower_decl/helpers.rs
@@ -170,16 +170,49 @@ pub fn build_default_param_stmts(params: &[Param]) -> Vec<Stmt> {
         let Some(default_expr) = param.default.as_ref() else {
             continue;
         };
+        let mut default_refs = Vec::new();
+        let mut visited_closures = std::collections::HashSet::new();
+        crate::analysis::collect_local_refs_expr(
+            default_expr,
+            &mut default_refs,
+            &mut visited_closures,
+        );
+        let default_reads_own_param = default_refs.contains(&param.id);
+        let default_is_throw_helper = matches!(
+            default_expr,
+            Expr::Call { callee, .. }
+                if matches!(
+                    callee.as_ref(),
+                    Expr::ExternFuncRef { name, .. } if name.starts_with("js_throw_")
+                )
+        );
+        let default_is_eval_syntax_error = matches!(
+            default_expr,
+            Expr::SyntaxErrorNew(msg)
+                if matches!(
+                    msg.as_ref(),
+                    Expr::String(message)
+                        if message.starts_with("eval var declaration conflicts with")
+                )
+        );
         out.push(Stmt::If {
             condition: Expr::Compare {
                 op: CompareOp::Eq,
                 left: Box::new(Expr::LocalGet(param.id)),
                 right: Box::new(Expr::Undefined),
             },
-            then_branch: vec![Stmt::Expr(Expr::LocalSet(
-                param.id,
-                Box::new(default_expr.clone()),
-            ))],
+            then_branch: if default_reads_own_param {
+                vec![Stmt::Throw(Expr::ReferenceErrorNew(Box::new(
+                    Expr::String("Cannot access parameter in its own initializer".to_string()),
+                )))]
+            } else if default_is_throw_helper || default_is_eval_syntax_error {
+                vec![Stmt::Throw(default_expr.clone())]
+            } else {
+                vec![Stmt::Expr(Expr::LocalSet(
+                    param.id,
+                    Box::new(default_expr.clone()),
+                ))]
+            },
             else_branch: None,
         });
     }

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -1,5 +1,5 @@
 use perry_diagnostics::SourceCache;
-use perry_hir::{lower_module, ArrayElement, BinaryOp, Expr, Stmt};
+use perry_hir::{lower_module, ArrayElement, BinaryOp, Expr, Function, Stmt};
 use perry_parser::parse_typescript_with_cache;
 
 fn lower_src(src: &str) -> perry_hir::Module {
@@ -24,6 +24,27 @@ fn top_level_init<'a>(module: &'a perry_hir::Module, name: &str) -> &'a Expr {
         .unwrap_or_else(|| panic!("top-level binding `{name}` not found"))
 }
 
+fn top_level_local_id(module: &perry_hir::Module, name: &str) -> perry_types::LocalId {
+    module
+        .init
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Let {
+                id, name: binding, ..
+            } if binding == name => Some(*id),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("top-level binding `{name}` not found"))
+}
+
+fn function<'a>(module: &'a perry_hir::Module, name: &str) -> &'a Function {
+    module
+        .functions
+        .iter()
+        .find(|func| func.name == name)
+        .unwrap_or_else(|| panic!("function `{name}` not found"))
+}
+
 fn is_number_literal(expr: &Expr, expected: f64) -> bool {
     match expr {
         Expr::Number(actual) => *actual == expected,
@@ -40,6 +61,71 @@ fn direct_eval_constant_addition_with_test262_whitespace_folds() {
         top_level_init(&module, "folded"),
         Expr::Number(n) if *n == 2.0
     ));
+}
+
+#[test]
+fn direct_eval_simple_assignment_updates_captured_var_binding() {
+    let module = lower_src(
+        r#"
+        var a;
+        function foo() {
+          eval("a = 10");
+          return () => a;
+        }
+        "#,
+    );
+    let a_id = top_level_local_id(&module, "a");
+    let foo = function(&module, "foo");
+
+    assert!(
+        matches!(
+            foo.body.first(),
+            Some(Stmt::Expr(Expr::LocalSet(id, value)))
+                if *id == a_id && is_number_literal(value, 10.0)
+        ),
+        "{:?}",
+        foo.body
+    );
+}
+
+#[test]
+fn arrow_default_parameter_self_reference_throws_reference_error() {
+    let module = lower_src("var f = (x = x) => { return 1; };");
+    let Expr::Closure { body, .. } = top_level_init(&module, "f") else {
+        panic!("expected arrow closure");
+    };
+    let Some(Stmt::If { then_branch, .. }) = body.first() else {
+        panic!("expected default-parameter guard, got {body:?}");
+    };
+
+    let throws_reference_error = match then_branch.as_slice() {
+        [Stmt::Throw(Expr::ReferenceErrorNew(_))] => true,
+        [Stmt::Throw(Expr::Call { callee, .. })] => matches!(
+            callee.as_ref(),
+            Expr::ExternFuncRef { name, .. } if name.starts_with("js_throw_")
+        ),
+        _ => false,
+    };
+    assert!(throws_reference_error, "{then_branch:?}");
+}
+
+#[test]
+fn arrow_default_parameter_eval_var_conflict_throws_syntax_error() {
+    let module = lower_src(r#"var f = (a = eval("var a = 42")) => { return 1; };"#);
+    let Expr::Closure { body, .. } = top_level_init(&module, "f") else {
+        panic!("expected arrow closure");
+    };
+    let Some(Stmt::If { then_branch, .. }) = body.first() else {
+        panic!("expected default-parameter guard, got {body:?}");
+    };
+
+    assert!(
+        matches!(
+            then_branch.as_slice(),
+            [Stmt::Throw(Expr::SyntaxErrorNew(_))]
+        ),
+        "{then_branch:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What changed

This closes a bounded arrow-function Test262 parity bucket around tiny direct-eval/default-parameter behavior:

- folds direct eval of simple literal assignments into the current local binding, including `var x = ...` when it resolves to an existing hoisted var or a new sloppy local
- treats direct-eval `var` collisions with arrow parameter bindings as a `SyntaxError` in the default-param guard
- lowers arrow parameter defaults after registering the parameter local so `(x = x)` observes the parameter binding and throws before the body runs
- throws abrupt default expressions from the generated default-param guard instead of assigning their error object
- adds focused HIR regressions for direct eval assignment, self-referential arrow defaults, and eval-var parameter conflicts

## Why

The arrow-function Test262 slice was at `138 pass / 13 runtime-fail / 4 compile-fail` after PR #4084. These failures shared a narrow lowering issue: a few constant direct-eval/default-param cases were being modeled as ordinary values, or were resolving before the arrow parameter environment existed.

## Validation

- `cargo fmt`
- `cargo test -p perry-hir --test c262_parity` -> `6 passed; 0 failed`
- `cargo check -p perry-hir` -> passed
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib` -> passed
- `tests/test_c262_arrow_function_parity.sh` -> `PASS: c262 arrow parity`
- Baseline arrow slice before changes: `pass=138 diff=0 rt-fail=13 compile-fail=4 skip=0 parity=89%`
- Final arrow slice: `scripts/test262_subset.py --root vendor/test262 --dir language/expressions/arrow-function --sample-cap 1000000` -> `pass=143 diff=0 runtime-fail=8 compile-fail=4 skip=0 parity=92.3%`

## Residual Test262 arrow paths

Runtime failures:

- `language/expressions/arrow-function/length-dflt.js`: `TypeError: value is not a function`
- `language/expressions/arrow-function/lexical-super-call-from-within-constructor.js`: expected `ReferenceError`, no throw
- `language/expressions/arrow-function/name.js`: `TypeError: value is not a function`
- `language/expressions/arrow-function/non-strict.js`: unresolved identifier `ReferenceError`
- `language/expressions/arrow-function/scope-body-lex-distinct.js`: expected `SyntaxError`, no throw
- `language/expressions/arrow-function/scope-param-rest-elem-var-close.js`: `TypeError: value is not a function`
- `language/expressions/arrow-function/scope-param-rest-elem-var-open.js`: expected outside/inside mismatch still inverted
- `language/expressions/arrow-function/scope-paramsbody-var-open.js`: expected params/body var environment split still inverted

Compile failures:

- `language/expressions/arrow-function/arrow/capturing-closure-variables-2.js`: parser warning `TS2410`
- `language/expressions/arrow-function/param-dflt-yield-id-non-strict.js`: parser `TS1109`
- `language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-yield.js`: parser `TS1109`
- `language/expressions/arrow-function/syntax/arrowparameters-cover-formalparameters-yield.js`: parser `TS1109`

