### PR TITLE
Preserve generator call this binding

### DIFF
--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -1,6 +1,7 @@
 //! Generator-function state-machine lowering and async step-driver construction.
 
 use super::*;
+use perry_hir::walker::walk_expr_children;
 
 /// Transform a single generator function into a state machine.
 pub fn transform_generator_function(
@@ -39,6 +40,10 @@ pub fn transform_generator_function_with_extra_captures(
     captures_this: bool,
     enclosing_class: Option<String>,
 ) {
+    // Generator bodies run later inside synthesized step closures, so direct
+    // `this` reads need the receiver from the original generator call.
+    let captures_this = captures_this || generator_body_uses_call_this(&func.body);
+
     // Remember whether this was an async generator (`async function*`).
     // Async generators are still lowered via the same state-machine
     // transform, but:
@@ -597,6 +602,106 @@ pub fn transform_generator_function_with_extra_captures(
 
     func.body = new_body;
     func.is_generator = false;
+}
+
+fn generator_body_uses_call_this(body: &[Stmt]) -> bool {
+    body.iter().any(generator_stmt_uses_call_this)
+}
+
+fn generator_stmt_uses_call_this(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Let {
+            init: Some(expr), ..
+        } => generator_expr_uses_call_this(expr),
+        Stmt::Let { init: None, .. } => false,
+        Stmt::Expr(expr) | Stmt::Return(Some(expr)) | Stmt::Throw(expr) => {
+            generator_expr_uses_call_this(expr)
+        }
+        Stmt::Return(None)
+        | Stmt::Break
+        | Stmt::Continue
+        | Stmt::LabeledBreak(_)
+        | Stmt::LabeledContinue(_)
+        | Stmt::PreallocateBoxes(_) => false,
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            generator_expr_uses_call_this(condition)
+                || then_branch.iter().any(generator_stmt_uses_call_this)
+                || else_branch
+                    .as_ref()
+                    .is_some_and(|body| body.iter().any(generator_stmt_uses_call_this))
+        }
+        Stmt::While { condition, body } => {
+            generator_expr_uses_call_this(condition)
+                || body.iter().any(generator_stmt_uses_call_this)
+        }
+        Stmt::DoWhile { body, condition } => {
+            body.iter().any(generator_stmt_uses_call_this)
+                || generator_expr_uses_call_this(condition)
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            init.as_ref()
+                .is_some_and(|stmt| generator_stmt_uses_call_this(stmt))
+                || condition
+                    .as_ref()
+                    .is_some_and(generator_expr_uses_call_this)
+                || update.as_ref().is_some_and(generator_expr_uses_call_this)
+                || body.iter().any(generator_stmt_uses_call_this)
+        }
+        Stmt::Labeled { body, .. } => generator_stmt_uses_call_this(body),
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            body.iter().any(generator_stmt_uses_call_this)
+                || catch
+                    .as_ref()
+                    .is_some_and(|catch| catch.body.iter().any(generator_stmt_uses_call_this))
+                || finally
+                    .as_ref()
+                    .is_some_and(|body| body.iter().any(generator_stmt_uses_call_this))
+        }
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            generator_expr_uses_call_this(discriminant)
+                || cases.iter().any(|case| {
+                    case.test
+                        .as_ref()
+                        .is_some_and(generator_expr_uses_call_this)
+                        || case.body.iter().any(generator_stmt_uses_call_this)
+                })
+        }
+    }
+}
+
+fn generator_expr_uses_call_this(expr: &Expr) -> bool {
+    match expr {
+        Expr::This
+        | Expr::SuperCall(_)
+        | Expr::SuperMethodCall { .. }
+        | Expr::SuperPropertyGet { .. } => true,
+        Expr::Closure { captures_this, .. } => *captures_this,
+        _ => {
+            let mut found = false;
+            walk_expr_children(expr, &mut |child| {
+                if !found && generator_expr_uses_call_this(child) {
+                    found = true;
+                }
+            });
+            found
+        }
+    }
 }
 
 /// Build the async-step driver (issue #256). Returns the statements that

--- a/test-parity/node-suite/globals/proxy-generator-apply-this.ts
+++ b/test-parity/node-suite/globals/proxy-generator-apply-this.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+
+function dump(label, gen) {
+  console.log(label + ":" + JSON.stringify(Array.from(gen)));
+}
+
+const sum = function* (arg) {
+  yield this.foo;
+  yield arg;
+};
+
+const sumProxy = new Proxy(new Proxy(sum, {}), { apply: undefined });
+dump("proxy", Reflect.apply(sumProxy, { foo: 10 }, [1]));
+
+function* named(arg) {
+  yield this.foo;
+  yield arg;
+}
+
+dump("direct", Reflect.apply(named, { foo: 11 }, [2]));
+
+const receiver = {
+  foo: 12,
+  g: function* (arg) {
+    yield this.foo;
+    yield arg;
+  },
+};
+
+dump("method", receiver.g(3));


### PR DESCRIPTION
## Linked Issues
- Closes #3876

## Summary
- Detect generator bodies that read call-time `this` before lowering them into state-machine closures.
- Mark the synthesized generator step closures to capture that receiver, so calls through `Reflect.apply` and trap-less proxy forwarding preserve `thisArg` across yield/resume.
- Add a Node parity fixture covering a trap-less proxy chain, direct `Reflect.apply`, and object method generator calls.

## Why This Cut
These cases share the same lowered generator receiver-capture path. Proxy dispatch already forwards the call receiver through `IMPLICIT_THIS`; the missing piece was carrying that receiver into the delayed generator frame.

## Tests
- `cargo check -p perry-transform`
- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`
- `npm exec --package=node@25 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module globals --filter proxy-generator-apply-this'` - pass, 1/0
- `npm exec --package=node@25 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module globals --filter generator'` - 3 pass / 1 fail; remaining known nearby mismatch is `generator-intrinsics` at `g.constructor.name`, outside this receiver-capture path

## Non-goals
- No changes to proxy trap dispatch.
- No changes to generator prototype or intrinsic descriptor wiring.
- No broader changes to ordinary function-call `this` semantics.
