### PR TITLE
[codex] Fix OpenTUI native render lowering

### DIFF
--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -132,6 +132,16 @@ fn same_side_effect_free_receiver(target: &Expr, receiver: &Expr) -> bool {
     match (target, receiver) {
         (Expr::LocalGet(id), Expr::LocalGet(receiver_id)) => id == receiver_id,
         (Expr::This, Expr::This) => true,
+        (
+            Expr::PropertyGet { object, property },
+            Expr::PropertyGet {
+                object: receiver_object,
+                property: receiver_property,
+            },
+        ) => {
+            property == receiver_property
+                && same_side_effect_free_receiver(object.as_ref(), receiver_object.as_ref())
+        }
         _ => false,
     }
 }

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -603,14 +603,6 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 crate::lower_call::FieldInitMode::SelfOnly,
             )?;
 
-            if ctx.current_closure_ptr.is_some() {
-                return Ok(ctx.block().call(
-                    DOUBLE,
-                    "js_throw_reference_error_unresolved_get",
-                    &[],
-                ));
-            }
-
             // super() evaluates to undefined in JS.
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1703,6 +1703,7 @@ pub(crate) fn receiver_class_name(ctx: &FnCtx<'_>, e: &Expr) -> Option<String> {
 pub(crate) fn is_array_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     match static_type_of(ctx, e) {
         Some(HirType::Array(_)) | Some(HirType::Tuple(_)) => true,
+        Some(HirType::Generic { ref base, .. }) if base == "Array" => true,
         // #3148: %TypedArray% receivers route their not-already-folded methods
         // (fill / reverse / keys / values / entries / set / subarray) through
         // `lower_array_method`; the generic `js_array_*` helpers delegate to the

--- a/tests/test_issue_4150_array_property_index_set.sh
+++ b/tests/test_issue_4150_array_property_index_set.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/array_property_index_set.ts" <<'TS'
+interface State {
+  width: number
+  mirror: number[]
+}
+
+function write(state: State, cell: number, value: number): void {
+  state.mirror[cell] = value
+}
+
+const state: State = { width: 20, mirror: new Array(40) }
+write(state, 0, 112)
+write(state, 1, 101)
+state.mirror[2] = 114
+
+if (state.mirror[0] !== 112 || state.mirror[1] !== 101 || state.mirror[2] !== 114) {
+  throw new Error(
+    `expected property array indexed writes to round-trip, got ${state.mirror[0]}, ${state.mirror[1]}, ${state.mirror[2]}`,
+  )
+}
+
+console.log("array property index set ok")
+TS
+
+"$PERRY" compile --no-cache --no-auto-optimize "$TMPDIR/array_property_index_set.ts" \
+    -o "$TMPDIR/array_property_index_set" >"$TMPDIR/compile.log" 2>&1 || {
+    echo "FAIL: compile failed"
+    sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+    exit 1
+}
+
+"$TMPDIR/array_property_index_set" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q "array property index set ok" "$TMPDIR/run.log"; then
+    echo "FAIL: expected success marker"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+echo "PASS: array property index set"

--- a/tests/test_issue_4150_derived_constructor_arrow_new.sh
+++ b/tests/test_issue_4150_derived_constructor_arrow_new.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/derived_constructor_arrow_new.ts" <<'TS'
+class Base {
+}
+
+class Cache extends Base {
+  constructor() {
+    super();
+  }
+}
+
+const factory = () => new Cache();
+
+const value = factory();
+if (!(value instanceof Cache)) {
+  throw new Error("expected Cache instance");
+}
+
+console.log("derived constructor arrow new ok");
+TS
+
+"$PERRY" compile --no-cache --no-auto-optimize "$TMPDIR/derived_constructor_arrow_new.ts" \
+    -o "$TMPDIR/derived_constructor_arrow_new" >"$TMPDIR/compile.log" 2>&1 || {
+    echo "FAIL: compile failed"
+    sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+    exit 1
+}
+
+"$TMPDIR/derived_constructor_arrow_new" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q "derived constructor arrow new ok" "$TMPDIR/run.log"; then
+    echo "FAIL: expected success marker"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+echo "PASS: derived constructor arrow new"

--- a/tests/test_issue_4150_new_array_index_set.sh
+++ b/tests/test_issue_4150_new_array_index_set.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/new_array_index_set.ts" <<'TS'
+const values = new Array(4);
+values[0] = 112;
+values[1] = 101;
+
+if (values.length !== 4) {
+  throw new Error("expected preserved array length");
+}
+if (values[0] !== 112 || values[1] !== 101) {
+  throw new Error(`expected indexed writes to round-trip, got ${values[0]}, ${values[1]}`);
+}
+if (values[2] !== undefined) {
+  throw new Error("expected unwritten new Array slot to remain undefined");
+}
+
+console.log("new Array index set ok");
+TS
+
+"$PERRY" compile --no-cache --no-auto-optimize "$TMPDIR/new_array_index_set.ts" \
+    -o "$TMPDIR/new_array_index_set" >"$TMPDIR/compile.log" 2>&1 || {
+    echo "FAIL: compile failed"
+    sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+    exit 1
+}
+
+"$TMPDIR/new_array_index_set" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q "new Array index set ok" "$TMPDIR/run.log"; then
+    echo "FAIL: expected success marker"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+echo "PASS: new Array index set"


### PR DESCRIPTION
## Summary

Fix the remaining generic Perry-native OpenTUI render smoke blocker after #4150 by correcting three scoped lowering/runtime-shape issues exercised by the render path:

- allow builtin generic `Array` static types to use array receiver lowering
- route side-effect-free `obj.arrayProp[index] = value` through the existing `IndexSet` fast path when target and receiver property paths match
- remove the invalid closure guard that made `super()` in a derived constructor fail when the constructor was reached through a closure-created `new Cache()` path

This is scoped to generic OpenTUI render/input/update/clean-teardown evidence. It does not claim actual OpenCode native completion.

## #4176 comparison

I compared #4176 (`addf0430271e2efa97a2e7ceea7d8f8d144e9065`, `crates/perry-runtime/src/proxy.rs`) against the previously validated safe OpenTUI patch. #4176 is only a subset and was not sufficient for the generic OpenTUI lane:

- the derived-constructor reducer still failed with `ReferenceError: identifier is not defined`
- the property-array reducer exited 139
- the OpenTUI renderlib reducer exited 139

So this PR keeps the complete scoped compiler-side fix instead of the unsafe exploratory PutValue route.

## Validation

- `cargo fmt`
- `cargo build --release -p perry`
- `cargo build --release -p perry-runtime`
- `cargo build --release -p perry-stdlib`
- `PERRY_RUNTIME_DIR=/tmp/perry-opentui-render-pr/target/release tests/test_issue_4150_array_property_index_set.sh`
- `PERRY_RUNTIME_DIR=/tmp/perry-opentui-render-pr/target/release tests/test_issue_4150_new_array_index_set.sh`
- `PERRY_RUNTIME_DIR=/tmp/perry-opentui-render-pr/target/release tests/test_issue_4150_derived_constructor_arrow_new.sh`
- OpenTUI renderlib reducer: `repro-perry-renderlib-drawtext.ts` reached expected `before`/`after` visible buffer text
- Generic Perry-native OpenTUI fallback smoke passed with full stdlib:

```sh
cd /Users/andrew/Documents/opentui/packages/core
PERRY_BIN=/tmp/perry-opentui-render-pr/target/release/perry \
  OTUI_PERRY_NATIVE_SMOKE_DIAGNOSTICS=1 \
  bun scripts/perry-native-smoke.ts --compile-timeout-ms 120000 --keep-temp
```

Observed output:

```text
Perry-native generic OpenTUI fallback smoke passed.
Observed output: perry-native: idle -> perry-native: pressed:x
Product status: incomplete because the OpenCode TUI entrypoint was not available.
```
