### PR TITLE
[codex] fix util styleText aliases

### DIFF
--- a/crates/perry-runtime/src/util_style_text.rs
+++ b/crates/perry-runtime/src/util_style_text.rs
@@ -240,12 +240,71 @@ pub(crate) const INSPECT_COLOR_STYLES: &[AnsiStyle] = &[
     },
 ];
 
-// #3870-adjacent (util/style-text): Node's `styleText` validates `format`
-// against `Object.keys(util.inspect.colors)` — exactly the 44 names in
-// `INSPECT_COLOR_STYLES`. It does NOT accept British/camelCase aliases
-// (`grey`, `bgGrey`, `strikeThrough`, `swapColors`, `doubleUnderline`,
-// `crossedout`, `conceal`, `faint`, `blackBright`, …); those throw
-// `ERR_INVALID_ARG_VALUE`. The previous alias table made Perry too lenient.
+const STYLE_ALIASES: &[AnsiStyle] = &[
+    AnsiStyle {
+        name: "grey",
+        open: 90,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "blackBright",
+        open: 90,
+        close: 39,
+    },
+    AnsiStyle {
+        name: "bgGrey",
+        open: 100,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "bgBlackBright",
+        open: 100,
+        close: 49,
+    },
+    AnsiStyle {
+        name: "faint",
+        open: 2,
+        close: 22,
+    },
+    AnsiStyle {
+        name: "crossedout",
+        open: 9,
+        close: 29,
+    },
+    AnsiStyle {
+        name: "strikeThrough",
+        open: 9,
+        close: 29,
+    },
+    AnsiStyle {
+        name: "crossedOut",
+        open: 9,
+        close: 29,
+    },
+    AnsiStyle {
+        name: "conceal",
+        open: 8,
+        close: 28,
+    },
+    AnsiStyle {
+        name: "swapColors",
+        open: 7,
+        close: 27,
+    },
+    AnsiStyle {
+        name: "swapcolors",
+        open: 7,
+        close: 27,
+    },
+    AnsiStyle {
+        name: "doubleUnderline",
+        open: 21,
+        close: 24,
+    },
+];
+
+// `Object.keys(util.inspect.colors)` reports the canonical styles above, but
+// Node also accepts non-enumerable legacy aliases in `styleText()`.
 
 const VALID_FORMATS_MESSAGE: &str = "'reset', 'bold', 'dim', 'italic', 'underline', 'blink', \
     'inverse', 'hidden', 'strikethrough', 'doubleunderline', 'black', 'red', 'green', \
@@ -254,11 +313,14 @@ const VALID_FORMATS_MESSAGE: &str = "'reset', 'bold', 'dim', 'italic', 'underlin
     'gray', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', \
     'cyanBright', 'whiteBright', 'bgGray', 'bgRedBright', 'bgGreenBright', \
     'bgYellowBright', 'bgBlueBright', 'bgMagentaBright', 'bgCyanBright', \
-    'bgWhiteBright'";
+    'bgWhiteBright', 'grey', 'blackBright', 'bgGrey', 'bgBlackBright', \
+    'faint', 'crossedout', 'strikeThrough', 'crossedOut', 'conceal', \
+    'swapColors', 'swapcolors', 'doubleUnderline'";
 
 fn style_for(name: &str) -> Option<AnsiStyle> {
     INSPECT_COLOR_STYLES
         .iter()
+        .chain(STYLE_ALIASES.iter())
         .find(|style| style.name == name)
         .copied()
 }


### PR DESCRIPTION
## Summary
- accept Node 25 styleText legacy aliases such as grey, bgGrey, strikeThrough, swapColors, and doubleUnderline
- keep the canonical inspect color style table separate from the alias resolution path
- update the invalid-format message list to include Node's accepted alias names

## Root Cause
Perry treated util.styleText() as if it only accepted Object.keys(util.inspect.colors). Node also accepts non-enumerable legacy color aliases through styleText(), so the util/style-text parity fixture stopped at the first alias mismatch.

## Validation
- NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" perl -e 'alarm shift; exec @ARGV' 300 ./run_parity_tests.sh --suite node-suite --module util --filter style-text/basic
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh
- cargo check -p perry-runtime -p perry

Refs #2514