### PR TITLE
fix(runtime): link generator/async-generator instance prototype chain (#4141)

### DIFF
--- a/crates/perry-codegen/src/boxed_vars.rs
+++ b/crates/perry-codegen/src/boxed_vars.rs
@@ -320,6 +320,12 @@ fn collect_nested_closure_boxed_vars_in_expr(expr: &perry_hir::Expr, out: &mut H
                 collect_nested_closure_boxed_vars_in_expr(i, out);
             }
         }
+        Expr::LinkGeneratorPrototype { obj, .. } => {
+            // #4141: the generator iterator object (with its next/return/throw
+            // closures capturing+mutating the state-machine locals) is wrapped
+            // here in return position — recurse so those locals still get boxed.
+            collect_nested_closure_boxed_vars_in_expr(obj, out);
+        }
         Expr::Object(props) => {
             for (_, v) in props {
                 collect_nested_closure_boxed_vars_in_expr(v, out);

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -48,14 +48,23 @@ fn function_body_returns_generator_object(body: &[perry_hir::Stmt]) -> bool {
         return false;
     }
     body.iter().any(|stmt| match stmt {
-        perry_hir::Stmt::Return(Some(perry_hir::Expr::Object(props))) => {
-            props.len() == 3
-                && props[0].0 == "next"
-                && props[1].0 == "return"
-                && props[2].0 == "throw"
-                && props
-                    .iter()
-                    .all(|(_, value)| matches!(value, perry_hir::Expr::Closure { .. }))
+        // #4141: the returned iterator object is wrapped in
+        // `LinkGeneratorPrototype` (instance `[[Prototype]]` linker); unwrap it
+        // so the `{next,return,throw}` shape — the signal that this function is
+        // a generator wrapper — is still recognized.
+        perry_hir::Stmt::Return(Some(expr)) => {
+            let inner = match expr {
+                perry_hir::Expr::LinkGeneratorPrototype { obj, .. } => obj.as_ref(),
+                other => other,
+            };
+            matches!(inner, perry_hir::Expr::Object(props)
+                if props.len() == 3
+                    && props[0].0 == "next"
+                    && props[1].0 == "return"
+                    && props[2].0 == "throw"
+                    && props
+                        .iter()
+                        .all(|(_, value)| matches!(value, perry_hir::Expr::Closure { .. })))
         }
         _ => false,
     })

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1844,6 +1844,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::RegisterFunctionPrototypeMethod { .. }
         | Expr::GetFunctionPrototypeMethod { .. }
         | Expr::ClassStaticSymbolSet { .. }
+        | Expr::LinkGeneratorPrototype { .. }
         | Expr::NativeModuleRef(..) => static_field_meta::lower(ctx, expr),
         Expr::PodLayoutSizeOf { .. }
         | Expr::PodLayoutAlignOf { .. }

--- a/crates/perry-codegen/src/expr/static_field_meta.rs
+++ b/crates/perry-codegen/src/expr/static_field_meta.rs
@@ -333,6 +333,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             );
             Ok(proto_val)
         }
+        // #4141: link a generator/async-generator instance into the spec
+        // prototype chain. `js_generator_attach_prototype` interposes a fresh
+        // intermediate object so `Object.getPrototypeOf(Object.getPrototypeOf(
+        // gen()))` resolves to `%Generator.prototype%`. Returns the instance
+        // unchanged for inline use in return position.
+        Expr::LinkGeneratorPrototype { obj, is_async } => {
+            let obj_val = lower_expr(ctx, obj)?;
+            let is_async_str = if *is_async { "1" } else { "0" };
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_generator_attach_prototype",
+                &[(DOUBLE, &obj_val), (crate::types::I32, is_async_str)],
+            ))
+        }
         // Issue #838: `<Class>.prototype.<method> = <fn>` and the
         // aliased `let p = <Class>.prototype; p.<method> = <fn>`
         // shape. HIR recognises the assignment pattern and lowers it

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -321,6 +321,8 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE],
     );
+    // #4141: generator/async-generator instance `[[Prototype]]` linker.
+    module.declare_function("js_generator_attach_prototype", DOUBLE, &[DOUBLE, I32]);
     // WeakRef / FinalizationRegistry (weakref.rs). `js_weakref_new` /
     // `js_finreg_new` return raw `*mut ObjectHeader` (i64 pointer, must be
     // POINTER_TAG-boxed at the call site). The deref/register/unregister

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -843,6 +843,20 @@ pub enum Expr {
         value: Box<Expr>,
         options: Box<Expr>,
     },
+    /// #4141: link a freshly-built generator/async-generator instance object
+    /// to the spec prototype chain. Emitted ONLY by `transform_generators`
+    /// wrapping the `{next,return,throw}` iterator object it returns. At
+    /// runtime, `js_generator_attach_prototype(obj, is_async)` interposes a
+    /// fresh intermediate object as `obj`'s `[[Prototype]]` whose own
+    /// `[[Prototype]]` is `%Generator.prototype%` / `%AsyncGenerator.prototype%`,
+    /// so `Object.getPrototypeOf(Object.getPrototypeOf(gen()))` resolves to the
+    /// brand-checked prototype (mirrors `instance → g.prototype →
+    /// %Generator.prototype%`). Evaluates to `obj` unchanged. `is_async` selects
+    /// the sync vs async generator prototype tower.
+    LinkGeneratorPrototype {
+        obj: Box<Expr>,
+        is_async: bool,
+    },
     /// queueMicrotask(callback) -> void
     QueueMicrotask(Box<Expr>),
 

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -252,6 +252,7 @@ impl SH for Expr {
             Expr::DecodeURIComponent(e) => { tag(h, 186); e.as_ref().hash(h); }
             Expr::StructuredClone { value, options } => { tag(h, 187); value.as_ref().hash(h); options.as_ref().hash(h); }
             Expr::QueueMicrotask(e) => { tag(h, 188); e.as_ref().hash(h); }
+            Expr::LinkGeneratorPrototype { obj, is_async } => { tag(h, 4141); obj.as_ref().hash(h); is_async.hash(h); }
             Expr::IterResultSet(e, b) => { tag(h, 189); e.as_ref().hash(h); b.hash(h); }
             Expr::IterResultGetValue => tag(h, 190),
             Expr::IterResultGetDone => tag(h, 191),

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1105,6 +1105,9 @@ where
             f(value);
             f(options);
         }
+        Expr::LinkGeneratorPrototype { obj, .. } => {
+            f(obj);
+        }
         Expr::BufferFromArrayBuffer {
             data,
             byte_offset,

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1090,6 +1090,9 @@ where
             f(value);
             f(options);
         }
+        Expr::LinkGeneratorPrototype { obj, .. } => {
+            f(obj);
+        }
         Expr::BufferFromArrayBuffer {
             data,
             byte_offset,

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1552,6 +1552,48 @@ extern "C" fn async_generator_proto_throw_thunk(
     generator_proto_method(b"throw", arg, true)
 }
 
+/// #4141: link a freshly-built generator/async-generator instance object into
+/// the spec `[[Prototype]]` chain. Perry lowers `gen()` to a `{next,return,
+/// throw}` object literal; this interposes a fresh intermediate object (the
+/// per-instance stand-in for `g.prototype`) as the instance's `[[Prototype]]`,
+/// whose own `[[Prototype]]` is `%Generator.prototype%` / `%AsyncGenerator.
+/// prototype%`. The result is the two-hop chain Node exposes:
+/// `Object.getPrototypeOf(gen())` → intermediate →
+/// `Object.getPrototypeOf(...)` → the brand-checked prototype carrying
+/// `next`/`return`/`throw`.
+///
+/// Returns `obj` unchanged so codegen can use it inline in return position.
+/// GC: both links go through `object_set_static_prototype`, whose side-table is
+/// traced + pointer-rewritten by the collector (see `prototype_chain.rs`), so
+/// the intermediate stays live as long as the instance does and dies with it.
+#[no_mangle]
+pub extern "C" fn js_generator_attach_prototype(obj: f64, is_async: i32) -> f64 {
+    let jv = JSValue::from_bits(obj.to_bits());
+    if !jv.is_pointer() {
+        return obj;
+    }
+    let obj_ptr = jv.as_pointer::<u8>() as usize;
+    if obj_ptr == 0 {
+        return obj;
+    }
+    let gen_proto = generator_prototype_ptr(is_async != 0);
+    if gen_proto.is_null() {
+        return obj;
+    }
+    // Intermediate object stands in for `g.prototype`: own `[[Prototype]]` is
+    // `%Generator.prototype%`, carries no own methods (the instance inherits
+    // `next`/`return`/`throw` from the brand-checked prototype two hops up).
+    let intermediate = js_object_alloc(0, 0);
+    if intermediate.is_null() {
+        return obj;
+    }
+    let gen_proto_bits = crate::value::js_nanbox_pointer(gen_proto as i64).to_bits();
+    super::prototype_chain::object_set_static_prototype(intermediate as usize, gen_proto_bits);
+    let intermediate_bits = crate::value::js_nanbox_pointer(intermediate as i64).to_bits();
+    super::prototype_chain::object_set_static_prototype(obj_ptr, intermediate_bits);
+    obj
+}
+
 /// Build one generator-intrinsic tower (sync or async) and store its three
 /// objects in the GC-rooted atomics declared in `object/mod.rs`.
 ///

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -581,7 +581,18 @@ pub fn transform_generator_function_with_extra_captures(
             ("return".to_string(), return_closure),
             ("throw".to_string(), throw_closure),
         ]);
-        new_body.push(Stmt::Return(Some(iter_obj)));
+        // #4141: wire the instance's `[[Prototype]]` chain
+        // (`gen() → g.prototype → %Generator.prototype%`) so reflective
+        // access via the instance (`Object.getPrototypeOf(Object.getPrototypeOf(
+        // gen()))`) reaches the brand-checked prototype methods. The object
+        // literal is hidden inside the wrapper in return position; escape
+        // analysis leaves the unanalyzed allocation on the heap (correct — a
+        // generator object always escapes via the return).
+        let linked = Expr::LinkGeneratorPrototype {
+            obj: Box::new(iter_obj),
+            is_async: is_async_generator,
+        };
+        new_body.push(Stmt::Return(Some(linked)));
     }
 
     func.body = new_body;

--- a/test-parity/node-suite/globals/generator-prototype-chain.ts
+++ b/test-parity/node-suite/globals/generator-prototype-chain.ts
@@ -1,0 +1,54 @@
+// #4141: a generator/async-generator INSTANCE must sit on the spec prototype
+// chain — `Object.getPrototypeOf(Object.getPrototypeOf(gen()))` resolves to
+// `%Generator.prototype%` / `%AsyncGenerator.prototype%`, the object carrying
+// the brand-checked `next`/`return`/`throw` with `configurable:true`
+// descriptors. Complements globals/generator-intrinsics.ts (function-side).
+
+function* g() {
+  yield 1;
+}
+async function* ag() {
+  yield 1;
+}
+
+function descOf(o: any, k: string) {
+  const d = Object.getOwnPropertyDescriptor(o, k);
+  return d
+    ? { writable: d.writable, enumerable: d.enumerable, configurable: d.configurable }
+    : undefined;
+}
+
+// --- instance two-hop chain reaches the brand-checked prototype ---
+const SyncProto = Object.getPrototypeOf(Object.getPrototypeOf(g()));
+console.log("sync inst proto has next:", typeof SyncProto.next);
+console.log("sync next desc:", JSON.stringify(descOf(SyncProto, "next")));
+console.log("sync return desc:", JSON.stringify(descOf(SyncProto, "return")));
+console.log("sync throw desc:", JSON.stringify(descOf(SyncProto, "throw")));
+console.log("sync constructor desc:", JSON.stringify(descOf(SyncProto, "constructor")));
+
+const AsyncProto = Object.getPrototypeOf(Object.getPrototypeOf(ag()));
+console.log("async inst proto has next:", typeof AsyncProto.next);
+console.log("async next desc:", JSON.stringify(descOf(AsyncProto, "next")));
+console.log("async constructor desc:", JSON.stringify(descOf(AsyncProto, "constructor")));
+
+// --- the instance proto and %Generator.prototype% are distinct objects ---
+console.log("sync two distinct hops:", Object.getPrototypeOf(g()) !== SyncProto);
+
+// --- brand check via the instance-reached prototype ---
+for (const bad of [undefined, null, {}, function () {}]) {
+  try {
+    SyncProto.next.call(bad as any);
+    console.log("sync brand NO THROW");
+  } catch (e) {
+    console.log("sync brand throws TypeError:", e instanceof TypeError);
+  }
+}
+
+// --- delegation: prototype method drives a real instance ---
+console.log("sync delegated:", JSON.stringify(SyncProto.next.call(g())));
+
+// --- async brand check rejects (queued last, deterministic) ---
+AsyncProto.next.call(undefined as any).then(
+  () => console.log("async brand NO REJECT"),
+  (e: any) => console.log("async brand rejects TypeError:", e instanceof TypeError),
+);


### PR DESCRIPTION
## Summary

Fixes #4141. Links a generator/async-generator **instance** into the spec
`[[Prototype]]` chain so reflective access via the instance reaches the
brand-checked prototype methods.

Perry lowers `gen()` to a `{next,return,throw}` object literal but never wired
its `[[Prototype]]`, so `Object.getPrototypeOf(Object.getPrototypeOf(gen()))`
landed on the wrong object instead of `%Generator.prototype%` /
`%AsyncGenerator.prototype%`. That broke the instance-side brand-check and
descriptor cases (the issue's repro #2 and test262's
`AsyncGeneratorPrototype/.../this-val-not-async-generator`).

> Note: the *function-side* descriptor + brand-check layer the issue describes
> was already fixed on `main` by #4086 (merged hours after the radar sweep that
> filed #4141) — verified byte-identical to Node via the canonical
> `Object.getPrototypeOf(function*(){}).prototype` access. This PR fills the one
> genuinely-remaining gap: the **instance** chain.

## Approach

- `transform_generators` wraps the returned iterator object in a new
  `Expr::LinkGeneratorPrototype { obj, is_async }` (the single iter-object
  construction site, so it covers functions / methods / closures / nested,
  sync + async uniformly; `was_plain_async` async functions are excluded).
- Runtime `js_generator_attach_prototype(obj, is_async)` interposes a fresh
  intermediate object as the instance's `[[Prototype]]` whose own
  `[[Prototype]]` is the sync/async generator prototype — reproducing Node's
  two-hop `instance → g.prototype → %Generator.prototype%`. Both links go
  through the GC-traced static-prototype side-table (`prototype_chain.rs`).
- New HIR variant threaded through both `walk_expr_children` walkers,
  `stable_hash`, and `boxed_vars`' nested-closure walker (so generator state
  locals still get boxed).
- `function_body_returns_generator_object` unwraps the wrapper so generator
  registration (which drives `g.prototype` + `isGeneratorFunction`) still fires.
- Escape analysis leaves the wrapped, unanalyzed iterator allocation on the heap
  — correct, since a generator object always escapes via the return.

## Validation

Byte-identical to `node --experimental-strip-types` for: descriptors
(`next`/`return`/`throw`/`constructor`, sync + async), brand checks (sync throws
`TypeError`, async rejects `TypeError`), stateful generators, `for-of`,
`yield*`, class/object generator methods, and nested generators. New node-suite
test `globals/generator-prototype-chain.ts`. Full `perry-hir`,
`perry-transform`, `perry-codegen`, `perry-runtime` test suites pass (`cargo fmt
--check` clean); verified under both default (auto-optimize) and
`PERRY_NO_AUTO_OPTIMIZE=1` builds.

## Known limitation

The interposed prototype is per-call, so `Object.getPrototypeOf(gen()) ===
gen.prototype` is currently `false` (the intermediate is not the closure-cached
`gen.prototype` object — making them identical needs the generator closure at
instance-construction time, which isn't in scope at the lowering site).
Brand-check / descriptor semantics are unaffected. Worth a follow-up if a
test262 identity case requires it.
