### PR TITLE
c262 parity: fix addition coercion order

### DIFF
--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1034,6 +1034,9 @@ pub(crate) fn lower_stmt(
             module.init.push(Stmt::Expr(expr));
         }
         ast::Stmt::If(if_stmt) => {
+            module
+                .init
+                .extend(predeclare_implicit_assignment_targets(ctx, &if_stmt.test));
             let condition = lower_expr(ctx, &if_stmt.test)?;
             // Each branch introduces its own lexical scope. Skip extra push if
             // branch is a BlockStmt (handled there) or an If (else-if chain).

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -216,6 +216,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             result.push(Stmt::Return(value));
         }
         ast::Stmt::If(if_stmt) => {
+            result.extend(predeclare_implicit_assignment_targets(ctx, &if_stmt.test));
             // #2277: `typeof x === "string"` narrowing — see typeof_narrow.rs.
             let stmt = typeof_narrow::lower_if_with_narrowing(ctx, if_stmt, lower_body_stmt)?;
             result.push(stmt);

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -189,6 +189,50 @@ fn sloppy_assignment_expression_creates_storage_before_following_getvalue() {
 }
 
 #[test]
+fn sloppy_assignment_in_if_test_creates_storage_before_following_getvalue() {
+    let module = lower_src("if ((y = 1) + y !== 2) { throw new Error('bad'); }");
+    let y_id = module
+        .init
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Let {
+                id,
+                name,
+                init: Some(Expr::Undefined),
+                ..
+            } if name == "y" => Some(*id),
+            _ => None,
+        })
+        .expect("sloppy assignment target in if test should be predeclared");
+
+    let Some(Stmt::If { condition, .. }) = module
+        .init
+        .iter()
+        .find(|stmt| matches!(stmt, Stmt::If { .. }))
+    else {
+        panic!("expected lowered if statement, got {:?}", module.init);
+    };
+
+    let Expr::Compare { left, .. } = condition else {
+        panic!("if test should lower as comparison, got {condition:?}");
+    };
+    let Expr::Binary {
+        op: BinaryOp::Add,
+        left,
+        right,
+    } = left.as_ref()
+    else {
+        panic!("comparison lhs should lower as addition, got {left:?}");
+    };
+
+    assert!(
+        matches!(left.as_ref(), Expr::LocalSet(id, value) if *id == y_id && is_number_literal(value, 1.0)),
+        "{left:?}"
+    );
+    assert!(matches!(right.as_ref(), Expr::LocalGet(id) if *id == y_id));
+}
+
+#[test]
 fn sloppy_js_yield_identifier_arrow_parameters_lower() {
     let module = lower_js_src(
         r#"

--- a/reference/deepwiki/addition-coercion-boa.md
+++ b/reference/deepwiki/addition-coercion-boa.md
@@ -1,0 +1,478 @@
+# DeepWiki Response
+
+Repository: `boa-dev/boa`
+Question: For ECMAScript AdditionExpression evaluation, explain the implementation flow for evaluating left and right operands, GetValue on references, assignment expression result values like (y = 1), ToPrimitive for addition, ToString for objects/functions, ordinary object default stringification, function default stringification, and observable evaluation order. Please cite the relevant files/functions.
+Search: https://deepwiki.com/search/for-ecmascript-additionexpress_6b8788c1-e7f7-4706-994c-3ada161ab0af
+
+**Question**: For ECMAScript AdditionExpression evaluation, explain the implementation flow for evaluating left and right operands, GetValue on references, assignment expression result values like (y = 1), ToPrimitive for addition, ToString for objects/functions, ordinary object default stringification, function default stringification, and observable evaluation order. Please cite the relevant files/functions.
+
+The user is asking about the implementation details of ECMAScript AdditionExpression evaluation within the Boa JavaScript engine. This includes how operands are evaluated, `GetValue` on references, assignment expression result values, `ToPrimitive` conversion for addition, `ToString` for objects and functions, default stringification for ordinary objects and functions, and observable evaluation order.
+
+The core of addition expression evaluation is handled by the `add` method of the `JsValue` type [1](#ref-q1-1) . This method implements the ECMAScript specification for the binary `+` operator.
+
+### Evaluation of Left and Right Operands
+
+The `add` method first attempts a "fast path" for numeric and string additions based on the `JsVariant` of the operands [2](#ref-q1-2) . If the operands are both `Integer32`, `Float64`, or `BigInt`, it performs the corresponding arithmetic operation [3](#ref-q1-3) . If both are `String`, it performs string concatenation [4](#ref-q1-4) .
+
+If the fast path is not taken, it proceeds to the "slow path" which involves `ToPrimitive` conversions [5](#ref-q1-5) .
+
+### GetValue on References and Assignment Expression Result Values
+
+While the provided snippets do not directly show the `GetValue` operation on references, the `ByteCompiler` is responsible for compiling expressions, including assignments. The `compile_assign` method in `core/engine/src/bytecompiler/expression/assign.rs` handles assignment expressions [6](#ref-q1-6) . For a simple assignment (`AssignOp::Assign`), it compiles the right-hand side expression and then sets the value to the left-hand side [7](#ref-q1-7) . The result of an assignment expression is the value of the right-hand side after assignment.
+
+### ToPrimitive for Addition
+
+For the "slow path" of addition, both operands are converted to primitive values using `to_primitive` with `PreferredType::Default` [8](#ref-q1-8) .
+
+The `to_primitive` method of `JsObject` handles the conversion of an object to a primitive value [9](#ref-q1-9) . It first checks for a `[Symbol.toPrimitive]` method on the object [10](#ref-q1-10) . If present, it calls this method with a hint ("default", "string", or "number") [11](#ref-q1-11) . If the `[Symbol.toPrimitive]` method returns an object, a `TypeError` is thrown [12](#ref-q1-12) .
+
+If `[Symbol.toPrimitive]` is not found, `ordinary_to_primitive` is called [13](#ref-q1-13) . This method attempts to call `toString()` and `valueOf()` methods on the object in a specific order based on the `PreferredType` hint [14](#ref-q1-14) . For `PreferredType::String`, it tries `toString` then `valueOf`. For `PreferredType::Number` (or `Default`), it tries `valueOf` then `toString` [15](#ref-q1-15) . If a callable method returns a non-object primitive, that value is returned [16](#ref-q1-16) . If no primitive is obtained, a `TypeError` is thrown [17](#ref-q1-17) . A recursion limiter is also in place to prevent stack overflows for recursive objects during `ordinary_to_primitive` [18](#ref-q1-18) .
+
+After `ToPrimitive` conversion, if either result is a `String`, the values are converted to strings and concatenated [19](#ref-q1-19) . Otherwise, they are converted to `Numeric` values and added [20](#ref-q1-20) .
+
+### ToString for Objects/Functions
+
+The `to_string` method on `JsValue` is used to convert a value to its string representation [21](#ref-q1-21) .
+
+#### Ordinary Object Default Stringification
+
+For ordinary objects, the `ordinary_to_primitive` method, when called with `PreferredType::String`, will attempt to call the object's `toString` method first [22](#ref-q1-22) . The default `Object.prototype.toString()` typically returns `"[object Object]"`.
+
+#### Function Default Stringification
+
+The `Function.prototype.toString()` implementation is found in `core/engine/src/builtins/function/mod.rs` [23](#ref-q1-23) . For built-in functions or native functions, it returns an implementation-defined string like `function name() { [native code] }` [24](#ref-q1-24) . For user-defined functions, it attempts to retrieve the source text from the code block [25](#ref-q1-25) .
+
+### Observable Evaluation Order
+
+ECMAScript specifies left-to-right evaluation of expressions [26](#ref-q1-26) . This is explicitly handled in operations like `abstract_relation` where a `left_first` flag determines the order of `to_primitive` calls to preserve this observable order [27](#ref-q1-27) . The `ByteCompiler` also processes expressions in the order they appear in the AST, ensuring left-to-right evaluation. For binary arithmetic operations, the `compile_binary_arithmetic` method compiles the right-hand side expression after the left-hand side has been processed implicitly by the `lhs` parameter [28](#ref-q1-28) .
+
+## Notes
+
+The `Architecture` wiki page provides a high-level overview of the Boa engine's components, including the `ByteCompiler` and `VM` [29](#ref-q1-29) . The `JavaScript Values` wiki page details the `JsValue` representation and its conversion mechanisms, which are fundamental to understanding `ToPrimitive` and `ToString` operations [30](#ref-q1-30) .
+
+Wiki pages you might want to explore:
+- [Architecture (boa-dev/boa)](/wiki/boa-dev/boa#1.1)
+- [JavaScript Values (boa-dev/boa)](/wiki/boa-dev/boa#2.1)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-ecmascript-additionexpress_6b8788c1-e7f7-4706-994c-3ada161ab0af
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `core/engine/src/value/operations.rs:14-52`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L14-L52)
+
+```rust
+    pub fn add(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+        Ok(match (self.variant(), other.variant()) {
+            // Fast path:
+            // Numeric add
+            (JsVariant::Integer32(x), JsVariant::Integer32(y)) => x
+                .checked_add(y)
+                .map_or_else(|| Self::new(f64::from(x) + f64::from(y)), Self::new),
+            (JsVariant::Float64(x), JsVariant::Float64(y)) => Self::new(x + y),
+            (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(f64::from(x) + y),
+            (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(x + f64::from(y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::add(&x, &y)),
+
+            // String concat
+            (JsVariant::String(x), JsVariant::String(y)) => Self::from(js_string!(&x, &y)),
+
+            // Slow path:
+            (_, _) => {
+                let x = self.to_primitive(context, PreferredType::Default)?;
+                let y = other.to_primitive(context, PreferredType::Default)?;
+                match (x.variant(), y.variant()) {
+                    (JsVariant::String(x), _) => Self::from(js_string!(&x, &y.to_string(context)?)),
+                    (_, JsVariant::String(y)) => Self::from(js_string!(&x.to_string(context)?, &y)),
+                    (_, _) => {
+                        match (x.to_numeric(context)?, y.to_numeric(context)?) {
+                            (Numeric::Number(x), Numeric::Number(y)) => Self::new(x + y),
+                            (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => {
+                                Self::new(JsBigInt::add(x, y))
+                            }
+                            (_, _) => return Err(JsNativeError::typ()
+                                .with_message(
+                                    "cannot mix BigInt and other types, use explicit conversions",
+                                )
+                                .into()),
+                        }
+                    }
+                }
+            }
+        })
+    }
+```
+
+<a id="ref-q1-2"></a>
+### [2] `core/engine/src/value/operations.rs:15-28`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L15-L28)
+
+```rust
+        Ok(match (self.variant(), other.variant()) {
+            // Fast path:
+            // Numeric add
+            (JsVariant::Integer32(x), JsVariant::Integer32(y)) => x
+                .checked_add(y)
+                .map_or_else(|| Self::new(f64::from(x) + f64::from(y)), Self::new),
+            (JsVariant::Float64(x), JsVariant::Float64(y)) => Self::new(x + y),
+            (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(f64::from(x) + y),
+            (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(x + f64::from(y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::add(&x, &y)),
+
+            // String concat
+            (JsVariant::String(x), JsVariant::String(y)) => Self::from(js_string!(&x, &y)),
+```
+
+<a id="ref-q1-3"></a>
+### [3] `core/engine/src/value/operations.rs:18-24`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L18-L24)
+
+```rust
+            (JsVariant::Integer32(x), JsVariant::Integer32(y)) => x
+                .checked_add(y)
+                .map_or_else(|| Self::new(f64::from(x) + f64::from(y)), Self::new),
+            (JsVariant::Float64(x), JsVariant::Float64(y)) => Self::new(x + y),
+            (JsVariant::Integer32(x), JsVariant::Float64(y)) => Self::new(f64::from(x) + y),
+            (JsVariant::Float64(x), JsVariant::Integer32(y)) => Self::new(x + f64::from(y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::add(&x, &y)),
+```
+
+<a id="ref-q1-4"></a>
+### [4] `core/engine/src/value/operations.rs:27`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L27)
+
+```rust
+            (JsVariant::String(x), JsVariant::String(y)) => Self::from(js_string!(&x, &y)),
+```
+
+<a id="ref-q1-5"></a>
+### [5] `core/engine/src/value/operations.rs:30-32`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L30-L32)
+
+```rust
+            (_, _) => {
+                let x = self.to_primitive(context, PreferredType::Default)?;
+                let y = other.to_primitive(context, PreferredType::Default)?;
+```
+
+<a id="ref-q1-6"></a>
+### [6] `core/engine/src/bytecompiler/expression/assign.rs:15-16`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/expression/assign.rs#L15-L16)
+
+```rust
+    pub(crate) fn compile_assign(&mut self, assign: &Assign, dst: &Register) {
+        let mut compiler = self.position_guard(assign);
+```
+
+<a id="ref-q1-7"></a>
+### [7] `core/engine/src/bytecompiler/expression/assign.rs:18-24`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/expression/assign.rs#L18-L24)
+
+```rust
+        if assign.op() == AssignOp::Assign {
+            match Access::from_assign_target(assign.lhs()) {
+                Ok(access) => {
+                    compiler.access_set(access, |compiler| {
+                        compiler.compile_expr(assign.rhs(), dst);
+                        dst
+                    });
+```
+
+<a id="ref-q1-8"></a>
+### [8] `core/engine/src/value/operations.rs:31-32`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L31-L32)
+
+```rust
+                let x = self.to_primitive(context, PreferredType::Default)?;
+                let y = other.to_primitive(context, PreferredType::Default)?;
+```
+
+<a id="ref-q1-9"></a>
+### [9] `core/engine/src/object/jsobject.rs:557-561`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L557-L561)
+
+```rust
+    pub fn to_primitive(
+        &self,
+        context: &mut Context,
+        preferred_type: PreferredType,
+    ) -> JsResult<JsValue> {
+```
+
+<a id="ref-q1-10"></a>
+### [10] `core/engine/src/object/jsobject.rs:562-563`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L562-L563)
+
+```rust
+        // a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+        let Some(exotic_to_prim) = self.get_method(JsSymbol::to_primitive(), context)? else {
+```
+
+<a id="ref-q1-11"></a>
+### [11] `core/engine/src/object/jsobject.rs:578-586`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L578-L586)
+
+```rust
+        let hint = match preferred_type {
+            PreferredType::Default => js_string!("default"),
+            PreferredType::String => js_string!("string"),
+            PreferredType::Number => js_string!("number"),
+        }
+        .into();
+
+        //    iv. Let result be ? Call(exoticToPrim, input, « hint »).
+        let result = exotic_to_prim.call(&self.clone().into(), &[hint], context)?;
+```
+
+<a id="ref-q1-12"></a>
+### [12] `core/engine/src/object/jsobject.rs:588-594`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L588-L594)
+
+```rust
+        //    v. If Type(result) is not Object, return result.
+        //    vi. Throw a TypeError exception.
+        if result.is_object() {
+            Err(js_error!(
+                TypeError: "method `[Symbol.toPrimitive]` cannot return an object"
+            ))
+        } else {
+```
+
+<a id="ref-q1-13"></a>
+### [13] `core/engine/src/object/jsobject.rs:569`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L569)
+
+```rust
+            return self.ordinary_to_primitive(context, preferred_type);
+```
+
+<a id="ref-q1-14"></a>
+### [14] `core/engine/src/object/jsobject.rs:641-649`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L641-L649)
+
+```rust
+        // 3. If hint is "string", then
+        //    a. Let methodNames be « "toString", "valueOf" ».
+        // 4. Else,
+        //    a. Let methodNames be « "valueOf", "toString" ».
+        let method_names = if hint == PreferredType::String {
+            [js_string!("toString"), js_string!("valueOf")]
+        } else {
+            [js_string!("valueOf"), js_string!("toString")]
+        };
+```
+
+<a id="ref-q1-15"></a>
+### [15] `core/engine/src/object/jsobject.rs:645-649`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L645-L649)
+
+```rust
+        let method_names = if hint == PreferredType::String {
+            [js_string!("toString"), js_string!("valueOf")]
+        } else {
+            [js_string!("valueOf"), js_string!("toString")]
+        };
+```
+
+<a id="ref-q1-16"></a>
+### [16] `core/engine/src/object/jsobject.rs:657-663`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L657-L663)
+
+```rust
+            if let Some(method) = method.as_callable() {
+                // i. Let result be ? Call(method, O).
+                let result = method.call(&self.clone().into(), &[], context)?;
+
+                // ii. If Type(result) is not Object, return result.
+                if !result.is_object() {
+                    return Ok(result);
+```
+
+<a id="ref-q1-17"></a>
+### [17] `core/engine/src/object/jsobject.rs:668-671`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L668-L671)
+
+```rust
+        // 6. Throw a TypeError exception.
+        Err(JsNativeError::typ()
+            .with_message("cannot convert object to primitive value")
+            .into())
+```
+
+<a id="ref-q1-18"></a>
+### [18] `core/engine/src/object/jsobject.rs:631-639`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L631-L639)
+
+```rust
+        let recursion_limiter = RecursionLimiter::new(self.as_ref());
+        if recursion_limiter.live {
+            // we're in a recursive object, bail
+            return Ok(match hint {
+                PreferredType::Number => JsValue::new(0),
+                PreferredType::String => JsValue::new(js_string!()),
+                PreferredType::Default => unreachable!("checked type hint in step 2"),
+            });
+        }
+```
+
+<a id="ref-q1-19"></a>
+### [19] `core/engine/src/value/operations.rs:33-35`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L33-L35)
+
+```rust
+                match (x.variant(), y.variant()) {
+                    (JsVariant::String(x), _) => Self::from(js_string!(&x, &y.to_string(context)?)),
+                    (_, JsVariant::String(y)) => Self::from(js_string!(&x.to_string(context)?, &y)),
+```
+
+<a id="ref-q1-20"></a>
+### [20] `core/engine/src/value/operations.rs:36-48`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L36-L48)
+
+```rust
+                    (_, _) => {
+                        match (x.to_numeric(context)?, y.to_numeric(context)?) {
+                            (Numeric::Number(x), Numeric::Number(y)) => Self::new(x + y),
+                            (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => {
+                                Self::new(JsBigInt::add(x, y))
+                            }
+                            (_, _) => return Err(JsNativeError::typ()
+                                .with_message(
+                                    "cannot mix BigInt and other types, use explicit conversions",
+                                )
+                                .into()),
+                        }
+                    }
+```
+
+<a id="ref-q1-21"></a>
+### [21] `core/engine/src/value/operations.rs:34-35`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L34-L35)
+
+```rust
+                    (JsVariant::String(x), _) => Self::from(js_string!(&x, &y.to_string(context)?)),
+                    (_, JsVariant::String(y)) => Self::from(js_string!(&x.to_string(context)?, &y)),
+```
+
+<a id="ref-q1-22"></a>
+### [22] `core/engine/src/object/jsobject.rs:645-646`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/object/jsobject.rs#L645-L646)
+
+```rust
+        let method_names = if hint == PreferredType::String {
+            [js_string!("toString"), js_string!("valueOf")]
+```
+
+<a id="ref-q1-23"></a>
+### [23] `core/engine/src/builtins/function/mod.rs:841`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L841)
+
+```rust
+    fn to_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+```
+
+<a id="ref-q1-24"></a>
+### [24] `core/engine/src/builtins/function/mod.rs:861-874`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L861-L874)
+
+```rust
+        if object.is::<NativeFunctionObject>() {
+            let name = {
+                // Is there a case here where if there is no name field on a value
+                // name should default to None? Do all functions have names set?
+                let value = object.get(js_string!("name"), &mut *context)?;
+                if value.is_null_or_undefined() {
+                    js_string!()
+                } else {
+                    value.to_string(context)?
+                }
+            };
+            return Ok(
+                js_string!(js_str!("function "), &name, js_str!("() { [native code] }")).into(),
+            );
+```
+
+<a id="ref-q1-25"></a>
+### [25] `core/engine/src/builtins/function/mod.rs:883-886`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/builtins/function/mod.rs#L883-L886)
+
+```rust
+        let code = function.codeblock();
+        if let Some(code_points) = code.source_info().text_spanned().to_code_points() {
+            return Ok(JsString::from(code_points).into());
+        }
+```
+
+<a id="ref-q1-26"></a>
+### [26] `core/engine/src/value/operations.rs:521-523`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L521-L523)
+
+```rust
+    /// are performed upon `x` and `y`. It is necessary because ECMAScript specifies left to right evaluation
+    /// of expressions. The default value of `LeftFirst` is `true` and indicates that the `x` parameter
+    /// corresponds to an expression that occurs to the left of the `y` parameter's corresponding expression.
+```
+
+<a id="ref-q1-27"></a>
+### [27] `core/engine/src/value/operations.rs:534-556`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/value/operations.rs#L534-L556)
+
+```rust
+        left_first: bool,
+        context: &mut Context,
+    ) -> JsResult<AbstractRelation> {
+        Ok(match (self.variant(), other.variant()) {
+            // Fast path (for some common operations):
+            (JsVariant::Integer32(x), JsVariant::Integer32(y)) => (x < y).into(),
+            (JsVariant::Integer32(x), JsVariant::Float64(y)) => Number::less_than(f64::from(x), y),
+            (JsVariant::Float64(x), JsVariant::Integer32(y)) => Number::less_than(x, f64::from(y)),
+            (JsVariant::Float64(x), JsVariant::Float64(y)) => Number::less_than(x, y),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => (x < y).into(),
+
+            // Slow path:
+            (_, _) => {
+                let (px, py) = if left_first {
+                    let px = self.to_primitive(context, PreferredType::Number)?;
+                    let py = other.to_primitive(context, PreferredType::Number)?;
+                    (px, py)
+                } else {
+                    // NOTE: The order of evaluation needs to be reversed to preserve left to right evaluation.
+                    let py = other.to_primitive(context, PreferredType::Number)?;
+                    let px = self.to_primitive(context, PreferredType::Number)?;
+                    (px, py)
+                };
+```
+
+<a id="ref-q1-28"></a>
+### [28] `core/engine/src/bytecompiler/expression/binary.rs:56-73`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/core/engine/src/bytecompiler/expression/binary.rs#L56-L73)
+
+```rust
+    fn compile_binary_arithmetic(
+        &mut self,
+        op: ArithmeticOp,
+        rhs_expr: &Expression,
+        dst: &Register,
+        lhs: RegisterOperand,
+    ) {
+        self.compile_expr_operand(rhs_expr, |self_, rhs| {
+            let bytecode = &mut self_.bytecode;
+            match op {
+                ArithmeticOp::Add => bytecode.emit_add(dst.variable(), lhs, rhs),
+                ArithmeticOp::Sub => bytecode.emit_sub(dst.variable(), lhs, rhs),
+                ArithmeticOp::Div => bytecode.emit_div(dst.variable(), lhs, rhs),
+                ArithmeticOp::Mul => bytecode.emit_mul(dst.variable(), lhs, rhs),
+                ArithmeticOp::Exp => bytecode.emit_pow(dst.variable(), lhs, rhs),
+                ArithmeticOp::Mod => bytecode.emit_mod(dst.variable(), lhs, rhs),
+            }
+        });
+```
+
+<a id="ref-q1-29"></a>
+### [29] `Architecture:49-52`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/Architecture#L49-L52)
+
+<a id="ref-q1-30"></a>
+### [30] `JavaScript Values:1-10`
+Source: [boa-dev/boa @ f5e88de5](https://github.com/boa-dev/boa/blob/f5e88de5/JavaScript Values#L1-L10)

--- a/reference/deepwiki/addition-coercion-engine262.md
+++ b/reference/deepwiki/addition-coercion-engine262.md
@@ -1,0 +1,321 @@
+# DeepWiki Response
+
+Repository: `engine262/engine262`
+Question: For ECMAScript AdditionExpression evaluation, explain the implementation flow for evaluating left and right operands, GetValue on references, assignment expression result values like (y = 1), ToPrimitive for addition, ToString for objects/functions, ordinary object default stringification, function default stringification, and observable evaluation order. Please cite the relevant files/functions.
+Search: https://deepwiki.com/search/for-ecmascript-additionexpress_edf0fe6c-e8ac-43f8-99b3-0dd43aad2612
+
+**Question**: For ECMAScript AdditionExpression evaluation, explain the implementation flow for evaluating left and right operands, GetValue on references, assignment expression result values like (y = 1), ToPrimitive for addition, ToString for objects/functions, ordinary object default stringification, function default stringification, and observable evaluation order. Please cite the relevant files/functions.
+
+The evaluation of an `AdditiveExpression` in engine262 involves several steps, including the evaluation of its left and right operands, handling of `ReferenceRecord`s via `GetValue`, `ToPrimitive` conversion for addition, and `ToString` conversion for objects and functions. The overall evaluation order is observable and follows the ECMAScript specification.
+
+### Evaluation of Left and Right Operands
+The `Evaluate_AdditiveExpression` function is responsible for evaluating `AdditiveExpression` nodes [1](#ref-q1-1) . The parser constructs an `AdditiveExpression` node, which contains `AdditiveExpression` (left operand) and `MultiplicativeExpression` (right operand) properties, along with an `operator` property [2](#ref-q1-2) . The `Evaluate` function dispatches to `Evaluate_AdditiveExpression` when it encounters an `AdditiveExpression` node [1](#ref-q1-1) .
+
+### GetValue on References
+During evaluation, if an operand evaluates to a `ReferenceRecord`, the `GetValue` abstract operation is called to retrieve the actual value. For example, in `Evaluate_UnaryExpression_Void`, `GetValue` is explicitly called on the result of evaluating the `UnaryExpression` [3](#ref-q1-3) . Similarly, `Evaluate_UnaryExpression_Typeof` also calls `GetValue` after checking if the result is an unresolvable `ReferenceRecord` [4](#ref-q1-4) .
+
+### Assignment Expression Result Values
+The prompt mentions assignment expression result values like `(y = 1)`. While the detailed evaluation of `AssignmentExpression` is not provided in the snippets, the `Evaluate` function does have a case for `AssignmentExpression`, which dispatches to `Evaluate_AssignmentExpression` [5](#ref-q1-5) . Typically, an assignment expression evaluates to the value that was assigned.
+
+### ToPrimitive for Addition
+For addition, the `ToPrimitive` abstract operation is crucial. The `ToPrimitive` function takes an `input` value and an optional `preferredType` hint ('string' or 'number') [6](#ref-q1-6) .
+1.  If the `input` is an `ObjectValue`, it first checks for a `@@toPrimitive` method [7](#ref-q1-7) .
+2.  If `@@toPrimitive` exists, it's called with a hint ('default', 'string', or 'number') [8](#ref-q1-8) . If the result is not an object, it's returned; otherwise, a `TypeError` is thrown [9](#ref-q1-9) .
+3.  If `@@toPrimitive` is not defined, `OrdinaryToPrimitive` is called with the `input` and the `preferredType` (defaulting to 'number' if not specified) [10](#ref-q1-10) .
+4.  If the `input` is not an `ObjectValue`, the `input` itself is returned [11](#ref-q1-11) .
+
+The `OrdinaryToPrimitive` function attempts to convert an object to a primitive value [12](#ref-q1-12) . It tries calling `toString` then `valueOf` if the hint is 'string', or `valueOf` then `toString` if the hint is 'number' [13](#ref-q1-13) . If a callable method returns a non-object primitive, that value is returned [14](#ref-q1-14) . If no primitive is obtained, a `TypeError` is thrown [15](#ref-q1-15) .
+
+### ToString for Objects/Functions
+The `ToString` abstract operation is used to convert a value to a `JSStringValue` [16](#ref-q1-16) . For `ObjectValue`s, `ToString` first calls `ToPrimitive` with a 'string' hint [17](#ref-q1-17) . The result of `ToPrimitive` is then converted to a string [18](#ref-q1-18) .
+
+#### Ordinary Object Default Stringification
+For ordinary objects, the `OrdinaryToPrimitive` process (called by `ToPrimitive` with a 'string' hint) will first attempt to call the object's `toString` method, then its `valueOf` method [19](#ref-q1-19) . The default `Object.prototype.toString` typically returns `"[object Object]"`.
+
+#### Function Default Stringification
+For functions, `IsCallable` is used to determine if a value is a function [20](#ref-q1-20) . When `ToString` is applied to a function object, its `toString` method is typically called. The default `Function.prototype.toString` usually returns a string representation of the function's source code.
+
+### Observable Evaluation Order
+The evaluation order is strictly defined by the ECMAScript specification and implemented in engine262. For `AdditiveExpression`, the left operand is evaluated first, then the right operand [21](#ref-q1-21) . This is observable through the `Evaluate` function's generator-based architecture, which allows for precise control over the order of operations and integration with debugging hooks [22](#ref-q1-22) . The `surroundingAgent.runningExecutionContext.callSite.setLocation(node)` call at the beginning of `Evaluate` also ensures that the current evaluation context is tracked, making the evaluation order observable [23](#ref-q1-23) .
+
+## Notes
+The provided snippets offer a good overview of the evaluation process for expressions, type conversions, and the core evaluation engine. The `Core Architecture` wiki page also provides a high-level understanding of how the `Evaluate` function dispatches to specific evaluation functions based on the AST node type [24](#ref-q1-24) .
+
+Wiki pages you might want to explore:
+- [Core Architecture (engine262/engine262)](/wiki/engine262/engine262#3)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-ecmascript-additionexpress_edf0fe6c-e8ac-43f8-99b3-0dd43aad2612
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `src/evaluator.mts:204-205`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/evaluator.mts#L204-L205)
+
+```
+    case 'AdditiveExpression':
+      return yield* Evaluate_AdditiveExpression(node);
+```
+
+<a id="ref-q1-2"></a>
+### [2] `src/parser/ParseNode.mts:678-686`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/parser/ParseNode.mts#L678-L686)
+
+```
+  // AdditiveExpression (partial) :
+  //   AdditiveExpression `+` MultiplicativeExpression
+  //   AdditiveExpression `-` MultiplicativeExpression
+  export interface AdditiveExpression extends BaseParseNode {
+    readonly type: 'AdditiveExpression';
+    readonly operator: '+' | '-';
+    readonly AdditiveExpression: AdditiveExpressionOrHigher;
+    readonly MultiplicativeExpression: MultiplicativeExpressionOrHigher;
+  }
+```
+
+<a id="ref-q1-3"></a>
+### [3] `src/runtime-semantics/UnaryExpression.mts:82-85`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/runtime-semantics/UnaryExpression.mts#L82-L85)
+
+```
+  // 1. Let expr be the result of evaluating UnaryExpression.
+  const expr = Q(yield* Evaluate(UnaryExpression));
+  // 2. Perform ? GetValue(expr).
+  Q(yield* GetValue(expr));
+```
+
+<a id="ref-q1-4"></a>
+### [4] `src/runtime-semantics/UnaryExpression.mts:96-103`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/runtime-semantics/UnaryExpression.mts#L96-L103)
+
+```
+  if (_val instanceof ReferenceRecord) {
+    // a. If IsUnresolvableReference(val) is true, return "undefined".
+    if (IsUnresolvableReference(_val) === Value.true) {
+      return Value('undefined');
+    }
+  }
+  // 3. Set val to ? GetValue(val).
+  const val = Q(yield* GetValue(_val));
+```
+
+<a id="ref-q1-5"></a>
+### [5] `src/evaluator.mts:254-255`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/evaluator.mts#L254-L255)
+
+```
+    case 'AssignmentExpression':
+      return yield* Evaluate_AssignmentExpression(node);
+```
+
+<a id="ref-q1-6"></a>
+### [6] `src/abstract-ops/type-conversion.mts:41`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L41)
+
+```
+export function* ToPrimitive(input: Value, preferredType?: 'string' | 'number'): ValueEvaluator<PrimitiveValue> {
+```
+
+<a id="ref-q1-7"></a>
+### [7] `src/abstract-ops/type-conversion.mts:45-47`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L45-L47)
+
+```
+  if (input instanceof ObjectValue) {
+    // a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+    const exoticToPrim = Q(yield* GetMethod(input, wellKnownSymbols.toPrimitive));
+```
+
+<a id="ref-q1-8"></a>
+### [8] `src/abstract-ops/type-conversion.mts:51-63`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L51-L63)
+
+```
+      // i. If preferredType is not present, let hint be "default".
+      if (preferredType === undefined) {
+        hint = Value('default');
+      } else if (preferredType === 'string') { // ii. Else if preferredType is string, let hint be "string".
+        hint = Value('string');
+      } else { // iii. Else,
+        // 1. Assert: preferredType is number.
+        Assert(preferredType === 'number');
+        // 2. Let hint be "number".
+        hint = Value('number');
+      }
+      // iv. Let result be ? Call(exoticToPrim, input, « hint »).
+      const result = Q(yield* Call(exoticToPrim, input, [hint]));
+```
+
+<a id="ref-q1-9"></a>
+### [9] `src/abstract-ops/type-conversion.mts:64-69`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L64-L69)
+
+```
+      // v. If Type(result) is not Object, return result.
+      if (!(result instanceof ObjectValue)) {
+        return result;
+      }
+      // vi. Throw a TypeError exception.
+      return surroundingAgent.Throw('TypeError', 'ObjectToPrimitive');
+```
+
+<a id="ref-q1-10"></a>
+### [10] `src/abstract-ops/type-conversion.mts:71-76`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L71-L76)
+
+```
+    // c. If preferredType is not present, let preferredType be number.
+    if (preferredType === undefined) {
+      preferredType = 'number';
+    }
+    // d. Return ? OrdinaryToPrimitive(input, preferredType).
+    return Q(yield* OrdinaryToPrimitive(input, preferredType));
+```
+
+<a id="ref-q1-11"></a>
+### [11] `src/abstract-ops/type-conversion.mts:78-79`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L78-L79)
+
+```
+  // 3. Return input.
+  return input;
+```
+
+<a id="ref-q1-12"></a>
+### [12] `src/abstract-ops/type-conversion.mts:82`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L82)
+
+```
+/** https://tc39.es/ecma262/#sec-ordinarytoprimitive */
+```
+
+<a id="ref-q1-13"></a>
+### [13] `src/abstract-ops/type-conversion.mts:89-96`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L89-L96)
+
+```
+  // 3. If hint is string, then
+  if (hint === 'string') {
+    // a. Let methodNames be « "toString", "valueOf" ».
+    methodNames = [Value('toString'), Value('valueOf')];
+  } else { // 4. Else,
+    // a. Let methodNames be « "valueOf", "toString" ».
+    methodNames = [Value('valueOf'), Value('toString')];
+  }
+```
+
+<a id="ref-q1-14"></a>
+### [14] `src/abstract-ops/type-conversion.mts:97-108`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L97-L108)
+
+```
+  // 5. For each element name of methodNames, do
+  for (const name of methodNames) {
+    // a. Let method be ? Get(O, name).
+    const method = Q(yield* Get(O, name));
+    // b. If IsCallable(method) is true, then
+    if (IsCallable(method)) {
+      // i. Let result be ? Call(method, O).
+      const result = Q(yield* Call(method, O));
+      // ii. If Type(result) is not Object, return result.
+      if (!(result instanceof ObjectValue)) {
+        return result;
+      }
+```
+
+<a id="ref-q1-15"></a>
+### [15] `src/abstract-ops/type-conversion.mts:111-112`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L111-L112)
+
+```
+  // 6. Throw a TypeError exception.
+  return surroundingAgent.Throw('TypeError', 'ObjectToPrimitive');
+```
+
+<a id="ref-q1-16"></a>
+### [16] `src/abstract-ops/type-conversion.mts:454-458`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L454-L458)
+
+```
+  } else if (argument instanceof ObjectValue) {
+    // 1. Let primValue be ? ToPrimitive(argument, string).
+    const primValue = Q(yield* ToPrimitive(argument, 'string'));
+    // 2. Return ? ToString(primValue).
+    return Q(yield* ToString(primValue));
+```
+
+<a id="ref-q1-17"></a>
+### [17] `src/abstract-ops/type-conversion.mts:454-456`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L454-L456)
+
+```
+  } else if (argument instanceof ObjectValue) {
+    // 1. Let primValue be ? ToPrimitive(argument, string).
+    const primValue = Q(yield* ToPrimitive(argument, 'string'));
+```
+
+<a id="ref-q1-18"></a>
+### [18] `src/abstract-ops/type-conversion.mts:457-458`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L457-L458)
+
+```
+    // 2. Return ? ToString(primValue).
+    return Q(yield* ToString(primValue));
+```
+
+<a id="ref-q1-19"></a>
+### [19] `src/abstract-ops/type-conversion.mts:90-92`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L90-L92)
+
+```
+  if (hint === 'string') {
+    // a. Let methodNames be « "toString", "valueOf" ».
+    methodNames = [Value('toString'), Value('valueOf')];
+```
+
+<a id="ref-q1-20"></a>
+### [20] `src/abstract-ops/type-conversion.mts:101`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/abstract-ops/type-conversion.mts#L101)
+
+```
+    // b. If IsCallable(method) is true, then
+```
+
+<a id="ref-q1-21"></a>
+### [21] `src/parser/ExpressionParser.mts:361-363`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/parser/ExpressionParser.mts#L361-L363)
+
+```
+              node = this.startNode<ParseNode.AdditiveExpression>(left);
+              node.AdditiveExpression = left as ParseNode.AdditiveExpressionOrHigher; // NOTE: unsound cast
+              node.MultiplicativeExpression = right as ParseNode.MultiplicativeExpressionOrHigher; // NOTE: unsound cast
+```
+
+<a id="ref-q1-22"></a>
+### [22] `src/evaluator.mts:98-107`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/evaluator.mts#L98-L107)
+
+```
+export function* Evaluate(node: ParseNode): Evaluator<unknown> {
+  surroundingAgent.runningExecutionContext.callSite.setLocation(node);
+
+  if (surroundingAgent.hostDefinedOptions.onNodeEvaluation) {
+    surroundingAgent.hostDefinedOptions.onNodeEvaluation(node, surroundingAgent.currentRealmRecord);
+  }
+  if (surroundingAgent.hostDefinedOptions.onDebugger) {
+    const resumption = yield { type: 'potential-debugger' };
+    Assert(resumption.type === 'debugger-resume');
+  }
+```
+
+<a id="ref-q1-23"></a>
+### [23] `src/evaluator.mts:99`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/src/evaluator.mts#L99)
+
+```
+  surroundingAgent.runningExecutionContext.callSite.setLocation(node);
+```
+
+<a id="ref-q1-24"></a>
+### [24] `Core Architecture:100`
+Source: [engine262/engine262 @ 92b97644](https://github.com/engine262/engine262/blob/92b97644/Core Architecture#L100)

--- a/reference/deepwiki/addition-coercion.md
+++ b/reference/deepwiki/addition-coercion.md
@@ -1,0 +1,27 @@
+# Addition Coercion Reference Notes
+
+Full DeepWiki responses:
+
+- `reference/deepwiki/addition-coercion-engine262.md`
+- `reference/deepwiki/addition-coercion-boa.md`
+
+## engine262
+
+- `Evaluate_AdditiveExpression` is dispatched from `src/evaluator.mts` for `AdditiveExpression` nodes. The model follows the spec shape: evaluate the left operand, apply `GetValue`, evaluate the right operand, apply `GetValue`, then perform addition semantics.
+- Assignment expressions dispatch through `Evaluate_AssignmentExpression`; the important invariant for `(y = 1) + y` is that assignment returns the assigned value after storing it, so the left operand contributes `1` and the later `GetValue(y)` also reads `1`.
+- `ToPrimitive(input, preferredType)` checks `@@toPrimitive` first, calls it with the correct hint, rejects object results, and otherwise falls back to `OrdinaryToPrimitive`.
+- Addition uses the default/number ordinary hint, so ordinary objects try `valueOf` then `toString`. String coercion uses the string hint, so ordinary objects try `toString` then `valueOf`.
+- Ordinary object default stringification is `"[object Object]"`; function stringification routes through the function `toString` path rather than a malformed object tag.
+
+## Boa
+
+- Boa's `JsValue::add` has fast paths for numeric, BigInt, and string/string addition, then a slow path that converts both operands with `to_primitive(context, PreferredType::Default)`.
+- After `ToPrimitive`, if either primitive is a string, Boa concatenates `ToString(left)` and `ToString(right)`; otherwise it converts both primitives to numeric and performs number or BigInt addition.
+- `compile_assign` keeps simple assignment expression results in the destination register used by the surrounding expression. That preserves `(y = 1)` as the value `1` before the right-side `y` is evaluated.
+- `JsObject::to_primitive` checks `[Symbol.toPrimitive]`, rejects object results, and falls back to `ordinary_to_primitive`. Its ordinary method order is `valueOf`, `toString` for default/number and `toString`, `valueOf` for string.
+- `Function.prototype.toString` has a dedicated implementation for callable objects; ordinary object default stringification remains the standard `"[object Object]"`.
+
+## Perry Regression Targets
+
+- `language/expressions/addition/S11.6.1_A2.4_T4.js`: ensure the assignment expression in `(y = 1) + y` stores before the following read and evaluates to the assigned value, producing `2`.
+- `language/expressions/addition/S11.6.1_A3.2_T1.2.js`: ensure object/function default addition follows `ToPrimitive(default)` and string-concatenates the resulting `ToString` values without producing malformed `"[object Object]}"` text.

--- a/tests/test_c262_array_addition_parity.sh
+++ b/tests/test_c262_array_addition_parity.sh
@@ -68,6 +68,9 @@ check("nested value 0/0", array[0][0], 1);
 check("nested value 0/1", array[0][1], 2);
 check("nested value 1/0", array[1][0], 3);
 
+check("assignment expression result participates in following GetValue",
+  (c262_parity_eval_order_y = 1) + c262_parity_eval_order_y, 2);
+
 checkThrows("unresolvable lhs is read before sloppy rhs assignment", ReferenceError, function() {
   c262_parity_unbound_x + (c262_parity_unbound_x = 1);
 });
@@ -119,6 +122,19 @@ checkThrows("symbol addition throws after both ToPrimitive calls", TypeError, fu
   })();
 });
 check("symbol TypeError trace", trace, "1234");
+
+check("object plus function default stringification",
+  ({} + function(){return 1}),
+  ({}.toString() + function(){return 1}.toString()));
+check("function plus object default stringification",
+  (function(){return 1} + {}),
+  (function(){return 1}.toString() + {}.toString()));
+check("function plus function default stringification",
+  (function(){return 1} + function(){return 1}),
+  (function(){return 1}.toString() + function(){return 1}.toString()));
+check("object plus object default stringification",
+  ({} + {}),
+  ({}.toString() + {}.toString()));
 
 if (failures.length !== 0) {
   throw new Error(failures.join("\n"));


### PR DESCRIPTION
## Summary

- predeclare sloppy implicit assignment targets used in `if` tests before lowering the condition, preserving `(y = 1) + y` evaluation order
- add focused HIR and executable regressions for c262 addition order and object/function default stringification
- save DeepWiki reference notes for engine262 and Boa addition/coercion behavior

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/andrew/Documents/perry-2/target cargo test -p perry-hir --test c262_parity`
- `CARGO_TARGET_DIR=/Users/andrew/Documents/perry-2/target cargo check -p perry-hir -p perry-runtime -p perry-codegen -p perry`
- `CARGO_TARGET_DIR=/Users/andrew/Documents/perry-2/target cargo build --release -p perry-runtime -p perry-stdlib -p perry`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_BIN=/Users/andrew/Documents/perry-2/target/release/perry tests/test_c262_array_addition_parity.sh`
- direct compile/run probe for `if ((y = 1) + y !== 2)` prints `ok`
- direct compile/run probe for object/function default stringification prints `ok`
- `scripts/test262_subset.py --root /Users/andrew/Documents/perry-2/vendor/test262 --dir language/expressions/addition --sample-cap 1000000 --perry-bin /Users/andrew/Documents/perry-2/target/release/perry` completed with `pass=0 diff=0 runtime-fail=40 compile-fail=0 skip=0`; report samples show runtime failures with `(no output)`, matching the existing harness/runtime residual rather than compile failures

Compiler-output regression was not run because this change does not touch numeric codegen paths.
