### PR TITLE
[codex] lower mixed spread array push

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -160,14 +160,27 @@ pub(super) fn try_local_array_methods(
                                 // exactly what the last ArrayPush returns.
                                 let any_spread = call.args.iter().any(|a| a.spread.is_some());
                                 if any_spread {
-                                    if args.len() == 1 {
+                                    if args.len() == 1 && call.args[0].spread.is_some() {
                                         return Ok(Ok(Expr::ArrayPushSpread {
                                             array_id,
                                             source: Box::new(args.into_iter().next().unwrap()),
                                         }));
                                     }
-                                    // Mixed regular + spread: bail to generic
-                                    // dispatch (no current single-IR-shape).
+                                    let mut stmts: Vec<Expr> = Vec::with_capacity(args.len());
+                                    for (ast_arg, arg) in call.args.iter().zip(args.into_iter()) {
+                                        if ast_arg.spread.is_some() {
+                                            stmts.push(Expr::ArrayPushSpread {
+                                                array_id,
+                                                source: Box::new(arg),
+                                            });
+                                        } else {
+                                            stmts.push(Expr::ArrayPush {
+                                                array_id,
+                                                value: Box::new(arg),
+                                            });
+                                        }
+                                    }
+                                    return Ok(Ok(Expr::Sequence(stmts)));
                                 } else {
                                     if args.len() == 1 {
                                         return Ok(Ok(Expr::ArrayPush {

--- a/crates/perry-hir/tests/array_push_mixed_spread.rs
+++ b/crates/perry-hir/tests/array_push_mixed_spread.rs
@@ -1,0 +1,60 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Expr};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_src(src: &str) -> anyhow::Result<perry_hir::Module> {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "array_push_mixed_spread.ts", &mut cache)?;
+    lower_module(&parsed.module, "test", "array_push_mixed_spread.ts")
+}
+
+#[test]
+fn array_push_mixed_spread_lowers_to_ordered_push_sequence() {
+    let module = lower_src(
+        r#"
+        const parts = [];
+        const extras = [1, 2];
+        const tail = 3;
+        parts.push(...extras, tail);
+        "#,
+    )
+    .expect("mixed spread push should lower");
+
+    let debug = format!("{module:#?}");
+    assert!(
+        debug.contains("ArrayPushSpread"),
+        "mixed spread push should include the spread push step: {debug}"
+    );
+    assert!(
+        debug.contains("ArrayPush"),
+        "mixed spread push should include the plain push step: {debug}"
+    );
+}
+
+#[test]
+fn array_push_plain_then_spread_lowers_to_ordered_push_sequence() {
+    let module = lower_src(
+        r#"
+        const parts = [];
+        const head = 1;
+        const extras = [2, 3];
+        parts.push(head, ...extras);
+        "#,
+    )
+    .expect("plain then spread push should lower");
+
+    let found_mixed_sequence = module.init.iter().any(|stmt| {
+        let perry_hir::Stmt::Expr(Expr::Sequence(exprs)) = stmt else {
+            return false;
+        };
+        matches!(
+            exprs.as_slice(),
+            [Expr::ArrayPush { .. }, Expr::ArrayPushSpread { .. }]
+        )
+    });
+
+    assert!(
+        found_mixed_sequence,
+        "plain then spread push should preserve source order in a sequence: {module:#?}"
+    );
+}


### PR DESCRIPTION
Stacked on #4169 (`codex/fix-optional-chain-member`, commit `b258d578c`), which is stacked on #4163. Please review this after #4169 or compare the top commit `1128c9deb` for this scoped mixed-spread push fix.

## What changed
- Keeps `Array.prototype.push` on local array receivers in the array fast path when args mix spreads and plain values.
- Lowers mixed calls into an ordered `Expr::Sequence` of `ArrayPushSpread` and `ArrayPush`, preserving source argument order for shapes like `push(...items, tail)` and `push(head, ...items)`.
- Adds focused HIR regressions for both spread-then-plain and plain-then-spread push forms.

## Why
The OpenTUI focused repro reached `glob@13.0.5` after #4163 and #4169, then failed in `glob/dist/esm/index.min.js` static private method `Q::#i` on the representative minified call `e.push(...c,u)` with `array.push_spread expects exactly 1 arg, got 2`.

## Validation
- Reproduced with #4169 binary: `array.push_spread expects exactly 1 arg, got 2` near `e.push(...c,u)`.
- `cargo test -p perry-hir --test array_push_mixed_spread -- --nocapture` (2 passed)
- `cargo build --release`
- Focused OpenTUI repro with `PERRY_BIN=/Users/andrew/.codex/worktrees/perry-array-push-mixed-spread/target/release/perry` compiled and linked `glob/dist/esm/index.min.js` successfully. The repro wrapper still exits nonzero because its expected current-result marker is now stale (`case-result=js-esm-package-parse: unexpected current result`).
