### PR TITLE
[codex] Fix native instance walk for fluent chains

### DIFF
--- a/crates/perry-hir/src/js_transform/local_natives.rs
+++ b/crates/perry-hir/src/js_transform/local_natives.rs
@@ -937,6 +937,7 @@ pub fn fix_native_instance_expr_with_locals(
     match expr {
         // The key case: method calls that might be on native instances
         Expr::Call { callee, args, .. } => {
+            let mut recursed_into_property_object = false;
             // Issue #1193: `$(selector)` where `$` is a CheerioAPI handle.
             // Cheerio's only "call-as-function" shape is `load(html)`'s
             // return value used as a selector — rewrite to the existing
@@ -1033,6 +1034,7 @@ pub fn fix_native_instance_expr_with_locals(
                         native_instances,
                         local_id_instances,
                     );
+                    recursed_into_property_object = true;
                     if let Expr::NativeMethodCall {
                         module: inner_module,
                         method: inner_method,
@@ -1065,7 +1067,14 @@ pub fn fix_native_instance_expr_with_locals(
             }
 
             // Not a native instance call, recurse
-            fix_native_instance_expr_with_locals(callee, native_instances, local_id_instances);
+            if recursed_into_property_object {
+                // The fluent-chain case above already walked the receiver
+                // of this property call. Walking the whole callee again would
+                // revisit the same receiver at every chain level, making long
+                // non-native fluent chains exponential.
+            } else {
+                fix_native_instance_expr_with_locals(callee, native_instances, local_id_instances);
+            }
             for arg in args {
                 fix_native_instance_expr_with_locals(arg, native_instances, local_id_instances);
             }

--- a/crates/perry-hir/tests/cheerio_call_rewrite.rs
+++ b/crates/perry-hir/tests/cheerio_call_rewrite.rs
@@ -3,8 +3,11 @@
 //! that the runtime can't resolve.
 
 use perry_diagnostics::SourceCache;
-use perry_hir::{clear_current_module_source, fix_local_native_instances, lower_module, Expr};
+use perry_hir::{
+    clear_current_module_source, fix_local_native_instances, lower_module, Expr, Module, Stmt,
+};
 use perry_parser::parse_typescript_with_cache;
+use perry_types::Type;
 
 fn lower(src: &str) -> perry_hir::Module {
     let mut cache = SourceCache::new();
@@ -86,4 +89,71 @@ fn cheerio_call_handle_lowers_to_select() {
     };
     assert_eq!(n_module, "cheerio");
     assert_eq!(n_method, "length");
+}
+
+#[test]
+fn non_native_fluent_chains_are_walked_linearly() {
+    let mut init = Expr::Call {
+        callee: Box::new(Expr::ExternFuncRef {
+            name: "yargs".to_string(),
+            param_types: vec![Type::Any],
+            return_type: Type::Any,
+        }),
+        args: vec![Expr::ExternFuncRef {
+            name: "args".to_string(),
+            param_types: Vec::new(),
+            return_type: Type::Any,
+        }],
+        type_args: Vec::new(),
+    };
+
+    for i in 0..32 {
+        init = Expr::Call {
+            callee: Box::new(Expr::PropertyGet {
+                object: Box::new(init),
+                property: "command".to_string(),
+            }),
+            args: vec![Expr::ExternFuncRef {
+                name: format!("cmd{i}"),
+                param_types: Vec::new(),
+                return_type: Type::Any,
+            }],
+            type_args: Vec::new(),
+        };
+    }
+
+    init = Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(init),
+            property: "strict".to_string(),
+        }),
+        args: Vec::new(),
+        type_args: Vec::new(),
+    };
+
+    let mut module = Module::new("non-native-fluent-chain");
+    module.init.push(Stmt::Let {
+        id: 0,
+        name: "cli".to_string(),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(init),
+    });
+
+    fix_local_native_instances(&mut module);
+
+    let cli_init = module
+        .init
+        .iter()
+        .find_map(|s| match s {
+            Stmt::Let {
+                name,
+                init: Some(e),
+                ..
+            } if name == "cli" => Some(e),
+            _ => None,
+        })
+        .expect("expected a `cli` Let binding");
+
+    assert!(matches!(cli_init, Expr::Call { .. }));
 }


### PR DESCRIPTION
## Summary

Fixes the local native-instance rewrite pass so non-native fluent call chains are walked linearly instead of revisiting the same property receiver at every chain level.

The OpenCode/Perry graph previously reached module collection/tree-shake and then timed out in `run_native_instance_fixups` while processing the long yargs chain in the OpenCode overlay `src/index.ts`. The Cheerio chained-call special case recursively fixed a property receiver, then the generic fallback walked the whole callee again, making long non-native fluent chains exponential.

## Changes

- Tracks when the property receiver has already been recursively fixed in `fix_native_instance_expr_with_locals`.
- Skips the duplicate generic callee recursion in that case while still visiting call arguments.
- Adds a regression that constructs a non-native fluent HIR chain directly and runs `fix_local_native_instances` over it.

## Validation

- `cargo test -p perry-hir --test cheerio_call_rewrite` -> `2 passed; 0 failed`.
- `cargo build --release -p perry` -> finished release build.
- Direct OpenCode compile repro with the fixed release binary moved past the previous native-fixup timeout, reached `Found 2760 module(s): 2760 native, 0 JavaScript`, entered `Generating code...`, then hit the next compiler blocker: `thread '<unknown>' has overflowed its stack` during codegen.
- OpenTUI harness with the fixed release binary also moved past native-fixup and failed at the next codegen stack overflow. Kept temp dir: `/var/folders/8q/vx4z9tqd08jd1b5_bykzbdkr0000gn/T/opentui-perry-native-Irv8KZ`.

## Notes

This does not complete the OpenTUI/OpenCode Perry-native migration. It only moves the fluent-chain/native-fixup timeout blocker; the next blocker is a Perry codegen stack overflow before a binary is produced.
