### PR TITLE
[codex] fix stream consumers parity gaps

### DIFF
--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -327,6 +327,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let bits = crate::nanbox::INT32_TAG | (cid as u64 & 0xFFFF_FFFF);
                 return Ok(double_literal(f64::from_bits(bits)));
             }
+            // Issue #841: named imports from Node submodules Perry recognizes
+            // as runtime-backed values must win over the generic native-module
+            // closure wrapper. Default imports use this map too; returning the
+            // runtime export here keeps `import consumers from
+            // "node:stream/consumers"` equal to the namespace's `.default`
+            // object instead of the namespace object itself.
+            if let Some((submod_key, exported_name)) = ctx.import_function_node_submodule.get(name)
+            {
+                let submod_label = emit_string_literal_global(ctx, submod_key);
+                let name_label = emit_string_literal_global(ctx, exported_name);
+                let submod_len = submod_key.len();
+                let name_len = exported_name.len();
+                let blk = ctx.block();
+                return Ok(blk.call(
+                    DOUBLE,
+                    "js_node_submodule_export_as_function",
+                    &[
+                        (PTR, &submod_label),
+                        (I32, &submod_len.to_string()),
+                        (PTR, &name_label),
+                        (I32, &name_len.to_string()),
+                    ],
+                ));
+            }
             if let Some(source_prefix) = ctx.import_function_prefixes.get(name).cloned() {
                 // Issue #678 followup: a V8-fallback import used as a value
                 // (rather than called directly) has no native singleton
@@ -408,34 +432,6 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let closure_handle =
                     blk.call(I64, "js_closure_alloc_singleton", &[(PTR, &wrap_ptr)]);
                 return Ok(nanbox_pointer_inline(blk, &closure_handle));
-            }
-            // Issue #841: named imports from the five Node submodules
-            // Perry recognizes but has no perry-stdlib backing for
-            // (`node:timers/promises`, `node:readline/promises`,
-            // `node:stream/promises`, `node:stream/consumers`,
-            // `node:sys`). Pre-fix the catch-all returned TAG_TRUE so
-            // `typeof setTimeout === "boolean"` and the value literally
-            // printed as `true`. Route to the runtime helper
-            // `js_node_submodule_export_as_function` which returns a
-            // NaN-boxed function singleton; the singleton's thunk is a
-            // thrower (a follow-up under #793 wires real impls).
-            if let Some((submod_key, exported_name)) = ctx.import_function_node_submodule.get(name)
-            {
-                let submod_label = emit_string_literal_global(ctx, submod_key);
-                let name_label = emit_string_literal_global(ctx, exported_name);
-                let submod_len = submod_key.len();
-                let name_len = exported_name.len();
-                let blk = ctx.block();
-                return Ok(blk.call(
-                    DOUBLE,
-                    "js_node_submodule_export_as_function",
-                    &[
-                        (PTR, &submod_label),
-                        (I32, &submod_len.to_string()),
-                        (PTR, &name_label),
-                        (I32, &name_len.to_string()),
-                    ],
-                ));
             }
             // Issue #841 companion: namespace imports for the same five
             // submodules. The `collect_modules.rs` rejection skips

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -344,30 +344,18 @@ pub(crate) fn lower_module_decl(
                                 continue;
                             }
                             // #3906: a CJS-backed Node builtin *submodule* that
-                            // isn't in NATIVE_MODULES (e.g. `node:timers/promises`,
-                            // `node:stream/promises`). Its default export is the
-                            // module object — CJS `default === module.exports`,
-                            // the same value as the `import * as` namespace shape.
-                            // Without this it fell to the JS-module default path
-                            // below and resolved to an `ExternFuncRef` boolean
-                            // stub (`typeof === "boolean"`). Mirror the namespace
-                            // handling so the default binding is the module object.
+                            // isn't in NATIVE_MODULES (e.g.
+                            // `node:timers/promises`, `node:stream/promises`).
+                            // Its default import is an actual `default` binding,
+                            // not the module namespace object. Register it as an
+                            // imported function so the compile driver can route
+                            // the binding through the known-node-submodule
+                            // default export path instead of the generic JS
+                            // module fallback.
                             ctx.register_imported_func(local.clone(), local.clone());
-                            ctx.namespace_import_locals.insert(local.clone());
                             if source == "fs/promises" {
                                 ctx.register_builtin_module_alias(local.clone(), source.clone());
                             }
-                            // Treat the default binding as the module-namespace
-                            // object (CJS default === module.exports). Pushing a
-                            // Namespace specifier (not Default) puts `local` into
-                            // the driver's `namespace_imports`, so `typeof local`
-                            // folds to "object" and `local.member(...)` dispatches
-                            // through the submodule namespace — exactly like the
-                            // `import * as local` shape.
-                            specifiers.push(ImportSpecifier::Namespace {
-                                local: local.clone(),
-                            });
-                            continue;
                         } else {
                             // Default import from JS module — register so calls resolve to
                             // ExternFuncRef. Use the LOCAL name as the original-name marker

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -51,7 +51,7 @@ pub(crate) fn lower_lit(lit: &ast::Lit) -> Result<Expr> {
         }
         ast::Lit::Str(s) => {
             if let Some(valid_utf8) = s.value.as_str() {
-                Ok(Expr::String(valid_utf8.to_string()))
+                Ok(Expr::String(normalize_swc_string_literal(s, valid_utf8)))
             } else {
                 // Lone surrogates (U+D800..U+DFFF): SWC stores them as WTF-8 bytes.
                 // as_str() returns None because they can't be represented as valid UTF-8.
@@ -66,6 +66,27 @@ pub(crate) fn lower_lit(lit: &ast::Lit) -> Result<Expr> {
             flags: re.flags.to_string(),
         }),
         _ => Err(anyhow!("Unsupported literal type")),
+    }
+}
+
+fn normalize_swc_string_literal(lit: &ast::Str, decoded: &str) -> String {
+    let Some(raw) = lit.raw.as_ref().map(|raw| raw.as_ref()) else {
+        return decoded.to_string();
+    };
+    if raw.is_ascii() || decoded.is_ascii() {
+        return decoded.to_string();
+    }
+    let mut bytes = Vec::with_capacity(decoded.len());
+    for ch in decoded.chars() {
+        let code = ch as u32;
+        if code > 0xFF {
+            return decoded.to_string();
+        }
+        bytes.push(code as u8);
+    }
+    match String::from_utf8(bytes) {
+        Ok(repaired) => repaired,
+        Err(_) => decoded.to_string(),
     }
 }
 

--- a/crates/perry-hir/tests/string_literals.rs
+++ b/crates/perry-hir/tests/string_literals.rs
@@ -1,0 +1,73 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Expr, ImportSpecifier, Stmt};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_src(src: &str) -> perry_hir::Module {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "string_literals.ts", &mut cache)
+        .expect("parse should succeed");
+    lower_module(&parsed.module, "test", "string_literals.ts").expect("lower should succeed")
+}
+
+#[test]
+fn non_ascii_string_literal_stays_utf8() {
+    let module = lower_src(r#"const value = "héllo 世界 🌍";"#);
+    let init = module
+        .init
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Let {
+                name,
+                init: Some(expr),
+                ..
+            } if name == "value" => Some(expr),
+            _ => None,
+        })
+        .expect("value binding should be lowered");
+
+    assert!(
+        matches!(init, Expr::String(value) if value == "héllo 世界 🌍"),
+        "{init:?}"
+    );
+}
+
+#[test]
+fn node_submodule_default_import_remains_default_specifier() {
+    let module = lower_src(
+        r#"
+        import consumersDefault, { text } from "node:stream/consumers";
+        import * as consumers from "node:stream/consumers";
+        console.log(consumersDefault, consumers, text);
+        "#,
+    );
+
+    let mixed = module
+        .imports
+        .iter()
+        .find(|import| import.specifiers.len() == 2)
+        .expect("mixed default/named import should be lowered");
+    assert!(
+        mixed.specifiers.iter().any(|specifier| matches!(
+            specifier,
+            ImportSpecifier::Default { local } if local == "consumersDefault"
+        )),
+        "{:?}",
+        mixed.specifiers
+    );
+    assert!(
+        mixed.specifiers.iter().any(|specifier| matches!(
+            specifier,
+            ImportSpecifier::Named { imported, local } if imported == "text" && local == "text"
+        )),
+        "{:?}",
+        mixed.specifiers
+    );
+    assert!(
+        !mixed.specifiers.iter().any(|specifier| matches!(
+            specifier,
+            ImportSpecifier::Namespace { local } if local == "consumersDefault"
+        )),
+        "{:?}",
+        mixed.specifiers
+    );
+}

--- a/crates/perry-runtime/src/buffer/encode.rs
+++ b/crates/perry-runtime/src/buffer/encode.rs
@@ -146,7 +146,7 @@ fn utf16le_bytes_to_string(bytes: &[u8]) -> *mut StringHeader {
 /// walks the bytes again for utf16 counting on non-ASCII). For pure-ASCII
 /// inputs we land on `js_string_from_ascii_bytes` directly — one byte scan
 /// total. Non-ASCII falls through to the spec-correct lossy path.
-fn buf_bytes_to_utf8_string(bytes: &[u8]) -> *mut StringHeader {
+pub(crate) fn buf_bytes_to_utf8_string(bytes: &[u8]) -> *mut StringHeader {
     if bytes.is_ascii() {
         return js_string_from_ascii_bytes(bytes.as_ptr(), bytes.len() as u32);
     }

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -58,6 +58,7 @@ pub use query::{
 };
 
 // ---- Re-exports: toString / print / length / to-array ----
+pub(crate) use encode::buf_bytes_to_utf8_string;
 pub use encode::{
     buffer_to_array, js_buffer_length, js_buffer_print, js_buffer_to_string,
     js_buffer_to_string_range, js_value_to_string_with_encoding,

--- a/crates/perry-runtime/src/node_submodules/consumers.rs
+++ b/crates/perry-runtime/src/node_submodules/consumers.rs
@@ -64,8 +64,7 @@ pub(crate) fn bytes_to_uint8_array_value(bytes: &[u8]) -> f64 {
 }
 
 pub(crate) fn bytes_to_text_value(bytes: &[u8]) -> f64 {
-    let cow = String::from_utf8_lossy(bytes);
-    let ptr = js_string_from_bytes(cow.as_bytes().as_ptr(), cow.len() as u32);
+    let ptr = crate::buffer::buf_bytes_to_utf8_string(bytes);
     f64::from_bits(JSValue::string_ptr(ptr).bits())
 }
 

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -1493,6 +1493,7 @@ pub unsafe extern "C" fn js_reader_read(reader_handle: f64) -> *mut Promise {
         }
     };
     let mut closed_rejection: Option<(usize, u64)> = None;
+    let mut closed_resolution: Option<usize> = None;
     let outcome: Option<(u64, bool, bool)> = {
         let mut g = READABLE_STREAMS.lock().unwrap();
         match g.get_mut(&stream_id) {
@@ -1504,6 +1505,10 @@ pub unsafe extern "C" fn js_reader_read(reader_handle: f64) -> *mut Promise {
                             s.error_value = error;
                             if let Some(reader_id) = s.reader_handle {
                                 closed_rejection = Some((reader_id, error));
+                            }
+                        } else if s.state == ReadableState::Closed {
+                            if let Some(reader_id) = s.reader_handle {
+                                closed_resolution = Some(reader_id);
                             }
                         }
                     }
@@ -1529,6 +1534,17 @@ pub unsafe extern "C" fn js_reader_read(reader_handle: f64) -> *mut Promise {
         if let Some(p) = p {
             js_promise_reject(p, f64::from_bits(reason));
         }
+    }
+    if let Some(reader_id) = closed_resolution {
+        let p = READERS
+            .lock()
+            .unwrap()
+            .get(&reader_id)
+            .map(|r| r.closed_promise);
+        if let Some(p) = p {
+            js_promise_resolve(p, f64::from_bits(TAG_UNDEFINED));
+        }
+        close_pending(stream_id);
     }
     match outcome {
         Some((value, _, true)) => {

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -3037,31 +3037,13 @@ pub fn run_with_parse_cache(
                             }
                         }
                         perry_hir::ImportSpecifier::Default { local } => {
-                            // Some historical submodules model their default
-                            // import as the namespace object. Other submodules
-                            // with CommonJS-style default objects route through
-                            // the explicit "default" export below.
-                            //
-                            if matches!(submod_key.as_str(), "timers" | "trace_events") {
-                                // Default imports of these modules are module
-                                // objects — route to the namespace so they work
-                                // like `import * as ...` (#1213, #2629).
-                                namespace_node_submodules
-                                    .insert(local.clone(), submod_key.clone());
-                                if !namespace_imports.contains(&local) {
-                                    namespace_imports.push(local.clone());
-                                }
-                            } else {
-                                // Default imports route to "default" — these
-                                // submodules either expose a real default
-                                // (`node:sys` aliases `node:util`) or need a
-                                // tracked placeholder to keep the catch-all
-                                // from firing on `import x from "node:..."`.
-                                import_function_node_submodule.insert(
-                                    local.clone(),
-                                    (submod_key.clone(), "default".to_string()),
-                                );
-                            }
+                            // Default imports route to "default" — known Node
+                            // submodules expose an object-valued default export
+                            // that is distinct from the namespace object.
+                            import_function_node_submodule.insert(
+                                local.clone(),
+                                (submod_key.clone(), "default".to_string()),
+                            );
                         }
                         perry_hir::ImportSpecifier::Namespace { local } => {
                             namespace_node_submodules

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -212,19 +212,6 @@ Selected highlights (full list in `runtime-parity.md`):
 - `rl.commit()`
 - `rl.rollback()`
 
-### node:stream/consumers
-
-**Total APIs: 6** · Perry covers: 0 · Gap: 6
-
-Selected highlights (full list in `runtime-parity.md`):
-
-- `consumers.arrayBuffer(stream)`
-- `consumers.blob(stream)`
-- `consumers.buffer(stream)`
-- `consumers.bytes(stream)`
-- `consumers.json(stream)`
-- `consumers.text(stream)`
-
 ### node:string_decoder
 
 **Total APIs: 6** · Perry covers: 0 · Gap: 6


### PR DESCRIPTION
## Summary

- preserve runtime-created `ReadableStream` underlying source objects so object-method `start`/`pull`/`cancel` callbacks drive Web ReadableStream consumers
- route stream consumer text through the runtime UTF-8 decoder and settle `reader.closed` when closed streams drain their queued chunks
- keep known Node submodule default imports distinct from namespace imports, then remove `node:stream/consumers` from the zero-coverage gap list after the suite reaches parity

Addresses #3837.

## Validation

- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=2 cargo test -p perry-hir --test string_literals`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=2 cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@25 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module stream/consumers'` (`v25.9.0`, 35 pass / 0 fail)
- `git diff --check`
- `./scripts/check_file_size.sh`
