### PR TITLE
c262 parity: array and addition follow-up

### DIFF
--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -541,26 +541,6 @@ pub fn lower_module_full(
         }
     }
 
-    if !ctx.current_strict {
-        let mut implicit_globals: Vec<_> = reassigned_function_candidates.iter().cloned().collect();
-        implicit_globals.sort();
-        for name in implicit_globals {
-            if ctx.lookup_local(&name).is_none()
-                && ctx.lookup_func(&name).is_none()
-                && ctx.lookup_class(&name).is_none()
-            {
-                let id = ctx.define_local(name.clone(), Type::Any);
-                module.init.push(Stmt::Let {
-                    id,
-                    name,
-                    ty: Type::Any,
-                    mutable: true,
-                    init: Some(Expr::Undefined),
-                });
-            }
-        }
-    }
-
     // Main pass: lower everything
     for item in &ast_module.body {
         match item {

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -442,6 +442,266 @@ fn collect_implicit_assignment_expr_names(
     }
 }
 
+fn implicit_assignment_pat_contains_name(pat: &ast::Pat, name: &str) -> bool {
+    match pat {
+        ast::Pat::Ident(ident) => ident.id.sym.as_ref() == name,
+        ast::Pat::Array(arr) => arr
+            .elems
+            .iter()
+            .flatten()
+            .any(|elem| implicit_assignment_pat_contains_name(elem, name)),
+        ast::Pat::Object(obj) => obj.props.iter().any(|prop| match prop {
+            ast::ObjectPatProp::Assign(assign) => assign.key.sym.as_ref() == name,
+            ast::ObjectPatProp::KeyValue(kv) => {
+                implicit_assignment_pat_contains_name(&kv.value, name)
+            }
+            ast::ObjectPatProp::Rest(rest) => {
+                implicit_assignment_pat_contains_name(&rest.arg, name)
+            }
+        }),
+        ast::Pat::Assign(assign) => implicit_assignment_pat_contains_name(&assign.left, name),
+        ast::Pat::Rest(rest) => implicit_assignment_pat_contains_name(&rest.arg, name),
+        ast::Pat::Expr(_) | ast::Pat::Invalid(_) => false,
+    }
+}
+
+fn implicit_assignment_target_contains_name(target: &ast::AssignTarget, name: &str) -> bool {
+    match target {
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::Ident(ident)) => {
+            ident.id.sym.as_ref() == name
+        }
+        ast::AssignTarget::Pat(pat) => match pat {
+            ast::AssignTargetPat::Array(arr) => arr
+                .elems
+                .iter()
+                .flatten()
+                .any(|elem| implicit_assignment_pat_contains_name(elem, name)),
+            ast::AssignTargetPat::Object(obj) => obj.props.iter().any(|prop| match prop {
+                ast::ObjectPatProp::Assign(assign) => assign.key.sym.as_ref() == name,
+                ast::ObjectPatProp::KeyValue(kv) => {
+                    implicit_assignment_pat_contains_name(&kv.value, name)
+                }
+                ast::ObjectPatProp::Rest(rest) => {
+                    implicit_assignment_pat_contains_name(&rest.arg, name)
+                }
+            }),
+            ast::AssignTargetPat::Invalid(_) => false,
+        },
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::Paren(paren)) => {
+            expr_assigns_name(&paren.expr, name)
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::TsAs(ts_as)) => {
+            expr_assigns_name(&ts_as.expr, name)
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::TsNonNull(ts_nn)) => {
+            expr_assigns_name(&ts_nn.expr, name)
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::TsTypeAssertion(ts_ta)) => {
+            expr_assigns_name(&ts_ta.expr, name)
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::TsSatisfies(ts_sat)) => {
+            expr_assigns_name(&ts_sat.expr, name)
+        }
+        ast::AssignTarget::Simple(
+            ast::SimpleAssignTarget::Member(_)
+            | ast::SimpleAssignTarget::SuperProp(_)
+            | ast::SimpleAssignTarget::OptChain(_)
+            | ast::SimpleAssignTarget::TsInstantiation(_)
+            | ast::SimpleAssignTarget::Invalid(_),
+        ) => false,
+    }
+}
+
+fn expr_assigns_name(expr: &ast::Expr, name: &str) -> bool {
+    match expr {
+        ast::Expr::Assign(assign) => {
+            implicit_assignment_target_contains_name(&assign.left, name)
+                || expr_assigns_name(&assign.right, name)
+        }
+        ast::Expr::Seq(seq) => seq.exprs.iter().any(|expr| expr_assigns_name(expr, name)),
+        ast::Expr::Paren(paren) => expr_assigns_name(&paren.expr, name),
+        ast::Expr::TsAs(ts_as) => expr_assigns_name(&ts_as.expr, name),
+        ast::Expr::TsNonNull(ts_nn) => expr_assigns_name(&ts_nn.expr, name),
+        ast::Expr::TsTypeAssertion(ts_ta) => expr_assigns_name(&ts_ta.expr, name),
+        ast::Expr::TsSatisfies(ts_sat) => expr_assigns_name(&ts_sat.expr, name),
+        _ => false,
+    }
+}
+
+fn assignment_target_reads_name_before_assignment(
+    target: &ast::AssignTarget,
+    name: &str,
+    assigned: &mut bool,
+) -> bool {
+    match target {
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::Member(member)) => {
+            expr_reads_name_before_assignment(&member.obj, name, assigned)
+                || matches!(
+                    &member.prop,
+                    ast::MemberProp::Computed(computed)
+                        if expr_reads_name_before_assignment(&computed.expr, name, assigned)
+                )
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::OptChain(opt_chain)) => {
+            match opt_chain.base.as_ref() {
+                ast::OptChainBase::Member(member) => {
+                    expr_reads_name_before_assignment(&member.obj, name, assigned)
+                        || matches!(
+                            &member.prop,
+                            ast::MemberProp::Computed(computed)
+                                if expr_reads_name_before_assignment(&computed.expr, name, assigned)
+                        )
+                }
+                ast::OptChainBase::Call(call) => {
+                    if expr_reads_name_before_assignment(&call.callee, name, assigned) {
+                        return true;
+                    }
+                    call.args
+                        .iter()
+                        .any(|arg| expr_reads_name_before_assignment(&arg.expr, name, assigned))
+                }
+            }
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::Paren(paren)) => {
+            expr_reads_name_before_assignment(&paren.expr, name, assigned)
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::TsAs(ts_as)) => {
+            expr_reads_name_before_assignment(&ts_as.expr, name, assigned)
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::TsNonNull(ts_nn)) => {
+            expr_reads_name_before_assignment(&ts_nn.expr, name, assigned)
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::TsTypeAssertion(ts_ta)) => {
+            expr_reads_name_before_assignment(&ts_ta.expr, name, assigned)
+        }
+        ast::AssignTarget::Simple(ast::SimpleAssignTarget::TsSatisfies(ts_sat)) => {
+            expr_reads_name_before_assignment(&ts_sat.expr, name, assigned)
+        }
+        ast::AssignTarget::Simple(
+            ast::SimpleAssignTarget::Ident(_)
+            | ast::SimpleAssignTarget::SuperProp(_)
+            | ast::SimpleAssignTarget::TsInstantiation(_)
+            | ast::SimpleAssignTarget::Invalid(_),
+        )
+        | ast::AssignTarget::Pat(_) => false,
+    }
+}
+
+fn expr_reads_name_before_assignment(expr: &ast::Expr, name: &str, assigned: &mut bool) -> bool {
+    match expr {
+        ast::Expr::Ident(ident) => ident.sym.as_ref() == name && !*assigned,
+        ast::Expr::Assign(assign) => {
+            if assignment_target_reads_name_before_assignment(&assign.left, name, assigned) {
+                return true;
+            }
+            if assign.op != ast::AssignOp::Assign
+                && implicit_assignment_target_contains_name(&assign.left, name)
+                && !*assigned
+            {
+                return true;
+            }
+            if expr_reads_name_before_assignment(&assign.right, name, assigned) {
+                return true;
+            }
+            if assign.op == ast::AssignOp::Assign
+                && implicit_assignment_target_contains_name(&assign.left, name)
+            {
+                *assigned = true;
+            }
+            false
+        }
+        ast::Expr::Seq(seq) => seq
+            .exprs
+            .iter()
+            .any(|expr| expr_reads_name_before_assignment(expr, name, assigned)),
+        ast::Expr::Paren(paren) => expr_reads_name_before_assignment(&paren.expr, name, assigned),
+        ast::Expr::TsAs(ts_as) => expr_reads_name_before_assignment(&ts_as.expr, name, assigned),
+        ast::Expr::TsNonNull(ts_nn) => {
+            expr_reads_name_before_assignment(&ts_nn.expr, name, assigned)
+        }
+        ast::Expr::TsTypeAssertion(ts_ta) => {
+            expr_reads_name_before_assignment(&ts_ta.expr, name, assigned)
+        }
+        ast::Expr::TsSatisfies(ts_sat) => {
+            expr_reads_name_before_assignment(&ts_sat.expr, name, assigned)
+        }
+        ast::Expr::Bin(bin) => {
+            expr_reads_name_before_assignment(&bin.left, name, assigned)
+                || expr_reads_name_before_assignment(&bin.right, name, assigned)
+        }
+        ast::Expr::Unary(unary) => expr_reads_name_before_assignment(&unary.arg, name, assigned),
+        ast::Expr::Update(update) => {
+            if let ast::Expr::Ident(ident) = update.arg.as_ref() {
+                ident.sym.as_ref() == name && !*assigned
+            } else {
+                expr_reads_name_before_assignment(&update.arg, name, assigned)
+            }
+        }
+        ast::Expr::Cond(cond) => {
+            if expr_reads_name_before_assignment(&cond.test, name, assigned) {
+                return true;
+            }
+            let mut cons_assigned = *assigned;
+            let mut alt_assigned = *assigned;
+            let cons_reads =
+                expr_reads_name_before_assignment(&cond.cons, name, &mut cons_assigned);
+            let alt_reads = expr_reads_name_before_assignment(&cond.alt, name, &mut alt_assigned);
+            *assigned = cons_assigned && alt_assigned;
+            cons_reads || alt_reads
+        }
+        ast::Expr::Call(call) => {
+            if let ast::Callee::Expr(callee) = &call.callee {
+                if expr_reads_name_before_assignment(callee, name, assigned) {
+                    return true;
+                }
+            }
+            call.args
+                .iter()
+                .any(|arg| expr_reads_name_before_assignment(&arg.expr, name, assigned))
+        }
+        ast::Expr::New(new_expr) => {
+            if expr_reads_name_before_assignment(&new_expr.callee, name, assigned) {
+                return true;
+            }
+            new_expr.args.as_ref().is_some_and(|args| {
+                args.iter()
+                    .any(|arg| expr_reads_name_before_assignment(&arg.expr, name, assigned))
+            })
+        }
+        ast::Expr::Member(member) => {
+            expr_reads_name_before_assignment(&member.obj, name, assigned)
+                || matches!(
+                    &member.prop,
+                    ast::MemberProp::Computed(computed)
+                        if expr_reads_name_before_assignment(&computed.expr, name, assigned)
+                )
+        }
+        ast::Expr::Array(array) => array
+            .elems
+            .iter()
+            .flatten()
+            .any(|elem| expr_reads_name_before_assignment(&elem.expr, name, assigned)),
+        ast::Expr::Object(object) => object.props.iter().any(|prop| match prop {
+            ast::PropOrSpread::Spread(spread) => {
+                expr_reads_name_before_assignment(&spread.expr, name, assigned)
+            }
+            ast::PropOrSpread::Prop(prop) => match prop.as_ref() {
+                ast::Prop::KeyValue(kv) => {
+                    expr_reads_name_before_assignment(&kv.value, name, assigned)
+                }
+                ast::Prop::Assign(assign) => {
+                    expr_reads_name_before_assignment(&assign.value, name, assigned)
+                }
+                _ => false,
+            },
+        }),
+        ast::Expr::Await(await_expr) => {
+            expr_reads_name_before_assignment(&await_expr.arg, name, assigned)
+        }
+        _ => false,
+    }
+}
+
 /// Sloppy-mode simple assignment to an unresolvable reference creates a global
 /// binding. Perry models the binding as a mutable local in the current lowering
 /// context; this helper emits backing `Stmt::Let`s before the containing
@@ -459,6 +719,12 @@ pub(crate) fn predeclare_implicit_assignment_targets(
 
     let mut stmts = Vec::new();
     for name in names {
+        let mut assigned = false;
+        if !ctx.pre_registered_module_var_decls.contains(&name)
+            && expr_reads_name_before_assignment(expr, &name, &mut assigned)
+        {
+            continue;
+        }
         if ctx.lookup_class(&name).is_some() || ctx.lookup_func(&name).is_some() {
             continue;
         }

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -67,7 +67,7 @@ pub fn is_date_cell_addr(addr: usize) -> bool {
     // 0x40000 (past the old 0x1000 floor), any untyped `request.headers.get()`
     // dispatch routed its receiver through `is_date_value` here and segfaulted.
     // Reject the whole small-handle band so this is an exact heap-pointer check.
-    if addr < 0x100000 {
+    if addr < 0x100000 || !crate::object::is_valid_obj_ptr(addr as *const u8) {
         return false;
     }
     unsafe {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -84,6 +84,13 @@ pub(crate) unsafe fn own_data_field_by_name(
     if key.is_null() {
         return None;
     }
+    if obj.is_null() || !is_valid_obj_ptr(obj as *const u8) {
+        return None;
+    }
+    let obj_gc = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*obj_gc).obj_type != crate::gc::GC_TYPE_OBJECT {
+        return None;
+    }
     let keys = (*obj).keys_array;
     let keys_ptr = keys as usize;
     if keys.is_null() || (keys_ptr as u64) >> 48 != 0 || keys_ptr < 0x10000 {
@@ -1845,7 +1852,7 @@ pub extern "C" fn js_object_get_field_by_name(
         };
         // Native-module registry handles live below 0x100000 and can also be
         // POINTER_TAG-boxed; do not walk back to a GcHeader for those.
-        if raw >= 0x100000 && !key.is_null() {
+        if raw >= 0x100000 && !key.is_null() && is_valid_obj_ptr(raw as *const u8) {
             {
                 unsafe {
                     let gc_header = (raw - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
@@ -2283,7 +2290,9 @@ pub extern "C" fn js_object_get_field_by_name(
         // Check GcHeader first (reliable for heap objects), then fallback to ObjectHeader.object_type
         // for static/const objects that don't have GcHeaders.
         // Guard: ensure we can safely read GC_HEADER_SIZE bytes before obj
-        if (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        if (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000
+            || !is_valid_obj_ptr(obj as *const u8)
+        {
             return JSValue::undefined();
         }
         let gc_header =
@@ -3602,14 +3611,20 @@ pub extern "C" fn js_object_get_field_ic_miss(
         // The codegen guard funnels non-OBJECT receivers here too, so this
         // belt-and-braces check keeps the cache from being primed with
         // values that would survive into the inline hot path.
-        let is_object = (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 && {
-            let gc_header =
-                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-            (*gc_header).obj_type == crate::gc::GC_TYPE_OBJECT
-        };
-        let keys = (*obj).keys_array;
+        let is_object = (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000
+            && is_valid_obj_ptr(obj as *const u8)
+            && {
+                let gc_header =
+                    (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                (*gc_header).obj_type == crate::gc::GC_TYPE_OBJECT
+            };
         let is_regular = is_object && (*obj).object_type == crate::error::OBJECT_TYPE_REGULAR;
-        if can_cache && is_regular && !keys.is_null() && (keys as usize) > 0x10000 {
+        if can_cache && is_regular {
+            let keys = (*obj).keys_array;
+            if keys.is_null() || (keys as usize) <= 0x10000 {
+                let value = js_object_get_field_by_name(obj, key);
+                return f64::from_bits(value.bits());
+            }
             let key_count = *(keys as *const u32) as usize;
             let keys_data = (keys as *const u8).add(8) as *const f64;
             let alloc_limit = std::cmp::max((*obj).field_count, 8) as usize;

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -190,7 +190,8 @@ unsafe fn call_method_for_primitive(
         || ret_jsv.is_bool()
         || ret_jsv.is_null()
         || ret_jsv.is_undefined()
-        || ret_jsv.is_bigint();
+        || ret_jsv.is_bigint()
+        || crate::symbol::js_is_symbol(ret) != 0;
     if is_primitive {
         MethodOutcome::Primitive(ret)
     } else {

--- a/tests/test_c262_array_addition_parity.sh
+++ b/tests/test_c262_array_addition_parity.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/c262_array_addition_parity.js" <<'JS'
+var failures = [];
+
+function check(label, actual, expected) {
+  if (actual !== expected) {
+    failures.push(label + ": expected " + String(expected) + ", got " + String(actual));
+  }
+}
+
+function checkThrows(label, ctor, fn) {
+  try {
+    fn();
+    failures.push(label + ": expected " + ctor.name);
+  } catch (e) {
+    if (!(e instanceof ctor) && e.name !== ctor.name) {
+      failures.push(label + ": expected " + ctor.name + ", got " + String(e && e.name));
+    }
+  }
+}
+
+function MyError() {}
+
+var array = [[1, 2], [3], []];
+check("array typeof", typeof array, "object");
+check("array instanceof", array instanceof Array, true);
+check("array toString property", array.toString, Array.prototype.toString);
+check("array length", array.length, 3);
+
+var subarray = array[0];
+check("subarray 0 typeof", typeof subarray, "object");
+check("subarray 0 instanceof", subarray instanceof Array, true);
+check("subarray 0 toString property", subarray.toString, Array.prototype.toString);
+check("subarray 0 length", subarray.length, 2);
+check("subarray 0 value 0", subarray[0], 1);
+check("subarray 0 value 1", subarray[1], 2);
+
+subarray = array[1];
+check("subarray 1 typeof", typeof subarray, "object");
+check("subarray 1 instanceof", subarray instanceof Array, true);
+check("subarray 1 toString property", subarray.toString, Array.prototype.toString);
+check("subarray 1 length", subarray.length, 1);
+check("subarray 1 value 0", subarray[0], 3);
+
+subarray = array[2];
+check("subarray 2 typeof", typeof subarray, "object");
+check("subarray 2 instanceof", subarray instanceof Array, true);
+check("subarray 2 toString property", subarray.toString, Array.prototype.toString);
+check("subarray 2 length", subarray.length, 0);
+check("nested value 0/0", array[0][0], 1);
+check("nested value 0/1", array[0][1], 2);
+check("nested value 1/0", array[1][0], 3);
+
+checkThrows("unresolvable lhs is read before sloppy rhs assignment", ReferenceError, function() {
+  c262_parity_unbound_x + (c262_parity_unbound_x = 1);
+});
+checkThrows("computed assignment target reads before later sloppy assignment", ReferenceError, function() {
+  var o = {};
+  (o[c262_parity_member_x] = 1) + (c262_parity_member_x = 2);
+});
+
+var trace = "";
+checkThrows("rhs ToPrimitive before lhs ToNumeric", MyError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf: function() {
+        trace += "3";
+        return Symbol("1");
+      }
+    };
+  })() + (function() {
+    trace += "2";
+    return {
+      valueOf: function() {
+        trace += "4";
+        throw new MyError();
+      }
+    };
+  })();
+});
+check("rhs ToPrimitive trace", trace, "1234");
+
+trace = "";
+checkThrows("symbol addition throws after both ToPrimitive calls", TypeError, function() {
+  (function() {
+    trace += "1";
+    return {
+      valueOf: function() {
+        trace += "3";
+        return 1;
+      }
+    };
+  })() + (function() {
+    trace += "2";
+    return {
+      valueOf: function() {
+        trace += "4";
+        return Symbol("1");
+      }
+    };
+  })();
+});
+check("symbol TypeError trace", trace, "1234");
+
+if (failures.length !== 0) {
+  throw new Error(failures.join("\n"));
+}
+
+console.log("PASS c262 array addition parity");
+JS
+
+"$PERRY" compile --no-cache "$TMPDIR/c262_array_addition_parity.js" -o "$TMPDIR/c262_array_addition_parity" \
+    >"$TMPDIR/compile.log" 2>&1 || {
+        echo "FAIL: compile failed"
+        sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+        exit 1
+    }
+
+"$TMPDIR/c262_array_addition_parity" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+EXPECTED="PASS c262 array addition parity"
+RUN_OUTPUT="$(cat "$TMPDIR/run.log")"
+if [[ "$RUN_OUTPUT" != "$EXPECTED" ]]; then
+    echo "FAIL: c262 array/addition parity fixture output mismatch"
+    echo "Expected:"
+    echo "$EXPECTED"
+    echo ""
+    echo "Got:"
+    echo "$RUN_OUTPUT"
+    exit 1
+fi
+
+echo "PASS: c262 array/addition parity"


### PR DESCRIPTION
## Summary
- fix nested array property lookup crashes by preventing array payloads and invalid tagged values from being treated as regular object headers
- preserve sloppy unresolvable-reference evaluation order so reads before later implicit assignments still throw `ReferenceError`
- treat Symbol results as primitive during addition ToPrimitive so the expected TypeError/evaluation order is preserved
- add a focused array/addition parity regression script

## Validation
- `cargo fmt`
- `cargo check -p perry-hir -p perry-runtime -p perry -p perry-stdlib`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `cargo test -p perry-hir`
- `cargo test -p perry-runtime --lib -- --test-threads=1`
- `tests/test_c262_array_addition_parity.sh`
- `scripts/test262_subset.py --root vendor/test262 --dir language/expressions/array --sample-cap 1000000` -> pass=33 diff=0 runtime-fail=0 compile-fail=0 skip=0 parity=100%
- `scripts/test262_subset.py --root vendor/test262 --dir language/expressions/addition --sample-cap 1000000` -> pass=38 diff=0 runtime-fail=2 compile-fail=0 skip=0 parity=95%

## Residual addition slice runtime failures
- `language/expressions/addition/S11.6.1_A2.4_T4.js`: `(y = 1) + y` still reports `NaN` instead of `2`
- `language/expressions/addition/S11.6.1_A3.2_T1.2.js`: object/function stringification still reports `[object Object]}`

Compiler-output regression was not run because this change does not touch codegen numeric paths.