### PR TITLE
[codex] Fix Effect isFinite lowering and Number.isFinite property path

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -24,6 +24,13 @@ pub(super) fn try_global_builtins(
     // Check for global built-in function calls (parseInt, parseFloat, Number, String, isNaN, isFinite)
     if let ast::Expr::Ident(ident) = expr {
         let func_name = ident.sym.as_ref();
+        if ctx.lookup_local(func_name).is_some()
+            || ctx.lookup_func(func_name).is_some()
+            || ctx.lookup_imported_func(func_name).is_some()
+            || ctx.lookup_class(func_name).is_some()
+        {
+            return Ok(Err(args));
+        }
         match func_name {
             "parseInt" => {
                 let string_arg = if !args.is_empty() {

--- a/crates/perry-hir/tests/global_builtin_shadowing.rs
+++ b/crates/perry-hir/tests/global_builtin_shadowing.rs
@@ -1,0 +1,60 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Expr, Stmt};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_src(src: &str) -> anyhow::Result<perry_hir::Module> {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "global_builtin_shadowing.ts", &mut cache)?;
+    lower_module(&parsed.module, "test", "global_builtin_shadowing.ts")
+}
+
+#[test]
+fn local_isfinite_helper_zero_arg_call_does_not_use_global_builtin_arity() {
+    let module = lower_src(
+        r#"
+        function isFinite(annotations?: unknown) {
+          return annotations === undefined;
+        }
+        const result = isFinite();
+        "#,
+    )
+    .expect("local isFinite helper should shadow the global builtin");
+
+    let func_id = module
+        .functions
+        .iter()
+        .find(|func| func.name == "isFinite")
+        .map(|func| func.id)
+        .expect("local helper function should be registered");
+
+    let result_init = module
+        .init
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Let {
+                name,
+                init: Some(init),
+                ..
+            } if name == "result" => Some(init),
+            _ => None,
+        })
+        .expect("result binding should be lowered");
+
+    assert!(
+        matches!(
+            result_init,
+            Expr::Call { callee, .. } if matches!(callee.as_ref(), Expr::FuncRef(id) if *id == func_id)
+        ),
+        "{result_init:?}"
+    );
+}
+
+#[test]
+fn unshadowed_global_isfinite_zero_arg_call_keeps_builtin_arity_error() {
+    let err = lower_src("const result = isFinite();")
+        .expect_err("unshadowed global isFinite() should keep the builtin arity diagnostic");
+    assert!(
+        err.to_string().contains("isFinite requires one argument"),
+        "{err}"
+    );
+}

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2273,6 +2273,49 @@ extern "C" fn array_of_thunk(_closure: *const crate::closure::ClosureHeader, res
     crate::value::js_nanbox_pointer(arr as i64)
 }
 
+extern "C" fn number_is_nan_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    crate::builtins::js_number_is_nan(value)
+}
+
+extern "C" fn number_is_finite_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    crate::builtins::js_number_is_finite(value)
+}
+
+extern "C" fn number_is_integer_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    crate::builtins::js_number_is_integer(value)
+}
+
+extern "C" fn number_is_safe_integer_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    crate::builtins::js_number_is_safe_integer(value)
+}
+
+extern "C" fn number_parse_float_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    global_this_parse_float_thunk(closure, value)
+}
+
+extern "C" fn number_parse_int_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    value: f64,
+    radix: f64,
+) -> f64 {
+    global_this_parse_int_thunk(closure, value, radix)
+}
+
 extern "C" fn typed_array_from_thunk(
     _closure: *const crate::closure::ClosureHeader,
     source: f64,
@@ -2467,6 +2510,44 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
             );
             install_constructor_static(ctor, "from", array_from_thunk as *const u8, 1, false);
             install_constructor_static(ctor, "of", array_of_thunk as *const u8, 0, true);
+        }
+        "Number" => {
+            install_constructor_static(ctor, "isNaN", number_is_nan_thunk as *const u8, 1, false);
+            install_constructor_static(
+                ctor,
+                "isFinite",
+                number_is_finite_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "isInteger",
+                number_is_integer_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "isSafeInteger",
+                number_is_safe_integer_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "parseFloat",
+                number_parse_float_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "parseInt",
+                number_parse_int_thunk as *const u8,
+                2,
+                false,
+            );
         }
         "ArrayBuffer" => {
             install_constructor_static(

--- a/tests/test_effect_number_isfinite_property_path.sh
+++ b/tests/test_effect_number_isfinite_property_path.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/effect_number_isfinite_property_path.ts" <<'TS'
+let failures = 0;
+
+function check(label: string, actual: any, expected: any): void {
+  if (actual !== expected) {
+    console.log(label + ": expected " + String(expected) + ", got " + String(actual));
+    failures = failures + 1;
+  }
+}
+
+check("direct finite", Number.isFinite(1), true);
+check("direct infinity", Number.isFinite(Infinity), false);
+check("direct string", Number.isFinite("1"), false);
+
+check("global finite", globalThis.Number.isFinite(1), true);
+check("global infinity", globalThis.Number.isFinite(Infinity), false);
+check("global string", globalThis.Number.isFinite("1"), false);
+
+if (failures !== 0) {
+  throw new Error("Number.isFinite property-path parity failed");
+}
+
+console.log("effect Number.isFinite property path ok");
+TS
+
+"$PERRY" compile --no-auto-optimize "$TMPDIR/effect_number_isfinite_property_path.ts" \
+    -o "$TMPDIR/effect_number_isfinite_property_path" >"$TMPDIR/compile.log" 2>&1 || {
+        echo "FAIL: compile failed"
+        sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+        exit 1
+    }
+
+"$TMPDIR/effect_number_isfinite_property_path" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q "effect Number.isFinite property path ok" "$TMPDIR/run.log"; then
+    echo "FAIL: expected success marker"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+echo "PASS: effect Number.isFinite property path"


### PR DESCRIPTION
## What changed

- Makes global builtin call lowering respect local/function/import/class shadowing before recognizing names like `isFinite` as Perry intrinsics.
- Adds a focused HIR regression for a local `function isFinite(annotations?)` called with zero args, preserving the unshadowed global `isFinite()` arity error.
- Reifies callable `Number` static methods on the runtime global constructor value, including `Number.isFinite`, `Number.isNaN`, `Number.isInteger`, `Number.isSafeInteger`, `Number.parseFloat`, and `Number.parseInt`.
- Adds a runtime regression for the Effect-shaped `globalThis.Number.isFinite(...)` property path.

## Why

The OpenCode/Effect graph hit `Schema.Finite = Number.check(isFinite())`, where Effect defines a local helper named `isFinite(annotations?)`. Perry lowered the zero-arg local helper call as the global builtin and failed with `isFinite requires one argument`.

After that compiler fix, the same focused reducer compiled but failed at runtime because `globalThis.Number.isFinite(1)` produced an object-like result instead of the boolean returned by direct `Number.isFinite(1)`.

## Validation

- `cargo fmt`
- `cargo test -p perry-hir --test global_builtin_shadowing -- --nocapture`
- `cargo build --release -p perry -p perry-runtime`
- `PERRY_BIN=/Users/andrew/.codex/worktrees/perry-effect-isfinite/target/release/perry tests/test_effect_number_isfinite_property_path.sh`
- OpenTUI focused reducer: `PERRY_BIN=/Users/andrew/.codex/worktrees/perry-effect-isfinite/target/release/perry bun scripts/perry-runtime-blockers/effect-schema-isfinite.ts`
  - The harness still exits nonzero because it is marked as an expected compile-failure repro, but the compiled Perry binary now runs successfully and prints `effect-schema-isfinite: ok`.

## Scope notes

This moves the scoped Effect/Perry blocker. It does not claim actual OpenCode Perry-native completion; the actual OpenCode graph still needs to be rerun with this Perry binary/PR.
