### PR TITLE
fix(module): restore module_noop_function for deregister hook

### DIFF
--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -396,6 +396,18 @@ thread_local! {
         const { Cell::new(false) };
 }
 
+extern "C" fn module_source_map_noop(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+fn module_noop_function(name: &str) -> f64 {
+    let func_ptr = module_source_map_noop as *const u8;
+    crate::closure::js_register_closure_arity(func_ptr, 0);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    crate::object::set_bound_native_closure_name(closure, name);
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
 fn module_function1(name: &str, thunk: ModuleFunction1, length: u32) -> f64 {
     let func_ptr = thunk as *const u8;
     crate::closure::js_register_closure_arity(func_ptr, 1);


### PR DESCRIPTION
Main is currently unbuildable: PR #4199 (process finalization hooks) removed the `module_noop_function` / `module_source_map_noop` helpers, while the earlier-merged PR #4168 (loader registration entry behavior) added a `module.deregister` noop call referencing `module_noop_function`. Both merged cleanly but together break the build (`cannot find function module_noop_function`).

This restores the two small private helpers so `deregister` keeps its #4168 noop behavior. `register`/`unregister` retain #4199's real implementations.