### PR TITLE
fix(typedarray): BYTES_PER_ELEMENT own props on constructor + prototype (#4140)

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1924,6 +1924,35 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                     (*gc)._reserved |= crate::gc::OBJ_FLAG_TYPED_ARRAY_PROTO;
                 }
             }
+            // #4140: per-kind `BYTES_PER_ELEMENT` own data property on BOTH the
+            // constructor and its prototype, matching Node's descriptor
+            // `{ value, writable:false, enumerable:false, configurable:false }`.
+            // The bare `Uint8Array.BYTES_PER_ELEMENT` read folds at compile time
+            // (#2902), but the reflective forms — `getOwnPropertyDescriptor`,
+            // `hasOwnProperty`, and the chained `Float64Array.prototype
+            // .BYTES_PER_ELEMENT` — resolve off these installed own properties.
+            let ta_bytes_per_element = match name {
+                "Int8Array" | "Uint8Array" | "Uint8ClampedArray" => Some(1.0),
+                "Int16Array" | "Uint16Array" | "Float16Array" => Some(2.0),
+                "Int32Array" | "Uint32Array" | "Float32Array" => Some(4.0),
+                "Float64Array" | "BigInt64Array" | "BigUint64Array" => Some(8.0),
+                _ => None,
+            };
+            if let Some(bytes) = ta_bytes_per_element {
+                let bpe_attrs = super::PropertyAttrs::new(false, false, false);
+                for target in [closure_ptr as *mut ObjectHeader, proto_obj] {
+                    let bpe_key = crate::string::js_string_from_bytes(
+                        b"BYTES_PER_ELEMENT".as_ptr(),
+                        b"BYTES_PER_ELEMENT".len() as u32,
+                    );
+                    js_object_set_field_by_name(target, bpe_key, bytes);
+                    super::set_builtin_property_attrs(
+                        target as usize,
+                        "BYTES_PER_ELEMENT".to_string(),
+                        bpe_attrs,
+                    );
+                }
+            }
         }
         let name_bytes = name.as_bytes();
         let name_key =

--- a/test-parity/node-suite/globals/typedarray-constructor-own-props.ts
+++ b/test-parity/node-suite/globals/typedarray-constructor-own-props.ts
@@ -1,0 +1,52 @@
+// #4140 — every concrete TypedArray constructor carries the spec-required own
+// properties: `BYTES_PER_ELEMENT` on BOTH the constructor and its prototype
+// (`{ value, writable:false, enumerable:false, configurable:false }`) and the
+// prototype's `constructor` back-link to the constructor.
+//
+// The bare `Uint8Array.BYTES_PER_ELEMENT` read folds at compile time (#2902),
+// so each constructor is also probed through a runtime `any` binding and the
+// reflective protocol (`getOwnPropertyDescriptor`, `hasOwnProperty`, the
+// chained `Ctor.prototype.BYTES_PER_ELEMENT` read) which resolve off the real
+// installed own properties rather than the fold.
+
+function desc(o: any, k: string): string {
+  return JSON.stringify(Object.getOwnPropertyDescriptor(o, k));
+}
+
+const sizes: Record<string, number> = {
+  Int8Array: 1,
+  Uint8Array: 1,
+  Uint8ClampedArray: 1,
+  Int16Array: 2,
+  Uint16Array: 2,
+  Float16Array: 2,
+  Int32Array: 4,
+  Uint32Array: 4,
+  Float32Array: 4,
+  Float64Array: 8,
+  BigInt64Array: 8,
+  BigUint64Array: 8,
+};
+
+for (const name of Object.keys(sizes)) {
+  const C: any = (globalThis as any)[name];
+  const expected = sizes[name];
+  console.log("== " + name + " ==");
+  // Folded constant form and the runtime value form agree with the spec size.
+  console.log("ctor BPE", C.BYTES_PER_ELEMENT, C.BYTES_PER_ELEMENT === expected);
+  console.log("proto BPE", C.prototype.BYTES_PER_ELEMENT, C.prototype.BYTES_PER_ELEMENT === expected);
+  // Descriptors: value + the non-writable/non-enumerable/non-configurable attrs.
+  console.log("ctor BPE desc", desc(C, "BYTES_PER_ELEMENT"));
+  console.log("proto BPE desc", desc(C.prototype, "BYTES_PER_ELEMENT"));
+  // Own-ness via the uncurried hasOwnProperty.
+  console.log(
+    "hasOwn BPE",
+    Object.prototype.hasOwnProperty.call(C, "BYTES_PER_ELEMENT"),
+    Object.prototype.hasOwnProperty.call(C.prototype, "BYTES_PER_ELEMENT"),
+  );
+  // Non-enumerable: must not leak into the constructor's own-keys.
+  console.log("ctor keys has BPE", Object.keys(C).includes("BYTES_PER_ELEMENT"));
+  // The prototype's `constructor` back-link and its descriptor.
+  console.log("proto.constructor === Ctor", C.prototype.constructor === C);
+  console.log("constructor desc", desc(C.prototype, "constructor"));
+}


### PR DESCRIPTION
Closes the headline gap in #4140.

## What was missing

Every concrete `TypedArray` constructor (`Int8Array` … `BigUint64Array`) was
missing the `BYTES_PER_ELEMENT` own data property on **both** the constructor
and its prototype. The bare `Uint8Array.BYTES_PER_ELEMENT` read folds at compile
time (#2902) so it looked fine, but the reflective forms returned `undefined`:

```js
Object.getOwnPropertyDescriptor(Uint8Array, 'BYTES_PER_ELEMENT')   // was undefined
Float64Array.prototype.BYTES_PER_ELEMENT                            // was undefined
Object.prototype.hasOwnProperty.call(Uint8Array, 'BYTES_PER_ELEMENT') // was false
```

## Fix

In the global built-in constructor loop (`global_this.rs`), install
`BYTES_PER_ELEMENT` on both the constructor closure and its prototype object
with Node's descriptor `{ value, writable:false, enumerable:false,
configurable:false }`, keyed per element width (1/2/4/8 bytes).

## Already correct on `main` (verified, left unchanged)

While auditing the rest of #4140's checklist I confirmed these already match
Node byte-for-byte:

- `Ctor.prototype.constructor === Ctor` back-link (generic builtin-proto wiring)
- the prototype `constructor` descriptor `{ writable:true, enumerable:false, configurable:true }`
- `name` / `length` / `prototype` descriptor attributes (broader descriptor
  conformance is tracked separately under #4139)
- the abstract `%TypedArray%` call/construct `TypeError`

The `not-typedarray-object.js` validation item could not be reproduced as a
divergence — the obvious candidate (calling/constructing the abstract intrinsic)
already throws `TypeError` to match Node.

## Verification

New fixture `test-parity/node-suite/globals/typedarray-constructor-own-props.ts`
exercises all 12 typed-array types through the reflective protocol
(`getOwnPropertyDescriptor`, `hasOwnProperty`, `Object.keys`, chained
`prototype.BYTES_PER_ELEMENT`, `prototype.constructor`). Output is byte-identical
to `node --experimental-strip-types` in both optimized and `PERRY_NO_AUTO_OPTIMIZE=1`
builds.
