### PR TITLE
[codex] fix util stripVTControlCharacters unicode literals

### DIFF
--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -357,19 +357,21 @@ fn normalize_unicode_identifier_escapes(source: &str) -> String {
                 }
             }
             State::String(quote) => {
-                out.push(bytes[i] as char);
                 if bytes[i] == b'\\' {
-                    if let Some(&next) = bytes.get(i + 1) {
-                        out.push(next as char);
-                        i += 2;
-                    } else {
-                        i += 1;
+                    out.push('\\');
+                    i += 1;
+                    if i < bytes.len() {
+                        let ch = source[i..].chars().next().unwrap();
+                        out.push(ch);
+                        i += ch.len_utf8();
                     }
                 } else {
+                    let ch = source[i..].chars().next().unwrap();
+                    out.push(ch);
                     if bytes[i] == quote {
                         state = State::Code;
                     }
-                    i += 1;
+                    i += ch.len_utf8();
                 }
             }
             State::Regex { in_class } => {
@@ -395,20 +397,23 @@ fn normalize_unicode_identifier_escapes(source: &str) -> String {
                 }
             }
             State::LineComment => {
-                out.push(bytes[i] as char);
+                let ch = source[i..].chars().next().unwrap();
+                out.push(ch);
                 if bytes[i] == b'\n' {
                     state = State::Code;
                 }
-                i += 1;
+                i += ch.len_utf8();
             }
             State::BlockComment => {
-                out.push(bytes[i] as char);
                 if bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                    out.push('*');
                     out.push('/');
                     i += 2;
                     state = State::Code;
                 } else {
-                    i += 1;
+                    let ch = source[i..].chars().next().unwrap();
+                    out.push(ch);
+                    i += ch.len_utf8();
                 }
             }
         }
@@ -569,5 +574,20 @@ if (!ASCII_WHITESPACE_REPLACE_REGEX.test(' ')) {
                 .unwrap();
 
         assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn normalize_preserves_non_ascii_in_strings_and_comments() {
+        let source = "const s = \"café\"; // déjà\nconst t = `naïve`; /* año */";
+        assert_eq!(normalize_unicode_identifier_escapes(source), source);
+    }
+
+    #[test]
+    fn normalize_keeps_string_unicode_escapes_literal() {
+        let source = r#"let \u0061 = "\u0062";"#;
+        assert_eq!(
+            normalize_unicode_identifier_escapes(source),
+            r#"let a = "\u0062";"#
+        );
     }
 }

--- a/crates/perry-runtime/src/builtins/formatting/strip_vt.rs
+++ b/crates/perry-runtime/src/builtins/formatting/strip_vt.rs
@@ -37,14 +37,13 @@ fn skip_string_control(bytes: &[u8], mut i: usize) -> usize {
     i
 }
 
-fn strip_vt_control_sequences(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let bytes = input.as_bytes();
+fn strip_vt_control_sequences(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == 0x1b {
             if i + 1 >= bytes.len() {
-                out.push('\x1b');
+                out.push(0x1b);
                 i += 1;
                 continue;
             }
@@ -67,7 +66,7 @@ fn strip_vt_control_sequences(input: &str) -> String {
                     continue;
                 }
                 _ => {
-                    out.push('\x1b');
+                    out.push(0x1b);
                     i += 1;
                     continue;
                 }
@@ -87,9 +86,8 @@ fn strip_vt_control_sequences(input: &str) -> String {
             continue;
         }
 
-        let ch = input[i..].chars().next().unwrap_or_default();
-        out.push(ch);
-        i += ch.len_utf8();
+        out.push(bytes[i]);
+        i += 1;
     }
     out
 }
@@ -101,8 +99,16 @@ pub extern "C" fn js_util_strip_vt_control_characters(value: f64) -> f64 {
         throw_invalid_str_arg(value);
     }
 
-    let input = crate::url::get_string_content(value);
-    let out = strip_vt_control_sequences(&input);
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(value, &mut scratch) else {
+        throw_invalid_str_arg(value);
+    };
+    let input = if ptr.is_null() {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(ptr, len as usize) }
+    };
+    let out = strip_vt_control_sequences(input);
     let ptr = crate::string::js_string_from_bytes(out.as_ptr(), out.len() as u32);
     f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits())
 }


### PR DESCRIPTION
## Summary
- preserve UTF-8 characters while the parser normalizes Unicode identifier escapes outside strings
- strip VT control sequences over JS string bytes so multibyte payload text is copied through unchanged
- keep `stripVTControlCharacters()` string argument handling SSO-aware via the shared string byte-view helper

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo test -p perry-parser normalize_`
- `cargo check -p perry-parser -p perry-runtime -p perry`
- `./run_parity_tests.sh --suite node-suite --module util --filter strip-vt-control-characters/non-ascii`
- `./run_parity_tests.sh --suite node-suite --module util --filter strip-vt-control-characters`
- `./run_parity_tests.sh --suite node-suite --module buffer --filter from/string-encodings`
- `cargo build --release -p perry`

Refs #2514
