### PR TITLE
[codex] fix util arguments object predicate

### DIFF
--- a/crates/perry-runtime/src/object/util_types.rs
+++ b/crates/perry-runtime/src/object/util_types.rs
@@ -73,12 +73,15 @@ fn pointer_addr(value: f64) -> Option<usize> {
 
 #[inline]
 fn value_is_arguments_object(value: f64) -> bool {
-    if crate::array::js_array_is_array(value).to_bits() != crate::value::TAG_TRUE {
-        return false;
-    }
     let Some(addr) = pointer_addr(value) else {
         return false;
     };
+    if crate::object::is_arguments_object(addr as *const ObjectHeader) {
+        return true;
+    }
+    if crate::array::js_array_is_array(value).to_bits() != crate::value::TAG_TRUE {
+        return false;
+    }
     unsafe {
         crate::array::array_has_arguments_object_flag(addr as *const crate::array::ArrayHeader)
     }


### PR DESCRIPTION
## Summary
- make util.types.isArgumentsObject() recognize Perry's object-backed ECMAScript Arguments objects
- keep the existing array-backed synthetic arguments marker fallback intact

## Root Cause
Perry has two internal arguments representations. The predicate only checked the array-backed marker used by synthetic call paths, so a normal function returning its object-backed arguments value reported false.

## Validation
- NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" perl -e 'alarm shift; exec @ARGV' 300 ./run_parity_tests.sh --suite node-suite --module util --filter types/predicate-tail
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh
- cargo check -p perry-runtime -p perry

Refs #2514