### PR TITLE
[codex] fix fetch globals and response redirect parity

### DIFF
--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -90,8 +90,10 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                 return Ok(Some(handle));
             }
             "static_redirect" => {
-                let url_ptr = if !args.is_empty() {
-                    get_raw_string_ptr(ctx, &args[0])?
+                let url_ptr = if let Some(url_expr) = args.first() {
+                    let url_value = lower_expr(ctx, url_expr)?;
+                    ctx.block()
+                        .call(I64, "js_jsvalue_to_string", &[(DOUBLE, &url_value)])
                 } else {
                     "0".to_string()
                 };

--- a/crates/perry-ext-fetch/src/lib.rs
+++ b/crates/perry-ext-fetch/src/lib.rs
@@ -20,7 +20,8 @@ use std::sync::Mutex;
 // keep lib.rs under the 2,000-line lint gate.
 mod validation;
 use validation::{
-    is_forbidden_method, is_null_body_status, is_valid_status_text, normalize_method,
+    is_forbidden_method, is_null_body_status, is_redirect_status, is_valid_status_text,
+    normalize_method, parse_redirect_location, redirect_status_from_value,
 };
 use validation::{throw_range_error, throw_type_error};
 
@@ -1300,22 +1301,27 @@ pub unsafe extern "C" fn js_response_static_json(
     }) as f64
 }
 
-/// `Response.redirect(url, status)` — static.
-///
-/// # Safety
-/// `url_ptr` must be null or a Perry-runtime `StringHeader`.
+/// `Response.redirect(url, status)` — static. `url_ptr` must be null or a
+/// Perry-runtime `StringHeader`.
 #[no_mangle]
 pub unsafe extern "C" fn js_response_static_redirect(
     url_ptr: *const StringHeader,
     status: f64,
 ) -> f64 {
     let url = read_str(url_ptr).unwrap_or_default();
-    let status = status as u16;
+    let status = redirect_status_from_value(status);
+    if !is_redirect_status(status) {
+        throw_range_error(&format!("Invalid status code {status}"));
+    }
+    let location = match parse_redirect_location(&url) {
+        Ok(location) => location,
+        Err(_) => throw_type_error(&format!("Failed to parse URL from {url}")),
+    };
     let mut headers = HeadersStore::default();
-    headers.set("location", &url);
+    headers.set("location", &location);
     store_response(FetchResponse {
-        status,
-        status_text: "Found".to_string(),
+        status: status as u16,
+        status_text: String::new(),
         headers,
         body: Vec::new(),
         type_name: "default".to_string(),

--- a/crates/perry-ext-fetch/src/validation.rs
+++ b/crates/perry-ext-fetch/src/validation.rs
@@ -6,6 +6,8 @@
 
 use perry_ffi::{alloc_string, JsValue, StringHeader};
 
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
 // Web Fetch constructor validation throws real TypeError / RangeError
 // objects. perry-ffi doesn't re-export the runtime error/throw entry
 // points, but with the `runtime-link` feature the `#[no_mangle]` symbols
@@ -58,4 +60,25 @@ pub(crate) fn normalize_method(raw: &str) -> String {
         "DELETE" | "GET" | "HEAD" | "OPTIONS" | "POST" | "PUT" => upper,
         _ => raw.to_string(),
     }
+}
+
+pub(crate) fn redirect_status_from_value(status: f64) -> i32 {
+    if status.to_bits() == TAG_UNDEFINED {
+        return 302;
+    }
+    let number = JsValue::from_bits(status.to_bits()).to_number();
+    if !number.is_finite() {
+        return 0;
+    }
+    (number.trunc() % 65536.0) as i32
+}
+
+pub(crate) fn is_redirect_status(status: i32) -> bool {
+    matches!(status, 301 | 302 | 303 | 307 | 308)
+}
+
+pub(crate) fn parse_redirect_location(raw: &str) -> Result<String, ()> {
+    reqwest::Url::parse(raw)
+        .map(|parsed| parsed.to_string())
+        .map_err(|_| ())
 }

--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-fn is_global_this_value(expr: &Expr) -> bool {
+fn is_global_this_value(ctx: &LoweringContext, expr: &Expr) -> bool {
     matches!(expr, Expr::GlobalGet(_))
         || matches!(
             expr,
@@ -10,6 +10,30 @@ fn is_global_this_value(expr: &Expr) -> bool {
                 if matches!(object.as_ref(), Expr::GlobalGet(_))
                     && property == "globalThis"
         )
+        || matches!(expr, Expr::LocalGet(id) if ctx.global_this_aliases.contains(id))
+}
+
+fn global_this_constructor_alias(name: &str) -> Option<&'static str> {
+    match name {
+        "URL" => Some("URL"),
+        "URLSearchParams" => Some("URLSearchParams"),
+        "TextEncoder" => Some("TextEncoder"),
+        "TextDecoder" => Some("TextDecoder"),
+        "Blob" => Some("Blob"),
+        "File" => Some("File"),
+        "FormData" => Some("FormData"),
+        "Headers" => Some("Headers"),
+        "Request" => Some("Request"),
+        "Response" => Some("Response"),
+        _ => None,
+    }
+}
+
+fn is_global_this_fetch_constructor(name: &str) -> bool {
+    matches!(
+        name,
+        "Blob" | "File" | "FormData" | "Headers" | "Request" | "Response"
+    )
 }
 
 /// Recursively lower a binding pattern against a source expression, producing
@@ -131,7 +155,7 @@ pub(crate) fn lower_pattern_binding_into(
         }
         ast::Pat::Object(obj_pat) => {
             // Materialize source into a temp
-            let source_is_global_this = is_global_this_value(&source);
+            let source_is_global_this = is_global_this_value(ctx, &source);
             let obj_ty = obj_pat
                 .type_ann
                 .as_ref()
@@ -158,17 +182,19 @@ pub(crate) fn lower_pattern_binding_into(
                             ast::PropName::Ident(ident) => {
                                 let key = ident.sym.to_string();
                                 static_keys.push(key.clone());
-                                if source_is_global_this
-                                    && matches!(
-                                        key.as_str(),
-                                        "URL" | "URLSearchParams" | "TextEncoder" | "TextDecoder"
-                                    )
-                                {
+                                if source_is_global_this {
                                     if let ast::Pat::Ident(alias) = kv.value.as_ref() {
-                                        ctx.register_let_class_alias(
-                                            alias.id.sym.to_string(),
-                                            key.clone(),
-                                        );
+                                        if let Some(class_name) =
+                                            global_this_constructor_alias(&key)
+                                        {
+                                            ctx.register_let_class_alias(
+                                                alias.id.sym.to_string(),
+                                                class_name.to_string(),
+                                            );
+                                            if is_global_this_fetch_constructor(class_name) {
+                                                ctx.uses_fetch = true;
+                                            }
+                                        }
                                     }
                                 }
                                 Expr::PropertyGet {
@@ -179,17 +205,19 @@ pub(crate) fn lower_pattern_binding_into(
                             ast::PropName::Str(s) => {
                                 let key = s.value.as_str().unwrap_or("").to_string();
                                 static_keys.push(key.clone());
-                                if source_is_global_this
-                                    && matches!(
-                                        key.as_str(),
-                                        "URL" | "URLSearchParams" | "TextEncoder" | "TextDecoder"
-                                    )
-                                {
+                                if source_is_global_this {
                                     if let ast::Pat::Ident(alias) = kv.value.as_ref() {
-                                        ctx.register_let_class_alias(
-                                            alias.id.sym.to_string(),
-                                            key.clone(),
-                                        );
+                                        if let Some(class_name) =
+                                            global_this_constructor_alias(&key)
+                                        {
+                                            ctx.register_let_class_alias(
+                                                alias.id.sym.to_string(),
+                                                class_name.to_string(),
+                                            );
+                                            if is_global_this_fetch_constructor(class_name) {
+                                                ctx.uses_fetch = true;
+                                            }
+                                        }
                                     }
                                 }
                                 Expr::PropertyGet {
@@ -222,13 +250,13 @@ pub(crate) fn lower_pattern_binding_into(
                         // Shorthand { key } or { key = default }
                         let name = assign.key.sym.to_string();
                         static_keys.push(name.clone());
-                        if source_is_global_this
-                            && matches!(
-                                name.as_str(),
-                                "URL" | "URLSearchParams" | "TextEncoder" | "TextDecoder"
-                            )
-                        {
-                            ctx.register_let_class_alias(name.clone(), name.clone());
+                        if source_is_global_this {
+                            if let Some(class_name) = global_this_constructor_alias(&name) {
+                                ctx.register_let_class_alias(name.clone(), class_name.to_string());
+                                if is_global_this_fetch_constructor(class_name) {
+                                    ctx.uses_fetch = true;
+                                }
+                            }
                         }
                         let ty = assign
                             .key

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-fn is_global_this_value(expr: &Expr) -> bool {
+fn is_global_this_value(ctx: &LoweringContext, expr: &Expr) -> bool {
     matches!(expr, Expr::GlobalGet(_))
         || matches!(
             expr,
@@ -10,6 +10,7 @@ fn is_global_this_value(expr: &Expr) -> bool {
                 if matches!(object.as_ref(), Expr::GlobalGet(_))
                     && property == "globalThis"
         )
+        || matches!(expr, Expr::LocalGet(id) if ctx.global_this_aliases.contains(id))
 }
 
 /// #3663: classic-stream constructor export names from `node:stream`.
@@ -1678,6 +1679,27 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         {
                             Some("Array.isArray".to_string())
                         }
+                        (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(method_ident))
+                            if matches!(
+                                method_ident.sym.as_ref(),
+                                "json" | "redirect" | "error"
+                            ) && {
+                                let obj_name = obj_ident.sym.as_ref();
+                                (obj_name == "Response" && ctx.lookup_local("Response").is_none())
+                                    || ctx
+                                        .resolve_class_alias(obj_name)
+                                        .as_deref()
+                                        .is_some_and(|resolved| resolved == "Response")
+                            } =>
+                        {
+                            let method = match method_ident.sym.as_ref() {
+                                "json" => "Response.static_json",
+                                "redirect" => "Response.static_redirect",
+                                "error" => "Response.static_error",
+                                _ => unreachable!(),
+                            };
+                            Some(method.to_string())
+                        }
                         _ => None,
                     },
                     _ => None,
@@ -1710,6 +1732,21 @@ pub(crate) fn lower_var_decl_with_destructuring(
             if let Some(method_name) = array_method_alias {
                 ctx.array_static_method_aliases.insert(id, method_name);
             }
+            if let Some(Expr::NativeMethodCall { module, method, .. }) = &init {
+                if module == "fetch"
+                    && matches!(
+                        method.as_str(),
+                        "static_json" | "static_redirect" | "static_error"
+                    )
+                {
+                    ctx.register_native_instance(
+                        name.clone(),
+                        "fetch".to_string(),
+                        "Response".to_string(),
+                    );
+                    ctx.uses_fetch = true;
+                }
+            }
 
             // Issue #740: track `let/const/var <name> = ClassRef(...)` so
             // `new <name>(...)` can resolve captures via the alias chain.
@@ -1727,6 +1764,9 @@ pub(crate) fn lower_var_decl_with_destructuring(
                 // expression assigned to a local).
                 if matches!(init_expr, Expr::Closure { .. } | Expr::FuncRef(_)) {
                     ctx.function_valued_locals.insert(id);
+                }
+                if is_global_this_value(ctx, init_expr) {
+                    ctx.global_this_aliases.insert(id);
                 }
                 match init_expr {
                     Expr::ClassRef(class_name) => {
@@ -1778,7 +1818,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         }
                     }
                     Expr::PropertyGet { object, property }
-                        if is_global_this_value(object.as_ref())
+                        if is_global_this_value(ctx, object.as_ref())
                             && matches!(
                                 property.as_str(),
                                 "URL"
@@ -1787,11 +1827,18 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                     | "TextDecoder"
                                     | "Blob"
                                     | "File"
+                                    | "FormData"
+                                    | "Headers"
+                                    | "Request"
+                                    | "Response"
                                     | "WebSocket"
                             ) =>
                     {
                         ctx.register_let_class_alias(name.clone(), property.clone());
-                        if matches!(property.as_str(), "Blob" | "File") {
+                        if matches!(
+                            property.as_str(),
+                            "Blob" | "File" | "FormData" | "Headers" | "Request" | "Response"
+                        ) {
                             ctx.uses_fetch = true;
                         }
                     }

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -119,6 +119,7 @@ impl LoweringContext {
             class_method_return_types: Vec::new(),
             class_captures: Vec::new(),
             let_class_aliases: Vec::new(),
+            global_this_aliases: HashSet::new(),
             prototype_aliases: HashMap::new(),
             prototype_function_aliases: HashMap::new(),
             function_valued_locals: HashSet::new(),

--- a/crates/perry-hir/src/lower/expr_call/post_args_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_call/post_args_dispatch.rs
@@ -78,6 +78,15 @@ pub(super) fn try_object_static_alias_call(
                 let name = ident.sym.to_string();
                 if let Some(id) = ctx.lookup_local(&name) {
                     if let Some(method) = ctx.object_static_method_aliases.get(&id).cloned() {
+                        if let Some(method) = method.strip_prefix("Response.") {
+                            return Ok(Expr::NativeMethodCall {
+                                module: "fetch".to_string(),
+                                class_name: None,
+                                object: None,
+                                method: method.to_string(),
+                                args,
+                            });
+                        }
                         if method == "Array.isArray" {
                             let value = args.first().cloned().unwrap_or(Expr::Undefined);
                             return Ok(Expr::ArrayIsArray(Box::new(value)));

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1657,16 +1657,36 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
             }
         }
     }
-    let member_reads_global_fetch = matches!(
+    let member_object_is_global_this = matches!(
         unwrap_transparent(member.obj.as_ref()),
         ast::Expr::Ident(i) if i.sym.as_ref() == "globalThis"
-    ) && match &member.prop {
-        ast::MemberProp::Ident(p) => p.sym.as_ref() == "fetch",
-        ast::MemberProp::Computed(c) => {
-            matches!(c.expr.as_ref(), ast::Expr::Lit(ast::Lit::Str(s)) if s.value.as_str() == Some("fetch"))
-        }
-        ast::MemberProp::PrivateName(_) => false,
-    };
+    ) || matches!(&object_expr, Expr::LocalGet(id) if ctx.global_this_aliases.contains(id));
+    let member_reads_global_fetch = member_object_is_global_this
+        && match &member.prop {
+            ast::MemberProp::Ident(p) => matches!(
+                p.sym.as_ref(),
+                "fetch" | "Blob" | "File" | "FormData" | "Headers" | "Request" | "Response"
+            ),
+            ast::MemberProp::Computed(c) => {
+                matches!(
+                    c.expr.as_ref(),
+                    ast::Expr::Lit(ast::Lit::Str(s))
+                        if matches!(
+                            s.value.as_str(),
+                            Some(
+                                "fetch"
+                                    | "Blob"
+                                    | "File"
+                                    | "FormData"
+                                    | "Headers"
+                                    | "Request"
+                                    | "Response"
+                            )
+                        )
+                )
+            }
+            ast::MemberProp::PrivateName(_) => false,
+        };
     if member_reads_global_fetch {
         ctx.uses_fetch = true;
     }

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -243,6 +243,18 @@ fn is_worker_threads_module_name(module_name: &str) -> bool {
     module_name == "worker_threads" || module_name == "node:worker_threads"
 }
 
+fn is_fetch_constructor_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Blob" | "File" | "FormData" | "Headers" | "Request" | "Response"
+    )
+}
+
+fn is_global_object_expr(ctx: &LoweringContext, expr: &Expr) -> bool {
+    matches!(expr, Expr::GlobalGet(_))
+        || matches!(expr, Expr::LocalGet(id) if ctx.global_this_aliases.contains(id))
+}
+
 pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> Result<Expr> {
     let callee_expr = peel_new_callee(new_expr.callee.as_ref());
 
@@ -1450,8 +1462,17 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 .unwrap_or_default();
             if ctx.lookup_class(&class_name).is_none() {
                 if let Some(resolved) = ctx.resolve_class_alias(&class_name) {
-                    if matches!(resolved.as_str(), "Blob" | "File" | "WebSocket") {
-                        if matches!(resolved.as_str(), "Blob" | "File") {
+                    if matches!(
+                        resolved.as_str(),
+                        "Blob"
+                            | "File"
+                            | "FormData"
+                            | "Headers"
+                            | "Request"
+                            | "Response"
+                            | "WebSocket"
+                    ) {
+                        if is_fetch_constructor_name(&resolved) {
                             ctx.uses_fetch = true;
                         }
                         return Ok(Expr::New {
@@ -1593,10 +1614,19 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 {
                     return Ok(nonconstructable_builtin_throw_expr(property, args));
                 }
-                if matches!(object.as_ref(), Expr::GlobalGet(_))
-                    && matches!(property.as_str(), "Blob" | "File" | "WebSocket")
+                if is_global_object_expr(ctx, object.as_ref())
+                    && matches!(
+                        property.as_str(),
+                        "Blob"
+                            | "File"
+                            | "FormData"
+                            | "Headers"
+                            | "Request"
+                            | "Response"
+                            | "WebSocket"
+                    )
                 {
-                    if matches!(property.as_str(), "Blob" | "File") {
+                    if is_fetch_constructor_name(property) {
                         ctx.uses_fetch = true;
                     }
                     return Ok(Expr::New {

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -27,6 +27,26 @@ use crate::lower_types::{extract_param_type_with_ctx, extract_ts_type_with_ctx};
 
 use super::{lower_expr, LoweringContext};
 
+fn is_fetch_global_value_name(name: &str) -> bool {
+    matches!(
+        name,
+        "fetch" | "Blob" | "File" | "FormData" | "Headers" | "Request" | "Response"
+    )
+}
+
+fn builtin_global_value_expr(ctx: &mut LoweringContext, name: &str) -> Option<Expr> {
+    if !crate::analysis::is_builtin_global_value_name(name) {
+        return None;
+    }
+    if is_fetch_global_value_name(name) {
+        ctx.uses_fetch = true;
+    }
+    Some(Expr::PropertyGet {
+        object: Box::new(Expr::GlobalGet(0)),
+        property: name.to_string(),
+    })
+}
+
 /// Resolution of an object-literal `KeyValue` property key.
 enum KeyResolution {
     /// A statically-known string key (`x:`, `"x":`, `1:`, `[Enum.M]:`,
@@ -525,6 +545,8 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                         (Expr::FuncRef(func_id), Type::Any)
                     } else if ctx.lookup_class(&name).is_some() {
                         (Expr::ClassRef(name.clone()), Type::Any)
+                    } else if let Some(value) = builtin_global_value_expr(ctx, &name) {
+                        (value, Type::Any)
                     } else {
                         bail = true;
                         break;
@@ -703,6 +725,8 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                             Expr::FuncRef(func_id)
                         } else if ctx.lookup_class(&name).is_some() {
                             Expr::ClassRef(name.clone())
+                        } else if let Some(value) = builtin_global_value_expr(ctx, &name) {
+                            value
                         } else {
                             continue;
                         };
@@ -977,6 +1001,8 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                         Expr::LocalGet(local_id)
                     } else if ctx.lookup_class(&name).is_some() {
                         Expr::ClassRef(name.clone())
+                    } else if let Some(value) = builtin_global_value_expr(ctx, &name) {
+                        value
                     } else {
                         continue;
                     };

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -118,9 +118,12 @@ fn is_known_global_identifier_name(name: &str) -> bool {
             | "URL"
             | "URLSearchParams"
             | "AbortController"
+            | "Blob"
             | "FormData"
             | "File"
             | "Headers"
+            | "Request"
+            | "Response"
             | "fetch"
             | "crypto"
             | "performance"
@@ -131,6 +134,13 @@ fn is_known_global_identifier_name(name: &str) -> bool {
             | "BigInt"
             | "WebAssembly"
     ) || is_builtin_global_value_name(name)
+}
+
+fn is_fetch_global_value_name(name: &str) -> bool {
+    matches!(
+        name,
+        "fetch" | "Blob" | "File" | "FormData" | "Headers" | "Request" | "Response"
+    )
 }
 
 fn is_cjs_style_native_default_import(module_name: &str) -> bool {
@@ -505,7 +515,7 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 // `Expr::Date*Get(...)` — so they don't reach this arm.
                 // date-fns / drizzle / lodash duck-typing path.
                 if is_builtin_global_value_name(&name) {
-                    if name == "fetch" {
+                    if is_fetch_global_value_name(&name) {
                         ctx.uses_fetch = true;
                     }
                     return Ok(Expr::PropertyGet {

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -417,6 +417,10 @@ pub struct LoweringContext {
     /// the HIR (where codegen consumes them) rather than being patched in
     /// after lowering.
     pub(crate) let_class_aliases: Vec<(String, String)>,
+    /// LocalIds known to hold the global object (`globalThis`). This lets
+    /// value-read recognisers treat `const g = globalThis; g.Response` like
+    /// `globalThis.Response` without relying on source-level names.
+    pub(crate) global_this_aliases: HashSet<LocalId>,
     /// Issue #838: locals whose initializer is `<ClassName>.prototype`.
     /// Lets the assignment lowering recognise `proto.method = fn` as a
     /// prototype-method assignment on the underlying class (rather than

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -698,6 +698,10 @@ pub(super) fn identify_global_builtin_constructor(func_value: f64) -> Option<&'s
             || func_ptr == global_this_array_thunk as *const u8 as usize
             || func_ptr == global_this_object_thunk as *const u8 as usize
             || func_ptr == global_this_date_thunk as *const u8 as usize
+            || func_ptr == global_this_blob_thunk as *const u8 as usize
+            || func_ptr == global_this_headers_thunk as *const u8 as usize
+            || func_ptr == global_this_request_thunk as *const u8 as usize
+            || func_ptr == global_this_response_thunk as *const u8 as usize
             || func_ptr == webcrypto_illegal_constructor_thunk as *const u8 as usize
             || func_ptr
                 == crate::messaging::js_message_channel_constructor_call_error as *const u8
@@ -1349,6 +1353,46 @@ pub unsafe extern "C" fn js_new_function_construct(
                     .copied()
                     .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
                 return crate::object::js_object_coerce(value);
+            }
+            "Blob" => {
+                let parts = args
+                    .first()
+                    .copied()
+                    .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                let options = args
+                    .get(1)
+                    .copied()
+                    .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                return crate::object::global_this_blob_thunk(std::ptr::null(), parts, options);
+            }
+            "Headers" => {
+                let init = args
+                    .first()
+                    .copied()
+                    .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                return crate::object::global_this_headers_thunk(std::ptr::null(), init);
+            }
+            "Request" => {
+                let input = args
+                    .first()
+                    .copied()
+                    .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                let init = args
+                    .get(1)
+                    .copied()
+                    .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                return crate::object::global_this_request_thunk(std::ptr::null(), input, init);
+            }
+            "Response" => {
+                let body = args
+                    .first()
+                    .copied()
+                    .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                let init = args
+                    .get(1)
+                    .copied()
+                    .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
+                return crate::object::global_this_response_thunk(std::ptr::null(), body, init);
             }
             "Event" => {
                 let event_type = args

--- a/crates/perry-runtime/src/object/global_fetch.rs
+++ b/crates/perry-runtime/src/object/global_fetch.rs
@@ -7,7 +7,6 @@ use super::*;
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-#[cfg(not(feature = "external-fetch-symbols"))]
 const FETCH_REASON: &str =
     "fetch symbol from perry-stdlib not linked into this binary (runtime-only build)";
 
@@ -18,11 +17,68 @@ type FetchWithOptionsFn = unsafe extern "C" fn(
     *const crate::StringHeader,
 ) -> *mut crate::promise::Promise;
 
+type FetchBlobNewFn = unsafe extern "C" fn(f64, f64) -> f64;
+type FetchHeadersNewFn = extern "C" fn() -> f64;
+type FetchHeadersInitFromValueFn = unsafe extern "C" fn(f64, f64) -> f64;
+type FetchRequestNewFn = unsafe extern "C" fn(
+    *const crate::StringHeader,
+    *const crate::StringHeader,
+    *const crate::StringHeader,
+    f64,
+    *const crate::StringHeader,
+    *const crate::StringHeader,
+    *const crate::StringHeader,
+    *const crate::StringHeader,
+    *const crate::StringHeader,
+    *const crate::StringHeader,
+    *const crate::StringHeader,
+    f64,
+    *const crate::StringHeader,
+    f64,
+) -> f64;
+type FetchResponseNewFn =
+    unsafe extern "C" fn(*const crate::StringHeader, f64, *const crate::StringHeader, f64) -> f64;
+type FetchResponseStaticJsonFn =
+    unsafe extern "C" fn(f64, f64, *const crate::StringHeader, f64) -> f64;
+type FetchResponseStaticRedirectFn = unsafe extern "C" fn(*const crate::StringHeader, f64) -> f64;
+type FetchResponseStaticErrorFn = extern "C" fn() -> f64;
+
 static GLOBAL_FETCH_WITH_OPTIONS: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_BLOB_NEW: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_HEADERS_NEW: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_HEADERS_INIT_FROM_VALUE: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_REQUEST_NEW: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_RESPONSE_NEW: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_RESPONSE_STATIC_JSON: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_RESPONSE_STATIC_REDIRECT: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_RESPONSE_STATIC_ERROR: AtomicPtr<()> = AtomicPtr::new(null_mut());
 
 #[no_mangle]
 pub extern "C" fn js_register_global_fetch_with_options(f: FetchWithOptionsFn) {
     GLOBAL_FETCH_WITH_OPTIONS.store(f as *mut (), Ordering::Release);
+}
+
+#[no_mangle]
+pub extern "C" fn js_register_global_fetch_constructors(
+    blob_new: FetchBlobNewFn,
+    headers_new: FetchHeadersNewFn,
+    headers_init_from_value: FetchHeadersInitFromValueFn,
+    request_new: FetchRequestNewFn,
+    response_new: FetchResponseNewFn,
+    response_static_json: FetchResponseStaticJsonFn,
+    response_static_redirect: FetchResponseStaticRedirectFn,
+    response_static_error: FetchResponseStaticErrorFn,
+) {
+    GLOBAL_FETCH_BLOB_NEW.store(blob_new as *mut (), Ordering::Release);
+    GLOBAL_FETCH_HEADERS_NEW.store(headers_new as *mut (), Ordering::Release);
+    GLOBAL_FETCH_HEADERS_INIT_FROM_VALUE
+        .store(headers_init_from_value as *mut (), Ordering::Release);
+    GLOBAL_FETCH_REQUEST_NEW.store(request_new as *mut (), Ordering::Release);
+    GLOBAL_FETCH_RESPONSE_NEW.store(response_new as *mut (), Ordering::Release);
+    GLOBAL_FETCH_RESPONSE_STATIC_JSON.store(response_static_json as *mut (), Ordering::Release);
+    GLOBAL_FETCH_RESPONSE_STATIC_REDIRECT
+        .store(response_static_redirect as *mut (), Ordering::Release);
+    GLOBAL_FETCH_RESPONSE_STATIC_ERROR.store(response_static_error as *mut (), Ordering::Release);
 }
 
 fn fetch_option(init: f64, name: &[u8]) -> f64 {
@@ -94,6 +150,128 @@ unsafe fn call_fetch_with_options(
     }
     crate::stub_diag::perry_stub_warn("js_fetch_with_options", FETCH_REASON, None);
     null_mut()
+}
+
+fn warn_unregistered_fetch_symbol(name: &'static str) -> f64 {
+    crate::stub_diag::perry_stub_warn(name, FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+pub(super) fn call_global_blob_new(parts: f64, type_value: f64) -> f64 {
+    let f = GLOBAL_FETCH_BLOB_NEW.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: FetchBlobNewFn = unsafe { std::mem::transmute(f) };
+        return unsafe { func(parts, type_value) };
+    }
+    warn_unregistered_fetch_symbol("js_blob_new")
+}
+
+pub(super) fn call_global_headers_new() -> f64 {
+    let f = GLOBAL_FETCH_HEADERS_NEW.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: FetchHeadersNewFn = unsafe { std::mem::transmute(f) };
+        return func();
+    }
+    warn_unregistered_fetch_symbol("js_headers_new")
+}
+
+pub(super) fn call_global_headers_init_from_value(handle: f64, init: f64) -> f64 {
+    let f = GLOBAL_FETCH_HEADERS_INIT_FROM_VALUE.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: FetchHeadersInitFromValueFn = unsafe { std::mem::transmute(f) };
+        return unsafe { func(handle, init) };
+    }
+    warn_unregistered_fetch_symbol("js_headers_init_from_value")
+}
+
+pub(super) fn call_global_request_new(
+    url_ptr: *const crate::StringHeader,
+    method_ptr: *const crate::StringHeader,
+    body_ptr: *const crate::StringHeader,
+    headers_handle: f64,
+    referrer_ptr: *const crate::StringHeader,
+    referrer_policy_ptr: *const crate::StringHeader,
+    mode_ptr: *const crate::StringHeader,
+    credentials_ptr: *const crate::StringHeader,
+    cache_ptr: *const crate::StringHeader,
+    redirect_ptr: *const crate::StringHeader,
+    integrity_ptr: *const crate::StringHeader,
+    keepalive: f64,
+    duplex_ptr: *const crate::StringHeader,
+    signal: f64,
+) -> f64 {
+    let f = GLOBAL_FETCH_REQUEST_NEW.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: FetchRequestNewFn = unsafe { std::mem::transmute(f) };
+        return unsafe {
+            func(
+                url_ptr,
+                method_ptr,
+                body_ptr,
+                headers_handle,
+                referrer_ptr,
+                referrer_policy_ptr,
+                mode_ptr,
+                credentials_ptr,
+                cache_ptr,
+                redirect_ptr,
+                integrity_ptr,
+                keepalive,
+                duplex_ptr,
+                signal,
+            )
+        };
+    }
+    warn_unregistered_fetch_symbol("js_request_new")
+}
+
+pub(super) fn call_global_response_new(
+    body_ptr: *const crate::StringHeader,
+    status: f64,
+    status_text_ptr: *const crate::StringHeader,
+    headers_handle: f64,
+) -> f64 {
+    let f = GLOBAL_FETCH_RESPONSE_NEW.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: FetchResponseNewFn = unsafe { std::mem::transmute(f) };
+        return unsafe { func(body_ptr, status, status_text_ptr, headers_handle) };
+    }
+    warn_unregistered_fetch_symbol("js_response_new")
+}
+
+pub(super) fn call_global_response_static_json(
+    value: f64,
+    init_status: f64,
+    init_status_text_ptr: *const crate::StringHeader,
+    headers_handle: f64,
+) -> f64 {
+    let f = GLOBAL_FETCH_RESPONSE_STATIC_JSON.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: FetchResponseStaticJsonFn = unsafe { std::mem::transmute(f) };
+        return unsafe { func(value, init_status, init_status_text_ptr, headers_handle) };
+    }
+    warn_unregistered_fetch_symbol("js_response_static_json")
+}
+
+pub(super) fn call_global_response_static_redirect(
+    url_ptr: *const crate::StringHeader,
+    status: f64,
+) -> f64 {
+    let f = GLOBAL_FETCH_RESPONSE_STATIC_REDIRECT.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: FetchResponseStaticRedirectFn = unsafe { std::mem::transmute(f) };
+        return unsafe { func(url_ptr, status) };
+    }
+    warn_unregistered_fetch_symbol("js_response_static_redirect")
+}
+
+pub(super) fn call_global_response_static_error() -> f64 {
+    let f = GLOBAL_FETCH_RESPONSE_STATIC_ERROR.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: FetchResponseStaticErrorFn = unsafe { std::mem::transmute(f) };
+        return func();
+    }
+    warn_unregistered_fetch_symbol("js_response_static_error")
 }
 
 pub(super) extern "C" fn global_this_fetch_thunk(

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -102,6 +102,184 @@ pub(crate) extern "C" fn global_this_date_thunk(
     crate::value::js_nanbox_string(string as i64)
 }
 
+fn global_this_fetch_option(init: f64, name: &[u8]) -> f64 {
+    let value = crate::value::JSValue::from_bits(init.to_bits());
+    if !value.is_pointer() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let raw = crate::value::js_nanbox_get_pointer(init);
+    if raw < 0x10000 || !is_valid_obj_ptr(raw as *const u8) {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_get_field_by_name_f64(raw as *const ObjectHeader, key)
+}
+
+fn global_this_fetch_option_string_ptr(init: f64, name: &[u8]) -> *const crate::StringHeader {
+    let value = global_this_fetch_option(init, name);
+    if matches!(
+        value.to_bits(),
+        crate::value::TAG_UNDEFINED | crate::value::TAG_NULL
+    ) {
+        return std::ptr::null();
+    }
+    crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader
+}
+
+fn global_this_body_string_ptr(value: f64) -> *const crate::StringHeader {
+    if matches!(
+        value.to_bits(),
+        crate::value::TAG_UNDEFINED | crate::value::TAG_NULL
+    ) {
+        return std::ptr::null();
+    }
+    crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader
+}
+
+fn global_this_headers_handle_from_value(value: f64) -> f64 {
+    if matches!(
+        value.to_bits(),
+        crate::value::TAG_UNDEFINED | crate::value::TAG_NULL
+    ) {
+        return 0.0;
+    }
+    let headers = super::global_fetch::call_global_headers_new();
+    if headers.to_bits() == crate::value::TAG_UNDEFINED {
+        return 0.0;
+    }
+    super::global_fetch::call_global_headers_init_from_value(headers, value);
+    headers
+}
+
+fn global_this_init_headers_handle(init: f64) -> f64 {
+    global_this_headers_handle_from_value(global_this_fetch_option(init, b"headers"))
+}
+
+pub(crate) extern "C" fn global_this_blob_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    parts: f64,
+    options: f64,
+) -> f64 {
+    let type_value = global_this_fetch_option(options, b"type");
+    super::global_fetch::call_global_blob_new(parts, type_value)
+}
+
+pub(crate) extern "C" fn global_this_headers_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    init: f64,
+) -> f64 {
+    let headers = super::global_fetch::call_global_headers_new();
+    if headers.to_bits() == crate::value::TAG_UNDEFINED {
+        return headers;
+    }
+    if init.to_bits() != crate::value::TAG_UNDEFINED {
+        super::global_fetch::call_global_headers_init_from_value(headers, init);
+    }
+    headers
+}
+
+pub(crate) extern "C" fn global_this_response_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    body: f64,
+    init: f64,
+) -> f64 {
+    let body_ptr = global_this_body_string_ptr(body);
+    let status = global_this_fetch_option(init, b"status");
+    let status = if status.to_bits() == crate::value::TAG_UNDEFINED {
+        0.0
+    } else {
+        status
+    };
+    let status_text_ptr = global_this_fetch_option_string_ptr(init, b"statusText");
+    let headers_handle = global_this_init_headers_handle(init);
+    super::global_fetch::call_global_response_new(body_ptr, status, status_text_ptr, headers_handle)
+}
+
+pub(crate) extern "C" fn global_this_request_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    input: f64,
+    init: f64,
+) -> f64 {
+    let url_ptr = crate::value::js_get_string_pointer_unified(input) as *const crate::StringHeader;
+    let method_ptr = global_this_fetch_option_string_ptr(init, b"method");
+    let body_ptr = global_this_fetch_option_string_ptr(init, b"body");
+    let headers_handle = global_this_init_headers_handle(init);
+    let referrer_ptr = global_this_fetch_option_string_ptr(init, b"referrer");
+    let referrer_policy_ptr = global_this_fetch_option_string_ptr(init, b"referrerPolicy");
+    let mode_ptr = global_this_fetch_option_string_ptr(init, b"mode");
+    let credentials_ptr = global_this_fetch_option_string_ptr(init, b"credentials");
+    let cache_ptr = global_this_fetch_option_string_ptr(init, b"cache");
+    let redirect_ptr = global_this_fetch_option_string_ptr(init, b"redirect");
+    let integrity_ptr = global_this_fetch_option_string_ptr(init, b"integrity");
+    let keepalive = {
+        let value = global_this_fetch_option(init, b"keepalive");
+        if value.to_bits() == crate::value::TAG_UNDEFINED {
+            f64::from_bits(crate::value::TAG_FALSE)
+        } else {
+            value
+        }
+    };
+    let duplex_ptr = global_this_fetch_option_string_ptr(init, b"duplex");
+    let signal = global_this_fetch_option(init, b"signal");
+    super::global_fetch::call_global_request_new(
+        url_ptr,
+        method_ptr,
+        body_ptr,
+        headers_handle,
+        referrer_ptr,
+        referrer_policy_ptr,
+        mode_ptr,
+        credentials_ptr,
+        cache_ptr,
+        redirect_ptr,
+        integrity_ptr,
+        keepalive,
+        duplex_ptr,
+        signal,
+    )
+}
+
+extern "C" fn global_this_response_error_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    super::global_fetch::call_global_response_static_error()
+}
+
+extern "C" fn global_this_response_json_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+    init: f64,
+) -> f64 {
+    let init_status = global_this_fetch_option(init, b"status");
+    let init_status = if init_status.to_bits() == crate::value::TAG_UNDEFINED {
+        0.0
+    } else {
+        init_status
+    };
+    let init_status_text_ptr = global_this_fetch_option_string_ptr(init, b"statusText");
+    let headers_handle = global_this_init_headers_handle(init);
+    super::global_fetch::call_global_response_static_json(
+        value,
+        init_status,
+        init_status_text_ptr,
+        headers_handle,
+    )
+}
+
+extern "C" fn global_this_response_redirect_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    url: f64,
+    status: f64,
+) -> f64 {
+    let url_ptr = crate::value::js_jsvalue_to_string(url) as *const crate::StringHeader;
+    let status = if status.to_bits() == crate::value::TAG_UNDEFINED {
+        302.0
+    } else {
+        status
+    };
+    super::global_fetch::call_global_response_static_redirect(url_ptr, status)
+}
+
 extern "C" fn global_this_eval_thunk(
     _closure: *const crate::closure::ClosureHeader,
     source: f64,
@@ -1788,6 +1966,10 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                 crate::messaging::js_broadcast_channel_constructor_call_error as *const u8
             }
             "Date" => global_this_date_thunk as *const u8,
+            "Blob" => global_this_blob_thunk as *const u8,
+            "Headers" => global_this_headers_thunk as *const u8,
+            "Request" => global_this_request_thunk as *const u8,
+            "Response" => global_this_response_thunk as *const u8,
             "URLPattern" => global_this_url_pattern_call_thunk as *const u8,
             "Storage" => crate::web_storage::storage_constructor_illegal as *const u8,
             "Crypto" | "CryptoKey" | "SubtleCrypto" => {
@@ -1811,6 +1993,12 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             }
             "Object" | "String" | "Number" | "Boolean" | "BroadcastChannel" => {
                 crate::closure::js_register_closure_arity(func_ptr, 1);
+            }
+            "Headers" => {
+                crate::closure::js_register_closure_arity(func_ptr, 1);
+            }
+            "Blob" | "Request" | "Response" => {
+                crate::closure::js_register_closure_arity(func_ptr, 2);
             }
             "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
             | "EvalError" | "URIError" => {
@@ -2710,22 +2898,24 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
             install_constructor_static(
                 ctor,
                 "error",
-                global_this_builtin_noop_thunk as *const u8,
+                global_this_response_error_thunk as *const u8,
                 0,
                 false,
             );
-            install_constructor_static(
+            install_constructor_static_with_call_arity(
                 ctor,
                 "json",
-                global_this_builtin_noop_thunk as *const u8,
+                global_this_response_json_thunk as *const u8,
                 1,
+                2,
                 false,
             );
-            install_constructor_static(
+            install_constructor_static_with_call_arity(
                 ctor,
                 "redirect",
-                global_this_builtin_noop_thunk as *const u8,
+                global_this_response_redirect_thunk as *const u8,
                 1,
+                2,
                 false,
             );
         }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -825,7 +825,11 @@ pub unsafe extern "C" fn js_native_call_method(
         } else {
             0
         };
-        if crate::closure::is_closure_ptr(raw_addr)
+        // Fetch, stream, and other runtime objects use small tagged handles that
+        // are pointer-shaped but not heap allocations. Avoid asking the closure
+        // probe to dereference those handles as addresses.
+        if raw_addr >= 0x100000
+            && crate::closure::is_closure_ptr(raw_addr)
             && !crate::closure::closure_is_key_deleted(raw_addr, method_name)
         {
             let dyn_val = crate::closure::closure_get_dynamic_prop(raw_addr, method_name);
@@ -886,7 +890,7 @@ pub unsafe extern "C" fn js_native_call_method(
         // codegen-registered text (or a synthesized native form), rather than
         // falling through to the generic `"[object Object]"`.
         let raw_addr = crate::value::js_nanbox_get_pointer(object) as usize;
-        if crate::closure::is_closure_ptr(raw_addr) {
+        if raw_addr >= 0x100000 && crate::closure::is_closure_ptr(raw_addr) {
             let func_ptr = (*(raw_addr as *const crate::closure::ClosureHeader)).func_ptr as usize;
             let s = crate::builtins::function_source_for_func_ptr(func_ptr);
             let str_ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);

--- a/crates/perry-runtime/src/stdlib_stubs.rs
+++ b/crates/perry-runtime/src/stdlib_stubs.rs
@@ -151,6 +151,90 @@ pub extern "C" fn js_fetch_with_options(
     std::ptr::null_mut()
 }
 
+#[cfg(not(feature = "external-fetch-symbols"))]
+#[no_mangle]
+pub extern "C" fn js_blob_new(_parts: f64, _type_value: f64) -> f64 {
+    perry_stub_warn("js_blob_new", FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[cfg(not(feature = "external-fetch-symbols"))]
+#[no_mangle]
+pub extern "C" fn js_headers_new() -> f64 {
+    perry_stub_warn("js_headers_new", FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[cfg(not(feature = "external-fetch-symbols"))]
+#[no_mangle]
+pub extern "C" fn js_headers_init_from_value(_handle: f64, _init: f64) -> f64 {
+    perry_stub_warn("js_headers_init_from_value", FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[cfg(not(feature = "external-fetch-symbols"))]
+#[no_mangle]
+pub extern "C" fn js_request_new(
+    _url_ptr: *const crate::string::StringHeader,
+    _method_ptr: *const crate::string::StringHeader,
+    _body_ptr: *const crate::string::StringHeader,
+    _headers_handle: f64,
+    _referrer_ptr: *const crate::string::StringHeader,
+    _referrer_policy_ptr: *const crate::string::StringHeader,
+    _mode_ptr: *const crate::string::StringHeader,
+    _credentials_ptr: *const crate::string::StringHeader,
+    _cache_ptr: *const crate::string::StringHeader,
+    _redirect_ptr: *const crate::string::StringHeader,
+    _integrity_ptr: *const crate::string::StringHeader,
+    _keepalive: f64,
+    _duplex_ptr: *const crate::string::StringHeader,
+    _signal: f64,
+) -> f64 {
+    perry_stub_warn("js_request_new", FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[cfg(not(feature = "external-fetch-symbols"))]
+#[no_mangle]
+pub extern "C" fn js_response_new(
+    _body_ptr: *const crate::string::StringHeader,
+    _status: f64,
+    _status_text_ptr: *const crate::string::StringHeader,
+    _headers_handle: f64,
+) -> f64 {
+    perry_stub_warn("js_response_new", FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[cfg(not(feature = "external-fetch-symbols"))]
+#[no_mangle]
+pub extern "C" fn js_response_static_json(
+    _value: f64,
+    _init_status: f64,
+    _init_status_text_ptr: *const crate::string::StringHeader,
+    _headers_handle: f64,
+) -> f64 {
+    perry_stub_warn("js_response_static_json", FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[cfg(not(feature = "external-fetch-symbols"))]
+#[no_mangle]
+pub extern "C" fn js_response_static_redirect(
+    _url_ptr: *const crate::string::StringHeader,
+    _status: f64,
+) -> f64 {
+    perry_stub_warn("js_response_static_redirect", FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[cfg(not(feature = "external-fetch-symbols"))]
+#[no_mangle]
+pub extern "C" fn js_response_static_error() -> f64 {
+    perry_stub_warn("js_response_static_error", FETCH_REASON, None);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
 // === readline (#347) stubs ===
 // `process.stdin.setRawMode(...)` and `process.stdin.on(...)` always
 // codegen direct extern calls to these symbols, even when the user's

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -2490,6 +2490,45 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
                 *const perry_runtime::StringHeader,
             ) -> *mut perry_runtime::Promise,
         );
+        #[cfg(feature = "http-client")]
+        fn js_register_global_fetch_constructors(
+            blob_new: unsafe extern "C" fn(f64, f64) -> f64,
+            headers_new: extern "C" fn() -> f64,
+            headers_init_from_value: unsafe extern "C" fn(f64, f64) -> f64,
+            request_new: unsafe extern "C" fn(
+                *const perry_runtime::StringHeader,
+                *const perry_runtime::StringHeader,
+                *const perry_runtime::StringHeader,
+                f64,
+                *const perry_runtime::StringHeader,
+                *const perry_runtime::StringHeader,
+                *const perry_runtime::StringHeader,
+                *const perry_runtime::StringHeader,
+                *const perry_runtime::StringHeader,
+                *const perry_runtime::StringHeader,
+                *const perry_runtime::StringHeader,
+                f64,
+                *const perry_runtime::StringHeader,
+                f64,
+            ) -> f64,
+            response_new: unsafe extern "C" fn(
+                *const perry_runtime::StringHeader,
+                f64,
+                *const perry_runtime::StringHeader,
+                f64,
+            ) -> f64,
+            response_static_json: unsafe extern "C" fn(
+                f64,
+                f64,
+                *const perry_runtime::StringHeader,
+                f64,
+            ) -> f64,
+            response_static_redirect: unsafe extern "C" fn(
+                *const perry_runtime::StringHeader,
+                f64,
+            ) -> f64,
+            response_static_error: extern "C" fn() -> f64,
+        );
         fn js_register_worker_threads_namespace_getters(
             worker_data: extern "C" fn() -> f64,
             is_main_thread: extern "C" fn() -> f64,
@@ -2510,6 +2549,17 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     crate::string_decoder::string_decoder_prototype_value();
     #[cfg(feature = "http-client")]
     js_register_global_fetch_with_options(crate::fetch::js_fetch_with_options);
+    #[cfg(feature = "http-client")]
+    js_register_global_fetch_constructors(
+        crate::fetch_blob::js_blob_new,
+        crate::fetch::js_headers_new,
+        crate::fetch::js_headers_init_from_value,
+        crate::fetch::js_request_new,
+        crate::fetch::js_response_new,
+        crate::fetch::js_response_static_json,
+        crate::fetch::js_response_static_redirect,
+        crate::fetch::js_response_static_error,
+    );
     #[cfg(feature = "bundled-events")]
     unsafe extern "C" fn event_emitter_probe(handle: i64) -> bool {
         crate::events::is_event_emitter_handle(handle)

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -499,7 +499,7 @@ pub fn dispatch_form_data_method(form_id: usize, method: &str, args: &[f64]) -> 
     let form_f64 = handle_to_f64(form_id);
     let str_arg = |i: usize| -> *const StringHeader {
         if i < args.len() {
-            (args[i].to_bits() & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader
+            js_get_string_pointer_unified(args[i]) as *const StringHeader
         } else {
             std::ptr::null()
         }
@@ -585,12 +585,12 @@ pub fn dispatch_headers_method(headers_id: usize, method: &str, args: &[f64]) ->
         guard.get(&headers_id)?;
     }
     let h_f64 = handle_to_f64(headers_id);
-    // String args arrive as NaN-boxed STRING_TAG f64 values; extract the raw
-    // StringHeader pointer for the runtime helpers.
+    // String args can arrive as heap strings or SSO/short-string values; use
+    // the runtime's unified coercion helper before passing a StringHeader to
+    // the FFI helpers.
     let str_arg = |i: usize| -> *const StringHeader {
         if i < args.len() {
-            let v = args[i];
-            (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader
+            js_get_string_pointer_unified(args[i]) as *const StringHeader
         } else {
             std::ptr::null()
         }
@@ -637,6 +637,25 @@ pub fn dispatch_headers_method(headers_id: usize, method: &str, args: &[f64]) ->
 pub fn dispatch_blob_property(blob_id: usize, prop: &str) -> Option<f64> {
     let guard = BLOB_REGISTRY.lock().unwrap();
     let blob = guard.get(&blob_id)?;
+    if matches!(prop, "text" | "arrayBuffer" | "bytes" | "slice") {
+        extern "C" {
+            fn js_class_method_bind(
+                instance: f64,
+                method_name_ptr: *const u8,
+                method_name_len: usize,
+            ) -> f64;
+        }
+        let name: &'static [u8] = match prop {
+            "text" => b"text",
+            "arrayBuffer" => b"arrayBuffer",
+            "bytes" => b"bytes",
+            "slice" => b"slice",
+            _ => unreachable!(),
+        };
+        return Some(unsafe {
+            js_class_method_bind(handle_to_f64(blob_id), name.as_ptr(), name.len())
+        });
+    }
     let bits = match prop {
         "size" => return Some(blob.body.len() as f64),
         "type" => {

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -38,8 +38,8 @@ pub use body_metadata::*;
 // keep this file under the 2,000-line lint gate.
 mod validation;
 use validation::{
-    canonical_reason, is_forbidden_method, is_null_body_status, is_valid_status_text,
-    normalize_method,
+    is_forbidden_method, is_null_body_status, is_redirect_status, is_valid_status_text,
+    normalize_method, parse_redirect_location, redirect_status_from_value,
 };
 
 // Web Fetch handles must stay below the `0x100000` small-handle cutoff while
@@ -1677,16 +1677,19 @@ pub unsafe extern "C" fn js_response_static_redirect(
     status: f64,
 ) -> f64 {
     let url = string_from_header(url_ptr).unwrap_or_default();
-    let status_u16 = if status == 0.0 || status.is_nan() {
-        302
-    } else {
-        status as u16
+    let status_u16 = redirect_status_from_value(status);
+    if !is_redirect_status(status_u16) {
+        throw_fetch_range_error(&format!("Invalid status code {status_u16}"));
+    }
+    let location = match parse_redirect_location(&url) {
+        Ok(location) => location,
+        Err(_) => throw_fetch_type_error(&format!("Failed to parse URL from {url}")),
     };
     let mut headers = HeadersStore::default();
-    headers.set("location", &url);
+    headers.set("location", &location);
     handle_to_f64(alloc_response(
-        status_u16,
-        canonical_reason(status_u16).to_string(),
+        status_u16 as u16,
+        String::new(),
         headers,
         Vec::new(),
         false,

--- a/crates/perry-stdlib/src/fetch/validation.rs
+++ b/crates/perry-stdlib/src/fetch/validation.rs
@@ -4,6 +4,10 @@
 //! statusText validation + empty-string default) and #2643 (Request method
 //! normalization + forbidden methods + GET/HEAD body rejection).
 
+use perry_runtime::JSValue;
+
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
 /// Web Fetch reason-phrase validation (HTTP token rules). A valid
 /// `statusText` byte is HTAB (0x09), SP (0x20), VCHAR (0x21..=0x7E),
 /// or obs-text (0x80..=0xFF). Anything else (e.g. a newline) is invalid.
@@ -34,19 +38,23 @@ pub(crate) fn normalize_method(raw: &str) -> String {
     }
 }
 
-pub(crate) fn canonical_reason(status: u16) -> &'static str {
-    match status {
-        200 => "OK",
-        201 => "Created",
-        204 => "No Content",
-        301 => "Moved Permanently",
-        302 => "Found",
-        304 => "Not Modified",
-        400 => "Bad Request",
-        401 => "Unauthorized",
-        403 => "Forbidden",
-        404 => "Not Found",
-        500 => "Internal Server Error",
-        _ => "",
+pub(crate) fn redirect_status_from_value(status: f64) -> i32 {
+    if status.to_bits() == TAG_UNDEFINED {
+        return 302;
     }
+    let number = JSValue::from_bits(status.to_bits()).to_number();
+    if !number.is_finite() {
+        return 0;
+    }
+    (number.trunc() % 65536.0) as i32
+}
+
+pub(crate) fn is_redirect_status(status: i32) -> bool {
+    matches!(status, 301 | 302 | 303 | 307 | 308)
+}
+
+pub(crate) fn parse_redirect_location(raw: &str) -> Result<String, ()> {
+    reqwest::Url::parse(raw)
+        .map(|parsed| parsed.to_string())
+        .map_err(|_| ())
 }

--- a/test-parity/node-suite/fetch/response/static-globals-redirect.ts
+++ b/test-parity/node-suite/fetch/response/static-globals-redirect.ts
@@ -1,0 +1,99 @@
+function log(label: string, value: unknown) {
+  console.log(label, value);
+}
+
+function logSync(label: string, fn: () => unknown) {
+  try {
+    console.log(label, fn());
+  } catch (err: any) {
+    console.log(label, "throw", err.name, err.message.split("\n")[0]);
+  }
+}
+
+async function logAsync(label: string, fn: () => Promise<unknown>) {
+  try {
+    console.log(label, await fn());
+  } catch (err: any) {
+    console.log(label, "throw", err.name, err.message.split("\n")[0]);
+  }
+}
+
+const g = globalThis as any;
+const {
+  Blob: GlobalBlob,
+  Headers: GlobalHeaders,
+  Request: GlobalRequest,
+  Response: GlobalResponse,
+} = g;
+const bareConstructors: Record<string, any> = {
+  Blob,
+  Headers,
+  Request,
+  Response,
+};
+
+for (const name of ["Blob", "Headers", "Request", "Response"]) {
+  const C = g[name];
+  log(`${name} global typeof`, typeof C);
+  log(`${name} global same bare`, C === bareConstructors[name]);
+  log(`${name} prototype constructor`, C.prototype.constructor === C);
+}
+
+log("destructured Blob text", typeof new GlobalBlob(["x"]).text);
+log("destructured Headers get", new GlobalHeaders({ A: "b" }).get("a"));
+log(
+  "destructured Request method",
+  new GlobalRequest("http://example.com/path", { method: "POST" }).method,
+);
+
+const responseJson = GlobalResponse.json;
+const responseRedirect = GlobalResponse.redirect;
+const responseError = GlobalResponse.error;
+
+function callRedirect(args: readonly [string] | readonly [string, number]) {
+  return args.length === 1
+    ? responseRedirect(args[0])
+    : responseRedirect(args[0], args[1]);
+}
+
+log(
+  "Response statics typeof",
+  `error:${typeof responseError},json:${typeof responseJson},redirect:${typeof responseRedirect}`,
+);
+
+await logAsync("Response.json rebound", async () => {
+  const r = responseJson({ ok: true });
+  return `${r.status}|${r.headers.get("content-type")}|${await r.text()}`;
+});
+
+for (const args of [
+  ["http://example.com/a"],
+  ["http://example.com/b", 301],
+  ["http://example.com/c", 302],
+  ["http://example.com/d", 303],
+  ["http://example.com/e", 307],
+  ["http://example.com/f", 308],
+  ["https://example.com/a b", 302],
+  ["http://example.com/g", 302.9],
+  ["http://example.com/h", 65837],
+] as const) {
+  logSync(`Response.redirect ok ${JSON.stringify(args)}`, () => {
+    const r = callRedirect(args);
+    return `${r.status}|${JSON.stringify(r.statusText)}|${r.headers.get("location")}|${r.type}|${r.redirected}|${r.ok}`;
+  });
+}
+
+for (const args of [
+  ["http://example.com/bad", 200],
+  ["http://example.com/bad", 300],
+  ["http://example.com/bad", 304],
+  ["http://example.com/bad", 400],
+  ["http://example.com/bad", 99999],
+  ["http://example.com/bad", -1],
+  ["not a url", 302],
+] as const) {
+  logSync(`Response.redirect invalid ${JSON.stringify(args)}`, () => {
+    callRedirect(args);
+    return "ok";
+  });
+}


### PR DESCRIPTION
## Summary

Addresses #2608 and #2637.

- Bind global `Blob`, `Headers`, `Request`, and `Response` to real fetch constructor thunks instead of inert builtin placeholders.
- Teach HIR lowering to preserve those constructor identities through `globalThis` aliases, destructuring, object literal shorthand, dynamic `new`, and rebound `Response` static methods.
- Register fetch constructor/static callbacks from stdlib, add runtime stubs for runtime-only builds, and route dynamic construction through the same global thunks.
- Match Node `Response.redirect()` validation: allowed redirect statuses only, empty `statusText`, URL parsing/serialization for `Location`, and unsigned-short status coercion.
- Add a focused node-suite fixture covering constructor identity, destructured constructors, rebound `Response.json`, and redirect success/error cases.

## Root Cause

The global fetch constructors existed as generic builtin closures, so `globalThis.Response`, bare `Response`, destructured globals, and dynamic construction did not consistently resolve to the real fetch implementations. `Response.redirect()` also accepted loose statuses and populated the canonical reason phrase instead of Node's empty redirect `statusText`.

## Validation

- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=2 cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-ext-fetch`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry test-parity/node-suite/fetch/response/static-globals-redirect.ts -o /tmp/perry_fetch_static_globals_redirect && /tmp/perry_fetch_static_globals_redirect`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" node --experimental-strip-types test-parity/node-suite/fetch/response/static-globals-redirect.ts`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" RUSTC_WRAPPER= SCCACHE_DISABLE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module fetch --filter static-globals-redirect`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=2 cargo check -p perry-hir -p perry-codegen -p perry-runtime -p perry-stdlib -p perry-ext-fetch`
