### PR TITLE
[codex] Implement WASI lifecycle methods

### DIFF
--- a/crates/perry-runtime/src/wasi.rs
+++ b/crates/perry-runtime/src/wasi.rs
@@ -1,8 +1,7 @@
-//! Minimal `node:wasi` surface for constructor/import-object parity.
+//! Minimal `node:wasi` surface for constructor/import-object and lifecycle parity.
 //!
-//! This intentionally stops at option validation plus preview1/unstable import
-//! object shape. Running WASI modules and full syscall fidelity are separate
-//! lifecycle work.
+//! This intentionally validates lifecycle state and WASI instance export shape
+//! without attempting full WASI syscall fidelity.
 
 use crate::closure::ClosureHeader;
 use crate::object::ObjectHeader;
@@ -14,6 +13,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub const CLASS_ID_WASI: u32 = 0xFFFF_00B2;
 const CLASS_ID_WASI_IMPORT_PREVIEW1: u32 = 0xFFFF_00B3;
 const CLASS_ID_WASI_IMPORT_UNSTABLE: u32 = 0xFFFF_00B4;
+const FIELD_WASI_IMPORT: &str = "wasiImport";
+const FIELD_WASI_STARTED: &str = "__wasiStarted";
 
 static WASI_PROTOTYPE_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
@@ -74,6 +75,14 @@ fn undefined() -> f64 {
     f64::from_bits(TAG_UNDEFINED)
 }
 
+fn bool_value(value: bool) -> f64 {
+    f64::from_bits(JSValue::bool(value).bits())
+}
+
+fn is_undefined(value: f64) -> bool {
+    JSValue::from_bits(value.to_bits()).is_undefined()
+}
+
 fn named_key(name: &[u8]) -> *mut StringHeader {
     crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32)
 }
@@ -129,12 +138,28 @@ fn type_error_with_code(message: &str, code: &'static str) -> ! {
     crate::fs::validate::throw_type_error_with_code(message, code)
 }
 
+fn invalid_arg_type(message: &str) -> ! {
+    type_error_with_code(message, "ERR_INVALID_ARG_TYPE")
+}
+
 fn invalid_type(property: &str, expected: &str, value: f64) -> ! {
     let message = format!(
         "The \"{property}\" property must be of type {expected}. Received {}",
         crate::fs::validate::describe_received(value)
     );
-    type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+    invalid_arg_type(&message)
+}
+
+fn invalid_undefined_property(property: &str, value: f64) -> ! {
+    let message = format!(
+        "The \"{property}\" property must be undefined. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    invalid_arg_type(&message)
+}
+
+fn invalid_wasm_memory() -> ! {
+    invalid_arg_type("\"instance.exports.memory\" property must be a WebAssembly.Memory object")
 }
 
 fn invalid_options(value: f64) -> ! {
@@ -337,15 +362,21 @@ pub extern "C" fn js_wasi_new(options: f64) -> f64 {
     let (_, import_class_id) = validate_options(options);
     ensure_wasi_prototype();
     let import_obj = create_import_object(import_class_id);
-    let keys = b"wasiImport\0";
+    let keys = b"wasiImport\0__wasiStarted\0";
     let obj = crate::object::js_object_alloc_class_with_keys(
         CLASS_ID_WASI,
         0,
-        1,
+        2,
         keys.as_ptr(),
         keys.len() as u32,
     );
     crate::object::js_object_set_field(obj, 0, JSValue::from_bits(ptr_value(import_obj).to_bits()));
+    crate::object::js_object_set_field(obj, 1, JSValue::from_bits(bool_value(false).to_bits()));
+    crate::object::set_builtin_property_attrs(
+        obj as usize,
+        FIELD_WASI_STARTED.to_string(),
+        crate::object::PropertyAttrs::new(true, false, true),
+    );
     ptr_value(obj)
 }
 
@@ -355,8 +386,10 @@ pub extern "C" fn js_wasi_get_import_object(_closure: *const ClosureHeader) -> f
     let Some(obj) = heap_object_ptr(this) else {
         invalid_options(this);
     };
-    let import_value =
-        crate::object::js_object_get_field_by_name_f64(obj, named_key(b"wasiImport"));
+    let import_value = crate::object::js_object_get_field_by_name_f64(
+        obj,
+        named_key(FIELD_WASI_IMPORT.as_bytes()),
+    );
     let Some(import_obj) = heap_object_ptr(import_value) else {
         return undefined();
     };
@@ -372,38 +405,141 @@ pub extern "C" fn js_wasi_get_import_object(_closure: *const ClosureHeader) -> f
 
 #[no_mangle]
 pub extern "C" fn js_wasi_start(_closure: *const ClosureHeader, instance: f64) -> f64 {
-    validate_instance_arg(instance);
-    throw_wasi_lifecycle_unimplemented()
+    let wasi = wasi_receiver_or_throw();
+    ensure_wasi_not_started(wasi);
+    let exports = validate_instance_exports(instance);
+    validate_start_exports(exports);
+    mark_wasi_started(wasi);
+    0.0
 }
 
 #[no_mangle]
 pub extern "C" fn js_wasi_initialize(_closure: *const ClosureHeader, instance: f64) -> f64 {
-    validate_instance_arg(instance);
-    throw_wasi_lifecycle_unimplemented()
+    let wasi = wasi_receiver_or_throw();
+    ensure_wasi_not_started(wasi);
+    let exports = validate_instance_exports(instance);
+    validate_initialize_exports(exports);
+    mark_wasi_started(wasi);
+    undefined()
 }
 
 #[no_mangle]
 pub extern "C" fn js_wasi_finalize_bindings(_closure: *const ClosureHeader, instance: f64) -> f64 {
-    validate_instance_arg(instance);
-    throw_wasi_lifecycle_unimplemented()
+    let wasi = wasi_receiver_or_throw();
+    ensure_wasi_not_started(wasi);
+    let exports = validate_instance_exports(instance);
+    validate_memory_export(exports);
+    mark_wasi_started(wasi);
+    undefined()
 }
 
-fn validate_instance_arg(instance: f64) {
-    if !is_object_value(instance) {
+fn wasi_receiver_or_throw() -> *mut ObjectHeader {
+    let this = crate::object::js_implicit_this_get();
+    let Some(obj) = heap_object_ptr(this) else {
+        type_error_with_code("Value of \"this\" must be of type WASI", "ERR_INVALID_THIS");
+    };
+    unsafe {
+        if (*obj).class_id != CLASS_ID_WASI {
+            type_error_with_code("Value of \"this\" must be of type WASI", "ERR_INVALID_THIS");
+        }
+    }
+    obj
+}
+
+fn wasi_started(obj: *mut ObjectHeader) -> bool {
+    let value = crate::object::js_object_get_field_by_name_f64(
+        obj,
+        named_key(FIELD_WASI_STARTED.as_bytes()),
+    );
+    let jsval = JSValue::from_bits(value.to_bits());
+    jsval.is_bool() && jsval.as_bool()
+}
+
+fn ensure_wasi_not_started(obj: *mut ObjectHeader) {
+    if wasi_started(obj) {
+        crate::fs::validate::throw_error_with_code(
+            "WASI instance has already started",
+            "ERR_WASI_ALREADY_STARTED",
+        );
+    }
+}
+
+fn mark_wasi_started(obj: *mut ObjectHeader) {
+    crate::object::js_object_set_field_by_name(
+        obj,
+        named_key(FIELD_WASI_STARTED.as_bytes()),
+        bool_value(true),
+    );
+    crate::object::set_builtin_property_attrs(
+        obj as usize,
+        FIELD_WASI_STARTED.to_string(),
+        crate::object::PropertyAttrs::new(true, false, true),
+    );
+}
+
+fn validate_instance_arg(instance: f64) -> *mut ObjectHeader {
+    let Some(obj) = heap_object_ptr(instance) else {
         let message = format!(
             "The \"instance\" argument must be of type object. Received {}",
             crate::fs::validate::describe_received(instance)
         );
-        type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+        invalid_arg_type(&message);
+    };
+    obj
+}
+
+fn validate_instance_exports(instance: f64) -> *mut ObjectHeader {
+    let instance_obj = validate_instance_arg(instance);
+    let exports =
+        crate::object::js_object_get_field_by_name_f64(instance_obj, named_key(b"exports"));
+    let Some(exports_obj) = heap_object_ptr(exports) else {
+        let message = format!(
+            "The \"instance.exports\" property must be of type object. Received {}",
+            crate::fs::validate::describe_received(exports)
+        );
+        invalid_arg_type(&message);
+    };
+    exports_obj
+}
+
+fn export_value(exports: *mut ObjectHeader, name: &[u8]) -> f64 {
+    crate::object::js_object_get_field_by_name_f64(exports, named_key(name))
+}
+
+fn is_callable_value(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return false;
+    }
+    let ptr = jsval.as_pointer::<u8>() as usize;
+    crate::closure::is_closure_ptr(ptr)
+}
+
+fn validate_memory_export(exports: *mut ObjectHeader) {
+    let memory = export_value(exports, b"memory");
+    if !is_object_value(memory) {
+        invalid_wasm_memory();
     }
 }
 
-fn throw_wasi_lifecycle_unimplemented() -> f64 {
-    let message = "WASI lifecycle execution is not implemented in Perry";
-    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
-    crate::node_submodules::register_error_code_pub(msg, "ERR_WASI_NOT_STARTED");
-    let err = crate::error::js_error_new_with_message(msg);
-    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+fn validate_start_exports(exports: *mut ObjectHeader) {
+    validate_memory_export(exports);
+    let start = export_value(exports, b"_start");
+    if !is_callable_value(start) {
+        invalid_type("instance.exports._start", "function", start);
+    }
+    let initialize = export_value(exports, b"_initialize");
+    if !is_undefined(initialize) {
+        invalid_undefined_property("instance.exports._initialize", initialize);
+    }
+}
+
+fn validate_initialize_exports(exports: *mut ObjectHeader) {
+    validate_memory_export(exports);
+    let start = export_value(exports, b"_start");
+    if !is_undefined(start) {
+        invalid_undefined_property("instance.exports._start", start);
+    }
 }
 
 #[no_mangle]

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -1749,13 +1749,7 @@ The FileHandle stream-iter tail is runtime-backed for the direct no-transform so
 
 ### node:wasi
 
-**Gap APIs: 3** · Already covered: 3
-
-#### Missing from Perry
-
-- `wasi.start(instance)`
-- `wasi.initialize(instance)`
-- `wasi.finalizeBindings(instance[, options])`
+**Gap APIs: 0** · Already covered: 6
 
 #### Covered (sampled)
 
@@ -1764,6 +1758,9 @@ The FileHandle stream-iter tail is runtime-backed for the direct no-transform so
 | `new WASI([options])` | `manifest:wasi.WASI`; `test-parity/node-suite/wasi/classes/constructor-validation.ts` |
 | `wasi.getImportObject()` | `manifest:wasi.getImportObject`; `test-parity/node-suite/wasi/classes/import-object.ts` |
 | `wasi.wasiImport` | `manifest:wasi.wasiImport`; `test-parity/node-suite/wasi/classes/import-object.ts` |
+| `wasi.start(instance)` | `manifest:wasi.start`; `test-parity/node-suite/wasi/lifecycle/start-initialize-finalize.ts` |
+| `wasi.initialize(instance)` | `manifest:wasi.initialize`; `test-parity/node-suite/wasi/lifecycle/start-initialize-finalize.ts` |
+| `wasi.finalizeBindings(instance[, options])` | `manifest:wasi.finalizeBindings`; `test-parity/node-suite/wasi/lifecycle/start-initialize-finalize.ts` |
 
 ### node:module
 

--- a/test-parity/node-suite/wasi/README.md
+++ b/test-parity/node-suite/wasi/README.md
@@ -1,5 +1,5 @@
 # node:wasi granular parity suite
 
 Focused deterministic cases for Perry's `node:wasi` compatibility layer. These
-cover constructor/import-object shape without executing WASI modules or host
-syscalls.
+cover constructor/import-object shape plus lifecycle state transitions without
+executing WASI modules or host syscalls.

--- a/test-parity/node-suite/wasi/lifecycle/start-initialize-finalize.ts
+++ b/test-parity/node-suite/wasi/lifecycle/start-initialize-finalize.ts
@@ -1,0 +1,146 @@
+import { WASI } from "node:wasi";
+
+const W: any = WASI;
+
+const commandBytes = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2,
+  1, 0, 5, 3, 1, 0, 1, 7, 19, 2, 6, 109, 101, 109, 111, 114,
+  121, 2, 0, 6, 95, 115, 116, 97, 114, 116, 0, 0, 10, 4, 1,
+  2, 0, 11,
+]);
+
+const reactorBytes = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2,
+  1, 0, 5, 3, 1, 0, 1, 7, 24, 2, 6, 109, 101, 109, 111, 114,
+  121, 2, 0, 11, 95, 105, 110, 105, 116, 105, 97, 108, 105,
+  122, 101, 0, 0, 10, 4, 1, 2, 0, 11,
+]);
+
+const bothBytes = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 3,
+  2, 0, 0, 5, 3, 1, 0, 1, 7, 33, 3, 6, 109, 101, 109, 111,
+  114, 121, 2, 0, 6, 95, 115, 116, 97, 114, 116, 0, 0, 11,
+  95, 105, 110, 105, 116, 105, 97, 108, 105, 122, 101, 0, 1,
+  10, 8, 2, 3, 0, 0, 11, 2, 0, 11,
+]);
+
+const memoryOnlyBytes = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 5, 3, 1, 0, 1, 7, 10, 1,
+  6, 109, 101, 109, 111, 114, 121, 2, 0,
+]);
+
+type InstanceLike = { exports: Record<string, any> };
+
+function fallbackCommand(): InstanceLike {
+  return { exports: { memory: {}, _start() {} } };
+}
+
+function fallbackReactor(): InstanceLike {
+  return { exports: { memory: {}, _initialize() {} } };
+}
+
+function fallbackBoth(): InstanceLike {
+  return { exports: { memory: {}, _start() {}, _initialize() {} } };
+}
+
+function fallbackMemoryOnly(): InstanceLike {
+  return { exports: { memory: {} } };
+}
+
+async function instanceOrFallback(
+  bytes: Uint8Array,
+  fallback: () => InstanceLike,
+): Promise<any> {
+  const WA: any = (globalThis as any)["WebAssembly"];
+  const instantiate = WA?.["instantiate"];
+  try {
+    if (typeof instantiate === "function") {
+      const result: any = await instantiate.call(WA, bytes, {});
+      const instance = result?.instance ?? result;
+      if (
+        instance &&
+        typeof instance === "object" &&
+        typeof instance.exports === "object"
+      ) {
+        return instance;
+      }
+    }
+  } catch {}
+  return fallback();
+}
+
+function errorTag(err: any) {
+  const message = String(err?.message ?? "");
+  if (message.includes("already started")) return "already-started";
+  if (message.includes("instance.exports._start") && message.includes("of type function")) {
+    return "_start-function";
+  }
+  if (message.includes("instance.exports._start") && message.includes("must be undefined")) {
+    return "_start-undefined";
+  }
+  if (message.includes("instance.exports._initialize")) return "_initialize-undefined";
+  if (message.includes("instance.exports.memory")) return "memory";
+  if (message.includes("instance.exports")) return "exports-object";
+  if (message.includes("\"instance\" argument")) return "instance-object";
+  return "other";
+}
+
+function show(label: string, fn: () => any) {
+  try {
+    console.log(`${label}: ok`, String(fn()));
+  } catch (err: any) {
+    console.log(`${label}: throw`, err?.name, err?.code || "no-code", errorTag(err));
+  }
+}
+
+const command = await instanceOrFallback(commandBytes, fallbackCommand);
+const reactor = await instanceOrFallback(reactorBytes, fallbackReactor);
+const both = await instanceOrFallback(bothBytes, fallbackBoth);
+const memoryOnly = await instanceOrFallback(memoryOnlyBytes, fallbackMemoryOnly);
+
+const startedByStart = new W({ version: "preview1", returnOnExit: true });
+console.log("own keys before:", Object.keys(startedByStart).join(","));
+show("start command", () => startedByStart.start(command));
+console.log("own keys after:", Object.keys(startedByStart).join(","));
+show("start command again", () => startedByStart.start(command));
+show("initialize after start", () => startedByStart.initialize(reactor));
+show("finalize after start", () => startedByStart.finalizeBindings(command));
+
+const startedByInitialize = new W({ version: "preview1", returnOnExit: true });
+show("initialize reactor", () => startedByInitialize.initialize(reactor));
+show("initialize reactor again", () => startedByInitialize.initialize(reactor));
+show("start after initialize", () => startedByInitialize.start(command));
+
+show("start reactor fresh", () =>
+  new W({ version: "preview1", returnOnExit: true }).start(reactor)
+);
+show("initialize command fresh", () =>
+  new W({ version: "preview1", returnOnExit: true }).initialize(command)
+);
+show("start both fresh", () =>
+  new W({ version: "preview1", returnOnExit: true }).start(both)
+);
+show("initialize memory-only fresh", () =>
+  new W({ version: "preview1", returnOnExit: true }).initialize(memoryOnly)
+);
+show("start memory-only fresh", () =>
+  new W({ version: "preview1", returnOnExit: true }).start(memoryOnly)
+);
+show("finalize reactor fresh", () =>
+  new W({ version: "preview1", returnOnExit: true }).finalizeBindings(reactor)
+);
+
+const startedByFinalize = new W({ version: "preview1", returnOnExit: true });
+show("finalize command", () => startedByFinalize.finalizeBindings(command));
+show("start after finalize", () => startedByFinalize.start(command));
+
+for (const [label, value] of [
+  ["undefined", undefined],
+  ["null", null],
+  ["number", 1],
+  ["plain object", {}],
+] as const) {
+  show(`initialize input ${label}`, () =>
+    new W({ version: "preview1", returnOnExit: true }).initialize(value)
+  );
+}


### PR DESCRIPTION
## What changed

- Implemented `node:wasi` lifecycle state for `start()`, `initialize()`, and `finalizeBindings()`.
- Added Node-shaped export validation for command/reactor instances, including repeated-start `ERR_WASI_ALREADY_STARTED` behavior.
- Kept the internal lifecycle flag non-enumerable so `Object.keys(wasi)` remains `wasiImport`.
- Added a deterministic lifecycle parity fixture and updated the WASI gap ledger.

## Notes

This validates lifecycle state and export shape without adding full WASI syscall execution or preopen filesystem fidelity.

Fixes #3211.

## Validation

- `cargo check -p perry-runtime -p perry-hir -p perry-codegen`
- `cargo build -p perry`
- `cargo build --release -p perry-runtime`
- `cargo test -p perry-runtime import_name_count_matches_node_preview1_surface -- --nocapture`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 target/debug/perry run test-parity/node-suite/wasi/lifecycle/start-initialize-finalize.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 target/debug/perry run test-parity/node-suite/wasi/classes/constructor-validation.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 target/debug/perry run test-parity/node-suite/wasi/classes/import-object.ts`
- `npx -y node@25.9.0 --experimental-wasi-unstable-preview1 --experimental-strip-types test-parity/node-suite/wasi/lifecycle/start-initialize-finalize.ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
