### PR TITLE
[codex] fix zlib.codes negative reverse lookups

### DIFF
--- a/crates/perry-runtime/src/node_submodules/tests.rs
+++ b/crates/perry-runtime/src/node_submodules/tests.rs
@@ -319,6 +319,14 @@ fn zlib_codes_export_resolves_to_return_code_map() {
         string_from_value(get_object_property(codes, b"-6").unwrap()).as_deref(),
         Some("Z_VERSION_ERROR")
     );
+    assert_eq!(
+        string_from_value(crate::value::js_dyn_index_get(codes, -1.0)).as_deref(),
+        Some("Z_ERRNO")
+    );
+    assert_eq!(
+        string_from_value(crate::value::js_dyn_index_get(codes, -6.0)).as_deref(),
+        Some("Z_VERSION_ERROR")
+    );
 }
 
 #[test]

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -81,16 +81,15 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
     } else {
         index as i32
     };
-    if idx_i32 < 0 {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
-    if let Some(value) = unsafe {
-        crate::object::arguments_object_get_index(
-            raw_ptr as *const crate::object::ObjectHeader,
-            idx_i32 as u32,
-        )
-    } {
-        return value;
+    if idx_i32 >= 0 {
+        if let Some(value) = unsafe {
+            crate::object::arguments_object_get_index(
+                raw_ptr as *const crate::object::ObjectHeader,
+                idx_i32 as u32,
+            )
+        } {
+            return value;
+        }
     }
     // Registry-backed Buffer (`Buffer.from(...)`, `js_buffer_alloc`, the
     // `'data'`-event chunk an http/net listener receives). These carry NO


### PR DESCRIPTION
Fixes #2688.

## Summary
- let `js_dyn_index_get` fall through negative numeric indices for object and closure receivers so numeric computed property reads use the same string-key path as JavaScript property access
- preserve the non-negative arguments fast path and the existing array/buffer negative-index behavior
- extend the `zlib.codes` runtime test to cover `codes[-1]` and `codes[-6]` in addition to string-key reads

## Root Cause
`zlib.codes` already exposed the negative reverse lookup keys as string properties, but `js_dyn_index_get` returned `undefined` for every negative numeric key before object property-key stringification could run. That made `codes["-1"]` work while `codes[-1]` did not.

## Why This PR
This is a small leaf fix for the single remaining zlib parity failure in the current Node 26 zlib suite. There were no related unclaimed `zlib.codes` gaps to batch without widening the scope beyond the property access regression.

## Validation
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=1 cargo test -p perry-runtime zlib_codes_export_resolves_to_return_code_map -- --nocapture`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=1 cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module zlib --filter constants/codes'` (`v26.3.0`, 1 pass / 0 fail)
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module zlib'` (`v26.3.0`, 57 pass / 0 fail)
- `cargo fmt --all -- --check`
- `git diff --check`

## Known Limitations
- `./scripts/check_file_size.sh` currently fails on rebased `origin/main` because `crates/perry-codegen/src/lower_call/native_table/http.rs` is 2024 lines there. This branch does not touch that file; its diff is limited to `crates/perry-runtime/src/value/dyn_index.rs` and `crates/perry-runtime/src/node_submodules/tests.rs`.

## Non-Goals
- This does not change the `zlib.codes` table contents.
- This does not add support for negative numeric indices on arrays, buffers, or other indexed storage types.
