### PR TITLE
[codex] worker_threads BroadcastChannel global delivery

### DIFF
--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -181,6 +181,8 @@ fn global_member_constructor_name(
             "URLPattern" => Some("URLPattern"),
             "TextEncoder" => Some("TextEncoder"),
             "TextDecoder" => Some("TextDecoder"),
+            "MessageChannel" => Some("MessageChannel"),
+            "BroadcastChannel" => Some("BroadcastChannel"),
             _ => None,
         };
     }
@@ -196,6 +198,24 @@ fn global_member_constructor_name(
         }
     }
     None
+}
+
+fn is_worker_messaging_constructor_name(name: &str) -> bool {
+    matches!(name, "MessageChannel" | "BroadcastChannel")
+}
+
+fn lower_worker_messaging_new(
+    ctx: &mut LoweringContext,
+    class_name: &str,
+    args: Option<&[ast::ExprOrSpread]>,
+) -> Result<Expr> {
+    Ok(Expr::NativeMethodCall {
+        module: "worker_threads".to_string(),
+        class_name: None,
+        object: None,
+        method: class_name.to_string(),
+        args: lower_optional_args(ctx, args)?,
+    })
 }
 
 fn lower_worker_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> Result<Expr> {
@@ -244,6 +264,9 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             if let Some(class_name) =
                 global_member_constructor_name(ctx, obj_name, prop_ident.sym.as_ref())
             {
+                if is_worker_messaging_constructor_name(class_name) {
+                    return lower_worker_messaging_new(ctx, class_name, new_expr.args.as_deref());
+                }
                 if let Some(expr) =
                     lower_url_encoding_constructor(ctx, class_name, new_expr.args.as_deref())?
                 {
@@ -447,29 +470,12 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     Some((module_name, _)) => is_worker_threads_module_name(module_name),
                     None => false,
                 };
-            if is_worker_threads_module
-                && matches!(
+            if is_worker_threads_module && is_worker_messaging_constructor_name(&prop_ident.sym) {
+                return lower_worker_messaging_new(
+                    ctx,
                     prop_ident.sym.as_ref(),
-                    "MessageChannel" | "BroadcastChannel"
-                )
-            {
-                let args = new_expr
-                    .args
-                    .as_ref()
-                    .map(|args| {
-                        args.iter()
-                            .map(|a| lower_expr(ctx, &a.expr))
-                            .collect::<Result<Vec<_>>>()
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-                return Ok(Expr::NativeMethodCall {
-                    module: "worker_threads".to_string(),
-                    class_name: None,
-                    object: None,
-                    method: prop_ident.sym.to_string(),
-                    args,
-                });
+                    new_expr.args.as_deref(),
+                );
             }
             if is_worker_threads_module && prop_ident.sym.as_ref() == "Worker" {
                 return lower_worker_new(ctx, new_expr);
@@ -649,23 +655,13 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 Some(("worker_threads", Some("MessageChannel")))
                     | Some(("worker_threads", Some("BroadcastChannel")))
             ) {
-                let args = new_expr
-                    .args
-                    .as_ref()
-                    .map(|args| {
-                        args.iter()
-                            .map(|a| lower_expr(ctx, &a.expr))
-                            .collect::<Result<Vec<_>>>()
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-                return Ok(Expr::NativeMethodCall {
-                    module: "worker_threads".to_string(),
-                    class_name: None,
-                    object: None,
-                    method: class_name,
-                    args,
-                });
+                return lower_worker_messaging_new(ctx, &class_name, new_expr.args.as_deref());
+            }
+
+            if is_worker_messaging_constructor_name(&class_name)
+                && ctx.lookup_local(&class_name).is_none()
+            {
+                return lower_worker_messaging_new(ctx, &class_name, new_expr.args.as_deref());
             }
 
             let inspector_session_module = ctx.lookup_native_module(&class_name).and_then(

--- a/crates/perry-hir/tests/node_named_export_hygiene.rs
+++ b/crates/perry-hir/tests/node_named_export_hygiene.rs
@@ -219,3 +219,27 @@ fn worker_threads_post_message_call_keeps_property_call_shape() {
         "postMessage() should remain a normal call of worker_threads.postMessage: {debug}"
     );
 }
+
+#[test]
+fn global_worker_messaging_constructors_lower_to_worker_threads() {
+    let module = lower_result(
+        r#"
+        const a = new BroadcastChannel("a");
+        const b = new globalThis.BroadcastChannel("b");
+        const c = new MessageChannel();
+        const d = new globalThis.MessageChannel();
+        console.log(a, b, c, d);
+    "#,
+    )
+    .expect("global messaging constructors should lower");
+
+    let debug = format!("{module:#?}");
+    let broadcast_count = debug.matches("method: \"BroadcastChannel\"").count();
+    let message_channel_count = debug.matches("method: \"MessageChannel\"").count();
+    assert!(
+        debug.contains("module: \"worker_threads\"")
+            && broadcast_count >= 2
+            && message_channel_count >= 2,
+        "global messaging constructors should route through worker_threads native constructors: {debug}"
+    );
+}

--- a/crates/perry-runtime/src/messaging.rs
+++ b/crates/perry-runtime/src/messaging.rs
@@ -5,6 +5,41 @@ use crate::closure::{js_closure_alloc, js_register_closure_arity, ClosureHeader}
 use crate::object::{self, ObjectHeader};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
+use std::ptr::null_mut;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+type MessageChannelFactory = extern "C" fn() -> f64;
+type BroadcastChannelFactory = extern "C" fn(f64) -> f64;
+
+static WORKER_THREADS_MESSAGE_CHANNEL_FACTORY: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static WORKER_THREADS_BROADCAST_CHANNEL_FACTORY: AtomicPtr<()> = AtomicPtr::new(null_mut());
+
+#[no_mangle]
+pub extern "C" fn js_register_worker_threads_messaging_constructors(
+    message_channel: MessageChannelFactory,
+    broadcast_channel: BroadcastChannelFactory,
+) {
+    WORKER_THREADS_MESSAGE_CHANNEL_FACTORY.store(message_channel as *mut (), Ordering::Release);
+    WORKER_THREADS_BROADCAST_CHANNEL_FACTORY.store(broadcast_channel as *mut (), Ordering::Release);
+}
+
+fn worker_threads_message_channel_factory() -> Option<MessageChannelFactory> {
+    let ptr = WORKER_THREADS_MESSAGE_CHANNEL_FACTORY.load(Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute(ptr) })
+    }
+}
+
+fn worker_threads_broadcast_channel_factory() -> Option<BroadcastChannelFactory> {
+    let ptr = WORKER_THREADS_BROADCAST_CHANNEL_FACTORY.load(Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute(ptr) })
+    }
+}
 
 fn js_undefined() -> f64 {
     f64::from_bits(JSValue::undefined().bits())
@@ -143,6 +178,9 @@ fn message_port_object() -> *mut ObjectHeader {
 
 #[no_mangle]
 pub extern "C" fn js_message_channel_new() -> f64 {
+    if let Some(factory) = worker_threads_message_channel_factory() {
+        return factory();
+    }
     let obj = object::js_object_alloc(0, 0);
     set_object_prototype(obj, constructor_prototype("MessageChannel"));
     set_field(obj, "constructor", get_global_constructor("MessageChannel"));
@@ -159,6 +197,9 @@ pub(crate) extern "C" fn js_message_channel_constructor_call_error(
 
 #[no_mangle]
 pub extern "C" fn js_broadcast_channel_new(name: f64) -> f64 {
+    if let Some(factory) = worker_threads_broadcast_channel_factory() {
+        return factory(name);
+    }
     let obj = object::js_object_alloc(0, 0);
     set_object_prototype(obj, constructor_prototype("BroadcastChannel"));
     set_field(

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -2274,6 +2274,10 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
             thread_name: extern "C" fn() -> f64,
             resource_limits: extern "C" fn() -> f64,
         );
+        fn js_register_worker_threads_messaging_constructors(
+            message_channel: extern "C" fn() -> f64,
+            broadcast_channel: extern "C" fn(f64) -> f64,
+        );
     }
     js_register_handle_method_dispatch(js_handle_method_dispatch);
     js_register_handle_property_dispatch(js_handle_property_dispatch);
@@ -2304,6 +2308,10 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
         crate::worker_threads::js_worker_threads_parent_port,
         crate::worker_threads::js_worker_threads_thread_name,
         crate::worker_threads::js_worker_threads_resource_limits,
+    );
+    js_register_worker_threads_messaging_constructors(
+        crate::worker_threads::js_worker_threads_message_channel_new,
+        crate::worker_threads::js_worker_threads_broadcast_channel_new,
     );
     // #1577: route captured-then-called `crypto.*` methods (which reach the
     // runtime's native-module dispatch) back to the stdlib crypto impls.

--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -1434,6 +1434,14 @@ extern "C" fn broadcast_close(closure: *const ClosureHeader) -> f64 {
     js_undefined()
 }
 
+extern "C" fn broadcast_ref_or_unref(closure: *const ClosureHeader) -> f64 {
+    let channel_id = port_id_from_closure(closure);
+    BROADCAST_CHANNELS.with(|channels| match channels.borrow().get(&channel_id) {
+        Some(state) => f64::from_bits(state.object_bits),
+        None => js_undefined(),
+    })
+}
+
 extern "C" fn broadcast_add_event_listener(
     closure: *const ClosureHeader,
     event: f64,
@@ -1509,17 +1517,12 @@ pub extern "C" fn js_worker_threads_broadcast_channel_new(name: f64) -> f64 {
     set_object_field(
         obj,
         "ref",
-        closure_value(worker_threads_noop0 as *const u8, 0),
+        port_bound_closure(broadcast_ref_or_unref as *const u8, 0, id),
     );
     set_object_field(
         obj,
         "unref",
-        closure_value(worker_threads_noop0 as *const u8, 0),
-    );
-    set_object_field(
-        obj,
-        "hasRef",
-        closure_value(worker_threads_has_ref as *const u8, 0),
+        port_bound_closure(broadcast_ref_or_unref as *const u8, 0, id),
     );
     set_object_field(
         obj,
@@ -1970,6 +1973,8 @@ fn dispatch_worker_event(worker_id: u64, event: &str, arg: Option<f64>) {
 // [[project_auto_optimize_keepalive_3320]].
 #[used]
 static KEEP_WT_MESSAGE_CHANNEL_NEW: extern "C" fn() -> f64 = js_worker_threads_message_channel_new;
+#[used]
+static KEEP_WT_BROADCAST_NEW: extern "C" fn(f64) -> f64 = js_worker_threads_broadcast_channel_new;
 #[used]
 static KEEP_WT_RECEIVE_MESSAGE_ON_PORT: extern "C" fn(f64) -> f64 =
     js_worker_threads_receive_message_on_port;

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -32,7 +32,7 @@ Issue #3598 ("Node API compatibility epic: globalThis and Web-compatible Node gl
 
 This branch intentionally does **not** cherry-pick or stack those feature PRs. The generated manifest surfaces on current `origin/main` were audited with `./scripts/regen_api_docs.sh`; `docs/src/api/reference.md` and `docs/api/perry.d.ts` produced no diff, and `crates/perry-api-manifest/src/entries.rs` was not changed. That means this closure PR does not truthfully decrement the generated API/type counts for globals that only exist on the open feature branches.
 
-Residual #3598 work that should remain tracked by child issues includes true WeakRef/FinalizationRegistry weak semantics, BroadcastChannel delivery semantics, deeper FormData/File/Blob/multipart/body parity, full WebAssembly Instance/Memory/Table/Global/streaming execution surface beyond the current host-shim shape, and full TextEncoderStream/TextDecoderStream transform behavior.
+Residual #3598 work that should remain tracked by child issues includes true WeakRef/FinalizationRegistry weak semantics, deeper FormData/File/Blob/multipart/body parity, full WebAssembly Instance/Memory/Table/Global/streaming execution surface beyond the current host-shim shape, and full TextEncoderStream/TextDecoderStream transform behavior.
 
 ## Whole-module gaps
 
@@ -2078,8 +2078,8 @@ The counts above are the last generated parity-gap counts on this branch. They w
 | `AbortSignal.timeout(ms)` | `ffi:js_abort_signal_timeout` |
 | `new TextEncoder()` | `expr:TextEncoderNew` |
 | `new TextDecoder(label?, options?)` | `expr:TextDecoderNew` |
-| `new MessageChannel()` | `rt:js_message_channel_new` |
-| `new BroadcastChannel(name)` | `rt:js_broadcast_channel_new` |
+| `new MessageChannel()` | `stdlib:js_worker_threads_message_channel_new` via global constructor registration |
+| `new BroadcastChannel(name)` | `stdlib:js_worker_threads_broadcast_channel_new` via global constructor registration |
 | `globalThis.WebSocket` / `new WebSocket(url, protocols?)` | `ffi:js_ws_connect` + global constructor shape |
 | `crypto.getRandomValues(typedArray)` | `manifest:crypto.getRandomValues` |
 | `crypto.randomUUID()` | `expr:CryptoRandomUUID` |

--- a/test-parity/node-suite/worker_threads/message-channel/broadcast-delivery.ts
+++ b/test-parity/node-suite/worker_threads/message-channel/broadcast-delivery.ts
@@ -6,32 +6,52 @@ import {
 const sender = new BroadcastChannel("perry-broadcast");
 const listener = new BroadcastChannel("perry-broadcast");
 const syncReceiver = new BroadcastChannel("perry-broadcast");
+const globalSender = new globalThis.BroadcastChannel("perry-global-broadcast");
+const globalListener = new globalThis.BroadcastChannel("perry-global-broadcast");
 
 let delivered = 0;
+const observed: Record<string, string> = {};
 const finish = () => {
   delivered += 1;
-  if (delivered !== 2) {
+  if (delivered !== 3) {
     return;
   }
+  console.log(observed.handler);
+  console.log(observed.event);
+  console.log(observed.global);
   const afterEvent = receiveMessageOnPort(syncReceiver);
   console.log("broadcast after event:", afterEvent ? afterEvent.message : afterEvent);
   setTimeout(() => {
     sender.close();
     listener.close();
     syncReceiver.close();
+    globalSender.close();
+    globalListener.close();
   }, 25);
 };
 
 listener.onmessage = (event: any) => {
-  console.log("broadcast handler:", event.type, event.data, event.target === listener);
+  observed.handler = `broadcast handler: ${event.type} ${event.data} ${event.target === listener}`;
   finish();
 };
 listener.addEventListener("message", (event: any) => {
-  console.log("broadcast event:", event.type, event.data, event.target === listener);
+  observed.event = `broadcast event: ${event.type} ${event.data} ${event.target === listener}`;
   finish();
 });
+globalListener.onmessage = (event: any) => {
+  observed.global = `global broadcast handler: ${event.type} ${event.data} ${event.target === globalListener}`;
+  finish();
+};
+
+console.log(
+  "global broadcast refs:",
+  globalListener.ref() === globalListener,
+  globalListener.unref() === globalListener,
+  typeof (globalListener as any).hasRef,
+);
 
 sender.postMessage("bc-1");
+globalSender.postMessage("global-bc-1");
 
 const received = receiveMessageOnPort(syncReceiver);
 console.log("broadcast receive:", received ? received.message : received);

--- a/test-parity/node-suite/worker_threads/message-channel/globals.ts
+++ b/test-parity/node-suite/worker_threads/message-channel/globals.ts
@@ -111,4 +111,10 @@ console.log(
   hasFunction(bc, "unref"),
 );
 console.log("broadcast events:", bc.onmessage, bc.onmessageerror);
+console.log(
+  "broadcast refs:",
+  bc.ref() === bc,
+  bc.unref() === bc,
+  typeof (bc as any).hasRef,
+);
 bc.close();


### PR DESCRIPTION
Fixes #3158.

## Summary
- Route bare and `globalThis` `MessageChannel` / `BroadcastChannel` construction through the `worker_threads` native constructors.
- Register stdlib worker_threads messaging constructors with the runtime global constructor fallback.
- Match Node's BroadcastChannel shape for `ref()` / `unref()` returning self and no `hasRef` own method.
- Extend worker_threads parity fixtures and update runtime parity gap docs.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perry-hir --test node_named_export_hygiene global_worker_messaging_constructors_lower_to_worker_threads`
- `cargo test -p perry-stdlib worker_threads`
- `cargo test -p perry-codegen --test manifest_consistency`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `PATH=/tmp/perry-node25.1fngoW:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module worker_threads --filter message-channel` (100%, report `test-parity/reports/parity_report_20260602_163532.json`)
