### PR TITLE
[codex] implement process finalization hooks

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -495,6 +495,8 @@ pub(super) fn compile_module_entry(
                 let _ = ctx.block().call(I32, "js_timer_tick_if_refed", &[]);
                 let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
                 let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
+                ctx.block()
+                    .call_void("js_process_run_finalization_exit", &[]);
                 ctx.block().ret(I32, "0");
             }
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -738,6 +738,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_prepend_once_listener", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_emit", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_emit_before_exit", VOID, &[DOUBLE]);
+    module.declare_function("js_process_run_finalization_exit", VOID, &[]);
     module.declare_function("js_process_remove_listener", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_off", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_remove_all_listeners", DOUBLE, &[I64]);

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -336,23 +336,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // .includes(name)) now does the right thing instead
                     // of crashing on the 0.0 sentinel.
                     "moduleLoadList" => return Ok(Expr::Array(vec![])),
-                    // #1482: process.finalization — control surface added
-                    // in Node 22 for FinalizationRegistry-like lifecycle
-                    // hooks (register / registerBeforeExit / unregister).
-                    // Perry doesn't have the runtime support yet, but
-                    // shape-only consumers feature-detect on
-                    // `typeof process.finalization === "object"` first;
-                    // returning an Object with the three documented
-                    // method names (currently undefined) closes that
-                    // gap. Real implementations of register / unregister
-                    // are tracked separately.
-                    "finalization" => {
-                        return Ok(Expr::Object(vec![
-                            ("register".to_string(), Expr::Undefined),
-                            ("registerBeforeExit".to_string(), Expr::Undefined),
-                            ("unregister".to_string(), Expr::Undefined),
-                        ]));
-                    }
+                    "finalization" => return Ok(process_native_property("finalization")),
                     // #1379: process.config — object describing build-time
                     // config (`{ variables, target_defaults }` in Node).
                     // Perry has no `node-gyp`-style build to surface, but
@@ -529,13 +513,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         })
                     }
                     "moduleLoadList" => return Ok(Expr::Array(vec![])),
-                    "finalization" => {
-                        return Ok(Expr::Object(vec![
-                            ("register".to_string(), Expr::Undefined),
-                            ("registerBeforeExit".to_string(), Expr::Undefined),
-                            ("unregister".to_string(), Expr::Undefined),
-                        ]));
-                    }
+                    "finalization" => return Ok(process_native_property("finalization")),
                     "config" => {
                         return Ok(Expr::Object(vec![
                             ("variables".to_string(), Expr::Object(Vec::new())),

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -342,6 +342,7 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::object::scan_native_callable_export_roots_mut);
     gc_register_mutable_root_scanner(crate::node_vm::scan_vm_roots_mut);
     gc_register_mutable_root_scanner(crate::tls::scan_tls_roots_mut);
+    gc_register_mutable_root_scanner(crate::process::scan_process_finalization_roots_mut);
     gc_register_mutable_root_scanner(crate::os::scan_process_event_listener_roots_mut);
     gc_register_mutable_root_scanner(crate::os::scan_process_stream_singleton_roots_mut);
     gc_register_mutable_root_scanner(crate::fs::scan_fs_stream_roots_mut);

--- a/crates/perry-runtime/src/os/os_process_emitter.rs
+++ b/crates/perry-runtime/src/os/os_process_emitter.rs
@@ -235,6 +235,46 @@ fn register_process_listener(
     process_namespace_value()
 }
 
+pub(crate) fn add_internal_process_listener(
+    event: &str,
+    callback: *const crate::closure::ClosureHeader,
+) {
+    if callback.is_null() {
+        return;
+    }
+    PROCESS_EMITTER.with(|emitter| {
+        let mut emitter = emitter.borrow_mut();
+        emitter.ensure_event_order(event);
+        emitter
+            .events
+            .entry(event.to_string())
+            .or_default()
+            .push(ProcessListener {
+                callback,
+                raw_wrapper: std::ptr::null(),
+                once: false,
+            });
+    });
+    sync_process_signal_listener(event);
+}
+
+pub(crate) fn remove_internal_process_listener(
+    event: &str,
+    callback: *const crate::closure::ClosureHeader,
+) {
+    if callback.is_null() {
+        return;
+    }
+    PROCESS_EMITTER.with(|emitter| {
+        let mut emitter = emitter.borrow_mut();
+        if let Some(listeners) = emitter.events.get_mut(event) {
+            listeners.retain(|listener| listener.callback != callback);
+        }
+        emitter.prune_event_if_empty(event);
+    });
+    sync_process_signal_listener(event);
+}
+
 fn boxed_bool(value: bool) -> f64 {
     f64::from_bits(if value {
         crate::value::TAG_TRUE

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -5,6 +5,7 @@ use crate::closure::{
 };
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
+use std::cell::{Cell, RefCell};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 mod credentials;
@@ -94,6 +95,7 @@ pub extern "C" fn js_process_exit(code: f64) {
         Some(c) => c,
         None => 0,
     };
+    js_process_run_finalization_exit();
     // Use _exit() instead of std::process::exit() to avoid SIGILL during cleanup.
     // std::process::exit() runs atexit handlers and C++ destructors which can trigger
     // illegal instructions when exception handler state (jmp_buf), GC roots, or
@@ -341,19 +343,32 @@ fn module_set_field(obj: *mut crate::object::ObjectHeader, name: &str, value: f6
     crate::object::js_object_set_field_by_name(obj, key, value);
 }
 
-extern "C" fn module_source_map_noop(_closure: *const crate::closure::ClosureHeader) -> f64 {
-    f64::from_bits(crate::value::TAG_UNDEFINED)
-}
-
 type ModuleFunction1 = extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64;
 type ModuleFunction2 = extern "C" fn(*const crate::closure::ClosureHeader, f64, f64) -> f64;
 
-fn module_noop_function(name: &str) -> f64 {
-    let func_ptr = module_source_map_noop as *const u8;
-    crate::closure::js_register_closure_arity(func_ptr, 0);
-    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
-    crate::object::set_bound_native_closure_name(closure, name);
-    crate::value::js_nanbox_pointer(closure as i64)
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ProcessFinalizationKind {
+    Exit,
+    BeforeExit,
+}
+
+#[derive(Clone, Copy)]
+struct ProcessFinalizationEntry {
+    obj: f64,
+    callback: f64,
+    kind: ProcessFinalizationKind,
+}
+
+thread_local! {
+    static PROCESS_FINALIZATION_REGISTRY: RefCell<Vec<ProcessFinalizationEntry>> =
+        RefCell::new(Vec::new());
+    static PROCESS_FINALIZATION_BEFORE_EXIT_RAN: Cell<bool> = const { Cell::new(false) };
+    static PROCESS_FINALIZATION_EXIT_RAN: Cell<bool> = const { Cell::new(false) };
+    static PROCESS_FINALIZATION_OBJECT: Cell<f64> = const { Cell::new(0.0) };
+    static PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER: Cell<*const crate::closure::ClosureHeader> =
+        const { Cell::new(std::ptr::null()) };
+    static PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER_INSTALLED: Cell<bool> =
+        const { Cell::new(false) };
 }
 
 fn module_function1(name: &str, thunk: ModuleFunction1, length: u32) -> f64 {
@@ -374,6 +389,224 @@ fn module_function2(name: &str, thunk: ModuleFunction2, length: u32) -> f64 {
     crate::object::set_bound_native_closure_name(closure, name);
     crate::object::set_builtin_closure_length(closure as usize, length);
     crate::value::js_nanbox_pointer(closure as i64)
+}
+
+extern "C" fn process_finalization_before_exit_listener(
+    _closure: *const crate::closure::ClosureHeader,
+    _code: f64,
+) -> f64 {
+    js_process_run_finalization_before_exit();
+    undefined_value()
+}
+
+fn process_finalization_before_exit_listener_ptr() -> *const crate::closure::ClosureHeader {
+    PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER.with(|cell| {
+        let existing = cell.get();
+        if !existing.is_null() {
+            return existing;
+        }
+        let func_ptr = process_finalization_before_exit_listener as *const u8;
+        crate::closure::js_register_closure_arity(func_ptr, 1);
+        crate::closure::js_register_closure_length(func_ptr, 1);
+        let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+        crate::object::set_bound_native_closure_name(closure, "processFinalizationBeforeExit");
+        crate::object::set_builtin_closure_length(closure as usize, 1);
+        cell.set(closure);
+        closure
+    })
+}
+
+fn process_finalization_has_before_exit_entries() -> bool {
+    PROCESS_FINALIZATION_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .iter()
+            .any(|entry| entry.kind == ProcessFinalizationKind::BeforeExit)
+    })
+}
+
+fn ensure_process_finalization_before_exit_listener() {
+    let callback = process_finalization_before_exit_listener_ptr();
+    PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER_INSTALLED.with(|installed| {
+        if installed.replace(true) {
+            return;
+        }
+        crate::os::add_internal_process_listener("beforeExit", callback);
+    });
+}
+
+fn sync_process_finalization_before_exit_listener() {
+    if process_finalization_has_before_exit_entries() {
+        ensure_process_finalization_before_exit_listener();
+        return;
+    }
+    let callback = PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER.with(|cell| cell.get());
+    PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER_INSTALLED.with(|installed| {
+        if !installed.replace(false) {
+            return;
+        }
+        crate::os::remove_internal_process_listener("beforeExit", callback);
+    });
+}
+
+fn process_finalization_ref_is_valid(value: f64) -> bool {
+    if is_function_value(value) {
+        return true;
+    }
+    if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+        return false;
+    }
+    module_object_ptr(value).is_some()
+}
+
+fn validate_process_finalization_ref(value: f64) {
+    if process_finalization_ref_is_valid(value) {
+        return;
+    }
+    let message = format!(
+        "The \"obj\" argument must be of type object. Received {}",
+        crate::fs::validate::describe_received(value)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+fn process_finalization_register(kind: ProcessFinalizationKind, obj: f64, callback: f64) -> f64 {
+    validate_process_finalization_ref(obj);
+    PROCESS_FINALIZATION_REGISTRY.with(|registry| {
+        registry.borrow_mut().push(ProcessFinalizationEntry {
+            obj,
+            callback,
+            kind,
+        });
+    });
+    if kind == ProcessFinalizationKind::BeforeExit {
+        ensure_process_finalization_before_exit_listener();
+    }
+    undefined_value()
+}
+
+fn process_finalization_unregister(obj: f64) -> f64 {
+    let obj_bits = obj.to_bits();
+    PROCESS_FINALIZATION_REGISTRY.with(|registry| {
+        registry
+            .borrow_mut()
+            .retain(|entry| entry.obj.to_bits() != obj_bits);
+    });
+    sync_process_finalization_before_exit_listener();
+    undefined_value()
+}
+
+fn process_finalization_mark_ran(kind: ProcessFinalizationKind) -> bool {
+    match kind {
+        ProcessFinalizationKind::BeforeExit => {
+            PROCESS_FINALIZATION_BEFORE_EXIT_RAN.with(|ran| ran.replace(true))
+        }
+        ProcessFinalizationKind::Exit => {
+            PROCESS_FINALIZATION_EXIT_RAN.with(|ran| ran.replace(true))
+        }
+    }
+}
+
+fn process_finalization_event_name(kind: ProcessFinalizationKind) -> &'static str {
+    match kind {
+        ProcessFinalizationKind::BeforeExit => "beforeExit",
+        ProcessFinalizationKind::Exit => "exit",
+    }
+}
+
+fn run_process_finalization_callbacks(kind: ProcessFinalizationKind) {
+    if process_finalization_mark_ran(kind) {
+        return;
+    }
+    let entries = PROCESS_FINALIZATION_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .iter()
+            .filter(|entry| entry.kind == kind)
+            .copied()
+            .collect::<Vec<_>>()
+    });
+    if entries.is_empty() {
+        return;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let event_handle =
+        scope.root_nanbox_f64(module_string_value(process_finalization_event_name(kind)));
+    let handles = entries
+        .iter()
+        .map(|entry| {
+            (
+                scope.root_nanbox_f64(entry.obj),
+                scope.root_nanbox_f64(entry.callback),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for (obj_handle, callback_handle) in handles {
+        let callback = callback_handle.get_nanbox_f64();
+        if !is_function_value(callback) {
+            crate::closure::throw_not_callable();
+        }
+        let args = [obj_handle.get_nanbox_f64(), event_handle.get_nanbox_f64()];
+        unsafe {
+            crate::closure::js_native_call_value(callback, args.as_ptr(), args.len());
+        }
+    }
+}
+
+pub fn scan_process_finalization_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    PROCESS_FINALIZATION_OBJECT.with(|cell| {
+        let mut value = cell.get();
+        if value != 0.0 && visitor.visit_nanbox_f64_slot(&mut value) {
+            cell.set(value);
+        }
+    });
+    PROCESS_FINALIZATION_REGISTRY.with(|registry| {
+        for entry in registry.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut entry.obj);
+            visitor.visit_nanbox_f64_slot(&mut entry.callback);
+        }
+    });
+    PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER.with(|cell| {
+        let mut callback = cell.get();
+        if !callback.is_null() && visitor.visit_raw_const_ptr_slot(&mut callback) {
+            cell.set(callback);
+        }
+    });
+}
+
+extern "C" fn process_finalization_register_function(
+    _closure: *const crate::closure::ClosureHeader,
+    obj: f64,
+    callback: f64,
+) -> f64 {
+    process_finalization_register(ProcessFinalizationKind::Exit, obj, callback)
+}
+
+extern "C" fn process_finalization_register_before_exit_function(
+    _closure: *const crate::closure::ClosureHeader,
+    obj: f64,
+    callback: f64,
+) -> f64 {
+    process_finalization_register(ProcessFinalizationKind::BeforeExit, obj, callback)
+}
+
+extern "C" fn process_finalization_unregister_function(
+    _closure: *const crate::closure::ClosureHeader,
+    obj: f64,
+) -> f64 {
+    process_finalization_unregister(obj)
+}
+
+#[no_mangle]
+pub extern "C" fn js_process_run_finalization_before_exit() {
+    run_process_finalization_callbacks(ProcessFinalizationKind::BeforeExit);
+}
+
+#[no_mangle]
+pub extern "C" fn js_process_run_finalization_exit() {
+    run_process_finalization_callbacks(ProcessFinalizationKind::Exit);
 }
 
 fn module_array_value(items: &[&str]) -> f64 {
@@ -436,15 +669,34 @@ fn process_features_value() -> f64 {
 }
 
 fn process_finalization_value() -> f64 {
+    let cached = PROCESS_FINALIZATION_OBJECT.with(|c| c.get());
+    if cached != 0.0 {
+        return cached;
+    }
+
     let obj = crate::object::js_object_alloc(0, 3);
-    module_set_field(obj, "register", module_noop_function("register"));
+    module_set_field(
+        obj,
+        "register",
+        module_function2("register", process_finalization_register_function, 2),
+    );
     module_set_field(
         obj,
         "registerBeforeExit",
-        module_noop_function("registerBeforeExit"),
+        module_function2(
+            "registerBeforeExit",
+            process_finalization_register_before_exit_function,
+            2,
+        ),
     );
-    module_set_field(obj, "unregister", module_noop_function("unregister"));
-    module_object_value(obj)
+    module_set_field(
+        obj,
+        "unregister",
+        module_function1("unregister", process_finalization_unregister_function, 1),
+    );
+    let value = module_object_value(obj);
+    PROCESS_FINALIZATION_OBJECT.with(|c| c.set(value));
+    value
 }
 
 extern "C" fn process_report_function_get_report(

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -530,9 +530,6 @@ Behavior caveats remain around live terminal integration, readline inheritance d
 - `process.hrtime([time])`
 - `process.umask()`
 - `process.umask(mask)`
-- `process.finalization.register(ref, callback)`
-- `process.finalization.registerBeforeExit(ref, callback)`
-- `process.finalization.unregister(ref)`
 - `process.ref(maybeRefable)`
 - `process.unref(maybeRefable)`
 - `process.binding(name)`

--- a/docs/runtime-parity.md
+++ b/docs/runtime-parity.md
@@ -2298,9 +2298,9 @@ Bun status: 🟡 Mostly implemented. `process.binding` partial. `process.title` 
 | `process.permission.has(scope[, reference])` | ✓ | ⚠ |  |
 | `process.umask()` | ✓ | ✓ |  |
 | `process.umask(mask)` | ✓ | ✓ |  |
-| `process.finalization.register(ref, callback)` | ✓ | ⚠ |  |
-| `process.finalization.registerBeforeExit(ref, callback)` | ✓ | ⚠ |  |
-| `process.finalization.unregister(ref)` | ✓ | ⚠ |  |
+| `process.finalization.register(ref, callback)` | ✓ | ✓ |  |
+| `process.finalization.registerBeforeExit(ref, callback)` | ✓ | ✓ |  |
+| `process.finalization.unregister(ref)` | ✓ | ✓ |  |
 | `process.nextTick(callback[, ...args])` | ✓ | ✓ |  |
 | `process.ref(maybeRefable)` | ✓ | ⚠ |  |
 | `process.unref(maybeRefable)` | ✓ | ⚠ |  |

--- a/test-parity/node-suite/process/methods/finalization-lifecycle.ts
+++ b/test-parity/node-suite/process/methods/finalization-lifecycle.ts
@@ -1,0 +1,29 @@
+// parity-node-argv: --no-warnings
+
+const refs = {
+  before: { name: "before" },
+  exit: { name: "exit" },
+  removed: { name: "removed" },
+};
+
+process.on("beforeExit", () => {
+  console.log("event beforeExit");
+});
+
+process.finalization.registerBeforeExit(refs.before, (obj, event) => {
+  console.log("final beforeExit:", obj === refs.before, event);
+});
+process.finalization.register(refs.exit, (obj, event) => {
+  console.log("final exit:", obj === refs.exit, event);
+});
+process.finalization.registerBeforeExit(refs.removed, () => {
+  console.log("removed beforeExit");
+});
+process.finalization.register(refs.removed, () => {
+  console.log("removed exit");
+});
+
+console.log("beforeExit listener count:", process.listenerCount("beforeExit"));
+console.log("unregister removed:", process.finalization.unregister(refs.removed) === undefined);
+console.log("beforeExit listener count after unregister:", process.listenerCount("beforeExit"));
+console.log("body done");

--- a/test-parity/node-suite/process/methods/finalization-validation.ts
+++ b/test-parity/node-suite/process/methods/finalization-validation.ts
@@ -1,0 +1,50 @@
+// parity-node-argv: --no-warnings
+
+function report(label: string, run: () => unknown) {
+  try {
+    const value = run();
+    console.log(label + ":", value === undefined ? "undefined" : String(value));
+  } catch (err) {
+    const e = err as any;
+    console.log(label + ":", e.constructor.name, e.code, e.message);
+  }
+}
+
+const objectRef = { name: "object" };
+function functionRef() {}
+
+console.log("same object:", process.finalization === process.finalization);
+console.log("keys:", Object.keys(process.finalization).join(","));
+console.log(
+  "lengths:",
+  process.finalization.register.length,
+  process.finalization.registerBeforeExit.length,
+  process.finalization.unregister.length,
+);
+
+report("register object", () => {
+  const value = process.finalization.register(objectRef, 1 as any);
+  process.finalization.unregister(objectRef);
+  return value;
+});
+report("register function", () => {
+  const value = process.finalization.register(functionRef, () => {});
+  process.finalization.unregister(functionRef);
+  return value;
+});
+report("before object", () => {
+  const value = process.finalization.registerBeforeExit(objectRef, 1 as any);
+  process.finalization.unregister(objectRef);
+  return value;
+});
+report("unregister undefined", () => process.finalization.unregister(undefined as any));
+report("unregister number", () => process.finalization.unregister(1 as any));
+report("unregister array", () => process.finalization.unregister([] as any));
+
+report("register no args", () => process.finalization.register());
+report("register null", () => process.finalization.register(null as any, () => {}));
+report("register number", () => process.finalization.register(1 as any, () => {}));
+report("register boolean", () => process.finalization.register(true as any, () => {}));
+report("register string", () => process.finalization.register("x" as any, () => {}));
+report("register symbol", () => process.finalization.register(Symbol("x") as any, () => {}));
+report("register array", () => process.finalization.register([] as any, () => {}));


### PR DESCRIPTION
Closes #2523.

## What changed

Implemented the `process.finalization` lifecycle surface as a rooted singleton with callable `register`, `registerBeforeExit`, and `unregister` methods. Registrations now validate the `obj` argument like Node, keep the registry/callbacks rooted through Perry's GC scanner, and invoke callbacks with `(obj, event)` for natural shutdown and explicit `process.exit()` exit paths.

`registerBeforeExit` installs one internal `beforeExit` listener so listener count, listener ordering, and unregister cleanup match Node's observable EventEmitter behavior. The natural-exit codegen epilogue and `process.exit()` path both run exit finalizers. The stale HIR fold for `process.finalization` now routes to the live native process property, and the parity docs were updated.

## Why this cut

The three methods share one registry, validation surface, EventEmitter integration point, GC rooting story, and exit lifecycle. Splitting them would leave observable partial behavior, especially around `registerBeforeExit` listener visibility and `unregister` cleanup.

## Tests added

- `test-parity/node-suite/process/methods/finalization-lifecycle.ts`
- `test-parity/node-suite/process/methods/finalization-validation.ts`
- `test-parity/node-suite/process/methods/finalization-process-exit.ts`

## Validation

- `cargo fmt --all -- --check`
- `cargo build -q -p perry-runtime`
- `cargo build -q -p perry`
- `cargo build --release -q -p perry-runtime`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- Node 25/Perry stdout diffs for the three finalization fixtures above
- `PATH=/tmp/perry-node25-bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=target/release ./run_parity_tests.sh --suite node-suite --module process/methods --filter finalization`

The system `node` in this container is v22.22.1 without TypeScript strip support, so the focused harness run used the same Node 25.9.0 binary used for behavior probes.

## Known limitations / non-goals

Perry's broader weak-reference GC model is unchanged; registered process finalization refs remain rooted until unregister or shutdown. This PR implements the lifecycle delivery surface for registered live refs, but does not add V8-style weak-GC removal when a ref is collected before process exit.

This also stays scoped away from child-side IPC, `process.ref`/`process.unref` handle dispatch, and broader `process.exit()` EventEmitter semantics.
