### PR TITLE
[codex] Fix object numeric index assignment

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -492,21 +492,22 @@ fn reflect_ordinary_set(target: f64, key: f64, value: f64) -> f64 {
 }
 
 fn target_set(target: f64, key: f64, value: f64) {
-    if unsafe { crate::symbol::js_is_symbol(key) } != 0 {
+    let property_key = unsafe { crate::object::js_to_property_key(key) };
+    if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
         unsafe {
-            crate::symbol::js_object_set_symbol_property(target, key, value);
+            crate::symbol::js_object_set_symbol_property(target, property_key, value);
         }
         return;
     }
     let obj_addr = extract_pointer(target.to_bits()) as usize;
     if crate::closure::is_closure_ptr(obj_addr) {
-        if let Some(name) = key_to_rust_string(key) {
+        if let Some(name) = key_to_rust_string(property_key) {
             crate::closure::closure_set_dynamic_prop(obj_addr, &name, value);
         }
         return;
     }
     let obj_ptr = obj_addr as *mut crate::ObjectHeader;
-    let key_ptr = extract_pointer(key.to_bits()) as *const crate::StringHeader;
+    let key_ptr = extract_pointer(property_key.to_bits()) as *const crate::StringHeader;
     if obj_ptr.is_null() || key_ptr.is_null() {
         return;
     }

--- a/tests/test_c262_object_numeric_index_assignment.sh
+++ b/tests/test_c262_object_numeric_index_assignment.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/c262_object_numeric_index_assignment.js" <<'JS'
+var failures = [];
+
+function check(label, actual, expected) {
+  if (actual !== expected) {
+    failures.push(label + ": expected " + String(expected) + ", got " + String(actual));
+  }
+}
+
+var map = {};
+map[1] = "one";
+map["two"] = 2;
+map["3"] = "tre";
+
+check("numeric write creates property readable by numeric key", map[1], "one");
+check("numeric write creates string property", map["1"], "one");
+check("string write remains readable", map["two"], 2);
+check("numeric string write remains readable", map[3], "tre");
+
+var existing = {1: "one", two: 2};
+existing[1] = "uno";
+check("numeric write overwrites existing numeric literal key", existing[1], "uno");
+check("numeric write overwrites existing string key", existing["1"], "uno");
+
+existing["1"] = 1;
+check("string numeric write overwrites same key", existing[1], 1);
+
+existing["two"] = "two";
+check("computed string write overwrites existing property", existing.two, "two");
+
+existing.two = "duo";
+check("dot write still overwrites existing property", existing["two"], "duo");
+
+if (failures.length !== 0) {
+  throw new Error(failures.join("\n"));
+}
+
+console.log("PASS c262 object numeric index assignment");
+JS
+
+"$PERRY" compile --no-cache "$TMPDIR/c262_object_numeric_index_assignment.js" -o "$TMPDIR/c262_object_numeric_index_assignment" \
+    >"$TMPDIR/compile.log" 2>&1 || {
+        echo "FAIL: compile failed"
+        sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+        exit 1
+    }
+
+"$TMPDIR/c262_object_numeric_index_assignment" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+EXPECTED="PASS c262 object numeric index assignment"
+RUN_OUTPUT="$(cat "$TMPDIR/run.log")"
+if [[ "$RUN_OUTPUT" != "$EXPECTED" ]]; then
+    echo "FAIL: c262 object numeric index assignment output mismatch"
+    echo "Expected:"
+    echo "$EXPECTED"
+    echo ""
+    echo "Got:"
+    echo "$RUN_OUTPUT"
+    exit 1
+fi
+
+echo "PASS: c262 object numeric index assignment"


### PR DESCRIPTION
## Summary

- canonicalize property keys in the ordinary PutValue target setter before writing object fields
- fixes numeric computed assignment on ordinary objects, e.g. `obj[1] = value` creating/updating property `"1"`
- adds a focused c262 regression for creating and overwriting numeric object keys

## Scan notes

Initial baseline after building only the Perry CLI was infrastructure noise: `scripts/test262_focused_report.py --root vendor/test262 --dir language/expressions --max 500 --sample-cap 1000000 --timeout 20` reported 285 compile-fail, all `Error: Could not find libperry_runtime.a.`

After building static archives with `cargo build --release -p perry-runtime -p perry-stdlib`, the same baseline was real parity signal: 500 judged, 482 pass, 18 runtime-fail, 0 compile-fail, 0 skip.

The fixed failures were:
- `language/expressions/assignment/S8.12.5_A1.js`: `obj[1] = ...` did not create property `"1"`
- `language/expressions/assignment/S8.12.5_A2.js`: `obj[1] = ...` did not overwrite existing property `"1"`

Post-fix `language/expressions --max 500`: 500 judged, 484 pass, 16 runtime-fail, 0 compile-fail, 0 skip.

Focused assignment follow-up: `scripts/test262_focused_report.py --root vendor/test262 --dir language/expressions/assignment --max 500 --sample-cap 1000000 --timeout 20 --skip-vendor --skip-build` reported 207 judged, 196 pass, 11 runtime-fail, 0 compile-fail, 0 skip; `S8.12.5_A1/A2` no longer appear in the problem TSV.

## Validation

- `cargo build --release -p perry-runtime -p perry`
- `cargo fmt --package perry-runtime --check`
- `tests/test_c262_object_numeric_index_assignment.sh`
- `scripts/test262_focused_report.py --root vendor/test262 --dir language/expressions/assignment --max 500 --sample-cap 1000000 --timeout 20 --skip-vendor --skip-build`
- `scripts/test262_focused_report.py --root vendor/test262 --dir language/expressions --max 500 --sample-cap 1000000 --timeout 20 --skip-vendor --skip-build`