### PR TITLE
[codex] node:domain parity reconciliation

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/node_domain.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_domain.rs
@@ -107,7 +107,7 @@ pub(super) const NODE_DOMAIN_ROWS: &[NativeModSig] = &[
         class_filter: None,
         runtime: "js_domain_enter",
         args: &[],
-        ret: NR_PTR,
+        ret: NR_F64,
     },
     NativeModSig {
         module: "domain",
@@ -116,6 +116,6 @@ pub(super) const NODE_DOMAIN_ROWS: &[NativeModSig] = &[
         class_filter: None,
         runtime: "js_domain_exit",
         args: &[],
-        ret: NR_PTR,
+        ret: NR_F64,
     },
 ];

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1318,8 +1318,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_domain_intercept", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_domain_add", I64, &[I64, DOUBLE]);
     module.declare_function("js_domain_remove", I64, &[I64, DOUBLE]);
-    module.declare_function("js_domain_enter", I64, &[I64]);
-    module.declare_function("js_domain_exit", I64, &[I64]);
+    module.declare_function("js_domain_enter", DOUBLE, &[I64]);
+    module.declare_function("js_domain_exit", DOUBLE, &[I64]);
 
     // ========== StringDecoder (issue #848) ==========
     // `js_string_decoder_new` allocates a real handle; `write` / `end`

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -1195,9 +1195,19 @@ pub fn process_metadata_property(property: &str) -> Option<f64> {
         "_exiting" => bool_value(false),
         "_maxListeners" => undefined_value(),
         "_preload_modules" => module_array_value(&[]),
-        "domain" => f64::from_bits(crate::value::TAG_NULL),
+        "domain" => active_domain_value(),
         _ => return None,
     })
+}
+
+fn active_domain_value() -> f64 {
+    let ptr = crate::value::JS_NATIVE_DOMAIN_DISPATCH.load(Ordering::SeqCst);
+    if ptr.is_null() {
+        return f64::from_bits(crate::value::TAG_NULL);
+    }
+    let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
+        unsafe { std::mem::transmute(ptr) };
+    unsafe { dispatch(b"active".as_ptr(), b"active".len(), std::ptr::null(), 0) }
 }
 
 /// `module.builtinModules` — Node exposes this as an Array of builtin module

--- a/crates/perry-stdlib/src/domain.rs
+++ b/crates/perry-stdlib/src/domain.rs
@@ -178,7 +178,7 @@ fn exit_domain(handle: Handle) {
     ACTIVE_DOMAINS.with(|stack| {
         let mut stack = stack.borrow_mut();
         if let Some(pos) = stack.iter().rposition(|candidate| *candidate == handle) {
-            stack.remove(pos);
+            stack.truncate(pos);
         }
     });
 }
@@ -381,15 +381,15 @@ pub unsafe extern "C" fn js_domain_remove(handle: Handle, member: f64) -> Handle
 }
 
 #[no_mangle]
-pub extern "C" fn js_domain_enter(handle: Handle) -> Handle {
+pub extern "C" fn js_domain_enter(handle: Handle) -> f64 {
     enter_domain(handle);
-    handle
+    undefined()
 }
 
 #[no_mangle]
-pub extern "C" fn js_domain_exit(handle: Handle) -> Handle {
+pub extern "C" fn js_domain_exit(handle: Handle) -> f64 {
     exit_domain(handle);
-    handle
+    undefined()
 }
 
 extern "C" fn domain_bound_wrapper(closure: *const ClosureHeader, rest: f64) -> f64 {
@@ -460,8 +460,8 @@ pub unsafe fn dispatch_domain_method(handle: Handle, method: &str, args: &[f64])
         "intercept" if !args.is_empty() => Some(js_domain_intercept(handle, args[0])),
         "add" if !args.is_empty() => Some(nanbox_handle(js_domain_add(handle, args[0]))),
         "remove" if !args.is_empty() => Some(nanbox_handle(js_domain_remove(handle, args[0]))),
-        "enter" => Some(nanbox_handle(js_domain_enter(handle))),
-        "exit" => Some(nanbox_handle(js_domain_exit(handle))),
+        "enter" => Some(js_domain_enter(handle)),
+        "exit" => Some(js_domain_exit(handle)),
         _ => None,
     }
 }

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -203,23 +203,6 @@ Selected highlights (full list in `runtime-parity.md`):
 - `inspector.Network.responseReceived(params)`
 - … and 7 more
 
-### node:domain
-
-**Total APIs: 10** · Perry covers: 0 · Gap: 10
-
-Selected highlights (full list in `runtime-parity.md`):
-
-- `domain.create()`
-- `domain.active`
-- `domain.members`
-- `domain.add(emitter)`
-- `domain.bind(callback)`
-- `domain.intercept(callback)`
-- `domain.enter()`
-- `domain.exit()`
-- `domain.remove(emitter)`
-- `domain.run(fn[, ...args])`
-
 ### node:readline/promises
 
 **Total APIs: 7** · Perry covers: 0 · Gap: 7

--- a/scripts/parity-skiplist.toml
+++ b/scripts/parity-skiplist.toml
@@ -50,7 +50,6 @@
 # getHeapCodeStatistics/cachedDataVersionTag return runtime-specific values
 # (categories 2 + 3). Roundtrips and shapes work; byte-for-byte diffing does not.
 "v8" = "V8-specific introspection + JSC-format serialization; callable but not byte-parity-testable (see #3700)."
-"domain" = "Deprecated since Node 4; not implementing legacy error-routing system."
 
 # Out-of-scope test surface.
 "test/mock" = "Test-runner mocking; covered transitively by node:test if pursued."

--- a/test-parity/node-suite/domain/enter-exit-process-domain.ts
+++ b/test-parity/node-suite/domain/enter-exit-process-domain.ts
@@ -1,0 +1,28 @@
+import domain from "node:domain";
+
+const d1 = domain.create();
+const d2 = domain.create();
+
+function domainLabel(value: any): string {
+  if (value === d1) return "d1";
+  if (value === d2) return "d2";
+  return String(value);
+}
+
+function logState(label: string) {
+  console.log(label, domainLabel(domain.active), domainLabel((process as any).domain));
+}
+
+logState("initial:");
+console.log("enter d1 return:", String(d1.enter()));
+logState("after enter d1:");
+d2.enter();
+logState("after enter d2:");
+console.log("exit d2 return:", String(d2.exit()));
+logState("after exit d2:");
+d2.enter();
+logState("after reenter d2:");
+d1.exit();
+logState("after exit d1:");
+d2.exit();
+logState("after duplicate exit d2:");


### PR DESCRIPTION
## Linked issues

Closes #3842.

## Behavior cluster

This reconciles the `node:domain` surface that Perry already exposes in the manifest/runtime with the parity metadata and adds one missing behavior fixture around explicit domain stack management.

Changes:
- remove `node:domain` from the module parity skiplist;
- remove the stale `node:domain` 0/10 gap block from `runtime-parity-gaps.md`;
- make `Domain#enter()` and `Domain#exit()` return `undefined`, matching Node;
- make `Domain#exit()` unwind the active domain stack from the exited domain upward;
- expose `process.domain` through the same active-domain state as `domain.active`;
- correct codegen declarations/table returns for `js_domain_enter` and `js_domain_exit` to `f64`/native JS value returns;
- add a domain fixture covering `enter()`, `exit()`, nested stack behavior, duplicate exit, and `process.domain` mirroring.

## Why batched

These are one coherent `node:domain` reconciliation cut for #3842: the stale skiplist/docs claim, active-domain runtime behavior, codegen ABI metadata, and parity fixture all describe the same manifest-claimed module surface. Splitting them would leave contradictory state in either tests, runtime, or documentation.

## Tests added

- `test-parity/node-suite/domain/enter-exit-process-domain.ts`

## Verification

- `PATH=/tmp/perry-node25-bin:$PATH node test-parity/node-suite/domain/enter-exit-process-domain.ts`
- `PATH=/tmp/perry-node25-bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module domain --filter enter-exit-process-domain`
- `PATH=/tmp/perry-node25-bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module domain`
- `CARGO_BUILD_JOBS=2 RUSTFLAGS='-C linker=cc -C link-arg=-fuse-ld=bfd' cargo test -p perry-runtime process`
- `CARGO_BUILD_JOBS=2 RUSTFLAGS='-C linker=cc -C link-arg=-fuse-ld=bfd' cargo test -p perry-stdlib domain`
- `CARGO_BUILD_JOBS=2 RUSTFLAGS='-C linker=cc -C link-arg=-fuse-ld=bfd' cargo test -p perry-codegen --test manifest_consistency`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations

`node:domain` remains a deprecated Node API. This PR does not attempt a broad domain rearchitecture or full async-context propagation beyond Perry's existing runtime surface and the covered active-stack/EventEmitter/error-routing paths.

## Non-goals

- unrelated EventEmitter behavior changes;
- unrelated docs/API regeneration churn;
- changing unsupported V8-specific or inspector parity policy.
