### PR TITLE
[codex] add Node builtin manifest radar check

### DIFF
--- a/scripts/node_builtin_manifest_radar.py
+++ b/scripts/node_builtin_manifest_radar.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Check Node builtin modules against Perry's manifest and parity skiplist.
+
+The radar answers one narrow question: every builtin module reported by
+Node must either be claimed by Perry's API manifest or explicitly skiplisted
+with a reason. The parity suite directory map is included in the report so
+suite-only drift is visible while triaging manifest gaps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKIPLIST = REPO_ROOT / "scripts" / "parity-skiplist.toml"
+SUITE_DIR = REPO_ROOT / "test-parity" / "node-suite"
+
+SUITE_ALIASES = {
+    "fs-promises": "fs/promises",
+    "inspector-promises": "inspector/promises",
+}
+
+
+def normalize_module(name: str) -> str:
+    if name.startswith("node:"):
+        return name.removeprefix("node:")
+    return name
+
+
+def load_skip_modules(path: Path) -> set[str]:
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return {normalize_module(name) for name in data.get("skip-modules", {})}
+
+
+def load_manifest_modules(manifest_json: str) -> set[str]:
+    manifest = json.loads(manifest_json)
+    entries = manifest.get("entries", [])
+    return {normalize_module(entry["module"]) for entry in entries if "module" in entry}
+
+
+def load_manifest_from_perry(perry: str) -> str:
+    proc = subprocess.run(
+        [perry, "--print-api-manifest=json"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return proc.stdout
+
+
+def load_node_builtins(node: str) -> set[str]:
+    script = (
+        "console.log(JSON.stringify("
+        "require('module').builtinModules.map((m) => m.replace(/^node:/, '')).sort()"
+        "))"
+    )
+    proc = subprocess.run(
+        [node, "-e", script],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return {normalize_module(name) for name in json.loads(proc.stdout)}
+
+
+def load_suite_modules(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+
+    modules: set[str] = set()
+    for child in path.iterdir():
+        if not child.is_dir():
+            continue
+        name = SUITE_ALIASES.get(child.name, child.name)
+        modules.add(name)
+        for subdir in child.iterdir():
+            if not subdir.is_dir():
+                continue
+            candidate = f"{child.name}/{subdir.name}"
+            modules.add(SUITE_ALIASES.get(candidate, candidate))
+    return modules
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--node", default="node", help="Node executable to query")
+    parser.add_argument(
+        "--perry",
+        default=str(REPO_ROOT / "target" / "release" / "perry"),
+        help="Perry binary used to emit --print-api-manifest=json",
+    )
+    parser.add_argument(
+        "--manifest-json",
+        type=Path,
+        help="Read an existing Perry manifest JSON file instead of running --perry",
+    )
+    parser.add_argument("--skiplist", type=Path, default=SKIPLIST)
+    parser.add_argument("--suite-dir", type=Path, default=SUITE_DIR)
+    args = parser.parse_args()
+
+    node_builtins = load_node_builtins(args.node)
+    if args.manifest_json:
+        manifest_json = args.manifest_json.read_text()
+    else:
+        manifest_json = load_manifest_from_perry(args.perry)
+    manifest_modules = load_manifest_modules(manifest_json)
+    skip_modules = load_skip_modules(args.skiplist)
+    suite_modules = load_suite_modules(args.suite_dir)
+
+    unclassified = sorted(node_builtins - manifest_modules - skip_modules)
+    suite_only = sorted((node_builtins & suite_modules) - manifest_modules - skip_modules)
+
+    if unclassified:
+        print("Unclassified Node builtin modules:", file=sys.stderr)
+        for module in unclassified:
+            suite_note = " suite=yes" if module in suite_modules else " suite=no"
+            print(f"  - {module}{suite_note}", file=sys.stderr)
+        print(
+            "\nAdd a Perry API manifest entry or a scripts/parity-skiplist.toml "
+            "skip-modules reason for each module above.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "Node builtin manifest radar clean: "
+        f"{len(node_builtins)} Node builtins, "
+        f"{len(manifest_modules)} manifest modules, "
+        f"{len(skip_modules)} skiplisted modules."
+    )
+    if suite_only:
+        print(
+            "Suite-only builtins with no manifest/skiplist classification: "
+            + ", ".join(suite_only)
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/parity-skiplist.toml
+++ b/scripts/parity-skiplist.toml
@@ -44,6 +44,23 @@
 "inspector" = "V8 inspector protocol; Perry is not V8."
 "inspector/promises" = "V8 inspector protocol; Perry is not V8."
 "trace_events" = "V8 trace events; not applicable to native binaries."
+
+# Out-of-scope — Node implementation internals, not public userland modules.
+"_http_agent" = "Internal Node implementation module; not public userland API."
+"_http_client" = "Internal Node implementation module; not public userland API."
+"_http_common" = "Internal Node implementation module; not public userland API."
+"_http_incoming" = "Internal Node implementation module; not public userland API."
+"_http_outgoing" = "Internal Node implementation module; not public userland API."
+"_http_server" = "Internal Node implementation module; not public userland API."
+"_stream_duplex" = "Internal Node implementation module; not public userland API."
+"_stream_passthrough" = "Internal Node implementation module; not public userland API."
+"_stream_readable" = "Internal Node implementation module; not public userland API."
+"_stream_transform" = "Internal Node implementation module; not public userland API."
+"_stream_wrap" = "Internal Node implementation module; not public userland API."
+"_stream_writable" = "Internal Node implementation module; not public userland API."
+"_tls_common" = "Internal Node implementation module; not public userland API."
+"_tls_wrap" = "Internal Node implementation module; not public userland API."
+
 # Implemented and manifest-claimed, but not byte-parity-testable: serialize/
 # deserialize use the JSC wire format (Perry isn't V8, so the bytes differ from
 # Node's V8 format), and getHeapStatistics/getHeapSpaceStatistics/


### PR DESCRIPTION
Fixes #3699.

## Summary
- add `scripts/node_builtin_manifest_radar.py` to compare Node's `module.builtinModules` against Perry's API manifest, the parity skiplist, and node-suite directories
- classify Node underscored implementation modules (`_http_*`, `_stream_*`, `_tls_*`) in `scripts/parity-skiplist.toml` as out-of-scope internals
- include suite directory aliases for slash-module suite folders such as `fs-promises` and `inspector-promises`

## Root Cause
Current Node exposes underscored implementation modules through `module.builtinModules`. Perry should not manifest-claim those as public userland compatibility targets, but they also were not explicitly skiplisted, so a builtin-vs-manifest radar reported them as unclassified rather than intentionally out of scope.

## Why This PR
This is a narrow manifest/radar cut for #3699. It does not add runtime support for Node internal modules, and it does not revisit already-claimed public submodules.

## Validation
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=1 cargo build --release --quiet -p perry`
- `npm exec --yes --package=node@26 -- bash -lc 'node --version; python3 scripts/node_builtin_manifest_radar.py --node node --perry target/release/perry --skiplist /tmp/perry-radar-skiplist-head.toml'` (`v26.3.0`, reproduces `_http_*` / `_tls_*` unclassified modules)
- `npm exec --yes --package=node@26 -- bash -lc 'node --version; python3 scripts/node_builtin_manifest_radar.py --node node --perry target/release/perry'` (`v26.3.0`, clean: 66 Node builtins, 112 manifest modules, 20 skiplisted modules)
- `python3 -m py_compile scripts/node_builtin_manifest_radar.py`
- `cargo fmt --all -- --check`
- `git diff --check`

## Known Limitations
- `./scripts/check_file_size.sh` currently fails on rebased `origin/main` because `crates/perry-codegen/src/lower_call/native_table/http.rs` is 2024 lines. This PR does not touch that Rust file; its diff is limited to the radar script and skiplist.
- The radar checks builtin module classification only. It does not verify per-API parity behavior within already claimed modules.

## Non-Goals
- No runtime implementation for Node underscored internal modules.
- No changes to public module manifest rows.
- No parity fixture regeneration.