### PR TITLE
runtime: shared %IteratorPrototype% objects for built-in iterators

### DIFF
--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -56,6 +56,9 @@ unsafe fn alloc_iterator(arr_ptr: *mut ArrayHeader, kind: i32) -> f64 {
     js_object_set_field(obj, 1, JSValue::number(0.0));
     // Field 2: iterator kind.
     js_object_set_field(obj, 2, JSValue::number(kind as f64));
+    // Link `[[Prototype]]` to the shared `%ArrayIteratorPrototype%` singleton so
+    // `Object.getPrototypeOf(it)` and the inherited `.next` read resolve.
+    crate::object::attach_iterator_prototype(obj, ARRAY_ITERATOR_CLASS_ID);
     js_nanbox_pointer(obj as i64)
 }
 

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -238,6 +238,16 @@ pub(crate) fn array_from_spread_value(value: f64) -> *mut ArrayHeader {
             raw_ptr as *const crate::typedarray::TypedArrayHeader,
         );
     }
+    // A built-in iterator object (`arr.values()`, `map.entries()`, a String
+    // iterator, …) IS already an iterator: drive `.next()` via the class-id
+    // tower directly. These now inherit `[Symbol.iterator]` from the shared
+    // `%IteratorPrototype%`, so the symbol-method read below would resolve the
+    // inherited thunk and call it WITHOUT binding `this` — which yields a bad
+    // result. Short-circuit here to keep `Array.from(arr.values())` / `[...it]`
+    // working.
+    if is_builtin_iterator_class_id(raw_ptr) {
+        return js_iterator_to_array(value);
+    }
     // Arguments objects spread like arrays (spec:
     // `arguments[Symbol.iterator] === Array.prototype.values`).
     if crate::object::is_arguments_object(raw_ptr as *const crate::object::ObjectHeader) {
@@ -289,6 +299,33 @@ pub(crate) fn array_from_spread_value(value: f64) -> *mut ArrayHeader {
 pub extern "C" fn js_array_spread_append(dest: *mut ArrayHeader, source: f64) -> *mut ArrayHeader {
     let arr = array_from_spread_value(source);
     js_array_concat(dest, arr)
+}
+
+/// `true` when `raw_ptr` is a heap `GC_TYPE_OBJECT` whose class id is one of the
+/// built-in iterator families (array / map / set / string / buffer / iterator-
+/// helper). These dispatch `.next()` via the class-id tower in
+/// `js_native_call_method`, so they should be driven directly rather than via the
+/// (now inherited) `[Symbol.iterator]` method.
+pub(crate) fn is_builtin_iterator_class_id(raw_ptr: usize) -> bool {
+    if raw_ptr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return false;
+    }
+    unsafe {
+        let gc =
+            (raw_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return false;
+        }
+        let class_id = (*(raw_ptr as *const crate::object::ObjectHeader)).class_id;
+        matches!(
+            class_id,
+            crate::array::ARRAY_ITERATOR_CLASS_ID
+                | crate::collection_iter_object::MAP_ITERATOR_CLASS_ID
+                | crate::collection_iter_object::SET_ITERATOR_CLASS_ID
+                | crate::buffer::BUFFER_ITERATOR_CLASS_ID
+                | crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID
+        ) || class_id == crate::string::STRING_ITERATOR_CLASS_ID
+    }
 }
 
 fn is_object_like_value(value: f64) -> bool {
@@ -385,10 +422,13 @@ pub(crate) fn sync_iterator_to_array_if_not_async(iter_f64: f64) -> Option<*mut 
     if iter_ptr == 0 {
         return Some(arr);
     }
-    let iter_obj = iter_ptr as *const ObjectHeader;
+    let _iter_obj = iter_ptr as *const ObjectHeader;
 
-    let next_key = js_string_from_bytes(b"next".as_ptr(), 4);
-    let next_val = js_object_get_field_by_name(iter_obj, next_key);
+    // OWN-field only: an inherited built-in `.next` (now provided by the shared
+    // `%...IteratorPrototype%`) needs `this` bound by the class-id tower, so it
+    // must take the method-dispatch path, not the raw closure call.
+    let next_val = crate::object::js_object_get_own_field_or_undef(iter_f64, b"next".as_ptr(), 4);
+    let next_val = crate::value::JSValue::from_bits(next_val.to_bits());
     let next_f64 = unsafe { f64::from_bits(std::mem::transmute::<_, u64>(next_val)) };
     let next_ptr = if next_val.is_undefined() {
         std::ptr::null::<closure::ClosureHeader>()
@@ -499,13 +539,18 @@ pub extern "C" fn js_iterator_to_array(iter_f64: f64) -> *mut ArrayHeader {
     if iter_ptr == 0 {
         return arr;
     }
-    let iter_obj = iter_ptr as *const ObjectHeader;
+    let _iter_obj = iter_ptr as *const ObjectHeader;
 
     // Look up the "next" method on the iterator object as a stored closure
     // FIELD (the common case for generator objects / effect's `SingleShotGen`,
-    // which store `next` as an own callable property).
-    let next_key = js_string_from_bytes(b"next".as_ptr(), 4);
-    let next_val = js_object_get_field_by_name(iter_obj, next_key);
+    // which store `next` as an own callable property). Use the OWN-field getter:
+    // built-in iterators (array/map/set/string) now inherit `.next` from their
+    // shared `%...IteratorPrototype%` singleton, and that inherited thunk relies
+    // on `this` being bound by the class-id method tower — so an INHERITED
+    // `.next` must take the method-dispatch path below, not this raw
+    // closure-call (which doesn't bind `this`).
+    let next_val = crate::object::js_object_get_own_field_or_undef(iter_f64, b"next".as_ptr(), 4);
+    let next_val = crate::value::JSValue::from_bits(next_val.to_bits());
     let next_f64 = unsafe { f64::from_bits(std::mem::transmute::<_, u64>(next_val)) };
     let next_ptr = if next_val.is_undefined() {
         std::ptr::null::<closure::ClosureHeader>()
@@ -574,9 +619,11 @@ fn js_async_iterator_to_array(iter_f64: f64) -> *mut ArrayHeader {
     if iter_ptr == 0 {
         return arr;
     }
-    let iter_obj = iter_ptr as *const ObjectHeader;
-    let next_key = js_string_from_bytes(b"next".as_ptr(), 4);
-    let next_val = js_object_get_field_by_name(iter_obj, next_key);
+    let _ = iter_ptr;
+    // OWN-field only (see sync variant): inherited built-in `.next` needs the
+    // class-id method tower to bind `this`.
+    let next_val = crate::object::js_object_get_own_field_or_undef(iter_f64, b"next".as_ptr(), 4);
+    let next_val = crate::value::JSValue::from_bits(next_val.to_bits());
     let next_f64 = unsafe { f64::from_bits(std::mem::transmute::<_, u64>(next_val)) };
     let next_ptr = if next_val.is_undefined() {
         std::ptr::null::<closure::ClosureHeader>()

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -63,6 +63,7 @@ pub use self::iter_object::{
     js_array_entries_iter_obj, js_array_keys_iter_obj, js_array_values_iter_obj,
     ARRAY_ITERATOR_CLASS_ID,
 };
+pub(crate) use self::iterator::is_builtin_iterator_class_id;
 pub use self::iterator::{js_array_spread_append, js_for_of_to_array, js_iterator_to_array};
 // Issue #1572 — flatten helpers reused by `node_stream::ns_iter_flat_map`
 // so an `async function*` mapper return is driven through the iterator

--- a/crates/perry-runtime/src/collection_iter_object.rs
+++ b/crates/perry-runtime/src/collection_iter_object.rs
@@ -65,6 +65,10 @@ unsafe fn alloc_iterator(class_id: u32, coll_nanboxed: f64, kind: i32) -> f64 {
     js_object_set_field(obj, 1, JSValue::number(0.0));
     // Field 2: iterator kind.
     js_object_set_field(obj, 2, JSValue::number(kind as f64));
+    // Link `[[Prototype]]` to the shared `%MapIteratorPrototype%` /
+    // `%SetIteratorPrototype%` singleton so `Object.getPrototypeOf(it)` and the
+    // inherited `.next` read resolve.
+    crate::object::attach_iterator_prototype(obj, class_id);
     js_nanbox_pointer(obj as i64)
 }
 

--- a/crates/perry-runtime/src/object/iterator_prototypes.rs
+++ b/crates/perry-runtime/src/object/iterator_prototypes.rs
@@ -1,0 +1,269 @@
+//! Shared `%IteratorPrototype%`-style prototype singletons for the built-in
+//! iterator objects (Array / Map / Set / String iterators).
+//!
+//! test262's `verifyProperty` suite (built-ins/{Array,Map,Set,String}
+//! IteratorPrototype) requires that:
+//!   1. `Object.getPrototypeOf([][Symbol.iterator]())` returns a SHARED
+//!      singleton `%ArrayIteratorPrototype%` (the same object every call), not
+//!      the iterator instance itself.
+//!   2. `.next` is an OWN property of that prototype (the instance inherits it)
+//!      with descriptor `{ writable: true, enumerable: false, configurable: true }`.
+//!   3. `proto.next.name === "next"` (non-writable, non-enum, configurable) and
+//!      `proto.next.length === 0`.
+//!   4. Each family prototype chains up to a shared `%IteratorPrototype%` that
+//!      carries `[Symbol.iterator]` returning `this`.
+//!
+//! Design: each iterator instance (allocated in `array/iter_object.rs` and
+//! `collection_iter_object.rs` / `string_iter_object.rs`) has its `[[Prototype]]`
+//! set to the matching singleton via `prototype_chain::object_set_static_prototype`
+//! at allocation time. From there ALL existing machinery just works:
+//!   - `Object.getPrototypeOf(it)` resolves through the early
+//!     `object_static_prototype` check in `js_object_get_prototype_of`.
+//!   - `it.next` (a value READ) resolves through `resolve_inherited_field`, which
+//!     binds `this` to the instance before reading the inherited `next` closure.
+//!   - `getOwnPropertyDescriptor(proto, "next")` reads the recorded builtin
+//!     attrs off the prototype object (it's a regular `GC_TYPE_OBJECT` field).
+//!
+//! The `next` closures are thin thunks: they read `js_implicit_this_get()` and
+//! route by the receiver's class id to the existing
+//! `dispatch_{array,map,set,string}_iterator_method`. This is the ONLY behaviour
+//! addition for `proto.next.call(it)` / value-read `it.next()`; the class-id CALL
+//! fast path in `native_call_method.rs` is untouched, so `for-of`, spread, and
+//! `Array.from` keep driving `.next()` directly.
+
+use super::{
+    install_proto_method, js_object_alloc, set_builtin_property_attrs, ObjectHeader, PropertyAttrs,
+};
+use crate::value::JSValue;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+// GC-rooted singleton slots. Scanned in `object/mod.rs::scan_object_cache_roots_mut`.
+pub(crate) static ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static ARRAY_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static MAP_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static SET_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static STRING_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
+
+/// Dispatch `method` on the implicit-`this` iterator instance, routing by class
+/// id to the matching existing iterator dispatcher. Shared by the per-family
+/// `next` thunks (read as a value or invoked via `.call`) and the parent
+/// `[Symbol.iterator]` thunk. Returns a `{ value:undefined, done:true }`-ish
+/// throw when `this` is not a recognized iterator (test262 `this-not-object` /
+/// `does-not-have-...-internal-slots` brand checks).
+unsafe fn dispatch_on_implicit_this(method: &str) -> f64 {
+    let this = super::js_implicit_this_get();
+    let jv = JSValue::from_bits(this.to_bits());
+    if !jv.is_pointer() {
+        return brand_type_error(method);
+    }
+    let obj = jv.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+    if obj.is_null() || !super::is_valid_obj_ptr(obj as *const u8) {
+        return brand_type_error(method);
+    }
+    let class_id = (*obj).class_id;
+    match class_id {
+        crate::array::ARRAY_ITERATOR_CLASS_ID => {
+            crate::array::dispatch_array_iterator_method(obj, method)
+        }
+        crate::collection_iter_object::MAP_ITERATOR_CLASS_ID => {
+            crate::collection_iter_object::dispatch_map_iterator_method(obj, method)
+        }
+        crate::collection_iter_object::SET_ITERATOR_CLASS_ID => {
+            crate::collection_iter_object::dispatch_set_iterator_method(obj, method)
+        }
+        crate::string::STRING_ITERATOR_CLASS_ID => {
+            crate::string::dispatch_string_iterator_method(obj, method)
+        }
+        _ => brand_type_error(method),
+    }
+}
+
+/// TypeError thrown by an iterator-prototype method invoked on an incompatible
+/// receiver (test262's brand-check cases).
+fn brand_type_error(method: &str) -> f64 {
+    let mut msg = b"Method %IteratorPrototype%.".to_vec();
+    msg.extend_from_slice(method.as_bytes());
+    msg.extend_from_slice(b" called on incompatible receiver");
+    let h = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(h);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+// --- `next` thunks, one per family (all read implicit-this, dispatch by id) ---
+
+extern "C" fn array_iterator_next_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    unsafe { dispatch_on_implicit_this("next") }
+}
+extern "C" fn map_iterator_next_thunk(_c: *const crate::closure::ClosureHeader, _arg: f64) -> f64 {
+    unsafe { dispatch_on_implicit_this("next") }
+}
+extern "C" fn set_iterator_next_thunk(_c: *const crate::closure::ClosureHeader, _arg: f64) -> f64 {
+    unsafe { dispatch_on_implicit_this("next") }
+}
+extern "C" fn string_iterator_next_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    unsafe { dispatch_on_implicit_this("next") }
+}
+
+/// `%IteratorPrototype%[Symbol.iterator]()` returns `this` (the iterator).
+extern "C" fn iterator_proto_symbol_iterator_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    super::js_implicit_this_get()
+}
+
+/// Set `obj[Symbol.toStringTag] = tag` with the spec descriptor
+/// `{ writable:false, enumerable:false, configurable:true }`. Mirrors the
+/// generator-tower helper in `global_this.rs`.
+fn set_to_string_tag(obj: *mut ObjectHeader, tag: &str) {
+    let sym = crate::symbol::well_known_symbol("toStringTag");
+    if sym.is_null() {
+        return;
+    }
+    let tag_str = crate::string::js_string_from_bytes(tag.as_ptr(), tag.len() as u32);
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            crate::value::js_nanbox_pointer(obj as i64),
+            f64::from_bits(JSValue::pointer(sym as *const u8).bits()),
+            f64::from_bits(crate::js_nanbox_string(tag_str as i64).to_bits()),
+        );
+    }
+}
+
+/// Link `child`'s `[[Prototype]]` to `parent`.
+fn chain_to(child: *mut ObjectHeader, parent: *mut ObjectHeader) {
+    let parent_bits = crate::value::js_nanbox_pointer(parent as i64).to_bits();
+    super::prototype_chain::object_set_static_prototype(child as usize, parent_bits);
+}
+
+/// Build the shared `%IteratorPrototype%` and the four family prototypes,
+/// storing them in the GC-rooted slots. Idempotent.
+fn build_iterator_prototypes() {
+    // Shared %IteratorPrototype% — carries [Symbol.iterator] returning `this`.
+    let shared = js_object_alloc(0, 0);
+    if shared.is_null() {
+        return;
+    }
+    install_symbol_iterator(shared);
+
+    let array_proto = build_family_proto(array_iterator_next_thunk, "Array Iterator", shared);
+    let map_proto = build_family_proto(map_iterator_next_thunk, "Map Iterator", shared);
+    let set_proto = build_family_proto(set_iterator_next_thunk, "Set Iterator", shared);
+    let string_proto = build_family_proto(string_iterator_next_thunk, "String Iterator", shared);
+
+    ITERATOR_PROTOTYPE_PTR.store(shared as i64, Ordering::Release);
+    ARRAY_ITERATOR_PROTOTYPE_PTR.store(array_proto as i64, Ordering::Release);
+    MAP_ITERATOR_PROTOTYPE_PTR.store(map_proto as i64, Ordering::Release);
+    SET_ITERATOR_PROTOTYPE_PTR.store(set_proto as i64, Ordering::Release);
+    STRING_ITERATOR_PROTOTYPE_PTR.store(string_proto as i64, Ordering::Release);
+}
+
+/// Install `[Symbol.iterator]` on the shared parent as a real method whose
+/// `name`/`length` own props match the spec (`"[Symbol.iterator]"`, length 0).
+fn install_symbol_iterator(shared: *mut ObjectHeader) {
+    let func_ptr = iterator_proto_symbol_iterator_thunk as *const u8;
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return;
+    }
+    crate::closure::js_register_closure_arity(func_ptr, 0);
+    super::native_module::set_bound_native_closure_name(closure, "[Symbol.iterator]");
+    super::native_module::set_builtin_closure_length(closure as usize, 0);
+    set_builtin_property_attrs(
+        closure as usize,
+        "name".to_string(),
+        PropertyAttrs::new(false, false, true),
+    );
+    set_builtin_property_attrs(
+        closure as usize,
+        "length".to_string(),
+        PropertyAttrs::new(false, false, true),
+    );
+    let sym = crate::symbol::well_known_symbol("iterator");
+    if sym.is_null() {
+        return;
+    }
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            crate::value::js_nanbox_pointer(shared as i64),
+            f64::from_bits(JSValue::pointer(sym as *const u8).bits()),
+            crate::value::js_nanbox_pointer(closure as i64),
+        );
+    }
+}
+
+/// Allocate one family prototype with an own `next` method (spec descriptor),
+/// a `[Symbol.toStringTag]`, and `[[Prototype]] === shared %IteratorPrototype%`.
+fn build_family_proto(
+    next_thunk: extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64,
+    tag: &str,
+    shared: *mut ObjectHeader,
+) -> *mut ObjectHeader {
+    let proto = js_object_alloc(0, 0);
+    if proto.is_null() {
+        return std::ptr::null_mut();
+    }
+    // `install_proto_method` records `next` as `{ writable:true, enumerable:false,
+    // configurable:true }` and the closure's `name`/`length` as
+    // `{ writable:false, enumerable:false, configurable:true }` — exactly the
+    // spec descriptor shape test262 verifies. `.length` 0 (next takes no args).
+    install_proto_method(proto, "next", next_thunk as *const u8, 0);
+    set_to_string_tag(proto, tag);
+    chain_to(proto, shared);
+    proto
+}
+
+/// Lazily build the prototypes (idempotent). Cheap after the first call.
+pub(crate) fn ensure_iterator_prototypes() {
+    if ITERATOR_PROTOTYPE_PTR.load(Ordering::Acquire) == 0 {
+        build_iterator_prototypes();
+    }
+}
+
+/// The singleton prototype for an iterator class id, NaN-boxed, or `None` if the
+/// class id is not a built-in iterator. Used by `js_object_get_prototype_of`.
+pub(crate) fn iterator_prototype_for_class_id(class_id: u32) -> Option<f64> {
+    ensure_iterator_prototypes();
+    let slot = match class_id {
+        crate::array::ARRAY_ITERATOR_CLASS_ID => &ARRAY_ITERATOR_PROTOTYPE_PTR,
+        crate::collection_iter_object::MAP_ITERATOR_CLASS_ID => &MAP_ITERATOR_PROTOTYPE_PTR,
+        crate::collection_iter_object::SET_ITERATOR_CLASS_ID => &SET_ITERATOR_PROTOTYPE_PTR,
+        crate::string::STRING_ITERATOR_CLASS_ID => &STRING_ITERATOR_PROTOTYPE_PTR,
+        _ => return None,
+    };
+    let ptr = slot.load(Ordering::Acquire);
+    if ptr == 0 {
+        None
+    } else {
+        Some(crate::value::js_nanbox_pointer(ptr))
+    }
+}
+
+/// Set a freshly-allocated iterator instance's `[[Prototype]]` to the matching
+/// family singleton. Called from each iterator allocator so `it.next` reads and
+/// `getPrototypeOf(it)` resolve through the shared prototype. No-op for unknown
+/// class ids.
+pub(crate) fn attach_iterator_prototype(obj_ptr: *mut ObjectHeader, class_id: u32) {
+    if obj_ptr.is_null() {
+        return;
+    }
+    ensure_iterator_prototypes();
+    let slot = match class_id {
+        crate::array::ARRAY_ITERATOR_CLASS_ID => &ARRAY_ITERATOR_PROTOTYPE_PTR,
+        crate::collection_iter_object::MAP_ITERATOR_CLASS_ID => &MAP_ITERATOR_PROTOTYPE_PTR,
+        crate::collection_iter_object::SET_ITERATOR_CLASS_ID => &SET_ITERATOR_PROTOTYPE_PTR,
+        crate::string::STRING_ITERATOR_CLASS_ID => &STRING_ITERATOR_PROTOTYPE_PTR,
+        _ => return,
+    };
+    let proto_ptr = slot.load(Ordering::Acquire);
+    if proto_ptr == 0 {
+        return;
+    }
+    chain_to(obj_ptr, proto_ptr as *mut ObjectHeader);
+}

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -39,6 +39,7 @@ mod global_this_tables;
 mod groupby;
 pub(crate) mod has_own_helpers;
 mod instanceof;
+pub(crate) mod iterator_prototypes;
 mod namespace_create;
 mod native_call_method;
 mod native_module;
@@ -84,6 +85,7 @@ pub use global_this::*;
 pub(crate) use global_this_tables::*;
 pub use groupby::*;
 pub use instanceof::*;
+pub(crate) use iterator_prototypes::{attach_iterator_prototype, iterator_prototype_for_class_id};
 pub use namespace_create::*;
 pub use native_call_method::*;
 pub use native_module::*;
@@ -1394,6 +1396,18 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
     );
     visitor.visit_atomic_i64_slot(&LOCAL_STORAGE_PTR, Ordering::Acquire, Ordering::Release);
     visitor.visit_atomic_i64_slot(&SESSION_STORAGE_PTR, Ordering::Acquire, Ordering::Release);
+    // Shared `%IteratorPrototype%`-style singletons for Array/Map/Set/String
+    // iterator objects. Each iterator instance's `[[Prototype]]` points here, so
+    // these must stay live for the lifetime of any iterator.
+    for slot in [
+        &iterator_prototypes::ITERATOR_PROTOTYPE_PTR,
+        &iterator_prototypes::ARRAY_ITERATOR_PROTOTYPE_PTR,
+        &iterator_prototypes::MAP_ITERATOR_PROTOTYPE_PTR,
+        &iterator_prototypes::SET_ITERATOR_PROTOTYPE_PTR,
+        &iterator_prototypes::STRING_ITERATOR_PROTOTYPE_PTR,
+    ] {
+        visitor.visit_atomic_i64_slot(slot, Ordering::Acquire, Ordering::Release);
+    }
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -243,6 +243,43 @@ pub unsafe extern "C" fn js_native_call_method_value(
         }
     }
 
+    // `str[Symbol.iterator]()` — a primitive string carries no symbol property
+    // slot, so the symbol-property read below would return undefined. Route the
+    // well-known iterator symbol on a string receiver to the string method
+    // dispatcher, which builds a real String iterator object.
+    if is_symbol_key {
+        let iter_wk = crate::symbol::well_known_symbol("iterator");
+        let is_iterator_symbol = !iter_wk.is_null() && {
+            let iter_f64 = f64::from_bits(JSValue::pointer(iter_wk as *const u8).bits());
+            crate::symbol::sym_key_from_f64(key) == crate::symbol::sym_key_from_f64(iter_f64)
+        };
+        if is_iterator_symbol {
+            let obj_val = JSValue::from_bits(object.to_bits());
+            if obj_val.is_any_string() {
+                // `str[Symbol.iterator]()` — a primitive string carries no symbol
+                // property slot, so route to the string method dispatcher which
+                // builds a real String iterator object.
+                let name = b"Symbol.iterator";
+                return js_native_call_method(
+                    object,
+                    name.as_ptr() as *const i8,
+                    name.len(),
+                    args_ptr,
+                    args_len,
+                );
+            }
+            if obj_val.is_pointer() {
+                let obj = obj_val.as_pointer::<ObjectHeader>();
+                // `arguments[Symbol.iterator]()` — an arguments exotic object
+                // implements the Array iterator protocol but stores no symbol
+                // slot. `js_get_iterator` materializes it to an array iterator.
+                if !obj.is_null() && crate::object::is_arguments_object(obj) {
+                    return crate::symbol::js_get_iterator(object);
+                }
+            }
+        }
+    }
+
     // Non-string key: read the property value, then invoke it with `this`
     // bound to the receiver (the codegen `Expr::This` fallback reads
     // `IMPLICIT_THIS` when there's no lexical `this`).
@@ -1441,6 +1478,13 @@ pub unsafe extern "C" fn js_native_call_method(
                 "at" => {
                     return crate::string::js_string_at(s_ptr, arg_i32(0));
                 }
+                // `str[Symbol.iterator]()` returns a real String iterator object
+                // (codepoint-aware, surrogate pairs collapse to one element) so
+                // `Object.getPrototypeOf(''[Symbol.iterator]())` resolves to
+                // `%StringIteratorPrototype%` and generic `.next()` drivers work.
+                "Symbol.iterator" | "@@iterator" => {
+                    return crate::string::string_values_iter(receiver_string());
+                }
                 "charAt" => {
                     let result = crate::string::js_string_char_at(s_ptr, arg_i32(0));
                     if result.is_null() {
@@ -2441,6 +2485,12 @@ pub unsafe extern "C" fn js_native_call_method(
                     method_name,
                 );
             }
+            if (*obj).class_id == crate::string::STRING_ITERATOR_CLASS_ID {
+                return crate::string::dispatch_string_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
             // #2874: lazy iterator-helper objects (`Iterator.from(x)` and the
             // chain it produces: `.map`/`.filter`/`.take`/`.drop`/`.flatMap`/
             // `.toArray`/`.forEach`/`.reduce`/`.some`/`.every`/`.find`/`.next`).
@@ -2927,6 +2977,12 @@ pub unsafe extern "C" fn js_native_call_method(
             }
             if (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID {
                 return crate::collection_iter_object::dispatch_set_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
+            if (*obj).class_id == crate::string::STRING_ITERATOR_CLASS_ID {
+                return crate::string::dispatch_string_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,
                 );

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1595,6 +1595,16 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                     }
                     return f64::from_bits(TAG_NULL);
                 }
+                // Built-in iterator instances (Array/Map/Set/String iterators)
+                // share a `%...IteratorPrototype%` singleton. Their instances
+                // normally carry it as a recorded static prototype (returned
+                // above), but resolve by class id too so the chain holds even if
+                // the static-prototype side-table entry was dropped.
+                if (*gc).obj_type == crate::gc::GC_TYPE_OBJECT {
+                    if let Some(proto) = super::iterator_prototype_for_class_id((*obj).class_id) {
+                        return proto;
+                    }
+                }
             }
             return obj_value;
         }
@@ -1660,6 +1670,11 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                         return f64::from_bits(proto_bits);
                     }
                     return f64::from_bits(TAG_NULL);
+                }
+                if (*gc).obj_type == crate::gc::GC_TYPE_OBJECT {
+                    if let Some(proto) = super::iterator_prototype_for_class_id((*obj).class_id) {
+                        return proto;
+                    }
                 }
             }
             return obj_value;

--- a/crates/perry-runtime/src/string/iter_object.rs
+++ b/crates/perry-runtime/src/string/iter_object.rs
@@ -1,0 +1,94 @@
+//! Real String iterator objects.
+//!
+//! Node's `''[Symbol.iterator]()` returns a String Iterator OBJECT exposing a
+//! `.next()` returning `{ value, done }`, iterable via `Symbol.iterator`, whose
+//! `[[Prototype]]` is `%StringIteratorPrototype%` (chaining to the shared
+//! `%IteratorPrototype%`). test262's built-ins/StringIteratorPrototype suite
+//! checks this shape.
+//!
+//! Representation mirrors `array/iter_object.rs`: a regular `ObjectHeader` with
+//! a dedicated class id. Iteration is over Unicode CODE POINTS (surrogate pairs
+//! collapse to one element, per ECMA-262 §22.1.5), so we materialize the source
+//! string into a codepoint array once (field 0, NaN-boxed pointer so the GC
+//! scanner keeps it alive) and advance a cursor (field 1).
+//!
+//! Dispatch lives in `object/native_call_method.rs` via the class-id check next
+//! to the array iterator one.
+
+use crate::array::ArrayHeader;
+use crate::object::{js_object_alloc, js_object_get_field, js_object_set_field, ObjectHeader};
+use crate::value::{js_nanbox_get_pointer, js_nanbox_pointer, JSValue, TAG_UNDEFINED};
+use crate::StringHeader;
+
+/// Class id reserved for String iterators. Sits just past the Set iterator id
+/// (0xFFFF0008) in the 0xFFFF prefix reserved for runtime-defined classes.
+pub const STRING_ITERATOR_CLASS_ID: u32 = 0xFFFF_0009;
+
+unsafe fn alloc_iterator(cp_array: *mut ArrayHeader) -> f64 {
+    let obj = js_object_alloc(STRING_ITERATOR_CLASS_ID, 2);
+    // Field 0: backing codepoint array (NaN-boxed pointer for the GC scanner).
+    js_object_set_field(
+        obj,
+        0,
+        JSValue::from_bits(js_nanbox_pointer(cp_array as i64).to_bits()),
+    );
+    // Field 1: cursor index, starts at 0.
+    js_object_set_field(obj, 1, JSValue::number(0.0));
+    crate::object::attach_iterator_prototype(obj, STRING_ITERATOR_CLASS_ID);
+    js_nanbox_pointer(obj as i64)
+}
+
+/// `''[Symbol.iterator]()` — build a String iterator over `s`'s code points.
+/// Returns a NaN-boxed pointer to the iterator object (or undefined on null).
+pub fn string_values_iter(s: *const StringHeader) -> f64 {
+    if s.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe {
+        let cp_array = crate::array::js_array_from_string_codepoints(s);
+        alloc_iterator(cp_array)
+    }
+}
+
+/// Build the `{ value, done }` iterator-result object. Mirrors
+/// `array/iter_object.rs::make_iter_result`.
+unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
+    let obj = js_object_alloc(0, 2);
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
+    let keys = crate::array::js_array_alloc(2);
+    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
+    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
+    crate::object::js_object_set_keys(obj, keys);
+    js_object_set_field(obj, 0, value);
+    js_object_set_field(obj, 1, JSValue::bool(done));
+    js_nanbox_pointer(obj as i64)
+}
+
+/// Dispatch `.next()` / `[Symbol.iterator]()` on a String iterator object.
+pub unsafe fn dispatch_string_iterator_method(
+    iter_obj: *mut ObjectHeader,
+    method_name: &str,
+) -> f64 {
+    match method_name {
+        "next" => {
+            let backing = f64::from_bits(js_object_get_field(iter_obj, 0).bits());
+            let arr = js_nanbox_get_pointer(backing) as *const ArrayHeader;
+            let idx = f64::from_bits(js_object_get_field(iter_obj, 1).bits()) as u32;
+            let len = if arr.is_null() {
+                0
+            } else {
+                crate::array::js_array_length(arr)
+            };
+            if idx >= len {
+                return make_iter_result(JSValue::undefined(), true);
+            }
+            js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+            let elem = crate::array::js_array_get_f64(arr, idx);
+            make_iter_result(JSValue::from_bits(elem.to_bits()), false)
+        }
+        "Symbol.iterator" | "@@iterator" => js_nanbox_pointer(iter_obj as i64),
+        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -27,6 +27,7 @@ mod concat;
 mod format;
 mod intern;
 mod io;
+mod iter_object;
 mod locale;
 mod pad;
 mod raw;
@@ -72,6 +73,9 @@ pub use format::{
 };
 pub use intern::{js_string_intern, scan_intern_table_roots, scan_intern_table_roots_mut};
 pub use io::{js_string_error, js_string_print, js_string_warn};
+pub use iter_object::{
+    dispatch_string_iterator_method, string_values_iter, STRING_ITERATOR_CLASS_ID,
+};
 pub use locale::{
     js_string_to_locale_lower_case, js_string_to_locale_upper_case, js_string_validate_locales,
 };

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1731,6 +1731,20 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
             }
         }
     }
+    // A built-in iterator object (array/map/set/string/buffer/iterator-helper)
+    // IS already an iterator and returns itself from `[Symbol.iterator]`. It now
+    // INHERITS `[Symbol.iterator]` from the shared `%IteratorPrototype%`, but
+    // that inherited thunk relies on the caller binding `this`; reading + calling
+    // it here would not, yielding a bad result. Return the iterator unchanged.
+    {
+        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
+        if jsv.is_pointer() {
+            let raw = jsv.as_pointer::<u8>() as usize;
+            if crate::array::is_builtin_iterator_class_id(raw) {
+                return val_f64;
+            }
+        }
+    }
     let iter_wk = well_known_symbol("iterator");
     if !iter_wk.is_null() {
         let sym_f64 = f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());


### PR DESCRIPTION
## What

Built-in iterator objects (Array/Map/Set/String) now use real shared
`%IteratorPrototype%`-style prototype objects, so `Object.getPrototypeOf` returns
a stable singleton, `.next` is an inherited (not own-of-instance) property with
the spec-correct descriptor, and `getOwnPropertyDescriptor` sees it.

## Why

A parity sweep flagged ~50 test262 `*IteratorPrototype` failures. The root cause:
Perry dispatched iterator `.next()` via a hardcoded class-id check, with no real
prototype object — `getPrototypeOf(it)` returned the instance itself and `it.next`
read as `undefined`, so `verifyProperty` assertions aborted.

## How

- New `object/iterator_prototypes.rs`: lazily builds 5 GC-rooted singletons (shared
  `%IteratorPrototype%` parent + Array/Map/Set/String family prototypes). `next`
  installed via the existing #3143 descriptor machinery (correct `name`/`length`/
  attrs for free). Per-family `next` thunks read implicit-`this` and dispatch by
  class-id to the existing `dispatch_*_iterator_method`.
- New `string/iter_object.rs`: real codepoint-aware String iterator object.
- Each iterator instance's `[[Prototype]]` is set to its singleton, so all existing
  machinery (getPrototypeOf, inherited-field read with `this` binding,
  getOwnPropertyDescriptor) works unchanged.
- The class-id `.next()` CALL fast path (for-of / spread / Array.from) is untouched.

## Verification

- **test262 `built-ins/{Array,Map,Set,String}IteratorPrototype`: 42 → 24** runtime-fails.
  All four numbered spec requirements pass. Remaining 24 are deeper features
  (brand-check-via-`Function.prototype.call`, live arguments/collection mutation,
  boxed `new String()`) — separate root causes, not this contract.
- **Byte-identical to `node --experimental-strip-types`** on the full spec-contract
  + regression set: for-of, `[...arr]`, `Array.from(arr.values())`, `Array.from("hi")`,
  Map/Set/String for-of, manual `.next()`, prototype identity, descriptor shapes,
  instance-has-no-own-`next`, array destructuring.
- `perry-runtime` suite: 974/974 (one pre-existing cwd-dependent flake in
  `url::node_compat` — unrelated; this PR touches no url code).
- `cargo fmt --all -- --check` clean. Rebased on current main.

## Out of scope (pre-existing, confirmed on clean main)

Astral-char string spread (WTF-8) and iterator-destructuring lowering are
pre-existing bugs unrelated to prototypes — neither fixed nor worsened here.
