### PR TITLE
c262 parity: destructuring iterator assignment

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -81,6 +81,36 @@ pub(crate) fn lower_native_method_call(
     object: Option<&Expr>,
     args: &[Expr],
 ) -> Result<String> {
+    if module == "__perry_runtime" && class_name.is_none() && object.is_none() {
+        match method {
+            "iteratorNextResult" => {
+                let iter = args.first().map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                return Ok(ctx
+                    .block()
+                    .call(DOUBLE, "js_iterator_next_result", &[(DOUBLE, &iter)]));
+            }
+            "iteratorCloseIfNotDone" => {
+                let iter = args.first().map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                let done = args.get(1).map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_iterator_close_if_not_done",
+                    &[(DOUBLE, &iter), (DOUBLE, &done)],
+                ));
+            }
+            _ => {}
+        }
+    }
+
     // Web Fetch API dispatch — Response / Headers / Request / static
     // factories. Handled before the receiver-less early-out so that
     // `Response.json(v)` (object.is_none()) finds its runtime function.

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -137,6 +137,8 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     module.declare_function("js_array_spread_append", I64, &[I64, DOUBLE]);
     // Generator / iterator protocol: walk `.next()`/`.value` loop and collect into array.
     module.declare_function("js_iterator_to_array", I64, &[DOUBLE]);
+    module.declare_function("js_iterator_next_result", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_iterator_close_if_not_done", DOUBLE, &[DOUBLE, DOUBLE]);
     // #1831: `yield*` iterator resolution — `operand[Symbol.iterator]()` or the
     // operand itself when already an iterator. Returns a NaN-boxed JSValue.
     module.declare_function("js_get_iterator", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/destructuring/assignment_stmt.rs
+++ b/crates/perry-hir/src/destructuring/assignment_stmt.rs
@@ -2,446 +2,465 @@
 
 use super::*;
 
+#[derive(Clone)]
+enum PreparedTarget {
+    Local(LocalId),
+    Property { object: Expr, property: String },
+    Index { object: Expr, index: Expr },
+    Array(ast::ArrayPat),
+    Object(ast::ObjectPat),
+    Skip,
+}
+
+fn fresh_destruct_local(ctx: &mut LoweringContext, prefix: &str, ty: Type) -> (LocalId, String) {
+    let id = ctx.fresh_local();
+    let name = format!("__{}_{}", prefix, id);
+    ctx.locals.push((name.clone(), id, ty));
+    (id, name)
+}
+
+fn runtime_iterator_call(method: &str, args: Vec<Expr>) -> Expr {
+    Expr::NativeMethodCall {
+        module: "__perry_runtime".to_string(),
+        class_name: None,
+        object: None,
+        method: method.to_string(),
+        args,
+    }
+}
+
+fn extern_call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::ExternFuncRef {
+            name: name.to_string(),
+            param_types: Vec::new(),
+            return_type: Type::Any,
+        }),
+        args,
+        type_args: Vec::new(),
+    }
+}
+
 pub(crate) fn lower_destructuring_assignment_stmt(
     ctx: &mut LoweringContext,
     pat: &ast::AssignTargetPat,
     rhs: &ast::Expr,
 ) -> Result<Vec<Stmt>> {
-    let mut result = Vec::new();
-
-    // First, evaluate and store the RHS in a temporary variable
     let rhs_expr = lower_expr(ctx, rhs)?;
-    let tmp_id = ctx.fresh_local();
-    let tmp_name = format!("__destruct_{}", tmp_id);
-    let tmp_ty = Type::Any; // Could infer from rhs, but Any is safe
-    ctx.locals.push((tmp_name.clone(), tmp_id, tmp_ty.clone()));
+    let (tmp_id, tmp_name) = fresh_destruct_local(ctx, "destruct", Type::Any);
 
-    result.push(Stmt::Let {
+    let mut result = vec![Stmt::Let {
         id: tmp_id,
         name: tmp_name,
-        ty: tmp_ty,
+        ty: Type::Any,
         mutable: false,
         init: Some(rhs_expr),
-    });
+    }];
 
-    // Now generate assignments from the temp
+    result.extend(lower_destructuring_assignment_stmt_from_local(
+        ctx, pat, tmp_id,
+    )?);
+    Ok(result)
+}
+
+/// Helper for nested destructuring - assigns from an already-computed local.
+pub(crate) fn lower_destructuring_assignment_stmt_from_local(
+    ctx: &mut LoweringContext,
+    pat: &ast::AssignTargetPat,
+    source_id: LocalId,
+) -> Result<Vec<Stmt>> {
     match pat {
         ast::AssignTargetPat::Array(arr_pat) => {
-            for (idx, elem) in arr_pat.elems.iter().enumerate() {
-                if let Some(elem_pat) = elem {
-                    let index_expr = Expr::IndexGet {
-                        object: Box::new(Expr::LocalGet(tmp_id)),
-                        index: Box::new(Expr::Number(idx as f64)),
-                    };
-
-                    match elem_pat {
-                        ast::Pat::Ident(ident) => {
-                            let name = ident.id.sym.to_string();
-                            if let Some(id) = ctx.lookup_local(&name) {
-                                result.push(Stmt::Expr(Expr::LocalSet(id, Box::new(index_expr))));
-                            } else {
-                                return Err(anyhow!(
-                                    "Assignment to undeclared variable in destructuring: {}",
-                                    name
-                                ));
-                            }
-                        }
-                        ast::Pat::Array(nested_arr) => {
-                            // Nested array destructuring
-                            // First create a temp for this element
-                            let nested_tmp_id = ctx.fresh_local();
-                            let nested_tmp_name = format!("__destruct_{}", nested_tmp_id);
-                            ctx.locals
-                                .push((nested_tmp_name.clone(), nested_tmp_id, Type::Any));
-                            result.push(Stmt::Let {
-                                id: nested_tmp_id,
-                                name: nested_tmp_name,
-                                ty: Type::Any,
-                                mutable: false,
-                                init: Some(index_expr),
-                            });
-                            // Then recursively assign from it
-                            let nested_stmts = lower_destructuring_assignment_stmt_from_local(
-                                ctx,
-                                &ast::AssignTargetPat::Array(nested_arr.clone()),
-                                nested_tmp_id,
-                            )?;
-                            result.extend(nested_stmts);
-                        }
-                        ast::Pat::Object(nested_obj) => {
-                            // Nested object destructuring
-                            let nested_tmp_id = ctx.fresh_local();
-                            let nested_tmp_name = format!("__destruct_{}", nested_tmp_id);
-                            ctx.locals
-                                .push((nested_tmp_name.clone(), nested_tmp_id, Type::Any));
-                            result.push(Stmt::Let {
-                                id: nested_tmp_id,
-                                name: nested_tmp_name,
-                                ty: Type::Any,
-                                mutable: false,
-                                init: Some(index_expr),
-                            });
-                            let nested_stmts = lower_destructuring_assignment_stmt_from_local(
-                                ctx,
-                                &ast::AssignTargetPat::Object(nested_obj.clone()),
-                                nested_tmp_id,
-                            )?;
-                            result.extend(nested_stmts);
-                        }
-                        ast::Pat::Expr(inner_expr) => {
-                            // Expression pattern like [obj.prop, obj2.prop2] = arr
-                            match inner_expr.as_ref() {
-                                ast::Expr::Member(member) => {
-                                    let object = Box::new(lower_expr(ctx, &member.obj)?);
-                                    match &member.prop {
-                                        ast::MemberProp::Ident(prop_ident) => {
-                                            let property = prop_ident.sym.to_string();
-                                            result.push(Stmt::Expr(Expr::PropertySet {
-                                                object,
-                                                property,
-                                                value: Box::new(index_expr),
-                                            }));
-                                        }
-                                        ast::MemberProp::Computed(computed) => {
-                                            let index = Box::new(lower_expr(ctx, &computed.expr)?);
-                                            result.push(Stmt::Expr(Expr::IndexSet {
-                                                object,
-                                                index,
-                                                value: Box::new(index_expr),
-                                            }));
-                                        }
-                                        _ => {
-                                            return Err(anyhow!(
-                                                "Unsupported member expression in destructuring assignment"
-                                            ));
-                                        }
-                                    }
-                                }
-                                _ => {
-                                    return Err(anyhow!(
-                                        "Unsupported expression pattern in destructuring assignment"
-                                    ));
-                                }
-                            }
-                        }
-                        _ => {
-                            // Other patterns (Rest, etc.) - skip for now
-                        }
-                    }
-                }
-            }
+            lower_array_assignment_from_expr(ctx, arr_pat, Expr::LocalGet(source_id))
         }
         ast::AssignTargetPat::Object(obj_pat) => {
-            for prop in &obj_pat.props {
-                match prop {
-                    ast::ObjectPatProp::KeyValue(kv) => {
-                        let key = match &kv.key {
-                            ast::PropName::Ident(ident) => ident.sym.to_string(),
-                            ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
-                            ast::PropName::Num(n) => n.value.to_string(),
-                            _ => continue,
-                        };
+            lower_object_assignment_from_expr(ctx, obj_pat, Expr::LocalGet(source_id))
+        }
+        ast::AssignTargetPat::Invalid(_) => Err(anyhow!("Invalid assignment target pattern")),
+    }
+}
 
-                        let prop_expr = Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(tmp_id)),
-                            property: key,
-                        };
+fn lower_array_assignment_from_expr(
+    ctx: &mut LoweringContext,
+    arr_pat: &ast::ArrayPat,
+    source: Expr,
+) -> Result<Vec<Stmt>> {
+    let (iter_id, iter_name) = fresh_destruct_local(ctx, "destruct_iter", Type::Any);
+    let (done_id, done_name) = fresh_destruct_local(ctx, "destruct_done", Type::Boolean);
 
-                        match &*kv.value {
-                            ast::Pat::Ident(ident) => {
-                                let name = ident.id.sym.to_string();
-                                if let Some(id) = ctx.lookup_local(&name) {
-                                    result
-                                        .push(Stmt::Expr(Expr::LocalSet(id, Box::new(prop_expr))));
-                                } else {
-                                    return Err(anyhow!(
-                                        "Assignment to undeclared variable in destructuring: {}",
-                                        name
-                                    ));
-                                }
-                            }
-                            ast::Pat::Array(nested_arr) => {
-                                let nested_tmp_id = ctx.fresh_local();
-                                let nested_tmp_name = format!("__destruct_{}", nested_tmp_id);
-                                ctx.locals.push((
-                                    nested_tmp_name.clone(),
-                                    nested_tmp_id,
-                                    Type::Any,
-                                ));
-                                result.push(Stmt::Let {
-                                    id: nested_tmp_id,
-                                    name: nested_tmp_name,
-                                    ty: Type::Any,
-                                    mutable: false,
-                                    init: Some(prop_expr),
-                                });
-                                let nested_stmts = lower_destructuring_assignment_stmt_from_local(
-                                    ctx,
-                                    &ast::AssignTargetPat::Array(nested_arr.clone()),
-                                    nested_tmp_id,
-                                )?;
-                                result.extend(nested_stmts);
-                            }
-                            ast::Pat::Object(nested_obj) => {
-                                let nested_tmp_id = ctx.fresh_local();
-                                let nested_tmp_name = format!("__destruct_{}", nested_tmp_id);
-                                ctx.locals.push((
-                                    nested_tmp_name.clone(),
-                                    nested_tmp_id,
-                                    Type::Any,
-                                ));
-                                result.push(Stmt::Let {
-                                    id: nested_tmp_id,
-                                    name: nested_tmp_name,
-                                    ty: Type::Any,
-                                    mutable: false,
-                                    init: Some(prop_expr),
-                                });
-                                let nested_stmts = lower_destructuring_assignment_stmt_from_local(
-                                    ctx,
-                                    &ast::AssignTargetPat::Object(nested_obj.clone()),
-                                    nested_tmp_id,
-                                )?;
-                                result.extend(nested_stmts);
-                            }
-                            _ => {}
-                        }
-                    }
-                    ast::ObjectPatProp::Assign(assign) => {
-                        let name = assign.key.sym.to_string();
-                        let prop_expr = Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(tmp_id)),
-                            property: name.clone(),
-                        };
+    let mut result = vec![
+        Stmt::Let {
+            id: iter_id,
+            name: iter_name,
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::GetIterator(Box::new(source))),
+        },
+        Stmt::Let {
+            id: done_id,
+            name: done_name,
+            ty: Type::Boolean,
+            mutable: true,
+            init: Some(Expr::Bool(false)),
+        },
+    ];
 
-                        if let Some(id) = ctx.lookup_local(&name) {
-                            result.push(Stmt::Expr(Expr::LocalSet(id, Box::new(prop_expr))));
-                        } else {
-                            return Err(anyhow!(
-                                "Assignment to undeclared variable in destructuring: {}",
-                                name
-                            ));
-                        }
-                    }
-                    ast::ObjectPatProp::Rest(_) => {
-                        // Rest pattern - skip for now
-                    }
+    let mut body = Vec::new();
+    for elem in &arr_pat.elems {
+        let (value_id, value_name) = fresh_destruct_local(ctx, "destruct_value", Type::Any);
+        body.push(Stmt::Let {
+            id: value_id,
+            name: value_name,
+            ty: Type::Any,
+            mutable: true,
+            init: Some(Expr::Undefined),
+        });
+
+        if let Some(elem_pat) = elem {
+            let (prepare, target, default_value) = prepare_target_with_default(ctx, elem_pat)?;
+            body.extend(prepare);
+            body.extend(iterator_next_value_stmts(ctx, iter_id, done_id, value_id));
+            let assigned = value_with_default(ctx, Expr::LocalGet(value_id), default_value)?;
+            body.extend(assign_prepared_target(ctx, target, assigned)?);
+        } else {
+            body.extend(iterator_next_value_stmts(ctx, iter_id, done_id, value_id));
+        }
+    }
+
+    let close_stmt = Stmt::Expr(runtime_iterator_call(
+        "iteratorCloseIfNotDone",
+        vec![Expr::LocalGet(iter_id), Expr::LocalGet(done_id)],
+    ));
+    let (exc_id, exc_name) = fresh_destruct_local(ctx, "destruct_error", Type::Any);
+    result.push(Stmt::Try {
+        body,
+        catch: Some(CatchClause {
+            param: Some((exc_id, exc_name)),
+            body: vec![
+                Stmt::Try {
+                    body: vec![close_stmt.clone()],
+                    catch: Some(CatchClause {
+                        param: None,
+                        body: Vec::new(),
+                    }),
+                    finally: None,
+                },
+                Stmt::Throw(Expr::LocalGet(exc_id)),
+            ],
+        }),
+        finally: None,
+    });
+    result.push(close_stmt);
+
+    Ok(result)
+}
+
+fn iterator_next_value_stmts(
+    ctx: &mut LoweringContext,
+    iter_id: LocalId,
+    done_id: LocalId,
+    value_id: LocalId,
+) -> Vec<Stmt> {
+    let (step_id, step_name) = fresh_destruct_local(ctx, "destruct_step", Type::Any);
+    let pull_next = vec![
+        Stmt::Let {
+            id: step_id,
+            name: step_name,
+            ty: Type::Any,
+            mutable: false,
+            init: Some(runtime_iterator_call(
+                "iteratorNextResult",
+                vec![Expr::LocalGet(iter_id)],
+            )),
+        },
+        Stmt::If {
+            condition: Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(step_id)),
+                property: "done".to_string(),
+            },
+            then_branch: vec![
+                Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))),
+                Stmt::Expr(Expr::LocalSet(value_id, Box::new(Expr::Undefined))),
+            ],
+            else_branch: Some(vec![Stmt::Expr(Expr::LocalSet(
+                value_id,
+                Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(step_id)),
+                    property: "value".to_string(),
+                }),
+            ))]),
+        },
+    ];
+
+    vec![Stmt::If {
+        condition: Expr::LocalGet(done_id),
+        then_branch: vec![Stmt::Expr(Expr::LocalSet(
+            value_id,
+            Box::new(Expr::Undefined),
+        ))],
+        else_branch: Some(pull_next),
+    }]
+}
+
+fn lower_object_assignment_from_expr(
+    ctx: &mut LoweringContext,
+    obj_pat: &ast::ObjectPat,
+    source: Expr,
+) -> Result<Vec<Stmt>> {
+    let mut result = Vec::new();
+
+    for prop in &obj_pat.props {
+        match prop {
+            ast::ObjectPatProp::KeyValue(kv) => {
+                let (key_prepare, get_value) =
+                    object_property_get_expr(ctx, &kv.key, source.clone())?;
+                result.extend(key_prepare);
+
+                let (prepare, target, default_value) = prepare_target_with_default(ctx, &kv.value)?;
+                result.extend(prepare);
+
+                let (value_id, value_name) = fresh_destruct_local(ctx, "destruct_value", Type::Any);
+                result.push(Stmt::Let {
+                    id: value_id,
+                    name: value_name,
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(get_value),
+                });
+                let assigned = value_with_default(ctx, Expr::LocalGet(value_id), default_value)?;
+                result.extend(assign_prepared_target(ctx, target, assigned)?);
+            }
+            ast::ObjectPatProp::Assign(assign) => {
+                let name = assign.key.sym.to_string();
+                let (value_id, value_name) = fresh_destruct_local(ctx, "destruct_value", Type::Any);
+                result.push(Stmt::Let {
+                    id: value_id,
+                    name: value_name,
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(Expr::PropertyGet {
+                        object: Box::new(source.clone()),
+                        property: name.clone(),
+                    }),
+                });
+
+                if let Some(id) = ctx.lookup_local(&name) {
+                    result.push(Stmt::Expr(Expr::LocalSet(
+                        id,
+                        Box::new(Expr::LocalGet(value_id)),
+                    )));
+                } else {
+                    return Err(anyhow!(
+                        "Assignment to undeclared variable in destructuring: {}",
+                        name
+                    ));
                 }
             }
-        }
-        ast::AssignTargetPat::Invalid(_) => {
-            return Err(anyhow!("Invalid assignment target pattern"));
+            ast::ObjectPatProp::Rest(_) => {}
         }
     }
 
     Ok(result)
 }
 
-/// Helper for nested destructuring - assigns from an already-computed local
-pub(crate) fn lower_destructuring_assignment_stmt_from_local(
+fn object_property_get_expr(
     ctx: &mut LoweringContext,
-    pat: &ast::AssignTargetPat,
-    source_id: LocalId,
-) -> Result<Vec<Stmt>> {
-    let mut result = Vec::new();
-
-    match pat {
-        ast::AssignTargetPat::Array(arr_pat) => {
-            for (idx, elem) in arr_pat.elems.iter().enumerate() {
-                if let Some(elem_pat) = elem {
-                    let index_expr = Expr::IndexGet {
-                        object: Box::new(Expr::LocalGet(source_id)),
-                        index: Box::new(Expr::Number(idx as f64)),
-                    };
-
-                    match elem_pat {
-                        ast::Pat::Ident(ident) => {
-                            let name = ident.id.sym.to_string();
-                            if let Some(id) = ctx.lookup_local(&name) {
-                                result.push(Stmt::Expr(Expr::LocalSet(id, Box::new(index_expr))));
-                            } else {
-                                return Err(anyhow!(
-                                    "Assignment to undeclared variable in destructuring: {}",
-                                    name
-                                ));
-                            }
-                        }
-                        ast::Pat::Array(nested_arr) => {
-                            let nested_tmp_id = ctx.fresh_local();
-                            let nested_tmp_name = format!("__destruct_{}", nested_tmp_id);
-                            ctx.locals
-                                .push((nested_tmp_name.clone(), nested_tmp_id, Type::Any));
-                            result.push(Stmt::Let {
-                                id: nested_tmp_id,
-                                name: nested_tmp_name,
-                                ty: Type::Any,
-                                mutable: false,
-                                init: Some(index_expr),
-                            });
-                            let nested_stmts = lower_destructuring_assignment_stmt_from_local(
-                                ctx,
-                                &ast::AssignTargetPat::Array(nested_arr.clone()),
-                                nested_tmp_id,
-                            )?;
-                            result.extend(nested_stmts);
-                        }
-                        ast::Pat::Object(nested_obj) => {
-                            let nested_tmp_id = ctx.fresh_local();
-                            let nested_tmp_name = format!("__destruct_{}", nested_tmp_id);
-                            ctx.locals
-                                .push((nested_tmp_name.clone(), nested_tmp_id, Type::Any));
-                            result.push(Stmt::Let {
-                                id: nested_tmp_id,
-                                name: nested_tmp_name,
-                                ty: Type::Any,
-                                mutable: false,
-                                init: Some(index_expr),
-                            });
-                            let nested_stmts = lower_destructuring_assignment_stmt_from_local(
-                                ctx,
-                                &ast::AssignTargetPat::Object(nested_obj.clone()),
-                                nested_tmp_id,
-                            )?;
-                            result.extend(nested_stmts);
-                        }
-                        ast::Pat::Expr(inner_expr) => match inner_expr.as_ref() {
-                            ast::Expr::Member(member) => {
-                                let object = Box::new(lower_expr(ctx, &member.obj)?);
-                                match &member.prop {
-                                    ast::MemberProp::Ident(prop_ident) => {
-                                        let property = prop_ident.sym.to_string();
-                                        result.push(Stmt::Expr(Expr::PropertySet {
-                                            object,
-                                            property,
-                                            value: Box::new(index_expr),
-                                        }));
-                                    }
-                                    ast::MemberProp::Computed(computed) => {
-                                        let index = Box::new(lower_expr(ctx, &computed.expr)?);
-                                        result.push(Stmt::Expr(Expr::IndexSet {
-                                            object,
-                                            index,
-                                            value: Box::new(index_expr),
-                                        }));
-                                    }
-                                    _ => {
-                                        return Err(anyhow!(
-                                                "Unsupported member expression in destructuring assignment"
-                                            ));
-                                    }
-                                }
-                            }
-                            _ => {
-                                return Err(anyhow!(
-                                    "Unsupported expression pattern in destructuring assignment"
-                                ));
-                            }
-                        },
-                        _ => {}
-                    }
-                }
-            }
+    key: &ast::PropName,
+    source: Expr,
+) -> Result<(Vec<Stmt>, Expr)> {
+    match key {
+        ast::PropName::Ident(ident) => Ok((
+            Vec::new(),
+            Expr::PropertyGet {
+                object: Box::new(source),
+                property: ident.sym.to_string(),
+            },
+        )),
+        ast::PropName::Str(s) => Ok((
+            Vec::new(),
+            Expr::PropertyGet {
+                object: Box::new(source),
+                property: s.value.as_str().unwrap_or("").to_string(),
+            },
+        )),
+        ast::PropName::Num(n) => Ok((
+            Vec::new(),
+            Expr::PropertyGet {
+                object: Box::new(source),
+                property: n.value.to_string(),
+            },
+        )),
+        ast::PropName::Computed(computed) => {
+            let key_expr = extern_call(
+                "js_object_literal_to_property_key",
+                vec![lower_expr(ctx, &computed.expr)?],
+            );
+            let (key_id, key_name) = fresh_destruct_local(ctx, "destruct_key", Type::Any);
+            Ok((
+                vec![Stmt::Let {
+                    id: key_id,
+                    name: key_name,
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(key_expr),
+                }],
+                Expr::IndexGet {
+                    object: Box::new(source),
+                    index: Box::new(Expr::LocalGet(key_id)),
+                },
+            ))
         }
-        ast::AssignTargetPat::Object(obj_pat) => {
-            for prop in &obj_pat.props {
-                match prop {
-                    ast::ObjectPatProp::KeyValue(kv) => {
-                        let key = match &kv.key {
-                            ast::PropName::Ident(ident) => ident.sym.to_string(),
-                            ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
-                            ast::PropName::Num(n) => n.value.to_string(),
-                            _ => continue,
-                        };
-
-                        let prop_expr = Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(source_id)),
-                            property: key,
-                        };
-
-                        match &*kv.value {
-                            ast::Pat::Ident(ident) => {
-                                let name = ident.id.sym.to_string();
-                                if let Some(id) = ctx.lookup_local(&name) {
-                                    result
-                                        .push(Stmt::Expr(Expr::LocalSet(id, Box::new(prop_expr))));
-                                } else {
-                                    return Err(anyhow!(
-                                        "Assignment to undeclared variable in destructuring: {}",
-                                        name
-                                    ));
-                                }
-                            }
-                            ast::Pat::Array(nested_arr) => {
-                                let nested_tmp_id = ctx.fresh_local();
-                                let nested_tmp_name = format!("__destruct_{}", nested_tmp_id);
-                                ctx.locals.push((
-                                    nested_tmp_name.clone(),
-                                    nested_tmp_id,
-                                    Type::Any,
-                                ));
-                                result.push(Stmt::Let {
-                                    id: nested_tmp_id,
-                                    name: nested_tmp_name,
-                                    ty: Type::Any,
-                                    mutable: false,
-                                    init: Some(prop_expr),
-                                });
-                                let nested_stmts = lower_destructuring_assignment_stmt_from_local(
-                                    ctx,
-                                    &ast::AssignTargetPat::Array(nested_arr.clone()),
-                                    nested_tmp_id,
-                                )?;
-                                result.extend(nested_stmts);
-                            }
-                            ast::Pat::Object(nested_obj) => {
-                                let nested_tmp_id = ctx.fresh_local();
-                                let nested_tmp_name = format!("__destruct_{}", nested_tmp_id);
-                                ctx.locals.push((
-                                    nested_tmp_name.clone(),
-                                    nested_tmp_id,
-                                    Type::Any,
-                                ));
-                                result.push(Stmt::Let {
-                                    id: nested_tmp_id,
-                                    name: nested_tmp_name,
-                                    ty: Type::Any,
-                                    mutable: false,
-                                    init: Some(prop_expr),
-                                });
-                                let nested_stmts = lower_destructuring_assignment_stmt_from_local(
-                                    ctx,
-                                    &ast::AssignTargetPat::Object(nested_obj.clone()),
-                                    nested_tmp_id,
-                                )?;
-                                result.extend(nested_stmts);
-                            }
-                            _ => {}
-                        }
-                    }
-                    ast::ObjectPatProp::Assign(assign) => {
-                        let name = assign.key.sym.to_string();
-                        let prop_expr = Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(source_id)),
-                            property: name.clone(),
-                        };
-
-                        if let Some(id) = ctx.lookup_local(&name) {
-                            result.push(Stmt::Expr(Expr::LocalSet(id, Box::new(prop_expr))));
-                        } else {
-                            return Err(anyhow!(
-                                "Assignment to undeclared variable in destructuring: {}",
-                                name
-                            ));
-                        }
-                    }
-                    ast::ObjectPatProp::Rest(_) => {}
-                }
-            }
-        }
-        ast::AssignTargetPat::Invalid(_) => {
-            return Err(anyhow!("Invalid assignment target pattern"));
-        }
+        _ => Ok((Vec::new(), Expr::Undefined)),
     }
+}
 
-    Ok(result)
+fn prepare_target_with_default(
+    ctx: &mut LoweringContext,
+    pat: &ast::Pat,
+) -> Result<(Vec<Stmt>, PreparedTarget, Option<Expr>)> {
+    if let ast::Pat::Assign(assign_pat) = pat {
+        let (prepare, target, _) = prepare_assignment_target(ctx, &assign_pat.left)?;
+        let default_value = lower_expr(ctx, &assign_pat.right)?;
+        return Ok((prepare, target, Some(default_value)));
+    }
+    let (prepare, target, default_value) = prepare_assignment_target(ctx, pat)?;
+    Ok((prepare, target, default_value))
+}
+
+fn prepare_assignment_target(
+    ctx: &mut LoweringContext,
+    pat: &ast::Pat,
+) -> Result<(Vec<Stmt>, PreparedTarget, Option<Expr>)> {
+    match pat {
+        ast::Pat::Ident(ident) => {
+            let name = ident.id.sym.to_string();
+            if let Some(id) = ctx.lookup_local(&name) {
+                Ok((Vec::new(), PreparedTarget::Local(id), None))
+            } else {
+                Err(anyhow!(
+                    "Assignment to undeclared variable in destructuring: {}",
+                    name
+                ))
+            }
+        }
+        ast::Pat::Array(nested_arr) => {
+            Ok((Vec::new(), PreparedTarget::Array(nested_arr.clone()), None))
+        }
+        ast::Pat::Object(nested_obj) => {
+            Ok((Vec::new(), PreparedTarget::Object(nested_obj.clone()), None))
+        }
+        ast::Pat::Expr(inner_expr) => match inner_expr.as_ref() {
+            ast::Expr::Member(member) => {
+                let mut prepare = Vec::new();
+                let (object_id, object_name) =
+                    fresh_destruct_local(ctx, "destruct_target", Type::Any);
+                prepare.push(Stmt::Let {
+                    id: object_id,
+                    name: object_name,
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(lower_expr(ctx, &member.obj)?),
+                });
+                match &member.prop {
+                    ast::MemberProp::Ident(prop_ident) => Ok((
+                        prepare,
+                        PreparedTarget::Property {
+                            object: Expr::LocalGet(object_id),
+                            property: prop_ident.sym.to_string(),
+                        },
+                        None,
+                    )),
+                    ast::MemberProp::Computed(computed) => {
+                        let (key_id, key_name) =
+                            fresh_destruct_local(ctx, "destruct_target_key", Type::Any);
+                        prepare.push(Stmt::Let {
+                            id: key_id,
+                            name: key_name,
+                            ty: Type::Any,
+                            mutable: false,
+                            init: Some(lower_expr(ctx, &computed.expr)?),
+                        });
+                        Ok((
+                            prepare,
+                            PreparedTarget::Index {
+                                object: Expr::LocalGet(object_id),
+                                index: Expr::LocalGet(key_id),
+                            },
+                            None,
+                        ))
+                    }
+                    _ => Err(anyhow!(
+                        "Unsupported member expression in destructuring assignment"
+                    )),
+                }
+            }
+            _ => Err(anyhow!(
+                "Unsupported expression pattern in destructuring assignment"
+            )),
+        },
+        ast::Pat::Rest(_) => Ok((Vec::new(), PreparedTarget::Skip, None)),
+        _ => Ok((Vec::new(), PreparedTarget::Skip, None)),
+    }
+}
+
+fn value_with_default(
+    _ctx: &mut LoweringContext,
+    value: Expr,
+    default_value: Option<Expr>,
+) -> Result<Expr> {
+    let Some(default_value) = default_value else {
+        return Ok(value);
+    };
+
+    Ok(Expr::Conditional {
+        condition: Box::new(Expr::IsUndefinedOrBareNan(Box::new(value.clone()))),
+        then_expr: Box::new(default_value),
+        else_expr: Box::new(value),
+    })
+}
+
+fn assign_prepared_target(
+    ctx: &mut LoweringContext,
+    target: PreparedTarget,
+    value: Expr,
+) -> Result<Vec<Stmt>> {
+    match target {
+        PreparedTarget::Local(id) => Ok(vec![Stmt::Expr(Expr::LocalSet(id, Box::new(value)))]),
+        PreparedTarget::Property { object, property } => Ok(vec![Stmt::Expr(Expr::PropertySet {
+            object: Box::new(object),
+            property,
+            value: Box::new(value),
+        })]),
+        PreparedTarget::Index { object, index } => {
+            let (value_id, value_name) = fresh_destruct_local(ctx, "destruct_assign", Type::Any);
+            let (key_id, key_name) = fresh_destruct_local(ctx, "destruct_property_key", Type::Any);
+            Ok(vec![
+                Stmt::Let {
+                    id: value_id,
+                    name: value_name,
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(value),
+                },
+                Stmt::Let {
+                    id: key_id,
+                    name: key_name,
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(extern_call(
+                        "js_object_literal_to_property_key",
+                        vec![index],
+                    )),
+                },
+                Stmt::Expr(Expr::IndexSet {
+                    object: Box::new(object),
+                    index: Box::new(Expr::LocalGet(key_id)),
+                    value: Box::new(Expr::LocalGet(value_id)),
+                }),
+            ])
+        }
+        PreparedTarget::Array(arr) => lower_array_assignment_from_expr(ctx, &arr, value),
+        PreparedTarget::Object(obj) => lower_object_assignment_from_expr(ctx, &obj, value),
+        PreparedTarget::Skip => Ok(Vec::new()),
+    }
 }

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1021,7 +1021,15 @@ pub(crate) fn lower_stmt(
                 .init
                 .extend(predeclare_implicit_assignment_targets(ctx, &expr_stmt.expr));
             // Check if this is a destructuring assignment that needs special handling
-            if let ast::Expr::Assign(assign) = expr_stmt.expr.as_ref() {
+            let maybe_assign = match expr_stmt.expr.as_ref() {
+                ast::Expr::Assign(assign) => Some(assign),
+                ast::Expr::Paren(paren) => match paren.expr.as_ref() {
+                    ast::Expr::Assign(assign) => Some(assign),
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(assign) = maybe_assign {
                 if let ast::AssignTarget::Pat(pat) = &assign.left {
                     // This is a destructuring assignment at statement level
                     // We can emit proper Let statements for temporaries

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -301,7 +301,15 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             }
 
             // Check if this is a destructuring assignment that needs special handling
-            if let ast::Expr::Assign(assign) = expr_stmt.expr.as_ref() {
+            let maybe_assign = match expr_stmt.expr.as_ref() {
+                ast::Expr::Assign(assign) => Some(assign),
+                ast::Expr::Paren(paren) => match paren.expr.as_ref() {
+                    ast::Expr::Assign(assign) => Some(assign),
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(assign) = maybe_assign {
                 if let ast::AssignTarget::Pat(pat) = &assign.left {
                     // This is a destructuring assignment at statement level
                     // We can emit proper Let statements for temporaries

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -291,6 +291,67 @@ pub extern "C" fn js_array_spread_append(dest: *mut ArrayHeader, source: f64) ->
     js_array_concat(dest, arr)
 }
 
+fn is_object_like_value(value: f64) -> bool {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        let bits = value.to_bits();
+        return bits != 0
+            && bits <= 0x0000_FFFF_FFFF_FFFF
+            && bits > 0x10000
+            && crate::closure::is_closure_ptr(bits as usize);
+    }
+    let raw = crate::value::js_nanbox_get_pointer(value) as usize;
+    raw >= 0x10000 && !crate::symbol::is_registered_symbol(raw)
+}
+
+#[cold]
+fn throw_iterator_result_not_object() -> ! {
+    let msg = b"Iterator result is not an object";
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_str);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// `IteratorNext(iterator)` for assignment destructuring lowering.
+#[no_mangle]
+pub extern "C" fn js_iterator_next_result(iter_f64: f64) -> f64 {
+    let next = named_field(iter_f64, b"next");
+    if !is_callable_value(next) {
+        crate::closure::throw_not_callable();
+    }
+    let prev_this = crate::object::js_implicit_this_set(iter_f64);
+    let result = unsafe { crate::closure::js_native_call_value(next, std::ptr::null(), 0) };
+    crate::object::js_implicit_this_set(prev_this);
+    if !is_object_like_value(result) {
+        throw_iterator_result_not_object();
+    }
+    result
+}
+
+/// `IteratorClose(iterator)` when destructuring exits before the iterator is done.
+#[no_mangle]
+pub extern "C" fn js_iterator_close_if_not_done(iter_f64: f64, done_f64: f64) -> f64 {
+    if crate::value::js_is_truthy(done_f64) != 0 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+
+    let ret = named_field(iter_f64, b"return");
+    if ret.to_bits() == crate::value::TAG_UNDEFINED {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    if !is_callable_value(ret) {
+        crate::closure::throw_not_callable();
+    }
+
+    let prev_this = crate::object::js_implicit_this_set(iter_f64);
+    let result = unsafe { crate::closure::js_native_call_value(ret, std::ptr::null(), 0) };
+    crate::object::js_implicit_this_set(prev_this);
+    if !is_object_like_value(result) {
+        throw_iterator_result_not_object();
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
 /// Issue #1572 — node:stream uses this from `node_stream::ns_iter_flat_map`
 /// to drive an async-iterable mapper result (an `async function*` return
 /// value) without re-deriving the `Symbol.asyncIterator` lookup +

--- a/reference/deepwiki/destructuring-iterator-boa.md
+++ b/reference/deepwiki/destructuring-iterator-boa.md
@@ -1,0 +1,473 @@
+# DeepWiki Response
+
+Repository: `boa-dev/boa`
+Question: For ECMAScript destructuring assignment, how does this implementation handle IteratorClose and target evaluation order? Please focus on array/object assignment destructuring, abrupt completions from target evaluation or assignment, iterator.return error precedence, and cite the relevant implementation files/functions.
+Search: https://deepwiki.com/search/for-ecmascript-destructuring-a_de3b0406-4212-4765-a674-2751d8623fb1
+
+**Question**: For ECMAScript destructuring assignment, how does this implementation handle IteratorClose and target evaluation order? Please focus on array/object assignment destructuring, abrupt completions from target evaluation or assignment, iterator.return error precedence, and cite the relevant implementation files/functions.
+
+# ECMAScript Destructuring Assignment: IteratorClose and Target Evaluation Order
+
+This implementation handles destructuring assignment through bytecode compilation with careful attention to iterator cleanup and evaluation order. The key mechanisms are in the bytecompiler and iterator handling code.
+
+## Array Destructuring: Iterator Management and IteratorClose [1](#ref-q1-1)
+
+For array patterns, the compiler emits `emit_get_iterator` to obtain an iterator, then processes each element. Critically, it uses exception handlers to ensure `IteratorClose` is called on abrupt completions:
+
+1. **Normal path**: Elements are processed via `compile_array_pattern_element`
+2. **Exception handler**: If any element throws, the handler at line 248 catches it, then calls `iterator_close(false)` at line 256 to clean up the iterator
+3. **Final cleanup**: After normal completion, `iterator_close(false)` is called again at line 270
+
+The `iterator_close` function itself is implemented in [2](#ref-q1-2) . It:
+- Calls `emit_iterator_return` to invoke the iterator's `return` method
+- Checks if the result is an object (lines 34-35)
+- Throws a TypeError if the result is not an object (line 42)
+
+This ensures that **iterator.return errors take precedence** over the original completion, as the error from `iterator_return` is what gets thrown if it fails.
+
+## Target Evaluation Order in Array Patterns [3](#ref-q1-3)
+
+Each array pattern element is compiled in sequence. For example:
+- **SingleName** (line 287-308): Calls `emit_iterator_next`, checks `done`, extracts value, applies default initializer, then binds
+- **PropertyAccess** (line 309-332): Uses `access_set` to evaluate the target location, then assigns the iterator value
+- **Pattern** (line 334-354): Recursively compiles nested patterns
+
+The key insight is that **target evaluation happens after iterator value extraction**. For instance, in `PropertyAccess`, the target property access is evaluated within `access_set` (line 314), which occurs after the iterator value is obtained (line 315).
+
+## Object Destructuring: Property Evaluation Order [4](#ref-q1-4)
+
+For object patterns, the implementation:
+1. Evaluates the source object (line 155)
+2. For each property, evaluates the property name (lines 206-220)
+3. Gets the property value (line 207 or 212-217)
+4. Applies default initializers (lines 222-226)
+5. Recursively compiles nested patterns (line 227)
+
+Notably, **property names are evaluated in order** before any assignments occur. This matches the spec requirement that all property keys are evaluated before side effects from assignments.
+
+## Abrupt Completions and IteratorClose Precedence
+
+The implementation uses the `if_abrupt_close_iterator!` macro throughout. In [5](#ref-q1-5) , the `if_abrupt_close_iterator` method shows the pattern:
+
+When an abrupt completion occurs during element processing, `IteratorClose` is invoked with that error. The spec semantics are preserved: **if `iterator.return()` throws, that error replaces the original error**.
+
+This is visible in [6](#ref-q1-6) , the `close` method:
+- Line 614: Gets the `return` method
+- Lines 617-637: If getting `return` throws, that error is returned (line 635)
+- Lines 640-643: If calling `return` throws, that error is returned (line 643)
+- Line 647: Only if both succeed does the original completion return
+
+## Assignment Expression Destructuring [7](#ref-q1-7)
+
+For assignment expressions (not declarations), the compiler:
+1. Evaluates the RHS (line 27)
+2. Calls `compile_declaration_pattern` with `BindingOpcode::SetName` (line 28)
+
+This reuses the same pattern compilation logic, ensuring consistent IteratorClose behavior across both binding and assignment contexts.
+
+## Notes
+
+The implementation correctly prioritizes iterator.return errors over original completion errors through the exception handling structure in `iterator_close`. The evaluation order is strictly left-to-right for property names in objects and element-by-element for arrays, with iterator cleanup guaranteed via exception handlers. The CHANGELOG entry at line 437 ("Fix evaluation order in destructive property assignments") confirms this was a deliberate fix to match spec semantics.
+
+
+
+Wiki pages you might want to explore:
+- [Architecture (boa-dev/boa)](/wiki/boa-dev/boa#1.1)
+- [Standard Builtins (boa-dev/boa)](/wiki/boa-dev/boa#3.1)
+- [Async, Generators & Promises (boa-dev/boa)](/wiki/boa-dev/boa#3.4)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-ecmascript-destructuring-a_de3b0406-4212-4765-a674-2751d8623fb1
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `core/engine/src/bytecompiler/declaration/declaration_pattern.rs:237-271`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/declaration/declaration_pattern.rs#L237-L271)
+
+```rust
+            Pattern::Array(pattern) => {
+                self.bytecode
+                    .emit_value_not_null_or_undefined(object.variable());
+                self.bytecode.emit_get_iterator(object.variable());
+
+                let handler_index = self.push_handler();
+                for element in pattern.bindings() {
+                    self.compile_array_pattern_element(element, def);
+                }
+
+                let no_exception_thrown = self.jump();
+                self.patch_handler(handler_index);
+
+                let has_exception = self.register_allocator.alloc();
+                let exception = self.register_allocator.alloc();
+                self.bytecode
+                    .emit_maybe_exception(has_exception.variable(), exception.variable());
+
+                let iterator_close_handler = self.push_handler();
+                self.iterator_close(false);
+                self.patch_handler(iterator_close_handler);
+
+                let jump = self.jump_if_false(&has_exception);
+                self.register_allocator.dealloc(has_exception);
+
+                self.bytecode.emit_throw(exception.variable());
+                self.register_allocator.dealloc(exception);
+
+                self.patch_jump(jump);
+                self.bytecode.emit_re_throw();
+
+                self.patch_jump(no_exception_thrown);
+
+                self.iterator_close(false);
+            }
+```
+
+<a id="ref-q1-2"></a>
+### [2] `core/engine/src/bytecompiler/utils.rs:15-46`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/utils.rs#L15-L46)
+
+```rust
+    pub(super) fn iterator_close(&mut self, async_: bool) {
+        let value = self.register_allocator.alloc();
+        let called = self.register_allocator.alloc();
+        self.bytecode
+            .emit_iterator_return(value.variable(), called.variable());
+
+        // `iterator` didn't have a `return` method, is already done or is not on the iterator stack.
+        let early_exit = self.jump_if_false(&called);
+        self.register_allocator.dealloc(called);
+
+        if async_ {
+            self.bytecode.emit_await(value.variable());
+            let resume_kind = self.register_allocator.alloc();
+            self.pop_into_register(&resume_kind);
+            self.pop_into_register(&value);
+            self.generator_next(&value, &resume_kind);
+            self.register_allocator.dealloc(resume_kind);
+        }
+
+        self.bytecode.emit_is_object(value.variable());
+        let skip_throw = self.jump_if_true(&value);
+
+        self.register_allocator.dealloc(value);
+
+        let error_msg = self.get_or_insert_literal(Literal::String(js_string!(
+            "inner result was not an object"
+        )));
+        self.bytecode.emit_throw_new_type_error(error_msg.into());
+
+        self.patch_jump(skip_throw);
+        self.patch_jump(early_exit);
+    }
+```
+
+<a id="ref-q1-3"></a>
+### [3] `core/engine/src/bytecompiler/declaration/declaration_pattern.rs:275-378`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/declaration/declaration_pattern.rs#L275-L378)
+
+```rust
+    fn compile_array_pattern_element(&mut self, element: &ArrayPatternElement, def: BindingOpcode) {
+        use ArrayPatternElement::{
+            Elision, Pattern, PatternRest, PropertyAccess, PropertyAccessRest, SingleName,
+            SingleNameRest,
+        };
+
+        match element {
+            // ArrayBindingPattern : [ Elision ]
+            Elision => {
+                self.bytecode.emit_iterator_next();
+            }
+            // SingleNameBinding : BindingIdentifier Initializer[opt]
+            SingleName {
+                ident,
+                default_init,
+            } => {
+                self.bytecode.emit_iterator_next();
+                let value = self.register_allocator.alloc();
+                self.bytecode.emit_iterator_done(value.variable());
+                self.if_else(
+                    &value,
+                    |compiler| compiler.bytecode.emit_store_undefined(value.variable()),
+                    |compiler| compiler.bytecode.emit_iterator_value(value.variable()),
+                );
+
+                if let Some(init) = default_init {
+                    let skip = self.jump_if_not_undefined(&value);
+                    self.compile_expr(init, &value);
+                    self.patch_jump(skip);
+                }
+
+                self.emit_binding(def, ident.to_js_string(self.interner()), &value);
+                self.register_allocator.dealloc(value);
+            }
+            PropertyAccess {
+                access,
+                default_init,
+            } => {
+                let value = self.register_allocator.alloc();
+                self.access_set(Access::Property { access }, |compiler| {
+                    compiler.bytecode.emit_iterator_next();
+                    compiler.bytecode.emit_iterator_done(value.variable());
+                    compiler.if_else(
+                        &value,
+                        |compiler| compiler.bytecode.emit_store_undefined(value.variable()),
+                        |compiler| compiler.bytecode.emit_iterator_value(value.variable()),
+                    );
+
+                    if let Some(init) = default_init {
+                        let skip = compiler.jump_if_not_undefined(&value);
+                        compiler.compile_expr(init, &value);
+                        compiler.patch_jump(skip);
+                    }
+
+                    &value
+                });
+                self.register_allocator.dealloc(value);
+            }
+            // BindingElement : BindingPattern Initializer[opt]
+            Pattern {
+                pattern,
+                default_init,
+            } => {
+                self.bytecode.emit_iterator_next();
+                let value = self.register_allocator.alloc();
+                self.bytecode.emit_iterator_done(value.variable());
+                self.if_else(
+                    &value,
+                    |compiler| compiler.bytecode.emit_store_undefined(value.variable()),
+                    |compiler| compiler.bytecode.emit_iterator_value(value.variable()),
+                );
+
+                if let Some(init) = default_init {
+                    let skip = self.jump_if_not_undefined(&value);
+                    self.compile_expr(init, &value);
+                    self.patch_jump(skip);
+                }
+                self.compile_declaration_pattern(pattern, def, &value);
+                self.register_allocator.dealloc(value);
+            }
+            // BindingRestElement : ... BindingIdentifier
+            SingleNameRest { ident } => {
+                let value = self.register_allocator.alloc();
+                self.bytecode.emit_iterator_to_array(value.variable());
+                self.emit_binding(def, ident.to_js_string(self.interner()), &value);
+                self.register_allocator.dealloc(value);
+            }
+            PropertyAccessRest { access } => {
+                let value = self.register_allocator.alloc();
+                self.access_set(Access::Property { access }, |compiler| {
+                    compiler.bytecode.emit_iterator_to_array(value.variable());
+                    &value
+                });
+                self.register_allocator.dealloc(value);
+            }
+            // BindingRestElement : ... BindingPattern
+            PatternRest { pattern } => {
+                let value = self.register_allocator.alloc();
+                self.bytecode.emit_iterator_to_array(value.variable());
+                self.compile_declaration_pattern(pattern, def, &value);
+                self.register_allocator.dealloc(value);
+            }
+        }
+    }
+```
+
+<a id="ref-q1-4"></a>
+### [4] `core/engine/src/bytecompiler/declaration/declaration_pattern.rs:155-236`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/declaration/declaration_pattern.rs#L155-L236)
+
+```rust
+                                |compiler: &mut ByteCompiler<'_>| {
+                                    match name {
+                                        PropertyName::Literal(ident) => {
+                                            compiler.emit_get_property_by_name(
+                                                &dst,
+                                                None,
+                                                object,
+                                                ident.sym(),
+                                            );
+                                            compiler.register_allocator.dealloc(key);
+                                        }
+                                        PropertyName::Computed(_) => {
+                                            if rest_exits {
+                                                compiler.bytecode.emit_get_property_by_value_push(
+                                                    dst.variable(),
+                                                    key.variable(),
+                                                    object.variable(),
+                                                    object.variable(),
+                                                );
+                                                excluded_keys_registers.push(key);
+                                            } else {
+                                                compiler.bytecode.emit_get_property_by_value(
+                                                    dst.variable(),
+                                                    key.variable(),
+                                                    object.variable(),
+                                                    object.variable(),
+                                                );
+                                                compiler.register_allocator.dealloc(key);
+                                            }
+                                        }
+                                    }
+
+                                    if let Some(init) = default_init {
+                                        let skip = compiler.jump_if_not_undefined(&dst);
+                                        compiler.compile_expr(init, &dst);
+                                        compiler.patch_jump(skip);
+                                    }
+
+                                    &dst
+                                },
+                            );
+                            self.register_allocator.dealloc(dst);
+                        }
+                        Pattern {
+                            name,
+                            pattern,
+                            default_init,
+                        } => {
+                            let dst = self.register_allocator.alloc();
+
+                            match name {
+                                PropertyName::Literal(ident) => {
+                                    self.emit_get_property_by_name(&dst, None, object, ident.sym());
+                                }
+                                PropertyName::Computed(node) => {
+                                    let key = self.register_allocator.alloc();
+                                    self.compile_expr(node, &key);
+                                    self.bytecode.emit_get_property_by_value(
+                                        dst.variable(),
+                                        key.variable(),
+                                        object.variable(),
+                                        object.variable(),
+                                    );
+                                    self.register_allocator.dealloc(key);
+                                }
+                            }
+
+                            if let Some(init) = default_init {
+                                let skip = self.jump_if_not_undefined(&dst);
+                                self.compile_expr(init, &dst);
+                                self.patch_jump(skip);
+                            }
+                            self.compile_declaration_pattern(pattern, def, &dst);
+                            self.register_allocator.dealloc(dst);
+                        }
+                    }
+                }
+
+                while let Some(r) = excluded_keys_registers.pop() {
+                    self.register_allocator.dealloc(r);
+                }
+            }
+```
+
+<a id="ref-q1-5"></a>
+### [5] `core/engine/src/builtins/iterable/mod.rs:570-590`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/iterable/mod.rs#L570-L590)
+
+```rust
+    /// [`IfAbruptCloseIterator( value, iteratorRecord )`][spec], but
+    /// adapted to be used inside `NativeCoroutine`.
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-ifabruptcloseiterator
+    pub(crate) fn if_abrupt_close_iterator(
+        &self,
+        completion: CompletionRecord,
+        context: &mut Context,
+    ) -> CoroutineState {
+        // 1. Assert: value is a Completion Record.
+        // 2. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+        // 3. Set value to ! value.
+        match completion {
+            CompletionRecord::Return(value) => {
+                self.close(Ok(value), context).branch()?;
+                CoroutineState::Break(Ok(()))
+            }
+            CompletionRecord::Throw(err) => self.close(Err(err), context).branch(),
+            CompletionRecord::Normal(value) => CoroutineState::Continue(value),
+        }
+    }
+```
+
+<a id="ref-q1-6"></a>
+### [6] `core/engine/src/builtins/iterable/mod.rs:603-654`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/iterable/mod.rs#L603-L654)
+
+```rust
+    pub(crate) fn close(
+        &self,
+        completion: JsResult<JsValue>,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Assert: Type(iteratorRecord.[[Iterator]]) is Object.
+
+        // 2. Let iterator be iteratorRecord.[[Iterator]].
+        let iterator = &self.iterator;
+
+        // 3. Let innerResult be Completion(GetMethod(iterator, "return")).
+        let inner_result = iterator.get_method(js_string!("return"), context);
+
+        // 4. If innerResult.[[Type]] is normal, then
+        let inner_result = match inner_result {
+            Ok(inner_result) => {
+                // a. Let return be innerResult.[[Value]].
+                let r#return = inner_result;
+
+                if let Some(r#return) = r#return {
+                    // c. Set innerResult to Completion(Call(return, iterator)).
+                    r#return.call(&iterator.clone().into(), &[], context)
+                } else {
+                    // b. If return is undefined, return ? completion.
+                    return completion;
+                }
+            }
+            Err(inner_result) => {
+                // 5. If completion.[[Type]] is throw, return ? completion.
+                completion?;
+
+                // 6. If innerResult.[[Type]] is throw, return ? innerResult.
+                return Err(inner_result);
+            }
+        };
+
+        // 5. If completion.[[Type]] is throw, return ? completion.
+        let completion = completion?;
+
+        // 6. If innerResult.[[Type]] is throw, return ? innerResult.
+        let inner_result = inner_result?;
+
+        if inner_result.is_object() {
+            // 8. Return ? completion.
+            Ok(completion)
+        } else {
+            // 7. If Type(innerResult.[[Value]]) is not Object, throw a TypeError exception.
+            Err(JsNativeError::typ()
+                .with_message("inner result was not an object")
+                .into())
+        }
+    }
+```
+
+<a id="ref-q1-7"></a>
+### [7] `core/engine/src/bytecompiler/expression/assign.rs:14-30`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/expression/assign.rs#L14-L30)
+
+```rust
+impl ByteCompiler<'_> {
+    pub(crate) fn compile_assign(&mut self, assign: &Assign, dst: &Register) {
+        let mut compiler = self.position_guard(assign);
+
+        if assign.op() == AssignOp::Assign {
+            match Access::from_assign_target(assign.lhs()) {
+                Ok(access) => {
+                    compiler.access_set(access, |compiler| {
+                        compiler.compile_expr(assign.rhs(), dst);
+                        dst
+                    });
+                }
+                Err(pattern) => {
+                    compiler.compile_expr(assign.rhs(), dst);
+                    compiler.compile_declaration_pattern(pattern, BindingOpcode::SetName, dst);
+                }
+            }
+```

--- a/reference/deepwiki/destructuring-iterator-engine262.md
+++ b/reference/deepwiki/destructuring-iterator-engine262.md
@@ -1,0 +1,253 @@
+# DeepWiki Response
+
+Repository: `engine262/engine262`
+Question: For ECMAScript destructuring assignment, how does this implementation handle IteratorClose and target evaluation order? Please focus on array/object assignment destructuring, abrupt completions from target evaluation or assignment, iterator.return error precedence, and cite the relevant implementation files/functions.
+Search: https://deepwiki.com/search/for-ecmascript-destructuring-a_07f50f08-1a0b-40c8-9418-c3289a38e7e4
+
+**Question**: For ECMAScript destructuring assignment, how does this implementation handle IteratorClose and target evaluation order? Please focus on array/object assignment destructuring, abrupt completions from target evaluation or assignment, iterator.return error precedence, and cite the relevant implementation files/functions.
+
+This implementation handles `IteratorClose` and target evaluation order in ECMAScript destructuring assignments by using specific macros and abstract operations to manage abrupt completions and ensure proper iterator cleanup. The core mechanisms involve the `Q` macro for propagating abrupt completions, and `IfAbruptCloseIterator` for handling iterator closing when an abrupt completion occurs during iteration or target evaluation.
+
+### IteratorClose and Abrupt Completions
+
+The `IteratorClose` abstract operation is crucial for ensuring that iterators are properly closed, especially when an abrupt completion (like an error) occurs during iteration [1](#ref-q1-1) . When an abrupt completion `completion` is passed to `IteratorClose`, the `completion` is returned directly, prioritizing the original abrupt completion [2](#ref-q1-2) . If the `iterator.return` method itself throws an error, that error takes precedence and is returned [3](#ref-q1-3) .
+
+The `IfAbruptCloseIterator` macro is used to integrate this behavior into various operations that consume iterators [4](#ref-q1-4) . This macro checks if a `value` is an `AbruptCompletion`. If it is, `IteratorClose` is called with the `iteratorRecord` and the `AbruptCompletion`, and the result is returned [5](#ref-q1-5) . This ensures that if any step in the destructuring process results in an abrupt completion, the iterator is closed before propagating the error.
+
+### Target Evaluation Order and Abrupt Completions
+
+Destructuring assignments, particularly for arrays and objects, involve evaluating assignment targets. The `engine262` implementation uses a macro system to handle abrupt completions during these evaluations. The `Q` macro (short for `ReturnIfAbrupt`) is a fundamental mechanism for propagating abrupt completions [6](#ref-q1-6) . If an expression evaluated using `Q` results in an `AbruptCompletion`, that completion is immediately returned, effectively short-circuiting further evaluation [7](#ref-q1-7) .
+
+For example, in `Array.from`, when iterating over items, `IteratorStepValue` is called using `Q` [8](#ref-q1-8) . If `IteratorStepValue` produces an abrupt completion, the `Q` macro will cause it to be returned. Subsequently, `IfAbruptCloseIterator` is used to ensure the iterator is closed if a mapped value results in an abrupt completion [9](#ref-q1-9) .
+
+The `X` macro is similar to `Q` but asserts that the completion must be normal; if it's an `AbruptCompletion`, it throws an `Assert.Error` [10](#ref-q1-10) . This is used in scenarios where an abrupt completion at that point would indicate an internal engine error rather than a recoverable JavaScript error [11](#ref-q1-11) .
+
+### Array and Object Assignment Destructuring
+
+The parsing of array and object assignment patterns is defined in `src/parser/ParseNode.mts` [12](#ref-q1-12) . These definitions include `ObjectAssignmentPattern`, `ArrayAssignmentPattern`, `AssignmentProperty`, `AssignmentElement`, and `AssignmentRestProperty`. The runtime semantics for these are handled by operations like `DestructuringAssignmentEvaluation` [13](#ref-q1-13) .
+
+The evaluation order for destructuring assignments generally follows the order of elements in the pattern. Each element's evaluation can potentially lead to an abrupt completion, which would then be propagated by the `Q` macro, and iterators would be closed via `IfAbruptCloseIterator` if applicable.
+
+### Iterator.return Error Precedence
+
+The `IteratorClose` abstract operation explicitly defines the precedence of errors [1](#ref-q1-1) . If the `completion` argument passed to `IteratorClose` is an `AbruptCompletion`, that completion is preserved and returned [2](#ref-q1-2) . However, if the `iterator.return` method itself throws an error, that new error takes precedence and is returned instead [3](#ref-q1-3) . This ensures that errors originating from the iterator's cleanup process are not silently discarded.
+
+## Notes
+
+The provided context primarily focuses on the internal mechanisms for handling completions and iterator operations. While `src/parser/ParseNode.mts` [12](#ref-q1-12)  and `src/parser/ExpressionParser.mts` [14](#ref-q1-14)  define the structure and validation of destructuring patterns, the detailed runtime semantics for how each part of a destructuring assignment is evaluated and how errors are propagated during that evaluation are handled by the abstract operations and macros described. The specific implementation of `DestructuringAssignmentEvaluation` was not provided in the snippets, but its presence in `src/runtime-semantics/all.mts` [13](#ref-q1-13)  indicates where these detailed semantics would reside.
+
+Wiki pages you might want to explore:
+- [Core Architecture (engine262/engine262)](/wiki/engine262/engine262#3)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-ecmascript-destructuring-a_07f50f08-1a0b-40c8-9418-c3289a38e7e4
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `src/abstract-ops/iterator-operations.mts:185-207`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/iterator-operations.mts#L185-L207)
+
+```
+/** https://tc39.es/ecma262/#sec-iteratorclose */
+export function* IteratorClose<T, C extends Completion<T>>(iteratorRecord: IteratorRecord, completion: C): Evaluator<C | ThrowCompletion> {
+  Assert(iteratorRecord.Iterator instanceof ObjectValue);
+  const iterator = iteratorRecord.Iterator;
+  let innerResult: ValueCompletion = EnsureCompletion(yield* GetMethod(iterator, Value('return')));
+  if (innerResult instanceof NormalCompletion) {
+    const ret = innerResult.Value;
+    if (ret === Value.undefined) {
+      return completion;
+    }
+    innerResult = EnsureCompletion(yield* Call(ret, iterator));
+  }
+  if (completion instanceof ThrowCompletion) {
+    return completion;
+  }
+  if (innerResult instanceof ThrowCompletion) {
+    return innerResult;
+  }
+  if (!(innerResult.Value instanceof ObjectValue)) {
+    return surroundingAgent.Throw('TypeError', 'NotAnObject', innerResult.Value);
+  }
+  return completion;
+}
+```
+
+<a id="ref-q1-2"></a>
+### [2] `src/abstract-ops/iterator-operations.mts:197-199`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/iterator-operations.mts#L197-L199)
+
+```
+  if (completion instanceof ThrowCompletion) {
+    return completion;
+  }
+```
+
+<a id="ref-q1-3"></a>
+### [3] `src/abstract-ops/iterator-operations.mts:200-202`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/iterator-operations.mts#L200-L202)
+
+```
+  if (innerResult instanceof ThrowCompletion) {
+    return innerResult;
+  }
+```
+
+<a id="ref-q1-4"></a>
+### [4] `scripts/transform.mts:156-165`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/scripts/transform.mts#L156-L165)
+
+```
+    IfAbruptCloseIterator: {
+      template: template(`
+      /* IfAbruptCloseIterator */
+      /* node:coverage ignore next */
+      if (%%value%% instanceof AbruptCompletion) return skipDebugger(IteratorClose(%%iteratorRecord%%, %%value%%));
+      /* node:coverage ignore next */
+      if (%%value%% instanceof Completion) %%value%% = %%value%%.Value;
+      `, { preserveComments: true }),
+      imports: ['IteratorClose', 'AbruptCompletion', 'Completion', 'skipDebugger'],
+    },
+```
+
+<a id="ref-q1-5"></a>
+### [5] `scripts/transform.mts:159-160`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/scripts/transform.mts#L159-L160)
+
+```
+      /* node:coverage ignore next */
+      if (%%value%% instanceof AbruptCompletion) return skipDebugger(IteratorClose(%%iteratorRecord%%, %%value%%));
+```
+
+<a id="ref-q1-6"></a>
+### [6] `scripts/transform.mts:136-145`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/scripts/transform.mts#L136-L145)
+
+```
+    Q: {
+      template: template(`
+      /* ReturnIfAbrupt */
+      %%checkYieldStar%%
+      /* node:coverage ignore next */ if (%%value%% instanceof AbruptCompletion) return %%value%%;
+      /* node:coverage ignore next */ if (%%value%% instanceof Completion) %%value%% = %%value%%.Value;
+      `, { preserveComments: true }),
+      imports: ['AbruptCompletion', 'Completion', 'Assert'],
+      allowAnyExpression: true,
+    },
+```
+
+<a id="ref-q1-7"></a>
+### [7] `scripts/transform.mts:139-140`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/scripts/transform.mts#L139-L140)
+
+```
+      %%checkYieldStar%%
+      /* node:coverage ignore next */ if (%%value%% instanceof AbruptCompletion) return %%value%%;
+```
+
+<a id="ref-q1-8"></a>
+### [8] `src/intrinsics/Array.mts:141`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/Array.mts#L141)
+
+```
+      const next = Q(yield* IteratorStepValue(iteratorRecord));
+```
+
+<a id="ref-q1-9"></a>
+### [9] `src/intrinsics/Array.mts:148-149`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/intrinsics/Array.mts#L148-L149)
+
+```
+        mappedValue = yield* Call(mapper, thisArg, [next, F(k)]);
+        IfAbruptCloseIterator(mappedValue, iteratorRecord);
+```
+
+<a id="ref-q1-10"></a>
+### [10] `scripts/transform.mts:146-155`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/scripts/transform.mts#L146-L155)
+
+```
+    X: {
+      template: template(`
+      /* X */
+      %%checkYieldStar%%
+      /* node:coverage ignore next */ if (%%value%% instanceof AbruptCompletion) throw new Assert.Error(%%source%%, { cause: %%value%% });
+      /* node:coverage ignore next */ if (%%value%% instanceof Completion) %%value%% = %%value%%.Value;
+      `, { preserveComments: true }),
+      imports: ['Assert', 'Completion', 'AbruptCompletion', 'skipDebugger'],
+      allowAnyExpression: true,
+    },
+```
+
+<a id="ref-q1-11"></a>
+### [11] `src/completion.mts:359-360`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/completion.mts#L359-L360)
+
+```
+  /* node:coverage ignore next */
+  throw new Assert.Error('Unexpected AbruptCompletion.', { cause: c });
+```
+
+<a id="ref-q1-12"></a>
+### [12] `src/parser/ParseNode.mts:2180-2210`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/parser/ParseNode.mts#L2180-L2210)
+
+```
+  export type AssignmentPattern = ObjectAssignmentPattern | ArrayAssignmentPattern | AssignmentProperty | AssignmentElement | ParseNode.Elision;
+  export type ObjectAssignmentPattern = {
+    type: 'ObjectAssignmentPattern';
+    AssignmentPropertyList: (AssignmentProperty | AssignmentPattern)[];
+    AssignmentRestProperty: AssignmentRestProperty | undefined;
+  }
+  export type AssignmentProperty = {
+    type: 'AssignmentProperty';
+    IdentifierReference: ParseNode.IdentifierReference;
+    Initializer?: ParseNode.Initializer | null | undefined;
+  } | {
+    type: 'AssignmentProperty';
+    PropertyName: ParseNode.PropertyNameLike | null;
+    AssignmentElement: AssignmentElement;
+  }
+  export type AssignmentElement = {
+    type: 'AssignmentElement';
+    DestructuringAssignmentTarget: ParseNode.AssignmentExpressionOrHigher;
+    Initializer: ParseNode.Initializer | undefined | null;
+  }
+
+  export type ArrayAssignmentPattern = {
+    type: 'ArrayAssignmentPattern';
+    AssignmentElementList: AssignmentElisionElement[];
+    AssignmentRestElement: AssignmentRestElement | undefined;
+  }
+  export type AssignmentElisionElement = ParseNode.Elision | AssignmentElement | AssignmentPattern;
+  export type AssignmentRestProperty = {
+    type: 'AssignmentRestProperty';
+    DestructuringAssignmentTarget: ParseNode.AssignmentExpressionOrHigher;
+  }
+```
+
+<a id="ref-q1-13"></a>
+### [13] `src/runtime-semantics/all.mts:97`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/runtime-semantics/all.mts#L97)
+
+```
+export * from './DestructuringAssignmentEvaluation.mts';
+```
+
+<a id="ref-q1-14"></a>
+### [14] `src/parser/ExpressionParser.mts:170-180`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/parser/ExpressionParser.mts#L170-L180)
+
+```
+        node.ElementList.forEach((p, i) => {
+          if (p.type === 'SpreadElement' && (i !== node.ElementList.length - 1 || node.hasTrailingComma)) {
+            this.raiseEarly('InvalidAssignmentTarget', p);
+          }
+          if (p.type === 'AssignmentExpression') {
+            this.validateAssignmentTarget(p.LeftHandSideExpression);
+          } else {
+            this.validateAssignmentTarget(p);
+          }
+        });
+        return;
+```

--- a/reference/deepwiki/destructuring-iterator.md
+++ b/reference/deepwiki/destructuring-iterator.md
@@ -1,0 +1,22 @@
+# Destructuring Iterator Reference Findings
+
+DeepWiki raw responses:
+
+- `reference/deepwiki/destructuring-iterator-engine262.md`
+- `reference/deepwiki/destructuring-iterator-boa.md`
+
+Implementation notes used for the Perry change:
+
+- Array assignment destructuring must evaluate the assignment reference before
+  consuming the iterator value, then perform `PutValue` after the value/default
+  is resolved.
+- Object assignment destructuring evaluates the property name first, then the
+  assignment reference, then `GetV(source, key)`, then `PutValue`.
+- Array destructuring owns an iterator record. If a target assignment or default
+  initializer completes abruptly while the iterator is not done, the iterator is
+  closed before the original completion is propagated.
+- `IteratorClose` calls `return` only for an open iterator. If `return` is
+  missing, close is a no-op. If `return` is non-callable, throws, or returns a
+  non-object, the close path is abrupt; on the current Test262 bucket, the
+  original throw completion remains the observed error while the close side
+  effect still occurs.

--- a/tests/test_destructuring_iterator_assignment.sh
+++ b/tests/test_destructuring_iterator_assignment.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Regression: destructuring assignment must match iterator-close and
+# target-evaluation order from Test262's assignment/destructuring bucket.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+function check(value: boolean, label: string) {
+  if (!value) {
+    throw label;
+  }
+}
+
+let arrayOrder = "";
+const arrayIterable: any = {};
+arrayIterable[Symbol.iterator] = function() {
+  arrayOrder += "iterator,";
+  return {
+    next: function() {
+      arrayOrder += "next,";
+      return { done: false, value: 42 };
+    },
+    return: function() {
+      arrayOrder += "return,";
+      return { done: true };
+    }
+  };
+};
+const arrayTargetObject: any = {};
+const arrayTargetKey: any = {
+  toString: function() {
+    arrayOrder += "target-key-tostring,";
+    return "slot";
+  }
+};
+function arraySource(): any {
+  arrayOrder += "source,";
+  return arrayIterable;
+}
+function arrayTarget(): any {
+  arrayOrder += "target,";
+  return arrayTargetObject;
+}
+function arrayKey(): any {
+  arrayOrder += "target-key,";
+  return arrayTargetKey;
+}
+[arrayTarget()[arrayKey()]] = arraySource();
+check(arrayTargetObject.slot === 42, "array destructuring assignment value");
+check(
+  arrayOrder === "source,iterator,target,target-key,next,target-key-tostring,return,",
+  "array destructuring assignment order: " + arrayOrder
+);
+
+let objectOrder = "";
+const objectSourceObject: any = { prop: 7 };
+const objectSourceKey: any = {
+  toString: function() {
+    objectOrder += "source-key-tostring,";
+    return "prop";
+  }
+};
+const objectTargetObject: any = {};
+const objectTargetKey: any = {
+  toString: function() {
+    objectOrder += "target-key-tostring,";
+    return "slot";
+  }
+};
+function objectSource(): any {
+  objectOrder += "source,";
+  return objectSourceObject;
+}
+function objectKey(): any {
+  objectOrder += "source-key,";
+  return objectSourceKey;
+}
+function objectTarget(): any {
+  objectOrder += "target,";
+  return objectTargetObject;
+}
+function objectTargetProperty(): any {
+  objectOrder += "target-key,";
+  return objectTargetKey;
+}
+({ [objectKey()]: objectTarget()[objectTargetProperty()] } = objectSource());
+check(objectTargetObject.slot === 7, "object destructuring assignment value");
+check(
+  objectOrder === "source,source-key,source-key-tostring,target,target-key,target-key-tostring,",
+  "object destructuring assignment order: " + objectOrder
+);
+
+let closeCount = 0;
+let caught = "";
+const abruptIterable: any = {};
+abruptIterable[Symbol.iterator] = function() {
+  return {
+    next: function() {
+      return { done: false, value: undefined };
+    },
+    return: function() {
+      closeCount = closeCount + 1;
+      throw "close";
+    }
+  };
+};
+function defaultThrow(): any {
+  throw "default";
+}
+try {
+  let value: any = null;
+  [value = defaultThrow()] = abruptIterable;
+} catch (e: any) {
+  caught = e;
+}
+check(closeCount === 1, "iterator return called after abrupt default");
+check(caught === "default", "original abrupt completion preserved: " + caught);
+
+console.log("ok");
+EOF
+
+cd "$TMPDIR"
+"$PERRY" compile main.ts --output test_bin >/dev/null
+set +e
+RUN_OUTPUT=$(./test_bin 2>&1)
+RUN_STATUS=$?
+set -e
+
+if [ "$RUN_STATUS" -eq 0 ] && [ "$RUN_OUTPUT" = "ok" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: unexpected output"
+echo "Status: $RUN_STATUS"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Summary
- add iterator-protocol assignment destructuring lowering with IteratorNext/IteratorClose helpers
- preserve destructuring target/source evaluation order for array and object assignment statements
- route parenthesized destructuring assignment statements through the statement lowering path
- add focused regression coverage and DeepWiki reference notes

## Validation
- cargo fmt --check
- cargo check -p perry-hir -p perry-codegen -p perry-runtime
- worker validation before rebase: CARGO_BUILD_JOBS=1 cargo build --release -p perry -p perry-runtime -p perry-stdlib
- worker validation before rebase: tests/test_destructuring_iterator_assignment.sh
- worker exact Test262 bucket: 6 pass / 1 runtime-fail
- worker focused slice: 7 pass / 1 runtime-fail

## Residual
- language/expressions/assignment/destructuring/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js still depends on `with (env)` dynamic scope/Proxy binding lookup.