### PR TITLE
[codex] Add sqlite extension loading parity coverage

### DIFF
--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -1330,15 +1330,16 @@ The FileHandle stream-iter tail is runtime-backed for the direct no-transform so
 
 ### node:sqlite
 
-**Gap APIs: 44** · Already covered: 8
+**Gap APIs: 42** · Already covered: 10
 
-#### Covered by Perry (#3183/#3184)
+#### Covered by Perry
 
 - `new DatabaseSync(path)` (incl. `:memory:`) → rusqlite connection
 - `db.exec(sql)` / `db.prepare(sql)` → `StatementSync` / `db.close()`
 - `stmt.run(...params)` → `{ changes, lastInsertRowid }`
 - `stmt.get(...params)` / `stmt.all(...params)` → row object(s)
 - `stmt.iterate(...params)` (array-backed) / `stmt.columns()` metadata
+- `db.enableLoadExtension(allow)` / `db.loadExtension(path)` extension-loading controls
 
 #### Missing from Perry
 
@@ -1347,8 +1348,6 @@ The FileHandle stream-iter tail is runtime-backed for the direct no-transform so
 - `db.applyChangeset(changeset[, options])`
 - `db.createSession([options])`
 - `db.createTagStore([maxSize])`
-- `db.enableLoadExtension(allow)`
-- `db.loadExtension(path)`
 - `db.location([dbName])`
 - `db.enableDefensive(active)`
 - `db.serialize([dbName])`

--- a/test-parity/node-suite/sqlite/README.md
+++ b/test-parity/node-suite/sqlite/README.md
@@ -1,0 +1,5 @@
+# node:sqlite granular parity suite
+
+Focused deterministic cases for Perry's `node:sqlite` compatibility layer. These
+cover `DatabaseSync` behavior that can be compared without a real SQLite
+extension or external database service.

--- a/test-parity/node-suite/sqlite/extension-loading/controls.ts
+++ b/test-parity/node-suite/sqlite/extension-loading/controls.ts
@@ -1,0 +1,47 @@
+// parity-node-argv: --experimental-sqlite
+import { DatabaseSync } from "node:sqlite";
+
+const missingExtensionPath = "/tmp/perry-node-sqlite-missing-extension";
+
+function summarize(value) {
+  return value === undefined ? "undefined" : String(value);
+}
+
+function summarizeError(error) {
+  return `${error.name}:${error.code || "nocode"}`;
+}
+
+function report(label, fn) {
+  try {
+    console.log(label, "OK", summarize(fn()));
+  } catch (error) {
+    console.log(label, "THROW", summarizeError(error));
+  }
+}
+
+console.log("constructor:", typeof DatabaseSync);
+
+const defaultDb = new DatabaseSync(":memory:");
+console.log("method shapes:", typeof defaultDb.enableLoadExtension, typeof defaultDb.loadExtension);
+
+report("default enable false", () => defaultDb.enableLoadExtension(false));
+report("default enable true", () => defaultDb.enableLoadExtension(true));
+report("default load", () => defaultDb.loadExtension(missingExtensionPath));
+
+for (const value of [undefined, null, 0, "true"]) {
+  report(`enable arg ${String(value)}`, () => defaultDb.enableLoadExtension(value));
+}
+
+for (const value of [null, 1, "true"]) {
+  report(`constructor allow ${String(value)}`, () => {
+    const db = new DatabaseSync(":memory:", { allowExtension: value });
+    db.close();
+    return "created";
+  });
+}
+
+const enabledDb = new DatabaseSync(":memory:", { allowExtension: true });
+report("enabled enable true", () => enabledDb.enableLoadExtension(true));
+report("enabled load missing", () => enabledDb.loadExtension(missingExtensionPath));
+report("enabled disable", () => enabledDb.enableLoadExtension(false));
+report("enabled load disabled", () => enabledDb.loadExtension(missingExtensionPath));


### PR DESCRIPTION
## Summary
- add a deterministic `node:sqlite` DatabaseSync extension-loading parity fixture
- cover default-denied state, `allowExtension`, `enableLoadExtension`, invalid boolean args, and nonexistent extension load errors
- move `enableLoadExtension` and `loadExtension` out of the sqlite gap list

## Validation
- `npx -y node@25.9.0 --experimental-strip-types --experimental-sqlite test-parity/node-suite/sqlite/extension-loading/controls.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 target/debug/perry run test-parity/node-suite/sqlite/extension-loading/controls.ts`
- `cargo build -p perry`
- `cargo build --release -p perry-runtime`
- `cargo build --release -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

Note: local `./run_parity_tests.sh --suite=node-suite --module=sqlite --filter=extension-loading/controls` skipped before compare because this machine system `node` v22.22.1 reports `ERR_NO_TYPESCRIPT` for `--experimental-strip-types`; the direct Node v25.9.0 and Perry outputs match byte-for-byte.
