### PR TITLE
[codex] expose crypto KeyObject shape for secret keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1107 — feat(crypto): expose KeyObject shape for secret keys (#4132)
+
+Folds in external contributor PR #4132: exposes the `crypto` `KeyObject` shape for secret keys — `createSecretKey(...)` returns a `KeyObject` with the expected `type`/`symmetricKeySize`/`asymmetricKeyType` surface and `KeyObject`/`instanceof` branding. Adds `crates/perry-runtime/src/object/native_module_crypto_key_object.rs` plus supporting dispatch wiring and a node-suite fixture. Merged on top of current `main`; only the auto-generated doc count/coverage lines conflicted and are reconciled by the end-of-batch manifest regen.
+
 ## v0.5.1106 — fix(child_process): fork lifecycle exports (#4110)
 
 Folds in external contributor PR #4110: rounds out the `child_process` fork lifecycle surface — `subprocess[Symbol.dispose]`, the `fork(...).send(...)` callback firing once the IPC channel has closed, and the forked-child object shape. Adds the supporting runtime wiring in `crates/perry-runtime/src/child_process/` plus node-suite parity fixtures. Merged on top of current `main`; only the auto-generated doc count/coverage lines conflicted and were regenerated from the manifest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1106
+**Current Version:** 0.5.1107
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1106"
+version = "0.5.1107"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "bytes",
  "h2",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5316,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "bson",
  "futures-util",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "image",
@@ -5419,14 +5419,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "brotli",
  "flate2",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "base64",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5638,14 +5638,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "itoa",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "block2",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "block2",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1106"
+version = "0.5.1107"
 
 [[package]]
 name = "perry-ui-test"
@@ -5734,11 +5734,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1106"
+version = "0.5.1107"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "block2",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "block2",
@@ -5770,7 +5770,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "block2",
  "libc",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "libc",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1106"
+version = "0.5.1107"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1106"
+version = "0.5.1107"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2858,6 +2858,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // #1367: X509Certificate — `new X509Certificate(pem|der)` + read-only
     // subject/issuer/validFrom/validTo/serialNumber/fingerprint/ca props.
     class("crypto", "X509Certificate"),
+    // #2565: public `KeyObject` constructor export. Runtime exposes the
+    // class-like function and the supported secret-key `KeyObject.from`.
+    class("crypto", "KeyObject"),
     // Legacy Netscape SPKAC helper namespace:
     // crypto.Certificate.{verifySpkac,exportPublicKey,exportChallenge}.
     property("crypto", "Certificate"),

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -158,6 +158,17 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
         {
             return f64::from_bits(crate::value::TAG_TRUE);
         }
+        if module == "crypto" && method == "KeyObject" {
+            let addr = value_addr(value);
+            return if addr != 0
+                && (crate::buffer::is_secret_key(addr)
+                    || crate::buffer::asymmetric_key_meta(addr).is_some())
+            {
+                f64::from_bits(crate::value::TAG_TRUE)
+            } else {
+                f64::from_bits(TAG_FALSE)
+            };
+        }
         if module == "perf_hooks" {
             let class_id = match method.as_str() {
                 "Performance" => crate::perf_hooks::CLASS_ID_PERFORMANCE,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -42,6 +42,8 @@ mod instanceof;
 mod namespace_create;
 mod native_call_method;
 mod native_module;
+mod native_module_crypto_key_object;
+mod native_module_crypto_random;
 mod native_module_dispatch;
 mod native_module_stream;
 mod object_literal_ops;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -3068,6 +3068,9 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
     if export_module_name == "assert" && property_name == "Assert" {
         attach_assert_prototype(value);
     }
+    if export_module_name == "crypto" && property_name == "KeyObject" {
+        attach_crypto_key_object_shape(closure_addr, value);
+    }
 
     // `PerformanceObserver.supportedEntryTypes` is a static array on the
     // constructor. `PerformanceObserver` is a function value (a bound-method
@@ -3337,6 +3340,8 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         // #3726: `crypto.Cipheriv` / `crypto.Decipheriv` constructor exports —
         // `(cipher, key, iv, options)` arity matches Node's length 4.
         ("crypto", "Cipheriv" | "Decipheriv") => Some(4),
+        ("crypto", "KeyObject") => Some(2),
+        ("crypto.KeyObject", "from") => Some(1),
         ("url", "Url") => Some(0),
         ("url", "resolveObject") => Some(2),
         ("process", "setSourceMapsEnabled") => Some(1),
@@ -3900,6 +3905,38 @@ pub(crate) fn is_buffer_constructor_value(value: f64) -> bool {
         let cached = slot.get();
         cached != 0 && cached == value.to_bits()
     })
+}
+
+fn attach_crypto_key_object_shape(closure_addr: usize, constructor_value: f64) {
+    let from_value = bound_native_callable_export_value("crypto.KeyObject", "from");
+    crate::closure::closure_set_dynamic_prop(closure_addr, "from", from_value);
+    super::set_builtin_property_attrs(
+        closure_addr,
+        "from".to_string(),
+        super::PropertyAttrs::new(true, false, true),
+    );
+
+    let proto = js_object_alloc(0, 0);
+    if proto.is_null() {
+        return;
+    }
+    let constructor = "constructor";
+    let constructor_key =
+        crate::string::js_string_from_bytes(constructor.as_ptr(), constructor.len() as u32);
+    js_object_set_field_by_name(proto, constructor_key, constructor_value);
+    super::set_builtin_property_attrs(
+        proto as usize,
+        constructor.to_string(),
+        super::PropertyAttrs::new(true, false, true),
+    );
+
+    let proto_value = crate::value::js_nanbox_pointer(proto as i64);
+    crate::closure::closure_set_dynamic_prop(closure_addr, "prototype", proto_value);
+    super::set_builtin_property_attrs(
+        closure_addr,
+        "prototype".to_string(),
+        super::PropertyAttrs::new(true, false, false),
+    );
 }
 
 fn native_string_value(value: &str) -> f64 {
@@ -4930,6 +4967,10 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             // callable functions so `typeof crypto.Cipheriv === "function"`.
             | ("crypto", "Cipheriv")
             | ("crypto", "Decipheriv")
+            // #2565: public KeyObject constructor shape plus the supported
+            // secret-key `KeyObject.from(CryptoKey)` static helper.
+            | ("crypto", "KeyObject")
+            | ("crypto.KeyObject", "from")
             | ("crypto", "createSecretKey")
             | ("crypto.Certificate", "verifySpkac")
             | ("crypto.Certificate", "exportPublicKey")

--- a/crates/perry-runtime/src/object/native_module_crypto_key_object.rs
+++ b/crates/perry-runtime/src/object/native_module_crypto_key_object.rs
@@ -1,0 +1,44 @@
+use crate::JSValue;
+
+fn value_addr(value: f64) -> usize {
+    let bits = value.to_bits();
+    if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    }
+}
+
+fn invalid_key(value: f64) -> ! {
+    let message = format!(
+        "The \"key\" argument must be an instance of CryptoKey. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+pub(super) unsafe fn key_object_from(value: f64) -> f64 {
+    let addr = value_addr(value);
+    let Some((_algo, _hash, kind, _extractable, _usages)) = crate::buffer::crypto_key_meta(addr)
+    else {
+        invalid_key(value);
+    };
+    if kind != 1 || !crate::buffer::is_registered_buffer(addr) {
+        invalid_key(value);
+    }
+
+    let src = addr as *const crate::buffer::BufferHeader;
+    let len = (*src).length as usize;
+    let out = crate::buffer::buffer_alloc(len as u32);
+    if !out.is_null() {
+        std::ptr::copy_nonoverlapping(
+            crate::buffer::buffer_data(src),
+            crate::buffer::buffer_data_mut(out),
+            len,
+        );
+        (*out).length = len as u32;
+        crate::buffer::mark_as_uint8array(out as usize);
+        crate::buffer::mark_as_secret_key(out as usize);
+    }
+    f64::from_bits(JSValue::pointer(out as *const u8).bits())
+}

--- a/crates/perry-runtime/src/object/native_module_crypto_random.rs
+++ b/crates/perry-runtime/src/object/native_module_crypto_random.rs
@@ -1,0 +1,110 @@
+use crate::JSValue;
+
+fn value_addr(value: f64) -> usize {
+    let bits = value.to_bits();
+    if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    }
+}
+
+fn number_arg(value: f64, name: &str) -> Option<f64> {
+    let js = JSValue::from_bits(value.to_bits());
+    if js.is_undefined() {
+        return None;
+    }
+    if !js.is_number() && !js.is_int32() {
+        let message = format!(
+            "The \"{}\" argument must be of type number. Received {}",
+            name,
+            crate::fs::validate::describe_received(value)
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    Some(if js.is_int32() {
+        js.as_int32() as f64
+    } else {
+        value
+    })
+}
+
+fn range(total: usize, offset_bits: f64, size_bits: f64) -> (usize, usize) {
+    let offset = match number_arg(offset_bits, "offset") {
+        Some(n) if n.is_finite() && n >= 0.0 && n <= total as f64 => n as usize,
+        Some(n) => {
+            let message = format!(
+                "The value of \"offset\" is out of range. It must be >= 0 && <= {}. Received {}",
+                total, n
+            );
+            crate::fs::validate::throw_range_error_with_code(&message);
+        }
+        None => 0,
+    };
+    let size = match number_arg(size_bits, "size") {
+        Some(n) if n.is_finite() && n >= 0.0 && n <= i32::MAX as f64 => n as usize,
+        Some(n) => {
+            let message = format!(
+                "The value of \"size\" is out of range. It must be >= 0 && <= 2147483647. Received {}",
+                n
+            );
+            crate::fs::validate::throw_range_error_with_code(&message);
+        }
+        None => total.saturating_sub(offset),
+    };
+    let end = offset.saturating_add(size);
+    if end > total {
+        let message = format!(
+            "The value of \"size + offset\" is out of range. It must be <= {}. Received {}",
+            total, end
+        );
+        crate::fs::validate::throw_range_error_with_code(&message);
+    }
+    (offset, size)
+}
+
+fn invalid_buf(value: f64) -> ! {
+    let message = format!(
+        "The \"buf\" argument must be an instance of Buffer, TypedArray, DataView, or ArrayBuffer. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+pub(super) unsafe fn random_fill_sync(target: f64, offset_bits: f64, size_bits: f64) -> f64 {
+    use rand::RngCore;
+
+    let addr = value_addr(target);
+    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let ta = addr as *mut crate::typedarray::TypedArrayHeader;
+        if let Some(data) = crate::typedarray::typed_array_bytes_mut(ta) {
+            let elem_size = (*ta).elem_size as usize;
+            let len = if elem_size == 0 {
+                0
+            } else {
+                data.len() / elem_size
+            };
+            let (start_elem, count_elem) = range(len, offset_bits, size_bits);
+            let start = start_elem.saturating_mul(elem_size);
+            let end = start
+                .saturating_add(count_elem.saturating_mul(elem_size))
+                .min(data.len());
+            if end > start {
+                rand::thread_rng().fill_bytes(&mut data[start..end]);
+            }
+            return target;
+        }
+        invalid_buf(target);
+    }
+    if crate::buffer::is_registered_buffer(addr) {
+        let buf = addr as *mut crate::buffer::BufferHeader;
+        let total = (*buf).length as usize;
+        let (start, count) = range(total, offset_bits, size_bits);
+        if count > 0 {
+            let data = crate::buffer::buffer_data_mut(buf);
+            rand::thread_rng().fill_bytes(std::slice::from_raw_parts_mut(data.add(start), count));
+        }
+        return target;
+    }
+    invalid_buf(target);
+}

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -7,115 +7,6 @@
 
 use super::*;
 
-fn crypto_dispatch_value_addr(value: f64) -> usize {
-    let bits = value.to_bits();
-    if (bits >> 48) >= 0x7FF8 {
-        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
-    } else {
-        bits as usize
-    }
-}
-
-fn crypto_random_fill_number_arg(value: f64, name: &str) -> Option<f64> {
-    let js = JSValue::from_bits(value.to_bits());
-    if js.is_undefined() {
-        return None;
-    }
-    if !js.is_number() && !js.is_int32() {
-        let message = format!(
-            "The \"{}\" argument must be of type number. Received {}",
-            name,
-            crate::fs::validate::describe_received(value)
-        );
-        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
-    }
-    Some(if js.is_int32() {
-        js.as_int32() as f64
-    } else {
-        value
-    })
-}
-
-fn crypto_random_fill_range(total: usize, offset_bits: f64, size_bits: f64) -> (usize, usize) {
-    let offset = match crypto_random_fill_number_arg(offset_bits, "offset") {
-        Some(n) if n.is_finite() && n >= 0.0 && n <= total as f64 => n as usize,
-        Some(n) => {
-            let message = format!(
-                "The value of \"offset\" is out of range. It must be >= 0 && <= {}. Received {}",
-                total, n
-            );
-            crate::fs::validate::throw_range_error_with_code(&message);
-        }
-        None => 0,
-    };
-    let size = match crypto_random_fill_number_arg(size_bits, "size") {
-        Some(n) if n.is_finite() && n >= 0.0 && n <= i32::MAX as f64 => n as usize,
-        Some(n) => {
-            let message = format!(
-                "The value of \"size\" is out of range. It must be >= 0 && <= 2147483647. Received {}",
-                n
-            );
-            crate::fs::validate::throw_range_error_with_code(&message);
-        }
-        None => total.saturating_sub(offset),
-    };
-    let end = offset.saturating_add(size);
-    if end > total {
-        let message = format!(
-            "The value of \"size + offset\" is out of range. It must be <= {}. Received {}",
-            total, end
-        );
-        crate::fs::validate::throw_range_error_with_code(&message);
-    }
-    (offset, size)
-}
-
-fn crypto_random_fill_invalid_buf(value: f64) -> ! {
-    let message = format!(
-        "The \"buf\" argument must be an instance of Buffer, TypedArray, DataView, or ArrayBuffer. Received {}",
-        crate::fs::validate::describe_received(value)
-    );
-    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
-}
-
-unsafe fn crypto_random_fill_sync_dispatch(target: f64, offset_bits: f64, size_bits: f64) -> f64 {
-    use rand::RngCore;
-
-    let addr = crypto_dispatch_value_addr(target);
-    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
-        let ta = addr as *mut crate::typedarray::TypedArrayHeader;
-        if let Some(data) = crate::typedarray::typed_array_bytes_mut(ta) {
-            let elem_size = (*ta).elem_size as usize;
-            let len = if elem_size == 0 {
-                0
-            } else {
-                data.len() / elem_size
-            };
-            let (start_elem, count_elem) = crypto_random_fill_range(len, offset_bits, size_bits);
-            let start = start_elem.saturating_mul(elem_size);
-            let end = start
-                .saturating_add(count_elem.saturating_mul(elem_size))
-                .min(data.len());
-            if end > start {
-                rand::thread_rng().fill_bytes(&mut data[start..end]);
-            }
-            return target;
-        }
-        crypto_random_fill_invalid_buf(target);
-    }
-    if crate::buffer::is_registered_buffer(addr) {
-        let buf = addr as *mut crate::buffer::BufferHeader;
-        let total = (*buf).length as usize;
-        let (start, count) = crypto_random_fill_range(total, offset_bits, size_bits);
-        if count > 0 {
-            let data = crate::buffer::buffer_data_mut(buf);
-            rand::thread_rng().fill_bytes(std::slice::from_raw_parts_mut(data.add(start), count));
-        }
-        return target;
-    }
-    crypto_random_fill_invalid_buf(target);
-}
-
 /// #3712: coerce a NaN-boxed value to an owned UTF-8 `String`, matching the
 /// `${val}` coercion Node applies before building HTTP error messages.
 unsafe fn http_value_to_owned_string(v: f64) -> String {
@@ -733,11 +624,18 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("process", "cpuUsage") => crate::process::js_process_cpu_usage(arg(0)),
         // ── crypto module ──
         ("crypto", "randomFillSync") if args_len >= 1 => {
-            crypto_random_fill_sync_dispatch(arg(0), arg(1), arg(2))
+            super::native_module_crypto_random::random_fill_sync(arg(0), arg(1), arg(2))
+        }
+        ("crypto", "KeyObject") => crate::fs::validate::throw_type_error_with_code(
+            "Class constructor KeyObject cannot be invoked without 'new'",
+            "ERR_CONSTRUCT_CALL_REQUIRED",
+        ),
+        ("crypto.KeyObject", "from") => {
+            super::native_module_crypto_key_object::key_object_from(arg(0))
         }
         ("crypto.webcrypto", "getRandomValues") if args_len >= 1 => {
             let undefined = f64::from_bits(JSValue::undefined().bits());
-            crypto_random_fill_sync_dispatch(arg(0), undefined, undefined)
+            super::native_module_crypto_random::random_fill_sync(arg(0), undefined, undefined)
         }
         // node:vm (createContext via #4050; rest #4079/#4087)
         ("vm", m) => crate::node_vm::dispatch_vm_method(m, arg(0), arg(1), arg(2)),

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -868,6 +868,8 @@ declare module "crypto" {
   /** stdlib */
   export class ECDH { [key: string]: any; }
   /** stdlib */
+  export class KeyObject { [key: string]: any; }
+  /** stdlib */
   export class X509Certificate { [key: string]: any; }
   /** stdlib */
   export const Certificate: any;

--- a/test-parity/node-suite/crypto/key-object/keyobject-class-from.ts
+++ b/test-parity/node-suite/crypto/key-object/keyobject-class-from.ts
@@ -1,0 +1,50 @@
+import * as crypto from "node:crypto";
+import { KeyObject as NamedKeyObject } from "node:crypto";
+import { Buffer } from "node:buffer";
+
+function report(label: string, fn: () => unknown) {
+  try {
+    console.log(`${label}:`, fn());
+  } catch (err: any) {
+    console.log(`${label}:`, "err", err.name, err.code ?? "");
+  }
+}
+
+async function reportAsync(label: string, fn: () => Promise<unknown>) {
+  try {
+    console.log(`${label}:`, await fn());
+  } catch (err: any) {
+    console.log(`${label}:`, "err", err.name, err.code ?? "");
+  }
+}
+
+const KeyObject = (crypto as any).KeyObject;
+const secret = crypto.createSecretKey(Buffer.from("00112233445566778899aabbccddeeff", "hex"));
+
+console.log("typeof KeyObject:", typeof KeyObject);
+console.log("typeof KeyObject.from:", typeof (KeyObject && KeyObject.from));
+console.log("KeyObject length:", KeyObject.length);
+console.log("KeyObject.from length:", KeyObject.from.length);
+console.log("KeyObject prototype object:", typeof KeyObject.prototype);
+console.log("KeyObject prototype constructor:", KeyObject.prototype.constructor === KeyObject);
+console.log("named KeyObject identity:", NamedKeyObject === KeyObject);
+report("secret instanceof KeyObject", () => secret instanceof KeyObject);
+console.log("secret type:", secret.type);
+console.log("secret export hex:", secret.export().toString("hex"));
+
+await reportAsync("from CryptoKey", async () => {
+  const cryptoKey = await crypto.webcrypto.subtle.importKey(
+    "raw",
+    secret.export(),
+    { name: "HMAC", hash: "SHA-256" },
+    true,
+    ["sign"],
+  );
+  const keyObject = KeyObject.from(cryptoKey);
+  return `${keyObject.type} ${keyObject instanceof KeyObject} ${keyObject.export().toString("hex")}`;
+});
+
+report("from undefined", () => KeyObject.from(undefined));
+report("from null", () => KeyObject.from(null));
+report("from object", () => KeyObject.from({}));
+report("from KeyObject", () => KeyObject.from(secret));


### PR DESCRIPTION
## Summary

Addresses a scoped part of #2565 by exposing the public `node:crypto` `KeyObject` class shape for supported secret-key paths.

- Adds `crypto.KeyObject` to the API manifest and native callable export table.
- Adds `KeyObject.from(CryptoKey)` for supported secret `CryptoKey` values by copying raw key bytes into a secret `KeyObject` surrogate.
- Makes existing secret/asymmetric key surrogates satisfy `instanceof crypto.KeyObject`.
- Splits the existing crypto random fill dispatch helper into a small helper module to keep Rust source file size under the project limit.

Non-goals for this slice: asymmetric `KeyObject#toCryptoKey()`, encrypted PEM/DER inputs, and the broader X509 key graph.

## Validation

- `cargo check -p perry-runtime -p perry-stdlib -p perry-api-manifest`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter keyobject-class-from`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter get-random-values`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
