### PR TITLE
Add c262 rest-param eval regression coverage

### DIFF
--- a/tests/test_c262_arrow_env_parity.sh
+++ b/tests/test_c262_arrow_env_parity.sh
@@ -88,6 +88,17 @@ var probe1, probe2;
 console.log(probe1() + ":" + probe2());
 JS
 
+cat >"$TMPDIR/scope-param-rest-elem-var-close.js" <<'JS'
+var x = "outside";
+var probeParam, probeBody;
+((
+    ...[_ = (eval("var x = \"inside\";"), probeParam = function() { return x; })]
+  ) => {
+    probeBody = function() { return x; };
+})();
+console.log(probeParam() + ":" + probeBody());
+JS
+
 cat >"$TMPDIR/scope-paramsbody-var-open.js" <<'JS'
 var x = "outside";
 var probeParams, probeBody;
@@ -104,6 +115,7 @@ run_case lexical-super-call-from-within-constructor true:2
 run_case non-strict 1
 run_case scope-body-lex-distinct ok
 run_case scope-param-rest-elem-var-open inside:inside
+run_case scope-param-rest-elem-var-close inside:inside
 run_case scope-paramsbody-var-open outside:inside
 
 echo "PASS: c262 arrow environment parity"


### PR DESCRIPTION
## Summary
- add focused coverage for Test262 `language/expressions/arrow-function/scope-param-rest-elem-var-close.js`
- pins the sloppy arrow rest-parameter destructuring + direct eval `var` binding case where both parameter-created and body-created closures must see the eval-introduced binding

## Notes
- The exact Test262 target already passes on current `origin/main`; no implementation change was needed.
- A broader `tests/test_c262_arrow_function_parity.sh` verification was timeboxed after hanging in Perry compile and was terminated.

## Verification
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `tests/test_c262_arrow_env_parity.sh`
- one-file Test262 run for `language/expressions/arrow-function/scope-param-rest-elem-var-close.js` via `scripts/test262_subset.py` with absolute `--perry-bin`
- `cargo test -p perry-hir --test c262_parity`

## Timeboxed / blocked
- `tests/test_c262_arrow_function_parity.sh` hung for ~4m34s inside `target/release/perry compile --no-cache .../c262_arrow_parity.ts`; process was terminated.