### PR TITLE
[codex] add SubtleCrypto.supports shape

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -741,6 +741,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &ctor_handle), (I64, &key_raw)],
                     ));
                 }
+                if property == "supports" {
+                    let ctor_idx = ctx.strings.intern("SubtleCrypto");
+                    let ctor_bytes_global =
+                        format!("@{}", ctx.strings.entry(ctor_idx).bytes_global);
+                    let ctor_len = "SubtleCrypto".len().to_string();
+                    let ctor = ctx.block().call(
+                        DOUBLE,
+                        "js_get_global_this_builtin_value",
+                        &[(PTR, &ctor_bytes_global), (I64, &ctor_len)],
+                    );
+                    let key_idx = ctx.strings.intern(property);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let blk = ctx.block();
+                    let ctor_handle = unbox_to_i64(blk, &ctor);
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_bits = blk.bitcast_double_to_i64(&key_box);
+                    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    return Ok(blk.call(
+                        DOUBLE,
+                        "js_object_get_field_by_name_f64",
+                        &[(I64, &ctor_handle), (I64, &key_raw)],
+                    ));
+                }
                 if matches!(property.as_str(), "f16round" | "random") {
                     let math_idx = ctx.strings.intern("Math");
                     let math_bytes_global =

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2390,6 +2390,40 @@ extern "C" fn url_parse_thunk(
     }
 }
 
+extern "C" fn subtle_crypto_supports_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let args = global_this_rest_array_values(rest);
+    if args.len() < 2 {
+        let message = format!(
+            "Failed to execute 'supports' on 'SubtleCrypto': 2 arguments required, but only {} present.",
+            args.len()
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_MISSING_ARGS");
+    }
+
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let op = args[0];
+    let algorithm = args[1];
+    let length = args.get(2).copied().unwrap_or(undefined);
+    let ptr = crate::value::JS_NATIVE_WEBCRYPTO_DISPATCH.load(Ordering::SeqCst);
+    if ptr.is_null() {
+        return f64::from_bits(crate::value::TAG_FALSE);
+    }
+    let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
+        unsafe { std::mem::transmute(ptr) };
+    let dispatch_args = [op, algorithm, length];
+    unsafe {
+        dispatch(
+            b"supports".as_ptr(),
+            "supports".len(),
+            dispatch_args.as_ptr(),
+            dispatch_args.len(),
+        )
+    }
+}
+
 /// Install a single callable static method on a constructor closure as a
 /// `{ writable: true, enumerable: false, configurable: true }` data property
 /// (matching Node's descriptors for built-in statics). `has_rest` registers
@@ -2595,6 +2629,21 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 false,
             );
             install_constructor_static(ctor, "parse", url_parse_thunk as *const u8, 1, false);
+        }
+        "SubtleCrypto" => {
+            install_constructor_static_with_call_arity(
+                ctor,
+                "supports",
+                subtle_crypto_supports_thunk as *const u8,
+                2,
+                0,
+                true,
+            );
+            super::set_builtin_property_attrs(
+                ctor as usize,
+                "supports".to_string(),
+                super::PropertyAttrs::new(true, true, true),
+            );
         }
         _ => {}
     }

--- a/crates/perry-stdlib/src/webcrypto.rs
+++ b/crates/perry-stdlib/src/webcrypto.rs
@@ -13,15 +13,16 @@ mod hmac;
 mod jwk;
 mod kdf;
 mod keys;
+mod supports;
 mod util;
 mod wrap;
 
 #[allow(unused_imports)]
 // Private imports keep sibling modules able to share `pub(super)` helpers.
-use self::{aes::*, digest::*, hmac::*, jwk::*, kdf::*, keys::*, util::*, wrap::*};
+use self::{aes::*, digest::*, hmac::*, jwk::*, kdf::*, keys::*, supports::*, util::*, wrap::*};
 
 // Public re-exports preserve the parent module surface for FFI entry points.
-pub use self::{aes::*, digest::*, hmac::*, jwk::*, kdf::*, keys::*, wrap::*};
+pub use self::{aes::*, digest::*, hmac::*, jwk::*, kdf::*, keys::*, supports::*, wrap::*};
 
 /// Dispatcher for captured/dynamic `crypto.subtle.*` calls. Static
 /// `crypto.subtle.method(...)` call sites still lower directly in codegen;
@@ -95,6 +96,7 @@ pub unsafe extern "C" fn js_webcrypto_native_dispatch(
             arg(5),
             arg(6),
         )),
+        "supports" if args_len >= 2 => js_webcrypto_supports(arg(0), arg(1), arg(2)),
         _ => undefined,
     }
 }

--- a/crates/perry-stdlib/src/webcrypto/supports.rs
+++ b/crates/perry-stdlib/src/webcrypto/supports.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+fn js_bool(value: bool) -> f64 {
+    f64::from_bits(JSValue::bool(value).bits())
+}
+
+fn normalize_name(name: &str) -> String {
+    name.chars().flat_map(char::to_uppercase).collect()
+}
+
+unsafe fn algorithm_name(bits: u64) -> Option<String> {
+    if let Some(name) = string_from_jsvalue(bits) {
+        return Some(name);
+    }
+    object_field_string(bits, b"name")
+}
+
+unsafe fn algorithm_is_object(bits: u64) -> bool {
+    string_from_jsvalue(bits).is_none() && strip_ptr(bits) >= 0x1000
+}
+
+unsafe fn algorithm_curve(bits: u64) -> Option<String> {
+    object_field_string(bits, b"namedCurve").map(|curve| normalize_name(&curve))
+}
+
+unsafe fn supports_generate_key(algorithm_bits: u64, algorithm: &str) -> bool {
+    let object_form = algorithm_is_object(algorithm_bits);
+    match algorithm {
+        "ED25519" | "X25519" => true,
+        "HMAC" | "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" => object_form,
+        "ECDSA" | "ECDH" => {
+            object_form
+                && matches!(
+                    algorithm_curve(algorithm_bits).as_deref(),
+                    Some("P-256" | "PRIME256V1" | "SECP256R1")
+                )
+        }
+        _ => false,
+    }
+}
+
+unsafe fn supports_import_key(algorithm_bits: u64, algorithm: &str) -> bool {
+    match algorithm {
+        "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" | "PBKDF2" | "HKDF" | "ED25519" | "X25519" => {
+            true
+        }
+        "HMAC" => algorithm_is_object(algorithm_bits),
+        "ECDSA" | "ECDH" => matches!(
+            algorithm_curve(algorithm_bits).as_deref(),
+            Some("P-256" | "PRIME256V1" | "SECP256R1")
+        ),
+        "RSA-OAEP" | "RSA-PSS" | "RSASSA-PKCS1-V1_5" => algorithm_is_object(algorithm_bits),
+        _ => false,
+    }
+}
+
+fn supports_export_key(algorithm: &str) -> bool {
+    matches!(
+        algorithm,
+        "HMAC"
+            | "AES-GCM"
+            | "AES-CBC"
+            | "AES-CTR"
+            | "AES-KW"
+            | "ECDSA"
+            | "ECDH"
+            | "ED25519"
+            | "X25519"
+            | "RSA-OAEP"
+            | "RSA-PSS"
+            | "RSASSA-PKCS1-V1_5"
+    )
+}
+
+/// Static `SubtleCrypto.supports(operation, algorithm, length?)` support
+/// detection. This reports Perry's implemented WebCrypto subset in the same
+/// operation contexts Node's static method uses; modern algorithms that still
+/// lack execution support remain `false` rather than being advertised early.
+#[no_mangle]
+pub unsafe extern "C" fn js_webcrypto_supports(
+    operation_bits: f64,
+    algorithm_bits: f64,
+    _length_bits: f64,
+) -> f64 {
+    let Some(operation) = string_from_jsvalue(operation_bits.to_bits()) else {
+        return js_bool(false);
+    };
+    let Some(algorithm) = algorithm_name(algorithm_bits.to_bits()) else {
+        return js_bool(false);
+    };
+    let operation = normalize_name(&operation);
+    let algorithm = normalize_name(&algorithm);
+    let supported = match operation.as_str() {
+        "DIGEST" => matches!(
+            algorithm.as_str(),
+            "SHA-1" | "SHA-256" | "SHA-384" | "SHA-512"
+        ),
+        "SIGN" | "VERIFY" => {
+            matches!(algorithm.as_str(), "HMAC" | "ED25519" | "RSASSA-PKCS1-V1_5")
+        }
+        "ENCRYPT" | "DECRYPT" => algorithm == "RSA-OAEP",
+        "GENERATEKEY" => supports_generate_key(algorithm_bits.to_bits(), &algorithm),
+        "IMPORTKEY" => supports_import_key(algorithm_bits.to_bits(), &algorithm),
+        "EXPORTKEY" => supports_export_key(&algorithm),
+        _ => false,
+    };
+    js_bool(supported)
+}

--- a/test-parity/node-suite/crypto/webcrypto/subtle-supports.ts
+++ b/test-parity/node-suite/crypto/webcrypto/subtle-supports.ts
@@ -1,0 +1,53 @@
+import { webcrypto } from "node:crypto";
+
+// Node 25 marks `SubtleCrypto.supports` and several algorithm names as
+// experimental. Keep the fixture focused on stdout API parity.
+(process as any).emitWarning = () => undefined;
+
+const descriptorShape = (desc: any) => ({
+  enumerable: desc?.enumerable,
+  configurable: desc?.configurable,
+  writable: "writable" in desc ? desc.writable : undefined,
+  value: typeof desc?.value,
+});
+
+const throwsShape = (label: string, fn: () => void) => {
+  try {
+    fn();
+    console.log(`${label}: no throw`);
+  } catch (error: any) {
+    console.log(`${label}:`, error.name, error.code ?? "");
+  }
+};
+
+console.log("supports typeof:", typeof SubtleCrypto.supports);
+console.log("supports name:", SubtleCrypto.supports.name);
+console.log("supports length:", SubtleCrypto.supports.length);
+console.log(
+  "supports desc:",
+  JSON.stringify(descriptorShape(Object.getOwnPropertyDescriptor(SubtleCrypto, "supports"))),
+);
+console.log("instance supports in subtle:", "supports" in webcrypto.subtle);
+console.log("instance supports typeof:", typeof (webcrypto.subtle as any).supports);
+
+for (const [label, op, algorithm] of [
+  ["digest sha256", "digest", "SHA-256"],
+  ["digest object", "digest", { name: "SHA-384" }],
+  ["sign hmac", "sign", "HMAC"],
+  ["verify ed25519", "verify", "Ed25519"],
+  ["generate aes object", "generateKey", { name: "AES-GCM", length: 128 }],
+  ["generate ecdh p256", "generateKey", { name: "ECDH", namedCurve: "P-256" }],
+  ["import aes", "importKey", "AES-GCM"],
+  ["export rsa", "exportKey", "RSA-OAEP"],
+  ["digest sha3 false", "digest", "SHA-3-256"],
+  ["encrypt aes ocb false", "encrypt", "AES-OCB"],
+  ["sign kmac false", "sign", "KMAC128"],
+  ["derive x448 false", "deriveBits", "X448"],
+  ["encapsulateKey mlkem false", "encapsulateKey", "ML-KEM-768"],
+] as const) {
+  console.log(`${label}:`, SubtleCrypto.supports(op, algorithm as any));
+}
+
+throwsShape("supports missing args", () => (SubtleCrypto.supports as any)());
+throwsShape("supports one arg", () => (SubtleCrypto.supports as any)("digest"));
+console.log("supports undefined args:", (SubtleCrypto.supports as any)(undefined, "SHA-256"));


### PR DESCRIPTION
## Summary

Partially addresses #2518 with the static `SubtleCrypto.supports(operation, algorithm, length?)` API-shape/support-detection slice.

- Installs `SubtleCrypto.supports` as a static constructor function with Node 25 shape (`typeof`, `name`, `length`, and enumerable descriptor behavior).
- Routes omitted-argument calls through Node-shaped `TypeError [ERR_MISSING_ARGS]` while preserving explicit `undefined` as a `false` result.
- Adds a WebCrypto stdlib support matrix for Perry's currently implemented algorithms in the operation contexts Node's static method reports, plus `false` results for selected modern-operation probes.
- Extends codegen's builtin-global static value-read path so direct `SubtleCrypto.supports` reads resolve to the real constructor static.
- Adds focused parity coverage and keeps `crypto.subtle.supports` absent, matching Node.

Non-goals for this slice: implementing P-384/P-521, Ed448/X448, AES-OCB, ChaCha20-Poly1305, KMAC, ML-KEM, Argon2 WebCrypto operations, or WebCrypto encapsulate/decapsulate methods. Node reports some of those algorithms as supported for specific operations; those remain #2518 follow-up slices until Perry can execute them.

## Tests

- Baseline before implementation: `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter subtle-supports` -> parity fail 1 (`test-parity/reports/parity_report_20260602_182233.json`)
- `cargo check -p perry-runtime -p perry-stdlib -p perry-codegen`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter subtle-supports` -> 1 pass, 0 fail (`test-parity/reports/parity_report_20260602_183722.json`)
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter webcrypto` -> 55 pass, 0 fail (`test-parity/reports/parity_report_20260602_183743.json`)
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module crypto --filter subtle` -> 2 pass, 0 fail (`test-parity/reports/parity_report_20260602_184011.json`)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
