### PR TITLE
[codex] fix vm module lifecycle edges

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4457,6 +4457,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Experimental VM module rows are gated at runtime and are not public
     // no-flag named exports, but the codegen dispatch table still needs
     // manifest counterparts for the lifecycle/cached-data methods.
+    internal_method("vm", "Module", false, None),
     internal_method("vm", "SourceTextModule", false, None),
     internal_method("vm", "SyntheticModule", false, None),
     internal_method("vm", "status", true, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_core.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core.rs
@@ -235,6 +235,15 @@ pub(super) const NODE_CORE_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "vm",
         has_receiver: false,
+        method: "Module",
+        class_filter: None,
+        runtime: "js_vm_module_call",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "vm",
+        has_receiver: false,
         method: "SourceTextModule",
         class_filter: None,
         runtime: "js_vm_source_text_module_new",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -13,6 +13,8 @@ use super::*;
 pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // ========== node:vm ==========
     module.declare_function("js_vm_create_context", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_vm_module_call", DOUBLE, &[]);
+    module.declare_function("js_vm_module_constructor_error", DOUBLE, &[]);
 
     // ========== node:repl ==========
     module.declare_function("js_repl_start", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1383,6 +1383,22 @@ pub(super) fn try_native_module_methods(
                         if module_name == "worker_threads" && method_name == "workerData" {
                             return Ok(Err(args));
                         }
+                        if module_name.strip_prefix("node:").unwrap_or(module_name) == "vm"
+                            && imported_method.is_none()
+                            && method_name == "Module"
+                        {
+                            let mut exprs = args;
+                            exprs.push(Expr::Call {
+                                callee: Box::new(Expr::ExternFuncRef {
+                                    name: "js_vm_module_call".to_string(),
+                                    param_types: Vec::new(),
+                                    return_type: Type::Any,
+                                }),
+                                args: Vec::new(),
+                                type_args: Vec::new(),
+                            });
+                            return Ok(Ok(Expr::Sequence(exprs)));
+                        }
                         // Unimplemented-API gate (#463 / #525) for the 2-deep
                         // `mod.method()` call form. Without this, perry/* and
                         // other native-module call sites short-circuited past

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -445,6 +445,28 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     args,
                 });
             }
+            if is_vm_module && prop_ident.sym.as_ref() == "Module" {
+                let mut exprs = new_expr
+                    .args
+                    .as_ref()
+                    .map(|args| {
+                        args.iter()
+                            .map(|a| lower_expr(ctx, &a.expr))
+                            .collect::<Result<Vec<_>>>()
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
+                exprs.push(Expr::Call {
+                    callee: Box::new(Expr::ExternFuncRef {
+                        name: "js_vm_module_constructor_error".to_string(),
+                        param_types: Vec::new(),
+                        return_type: Type::Any,
+                    }),
+                    args: Vec::new(),
+                    type_args: Vec::new(),
+                });
+                return Ok(Expr::Sequence(exprs));
+            }
             if obj_name == "WebAssembly" && prop_ident.sym.as_ref() == "Module" {
                 let args = new_expr
                     .args

--- a/crates/perry-runtime/src/node_vm.rs
+++ b/crates/perry-runtime/src/node_vm.rs
@@ -250,6 +250,18 @@ fn throw_vm_type(message: &str) -> f64 {
     crate::fs::validate::throw_error_with_code(message, "ERR_INVALID_ARG_TYPE")
 }
 
+fn throw_type_error_no_code(message: &str) -> f64 {
+    let msg = string_ptr(message);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn throw_reference_error_no_code(message: &str) -> f64 {
+    let msg = string_ptr(message);
+    let err = crate::error::js_referenceerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 fn throw_vm_module_cached_data_rejected() -> f64 {
     crate::fs::validate::throw_error_with_code(
         "cachedData buffer was rejected",
@@ -1585,10 +1597,12 @@ pub fn scan_vm_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
 }
 
 pub extern "C" fn js_vm_module_call() -> f64 {
-    crate::fs::validate::throw_error_with_code(
-        "Module is not a constructor",
-        "ERR_ILLEGAL_CONSTRUCTOR",
-    )
+    throw_type_error_no_code("Class constructor Module cannot be invoked without 'new'")
+}
+
+#[no_mangle]
+pub extern "C" fn js_vm_module_constructor_error() -> f64 {
+    throw_type_error_no_code("Module is not a constructor")
 }
 
 pub extern "C" fn js_vm_source_text_module_new(code: f64, options: f64) -> f64 {
@@ -1813,7 +1827,7 @@ pub extern "C" fn js_vm_synthetic_module_set_export(
     };
     let exports = read_exports(module);
     if !exports.iter().any(|export| export.name == name) {
-        return throw_vm_status("SyntheticModule export is not declared");
+        return throw_reference_error_no_code(&format!("Export '{name}' is not defined in module"));
     }
     let Some(namespace) = namespace_for_module(module) else {
         return throw_vm_status("SyntheticModule namespace is unavailable");

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -3543,7 +3543,7 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ) => Some(0),
         // #3127/#3128/#3130/#3284: node:vm no-flag export lengths.
         ("vm", "Script") => Some(1),
-        ("vm", "Module") => Some(0),
+        ("vm", "Module") => Some(1),
         ("vm", "SourceTextModule") => Some(1),
         ("vm", "SyntheticModule") => Some(2),
         ("vm", "createContext" | "measureMemory") => Some(0),

--- a/crates/perry-stdlib/src/vm.rs
+++ b/crates/perry-stdlib/src/vm.rs
@@ -53,6 +53,11 @@ pub extern "C" fn js_vm_measure_memory(options: f64) -> f64 {
 }
 
 #[no_mangle]
+pub extern "C" fn js_vm_module_call() -> f64 {
+    perry_runtime::node_vm::js_vm_module_call()
+}
+
+#[no_mangle]
 pub extern "C" fn js_vm_source_text_module_new(code: f64, options: f64) -> f64 {
     perry_runtime::node_vm::js_vm_source_text_module_new(code, options)
 }

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -132,9 +132,10 @@ Selected highlights (full list in `runtime-parity.md`):
 
 **Total APIs: 32** · Perry covers: import/require namespace shape, callable
 export metadata, `vm.constants`, `process.getBuiltinModule("vm")`, and
-`vm.isContext({})`, cached-data/source-map metadata shape, and
-`SourceTextModule.createCachedData()` · Gap: runtime VM execution,
-contextification, VM modules, context-loader constant behavior, and heap
+`vm.isContext({})`, cached-data/source-map metadata shape,
+`SourceTextModule.createCachedData()`, and gated
+`SourceTextModule`/`SyntheticModule` lifecycle behavior · Gap: runtime VM
+execution, contextification, context-loader constant behavior, and heap
 measurement
 
 Shape coverage is fixture-backed in `test-parity/node-suite/vm`; the generated
@@ -146,11 +147,7 @@ Selected highlights (full list in `runtime-parity.md`):
 - `script.runInContext(contextifiedObject[, options])`
 - `script.runInNewContext([contextObject[, options]])`
 - `script.runInThisContext([options])`
-- `module.error`
-- `module.identifier`
-- `module.namespace`
-- `module.status`
-- `module.evaluate([options])`
+- `vm.measureMemory([options])`
 - … and 16 more
 
 ### node:dgram

--- a/test-parity/node-suite/vm/modules/lifecycle.ts
+++ b/test-parity/node-suite/vm/modules/lifecycle.ts
@@ -2,6 +2,21 @@
 // parity-env: PERRY_EXPERIMENTAL_VM_MODULES=1
 import * as vm from "node:vm";
 
+function logError(label: string, fn: () => unknown): void {
+    try {
+        fn();
+        console.log(label, "ok");
+    } catch (error) {
+        console.log(
+            label,
+            error.constructor.name,
+            error.name,
+            error.code ?? "-",
+            error.message,
+        );
+    }
+}
+
 console.log(
     "module keys",
     Object.keys(vm).filter((key) => key.includes("Module")).join(","),
@@ -11,9 +26,18 @@ console.log(
     typeof vm.Module,
     typeof vm.SourceTextModule,
     typeof vm.SyntheticModule,
+    (vm as any).Module.length,
     vm.SourceTextModule.length,
     vm.SyntheticModule.length,
 );
+logError("module call", () => (vm as any).Module());
+logError("module construct", () => new (vm as any).Module());
+let moduleCallArgOrder = 0;
+logError("module call arg", () => (vm as any).Module((moduleCallArgOrder = 7)));
+console.log("module call arg side effect", moduleCallArgOrder);
+let moduleConstructArgOrder = 0;
+logError("module construct arg", () => new (vm as any).Module((moduleConstructArgOrder = 9)));
+console.log("module construct arg side effect", moduleConstructArgOrder);
 
 const dep = new vm.SyntheticModule(
     ["value", "label"],
@@ -24,14 +48,17 @@ const dep = new vm.SyntheticModule(
 );
 
 console.log("dep initial", dep.status, dep.identifier, dep.namespace.value === undefined);
+logError("dep missing before link", () => dep.setExport("missing", 1));
 dep.setExport("value", 1);
 console.log("dep preset", dep.namespace.value);
 await dep.link(() => {});
 console.log("dep linked", dep.status, dep.namespace.value);
+logError("dep missing linked", () => dep.setExport("missing", 2));
 dep.setExport("value", 41);
 dep.setExport("label", "dep");
 await dep.evaluate();
 console.log("dep evaluated", dep.status, dep.namespace.value, dep.namespace.label);
+logError("dep missing evaluated", () => dep.setExport("missing", 3));
 
 const source = new vm.SourceTextModule(
     [


### PR DESCRIPTION
## Linked issues

Closes #3132
Closes #3133
Closes #3322

## Behavior cluster

This PR tightens the experimental `node:vm` module lifecycle surface around `Module`, `SourceTextModule`, and `SyntheticModule`:

- exposes `vm.Module` through the manifest/native table so direct calls compile and throw Node-shaped errors
- distinguishes `vm.Module()` from `new vm.Module()` error messages and preserves argument side effects before either throw
- aligns `vm.Module.length` with Node's value
- updates `SyntheticModule#setExport()` for missing export names to throw Node-shaped no-code `ReferenceError`s in pre-link, linked, and evaluated states
- extends the VM module lifecycle parity fixture to cover constructor/call errors, argument side effects, missing export errors, and existing link/evaluate/module request behavior

## Why batched

#3132, #3133, and #3322 share the same gated VM module constructors, runtime module handle model, HIR lowering, native table/manifest rows, and `test-parity/node-suite/vm/modules/lifecycle.ts` fixture. Keeping them together avoids splitting one lifecycle state machine across multiple tiny PRs.

## Tests added

- Extended `test-parity/node-suite/vm/modules/lifecycle.ts` with `vm.Module` call/construct errors, function arity, argument side effects, and `SyntheticModule#setExport()` missing-name error cases.

## Commands run

- `PATH=/tmp/perry-node25-bin:$PATH node --experimental-vm-modules test-parity/node-suite/vm/modules/lifecycle.ts`
- `CARGO_BUILD_JOBS=2 RUSTFLAGS='-C linker=cc -C link-arg=-fuse-ld=bfd' cargo build -p perry -p perry-runtime -p perry-stdlib --release`
- `PERRY_EXPERIMENTAL_VM_MODULES=1 PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./target/release/perry run test-parity/node-suite/vm/modules/lifecycle.ts`
- `CARGO_BUILD_JOBS=2 RUSTFLAGS='-C linker=cc -C link-arg=-fuse-ld=bfd' cargo test -p perry-codegen --test manifest_consistency`
- `CARGO_BUILD_JOBS=2 RUSTFLAGS='-C linker=cc -C link-arg=-fuse-ld=bfd' cargo test -p perry-runtime node_vm` (0 matched; runtime has no focused `node_vm` unit tests)
- `CARGO_BUILD_JOBS=2 RUSTFLAGS='-C linker=cc -C link-arg=-fuse-ld=bfd' cargo test -p perry-hir vm` (0 matched; HIR smoke/filter check)
- `CARGO_BUILD_JOBS=2 RUSTFLAGS='-C linker=cc -C link-arg=-fuse-ld=bfd' PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 PATH=/tmp/perry-node25-bin:$PATH ./run_parity_tests.sh --suite node-suite --module vm --filter modules`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations and non-goals

- VM module support remains gated by `PERRY_EXPERIMENTAL_VM_MODULES`.
- This does not implement a general JavaScript module interpreter beyond the deterministic local module semantics covered by the fixture.
- This does not address broad VM `Script`/context execution, `compileFunction`, `measureMemory`, or additional cached-data fidelity outside the existing cached-data fixture surface.
