### PR TITLE
[codex] stream/web codec stream constructors

### DIFF
--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -1193,6 +1193,8 @@ mod tests {
                     ("CountQueuingStrategy", ApiKind::Class),
                     ("TextEncoderStream", ApiKind::Class),
                     ("TextDecoderStream", ApiKind::Class),
+                    ("CompressionStream", ApiKind::Class),
+                    ("DecompressionStream", ApiKind::Class),
                 ],
             ),
             (

--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -297,6 +297,8 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "TextDecoder"
             | "TextEncoderStream"
             | "TextDecoderStream"
+            | "CompressionStream"
+            | "DecompressionStream"
             | "Navigator"
             | "URL"
             | "URLSearchParams"

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -351,6 +351,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "ReadableStream" => 0xFFFF0060u32,
                 "WritableStream" => 0xFFFF0061u32,
                 "TransformStream" => 0xFFFF0062u32,
+                // node:stream/web codec stream constructors are heap
+                // ObjectHeader instances with runtime-owned class IDs.
+                "TextEncoderStream" => 0x7FFFFF30u32,
+                "TextDecoderStream" => 0x7FFFFF31u32,
+                "CompressionStream" => 0x7FFFFF32u32,
+                "DecompressionStream" => 0x7FFFFF33u32,
                 // node:perf_hooks entry classes. Runtime classifies the
                 // shaped entry objects returned by performance.mark/measure.
                 // #3871: Performance / PerformanceObserverEntryList /

--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -146,6 +146,10 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_transform_stream_readable",                OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_transform_stream_writable",                OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_stream_unwrap_handle",                     OwnerKind::Stdlib { feature: Some("bundled-streams") }),
+    ("js_stream_web_text_encoder_stream_new",       OwnerKind::Stdlib { feature: Some("bundled-streams") }),
+    ("js_stream_web_text_decoder_stream_new",       OwnerKind::Stdlib { feature: Some("bundled-streams") }),
+    ("js_stream_web_compression_stream_new",        OwnerKind::Stdlib { feature: Some("bundled-streams") }),
+    ("js_stream_web_decompression_stream_new",      OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     // #1545: node:stream/web QueuingStrategy constructors.
     ("js_streams_strategy_high_water_mark",         OwnerKind::Stdlib { feature: Some("bundled-streams") }),
     ("js_count_queuing_strategy_new",               OwnerKind::Stdlib { feature: Some("bundled-streams") }),

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -1367,16 +1367,53 @@ pub(super) fn lower_builtin_new(
             Ok(Some(h))
         }
 
-        "TextEncoderStream" | "TextDecoderStream" => {
+        "TextEncoderStream" => {
             for a in args {
                 let _ = lower_expr(ctx, a)?;
             }
-            let runtime = if class_name == "TextEncoderStream" {
-                "js_text_encoder_stream_new"
+            let h = ctx
+                .block()
+                .call(DOUBLE, "js_stream_web_text_encoder_stream_new", &[]);
+            Ok(Some(h))
+        }
+
+        "TextDecoderStream" => {
+            let label = if !args.is_empty() {
+                lower_expr(ctx, &args[0])?
             } else {
-                "js_text_decoder_stream_new"
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
             };
-            let h = ctx.block().call(DOUBLE, runtime, &[]);
+            let options = if args.len() >= 2 {
+                lower_expr(ctx, &args[1])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            for a in args.iter().skip(2) {
+                let _ = lower_expr(ctx, a)?;
+            }
+            let h = ctx.block().call(
+                DOUBLE,
+                "js_stream_web_text_decoder_stream_new",
+                &[(DOUBLE, &label), (DOUBLE, &options)],
+            );
+            Ok(Some(h))
+        }
+
+        "CompressionStream" | "DecompressionStream" => {
+            let format = if !args.is_empty() {
+                lower_expr(ctx, &args[0])?
+            } else {
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
+            for a in args.iter().skip(1) {
+                let _ = lower_expr(ctx, a)?;
+            }
+            let runtime = if class_name == "CompressionStream" {
+                "js_stream_web_compression_stream_new"
+            } else {
+                "js_stream_web_decompression_stream_new"
+            };
+            let h = ctx.block().call(DOUBLE, runtime, &[(DOUBLE, &format)]);
             Ok(Some(h))
         }
 

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -1038,6 +1038,14 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_text_encoding_stream_new", DOUBLE, &[]);
     module.declare_function("js_text_encoder_stream_new", DOUBLE, &[]);
     module.declare_function("js_text_decoder_stream_new", DOUBLE, &[]);
+    module.declare_function("js_stream_web_text_encoder_stream_new", DOUBLE, &[]);
+    module.declare_function(
+        "js_stream_web_text_decoder_stream_new",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
+    module.declare_function("js_stream_web_compression_stream_new", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_stream_web_decompression_stream_new", DOUBLE, &[DOUBLE]);
     // #1545: node:stream/web QueuingStrategy constructors — take the options
     // object, return a `{ highWaterMark, size }` object.
     module.declare_function("js_streams_strategy_high_water_mark", DOUBLE, &[DOUBLE]);

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -119,6 +119,8 @@ pub(crate) fn lower_let(
                         | "TextDecoder"
                         | "TextEncoderStream"
                         | "TextDecoderStream"
+                        | "CompressionStream"
+                        | "DecompressionStream"
                         | "File"
                         | "WebSocket"
                 )

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -75,6 +75,8 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
             | "TextDecoder"
             | "TextEncoderStream"
             | "TextDecoderStream"
+            | "CompressionStream"
+            | "DecompressionStream"
             | "Navigator"
             | "URL"
             | "URLSearchParams"
@@ -165,6 +167,7 @@ pub(crate) fn builtin_constructor_length(name: &str) -> Option<u32> {
         }
         "Symbol" | "Map" | "Set" | "WeakMap" | "WeakSet" | "MessageChannel" | "MessagePort"
         | "Navigator" | "TextEncoderStream" | "TextDecoderStream" | "DOMException" | "Storage" => 0,
+        "CompressionStream" | "DecompressionStream" => 1,
         "RegExp" | "Proxy" | "File" => 2,
         "BroadcastChannel" => 1,
         "Date" => 7,

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -165,6 +165,14 @@ fn module_constructor_name(module_name: &str, method_name: Option<&str>) -> Opti
         ("url", Some("URLPattern")) => Some("URLPattern"),
         ("util", Some("TextEncoder")) => Some("TextEncoder"),
         ("util", Some("TextDecoder")) => Some("TextDecoder"),
+        ("stream/web", Some("TextEncoderStream"))
+        | ("node:stream/web", Some("TextEncoderStream")) => Some("TextEncoderStream"),
+        ("stream/web", Some("TextDecoderStream"))
+        | ("node:stream/web", Some("TextDecoderStream")) => Some("TextDecoderStream"),
+        ("stream/web", Some("CompressionStream"))
+        | ("node:stream/web", Some("CompressionStream")) => Some("CompressionStream"),
+        ("stream/web", Some("DecompressionStream"))
+        | ("node:stream/web", Some("DecompressionStream")) => Some("DecompressionStream"),
         _ => None,
     }
 }
@@ -183,6 +191,10 @@ fn global_member_constructor_name(
             "TextDecoder" => Some("TextDecoder"),
             "MessageChannel" => Some("MessageChannel"),
             "BroadcastChannel" => Some("BroadcastChannel"),
+            "TextEncoderStream" => Some("TextEncoderStream"),
+            "TextDecoderStream" => Some("TextDecoderStream"),
+            "CompressionStream" => Some("CompressionStream"),
+            "DecompressionStream" => Some("DecompressionStream"),
             _ => None,
         };
     }

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -887,6 +887,20 @@ fn special_export_value(submod_key: &str, name: &str) -> Option<f64> {
     let value = match submod_key {
         "fs_promises" if name == "constants" => Some(fs_constants_namespace_value()),
         "timers_promises" if name == "scheduler" => Some(timers_promises_scheduler_value()),
+        "stream_web"
+            if matches!(
+                name,
+                "TextEncoderStream"
+                    | "TextDecoderStream"
+                    | "CompressionStream"
+                    | "DecompressionStream"
+            ) =>
+        {
+            Some(crate::object::js_get_global_this_builtin_value(
+                name.as_ptr(),
+                name.len(),
+            ))
+        }
         "test" => test::test_special_export_value(name),
         _ => None,
     };

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -775,8 +775,29 @@ fn text_decoder_bool_option(options: f64, name: &str) -> f64 {
     f64::from_bits(crate::value::JSValue::bool(crate::value::js_is_truthy(value_f64) != 0).bits())
 }
 
+unsafe fn validate_web_compression_stream_format(format: f64) {
+    let ptr = crate::builtins::js_string_coerce(format) as *const crate::StringHeader;
+    if ptr.is_null() {
+        crate::fs::validate::throw_type_error_with_code(
+            "The argument 'format' is invalid.",
+            "ERR_INVALID_ARG_VALUE",
+        );
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    if matches!(bytes, b"gzip" | b"deflate" | b"deflate-raw" | b"brotli") {
+        return;
+    }
+    let received = String::from_utf8_lossy(bytes);
+    let message = format!("The argument 'format' is invalid. Received '{received}'");
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE");
+}
+
 pub(crate) const CLASS_ID_TEXT_ENCODER_STREAM: u32 = 0x7FFF_FF30;
 pub(crate) const CLASS_ID_TEXT_DECODER_STREAM: u32 = 0x7FFF_FF31;
+pub(crate) const CLASS_ID_COMPRESSION_STREAM: u32 = 0x7FFF_FF32;
+pub(crate) const CLASS_ID_DECOMPRESSION_STREAM: u32 = 0x7FFF_FF33;
 
 unsafe fn text_encoding_stream_new_with_constructor(constructor: f64, class_id: u32) -> f64 {
     let stream = js_object_alloc(class_id, 0);
@@ -822,6 +843,16 @@ pub unsafe extern "C" fn js_text_encoder_stream_new() -> f64 {
 #[no_mangle]
 pub unsafe extern "C" fn js_text_decoder_stream_new() -> f64 {
     text_encoding_stream_new(b"TextDecoderStream", CLASS_ID_TEXT_DECODER_STREAM)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_compression_stream_new() -> f64 {
+    text_encoding_stream_new(b"CompressionStream", CLASS_ID_COMPRESSION_STREAM)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_decompression_stream_new() -> f64 {
+    text_encoding_stream_new(b"DecompressionStream", CLASS_ID_DECOMPRESSION_STREAM)
 }
 
 #[no_mangle]
@@ -1512,6 +1543,28 @@ pub unsafe extern "C" fn js_new_function_construct(
                 return text_encoding_stream_new_with_constructor(
                     func_value,
                     CLASS_ID_TEXT_DECODER_STREAM,
+                );
+            }
+            "CompressionStream" => {
+                let format = args
+                    .first()
+                    .copied()
+                    .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+                validate_web_compression_stream_format(format);
+                return text_encoding_stream_new_with_constructor(
+                    func_value,
+                    CLASS_ID_COMPRESSION_STREAM,
+                );
+            }
+            "DecompressionStream" => {
+                let format = args
+                    .first()
+                    .copied()
+                    .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+                validate_web_compression_stream_format(format);
+                return text_encoding_stream_new_with_constructor(
+                    func_value,
+                    CLASS_ID_DECOMPRESSION_STREAM,
                 );
             }
             "MessageChannel" => {

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2095,7 +2095,14 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                     super::PropertyAttrs::new(true, false, true),
                 );
             }
-            if name == "Navigator" || name == "TextEncoderStream" || name == "TextDecoderStream" {
+            if matches!(
+                name,
+                "Navigator"
+                    | "TextEncoderStream"
+                    | "TextDecoderStream"
+                    | "CompressionStream"
+                    | "DecompressionStream"
+            ) {
                 let constructor_key =
                     crate::string::js_string_from_bytes(b"constructor".as_ptr(), 11);
                 js_object_set_field_by_name(proto_obj, constructor_key, ctor_value);

--- a/crates/perry-runtime/src/object/global_this_tables.rs
+++ b/crates/perry-runtime/src/object/global_this_tables.rs
@@ -53,6 +53,8 @@ pub(crate) const GLOBAL_THIS_BUILTIN_CONSTRUCTORS: &[&str] = &[
     "TextDecoder",
     "TextEncoderStream",
     "TextDecoderStream",
+    "CompressionStream",
+    "DecompressionStream",
     "Navigator",
     "URL",
     "URLSearchParams",
@@ -122,6 +124,7 @@ pub(crate) fn builtin_constructor_spec_length(name: &str) -> Option<u32> {
         | "Navigator"
         | "DisposableStack"
         | "AsyncDisposableStack" => 0,
+        "CompressionStream" | "DecompressionStream" => 1,
         "Array"
         | "Object"
         | "String"

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -253,6 +253,8 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             "Navigator" => crate::navigator::NAVIGATOR_CLASS_ID,
             "TextEncoderStream" => crate::object::CLASS_ID_TEXT_ENCODER_STREAM,
             "TextDecoderStream" => crate::object::CLASS_ID_TEXT_DECODER_STREAM,
+            "CompressionStream" => crate::object::CLASS_ID_COMPRESSION_STREAM,
+            "DecompressionStream" => crate::object::CLASS_ID_DECOMPRESSION_STREAM,
             "Event" => crate::event_target::CLASS_ID_EVENT,
             "CustomEvent" => crate::event_target::CLASS_ID_CUSTOM_EVENT,
             "DOMException" => crate::event_target::CLASS_ID_DOM_EXCEPTION,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1904,6 +1904,11 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         let obj_ptr = (bits & POINTER_MASK) as *const ObjectHeader;
         if !obj_ptr.is_null() && (obj_ptr as usize) >= 0x1000 {
             let class_id = (*obj_ptr).class_id;
+            if class_id == crate::object::CLASS_ID_COMPRESSION_STREAM {
+                tag_str = Some("CompressionStream".to_string());
+            } else if class_id == crate::object::CLASS_ID_DECOMPRESSION_STREAM {
+                tag_str = Some("DecompressionStream".to_string());
+            }
             if let Some(func_ptr) = lookup_to_string_tag_hook(class_id) {
                 let getter: extern "C" fn(f64) -> f64 = std::mem::transmute(func_ptr as *const u8);
                 let result_f64 = getter(value);

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -93,7 +93,7 @@ http-client = ["dep:reqwest", "async-runtime", "bundled-streams"]
 # well-known flip routes `import 'streams'` to perry-ext-streams
 # by stripping this feature. Default-on through `default = ["full"]`
 # and through the `http-client` umbrella for legacy callers.
-bundled-streams = []
+bundled-streams = ["dep:flate2", "dep:brotli"]
 
 # WebSocket — `websocket` umbrella retained for backwards-compat;
 # v0.5.571's well-known flip toggles `bundled-ws` instead so

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -22,6 +22,10 @@
 //! Stubs: BYOB readers and full custom `QueuingStrategy` size accounting —
 //! see the inline comment on each site.
 
+use flate2::read::{
+    DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder,
+};
+use flate2::Compression;
 use perry_runtime::{
     js_array_alloc, js_array_push, js_closure_call0, js_closure_call1, js_closure_call2,
     js_nanbox_get_pointer, js_object_alloc, js_object_get_field_by_name, js_object_set_field,
@@ -29,6 +33,7 @@ use perry_runtime::{
     js_promise_resolve, js_string_from_bytes, ClosureHeader, JSValue, ObjectHeader, Promise,
 };
 use std::collections::{HashMap, VecDeque};
+use std::io::Read;
 use std::os::raw::c_int;
 use std::sync::Mutex;
 
@@ -107,6 +112,28 @@ struct TransformStreamData {
     writable_handle: usize,
     transform_cb: i64,
     flush_cb: i64,
+    native: Option<NativeTransformKind>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WebCompressionFormat {
+    Gzip,
+    Deflate,
+    DeflateRaw,
+    Brotli,
+}
+
+enum NativeTransformKind {
+    TextEncoder,
+    TextDecoder {
+        fatal: bool,
+        pending: Vec<u8>,
+    },
+    Compression {
+        format: WebCompressionFormat,
+        decompress: bool,
+        chunks: Vec<u8>,
+    },
 }
 
 struct ReaderData {
@@ -312,15 +339,26 @@ unsafe fn alloc_uint8array_from_bytes(bytes: &[u8]) -> u64 {
 
 unsafe fn read_bytes_from_chunk(chunk_bits: u64) -> Option<Vec<u8>> {
     let top = chunk_bits >> 48;
-    if top != 0x7FFD {
+    let addr = if top == 0x7FFD || top == 0x7FFF {
+        (chunk_bits & POINTER_MASK) as usize
+    } else if top == 0 && chunk_bits >= 0x10000 {
+        chunk_bits as usize
+    } else {
+        return None;
+    };
+    if addr < 0x1000 {
         return None;
     }
-    let ptr = (chunk_bits & POINTER_MASK) as *mut perry_runtime::buffer::BufferHeader;
-    if ptr.is_null() {
+    if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let ta = addr as *const perry_runtime::typedarray::TypedArrayHeader;
+        return perry_runtime::typedarray::typed_array_bytes(ta).map(|bytes| bytes.to_vec());
+    }
+    if !perry_runtime::buffer::is_registered_buffer(addr) {
         return None;
     }
+    let ptr = addr as *const perry_runtime::buffer::BufferHeader;
     let len = (*ptr).length as usize;
-    let data = perry_runtime::buffer::buffer_data_mut(ptr) as *const u8;
+    let data = perry_runtime::buffer::buffer_data(ptr);
     Some(std::slice::from_raw_parts(data, len).to_vec())
 }
 
@@ -358,6 +396,13 @@ unsafe fn make_type_error_with_message(msg: &str) -> u64 {
     JSValue::pointer(err as *const u8).bits()
 }
 
+unsafe fn make_type_error_with_code(message: &str, code: &'static str) -> u64 {
+    let s = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    perry_runtime::node_submodules::register_error_code_pub(s, code);
+    let err = perry_runtime::error::js_typeerror_new(s);
+    JSValue::pointer(err as *const u8).bits()
+}
+
 unsafe fn make_range_error_with_code(message: &str, code: &'static str) -> u64 {
     let s = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     perry_runtime::node_submodules::register_error_code_pub(s, code);
@@ -367,6 +412,11 @@ unsafe fn make_range_error_with_code(message: &str, code: &'static str) -> u64 {
 
 unsafe fn throw_type_error(message: &str) -> ! {
     let err = make_type_error_with_message(message);
+    perry_runtime::exception::js_throw(f64::from_bits(err))
+}
+
+unsafe fn throw_type_error_with_code(message: &str, code: &'static str) -> ! {
+    let err = make_type_error_with_code(message, code);
     perry_runtime::exception::js_throw(f64::from_bits(err))
 }
 
@@ -881,6 +931,25 @@ unsafe fn value_string_equals(value: f64, expected: &[u8]) -> bool {
 
     let data = (ptr as *const u8).add(std::mem::size_of::<perry_runtime::StringHeader>());
     std::slice::from_raw_parts(data, len) == expected
+}
+
+unsafe fn js_string_value_to_string(value: f64, coerce: bool) -> Option<String> {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !coerce && !jsval.is_any_string() {
+        return None;
+    }
+    let ptr = if coerce {
+        perry_runtime::value::js_jsvalue_to_string(value) as *const perry_runtime::StringHeader
+    } else {
+        perry_runtime::value::js_get_string_pointer_unified(value)
+            as *const perry_runtime::StringHeader
+    };
+    if ptr.is_null() || (ptr as usize) < 0x10000 {
+        return None;
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<perry_runtime::StringHeader>());
+    Some(String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned())
 }
 
 #[no_mangle]
@@ -2548,10 +2617,20 @@ pub unsafe extern "C" fn js_transform_stream_new(
     flush_bits: f64,
     hwm: f64,
 ) -> f64 {
-    ensure_gc_registered();
     let start_cb = closure_from_bits(start_bits.to_bits());
     let transform_cb = closure_from_bits(transform_bits.to_bits());
     let flush_cb = closure_from_bits(flush_bits.to_bits());
+    alloc_transform_stream(start_cb, transform_cb, flush_cb, None, hwm)
+}
+
+unsafe fn alloc_transform_stream(
+    start_cb: i64,
+    transform_cb: i64,
+    flush_cb: i64,
+    native: Option<NativeTransformKind>,
+    hwm: f64,
+) -> f64 {
+    ensure_gc_registered();
 
     // Allocate the readable side empty (controller is its own handle).
     let readable_id = alloc_readable(0, 0, 0, hwm);
@@ -2598,6 +2677,7 @@ pub unsafe extern "C" fn js_transform_stream_new(
             writable_handle: writable_id,
             transform_cb,
             flush_cb,
+            native,
         },
     );
     TRANSFORM_PAIRS.lock().unwrap().insert(writable_id, id);
@@ -2681,19 +2761,42 @@ pub(super) unsafe fn transform_write(writable_id: usize, chunk: f64) -> *mut Pro
             }
         }
     }
+    let mut handled_native = false;
+    let mut native_error = None;
     let (transform_cb, readable_id) = {
         let pairs = TRANSFORM_PAIRS.lock().unwrap();
         match pairs.get(&writable_id) {
             Some(t_id) => {
-                let g = TRANSFORM_STREAMS.lock().unwrap();
-                match g.get(t_id) {
-                    Some(t) => (t.transform_cb, t.readable_handle),
+                let mut g = TRANSFORM_STREAMS.lock().unwrap();
+                match g.get_mut(t_id) {
+                    Some(t) => {
+                        if let Some(native) = t.native.as_mut() {
+                            handled_native = true;
+                            if let Err(error_bits) =
+                                native_transform_write(native, t.readable_handle, chunk)
+                            {
+                                native_error = Some(error_bits);
+                            }
+                        }
+                        (t.transform_cb, t.readable_handle)
+                    }
                     None => (0, 0),
                 }
             }
             None => (0, 0),
         }
     };
+    if let Some(error_bits) = native_error {
+        if readable_id != 0 {
+            js_readable_stream_controller_error(readable_id as f64, f64::from_bits(error_bits));
+        }
+        js_promise_reject(promise, f64::from_bits(error_bits));
+        return promise;
+    }
+    if handled_native {
+        js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED));
+        return promise;
+    }
     if transform_cb != 0 && readable_id != 0 {
         js_closure_call2(
             transform_cb as *const ClosureHeader,
@@ -2710,20 +2813,45 @@ pub(super) unsafe fn transform_write(writable_id: usize, chunk: f64) -> *mut Pro
 
 pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
     let promise = js_promise_new();
+    let mut handled_native = false;
+    let mut native_error = None;
     let (flush_cb, readable_id) = {
         let pairs = TRANSFORM_PAIRS.lock().unwrap();
         match pairs.get(&writable_id) {
             Some(t_id) => {
-                let g = TRANSFORM_STREAMS.lock().unwrap();
-                match g.get(t_id) {
-                    Some(t) => (t.flush_cb, t.readable_handle),
+                let mut g = TRANSFORM_STREAMS.lock().unwrap();
+                match g.get_mut(t_id) {
+                    Some(t) => {
+                        if let Some(native) = t.native.as_mut() {
+                            handled_native = true;
+                            if let Err(error_bits) =
+                                native_transform_close(native, t.readable_handle)
+                            {
+                                native_error = Some(error_bits);
+                            }
+                        }
+                        (t.flush_cb, t.readable_handle)
+                    }
                     None => (0, 0),
                 }
             }
             None => (0, 0),
         }
     };
-    if flush_cb != 0 && readable_id != 0 {
+    if let Some(error_bits) = native_error {
+        if readable_id != 0 {
+            js_readable_stream_controller_error(readable_id as f64, f64::from_bits(error_bits));
+        }
+        if let Some(s) = WRITABLE_STREAMS.lock().unwrap().get_mut(&writable_id) {
+            s.state = WritableState::Errored;
+            s.error_value = error_bits;
+            let cp = s.closed_promise;
+            js_promise_reject(cp, f64::from_bits(error_bits));
+        }
+        js_promise_reject(promise, f64::from_bits(error_bits));
+        return promise;
+    }
+    if !handled_native && flush_cb != 0 && readable_id != 0 {
         js_closure_call1(flush_cb as *const ClosureHeader, readable_id as f64);
     }
     if readable_id != 0 {
@@ -2736,6 +2864,320 @@ pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
     }
     js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED));
     promise
+}
+
+fn split_utf8_prefix(bytes: &[u8]) -> Result<(usize, bool), ()> {
+    match std::str::from_utf8(bytes) {
+        Ok(_) => Ok((bytes.len(), false)),
+        Err(err) => {
+            if err.error_len().is_none() {
+                Ok((err.valid_up_to(), true))
+            } else {
+                Err(())
+            }
+        }
+    }
+}
+
+unsafe fn enqueue_string(readable_id: usize, text: &str) {
+    let ptr = js_string_from_bytes(text.as_ptr(), text.len() as u32);
+    js_readable_stream_controller_enqueue(
+        readable_id as f64,
+        f64::from_bits(JSValue::string_ptr(ptr).bits()),
+    );
+}
+
+unsafe fn native_text_decoder_drain(
+    pending: &mut Vec<u8>,
+    fatal: bool,
+    readable_id: usize,
+    flush: bool,
+) -> Result<(), u64> {
+    if pending.is_empty() {
+        return Ok(());
+    }
+    if fatal {
+        let (valid_len, incomplete) = split_utf8_prefix(pending).map_err(|_| {
+            make_type_error_with_code(
+                "The encoded data was not valid for encoding utf-8",
+                "ERR_ENCODING_INVALID_ENCODED_DATA",
+            )
+        })?;
+        if valid_len > 0 {
+            let text = std::str::from_utf8(&pending[..valid_len]).map_err(|_| {
+                make_type_error_with_code(
+                    "The encoded data was not valid for encoding utf-8",
+                    "ERR_ENCODING_INVALID_ENCODED_DATA",
+                )
+            })?;
+            enqueue_string(readable_id, text);
+            pending.drain(..valid_len);
+        }
+        if flush && !pending.is_empty() {
+            return Err(make_type_error_with_code(
+                "The encoded data was not valid for encoding utf-8",
+                "ERR_ENCODING_INVALID_ENCODED_DATA",
+            ));
+        }
+        if !incomplete && !pending.is_empty() {
+            return Err(make_type_error_with_code(
+                "The encoded data was not valid for encoding utf-8",
+                "ERR_ENCODING_INVALID_ENCODED_DATA",
+            ));
+        }
+        return Ok(());
+    }
+
+    if flush {
+        let text = String::from_utf8_lossy(pending).into_owned();
+        pending.clear();
+        if !text.is_empty() {
+            enqueue_string(readable_id, &text);
+        }
+        return Ok(());
+    }
+
+    let (valid_len, incomplete) = split_utf8_prefix(pending).unwrap_or((pending.len(), false));
+    let emit_len = if incomplete { valid_len } else { pending.len() };
+    if emit_len > 0 {
+        let text = String::from_utf8_lossy(&pending[..emit_len]).into_owned();
+        enqueue_string(readable_id, &text);
+        pending.drain(..emit_len);
+    }
+    Ok(())
+}
+
+fn run_web_compression_codec(
+    format: WebCompressionFormat,
+    decompress: bool,
+    input: &[u8],
+) -> std::io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    match (format, decompress) {
+        (WebCompressionFormat::Gzip, false) => {
+            GzEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        (WebCompressionFormat::Gzip, true) => {
+            GzDecoder::new(input).read_to_end(&mut out)?;
+        }
+        (WebCompressionFormat::Deflate, false) => {
+            ZlibEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        (WebCompressionFormat::Deflate, true) => {
+            ZlibDecoder::new(input).read_to_end(&mut out)?;
+        }
+        (WebCompressionFormat::DeflateRaw, false) => {
+            DeflateEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
+        }
+        (WebCompressionFormat::DeflateRaw, true) => {
+            DeflateDecoder::new(input).read_to_end(&mut out)?;
+        }
+        (WebCompressionFormat::Brotli, false) => {
+            let mut reader = brotli::CompressorReader::new(input, 4096, 11, 22);
+            reader.read_to_end(&mut out)?;
+        }
+        (WebCompressionFormat::Brotli, true) => {
+            let mut reader = brotli::Decompressor::new(input, 4096);
+            reader.read_to_end(&mut out)?;
+        }
+    }
+    Ok(out)
+}
+
+unsafe fn native_transform_write(
+    native: &mut NativeTransformKind,
+    readable_id: usize,
+    chunk: f64,
+) -> Result<(), u64> {
+    match native {
+        NativeTransformKind::TextEncoder => {
+            let text = js_string_value_to_string(chunk, true).unwrap_or_default();
+            let bytes = alloc_uint8array_from_bytes(text.as_bytes());
+            js_readable_stream_controller_enqueue(readable_id as f64, f64::from_bits(bytes));
+            Ok(())
+        }
+        NativeTransformKind::TextDecoder { fatal, pending } => {
+            let bytes = read_bytes_from_chunk(chunk.to_bits()).ok_or_else(|| {
+                make_type_error_with_code(
+                    "The \"chunk\" argument must be an instance of Buffer, TypedArray, DataView, or ArrayBuffer",
+                    "ERR_INVALID_ARG_TYPE",
+                )
+            })?;
+            pending.extend_from_slice(&bytes);
+            native_text_decoder_drain(pending, *fatal, readable_id, false)
+        }
+        NativeTransformKind::Compression { chunks, .. } => {
+            let bytes = read_bytes_from_chunk(chunk.to_bits()).ok_or_else(|| {
+                make_type_error_with_code(
+                    "The \"chunk\" argument must be an instance of Buffer, TypedArray, DataView, or ArrayBuffer",
+                    "ERR_INVALID_ARG_TYPE",
+                )
+            })?;
+            chunks.extend_from_slice(&bytes);
+            Ok(())
+        }
+    }
+}
+
+unsafe fn native_transform_close(
+    native: &mut NativeTransformKind,
+    readable_id: usize,
+) -> Result<(), u64> {
+    match native {
+        NativeTransformKind::TextEncoder => Ok(()),
+        NativeTransformKind::TextDecoder { fatal, pending } => {
+            native_text_decoder_drain(pending, *fatal, readable_id, true)
+        }
+        NativeTransformKind::Compression {
+            format,
+            decompress,
+            chunks,
+        } => match run_web_compression_codec(*format, *decompress, chunks) {
+            Ok(out) => {
+                let chunk = alloc_uint8array_from_bytes(&out);
+                js_readable_stream_controller_enqueue(readable_id as f64, f64::from_bits(chunk));
+                chunks.clear();
+                Ok(())
+            }
+            Err(err) => Err(make_type_error_with_code(&err.to_string(), "Z_DATA_ERROR")),
+        },
+    }
+}
+
+unsafe fn attach_stream_field(object_value: f64, name: &[u8], value: f64) {
+    let ptr = js_nanbox_get_pointer(object_value) as *mut ObjectHeader;
+    if ptr.is_null() || (ptr as usize) < 0x10000 {
+        return;
+    }
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(ptr, key, value);
+}
+
+unsafe fn attach_stream_string_field(object_value: f64, name: &[u8], value: &[u8]) {
+    let ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
+    attach_stream_field(
+        object_value,
+        name,
+        f64::from_bits(JSValue::string_ptr(ptr).bits()),
+    );
+}
+
+unsafe fn attach_stream_bool_field(object_value: f64, name: &[u8], value: bool) {
+    attach_stream_field(
+        object_value,
+        name,
+        f64::from_bits(if value { TAG_TRUE } else { TAG_FALSE }),
+    );
+}
+
+unsafe fn attach_transform_endpoints(object_value: f64, readable_id: usize, writable_id: usize) {
+    attach_stream_field(object_value, b"readable", readable_id as f64);
+    attach_stream_field(object_value, b"writable", writable_id as f64);
+}
+
+unsafe fn bool_option(options: f64, name: &[u8]) -> bool {
+    let jsval = JSValue::from_bits(options.to_bits());
+    if !jsval.is_pointer() {
+        return false;
+    }
+    let value =
+        perry_runtime::value::js_get_property(options, name.as_ptr() as i64, name.len() as i64);
+    perry_runtime::value::js_is_truthy(value) != 0
+}
+
+unsafe fn parse_text_decoder_stream_label(label: f64) {
+    let jsval = JSValue::from_bits(label.to_bits());
+    if jsval.is_undefined()
+        || value_string_equals(label, b"utf-8")
+        || value_string_equals(label, b"utf8")
+    {
+        return;
+    }
+    let label_text = js_string_value_to_string(label, true).unwrap_or_default();
+    let message = format!("The \"{label_text}\" encoding is not supported");
+    throw_range_error_with_code(&message, "ERR_ENCODING_NOT_SUPPORTED");
+}
+
+unsafe fn parse_web_compression_format(value: f64, constructor_name: &str) -> WebCompressionFormat {
+    if value_string_equals(value, b"gzip") {
+        return WebCompressionFormat::Gzip;
+    }
+    if value_string_equals(value, b"deflate") {
+        return WebCompressionFormat::Deflate;
+    }
+    if value_string_equals(value, b"deflate-raw") {
+        return WebCompressionFormat::DeflateRaw;
+    }
+    if value_string_equals(value, b"brotli") {
+        return WebCompressionFormat::Brotli;
+    }
+    let received =
+        js_string_value_to_string(value, true).unwrap_or_else(|| "undefined".to_string());
+    let message = format!(
+        "Failed to construct '{constructor_name}': 1st argument value '{received}' is not a valid enum value of type CompressionFormat."
+    );
+    throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE");
+}
+
+unsafe fn build_native_transform_object(object_value: f64, native: NativeTransformKind) -> f64 {
+    let handle = alloc_transform_stream(0, 0, 0, Some(native), 1.0);
+    let readable_id = js_transform_stream_readable(handle) as usize;
+    let writable_id = js_transform_stream_writable(handle) as usize;
+    attach_transform_endpoints(object_value, readable_id, writable_id);
+    object_value
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_stream_web_text_encoder_stream_new() -> f64 {
+    let object = perry_runtime::object::js_text_encoder_stream_new();
+    attach_stream_string_field(object, b"encoding", b"utf-8");
+    build_native_transform_object(object, NativeTransformKind::TextEncoder)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_stream_web_text_decoder_stream_new(label: f64, options: f64) -> f64 {
+    parse_text_decoder_stream_label(label);
+    let fatal = bool_option(options, b"fatal");
+    let ignore_bom = bool_option(options, b"ignoreBOM");
+    let object = perry_runtime::object::js_text_decoder_stream_new();
+    attach_stream_string_field(object, b"encoding", b"utf-8");
+    attach_stream_bool_field(object, b"fatal", fatal);
+    attach_stream_bool_field(object, b"ignoreBOM", ignore_bom);
+    build_native_transform_object(
+        object,
+        NativeTransformKind::TextDecoder {
+            fatal,
+            pending: Vec::new(),
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_stream_web_compression_stream_new(format: f64) -> f64 {
+    let format = parse_web_compression_format(format, "CompressionStream");
+    let object = perry_runtime::object::js_compression_stream_new();
+    build_native_transform_object(
+        object,
+        NativeTransformKind::Compression {
+            format,
+            decompress: false,
+            chunks: Vec::new(),
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_stream_web_decompression_stream_new(format: f64) -> f64 {
+    let format = parse_web_compression_format(format, "DecompressionStream");
+    let object = perry_runtime::object::js_decompression_stream_new();
+    build_native_transform_object(
+        object,
+        NativeTransformKind::Compression {
+            format,
+            decompress: true,
+            chunks: Vec::new(),
+        },
+    )
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -3190,5 +3632,28 @@ mod tests {
         assert!(emitted.contains(&(0x7FFD_0000_0000_0000 | 0x3456_7890)));
         assert!(emitted.contains(&0x7FFF_0000_0000_4567));
         READABLE_STREAMS.lock().unwrap().clear();
+    }
+
+    #[test]
+    fn web_compression_formats_round_trip() {
+        let input = b"hello stream/web compression";
+        for format in [
+            WebCompressionFormat::Gzip,
+            WebCompressionFormat::Deflate,
+            WebCompressionFormat::DeflateRaw,
+            WebCompressionFormat::Brotli,
+        ] {
+            let compressed = run_web_compression_codec(format, false, input).unwrap();
+            assert!(!compressed.is_empty());
+            let decompressed = run_web_compression_codec(format, true, &compressed).unwrap();
+            assert_eq!(decompressed, input);
+        }
+    }
+
+    #[test]
+    fn utf8_split_prefix_tracks_incomplete_sequence() {
+        assert_eq!(split_utf8_prefix(&[0x68, 0xc3]).unwrap(), (1, true));
+        assert_eq!(split_utf8_prefix(&[0xc3, 0xa9]).unwrap(), (2, false));
+        assert!(split_utf8_prefix(&[0xff]).is_err());
     }
 }

--- a/test-parity/node-suite/stream/web/compression-stream-roundtrip.ts
+++ b/test-parity/node-suite/stream/web/compression-stream-roundtrip.ts
@@ -1,0 +1,64 @@
+import { CompressionStream, DecompressionStream } from "node:stream/web";
+
+async function collectBytes(readable: ReadableStream<Uint8Array>) {
+  const reader = readable.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) {
+      break;
+    }
+    chunks.push(chunk.value);
+    total += chunk.value.byteLength;
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+async function writeAndClose(writable: WritableStream<Uint8Array>, chunks: Uint8Array[]) {
+  const writer = writable.getWriter();
+  for (const chunk of chunks) {
+    await writer.write(chunk);
+  }
+  await writer.close();
+}
+
+console.log("constructors:", CompressionStream.length, DecompressionStream.length);
+
+for (const Ctor of [CompressionStream, DecompressionStream]) {
+  for (const format of [undefined, "x-gzip"]) {
+    try {
+      format === undefined ? new Ctor(format as any) : new Ctor(format);
+      console.log("bad format:", Ctor.name, String(format), "ok");
+    } catch (err: any) {
+      console.log("bad format:", Ctor.name, String(format), err.constructor.name, err.code);
+    }
+  }
+}
+
+for (const format of ["gzip", "deflate", "deflate-raw", "brotli"] as const) {
+  const compressor = new CompressionStream(format);
+  console.log(
+    "codec streams:",
+    format,
+    compressor.readable instanceof ReadableStream,
+    compressor.writable instanceof WritableStream,
+    Object.prototype.toString.call(compressor),
+  );
+
+  const source = new TextEncoder().encode(`hello ${format}`);
+  const compressed = collectBytes(compressor.readable);
+  await writeAndClose(compressor.writable, [source.subarray(0, 3), source.subarray(3)]);
+
+  const decompressor = new DecompressionStream(format);
+  const plain = collectBytes(decompressor.readable);
+  await writeAndClose(decompressor.writable, [await compressed]);
+
+  console.log("codec roundtrip:", format, new TextDecoder().decode(await plain));
+}

--- a/test-parity/node-suite/stream/web/text-encoding-stream-properties.ts
+++ b/test-parity/node-suite/stream/web/text-encoding-stream-properties.ts
@@ -1,0 +1,81 @@
+import { TextDecoderStream, TextEncoderStream } from "node:stream/web";
+
+async function collectText(readable: ReadableStream<string>) {
+  const reader = readable.getReader();
+  let out = "";
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) {
+      return out;
+    }
+    out += chunk.value;
+  }
+}
+
+async function collectBytes(readable: ReadableStream<Uint8Array>) {
+  const reader = readable.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) {
+      break;
+    }
+    chunks.push(chunk.value);
+    total += chunk.value.byteLength;
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+const encoder = new TextEncoderStream();
+console.log("encoder props:", encoder.encoding);
+console.log(
+  "encoder streams:",
+  encoder.readable instanceof ReadableStream,
+  encoder.writable instanceof WritableStream,
+);
+console.log(
+  "encoder identity:",
+  encoder.constructor === TextEncoderStream,
+  encoder instanceof TextEncoderStream,
+);
+
+const encoded = collectBytes(encoder.readable);
+const encoderWriter = encoder.writable.getWriter();
+await encoderWriter.write("he");
+await encoderWriter.write("llo");
+await encoderWriter.close();
+console.log("encoded text:", new TextDecoder().decode(await encoded));
+
+const decoder = new TextDecoderStream("utf-8", { fatal: true, ignoreBOM: true });
+console.log("decoder props:", decoder.encoding, decoder.fatal, decoder.ignoreBOM);
+console.log(
+  "decoder streams:",
+  decoder.readable instanceof ReadableStream,
+  decoder.writable instanceof WritableStream,
+);
+console.log(
+  "decoder identity:",
+  decoder.constructor === TextDecoderStream,
+  decoder instanceof TextDecoderStream,
+);
+
+const decoded = collectText(decoder.readable);
+const decoderWriter = decoder.writable.getWriter();
+await decoderWriter.write(new Uint8Array([0x68, 0xc3]));
+await decoderWriter.write(new Uint8Array([0xa9]));
+await decoderWriter.close();
+console.log("decoded text:", await decoded);
+
+try {
+  new TextDecoderStream("not-an-encoding");
+  console.log("bad decoder label: ok");
+} catch (err: any) {
+  console.log("bad decoder label:", err.constructor.name, err.code);
+}


### PR DESCRIPTION
## Summary

Implements the remaining `node:stream/web` codec stream constructor surface covered by #2581 and #2614:

- Adds `CompressionStream` and `DecompressionStream` globals and `node:stream/web` exports, including constructor lengths, `instanceof`, object tags, and format validation.
- Backs compression and decompression roundtrips for `gzip`, `deflate`, `deflate-raw`, and `brotli` through the bundled streams feature.
- Completes `TextEncoderStream` and `TextDecoderStream` properties, imported/global constructor identity, `instanceof`, UTF-8 split chunk handling, and invalid label errors.
- Adds focused parity fixtures for text encoding stream properties and compression stream roundtrips.

The compression implementation buffers transform input and emits on close; true incremental streaming compression is left out of scope for this compatibility pass.

Closes #2581.
Closes #2614.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `./scripts/check_file_size.sh`
- `cargo test -p perry-stdlib --no-default-features --features bundled-streams,async-runtime streams::tests`
- `cargo test -p perry-runtime text_encoding_stream_globals_construct_readable_writable_shape`
- `cargo test -p perry-codegen registry_dispatch_routes_to_correct_owner`
- `cargo test -p perry-codegen --test manifest_consistency`
- `PATH=/tmp/perry-node25.1fngoW:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/web --filter text-encoding-stream-properties`
- `PATH=/tmp/perry-node25.1fngoW:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module stream/web --filter compression-stream-roundtrip`
