### PR TITLE
[codex] process: implement child IPC channel surface

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -82,8 +82,11 @@ fn process_metadata_native_property(prop: &str) -> Option<Expr> {
     Some(match prop {
         "allowedNodeEnvironmentFlags"
         | "argv0"
+        | "channel"
         | "config"
+        | "connected"
         | "debugPort"
+        | "disconnect"
         | "execArgv"
         | "execPath"
         | "features"
@@ -92,6 +95,7 @@ fn process_metadata_native_property(prop: &str) -> Option<Expr> {
         | "permission"
         | "release"
         | "report"
+        | "send"
         | "sourceMapsEnabled"
         | "title" => process_native_property(prop),
         _ => return None,
@@ -273,15 +277,6 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     "stdout" => return Ok(Expr::ProcessStdout),
                     "stderr" => return Ok(Expr::ProcessStderr),
                     "env" => return Ok(Expr::ProcessEnv),
-                    // #1407 / #1397: IPC-only members. When the process
-                    // wasn't spawned with an IPC channel (the default),
-                    // Node leaves these as `undefined` rather than
-                    // exposing a dummy method/boolean. Reads here must
-                    // short-circuit to Undefined so
-                    // `typeof process.send === "undefined"` matches Node
-                    // and downstream `if (process.send)` /
-                    // `if (process.connected)` guards do the right thing.
-                    "send" | "disconnect" | "connected" => return Ok(Expr::Undefined),
                     // #1349: process.execArgv is the array of runtime CLI
                     // flags the interpreter was started with (`["--inspect",
                     // ...]` for Node). Perry binaries are AOT — there's no
@@ -496,7 +491,6 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     "version" => return Ok(Expr::ProcessVersion),
                     "versions" => return Ok(Expr::ProcessVersions),
                     "env" => return Ok(Expr::ProcessEnv),
-                    "send" | "disconnect" | "connected" => return Ok(Expr::Undefined),
                     "execArgv" => return Ok(Expr::Array(Vec::new())),
                     "release" => {
                         return Ok(Expr::Object(vec![

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -373,6 +373,7 @@ mod stdlib_pump {
         // so it runs even when perry-stdlib isn't linked. Zero-cost (one relaxed
         // atomic load) when there are no live children.
         crate::child_process::reactor::cp_reactor_pump();
+        crate::process::js_process_ipc_drain();
         let f = STDLIB_PUMP_FN.load(Ordering::Acquire);
         if !f.is_null() {
             unsafe {
@@ -406,6 +407,9 @@ mod stdlib_pump {
         // #1934: a live spawn-reactor child keeps the event loop alive even when
         // perry-stdlib isn't linked (or reports no handles).
         if crate::child_process::reactor::cp_reactor_has_live() {
+            return 1;
+        }
+        if crate::process::js_process_ipc_has_active() != 0 {
             return 1;
         }
         if crate::os::js_process_signal_has_active() != 0 {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -3303,6 +3303,14 @@ pub extern "C" fn js_object_get_field_by_name(
             if !module_name.is_empty() {
                 let property_name =
                     std::str::from_utf8(std::slice::from_raw_parts(key_ptr, key_len)).unwrap_or("");
+                if matches!(
+                    module_name,
+                    "process" | "process.namespace" | "process.default"
+                ) {
+                    if let Some(value) = crate::process::process_ipc_property(property_name) {
+                        return JSValue::from_bits(value.to_bits());
+                    }
+                }
                 if let Some(value) = native_module_own_field_by_key(obj, key) {
                     return value;
                 }

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1731,12 +1731,15 @@ const PROCESS_NAMESPACE_KEYS: &[&[u8]] = &[
     b"argv0",
     b"arch",
     b"binding",
+    b"channel",
     b"chdir",
     b"config",
+    b"connected",
     b"cpuUsage",
     b"cwd",
     b"debugPort",
     b"default",
+    b"disconnect",
     b"dlopen",
     b"domain",
     b"env",
@@ -1775,6 +1778,7 @@ const PROCESS_NAMESPACE_KEYS: &[&[u8]] = &[
     b"reallyExit",
     b"setMaxListeners",
     b"setSourceMapsEnabled",
+    b"send",
     b"sourceMapsEnabled",
     b"title",
     b"unref",
@@ -1808,11 +1812,14 @@ const PROCESS_DEFAULT_KEYS: &[&[u8]] = &[
     b"argv0",
     b"arch",
     b"binding",
+    b"channel",
     b"chdir",
     b"config",
+    b"connected",
     b"cpuUsage",
     b"cwd",
     b"debugPort",
+    b"disconnect",
     b"dlopen",
     b"domain",
     b"env",
@@ -1852,6 +1859,7 @@ const PROCESS_DEFAULT_KEYS: &[&[u8]] = &[
     b"reallyExit",
     b"setMaxListeners",
     b"setSourceMapsEnabled",
+    b"send",
     b"sourceMapsEnabled",
     b"title",
     b"uptime",
@@ -3088,6 +3096,11 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
     } else {
         module_name
     };
+    if matches!(module_name, "process" | "process.default") {
+        if let Some(value) = crate::process::process_ipc_property(property_name) {
+            return value;
+        }
+    }
     // node:perf_hooks — `performance` and `constants` are object-valued
     // exports. Resolve them to a `perf_hooks`-tagged namespace object so
     // `typeof performance === "object"`, `performance.timeOrigin` (a

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -150,6 +150,7 @@ pub(crate) unsafe fn dispatch_native_module_method(
         "path.default" => ("path", false),
         "path.posix.default" => ("path.posix", false),
         "path.win32.default" => ("path.win32", false),
+        "process.default" => ("process", false),
         "querystring.default" => ("querystring", false),
         "url.default" => ("url", false),
         "util.default" => ("util", false),
@@ -509,6 +510,10 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("process", "eventNames") => ptr_to_f64(crate::os::js_process_event_names() as *const u8),
         ("process", "setMaxListeners") => crate::os::js_process_set_max_listeners(arg(0)),
         ("process", "getMaxListeners") => crate::os::js_process_get_max_listeners(),
+        ("process", "send") => {
+            crate::process::process_ipc_send_call(arg(0), arg(1), arg(2), arg(3))
+        }
+        ("process", "disconnect") => crate::process::process_ipc_disconnect_call(),
         ("process", "emitWarning") => {
             crate::process::js_process_emit_warning(arg(0), arg(1), arg(2));
             f64::from_bits(crate::value::TAG_UNDEFINED)

--- a/crates/perry-runtime/src/os/os_process_emitter.rs
+++ b/crates/perry-runtime/src/os/os_process_emitter.rs
@@ -232,6 +232,7 @@ fn register_process_listener(
         }
     });
     sync_process_signal_listener(&event);
+    crate::process::process_ipc_note_listener(&event);
     process_namespace_value()
 }
 

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -9,11 +9,13 @@ use std::cell::{Cell, RefCell};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 mod credentials;
+mod ipc;
 pub use credentials::{
     js_process_getegid, js_process_geteuid, js_process_getgid, js_process_getgroups,
     js_process_getuid, js_process_initgroups, js_process_setegid, js_process_seteuid,
     js_process_setgid, js_process_setgroups, js_process_setuid,
 };
+pub use ipc::*;
 
 static PROCESS_UNCAUGHT_CAPTURE_CALLBACK_SET: AtomicBool = AtomicBool::new(false);
 
@@ -3611,6 +3613,7 @@ pub(crate) fn get_rss_bytes() -> u64 {
 #[no_mangle]
 pub extern "C" fn js_process_env() -> f64 {
     use std::cell::Cell;
+    ipc::process_ipc_ensure_initialized();
     thread_local! {
         static CACHED_ENV: Cell<f64> = const { Cell::new(0.0) };
     }

--- a/crates/perry-runtime/src/process/ipc.rs
+++ b/crates/perry-runtime/src/process/ipc.rs
@@ -1,0 +1,488 @@
+//! Child-side `process` IPC surface.
+//!
+//! Node initializes this from `NODE_CHANNEL_FD` during bootstrap. Perry adopts
+//! the same inherited Unix fd convention used by its `child_process.fork()`
+//! parent side and speaks newline-delimited JSON frames for this cut.
+
+use crate::closure::{
+    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
+    js_register_closure_arity, js_register_closure_length, ClosureHeader,
+};
+use crate::string::{js_string_from_bytes, StringHeader};
+use crate::value::{JSValue, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED};
+use std::collections::VecDeque;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[cfg(unix)]
+use std::io::{BufRead, Write};
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+
+enum IpcEvent {
+    Message(String),
+    Closed,
+}
+
+struct ChildIpcState {
+    initialized: bool,
+    available: bool,
+    connected: bool,
+    refed: bool,
+    disconnect_emitted: bool,
+    #[cfg(unix)]
+    send: Option<UnixStream>,
+    queue: VecDeque<IpcEvent>,
+}
+
+impl ChildIpcState {
+    fn new() -> Self {
+        Self {
+            initialized: false,
+            available: false,
+            connected: false,
+            refed: false,
+            disconnect_emitted: false,
+            #[cfg(unix)]
+            send: None,
+            queue: VecDeque::new(),
+        }
+    }
+}
+
+static CHILD_IPC: OnceLock<Mutex<ChildIpcState>> = OnceLock::new();
+
+fn ipc_state() -> &'static Mutex<ChildIpcState> {
+    CHILD_IPC.get_or_init(|| Mutex::new(ChildIpcState::new()))
+}
+
+fn ipc_lock() -> MutexGuard<'static, ChildIpcState> {
+    match ipc_state().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn undefined_value() -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+fn null_value() -> f64 {
+    f64::from_bits(TAG_NULL)
+}
+
+fn bool_value(value: bool) -> f64 {
+    f64::from_bits(if value { TAG_TRUE } else { TAG_FALSE })
+}
+
+fn object_value(obj: *mut crate::object::ObjectHeader) -> f64 {
+    f64::from_bits(JSValue::object_ptr(obj as *mut u8).bits())
+}
+
+fn set_field(obj: *mut crate::object::ObjectHeader, name: &str, value: f64) {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::object::js_object_set_field_by_name(obj, key, value);
+}
+
+type IpcFunction0 = extern "C" fn(*const ClosureHeader) -> f64;
+type IpcFunction4 = extern "C" fn(*const ClosureHeader, f64, f64, f64, f64) -> f64;
+
+fn ipc_function0(name: &str, thunk: IpcFunction0, length: u32) -> f64 {
+    let func_ptr = thunk as *const u8;
+    js_register_closure_arity(func_ptr, 0);
+    js_register_closure_length(func_ptr, length);
+    let closure = js_closure_alloc(func_ptr, 0);
+    crate::object::set_bound_native_closure_name(closure, name);
+    crate::object::set_builtin_closure_length(closure as usize, length);
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
+fn ipc_function4(name: &str, thunk: IpcFunction4, length: u32) -> f64 {
+    let func_ptr = thunk as *const u8;
+    js_register_closure_arity(func_ptr, 4);
+    js_register_closure_length(func_ptr, length);
+    let closure = js_closure_alloc(func_ptr, 0);
+    crate::object::set_bound_native_closure_name(closure, name);
+    crate::object::set_builtin_closure_length(closure as usize, length);
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
+/// Initialize the inherited child IPC channel once. This also removes Node's
+/// bootstrap-only env vars so `process.env.NODE_CHANNEL_FD` follows Node.
+pub(crate) fn process_ipc_ensure_initialized() {
+    {
+        let mut state = ipc_lock();
+        if state.initialized {
+            return;
+        }
+        state.initialized = true;
+    }
+
+    let fd_var = std::env::var("NODE_CHANNEL_FD").ok();
+    let serialization_mode =
+        std::env::var("NODE_CHANNEL_SERIALIZATION_MODE").unwrap_or_else(|_| "json".to_string());
+    std::env::remove_var("NODE_CHANNEL_FD");
+    std::env::remove_var("NODE_CHANNEL_SERIALIZATION_MODE");
+
+    #[cfg(unix)]
+    initialize_unix_ipc(fd_var, &serialization_mode);
+
+    #[cfg(not(unix))]
+    {
+        let _ = (fd_var, serialization_mode);
+    }
+}
+
+#[cfg(unix)]
+fn initialize_unix_ipc(fd_var: Option<String>, serialization_mode: &str) {
+    if serialization_mode == "advanced" {
+        return;
+    }
+    let Some(fd) = fd_var
+        .and_then(|s| s.parse::<i32>().ok())
+        .filter(|fd| *fd >= 0)
+    else {
+        return;
+    };
+
+    let stream = unsafe { UnixStream::from_raw_fd(fd) };
+    let send = match stream.try_clone() {
+        Ok(send) => send,
+        Err(_) => return,
+    };
+    spawn_ipc_reader(stream);
+
+    let mut state = ipc_lock();
+    state.available = true;
+    state.connected = true;
+    state.refed = false;
+    state.disconnect_emitted = false;
+    state.send = Some(send);
+}
+
+#[cfg(unix)]
+fn spawn_ipc_reader(sock: UnixStream) {
+    std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(sock);
+        for line in reader.lines() {
+            match line {
+                Ok(line) if !line.is_empty() => push_ipc_event(IpcEvent::Message(line)),
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+        push_ipc_event(IpcEvent::Closed);
+    });
+}
+
+fn push_ipc_event(event: IpcEvent) {
+    ipc_lock().queue.push_back(event);
+}
+
+fn ipc_is_available() -> bool {
+    ipc_lock().available
+}
+
+fn ipc_is_connected() -> bool {
+    let state = ipc_lock();
+    state.available && state.connected
+}
+
+pub(crate) fn process_ipc_property(name: &str) -> Option<f64> {
+    match name {
+        "send" | "disconnect" | "connected" | "channel" => {}
+        _ => return None,
+    }
+
+    process_ipc_ensure_initialized();
+    let available = ipc_is_available();
+    Some(match name {
+        "send" => {
+            if available {
+                ipc_function4("send", process_ipc_send_fn, 4)
+            } else {
+                undefined_value()
+            }
+        }
+        "disconnect" => {
+            if available {
+                ipc_function0("disconnect", process_ipc_disconnect_fn, 0)
+            } else {
+                undefined_value()
+            }
+        }
+        "connected" => {
+            if available {
+                bool_value(ipc_is_connected())
+            } else {
+                undefined_value()
+            }
+        }
+        "channel" => {
+            if !available {
+                undefined_value()
+            } else if ipc_is_connected() {
+                process_channel_value()
+            } else {
+                null_value()
+            }
+        }
+        _ => undefined_value(),
+    })
+}
+
+fn process_channel_value() -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    set_field(obj, "ref", ipc_function0("ref", process_channel_ref_fn, 0));
+    set_field(
+        obj,
+        "unref",
+        ipc_function0("unref", process_channel_unref_fn, 0),
+    );
+    object_value(obj)
+}
+
+extern "C" fn process_channel_ref_fn(_closure: *const ClosureHeader) -> f64 {
+    process_ipc_ensure_initialized();
+    let mut state = ipc_lock();
+    if state.available && state.connected {
+        state.refed = true;
+    }
+    undefined_value()
+}
+
+extern "C" fn process_channel_unref_fn(_closure: *const ClosureHeader) -> f64 {
+    process_ipc_ensure_initialized();
+    let mut state = ipc_lock();
+    if state.available && state.connected {
+        state.refed = false;
+    }
+    undefined_value()
+}
+
+extern "C" fn process_ipc_disconnect_fn(_closure: *const ClosureHeader) -> f64 {
+    process_ipc_disconnect_call()
+}
+
+extern "C" fn process_ipc_send_fn(
+    _closure: *const ClosureHeader,
+    message: f64,
+    a2: f64,
+    a3: f64,
+    a4: f64,
+) -> f64 {
+    process_ipc_send_call(message, a2, a3, a4)
+}
+
+pub(crate) fn process_ipc_send_call(message: f64, a2: f64, a3: f64, a4: f64) -> f64 {
+    let callback = [a4, a3, a2]
+        .into_iter()
+        .find(|v| !crate::fs::extract_closure_ptr(*v).is_null());
+    let ok = process_ipc_send_message(message);
+    if let Some(cb) = callback {
+        defer_send_callback(cb, ok);
+    }
+    bool_value(ok)
+}
+
+pub(crate) fn process_ipc_disconnect_call() -> f64 {
+    process_ipc_disconnect_local();
+    undefined_value()
+}
+
+fn process_ipc_send_message(message: f64) -> bool {
+    process_ipc_ensure_initialized();
+    if !ipc_is_connected() {
+        return false;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = message;
+        false
+    }
+
+    #[cfg(unix)]
+    {
+        let Some(frame) = json_frame(message) else {
+            return false;
+        };
+        let mut emit_disconnect = false;
+        let ok = {
+            let mut state = ipc_lock();
+            if !state.available || !state.connected {
+                false
+            } else {
+                let write_ok = state
+                    .send
+                    .as_mut()
+                    .is_some_and(|sock| sock.write_all(&frame).is_ok());
+                if write_ok {
+                    true
+                } else {
+                    state.connected = false;
+                    state.refed = false;
+                    state.send = None;
+                    if !state.disconnect_emitted {
+                        state.disconnect_emitted = true;
+                        emit_disconnect = true;
+                    }
+                    false
+                }
+            }
+        };
+        if emit_disconnect {
+            crate::os::emit_process_event("disconnect", &[]);
+        }
+        ok
+    }
+}
+
+#[cfg(unix)]
+fn json_frame(message: f64) -> Option<Vec<u8>> {
+    let sh = unsafe { crate::json::js_json_stringify(message, 0) };
+    if sh.is_null() {
+        return None;
+    }
+    let len = unsafe { (*sh).byte_len as usize };
+    let data = unsafe { (sh as *const u8).add(std::mem::size_of::<StringHeader>()) };
+    let mut line = Vec::with_capacity(len + 1);
+    line.extend_from_slice(unsafe { std::slice::from_raw_parts(data, len) });
+    line.push(b'\n');
+    Some(line)
+}
+
+fn defer_send_callback(cb: f64, ok: bool) {
+    let func_ptr = process_ipc_send_callback_thunk as *const u8;
+    js_register_closure_arity(func_ptr, 0);
+    js_register_closure_length(func_ptr, 0);
+    let deferred = js_closure_alloc(func_ptr, 2);
+    js_closure_set_capture_ptr(deferred, 0, cb.to_bits() as i64);
+    let flag = if ok { TAG_TRUE } else { TAG_FALSE };
+    js_closure_set_capture_ptr(deferred, 1, flag as i64);
+    crate::timer::js_set_immediate_callback(deferred as i64);
+}
+
+extern "C" fn process_ipc_send_callback_thunk(closure: *const ClosureHeader) -> f64 {
+    let cb = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    if crate::fs::extract_closure_ptr(cb).is_null() {
+        return undefined_value();
+    }
+    let flag = js_closure_get_capture_ptr(closure, 1) as u64;
+    let arg = if flag == TAG_TRUE {
+        null_value()
+    } else {
+        channel_closed_error()
+    };
+    let args = [arg];
+    unsafe { js_native_call_value(cb, args.as_ptr(), args.len()) };
+    undefined_value()
+}
+
+fn channel_closed_error() -> f64 {
+    let msg = js_string_from_bytes(b"Channel closed".as_ptr(), 14);
+    crate::node_submodules::register_error_code_pub(msg, "ERR_IPC_CHANNEL_CLOSED");
+    let err = crate::error::js_error_new_with_message(msg);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+fn process_ipc_disconnect_local() {
+    process_ipc_ensure_initialized();
+    #[cfg(unix)]
+    let send = {
+        let mut state = ipc_lock();
+        if !state.available {
+            return;
+        }
+        state.connected = false;
+        state.refed = false;
+        state.send.take()
+    };
+    #[cfg(unix)]
+    if let Some(sock) = send {
+        let _ = sock.shutdown(std::net::Shutdown::Both);
+    }
+
+    if mark_disconnect_emitted() {
+        crate::os::emit_process_event("disconnect", &[]);
+    }
+}
+
+fn mark_closed_from_event() -> bool {
+    let mut state = ipc_lock();
+    if !state.available {
+        return false;
+    }
+    state.connected = false;
+    state.refed = false;
+    #[cfg(unix)]
+    {
+        state.send = None;
+    }
+    if state.disconnect_emitted {
+        false
+    } else {
+        state.disconnect_emitted = true;
+        true
+    }
+}
+
+fn mark_disconnect_emitted() -> bool {
+    let mut state = ipc_lock();
+    if !state.available || state.disconnect_emitted {
+        false
+    } else {
+        state.disconnect_emitted = true;
+        true
+    }
+}
+
+pub(crate) fn process_ipc_note_listener(event: &str) {
+    if !matches!(event, "message" | "disconnect") {
+        return;
+    }
+    process_ipc_ensure_initialized();
+    let mut state = ipc_lock();
+    if state.available && state.connected {
+        state.refed = true;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_process_ipc_drain() -> i32 {
+    process_ipc_ensure_initialized();
+    let events = {
+        let mut state = ipc_lock();
+        state.queue.drain(..).collect::<Vec<_>>()
+    };
+    let mut count = 0i32;
+    for event in events {
+        match event {
+            IpcEvent::Message(json) => {
+                let sh = js_string_from_bytes(json.as_ptr(), json.len() as u32);
+                let msg = f64::from_bits(unsafe { crate::json::js_json_parse(sh) }.bits());
+                crate::os::emit_process_event("message", &[msg]);
+                count = count.saturating_add(1);
+            }
+            IpcEvent::Closed => {
+                if mark_closed_from_event() {
+                    crate::os::emit_process_event("disconnect", &[]);
+                }
+                count = count.saturating_add(1);
+            }
+        }
+    }
+    count
+}
+
+#[no_mangle]
+pub extern "C" fn js_process_ipc_has_active() -> i32 {
+    process_ipc_ensure_initialized();
+    let state = ipc_lock();
+    if state.available && state.connected && state.refed {
+        1
+    } else {
+        0
+    }
+}

--- a/test-parity/expected/child-channel.txt
+++ b/test-parity/expected/child-channel.txt
@@ -1,0 +1,19 @@
+close 0 null
+parent disconnect
+parent message reply ping
+stdout child channel object true true
+stdout child channel ref return false
+stdout child channel refs function function
+stdout child channel unref return false
+stdout child connected after disconnect false
+stdout child connected boolean true true
+stdout child direct channel type object
+stdout child direct connected true
+stdout child direct send type function
+stdout child disconnect function true true
+stdout child message ping
+stdout child ready
+stdout child send cb null
+stdout child send function true true
+stdout child send length 4
+stdout child send return true

--- a/test-parity/expected/connected.txt
+++ b/test-parity/expected/connected.txt
@@ -1,0 +1,1 @@
+connected: undefined

--- a/test-parity/expected/send-disconnect.txt
+++ b/test-parity/expected/send-disconnect.txt
@@ -1,0 +1,2 @@
+send: undefined
+disconnect: undefined

--- a/test-parity/node-suite/process/ipc/child-channel.ts
+++ b/test-parity/node-suite/process/ipc/child-channel.ts
@@ -1,0 +1,78 @@
+import { fork } from "node:child_process";
+
+const marker = "__perry_process_ipc_child__";
+const markerIndex = process.argv.indexOf(marker);
+
+if (markerIndex >= 0) {
+  const proc = process as any;
+  const keys = Object.keys(proc);
+
+  for (const key of ["send", "disconnect", "connected", "channel"]) {
+    console.log(
+      "child",
+      key,
+      typeof proc[key],
+      Object.prototype.hasOwnProperty.call(proc, key),
+      keys.includes(key),
+    );
+  }
+
+  console.log("child direct send type", typeof process.send);
+  console.log("child direct connected", (process as any).connected);
+  console.log("child direct channel type", typeof (process as any).channel);
+  console.log("child send length", proc.send.length);
+  console.log("child channel refs", typeof proc.channel.ref, typeof proc.channel.unref);
+  console.log("child channel unref return", proc.channel.unref() === proc.channel);
+  console.log("child channel ref return", proc.channel.ref() === proc.channel);
+
+  proc.on("message", (msg: any) => {
+    console.log("child message", msg && msg.kind);
+    const sendReturn = proc.send({ kind: "reply", got: msg.kind }, (err: any) => {
+      console.log("child send cb", err === null ? "null" : err?.code ?? err?.name);
+      proc.disconnect();
+      console.log("child connected after disconnect", proc.connected);
+    });
+    console.log("child send return", sendReturn);
+  });
+
+  console.log("child ready");
+} else {
+  const script = process.argv[1];
+  const modulePath = typeof script === "string" && script.endsWith(".ts") ? script : process.execPath;
+  const child = fork(modulePath, [marker], {
+    execPath: process.execPath,
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  const lines: string[] = [];
+  let sent = false;
+  const timeout = setTimeout(() => {
+    lines.push("timeout");
+    child.kill();
+  }, 3000);
+
+  child.stdout?.on("data", (chunk) => {
+    for (const line of chunk.toString().trim().split(/\n/).filter(Boolean)) {
+      lines.push("stdout " + line);
+      if (line === "child ready" && !sent) {
+        sent = true;
+        child.send({ kind: "ping" });
+      }
+    }
+  });
+  child.stderr?.on("data", (chunk) => {
+    for (const line of chunk.toString().trim().split(/\n/).filter(Boolean)) {
+      lines.push("stderr " + line);
+    }
+  });
+  child.on("message", (msg: any) => {
+    lines.push("parent message " + msg.kind + " " + msg.got);
+  });
+  child.on("disconnect", () => {
+    lines.push("parent disconnect");
+  });
+  child.on("close", (code, signal) => {
+    clearTimeout(timeout);
+    lines.push("close " + code + " " + (signal === null ? "null" : signal));
+    console.log(lines.sort().join("\n"));
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a child-side `process` IPC runtime surface initialized from `NODE_CHANNEL_FD`.
- Exposes live `process.send`, `process.disconnect`, `process.connected`, and `process.channel.ref/unref` through direct process reads and native module namespace objects.
- Drains child IPC messages through the process EventEmitter pump and keeps the loop alive only after `message`/`disconnect` listeners or explicit `channel.ref()`.
- Adds parity coverage for no-IPC reads and forked child JSON message round-trips.

Closes #2529.

## Notes

- This implements newline-delimited JSON child IPC framing. Advanced serialization and handle passing are left out of this cut.
- `NODE_CHANNEL_FD` and `NODE_CHANNEL_SERIALIZATION_MODE` are removed before `process.env` materialization to match Node bootstrap behavior.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-runtime -p perry-hir -p perry-codegen -p perry-api-manifest`
- `./run_parity_tests.sh --suite node-suite --module process --filter child-channel`
- `./run_parity_tests.sh --suite node-suite --module process --filter ipc`
- `./run_parity_tests.sh --suite node-suite --module child_process --filter fork-send-callback-closed` (local Node cannot run this `.ts` fixture; skip-only threshold failure)
- `./run_parity_tests.sh --suite node-suite --module child_process --filter fork-child-shape` (local Node cannot run this `.ts` fixture; skip-only threshold failure)
