### PR TITLE
[codex] fix array length assignment errors

### DIFF
--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -255,9 +255,9 @@ pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
     if arr.is_null() {
         return;
     }
+    let n = array_length_from_property_value_or_throw(new_length);
     let scope = crate::gc::RuntimeHandleScope::new();
     let _arr_handle = scope.root_raw_mut_ptr(arr);
-    let n = array_length_from_property_value_or_throw(new_length);
     unsafe {
         let cur = (*arr).length;
         if n < cur {

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -158,6 +158,18 @@ unsafe fn key_to_str_for_diag(key: *const crate::StringHeader) -> String {
         .unwrap_or_else(|_| "<unknown>".to_string())
 }
 
+unsafe fn string_key_eq(key: *const crate::StringHeader, expected: &[u8]) -> bool {
+    if key.is_null() || (key as usize) < 0x10000 {
+        return false;
+    }
+    let len = (*key).byte_len as usize;
+    if len != expected.len() {
+        return false;
+    }
+    let data = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    std::slice::from_raw_parts(data, len) == expected
+}
+
 /// Set a field value by its string key name (dynamic property access)
 /// This searches the keys array for a match and sets the corresponding value.
 /// If the key doesn't exist, it adds it to the object.
@@ -287,6 +299,16 @@ pub extern "C" fn js_object_set_field_by_name(
             }
         }
         return;
+    }
+    unsafe {
+        if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 && string_key_eq(key, b"length") {
+            let gc_header =
+                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+                crate::array::js_array_set_length(obj as *mut crate::array::ArrayHeader, value);
+                return;
+            }
+        }
     }
     let scope = crate::gc::RuntimeHandleScope::new();
     let obj_handle = scope.root_raw_mut_ptr(obj);

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -46,6 +46,22 @@ pub(crate) fn obj_value_has_own_key(value: f64, key: f64) -> bool {
             return false;
         }
         let obj_addr = obj as usize;
+        if obj_addr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let gc = gc_header_for(obj);
+            if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY
+                || (*gc).obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
+            {
+                let arr = crate::array::clean_arr_ptr(obj as *const crate::array::ArrayHeader);
+                if arr.is_null() {
+                    return false;
+                }
+                let key_str = crate::builtins::js_string_coerce(key);
+                if key_str.is_null() {
+                    return false;
+                }
+                return super::has_own_helpers::array_own_key_present(arr, key_str);
+            }
+        }
         if crate::closure::is_closure_ptr(obj_addr) {
             let Some(key_name) = key_to_rust_string(key) else {
                 return false;

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -513,6 +513,114 @@ fn target_set(target: f64, key: f64, value: f64) {
     crate::object::js_object_set_field_by_name(obj_ptr, key_ptr, value);
 }
 
+fn raw_ptr_from_value(value: f64) -> Option<usize> {
+    let bits = value.to_bits();
+    let top16 = bits >> 48;
+    let raw = if top16 == (POINTER_TAG >> 48) {
+        bits & POINTER_MASK
+    } else if top16 == 0 && bits > 0x10000 {
+        bits
+    } else {
+        return None;
+    } as usize;
+    if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    Some(raw)
+}
+
+fn array_ptr_from_value(value: f64) -> Option<*mut crate::array::ArrayHeader> {
+    let raw = raw_ptr_from_value(value)?;
+    if crate::buffer::is_registered_buffer(raw)
+        || crate::typedarray::lookup_typed_array_kind(raw).is_some()
+        || !crate::object::is_valid_obj_ptr(raw as *const u8)
+    {
+        return None;
+    }
+    unsafe {
+        let gc = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY
+            || (*gc).obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
+        {
+            Some(raw as *mut crate::array::ArrayHeader)
+        } else {
+            None
+        }
+    }
+}
+
+fn key_is_length(key: f64) -> bool {
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(key, &mut scratch) else {
+        return false;
+    };
+    if ptr.is_null() || len != 6 {
+        return false;
+    }
+    unsafe { std::slice::from_raw_parts(ptr, len as usize) == b"length" }
+}
+
+fn parse_canonical_nonnegative_i32(bytes: &[u8]) -> Option<i32> {
+    if bytes.is_empty() || (bytes.len() > 1 && bytes[0] == b'0') {
+        return None;
+    }
+    let mut value = 0u32;
+    for &byte in bytes {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value = value.checked_mul(10)?.checked_add((byte - b'0') as u32)?;
+        if value > i32::MAX as u32 {
+            return None;
+        }
+    }
+    Some(value as i32)
+}
+
+fn integer_index_key(key: f64) -> Option<i32> {
+    let jsval = crate::value::JSValue::from_bits(key.to_bits());
+    if jsval.is_int32() {
+        let index = jsval.as_int32();
+        return (index >= 0).then_some(index);
+    }
+    if !key.is_nan() {
+        return (key.is_finite() && key >= 0.0 && key.fract() == 0.0 && key <= i32::MAX as f64)
+            .then_some(key as i32);
+    }
+
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(key, &mut scratch) else {
+        return None;
+    };
+    if ptr.is_null() {
+        return None;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    parse_canonical_nonnegative_i32(bytes)
+}
+
+fn set_integer_indexed_exotic(target: f64, key: f64, value: f64) -> bool {
+    let Some(index) = integer_index_key(key) else {
+        return false;
+    };
+    let Some(raw) = raw_ptr_from_value(target) else {
+        return false;
+    };
+    if crate::buffer::is_registered_buffer(raw) {
+        crate::buffer::js_buffer_set(raw as *mut crate::buffer::BufferHeader, index, value as i32);
+        return true;
+    }
+    if crate::typedarray::lookup_typed_array_kind(raw).is_some() {
+        crate::typedarray::js_typed_array_set(
+            raw as *mut crate::typedarray::TypedArrayHeader,
+            index,
+            value,
+        );
+        return true;
+    }
+    false
+}
+
 #[derive(Clone, Copy)]
 enum OwnSetDescriptor {
     Data { writable: bool },
@@ -688,6 +796,18 @@ pub extern "C" fn js_put_value_set(
     receiver: f64,
     strict: i32,
 ) -> f64 {
+    if lookup(target).is_none() {
+        if set_integer_indexed_exotic(target, key, value) {
+            return value;
+        }
+        if target.to_bits() == receiver.to_bits() && key_is_length(key) {
+            if let Some(arr) = array_ptr_from_value(target) {
+                crate::array::js_array_set_length(arr, value);
+                return value;
+            }
+        }
+    }
+
     let scope = crate::gc::RuntimeHandleScope::new();
     let target_handle = scope.root_nanbox_f64(target);
     let key_handle = scope.root_nanbox_f64(key);

--- a/test-parity/node-suite/globals/array-length-invalid.ts
+++ b/test-parity/node-suite/globals/array-length-invalid.ts
@@ -56,3 +56,27 @@ expectThrow("set inf", () => {
 show("set inf length", typed.length);
 typed.length = 2;
 show("set valid length", typed.length);
+
+const dynamic: any = [1, 2, 3];
+expectThrow("dynamic set neg", () => {
+  dynamic.length = -1;
+});
+show("dynamic set neg length", dynamic.length);
+expectThrow("dynamic set frac", () => {
+  dynamic.length = 2.5;
+});
+show("dynamic set frac length", dynamic.length);
+expectThrow("dynamic set over", () => {
+  dynamic.length = 4294967296;
+});
+show("dynamic set over length", dynamic.length);
+expectThrow("dynamic set nan", () => {
+  dynamic.length = NaN;
+});
+show("dynamic set nan length", dynamic.length);
+expectThrow("dynamic set inf", () => {
+  dynamic.length = Infinity;
+});
+show("dynamic set inf length", dynamic.length);
+dynamic.length = 1;
+show("dynamic set valid length", dynamic.length);


### PR DESCRIPTION
## Summary
- validate array length writes before runtime handle scopes so invalid lengths throw RangeError instead of crossing Rust drops
- route dynamic array length writes through the array length setter from object/proxy assignment paths
- avoid object-header probing for array own-key checks and handle Buffer/TypedArray integer-index PutValue writes before descriptor probing

## Validation
- NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" perl -e 'alarm shift; exec @ARGV' 300 ./run_parity_tests.sh --suite node-suite --module globals --filter array-length-invalid
- NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" perl -e 'alarm shift; exec @ARGV' 300 ./run_parity_tests.sh --suite node-suite --module globals --filter structured-clone-transfer
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh
- cargo check -p perry-runtime -p perry
- cargo test -p perry-runtime array_length -- --nocapture

Refs #4175
