### PR TITLE
[codex] Avoid recursive constructor inlining

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -132,6 +132,41 @@ fn pack_lowered_args_array(ctx: &mut FnCtx<'_>, args: &[String]) -> String {
     nanbox_pointer_inline(ctx.block(), &current)
 }
 
+fn call_local_constructor_symbol(
+    ctx: &mut FnCtx<'_>,
+    class: &perry_hir::Class,
+    obj_box: &str,
+    lowered_args: &[String],
+) {
+    let ctor_method_name = format!("{}_constructor", class.name);
+    let Some(ctor_name) = ctx
+        .methods
+        .get(&(class.name.clone(), ctor_method_name))
+        .cloned()
+    else {
+        return;
+    };
+    let param_count = class
+        .constructor
+        .as_ref()
+        .map(|ctor| ctor.params.len())
+        .unwrap_or(0);
+    let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+    let mut ctor_values = lowered_args.to_vec();
+    ctor_values.truncate(param_count);
+    while ctor_values.len() < param_count {
+        ctor_values.push(undef_lit.clone());
+    }
+
+    let mut ctor_args: Vec<(crate::types::LlvmType, &str)> =
+        Vec::with_capacity(1 + ctor_values.len());
+    ctor_args.push((DOUBLE, obj_box));
+    for arg in &ctor_values {
+        ctor_args.push((DOUBLE, arg.as_str()));
+    }
+    let _ = ctx.block().call(DOUBLE, &ctor_name, &ctor_args);
+}
+
 /// Lower `new ClassName(args…)` — Phase C.1.
 ///
 /// Strategy: allocate an anonymous object via `js_object_alloc(0, N)`
@@ -563,6 +598,17 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
         )
     };
     let obj_box = nanbox_pointer_inline(ctx.block(), &obj_handle);
+
+    // Constructor bodies may contain terminating recursive construction
+    // shapes such as `if (typeof opts === "function") return new C(...)`.
+    // Structurally inlining `C` while `C` is already active expands the
+    // same constructor body forever at compile time. Use the standalone
+    // constructor symbol for the nested construction instead; it preserves
+    // the ordinary initializer path without recursively cloning HIR.
+    if ctx.class_stack.iter().any(|active| active == class_name) {
+        call_local_constructor_symbol(ctx, class, &obj_box, &lowered_args);
+        return Ok(obj_box);
+    }
 
     // Allocate a `this` slot and store the new object there. The
     // slot lives on this_stack for the duration of the inlined ctor

--- a/crates/perry-codegen/tests/constructor_recursion.rs
+++ b/crates/perry-codegen/tests/constructor_recursion.rs
@@ -1,0 +1,152 @@
+use perry_codegen::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::{Class, Expr, Function, Module, ModuleInitKind, Param, Stmt};
+use perry_types::Type;
+
+fn empty_opts() -> CompileOptions {
+    CompileOptions {
+        target: None,
+        is_entry_module: false,
+        non_entry_module_prefixes: Vec::new(),
+        import_function_prefixes: std::collections::HashMap::new(),
+        import_function_origin_names: std::collections::HashMap::new(),
+        import_function_v8_specifiers: std::collections::HashMap::new(),
+        import_function_node_submodule: std::collections::HashMap::new(),
+        namespace_node_submodules: std::collections::HashMap::new(),
+        namespace_v8_specifiers: std::collections::HashMap::new(),
+        namespace_member_prefixes: std::collections::HashMap::new(),
+        emit_ir_only: true,
+        verify_native_regions: false,
+        disable_buffer_fast_path: false,
+        namespace_imports: Vec::new(),
+        namespace_reexport_named_imports: std::collections::HashSet::new(),
+        imported_classes: Vec::new(),
+        imported_enums: Vec::new(),
+        imported_async_funcs: std::collections::HashSet::new(),
+        type_aliases: std::collections::HashMap::new(),
+        imported_func_param_counts: std::collections::HashMap::new(),
+        imported_func_has_rest: std::collections::HashSet::new(),
+        imported_func_synthetic_arguments: std::collections::HashSet::new(),
+        imported_func_return_types: std::collections::HashMap::new(),
+        imported_vars: std::collections::HashSet::new(),
+        output_type: "executable".to_string(),
+        needs_stdlib: false,
+        needs_ui: false,
+        needs_geisterhand: false,
+        geisterhand_port: 7676,
+        enabled_features: Vec::new(),
+        native_module_init_names: Vec::new(),
+        js_module_specifiers: Vec::new(),
+        bundled_extensions: Vec::new(),
+        native_library_functions: Vec::new(),
+        i18n_table: None,
+        fast_math: false,
+        fp_contract_mode: perry_codegen::FpContractMode::Off,
+        app_metadata: AppMetadata::default(),
+        namespace_entries: Vec::new(),
+        dynamic_import_path_to_prefix: std::collections::HashMap::new(),
+        deferred_module_prefixes: std::collections::HashSet::new(),
+        module_init_deps: Vec::new(),
+        is_dynamic_import_target: false,
+    }
+}
+
+fn param(id: u32, name: &str) -> Param {
+    Param {
+        id,
+        name: name.to_string(),
+        ty: Type::Any,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    }
+}
+
+fn module_with_recursive_constructor_return() -> Module {
+    let ctor = Function {
+        id: 1,
+        name: "constructor".to_string(),
+        type_params: Vec::new(),
+        params: vec![param(10, "flag"), param(11, "next")],
+        return_type: Type::Void,
+        body: vec![Stmt::If {
+            condition: Expr::Bool(false),
+            then_branch: vec![Stmt::Return(Some(Expr::New {
+                class_name: "RecursiveCtor".to_string(),
+                args: vec![Expr::Bool(false), Expr::LocalGet(11)],
+                type_args: Vec::new(),
+            }))],
+            else_branch: None,
+        }],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+    };
+
+    Module {
+        name: "constructor_recursion.ts".to_string(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        classes: vec![Class {
+            id: 1,
+            name: "RecursiveCtor".to_string(),
+            type_params: Vec::new(),
+            extends: None,
+            extends_name: None,
+            native_extends: None,
+            extends_expr: None,
+            fields: Vec::new(),
+            constructor: Some(ctor),
+            methods: Vec::new(),
+            getters: Vec::new(),
+            setters: Vec::new(),
+            computed_members: Vec::new(),
+            static_fields: Vec::new(),
+            static_methods: Vec::new(),
+            decorators: Vec::new(),
+            is_exported: false,
+            aliases: Vec::new(),
+        }],
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions: Vec::new(),
+        init: vec![Stmt::Expr(Expr::New {
+            class_name: "RecursiveCtor".to_string(),
+            args: vec![Expr::Bool(true), Expr::Undefined],
+            type_args: Vec::new(),
+        })],
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+    }
+}
+
+#[test]
+fn constructor_self_new_uses_symbol_call_instead_of_recursive_inlining() {
+    let ir = String::from_utf8(
+        compile_module(&module_with_recursive_constructor_return(), empty_opts()).unwrap(),
+    )
+    .unwrap();
+
+    assert!(ir.contains("define double @constructor_recursion_ts__RecursiveCtor_constructor"));
+    assert!(ir.contains("call double @constructor_recursion_ts__RecursiveCtor_constructor"));
+}

--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -533,28 +533,6 @@ fn normalize_unicode_identifier_escapes(source: &str) -> String {
                     i += 1;
                 }
             }
-            State::Regex { in_class } => {
-                out.push(bytes[i] as char);
-                if bytes[i] == b'\\' {
-                    if let Some(&next) = bytes.get(i + 1) {
-                        out.push(next as char);
-                        i += 2;
-                    } else {
-                        i += 1;
-                    }
-                } else if bytes[i] == b'[' {
-                    state = State::Regex { in_class: true };
-                    i += 1;
-                } else if bytes[i] == b']' {
-                    state = State::Regex { in_class: false };
-                    i += 1;
-                } else if bytes[i] == b'/' && !in_class {
-                    state = State::Code;
-                    i += 1;
-                } else {
-                    i += 1;
-                }
-            }
             State::LineComment => {
                 let ch = source[i..].chars().next().unwrap();
                 out.push(ch);

--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -533,6 +533,28 @@ fn normalize_unicode_identifier_escapes(source: &str) -> String {
                     i += 1;
                 }
             }
+            State::Regex { in_class } => {
+                out.push(bytes[i] as char);
+                if bytes[i] == b'\\' {
+                    if let Some(&next) = bytes.get(i + 1) {
+                        out.push(next as char);
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                } else if bytes[i] == b'[' {
+                    state = State::Regex { in_class: true };
+                    i += 1;
+                } else if bytes[i] == b']' {
+                    state = State::Regex { in_class: false };
+                    i += 1;
+                } else if bytes[i] == b'/' && !in_class {
+                    state = State::Code;
+                    i += 1;
+                } else {
+                    i += 1;
+                }
+            }
             State::LineComment => {
                 let ch = source[i..].chars().next().unwrap();
                 out.push(ch);


### PR DESCRIPTION
## Summary

- avoid structurally inlining a class constructor when `new C(...)` appears while `C` is already active on codegen's class stack
- route that nested construction through the registered standalone constructor symbol instead
- add a HIR-level regression for a constructor branch that returns `new SameClass(...)`

## Root Cause

OpenCode's graph reached `bonjour-service/dist/lib/browser.js`, whose constructor contains a terminating recursive-construction shape:

```js
if (typeof opts === 'function') return new Browser(mdns, null, opts)
```

Perry codegen lowered `new Browser(...)` by recursively inlining the `Browser` constructor body while that same constructor was already active, causing compile-time stack overflow before object output.

## Validation

- `cargo test -p perry-codegen --test constructor_recursion -- --nocapture`
- `cargo build --release -p perry`
- reduced Bonjour alias repro now exits `0` and writes object files:
  `RAYON_NUM_THREADS=1 PERRY_RUNTIME_DIR=/Users/andrew/.codex/worktrees/perry-opencode-compile-timeout/target/release /Users/andrew/.codex/worktrees/perry-opencode-compile-timeout/target/release/perry compile -v --no-auto-optimize --no-link entry.ts -o ./bonjour-release-fixed`

## OpenCode Smoke Status

This moves the prior Bonjour `Browser` constructor stack overflow. The full OpenTUI/OpenCode Perry-native smoke still does not produce a binary: after this fix it reaches `@actions/io/lib/io-util.js` around `visited=427/2760` and hits another codegen stack overflow. Kept temp dir from that run: `/var/folders/8q/vx4z9tqd08jd1b5_bykzbdkr0000gn/T/opentui-perry-native-t4yNTj`.

## Stack

Depends on / includes the current #4219 stack commit until #4219 is merged.
