### PR TITLE
c262 parity: detached function helpers

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -332,19 +332,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     );
                     Ok(blk.bitcast_i64_to_double(&tagged))
                 }
-                // delete arr[numericIndex] — set element to undefined
+                // delete obj[expr] — route dynamic keys through the runtime so
+                // string-valued locals (for example `delete fn[name]`) still
+                // use the ordinary property-delete path instead of being
+                // misread as numeric array indexes.
                 Expr::IndexGet { object, index } => {
-                    let arr_box = lower_expr(ctx, object)?;
+                    let obj_box = lower_expr(ctx, object)?;
                     let idx_box = lower_expr(ctx, index)?;
                     let blk = ctx.block();
-                    let arr_handle = unbox_to_i64(blk, &arr_box);
-                    // Convert index to i32. It may be a double (NaN-boxed
-                    // number) or a raw integer literal.
-                    let idx_i32 = blk.fptosi(DOUBLE, &idx_box, I32);
+                    let obj_handle = unbox_to_i64(blk, &obj_box);
                     let i32_v = blk.call(
                         I32,
-                        "js_array_delete",
-                        &[(I64, &arr_handle), (I32, &idx_i32)],
+                        "js_object_delete_dynamic",
+                        &[(I64, &obj_handle), (DOUBLE, &idx_box)],
                     );
                     let bit = blk.icmp_ne(I32, &i32_v, "0");
                     let tagged = blk.select(

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -163,7 +163,31 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
         }
     }
 
-    let rhs = lower_expr(ctx, &assign.right)?;
+    let anonymous_class_assignment = if assign.op == ast::AssignOp::Assign {
+        simple_ident_target_name(&assign.left).and_then(|target_name| match assign.right.as_ref() {
+            ast::Expr::Class(class_expr) if class_expr.ident.is_none() => {
+                Some((target_name.to_string(), class_expr))
+            }
+            ast::Expr::Paren(paren) => match paren.expr.as_ref() {
+                ast::Expr::Class(class_expr) if class_expr.ident.is_none() => {
+                    Some((target_name.to_string(), class_expr))
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+    } else {
+        None
+    };
+
+    let rhs = if let Some((target_name, class_expr)) = anonymous_class_assignment {
+        let class =
+            crate::lower_decl::lower_class_from_ast(ctx, &class_expr.class, &target_name, false)?;
+        ctx.pending_classes.push(class);
+        Expr::ClassRef(target_name)
+    } else {
+        lower_expr(ctx, &assign.right)?
+    };
 
     // Handle compound assignment operators (+=, -=, *=, /=, etc.)
     let value = match assign.op {

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -239,6 +239,11 @@ pub extern "C" fn js_build_class_keys_array(
     if !cached.is_null() {
         return cached;
     }
+    if field_count == 0 || packed_keys_len == 0 || packed_keys.is_null() {
+        let arr = crate::array::js_array_alloc_with_length_longlived(0);
+        shape_cache_insert(shape_id, arr);
+        return arr;
+    }
     let keys_bytes = unsafe { std::slice::from_raw_parts(packed_keys, packed_keys_len as usize) };
     let keys: Vec<&[u8]> = keys_bytes
         .split(|&b| b == 0)

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -28,6 +28,32 @@ pub use super::class_handles::{
 };
 use super::*;
 
+thread_local! {
+    static CLASS_DELETED_KEYS: std::cell::RefCell<std::collections::HashMap<u32, std::collections::HashSet<String>>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+pub(crate) fn class_mark_key_deleted(class_id: u32, key: &str) {
+    if class_id == 0 {
+        return;
+    }
+    CLASS_DELETED_KEYS.with(|m| {
+        m.borrow_mut()
+            .entry(class_id)
+            .or_default()
+            .insert(key.to_string());
+    });
+}
+
+pub(crate) fn class_is_key_deleted(class_id: u32, key: &str) -> bool {
+    CLASS_DELETED_KEYS.with(|m| {
+        m.borrow()
+            .get(&class_id)
+            .map(|keys| keys.contains(key))
+            .unwrap_or(false)
+    })
+}
+
 pub(crate) fn class_dynamic_prop_root_store(class_id: u32, name: String, value: f64) {
     CLASS_DYNAMIC_PROPS.with(|m| {
         m.borrow_mut()

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -12,7 +12,18 @@ pub extern "C" fn js_object_delete_field(
     obj: *mut ObjectHeader,
     key: *const crate::StringHeader,
 ) -> i32 {
-    if obj.is_null() || (obj as usize) < 0x10000 || key.is_null() {
+    if obj.is_null() || key.is_null() {
+        return 1;
+    }
+    if (obj as usize) < 0x10000 {
+        unsafe {
+            if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
+                let class_id = obj as usize as u32;
+                if super::class_registry::class_name_for_id(class_id).is_some() {
+                    super::class_registry::class_mark_key_deleted(class_id, name);
+                }
+            }
+        }
         return 1;
     }
     unsafe {

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -65,6 +65,36 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
         if let Some(class_id) = class_ref_id(obj_value) {
             let method_name = metadata_key_to_string(key_value);
             if let Some(method_name) = method_name {
+                if super::class_registry::class_is_key_deleted(class_id, &method_name) {
+                    return f64::from_bits(crate::value::TAG_UNDEFINED);
+                }
+                if method_name == "name" {
+                    if let Some(cname) = super::class_registry::class_name_for_id(class_id) {
+                        let value = {
+                            let s = crate::string::js_string_from_bytes(
+                                cname.as_ptr(),
+                                cname.len() as u32,
+                            );
+                            crate::js_nanbox_string(s as i64)
+                        };
+                        let packed = b"value\0writable\0enumerable\0configurable";
+                        let desc = js_object_alloc_with_shape(
+                            0x0D_E5_C2,
+                            4,
+                            packed.as_ptr(),
+                            packed.len() as u32,
+                        );
+                        let header_size = std::mem::size_of::<ObjectHeader>();
+                        let fields = (desc as *mut u8).add(header_size) as *mut f64;
+                        // GC_STORE_AUDIT(INIT): descriptor object is freshly allocated; layout is rebuilt before publication.
+                        *fields = value;
+                        *fields.add(1) = f64::from_bits(TAG_FALSE);
+                        *fields.add(2) = f64::from_bits(TAG_FALSE);
+                        *fields.add(3) = f64::from_bits(TAG_TRUE);
+                        super::rebuild_object_field_layout(desc, 4);
+                        return f64::from_bits((desc as u64) | 0x7FFD_0000_0000_0000);
+                    }
+                }
                 if method_name == "constructor" || class_has_own_method(class_id, &method_name) {
                     let value = if method_name == "constructor"
                         && super::class_prototype_ref_id(obj_value).is_some()

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1972,12 +1972,17 @@ pub extern "C" fn js_object_get_field_by_name(
                     // This is what `assert.throws` reads via
                     // `thrown.constructor.name` to label the thrown error.
                     if name == "name" && class_id != 0 {
-                        if let Some(cname) = super::class_registry::class_name_for_id(class_id) {
-                            let s = crate::string::js_string_from_bytes(
-                                cname.as_ptr(),
-                                cname.len() as u32,
-                            );
-                            return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+                        if !super::class_registry::class_is_key_deleted(class_id, name) {
+                            if let Some(cname) = super::class_registry::class_name_for_id(class_id)
+                            {
+                                let s = crate::string::js_string_from_bytes(
+                                    cname.as_ptr(),
+                                    cname.len() as u32,
+                                );
+                                return JSValue::from_bits(
+                                    crate::js_nanbox_string(s as i64).to_bits(),
+                                );
+                            }
                         }
                     }
                 }
@@ -3601,6 +3606,17 @@ pub extern "C" fn js_object_get_field_by_name_f64(
     obj: *const ObjectHeader,
     key: *const crate::StringHeader,
 ) -> f64 {
+    if (obj as usize) > 0 && (obj as usize) < 0x10000 && !key.is_null() {
+        if let Some(name) = unsafe { super::has_own_helpers::str_from_string_header(key) } {
+            let class_id = obj as usize as u32;
+            if name == "name" && !super::class_registry::class_is_key_deleted(class_id, name) {
+                if let Some(cname) = super::class_registry::class_name_for_id(class_id) {
+                    let s = crate::string::js_string_from_bytes(cname.as_ptr(), cname.len() as u32);
+                    return crate::js_nanbox_string(s as i64);
+                }
+            }
+        }
+    }
     // date-fns `constructFrom`: `new date.constructor(value)`. A Date is a
     // NaN-boxed `DateCell` pointer (#2089); `js_object_get_field_by_name`
     // routes `.constructor` to the global Date constructor closure and every

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -398,6 +398,8 @@ pub extern "C" fn js_object_set_field_by_name(
                         if !attrs.writable() {
                             return;
                         }
+                    } else if matches!(name_str, "name" | "length") {
+                        return;
                     }
                     crate::closure::closure_set_dynamic_prop(obj as usize, name_str, value);
                 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2251,6 +2251,23 @@ extern "C" fn object_get_own_property_names_thunk(
     super::js_object_get_own_property_names(value)
 }
 
+extern "C" fn object_get_own_property_descriptor_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    obj: f64,
+    key: f64,
+) -> f64 {
+    super::js_object_get_own_property_descriptor(obj, key)
+}
+
+extern "C" fn object_define_property_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    obj: f64,
+    key: f64,
+    descriptor: f64,
+) -> f64 {
+    super::js_object_define_property(obj, key, descriptor)
+}
+
 extern "C" fn object_from_entries_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
@@ -2556,6 +2573,20 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 "getOwnPropertyNames",
                 object_get_own_property_names_thunk as *const u8,
                 1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "getOwnPropertyDescriptor",
+                object_get_own_property_descriptor_thunk as *const u8,
+                2,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "defineProperty",
+                object_define_property_thunk as *const u8,
+                3,
                 false,
             );
             install_constructor_static(

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -2964,6 +2964,26 @@ pub unsafe extern "C" fn js_native_call_method(
             if jsval.is_undefined() || jsval.is_null() {
                 return f64::from_bits(JSValue::bool(false).bits());
             }
+            if (object.to_bits() >> 48) == 0x7FFE {
+                let key_value = if args_len >= 1 && !args_ptr.is_null() {
+                    *args_ptr
+                } else {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                };
+                let key_str = crate::builtins::js_string_coerce(key_value);
+                let class_id = (object.to_bits() & 0xFFFF_FFFF) as u32;
+                let present = if key_str.is_null() {
+                    false
+                } else {
+                    super::has_own_helpers::str_from_string_header(key_str)
+                        .map(|key| {
+                            matches!(key, "length" | "name" | "prototype")
+                                && !super::class_registry::class_is_key_deleted(class_id, key)
+                        })
+                        .unwrap_or(false)
+                };
+                return f64::from_bits(JSValue::bool(present).bits());
+            }
             if jsval.is_pointer() {
                 let key_value = if args_len >= 1 && !args_ptr.is_null() {
                     *args_ptr

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -509,6 +509,17 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
             return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
         }
 
+        if (obj_value.to_bits() >> 48) == 0x7FFE {
+            let class_id = (obj_value.to_bits() & 0xFFFF_FFFF) as u32;
+            let present = super::has_own_helpers::str_from_string_header(key_str)
+                .map(|key| {
+                    matches!(key, "length" | "name" | "prototype")
+                        && !super::class_registry::class_is_key_deleted(class_id, key)
+                })
+                .unwrap_or(false);
+            return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+        }
+
         // #3655: functions/closures carry built-in own `name`/`length`
         // (and `prototype` for constructors) plus any user-attached props.
         // Route them here instead of through `extract_obj_ptr`/`own_key_present`,

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -498,7 +498,14 @@ fn target_set(target: f64, key: f64, value: f64) {
         }
         return;
     }
-    let obj_ptr = extract_pointer(target.to_bits()) as *mut crate::ObjectHeader;
+    let obj_addr = extract_pointer(target.to_bits()) as usize;
+    if crate::closure::is_closure_ptr(obj_addr) {
+        if let Some(name) = key_to_rust_string(key) {
+            crate::closure::closure_set_dynamic_prop(obj_addr, &name, value);
+        }
+        return;
+    }
+    let obj_ptr = obj_addr as *mut crate::ObjectHeader;
     let key_ptr = extract_pointer(key.to_bits()) as *const crate::StringHeader;
     if obj_ptr.is_null() || key_ptr.is_null() {
         return;
@@ -550,6 +557,14 @@ fn own_set_descriptor(target: f64, key: f64) -> Option<OwnSetDescriptor> {
         return Some(OwnSetDescriptor::Data {
             writable: attrs.writable(),
         });
+    }
+    if crate::closure::is_closure_ptr(obj_ptr) {
+        if crate::object::has_own_helpers::closure_own_key_present(obj_ptr, &key_name) {
+            return Some(OwnSetDescriptor::Data {
+                writable: !matches!(key_name.as_str(), "name" | "length"),
+            });
+        }
+        return None;
     }
     if crate::object::obj_value_has_own_key(target, key) {
         return Some(OwnSetDescriptor::Data { writable: true });
@@ -624,6 +639,9 @@ fn create_or_update_receiver_property(receiver: f64, key: f64, value: f64) -> bo
                 return call_setter_with_receiver(setter_bits, receiver, value);
             }
         }
+    } else if crate::closure::is_closure_ptr(extract_pointer(receiver.to_bits()) as usize) {
+        target_set(receiver, key, value);
+        return true;
     } else if crate::object::obj_value_no_extend(receiver) {
         return false;
     }
@@ -648,6 +666,9 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
                 }
             };
         }
+        if crate::closure::is_closure_ptr(extract_pointer(current.to_bits()) as usize) {
+            return create_or_update_receiver_property(receiver, key, value);
+        }
         let Some(proto) = prototype_of_for_set(current) else {
             return create_or_update_receiver_property(receiver, key, value);
         };
@@ -667,6 +688,15 @@ pub extern "C" fn js_put_value_set(
     receiver: f64,
     strict: i32,
 ) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let value_handle = scope.root_nanbox_f64(value);
+    let receiver_handle = scope.root_nanbox_f64(receiver);
+    let target = target_handle.get_nanbox_f64();
+    let key = key_handle.get_nanbox_f64();
+    let value = value_handle.get_nanbox_f64();
+    let receiver = receiver_handle.get_nanbox_f64();
     let target_bits = target.to_bits();
     if target_bits == TAG_NULL || target_bits == TAG_UNDEFINED {
         let key_name = key_to_rust_string(key).unwrap_or_else(|| "property".to_string());
@@ -682,7 +712,7 @@ pub extern "C" fn js_put_value_set(
         let key_name = key_to_rust_string(key).unwrap_or_else(|| "property".to_string());
         crate::error::throw_immutable_write(0, &key_name);
     }
-    value
+    value_handle.get_nanbox_f64()
 }
 
 /// `key in proxy` — if handler.has exists, call it; otherwise delegate to

--- a/reference/deepwiki/function-detached-helpers-boa.md
+++ b/reference/deepwiki/function-detached-helpers-boa.md
@@ -1,0 +1,789 @@
+# DeepWiki Response
+
+Repository: `boa-dev/boa`
+Question: For Function.prototype.call/apply/bind in Boa, how are bound functions represented and invoked? Please focus on detached helper patterns such as Function.prototype.call.bind(Object.prototype.hasOwnProperty), IsCallable checks, Array.isArray as a callable builtin, and creation of function name/length property descriptors for ordinary and bound functions. Include relevant source paths and citations.
+Search: https://deepwiki.com/search/for-functionprototypecallapply_132b61a5-ea5e-4a85-9fdd-9a0155481a74
+
+**Question**: For Function.prototype.call/apply/bind in Boa, how are bound functions represented and invoked? Please focus on detached helper patterns such as Function.prototype.call.bind(Object.prototype.hasOwnProperty), IsCallable checks, Array.isArray as a callable builtin, and creation of function name/length property descriptors for ordinary and bound functions. Include relevant source paths and citations.
+
+In Boa, bound functions are represented by the `BoundFunction` struct and invoked through exotic internal methods. The `Function.prototype.bind` method creates a `BoundFunction` object, which encapsulates the target function, the `this` value, and any bound arguments. Invocation of bound functions, as well as `Function.prototype.call` and `Function.prototype.apply`, involves `IsCallable` checks and careful management of the call stack.
+
+## Bound Function Representation
+
+Bound functions are represented by the `BoundFunction` struct [1](#ref-q1-1) . This struct stores three key pieces of information:
+*   `target_function`: The original function that was bound [2](#ref-q1-2) .
+*   `this`: The `this` value that will be used when the `target_function` is called [3](#ref-q1-3) .
+*   `args`: A `Vec<JsValue>` containing the arguments that were bound during the creation of the bound function [4](#ref-q1-4) .
+
+The `BoundFunction::create` method is responsible for creating a new bound function object [5](#ref-q1-5) . It sets up the prototype chain and stores the `BoundFunction` data within a `JsObject` [6](#ref-q1-6) .
+
+## Invocation of Bound Functions and `call`/`apply`
+
+Bound functions, as well as `Function.prototype.call` and `Function.prototype.apply`, rely on the `IsCallable` check to ensure that the target is indeed a function.
+
+### `IsCallable` Checks
+
+The `is_callable` method on `JsValue` checks if a JavaScript value is a callable function [7](#ref-q1-7) . This method internally calls `JsObject::is_callable` [8](#ref-q1-8) , which determines if the object has a `[[Call]]` internal method different from the ordinary one [9](#ref-q1-9) .
+
+For example, in `Function.prototype.apply`, the `this` value is checked to be callable using `this.as_callable()` [10](#ref-q1-10) . Similarly, `Function.prototype.bind` also performs an `IsCallable` check on its `Target` [11](#ref-q1-11) .
+
+### `Function.prototype.call` and `Function.prototype.apply`
+
+Both `call` and `apply` methods on `Function.prototype` ultimately invoke the target function using its `[[Call]]` internal method.
+*   `Function.prototype.apply` [12](#ref-q1-12) : Takes `thisArg` and an `argArray`. It creates a list of arguments from `argArray` using `create_list_from_array_like` and then calls the function with the specified `thisArg` and the prepared argument list [13](#ref-q1-13) .
+*   `Function.prototype.call` [14](#ref-q1-14) : Takes `thisArg` and individual arguments. It extracts the `thisArg` and the rest of the arguments, then calls the function with them [15](#ref-q1-15) .
+
+The actual function invocation is handled by `JsObject::call` [16](#ref-q1-16) , which pushes the `this` value and arguments onto the VM stack and then executes the function's `[[Call]]` internal method [17](#ref-q1-17) .
+
+### Bound Function Invocation
+
+When a bound function is invoked, its `[[Call]]` internal method, `bound_function_exotic_call`, is executed [18](#ref-q1-18) . This method retrieves the `target_function`, `bound_this`, and `bound_args` from the `BoundFunction` object [19](#ref-q1-19) . It then sets the `this` value and inserts the bound arguments onto the VM stack before calling the `target_function` with the combined arguments [20](#ref-q1-20) .
+
+If the bound function is used as a constructor (e.g., `new BoundFunction()`), the `bound_function_exotic_construct` internal method is called [21](#ref-q1-21) . This method similarly retrieves the `target_function` and `bound_args`, prepares the arguments, and then calls the `target_function`'s `[[Construct]]` method [22](#ref-q1-22) .
+
+### Detached Helper Patterns
+
+The pattern `Function.prototype.call.bind(Object.prototype.hasOwnProperty)` is used to create a "detached" version of `hasOwnProperty`. This works because `Function.prototype.bind` creates a new function where the `this` value is permanently set. In this case, `Object.prototype.hasOwnProperty` becomes the `target_function` and `Function.prototype.call` becomes the `this` value for the `bind` call. When the resulting bound function is called, it will invoke `Function.prototype.call` with `Object.prototype.hasOwnProperty` as its `this` and the first argument of the bound function as the `this` for `hasOwnProperty`.
+
+## Function Name and Length Property Descriptors
+
+### Ordinary Functions
+
+For ordinary functions, the `name` and `length` properties are set during their creation. The `FunctionObjectBuilder` is used to construct native function objects [23](#ref-q1-23) . It allows specifying the `name` and `length` of the function [24](#ref-q1-24) . These properties are defined as non-writable, non-enumerable, and configurable [25](#ref-q1-25) .
+
+The `create_function_object_fast` function also sets the `name` and `length` properties when creating function objects from `CodeBlock`s [26](#ref-q1-26) . The `Intrinsics` struct provides templates for different function types (e.g., `function`, `async_function`, `generator_function`) which define the default property descriptors for `length` and `name` [27](#ref-q1-27) .
+
+### Bound Functions
+
+For bound functions, the `length` and `name` properties are specifically calculated and set during the `Function.prototype.bind` operation [28](#ref-q1-28) .
+*   **Length**: The `length` property of a bound function is calculated as `max(targetLenAsInt - argCount, 0)`, where `targetLenAsInt` is the length of the target function and `argCount` is the number of arguments bound [29](#ref-q1-29) . This property is defined as non-writable, non-enumerable, and configurable [30](#ref-q1-30) .
+*   **Name**: The `name` property of a bound function is derived from the `target_name` with a "bound" prefix. The `set_function_name` abstract operation handles this [31](#ref-q1-31) . The `name` property is also defined as non-writable, non-enumerable, and configurable [32](#ref-q1-32) .
+
+## `Array.isArray` as a Callable Builtin
+
+`Array.isArray` is a standard built-in function [33](#ref-q1-33) . While the provided snippets do not explicitly show `Array.isArray`'s implementation, it would be initialized as a callable function using the `BuiltInBuilder` pattern, similar to other built-in methods like `Array.prototype.map` [34](#ref-q1-34) . Its `is_callable` check would return `true` because it has a defined `[[Call]]` internal method.
+
+## Notes
+
+The `Glossary` wiki page provides a good overview of core engine concepts like `Context`, `JsValue`, and `Realm` [35](#ref-q1-35) . The `Standard Builtins` wiki page details how built-in objects are implemented in Boa, including the use of `BuiltInBuilder` for defining methods and properties <cite repo="boa-dev/boa" path="boa-dev/boa" start="3.1" end="3.1" />. These are foundational to understanding the implementation of `Function.prototype.call`, `apply`, and `bind`.
+
+Wiki pages you might want to explore:
+- [Standard Builtins (boa-dev/boa)](/wiki/boa-dev/boa#3.1)
+- [Glossary (boa-dev/boa)](/wiki/boa-dev/boa#7)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-functionprototypecallapply_132b61a5-ea5e-4a85-9fdd-9a0155481a74
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `core/engine/src/builtins/function/bound.rs:15-19`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L15-L19)
+
+```rust
+pub struct BoundFunction {
+    target_function: JsObject,
+    this: JsValue,
+    args: Vec<JsValue>,
+}
+```
+
+<a id="ref-q1-2"></a>
+### [2] `core/engine/src/builtins/function/bound.rs:16`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L16)
+
+```rust
+    target_function: JsObject,
+```
+
+<a id="ref-q1-3"></a>
+### [3] `core/engine/src/builtins/function/bound.rs:17`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L17)
+
+```rust
+    this: JsValue,
+```
+
+<a id="ref-q1-4"></a>
+### [4] `core/engine/src/builtins/function/bound.rs:18`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L18)
+
+```rust
+    args: Vec<JsValue>,
+```
+
+<a id="ref-q1-5"></a>
+### [5] `core/engine/src/builtins/function/bound.rs:49-78`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L49-L78)
+
+```rust
+    pub fn create(
+        target_function: JsObject,
+        this: JsValue,
+        args: Vec<JsValue>,
+        context: &mut Context,
+    ) -> JsResult<JsObject> {
+        // 1. Let proto be ? targetFunction.[[GetPrototypeOf]]().
+        let proto = target_function.__get_prototype_of__(context)?;
+
+        // 2. Let internalSlotsList be the internal slots listed in Table 35, plus [[Prototype]] and [[Extensible]].
+        // 3. Let obj be ! MakeBasicObject(internalSlotsList).
+        // 4. Set obj.[[Prototype]] to proto.
+        // 5. Set obj.[[Call]] as described in 10.4.1.1.
+        // 6. If IsConstructor(targetFunction) is true, then
+        // a. Set obj.[[Construct]] as described in 10.4.1.2.
+        // 7. Set obj.[[BoundTargetFunction]] to targetFunction.
+        // 8. Set obj.[[BoundThis]] to boundThis.
+        // 9. Set obj.[[BoundArguments]] to boundArgs.
+        // 10. Return obj.
+        Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            proto,
+            Self {
+                target_function,
+                this,
+                args,
+            },
+        )
+        .upcast())
+    }
+```
+
+<a id="ref-q1-6"></a>
+### [6] `core/engine/src/builtins/function/bound.rs:68-77`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L68-L77)
+
+```rust
+        Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            proto,
+            Self {
+                target_function,
+                this,
+                args,
+            },
+        )
+        .upcast())
+```
+
+<a id="ref-q1-7"></a>
+### [7] `core/engine/src/value/mod.rs:368-370`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/mod.rs#L368-L370)
+
+```rust
+    pub fn is_callable(&self) -> bool {
+        self.as_object().as_ref().is_some_and(JsObject::is_callable)
+    }
+```
+
+<a id="ref-q1-8"></a>
+### [8] `core/engine/src/value/mod.rs:369`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/mod.rs#L369)
+
+```rust
+        self.as_object().as_ref().is_some_and(JsObject::is_callable)
+```
+
+<a id="ref-q1-9"></a>
+### [9] `core/engine/src/object/jsobject.rs:1015-1020`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L1015-L1020)
+
+```rust
+    pub fn is_callable(&self) -> bool {
+        !fn_addr_eq(
+            self.inner.vtable.__call__,
+            ORDINARY_INTERNAL_METHODS.__call__,
+        )
+    }
+```
+
+<a id="ref-q1-10"></a>
+### [10] `core/engine/src/builtins/function/mod.rs:699-702`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L699-L702)
+
+```rust
+        // 2. If IsCallable(func) is false, throw a TypeError exception.
+        let func = this.as_callable().ok_or_else(|| {
+            JsNativeError::typ().with_message(format!("{} is not a function", this.display()))
+        })?;
+```
+
+<a id="ref-q1-11"></a>
+### [11] `core/engine/src/builtins/function/mod.rs:738-743`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L738-L743)
+
+```rust
+        // 1. Let Target be the this value.
+        // 2. If IsCallable(Target) is false, throw a TypeError exception.
+        let target = this.as_callable().ok_or_else(|| {
+            JsNativeError::typ()
+                .with_message("cannot bind `this` without a `[[Call]]` internal method")
+        })?;
+```
+
+<a id="ref-q1-12"></a>
+### [12] `core/engine/src/builtins/function/mod.rs:686-723`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L686-L723)
+
+```rust
+    /// `Function.prototype.apply ( thisArg, argArray )`
+    ///
+    /// The `apply()` method invokes self with the first argument as the `this` value
+    /// and the rest of the arguments provided as an array (or an array-like object).
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function.prototype.apply
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
+    fn apply(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // 1. Let func be the this value.
+        // 2. If IsCallable(func) is false, throw a TypeError exception.
+        let func = this.as_callable().ok_or_else(|| {
+            JsNativeError::typ().with_message(format!("{} is not a function", this.display()))
+        })?;
+
+        let this_arg = args.get_or_undefined(0);
+        let arg_array = args.get_or_undefined(1);
+        // 3. If argArray is undefined or null, then
+        if arg_array.is_null_or_undefined() {
+            // a. Perform PrepareForTailCall().
+            // TODO?: 3.a. PrepareForTailCall
+
+            // b. Return ? Call(func, thisArg).
+            return func.call(this_arg, &[], context);
+        }
+
+        // 4. Let argList be ? CreateListFromArrayLike(argArray).
+        let arg_list = arg_array.create_list_from_array_like(&[], context)?;
+
+        // 5. Perform PrepareForTailCall().
+        // TODO?: 5. PrepareForTailCall
+
+        // 6. Return ? Call(func, thisArg, argList).
+        func.call(this_arg, &arg_list, context)
+    }
+```
+
+<a id="ref-q1-13"></a>
+### [13] `core/engine/src/builtins/function/mod.rs:715-722`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L715-L722)
+
+```rust
+        // 4. Let argList be ? CreateListFromArrayLike(argArray).
+        let arg_list = arg_array.create_list_from_array_like(&[], context)?;
+
+        // 5. Perform PrepareForTailCall().
+        // TODO?: 5. PrepareForTailCall
+
+        // 6. Return ? Call(func, thisArg, argList).
+        func.call(this_arg, &arg_list, context)
+```
+
+<a id="ref-q1-14"></a>
+### [14] `core/engine/src/builtins/function/mod.rs:807-829`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L807-L829)
+
+```rust
+    /// `Function.prototype.call ( thisArg, ...args )`
+    ///
+    /// The `call()` method calls a function with a given this value and arguments provided individually.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function.prototype.call
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call
+    fn call(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // 1. Let func be the this value.
+        // 2. If IsCallable(func) is false, throw a TypeError exception.
+        let func = this.as_callable().ok_or_else(|| {
+            JsNativeError::typ().with_message(format!("{} is not a function", this.display()))
+        })?;
+        let this_arg = args.get_or_undefined(0);
+
+        // 3. Perform PrepareForTailCall().
+        // TODO?: 3. Perform PrepareForTailCall
+
+        // 4. Return ? Call(func, thisArg, args).
+        func.call(this_arg, args.get(1..).unwrap_or(&[]), context)
+```
+
+<a id="ref-q1-15"></a>
+### [15] `core/engine/src/builtins/function/mod.rs:823-829`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L823-L829)
+
+```rust
+        let this_arg = args.get_or_undefined(0);
+
+        // 3. Perform PrepareForTailCall().
+        // TODO?: 3. Perform PrepareForTailCall
+
+        // 4. Return ? Call(func, thisArg, args).
+        func.call(this_arg, args.get(1..).unwrap_or(&[]), context)
+```
+
+<a id="ref-q1-16"></a>
+### [16] `core/engine/src/object/operations.rs:429-464`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/operations.rs#L429-L464)
+
+```rust
+    pub fn call(
+        &self,
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // SKIP: 1. If argumentsList is not present, set argumentsList to a new empty List.
+        // SKIP: 2. If IsCallable(F) is false, throw a TypeError exception.
+        // NOTE(HalidOdat): For object's that are not callable we implement a special __call__ internal method
+        //                  that throws on call.
+
+        context.vm.stack.push(this.clone()); // this
+        context.vm.stack.push(self.clone()); // func
+        let argument_count = args.len();
+        context.vm.stack.calling_convention_push_arguments(args);
+
+        // 3. Return ? F.[[Call]](V, argumentsList).
+        let frame_index = context.vm.frames.len();
+        if self.__call__(argument_count).resolve(context)? {
+            return Ok(context.vm.stack.pop());
+        }
+
+        if frame_index + 1 == context.vm.frames.len() {
+            context.vm.frame_mut().set_exit_early(true);
+        } else {
+            context.vm.frames[frame_index + 1].set_exit_early(true);
+        }
+
+        context.vm.host_call_depth += 1;
+        let result = context.run().consume();
+        context.vm.host_call_depth = context.vm.host_call_depth.saturating_sub(1);
+
+        context.vm.pop_frame().js_expect("frame must exist")?;
+
+        result
+    }
+```
+
+<a id="ref-q1-17"></a>
+### [17] `core/engine/src/object/operations.rs:440-447`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/operations.rs#L440-L447)
+
+```rust
+        context.vm.stack.push(this.clone()); // this
+        context.vm.stack.push(self.clone()); // func
+        let argument_count = args.len();
+        context.vm.stack.calling_convention_push_arguments(args);
+
+        // 3. Return ? F.[[Call]](V, argumentsList).
+        let frame_index = context.vm.frames.len();
+        if self.__call__(argument_count).resolve(context)? {
+```
+
+<a id="ref-q1-18"></a>
+### [18] `core/engine/src/builtins/function/bound.rs:24`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L24)
+
+```rust
+            __call__: bound_function_exotic_call,
+```
+
+<a id="ref-q1-19"></a>
+### [19] `core/engine/src/builtins/function/bound.rs:115-130`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L115-L130)
+
+```rust
+    // 1. Let target be F.[[BoundTargetFunction]].
+    let target = bound_function.target_function();
+    context
+        .vm
+        .stack
+        .calling_convention_set_function(argument_count, target.clone().into());
+
+    // 2. Let boundThis be F.[[BoundThis]].
+    let bound_this = bound_function.this();
+    context
+        .vm
+        .stack
+        .calling_convention_set_this(argument_count, bound_this.clone());
+
+    // 3. Let boundArgs be F.[[BoundArguments]].
+    let bound_args = bound_function.args();
+```
+
+<a id="ref-q1-20"></a>
+### [20] `core/engine/src/builtins/function/bound.rs:124-139`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L124-L139)
+
+```rust
+    context
+        .vm
+        .stack
+        .calling_convention_set_this(argument_count, bound_this.clone());
+
+    // 3. Let boundArgs be F.[[BoundArguments]].
+    let bound_args = bound_function.args();
+
+    // 4. Let args be the list-concatenation of boundArgs and argumentsList.
+    context
+        .vm
+        .stack
+        .calling_convention_insert_arguments(argument_count, bound_args);
+
+    // 5. Return ? Call(target, boundThis, args).
+    Ok(target.__call__(bound_args.len() + argument_count))
+```
+
+<a id="ref-q1-21"></a>
+### [21] `core/engine/src/builtins/function/bound.rs:25`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L25)
+
+```rust
+            __construct__: bound_function_exotic_construct,
+```
+
+<a id="ref-q1-22"></a>
+### [22] `core/engine/src/builtins/function/bound.rs:162-186`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/bound.rs#L162-L186)
+
+```rust
+    // 1. Let target be F.[[BoundTargetFunction]].
+    let target = bound_function.target_function();
+
+    // 2. Assert: IsConstructor(target) is true.
+
+    // 3. Let boundArgs be F.[[BoundArguments]].
+    let bound_args = bound_function.args();
+
+    // 4. Let args be the list-concatenation of boundArgs and argumentsList.
+    context
+        .vm
+        .stack
+        .calling_convention_insert_arguments(argument_count, bound_args);
+
+    // 5. If SameValue(F, newTarget) is true, set newTarget to target.
+    let function_object: JsValue = function_object.clone().into();
+    let new_target = if JsValue::same_value(&function_object, &new_target) {
+        target.clone().into()
+    } else {
+        new_target
+    };
+
+    // 6. Return ? Construct(target, args, newTarget).
+    context.vm.stack.push(new_target);
+    Ok(target.__construct__(bound_args.len() + argument_count))
+```
+
+<a id="ref-q1-23"></a>
+### [23] `core/engine/src/object/mod.rs:387-394`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/mod.rs#L387-L394)
+
+```rust
+#[derive(Debug)]
+pub struct FunctionObjectBuilder<'realm> {
+    realm: &'realm Realm,
+    function: NativeFunction,
+    constructor: Option<ConstructorKind>,
+    name: JsString,
+    length: usize,
+}
+```
+
+<a id="ref-q1-24"></a>
+### [24] `core/engine/src/object/mod.rs:410-432`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/mod.rs#L410-L432)
+
+```rust
+    /// Specify the name property of object function object.
+    ///
+    /// The default is `""` (empty string).
+    #[must_use]
+    pub fn name<N>(mut self, name: N) -> Self
+    where
+        N: Into<JsString>,
+    {
+        self.name = name.into();
+        self
+    }
+
+    /// Specify the length property of object function object.
+    ///
+    /// How many arguments this function takes.
+    ///
+    /// The default is `0`.
+    #[inline]
+    #[must_use]
+    pub const fn length(mut self, length: usize) -> Self {
+        self.length = length;
+        self
+    }
+```
+
+<a id="ref-q1-25"></a>
+### [25] `core/engine/src/builtins/builder.rs:110-125`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/builder.rs#L110-L125)
+
+```rust
+        object.insert(
+            StaticJsStrings::LENGTH,
+            PropertyDescriptor::builder()
+                .value(self.length)
+                .writable(false)
+                .enumerable(false)
+                .configurable(true),
+        );
+        object.insert(
+            js_string!("name"),
+            PropertyDescriptor::builder()
+                .value(self.name)
+                .writable(false)
+                .enumerable(false)
+                .configurable(true),
+        );
+```
+
+<a id="ref-q1-26"></a>
+### [26] `core/engine/src/vm/code_block.rs:1167-1170`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/vm/code_block.rs#L1167-L1170)
+
+```rust
+pub(crate) fn create_function_object_fast(code: Gc<CodeBlock>, context: &mut Context) -> JsObject {
+    let name: JsValue = code.name().clone().into();
+    let length: JsValue = code.length.into();
+```
+
+<a id="ref-q1-27"></a>
+### [27] `core/engine/src/context/intrinsics.rs:1749-1750`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/context/intrinsics.rs#L1749-L1750)
+
+```rust
+    /// 1. `"length"`: (`READONLY`, `NON_ENUMERABLE`, `CONFIGURABLE`)
+    /// 2. `"name"`: (`READONLY`, `NON_ENUMERABLE`, `CONFIGURABLE`)
+```
+
+<a id="ref-q1-28"></a>
+### [28] `core/engine/src/builtins/function/mod.rs:753-801`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L753-L801)
+
+```rust
+        let mut l = JsValue::new(0);
+
+        // 5. Let targetHasLength be ? HasOwnProperty(Target, "length").
+        // 6. If targetHasLength is true, then
+        if target.has_own_property(StaticJsStrings::LENGTH, context)? {
+            // a. Let targetLen be ? Get(Target, "length").
+            let target_len = target.get(StaticJsStrings::LENGTH, context)?;
+            // b. If Type(targetLen) is Number, then
+            if target_len.is_number() {
+                // 1. Let targetLenAsInt be ! ToIntegerOrInfinity(targetLen).
+                match target_len
+                    .to_integer_or_infinity(context)
+                    .js_expect("to_integer_or_infinity cannot fail for a number")?
+                {
+                    // i. If targetLen is +∞𝔽, set L to +∞.
+                    IntegerOrInfinity::PositiveInfinity => l = f64::INFINITY.into(),
+                    // ii. Else if targetLen is -∞𝔽, set L to 0.
+                    IntegerOrInfinity::NegativeInfinity => {}
+                    // iii. Else,
+                    IntegerOrInfinity::Integer(target_len) => {
+                        // 2. Assert: targetLenAsInt is finite.
+                        // 3. Let argCount be the number of elements in args.
+                        // 4. Set L to max(targetLenAsInt - argCount, 0).
+                        l = (target_len - arg_count).max(0).into();
+                    }
+                }
+            }
+        }
+
+        // 7. Perform ! SetFunctionLength(F, L).
+        f.define_property_or_throw(
+            StaticJsStrings::LENGTH,
+            PropertyDescriptor::builder()
+                .value(l)
+                .writable(false)
+                .enumerable(false)
+                .configurable(true),
+            context,
+        )
+        .js_expect("defining the `length` property for a new object should not fail")?;
+
+        // 8. Let targetName be ? Get(Target, "name").
+        let target_name = target.get(js_string!("name"), context)?;
+
+        // 9. If Type(targetName) is not String, set targetName to the empty String.
+        let target_name = target_name.as_string().unwrap_or_default();
+
+        // 10. Perform SetFunctionName(F, targetName, "bound").
+        set_function_name(&f, &target_name.into(), Some(js_str!("bound")), context)?;
+```
+
+<a id="ref-q1-29"></a>
+### [29] `core/engine/src/builtins/function/mod.rs:772-776`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L772-L776)
+
+```rust
+                    IntegerOrInfinity::Integer(target_len) => {
+                        // 2. Assert: targetLenAsInt is finite.
+                        // 3. Let argCount be the number of elements in args.
+                        // 4. Set L to max(targetLenAsInt - argCount, 0).
+                        l = (target_len - arg_count).max(0).into();
+```
+
+<a id="ref-q1-30"></a>
+### [30] `core/engine/src/builtins/function/mod.rs:783-792`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L783-L792)
+
+```rust
+        f.define_property_or_throw(
+            StaticJsStrings::LENGTH,
+            PropertyDescriptor::builder()
+                .value(l)
+                .writable(false)
+                .enumerable(false)
+                .configurable(true),
+            context,
+        )
+        .js_expect("defining the `length` property for a new object should not fail")?;
+```
+
+<a id="ref-q1-31"></a>
+### [31] `core/engine/src/builtins/function/mod.rs:794-801`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L794-L801)
+
+```rust
+        // 8. Let targetName be ? Get(Target, "name").
+        let target_name = target.get(js_string!("name"), context)?;
+
+        // 9. If Type(targetName) is not String, set targetName to the empty String.
+        let target_name = target_name.as_string().unwrap_or_default();
+
+        // 10. Perform SetFunctionName(F, targetName, "bound").
+        set_function_name(&f, &target_name.into(), Some(js_str!("bound")), context)?;
+```
+
+<a id="ref-q1-32"></a>
+### [32] `core/engine/src/builtins/function/mod.rs:958-970`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L958-L970)
+
+```rust
+    // 6. Return ! DefinePropertyOrThrow(F, "name", PropertyDescriptor { [[Value]]: name,
+    // [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
+    function
+        .define_property_or_throw(
+            js_string!("name"),
+            PropertyDescriptor::builder()
+                .value(name)
+                .writable(false)
+                .enumerable(false)
+                .configurable(true),
+            context,
+        )
+        .js_expect("defining the `name` property must not fail per the spec")?;
+```
+
+<a id="ref-q1-33"></a>
+### [33] `core/engine/src/builtins/array/mod.rs:1384-1432`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array/mod.rs#L1384-L1432)
+
+```rust
+    /// `Array.prototype.map( callback, [ thisArg ] )`
+    ///
+    /// For each element in the array the callback function is called, and a new
+    /// array is constructed from the return values of these calls.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.map
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
+    pub(crate) fn map(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be ? ToObject(this value).
+        let o = this.to_object(context)?;
+        // 2. Let len be ? LengthOfArrayLike(O).
+        let len = o.length_of_array_like(context)?;
+        // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
+        let callback = args.get_or_undefined(0).as_callable().ok_or_else(|| {
+            JsNativeError::typ().with_message("Array.prototype.map: Callbackfn is not callable")
+        })?;
+
+        // 4. Let A be ? ArraySpeciesCreate(O, len).
+        let a = Self::array_species_create(&o, len, context)?;
+
+        let this_arg = args.get_or_undefined(1);
+
+        // 5. Let k be 0.
+        // 6. Repeat, while k < len,
+        for k in 0..len {
+            // a. Let Pk be ! ToString(𝔽(k)).
+            // b. Let k_present be ? HasProperty(O, Pk).
+            // c. If k_present is true, then
+            // c.i. Let kValue be ? Get(O, Pk).
+            if let Some(k_value) = o.try_get(k, context)? {
+                // ii. Let mappedValue be ? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »).
+                let mapped_value =
+                    callback.call(this_arg, &[k_value, k.into(), o.clone().into()], context)?;
+                // iii. Perform ? CreateDataPropertyOrThrow(A, Pk, mappedValue).
+                a.create_data_property_or_throw(k, mapped_value, context)?;
+            }
+            // d. Set k to k + 1.
+        }
+        // 7. Return A.
+        Ok(a.into())
+    }
+```
+
+<a id="ref-q1-34"></a>
+### [34] `core/engine/src/builtins/array/mod.rs:1395-1432`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/array/mod.rs#L1395-L1432)
+
+```rust
+    pub(crate) fn map(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be ? ToObject(this value).
+        let o = this.to_object(context)?;
+        // 2. Let len be ? LengthOfArrayLike(O).
+        let len = o.length_of_array_like(context)?;
+        // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
+        let callback = args.get_or_undefined(0).as_callable().ok_or_else(|| {
+            JsNativeError::typ().with_message("Array.prototype.map: Callbackfn is not callable")
+        })?;
+
+        // 4. Let A be ? ArraySpeciesCreate(O, len).
+        let a = Self::array_species_create(&o, len, context)?;
+
+        let this_arg = args.get_or_undefined(1);
+
+        // 5. Let k be 0.
+        // 6. Repeat, while k < len,
+        for k in 0..len {
+            // a. Let Pk be ! ToString(𝔽(k)).
+            // b. Let k_present be ? HasProperty(O, Pk).
+            // c. If k_present is true, then
+            // c.i. Let kValue be ? Get(O, Pk).
+            if let Some(k_value) = o.try_get(k, context)? {
+                // ii. Let mappedValue be ? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »).
+                let mapped_value =
+                    callback.call(this_arg, &[k_value, k.into(), o.clone().into()], context)?;
+                // iii. Perform ? CreateDataPropertyOrThrow(A, Pk, mappedValue).
+                a.create_data_property_or_throw(k, mapped_value, context)?;
+            }
+            // d. Set k to k + 1.
+        }
+        // 7. Return A.
+        Ok(a.into())
+    }
+```
+
+<a id="ref-q1-35"></a>
+### [35] `boa-dev/boa:7`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/boa-dev/boa#L7)

--- a/reference/deepwiki/function-detached-helpers-engine262.md
+++ b/reference/deepwiki/function-detached-helpers-engine262.md
@@ -1,0 +1,766 @@
+# DeepWiki Response
+
+Repository: `engine262/engine262`
+Question: For Function.prototype.call/apply/bind in engine262, how are bound functions represented and invoked? Please focus on detached helper patterns such as Function.prototype.call.bind(Object.prototype.hasOwnProperty), IsCallable checks, Array.isArray as a callable builtin, and creation of function name/length property descriptors for ordinary and bound functions. Include relevant source paths and citations.
+Search: https://deepwiki.com/search/for-functionprototypecallapply_3b4a99f9-2a43-46cc-8323-eaee41799f1d
+
+**Question**: For Function.prototype.call/apply/bind in engine262, how are bound functions represented and invoked? Please focus on detached helper patterns such as Function.prototype.call.bind(Object.prototype.hasOwnProperty), IsCallable checks, Array.isArray as a callable builtin, and creation of function name/length property descriptors for ordinary and bound functions. Include relevant source paths and citations.
+
+In engine262, bound functions are represented as `BoundFunctionObject`s and their invocation is handled by the `BoundFunctionExoticObjectCall` and `BoundFunctionExoticObjectConstruct` internal methods [1](#ref-q1-1)  [2](#ref-q1-2)  [3](#ref-q1-3) . The `Function.prototype.bind` method creates these bound function objects [4](#ref-q1-4) , while `Function.prototype.call` and `Function.prototype.apply` are used to invoke callable functions with a specified `this` value and arguments [5](#ref-q1-5)  [6](#ref-q1-6) .
+
+## Bound Function Representation and Creation
+
+A bound function is represented by the `BoundFunctionObject` interface, which extends `ExoticObject` and `BuiltinFunctionObject` [1](#ref-q1-1) . It contains internal slots:
+*   `BoundTargetFunction`: The original function that was bound [7](#ref-q1-7) .
+*   `BoundThis`: The `this` value to be used when the bound function is called [8](#ref-q1-8) .
+*   `BoundArguments`: A list of arguments to be prepended to any arguments passed during invocation [9](#ref-q1-9) .
+
+The `FunctionProto_bind` method, which implements `Function.prototype.bind`, is responsible for creating a `BoundFunctionObject` [4](#ref-q1-4) . It first checks if the `Target` (the `this` value of the `bind` call) is callable using `IsCallable` [10](#ref-q1-10) . If it is, `BoundFunctionCreate` is called to construct the bound function object [11](#ref-q1-11) .
+
+The `BoundFunctionCreate` abstract operation performs the following steps:
+1.  It creates a basic object with specific internal slots, including `BoundTargetFunction`, `BoundThis`, and `BoundArguments` [12](#ref-q1-12) .
+2.  It sets the `[[Call]]` internal method of the new object to `BoundFunctionExoticObjectCall` [13](#ref-q1-13) .
+3.  If the `targetFunction` is a constructor, it also sets the `[[Construct]]` internal method to `BoundFunctionExoticObjectConstruct` [14](#ref-q1-14) .
+4.  It populates the `BoundTargetFunction`, `BoundThis`, and `BoundArguments` internal slots with the provided values [15](#ref-q1-15) .
+
+## Invocation of Bound Functions
+
+When a `BoundFunctionObject` is invoked, its `[[Call]]` internal method, `BoundFunctionExoticObjectCall`, is executed [2](#ref-q1-2) . This method retrieves the `BoundTargetFunction`, `BoundThis`, and `BoundArguments` from the bound function object [16](#ref-q1-16) . It then concatenates the `BoundArguments` with the `argumentsList` provided during the current invocation and calls the `BoundTargetFunction` using the `Call` abstract operation, passing `BoundThis` as the `this` value and the combined arguments [17](#ref-q1-17) .
+
+Similarly, if a `BoundFunctionObject` is used with the `new` operator, its `[[Construct]]` internal method, `BoundFunctionExoticObjectConstruct`, is invoked [3](#ref-q1-3) . This method asserts that the `BoundTargetFunction` is a constructor [18](#ref-q1-18) . It combines the `BoundArguments` with the `argumentsList` and then calls the `Construct` abstract operation on the `BoundTargetFunction` [19](#ref-q1-19) .
+
+## `Function.prototype.call` and `Function.prototype.apply`
+
+The `FunctionProto_call` method implements `Function.prototype.call` [5](#ref-q1-5) . It takes a `thisArg` and a variable number of `args` [20](#ref-q1-20) . It first checks if the `func` (the `this` value of the `call` call) is callable using `IsCallable` [21](#ref-q1-21) . It then constructs an `argList` from the provided `args` and invokes `Call(func, thisArg, argList)` [22](#ref-q1-22) .
+
+The `FunctionProto_apply` method implements `Function.prototype.apply` [6](#ref-q1-6) . Similar to `call`, it checks if the `func` is callable [23](#ref-q1-23) . If `argArray` is `undefined` or `null`, it calls `Call(func, thisArg)` [24](#ref-q1-24) . Otherwise, it uses `CreateListFromArrayLike` to convert `argArray` into a list of arguments and then calls `Call(func, thisArg, argList)` [25](#ref-q1-25) .
+
+## `IsCallable` Checks
+
+The `IsCallable` abstract operation determines if a `Value` is a callable function [26](#ref-q1-26) . It returns `true` if the argument is an `ObjectValue` and has a `Call` internal method [27](#ref-q1-27) . This check is crucial for `Function.prototype.call`, `apply`, and `bind` to ensure that the target is indeed a function that can be invoked [23](#ref-q1-23)  [10](#ref-q1-10)  [21](#ref-q1-21) .
+
+## Function Name and Length Property Descriptors
+
+For both ordinary and bound functions, the `name` and `length` properties are set as non-writable, non-enumerable, and configurable data properties [28](#ref-q1-28)  [29](#ref-q1-29) .
+
+The `SetFunctionName` abstract operation sets the `name` property of a function [30](#ref-q1-30) . For bound functions, the `FunctionProto_bind` method calls `SetFunctionName` with a `prefix` of `"bound"` [31](#ref-q1-31) . This results in a name like "bound funcName" for bound functions [32](#ref-q1-32) .
+
+The `SetFunctionLength` abstract operation sets the `length` property of a function [33](#ref-q1-33) . For bound functions, the `FunctionProto_bind` method calculates the `length` based on the `target` function's length and the number of `BoundArguments` [34](#ref-q1-34) . The calculated length is then passed to `SetFunctionLength` [35](#ref-q1-35) .
+
+## Detached Helper Patterns
+
+The pattern `Function.prototype.call.bind(Object.prototype.hasOwnProperty)` is a way to create a "detached" version of `hasOwnProperty` that can be called with any object as its `this` value.
+1.  `Function.prototype.call` is a built-in function [36](#ref-q1-36) .
+2.  Calling `.bind(Object.prototype.hasOwnProperty)` on `Function.prototype.call` creates a new bound function [4](#ref-q1-4) .
+3.  In this bound function, `Function.prototype.call` becomes the `BoundTargetFunction`, and `Object.prototype.hasOwnProperty` becomes the `BoundThis` [37](#ref-q1-37) .
+4.  When this bound function is invoked, `BoundFunctionExoticObjectCall` will effectively call `Function.prototype.call.call(Object.prototype.hasOwnProperty, ...)` [2](#ref-q1-2) . This means `Object.prototype.hasOwnProperty` will be invoked with the `this` value and arguments provided to the bound function.
+
+## `Array.isArray` as a Callable Builtin
+
+`Array.isArray` is a built-in function [38](#ref-q1-38) . Built-in functions are created using `CreateBuiltinFunction` [39](#ref-q1-39) . They have a `Call` internal method set to `BuiltinFunctionCall` [40](#ref-q1-40) , which makes them callable according to `IsCallable` [26](#ref-q1-26) . The `BuiltinFunctionCall` method executes the native steps associated with the built-in function [41](#ref-q1-41)  [42](#ref-q1-42) .
+
+## Notes
+The provided context focuses on the core mechanisms of `Function.prototype.call`, `apply`, and `bind` within engine262. It details how bound functions are structured and how their invocation is delegated to the target function with the pre-bound `this` and arguments. The `IsCallable` abstract operation is fundamental to these operations, ensuring that only valid functions are processed. The setting of `name` and `length` properties for bound functions also follows specific rules to reflect their bound nature.
+
+View this search on DeepWiki: https://deepwiki.com/search/for-functionprototypecallapply_3b4a99f9-2a43-46cc-8323-eaee41799f1d
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `src/intrinsics/FunctionPrototype.mts:45-49`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L45-L49)
+
+```
+export interface BoundFunctionObject extends ExoticObject, BuiltinFunctionObject {
+  readonly BoundTargetFunction: FunctionObject;
+  readonly BoundThis: Value;
+  readonly BoundArguments: Arguments;
+}
+```
+
+<a id="ref-q1-2"></a>
+### [2] `src/intrinsics/FunctionPrototype.mts:83-92`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L83-L92)
+
+```
+
+function* BoundFunctionExoticObjectCall(this: BoundFunctionObject, _thisArgument: ObjectValue, argumentsList: Arguments): ValueEvaluator {
+  const F = this;
+
+  const target = F.BoundTargetFunction;
+  const boundThis = F.BoundThis;
+  const boundArgs = F.BoundArguments;
+  const args = [...boundArgs, ...argumentsList];
+  return Q(yield* Call(target, boundThis, args));
+}
+```
+
+<a id="ref-q1-3"></a>
+### [3] `src/intrinsics/FunctionPrototype.mts:94-105`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L94-L105)
+
+```
+function* BoundFunctionExoticObjectConstruct(this: BoundFunctionObject, argumentsList: Arguments, newTarget: FunctionObject | UndefinedValue): ValueEvaluator<ObjectValue> {
+  const F = this;
+
+  const target = F.BoundTargetFunction;
+  Assert(IsConstructor(target));
+  const boundArgs = F.BoundArguments;
+  const args = [...boundArgs, ...argumentsList];
+  if (SameValue(F, newTarget) === Value.true) {
+    newTarget = target;
+  }
+  return Q(yield* Construct(target, args, newTarget));
+}
+```
+
+<a id="ref-q1-4"></a>
+### [4] `src/intrinsics/FunctionPrototype.mts:142-192`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L142-L192)
+
+```
+/** https://tc39.es/ecma262/#sec-function.prototype.bind */
+function* FunctionProto_bind([thisArg = Value.undefined, ...args]: Arguments, { thisValue }: FunctionCallContext): ValueEvaluator {
+  // 1. Let Target be the this value.
+  const Target = thisValue;
+  // 2. If IsCallable(Target) is false, throw a TypeError exception.
+  if (!IsCallable(Target)) {
+    return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', Target);
+  }
+  __ts_cast__<ObjectValue>(Target);
+  // 3. Let F be ? BoundFunctionCreate(Target, thisArg, args).
+  const F = Q(yield* BoundFunctionCreate(Target, thisArg, args));
+  // 4. Let L be 0.
+  let L = 0;
+  // 5. Let targetHasLength be ? HasOwnProperty(Target, "length").
+  const targetHasLength = Q(yield* HasOwnProperty(Target, Value('length')));
+  // 6. If targetHasLength is true, then
+  if (targetHasLength === Value.true) {
+    // a. Let targetLen be ? Get(Target, "length").
+    const targetLen = Q(yield* Get(Target, Value('length')));
+    // b. If Type(targetLen) is Number, then
+    if (targetLen instanceof NumberValue) {
+      // i. If targetLen is +∞𝔽, set L to +∞.
+      if (R(targetLen) === +Infinity) {
+        L = +Infinity;
+      } else if (R(targetLen) === -Infinity) { // ii. Else if targetLen is -∞𝔽, set L to 0.
+        L = 0;
+      } else { // iii. Else,
+        // 1. Set targetLen to ! ToIntegerOrInfinity(targetLen).
+        const targetLenAsInt = Q(yield* ToIntegerOrInfinity(targetLen));
+        // 2. Assert: targetLenAsInt is finite.
+        Assert(Number.isFinite(targetLenAsInt));
+        // 3. Let argCount be the number of elements in args.
+        const argCount = args.length;
+        // 4. Set L to max(targetLenAsInt - argCount, 0).
+        L = Math.max(targetLenAsInt - argCount, 0);
+      }
+    }
+  }
+  // 7. Perform ! SetFunctionLength(F, L).
+  X(SetFunctionLength(F, L));
+  // 8. Let targetName be ? Get(Target, "name").
+  let targetName = Q(yield* Get(Target, Value('name')));
+  // 9. If Type(targetName) is not String, set targetName to the empty String.
+  if (!(targetName instanceof JSStringValue)) {
+    targetName = Value('');
+  }
+  // 10. Perform SetFunctionName(F, targetName, "bound").
+  SetFunctionName(F, targetName, Value('bound'));
+  // 11. Return F.
+  return F;
+}
+```
+
+<a id="ref-q1-5"></a>
+### [5] `src/intrinsics/FunctionPrototype.mts:194-212`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L194-L212)
+
+```
+/** https://tc39.es/ecma262/#sec-function.prototype.call */
+function* FunctionProto_call([thisArg = Value.undefined, ...args]: Arguments, { thisValue }: FunctionCallContext): ValueEvaluator {
+  // 1. Let func be the this value.
+  const func = thisValue;
+  // 2. If IsCallable(func) is false, throw a TypeError exception.
+  if (!IsCallable(func)) {
+    return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', func);
+  }
+  // 3. Let argList be a new empty List.
+  const argList = [];
+  // 4. If this method was called with more than one argument, then in left to right order, starting with the second argument, append each argument as the last element of argList.
+  for (const arg of args) {
+    argList.push(arg);
+  }
+  // 5. Perform PrepareForTailCall().
+  PrepareForTailCall();
+  // 6. Return ? Call(func, thisArg, argList).
+  return Q(yield* Call(func, thisArg, argList));
+}
+```
+
+<a id="ref-q1-6"></a>
+### [6] `src/intrinsics/FunctionPrototype.mts:61-82`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L61-L82)
+
+```
+/** https://tc39.es/ecma262/#sec-function.prototype.apply */
+function* FunctionProto_apply([thisArg = Value.undefined, argArray = Value.undefined]: Arguments, { thisValue }: FunctionCallContext): ValueEvaluator {
+  // 1. Let func be the this value.
+  const func = thisValue;
+  // 2. If IsCallable(func) is false, throw a TypeError exception.
+  if (!IsCallable(func)) {
+    return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', func);
+  }
+  // 3. If argArray is undefined or null, then
+  if (argArray === Value.undefined || argArray === Value.null) {
+    // a. Perform PrepareForTailCall().
+    PrepareForTailCall();
+    // b. Return ? Call(func, thisArg).
+    return Q(yield* Call(func, thisArg));
+  }
+  // 4. Let argList be ? CreateListFromArrayLike(argArray).
+  const argList = Q(yield* CreateListFromArrayLike(argArray));
+  // 5. Perform PrepareForTailCall().
+  PrepareForTailCall();
+  // 6. Return ? Call(func, thisArg, argList).
+  return Q(yield* Call(func, thisArg, argList));
+}
+```
+
+<a id="ref-q1-7"></a>
+### [7] `src/intrinsics/FunctionPrototype.mts:46`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L46)
+
+```
+  readonly BoundTargetFunction: FunctionObject;
+```
+
+<a id="ref-q1-8"></a>
+### [8] `src/intrinsics/FunctionPrototype.mts:47`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L47)
+
+```
+  readonly BoundThis: Value;
+```
+
+<a id="ref-q1-9"></a>
+### [9] `src/intrinsics/FunctionPrototype.mts:48`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L48)
+
+```
+  readonly BoundArguments: Arguments;
+```
+
+<a id="ref-q1-10"></a>
+### [10] `src/intrinsics/FunctionPrototype.mts:147-149`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L147-L149)
+
+```
+  if (!IsCallable(Target)) {
+    return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', Target);
+  }
+```
+
+<a id="ref-q1-11"></a>
+### [11] `src/intrinsics/FunctionPrototype.mts:151`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L151)
+
+```
+  // 3. Let F be ? BoundFunctionCreate(Target, thisArg, args).
+```
+
+<a id="ref-q1-12"></a>
+### [12] `src/intrinsics/FunctionPrototype.mts:114-122`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L114-L122)
+
+```
+  const internalSlotsList = [
+    'BoundTargetFunction',
+    'BoundThis',
+    'BoundArguments',
+    'Prototype',
+    'Extensible',
+  ];
+  // 4. Let obj be ! MakeBasicObject(internalSlotsList).
+  const obj = X(MakeBasicObject(internalSlotsList)) as Mutable<BoundFunctionObject>;
+```
+
+<a id="ref-q1-13"></a>
+### [13] `src/intrinsics/FunctionPrototype.mts:126`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L126)
+
+```
+  obj.Call = BoundFunctionExoticObjectCall;
+```
+
+<a id="ref-q1-14"></a>
+### [14] `src/intrinsics/FunctionPrototype.mts:127-131`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L127-L131)
+
+```
+  // 7. If IsConstructor(targetFunction) is true, then
+  if (IsConstructor(targetFunction)) {
+    // a. Set obj.[[Construct]] as described in 9.4.1.2.
+    obj.Construct = BoundFunctionExoticObjectConstruct;
+  }
+```
+
+<a id="ref-q1-15"></a>
+### [15] `src/intrinsics/FunctionPrototype.mts:133-136`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L133-L136)
+
+```
+  obj.BoundTargetFunction = targetFunction as FunctionObject;
+  // 9. Set obj.[[BoundThis]] to boundThis.
+  obj.BoundThis = boundThis;
+  // 10. Set obj.[[BoundArguments]] to boundArguments.
+```
+
+<a id="ref-q1-16"></a>
+### [16] `src/intrinsics/FunctionPrototype.mts:87-89`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L87-L89)
+
+```
+  const target = F.BoundTargetFunction;
+  const boundThis = F.BoundThis;
+  const boundArgs = F.BoundArguments;
+```
+
+<a id="ref-q1-17"></a>
+### [17] `src/intrinsics/FunctionPrototype.mts:90-91`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L90-L91)
+
+```
+  const args = [...boundArgs, ...argumentsList];
+  return Q(yield* Call(target, boundThis, args));
+```
+
+<a id="ref-q1-18"></a>
+### [18] `src/intrinsics/FunctionPrototype.mts:98`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L98)
+
+```
+  Assert(IsConstructor(target));
+```
+
+<a id="ref-q1-19"></a>
+### [19] `src/intrinsics/FunctionPrototype.mts:100-104`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L100-L104)
+
+```
+  const args = [...boundArgs, ...argumentsList];
+  if (SameValue(F, newTarget) === Value.true) {
+    newTarget = target;
+  }
+  return Q(yield* Construct(target, args, newTarget));
+```
+
+<a id="ref-q1-20"></a>
+### [20] `src/intrinsics/FunctionPrototype.mts:195`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L195)
+
+```
+function* FunctionProto_call([thisArg = Value.undefined, ...args]: Arguments, { thisValue }: FunctionCallContext): ValueEvaluator {
+```
+
+<a id="ref-q1-21"></a>
+### [21] `src/intrinsics/FunctionPrototype.mts:197-201`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L197-L201)
+
+```
+  const func = thisValue;
+  // 2. If IsCallable(func) is false, throw a TypeError exception.
+  if (!IsCallable(func)) {
+    return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', func);
+  }
+```
+
+<a id="ref-q1-22"></a>
+### [22] `src/intrinsics/FunctionPrototype.mts:202-211`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L202-L211)
+
+```
+  // 3. Let argList be a new empty List.
+  const argList = [];
+  // 4. If this method was called with more than one argument, then in left to right order, starting with the second argument, append each argument as the last element of argList.
+  for (const arg of args) {
+    argList.push(arg);
+  }
+  // 5. Perform PrepareForTailCall().
+  PrepareForTailCall();
+  // 6. Return ? Call(func, thisArg, argList).
+  return Q(yield* Call(func, thisArg, argList));
+```
+
+<a id="ref-q1-23"></a>
+### [23] `src/intrinsics/FunctionPrototype.mts:65-68`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L65-L68)
+
+```
+  // 2. If IsCallable(func) is false, throw a TypeError exception.
+  if (!IsCallable(func)) {
+    return surroundingAgent.Throw('TypeError', 'ThisNotAFunction', func);
+  }
+```
+
+<a id="ref-q1-24"></a>
+### [24] `src/intrinsics/FunctionPrototype.mts:69-75`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L69-L75)
+
+```
+  // 3. If argArray is undefined or null, then
+  if (argArray === Value.undefined || argArray === Value.null) {
+    // a. Perform PrepareForTailCall().
+    PrepareForTailCall();
+    // b. Return ? Call(func, thisArg).
+    return Q(yield* Call(func, thisArg));
+  }
+```
+
+<a id="ref-q1-25"></a>
+### [25] `src/intrinsics/FunctionPrototype.mts:76-81`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L76-L81)
+
+```
+  // 4. Let argList be ? CreateListFromArrayLike(argArray).
+  const argList = Q(yield* CreateListFromArrayLike(argArray));
+  // 5. Perform PrepareForTailCall().
+  PrepareForTailCall();
+  // 6. Return ? Call(func, thisArg, argList).
+  return Q(yield* Call(func, thisArg, argList));
+```
+
+<a id="ref-q1-26"></a>
+### [26] `src/abstract-ops/testing-comparison.mts:60-69`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/testing-comparison.mts#L60-L69)
+
+```
+/** https://tc39.es/ecma262/#sec-iscallable */
+export function IsCallable(argument: Value): argument is FunctionObject {
+  if (!(argument instanceof ObjectValue)) {
+    return false;
+  }
+  if ('Call' in argument) {
+    return true;
+  }
+  return false;
+}
+```
+
+<a id="ref-q1-27"></a>
+### [27] `src/abstract-ops/testing-comparison.mts:63-67`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/testing-comparison.mts#L63-L67)
+
+```
+    return false;
+  }
+  if ('Call' in argument) {
+    return true;
+  }
+```
+
+<a id="ref-q1-28"></a>
+### [28] `src/abstract-ops/function-operations.mts:498-504`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L498-L504)
+
+```
+  // 6. Return ! DefinePropertyOrThrow(F, "name", PropertyDescriptor { [[Value]]: name, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
+  X(DefinePropertyOrThrow(F, Value('name'), Descriptor({
+    Value: name,
+    Writable: Value.false,
+    Enumerable: Value.false,
+    Configurable: Value.true,
+  })));
+```
+
+<a id="ref-q1-29"></a>
+### [29] `src/abstract-ops/function-operations.mts:513-518`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L513-L518)
+
+```
+  X(DefinePropertyOrThrow(F, Value('length'), Descriptor({
+    Value: toNumberValue(length),
+    Writable: Value.false,
+    Enumerable: Value.false,
+    Configurable: Value.true,
+  })));
+```
+
+<a id="ref-q1-30"></a>
+### [30] `src/abstract-ops/function-operations.mts:462-505`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L462-L505)
+
+```
+export function SetFunctionName(F: FunctionObject, name: PropertyKeyValue | PrivateName, prefix?: JSStringValue): void {
+  // 1. Assert: F is an extensible object that does not have a "name" own property.
+  Assert(skipDebugger(IsExtensible(F)) === Value.true && skipDebugger(HasOwnProperty(F, Value('name'))) === Value.false);
+  // 2. If Type(name) is Symbol, then
+  if (name instanceof SymbolValue) {
+    // a. Let description be name's [[Description]] value.
+    const description = name.Description;
+    // b. If description is undefined, set name to the empty String.
+    if (description === Value.undefined) {
+      name = Value('');
+    } else {
+      // c. Else, set name to the string-concatenation of "[", description, and "]".
+      name = Value(`[${(description as JSStringValue).stringValue()}]`);
+    }
+  } else if (name instanceof PrivateName) { // 3. Else if name is a Private Name, then
+    // a. Set name to name.[[Description]].
+    name = name.Description;
+  }
+  // 4. If F has an [[InitialName]] internal slot, then
+  if ('InitialName' in F) {
+    // a. Set F.[[InitialName]] to name.
+    (F as Mutable<FunctionObject>).InitialName = name;
+  }
+  if ('HostInitialName' in F) {
+    // a. Set F.[[InitialName]] to name.
+    (F as Mutable<ECMAScriptFunctionObject>).HostInitialName = name.stringValue();
+  }
+  // 5. If prefix is present, then
+  if (prefix !== undefined) {
+    // a. Set name to the string-concatenation of prefix, the code unit 0x0020 (SPACE), and name.
+    name = Value(`${prefix.stringValue()} ${name.stringValue()}`);
+    // b. If F has an [[InitialName]] internal slot, then
+    if ('InitialName' in F) {
+      // i. Optionally, set F.[[InitialName]] to name.
+    }
+  }
+  // 6. Return ! DefinePropertyOrThrow(F, "name", PropertyDescriptor { [[Value]]: name, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
+  X(DefinePropertyOrThrow(F, Value('name'), Descriptor({
+    Value: name,
+    Writable: Value.false,
+    Enumerable: Value.false,
+    Configurable: Value.true,
+  })));
+}
+```
+
+<a id="ref-q1-31"></a>
+### [31] `src/intrinsics/FunctionPrototype.mts:189`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L189)
+
+```
+  SetFunctionName(F, targetName, Value('bound'));
+```
+
+<a id="ref-q1-32"></a>
+### [32] `src/abstract-ops/function-operations.mts:491-492`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L491-L492)
+
+```
+    // a. Set name to the string-concatenation of prefix, the code unit 0x0020 (SPACE), and name.
+    name = Value(`${prefix.stringValue()} ${name.stringValue()}`);
+```
+
+<a id="ref-q1-33"></a>
+### [33] `src/abstract-ops/function-operations.mts:508-519`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L508-L519)
+
+```
+export function SetFunctionLength(F: FunctionObject, length: number): void {
+  Assert(isNonNegativeInteger(length) || length === Infinity);
+  // 1. Assert: F is an extensible object that does not have a "length" own property.
+  Assert(skipDebugger(IsExtensible(F)) === Value.true && skipDebugger(HasOwnProperty(F, Value('length'))) === Value.false);
+  // 2. Return ! DefinePropertyOrThrow(F, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
+  X(DefinePropertyOrThrow(F, Value('length'), Descriptor({
+    Value: toNumberValue(length),
+    Writable: Value.false,
+    Enumerable: Value.false,
+    Configurable: Value.true,
+  })));
+}
+```
+
+<a id="ref-q1-34"></a>
+### [34] `src/intrinsics/FunctionPrototype.mts:153-177`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L153-L177)
+
+```
+  // 4. Let L be 0.
+  let L = 0;
+  // 5. Let targetHasLength be ? HasOwnProperty(Target, "length").
+  const targetHasLength = Q(yield* HasOwnProperty(Target, Value('length')));
+  // 6. If targetHasLength is true, then
+  if (targetHasLength === Value.true) {
+    // a. Let targetLen be ? Get(Target, "length").
+    const targetLen = Q(yield* Get(Target, Value('length')));
+    // b. If Type(targetLen) is Number, then
+    if (targetLen instanceof NumberValue) {
+      // i. If targetLen is +∞𝔽, set L to +∞.
+      if (R(targetLen) === +Infinity) {
+        L = +Infinity;
+      } else if (R(targetLen) === -Infinity) { // ii. Else if targetLen is -∞𝔽, set L to 0.
+        L = 0;
+      } else { // iii. Else,
+        // 1. Set targetLen to ! ToIntegerOrInfinity(targetLen).
+        const targetLenAsInt = Q(yield* ToIntegerOrInfinity(targetLen));
+        // 2. Assert: targetLenAsInt is finite.
+        Assert(Number.isFinite(targetLenAsInt));
+        // 3. Let argCount be the number of elements in args.
+        const argCount = args.length;
+        // 4. Set L to max(targetLenAsInt - argCount, 0).
+        L = Math.max(targetLenAsInt - argCount, 0);
+      }
+```
+
+<a id="ref-q1-35"></a>
+### [35] `src/intrinsics/FunctionPrototype.mts:180`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L180)
+
+```
+  // 7. Perform ! SetFunctionLength(F, L).
+```
+
+<a id="ref-q1-36"></a>
+### [36] `src/intrinsics/FunctionPrototype.mts:268-270`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L268-L270)
+
+```
+    ['apply', FunctionProto_apply, 2],
+    ['bind', FunctionProto_bind, 1],
+    ['call', FunctionProto_call, 1],
+```
+
+<a id="ref-q1-37"></a>
+### [37] `src/intrinsics/FunctionPrototype.mts:133-135`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/FunctionPrototype.mts#L133-L135)
+
+```
+  obj.BoundTargetFunction = targetFunction as FunctionObject;
+  // 9. Set obj.[[BoundThis]] to boundThis.
+  obj.BoundThis = boundThis;
+```
+
+<a id="ref-q1-38"></a>
+### [38] `src/abstract-ops/testing-comparison.mts:43-58`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/testing-comparison.mts#L43-L58)
+
+```
+export function IsArray(argument: Value) {
+  if (!(argument instanceof ObjectValue)) {
+    return Value.false;
+  }
+  if (isArrayExoticObject(argument)) {
+    return Value.true;
+  }
+  if (isProxyExoticObject(argument)) {
+    if (argument.ProxyHandler === Value.null) {
+      return surroundingAgent.Throw('TypeError', 'ProxyRevoked', 'IsArray');
+    }
+    const target = argument.ProxyTarget;
+    return IsArray(target);
+  }
+  return Value.false;
+}
+```
+
+<a id="ref-q1-39"></a>
+### [39] `src/abstract-ops/function-operations.mts:568-610`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L568-L610)
+
+```
+export function CreateBuiltinFunction(steps: NativeSteps, length: number, name: PropertyKeyValue | PrivateName, internalSlotsList: readonly string[], realm?: Realm, prototype?: ObjectValue | NullValue, prefix?: JSStringValue, isConstructor: BooleanValue = Value.false): BuiltinFunctionObject {
+  // 1. Assert: steps is either a set of algorithm steps or other definition of a function's behaviour provided in this specification.
+  Assert(typeof steps === 'function');
+  // 2. If realm is not present, set realm to the current Realm Record.
+  if (realm === undefined) {
+    realm = surroundingAgent.currentRealmRecord;
+  }
+  // 3. Assert: realm is a Realm Record.
+  Assert(realm instanceof Realm);
+  // 4. If prototype is not present, set prototype to realm.[[Intrinsics]].[[%Function.prototype%]].
+  if (prototype === undefined) {
+    prototype = realm.Intrinsics['%Function.prototype%'];
+  }
+  // 5. Let func be a new built-in function object that when called performs the action described by steps. The new function object has internal slots whose names are the elements of internalSlotsList.
+  const func = X(MakeBasicObject(['Prototype', 'Extensible', 'Realm', 'ScriptOrModule', 'InitialName', 'IsClassConstructor'].concat(internalSlotsList))) as Mutable<BuiltinFunctionObject>;
+  func.Call = BuiltinFunctionCall;
+  if (isConstructor === Value.true) {
+    func.Construct = BuiltinFunctionConstruct;
+  }
+  func.nativeFunction = steps;
+  // 6. Set func.[[Realm]] to realm.
+  func.Realm = realm;
+  // 7. Set func.[[Prototype]] to prototype.
+  func.Prototype = prototype;
+  // 8. Set func.[[Extensible]] to true.
+  func.Extensible = Value.true;
+  // 10. Set func.[[InitialName]] to null.
+  func.InitialName = Value.null;
+  // https://github.com/tc39/ecma262/pull/3212/
+  func.IsClassConstructor = Value.false;
+  // 11. Perform ! SetFunctionLength(func, length).
+  X(SetFunctionLength(func, length));
+  // 12. If prefix is not present, then
+  if (prefix === undefined) {
+    // a. Perform ! SetFunctionName(func, name).
+    X(SetFunctionName(func, name));
+  } else { // 13. Else
+    // a. Perform ! SetFunctionName(func, name, prefix).
+    X(SetFunctionName(func, name, prefix));
+  }
+  // 13. Return func.
+  return func;
+}
+```
+
+<a id="ref-q1-40"></a>
+### [40] `src/abstract-ops/function-operations.mts:583`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L583)
+
+```
+  func.Call = BuiltinFunctionCall;
+```
+
+<a id="ref-q1-41"></a>
+### [41] `src/abstract-ops/function-operations.mts:521-522`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L521-L522)
+
+```
+function BuiltinFunctionCall(this: BuiltinFunctionObject, thisArgument: Value, argumentsList: Arguments): ValueEvaluator {
+  return BuiltinCallOrConstruct(this, thisArgument, argumentsList, Value.undefined);
+```
+
+<a id="ref-q1-42"></a>
+### [42] `src/abstract-ops/function-operations.mts:531-565`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/function-operations.mts#L531-L565)
+
+```
+function* BuiltinCallOrConstruct(F: BuiltinFunctionObject, thisArgument: Value | 'uninitialized', argumentsList: Arguments, newTarget: FunctionObject | UndefinedValue): ValueEvaluator {
+  const calleeContext = new ExecutionContext();
+  calleeContext.Function = F;
+  const calleeRealm = F.Realm;
+  calleeContext.Realm = calleeRealm;
+  calleeContext.ScriptOrModule = Value.null;
+  surroundingAgent.executionContextStack.push(calleeContext);
+
+  const isNew = thisArgument === 'uninitialized';
+  // Perform any necessary implementation-defined initialization of calleeContext.
+  surroundingAgent.runningExecutionContext.callSite.constructCall = isNew;
+
+  let completion = F.nativeFunction(argumentsList, {
+    thisValue: thisArgument === 'uninitialized' ? Value.undefined : thisArgument,
+    NewTarget: newTarget,
+  });
+  // in case of debugging, use the following version so F.nativeFunction's name can appears in the stack trace.
+  // let completion = Reflect['apply'](F.nativeFunction, F, [argumentsList, {
+  //   thisValue: thisArgument || Value.undefined,
+  //   NewTarget: newTarget || Value.undefined,
+  // }]);
+  if (completion && 'next' in completion) {
+    completion = yield* completion;
+  }
+  if (completion instanceof Completion) {
+    Assert(completion instanceof NormalCompletion || completion instanceof ThrowCompletion);
+  }
+
+  surroundingAgent.executionContextStack.pop(calleeContext);
+  const result = Q(completion) || Value.undefined;
+  if (isNew) {
+    Assert(result instanceof ObjectValue);
+  }
+  return result;
+}
+```

--- a/reference/deepwiki/function-detached-helpers.md
+++ b/reference/deepwiki/function-detached-helpers.md
@@ -1,0 +1,14 @@
+# Function Detached Helper References
+
+DeepWiki was queried for `engine262/engine262` and `boa-dev/boa`; the full responses are saved next to this file:
+
+- `reference/deepwiki/function-detached-helpers-engine262.md`
+- `reference/deepwiki/function-detached-helpers-boa.md`
+
+Useful implementation notes:
+
+- Both engines model bound functions as callable exotic objects with target function, bound receiver, and bound argument slots.
+- `Function.prototype.bind` rejects non-callable targets, creates a callable bound object, sets `length` to `max(target.length - boundArgs.length, 0)`, and sets `name` with a `"bound "` prefix.
+- Bound function invocation prepends bound arguments and delegates to the target with the bound receiver. This is the behavior that makes `Function.prototype.call.bind(Object.prototype.hasOwnProperty)` work.
+- Built-in functions such as `Array.isArray`, `Object.defineProperty`, and `Object.getOwnPropertyDescriptor` are ordinary callable values for `IsCallable` purposes when detached from their constructor object.
+- Function `name` and `length` descriptors are non-writable, non-enumerable, and configurable for ordinary and bound functions.

--- a/tests/test_c262_detached_function_helpers.sh
+++ b/tests/test_c262_detached_function_helpers.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/c262_detached_function_helpers.js" <<'JS'
+var failures = [];
+
+function check(label, actual, expected) {
+  if (actual !== expected) {
+    failures.push(label + ": expected " + String(expected) + ", got " + String(actual));
+  }
+}
+
+var __isArray = Array.isArray;
+var __defineProperty = Object.defineProperty;
+var __getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+var __getOwnPropertyNames = Object.getOwnPropertyNames;
+var __join = Function.prototype.call.bind(Array.prototype.join);
+var __push = Function.prototype.call.bind(Array.prototype.push);
+var __hasOwnProperty = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+var __propertyIsEnumerable = Function.prototype.call.bind(Object.prototype.propertyIsEnumerable);
+
+var obj = {};
+__defineProperty(obj, "x", {
+  value: 42,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
+var desc = __getOwnPropertyDescriptor(obj, "x");
+check("detached getOwnPropertyDescriptor value", desc.value, 42);
+check("detached getOwnPropertyDescriptor writable", desc.writable, false);
+check("detached getOwnPropertyDescriptor enumerable", desc.enumerable, false);
+check("detached getOwnPropertyDescriptor configurable", desc.configurable, true);
+check("detached hasOwnProperty", __hasOwnProperty(obj, "x"), true);
+check("detached propertyIsEnumerable", __propertyIsEnumerable(obj, "x"), false);
+check("detached Array.isArray", __isArray(__getOwnPropertyNames(obj)), true);
+
+__push(failures, "sentinel");
+check("detached Array.prototype.push", failures.length, 1);
+check("detached Array.prototype.join", __join(failures, ","), "sentinel");
+failures.length = 0;
+
+var cls;
+cls = class {};
+var classNameDesc = __getOwnPropertyDescriptor(cls, "name");
+check("class assignment inferred name", cls.name, "cls");
+check("class dynamic name read", (function(obj, name) { return obj[name]; })(cls, "name"), "cls");
+check("class name descriptor value", classNameDesc.value, "cls");
+check("class name descriptor writable", classNameDesc.writable, false);
+check("class name descriptor enumerable", classNameDesc.enumerable, false);
+check("class name descriptor configurable", classNameDesc.configurable, true);
+check("class name hasOwnProperty before delete", __hasOwnProperty(cls, "name"), true);
+check("class name delete", delete cls["name"], true);
+check("class name hasOwnProperty after delete", __hasOwnProperty(cls, "name"), false);
+check("class name descriptor after delete", __getOwnPropertyDescriptor(cls, "name"), undefined);
+
+if (failures.length !== 0) {
+  throw new Error(__join(failures, "\n"));
+}
+
+console.log("c262 detached function helpers ok");
+JS
+
+"$PERRY" compile --no-cache --no-auto-optimize "$TMPDIR/c262_detached_function_helpers.js" -o "$TMPDIR/c262_detached_function_helpers" \
+    >"$TMPDIR/compile.log" 2>&1 || {
+        echo "FAIL: compile failed"
+        sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+        exit 1
+    }
+
+"$TMPDIR/c262_detached_function_helpers" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q "c262 detached function helpers ok" "$TMPDIR/run.log"; then
+    echo "FAIL: expected success marker"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+echo "PASS: c262 detached function helpers"


### PR DESCRIPTION
## Summary
- add detached Object static callability for Test262 propertyHelper primordials
- preserve function/class name and length descriptor behavior through writes, deletes, dynamic reads, and hasOwn checks
- add focused detached-helper/class descriptor regression coverage and DeepWiki notes

## Validation
- cargo fmt --all
- cargo check -p perry-hir -p perry-runtime -p perry-codegen -p perry
- tests/test_c262_detached_function_helpers.sh
- exact scoped Test262 bucket improved to 3/4 pass

## Residual
- language/expressions/arrow-function/scope-param-rest-elem-var-close.js remains failing due a separate rest-parameter/eval binding issue (probeParam remains undefined), not the detached helper path.
- full cargo test -p perry-runtime showed one order-sensitive array descriptor/prototype identity failure; the exact failing test passed in isolation.