### PR TITLE
[codex] fix vm contextified execution targets

### DIFF
--- a/crates/perry-runtime/src/node_vm.rs
+++ b/crates/perry-runtime/src/node_vm.rs
@@ -973,6 +973,10 @@ fn new_plain_context() -> f64 {
     value
 }
 
+pub(crate) fn create_context(value: f64) -> f64 {
+    context_from_arg(value, "object")
+}
+
 fn context_from_arg(value: f64, arg_name: &str) -> f64 {
     let jv = JSValue::from_bits(value.to_bits());
     if jv.is_undefined() || is_dont_contextify(value) {
@@ -1439,7 +1443,7 @@ extern "C" fn vm_script_run_in_new_context_method(
     let Some(source) = script_source(script) else {
         return undefined_value();
     };
-    let context = context_from_arg(context_object, "contextObject");
+    let context = context_from_arg(context_object, "object");
     run_source(&source, context, HashMap::new())
 }
 
@@ -1472,7 +1476,7 @@ pub extern "C" fn js_vm_run_in_context(code: f64, contextified_object: f64, _opt
 
 pub extern "C" fn js_vm_run_in_new_context(code: f64, context_object: f64, _options: f64) -> f64 {
     let code = code_string_required(code, "code");
-    let context = context_from_arg(context_object, "contextObject");
+    let context = context_from_arg(context_object, "object");
     run_source(&code, context, HashMap::new())
 }
 
@@ -1953,7 +1957,7 @@ pub fn dispatch_vm_method(method: &str, arg0: f64, arg1: f64, arg2: f64) -> f64 
         "Module" => js_vm_module_call(),
         "SourceTextModule" => js_vm_source_text_module_new(arg0, arg1),
         "SyntheticModule" => js_vm_synthetic_module_new(arg0, arg1, arg2),
-        "createContext" => crate::object::js_vm_create_context(arg0),
+        "createContext" => create_context(arg0),
         "createScript" => js_vm_create_script(arg0, arg1),
         "runInContext" => js_vm_run_in_context(arg0, arg1, arg2),
         "runInNewContext" => js_vm_run_in_new_context(arg0, arg1, arg2),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -36,12 +36,7 @@ thread_local! {
 
 #[no_mangle]
 pub extern "C" fn js_vm_create_context(sandbox: f64) -> f64 {
-    let value = JSValue::from_bits(sandbox.to_bits());
-    if value.is_undefined() || value.is_null() {
-        let obj = js_object_alloc(0, 0);
-        return crate::value::js_nanbox_pointer(obj as i64);
-    }
-    sandbox
+    crate::node_vm::create_context(sandbox)
 }
 
 pub fn scan_native_callable_export_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -129,23 +129,24 @@ Selected highlights (full list in `runtime-parity.md`):
 ### node:vm
 
 **Total APIs: 32** · Perry covers: import/require namespace shape, callable
-export metadata, `vm.constants`, `process.getBuiltinModule("vm")`, and
-`vm.isContext({})`, cached-data/source-map metadata shape,
-`SourceTextModule.createCachedData()`, gated
-`SourceTextModule`/`SyntheticModule` lifecycle behavior, and
-`vm.measureMemory()` result shape and option validation · Gap: runtime VM
-execution, contextification, context-loader constant behavior, and exact V8
-heap accounting
+export metadata, `vm.constants`, `process.getBuiltinModule("vm")`,
+`vm.isContext({})`, the narrowed deterministic execution subset for
+`Script`, object-backed context mutation/isolation, `compileFunction`,
+cached-data/source-map metadata shape, `SourceTextModule.createCachedData()`,
+gated `SourceTextModule`/`SyntheticModule` lifecycle behavior, and
+`vm.measureMemory()` result shape and option validation · Gap: full VM module
+parsing/evaluation beyond deterministic lifecycle fixtures,
+`USE_MAIN_CONTEXT_DEFAULT_LOADER` dynamic-import behavior, context-loader
+constant behavior, and exact V8 heap accounting
 
-Shape coverage is fixture-backed in `test-parity/node-suite/vm`; the generated
+Coverage is fixture-backed in `test-parity/node-suite/vm`; the generated
 `test_parity_vm` inventory now skip-lists only the still-open behavior leaves.
 
 Selected highlights (full list in `runtime-parity.md`):
 
-- `new vm.Script(code[, options])`
-- `script.runInContext(contextifiedObject[, options])`
-- `script.runInNewContext([contextObject[, options]])`
-- `script.runInThisContext([options])`
+- full `SourceTextModule` / `SyntheticModule` parsing, linking, and evaluation
+  semantics beyond deterministic lifecycle fixtures
+- `vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER` dynamic-import participation
 - `vm.measureMemory([options])`
 - … and 16 more
 

--- a/test-parity/node-suite/vm/execution/script-context.ts
+++ b/test-parity/node-suite/vm/execution/script-context.ts
@@ -1,11 +1,21 @@
 // node:vm Script execution and object-backed context semantics.
 import vm from "node:vm";
 
+function errorShape(label: string, fn: () => void) {
+  try {
+    fn();
+    console.log(label + ":", "ok");
+  } catch (error: any) {
+    console.log(label + ":", error.name, error.code || "-");
+  }
+}
+
 const sandbox: any = { x: 1 };
 const context = vm.createContext(sandbox);
 
 console.log("context identity:", context === sandbox);
 console.log("context markers:", vm.isContext(context), vm.isContext({}));
+errorShape("createContext validation", () => vm.createContext(123 as any));
 
 const script = new vm.Script("x = x + 2; y = x + 1; y");
 console.log(
@@ -15,6 +25,7 @@ console.log(
   sandbox.y,
   typeof (globalThis as any).y,
 );
+errorShape("run plain object validation", () => vm.runInContext("1", {} as any));
 
 try {
   (vm as any).Script("1");


### PR DESCRIPTION
## Linked issues

Closes #3127.
Closes #3128.
Closes #3130.

## Behavior cluster summary

This PR fixes the default `node:vm` execution/context slice:

- routes every public `vm.createContext()` path through the same VM context registry used by `vm.isContext()` and `runInContext()` validation;
- preserves object-backed context identity so `vm.Script#runInContext()` and `vm.compileFunction(..., { parsingContext })` accept the object returned by `createContext()`;
- aligns invalid sandbox validation for `createContext()` / `runInNewContext()` with Node's `ERR_INVALID_ARG_TYPE` shape for the covered cases;
- updates the VM gap summary so the narrowed Script/context/compileFunction fixtures are no longer described as current gaps.

## Why these were batched

#3127, #3128, and #3130 all fail through the same VM contextification path. `createContext()` returned the original sandbox object but did not mark that object in the VM context registry, so `isContext()`, `Script#runInContext()`, and `compileFunction({ parsingContext })` disagreed about the same value. Fixing them together keeps Script execution, sandbox execution, and compiled-function parsing contexts coherent.

## Tests added or updated

- Extended `test-parity/node-suite/vm/execution/script-context.ts` with `createContext(123)` and plain-object `runInContext()` validation checks.

## Commands run

- Baseline before fix: `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module vm` -> 5 pass, 2 fail (`execution/compile-function`, `execution/script-context`)
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" node --experimental-strip-types test-parity/node-suite/vm/execution/script-context.ts`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" node --experimental-strip-types test-parity/node-suite/vm/execution/compile-function.ts`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module vm --filter execution` -> 2 pass, 0 fail
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module vm` -> 7 pass, 0 fail
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo check -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations

- This preserves Perry's narrowed VM evaluator subset; it is not a full JavaScript interpreter.
- Full `SourceTextModule` / `SyntheticModule` parsing, linking, and evaluation semantics beyond deterministic lifecycle fixtures remain open.
- `USE_MAIN_CONTEXT_DEFAULT_LOADER` dynamic-import participation and `vm.measureMemory()` remain open.

## Non-goals

- No cached-data bytecode fidelity changes.
- No broader VM module lifecycle work.
- No security sandbox hardening beyond Node-observable context identity and validation behavior.