### PR TITLE
[codex] Support exported destructuring bindings

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -505,6 +505,26 @@ pub(crate) fn lower_module_decl(
                 ast::Decl::Var(var_decl) => {
                     // Handle exported variables
                     for decl in &var_decl.decls {
+                        if is_destructuring_pattern(&decl.name) {
+                            let mut names = Vec::new();
+                            collect_binding_names(&decl.name, &mut names);
+                            if decl.init.is_some() {
+                                let mutable = var_decl.kind != ast::VarDeclKind::Const;
+                                let is_var = var_decl.kind == ast::VarDeclKind::Var;
+                                let stmts =
+                                    lower_var_decl_with_destructuring(ctx, decl, mutable, is_var)?;
+                                module.init.extend(stmts);
+                                for name in names {
+                                    module.exports.push(Export::Named {
+                                        local: name.clone(),
+                                        exported: name.clone(),
+                                    });
+                                    module.exported_objects.push(name);
+                                }
+                                continue;
+                            }
+                        }
+
                         let name = get_binding_name(&decl.name)?;
                         let ty = extract_binding_type(&decl.name);
                         if let Some(init) = &decl.init {
@@ -1926,7 +1946,36 @@ pub(crate) fn lower_namespace_as_class(
                     ast::Decl::Var(var_decl) => {
                         // Lower exported namespace variables as module-level locals
                         let mutable = var_decl.kind != ast::VarDeclKind::Const;
+                        let is_var = var_decl.kind == ast::VarDeclKind::Var;
                         for decl in &var_decl.decls {
+                            if is_destructuring_pattern(&decl.name) {
+                                let mut names = Vec::new();
+                                collect_binding_names(&decl.name, &mut names);
+                                if decl.init.is_some() {
+                                    let stmts = lower_var_decl_with_destructuring(
+                                        ctx, decl, mutable, is_var,
+                                    )?;
+                                    module.init.extend(stmts);
+                                    for name in names {
+                                        if let Some(id) = ctx.lookup_local(&name) {
+                                            ctx.namespace_vars.push((
+                                                ns_name.to_string(),
+                                                name.clone(),
+                                                id,
+                                            ));
+                                        }
+                                        if is_exported {
+                                            module.exported_objects.push(name.clone());
+                                            module.exports.push(Export::Named {
+                                                local: name.clone(),
+                                                exported: name,
+                                            });
+                                        }
+                                    }
+                                    continue;
+                                }
+                            }
+
                             let name = get_binding_name(&decl.name)?;
                             let ty = extract_binding_type(&decl.name);
                             if let Some(init) = &decl.init {

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -149,6 +149,31 @@ pub(crate) fn get_binding_name(pat: &ast::Pat) -> Result<String> {
     }
 }
 
+pub(crate) fn collect_binding_names(pat: &ast::Pat, out: &mut Vec<String>) {
+    match pat {
+        ast::Pat::Ident(ident) => push_unique_name(out, ident.id.sym.to_string()),
+        ast::Pat::Array(arr) => {
+            for elem in arr.elems.iter().flatten() {
+                collect_binding_names(elem, out);
+            }
+        }
+        ast::Pat::Object(obj) => {
+            for prop in &obj.props {
+                match prop {
+                    ast::ObjectPatProp::Assign(assign) => {
+                        push_unique_name(out, assign.key.sym.to_string());
+                    }
+                    ast::ObjectPatProp::KeyValue(kv) => collect_binding_names(&kv.value, out),
+                    ast::ObjectPatProp::Rest(rest) => collect_binding_names(&rest.arg, out),
+                }
+            }
+        }
+        ast::Pat::Assign(assign) => collect_binding_names(&assign.left, out),
+        ast::Pat::Rest(rest) => collect_binding_names(&rest.arg, out),
+        ast::Pat::Expr(_) | ast::Pat::Invalid(_) => {}
+    }
+}
+
 /// Static counter for generating unique synthetic names for destructuring patterns
 static DESTRUCT_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 

--- a/crates/perry-hir/tests/exported_destructuring_lowering.rs
+++ b/crates/perry-hir/tests/exported_destructuring_lowering.rs
@@ -1,0 +1,73 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Export, Module};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_result(src: &str) -> Result<Module, String> {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = parse_typescript_with_cache(&src, "exported_destructuring.ts", &mut cache)
+                .expect("parse should succeed");
+            lower_module(&parsed.module, "test", "exported_destructuring.ts")
+                .map_err(|e| e.to_string())
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+fn named_exports(module: &Module) -> Vec<(String, String)> {
+    module
+        .exports
+        .iter()
+        .filter_map(|export| match export {
+            Export::Named { local, exported } => Some((local.clone(), exported.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn exported_object_binding_pattern_with_rename_and_shorthand_lowers() {
+    let module = lower_result(
+        r#"
+        const Data: any = {
+            taggedEnum() {
+                return {
+                    $match: "match",
+                    EntityRegistered: "entity",
+                    SingletonRegistered: "singleton"
+                };
+            }
+        };
+
+        export const {
+            $match: match,
+            EntityRegistered,
+            SingletonRegistered
+        } = Data.taggedEnum();
+        "#,
+    )
+    .expect("exported object destructuring should lower");
+
+    let exports = named_exports(&module);
+    for name in ["match", "EntityRegistered", "SingletonRegistered"] {
+        assert!(
+            exports.contains(&(name.to_string(), name.to_string())),
+            "destructured binding {name} should be exported: {exports:?}"
+        );
+        assert!(
+            module.exported_objects.contains(&name.to_string()),
+            "destructured binding {name} should get an export global: {:?}",
+            module.exported_objects
+        );
+    }
+
+    let debug = format!("{module:#?}");
+    assert!(
+        debug.contains("name: \"match\"") && debug.contains("property: \"$match\""),
+        "renamed $match binding should lower through a property read: {debug}"
+    );
+}

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -157,6 +157,11 @@ crates/perry-hir/src/lower/expr_member.rs
 # `default` namespace shims (#3903). Splitting the per-namespace dispatch
 # helpers into a sibling module is tracked under #1435.
 crates/perry-hir/src/lower/lower_expr.rs
+# Module-declaration lowering tower (import/export binding resolution, re-export
+# wiring, namespace shims). Crossed the 2000-line gate after exported
+# destructuring-binding support added the pattern-walk arms. Splitting the
+# export-binding helpers into a sibling module is tracked under #1435.
+crates/perry-hir/src/lower/module_decl.rs
 # node:process surface (env/argv/hrtime/cpuUsage/resourceUsage + EventEmitter
 # wiring + warning/deprecation emit). Crossed the limit at 2047 LOC after the
 # argument-validation batch landed on main without a split (#3493 setuid/setgid/


### PR DESCRIPTION
## Summary

Fixes HIR lowering for exported binding patterns such as:

```ts
export const {
  $match: match,
  EntityRegistered,
  SingletonRegistered
} = Data.taggedEnum<ShardingRegistrationEvent>()
```

The exported variable lowering path previously required every exported `const`/`let`/`var` declarator to have a single identifier binding name. Object and array binding patterns already had ordinary declaration support, but exported declarations hit `Unsupported binding pattern` before that shared destructuring lowering could run.

This PR routes exported destructuring declarations through the existing destructuring lowering helper, then registers each leaf binding as a named export/exported object. It also applies the same treatment to the namespace exported-variable path so the same identifier-only assumption is not reintroduced there.

## Validation

- `cargo test -p perry-hir --test exported_destructuring_lowering -- --nocapture`
- `cargo build -p perry`
- `cargo build --release -p perry-runtime`
- OpenTUI focused repro with fixed Perry binary:

```sh
cd /Users/andrew/Documents/opentui/packages/core
PERRY_BIN=/Users/andrew/.codex/worktrees/perry-effect-binding-pattern/target/debug/perry \
PERRY_RUNTIME_DIR=/Users/andrew/.codex/worktrees/perry-effect-binding-pattern/target/release \
bun scripts/perry-runtime-blockers/effect-tagged-enum-binding-pattern.ts --keep-temp
```

The repro compiled, linked, and ran successfully (`effect-tagged-enum-binding-pattern: ok`). The script still exited nonzero because its expected-current-result is the old compile failure, so it reported the now-successful result as unexpected.
