### PR TITLE
release: bump version to 0.5.1112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1112 — release: cut v0.5.1112
+
+Distribution release tagging the accumulated work since `v0.5.1028` (1198
+commits: 852 fixes, 42 features, plus tests/docs/chore). No code changes in
+this commit — it is a clean version-bump checkpoint so the release tag points
+at a freshly-CI'd `main` HEAD. Highlights since the last published tag span
+Node.js builtin parity (crypto/webcrypto, http/http2, streams, vm, dgram,
+cluster, path), reflective builtin-prototype brand checks (#3662 family),
+typed-array prototype/constructor coverage, web stream codec constructors, and
+generational-GC evacuation fixes.
+
 ## v0.5.1111 — refactor(codegen): split native_table/http.rs (file-size gate)
 
 `crates/perry-codegen/src/lower_call/native_table/http.rs` had grown to 2024

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1111
+**Current Version:** 0.5.1112
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "base64",
@@ -4998,14 +4998,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "cc",
  "libc",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "serde",
  "serde_json",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1111"
+version = "0.5.1112"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "clap",
@@ -5119,14 +5119,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "chrono",
  "cron",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5225,14 +5225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "bytes",
  "h2",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5316,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "bson",
  "futures-util",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "image",
@@ -5419,14 +5419,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "brotli",
  "flate2",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "base64",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5638,14 +5638,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "itoa",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "block2",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "block2",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1111"
+version = "0.5.1112"
 
 [[package]]
 name = "perry-ui-test"
@@ -5734,11 +5734,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1111"
+version = "0.5.1112"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "block2",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "block2",
@@ -5770,7 +5770,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "block2",
  "libc",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "libc",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1111"
+version = "0.5.1112"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1111"
+version = "0.5.1112"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
Clean version-bump checkpoint to cut the **v0.5.1112** distribution release.

- Bumps `[workspace.package].version` 0.5.1111 → 0.5.1112 (`Cargo.toml`, `Cargo.lock`)
- Updates `**Current Version:**` in `CLAUDE.md`
- Prepends a `## v0.5.1112` block to `CHANGELOG.md`

No code changes — this exists so the release tag points at a freshly-CI'd `main` HEAD. The tag (`v0.5.1112`) and GitHub Release will be cut once this merges green.

Release spans 1198 commits since the last published tag `v0.5.1028` (852 fixes, 42 features).
