### PR TITLE
[codex] Fix private name brand checks

### DIFF
--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -383,6 +383,25 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 &[(DOUBLE, &obj), (DOUBLE, &key)],
             ))
         }
+        Expr::PrivateBrandCheck {
+            class_name,
+            field_name,
+            object,
+        } => {
+            let obj = lower_expr(ctx, object)?;
+            let class_id = ctx.class_ids.get(class_name).copied().unwrap_or(0);
+            let key_label = emit_string_literal_global(ctx, field_name);
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_private_brand_check",
+                &[
+                    (DOUBLE, &obj),
+                    (I32, &class_id.to_string()),
+                    (PTR, &key_label),
+                    (I32, &field_name.len().to_string()),
+                ],
+            ))
+        }
 
         // -------- fs.writeFileSync(path, content) --------
         // The runtime takes both args as NaN-boxed doubles directly.

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1480,6 +1480,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ArrayShift(..)
         | Expr::SetNew
         | Expr::In { .. }
+        | Expr::PrivateBrandCheck { .. }
         | Expr::ParseInt { .. }
         | Expr::ParseFloat(..)
         | Expr::RegExp { .. }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -323,6 +323,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_map_from_array", I64, &[I64]);
     module.declare_function("js_map_from_iterable", I64, &[DOUBLE]);
     module.declare_function("js_object_has_property", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_private_brand_check", DOUBLE, &[DOUBLE, I32, PTR, I32]);
     module.declare_function("js_fs_to_unix_timestamp", DOUBLE, &[DOUBLE]);
     module.declare_function("js_fs_write_file_sync", I32, &[DOUBLE, DOUBLE]);
     module.declare_function(

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -241,6 +241,15 @@ pub enum Expr {
         property: Box<Expr>,
         object: Box<Expr>,
     },
+    /// Private-name brand check: `#field in obj`.
+    ///
+    /// This is intentionally separate from `In { property: "#field", ... }`
+    /// so ordinary public string keys cannot satisfy private-field syntax.
+    PrivateBrandCheck {
+        class_name: String,
+        field_name: String,
+        object: Box<Expr>,
+    },
 
     // Await expression (for async functions)
     Await(Box<Expr>),

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -505,6 +505,18 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
         ast::Expr::Bin(bin) => {
             // Handle 'in' operator: property in object
             if matches!(bin.op, ast::BinaryOp::In) {
+                if let ast::Expr::PrivateName(private) = bin.left.as_ref() {
+                    let class_name = ctx.current_class.clone().ok_or_else(|| {
+                        anyhow!("Private name brand check is only supported inside a class")
+                    })?;
+                    let field_name = format!("#{}", private.name);
+                    let object = Box::new(lower_expr(ctx, &bin.right)?);
+                    return Ok(Expr::PrivateBrandCheck {
+                        class_name,
+                        field_name,
+                        object,
+                    });
+                }
                 // Proxy fast path: `key in proxy` routes through js_proxy_has.
                 if let ast::Expr::Ident(obj_ident) = bin.right.as_ref() {
                     let obj_name = obj_ident.sym.to_string();
@@ -1813,15 +1825,21 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 .iter()
                 .map(|member| class_computed_member_registration_expr(&synthetic_name, member))
                 .collect();
+            let captured_args: Vec<Expr> = ctx
+                .lookup_class_captures(&synthetic_name)
+                .map(|ids| ids.iter().map(|id| Expr::LocalGet(*id)).collect())
+                .unwrap_or_default();
             ctx.pending_classes.push(class);
             // #1772: a class EXPRESSION that carries per-evaluation static
             // fields and is NOT a mixin (`class extends <expr>`) lowers to a
             // fresh heap class object per evaluation (`ClassExprFresh`), so
             // `make(a) !== make(b)` and each holds its own statics as own
-            // properties. Mixins and static-less class expressions keep the
-            // historical (shared-template) path.
+            // properties. Mixins and class expressions without statics/captures
+            // keep the historical (shared-template) path.
             if parent_expr.is_none()
-                && (!named_statics.is_empty() || !static_symbol_registrations.is_empty())
+                && (!named_statics.is_empty()
+                    || !static_symbol_registrations.is_empty()
+                    || !captured_args.is_empty())
             {
                 // #1787: snapshot the class's captured outer-scope values so a
                 // later `new <classObjectValue>()` can run the instance-field
@@ -1831,10 +1849,6 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 // captured outer id, in `captures_vec` order — read them back in
                 // that same order as `LocalGet(outer_id)`, evaluated here where
                 // the captures are still live.
-                let captured_args: Vec<Expr> = ctx
-                    .lookup_class_captures(&synthetic_name)
-                    .map(|ids| ids.iter().map(|id| Expr::LocalGet(*id)).collect())
-                    .unwrap_or_default();
                 let fresh_expr = Expr::ClassExprFresh {
                     template: synthetic_name,
                     named_statics,

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -73,6 +73,7 @@ impl SH for Expr {
             Expr::Void(e) => { tag(h, 37); e.as_ref().hash(h); }
             Expr::InstanceOf { expr, ty, ty_expr } => { tag(h, 38); expr.as_ref().hash(h); ty.hash(h); ty_expr.hash(h); }
             Expr::In { property, object } => { tag(h, 39); property.as_ref().hash(h); object.as_ref().hash(h); }
+            Expr::PrivateBrandCheck { class_name, field_name, object } => { tag(h, 12401); class_name.hash(h); field_name.hash(h); object.as_ref().hash(h); }
             Expr::Await(e) => { tag(h, 40); e.as_ref().hash(h); }
             Expr::Yield { value, delegate } => { tag(h, 41); value.hash(h); delegate.hash(h); }
             Expr::New { class_name, args, type_args, } => { tag(h, 42); class_name.hash(h); args.hash(h); type_args.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -636,6 +636,9 @@ where
             f(property);
             f(object);
         }
+        Expr::PrivateBrandCheck { object, .. } => {
+            f(object);
+        }
         Expr::FsWriteFileSync(a, b)
         | Expr::FsAppendFileSync(a, b)
         | Expr::PathJoin(a, b)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -637,6 +637,9 @@ where
             f(property);
             f(object);
         }
+        Expr::PrivateBrandCheck { object, .. } => {
+            f(object);
+        }
         Expr::FsWriteFileSync(a, b)
         | Expr::FsAppendFileSync(a, b)
         | Expr::PathJoin(a, b)

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -4000,6 +4000,52 @@ mod sso_tests_1781 {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn js_private_brand_check(
+    obj: f64,
+    declaring_class_id: u32,
+    field_name_ptr: *const u8,
+    field_name_len: u32,
+) -> f64 {
+    let false_value = f64::from_bits(crate::value::TAG_FALSE);
+    let true_value = f64::from_bits(crate::value::TAG_TRUE);
+    if declaring_class_id == 0 || field_name_ptr.is_null() || field_name_len == 0 {
+        return false_value;
+    }
+
+    let value = JSValue::from_bits(obj.to_bits());
+    if !value.is_pointer() {
+        return false_value;
+    }
+    let obj_ptr = value.as_pointer::<ObjectHeader>();
+    if obj_ptr.is_null() {
+        return false_value;
+    }
+
+    let obj_class_id = js_object_get_class_id(obj_ptr);
+    if obj_class_id == 0 {
+        return false_value;
+    }
+
+    let mut cur = obj_class_id;
+    let mut has_declaring_brand = false;
+    for _ in 0..32 {
+        if cur == declaring_class_id {
+            has_declaring_brand = true;
+            break;
+        }
+        match super::class_registry::get_parent_class_id(cur) {
+            Some(parent) if parent != 0 && parent != cur => cur = parent,
+            _ => break,
+        }
+    }
+    if !has_declaring_brand {
+        return false_value;
+    }
+
+    true_value
+}
+
 #[cfg(test)]
 mod buffer_ic_miss_tests {
     use super::*;

--- a/test-files/test_private_name_brand_check.ts
+++ b/test-files/test_private_name_brand_check.ts
@@ -1,0 +1,114 @@
+let failures = 0;
+
+function check(label: string, ok: boolean): void {
+    if (!ok) {
+        failures = failures + 1;
+        console.log("FAIL " + label);
+    }
+}
+
+class BrandOwner {
+    #x = 1;
+
+    ownsSelf(): boolean {
+        return #x in this;
+    }
+
+    owns(value: any): boolean {
+        return #x in value;
+    }
+}
+
+class OtherBrandOwner {
+    #x = 1;
+}
+
+const owner = new BrandOwner();
+check("#x in this", owner.ownsSelf() === true);
+check("#x false for plain object", owner.owns({}) === false);
+check("#x false for public hash key", owner.owns({ "#x": 1 }) === false);
+check("#x false for unrelated class", owner.owns(new OtherBrandOwner()) === false);
+
+class UndiciShapedIterator {
+    #target: string[];
+    #kind: string;
+    #index = 0;
+
+    constructor(target: string[], kind: string) {
+        this.#target = target;
+        this.#kind = kind;
+    }
+
+    next(): any {
+        if (!(#target in this)) {
+            return { done: true, value: undefined };
+        }
+        if (this.#index >= this.#target.length) {
+            return { done: true, value: undefined };
+        }
+        const index = this.#index;
+        this.#index = this.#index + 1;
+        if (this.#kind === "key") {
+            return { done: false, value: index };
+        }
+        return { done: false, value: this.#target[index] };
+    }
+}
+
+const iterator = new UndiciShapedIterator(["a", "b"], "value");
+const first = iterator.next();
+const second = iterator.next();
+const third = iterator.next();
+check("undici iterator first value", first.done === false && first.value === "a");
+check("undici iterator second value", second.done === false && second.value === "b");
+check("undici iterator done", third.done === true);
+
+const detachedNext = iterator.next;
+const detachedResult = detachedNext.call({});
+check("undici iterator guard false for non-instance", detachedResult.done === true);
+
+function createIterator(name: string, internalIterator: (target: string[]) => string[]) {
+    return class FastIterableIterator {
+        #target: string[];
+        #kind: "key" | "value" | "key+value";
+        #index: number;
+
+        constructor(target: string[], kind: "key" | "value" | "key+value") {
+            this.#target = target;
+            this.#kind = kind;
+            this.#index = 0;
+        }
+
+        next(): any {
+            if (typeof this !== "object" || this === null || !(#target in this)) {
+                throw new TypeError(
+                    "'next' called on an object that does not implement interface " +
+                        name +
+                        " Iterator."
+                );
+            }
+
+            const values = internalIterator(this.#target);
+            if (this.#index >= values.length) return { value: undefined, done: true };
+            const index = this.#index;
+            this.#index = this.#index + 1;
+            if (this.#kind === "key") return { value: index, done: false };
+            if (this.#kind === "value") return { value: values[index], done: false };
+            return { value: [index, values[index]], done: false };
+        }
+    };
+}
+
+const IteratorClass = createIterator("Headers", (target) => target);
+const factoryIterator = new IteratorClass(["content-type"], "value");
+const factoryNext = factoryIterator.next();
+check(
+    "undici factory-returned iterator brand guard",
+    factoryNext.done === false && factoryNext.value === "content-type"
+);
+
+if (failures !== 0) {
+    throw new Error("private brand check failures: " + failures.toString());
+}
+
+console.log("private name brand checks ok");


### PR DESCRIPTION
## What changed

- Lower `#private in obj` into a dedicated HIR private brand-check expression instead of treating `PrivateName` as an unsupported generic expression.
- Add codegen/runtime support for private brand checks using Perry class ids rather than public string/symbol property lookup.
- Route captured class expressions through the existing `ClassExprFresh` snapshot path so Undici-style factory-returned iterator classes keep method captures.
- Add focused regression coverage for `#x in this`, non-instance false cases, public `"#x"` spoofing, unrelated same-name private fields, and the Undici-shaped iterator guard.

## Why

Undici’s fetch iterator helper uses `#target in this` inside a class. Perry previously failed compilation with `Unsupported expression type: PrivateName`. The brand check needs to preserve private-field semantics, so this avoids lowering it to a public property check.

## Validation

- `cargo fmt`
- `cargo check`
- `cargo build --bin perry && ./target/debug/perry compile test-files/test_private_name_brand_check.ts -o /tmp/perry_private_name_brand_check && /tmp/perry_private_name_brand_check`
- `cargo build --release -p perry-runtime -p perry-stdlib`
- OpenTUI focused repro with fixed Perry/runtime: compile status 0, run status 0, stdout `undici-private-name-brand-check: ok` (the harness still exits nonzero because the case metadata expects `compile-fails`).
