### PR TITLE
[codex] honor child_process stdio ignore

### DIFF
--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -17,7 +17,7 @@
 //! launches the child but reports `connected: false`.
 
 use super::*;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 /// `child_process.fork(modulePath[, args][, options])`. `module_ptr`/`args_ptr`
 /// are raw (unboxed) `StringHeader` / `ArrayHeader` pointers; `opts_ptr` is a
@@ -65,6 +65,7 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     let stdout_obj = cp_build_readable();
     let stderr_obj = cp_build_readable();
     let stdin_obj = cp_build_writable();
+    let stdio_kinds = cp_read_stdio(opts_val, 3);
 
     // spawnargs = [execPath, ...execArgv, module, ...args] (matches Node).
     let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + exec_argv.len() + 2) as u32);
@@ -100,13 +101,13 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     let cp = cp_box_ptr(cp_obj as *const u8);
     cp_install_dispose(cp);
 
-    cp_set_field(cp, b"stdout", stdout_obj);
-    cp_set_field(cp, b"stderr", stderr_obj);
-    cp_set_field(cp, b"stdin", stdin_obj);
+    cp_set_field(cp, b"stdout", cp_stdio_js_value(stdio_kinds[1], stdout_obj));
+    cp_set_field(cp, b"stderr", cp_stdio_js_value(stdio_kinds[2], stderr_obj));
+    cp_set_field(cp, b"stdin", cp_stdio_js_value(stdio_kinds[0], stdin_obj));
     let mut stdio = crate::array::js_array_alloc(4);
-    stdio = crate::array::js_array_push_f64(stdio, stdin_obj);
-    stdio = crate::array::js_array_push_f64(stdio, stdout_obj);
-    stdio = crate::array::js_array_push_f64(stdio, stderr_obj);
+    stdio = crate::array::js_array_push_f64(stdio, cp_stdio_js_value(stdio_kinds[0], stdin_obj));
+    stdio = crate::array::js_array_push_f64(stdio, cp_stdio_js_value(stdio_kinds[1], stdout_obj));
+    stdio = crate::array::js_array_push_f64(stdio, cp_stdio_js_value(stdio_kinds[2], stderr_obj));
     stdio = crate::array::js_array_push_f64(stdio, TAG_NULL_F64); // fd 3 = ipc
     cp_set_field(cp, b"stdio", cp_box_ptr(stdio as *const u8));
     cp_set_field(cp, b"exitCode", TAG_NULL_F64);
@@ -123,9 +124,7 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     command.arg(&module);
     command.args(&arg_strs);
     cp_apply_options(&mut command, opts_val);
-    command.stdin(Stdio::piped());
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
+    cp_apply_live_stdio(&mut command, &stdio_kinds);
 
     let launched = fork_launch(cp, stdout_obj, stderr_obj, stdin_obj, command, advanced);
     if !launched {

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -1379,6 +1379,63 @@ fn cp_apply_options(command: &mut Command, opts_val: f64) {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum CpStdio {
+    Pipe,
+    Ignore,
+}
+
+fn cp_stdio_kind(value: f64) -> CpStdio {
+    match cp_value_to_string(value).as_deref() {
+        Some("ignore") => CpStdio::Ignore,
+        _ => CpStdio::Pipe,
+    }
+}
+
+/// Read the deterministic live-stdio subset: `pipe` (default) and `ignore`.
+/// Other Node forms (`inherit`, numeric fds, custom streams) intentionally
+/// remain in #2555.
+pub(super) fn cp_read_stdio(opts_val: f64, fds: usize) -> Vec<CpStdio> {
+    let mut out = vec![CpStdio::Pipe; fds];
+    if cp_object_ptr(opts_val).is_none() {
+        return out;
+    }
+
+    let stdio = cp_get_field(opts_val, b"stdio");
+    if let Some(s) = cp_value_to_string(stdio) {
+        if s == "ignore" {
+            out.fill(CpStdio::Ignore);
+        }
+        return out;
+    }
+
+    let Some(arr) = cp_array_ptr(stdio) else {
+        return out;
+    };
+    let n = crate::array::js_array_length(arr).min(fds as u32);
+    for i in 0..n {
+        out[i as usize] = cp_stdio_kind(crate::array::js_array_get_f64(arr, i));
+    }
+    out
+}
+
+pub(super) fn cp_stdio_js_value(kind: CpStdio, pipe_obj: f64) -> f64 {
+    match kind {
+        CpStdio::Pipe => pipe_obj,
+        CpStdio::Ignore => TAG_NULL_F64,
+    }
+}
+
+pub(super) fn cp_apply_live_stdio(command: &mut Command, stdio: &[CpStdio]) {
+    let to_stdio = |kind: CpStdio| match kind {
+        CpStdio::Pipe => Stdio::piped(),
+        CpStdio::Ignore => Stdio::null(),
+    };
+    command.stdin(to_stdio(stdio.first().copied().unwrap_or(CpStdio::Pipe)));
+    command.stdout(to_stdio(stdio.get(1).copied().unwrap_or(CpStdio::Pipe)));
+    command.stderr(to_stdio(stdio.get(2).copied().unwrap_or(CpStdio::Pipe)));
+}
+
 /// Default shell for `{ shell: true }` (`shell: "<path>"` overrides it).
 fn cp_default_shell() -> String {
     #[cfg(windows)]

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 #[cfg(unix)]
 use std::io::BufRead;
 use std::io::{Read, Write};
-use std::process::{Child, ChildStdin, Stdio};
+use std::process::{Child, ChildStdin};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, PoisonError};
 
@@ -437,6 +437,7 @@ pub extern "C" fn js_child_process_spawn_streams(
     let stdout_obj = cp_build_readable();
     let stderr_obj = cp_build_readable();
     let stdin_obj = cp_build_writable();
+    let stdio_kinds = cp_read_stdio(opts_val, 3);
 
     // spawnargs = [command, ...args]
     let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + 1) as u32);
@@ -465,14 +466,14 @@ pub extern "C" fn js_child_process_spawn_streams(
     let cp = cp_box_ptr(cp_obj as *const u8);
     cp_install_dispose(cp);
 
-    cp_set_field(cp, b"stdout", stdout_obj);
-    cp_set_field(cp, b"stderr", stderr_obj);
-    cp_set_field(cp, b"stdin", stdin_obj);
+    cp_set_field(cp, b"stdout", cp_stdio_js_value(stdio_kinds[1], stdout_obj));
+    cp_set_field(cp, b"stderr", cp_stdio_js_value(stdio_kinds[2], stderr_obj));
+    cp_set_field(cp, b"stdin", cp_stdio_js_value(stdio_kinds[0], stdin_obj));
 
     let mut stdio = crate::array::js_array_alloc(3);
-    stdio = crate::array::js_array_push_f64(stdio, stdin_obj);
-    stdio = crate::array::js_array_push_f64(stdio, stdout_obj);
-    stdio = crate::array::js_array_push_f64(stdio, stderr_obj);
+    stdio = crate::array::js_array_push_f64(stdio, cp_stdio_js_value(stdio_kinds[0], stdin_obj));
+    stdio = crate::array::js_array_push_f64(stdio, cp_stdio_js_value(stdio_kinds[1], stdout_obj));
+    stdio = crate::array::js_array_push_f64(stdio, cp_stdio_js_value(stdio_kinds[2], stderr_obj));
     cp_set_field(cp, b"stdio", cp_box_ptr(stdio as *const u8));
 
     cp_set_field(cp, b"exitCode", TAG_NULL_F64);
@@ -484,9 +485,7 @@ pub extern "C" fn js_child_process_spawn_streams(
 
     // Build + launch the child (honoring `shell`/`cwd`/`env`), non-blocking.
     let mut command = cp_build_command(&cmd_str, &arg_strs, opts_val);
-    command.stdin(Stdio::piped());
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
+    cp_apply_live_stdio(&mut command, &stdio_kinds);
 
     match command.spawn() {
         Ok(child) => {

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -220,6 +220,10 @@ crates/perry-runtime/src/object/object_ops.rs
 # http live-message + ClientRequest header-state surface additions (#4152/#4159).
 # Splitting per message-kind family is tracked under #1435.
 crates/perry-codegen/src/lower_call/native_table/http.rs
+# child_process module root (spawn/exec/fork dispatch + reactor wiring). Crossed
+# the 2000-line gate after the stdio `'ignore'` handling additions. Splitting the
+# spawn/exec/fork families into sibling modules is tracked under #1435.
+crates/perry-runtime/src/child_process/mod.rs
 EOF
 )
 

--- a/test-parity/node-suite/child_process/async/stdio-ignore.ts
+++ b/test-parity/node-suite/child_process/async/stdio-ignore.ts
@@ -1,0 +1,47 @@
+import { fork, spawn } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function slot(value: any): string {
+  return value === null ? "null" : typeof value;
+}
+
+function report(label: string, child: any) {
+  console.log(`${label} props:`, slot(child.stdin), slot(child.stdout), slot(child.stderr));
+  console.log(`${label} stdio:`, child.stdio.map(slot).join(","));
+}
+
+function close(child: any): Promise<number | null> {
+  return new Promise((resolve) => child.on("close", (code: number | null) => resolve(code)));
+}
+
+const ignored = spawn("sh", ["-c", "printf ignored-out; printf ignored-err >&2"], {
+  stdio: "ignore",
+});
+report("spawn ignore", ignored);
+console.log("spawn ignore close:", await close(ignored));
+
+const mixed = spawn("cat", [], { stdio: ["pipe", "ignore", "ignore"] });
+report("spawn mixed", mixed);
+mixed.stdin.end("mixed-input");
+console.log("spawn mixed close:", await close(mixed));
+
+const childFile = join(tmpdir(), `perry-fork-stdio-ignore-${process.pid}.js`);
+writeFileSync(
+  childFile,
+  "process.on('message', () => { if (process.send) process.send({ ok: true }); process.exit(0); });",
+);
+
+const forked = fork(childFile, [], { stdio: ["ignore", "ignore", "ignore", "ipc"] });
+report("fork ignore", forked);
+console.log("fork channel:", typeof forked.channel);
+const message: any = await new Promise((resolve) => {
+  forked.on("message", resolve);
+  forked.send({ ping: true });
+});
+console.log("fork ipc:", message.ok);
+console.log("fork ignore close:", await close(forked));
+try {
+  unlinkSync(childFile);
+} catch {}


### PR DESCRIPTION
## Summary
- honor live `spawn()` stdio `ignore` for string and array forms by exposing ignored fd 0..2 slots as `null` and wiring them to OS null handles
- apply the same fd 0..2 handling to `fork()` while preserving fd 3 IPC/channel behavior
- add a Node parity fixture covering `stdio: "ignore"`, mixed `["pipe", "ignore", "ignore"]`, and `fork(..., { stdio: ["ignore", "ignore", "ignore", "ipc"] })`

## Notes
- Advances #2555; broader option semantics remain out of scope here.
- This branch currently includes the one-commit upstream build hotfix from #4211 because `origin/main` fails `cargo check -p perry-runtime` without `module_noop_function`. That commit can be dropped/rebased away after #4211 lands.

## Verification
- `cargo fmt --all`
- `cargo check -p perry-runtime`
- `cargo build -p perry --release --quiet`
- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=target/release perl -e 'alarm shift; exec @ARGV' 300 ./run_parity_tests.sh --suite node-suite --module child_process --filter stdio-ignore` (1 pass / 0 fail)\n- `NODE25_DIR=$(dirname "$(npx -y node@25 -p 'process.execPath')") PATH="$NODE25_DIR:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=target/release perl -e 'alarm shift; exec @ARGV' 300 ./run_parity_tests.sh --suite node-suite --module child_process --filter fork-send-callback-closed` (1 pass / 0 fail)