### PR TITLE
[codex] preserve CommonJS require function name

### DIFF
--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -879,6 +879,107 @@ pub extern "C" fn js_object_define_property(
             return obj_value;
         }
 
+        // Closures are object-like but not ObjectHeader-backed, so descriptor
+        // writes have to route through the closure property side tables.
+        let target_closure_ptr = {
+            let value = crate::value::JSValue::from_bits(obj_value.to_bits());
+            let raw = if value.is_pointer() {
+                value.as_pointer::<u8>() as usize
+            } else {
+                let bits = obj_value.to_bits();
+                if bits != 0 && bits <= 0x0000_FFFF_FFFF_FFFF && bits > 0x10000 {
+                    bits as usize
+                } else {
+                    0
+                }
+            };
+            if raw >= 0x10000 && crate::closure::is_closure_ptr(raw) {
+                Some(raw)
+            } else {
+                None
+            }
+        };
+        if let Some(closure_ptr) = target_closure_ptr {
+            let key_str = crate::builtins::js_string_coerce(key_value);
+            if key_str.is_null() {
+                return obj_value;
+            }
+            let key_rust: Option<String> = {
+                let name_ptr =
+                    (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_len = (*key_str).byte_len as usize;
+                let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
+                std::str::from_utf8(name_bytes).ok().map(|s| s.to_string())
+            };
+            let Some(key_rust) = key_rust else {
+                return obj_value;
+            };
+            let desc_ptr = extract_obj_ptr(descriptor_value);
+            if desc_ptr.is_null() {
+                return obj_value;
+            }
+
+            let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
+            let set_key = crate::string::js_string_from_bytes(b"set".as_ptr(), 3);
+            let get_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, get_key);
+            let set_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, set_key);
+            let has_accessor = !get_field.is_undefined() || !set_field.is_undefined();
+
+            if has_accessor {
+                let get_bits = if get_field.is_undefined() {
+                    0
+                } else {
+                    crate::closure::clone_closure_rebind_this(get_field.bits(), obj_value)
+                };
+                let set_bits = if set_field.is_undefined() {
+                    0
+                } else {
+                    crate::closure::clone_closure_rebind_this(set_field.bits(), obj_value)
+                };
+                set_accessor_descriptor(
+                    closure_ptr,
+                    key_rust.clone(),
+                    AccessorDescriptor {
+                        get: get_bits,
+                        set: set_bits,
+                    },
+                );
+            } else {
+                let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+                let value_field =
+                    js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
+                ACCESSOR_DESCRIPTORS.with(|m| {
+                    m.borrow_mut().remove(&(closure_ptr, key_rust.clone()));
+                });
+                if !value_field.is_undefined() {
+                    crate::closure::closure_set_dynamic_prop(
+                        closure_ptr,
+                        &key_rust,
+                        f64::from_bits(value_field.bits()),
+                    );
+                }
+            }
+
+            let read_bool = |name: &[u8]| -> Option<bool> {
+                let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
+                if v.is_undefined() {
+                    None
+                } else {
+                    Some(crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0)
+                }
+            };
+            let writable = read_bool(b"writable").unwrap_or(has_accessor);
+            let enumerable = read_bool(b"enumerable").unwrap_or(false);
+            let configurable = read_bool(b"configurable").unwrap_or(false);
+            set_property_attrs(
+                closure_ptr,
+                key_rust,
+                PropertyAttrs::new(writable, enumerable, configurable),
+            );
+            return obj_value;
+        }
+
         let obj = extract_obj_ptr(obj_value);
         if obj.is_null() {
             return obj_value;

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -77,6 +77,77 @@ fn closure_name_and_length_ignore_plain_assignment() {
 }
 
 #[test]
+fn closure_name_can_be_redefined_with_define_property() {
+    crate::closure::test_clear_closure_side_tables();
+    unsafe {
+        let closure = crate::closure::js_closure_alloc(
+            crate::object::global_this_builtin_noop_thunk as *const u8,
+            0,
+        );
+        assert!(!closure.is_null());
+        super::native_module::set_bound_native_closure_name(closure, "fn");
+
+        let name_key = crate::string::js_string_from_bytes(b"name".as_ptr(), 4);
+        let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+        let writable_key = crate::string::js_string_from_bytes(b"writable".as_ptr(), 8);
+        let enumerable_key = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
+        let configurable_key = crate::string::js_string_from_bytes(b"configurable".as_ptr(), 12);
+        let replacement = crate::string::js_string_from_bytes(b"require".as_ptr(), 7);
+
+        let descriptor = js_object_alloc(0, 0);
+        assert!(!descriptor.is_null());
+        js_object_set_field_by_name(
+            descriptor,
+            value_key,
+            f64::from_bits(JSValue::string_ptr(replacement).bits()),
+        );
+        js_object_set_field_by_name(
+            descriptor,
+            writable_key,
+            f64::from_bits(crate::value::TAG_FALSE),
+        );
+        js_object_set_field_by_name(
+            descriptor,
+            enumerable_key,
+            f64::from_bits(crate::value::TAG_FALSE),
+        );
+        js_object_set_field_by_name(
+            descriptor,
+            configurable_key,
+            f64::from_bits(crate::value::TAG_TRUE),
+        );
+
+        let closure_value = crate::value::js_nanbox_pointer(closure as i64);
+        let name_value = f64::from_bits(JSValue::string_ptr(name_key).bits());
+        let descriptor_value = crate::value::js_nanbox_pointer(descriptor as i64);
+        js_object_define_property(closure_value, name_value, descriptor_value);
+
+        let name = js_object_get_field_by_name(closure as *const ObjectHeader, name_key);
+        assert_eq!(js_string_to_rust(name), "require");
+
+        let own_descriptor = js_object_get_own_property_descriptor(closure_value, name_value);
+        let own_descriptor_obj = crate::value::js_nanbox_get_pointer(own_descriptor)
+            as *const crate::object::ObjectHeader;
+        assert_eq!(
+            js_object_get_field_by_name(own_descriptor_obj, value_key).bits(),
+            JSValue::string_ptr(replacement).bits()
+        );
+        assert_eq!(
+            js_object_get_field_by_name(own_descriptor_obj, writable_key).bits(),
+            crate::value::TAG_FALSE
+        );
+        assert_eq!(
+            js_object_get_field_by_name(own_descriptor_obj, enumerable_key).bits(),
+            crate::value::TAG_FALSE
+        );
+        assert_eq!(
+            js_object_get_field_by_name(own_descriptor_obj, configurable_key).bits(),
+            crate::value::TAG_TRUE
+        );
+    }
+}
+
+#[test]
 fn test_object_alloc_and_fields() {
     let obj = js_object_alloc(1, 3);
 

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -412,14 +412,18 @@ const _cjs = (function() {{
 {require_cases}
         throw new Error('require() is not supported: ' + specifier);
     }}
-    require.name = 'require';
+    Object.defineProperty(require, 'name', {{
+        value: 'require',
+        writable: false,
+        enumerable: false,
+        configurable: true,
+    }});
     require.resolve = function resolve(specifier, options) {{
         if (typeof specifier !== 'string') throw __perry_cjs_require_error('type', 'ERR_INVALID_ARG_TYPE', 'The "request" argument must be of type string.');
 {require_resolve_cases}
         if (__perry_cjs_require_is_builtin(specifier)) return specifier;
         throw __perry_cjs_require_error('error', 'MODULE_NOT_FOUND', 'Cannot find module ' + specifier);
     }};
-    require.resolve.name = 'resolve';
     require.resolve.paths = function paths(specifier) {{
         if (typeof specifier !== 'string') throw __perry_cjs_require_error('type', 'ERR_INVALID_ARG_TYPE', 'The "request" argument must be of type string.');
         return null;


### PR DESCRIPTION
## Summary
- route Object.defineProperty on closure/function targets through the closure property side tables so function own data descriptors can be installed
- update the generated CommonJS wrapper to define require.name with descriptor semantics instead of assigning to the read-only Function name property
- add runtime coverage for redefining a closure name with Object.defineProperty

Fixes #2616.

## Validation
- cargo fmt --all -- --check
- cargo test -p perry-runtime closure_name_can_be_redefined_with_define_property -- --nocapture
- PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module module' -> 11 pass / 0 parity fail / 0 compile fail / 0 skipped, parity rate 100.0%, report test-parity/reports/parity_report_20260603_065240.json
- git diff --check
- ./scripts/check_file_size.sh
