### PR TITLE
c262 parity: with dynamic scope

### DIFF
--- a/crates/perry-codegen/src/boxed_vars.rs
+++ b/crates/perry-codegen/src/boxed_vars.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::collectors::{collect_let_ids, collect_ref_ids_in_stmts};
+use perry_hir::WithSetFallback;
 
 /// Determine which local ids in the given statement sequence need
 /// heap-boxed storage. An id gets boxed when:
@@ -957,6 +958,18 @@ fn collect_outer_writes_in_expr(expr: &perry_hir::Expr, out: &mut HashSet<u32>) 
             out.insert(*id);
             collect_outer_writes_in_expr(v, out);
         }
+        Expr::WithSet {
+            object,
+            value,
+            fallback,
+            ..
+        } => {
+            if let WithSetFallback::Local(id) | WithSetFallback::SloppyImplicit(id) = fallback {
+                out.insert(*id);
+            }
+            collect_outer_writes_in_expr(object, out);
+            collect_outer_writes_in_expr(value, out);
+        }
         Expr::Update { id, .. } => {
             out.insert(*id);
         }
@@ -1151,6 +1164,18 @@ fn collect_write_ids_in_expr(expr: &perry_hir::Expr, out: &mut HashSet<u32>) {
         Expr::LocalSet(id, v) => {
             out.insert(*id);
             collect_write_ids_in_expr(v, out);
+        }
+        Expr::WithSet {
+            object,
+            value,
+            fallback,
+            ..
+        } => {
+            if let WithSetFallback::Local(id) | WithSetFallback::SloppyImplicit(id) = fallback {
+                out.insert(*id);
+            }
+            collect_write_ids_in_expr(object, out);
+            collect_write_ids_in_expr(value, out);
         }
         Expr::Update { id, .. } => {
             out.insert(*id);

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -1,4 +1,4 @@
-use perry_hir::{BinaryOp, Expr, Function, Stmt};
+use perry_hir::{BinaryOp, Expr, Function, Stmt, WithSetFallback};
 use std::collections::HashSet;
 
 use super::*;
@@ -175,6 +175,24 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         Expr::LocalSet(id, value) => {
             out.insert(*id);
             walk(value, out);
+        }
+        Expr::WithGet {
+            object, fallback, ..
+        } => {
+            walk(object, out);
+            walk(fallback, out);
+        }
+        Expr::WithSet {
+            object,
+            value,
+            fallback,
+            ..
+        } => {
+            walk(object, out);
+            walk(value, out);
+            if let WithSetFallback::Local(id) | WithSetFallback::SloppyImplicit(id) = fallback {
+                out.insert(*id);
+            }
         }
         Expr::Update { id, .. } => {
             out.insert(*id);

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{anyhow, bail, Result};
 #[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
+use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp, WithSetFallback};
 #[allow(unused_imports)]
 use perry_types::Type as HirType;
 
@@ -32,12 +32,12 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
+    emit_root_nanbox_store_on_block, emit_shadow_slot_bind_for_local, emit_shadow_slot_clear,
+    emit_shadow_slot_update_for_expr, emit_string_literal_global, emit_v8_export_call,
+    emit_v8_member_method_call, emit_write_barrier, emit_write_barrier_slot_on_block,
+    expr_is_known_non_pointer_shadow_value, extract_array_of_object_shape, i32_bool_to_nanbox,
+    import_origin_suffix, is_global_this_builtin_function_name, is_global_this_builtin_name,
+    is_known_finite, lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
     lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
     lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
     nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
@@ -46,8 +46,190 @@ use super::{
     I18nLowerCtx,
 };
 
+fn emit_with_key(ctx: &mut FnCtx<'_>, property: &str) -> (String, String) {
+    let key_idx = ctx.strings.intern(property);
+    let key_entry = ctx.strings.entry(key_idx);
+    let key_global = format!("@{}", key_entry.handle_global);
+    let key_box = ctx.block().load(DOUBLE, &key_global);
+    let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
+    let key_raw = ctx.block().and(I64, &key_bits, POINTER_MASK_I64);
+    (key_box, key_raw)
+}
+
+fn store_prelowered_local(ctx: &mut FnCtx<'_>, id: u32, value: &str) -> Result<String> {
+    super::invalidate_local_write_facts(ctx, id);
+    if let Some(&capture_idx) = ctx.closure_captures.get(&id) {
+        let closure_ptr = ctx
+            .current_closure_ptr
+            .clone()
+            .ok_or_else(|| anyhow!("captured with-fallback set but no current_closure_ptr"))?;
+        let idx_str = capture_idx.to_string();
+        if ctx.boxed_vars.contains(&id) {
+            let blk = ctx.block();
+            let cap_dbl = blk.call(
+                DOUBLE,
+                "js_closure_get_capture_f64",
+                &[(I64, &closure_ptr), (I32, &idx_str)],
+            );
+            let box_ptr = blk.bitcast_double_to_i64(&cap_dbl);
+            blk.call_void("js_box_set", &[(I64, &box_ptr), (DOUBLE, value)]);
+            let value_bits = ctx.block().bitcast_double_to_i64(value);
+            emit_write_barrier(ctx, &box_ptr, &value_bits);
+        } else {
+            ctx.block().call_void(
+                "js_closure_set_capture_f64",
+                &[(I64, &closure_ptr), (I32, &idx_str), (DOUBLE, value)],
+            );
+            let value_bits = ctx.block().bitcast_double_to_i64(value);
+            emit_write_barrier(ctx, &closure_ptr, &value_bits);
+        }
+    } else if ctx.boxed_vars.contains(&id) && !ctx.module_globals.contains_key(&id) {
+        if let Some(slot) = ctx.locals.get(&id).cloned() {
+            let blk = ctx.block();
+            let box_dbl = blk.load(DOUBLE, &slot);
+            let box_ptr = blk.bitcast_double_to_i64(&box_dbl);
+            blk.call_void("js_box_set", &[(I64, &box_ptr), (DOUBLE, value)]);
+            let value_bits = ctx.block().bitcast_double_to_i64(value);
+            emit_write_barrier(ctx, &box_ptr, &value_bits);
+        }
+    } else if let Some(slot) = ctx.locals.get(&id).cloned() {
+        ctx.block().store(DOUBLE, value, &slot);
+        if let Some(slot_idx) = ctx.shadow_slot_map.get(&id).copied() {
+            emit_shadow_slot_bind_for_local(ctx, id);
+            let value_bits = ctx.block().bitcast_double_to_i64(value);
+            ctx.block().call_void(
+                "js_shadow_slot_set",
+                &[(I32, &slot_idx.to_string()), (I64, &value_bits)],
+            );
+        }
+        if let Some(i32_slot) = ctx.i32_counter_slots.get(&id).cloned() {
+            let value_i64 = ctx.block().fptosi(DOUBLE, value, I64);
+            let value_i32 = ctx.block().trunc(I64, &value_i64, I32);
+            ctx.block().store(I32, &value_i32, &i32_slot);
+        }
+    } else if let Some(global_name) = ctx.module_globals.get(&id).cloned() {
+        let g_ref = format!("@{}", global_name);
+        emit_root_nanbox_store_on_block(ctx.block(), value, &g_ref);
+    }
+    Ok(value.to_string())
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
+        Expr::WithGet {
+            object,
+            property,
+            fallback,
+        } => {
+            let obj = lower_expr(ctx, object)?;
+            let (_key_box, key_raw) = emit_with_key(ctx, property);
+            let has = ctx.block().call(
+                I32,
+                "js_with_has_binding",
+                &[(DOUBLE, &obj), (I64, &key_raw)],
+            );
+            let has_bool = ctx.block().icmp_ne(I32, &has, "0");
+
+            let hit_idx = ctx.new_block("with.get.hit");
+            let miss_idx = ctx.new_block("with.get.miss");
+            let merge_idx = ctx.new_block("with.get.merge");
+            let hit_label = ctx.block_label(hit_idx);
+            let miss_label = ctx.block_label(miss_idx);
+            let merge_label = ctx.block_label(merge_idx);
+            ctx.block().cond_br(&has_bool, &hit_label, &miss_label);
+
+            ctx.current_block = hit_idx;
+            let hit = ctx.block().call(
+                DOUBLE,
+                "js_with_get_binding",
+                &[(DOUBLE, &obj), (I64, &key_raw)],
+            );
+            let hit_after = ctx.block().label.clone();
+            if !ctx.block().is_terminated() {
+                ctx.block().br(&merge_label);
+            }
+
+            ctx.current_block = miss_idx;
+            let miss = lower_expr(ctx, fallback)?;
+            let miss_after = ctx.block().label.clone();
+            if !ctx.block().is_terminated() {
+                ctx.block().br(&merge_label);
+            }
+
+            ctx.current_block = merge_idx;
+            Ok(ctx
+                .block()
+                .phi(DOUBLE, &[(&hit, &hit_after), (&miss, &miss_after)]))
+        }
+        Expr::WithSet {
+            object,
+            property,
+            value,
+            fallback,
+            strict,
+        } => {
+            let obj = lower_expr(ctx, object)?;
+            let (key_box, key_raw) = emit_with_key(ctx, property);
+            let had = ctx.block().call(
+                I32,
+                "js_with_has_binding",
+                &[(DOUBLE, &obj), (I64, &key_raw)],
+            );
+            let value_reg = lower_expr(ctx, value)?;
+            let had_bool = ctx.block().icmp_ne(I32, &had, "0");
+
+            let hit_idx = ctx.new_block("with.set.hit");
+            let miss_idx = ctx.new_block("with.set.miss");
+            let merge_idx = ctx.new_block("with.set.merge");
+            let hit_label = ctx.block_label(hit_idx);
+            let miss_label = ctx.block_label(miss_idx);
+            let merge_label = ctx.block_label(merge_idx);
+            ctx.block().cond_br(&had_bool, &hit_label, &miss_label);
+
+            ctx.current_block = hit_idx;
+            let strict_i32 = if *strict { "1" } else { "0" };
+            let hit = ctx.block().call(
+                DOUBLE,
+                "js_with_set_binding",
+                &[
+                    (DOUBLE, &obj),
+                    (I64, &key_raw),
+                    (DOUBLE, &value_reg),
+                    (I32, strict_i32),
+                ],
+            );
+            let hit_after = ctx.block().label.clone();
+            if !ctx.block().is_terminated() {
+                ctx.block().br(&merge_label);
+            }
+
+            ctx.current_block = miss_idx;
+            let miss = match fallback {
+                WithSetFallback::Local(id) | WithSetFallback::SloppyImplicit(id) => {
+                    store_prelowered_local(ctx, *id, &value_reg)?
+                }
+                WithSetFallback::ThrowReferenceError => ctx.block().call(
+                    DOUBLE,
+                    "js_throw_reference_error_unresolvable_assignment",
+                    &[(DOUBLE, &key_box)],
+                ),
+                WithSetFallback::ThrowConstAssignment => ctx.block().call(
+                    DOUBLE,
+                    "js_throw_type_error_const_assignment",
+                    &[(DOUBLE, &key_box)],
+                ),
+                WithSetFallback::Ignore => value_reg.clone(),
+            };
+            let miss_after = ctx.block().label.clone();
+            if !ctx.block().is_terminated() {
+                ctx.block().br(&merge_label);
+            }
+
+            ctx.current_block = merge_idx;
+            Ok(ctx
+                .block()
+                .phi(DOUBLE, &[(&hit, &hit_after), (&miss, &miss_after)]))
+        }
         Expr::InstanceOf {
             expr: e,
             ty,

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1493,7 +1493,9 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ObjectSuperPropertyGet { .. }
         | Expr::ObjectSuperMethodCall { .. }
         | Expr::FsReadFileBinary(..) => super_method::lower(ctx, expr),
-        Expr::InstanceOf { .. }
+        Expr::WithGet { .. }
+        | Expr::WithSet { .. }
+        | Expr::InstanceOf { .. }
         | Expr::Delete(..)
         | Expr::Sequence(..)
         | Expr::ArrayFrom(..)

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -53,6 +53,9 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function("js_object_set_unboxed_f64_field", VOID, &[I64, I32, DOUBLE]);
     module.declare_function("js_object_get_unboxed_f64_field", DOUBLE, &[I64, I32]);
     module.declare_function("js_object_set_field_by_name", VOID, &[I64, I64, DOUBLE]);
+    module.declare_function("js_with_has_binding", I32, &[DOUBLE, I64]);
+    module.declare_function("js_with_get_binding", DOUBLE, &[DOUBLE, I64]);
+    module.declare_function("js_with_set_binding", DOUBLE, &[DOUBLE, I64, DOUBLE, I32]);
     module.declare_function("js_pod_scalar_write_compatible", I32, &[DOUBLE, I32]);
     module.declare_function(
         "js_typed_feedback_register_site",

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -5,6 +5,18 @@
 use super::*;
 use perry_types::{FuncId, GlobalId, LocalId, Type};
 
+/// Fallback when a dynamic `with` object environment does not bind the
+/// assignment target. The object lookup is performed before the RHS is
+/// evaluated, matching ECMAScript Reference resolution order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WithSetFallback {
+    Local(LocalId),
+    ThrowReferenceError,
+    ThrowConstAssignment,
+    Ignore,
+    SloppyImplicit(LocalId),
+}
+
 /// Expression
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -44,6 +56,24 @@ pub enum Expr {
     LocalSet(LocalId, Box<Expr>),
     GlobalGet(GlobalId),
     GlobalSet(GlobalId, Box<Expr>),
+    /// Dynamic object-environment read produced by `with (obj) { name }`.
+    /// If `obj` has a non-unscopable property named `property`, read it;
+    /// otherwise evaluate `fallback` (outer lexical/global resolution).
+    WithGet {
+        object: Box<Expr>,
+        property: String,
+        fallback: Box<Expr>,
+    },
+    /// Dynamic object-environment write produced by `with (obj) { name = v }`.
+    /// Codegen probes the object before lowering `value`; strict PutValue then
+    /// re-checks that the property survived RHS side effects.
+    WithSet {
+        object: Box<Expr>,
+        property: String,
+        value: Box<Expr>,
+        fallback: WithSetFallback,
+        strict: bool,
+    },
 
     // Update (++/--)
     Update {

--- a/crates/perry-hir/src/ir/mod.rs
+++ b/crates/perry-hir/src/ir/mod.rs
@@ -57,7 +57,9 @@ pub use decl::{
 pub use stmt::{CatchClause, Stmt, SwitchCase};
 
 // ---- expr.rs ----
-pub use expr::{BoxedPrimitiveKind, Expr, PathWin32Method, ProcessStdinLifecycleMethod};
+pub use expr::{
+    BoxedPrimitiveKind, Expr, PathWin32Method, ProcessStdinLifecycleMethod, WithSetFallback,
+};
 
 // ---- ops.rs ----
 pub use ops::{ArrayElement, BinaryOp, CallArg, CompareOp, LogicalOp, UnaryOp, UpdateOp};

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -86,6 +86,7 @@ impl LoweringContext {
             suppress_stdlib_dispatch_guard_once: false,
             lowering_call_callee: false,
             unresolved_ident_as_global: false,
+            with_env_stack: Vec::new(),
             var_hoisted_ids: HashSet::new(),
             functions_index: HashMap::new(),
             classes_index: HashMap::new(),
@@ -633,6 +634,34 @@ impl LoweringContext {
             .rev()
             .find(|(n, _, _)| n == name)
             .map(|(_, id, _)| *id)
+    }
+
+    fn lookup_local_index(&self, name: &str) -> Option<usize> {
+        self.locals.iter().rposition(|(n, _, _)| n == name)
+    }
+
+    pub(crate) fn push_with_env(&mut self, local_id: LocalId) {
+        let local_mark = self.locals.len();
+        self.with_env_stack.push(WithEnvFrame {
+            local_id,
+            local_mark,
+        });
+    }
+
+    pub(crate) fn pop_with_env(&mut self) {
+        self.with_env_stack.pop();
+    }
+
+    pub(crate) fn active_with_envs_for_ident(&self, name: &str) -> Vec<LocalId> {
+        let nearest_local_index = self.lookup_local_index(name);
+        let mut envs = Vec::new();
+        for frame in self.with_env_stack.iter().rev() {
+            if nearest_local_index.is_some_and(|idx| idx >= frame.local_mark) {
+                break;
+            }
+            envs.push(frame.local_id);
+        }
+        envs
     }
 
     pub(crate) fn lookup_local_type(&self, name: &str) -> Option<&Type> {

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -14,7 +14,7 @@ use crate::destructuring::lower_destructuring_assignment;
 use crate::ir::{BinaryOp, Expr, LogicalOp};
 use crate::lower_patterns::lower_assign_target_to_expr;
 
-use super::{lower_expr, lower_expr_assignment, LoweringContext};
+use super::{lower_expr, lower_expr_assignment, with_set_fallback_for_ident, LoweringContext};
 
 fn throw_type_error_const_assignment(name: &str) -> Expr {
     Expr::Call {
@@ -300,6 +300,16 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
     match &assign.left {
         ast::AssignTarget::Simple(ast::SimpleAssignTarget::Ident(ident)) => {
             let name = ident.id.sym.to_string();
+            if let Some(env_id) = ctx.active_with_envs_for_ident(&name).into_iter().next() {
+                let fallback = with_set_fallback_for_ident(ctx, &name);
+                return Ok(Expr::WithSet {
+                    object: Box::new(Expr::LocalGet(env_id)),
+                    property: name,
+                    value,
+                    fallback,
+                    strict: ctx.current_strict,
+                });
+            }
             if let Some(id) = ctx.lookup_local(&name) {
                 if ctx.is_local_immutable(id) {
                     return Ok(throw_type_error_const_assignment(&name));

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -155,6 +155,40 @@ fn is_cjs_style_native_default_import(module_name: &str) -> bool {
     )
 }
 
+fn wrap_with_gets(property: &str, fallback: Expr, envs: Vec<LocalId>) -> Expr {
+    envs.into_iter()
+        .rev()
+        .fold(fallback, |fallback, env_id| Expr::WithGet {
+            object: Box::new(Expr::LocalGet(env_id)),
+            property: property.to_string(),
+            fallback: Box::new(fallback),
+        })
+}
+
+pub(crate) fn with_set_fallback_for_ident(
+    ctx: &mut LoweringContext,
+    name: &str,
+) -> WithSetFallback {
+    if let Some(id) = ctx.lookup_local(name) {
+        if ctx.is_local_immutable(id) {
+            WithSetFallback::ThrowConstAssignment
+        } else {
+            WithSetFallback::Local(id)
+        }
+    } else if ctx.lookup_class(name).is_some() || ctx.lookup_func(name).is_some() {
+        WithSetFallback::Ignore
+    } else if ctx.current_strict {
+        WithSetFallback::ThrowReferenceError
+    } else {
+        eprintln!(
+            "  Warning: Assignment to undeclared variable '{}', creating implicit local",
+            name
+        );
+        let id = ctx.define_local(name.to_string(), Type::Any);
+        WithSetFallback::SloppyImplicit(id)
+    }
+}
+
 pub(crate) fn lower_expr_assignment(
     ctx: &mut LoweringContext,
     expr: &ast::Expr,
@@ -163,6 +197,16 @@ pub(crate) fn lower_expr_assignment(
     match expr {
         ast::Expr::Ident(ident) => {
             let name = ident.sym.to_string();
+            if let Some(env_id) = ctx.active_with_envs_for_ident(&name).into_iter().next() {
+                let fallback = with_set_fallback_for_ident(ctx, &name);
+                return Ok(Expr::WithSet {
+                    object: Box::new(Expr::LocalGet(env_id)),
+                    property: name,
+                    value,
+                    fallback,
+                    strict: ctx.current_strict,
+                });
+            }
             if let Some(id) = ctx.lookup_local(&name) {
                 Ok(Expr::LocalSet(id, value))
             } else if ctx.lookup_class(&name).is_some() || ctx.lookup_func(&name).is_some() {
@@ -277,6 +321,13 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
         ast::Expr::Lit(lit) => lower_lit(lit),
         ast::Expr::Ident(ident) => {
             let name = ident.sym.to_string();
+            let with_envs = ctx.active_with_envs_for_ident(&name);
+            if !with_envs.is_empty() {
+                let saved_with_envs = std::mem::take(&mut ctx.with_env_stack);
+                let fallback = lower_expr(ctx, expr);
+                ctx.with_env_stack = saved_with_envs;
+                return Ok(wrap_with_gets(&name, fallback?, with_envs));
+            }
             if let Some(id) = ctx.lookup_local(&name) {
                 Ok(Expr::LocalGet(id))
             } else if let Some(id) = ctx.lookup_func(&name) {

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -11,6 +11,12 @@ use std::collections::{HashMap, HashSet};
 
 use crate::ir::*;
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WithEnvFrame {
+    pub(crate) local_id: LocalId,
+    pub(crate) local_mark: usize,
+}
+
 pub struct LoweringContext {
     /// Counter for generating unique local IDs
     pub(crate) next_local_id: LocalId,
@@ -256,6 +262,11 @@ pub struct LoweringContext {
     /// unresolvable identifiers throw ReferenceError, but member receivers are
     /// still allowed to use the existing GlobalGet sentinel path.
     pub(crate) unresolved_ident_as_global: bool,
+    /// Active `with` object environment records. Each frame points at the
+    /// synthetic local that stores the object value and the locals length when
+    /// the frame was entered, so declarations inside the block/function can
+    /// continue to lexically shadow the object environment.
+    pub(crate) with_env_stack: Vec<WithEnvFrame>,
     pub(crate) var_hoisted_ids: HashSet<LocalId>,
     /// Shadow index: function name -> index in `functions` Vec (last entry for shadowing)
     pub(crate) functions_index: HashMap<String, usize>,

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -71,7 +71,7 @@ pub(crate) use widget_decl::*;
 // transitively when downstream files reach into `crate::lower::Name`,
 // so spelling them out keeps the public-and-internal API stable.
 mod lowering_context;
-pub(crate) use lowering_context::LoweringContext;
+pub(crate) use lowering_context::{LoweringContext, WithEnvFrame};
 
 mod typed_parse;
 pub(crate) use typed_parse::{extract_typed_parse_source_order, resolve_typed_parse_ty};
@@ -95,6 +95,7 @@ pub use lower_module_fn::{
 mod lower_expr;
 pub(crate) use lower_expr::{
     lower_expr, lower_expr_assignment, throw_reference_error_expr, try_desugar_reactive_text,
+    with_set_fallback_for_ident,
 };
 
 // Re-export extracted module functions

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1315,6 +1315,26 @@ pub(crate) fn lower_stmt(
         ast::Stmt::ForIn(for_in_stmt) => {
             lower_stmt_for_in(ctx, module, for_in_stmt)?;
         }
+        ast::Stmt::With(with_stmt) => {
+            if ctx.current_strict_mode() || ctx.current_strict {
+                crate::lower_bail!(
+                    with_stmt.span,
+                    "`with` statement is forbidden in strict mode"
+                );
+            }
+            let env_id = ctx.define_local("__perry_with_env".to_string(), Type::Any);
+            module.init.push(Stmt::Let {
+                id: env_id,
+                name: format!("__perry_with_env_{}", env_id),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(lower_expr(ctx, &with_stmt.obj)?),
+            });
+            ctx.push_with_env(env_id);
+            let body_result = lower_body_stmt(ctx, &with_stmt.body);
+            ctx.pop_with_env();
+            module.init.extend(body_result?);
+        }
         _ => {}
     }
     Ok(())

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1796,13 +1796,25 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 "namespace/module declared inside a function body is not supported; declare it at module scope"
             );
         }
-        // `with` is forbidden under TS strict-mode (the implicit default for
-        // ES modules) — Perry does not implement dynamic scope chains.
         ast::Stmt::With(with_stmt) => {
-            crate::lower_bail!(
-                with_stmt.span,
-                "`with` statement is not supported (also forbidden in strict mode)"
-            );
+            if ctx.current_strict_mode() || ctx.current_strict {
+                crate::lower_bail!(
+                    with_stmt.span,
+                    "`with` statement is forbidden in strict mode"
+                );
+            }
+            let env_id = ctx.define_local("__perry_with_env".to_string(), Type::Any);
+            result.push(Stmt::Let {
+                id: env_id,
+                name: format!("__perry_with_env_{}", env_id),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(lower_expr(ctx, &with_stmt.obj)?),
+            });
+            ctx.push_with_env(env_id);
+            let body_result = lower_body_stmt(ctx, &with_stmt.body);
+            ctx.pop_with_env();
+            result.extend(body_result?);
         }
         // Final catch-all: any genuinely unexpected variant (e.g. a future
         // swc Stmt variant we haven't enumerated) bails instead of silently

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -10,6 +10,22 @@ use super::primitives::{tag, SH};
 use super::StableHasher;
 use crate::ir::*;
 
+fn hash_with_set_fallback<H: StableHasher>(h: &mut H, fallback: &WithSetFallback) {
+    match fallback {
+        WithSetFallback::Local(id) => {
+            tag(h, 0);
+            id.hash(h);
+        }
+        WithSetFallback::ThrowReferenceError => tag(h, 1),
+        WithSetFallback::ThrowConstAssignment => tag(h, 2),
+        WithSetFallback::Ignore => tag(h, 3),
+        WithSetFallback::SloppyImplicit(id) => {
+            tag(h, 4);
+            id.hash(h);
+        }
+    }
+}
+
 #[rustfmt::skip]
 impl SH for Expr {
     fn hash<H: StableHasher>(&self, h: &mut H) {
@@ -568,6 +584,8 @@ impl SH for Expr {
             Expr::ReflectGet { target, key, receiver } => { tag(h, 433); target.as_ref().hash(h); key.as_ref().hash(h); receiver.as_ref().hash(h); }
             Expr::ReflectSet { target, key, value } => { tag(h, 434); target.as_ref().hash(h); key.as_ref().hash(h); value.as_ref().hash(h); }
             Expr::PutValueSet { target, key, value, receiver, strict } => { tag(h, 12235); target.as_ref().hash(h); key.as_ref().hash(h); value.as_ref().hash(h); receiver.as_ref().hash(h); strict.hash(h); }
+            Expr::WithGet { object, property, fallback } => { tag(h, 12236); object.as_ref().hash(h); property.hash(h); fallback.as_ref().hash(h); }
+            Expr::WithSet { object, property, value, fallback, strict } => { tag(h, 12237); object.as_ref().hash(h); property.hash(h); value.as_ref().hash(h); hash_with_set_fallback(h, fallback); strict.hash(h); }
             Expr::ReflectHas { target, key } => { tag(h, 435); target.as_ref().hash(h); key.as_ref().hash(h); }
             Expr::ReflectDelete { target, key } => { tag(h, 436); target.as_ref().hash(h); key.as_ref().hash(h); }
             Expr::ReflectOwnKeys(e) => { tag(h, 437); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1651,6 +1651,16 @@ where
             f(value);
             f(receiver);
         }
+        Expr::WithGet {
+            object, fallback, ..
+        } => {
+            f(object);
+            f(fallback);
+        }
+        Expr::WithSet { object, value, .. } => {
+            f(object);
+            f(value);
+        }
         Expr::ReflectSetPrototypeOf { target, proto } => {
             f(target);
             f(proto);

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1622,6 +1622,16 @@ where
             f(value);
             f(receiver);
         }
+        Expr::WithGet {
+            object, fallback, ..
+        } => {
+            f(object);
+            f(fallback);
+        }
+        Expr::WithSet { object, value, .. } => {
+            f(object);
+            f(value);
+        }
         Expr::ReflectSetPrototypeOf { target, proto } => {
             f(target);
             f(proto);

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -58,6 +58,7 @@ mod prototype_helpers;
 mod reflect_support;
 mod util_types;
 mod websocket_global;
+mod with_env;
 pub use alloc::*;
 pub use arguments::*;
 pub(crate) use array_object_ops::*;
@@ -97,6 +98,7 @@ pub use property_key::*;
 pub(crate) use prototype_helpers::*;
 pub(crate) use reflect_support::*;
 pub use util_types::*;
+pub use with_env::*;
 
 static HTTP_METHODS_CACHE: AtomicU64 = AtomicU64::new(0);
 static FS_CONSTANTS_CACHE: AtomicU64 = AtomicU64::new(0);

--- a/crates/perry-runtime/src/object/with_env.rs
+++ b/crates/perry-runtime/src/object/with_env.rs
@@ -1,0 +1,89 @@
+//! Minimal ECMAScript ObjectEnvironmentRecord helpers for `with`.
+//!
+//! The compiler lowers `with (obj) { ident }` reads/writes into explicit
+//! probes of the captured object value. These helpers provide the runtime
+//! pieces that are genuinely dynamic: prototype-chain HasProperty,
+//! `Symbol.unscopables`, property reads, and strict PutValue rechecks.
+
+use super::*;
+use crate::string::{js_string_from_bytes, StringHeader};
+use crate::value::{js_is_truthy, js_nanbox_pointer, js_nanbox_string, JSValue};
+
+fn throw_type_error(message: &'static [u8]) -> ! {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+#[inline]
+fn key_as_value(key: *const StringHeader) -> f64 {
+    js_nanbox_string(key as i64)
+}
+
+#[inline]
+fn object_ptr(bindings: f64) -> *mut ObjectHeader {
+    let value = JSValue::from_bits(bindings.to_bits());
+    if value.is_null() || value.is_undefined() {
+        throw_type_error(b"Cannot convert undefined or null to object");
+    }
+    if !value.is_pointer() {
+        throw_type_error(b"with object environment requires an object");
+    }
+    let ptr = value.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+    if ptr.is_null() || (ptr as usize) < 0x10000 {
+        throw_type_error(b"with object environment requires an object");
+    }
+    ptr
+}
+
+#[inline]
+fn has_property(bindings: f64, key: *const StringHeader) -> bool {
+    !key.is_null() && js_is_truthy(js_object_has_property(bindings, key_as_value(key))) != 0
+}
+
+#[no_mangle]
+pub extern "C" fn js_with_has_binding(bindings: f64, key: *const StringHeader) -> i32 {
+    if key.is_null() {
+        return 0;
+    }
+    let _ = object_ptr(bindings);
+    if !has_property(bindings, key) {
+        return 0;
+    }
+
+    let unscopables_symbol = crate::symbol::well_known_symbol("unscopables");
+    let unscopables_symbol_value = js_nanbox_pointer(unscopables_symbol as i64);
+    let unscopables =
+        unsafe { crate::symbol::js_object_get_symbol_property(bindings, unscopables_symbol_value) };
+    let unscopables_value = JSValue::from_bits(unscopables.to_bits());
+    if unscopables_value.is_pointer() {
+        let unscopables_ptr = unscopables_value.as_pointer::<ObjectHeader>();
+        let blocked = js_object_get_field_by_name_f64(unscopables_ptr, key);
+        if js_is_truthy(blocked) != 0 {
+            return 0;
+        }
+    }
+
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn js_with_get_binding(bindings: f64, key: *const StringHeader) -> f64 {
+    let ptr = object_ptr(bindings);
+    js_object_get_field_by_name_f64(ptr as *const ObjectHeader, key)
+}
+
+#[no_mangle]
+pub extern "C" fn js_with_set_binding(
+    bindings: f64,
+    key: *const StringHeader,
+    value: f64,
+    strict: i32,
+) -> f64 {
+    let ptr = object_ptr(bindings);
+    if strict != 0 && !has_property(bindings, key) {
+        crate::error::js_throw_reference_error_unresolvable_assignment(key_as_value(key));
+    }
+    js_object_set_field_by_name(ptr, key, value);
+    value
+}

--- a/reference/deepwiki/with-semantics-boa.md
+++ b/reference/deepwiki/with-semantics-boa.md
@@ -1,0 +1,252 @@
+# DeepWiki Response
+
+Repository: `boa-dev/boa`
+Question: How does this ECMAScript engine implement with statement object environment records? Please focus on ObjectEnvironmentRecord/withEnvironment HasBinding, GetBindingValue, SetMutableBinding, DeleteBinding, @@unscopables handling, closure capture through with object environments, and strict-mode syntax restrictions. Include concrete source references.
+Search: https://deepwiki.com/search/how-does-this-ecmascript-engin_efd7bd82-9a12-486b-82a9-e5e76c71a4c0
+
+**Question**: How does this ECMAScript engine implement with statement object environment records? Please focus on ObjectEnvironmentRecord/withEnvironment HasBinding, GetBindingValue, SetMutableBinding, DeleteBinding, @@unscopables handling, closure capture through with object environments, and strict-mode syntax restrictions. Include concrete source references.
+
+The Boa ECMAScript engine implements `with` statement object environment records through the `Environment::Object` enum variant within its `EnvironmentStack` structure [1](#ref-q1-1) . This `EnvironmentStack` manages the lexical and variable scopes during execution [2](#ref-q1-2) .
+
+## ObjectEnvironmentRecord Operations
+
+### HasBinding
+The `has_property` method of the `JsObject` associated with the `Object` environment is used to determine if a binding exists [3](#ref-q1-3) . This check is performed within the `Context::find_runtime_binding` and `Context::this_from_object_environment_binding` methods [4](#ref-q1-4)  [5](#ref-q1-5) .
+
+### GetBindingValue
+To retrieve the value of a binding, the `get` method of the underlying `JsObject` is called [6](#ref-q1-6) . This occurs in the `Context::get_binding` method [7](#ref-q1-7) .
+
+### SetMutableBinding
+Setting a mutable binding in an `Object` environment is handled by the `set` method of the `JsObject` [8](#ref-q1-8) . The `Context::set_binding` method orchestrates this operation, passing along the `strict` mode flag [9](#ref-q1-9) .
+
+### DeleteBinding
+The `__delete__` method of the `JsObject` is invoked to delete a binding from an `Object` environment [10](#ref-q1-10) . This is part of the `Context::delete_binding` implementation [11](#ref-q1-11) .
+
+### @@unscopables Handling
+The `@@unscopables` symbol is checked during binding lookups within `Object` environments [12](#ref-q1-12) . If an object has an `@@unscopables` property and it contains the binding's key with a `true` value, the binding is effectively "skipped" and the search continues up the environment chain [12](#ref-q1-12) . This logic is present in `Context::find_runtime_binding` and `Context::this_from_object_environment_binding` [12](#ref-q1-12)  [13](#ref-q1-13) .
+
+## Closure Capture through `with` Object Environments
+The `EnvironmentStack` can be snapshotted for closures using `EnvironmentStack::snapshot_for_closure`, which performs a cheap clone due to the linked-list implementation [14](#ref-q1-14) . This ensures that the closure retains access to the environment chain, including any `Object` environments, at the time of its creation.
+
+## Strict-Mode Syntax Restrictions
+The `with` statement is explicitly disallowed in strict mode code [15](#ref-q1-15) . The engine enforces this restriction, throwing a `SyntaxError` if a `with` statement is encountered in strict mode [16](#ref-q1-16) . This check is performed during parsing or compilation. The `ByteCompiler` also tracks whether it is currently compiling code within a `with` statement via the `in_with` field [17](#ref-q1-17) . Additionally, the `eval_declaration_instantiation_scope` function notes that `with` statements cannot contain any lexical declarations, thus avoiding var/let hoisting conflicts [18](#ref-q1-18) .
+
+## Notes
+The `EnvironmentStack` uses a linked-list like structure where each `EnvironmentNode` contains an `Environment` and a pointer to its `parent` [19](#ref-q1-19) . The `Environment` enum can be either `Declarative` or `Object` [1](#ref-q1-1) . The `push_object` method is responsible for adding an `Object` environment to the stack [20](#ref-q1-20) . The `PushObjectEnvironment` opcode triggers this action during VM execution [21](#ref-q1-21) .
+
+Wiki pages you might want to explore:
+- [Context & Execution Environment (boa-dev/boa)](/wiki/boa-dev/boa#2.3)
+- [Parser & AST (boa-dev/boa)](/wiki/boa-dev/boa#5.4)
+
+View this search on DeepWiki: https://deepwiki.com/search/how-does-this-ecmascript-engin_efd7bd82-9a12-486b-82a9-e5e76c71a4c0
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `core/engine/src/environments/runtime/mod.rs:62-66`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L62-L66)
+
+```rust
+#[derive(Clone, Debug, Trace, Finalize)]
+pub(crate) enum Environment {
+    Declarative(Gc<DeclarativeEnvironment>),
+    Object(JsObject),
+}
+```
+
+<a id="ref-q1-2"></a>
+### [2] `core/engine/src/environments/mod.rs:1-3`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/mod.rs#L1-L3)
+
+```rust
+//! Boa's implementation of ECMAScript's `Environment Records`.
+//!
+//! Environments contain the bindings of identifiers to their values.
+```
+
+<a id="ref-q1-3"></a>
+### [3] `core/engine/src/environments/runtime/mod.rs:495`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L495)
+
+```rust
+                    if o.has_property(key.clone(), self)? {
+```
+
+<a id="ref-q1-4"></a>
+### [4] `core/engine/src/environments/runtime/mod.rs:462`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L462)
+
+```rust
+    pub(crate) fn find_runtime_binding(&mut self, locator: &mut BindingLocator) -> JsResult<()> {
+```
+
+<a id="ref-q1-5"></a>
+### [5] `core/engine/src/environments/runtime/mod.rs:521-523`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L521-L523)
+
+```rust
+        &mut self,
+        locator: &BindingLocator,
+    ) -> JsResult<Option<JsObject>> {
+```
+
+<a id="ref-q1-6"></a>
+### [6] `core/engine/src/environments/runtime/mod.rs:617`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L617)
+
+```rust
+                    obj.get(key, self).map(Some)
+```
+
+<a id="ref-q1-7"></a>
+### [7] `core/engine/src/environments/runtime/mod.rs:601`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L601)
+
+```rust
+    pub(crate) fn get_binding(&mut self, locator: &BindingLocator) -> JsResult<Option<JsValue>> {
+```
+
+<a id="ref-q1-8"></a>
+### [8] `core/engine/src/environments/runtime/mod.rs:652`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L652)
+
+```rust
+                    obj.set(key, value, strict, self)?;
+```
+
+<a id="ref-q1-9"></a>
+### [9] `core/engine/src/environments/runtime/mod.rs:629-634`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L629-L634)
+
+```rust
+    pub(crate) fn set_binding(
+        &mut self,
+        locator: &BindingLocator,
+        value: JsValue,
+        strict: bool,
+    ) -> JsResult<()> {
+```
+
+<a id="ref-q1-10"></a>
+### [10] `core/engine/src/environments/runtime/mod.rs:678`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L678)
+
+```rust
+                    let obj = obj.clone();
+```
+
+<a id="ref-q1-11"></a>
+### [11] `core/engine/src/environments/runtime/mod.rs:666`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L666)
+
+```rust
+    pub(crate) fn delete_binding(&mut self, locator: &BindingLocator) -> JsResult<bool> {
+```
+
+<a id="ref-q1-12"></a>
+### [12] `core/engine/src/environments/runtime/mod.rs:496-500`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L496-L500)
+
+```rust
+                        if let Some(unscopables) = o.get(JsSymbol::unscopables(), self)?.as_object()
+                            && unscopables.get(key.clone(), self)?.to_boolean()
+                        {
+                            continue;
+                        }
+```
+
+<a id="ref-q1-13"></a>
+### [13] `core/engine/src/environments/runtime/mod.rs:553-557`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L553-L557)
+
+```rust
+                    if o.has_property(key.clone(), self)? {
+                        if let Some(unscopables) = o.get(JsSymbol::unscopables(), self)?.as_object()
+                            && unscopables.get(key.clone(), self)?.to_boolean()
+                        {
+                            continue;
+```
+
+<a id="ref-q1-14"></a>
+### [14] `core/engine/src/environments/runtime/mod.rs:397-402`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L397-L402)
+
+```rust
+    ///
+    /// With the linked-list implementation, this is just a clone since
+    /// cloning is O(1) — a single ref-count bump on the tip pointer.
+    pub(crate) fn snapshot_for_closure(&self) -> EnvironmentStack {
+        self.clone()
+    }
+```
+
+<a id="ref-q1-15"></a>
+### [15] `core/engine/src/tests/mod.rs:404-406`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/tests/mod.rs#L404-L406)
+
+```rust
+fn strict_mode_with() {
+    // Checks as per https://tc39.es/ecma262/#sec-with-statement-static-semantics-early-errors
+    // that a with statement is an error in strict mode code.
+```
+
+<a id="ref-q1-16"></a>
+### [16] `core/engine/src/tests/mod.rs:416-418`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/tests/mod.rs#L416-L418)
+
+```rust
+        JsNativeErrorKind::Syntax,
+        "with statement not allowed in strict mode at line 3, col 5",
+    )]);
+```
+
+<a id="ref-q1-17"></a>
+### [17] `core/engine/src/bytecompiler/mod.rs:539-540`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/mod.rs#L539-L540)
+
+```rust
+    /// Whether the function is in a `with` statement.
+    pub(crate) in_with: bool,
+```
+
+<a id="ref-q1-18"></a>
+### [18] `core/ast/src/scope_analyzer.rs:2347-2348`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/ast/src/scope_analyzer.rs#L2347-L2348)
+
+```rust
+            // 1. NOTE: The environment of with statements cannot contain any lexical
+            //    declaration so it doesn't need to be checked for var/let hoisting conflicts.
+```
+
+<a id="ref-q1-19"></a>
+### [19] `core/engine/src/environments/runtime/mod.rs:408-411`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L408-L411)
+
+```rust
+        self.tip = Some(Gc::new(EnvironmentNode {
+            env,
+            parent: self.tip.take(),
+        }));
+```
+
+<a id="ref-q1-20"></a>
+### [20] `core/engine/src/environments/runtime/mod.rs:205-208`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/environments/runtime/mod.rs#L205-L208)
+
+```rust
+    /// Push a new object environment on the environments stack.
+    pub(crate) fn push_object(&mut self, object: JsObject) {
+        self.push_env(Environment::Object(object));
+    }
+```
+
+<a id="ref-q1-21"></a>
+### [21] `core/engine/src/vm/opcode/push/environment.rs:44-47`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/vm/opcode/push/environment.rs#L44-L47)
+
+```rust
+    pub(crate) fn operation(value: RegisterOperand, context: &mut Context) -> JsResult<()> {
+        let object = context.vm.get_register(value.into()).clone();
+        let object = object.to_object(context)?;
+        context.vm.frame_mut().environments.push_object(object);
+```

--- a/reference/deepwiki/with-semantics-engine262.md
+++ b/reference/deepwiki/with-semantics-engine262.md
@@ -1,0 +1,316 @@
+# DeepWiki Response
+
+Repository: `engine262/engine262`
+Question: How does this ECMAScript engine implement with statement object environment records? Please focus on ObjectEnvironmentRecord/withEnvironment HasBinding, GetBindingValue, SetMutableBinding, DeleteBinding, @@unscopables handling, closure capture through with object environments, and strict-mode syntax restrictions. Include concrete source references.
+Search: https://deepwiki.com/search/how-does-this-ecmascript-engin_420251b9-dd6d-428d-a5bd-233ec846e72b
+
+**Question**: How does this ECMAScript engine implement with statement object environment records? Please focus on ObjectEnvironmentRecord/withEnvironment HasBinding, GetBindingValue, SetMutableBinding, DeleteBinding, @@unscopables handling, closure capture through with object environments, and strict-mode syntax restrictions. Include concrete source references.
+
+This ECMAScript engine implements `with` statement object environment records using the `ObjectEnvironmentRecord` class, which is a subclass of `EnvironmentRecord` [1](#ref-q1-1)  [2](#ref-q1-2) . The `IsWithEnvironment` flag within `ObjectEnvironmentRecord` specifically indicates if the record is associated with a `with` statement [3](#ref-q1-3) .
+
+### `ObjectEnvironmentRecord` Methods
+
+The `ObjectEnvironmentRecord` class overrides several abstract methods from `EnvironmentRecord` to define its behavior [1](#ref-q1-1)  [2](#ref-q1-2) .
+
+#### `HasBinding`
+The `HasBinding` method checks for the existence of a binding for a given name `N` [4](#ref-q1-4) . It first checks if the `BindingObject` has the property [5](#ref-q1-5) . If the `IsWithEnvironment` flag is `true`, it then checks for `@@unscopables` [6](#ref-q1-6) . If `@@unscopables` is an object and `N` is `true` within it, the binding is considered blocked and `HasBinding` returns `false` [7](#ref-q1-7) .
+
+#### `GetBindingValue`
+The `GetBindingValue` method retrieves the value of a binding [8](#ref-q1-8) . It checks if the `BindingObject` has the property `N` [9](#ref-q1-9) . If not found and `S` (strict) is `false`, it returns `undefined`; otherwise, it throws a `ReferenceError` [10](#ref-q1-10) . If the property exists, it returns its value from the `BindingObject` [11](#ref-q1-11) .
+
+#### `SetMutableBinding`
+The `SetMutableBinding` method sets the value of a mutable binding [12](#ref-q1-12) . It first checks if the property `N` exists on the `BindingObject` [13](#ref-q1-13) . If it doesn't exist and `S` (strict) is `true`, it throws a `ReferenceError` [14](#ref-q1-14) . Otherwise, it calls the `Set` abstract operation on the `BindingObject` [15](#ref-q1-15) .
+
+#### `DeleteBinding`
+The `DeleteBinding` method attempts to delete a binding [16](#ref-q1-16) . It directly calls the `[[Delete]]` internal method of the `BindingObject` with the name `N` [17](#ref-q1-17) .
+
+### `@@unscopables` Handling
+The `@@unscopables` symbol is specifically handled within the `HasBinding` method of `ObjectEnvironmentRecord` when `IsWithEnvironment` is `true` [6](#ref-q1-6) . This mechanism prevents certain properties from being exposed through the `with` statement's environment, aligning with the ECMAScript specification for `with` statement behavior [7](#ref-q1-7) .
+
+### Closure Capture and Strict-Mode Restrictions
+The `ObjectEnvironmentRecord` itself does not directly implement closure capture; rather, it is part of the environment chain that functions close over [18](#ref-q1-18) . The `OuterEnv` property links environment records, forming the lexical environment chain [19](#ref-q1-19) .
+
+Strict-mode restrictions are reflected in the `SetMutableBinding` and `GetBindingValue` methods. For instance, in `SetMutableBinding`, if a binding does not exist and the operation is in strict mode (`S` is `true`), a `ReferenceError` is thrown [14](#ref-q1-14) . Similarly, in `GetBindingValue`, if a binding is not found and `S` is `true`, a `ReferenceError` is thrown [10](#ref-q1-10) . The `with` statement itself is forbidden in strict mode, but the `ObjectEnvironmentRecord` methods handle strictness for operations that might occur within a non-strict `with` block.
+
+## Notes
+The `GlobalEnvironmentRecord` also contains an `ObjectEnvironmentRecord` as its `ObjectRecord` property, but this `ObjectEnvironmentRecord` is initialized with `IsWithEnvironment` set to `false` [20](#ref-q1-20) . This means the `@@unscopables` logic is not applied to the global object's environment record [21](#ref-q1-21) .
+
+View this search on DeepWiki: https://deepwiki.com/search/how-does-this-ecmascript-engin_420251b9-dd6d-428d-a5bd-233ec846e72b
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `src/environment.mts:261`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L261)
+
+```
+export class ObjectEnvironmentRecord extends EnvironmentRecord {
+```
+
+<a id="ref-q1-2"></a>
+### [2] `src/environment.mts:37`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L37)
+
+```
+export abstract class EnvironmentRecord {
+```
+
+<a id="ref-q1-3"></a>
+### [3] `src/environment.mts:265`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L265)
+
+<a id="ref-q1-4"></a>
+### [4] `src/environment.mts:273-302`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L273-L302)
+
+```
+  /** https://tc39.es/ecma262/#sec-object-environment-records-hasbinding-n */
+  * HasBinding(N: JSStringValue): ValueEvaluator<BooleanValue> {
+    // 1. Let envRec be the object Environment Record for which the method was invoked.
+    const envRec = this;
+    // 2. Let bindings be the binding object for envRec.
+    const bindings = envRec.BindingObject;
+    // 3. Let foundBinding be ? HasProperty(bindings, N).
+    const foundBinding = Q(yield* HasProperty(bindings, N));
+    // 4. If foundBinding is false, return false.
+    if (foundBinding === Value.false) {
+      return Value.false;
+    }
+    // 5. If the IsWithEnvironment flag of envRec i s false, return true.
+    if (envRec.IsWithEnvironment === Value.false) {
+      return Value.true;
+    }
+    // 6. Let unscopables be ? Get(bindings, @@unscopables).
+    const unscopables = Q(yield* Get(bindings, wellKnownSymbols.unscopables));
+    // 7. If Type(unscopables) is Object, then
+    if (unscopables instanceof ObjectValue) {
+      // a. Let blocked be ! ToBoolean(? Get(unscopables, N)).
+      const blocked = X(ToBoolean(Q(yield* Get(unscopables, N))));
+      // b. If blocked is true, return false.
+      if (blocked === Value.true) {
+        return Value.false;
+      }
+    }
+    // 8. Return true.
+    return Value.true;
+  }
+```
+
+<a id="ref-q1-5"></a>
+### [5] `src/environment.mts:278-280`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L278-L280)
+
+```
+    const bindings = envRec.BindingObject;
+    // 3. Let foundBinding be ? HasProperty(bindings, N).
+    const foundBinding = Q(yield* HasProperty(bindings, N));
+```
+
+<a id="ref-q1-6"></a>
+### [6] `src/environment.mts:285-299`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L285-L299)
+
+```
+    // 5. If the IsWithEnvironment flag of envRec i s false, return true.
+    if (envRec.IsWithEnvironment === Value.false) {
+      return Value.true;
+    }
+    // 6. Let unscopables be ? Get(bindings, @@unscopables).
+    const unscopables = Q(yield* Get(bindings, wellKnownSymbols.unscopables));
+    // 7. If Type(unscopables) is Object, then
+    if (unscopables instanceof ObjectValue) {
+      // a. Let blocked be ! ToBoolean(? Get(unscopables, N)).
+      const blocked = X(ToBoolean(Q(yield* Get(unscopables, N))));
+      // b. If blocked is true, return false.
+      if (blocked === Value.true) {
+        return Value.false;
+      }
+    }
+```
+
+<a id="ref-q1-7"></a>
+### [7] `src/environment.mts:290-297`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L290-L297)
+
+```
+    const unscopables = Q(yield* Get(bindings, wellKnownSymbols.unscopables));
+    // 7. If Type(unscopables) is Object, then
+    if (unscopables instanceof ObjectValue) {
+      // a. Let blocked be ! ToBoolean(? Get(unscopables, N)).
+      const blocked = X(ToBoolean(Q(yield* Get(unscopables, N))));
+      // b. If blocked is true, return false.
+      if (blocked === Value.true) {
+        return Value.false;
+```
+
+<a id="ref-q1-8"></a>
+### [8] `src/environment.mts:351-370`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L351-L370)
+
+```
+  /** https://tc39.es/ecma262/#sec-object-environment-records-getbindingvalue-n-s */
+  * GetBindingValue(N: JSStringValue, S: BooleanValue): ValueEvaluator {
+    // 1. Let envRec be the object Environment Record for which the method was invoked.
+    const envRec = this;
+    // 2. Let bindings be the binding object for envRec.
+    const bindings = envRec.BindingObject;
+    // 3. Let value be ? HasProperty(bindings, N).
+    const value = Q(yield* HasProperty(bindings, N));
+    // 4. If value is false, then
+    if (value === Value.false) {
+      // a. If S is false, return the value undefined; otherwise throw a ReferenceError exception.
+      if (S === Value.false) {
+        return NormalCompletion(Value.undefined);
+      } else {
+        return surroundingAgent.Throw('ReferenceError', 'NotDefined', N);
+      }
+    }
+    // 5. Return Get(bindings, N).
+    return yield* Get(bindings, N);
+  }
+```
+
+<a id="ref-q1-9"></a>
+### [9] `src/environment.mts:357-358`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L357-L358)
+
+```
+    // 3. Let value be ? HasProperty(bindings, N).
+    const value = Q(yield* HasProperty(bindings, N));
+```
+
+<a id="ref-q1-10"></a>
+### [10] `src/environment.mts:360-366`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L360-L366)
+
+```
+    if (value === Value.false) {
+      // a. If S is false, return the value undefined; otherwise throw a ReferenceError exception.
+      if (S === Value.false) {
+        return NormalCompletion(Value.undefined);
+      } else {
+        return surroundingAgent.Throw('ReferenceError', 'NotDefined', N);
+      }
+```
+
+<a id="ref-q1-11"></a>
+### [11] `src/environment.mts:368-369`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L368-L369)
+
+```
+    // 5. Return Get(bindings, N).
+    return yield* Get(bindings, N);
+```
+
+<a id="ref-q1-12"></a>
+### [12] `src/environment.mts:335-349`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L335-L349)
+
+```
+  * SetMutableBinding(N: JSStringValue, V: Value, S: BooleanValue): PlainEvaluator {
+    // 1. Let envRec be the object Environment Record for which the method was invoked.
+    const envRec = this;
+    // 2. Let bindings be the binding object for envRec.
+    const bindings = envRec.BindingObject;
+    // 3. Let stillExists be ? HasProperty(bindings, N).
+    const stillExists = Q(yield* HasProperty(bindings, N));
+    // 4. If stillExists is false and S is true, throw a ReferenceError exception.
+    if (stillExists === Value.false && S === Value.true) {
+      return surroundingAgent.Throw('ReferenceError', 'NotDefined', N);
+    }
+    // 5. Return ? Set(bindings, N, V, S).
+    Q(yield* Set(bindings, N, V, S));
+    return undefined;
+  }
+```
+
+<a id="ref-q1-13"></a>
+### [13] `src/environment.mts:340-341`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L340-L341)
+
+```
+    // 3. Let stillExists be ? HasProperty(bindings, N).
+    const stillExists = Q(yield* HasProperty(bindings, N));
+```
+
+<a id="ref-q1-14"></a>
+### [14] `src/environment.mts:343-345`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L343-L345)
+
+```
+    if (stillExists === Value.false && S === Value.true) {
+      return surroundingAgent.Throw('ReferenceError', 'NotDefined', N);
+    }
+```
+
+<a id="ref-q1-15"></a>
+### [15] `src/environment.mts:346-347`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L346-L347)
+
+```
+    // 5. Return ? Set(bindings, N, V, S).
+    Q(yield* Set(bindings, N, V, S));
+```
+
+<a id="ref-q1-16"></a>
+### [16] `src/environment.mts:372-380`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L372-L380)
+
+```
+  /** https://tc39.es/ecma262/#sec-object-environment-records-deletebinding-n */
+  * DeleteBinding(N: JSStringValue): ValueEvaluator<BooleanValue> {
+    // 1. Let envRec be the object Environment Record for which the method was invoked.
+    const envRec = this;
+    // 2. Let bindings be the binding object for envRec.
+    const bindings = envRec.BindingObject;
+    // 3. Return ? bindings.[[Delete]](N).
+    return Q(yield* bindings.Delete(N));
+  }
+```
+
+<a id="ref-q1-17"></a>
+### [17] `src/environment.mts:378`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L378)
+
+```
+    // 3. Return ? bindings.[[Delete]](N).
+```
+
+<a id="ref-q1-18"></a>
+### [18] `src/environment.mts:38-42`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L38-L42)
+
+```
+  readonly OuterEnv: EnvironmentRecord | NullValue;
+
+  constructor(outerEnv: EnvironmentRecord | NullValue) {
+    this.OuterEnv = outerEnv;
+  }
+```
+
+<a id="ref-q1-19"></a>
+### [19] `src/environment.mts:38`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L38)
+
+```
+  readonly OuterEnv: EnvironmentRecord | NullValue;
+```
+
+<a id="ref-q1-20"></a>
+### [20] `src/environment.mts:538-539`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L538-L539)
+
+```
+    // 1. Let objRec be NewObjectEnvironment(G, false, null).
+    const objRec = new ObjectEnvironmentRecord(G, Value.false, Value.null);
+```
+
+<a id="ref-q1-21"></a>
+### [21] `src/environment.mts:285-287`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/environment.mts#L285-L287)
+
+```
+    // 5. If the IsWithEnvironment flag of envRec i s false, return true.
+    if (envRec.IsWithEnvironment === Value.false) {
+      return Value.true;
+```

--- a/reference/deepwiki/with-semantics.md
+++ b/reference/deepwiki/with-semantics.md
@@ -1,0 +1,38 @@
+# `with` object-environment semantics
+
+DeepWiki research was run against `engine262/engine262` and `boa-dev/boa`.
+The raw responses are kept next to this note:
+
+- `reference/deepwiki/with-semantics-engine262.md`
+- `reference/deepwiki/with-semantics-boa.md`
+
+Useful implementation points for c262:
+
+- A `with` statement inserts an object environment record into the lexical
+  environment chain. Closures created inside the statement retain that chain,
+  so reads in the closure must still consult the object environment before the
+  outer lexical fallback.
+- `HasBinding(name)` first checks `HasProperty(bindings, name)`. If the record
+  is a `with` environment, it then reads `bindings[Symbol.unscopables]`; when
+  that value is an object and `ToBoolean(unscopables[name])` is true, the
+  binding is skipped and lookup continues outward.
+- `GetBindingValue(name, strict)` rechecks property existence and returns
+  `Get(bindings, name)` when present. If absent, it returns `undefined` for
+  non-strict object-environment binding access or throws `ReferenceError` when
+  strict.
+- `SetMutableBinding(name, value, strict)` rechecks property existence at set
+  time. If the property disappeared and the write is strict, it throws
+  `ReferenceError`; otherwise it performs ordinary object `Set`.
+- `DeleteBinding(name)` delegates to object delete.
+- `with` is an early syntax error in strict-mode code, but strict functions can
+  be called from inside a non-strict `with` block. In that case the strict flag
+  matters when the strict function performs a write resolved through the
+  captured object environment.
+
+This PR implements a scoped subset of those rules in c262 lowering/codegen:
+identifier reads and writes inside a lowered `with` scope consult the captured
+object environment, respect `Symbol.unscopables` on lookup, and strict writes
+recheck the object binding after evaluating the RHS. Full object-environment
+coverage remains larger than this parity bucket: primitive `ToObject` at
+statement entry, unqualified `delete`, update expressions targeting with
+bindings, and fully chained writes across nested `with` scopes are not covered.

--- a/tests/test_c262_arrow_function_parity.sh
+++ b/tests/test_c262_arrow_function_parity.sh
@@ -44,6 +44,14 @@ const capturedArrow = () => captured;
 captured = 10;
 check("closure capture observes later write", capturedArrow(), 10);
 
+function makeWithReader(): () => any {
+  var a = { a: 10 };
+  with (a) {
+    return () => a;
+  }
+}
+check("arrow captures with object environment", makeWithReader()(), 10);
+
 function makeReader(value: any): () => any {
   let local = value;
   return () => local;

--- a/tests/test_c262_assignment_parity.sh
+++ b/tests/test_c262_assignment_parity.sh
@@ -167,6 +167,24 @@ try {
 }
 check(caught, "unresolved assignment evaluates RHS reference before PutValue");
 
+count = 0;
+caught = false;
+var scope = { withPutValueBinding: 1 };
+with (scope) {
+  (function() {
+    "use strict";
+    try {
+      count++;
+      withPutValueBinding = (delete scope.withPutValueBinding, 2);
+      count++;
+    } catch (e) {
+      caught = e instanceof ReferenceError;
+    }
+    count++;
+  })();
+}
+check(caught && count === 2 && !("withPutValueBinding" in scope), "with PutValue rechecks deleted binding in strict mode");
+
 if (failures.length !== 0) {
   throw new Error(failures);
 }

--- a/tests/test_c262_with_parity.sh
+++ b/tests/test_c262_with_parity.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/c262_with_parity.js" <<'JS'
+var failures = 0;
+
+function check(label, condition) {
+  if (!condition) {
+    console.log(label);
+    failures++;
+  }
+}
+
+function makeWithReader() {
+  var a = { a: 10 };
+  with (a) {
+    return () => a;
+  }
+}
+
+check("arrow captures with object environment", makeWithReader()() === 10);
+
+var count = 0;
+var scope = { x: 1 };
+with (scope) {
+  (function() {
+    "use strict";
+    var caught = false;
+    try {
+      count++;
+      x = (delete scope.x, 2);
+      count++;
+    } catch (e) {
+      caught = e instanceof ReferenceError;
+    }
+    check("strict with assignment throws ReferenceError after binding deletion", caught);
+    count++;
+  })();
+}
+
+check("strict with assignment evaluates RHS once and resumes", count === 2);
+check("strict with assignment leaves deleted property absent", !("x" in scope));
+
+if (failures !== 0) {
+  throw new Error("failures: " + failures);
+}
+JS
+
+pushd "$TMPDIR" >/dev/null
+if ! "$PERRY" compile c262_with_parity.js --output c262_with_parity --no-cache >compile.log 2>&1; then
+  echo "FAIL: compile failed"
+  sed 's/^/    /' compile.log
+  exit 1
+fi
+./c262_with_parity
+popd >/dev/null
+
+echo "PASS c262 with parity"


### PR DESCRIPTION
## Summary
- add bounded `with` object-environment support through HIR, lowering, codegen, and runtime helpers
- support dynamic with reads/writes, strict-mode rejection, `@@unscopables`, and fallback local write analysis
- add focused c262 with regression coverage and update adjacent arrow/assignment parity scripts
- add DeepWiki reference notes for engine262 and Boa behavior

## Validation
- cargo fmt --check
- cargo build -p perry
- cargo build --release -p perry -p perry-runtime -p perry-stdlib
- tests/test_c262_with_parity.sh
- tests/test_c262_assignment_parity.sh

## Residual
- the exact two vendored Test262 files compile but still runtime-fail under the assembled harness with no output, matching the earlier harness-level failure before target assertions
- broader arrow slice still fails on the existing new.target/bus-error path, not the added with closure check