### PR TITLE
[codex] Fix readable wrap old stream delivery

### DIFF
--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -189,7 +189,7 @@ extern "C" fn ns_wrap_data(closure: *const ClosureHeader, chunk: f64) -> f64 {
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    let stream = js_closure_get_capture_f64(closure, 0);
     let _ = push_chunk(stream, chunk);
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -198,7 +198,7 @@ extern "C" fn ns_wrap_end(closure: *const ClosureHeader) -> f64 {
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    let stream = js_closure_get_capture_f64(closure, 0);
     let _ = push_chunk(stream, f64::from_bits(TAG_NULL));
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -207,7 +207,7 @@ extern "C" fn ns_wrap_error(closure: *const ClosureHeader, err: f64) -> f64 {
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    let stream = js_closure_get_capture_f64(closure, 0);
     destroy_stream(stream, err);
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -216,7 +216,7 @@ extern "C" fn ns_wrap_close(closure: *const ClosureHeader) -> f64 {
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let stream = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    let stream = js_closure_get_capture_f64(closure, 0);
     destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -227,10 +227,10 @@ extern "C" fn ns_wrap1(closure: *const ClosureHeader, old_stream: f64) -> f64 {
     let end = js_closure_alloc(ns_wrap_end as *const u8, 1);
     let error = js_closure_alloc(ns_wrap_error as *const u8, 1);
     let close = js_closure_alloc(ns_wrap_close as *const u8, 1);
-    js_closure_set_capture_ptr(data, 0, stream.to_bits() as i64);
-    js_closure_set_capture_ptr(end, 0, stream.to_bits() as i64);
-    js_closure_set_capture_ptr(error, 0, stream.to_bits() as i64);
-    js_closure_set_capture_ptr(close, 0, stream.to_bits() as i64);
+    js_closure_set_capture_f64(data, 0, stream);
+    js_closure_set_capture_f64(end, 0, stream);
+    js_closure_set_capture_f64(error, 0, stream);
+    js_closure_set_capture_f64(close, 0, stream);
 
     call_old_stream_on(old_stream, b"data", data);
     call_old_stream_on(old_stream, b"end", end);

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -438,6 +438,31 @@ fn extract_pointer(bits: u64) -> u64 {
     }
 }
 
+fn small_handle_from_value(value: f64) -> Option<i64> {
+    let bits = value.to_bits();
+    let top = bits >> 48;
+    if top == (POINTER_TAG >> 48) {
+        let raw = (bits & POINTER_MASK) as i64;
+        if raw > 0 && raw < 0x10000 {
+            return Some(raw);
+        }
+    } else if top == 0 && bits > 0 && bits < 0x10000 {
+        return Some(bits as i64);
+    }
+    None
+}
+
+fn set_handle_property(target: f64, key: f64, value: f64) -> Option<bool> {
+    let handle = small_handle_from_value(target)?;
+    let Some(name) = key_to_rust_string(key) else {
+        return Some(false);
+    };
+    if let Some(dispatch) = crate::object::handle_property_set_dispatch() {
+        unsafe { dispatch(handle, name.as_ptr(), name.len(), value) };
+    }
+    Some(true)
+}
+
 fn target_get(target: f64, key: f64) -> f64 {
     let obj_ptr = extract_pointer(target.to_bits()) as *const crate::ObjectHeader;
     let key_ptr = extract_pointer(key.to_bits()) as *const crate::StringHeader;
@@ -537,6 +562,10 @@ fn key_to_rust_string(value: f64) -> Option<String> {
 }
 
 fn own_set_descriptor(target: f64, key: f64) -> Option<OwnSetDescriptor> {
+    if small_handle_from_value(target).is_some() {
+        return None;
+    }
+
     if unsafe { crate::symbol::js_is_symbol(key) } != 0 {
         let value = unsafe { crate::symbol::js_object_get_symbol_property(target, key) };
         return (value.to_bits() != TAG_UNDEFINED)
@@ -650,6 +679,10 @@ fn create_or_update_receiver_property(receiver: f64, key: f64, value: f64) -> bo
 }
 
 fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) -> bool {
+    if let Some(ok) = set_handle_property(target, key, value) {
+        return ok;
+    }
+
     let mut current = target;
     for _ in 0..64 {
         if let Some(desc) = own_set_descriptor(current, key) {

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -7,10 +7,10 @@ This document is a structured gap analysis comparing the public Node.js + Bun ru
 | Category | Modules | Gap APIs | Verified-covered |
 |----------|---------|----------|------------------|
 | Whole-module gaps (zero coverage) | 15 | 410 | n/a |
-| Partial-module gaps | 32 | 1470 | 607 |
+| Partial-module gaps | 32 | 1469 | 608 |
 | Web-global gaps | — | 282 | 107 |
 | Bun-only gaps (out of scope) | — | 394 | n/a |
-| **Total true gaps** |  | **2162** |  |
+| **Total true gaps** |  | **2161** |  |
 
 **Top modules by remaining true gaps (Node + Web):**
 
@@ -23,7 +23,7 @@ This document is a structured gap analysis comparing the public Node.js + Bun ru
 - `node:util` — 92
 - `node:http` — 89
 - `node:zlib` — 70
-- `node:stream` — 76
+- `node:stream` — 75
 - `node:worker_threads` — 60
 
 ### Issue #3598 docs/API closure note
@@ -841,7 +841,7 @@ Behavior caveats remain around live terminal integration, readline inheritance d
 
 ### node:stream
 
-**Gap APIs: 76** · Already covered: 5
+**Gap APIs: 75** · Already covered: 6
 
 #### Missing from Perry
 
@@ -869,7 +869,6 @@ Behavior caveats remain around live terminal integration, readline inheritance d
 - `readable.setEncoding(encoding)`
 - `readable.isPaused()`
 - `readable.destroy([error])`
-- `readable.wrap(stream)`
 - `readable.compose(stream[, options])`
 - `readable.iterator([options])`
 - `readable.map(fn[, options])`


### PR DESCRIPTION
## Summary

- keep `Readable.wrap()` listener closures rooted as JS-value captures while forwarding old-stream `data`, `end`, `error`, and close-like events
- let assignment to small handle-backed objects use the registered handle property setter, avoiding an EventEmitter setup crash when old-style streams attach `pause`/`resume`
- update the stream parity gap counts for `readable.wrap(stream)`

## Why Batched

This is one coherent `readable.wrap()` compatibility slice for #3341. The handle assignment guard is needed by the old-style stream setup used by the wrap fixtures before the wrapped stream can receive events.

## Validation

- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=2 cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=2 cargo test -p perry-runtime readable_wrap_method_is_present_and_chainable`
- Node/Perry comparison for `test-parity/node-suite/stream/readable/wrap-old-stream.ts` -> `joined: wrapped`
- Node/Perry comparison for `test-parity/node-suite/stream/readable/wrap-pipe-chain.ts` -> `piped: x`
- Node/Perry comparison for `test-parity/node-suite/stream/readable/wrap-error-forward.ts` -> `wrapped error: boom`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Notes

This does not attempt a full old-stream pause/resume backpressure implementation; it closes the event delivery and error-forwarding behavior covered by the current wrap fixtures.
