### PR TITLE
[codex] Route Reflect.construct through construct semantics

### DIFF
--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -348,7 +348,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let nt = lower_expr(ctx, new_target)?;
             Ok(ctx.block().call(
                 DOUBLE,
-                "js_proxy_construct",
+                "js_reflect_construct",
                 &[(DOUBLE, &t), (DOUBLE, &a), (DOUBLE, &nt)],
             ))
         }

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -246,6 +246,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function("js_proxy_delete", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_proxy_apply", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_proxy_construct", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_reflect_construct", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_reflect_get", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_reflect_set", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function(

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1601,6 +1601,81 @@ pub unsafe extern "C" fn js_new_function_construct(
     nan_boxed
 }
 
+fn constructor_prototype_bits(new_target: f64) -> Option<u64> {
+    let bits = new_target.to_bits();
+    if (bits >> 48) != 0x7FFD {
+        return global_object_prototype_bits();
+    }
+    let raw = (bits & crate::value::POINTER_MASK) as usize;
+    if raw == 0 {
+        return global_object_prototype_bits();
+    }
+    let key = crate::string::js_string_from_bytes(b"prototype".as_ptr(), b"prototype".len() as u32);
+    let proto = js_object_get_field_by_name_f64(raw as *const ObjectHeader, key);
+    if unsafe { super::value_is_object_like(proto) } || super::class_ref_id(proto).is_some() {
+        Some(proto.to_bits())
+    } else {
+        global_object_prototype_bits()
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_new_function_construct_with_new_target(
+    func_value: f64,
+    args_ptr: *const f64,
+    args_len: usize,
+    new_target: f64,
+) -> f64 {
+    let nt = if new_target.to_bits() == crate::value::TAG_UNDEFINED {
+        func_value
+    } else {
+        new_target
+    };
+    if nt.to_bits() == func_value.to_bits() {
+        return js_new_function_construct(func_value, args_ptr, args_len);
+    }
+    if crate::proxy::js_proxy_is_proxy(func_value) == 1 {
+        let arr = crate::array::js_array_alloc(0);
+        let mut a = arr;
+        if !args_ptr.is_null() {
+            for i in 0..args_len {
+                a = crate::array::js_array_push_f64(a, *args_ptr.add(i));
+            }
+        }
+        let arr_box = f64::from_bits(0x7FFD_0000_0000_0000 | (a as u64 & 0x0000_FFFF_FFFF_FFFF));
+        return crate::proxy::js_proxy_construct(func_value, arr_box, nt);
+    }
+    if !is_callable_function_value(func_value) {
+        return js_new_function_construct(func_value, args_ptr, args_len);
+    }
+    if is_arrow_function_value(func_value) {
+        crate::fs::validate::throw_type_error_with_code(
+            "Arrow function is not a constructor",
+            "ERR_INVALID_ARG_TYPE",
+        );
+    }
+
+    let obj_ptr = js_object_alloc(0, 0);
+    let nan_boxed = crate::value::js_nanbox_pointer(obj_ptr as i64);
+    if let Some(proto_bits) = constructor_prototype_bits(nt) {
+        super::prototype_chain::object_set_static_prototype(obj_ptr as usize, proto_bits);
+    }
+
+    let prev_this = crate::object::js_implicit_this_get();
+    let prev_new_target = crate::object::js_new_target_get();
+    crate::object::js_implicit_this_set(nan_boxed);
+    crate::object::js_new_target_set(nt);
+    let prev_current_new_target = CURRENT_NEW_TARGET.with(|value| value.replace(nt.to_bits()));
+    let result = crate::closure::js_native_call_value(func_value, args_ptr, args_len);
+    CURRENT_NEW_TARGET.with(|value| value.set(prev_current_new_target));
+    crate::object::js_new_target_set(prev_new_target);
+    crate::object::js_implicit_this_set(prev_this);
+    if constructor_return_overrides_this(result) {
+        return result;
+    }
+    nan_boxed
+}
+
 fn constructor_return_overrides_this(value: f64) -> bool {
     use crate::value::JSValue;
     let jv = JSValue::from_bits(value.to_bits());

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -887,26 +887,16 @@ fn forward_construct(target: f64, args_array: f64, new_target: f64) -> f64 {
     if lookup(target).is_some() {
         return js_proxy_construct(target, args_array, new_target);
     }
-    // Plain function/class target: build the positional arg buffer and
-    // construct via the function-as-constructor path.
-    let args_bits = args_array.to_bits();
-    let arr_ptr = (args_bits & POINTER_MASK) as *const crate::ArrayHeader;
-    let len = if arr_ptr.is_null() {
-        0
-    } else {
-        crate::array::js_array_length(arr_ptr) as usize
-    };
-    let mut buf: Vec<f64> = Vec::with_capacity(len);
-    for i in 0..len {
-        let v = crate::array::js_array_get(arr_ptr, i as u32);
-        buf.push(f64::from_bits(v.bits()));
+    if !is_callable_function(target) {
+        return throw_type_error("target is not a constructor");
     }
+    let buf = create_list_from_array_like(args_array);
     let (ptr, n) = if buf.is_empty() {
         (std::ptr::null::<f64>(), 0usize)
     } else {
         (buf.as_ptr(), buf.len())
     };
-    unsafe { crate::object::js_new_function_construct(target, ptr, n) }
+    unsafe { crate::object::js_new_function_construct_with_new_target(target, ptr, n, new_target) }
 }
 
 /// `new Proxy(...)` / `Reflect.construct(p, args, newTarget)`.
@@ -971,6 +961,41 @@ pub extern "C" fn js_proxy_construct(proxy_boxed: f64, args_array: f64, new_targ
         return throw_type_error("proxy [[Construct]] trap returned a non-object value");
     }
     result
+}
+
+fn array_from_args(args: &[f64]) -> f64 {
+    let arr = crate::array::js_array_alloc(0);
+    let mut a = arr;
+    for &arg in args {
+        a = crate::array::js_array_push_f64(a, arg);
+    }
+    f64::from_bits(POINTER_TAG | ((a as u64) & POINTER_MASK))
+}
+
+#[no_mangle]
+pub extern "C" fn js_reflect_construct(target: f64, args_like: f64, new_target: f64) -> f64 {
+    if !is_callable_function(target) {
+        return throw_type_error("target is not a constructor");
+    }
+    let nt = if new_target.to_bits() == TAG_UNDEFINED {
+        target
+    } else {
+        new_target
+    };
+    if !is_callable_function(nt) {
+        return throw_type_error("newTarget is not a constructor");
+    }
+    let args = create_list_from_array_like(args_like);
+    if lookup(target).is_some() {
+        let args_array = array_from_args(&args);
+        return js_proxy_construct(target, args_array, nt);
+    }
+    let (ptr, n) = if args.is_empty() {
+        (std::ptr::null::<f64>(), 0usize)
+    } else {
+        (args.as_ptr(), args.len())
+    };
+    unsafe { crate::object::js_new_function_construct_with_new_target(target, ptr, n, nt) }
 }
 
 // ---- Reflect.* helpers (direct wrappers, not proxy-specific) -----

--- a/test-parity/node-suite/object/reflect-proxy-construct.ts
+++ b/test-parity/node-suite/object/reflect-proxy-construct.ts
@@ -1,0 +1,86 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label, "ok", JSON.stringify(fn()));
+  } catch (err: any) {
+    console.log(label, "throw", err?.constructor?.name ?? err?.name ?? typeof err);
+  }
+}
+
+function Target(a: number, b: number) {
+  (this as any).sum = a + b;
+  (this as any).args = [a, b];
+}
+
+function NewTarget() {}
+(NewTarget as any).prototype.kind = "custom";
+
+show("Reflect.construct newTarget prototype", () => {
+  const obj: any = Reflect.construct(Target, [2, 3], NewTarget);
+  return [
+    obj.sum,
+    Object.getPrototypeOf(obj) === (NewTarget as any).prototype,
+    obj instanceof (NewTarget as any),
+  ];
+});
+
+show("Reflect.construct array-like args", () => {
+  const obj: any = Reflect.construct(Target, { 0: 4, 1: 5, length: 2 } as any);
+  return obj.sum;
+});
+
+show("Reflect.construct null args throws", () => {
+  return Reflect.construct(Target, null as any);
+});
+
+show("Reflect.construct nonconstructor target throws", () => {
+  return Reflect.construct(1 as any, []);
+});
+
+show("Reflect.construct nonconstructor newTarget throws", () => {
+  return Reflect.construct(Target, [], 1 as any);
+});
+
+function TrapTarget(a: string) {
+  (this as any).arg = a;
+}
+
+let proxyWithTrap: any;
+const handler = {
+  construct(target: any, args: any[], newTarget: any) {
+    return [args[0], newTarget === proxyWithTrap, this === handler, target === TrapTarget];
+  },
+};
+proxyWithTrap = new Proxy(TrapTarget, handler);
+
+show("proxy construct trap args", () => {
+  return Reflect.construct(proxyWithTrap, ["p"]);
+});
+
+const badReturn = new Proxy(function BadReturn() {}, {
+  construct() {
+    return 1 as any;
+  },
+});
+
+show("proxy construct trap bad return throws", () => {
+  return Reflect.construct(badReturn, []);
+});
+
+function Foo(a: number) {
+  (this as any).arg = a;
+}
+
+function Bar() {}
+(Bar as any).prototype = Object.create((Foo as any).prototype);
+(Bar as any).prototype.constructor = Bar;
+(Bar as any).prototype.isBar = true;
+
+const FooProxy: any = new Proxy(new Proxy(Foo, {}), { construct: null as any });
+
+show("proxy chain honors newTarget prototype", () => {
+  const bar: any = Reflect.construct(FooProxy, [7], Bar);
+  return [
+    bar.arg,
+    Object.getPrototypeOf(bar) === (Bar as any).prototype,
+  ];
+});


### PR DESCRIPTION
## Summary
- route `Reflect.construct` through a Reflect-specific runtime helper instead of the proxy-only construct helper
- convert `argumentsList` with the existing array-like path, validate target/newTarget constructor inputs, and preserve explicit `newTarget` for ordinary function construction
- forward trap-less proxy `[[Construct]]` through the same newTarget-aware construction path and add focused parity coverage

## Validation
- `PATH="/tmp/perry-node25-bin:$PATH" ./run_parity_tests.sh --suite node-suite --module object --filter reflect-proxy-construct`
- `PATH="/tmp/perry-node25-bin:$PATH" ./run_parity_tests.sh --suite node-suite --module object --filter is-prototype-of`
- `PATH="/tmp/perry-node25-bin:$PATH" ./run_parity_tests.sh --suite node-suite --module globals --filter reflective-builtins`
- `cargo build -p perry-runtime -p perry-hir -p perry-codegen -p perry`
- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`
