### PR TITLE
[codex] Guard array length against NaN-boxed non-pointers

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -4,11 +4,24 @@ use std::ptr;
 
 #[no_mangle]
 pub extern "C" fn js_array_length(arr: *const ArrayHeader) -> u32 {
+    let arr = {
+        let bits = arr as u64;
+        let top16 = bits >> 48;
+        if top16 >= 0x7FF8 {
+            if top16 != (crate::value::POINTER_TAG >> 48) {
+                return 0;
+            }
+            (bits & crate::value::POINTER_MASK) as *const ArrayHeader
+        } else {
+            arr
+        }
+    };
     if !arr.is_null() {
-        if crate::set::is_registered_set(arr as usize) {
+        let addr = arr as usize;
+        if crate::set::is_registered_set(addr) {
             return crate::set::js_set_size(arr as *const crate::set::SetHeader);
         }
-        if crate::map::is_registered_map(arr as usize) {
+        if crate::map::is_registered_map(addr) {
             return crate::map::js_map_size(arr as *const crate::map::MapHeader);
         }
     }

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -1025,6 +1025,20 @@ fn test_array_null_safety() {
 }
 
 #[test]
+fn test_array_length_rejects_nanboxed_non_pointers_before_registry_probe() {
+    for bits in [
+        crate::value::TAG_UNDEFINED,
+        crate::value::TAG_NULL,
+        crate::value::TAG_FALSE,
+        crate::value::TAG_TRUE,
+        crate::value::TAG_HOLE,
+        crate::value::INT32_TAG | 1,
+    ] {
+        assert_eq!(js_array_length(bits as *const ArrayHeader), 0);
+    }
+}
+
+#[test]
 fn test_array_splice_delete_middle() {
     // [1,2,3,4,5].splice(1, 2) -> deleted=[2,3], arr=[1,4,5]
     let arr = js_array_alloc(8);


### PR DESCRIPTION
## Summary

Fix a Perry runtime crash in `js_array_length` when callers pass a NaN-boxed non-pointer tag through a path that expects an array-like pointer.

The OpenTUI `PerryRenderLib.createRenderer(40, 10, ...)` reducer crashed after `before-create-renderer` with SIGSEGV. LLDB showed `js_array_length` calling the Set/Map registry probes before rejecting a `0x7FFC...` singleton/hole-style tag, causing `is_registered_set` to read a GC header from a fake pointer.

## Changes

- Normalize NaN-boxed pointer values, and reject non-pointer NaN-boxed tags, before Set/Map registry probes in `js_array_length`.
- Add a regression covering `undefined`, `null`, booleans, `TAG_HOLE`, and an int32 tag reaching `js_array_length`.

## Validation

- `cargo fmt --check` passed.
- Before rebasing onto current `origin/main`, `cargo test -p perry-runtime test_array_length_rejects_nanboxed_non_pointers_before_registry_probe` passed.
- Before rebasing, `cargo build --release -p perry`, `cargo build --release -p perry-runtime`, and `cargo build --release -p perry-stdlib` passed.
- Focused PTY repro passed after relinking with the fixed runtime: `/tmp/opentui-perry-create-renderer-syGcGq/create-renderer-fixed` reached `after-create-renderer:3`, `after-set-use-thread`, and `after-destroy-renderer` with rc 0.
- After rebasing, retrying the targeted test was blocked by local disk exhaustion: `rustc-LLVM ERROR: IO failure on output stream: No space left on device`.
- Generic OpenTUI smoke with the fixed binary compiled and ran, but is not green yet: it timed out waiting for initial visible text. Output showed the renderer no longer crashed and emitted a blank frame after `intermediateRender`; this is a follow-up render/content path blocker, not completion evidence.

## Notes

This PR is intentionally scoped to the runtime SIGSEGV guard. It does not claim generic OpenTUI smoke completion and does not claim OpenCode/OpenTUI migration completion.
