### PR TITLE
[codex] runtime descriptor metadata for Math and generators

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -827,7 +827,45 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &ctor_handle), (I64, &key_raw)],
                     ));
                 }
-                if matches!(property.as_str(), "f16round" | "random") {
+                if matches!(
+                    property.as_str(),
+                    "abs"
+                        | "acos"
+                        | "acosh"
+                        | "asin"
+                        | "asinh"
+                        | "atan"
+                        | "atan2"
+                        | "atanh"
+                        | "cbrt"
+                        | "ceil"
+                        | "clz32"
+                        | "cos"
+                        | "cosh"
+                        | "exp"
+                        | "expm1"
+                        | "f16round"
+                        | "floor"
+                        | "fround"
+                        | "hypot"
+                        | "imul"
+                        | "log"
+                        | "log1p"
+                        | "log2"
+                        | "log10"
+                        | "max"
+                        | "min"
+                        | "pow"
+                        | "random"
+                        | "round"
+                        | "sign"
+                        | "sin"
+                        | "sinh"
+                        | "sqrt"
+                        | "tan"
+                        | "tanh"
+                        | "trunc"
+                ) {
                     let math_idx = ctx.strings.intern("Math");
                     let math_bytes_global =
                         format!("@{}", ctx.strings.entry(math_idx).bytes_global);

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -119,6 +119,9 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
             | "fetch"
             | "process"
             | "console"
+            | "Math"
+            | "JSON"
+            | "Reflect"
             // Test262 installs `globalThis.print`; bare `print(...)` must
             // resolve through the global object instead of the unknown-ident
             // numeric fallback.

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -575,6 +575,154 @@ extern "C" fn math_random_thunk(_closure: *const crate::closure::ClosureHeader) 
     crate::math::js_math_random()
 }
 
+fn math_number_arg(value: f64) -> f64 {
+    crate::builtins::js_number_coerce(value)
+}
+
+fn math_to_int32(value: f64) -> i32 {
+    let n = math_number_arg(value);
+    if !n.is_finite() || n == 0.0 {
+        return 0;
+    }
+    const TWO_32: f64 = 4_294_967_296.0;
+    (n.trunc().rem_euclid(TWO_32) as u32) as i32
+}
+
+fn math_to_uint32(value: f64) -> u32 {
+    math_to_int32(value) as u32
+}
+
+macro_rules! math_unary_thunk {
+    ($name:ident, $body:expr) => {
+        extern "C" fn $name(_closure: *const crate::closure::ClosureHeader, value: f64) -> f64 {
+            let x = math_number_arg(value);
+            ($body)(x)
+        }
+    };
+}
+
+math_unary_thunk!(math_abs_thunk, |x: f64| x.abs());
+math_unary_thunk!(math_acos_thunk, |x: f64| crate::math::js_math_acos(x));
+math_unary_thunk!(math_acosh_thunk, |x: f64| crate::math::js_math_acosh(x));
+math_unary_thunk!(math_asin_thunk, |x: f64| crate::math::js_math_asin(x));
+math_unary_thunk!(math_asinh_thunk, |x: f64| crate::math::js_math_asinh(x));
+math_unary_thunk!(math_atan_thunk, |x: f64| crate::math::js_math_atan(x));
+math_unary_thunk!(math_atanh_thunk, |x: f64| crate::math::js_math_atanh(x));
+math_unary_thunk!(math_cbrt_thunk, |x: f64| crate::math::js_math_cbrt(x));
+math_unary_thunk!(math_ceil_thunk, |x: f64| x.ceil());
+math_unary_thunk!(math_cos_thunk, |x: f64| crate::math::js_math_cos(x));
+math_unary_thunk!(math_cosh_thunk, |x: f64| crate::math::js_math_cosh(x));
+math_unary_thunk!(math_exp_thunk, |x: f64| x.exp());
+math_unary_thunk!(math_expm1_thunk, |x: f64| crate::math::js_math_expm1(x));
+math_unary_thunk!(math_floor_thunk, |x: f64| x.floor());
+math_unary_thunk!(math_fround_thunk, |x: f64| crate::math::js_math_fround(x));
+math_unary_thunk!(math_log_thunk, |x: f64| crate::math::js_math_log(x));
+math_unary_thunk!(math_log10_thunk, |x: f64| crate::math::js_math_log10(x));
+math_unary_thunk!(math_log1p_thunk, |x: f64| crate::math::js_math_log1p(x));
+math_unary_thunk!(math_log2_thunk, |x: f64| crate::math::js_math_log2(x));
+math_unary_thunk!(math_sin_thunk, |x: f64| crate::math::js_math_sin(x));
+math_unary_thunk!(math_sinh_thunk, |x: f64| crate::math::js_math_sinh(x));
+math_unary_thunk!(math_sqrt_thunk, |x: f64| x.sqrt());
+math_unary_thunk!(math_tan_thunk, |x: f64| crate::math::js_math_tan(x));
+math_unary_thunk!(math_tanh_thunk, |x: f64| crate::math::js_math_tanh(x));
+math_unary_thunk!(math_trunc_thunk, |x: f64| x.trunc());
+
+extern "C" fn math_round_thunk(_closure: *const crate::closure::ClosureHeader, value: f64) -> f64 {
+    let x = math_number_arg(value);
+    if x == 0.0 || x.is_nan() || x.is_infinite() {
+        return x;
+    }
+    let rounded = (x + 0.5).floor();
+    if rounded == 0.0 && x.is_sign_negative() {
+        -0.0
+    } else {
+        rounded
+    }
+}
+
+extern "C" fn math_sign_thunk(_closure: *const crate::closure::ClosureHeader, value: f64) -> f64 {
+    let x = math_number_arg(value);
+    if x == 0.0 || x.is_nan() {
+        x
+    } else if x.is_sign_negative() {
+        -1.0
+    } else {
+        1.0
+    }
+}
+
+extern "C" fn math_clz32_thunk(_closure: *const crate::closure::ClosureHeader, value: f64) -> f64 {
+    math_to_uint32(value).leading_zeros() as f64
+}
+
+extern "C" fn math_atan2_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    y: f64,
+    x: f64,
+) -> f64 {
+    crate::math::js_math_atan2(math_number_arg(y), math_number_arg(x))
+}
+
+extern "C" fn math_imul_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    a: f64,
+    b: f64,
+) -> f64 {
+    math_to_int32(a).wrapping_mul(math_to_int32(b)) as f64
+}
+
+extern "C" fn math_pow_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    base: f64,
+    exp: f64,
+) -> f64 {
+    crate::math::js_math_pow(math_number_arg(base), math_number_arg(exp))
+}
+
+extern "C" fn math_min_thunk(_closure: *const crate::closure::ClosureHeader, rest: f64) -> f64 {
+    let values = global_this_rest_array_values(rest);
+    if values.is_empty() {
+        return f64::INFINITY;
+    }
+    let mut result = f64::INFINITY;
+    for value in values {
+        let n = math_number_arg(value);
+        if n.is_nan() {
+            return f64::NAN;
+        }
+        if n < result || (n == 0.0 && result == 0.0 && n.is_sign_negative()) {
+            result = n;
+        }
+    }
+    result
+}
+
+extern "C" fn math_max_thunk(_closure: *const crate::closure::ClosureHeader, rest: f64) -> f64 {
+    let values = global_this_rest_array_values(rest);
+    if values.is_empty() {
+        return f64::NEG_INFINITY;
+    }
+    let mut result = f64::NEG_INFINITY;
+    for value in values {
+        let n = math_number_arg(value);
+        if n.is_nan() {
+            return f64::NAN;
+        }
+        if n > result || (n == 0.0 && result == 0.0 && n.is_sign_positive()) {
+            result = n;
+        }
+    }
+    result
+}
+
+extern "C" fn math_hypot_thunk(_closure: *const crate::closure::ClosureHeader, rest: f64) -> f64 {
+    let mut result = 0.0;
+    for value in global_this_rest_array_values(rest) {
+        result = crate::math::js_math_hypot(result, math_number_arg(value).abs());
+    }
+    result
+}
+
 // #2905: thunks for the standard global helper functions. Each coerces its
 // arguments the same way the bare-call HIR lowering does and forwards to the
 // shared runtime helper so a rebound / property-read reference matches Node.
@@ -1896,6 +2044,75 @@ fn ensure_generator_intrinsics() {
     }
 }
 
+fn install_math_namespace(ns_obj: *mut ObjectHeader) {
+    if ns_obj.is_null() {
+        return;
+    }
+    for (name, func_ptr, arity) in [
+        ("abs", math_abs_thunk as *const u8, 1),
+        ("acos", math_acos_thunk as *const u8, 1),
+        ("acosh", math_acosh_thunk as *const u8, 1),
+        ("asin", math_asin_thunk as *const u8, 1),
+        ("asinh", math_asinh_thunk as *const u8, 1),
+        ("atan", math_atan_thunk as *const u8, 1),
+        ("atanh", math_atanh_thunk as *const u8, 1),
+        ("atan2", math_atan2_thunk as *const u8, 2),
+        ("ceil", math_ceil_thunk as *const u8, 1),
+        ("cbrt", math_cbrt_thunk as *const u8, 1),
+        ("expm1", math_expm1_thunk as *const u8, 1),
+        ("clz32", math_clz32_thunk as *const u8, 1),
+        ("cos", math_cos_thunk as *const u8, 1),
+        ("cosh", math_cosh_thunk as *const u8, 1),
+        ("exp", math_exp_thunk as *const u8, 1),
+        ("floor", math_floor_thunk as *const u8, 1),
+        ("fround", math_fround_thunk as *const u8, 1),
+    ] {
+        install_proto_method(ns_obj, name, func_ptr, arity);
+    }
+    install_proto_method_rest_with_length(ns_obj, "hypot", math_hypot_thunk as *const u8, 2, 0);
+    for (name, func_ptr, arity) in [
+        ("imul", math_imul_thunk as *const u8, 2),
+        ("log", math_log_thunk as *const u8, 1),
+        ("log1p", math_log1p_thunk as *const u8, 1),
+        ("log2", math_log2_thunk as *const u8, 1),
+        ("log10", math_log10_thunk as *const u8, 1),
+    ] {
+        install_proto_method(ns_obj, name, func_ptr, arity);
+    }
+    install_proto_method_rest_with_length(ns_obj, "max", math_max_thunk as *const u8, 2, 0);
+    install_proto_method_rest_with_length(ns_obj, "min", math_min_thunk as *const u8, 2, 0);
+    for (name, func_ptr, arity) in [
+        ("pow", math_pow_thunk as *const u8, 2),
+        ("random", math_random_thunk as *const u8, 0),
+        ("round", math_round_thunk as *const u8, 1),
+        ("sign", math_sign_thunk as *const u8, 1),
+        ("sin", math_sin_thunk as *const u8, 1),
+        ("sinh", math_sinh_thunk as *const u8, 1),
+        ("sqrt", math_sqrt_thunk as *const u8, 1),
+        ("tan", math_tan_thunk as *const u8, 1),
+        ("tanh", math_tanh_thunk as *const u8, 1),
+        ("trunc", math_trunc_thunk as *const u8, 1),
+    ] {
+        install_proto_method(ns_obj, name, func_ptr, arity);
+    }
+
+    let constant_attrs = super::PropertyAttrs::new(false, false, false);
+    for (name, value) in [
+        ("E", std::f64::consts::E),
+        ("LN10", std::f64::consts::LN_10),
+        ("LN2", std::f64::consts::LN_2),
+        ("LOG10E", std::f64::consts::LOG10_E),
+        ("LOG2E", std::f64::consts::LOG2_E),
+        ("PI", std::f64::consts::PI),
+        ("SQRT1_2", std::f64::consts::FRAC_1_SQRT_2),
+        ("SQRT2", std::f64::consts::SQRT_2),
+    ] {
+        set_intrinsic_data_prop(ns_obj, name, value, constant_attrs);
+    }
+
+    install_proto_method(ns_obj, "f16round", math_f16round_thunk as *const u8, 1);
+}
+
 /// Populate the freshly-allocated globalThis singleton with built-in
 /// constructor / namespace properties. Called exactly once from the CAS
 /// winner in `js_get_global_this`. Constructors get a ClosureHeader-
@@ -2276,13 +2493,14 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             if ns_obj.is_null() {
                 continue;
             }
-            // #4139: reify each namespace's own members as real properties so
-            // the reflection APIs (`getOwnPropertyDescriptor`,
+            // #4139 + #4149: reify each namespace's own members as real
+            // properties so the reflection APIs (`getOwnPropertyDescriptor`,
             // `getOwnPropertyNames`) observe them. Call sites (`Math.max(...)`,
             // `JSON.stringify(...)`, `Reflect.get(...)`) are codegen intrinsics
-            // gated on the AST shape and never read these fields.
+            // gated on the AST shape and never read these fields. Math uses the
+            // richer install that also exposes per-method name/length descriptors.
             match name {
-                "Math" => install_math_namespace_members(ns_obj),
+                "Math" => install_math_namespace(ns_obj),
                 "JSON" => install_json_namespace_members(ns_obj),
                 "Reflect" => install_reflect_namespace_members(ns_obj),
                 _ => {}
@@ -2290,13 +2508,11 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             crate::value::js_nanbox_pointer(ns_obj as i64)
         };
         js_object_set_field_by_name(singleton, name_key, ns_value);
-        if name == "WebAssembly" {
-            super::set_builtin_property_attrs(
-                singleton as usize,
-                name.to_string(),
-                super::PropertyAttrs::new(true, false, true),
-            );
-        }
+        super::set_builtin_property_attrs(
+            singleton as usize,
+            name.to_string(),
+            super::PropertyAttrs::new(true, false, true),
+        );
     }
     // node:perf_hooks `performance` global — bind it to the same singleton the
     // named import resolves to, so `globalThis.performance ===
@@ -3024,13 +3240,29 @@ fn install_proto_method_rest(
     func_ptr: *const u8,
     fixed_arity: u32,
 ) {
+    install_proto_method_rest_with_length(
+        proto_obj,
+        method_name,
+        func_ptr,
+        fixed_arity,
+        fixed_arity,
+    );
+}
+
+fn install_proto_method_rest_with_length(
+    proto_obj: *mut ObjectHeader,
+    method_name: &str,
+    func_ptr: *const u8,
+    spec_length: u32,
+    call_fixed_arity: u32,
+) -> f64 {
     let closure = crate::closure::js_closure_alloc(func_ptr, 0);
     if closure.is_null() {
-        return;
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
-    crate::closure::js_register_closure_rest(func_ptr, fixed_arity);
+    crate::closure::js_register_closure_rest(func_ptr, call_fixed_arity);
     super::native_module::set_bound_native_closure_name(closure, method_name);
-    super::native_module::set_builtin_closure_length(closure as usize, fixed_arity);
+    super::native_module::set_builtin_closure_length(closure as usize, spec_length);
     let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
     let value = crate::value::js_nanbox_pointer(closure as i64);
     js_object_set_field_by_name(proto_obj, key, value);
@@ -3049,89 +3281,11 @@ fn install_proto_method_rest(
         "length".to_string(),
         super::PropertyAttrs::new(false, false, true),
     );
-}
-
-/// #4139: reify the `Math` namespace's own members (methods + constants) as
-/// real own properties so reflection (`Object.getOwnPropertyDescriptor`,
-/// `Object.getOwnPropertyNames`) sees them. The actual `Math.<m>(...)` call
-/// sites are codegen intrinsics gated on the AST shape and never read these
-/// fields — this is reflection parity only, so the methods are backed by the
-/// shared no-op thunk (mirroring `install_proto_method`'s default). Methods
-/// are spec'd `{ writable:true, enumerable:false, configurable:true }`
-/// (set by `install_proto_method`); constants are `{ writable:false,
-/// enumerable:false, configurable:false }`. Member order matches V8/Node's
-/// own-key enumeration: methods, then constants, then the newer `f16round`.
-fn install_math_namespace_members(ns_obj: *mut ObjectHeader) {
-    let noop = global_this_builtin_noop_thunk as *const u8;
-    const METHODS: &[(&str, u32)] = &[
-        ("abs", 1),
-        ("acos", 1),
-        ("acosh", 1),
-        ("asin", 1),
-        ("asinh", 1),
-        ("atan", 1),
-        ("atanh", 1),
-        ("atan2", 2),
-        ("ceil", 1),
-        ("cbrt", 1),
-        ("expm1", 1),
-        ("clz32", 1),
-        ("cos", 1),
-        ("cosh", 1),
-        ("exp", 1),
-        ("floor", 1),
-        ("fround", 1),
-        ("hypot", 2),
-        ("imul", 2),
-        ("log", 1),
-        ("log1p", 1),
-        ("log2", 1),
-        ("log10", 1),
-        ("max", 2),
-        ("min", 2),
-        ("pow", 2),
-        ("random", 0),
-        ("round", 1),
-        ("sign", 1),
-        ("sin", 1),
-        ("sinh", 1),
-        ("sqrt", 1),
-        ("tan", 1),
-        ("tanh", 1),
-        ("trunc", 1),
-    ];
-    for (name, arity) in METHODS.iter().copied() {
-        // `random` keeps its dedicated thunk so the value-call path
-        // (`const r = Math.random; r()`) returns a real random number; the
-        // rest are reflection-only and share the no-op thunk. Installed in
-        // enumeration position so `getOwnPropertyNames(Math)` order matches V8.
-        let thunk = if name == "random" {
-            math_random_thunk as *const u8
-        } else {
-            noop
-        };
-        install_proto_method(ns_obj, name, thunk, arity);
-    }
-    let non_writable = super::PropertyAttrs::new(false, false, false);
-    const CONSTS: &[(&str, f64)] = &[
-        ("E", std::f64::consts::E),
-        ("LN10", std::f64::consts::LN_10),
-        ("LN2", std::f64::consts::LN_2),
-        ("LOG10E", std::f64::consts::LOG10_E),
-        ("LOG2E", std::f64::consts::LOG2_E),
-        ("PI", std::f64::consts::PI),
-        ("SQRT1_2", std::f64::consts::FRAC_1_SQRT_2),
-        ("SQRT2", std::f64::consts::SQRT_2),
-    ];
-    for (name, value) in CONSTS.iter().copied() {
-        set_intrinsic_data_prop(ns_obj, name, value, non_writable);
-    }
-    // `f16round` keeps its dedicated thunk (the only Math member with one).
-    install_proto_method(ns_obj, "f16round", math_f16round_thunk as *const u8, 1);
+    value
 }
 
 /// #4139: reify the `JSON` namespace's own methods for reflection parity. See
-/// `install_math_namespace_members` for the rationale (call sites are codegen
+/// `install_math_namespace` for the rationale (call sites are codegen
 /// intrinsics; these no-op-backed fields exist only for reflection).
 fn install_json_namespace_members(ns_obj: *mut ObjectHeader) {
     let noop = global_this_builtin_noop_thunk as *const u8;
@@ -3147,7 +3301,7 @@ fn install_json_namespace_members(ns_obj: *mut ObjectHeader) {
 }
 
 /// #4139: reify the `Reflect` namespace's own methods for reflection parity.
-/// See `install_math_namespace_members` for the rationale.
+/// See `install_math_namespace` for the rationale.
 fn install_reflect_namespace_members(ns_obj: *mut ObjectHeader) {
     let noop = global_this_builtin_noop_thunk as *const u8;
     const METHODS: &[(&str, u32)] = &[

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1730,6 +1730,40 @@ pub(crate) fn web_stream_to_string_tag(value: f64) -> Option<&'static str> {
     }
 }
 
+unsafe fn string_value_to_owned(value: f64) -> Option<String> {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if !jv.is_any_string() {
+        return None;
+    }
+    let s = crate::builtins::js_string_coerce(value);
+    if s.is_null() {
+        return None;
+    }
+    let len = (*s).byte_len as usize;
+    let data = (s as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+    std::str::from_utf8(std::slice::from_raw_parts(data, len))
+        .ok()
+        .map(ToOwned::to_owned)
+}
+
+unsafe fn object_to_string_tag_property(value: f64) -> Option<String> {
+    let bits = value.to_bits();
+    if (bits & 0xFFFF_0000_0000_0000) != 0x7FFD_0000_0000_0000 {
+        return None;
+    }
+    let raw_addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if raw_addr < 0x1000 {
+        return None;
+    }
+    let sym = crate::symbol::well_known_symbol("toStringTag");
+    if sym.is_null() {
+        return None;
+    }
+    let sym_f64 = f64::from_bits(0x7FFD_0000_0000_0000 | (sym as u64 & 0x0000_FFFF_FFFF_FFFF));
+    let tag_value = crate::symbol::own_symbol_property(value, sym_f64)?;
+    string_value_to_owned(tag_value)
+}
+
 /// `Object.prototype.toString.call(x)` — returns `[object <tag>]` where
 /// `<tag>` is read from the value's class-level `Symbol.toStringTag` getter
 /// if registered, otherwise `Object` (matching Node for plain objects).
@@ -1853,6 +1887,12 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
     }
     if let Some(tag) = crate::builtins::boxed_primitive_to_string_tag(value) {
+        let formatted = format!("[object {}]", tag);
+        let bytes = formatted.as_bytes();
+        let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+        return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    }
+    if let Some(tag) = object_to_string_tag_property(value) {
         let formatted = format!("[object {}]", tag);
         let bytes = formatted.as_bytes();
         let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);

--- a/test-parity/node-suite/globals/builtin-namespace-descriptors.ts
+++ b/test-parity/node-suite/globals/builtin-namespace-descriptors.ts
@@ -1,0 +1,58 @@
+// Built-in namespace own-property descriptors: methods and constants should be
+// visible through Object.getOwnPropertyDescriptor/Object.getOwnPropertyNames.
+
+function valueShape(value: any): string {
+  if (typeof value === "function") {
+    return "function:" + value.name + ":" + value.length;
+  }
+  return typeof value + ":" + String(value);
+}
+
+function showDesc(label: string, obj: any, key: any) {
+  const desc = Object.getOwnPropertyDescriptor(obj, key);
+  if (!desc) {
+    console.log(label + ": missing");
+    return;
+  }
+  if ("value" in desc) {
+    console.log(
+      label +
+        ": data:" +
+        valueShape(desc.value) +
+        ":" +
+        desc.writable +
+        ":" +
+        desc.enumerable +
+        ":" +
+        desc.configurable,
+    );
+    return;
+  }
+  console.log(
+    label +
+      ": accessor:" +
+      typeof desc.get +
+      ":" +
+      typeof desc.set +
+      ":" +
+      desc.enumerable +
+      ":" +
+      desc.configurable,
+  );
+}
+
+const mathSubset = Object.getOwnPropertyNames(Math).filter((name) =>
+  ["abs", "random", "E", "PI", "f16round"].includes(name),
+);
+console.log("Math names subset:", mathSubset.join(","));
+
+showDesc("Math.abs", Math, "abs");
+showDesc("Math.random", Math, "random");
+showDesc("Math.f16round", Math, "f16round");
+showDesc("Math.E", Math, "E");
+showDesc("Math.PI", Math, "PI");
+
+if (typeof Math.abs === "function") {
+  showDesc("Math.abs.name", Math.abs, "name");
+  showDesc("Math.abs.length", Math.abs, "length");
+}

--- a/test-parity/node-suite/globals/generator-prototype-descriptors.ts
+++ b/test-parity/node-suite/globals/generator-prototype-descriptors.ts
@@ -1,0 +1,125 @@
+// Generator and AsyncGenerator prototype method descriptors plus brand checks.
+
+function valueShape(value: any): string {
+  if (typeof value === "function") {
+    return "function:" + value.name + ":" + value.length;
+  }
+  if (value && typeof value === "object") {
+    return "object:" + Object.prototype.toString.call(value);
+  }
+  return typeof value + ":" + String(value);
+}
+
+function showDesc(label: string, obj: any, key: any) {
+  const desc = Object.getOwnPropertyDescriptor(obj, key);
+  if (!desc) {
+    console.log(label + ": missing");
+    return;
+  }
+  if ("value" in desc) {
+    console.log(
+      label +
+        ": data:" +
+        valueShape(desc.value) +
+        ":" +
+        desc.writable +
+        ":" +
+        desc.enumerable +
+        ":" +
+        desc.configurable,
+    );
+    return;
+  }
+  console.log(
+    label +
+      ": accessor:" +
+      typeof desc.get +
+      ":" +
+      typeof desc.set +
+      ":" +
+      desc.enumerable +
+      ":" +
+      desc.configurable,
+  );
+}
+
+function showMethod(prefix: string, proto: any, name: string) {
+  showDesc(prefix + "." + name, proto, name);
+  const method = proto[name];
+  showDesc(prefix + "." + name + ".name", method, "name");
+  showDesc(prefix + "." + name + ".length", method, "length");
+}
+
+function showSyncBad(proto: any, name: string, recv: any) {
+  try {
+    proto[name].call(recv, "x");
+    console.log("sync bad " + name + ": ok");
+  } catch (e) {
+    console.log("sync bad " + name + ":", e instanceof TypeError);
+  }
+}
+
+async function showAsyncBad(proto: any, name: string, recv: any) {
+  try {
+    const result = proto[name].call(recv, "x");
+    const thenType = result && typeof result.then;
+    try {
+      await result;
+      console.log("async bad " + name + ": resolved:" + thenType);
+    } catch (e) {
+      console.log(
+        "async bad " + name + ": rejected:" + thenType + ":" + (e instanceof TypeError),
+      );
+    }
+  } catch (e) {
+    console.log("async bad " + name + ": threw:" + (e instanceof TypeError));
+  }
+}
+
+async function main() {
+  function* g() {
+    yield 1;
+  }
+  async function* ag() {
+    yield 1;
+  }
+
+  const GeneratorPrototype = Object.getPrototypeOf(g).prototype;
+  const AsyncGeneratorPrototype = Object.getPrototypeOf(ag).prototype;
+
+  console.log(
+    "GeneratorPrototype names:",
+    Object.getOwnPropertyNames(GeneratorPrototype).join(","),
+  );
+  for (const name of ["next", "return", "throw"]) {
+    showMethod("GeneratorPrototype", GeneratorPrototype, name);
+  }
+  showDesc("GeneratorPrototype.constructor", GeneratorPrototype, "constructor");
+  for (const name of ["next", "return", "throw"]) {
+    showSyncBad(GeneratorPrototype, name, {});
+  }
+  for (const name of ["next", "return", "throw"]) {
+    showSyncBad(GeneratorPrototype, name, g.prototype);
+  }
+
+  console.log(
+    "AsyncGeneratorPrototype names:",
+    Object.getOwnPropertyNames(AsyncGeneratorPrototype).join(","),
+  );
+  for (const name of ["next", "return", "throw"]) {
+    showMethod("AsyncGeneratorPrototype", AsyncGeneratorPrototype, name);
+  }
+  showDesc(
+    "AsyncGeneratorPrototype.constructor",
+    AsyncGeneratorPrototype,
+    "constructor",
+  );
+  for (const name of ["next", "return", "throw"]) {
+    await showAsyncBad(AsyncGeneratorPrototype, name, {});
+  }
+  for (const name of ["next", "return", "throw"]) {
+    await showAsyncBad(AsyncGeneratorPrototype, name, ag.prototype);
+  }
+}
+
+main();


### PR DESCRIPTION
## Linked Issues

- Fixes #4139
- Partially addresses #4141

## Behavior Cluster

This is a focused runtime descriptor cut for builtin reflective metadata:

- installs descriptor-visible `Math` own methods and constants with Node-compatible data-property attributes
- routes escaped `Math.<method>` reads through the real `Math` namespace object so method `name`/`length` descriptors remain observable
- treats `Math`, `JSON`, and `Reflect` as builtin global values so bare namespace reads lower through `globalThis`
- honors own `Symbol.toStringTag` values in `Object.prototype.toString`, covering generator constructor reflection
- keeps Generator and AsyncGenerator prototype descriptor coverage pinned with focused parity fixtures

## Why Batched

#4139 and #4141 both fail in the same reflective surface: builtin own-property descriptors and intrinsic prototype metadata. The implementation path is shared across global namespace installation, object descriptor lookup, and codegen member reads, and the tests use the same `node-suite/globals` parity harness.

## Tests Added

- `test-parity/node-suite/globals/builtin-namespace-descriptors.ts`
- `test-parity/node-suite/globals/generator-prototype-descriptors.ts`

## Validation

- `cargo build --release -p perry-runtime -p perry`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 target/release/perry compile --no-cache test-parity/node-suite/globals/builtin-namespace-descriptors.ts -o /tmp/perry_builtin_namespace_descriptors && /tmp/perry_builtin_namespace_descriptors`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 target/release/perry compile --no-cache test-parity/node-suite/globals/generator-prototype-descriptors.ts -o /tmp/perry_generator_prototype_descriptors && /tmp/perry_generator_prototype_descriptors`
- `PATH=/tmp/perry-node25-bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter builtin-namespace-descriptors`
- `PATH=/tmp/perry-node25-bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter generator-prototype-descriptors`
- `cargo test -p perry-runtime object`
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`

## Known Limitations

- This does not attempt to close every builtin descriptor failure in #4139; it covers the Math/global namespace slice and generator-related reflection covered by the new parity fixtures.
- Async-generator scheduling/order failures called out in #4141 remain out of scope.
- The `Math` thunks added here are sufficient for descriptor-visible escaped method values, but this PR is not a full Math semantics audit.

## Non-Goals

- No TypedArray constructor descriptor work.
- No primitive wrapper reflective brand-check work.
- No broad descriptor-table rewrite across all builtins.