### PR TITLE
[codex] console: expose context and createTask helpers

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3839,6 +3839,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("console", "profile", false, None),
     method("console", "profileEnd", false, None),
     method("console", "timeStamp", false, None),
+    method("console", "context", false, None),
+    method("console", "createTask", false, None),
     // --- util (a small surface — Perry implements util.inspect /
     //     util.format / util.promisify shapes through builtins.rs;
     //     the rest are documented stubs) ---

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -1762,6 +1762,24 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
         args: &[],
         ret: NR_VOID,
     },
+    NativeModSig {
+        module: "console",
+        has_receiver: false,
+        method: "context",
+        class_filter: None,
+        runtime: "js_console_context",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "console",
+        has_receiver: false,
+        method: "createTask",
+        class_filter: None,
+        runtime: "js_console_create_task",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // ========== Node assert ==========
     // Root-callable `assert(value, message?)` — HIR lowers
     // `import assert from "node:assert"; assert(x, m)` to a

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1534,6 +1534,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_console_assert", VOID, &[DOUBLE, I64]);
     module.declare_function("js_console_assert_spread", VOID, &[DOUBLE, I64]);
     module.declare_function("js_console_group", VOID, &[I64]);
+    module.declare_function("js_console_context", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_console_create_task", DOUBLE, &[DOUBLE]);
 
     // ========== Fetch ==========
     module.declare_function("js_fetch_get", I64, &[I64]);

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -423,6 +423,166 @@ fn print_console_text(text: &str, stderr: bool) {
 #[no_mangle]
 pub extern "C" fn js_console_noop() {}
 
+fn console_undefined() -> f64 {
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+fn throw_plain_console_error(message: &str) -> ! {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_error_new_with_message(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn throw_console_symbol_to_string_type_error() -> ! {
+    let message = b"Cannot convert a Symbol value to a string";
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn console_is_callable(value: f64) -> bool {
+    let ptr = crate::value::js_nanbox_get_pointer(value) as usize;
+    ptr >= 0x1000 && crate::closure::is_closure_ptr(ptr)
+}
+
+unsafe fn console_string_len(value: f64) -> Option<usize> {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_any_string() {
+        return None;
+    }
+    let ptr = crate::value::js_jsvalue_to_string(value) as *const StringHeader;
+    if ptr.is_null() {
+        return None;
+    }
+    Some((*ptr).byte_len as usize)
+}
+
+fn console_make_named_function(
+    scope: &crate::gc::RuntimeHandleScope,
+    name: &str,
+    func_ptr: *const u8,
+    call_arity: u32,
+    exposed_length: u32,
+) -> f64 {
+    crate::closure::js_register_closure_arity(func_ptr, call_arity);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    let closure_handle = scope.root_raw_mut_ptr(closure);
+    crate::object::set_bound_native_closure_name(
+        closure_handle.get_raw_mut_ptr::<crate::closure::ClosureHeader>(),
+        name,
+    );
+    crate::object::set_builtin_closure_length(
+        closure_handle.get_raw_mut_ptr::<crate::closure::ClosureHeader>() as usize,
+        exposed_length,
+    );
+    let closure = closure_handle.get_raw_mut_ptr::<crate::closure::ClosureHeader>();
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
+fn console_set_field(obj: *mut crate::object::ObjectHeader, name: &str, value: f64) {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::object::js_object_set_field_by_name(obj, key, value);
+}
+
+extern "C" fn console_context_method_noop(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    console_undefined()
+}
+
+extern "C" fn console_task_run(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+) -> f64 {
+    if !console_is_callable(callback) {
+        throw_plain_console_error("First argument must be a function.");
+    }
+    unsafe { crate::closure::js_native_call_value(callback, std::ptr::null(), 0) }
+}
+
+/// `console.context([name])` returns an inspector-scoped console object in
+/// Node. Perry has no inspector context plumbing here, but the object shape is
+/// observable by feature detection.
+#[no_mangle]
+pub extern "C" fn js_console_context(name: f64) -> f64 {
+    let jsval = JSValue::from_bits(name.to_bits());
+    if !jsval.is_undefined() {
+        if unsafe { crate::symbol::js_is_symbol(name) != 0 } {
+            throw_console_symbol_to_string_type_error();
+        }
+        let _ = crate::value::js_jsvalue_to_string(name);
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj = crate::object::js_object_alloc(0, 0);
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    for method in [
+        "assert",
+        "clear",
+        "count",
+        "countReset",
+        "debug",
+        "dir",
+        "dirXml",
+        "error",
+        "group",
+        "groupCollapsed",
+        "groupEnd",
+        "info",
+        "log",
+        "profile",
+        "profileEnd",
+        "table",
+        "time",
+        "timeEnd",
+        "timeLog",
+        "timeStamp",
+        "trace",
+        "warn",
+    ] {
+        let func = console_make_named_function(
+            &scope,
+            method,
+            console_context_method_noop as *const u8,
+            0,
+            1,
+        );
+        let func_handle = scope.root_nanbox_f64(func);
+        console_set_field(
+            obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+            method,
+            func_handle.get_nanbox_f64(),
+        );
+    }
+
+    crate::value::js_nanbox_pointer(
+        obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>() as i64
+    )
+}
+
+/// `console.createTask(name)` is V8 inspector async-stack tagging. The
+/// compatibility surface returns `{ run(fn) }`; `run` executes and forwards
+/// the callback result while preserving thrown errors.
+#[no_mangle]
+pub extern "C" fn js_console_create_task(name: f64) -> f64 {
+    let len = unsafe { console_string_len(name) };
+    if len.unwrap_or(0) == 0 {
+        throw_plain_console_error("First argument must be a non-empty string.");
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj = crate::object::js_object_alloc(0, 0);
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    let run = console_make_named_function(&scope, "run", console_task_run as *const u8, 1, 0);
+    let run_handle = scope.root_nanbox_f64(run);
+    console_set_field(
+        obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        "run",
+        run_handle.get_nanbox_f64(),
+    );
+    crate::value::js_nanbox_pointer(
+        obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>() as i64
+    )
+}
+
 /// Debug trace for module initialization order.
 /// Called before each _perry_init_* call to identify which module crashes.
 /// No-op in release builds; re-enable eprintln for debugging.

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -55,18 +55,18 @@ pub use arithmetic::{
 };
 
 pub use console::{
-    js_console_assert, js_console_assert_spread, js_console_clear, js_console_count,
-    js_console_count_reset, js_console_count_reset_value, js_console_count_value,
-    js_console_dir_with_options, js_console_error_dynamic, js_console_error_i32,
-    js_console_error_number, js_console_error_spread, js_console_group, js_console_group_begin,
-    js_console_group_end, js_console_log, js_console_log_as_closure, js_console_log_dynamic,
-    js_console_log_i32, js_console_log_i64, js_console_log_number, js_console_log_spread,
-    js_console_new, js_console_new2, js_console_noop, js_console_time, js_console_time_end,
-    js_console_time_end_value, js_console_time_log, js_console_time_log_spread,
-    js_console_time_log_value, js_console_time_value, js_console_trace, js_console_trace_spread,
-    js_console_warn_dynamic, js_console_warn_i32, js_console_warn_number, js_console_warn_spread,
-    perry_debug_trace_init, perry_debug_trace_init_done, scan_console_log_singleton_roots,
-    scan_console_log_singleton_roots_mut,
+    js_console_assert, js_console_assert_spread, js_console_clear, js_console_context,
+    js_console_count, js_console_count_reset, js_console_count_reset_value, js_console_count_value,
+    js_console_create_task, js_console_dir_with_options, js_console_error_dynamic,
+    js_console_error_i32, js_console_error_number, js_console_error_spread, js_console_group,
+    js_console_group_begin, js_console_group_end, js_console_log, js_console_log_as_closure,
+    js_console_log_dynamic, js_console_log_i32, js_console_log_i64, js_console_log_number,
+    js_console_log_spread, js_console_new, js_console_new2, js_console_noop, js_console_time,
+    js_console_time_end, js_console_time_end_value, js_console_time_log,
+    js_console_time_log_spread, js_console_time_log_value, js_console_time_value, js_console_trace,
+    js_console_trace_spread, js_console_warn_dynamic, js_console_warn_i32, js_console_warn_number,
+    js_console_warn_spread, perry_debug_trace_init, perry_debug_trace_init_done,
+    scan_console_log_singleton_roots, scan_console_log_singleton_roots_mut,
 };
 
 pub(crate) use console::{

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -2607,6 +2607,33 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
         "buffer" => Some(BUFFER_NAMESPACE_KEYS),
         "querystring" => Some(QUERYSTRING_NAMESPACE_KEYS),
         "querystring.default" => Some(QUERYSTRING_DEFAULT_KEYS),
+        "console" | "console.default" => Some(&[
+            b"log",
+            b"info",
+            b"debug",
+            b"warn",
+            b"error",
+            b"dir",
+            b"time",
+            b"timeEnd",
+            b"timeLog",
+            b"trace",
+            b"assert",
+            b"clear",
+            b"count",
+            b"countReset",
+            b"group",
+            b"groupEnd",
+            b"table",
+            b"dirxml",
+            b"groupCollapsed",
+            b"Console",
+            b"profile",
+            b"profileEnd",
+            b"timeStamp",
+            b"context",
+            b"createTask",
+        ]),
         "punycode" => Some(PUNYCODE_NAMESPACE_KEYS),
         "punycode.default" => Some(PUNYCODE_DEFAULT_KEYS),
         "punycode.ucs2" => Some(PUNYCODE_UCS2_KEYS),
@@ -3150,6 +3177,9 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
         property_name
     };
     set_bound_native_closure_name(closure, exposed_name);
+    if let Some(length) = native_callable_export_arity(export_module_name, property_name) {
+        set_builtin_closure_length(closure as usize, length);
+    }
     let value = crate::value::js_nanbox_pointer(closure as i64);
     let closure_addr = closure as usize;
 
@@ -3510,6 +3540,8 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("process", "hasUncaughtExceptionCaptureCallback") => Some(0),
         ("fs", "_toUnixTimestamp") => Some(1),
         ("util", "debug" | "debuglog" | "inherits") => Some(2),
+        ("console", "context") => Some(1),
+        ("console", "createTask") => Some(0),
         ("util", "MIMEParams") => Some(0),
         ("util", "MIMEType") => Some(1),
         ("stream", "pipeline" | "compose") => Some(0),
@@ -4324,12 +4356,13 @@ pub(crate) unsafe fn bound_native_callable_module_and_method(
 
 pub(crate) unsafe fn bound_native_callable_value_arity(value: f64) -> Option<u32> {
     let (module, method) = bound_native_callable_module_and_method(value)?;
-    match (module.as_str(), method.as_str()) {
+    let module = normalize_native_module_alias(&module);
+    match (module, method.as_str()) {
         ("console", "Console") => Some(1),
         ("util", "isArray") => Some(1),
         ("module", "isBuiltin") => Some(1),
         ("process", "getBuiltinModule") => Some(1),
-        _ => native_callable_export_arity(module.as_str(), method.as_str()),
+        _ => native_callable_export_arity(module, method.as_str()),
     }
 }
 
@@ -5117,6 +5150,8 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("console", "profile")
             | ("console", "profileEnd")
             | ("console", "timeStamp")
+            | ("console", "context")
+            | ("console", "createTask")
             | ("crypto", "createHash")
             | ("crypto", "Hash")
             | ("crypto", "createSign")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1,5 +1,4 @@
-//! Dispatch table for `(native_module_namespace).method(...)` calls
-//! that escape into the runtime tower from
+//! Dispatch table for native module method calls that escape into the runtime tower from
 //! `js_native_call_method`.
 //!
 //! Split out of `object/mod.rs` (issue #1103). Pure relocation — no
@@ -7,6 +6,7 @@
 
 use super::native_module_dispatch_crypto::crypto_random_fill_sync_dispatch;
 use super::*;
+use crate::value::TAG_UNDEFINED;
 
 /// #3712: coerce a NaN-boxed value to an owned UTF-8 `String`, matching the
 /// `${val}` coercion Node applies before building HTTP error messages.
@@ -1574,6 +1574,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("console", "profile") | ("console", "profileEnd") | ("console", "timeStamp") => {
             f64::from_bits(JSValue::undefined().bits())
         }
+        ("console", "context") => crate::builtins::js_console_context(arg(0)),
+        ("console", "createTask") => crate::builtins::js_console_create_task(arg(0)),
         ("stream", _) => dispatch_stream_native_module_method(method_name, args_ptr, args_len)
             .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits())),
         ("readline", "clearLine") => {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1850 entries across 106 modules
+// Coverage: 1852 entries across 106 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -332,9 +332,13 @@ declare module "console" {
   /** stdlib */
   export function clear(...args: any[]): any;
   /** stdlib */
+  export function context(...args: any[]): any;
+  /** stdlib */
   export function count(...args: any[]): any;
   /** stdlib */
   export function countReset(...args: any[]): any;
+  /** stdlib */
+  export function createTask(...args: any[]): any;
   /** stdlib */
   export function debug(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2668 entries across 109 modules.
+Total: 2670 entries across 109 modules.
 
 ## Modules
 
@@ -407,8 +407,10 @@ Total: 2668 entries across 109 modules.
 
 - `assert` — module
 - `clear` — module
+- `context` — module
 - `count` — module
 - `countReset` — module
+- `createTask` — module
 - `debug` — module
 - `dir` — module
 - `dirxml` — module

--- a/test-parity/node-suite/console/properties/context-and-task-helpers.ts
+++ b/test-parity/node-suite/console/properties/context-and-task-helpers.ts
@@ -1,0 +1,71 @@
+import * as consoleModule from "node:console";
+
+function errorShape(fn: () => unknown): string {
+  try {
+    fn();
+    return "no error";
+  } catch (error) {
+    const err = error as Error & { code?: string };
+    return `${err.name}:${err.code ?? "no-code"}:${err.message}`;
+  }
+}
+
+console.log(
+  "module keys:",
+  Object.keys(consoleModule).includes("context"),
+  Object.keys(consoleModule).includes("createTask"),
+);
+
+for (const name of ["context", "createTask"] as const) {
+  const value = consoleModule[name] as unknown as Function;
+  const desc = Object.getOwnPropertyDescriptor(consoleModule, name);
+  if (name === "context") {
+    console.log(`${name} type/name:`, typeof value, value.name);
+  } else {
+    console.log(`${name} type/name/length:`, typeof value, value.name, value.length);
+  }
+  console.log(`${name} descriptor:`, desc?.enumerable, desc?.writable);
+}
+
+const scoped = consoleModule.context("scope");
+const scopedAgain = consoleModule.context("scope");
+console.log("context distinct:", scoped !== scopedAgain);
+console.log("context keys:", Object.keys(scoped).sort().join(","));
+console.log(
+  "context log shape:",
+  typeof scoped.log,
+  scoped.log.name,
+  scoped.log.length,
+);
+console.log(
+  "context helpers:",
+  ["assert", "clear", "dirXml", "groupEnd", "timeStamp", "warn"]
+    .map((name) => `${name}:${typeof (scoped as any)[name]}:${(scoped as any)[name].length}`)
+    .join(","),
+);
+console.log("context noargs:", typeof consoleModule.context());
+console.log(
+  "context symbol error:",
+  errorShape(() => consoleModule.context(Symbol("scope") as any)),
+);
+
+const task = consoleModule.createTask("task");
+console.log("task keys:", Object.keys(task).sort().join(","));
+console.log("task run shape:", typeof task.run, task.run.name, task.run.length);
+console.log("task run return:", task.run(() => 42));
+let sideEffect = 0;
+task.run(() => {
+  sideEffect = 7;
+});
+console.log("task side effect:", sideEffect);
+console.log("task invalid name:", errorShape(() => consoleModule.createTask("")));
+console.log("task non-string name:", errorShape(() => consoleModule.createTask(123 as any)));
+console.log("task run invalid:", errorShape(() => task.run(123 as any)));
+console.log(
+  "task run thrown:",
+  errorShape(() =>
+    task.run(() => {
+      throw new Error("boom");
+    }),
+  ),
+);


### PR DESCRIPTION
## Summary

Closes #2684.

- Adds `node:console` exports for `context` and `createTask` through the manifest, native dispatch, and codegen tables.
- Implements the observable helper surfaces: scoped console helper objects, task `run(fn)` execution, validation errors, function names, and callable lengths where the native export layer supports them.
- Adds focused Node parity coverage for the helper exports, returned object shapes, validation, callback return/throw forwarding, and descriptor/key visibility.

## Scope

This is a focused console helper cut. It does not add inspector async-stack tracking; `createTask(...).run(fn)` preserves the observable callback behavior Perry can support today, and `console.context(...)` provides the feature-detection and helper-object behavior covered by Node parity.

## Validation

- `PATH="/tmp/perry-node25-bin:$PATH" ./run_parity_tests.sh --suite node-suite --module console --filter context-and-task-helpers` (pass; report `parity_report_20260602_182659.json`)
- `cargo build -p perry-runtime -p perry-codegen -p perry-api-manifest` (pass; existing warnings only)
- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`

Additional context: a broader console-suite run before final hygiene still surfaced unrelated formatter/table failures in `no-tostring-on-string-format`, `sparse-array`, and `unicode-width`; the new helper fixture passed.
