### PR TITLE
[codex] fix Undici typed-array apply stack overflow

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1657,6 +1657,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::RegExpExecGroups => misc_methods::lower(ctx, expr),
         Expr::SetClear(..)
         | Expr::StringFromCodePoint(..)
+        | Expr::StringFromCharCodeSpread(..)
         | Expr::StringRaw { .. }
         | Expr::StringAt { .. }
         | Expr::StringCodePointAt { .. }

--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -402,6 +402,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let handle = blk.call(I64, "js_string_from_char_code", &[(DOUBLE, &v)]);
             Ok(nanbox_string_inline(blk, &handle))
         }
+        Expr::StringFromCharCodeSpread(o) => {
+            let v = lower_expr(ctx, o)?;
+            let blk = ctx.block();
+            let handle = blk.call(I64, "js_string_from_char_code_array", &[(DOUBLE, &v)]);
+            Ok(nanbox_string_inline(blk, &handle))
+        }
         Expr::RegExpSetLastIndex { regex, value } => {
             let r_box = lower_expr(ctx, regex)?;
             let v = lower_expr(ctx, value)?;

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -285,6 +285,7 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     // Callable String.raw(callSite, substitutionsArray) -> string (#2789)
     module.declare_function("js_string_raw", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_string_from_char_code", I64, &[DOUBLE]);
+    module.declare_function("js_string_from_char_code_array", I64, &[DOUBLE]);
     module.declare_function("js_string_char_code_at", DOUBLE, &[I64, I32]);
     module.declare_function("js_string_last_index_of", I32, &[I64, I64]);
     module.declare_function(

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -135,6 +135,7 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         | Expr::StringCoerce(_)
         | Expr::StringFromCodePoint(_)
         | Expr::StringFromCharCode(_)
+        | Expr::StringFromCharCodeSpread(_)
         | Expr::StringRaw { .. }
         | Expr::StringAt { .. }
         | Expr::RegExpSource(_)
@@ -969,6 +970,7 @@ pub(crate) fn is_definitely_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         | Expr::JsonStringifyFull(..)
         | Expr::StringFromCodePoint(_)
         | Expr::StringFromCharCode(_)
+        | Expr::StringFromCharCodeSpread(_)
         | Expr::StringRaw { .. }
         | Expr::FsReadFileSync(_)
         | Expr::FsReadFileBinary(_)
@@ -1178,6 +1180,7 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // / RegExp.source|flags — all produce string handles.
         Expr::StringFromCodePoint(_)
         | Expr::StringFromCharCode(_)
+        | Expr::StringFromCharCodeSpread(_)
         | Expr::StringRaw { .. }
         | Expr::StringAt { .. }
         | Expr::RegExpSource(_)

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -645,7 +645,7 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
             collect_assigned_locals_expr(string, assigned);
             collect_assigned_locals_expr(delimiter, assigned);
         }
-        Expr::StringFromCharCode(code) => {
+        Expr::StringFromCharCode(code) | Expr::StringFromCharCodeSpread(code) => {
             collect_assigned_locals_expr(code, assigned);
         }
         // Map operations

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1486,6 +1486,7 @@ pub enum Expr {
     // String methods
     StringSplit(Box<Expr>, Box<Expr>), // string.split(delimiter) -> string[]
     StringFromCharCode(Box<Expr>),     // String.fromCharCode(code) -> single-char string
+    StringFromCharCodeSpread(Box<Expr>), // String.fromCharCode(...arrayLike) -> string
     StringFromCodePoint(Box<Expr>),    // String.fromCodePoint(code) -> string
     StringRaw {
         // Callable String.raw(callSite, ...substitutions) — the non-tagged

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -1104,7 +1104,7 @@ pub fn transform_expr(
             transform_expr(a, js_imports, extern_func_to_js, local_name_to_js, tracker);
             transform_expr(b, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
-        Expr::StringFromCharCode(code) => {
+        Expr::StringFromCharCode(code) | Expr::StringFromCharCodeSpread(code) => {
             transform_expr(code, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
         // Map/Set methods

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1355,7 +1355,7 @@ pub(super) fn try_namespace_static_method_apply_call_bind(
             };
             if let Some(is_apply) = mode {
                 if let Some(inner) = match_namespace_static_member(ctx, outer.obj.as_ref()) {
-                    return Ok(Some(rewrite_dropping_this(ctx, call, &inner, is_apply)?));
+                    return rewrite_dropping_this(ctx, call, &inner, is_apply);
                 }
             }
         }
@@ -1432,7 +1432,7 @@ fn rewrite_dropping_this(
     call: &ast::CallExpr,
     inner: &ast::MemberExpr,
     is_apply: bool,
-) -> Result<Expr> {
+) -> Result<Option<Expr>> {
     let mut synth = call.clone();
     synth.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(inner.clone())));
     if is_apply {
@@ -1446,21 +1446,58 @@ fn rewrite_dropping_this(
                         .iter()
                         .all(|e| matches!(e, Some(eos) if eos.spread.is_none()));
                     if !clean {
-                        // Bail to the unrewritten form; the inner `<NS>.<static>`
-                        // value-read will still TypeError, but we don't pretend
-                        // to expand a non-literal apply-args array.
-                        return Ok(super::lower_call(ctx, call)?);
+                        return rewrite_dynamic_apply_spread(ctx, call, inner);
                     }
                     arr.elems.iter().filter_map(|e| e.clone()).collect()
                 }
-                _ => return Ok(super::lower_call(ctx, call)?),
+                _ => return rewrite_dynamic_apply_spread(ctx, call, inner),
             },
         };
     } else {
         // `.call(thisArg, …args)` — drop thisArg, keep the rest.
         synth.args = call.args.iter().skip(1).cloned().collect();
     }
-    Ok(super::lower_call(ctx, &synth)?)
+    Ok(Some(super::lower_call(ctx, &synth)?))
+}
+
+fn rewrite_dynamic_apply_spread(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+    inner: &ast::MemberExpr,
+) -> Result<Option<Expr>> {
+    if !namespace_static_supports_dynamic_apply_spread(inner) {
+        return Ok(None);
+    }
+    let Some(arg_array) = call.args.get(1) else {
+        return Ok(Some(super::lower_call(
+            ctx,
+            &ast::CallExpr {
+                callee: ast::Callee::Expr(Box::new(ast::Expr::Member(inner.clone()))),
+                args: Vec::new(),
+                ..call.clone()
+            },
+        )?));
+    };
+    let mut synth = call.clone();
+    synth.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(inner.clone())));
+    synth.args = vec![ast::ExprOrSpread {
+        spread: Some(call.span),
+        expr: arg_array.expr.clone(),
+    }];
+    Ok(Some(super::lower_call(ctx, &synth)?))
+}
+
+fn namespace_static_supports_dynamic_apply_spread(inner: &ast::MemberExpr) -> bool {
+    let ast::Expr::Ident(base) = inner.obj.as_ref() else {
+        return false;
+    };
+    let ast::MemberProp::Ident(prop) = &inner.prop else {
+        return false;
+    };
+    matches!(
+        (base.sym.as_ref(), prop.sym.as_ref()),
+        ("Math", "min" | "max") | ("String", "fromCharCode")
+    )
 }
 
 /// Followup to #957 / PR #959 — `Function('return this')()`.

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -982,6 +982,11 @@ pub(super) fn try_module_static_methods(
                                 // #2788: String.fromCharCode() -> "".
                                 return Ok(Ok(Expr::String(String::new())));
                             }
+                            if has_spread && args.len() == 1 {
+                                return Ok(Ok(Expr::StringFromCharCodeSpread(Box::new(
+                                    args.into_iter().next().unwrap(),
+                                ))));
+                            }
                             if args.len() == 1 {
                                 return Ok(Ok(Expr::StringFromCharCode(Box::new(
                                     args.into_iter().next().unwrap(),

--- a/crates/perry-hir/src/monomorph/driver.rs
+++ b/crates/perry-hir/src/monomorph/driver.rs
@@ -500,7 +500,7 @@ fn collect_instantiations_in_expr(
             collect_instantiations_in_expr(string, ctx, module, idx);
             collect_instantiations_in_expr(delimiter, ctx, module, idx);
         }
-        Expr::StringFromCharCode(code) => {
+        Expr::StringFromCharCode(code) | Expr::StringFromCharCodeSpread(code) => {
             collect_instantiations_in_expr(code, ctx, module, idx);
         }
         Expr::MapNew => {}

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -638,6 +638,9 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         Expr::StringFromCharCode(code) => {
             Expr::StringFromCharCode(Box::new(substitute_expr(code, substitutions)))
         }
+        Expr::StringFromCharCodeSpread(code) => {
+            Expr::StringFromCharCodeSpread(Box::new(substitute_expr(code, substitutions)))
+        }
 
         // Map operations
         Expr::MapNew => Expr::MapNew,

--- a/crates/perry-hir/src/monomorph/update_call_sites.rs
+++ b/crates/perry-hir/src/monomorph/update_call_sites.rs
@@ -432,7 +432,7 @@ fn update_call_sites_in_expr(
             update_call_sites_in_expr(string, ctx, lookup);
             update_call_sites_in_expr(delimiter, ctx, lookup);
         }
-        Expr::StringFromCharCode(code) => {
+        Expr::StringFromCharCode(code) | Expr::StringFromCharCodeSpread(code) => {
             update_call_sites_in_expr(code, ctx, lookup);
         }
         Expr::MapNew => {}

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -395,6 +395,7 @@ impl SH for Expr {
             Expr::ArrayValues(e) => { tag(h, 281); e.as_ref().hash(h); }
             Expr::StringSplit(a, b) => { tag(h, 282); a.as_ref().hash(h); b.as_ref().hash(h); }
             Expr::StringFromCharCode(e) => { tag(h, 283); e.as_ref().hash(h); }
+            Expr::StringFromCharCodeSpread(e) => { tag(h, 12048); e.as_ref().hash(h); }
             Expr::StringFromCodePoint(e) => { tag(h, 284); e.as_ref().hash(h); }
             Expr::StringRaw { call_site, substitutions } => { tag(h, 12047); call_site.as_ref().hash(h); substitutions.hash(h); }
             Expr::StringAt { string, index } => { tag(h, 285); string.as_ref().hash(h); index.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -665,7 +665,9 @@ where
                 f(v);
             }
         }
-        Expr::StringFromCharCode(v) | Expr::StringFromCodePoint(v) => {
+        Expr::StringFromCharCode(v)
+        | Expr::StringFromCharCodeSpread(v)
+        | Expr::StringFromCodePoint(v) => {
             f(v);
         }
         Expr::StringRaw {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -666,7 +666,9 @@ where
                 f(v);
             }
         }
-        Expr::StringFromCharCode(v) | Expr::StringFromCodePoint(v) => {
+        Expr::StringFromCharCode(v)
+        | Expr::StringFromCharCodeSpread(v)
+        | Expr::StringFromCodePoint(v) => {
             f(v);
         }
         Expr::StringRaw {

--- a/crates/perry-runtime/src/object/arguments.rs
+++ b/crates/perry-runtime/src/object/arguments.rs
@@ -481,6 +481,15 @@ pub extern "C" fn js_array_like_to_array(value: f64) -> *mut ArrayHeader {
         if let Some(arr) = arguments_object_to_array(raw as *const ObjectHeader) {
             return arr;
         }
+        let addr = raw as usize;
+        if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+            return crate::typedarray::typed_array_to_array(
+                raw as *const crate::typedarray::TypedArrayHeader,
+            );
+        }
+        if crate::buffer::is_registered_buffer(addr) {
+            return crate::buffer::buffer_to_array(raw as *const crate::buffer::BufferHeader);
+        }
         crate::array::clean_arr_ptr(raw as *const ArrayHeader) as *mut ArrayHeader
     }
 }

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -233,6 +233,31 @@ pub extern "C" fn js_string_from_char_code(code: f64) -> *mut StringHeader {
     js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32)
 }
 
+/// Create a string from a spread/apply argument source:
+/// `String.fromCharCode(...arrayLike)` / `String.fromCharCode.apply(_, bytes)`.
+#[no_mangle]
+pub extern "C" fn js_string_from_char_code_array(value: f64) -> *mut StringHeader {
+    let arr = crate::object::js_array_like_to_array(value);
+    if arr.is_null() {
+        return js_string_from_bytes(std::ptr::null(), 0);
+    }
+
+    let len = crate::array::js_array_length(arr) as usize;
+    if len == 0 {
+        return js_string_from_bytes(std::ptr::null(), 0);
+    }
+
+    let mut out = String::with_capacity(len);
+    for i in 0..len {
+        let unit = to_uint16(crate::array::js_array_get_f64(arr, i as u32));
+        match char::from_u32(unit as u32) {
+            Some(ch) => out.push(ch),
+            None => out.push('\u{FFFD}'),
+        }
+    }
+    js_string_from_bytes(out.as_ptr(), out.len() as u32)
+}
+
 /// Throw `RangeError: Invalid code point <n>` for `String.fromCodePoint`,
 /// matching Node's message. Rust's `f64` Display drops the trailing `.0` for
 /// integer-valued floats (`1114112.0` -> "1114112") and keeps fractional

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -47,8 +47,8 @@ pub use append::js_string_append;
 pub use base64_codec::{js_atob, js_btoa};
 pub use char_ops::{
     js_string_at, js_string_char_at, js_string_char_code_at, js_string_code_point_at,
-    js_string_from_char_code, js_string_from_code_point, js_string_index_get,
-    js_string_to_char_array,
+    js_string_from_char_code, js_string_from_char_code_array, js_string_from_code_point,
+    js_string_index_get, js_string_to_char_array,
 };
 pub use compare::{
     js_string_compare, js_string_ends_with, js_string_ends_with_at, js_string_equals,

--- a/tests/test_issue_undici_from_char_code_apply.sh
+++ b/tests/test_issue_undici_from_char_code_apply.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Regression for Undici's CJS `isomorphicDecode` path:
+# `String.fromCharCode.apply(null, Uint8Array)` must lower without recursively
+# re-entering the namespace-static `.apply` intrinsic and must materialize the
+# typed-array bytes as call arguments.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY:-$REPO_ROOT/target/release/perry}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build --release -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat > "$TMPDIR/main.js" << 'EOF'
+'use strict'
+
+const bytes = new Uint8Array([72, 101, 108, 108, 111])
+const viaApply = String.fromCharCode.apply(null, bytes)
+const viaSpread = String.fromCharCode(...bytes)
+const min = Math.min.apply(null, new Uint8Array([3, 1, 2]))
+
+if (viaApply !== 'Hello' || viaSpread !== 'Hello' || min !== 1) {
+  console.log('bad:' + viaApply + ':' + viaSpread + ':' + min)
+  process.exit(1)
+}
+
+console.log('ok:' + viaApply + ':' + min)
+EOF
+
+"$PERRY" compile --no-cache "$TMPDIR/main.js" -o "$TMPDIR/test_bin" >"$TMPDIR/compile.log" 2>&1 || {
+    echo "FAIL: compile failed"
+    sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+    exit 1
+}
+
+"$TMPDIR/test_bin" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: runtime failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q '^ok:Hello:1$' "$TMPDIR/run.log"; then
+    echo "FAIL: unexpected output"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+echo "PASS: Undici String.fromCharCode.apply typed-array regression"


### PR DESCRIPTION
## What changed

- Rewrite supported namespace-static dynamic `.apply` calls into spread calls instead of recursively re-entering the same `.apply` lowering path.
- Add `StringFromCharCodeSpread` HIR/codegen support and a runtime helper for `String.fromCharCode(...arrayLike)` / `String.fromCharCode.apply(_, typedArray)`.
- Add an end-to-end regression for the Undici `String.fromCharCode.apply(null, Uint8Array)` shape, including typed-array `Math.min.apply` coverage.

## Why

The OpenTUI/OpenCode Perry graph moved past the Undici regex parser blocker and then hit a compile-time stack overflow on Undici `isomorphicDecode`:

```js
String.fromCharCode.apply(null, input)
```

The dynamic `.apply` fallback lowered the original static `.apply` call again, so the compiler recursively re-entered the namespace-static apply rewrite until the Perry main thread stack overflowed. For the supported dynamic apply cases, the fix rewrites to a spread static call and lowers `String.fromCharCode(...arrayLike)` through a runtime helper that consumes arrays and typed arrays via existing array-like conversion.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo build --release -p perry-runtime -p perry`
- `PERRY=/Users/andrew/.codex/worktrees/perry-undici-typed-array-apply-stack/target/release/perry PERRY_RUNTIME_DIR=/Users/andrew/.codex/worktrees/perry-undici-typed-array-apply-stack/target/release tests/test_issue_undici_from_char_code_apply.sh`
- OpenTUI focused reducer with fixed Perry: `PERRY_BIN=/Users/andrew/.codex/worktrees/perry-undici-typed-array-apply-stack/target/release/perry PERRY_RUNTIME_DIR=/Users/andrew/.codex/worktrees/perry-undici-typed-array-apply-stack/target/release bun scripts/perry-runtime-blockers/undici-typed-array-apply-stack.ts --keep-temp`

Reducer result: Perry compile status 0, binary written, run status 0, stdout `ok`. The harness exits 1 because it still expects the previous stack-overflow compile failure.
