### PR TITLE
[codex] Fix direct toJSON member calls

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/static_receiver.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_receiver.rs
@@ -14,10 +14,10 @@ use super::super::LoweringContext;
 /// `toLocaleString`, `valueOf`, `to{Date,Time,LocaleDate,LocaleTime}String`)
 /// should fire. Returns `Some("Date")` for `new Date(...)` and locals typed
 /// as `Date`; `Some("URL")` for `new URL(...)` and locals typed as `URL`;
-/// `None` for everything else (in which case the call falls through to
-/// generic dispatch). Matches receiver shapes by AST first, then by the
-/// caller's `local_types` table — both source-level shapes the user typically
-/// writes for these objects.
+/// `Some("Object")` for source-visible class/object receivers that are
+/// definitely not Date; `None` for everything else. Matches receiver shapes by
+/// AST first, then by the caller's `local_types` table — both source-level
+/// shapes the user typically writes for these objects.
 pub(super) fn static_receiver_class(
     ctx: &LoweringContext,
     obj: &ast::Expr,
@@ -64,7 +64,10 @@ pub(super) fn static_receiver_class(
             _ => None,
         };
         if let Some(class_name) = class_name {
-            return match class_name {
+            let resolved_class = ctx
+                .resolve_class_alias(class_name)
+                .unwrap_or_else(|| class_name.to_string());
+            return match resolved_class.as_str() {
                 "Date" => Some("Date"),
                 "URL" => Some("URL"),
                 "URLPattern" => Some("URLPattern"),
@@ -73,6 +76,7 @@ pub(super) fn static_receiver_class(
                 "SocketAddress" => Some("SocketAddress"),
                 "Uint8Array" => Some("Uint8Array"),
                 "Uint8ClampedArray" => Some("Uint8ClampedArray"),
+                _ if ctx.lookup_class(&resolved_class).is_some() => Some("Object"),
                 _ => None,
             };
         }
@@ -129,8 +133,13 @@ pub(super) fn static_receiver_class(
             return Some("Object");
         }
         if let Some(ty) = ctx.lookup_local_type(name) {
-            if let Type::Named(n) = ty {
-                return match n.as_str() {
+            let named = match ty {
+                Type::Named(n) => Some(n.as_str()),
+                Type::Generic { base, .. } => Some(base.as_str()),
+                _ => None,
+            };
+            if let Some(n) = named {
+                return match n {
                     "Date" => Some("Date"),
                     "URL" => Some("URL"),
                     "URLPattern" => Some("URLPattern"),
@@ -139,7 +148,7 @@ pub(super) fn static_receiver_class(
                     "SocketAddress" => Some("SocketAddress"),
                     "Uint8Array" => Some("Uint8Array"),
                     "Uint8ClampedArray" => Some("Uint8ClampedArray"),
-                    _ => None,
+                    _ => Some("Object"),
                 };
             }
         }

--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -137,7 +137,7 @@ pub(super) fn try_url_date_weakref_instance(
         };
         // #809: `Some("Object")` (object literal / `Object.create`)
         // joins URL as a "definitely not a Date" receiver.
-        let allow_ambiguous_date = !matches!(
+        let receiver_may_be_date = !matches!(
             recv_class,
             Some("URL")
                 | Some("Object")
@@ -148,18 +148,20 @@ pub(super) fn try_url_date_weakref_instance(
                 | Some("Uint8ClampedArray")
                 | Some("Array")
         );
-        // Methods we treat as Date-only when the receiver is unambiguously
-        // Date or unknown (current behavior). `toString` / `toJSON` etc.
-        // skip these arms when `recv_class` proves the receiver is NOT a Date.
+        // Most ambiguous Date methods retain the historical "unknown may be
+        // Date" behavior. Direct `.toJSON()` is different: userland classes
+        // commonly expose it as a plain method, and bracket/computed forms
+        // already dispatch generically, so only statically-known Date
+        // receivers should use the Date intrinsic.
 
         // Check for Date instance method calls (date.getTime(), etc.)
         if let ast::MemberProp::Ident(method_ident) = &member.prop {
             let method_name = method_ident.sym.as_ref();
-            // toJSON has two competing receiver shapes: Buffer-like values
-            // need their own `.toJSON()` (exact Node toJSON output), every
-            // other shape falls into the Date arms below. We must lower the
-            // receiver to discriminate. Cache the lowered expr so we don't
-            // re-lower in the Date `toJSON` arm at line ~263.
+            // toJSON has competing receiver shapes: Buffer-like values need
+            // their own `.toJSON()` (exact Node toJSON output), statically
+            // known Dates need DateToJSON, and ordinary userland objects must
+            // remain a generic method call. Cache the lowered receiver so we
+            // don't re-lower in the Date `toJSON` arm below.
             let mut cached_recv: Option<Expr> = None;
             if method_name == "toJSON" {
                 let recv_expr = lower_expr(ctx, &member.obj)?;
@@ -195,6 +197,11 @@ pub(super) fn try_url_date_weakref_instance(
                     | "toISOString"
                     | "valueOf"
             );
+            let allow_date_method = if method_name == "toJSON" {
+                recv_class == Some("Date")
+            } else {
+                receiver_may_be_date
+            };
             if method_name == "setTime"
                 && is_node_test_mock_timers_receiver(ctx, member.obj.as_ref())
             {
@@ -202,8 +209,9 @@ pub(super) fn try_url_date_weakref_instance(
                 // Date setter fallback below also matches `.setTime(...)` on
                 // unknown receivers, so keep this known non-Date receiver on
                 // the generic method-call path.
-            } else if ambiguous && !allow_ambiguous_date {
-                // Receiver is statically a non-Date class (e.g. URL).
+            } else if ambiguous && !allow_date_method {
+                // Receiver is statically a non-Date class (e.g. URL), or this
+                // is `.toJSON()` on an unknown/userland receiver.
                 // Skip the Date arms below — fall through to generic.
             } else {
                 match method_name {

--- a/crates/perry-hir/tests/direct_tojson_call.rs
+++ b/crates/perry-hir/tests/direct_tojson_call.rs
@@ -50,3 +50,46 @@ fn user_class_tojson_calls_stay_generic() {
         "ordinary method-name control should stay generic too: {debug}"
     );
 }
+
+#[test]
+fn unknown_tojson_receiver_stays_generic() {
+    let debug = lower_debug(
+        r#"
+        function makeBuilder(): any {
+            return {};
+        }
+
+        const command: any = makeBuilder();
+        const out = command.toJSON();
+        "#,
+    );
+
+    assert!(
+        !debug.contains("DateToJSON"),
+        "unknown toJSON receivers must not lower to DateToJSON: {debug}"
+    );
+    assert!(
+        debug.contains("property: \"toJSON\""),
+        "unknown direct toJSON calls should stay generic: {debug}"
+    );
+}
+
+#[test]
+fn known_date_tojson_stays_date_intrinsic() {
+    let debug = lower_debug(
+        r#"
+        const inferred = new Date(0);
+        const annotated: Date = new Date(0);
+        const out = {
+            inline: new Date(0).toJSON(),
+            inferred: inferred.toJSON(),
+            annotated: annotated.toJSON(),
+        };
+        "#,
+    );
+
+    assert!(
+        debug.contains("DateToJSON"),
+        "known Date toJSON calls should still lower to DateToJSON: {debug}"
+    );
+}

--- a/crates/perry-hir/tests/direct_tojson_call.rs
+++ b/crates/perry-hir/tests/direct_tojson_call.rs
@@ -1,0 +1,52 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::lower_module;
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_debug(src: &str) -> String {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "direct_tojson_call.ts", &mut cache)
+        .expect("parse should succeed");
+    let module = lower_module(&parsed.module, "test", "direct_tojson_call.ts")
+        .expect("lowering should succeed");
+    format!("{module:#?}")
+}
+
+#[test]
+fn user_class_tojson_calls_stay_generic() {
+    let debug = lower_debug(
+        r#"
+        class Fixture {
+            value = "deploy";
+            toJSON(): any {
+                return { name: this.value };
+            }
+            describe(): any {
+                return { label: this.value };
+            }
+        }
+
+        const fixture: any = new Fixture();
+        const out = {
+            direct: fixture.toJSON(),
+            directNew: new Fixture().toJSON(),
+            bracket: fixture["toJSON"](),
+            computed: fixture["to" + "JSON"](),
+            callResult: fixture.toJSON.call(fixture),
+            control: fixture.describe(),
+        };
+        "#,
+    );
+
+    assert!(
+        !debug.contains("DateToJSON"),
+        "userland toJSON calls must not lower to DateToJSON: {debug}"
+    );
+    assert!(
+        debug.contains("property: \"toJSON\""),
+        "direct toJSON calls should stay on the generic property-call path: {debug}"
+    );
+    assert!(
+        debug.contains("property: \"describe\""),
+        "ordinary method-name control should stay generic too: {debug}"
+    );
+}

--- a/test-files/fixtures/direct_tojson_pkg/builder.ts
+++ b/test-files/fixtures/direct_tojson_pkg/builder.ts
@@ -1,0 +1,12 @@
+export class ImportedCommandBuilder {
+  value = "deploy";
+
+  setValue(value: string): this {
+    this.value = value;
+    return this;
+  }
+
+  toJSON(): any {
+    return { name: this.value };
+  }
+}

--- a/test-files/test_direct_tojson_call.ts
+++ b/test-files/test_direct_tojson_call.ts
@@ -1,0 +1,36 @@
+class Fixture {
+  value = "deploy";
+
+  toJSON(): any {
+    return { name: this.value };
+  }
+
+  describe(): any {
+    return { label: this.value + "-ok" };
+  }
+}
+
+const fixture: any = new Fixture();
+const stringifyActual = JSON.stringify(fixture);
+const stringifyExpected = '{"name":"deploy"}';
+const actual = JSON.stringify({
+  direct: fixture.toJSON(),
+  bracket: fixture["toJSON"](),
+  computed: fixture["to" + "JSON"](),
+  callResult: fixture.toJSON.call(fixture),
+  control: fixture.describe(),
+});
+const expected =
+  '{"direct":{"name":"deploy"},"bracket":{"name":"deploy"},"computed":{"name":"deploy"},"callResult":{"name":"deploy"},"control":{"label":"deploy-ok"}}';
+
+if (actual !== expected) {
+  console.log(actual);
+  throw new Error("direct toJSON call result did not match bracket/computed/call forms");
+}
+
+if (stringifyActual !== stringifyExpected) {
+  console.log(stringifyActual);
+  throw new Error("JSON.stringify no longer honors userland toJSON");
+}
+
+console.log(actual);

--- a/test-files/test_direct_tojson_imported_builder.ts
+++ b/test-files/test_direct_tojson_imported_builder.ts
@@ -1,0 +1,18 @@
+import { ImportedCommandBuilder } from "./fixtures/direct_tojson_pkg/builder.ts";
+
+const command: any = new ImportedCommandBuilder().setValue("deploy");
+const actual = JSON.stringify({
+  direct: command.toJSON(),
+  bracket: command["toJSON"](),
+  computed: command["to" + "JSON"](),
+  callResult: command.toJSON.call(command),
+});
+const expected =
+  '{"direct":{"name":"deploy"},"bracket":{"name":"deploy"},"computed":{"name":"deploy"},"callResult":{"name":"deploy"}}';
+
+if (actual !== expected) {
+  console.log(actual);
+  throw new Error("imported builder direct toJSON call did not match bracket/computed/call forms");
+}
+
+console.log(actual);


### PR DESCRIPTION
## Summary
- Keep direct `.toJSON()` calls on userland, named-object, and unknown/imported receivers on ordinary method dispatch instead of routing them through ambiguous Date-method lowering.
- Preserve the Date intrinsic for statically-known `Date#toJSON()` and keep URL/Buffer/userland paths separated.
- Add focused HIR coverage for userland, unknown receiver, and known Date `.toJSON()` lowering, plus compile/run fixtures for same-module and imported builder-style calls.

## Why
Direct `obj.toJSON()` could compile differently from equivalent bracket or computed calls. Same-module class cases were covered by static receiver classification, but imported builder-style code can leave the receiver unknown after package-style construction/chaining, causing direct `.toJSON()` to take the Date path and return the wrong value while `obj["toJSON"]()`, `obj["to" + "JSON"]()`, and `.call(...)` dispatched normally.

## Validation
- `cargo fmt --check` passed.
- `cargo test -p perry-hir --test direct_tojson_call` passed: 3 tests.
- Perry compile/run of `test-files/test_direct_tojson_call.ts` passed and printed `{"direct":{"name":"deploy"},"bracket":{"name":"deploy"},"computed":{"name":"deploy"},"callResult":{"name":"deploy"},"control":{"label":"deploy-ok"}}`.
- Perry compile/run of `test-files/test_direct_tojson_imported_builder.ts` passed and printed `{"direct":{"name":"deploy"},"bracket":{"name":"deploy"},"computed":{"name":"deploy"},"callResult":{"name":"deploy"}}`.
- Perry compile/run of `test-files/test_gap_json_prototype_tojson.ts` passed, including prototype `toJSON` serialization and Date JSON output.
- Perry compile/run of `test-files/test_issue_650_url_static.ts` passed, including URL `.toJSON()` and known Date `.toJSON()` output.
- Perry compile/run of `test-files/test_issue_748_invalid_date.ts` passed, including invalid Date `.toJSON()` returning `null`.

## Notes
- Imported builder-style direct `.toJSON()` calls now compile/run through ordinary method dispatch without rewriting source calls to bracket/helper forms.
- A package-style builder runtime check compiled with this branch proceeds past direct builder `.toJSON()` assertions; broader package/runtime parity remains out of scope for this PR.