### PR TITLE
[codex] support RSA encrypted PKCS8 PEM keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5940,12 +5940,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes 0.8.4",
+ "cbc",
+ "der",
+ "pbkdf2 0.12.2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki",
 ]
 

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -344,7 +344,7 @@ hmac = { version = "0.13", optional = true }
 bcrypt = { version = "0.17", optional = true }
 jsonwebtoken = { workspace = true, optional = true }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["pkcs8", "pem", "ecdsa", "ecdh"] }
-rsa = { version = "0.9", optional = true, default-features = false, features = ["pem", "sha2"] }
+rsa = { version = "0.9", optional = true, default-features = false, features = ["pem", "pkcs5", "sha2"] }
 # #1367 node:crypto X509Certificate — DER/PEM cert parsing (RustCrypto, reuses
 # the der/spki/const-oid already in the lock).
 x509-cert = { version = "0.2", optional = true, default-features = false, features = ["pem"] }

--- a/crates/perry-stdlib/src/crypto/sign.rs
+++ b/crates/perry-stdlib/src/crypto/sign.rs
@@ -395,13 +395,23 @@ pub unsafe extern "C" fn js_crypto_generate_key_pair_sync_rsa(
     };
     let public_key = RsaPublicKey::from(&private_key);
     let public_pem = rsa_public_key_to_pem(&public_key).unwrap_or_default();
-    let private_pem = private_key
-        .to_pkcs8_pem(Default::default())
-        .map(|pem| pem.to_string())
-        .unwrap_or_default();
     let options = options_bits.to_bits();
     let public_as_jwk = keygen_encoding_wants_jwk(options, b"publicKeyEncoding");
     let private_as_jwk = keygen_encoding_wants_jwk(options, b"privateKeyEncoding");
+    let private_passphrase = keygen_rsa_private_encryption_passphrase(options);
+    let private_pem = if private_as_jwk {
+        String::new()
+    } else if let Some(passphrase) = private_passphrase.as_deref() {
+        private_key
+            .to_pkcs8_encrypted_pem(&mut rng, passphrase, Default::default())
+            .map(|pem| pem.to_string())
+            .unwrap_or_default()
+    } else {
+        private_key
+            .to_pkcs8_pem(Default::default())
+            .map(|pem| pem.to_string())
+            .unwrap_or_default()
+    };
 
     let obj = js_object_alloc(0, 2);
 

--- a/crates/perry-stdlib/src/crypto/util.rs
+++ b/crates/perry-stdlib/src/crypto/util.rs
@@ -122,6 +122,24 @@ pub(super) fn parse_rsa_private_key_pem(pem: &str) -> Option<RsaPrivateKey> {
         .ok()
 }
 
+pub(super) fn parse_rsa_encrypted_private_key_pem(
+    pem: &str,
+    passphrase: &[u8],
+) -> Option<RsaPrivateKey> {
+    use rsa::pkcs8::DecodePrivateKey;
+
+    RsaPrivateKey::from_pkcs8_encrypted_pem(pem, passphrase).ok()
+}
+
+pub(super) fn rsa_private_key_to_pem(private_key: &RsaPrivateKey) -> Option<String> {
+    use rsa::pkcs8::EncodePrivateKey;
+
+    private_key
+        .to_pkcs8_pem(Default::default())
+        .ok()
+        .map(|pem| pem.to_string())
+}
+
 pub(super) fn parse_rsa_public_key_pem(pem: &str) -> Option<RsaPublicKey> {
     use rsa::pkcs1::DecodeRsaPublicKey;
     use rsa::pkcs8::DecodePublicKey;
@@ -438,6 +456,21 @@ pub(super) unsafe fn object_field_string(obj_bits: u64, name: &[u8]) -> Option<S
     string_from_jsvalue(object_field_bits(obj_bits, name)?)
 }
 
+pub(super) unsafe fn bytes_from_value_bits(bits: u64) -> Option<Vec<u8>> {
+    if let Some(s) = string_from_jsvalue(bits) {
+        return Some(s.into_bytes());
+    }
+    let ptr = bits & 0x0000_FFFF_FFFF_FFFF;
+    if ptr < 0x1000 {
+        return None;
+    }
+    Some(bytes_from_ptr(ptr as i64))
+}
+
+pub(super) unsafe fn object_field_bytes(obj_bits: u64, name: &[u8]) -> Option<Vec<u8>> {
+    bytes_from_value_bits(object_field_bits(obj_bits, name)?)
+}
+
 pub(super) fn b64u_decode_uint(s: &str) -> Option<RsaBigUint> {
     let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(s.as_bytes())
@@ -630,6 +663,19 @@ pub(super) unsafe fn crypto_key_input_to_private_pem(value_bits: u64) -> Option<
         if matches!(format.as_deref(), Some(f) if f.eq_ignore_ascii_case("jwk")) {
             return jwk_rsa_private_to_pem(key_bits).or_else(|| jwk_ec_private_to_pem(key_bits));
         }
+        let format_is_pem = format
+            .as_deref()
+            .map_or(true, |f| f.eq_ignore_ascii_case("pem"));
+        if format_is_pem {
+            if let Some(passphrase) = object_field_bytes(value_bits, b"passphrase") {
+                let key_bytes = bytes_from_value_bits(key_bits)?;
+                let pem = String::from_utf8(key_bytes).ok()?;
+                if pem.contains("ENCRYPTED PRIVATE KEY") {
+                    return parse_rsa_encrypted_private_key_pem(&pem, &passphrase)
+                        .and_then(|key| rsa_private_key_to_pem(&key));
+                }
+            }
+        }
         return crypto_key_input_to_private_pem(key_bits);
     }
     if matches!(format.as_deref(), Some(f) if f.eq_ignore_ascii_case("jwk")) {
@@ -719,6 +765,25 @@ pub(super) unsafe fn keygen_encoding_wants_jwk(options_bits: u64, field: &[u8]) 
         object_field_string(encoding_bits, b"format").as_deref(),
         Some(format) if format.eq_ignore_ascii_case("jwk")
     )
+}
+
+pub(super) unsafe fn keygen_rsa_private_encryption_passphrase(
+    options_bits: u64,
+) -> Option<Vec<u8>> {
+    let encoding_bits = object_field_bits(options_bits, b"privateKeyEncoding")?;
+    let format = object_field_string(encoding_bits, b"format")?;
+    if !format.eq_ignore_ascii_case("pem") {
+        return None;
+    }
+    let typ = object_field_string(encoding_bits, b"type")?;
+    if !typ.eq_ignore_ascii_case("pkcs8") {
+        return None;
+    }
+    let cipher = object_field_string(encoding_bits, b"cipher")?;
+    if !cipher.eq_ignore_ascii_case("aes-256-cbc") {
+        return None;
+    }
+    object_field_bytes(encoding_bits, b"passphrase")
 }
 
 pub(super) fn sign_rsa_data(

--- a/test-parity/node-suite/crypto/keygen/rsa-encrypted-pkcs8-pem.ts
+++ b/test-parity/node-suite/crypto/keygen/rsa-encrypted-pkcs8-pem.ts
@@ -1,0 +1,63 @@
+import * as crypto from "node:crypto";
+
+const passphrase = "secret passphrase";
+const data = Buffer.from("encrypted pkcs8 rsa parity");
+
+const pair = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 1024,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: {
+    type: "pkcs8",
+    format: "pem",
+    cipher: "aes-256-cbc",
+    passphrase,
+  },
+});
+
+console.log("sync public marker:", String(pair.publicKey).includes("BEGIN PUBLIC KEY"));
+console.log(
+  "sync private encrypted marker:",
+  String(pair.privateKey).includes("BEGIN ENCRYPTED PRIVATE KEY"),
+);
+
+const privateKey = crypto.createPrivateKey({
+  key: pair.privateKey,
+  format: "pem",
+  passphrase: Buffer.from(passphrase),
+});
+const signature = crypto.sign("sha256", data, privateKey);
+console.log("sync encrypted verify:", crypto.verify("sha256", data, pair.publicKey, signature));
+
+const asyncPair = await new Promise<{ publicKey: string; privateKey: string }>((resolve, reject) => {
+  crypto.generateKeyPair(
+    "rsa",
+    {
+      modulusLength: 1024,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "pem",
+        cipher: "aes-256-cbc",
+        passphrase,
+      },
+    },
+    (err, publicKey, privateKey) => {
+      if (err) reject(err);
+      else resolve({ publicKey, privateKey });
+    },
+  );
+});
+
+console.log("async public marker:", String(asyncPair.publicKey).includes("BEGIN PUBLIC KEY"));
+console.log(
+  "async private encrypted marker:",
+  String(asyncPair.privateKey).includes("BEGIN ENCRYPTED PRIVATE KEY"),
+);
+
+const asyncPrivateKey = crypto.createPrivateKey({
+  key: asyncPair.privateKey,
+  format: "pem",
+  passphrase,
+});
+const asyncSignature = crypto.sign("sha256", data, asyncPrivateKey);
+console.log("async encrypted verify:", crypto.verify("sha256", data, asyncPair.publicKey, asyncSignature));


### PR DESCRIPTION
## Summary
- Adds RSA encrypted PKCS#8 PEM output for `generateKeyPairSync()` and callback `generateKeyPair()` when `privateKeyEncoding` requests `{ type: "pkcs8", format: "pem", cipher: "aes-256-cbc", passphrase }`.
- Adds encrypted PKCS#8 PEM import through `createPrivateKey({ key, format: "pem", passphrase })`, normalizing decrypted RSA keys into Perry's existing private-key PEM path so `sign()` and `verify()` can use them.
- Enables the RustCrypto RSA `pkcs5` support needed for encrypted PKCS#8 handling.

## Related Issue
Fixes #2480 for the RSA encrypted PKCS#8 PEM keygen/import slice.

## Scope
This keeps the work grouped with the current `node:crypto` key import/export compatibility thread while avoiding unrelated key-object model changes. It covers the path needed for encrypted RSA PKCS#8 PEM generation, import, and signing round-trips.

Non-goals in this PR:
- DER encrypted key support
- EC encrypted key support
- `KeyObject#export({ cipher, passphrase })`
- Exact OpenSSL wrong-passphrase error text parity
- Broad `KeyObject` model replacement

## Tests
- Added `test-parity/node-suite/crypto/keygen/rsa-encrypted-pkcs8-pem.ts`
- Reproduced the new fixture failing before implementation: `parity_report_20260602_164306.json`
- `cargo check -p perry-runtime -p perry-stdlib -p perry-api-manifest`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter rsa-encrypted-pkcs8-pem` (`parity_report_20260602_170021.json`)
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter rsa-generate-keypair` (`parity_report_20260602_165230.json`)
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter export-equals` (`parity_report_20260602_165251.json`)
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter rsa-keyobject-as-input` (`parity_report_20260602_165302.json`)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
