### PR TITLE
[codex] Fix Math.random bind compatibility

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -741,7 +741,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &ctor_handle), (I64, &key_raw)],
                     ));
                 }
-                if property == "f16round" {
+                if matches!(property.as_str(), "f16round" | "random") {
                     let math_idx = ctx.strings.intern("Math");
                     let math_bytes_global =
                         format!("@{}", ctx.strings.entry(math_idx).bytes_global);

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -393,6 +393,10 @@ extern "C" fn math_f16round_thunk(
     crate::math::js_math_f16round(value)
 }
 
+extern "C" fn math_random_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    crate::math::js_math_random()
+}
+
 // #2905: thunks for the standard global helper functions. Each coerces its
 // arguments the same way the bare-call HIR lowering does and forwards to the
 // shared runtime helper so a rebound / property-read reference matches Node.
@@ -2008,6 +2012,7 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             }
             if name == "Math" {
                 install_proto_method(ns_obj, "f16round", math_f16round_thunk as *const u8, 1);
+                install_proto_method(ns_obj, "random", math_random_thunk as *const u8, 0);
             }
             crate::value::js_nanbox_pointer(ns_obj as i64)
         };

--- a/tests/test_issue_4120_math_random_bind.sh
+++ b/tests/test_issue_4120_math_random_bind.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/issue_4120.ts" <<'TS'
+const boundRandom = Math.random.bind(Math);
+
+console.log(typeof boundRandom);
+console.log(typeof boundRandom());
+
+let threwTypeError = false;
+try {
+  Function.prototype.bind.call({});
+} catch (error) {
+  threwTypeError = error instanceof TypeError;
+}
+
+console.log(threwTypeError);
+TS
+
+"$PERRY" compile --no-cache --no-auto-optimize "$TMPDIR/issue_4120.ts" -o "$TMPDIR/issue_4120" \
+    >"$TMPDIR/compile.log" 2>&1 || {
+        echo "FAIL: compile failed"
+        sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+        exit 1
+    }
+
+"$TMPDIR/issue_4120" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+EXPECTED=$'function\nnumber\ntrue'
+ACTUAL="$(cat "$TMPDIR/run.log")"
+if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+    echo "FAIL: unexpected output"
+    echo "expected:"
+    printf '%s\n' "$EXPECTED" | sed 's/^/    /'
+    echo "actual:"
+    printf '%s\n' "$ACTUAL" | sed 's/^/    /'
+    exit 1
+fi
+
+echo "PASS: Math.random.bind compatibility"


### PR DESCRIPTION
## Summary

- install a closure-backed `Math.random` method on the `Math` namespace
- route `Math.random` value reads through the populated global `Math` object, matching the existing `f16round` path
- add a compile/run regression for `Math.random.bind(Math)` and the non-function `Function.prototype.bind.call({})` TypeError path

## Root Cause

Valid JS `Math.random.bind(Math)` was throwing `TypeError: Bind must be called on a function`. Direct `Math.random()` calls are lowered as a Perry intrinsic, but reading `Math.random` as a value fell through Perry's collapsed builtin-global property path instead of producing a real callable closure. That made `Function.prototype.bind` see a non-callable receiver.

This blocked generic Perry-native OpenTUI startup in `createRuntimeHost()` because OpenTUI calls `Math.random.bind(Math)`.

## Validation

- `cargo fmt`
- `cargo build --release -p perry`
- `cargo build --release -p perry-runtime`
- `cargo build --release -p perry-stdlib`
- `tests/test_issue_4120_math_random_bind.sh`
- exact repro now prints `function`
- generic OpenTUI native smoke passed with the fresh Perry binary and full stdlib, observing `perry-native: idle -> perry-native: pressed:x`

This is runtime/function-binding compatibility only. It does not claim OpenTUI/OpenCode migration completion.
