### PR TITLE
[codex] Fix dynamic array length assignment crash

### DIFF
--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -144,12 +144,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // of `arr.length` returned the stale original count and the
             // elements stayed live. Statically Array-typed receivers route to
             // `js_array_set_length` which truncates / extends the header.
-            // Open question: dynamic `Any`-typed receivers that happen to be
-            // arrays at runtime still hit the generic path and miss the fix —
-            // they'd need a runtime-side check inside js_object_set_field_by_name
-            // (route to js_array_set_length when the target is registered as
-            // an array). Deliberately out of scope here; the static-typed
-            // case covers the issue's repro.
+            // Dynamic `Any`-typed receivers that happen to be arrays at
+            // runtime route through js_object_set_field_by_name, which has
+            // its own array-length check before ordinary property storage.
             if property == "length" && crate::type_analysis::is_array_expr(ctx, object) {
                 let arr_box = lower_expr(ctx, object)?;
                 let val_double = lower_expr(ctx, value)?;

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -380,6 +380,9 @@ pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
         }
         arr
     };
+    if (cleaned as usize) & 0x7 != 0 {
+        return std::ptr::null();
+    }
     // Issue #233: follow GC_FLAG_FORWARDED forwarding chains. When
     // an array grows (js_array_grow) we install a forwarding pointer
     // at the OLD location so any stale reference — e.g. an async
@@ -395,14 +398,16 @@ pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
     let mut cleaned = cleaned;
     unsafe {
         let mut steps = 0u32;
-        while (cleaned as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+        while (cleaned as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000
+            && (cleaned as usize) & 0x7 == 0
+        {
             let gc_header =
                 (cleaned as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
             if (*gc_header).gc_flags & crate::gc::GC_FLAG_FORWARDED == 0 {
                 break;
             }
             let new_user = crate::gc::forwarding_address(gc_header) as u64;
-            if !(HEAP_MIN..HEAP_MAX).contains(&new_user) {
+            if !(HEAP_MIN..HEAP_MAX).contains(&new_user) || new_user & 0x7 != 0 {
                 return std::ptr::null();
             }
             cleaned = new_user as *const ArrayHeader;
@@ -420,7 +425,8 @@ pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
     // pointer for every downstream accessor. O(1) on subsequent
     // calls (idempotent via the `materialized` cache).
     unsafe {
-        if (cleaned as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+        if (cleaned as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 && (cleaned as usize) & 0x7 == 0
+        {
             let gc_header =
                 (cleaned as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
             if (*gc_header).obj_type == crate::gc::GC_TYPE_LAZY_ARRAY {
@@ -566,7 +572,10 @@ unsafe fn array_slots_are_numeric(arr: *const ArrayHeader) -> bool {
 
 #[inline]
 unsafe fn array_gc_header(arr: *const ArrayHeader) -> Option<*mut crate::gc::GcHeader> {
-    if arr.is_null() || (arr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+    if arr.is_null()
+        || (arr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000
+        || (arr as usize) & 0x7 != 0
+    {
         return None;
     }
     let header = (arr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -41,7 +41,11 @@ pub extern "C" fn js_array_length(arr: *const ArrayHeader) -> u32 {
         } else {
             arr
         };
-        if !raw_ptr.is_null() && (raw_ptr as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+        let raw_addr = raw_ptr as usize;
+        if !raw_ptr.is_null()
+            && raw_addr >= crate::gc::GC_HEADER_SIZE + 0x1000
+            && raw_addr & 0x7 == 0
+        {
             let gc_header =
                 (raw_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
             if (*gc_header).obj_type == crate::gc::GC_TYPE_LAZY_ARRAY {
@@ -150,7 +154,11 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
         } else {
             arr
         };
-        if !raw_ptr.is_null() && (raw_ptr as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+        let raw_addr = raw_ptr as usize;
+        if !raw_ptr.is_null()
+            && raw_addr >= crate::gc::GC_HEADER_SIZE + 0x1000
+            && raw_addr & 0x7 == 0
+        {
             let gc_header =
                 (raw_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
             if (*gc_header).obj_type == crate::gc::GC_TYPE_LAZY_ARRAY {
@@ -424,7 +432,8 @@ pub extern "C" fn js_array_set_string_key(
     // (non-array) receivers, just call the object setter directly so
     // the standard expando-property path runs.
     let is_array = unsafe {
-        if (arr as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+        let addr = arr as usize;
+        if addr >= crate::gc::GC_HEADER_SIZE + 0x1000 && addr & 0x7 == 0 {
             let gc_header =
                 (arr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
             (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -91,7 +91,7 @@ pub fn is_registered_map(addr: usize) -> bool {
     // arena-allocated above it, so reject the whole small-handle band before
     // dereferencing `addr - GC_HEADER_SIZE` (deref'ing e.g. a 0x40000 fetch
     // handle reads unmapped memory and segfaults — see is_date_cell_addr).
-    if addr < 0x100000 {
+    if addr < 0x100000 || addr & 0x7 != 0 {
         return false;
     }
     unsafe {

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -158,6 +158,42 @@ unsafe fn key_to_str_for_diag(key: *const crate::StringHeader) -> String {
         .unwrap_or_else(|_| "<unknown>".to_string())
 }
 
+unsafe fn try_set_array_length_before_value_root(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+    value: f64,
+) -> bool {
+    if key.is_null()
+        || (key as usize) < 0x10000
+        || (key as usize) & 0x7 != 0
+        || obj.is_null()
+        || (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000
+        || (obj as usize) & 0x7 != 0
+    {
+        return false;
+    }
+
+    let value_kind = JSValue::from_bits(value.to_bits());
+    if value_kind.is_pointer() || value_kind.is_string() || value_kind.is_bigint() {
+        return false;
+    }
+
+    let gc_header = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*gc_header).obj_type != crate::gc::GC_TYPE_ARRAY {
+        return false;
+    }
+
+    let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let key_len = (*key).byte_len as usize;
+    let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+    if key_bytes != b"length" {
+        return false;
+    }
+
+    crate::array::js_array_set_length(obj as *mut crate::array::ArrayHeader, value);
+    true
+}
+
 /// Set a field value by its string key name (dynamic property access)
 /// This searches the keys array for a match and sets the corresponding value.
 /// If the key doesn't exist, it adds it to the object.
@@ -287,6 +323,11 @@ pub extern "C" fn js_object_set_field_by_name(
             }
         }
         return;
+    }
+    unsafe {
+        if try_set_array_length_before_value_root(obj, key, value) {
+            return;
+        }
     }
     let scope = crate::gc::RuntimeHandleScope::new();
     let obj_handle = scope.root_raw_mut_ptr(obj);

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -513,6 +513,46 @@ fn target_set(target: f64, key: f64, value: f64) {
     crate::object::js_object_set_field_by_name(obj_ptr, key_ptr, value);
 }
 
+fn put_value_value_needs_root(value: f64) -> bool {
+    let js_value = crate::value::JSValue::from_bits(value.to_bits());
+    js_value.is_pointer() || js_value.is_string() || js_value.is_bigint()
+}
+
+fn put_value_array_length_direct_set(target: f64, key: f64, value: f64, receiver: f64) -> bool {
+    if target.to_bits() != receiver.to_bits() || put_value_value_needs_root(value) {
+        return false;
+    }
+
+    let obj_addr = extract_pointer(target.to_bits()) as usize;
+    let key_ptr = extract_pointer(key.to_bits()) as *const crate::StringHeader;
+    if obj_addr < crate::gc::GC_HEADER_SIZE + 0x1000
+        || obj_addr & 0x7 != 0
+        || key_ptr.is_null()
+        || (key_ptr as usize) < 0x10000
+        || (key_ptr as usize) & 0x7 != 0
+    {
+        return false;
+    }
+
+    unsafe {
+        let gc_header =
+            (obj_addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_ARRAY {
+            return false;
+        }
+
+        let key_data = (key_ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let key_len = (*key_ptr).byte_len as usize;
+        let key_bytes = std::slice::from_raw_parts(key_data, key_len);
+        if key_bytes != b"length" {
+            return false;
+        }
+
+        crate::array::js_array_set_length(obj_addr as *mut crate::array::ArrayHeader, value);
+        true
+    }
+}
+
 #[derive(Clone, Copy)]
 enum OwnSetDescriptor {
     Data { writable: bool },
@@ -688,6 +728,10 @@ pub extern "C" fn js_put_value_set(
     receiver: f64,
     strict: i32,
 ) -> f64 {
+    if put_value_array_length_direct_set(target, key, value, receiver) {
+        return value;
+    }
+
     let scope = crate::gc::RuntimeHandleScope::new();
     let target_handle = scope.root_nanbox_f64(target);
     let key_handle = scope.root_nanbox_f64(key);

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -113,7 +113,7 @@ pub fn is_registered_set(addr: usize) -> bool {
     // timer ids are NaN-boxed POINTER_TAG values, not heap addresses) before
     // dereferencing the GC header. Managed Sets are arena-allocated above the
     // cutoff. See map::is_registered_map / date::is_date_cell_addr.
-    if addr < 0x100000 {
+    if addr < 0x100000 || addr & 0x7 != 0 {
         return false;
     }
     unsafe {

--- a/test-parity/node-suite/globals/array-length-invalid.ts
+++ b/test-parity/node-suite/globals/array-length-invalid.ts
@@ -56,3 +56,29 @@ expectThrow("set inf", () => {
 show("set inf length", typed.length);
 typed.length = 2;
 show("set valid length", typed.length);
+
+const dynamic: any = [1, 2, 3];
+expectThrow("any set neg", () => {
+  dynamic.length = -1;
+});
+show("any set neg length", dynamic.length);
+expectThrow("any set frac", () => {
+  dynamic.length = 2.5;
+});
+show("any set frac length", dynamic.length);
+expectThrow("any set over", () => {
+  dynamic.length = 4294967296;
+});
+show("any set over length", dynamic.length);
+expectThrow("any set nan", () => {
+  dynamic.length = NaN;
+});
+show("any set nan length", dynamic.length);
+expectThrow("any set inf", () => {
+  dynamic.length = Infinity;
+});
+show("any set inf length", dynamic.length);
+dynamic.length = 2;
+show("any set valid length", dynamic.length);
+show("any set valid has2", 2 in dynamic);
+show("any set valid third", dynamic[2]);


### PR DESCRIPTION
## Summary
- Route dynamic array `length` assignments through `js_array_set_length` before rooting primitive RHS values.
- Add conservative alignment guards before collection/array GC-header probes inspect pointer candidates.
- Extend `array-length-invalid` with dynamic `any` setter coverage.

## Root Cause
`js_put_value_set` and the generic dynamic setter rooted the RHS before recognizing an array `length` write. Raw invalid numeric values could be inspected like heap pointers before the array-length validator threw the expected `RangeError`.

## Validation
- `cargo build -p perry-runtime`
- `cargo build -p perry`
- `cargo build --release -p perry`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `npx -y node@25.9.0 --experimental-strip-types test-parity/node-suite/globals/array-length-invalid.ts > /tmp/node-array-length.out && PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=target/debug target/debug/perry compile test-parity/node-suite/globals/array-length-invalid.ts --no-cache --output array-length-invalid && ./array-length-invalid > /tmp/perry-array-length.out && diff -u /tmp/node-array-length.out /tmp/perry-array-length.out`