### PR TITLE
fix(typedarray): throw on prototype accessor reads off-instance (#4140)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -323,6 +323,86 @@ unsafe fn invoke_accessor_getter(get_bits: u64, receiver: f64) -> JSValue {
     JSValue::from_bits(result_f64.to_bits())
 }
 
+/// #4140: builtin *reflection-only* accessors — most prominently the four
+/// `%TypedArray%.prototype` getters (`length`/`byteLength`/`byteOffset`/
+/// `buffer`) — are installed via [`super::set_builtin_accessor_descriptor`],
+/// which deliberately does NOT flip the `ACCESSORS_IN_USE` hot-path gate (these
+/// getters are never written and exist purely so reflection sees them, see
+/// #2060). The downside: a plain *value* read that resolves to the hosting
+/// prototype object (e.g. `Uint8Array.prototype.buffer`, where the per-kind
+/// proto inherits from the shared `%TypedArray%.prototype`) skips the gated
+/// accessor short-circuit and returns the empty backing slot — `undefined`
+/// instead of Node's `TypeError`.
+///
+/// Invoke the real getter here for the one builtin object that hosts these
+/// getters, guarded by a cheap pointer compare so ordinary reads pay nothing.
+/// The receiver is the intrinsic prototype itself, which is never a concrete
+/// typed array (real `TypedArray` instances short-circuit far earlier in
+/// `js_object_get_field_by_name`), so the getter always throws the spec
+/// `TypeError` — matching `Uint8Array.prototype.buffer` in Node. When the gate
+/// IS on, the inline short-circuit below already handles this, so bail.
+unsafe fn builtin_reflection_accessor_read(
+    obj: *const ObjectHeader,
+    key_bytes: &[u8],
+) -> Option<JSValue> {
+    // Only the four `%TypedArray%.prototype` accessor names — the cheap key
+    // filter keeps this off every other property read entirely.
+    if !matches!(
+        key_bytes,
+        b"buffer" | b"byteLength" | b"byteOffset" | b"length"
+    ) {
+        return None;
+    }
+    // This helper runs before the heavy object validation further down, so a
+    // caller that passes a NaN-boxed number / raw `f64` as `obj` (e.g. the
+    // dynamic `arr.length = …` set path threading a numeric value through the
+    // generic getter) must not be dereferenced. A genuine heap pointer has its
+    // top 16 bits clear; reject anything else and confirm it points at a real
+    // GC object before reading its header below.
+    if (obj as u64) >> 48 != 0 || !super::is_valid_obj_ptr(obj as *const u8) {
+        return None;
+    }
+    let intrinsic_proto =
+        super::TYPED_ARRAY_INTRINSIC_PROTO_PTR.load(std::sync::atomic::Ordering::Relaxed);
+    if intrinsic_proto == 0 {
+        return None;
+    }
+    // Fire for the shared `%TypedArray%.prototype` intrinsic itself and for
+    // every per-kind prototype (`Uint8Array.prototype`, …). The per-kind protos
+    // carry `OBJ_FLAG_TYPED_ARRAY_PROTO` and resolve their `[[Prototype]]` to
+    // the intrinsic only through `Object.getPrototypeOf`'s flag check — they
+    // have `class_id == 0` and no recorded static-prototype link, so the normal
+    // chain walk in this function never reaches the intrinsic where these
+    // accessors live, and the read silently returned the empty slot
+    // (`undefined`) instead of Node's `TypeError`. None of these objects is a
+    // concrete typed array (real instances short-circuit far earlier via the
+    // `TYPED_ARRAY_REGISTRY` arm), so invoking the getter with the proto as the
+    // receiver always throws — matching `Uint8Array.prototype.buffer` in Node.
+    // #4140.
+    let is_intrinsic = obj as i64 == intrinsic_proto;
+    // `OBJ_FLAG_TYPED_ARRAY_PROTO` lives in the shared `_reserved` word, whose
+    // bits mean different things for `GC_TYPE_ARRAY` (raw-f64 layout, arguments,
+    // survival age, …). The per-kind typed-array prototypes are always plain
+    // `GC_TYPE_OBJECT`s, so gate the flag read on the object type — otherwise a
+    // regular array whose `_reserved` happens to have bit 0x100 set would be
+    // misread as a typed-array prototype and its `.length` get would crash.
+    let gc = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    let is_perkind_proto = (*gc).obj_type == crate::gc::GC_TYPE_OBJECT
+        && ((*gc)._reserved & crate::gc::OBJ_FLAG_TYPED_ARRAY_PROTO) != 0;
+    if !is_intrinsic && !is_perkind_proto {
+        return None;
+    }
+    // The accessor descriptors live on the intrinsic prototype, not the per-kind
+    // protos, so always resolve the getter off the intrinsic.
+    let name = std::str::from_utf8(key_bytes).ok()?;
+    let acc = get_accessor_descriptor(intrinsic_proto as usize, name)?;
+    if acc.get == 0 {
+        return Some(JSValue::undefined());
+    }
+    let receiver = crate::value::js_nanbox_pointer(obj as i64);
+    Some(invoke_accessor_getter(acc.get, receiver))
+}
+
 unsafe fn primitive_object_prototype_accessor(name: &str, receiver: f64) -> Option<JSValue> {
     if !ACCESSORS_IN_USE.with(|c| c.get()) {
         return None;
@@ -3413,6 +3493,14 @@ pub extern "C" fn js_object_get_field_by_name(
             (key as *const u8).add(std::mem::size_of::<crate::StringHeader>()),
             (*key).byte_len as usize,
         );
+        // #4140: builtin reflection-only accessors (e.g. the
+        // `%TypedArray%.prototype` getters) don't flip `ACCESSORS_IN_USE`, so the
+        // gated short-circuits below skip them on a plain value read. Handle the
+        // hosting prototype object here — a cheap pointer compare for everything
+        // else — before the slot scan returns the empty backing field.
+        if let Some(v) = builtin_reflection_accessor_read(obj, key_bytes) {
+            return v;
+        }
         let key_hash = {
             let mut h: u32 = 0x811c9dc5;
             for &b in key_bytes {

--- a/test-parity/node-suite/globals/typedarray-prototype-accessor-throws.ts
+++ b/test-parity/node-suite/globals/typedarray-prototype-accessor-throws.ts
@@ -1,0 +1,72 @@
+// #4140 — the `%TypedArray%.prototype` accessor getters
+// (`buffer`/`byteLength`/`byteOffset`/`length`) must throw a `TypeError` when
+// read off the prototype object instead of a concrete typed-array instance.
+// The prototype is an ordinary object with no `[[ViewedArrayBuffer]]` slot
+// (test262 `built-ins/TypedArrayConstructors/<T>/prototype/not-typedarray-object.js`),
+// so Node throws there. Perry previously returned `undefined`: the per-kind
+// prototypes resolve `[[Prototype]]` to the shared `%TypedArray%.prototype`
+// only through `Object.getPrototypeOf`, so a plain value read never reached the
+// inherited accessor.
+
+const accessors = ["buffer", "byteLength", "byteOffset", "length"] as const;
+
+const types = [
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float32Array",
+  "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
+];
+
+function reads(o: any, k: string): string {
+  try {
+    const v = o[k];
+    return "value:" + String(v);
+  } catch (e: any) {
+    return "throws:" + e.constructor.name;
+  }
+}
+
+for (const name of types) {
+  const C: any = (globalThis as any)[name];
+  console.log("== " + name + " ==");
+  for (const k of accessors) {
+    // Off the per-kind prototype: must throw TypeError.
+    console.log("proto." + k, reads(C.prototype, k));
+  }
+}
+
+// The shared %TypedArray%.prototype intrinsic also throws for these reads.
+const TAP: any = Object.getPrototypeOf(Uint8Array.prototype);
+console.log("== %TypedArray%.prototype ==");
+for (const k of accessors) {
+  console.log("intrinsic." + k, reads(TAP, k));
+}
+
+// Real instances keep working — the accessors return their concrete values.
+const inst = new Uint8Array(4);
+console.log("== instance ==");
+console.log("byteLength", inst.byteLength);
+console.log("byteOffset", inst.byteOffset);
+console.log("length", inst.length);
+console.log("buffer is object", typeof inst.buffer);
+
+// An object that merely inherits from a typed-array prototype is still not a
+// typed array, so the inherited accessor throws there too.
+const derived: any = Object.create(Uint8Array.prototype);
+console.log("== Object.create(Uint8Array.prototype) ==");
+for (const k of accessors) {
+  console.log("derived." + k, reads(derived, k));
+}
+
+// Reflection is unaffected: the getter is still discoverable on the intrinsic.
+console.log(
+  "intrinsic buffer has getter",
+  typeof Object.getOwnPropertyDescriptor(TAP, "buffer")?.get === "function",
+);


### PR DESCRIPTION
## Closes the `not-typedarray-object` family in #4140

PR #4143 fixed the headline `BYTES_PER_ELEMENT` gap. The one remaining
checklist item it marked "could not reproduce" — `not-typedarray-object.js`
(×11 concrete types) — was tested wrong (it called the abstract `%TypedArray%()`
rather than reading the prototype's accessor). It is in fact still failing on
`main`:

```js
Uint8Array.prototype.buffer       // Node: throws TypeError ; Perry: returned undefined
Uint8Array.prototype.byteLength   // Node: throws TypeError ; Perry: returned undefined
Uint8Array.prototype.byteOffset   // Node: throws TypeError ; Perry: returned undefined
Uint8Array.prototype.length       // Node: throws TypeError ; Perry: returned undefined
```

The prototype object is an ordinary object with no `[[ViewedArrayBuffer]]`
slot, so reading these accessors off it must throw `TypeError`.

### Root cause
The four `%TypedArray%.prototype` getters are installed as reflection-only
builtin accessors that don't flip the `ACCESSORS_IN_USE` hot-path gate (#2060),
**and** the per-kind prototypes carry no recorded `[[Prototype]]` link in the
chain the property getter walks — they reach the shared `%TypedArray%.prototype`
only via `Object.getPrototypeOf`'s `OBJ_FLAG_TYPED_ARRAY_PROTO` flag. So a plain
value read off the prototype never reached the inherited accessor and returned
the empty slot.

### Fix
In `js_object_get_field_by_name`, for the four accessor names, resolve the
getter off the shared intrinsic when `obj` is the intrinsic itself or any object
flagged `OBJ_FLAG_TYPED_ARRAY_PROTO`. Real instances short-circuit far earlier,
so the receiver here is never a concrete typed array and the getter throws —
matching Node. Guarded by a cheap key filter + heap-pointer / `GC_TYPE_OBJECT`
check so ordinary reads (and non-pointer `obj` values threaded through the
generic getter) pay nothing and are never dereferenced.

### Verification
- New fixture `typedarray-prototype-accessor-throws.ts` — all 11 types, the
  intrinsic, an `Object.create(Uint8Array.prototype)` derived object, and real
  instances — **byte-identical to `node --experimental-strip-types`**.
- `globals` node-suite sweep on an isolated build: PASS=40 / FAIL=9, the **exact
  same 9 pre-existing failures** as the unmodified base (no new regressions); the
  new fixture and the #4143 `typedarray-constructor-own-props.ts` both pass.
- `cargo test -p perry-runtime` green; `cargo fmt --check` clean.

### Out of scope (pre-existing, filed-worthy separately)
- `(arr as any).length = -1` on a regular array segfaults — reproduces on a clean
  `main` build (both `NO_AUTO_OPTIMIZE` and auto-optimize), unrelated to this
  change. This is what makes `array-length-invalid.ts` / `structured-clone-transfer.ts`
  fail in the sweep above.
- `propertyIsEnumerable` on a TA prototype returns `[object Object]` not a boolean.
- `Function.prototype`-style buffer getter `.call(realInstance)` throws (Perry
  doesn't fully model `ArrayBuffer` behind a view).
