### PR TITLE
fix(process): respect lexical process shadowing

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -686,6 +686,13 @@ impl LoweringContext {
         envs
     }
 
+    pub(crate) fn shadows_unqualified_global(&self, name: &str) -> bool {
+        self.lookup_local(name).is_some()
+            || self.lookup_func(name).is_some()
+            || self.lookup_imported_func(name).is_some()
+            || self.lookup_class(name).is_some()
+    }
+
     pub(crate) fn lookup_local_type(&self, name: &str) -> Option<&Type> {
         self.locals
             .iter()

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -92,12 +92,15 @@ pub(super) fn try_native_module_methods(
             // "node:process"` registers as the native `process` object, while
             // `import * as processNamespace` registers as `process.namespace`;
             // both must use the same strict method gate as the global object.
-            let is_process_ref = obj_name == "process"
-                || ctx.lookup_builtin_module_alias(&obj_name) == Some("process")
-                || matches!(
-                    ctx.lookup_native_module(&obj_name),
-                    Some(("process", _)) | Some(("process.namespace", _))
-                );
+            let process_name_is_shadowed =
+                obj_name == "process" && ctx.shadows_unqualified_global("process");
+            let is_process_ref = !process_name_is_shadowed
+                && (obj_name == "process"
+                    || ctx.lookup_builtin_module_alias(&obj_name) == Some("process")
+                    || matches!(
+                        ctx.lookup_native_module(&obj_name),
+                        Some(("process", _)) | Some(("process.namespace", _))
+                    ));
             if is_process_ref {
                 if let ast::MemberProp::Ident(method_ident) = &member.prop {
                     let method_name = method_ident.sym.as_ref();

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -219,9 +219,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
     // match the simple `process.X` Ident-then-prop dispatch. (#347 Phase 3.)
     if let ast::Expr::Member(inner_member) = member.obj.as_ref() {
         if let ast::Expr::Ident(root_ident) = inner_member.obj.as_ref() {
-            if root_ident.sym.as_ref() == "process"
-                && !ctx.shadows_unqualified_global("process")
-            {
+            if root_ident.sym.as_ref() == "process" && !ctx.shadows_unqualified_global("process") {
                 if let (ast::MemberProp::Ident(stream_ident), ast::MemberProp::Ident(prop_ident)) =
                     (&inner_member.prop, &member.prop)
                 {

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -219,7 +219,9 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
     // match the simple `process.X` Ident-then-prop dispatch. (#347 Phase 3.)
     if let ast::Expr::Member(inner_member) = member.obj.as_ref() {
         if let ast::Expr::Ident(root_ident) = inner_member.obj.as_ref() {
-            if root_ident.sym.as_ref() == "process" {
+            if root_ident.sym.as_ref() == "process"
+                && !ctx.shadows_unqualified_global("process")
+            {
                 if let (ast::MemberProp::Ident(stream_ident), ast::MemberProp::Ident(prop_ident)) =
                     (&inner_member.prop, &member.prop)
                 {
@@ -246,11 +248,15 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         // dedicated process-property lowering — otherwise the namespace form
         // fell through to a generic native-module PropertyGet that resolved
         // `pid`/`arch`/`platform`/… to `undefined`.
-        let is_process_obj = obj_ident.sym.as_ref() == "process"
-            || matches!(
-                ctx.lookup_native_module(obj_ident.sym.as_ref()),
-                Some(("process", None)) | Some(("process.namespace", None))
-            );
+        let obj_name = obj_ident.sym.as_ref();
+        let process_name_is_shadowed =
+            obj_name == "process" && ctx.shadows_unqualified_global("process");
+        let is_process_obj = !process_name_is_shadowed
+            && (obj_name == "process"
+                || matches!(
+                    ctx.lookup_native_module(obj_name),
+                    Some(("process", None)) | Some(("process.namespace", None))
+                ));
         if is_process_obj {
             if let ast::MemberProp::Ident(prop_ident) = &member.prop {
                 let prop = prop_ident.sym.as_ref();

--- a/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
+++ b/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
@@ -99,6 +99,91 @@ fn allows_user_object_dispatch() {
 }
 
 #[test]
+fn allows_local_process_shadow_pipe_call() {
+    let src = r#"
+        const process = {
+            pipe(value: string) {
+                return value + "!";
+            },
+        };
+        const out = process.pipe("ok");
+    "#;
+    try_lower(src, "/tmp/host.ts")
+        .expect("local `process` binding must not lower as global process");
+}
+
+#[test]
+fn allows_parameter_process_shadow_pipe_call() {
+    let src = r#"
+        function run(process: { pipe(value: string): string }) {
+            return process.pipe("ok");
+        }
+    "#;
+    try_lower(src, "/tmp/host.ts")
+        .expect("parameter `process` binding must not lower as global process");
+}
+
+#[test]
+fn allows_function_local_process_shadow_pipe_call() {
+    let src = r#"
+        interface Pipeable<T> {
+            pipe<U>(fn: (value: T) => U): U
+        }
+
+        function makePipeable<T>(value: T): Pipeable<T> {
+            return {
+                pipe(fn) {
+                    return fn(value)
+                },
+            }
+        }
+
+        function run(): string {
+            const process = makePipeable("effect-pipe-shadow")
+            return process.pipe((value) => `${value}: ok`)
+        }
+    "#;
+    try_lower(src, "/tmp/host.ts")
+        .expect("function-local `process` binding must not lower as global process");
+}
+
+#[test]
+fn allows_class_process_shadow_pipe_call() {
+    let src = r#"
+        class process {
+            static pipe(value: string) {
+                return value;
+            }
+        }
+        const out = process.pipe("ok");
+    "#;
+    try_lower(src, "/tmp/host.ts")
+        .expect("class `process` binding must not lower as global process");
+}
+
+#[test]
+fn allows_imported_process_shadow_pipe_call() {
+    let src = r#"
+        import { process } from "effect";
+        const out = process.pipe("ok");
+    "#;
+    try_lower(src, "/tmp/host.ts")
+        .expect("imported `process` binding must not lower as global process");
+}
+
+#[test]
+fn still_refuses_global_process_pipe_call() {
+    let src = r#"
+        process.pipe("ok");
+    "#;
+    let err = try_lower(src, "/tmp/host.ts").expect_err("global process.pipe must stay gated");
+    assert!(
+        err.contains("`process.pipe` is not implemented in Perry"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn site_annotation_opts_out() {
     let src = r#"
         const k: string = "exit";


### PR DESCRIPTION
## Summary
- prevent literal `process` receivers from being treated as the Node global when a lexical/function/import/class binding named `process` is in scope
- keep actual global/native `process.*` method and property handling gated as before
- add focused HIR regressions for local, parameter, function-local, class, and imported `process.pipe(...)` shadowing plus the global `process.pipe` refusal

## Validation
- `cargo test -p perry-hir --test dynamic_stdlib_dispatch -- --nocapture`
- `cargo build --release -p perry`
- `PERRY_BIN=/Users/andrew/.codex/worktrees/perry-process-shadow/target/release/perry bun scripts/perry-runtime-blockers/effect-process-shadow-pipe.ts` from `/Users/andrew/Documents/opentui/packages/core`

Note: the OpenTUI focused script exits nonzero because its expectation still says this case should compile-fail; the actual Perry compile status was 0, run status was 0, and stdout was `effect-pipe-shadow: ok`.
