### PR TITLE
[codex] fix child_process sync buffered options

### DIFF
--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -8,6 +8,8 @@ pub mod reactor;
 pub mod fork;
 // #2130: V8 structured-clone codec for `serialization: 'advanced'` IPC.
 mod v8_serde;
+// #2555: sync buffered `input`, `timeout`, and `maxBuffer` execution options.
+mod sync_run;
 // #3079: setup-time command/file/args validation (`ERR_INVALID_ARG_TYPE`).
 mod validate;
 pub use validate::{js_child_process_validate_args, js_child_process_validate_command};
@@ -32,6 +34,8 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
     Mutex,
 };
+
+use sync_run::{cp_read_run_options, cp_run_to_completion, CpRun, CpRunOptions};
 
 use crate::closure::{
     js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
@@ -386,7 +390,8 @@ pub extern "C" fn js_child_process_exec_sync(
     };
     cp_apply_options(&mut command, opts_val);
 
-    let run = cp_run_to_completion(command);
+    let run_options = cp_read_run_options(opts_val);
+    let run = cp_run_to_completion(command, &run_options);
     let stdout_box = cp_box_output(&run.stdout, &mode);
     if run.success() {
         return stdout_box;
@@ -427,7 +432,8 @@ pub extern "C" fn js_child_process_spawn_sync(
     // unless `shell` is set).
     let arg_strs = unsafe { cp_read_arg_strings(args_ptr as i64) };
     let command = cp_build_command(&cmd_str, &arg_strs, opts_val);
-    let run = cp_run_to_completion(command);
+    let run_options = cp_read_run_options(opts_val);
+    let run = cp_run_to_completion(command, &run_options);
 
     let spawn_failed_before_pid = run.spawn_error.is_some() && run.pid.is_none();
     let stdout_box = if spawn_failed_before_pid {
@@ -478,6 +484,19 @@ pub extern "C" fn js_child_process_spawn_sync(
                 ("errno", cp_errno_number(code)),
                 ("syscall", cp_box_string(&syscall)),
                 ("path", cp_box_string(&cmd_str)),
+            ],
+        );
+        set("error", err);
+    } else if let Some(run_error) = run.run_error {
+        let code = run_error.code();
+        let syscall = format!("spawnSync {cmd_str}");
+        let message = format!("{syscall} {code}");
+        let err = cp_make_error(
+            &message,
+            &[
+                ("code", cp_box_string(code)),
+                ("errno", cp_errno_number(code)),
+                ("syscall", cp_box_string(&syscall)),
             ],
         );
         set("error", err);
@@ -572,7 +591,8 @@ pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64,
         c
     };
     cp_apply_options(&mut command, arg1);
-    let run = cp_run_to_completion(command);
+    let run_options = CpRunOptions::default();
+    let run = cp_run_to_completion(command, &run_options);
 
     let stdout_box = cp_box_output(&run.stdout, &mode);
     if cb.is_null() {
@@ -1061,13 +1081,23 @@ fn cp_value_to_bytes(value: f64) -> Vec<u8> {
     let bits = value.to_bits();
     if JSValue::from_bits(bits).is_pointer() {
         let raw = (bits & crate::value::POINTER_MASK) as usize;
-        if raw >= 0x10000 && crate::buffer::is_registered_buffer(raw) {
-            let buf = raw as *const crate::buffer::BufferHeader;
-            unsafe {
-                let len = (*buf).length as usize;
-                let data =
-                    (buf as *const u8).add(std::mem::size_of::<crate::buffer::BufferHeader>());
-                return std::slice::from_raw_parts(data, len).to_vec();
+        if raw >= 0x10000 {
+            if crate::buffer::is_registered_buffer(raw) {
+                let buf = raw as *const crate::buffer::BufferHeader;
+                unsafe {
+                    let len = (*buf).length as usize;
+                    let data =
+                        (buf as *const u8).add(std::mem::size_of::<crate::buffer::BufferHeader>());
+                    return std::slice::from_raw_parts(data, len).to_vec();
+                }
+            }
+            if crate::typedarray::lookup_typed_array_kind(raw).is_some() {
+                let ta = raw as *const crate::typedarray::TypedArrayHeader;
+                unsafe {
+                    if let Some(bytes) = crate::typedarray::typed_array_bytes(ta) {
+                        return bytes.to_vec();
+                    }
+                }
             }
         }
     }
@@ -1291,14 +1321,13 @@ fn cp_args_from_value(value: f64) -> Vec<String> {
 }
 
 // ============================================================================
-// Spawn / exec options: `cwd`, `env`, `shell` — #1780
+// Spawn / exec options: `cwd`, `env`, `shell`, sync buffered I/O — #1780/#2555
 // ============================================================================
 //
-// The streaming-spawn / exec / execFile entry points previously ignored their
-// options object entirely. These helpers read the common, host-portable
-// options off a NaN-boxed options value and apply them to a `std::process::
-// Command`. Anything not listed here (`stdio`, `timeout`, `maxBuffer`, …) is
-// still ignored.
+// These helpers read the common, host-portable options off a NaN-boxed options
+// value and apply them to a `std::process::Command`. The sync buffered forms
+// also parse `{ input, timeout, maxBuffer }`; broader stdio routing remains
+// outside the current runtime surface.
 
 /// Coerce any JS value to an owned Rust string — string fast-path, else
 /// `js_jsvalue_to_string`. Used for `env` values, which Node stringifies.
@@ -1512,6 +1541,7 @@ fn cp_errno_number(code: &str) -> f64 {
         "EACCES" => libc::EACCES,
         "EEXIST" => libc::EEXIST,
         "EPIPE" => libc::EPIPE,
+        "ENOBUFS" => libc::ENOBUFS,
         "ETIMEDOUT" => libc::ETIMEDOUT,
         "ECONNREFUSED" => libc::ECONNREFUSED,
         _ => 0,
@@ -1519,67 +1549,6 @@ fn cp_errno_number(code: &str) -> f64 {
     #[cfg(not(unix))]
     let n = 0;
     -(n as f64)
-}
-
-/// Outcome of running a child to completion (buffered).
-struct CpRun {
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
-    code: Option<i32>,
-    signal: Option<i32>,
-    pid: Option<u32>,
-    /// `Some((code, message))` when the child could not be spawned at all.
-    spawn_error: Option<(&'static str, String)>,
-}
-
-impl CpRun {
-    fn success(&self) -> bool {
-        self.spawn_error.is_none() && self.code == Some(0)
-    }
-}
-
-/// Spawn `command` with piped stdout/stderr (and a closed stdin so children
-/// that read stdin see EOF instead of blocking), run it to completion, and
-/// capture stdout/stderr/exit/pid. Used by the synchronous + buffered-callback
-/// entry points.
-fn cp_run_to_completion(mut command: Command) -> CpRun {
-    command.stdin(Stdio::null());
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-    match command.spawn() {
-        Ok(child) => {
-            let pid = child.id();
-            match child.wait_with_output() {
-                Ok(o) => {
-                    let CpExit { code, signal } = cp_decode_status(&o.status);
-                    CpRun {
-                        stdout: o.stdout,
-                        stderr: o.stderr,
-                        code,
-                        signal,
-                        pid: Some(pid),
-                        spawn_error: None,
-                    }
-                }
-                Err(e) => CpRun {
-                    stdout: Vec::new(),
-                    stderr: Vec::new(),
-                    code: None,
-                    signal: None,
-                    pid: Some(pid),
-                    spawn_error: Some((cp_io_error_code(&e), e.to_string())),
-                },
-            }
-        }
-        Err(e) => CpRun {
-            stdout: Vec::new(),
-            stderr: Vec::new(),
-            code: None,
-            signal: None,
-            pid: None,
-            spawn_error: Some((cp_io_error_code(&e), e.to_string())),
-        },
-    }
 }
 
 /// Build an error-like heap object. `ErrorHeader` rejects dynamic-property
@@ -1691,6 +1660,26 @@ fn cp_sync_throw_error(run: &CpRun, cmd: &str, stdout: f64, stderr: f64) -> ! {
         None => TAG_NULL_F64,
     };
     let output = cp_output_array(stdout, stderr);
+    if let Some(run_error) = run.run_error {
+        let code = run_error.code();
+        let syscall = format!("spawnSync {cmd}");
+        let message = format!("{syscall} {code}");
+        let err = cp_make_error(
+            &message,
+            &[
+                ("code", cp_box_string(code)),
+                ("errno", cp_errno_number(code)),
+                ("syscall", cp_box_string(&syscall)),
+                ("status", status),
+                ("signal", signal),
+                ("output", output),
+                ("pid", pid),
+                ("stdout", stdout),
+                ("stderr", stderr),
+            ],
+        );
+        crate::exception::js_throw(err)
+    }
     // Node's execSync/execFileSync error enumerates exactly
     // status/signal/output/pid/stdout/stderr (no `cmd` own prop — that is on the
     // async exec callback error). The command is still surfaced in `message`.
@@ -1758,7 +1747,8 @@ pub extern "C" fn js_child_process_exec_file(
     let mut command = Command::new(&file_str);
     command.args(&arg_strs);
     cp_apply_options(&mut command, opts_val);
-    let run = cp_run_to_completion(command);
+    let run_options = CpRunOptions::default();
+    let run = cp_run_to_completion(command, &run_options);
 
     let stdout_box = cp_box_output(&run.stdout, &mode);
     if cb.is_null() {
@@ -1793,7 +1783,8 @@ pub extern "C" fn js_child_process_exec_file_sync(
     let mut command = Command::new(&file_str);
     command.args(&arg_strs);
     cp_apply_options(&mut command, opts_val);
-    let run = cp_run_to_completion(command);
+    let run_options = cp_read_run_options(opts_val);
+    let run = cp_run_to_completion(command, &run_options);
 
     let stdout_box = cp_box_output(&run.stdout, &mode);
     if run.success() {

--- a/crates/perry-runtime/src/child_process/sync_run.rs
+++ b/crates/perry-runtime/src/child_process/sync_run.rs
@@ -1,0 +1,243 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::value::JSValue;
+
+use super::{
+    cp_decode_status, cp_get_field, cp_io_error_code, cp_object_ptr, cp_value_to_bytes, CpExit,
+};
+
+const CP_DEFAULT_MAX_BUFFER: usize = 1024 * 1024;
+const CP_SIGTERM: i32 = 15;
+
+/// Options that affect buffered sync execution after the `Command` is built.
+pub(super) struct CpRunOptions {
+    input: Option<Vec<u8>>,
+    timeout: Option<Duration>,
+    max_buffer: usize,
+}
+
+impl Default for CpRunOptions {
+    fn default() -> Self {
+        Self {
+            input: None,
+            timeout: None,
+            max_buffer: CP_DEFAULT_MAX_BUFFER,
+        }
+    }
+}
+
+fn cp_read_option_number(opts_val: f64, key: &[u8]) -> Option<f64> {
+    if cp_object_ptr(opts_val).is_none() {
+        return None;
+    }
+    let value = cp_get_field(opts_val, key);
+    let js_value = JSValue::from_bits(value.to_bits());
+    if js_value.is_undefined() || js_value.is_null() {
+        return None;
+    }
+    let n = js_value.to_number();
+    if n.is_finite() {
+        Some(n)
+    } else {
+        None
+    }
+}
+
+fn cp_is_input_byte_value(value: f64) -> bool {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if js_value.is_any_string() {
+        return true;
+    }
+    if !js_value.is_pointer() {
+        return false;
+    }
+
+    let raw = (value.to_bits() & crate::value::POINTER_MASK) as usize;
+    if raw < 0x10000 {
+        return false;
+    }
+    if crate::typedarray::lookup_typed_array_kind(raw).is_some() {
+        return true;
+    }
+    crate::buffer::is_registered_buffer(raw) && !crate::buffer::is_any_array_buffer(raw)
+}
+
+fn cp_read_input_bytes(value: f64) -> Option<Vec<u8>> {
+    let js_value = JSValue::from_bits(value.to_bits());
+    if js_value.is_undefined() || js_value.is_null() {
+        return None;
+    }
+    if cp_is_input_byte_value(value) {
+        return Some(cp_value_to_bytes(value));
+    }
+
+    let message = format!(
+        "The \"options.stdio[0]\" property must be of type string or an instance of Buffer, TypedArray, or DataView. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+/// Read sync-only buffered options. `input` follows Node's byte-value
+/// validation; non-finite numeric limits are ignored so legacy callers keep the
+/// previous behavior.
+pub(super) fn cp_read_run_options(opts_val: f64) -> CpRunOptions {
+    let mut options = CpRunOptions::default();
+    if cp_object_ptr(opts_val).is_none() {
+        return options;
+    }
+
+    if let Some(input) = cp_read_input_bytes(cp_get_field(opts_val, b"input")) {
+        options.input = Some(input);
+    }
+
+    if let Some(timeout) = cp_read_option_number(opts_val, b"timeout") {
+        if timeout > 0.0 {
+            options.timeout = Some(Duration::from_millis(timeout as u64));
+        }
+    }
+
+    if let Some(max_buffer) = cp_read_option_number(opts_val, b"maxBuffer") {
+        if max_buffer >= 0.0 {
+            options.max_buffer = max_buffer.min(usize::MAX as f64) as usize;
+        }
+    }
+
+    options
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum CpRunError {
+    MaxBuffer,
+    Timeout,
+}
+
+impl CpRunError {
+    pub(super) fn code(self) -> &'static str {
+        match self {
+            Self::MaxBuffer => "ENOBUFS",
+            Self::Timeout => "ETIMEDOUT",
+        }
+    }
+}
+
+/// Outcome of running a child to completion (buffered).
+pub(super) struct CpRun {
+    pub(super) stdout: Vec<u8>,
+    pub(super) stderr: Vec<u8>,
+    pub(super) code: Option<i32>,
+    pub(super) signal: Option<i32>,
+    pub(super) pid: Option<u32>,
+    /// `Some((code, message))` when the child could not be spawned at all.
+    pub(super) spawn_error: Option<(&'static str, String)>,
+    /// `Some` for deterministic buffered execution failures after spawn.
+    pub(super) run_error: Option<CpRunError>,
+}
+
+impl CpRun {
+    pub(super) fn success(&self) -> bool {
+        self.spawn_error.is_none() && self.run_error.is_none() && self.code == Some(0)
+    }
+}
+
+/// Spawn `command` with piped stdout/stderr (and a closed stdin so children
+/// that read stdin see EOF instead of blocking), run it to completion, and
+/// capture stdout/stderr/exit/pid. Used by the synchronous + buffered-callback
+/// entry points.
+pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions) -> CpRun {
+    if options.input.is_some() {
+        command.stdin(Stdio::piped());
+    } else {
+        command.stdin(Stdio::null());
+    }
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    match command.spawn() {
+        Ok(mut child) => {
+            let pid = child.id();
+            if let Some(input) = &options.input {
+                if let Some(mut stdin) = child.stdin.take() {
+                    let _ = stdin.write_all(input);
+                }
+            }
+            let mut run_error = cp_wait_for_timeout(&mut child, options.timeout);
+            match child.wait_with_output() {
+                Ok(o) => {
+                    let CpExit { code, signal } = cp_decode_status(&o.status);
+                    if run_error.is_none()
+                        && (o.stdout.len() > options.max_buffer
+                            || o.stderr.len() > options.max_buffer)
+                    {
+                        run_error = Some(CpRunError::MaxBuffer);
+                    }
+                    let (code, signal) = match run_error {
+                        Some(CpRunError::Timeout) => (None, Some(CP_SIGTERM)),
+                        _ => (code, signal),
+                    };
+                    CpRun {
+                        stdout: o.stdout,
+                        stderr: o.stderr,
+                        code,
+                        signal,
+                        pid: Some(pid),
+                        spawn_error: None,
+                        run_error,
+                    }
+                }
+                Err(e) => CpRun {
+                    stdout: Vec::new(),
+                    stderr: Vec::new(),
+                    code: None,
+                    signal: None,
+                    pid: Some(pid),
+                    spawn_error: Some((cp_io_error_code(&e), e.to_string())),
+                    run_error: None,
+                },
+            }
+        }
+        Err(e) => CpRun {
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            code: None,
+            signal: None,
+            pid: None,
+            spawn_error: Some((cp_io_error_code(&e), e.to_string())),
+            run_error: None,
+        },
+    }
+}
+
+fn cp_wait_for_timeout(
+    child: &mut std::process::Child,
+    timeout: Option<Duration>,
+) -> Option<CpRunError> {
+    let timeout = timeout?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return None,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    cp_terminate_child(child);
+                    return Some(CpRunError::Timeout);
+                }
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                std::thread::sleep(remaining.min(Duration::from_millis(5)));
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+fn cp_terminate_child(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    unsafe {
+        let _ = libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = child.kill();
+    }
+}

--- a/test-parity/node-suite/child_process/sync/setup-validation.ts
+++ b/test-parity/node-suite/child_process/sync/setup-validation.ts
@@ -1,0 +1,27 @@
+import { exec, execFile, execFileSync, execSync, spawn, spawnSync } from "node:child_process";
+
+function report(label, run) {
+  try {
+    run();
+    console.log(`${label}: ok`);
+  } catch (err) {
+    console.log(`${label}:`, err.constructor.name, err.code, err.message);
+  }
+}
+
+report("exec command undefined", () => exec(undefined));
+report("exec command number", () => exec(123));
+report("execSync command undefined", () => execSync(undefined));
+report("execSync command number", () => execSync(123));
+report("execFile file undefined", () => execFile(undefined));
+report("execFile file number", () => execFile(123));
+report("execFile args string", () => execFile("echo", "-n"));
+report("execFileSync file undefined", () => execFileSync(undefined));
+report("execFileSync file number", () => execFileSync(123));
+report("execFileSync args string", () => execFileSync("echo", "-n"));
+report("spawn file undefined", () => spawn(undefined));
+report("spawn file number", () => spawn(123));
+report("spawn args string", () => spawn("echo", "-n"));
+report("spawnSync file undefined", () => spawnSync(undefined));
+report("spawnSync file number", () => spawnSync(123));
+report("spawnSync args string", () => spawnSync("echo", "-n"));

--- a/test-parity/node-suite/child_process/sync/sync-options.ts
+++ b/test-parity/node-suite/child_process/sync/sync-options.ts
@@ -1,0 +1,82 @@
+import { execFileSync, execSync, spawnSync } from "node:child_process";
+
+function text(value) {
+  return value === null ? "null" : String(value);
+}
+
+function reportThrow(label, run) {
+  try {
+    console.log(`${label} no throw:`, text(run()));
+  } catch (err) {
+    console.log(`${label} caught:`, err instanceof Error);
+    console.log(`${label} code:`, err.code);
+    console.log(`${label} status:`, err.status);
+    console.log(`${label} signal:`, err.signal);
+    console.log(`${label} stdout:`, text(err.stdout));
+    console.log(`${label} stderr:`, text(err.stderr));
+  }
+}
+
+const spawnInput = spawnSync("cat", [], { input: "spawn-in", encoding: "utf8" });
+console.log("spawn input stdout:", spawnInput.stdout);
+console.log("spawn input stderr:", spawnInput.stderr);
+console.log("spawn input status:", spawnInput.status);
+console.log("spawn input error:", spawnInput.error && spawnInput.error.code);
+
+const spawnNullInput = spawnSync("cat", [], { input: null, encoding: "utf8" });
+console.log("spawn null input stdout:", spawnNullInput.stdout);
+console.log("spawn null input status:", spawnNullInput.status);
+
+const spawnBufferInput = spawnSync("cat", [], { input: Buffer.from("buf-in"), encoding: "utf8" });
+console.log("spawn buffer input stdout:", spawnBufferInput.stdout);
+
+console.log(
+  "execFile input:",
+  execFileSync("cat", [], { input: "file-in", encoding: "utf8" }),
+);
+console.log("exec input:", execSync("cat", { input: "exec-in", encoding: "utf8" }));
+console.log("execFile null input:", execFileSync("cat", [], { input: null, encoding: "utf8" }));
+console.log("exec null input:", execSync("cat", { input: null, encoding: "utf8" }));
+
+reportThrow("spawn input number", () =>
+  spawnSync("cat", [], { input: 123, encoding: "utf8" })
+);
+reportThrow("execFile input number", () =>
+  execFileSync("cat", [], { input: 123, encoding: "utf8" })
+);
+reportThrow("exec input number", () =>
+  execSync("cat", { input: 123, encoding: "utf8" })
+);
+
+const spawnMax = spawnSync("sh", ["-c", "printf 123456"], {
+  maxBuffer: 3,
+  encoding: "utf8",
+});
+console.log("spawn max stdout:", spawnMax.stdout);
+console.log("spawn max status:", spawnMax.status);
+console.log("spawn max signal:", spawnMax.signal);
+console.log("spawn max error code:", spawnMax.error && spawnMax.error.code);
+console.log("spawn max error syscall:", spawnMax.error && spawnMax.error.syscall);
+
+reportThrow("execFile max", () =>
+  execFileSync("sh", ["-c", "printf 123456"], { maxBuffer: 3, encoding: "utf8" })
+);
+reportThrow("exec max", () =>
+  execSync("printf 123456", { maxBuffer: 3, encoding: "utf8" })
+);
+
+const spawnTimeout = spawnSync("sh", ["-c", "sleep 1"], {
+  timeout: 50,
+  encoding: "utf8",
+});
+console.log("spawn timeout status:", spawnTimeout.status);
+console.log("spawn timeout signal:", spawnTimeout.signal);
+console.log("spawn timeout error code:", spawnTimeout.error && spawnTimeout.error.code);
+console.log("spawn timeout error syscall:", spawnTimeout.error && spawnTimeout.error.syscall);
+
+reportThrow("execFile timeout", () =>
+  execFileSync("sh", ["-c", "sleep 1"], { timeout: 50, encoding: "utf8" })
+);
+reportThrow("exec timeout", () =>
+  execSync("sleep 1", { timeout: 50, encoding: "utf8" })
+);


### PR DESCRIPTION
## Linked issues

Closes #3079.
Advances #2555.

## Behavior cluster

This PR covers the `node:child_process` setup/sync buffered cluster:

- adds parity coverage for setup-time `command`, `file`, and `args` validation across `exec`, `execSync`, `execFile`, `execFileSync`, `spawn`, and `spawnSync`
- teaches sync buffered child-process execution to honor `input`, `maxBuffer`, and `timeout`
- surfaces `ENOBUFS` and `ETIMEDOUT` through `spawnSync().error` and sync throw diagnostics
- preserves existing captured stdout/stderr/status/signal behavior for nonzero exits and spawn failures

## Why these were batched

The selected issues share the same `child_process` setup/runtime path and the same parity harness. The validation fixture verifies the existing setup-time argument checks, while the sync-options fixture exercises the same buffered runner that backs `spawnSync`, `execSync`, and `execFileSync`.

## Tests added

- `test-parity/node-suite/child_process/sync/setup-validation.ts`
- `test-parity/node-suite/child_process/sync/sync-options.ts`

## Commands run

- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" node --experimental-strip-types test-parity/node-suite/child_process/sync/sync-options.ts`
- `cargo check -p perry-runtime`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module child_process --filter sync-options`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')"); PATH="$NODE25_DIR:$PATH" ./run_parity_tests.sh --suite node-suite --module child_process`
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `./scripts/check_file_size.sh`

## Known limitations

This is the deterministic sync buffered subset of #2555. It does not implement full `stdio` routing, async `exec`/`execFile` timeout semantics, `killSignal`, Windows-specific process options, or complete option validation beyond the covered `input` cases.

## Non-goals

- no broad child_process rewrite
- no manifest or docs regeneration
- no changes to known-failure metadata
