### PR TITLE
fix(runtime): Set instance method reads return prototype brand-checking thunk

### DIFF
--- a/crates/perry-runtime/src/object/collection_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/collection_proto_thunks.rs
@@ -65,6 +65,28 @@ fn installed_collection_method_value(
     }
 }
 
+/// Resolve a collection prototype method to the SAME brand-checking thunk value
+/// installed on `<Builtin>.prototype`. Used so reading a method off an *instance*
+/// (`const m = s.forEach`) yields the identical function object as
+/// `Set.prototype.forEach` — which (a) makes `m === Set.prototype.forEach` hold
+/// and (b) routes `m.call(badReceiver)` through the brand check that throws a
+/// `TypeError` on an incompatible `this`. Previously the instance read returned a
+/// `js_class_method_bind` closure pre-bound to the instance, so `.call(0)` kept
+/// the bound Set and silently skipped the check (test262
+/// `Set/prototype/forEach/this-not-object-throw-*`, and the Map/Set families).
+///
+/// `builtin_name` is one of `Map`/`Set`/`WeakMap`/`WeakSet`. Returns `None` for
+/// unknown names/methods so callers fall back to their existing path.
+pub(crate) fn collection_proto_method_value(builtin_name: &str, method_name: &str) -> Option<f64> {
+    let proto = super::global_this::builtin_prototype_value(builtin_name);
+    if proto.to_bits() == crate::value::TAG_UNDEFINED {
+        return None;
+    }
+    let proto_ptr = crate::value::js_nanbox_get_pointer(proto) as *mut ObjectHeader;
+    installed_collection_method_value(proto_ptr, method_name)
+        .filter(|v| v.to_bits() != crate::value::TAG_UNDEFINED)
+}
+
 /// Install the brand-checking `.prototype` methods for the collection named
 /// `builtin_name` (`Map`/`Set`/`WeakMap`/`WeakSet`). Returns `true` when
 /// `builtin_name` is one of those collections — the caller then adds the

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2663,6 +2663,21 @@ pub extern "C" fn js_object_get_field_by_name(
                     return JSValue::number(crate::set::js_set_size(s) as f64);
                 }
                 if let Some(name) = set_method_value_name(key_bytes) {
+                    // Return the SAME brand-checking thunk installed on
+                    // Set.prototype so `const m = s.forEach; m.call(badThis)`
+                    // throws a TypeError (and `m === Set.prototype.forEach`).
+                    // Falls back to the legacy instance-bound closure if the
+                    // prototype thunk isn't available.
+                    if let Ok(method_name) = std::str::from_utf8(name) {
+                        if let Some(v) =
+                            super::collection_proto_thunks::collection_proto_method_value(
+                                "Set",
+                                method_name,
+                            )
+                        {
+                            return JSValue::from_bits(v.to_bits());
+                        }
+                    }
                     let this_f64 =
                         f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
                     let result = js_class_method_bind(this_f64, name.as_ptr(), name.len());


### PR DESCRIPTION
## What

Reading a collection method off an *instance* (`const m = s.forEach`) now returns
the same brand-checking thunk installed on `Set.prototype`, so:
- `m.call(badReceiver)` throws a `TypeError` (was: silently did nothing), and
- `s.forEach === Set.prototype.forEach` holds.

## Why

The instance read resolved via `js_class_method_bind`, producing a closure
**pre-bound to the instance**. A later `m.call(0)` kept the bound Set, so the
brand check saw a valid receiver and never threw. test262's collection suites
assert exactly this (`Set/prototype/forEach/this-not-object-throw-*`,
`does-not-have-setdata-internal-slot-*`, etc.), each with a
`s.method.call(badThis)` second assertion.

## How

New `collection_proto_method_value(builtin, method)` in `collection_proto_thunks.rs`
fetches the already-installed thunk value off the `<Builtin>.prototype` singleton
(mirrors the existing `primitive_proto_method_value`). The Set instance
method-value read in `field_get_set.rs` returns that instead of the bound closure,
falling back to the legacy path if unavailable.

## Verification

- **test262 `built-ins/Set`: 103 → 26** runtime-fails of 180.
- Byte-identical to `node --experimental-strip-types`: `s.forEach.call(0)` throws
  TypeError; `s.forEach === Set.prototype.forEach`; the original failing assembled
  test exits clean.
- **No regression**: direct `s.forEach(cb)` / `s.add` / `m.forEach` (codegen
  fast path to `js_set_foreach`, separate from the value read) unaffected.
- `perry-runtime` suite 974/974 (two pre-existing flaky tests — url-cwd and a
  typed-array search — pass in isolation; this PR touches neither file).
- `cargo fmt --all -- --check` clean; file-size gate clean; rebased on main.

## Scope note

Map/WeakMap/WeakSet instance brand checks already throw correctly (they route
differently); this PR targets the Set instance-read path.
