### PR TITLE
fix(hir): brand-check typed Number/Boolean prototype .call (#4100)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1085,6 +1085,37 @@ fn is_function_prototype_member(expr: &ast::Expr) -> bool {
     matches!(member.obj.as_ref(), ast::Expr::Ident(id) if id.sym.as_ref() == "Function")
 }
 
+/// #4100: true when `recv.<method>` is a primitive-wrapper prototype method that
+/// performs a spec `this` brand check at runtime (throws `TypeError` on an
+/// incompatible receiver). Folding `<recv>.<method>.call(x)` into `x.<method>()`
+/// would route through the lenient codegen fast-path / `Object.prototype`
+/// fallback (returns `"[object Object]"`, no throw). Keeping it reflective lets
+/// the installed brand-check thunk run. `Number.prototype.toFixed`/
+/// `toExponential`/`toPrecision` are deliberately excluded — the fold is the
+/// *correct* path for those (their reflective dispatch over-throws on a valid
+/// receiver), and only the brand-checked `valueOf`/`toString`/`toLocaleString`
+/// methods are affected. Symbol/BigInt have no codegen fold path, so they need
+/// no guard here.
+fn is_primitive_wrapper_brand_method(recv: &ast::Expr, method: &str) -> bool {
+    let ast::Expr::Member(member) = recv else {
+        return false;
+    };
+    let ast::MemberProp::Ident(prop) = &member.prop else {
+        return false;
+    };
+    if prop.sym.as_ref() != "prototype" {
+        return false;
+    }
+    let ast::Expr::Ident(base) = member.obj.as_ref() else {
+        return false;
+    };
+    match base.sym.as_ref() {
+        "Number" => matches!(method, "valueOf" | "toString" | "toLocaleString"),
+        "Boolean" => matches!(method, "valueOf" | "toString"),
+        _ => false,
+    }
+}
+
 pub(super) fn try_builtin_prototype_method_apply_call(
     ctx: &mut LoweringContext,
     call: &ast::CallExpr,
@@ -1134,6 +1165,14 @@ pub(super) fn try_builtin_prototype_method_apply_call(
             if method_ident.sym.as_ref() == "toString"
                 && is_function_prototype_member(inner.obj.as_ref())
             {
+                return Ok(None);
+            }
+            // #4100: keep `Number.prototype.valueOf.call(x)` /
+            // `Boolean.prototype.toString.call(x)` reflective so the installed
+            // brand-check thunk runs (throws a `TypeError` on an incompatible
+            // `this`). Folding to `x.<method>()` routes through the lenient
+            // `Object.prototype` fallback (`"[object Object]"`, no throw).
+            if is_primitive_wrapper_brand_method(inner.obj.as_ref(), method_ident.sym.as_ref()) {
                 return Ok(None);
             }
             method_ident.clone()
@@ -1217,6 +1256,13 @@ pub(crate) fn as_builtin_proto_method_ref(
         return None;
     };
     if !is_builtin_prototype_receiver(ctx, &member.obj) {
+        return None;
+    }
+    // #4100: don't track `const v = Number.prototype.valueOf` for the fold —
+    // a later `v.call(x)` must stay reflective so the brand-check thunk runs
+    // (see `is_primitive_wrapper_brand_method`). Untracked, the value read goes
+    // through the reflective dispatch, which throws correctly.
+    if is_primitive_wrapper_brand_method(&member.obj, method.sym.as_ref()) {
         return None;
     }
     // For a `<Ctor>.prototype` receiver, any method ident is accepted (mirrors

--- a/test-files/test_gap_4100_primitive_proto_brand_check.ts
+++ b/test-files/test_gap_4100_primitive_proto_brand_check.ts
@@ -42,3 +42,30 @@ console.log("BigInt.valueOf(5n):", (BigInt.prototype.valueOf as any).call(5n) ==
 
 // --- Sanity: the fast direct-call path is unchanged. ---
 console.log("direct:", (5).valueOf(), true.toString(), (255n).toString(16), Symbol("z").toString());
+
+// --- Typed `.call`/`.apply` form (no `as any`) must brand-check too. ---
+// The statically-typed member `.call` previously folded to `x.<method>()` and
+// bypassed the brand-check thunk, returning "[object Object]" instead of
+// throwing (the #4100 residual after #4112).
+console.log("typed Number.valueOf{}:", threw(() => Number.prototype.valueOf.call({})));
+console.log("typed Number.toString{}:", threw(() => Number.prototype.toString.call({})));
+console.log("typed Number.toLocaleString{}:", threw(() => Number.prototype.toLocaleString.call({})));
+console.log("typed Boolean.valueOf{}:", threw(() => Boolean.prototype.valueOf.call({})));
+console.log("typed Boolean.toString{}:", threw(() => Boolean.prototype.toString.call({})));
+console.log("typed Number.valueOf.apply{}:", threw(() => Number.prototype.valueOf.apply({})));
+
+// Extracted-local form: `const v = Number.prototype.valueOf; v.call({})`.
+const extractedNumValueOf = Number.prototype.valueOf;
+const extractedBoolToString = Boolean.prototype.toString;
+console.log("extracted Number.valueOf{}:", threw(() => extractedNumValueOf.call({})));
+console.log("extracted Boolean.toString{}:", threw(() => extractedBoolToString.call({})));
+
+// Typed form on a valid receiver returns the correct value.
+console.log("typed Number.toString(5,2):", Number.prototype.toString.call(5, 2));
+console.log("typed Number.valueOf(42):", Number.prototype.valueOf.call(42));
+console.log("typed Boolean.toString(true):", Boolean.prototype.toString.call(true));
+console.log("extracted Number.valueOf(42):", extractedNumValueOf.call(42));
+
+// `toFixed`/`toExponential` keep folding (must not regress to a false throw).
+console.log("typed Number.toFixed(3.14159,2):", Number.prototype.toFixed.call(3.14159, 2));
+console.log("typed Number.toExponential(12345,2):", Number.prototype.toExponential.call(12345, 2));


### PR DESCRIPTION
## #4100 residual — typed `.call` on Number/Boolean prototype methods

#4112 fixed the reflective (`as any` / computed-key) form of the
Number/Boolean/Symbol/BigInt prototype brand checks, but a residual remained
for the **statically-typed member-access form**, verified on `main`:

```ts
Number.prototype.valueOf.call({})    // Perry: "[object Object]"   Node: TypeError
Number.prototype.toString.call({})   // Perry: "[object Object]"   Node: TypeError
Boolean.prototype.valueOf.call({})   // Perry: "[object Object]"   Node: TypeError
const v = Number.prototype.valueOf; v.call({})  // same gap
```

### Root cause
`try_builtin_prototype_method_apply_call` (HIR) folds a typed
`<recv>.<method>.call(x)` into `x.<method>()`. That routes through the lenient
codegen fast-path / `Object.prototype` fallback and never reaches the
brand-check thunk installed by #4112. The `as any` / computed-key forms aren't
folded, so they already throw correctly.

### Fix
Guard the fold (and the const-extracted-local fold in
`as_builtin_proto_method_ref`) so `Number.prototype`'s
`valueOf`/`toString`/`toLocaleString` and `Boolean.prototype`'s
`valueOf`/`toString` stay reflective and hit the thunk — mirroring the existing
`Function.prototype.toString` guard (#4101).

`toFixed`/`toExponential`/`toPrecision` are **deliberately not** guarded: the
fold is the correct path for them (their reflective dispatch over-throws on a
*valid* receiver), and only the brand-checked methods are affected. Symbol/BigInt
have no codegen fold path, so they need no guard.

### Verification
- `test-files/test_gap_4100_primitive_proto_brand_check.ts` extended with the
  typed-`.call`/`.apply`, extracted-local, valid-receiver, and toFixed/toExponential
  no-regression cases.
- Byte-identical to `node --experimental-strip-types` in both auto-optimize and
  `PERRY_NO_AUTO_OPTIMIZE` modes.
- Array/String/Function `.call` folds unchanged; `cargo test -p perry-hir` green.

Closes #4100.
