### PR TITLE
[codex] fix HTTP external symbol linking

### DIFF
--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -189,6 +189,16 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_http_agent_create_connection",             OwnerKind::Stdlib { feature: Some("http-client") }),
     ("js_http_agent_create_socket",                 OwnerKind::Stdlib { feature: Some("http-client") }),
 
+    // ── #3954: external node:http client/server surface ─────────────
+    // These native-table rows are implemented by `perry-ext-http`
+    // rather than `perry-stdlib`. They must flip the `"http"`
+    // well-known binding even when compiled-package lowering emits the
+    // call without a source-level `import "node:http"` in the entry.
+    ("js_http_request_overload",                    OwnerKind::WellKnown("http")),
+    ("js_http_get_overload",                        OwnerKind::WellKnown("http")),
+    ("js_https_request_overload",                   OwnerKind::WellKnown("http")),
+    ("js_https_get_overload",                       OwnerKind::WellKnown("http")),
+
     // ── #846: node:http server ───────────────────────────────────────
     // `perry-ext-http-server` defines `js_node_http_*`. It's pulled in
     // transitively via `perry-ext-http` (rlib dep), and the well-known
@@ -233,6 +243,46 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_node_http_server_max_requests_per_socket", OwnerKind::WellKnown("http")),
     ("js_node_http_server_set_max_requests_per_socket", OwnerKind::WellKnown("http")),
     ("js_node_http_server_set_timeout_method",      OwnerKind::WellKnown("http")),
+    ("js_node_http_im_on",                          OwnerKind::WellKnown("http")),
+    ("js_node_http_im_pause",                       OwnerKind::WellKnown("http")),
+    ("js_node_http_im_resume",                      OwnerKind::WellKnown("http")),
+    ("js_node_http_im_destroy",                     OwnerKind::WellKnown("http")),
+    ("js_node_http_im_read",                        OwnerKind::WellKnown("http")),
+    ("js_node_http_im_set_timeout",                 OwnerKind::WellKnown("http")),
+    ("js_node_http_im_method",                      OwnerKind::WellKnown("http")),
+    ("js_node_http_im_url",                         OwnerKind::WellKnown("http")),
+    ("js_node_http_im_http_version",                OwnerKind::WellKnown("http")),
+    ("js_node_http_im_complete",                    OwnerKind::WellKnown("http")),
+    ("js_node_http_im_aborted",                     OwnerKind::WellKnown("http")),
+    ("js_node_http_im_destroyed",                   OwnerKind::WellKnown("http")),
+    ("js_node_http_res_set_header_self",            OwnerKind::WellKnown("http")),
+    ("js_node_http_res_get_header",                 OwnerKind::WellKnown("http")),
+    ("js_node_http_res_remove_header",              OwnerKind::WellKnown("http")),
+    ("js_node_http_res_has_header_value",           OwnerKind::WellKnown("http")),
+    ("js_node_http_res_get_headers_json",           OwnerKind::WellKnown("http")),
+    ("js_node_http_res_get_header_names_json",      OwnerKind::WellKnown("http")),
+    ("js_node_http_res_append_header",              OwnerKind::WellKnown("http")),
+    ("js_node_http_res_set_headers",                OwnerKind::WellKnown("http")),
+    ("js_node_http_res_write_head",                 OwnerKind::WellKnown("http")),
+    ("js_node_http_res_write",                      OwnerKind::WellKnown("http")),
+    ("js_node_http_res_add_trailers",               OwnerKind::WellKnown("http")),
+    ("js_node_http_res_end",                        OwnerKind::WellKnown("http")),
+    ("js_node_http_res_flush_headers",              OwnerKind::WellKnown("http")),
+    ("js_node_http_res_cork",                       OwnerKind::WellKnown("http")),
+    ("js_node_http_res_uncork",                     OwnerKind::WellKnown("http")),
+    ("js_node_http_res_set_timeout",                OwnerKind::WellKnown("http")),
+    ("js_node_http_res_write_early_hints",          OwnerKind::WellKnown("http")),
+    ("js_node_http_res_write_continue",             OwnerKind::WellKnown("http")),
+    ("js_node_http_res_write_processing",           OwnerKind::WellKnown("http")),
+    ("js_node_http_res_on",                         OwnerKind::WellKnown("http")),
+    ("js_node_http_res_set_status",                 OwnerKind::WellKnown("http")),
+    ("js_node_http_res_get_status",                 OwnerKind::WellKnown("http")),
+    ("js_node_http_res_set_status_message",         OwnerKind::WellKnown("http")),
+    ("js_node_http_res_set_send_date",              OwnerKind::WellKnown("http")),
+    ("js_node_http_res_set_strict_content_length",  OwnerKind::WellKnown("http")),
+    ("js_node_http_res_headers_sent",               OwnerKind::WellKnown("http")),
+    ("js_node_http_res_writable_ended",             OwnerKind::WellKnown("http")),
+    ("js_node_http_res_writable_finished",          OwnerKind::WellKnown("http")),
     ("js_node_https_create_server",                 OwnerKind::WellKnown("http")),
     ("js_node_https_server_listen",                 OwnerKind::WellKnown("http")),
     ("js_node_https_server_close",                  OwnerKind::WellKnown("http")),
@@ -318,6 +368,8 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_net_socket_remove_all_listeners",          OwnerKind::WellKnown("net")),
     ("js_net_socket_listener_count",                OwnerKind::WellKnown("net")),
     ("js_net_socket_event_names",                   OwnerKind::WellKnown("net")),
+    ("js_net_socket_listeners",                     OwnerKind::WellKnown("net")),
+    ("js_net_socket_raw_listeners",                 OwnerKind::WellKnown("net")),
     ("js_net_socket_reset_and_destroy",             OwnerKind::WellKnown("net")),
     ("js_net_server_once",                          OwnerKind::WellKnown("net")),
     ("js_net_server_remove_listener",               OwnerKind::WellKnown("net")),
@@ -388,6 +440,19 @@ mod tests {
 
     static PROVIDER_TEST_LOCK: Mutex<()> = Mutex::new(());
 
+    fn assert_symbol_routes_to(symbol: &str, owner: OwnerKind) {
+        let _ = take_used_providers();
+        record_ffi_call(symbol);
+        let got = take_used_providers();
+        assert!(
+            got.contains(&owner),
+            "{} must route to {:?}, got {:?}",
+            symbol,
+            owner,
+            got
+        );
+    }
+
     // `USED_PROVIDERS` is a process-wide static; other tests in the same
     // process may concurrently insert into it via `LlBlock::call`, and these
     // module tests drain it. Serialize the explicit drain/record assertions so
@@ -456,13 +521,42 @@ mod tests {
         let _guard = PROVIDER_TEST_LOCK
             .lock()
             .expect("provider test lock poisoned");
-        let _ = take_used_providers();
-        record_ffi_call("js_node_http_create_server_with_options");
-        let got = take_used_providers();
-        assert!(
-            got.contains(&OwnerKind::WellKnown("http")),
-            "js_node_http_create_server_with_options must route to WellKnown(http), got {:?}",
-            got
+        assert_symbol_routes_to(
+            "js_node_http_create_server_with_options",
+            OwnerKind::WellKnown("http"),
         );
+    }
+
+    /// #3954 regression: HTTP-suite native-table rows can emit newer
+    /// `perry-ext-http`, `perry-ext-http-server`, or `perry-ext-net`
+    /// symbols without the module-import path being visible to collection.
+    /// Each emitted external symbol must independently flip its well-known
+    /// owner so the wrapper joins the link line.
+    #[test]
+    fn emitted_http_suite_external_symbols_route_to_owners() {
+        let _guard = PROVIDER_TEST_LOCK
+            .lock()
+            .expect("provider test lock poisoned");
+        for symbol in [
+            "js_http_request_overload",
+            "js_https_get_overload",
+            "js_node_http_im_set_timeout",
+            "js_node_http_res_cork",
+            "js_node_http_res_append_header",
+            "js_node_http_res_set_header_self",
+            "js_node_http_res_has_header_value",
+            "js_node_http_res_write_early_hints",
+            "js_node_http_res_set_send_date",
+            "js_node_http_res_set_strict_content_length",
+            "js_net_socket_listeners",
+            "js_net_socket_raw_listeners",
+        ] {
+            let owner = if symbol.starts_with("js_net_") {
+                OwnerKind::WellKnown("net")
+            } else {
+                OwnerKind::WellKnown("http")
+            };
+            assert_symbol_routes_to(symbol, owner);
+        }
     }
 }

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -1715,6 +1715,7 @@ mod force_link_http_server {
     extern "C" {
         // http server + IncomingMessage + ServerResponse entry points.
         pub fn js_node_http_create_server();
+        pub fn js_node_http_create_server_with_options();
         pub fn js_node_http_server_listen();
         pub fn js_node_http_server_listening();
         pub fn js_node_http_server_close();
@@ -1743,18 +1744,34 @@ mod force_link_http_server {
         pub fn js_node_http_res_write();
         pub fn js_node_http_res_write_head();
         pub fn js_node_http_res_set_header();
+        pub fn js_node_http_res_set_header_self();
         pub fn js_node_http_res_get_header();
         pub fn js_node_http_res_get_header_names_json();
         pub fn js_node_http_res_get_headers_json();
         pub fn js_node_http_res_has_header();
+        pub fn js_node_http_res_has_header_value();
         pub fn js_node_http_res_remove_header();
+        pub fn js_node_http_res_append_header();
+        pub fn js_node_http_res_set_headers();
         pub fn js_node_http_res_set_status();
         pub fn js_node_http_res_get_status();
         pub fn js_node_http_res_set_status_message();
+        pub fn js_node_http_res_get_status_message();
+        pub fn js_node_http_res_finished();
+        pub fn js_node_http_res_send_date();
+        pub fn js_node_http_res_set_send_date();
+        pub fn js_node_http_res_strict_content_length();
+        pub fn js_node_http_res_set_strict_content_length();
+        pub fn js_node_http_res_req_handle();
         pub fn js_node_http_res_headers_sent();
         pub fn js_node_http_res_writable_ended();
         pub fn js_node_http_res_writable_finished();
         pub fn js_node_http_res_flush_headers();
+        pub fn js_node_http_res_add_trailers();
+        pub fn js_node_http_res_cork();
+        pub fn js_node_http_res_uncork();
+        pub fn js_node_http_res_set_timeout();
+        pub fn js_node_http_res_write_early_hints();
         pub fn js_node_http_res_write_continue();
         pub fn js_node_http_res_write_processing();
         pub fn js_node_http_res_on();
@@ -1763,6 +1780,10 @@ mod force_link_http_server {
         pub fn js_node_http_im_http_version();
         pub fn js_node_http_im_headers_json();
         pub fn js_node_http_im_raw_headers_json();
+        pub fn js_node_http_im_headers_distinct_json();
+        pub fn js_node_http_im_trailers_json();
+        pub fn js_node_http_im_raw_trailers_json();
+        pub fn js_node_http_im_trailers_distinct_json();
         pub fn js_node_http_im_remote_address();
         pub fn js_node_http_im_remote_port();
         pub fn js_node_http_im_on();
@@ -1773,6 +1794,7 @@ mod force_link_http_server {
         pub fn js_node_http_im_complete();
         pub fn js_node_http_im_destroy();
         pub fn js_node_http_im_destroyed();
+        pub fn js_node_http_im_set_timeout();
         // https server.
         pub fn js_node_https_create_server();
         pub fn js_node_https_server_listen();
@@ -1819,6 +1841,7 @@ static FORCE_LINK_HTTP_SERVER: &[unsafe extern "C" fn()] = {
     use force_link_http_server::*;
     &[
         js_node_http_create_server,
+        js_node_http_create_server_with_options,
         js_node_http_server_listen,
         js_node_http_server_listening,
         js_node_http_server_close,
@@ -1847,18 +1870,34 @@ static FORCE_LINK_HTTP_SERVER: &[unsafe extern "C" fn()] = {
         js_node_http_res_write,
         js_node_http_res_write_head,
         js_node_http_res_set_header,
+        js_node_http_res_set_header_self,
         js_node_http_res_get_header,
         js_node_http_res_get_header_names_json,
         js_node_http_res_get_headers_json,
         js_node_http_res_has_header,
+        js_node_http_res_has_header_value,
         js_node_http_res_remove_header,
+        js_node_http_res_append_header,
+        js_node_http_res_set_headers,
         js_node_http_res_set_status,
         js_node_http_res_get_status,
         js_node_http_res_set_status_message,
+        js_node_http_res_get_status_message,
+        js_node_http_res_finished,
+        js_node_http_res_send_date,
+        js_node_http_res_set_send_date,
+        js_node_http_res_strict_content_length,
+        js_node_http_res_set_strict_content_length,
+        js_node_http_res_req_handle,
         js_node_http_res_headers_sent,
         js_node_http_res_writable_ended,
         js_node_http_res_writable_finished,
         js_node_http_res_flush_headers,
+        js_node_http_res_add_trailers,
+        js_node_http_res_cork,
+        js_node_http_res_uncork,
+        js_node_http_res_set_timeout,
+        js_node_http_res_write_early_hints,
         js_node_http_res_write_continue,
         js_node_http_res_write_processing,
         js_node_http_res_on,
@@ -1867,6 +1906,10 @@ static FORCE_LINK_HTTP_SERVER: &[unsafe extern "C" fn()] = {
         js_node_http_im_http_version,
         js_node_http_im_headers_json,
         js_node_http_im_raw_headers_json,
+        js_node_http_im_headers_distinct_json,
+        js_node_http_im_trailers_json,
+        js_node_http_im_raw_trailers_json,
+        js_node_http_im_trailers_distinct_json,
         js_node_http_im_remote_address,
         js_node_http_im_remote_port,
         js_node_http_im_on,
@@ -1877,6 +1920,7 @@ static FORCE_LINK_HTTP_SERVER: &[unsafe extern "C" fn()] = {
         js_node_http_im_complete,
         js_node_http_im_destroy,
         js_node_http_im_destroyed,
+        js_node_http_im_set_timeout,
         js_node_https_create_server,
         js_node_https_server_listen,
         js_node_https_server_close,

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -72,6 +72,13 @@ pub(super) fn build_optimized_libs(
     format: OutputFormat,
     verbose: u8,
 ) -> OptimizedLibs {
+    let use_well_known = std::env::var_os("PERRY_DISABLE_WELL_KNOWN").is_none();
+    let mut iteration_set: std::collections::BTreeSet<String> =
+        ctx.native_module_imports.iter().cloned().collect();
+    if ctx.uses_fetch && !iteration_set.contains("fetch") && !iteration_set.contains("node-fetch") {
+        iteration_set.insert("fetch".to_string());
+    }
+
     // `PERRY_NO_AUTO_OPTIMIZE=1` — opt out of the per-app feature-set
     // specialization and use the prebuilt `target/release/libperry_*.a`
     // built with the default `full` feature set. Used by CI doc-tests
@@ -81,11 +88,13 @@ pub(super) fn build_optimized_libs(
     // to a different `target/perry-auto-<hash>` cache dir). Trades
     // binary size for ~80% wall-time reduction on doc-tests.
     //
-    // Returning `OptimizedLibs::empty()` makes the link path fall
-    // through to `find_runtime_library` / `find_stdlib_library`,
-    // which probe `target/release/` and `target/<target-triple>/release/`
-    // in that order. The workflow's prebuild step is responsible for
-    // making sure those paths exist.
+    // The runtime/stdlib link path still falls through to
+    // `find_runtime_library` / `find_stdlib_library`, which probe
+    // `target/release/` and `target/<target-triple>/release/`. Keep the
+    // well-known wrapper lookup active, though: native-table rows such
+    // as `http.request(...)` and `http.createServer(...)` emit symbols
+    // owned by `perry-ext-http`, and the full prebuilt stdlib does not
+    // define those wrapper-only entry points.
     if std::env::var_os("PERRY_NO_AUTO_OPTIMIZE").is_some() {
         if matches!(format, OutputFormat::Text) && verbose > 0 {
             eprintln!(
@@ -93,7 +102,15 @@ pub(super) fn build_optimized_libs(
                  using prebuilt target/release/libperry_*.a"
             );
         }
-        return OptimizedLibs::empty();
+        let well_known_libs = if use_well_known {
+            resolve_prebuilt_ext_libs(&iteration_set, target, format, verbose)
+        } else {
+            Vec::new()
+        };
+        return OptimizedLibs {
+            well_known_libs,
+            ..OptimizedLibs::empty()
+        };
     }
     // (compute_required_features + features_to_cargo_arg imported at module top)
     let mut features = compute_required_features(
@@ -133,7 +150,6 @@ pub(super) fn build_optimized_libs(
     // each entry falls back to the perry-stdlib copy individually
     // (logged with `well-known: skipping` when verbose), so a
     // partially-built workspace still produces a working binary.
-    let use_well_known = std::env::var_os("PERRY_DISABLE_WELL_KNOWN").is_none();
     let mut well_known_libs: Vec<PathBuf> = Vec::new();
     // #507 — wrappers whose own crate-level `[dependencies]` pull tokio
     // (TcpStream, hyper, reqwest, mongodb, sqlx, tokio-tungstenite,
@@ -177,11 +193,6 @@ pub(super) fn build_optimized_libs(
     // perry-ext-fetch into the link line. The `'fetch'` binding strips
     // no perry-stdlib feature (see stdlib_features.rs — fetch falls
     // through to `_ => &[]`), so this is a pure-add.
-    let mut iteration_set: std::collections::BTreeSet<String> =
-        ctx.native_module_imports.iter().cloned().collect();
-    if ctx.uses_fetch && !iteration_set.contains("fetch") && !iteration_set.contains("node-fetch") {
-        iteration_set.insert("fetch".to_string());
-    }
     if use_well_known {
         for module in &iteration_set {
             let module_normalized = module.strip_prefix("node:").unwrap_or(module);


### PR DESCRIPTION
## Summary

This addresses the HTTP compile/linking portion of #3954.

- Register emitted `node:http` / `node:https` client and server wrapper symbols with the `http` well-known owner so native-table lowering pulls `perry-ext-http` into the link line.
- Register the HTTP agent socket listener helpers with the `net` well-known owner so `perry-ext-net` is linked for those emitted symbols.
- Keep well-known prebuilt wrapper resolution active under `PERRY_NO_AUTO_OPTIMIZE=1`, while still letting runtime/stdlib fall back to the prebuilt full archives.
- Extend the `perry-ext-http` force-link anchor so the archive retains newer HTTP server/IncomingMessage/ServerResponse entry points.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p perry-codegen emitted_http_suite_external_symbols_route_to_owners -- --nocapture`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib -p perry-ext-http -p perry-ext-net`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module http'`
  - Node `v26.3.0`
  - `5` parity pass / `12` parity fail / `0` compile fail / `0` skipped
  - report: `test-parity/reports/parity_report_20260603_055225.json`
  - nonzero exit is from the parity threshold; remaining failures are output/behavior mismatches, not compile/link failures
- `nm -g target/release/libperry_ext_http.a` spot-checks show representative HTTP symbols present.
- `nm -g target/release/libperry_ext_net.a` spot-checks show representative net socket listener symbols present.
