### PR TITLE
[codex] Preserve byte stream type for BYOB readers

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -18,7 +18,7 @@ use perry_hir::Expr;
 
 use crate::expr::{lower_array_literal, lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx};
 use crate::nanbox::double_literal;
-use crate::types::{DOUBLE, I32, I64};
+use crate::types::{DOUBLE, I32, I64, PTR};
 
 use super::{build_headers_from_object, extract_options_fields, get_raw_string_ptr};
 
@@ -1196,7 +1196,16 @@ pub(super) fn lower_builtin_new(
                         }
                     }
                 } else {
-                    let _ = lower_expr(ctx, &args[0])?;
+                    let source = lower_expr(ctx, &args[0])?;
+                    let key_idx = ctx.strings.intern("type");
+                    let entry = ctx.strings.entry(key_idx);
+                    let key_bytes = format!("@{}", entry.bytes_global);
+                    let key_len = entry.byte_len.to_string();
+                    source_type = ctx.block().call(
+                        DOUBLE,
+                        "js_get_property",
+                        &[(DOUBLE, &source), (PTR, &key_bytes), (I64, &key_len)],
+                    );
                 }
             }
             if args.len() >= 2 {

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -1056,14 +1056,12 @@ Behavior caveats remain around live terminal integration, readline inheritance d
 
 ### node:stream/web
 
-**Gap APIs: 56** · Already covered: 12
+**Gap APIs: 52** · Already covered: 16
 
 #### Missing from Perry
 
 - `new ReadableStream([underlyingSource[, strategy]])`
-- `readableStream.locked`
 - `readableStream.cancel([reason])`
-- `readableStream.getReader([options])`
 - `readableStream.pipeThrough(transform[, options])`
 - `readableStream.pipeTo(destination[, options])`
 - `readableStream.tee()`
@@ -1071,10 +1069,8 @@ Behavior caveats remain around live terminal integration, readline inheritance d
 - `readableStream[Symbol.asyncIterator]()`
 - `new ReadableStreamDefaultReader(stream)`
 - `new ReadableStreamBYOBReader(stream)`
-- `byobReader.closed`
 - `byobReader.read(view[, options])`
 - `byobReader.cancel([reason])`
-- `byobReader.releaseLock()`
 - `controller.desiredSize`
 - `controller.close()`
 - `controller.enqueue([chunk])`
@@ -1117,10 +1113,14 @@ Behavior caveats remain around live terminal integration, readline inheritance d
 | API | Coverage source |
 |-----|-----------------|
 | `ReadableStream.from(iterable)` | `manifest:stream.from` |
+| `readableStream.locked` | `ffi:js_readable_stream_locked`; `test-parity/node-suite/stream/web/byob-reader.ts` |
+| `readableStream.getReader([options])` | `ffi:js_readable_stream_get_reader_with_options`; `test-parity/node-suite/stream/web/byob-on-byte-stream.ts`; `test-parity/node-suite/stream/web/byob-reader-getReader.ts` |
 | `reader.closed` | `ffi:js_reader_closed` |
 | `reader.read()` | `ffi:js_reader_read` |
 | `reader.cancel([reason])` | `ffi:js_reader_cancel` |
 | `reader.releaseLock()` | `ffi:js_reader_release_lock` |
+| `byobReader.closed` | `ffi:js_reader_closed`; `test-parity/node-suite/stream/web/byob-reader.ts` |
+| `byobReader.releaseLock()` | `ffi:js_reader_release_lock`; `test-parity/node-suite/stream/web/byob-reader.ts` |
 | `writer.closed` | `ffi:js_writer_closed` |
 | `writer.desiredSize` | `ffi:js_writer_desired_size` |
 | `writer.ready` | `ffi:js_writer_ready` |

--- a/test-parity/node-suite/stream/web/byob-reader.ts
+++ b/test-parity/node-suite/stream/web/byob-reader.ts
@@ -6,3 +6,7 @@ const rs = new ReadableStream({
 });
 const reader = (rs as any).getReader({ mode: "byob" });
 console.log("has byobRead:", typeof reader.read === "function");
+console.log("has closed:", "closed" in reader);
+console.log("locked before release:", rs.locked);
+reader.releaseLock();
+console.log("locked after release:", rs.locked);


### PR DESCRIPTION
## Summary

- Preserve `underlyingSource.type` for `new ReadableStream(...)` when the source object cannot be statically extracted, so byte streams still reach BYOB reader validation as byte streams.
- Strengthen the BYOB reader parity fixture to cover `closed`, stream locking, and `releaseLock()`.
- Update the stream/web gap ledger for covered `locked`, `getReader`, `byobReader.closed`, and `byobReader.releaseLock()` surface while leaving BYOB read/request semantics listed as gaps.

Fixes #3221.

## Root Cause

The `ReadableStream` constructor lowering only passed the source `type` through when `extract_options_fields` could statically extract it. For source objects that fell back to ordinary expression lowering, the runtime received `undefined` for `source_type`, so `getReader({ mode: "byob" })` rejected otherwise valid `{ type: "bytes" }` streams.

## Validation

- `cargo build -p perry`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/stream/web/byob-reader.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 target/debug/perry run test-parity/node-suite/stream/web/byob-reader.ts`
- Direct Node 25/Perry checks for `byob-on-byte-stream.ts`, `byob-reader-getReader.ts`, and `byob-reader-method-shape.ts`
- `./run_parity_tests.sh --suite node-suite --module stream/web --filter byob` built the release compiler/runtime successfully, then skipped all BYOB fixtures because the harness system Node exited with `exit 1`; the threshold failed at 0% because no fixtures ran.
