### PR TITLE
[codex] implement vm measureMemory shape

### DIFF
--- a/crates/perry-runtime/src/node_vm.rs
+++ b/crates/perry-runtime/src/node_vm.rs
@@ -242,6 +242,10 @@ fn throw_invalid_arg(message: &str) -> ! {
     crate::fs::validate::throw_type_error_with_code(message, "ERR_INVALID_ARG_TYPE")
 }
 
+fn throw_invalid_arg_value(message: &str) -> ! {
+    crate::fs::validate::throw_type_error_with_code(message, "ERR_INVALID_ARG_VALUE")
+}
+
 fn throw_vm_status(message: &str) -> f64 {
     crate::fs::validate::throw_error_with_code(message, "ERR_VM_MODULE_STATUS")
 }
@@ -280,6 +284,20 @@ fn option_field(options: f64, name: &str) -> f64 {
     object_ptr_from_value(options)
         .map(|obj| get_field(obj, name))
         .unwrap_or_else(undefined_value)
+}
+
+fn options_object_or_default(options: f64) -> Option<*mut ObjectHeader> {
+    let jv = JSValue::from_bits(options.to_bits());
+    if jv.is_undefined() {
+        return None;
+    }
+    object_ptr_from_value(options).or_else(|| {
+        let message = format!(
+            "The \"options\" argument must be of type object. Received {}",
+            crate::fs::validate::describe_received(options)
+        );
+        throw_invalid_arg(&message);
+    })
 }
 
 fn validate_produce_cached_data(options: f64) -> bool {
@@ -325,6 +343,33 @@ fn validate_cached_data_option(options: f64) -> Option<Vec<u8>> {
         crate::fs::validate::describe_received(value)
     );
     throw_invalid_arg(&message);
+}
+
+fn validate_one_of_string(
+    value: f64,
+    property: &str,
+    allowed: &[&str],
+    default_value: &str,
+) -> String {
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() {
+        return default_value.to_string();
+    }
+    if let Some(value) = string_from_value(value) {
+        if allowed.iter().any(|allowed| value == *allowed) {
+            return value;
+        }
+    }
+    let expected = allowed
+        .iter()
+        .map(|value| format!("'{value}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let message = format!(
+        "The property '{property}' must be one of: {expected}. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    throw_invalid_arg_value(&message);
 }
 
 fn source_hash(kind: u8, source: &str, params: &[String]) -> u64 {
@@ -1528,8 +1573,71 @@ pub extern "C" fn js_vm_compile_function(code: f64, params: f64, options: f64) -
     value
 }
 
-pub extern "C" fn js_vm_measure_memory(_options: f64) -> f64 {
-    throw_vm_unimplemented("measureMemory", "3284")
+fn memory_range_value(estimate: f64) -> f64 {
+    let mut range = crate::array::js_array_alloc(2);
+    range = crate::array::js_array_push_f64(range, estimate);
+    range = crate::array::js_array_push_f64(range, estimate);
+    array_value(range)
+}
+
+fn memory_entry_value(estimate: f64) -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    set_field(obj, "jsMemoryEstimate", estimate);
+    set_field(obj, "jsMemoryRange", memory_range_value(estimate));
+    object_value(obj)
+}
+
+fn webassembly_memory_value() -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    set_field(obj, "code", 0.0);
+    set_field(obj, "metadata", 0.0);
+    object_value(obj)
+}
+
+fn measure_memory_result(detailed: bool) -> f64 {
+    let mut heap_used = 0_u64;
+    let mut heap_total = 0_u64;
+    crate::arena::js_arena_stats(&mut heap_used, &mut heap_total);
+    let estimate = heap_used.max(heap_total) as f64;
+    let obj = crate::object::js_object_alloc(0, if detailed { 4 } else { 2 });
+    set_field(obj, "total", memory_entry_value(estimate));
+    set_field(obj, "WebAssembly", webassembly_memory_value());
+    if detailed {
+        set_field(obj, "current", memory_entry_value(estimate));
+        set_field(obj, "other", array_value(crate::array::js_array_alloc(0)));
+    }
+    object_value(obj)
+}
+
+fn validate_measure_memory_options(options: f64) -> bool {
+    let options = options_object_or_default(options);
+    let mode_value = options
+        .map(|options| get_field(options, "mode"))
+        .unwrap_or_else(undefined_value);
+    let execution_value = options
+        .map(|options| get_field(options, "execution"))
+        .unwrap_or_else(undefined_value);
+    let mode = validate_one_of_string(
+        mode_value,
+        "options.mode",
+        &["summary", "detailed"],
+        "summary",
+    );
+    let _execution = validate_one_of_string(
+        execution_value,
+        "options.execution",
+        &["default", "eager"],
+        "default",
+    );
+    mode == "detailed"
+}
+
+pub extern "C" fn js_vm_measure_memory(options: f64) -> f64 {
+    let detailed = validate_measure_memory_options(options);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let result = scope.root_nanbox_f64(measure_memory_result(detailed));
+    let promise = crate::promise::js_promise_resolved(result.get_nanbox_f64());
+    crate::value::js_nanbox_pointer(promise as i64)
 }
 
 pub extern "C" fn js_vm_script_new(code: f64, options: f64) -> f64 {

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -131,10 +131,11 @@ Selected highlights (full list in `runtime-parity.md`):
 **Total APIs: 32** · Perry covers: import/require namespace shape, callable
 export metadata, `vm.constants`, `process.getBuiltinModule("vm")`, and
 `vm.isContext({})`, cached-data/source-map metadata shape,
-`SourceTextModule.createCachedData()`, and gated
-`SourceTextModule`/`SyntheticModule` lifecycle behavior · Gap: runtime VM
-execution, contextification, context-loader constant behavior, and heap
-measurement
+`SourceTextModule.createCachedData()`, gated
+`SourceTextModule`/`SyntheticModule` lifecycle behavior, and
+`vm.measureMemory()` result shape and option validation · Gap: runtime VM
+execution, contextification, context-loader constant behavior, and exact V8
+heap accounting
 
 Shape coverage is fixture-backed in `test-parity/node-suite/vm`; the generated
 `test_parity_vm` inventory now skip-lists only the still-open behavior leaves.

--- a/test-parity/node-suite/vm/README.md
+++ b/test-parity/node-suite/vm/README.md
@@ -16,4 +16,4 @@ Intentionally open leaves:
 - Full VM module parsing/evaluation beyond deterministic lifecycle fixtures:
   #3132, #3133
 - vm.constants deeper context-loader behavior: #3283
-- measureMemory: #3284
+- Exact V8-backed heap accounting for `measureMemory()` values

--- a/test-parity/node-suite/vm/metadata/measure-memory.ts
+++ b/test-parity/node-suite/vm/metadata/measure-memory.ts
@@ -1,0 +1,61 @@
+// parity-node-argv: --no-warnings
+// node:vm measureMemory result shape and option validation.
+import * as vm from "node:vm";
+
+function errorShape(label: string, fn: () => void) {
+  try {
+    fn();
+    console.log(label + ":", "ok");
+  } catch (error: any) {
+    console.log(label + ":", error.name, error.code || "-");
+  }
+}
+
+function entryShape(label: string, entry: any) {
+  console.log(
+    label + ":",
+    typeof entry.jsMemoryEstimate,
+    Array.isArray(entry.jsMemoryRange),
+    entry.jsMemoryRange.length,
+    entry.jsMemoryRange.map((value: unknown) => typeof value).join(","),
+  );
+}
+
+console.log("measure function:", typeof vm.measureMemory, vm.measureMemory.length);
+console.log("measure promise:", typeof vm.measureMemory().then);
+
+const summary: any = await vm.measureMemory({ execution: "eager" });
+console.log("summary keys:", Object.keys(summary).join(","));
+entryShape("summary total", summary.total);
+console.log(
+  "summary wasm:",
+  Object.keys(summary.WebAssembly).join(","),
+  typeof summary.WebAssembly.code,
+  typeof summary.WebAssembly.metadata,
+);
+
+const detailed: any = await vm.measureMemory({ mode: "detailed", execution: "eager" });
+console.log("detailed keys:", Object.keys(detailed).join(","));
+entryShape("detailed total", detailed.total);
+entryShape("detailed current", detailed.current);
+console.log("detailed other:", Array.isArray(detailed.other), detailed.other.length);
+
+errorShape("mode validation", () => {
+  vm.measureMemory({ mode: "bad" as any });
+});
+
+errorShape("execution validation", () => {
+  vm.measureMemory({ execution: "bad" as any });
+});
+
+errorShape("null validation", () => {
+  vm.measureMemory(null as any);
+});
+
+errorShape("number validation", () => {
+  vm.measureMemory(1 as any);
+});
+
+errorShape("array validation", () => {
+  vm.measureMemory([] as any);
+});


### PR DESCRIPTION
## Summary

- implement `node:vm` `measureMemory()` option validation and Promise-returning result shape
- return Node-shaped summary/detailed memory objects with `total`, `WebAssembly`, `current`, and `other` fields where applicable
- add a parity fixture for `mode` / `execution` validation and stable result structure
- update VM parity notes to leave exact V8-backed heap accounting as the remaining limitation

Fixes #3284.

## Why This Cut

This stays inside the remaining top-level `node:vm` API surface. Cached-data, source-map metadata, and deterministic VM module fixtures are already present on `origin/main`, so this PR focuses on the real unimplemented `measureMemory()` leaf rather than mixing in stale issue cleanup.

## Tests

- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" node --no-warnings --experimental-strip-types test-parity/node-suite/vm/metadata/measure-memory.ts`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module vm --filter measure-memory`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo check -p perry-runtime`

## Known Limitations

- Memory numbers are Perry heap estimates, not V8 isolate measurements.
- Node's experimental warning emission is not implemented in this cut.
