### PR TITLE
[codex] lower private optional chain members

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1478,7 +1478,10 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                                 index: Box::new(index),
                             }
                         }
-                        _ => return Err(anyhow!("Unsupported optional chain property type")),
+                        ast::MemberProp::PrivateName(private) => Expr::PropertyGet {
+                            object: Box::new(obj_expr.clone()),
+                            property: format!("#{}", private.name),
+                        },
                     };
 
                     // Issue #388: optional chaining short-circuits on
@@ -1537,7 +1540,10 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                                             index: Box::new(idx),
                                         }
                                     }
-                                    _ => return Err(anyhow!("Unsupported optional chain member")),
+                                    ast::MemberProp::PrivateName(private) => Expr::PropertyGet {
+                                        object: Box::new(obj.clone()),
+                                        property: format!("#{}", private.name),
+                                    },
                                 };
                                 Ok((obj, prop))
                             };

--- a/crates/perry-hir/tests/optional_chain_private_member.rs
+++ b/crates/perry-hir/tests/optional_chain_private_member.rs
@@ -1,0 +1,39 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::lower_module;
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_src(src: &str) -> anyhow::Result<perry_hir::Module> {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "optional_chain_private_member.js", &mut cache)?;
+    lower_module(&parsed.module, "test", "optional_chain_private_member.js")
+}
+
+#[test]
+fn optional_chain_on_private_member_lowers() {
+    lower_src(
+        r#"
+        class Example {
+          #state = { type: "ready" };
+          read() {
+            return this.#state?.type;
+          }
+        }
+        "#,
+    )
+    .expect("this.#state?.type should lower");
+}
+
+#[test]
+fn optional_call_after_private_member_chain_lowers() {
+    lower_src(
+        r#"
+        class Example {
+          #hooks = { done() { return "done"; } };
+          run() {
+            return this.#hooks?.done?.();
+          }
+        }
+        "#,
+    )
+    .expect("this.#hooks?.done?.() should lower");
+}


### PR DESCRIPTION
Stacked on #4163 (`codex/fix-glob-esm-js-parse`, commit `49d9240c8`). Please review this after #4163 or compare the top commit `b258d578c` for the scoped optional-chain fix.

## What changed
- Lower optional-chain member props that SWC represents as `MemberProp::PrivateName`, matching the existing private-member property representation (`#name`).
- Covers both optional member chains and optional-call chains whose callee/member path contains a private field.
- Adds a focused HIR regression for `this.#state?.type` and `this.#hooks?.done?.()`.

## Why
The OpenTUI focused repro for `glob@13.0.5` moved past the ESM `.js` parse blocker from #4163 and then failed on private optional-chain syntax in `glob/dist/esm/index.min.js`, representative syntax `this.#o?.type`, with `Unsupported optional chain member`.

## Validation
- `cargo test -p perry-hir --test optional_chain_private_member -- --nocapture` (2 passed)
- `cargo build --release`
- Focused OpenTUI repro with `PERRY_BIN=/Users/andrew/.codex/worktrees/perry-optional-chain-member/target/release/perry` moved past `Unsupported optional chain member`; next blocker is `array.push_spread expects exactly 1 arg, got 2` in `glob/dist/esm/index.min.js` static `Q::#i`, near `e.push(...c,u)`.
