### PR TITLE
[codex] implement String.matchAll iterator semantics

### DIFF
--- a/crates/perry-codegen/src/boxed_vars.rs
+++ b/crates/perry-codegen/src/boxed_vars.rs
@@ -1409,8 +1409,8 @@ fn refine_type_from_init_simple(init: &perry_hir::Expr) -> Option<perry_types::T
         | Expr::ArrayEntries { .. }
         | Expr::ArrayKeys { .. }
         | Expr::ArrayValues { .. }
-        | Expr::StringMatch { .. }
-        | Expr::StringMatchAll { .. } => Some(Type::Array(Box::new(Type::Any))),
+        | Expr::StringMatch { .. } => Some(Type::Array(Box::new(Type::Any))),
+        Expr::StringMatchAll { .. } => Some(Type::Any),
         Expr::String(_) | Expr::ArrayJoin { .. } | Expr::StringCoerce(_) => Some(Type::String),
         Expr::Bool(_) => Some(Type::Boolean),
         Expr::BigInt(_) | Expr::BigIntCoerce(_) => Some(Type::BigInt),

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -1123,21 +1123,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &result))
         }
 
-        // -------- string.matchAll(regex) --------
-        // Returns Array<Array<string>>, never null. Each inner array is
-        // [fullMatch, ...captureGroups], matching the shape Node produces
-        // when iterating `for (const m of s.matchAll(re))`. SSO-safe receiver
-        // unbox via `unbox_str_handle` for the same reason as `StringMatch`.
+        // -------- string.matchAll(pattern) --------
+        // Returns a RegExp String Iterator object. SSO-safe receiver unbox via
+        // `unbox_str_handle` for the same reason as `StringMatch`; pass the raw
+        // pattern value so runtime can validate RegExp globals or create a
+        // global RegExp for string/non-RegExp patterns.
         Expr::StringMatchAll { string, regex } => {
             let s_box = lower_expr(ctx, string)?;
             let r_box = lower_expr(ctx, regex)?;
             let blk = ctx.block();
             let s_handle = unbox_str_handle(blk, &s_box);
-            let r_handle = unbox_to_i64(blk, &r_box);
             let result = blk.call(
                 I64,
-                "js_string_match_all",
-                &[(I64, &s_handle), (I64, &r_handle)],
+                "js_string_match_all_value",
+                &[(I64, &s_handle), (DOUBLE, &r_box)],
             );
             Ok(nanbox_pointer_inline(blk, &result))
         }

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -640,22 +640,25 @@ pub(crate) fn lower_string_method(
             Ok(ctx.block().bitcast_i64_to_double(&selected))
         }
         "matchAll" => {
-            if args.len() != 1 {
+            if args.len() > 1 {
                 bail!(
-                    "perry-codegen: String.matchAll expects 1 arg, got {}",
+                    "perry-codegen: String.matchAll expects 0 or 1 arg, got {}",
                     args.len()
                 );
             }
-            let re_box = lower_expr(ctx, &args[0])?;
+            let pattern_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let re_handle = unbox_str_handle(blk, &re_box);
             let result = blk.call(
                 I64,
-                "js_string_match_all",
-                &[(I64, &recv_handle), (I64, &re_handle)],
+                "js_string_match_all_value",
+                &[(I64, &recv_handle), (DOUBLE, &pattern_box)],
             );
-            // matchAll always returns an array (possibly empty), never null.
+            // matchAll returns a RegExp String Iterator object.
             Ok(nanbox_pointer_inline(blk, &result))
         }
         "isWellFormed" => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1189,6 +1189,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_object_from_entries", DOUBLE, &[DOUBLE]);
     module.declare_function("js_string_match", I64, &[I64, I64]);
     module.declare_function("js_string_match_all", I64, &[I64, I64]);
+    module.declare_function("js_string_match_all_value", I64, &[I64, DOUBLE]);
     module.declare_function("llvm.log.f64", DOUBLE, &[DOUBLE]);
     module.declare_function("llvm.log2.f64", DOUBLE, &[DOUBLE]);
     module.declare_function("llvm.log10.f64", DOUBLE, &[DOUBLE]);

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -301,6 +301,7 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_string_is_well_formed", DOUBLE, &[I64]);
     module.declare_function("js_string_to_well_formed", I64, &[I64]);
     module.declare_function("js_string_match_all", I64, &[I64, I64]);
+    module.declare_function("js_string_match_all_value", I64, &[I64, DOUBLE]);
     module.declare_function("js_string_search_regex", I32, &[I64, I64]);
     // Regex extras (runtime has them; codegen was stubbing).
     module.declare_function("js_regexp_exec_get_index", DOUBLE, &[]);

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -95,8 +95,8 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         | Expr::ArrayEntries { .. }
         | Expr::ArrayKeys { .. }
         | Expr::ArrayValues { .. }
-        | Expr::StringMatch { .. }
-        | Expr::StringMatchAll { .. } => Some(HirType::Array(Box::new(HirType::Any))),
+        | Expr::StringMatch { .. } => Some(HirType::Array(Box::new(HirType::Any))),
+        Expr::StringMatchAll { .. } => Some(HirType::Any),
         // TextEncoder.encode(str) — runtime returns a BufferHeader with
         // packed u8 bytes (same shape as `new Uint8Array([...])`). Refining
         // the local type to Uint8Array lets `encoded[i]` route through the
@@ -1886,12 +1886,13 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
         // Call form that bypasses the `Expr::StringSplit` variant — e.g.
         // `"a,b,c".split(",")` in an expression position where we need
         // `.length` / `[i]` to follow the array fast path.
-        // Also: `str.match(regex)` / `str.matchAll(regex)` produce arrays.
+        // Also: `str.match(regex)` produces an array. `matchAll` deliberately
+        // stays dynamic because it returns a RegExp String Iterator object.
         Expr::Call { callee, .. }
             if matches!(
                 callee.as_ref(),
                 Expr::PropertyGet { property, object } if matches!(
-                    property.as_str(), "split" | "match" | "matchAll"
+                    property.as_str(), "split" | "match"
                 ) && is_string_expr(ctx, object)
             ) =>
         {

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1969,7 +1969,7 @@ pub enum Expr {
         string: Box<Expr>,
         regex: Box<Expr>,
     },
-    /// string.matchAll(regex) -> Array<Array<string>>
+    /// string.matchAll(pattern) -> RegExp String Iterator
     StringMatchAll {
         string: Box<Expr>,
         regex: Box<Expr>,

--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -344,7 +344,8 @@ pub extern "C" fn js_array_clone(src: *const ArrayHeader) -> *mut ArrayHeader {
                     // dispatch `.next()` via class id too — without this `[...buf.keys()]`
                     // / `Array.from(buf.values())` produced an empty array even though
                     // `.next()` and `for...of` already worked.
-                    || (*obj).class_id == crate::buffer::BUFFER_ITERATOR_CLASS_ID;
+                    || (*obj).class_id == crate::buffer::BUFFER_ITERATOR_CLASS_ID
+                    || (*obj).class_id == crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID;
                 let is_iterable = is_array_iterator || {
                     let iter_sym = crate::symbol::well_known_symbol("iterator");
                     if iter_sym.is_null() {

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -323,6 +323,7 @@ pub(crate) fn is_builtin_iterator_class_id(raw_ptr: usize) -> bool {
                 | crate::collection_iter_object::MAP_ITERATOR_CLASS_ID
                 | crate::collection_iter_object::SET_ITERATOR_CLASS_ID
                 | crate::buffer::BUFFER_ITERATOR_CLASS_ID
+                | crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID
                 | crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID
         ) || class_id == crate::string::STRING_ITERATOR_CLASS_ID
     }

--- a/crates/perry-runtime/src/object/iterator_prototypes.rs
+++ b/crates/perry-runtime/src/object/iterator_prototypes.rs
@@ -43,6 +43,7 @@ pub(crate) static ARRAY_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
 pub(crate) static MAP_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
 pub(crate) static SET_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
 pub(crate) static STRING_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
+pub(crate) static REGEXP_STRING_ITERATOR_PROTOTYPE_PTR: AtomicI64 = AtomicI64::new(0);
 
 /// Dispatch `method` on the implicit-`this` iterator instance, routing by class
 /// id to the matching existing iterator dispatcher. Shared by the per-family
@@ -74,6 +75,9 @@ unsafe fn dispatch_on_implicit_this(method: &str) -> f64 {
         crate::string::STRING_ITERATOR_CLASS_ID => {
             crate::string::dispatch_string_iterator_method(obj, method)
         }
+        crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID => {
+            crate::regex::dispatch_regexp_string_iterator_method(obj, method)
+        }
         _ => brand_type_error(method),
     }
 }
@@ -104,6 +108,12 @@ extern "C" fn set_iterator_next_thunk(_c: *const crate::closure::ClosureHeader, 
     unsafe { dispatch_on_implicit_this("next") }
 }
 extern "C" fn string_iterator_next_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    unsafe { dispatch_on_implicit_this("next") }
+}
+extern "C" fn regexp_string_iterator_next_thunk(
     _c: *const crate::closure::ClosureHeader,
     _arg: f64,
 ) -> f64 {
@@ -156,12 +166,18 @@ fn build_iterator_prototypes() {
     let map_proto = build_family_proto(map_iterator_next_thunk, "Map Iterator", shared);
     let set_proto = build_family_proto(set_iterator_next_thunk, "Set Iterator", shared);
     let string_proto = build_family_proto(string_iterator_next_thunk, "String Iterator", shared);
+    let regexp_string_proto = build_family_proto(
+        regexp_string_iterator_next_thunk,
+        "RegExp String Iterator",
+        shared,
+    );
 
     ITERATOR_PROTOTYPE_PTR.store(shared as i64, Ordering::Release);
     ARRAY_ITERATOR_PROTOTYPE_PTR.store(array_proto as i64, Ordering::Release);
     MAP_ITERATOR_PROTOTYPE_PTR.store(map_proto as i64, Ordering::Release);
     SET_ITERATOR_PROTOTYPE_PTR.store(set_proto as i64, Ordering::Release);
     STRING_ITERATOR_PROTOTYPE_PTR.store(string_proto as i64, Ordering::Release);
+    REGEXP_STRING_ITERATOR_PROTOTYPE_PTR.store(regexp_string_proto as i64, Ordering::Release);
 }
 
 /// Install `[Symbol.iterator]` on the shared parent as a real method whose
@@ -235,6 +251,7 @@ pub(crate) fn iterator_prototype_for_class_id(class_id: u32) -> Option<f64> {
         crate::collection_iter_object::MAP_ITERATOR_CLASS_ID => &MAP_ITERATOR_PROTOTYPE_PTR,
         crate::collection_iter_object::SET_ITERATOR_CLASS_ID => &SET_ITERATOR_PROTOTYPE_PTR,
         crate::string::STRING_ITERATOR_CLASS_ID => &STRING_ITERATOR_PROTOTYPE_PTR,
+        crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID => &REGEXP_STRING_ITERATOR_PROTOTYPE_PTR,
         _ => return None,
     };
     let ptr = slot.load(Ordering::Acquire);
@@ -259,6 +276,7 @@ pub(crate) fn attach_iterator_prototype(obj_ptr: *mut ObjectHeader, class_id: u3
         crate::collection_iter_object::MAP_ITERATOR_CLASS_ID => &MAP_ITERATOR_PROTOTYPE_PTR,
         crate::collection_iter_object::SET_ITERATOR_CLASS_ID => &SET_ITERATOR_PROTOTYPE_PTR,
         crate::string::STRING_ITERATOR_CLASS_ID => &STRING_ITERATOR_PROTOTYPE_PTR,
+        crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID => &REGEXP_STRING_ITERATOR_PROTOTYPE_PTR,
         _ => return,
     };
     let proto_ptr = slot.load(Ordering::Acquire);

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1405,6 +1405,7 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
         &iterator_prototypes::MAP_ITERATOR_PROTOTYPE_PTR,
         &iterator_prototypes::SET_ITERATOR_PROTOTYPE_PTR,
         &iterator_prototypes::STRING_ITERATOR_PROTOTYPE_PTR,
+        &iterator_prototypes::REGEXP_STRING_ITERATOR_PROTOTYPE_PTR,
     ] {
         visitor.visit_atomic_i64_slot(slot, Ordering::Acquire, Ordering::Release);
     }
@@ -1948,6 +1949,8 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
                 tag_str = Some("CompressionStream".to_string());
             } else if class_id == crate::object::CLASS_ID_DECOMPRESSION_STREAM {
                 tag_str = Some("DecompressionStream".to_string());
+            } else if class_id == crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID {
+                tag_str = Some("RegExp String Iterator".to_string());
             }
             if let Some(func_ptr) = lookup_to_string_tag_hook(class_id) {
                 let getter: extern "C" fn(f64) -> f64 = std::mem::transmute(func_ptr as *const u8);

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1517,21 +1517,25 @@ pub unsafe extern "C" fn js_native_call_method(
                 // function`) because no runtime arm handled `match`.
                 "match" | "matchAll" => {
                     if args_len >= 1 && !args_ptr.is_null() {
-                        let regex_val = unsafe { *args_ptr };
+                        let pattern_val = unsafe { *args_ptr };
+                        if method_name == "matchAll" {
+                            let result_ptr =
+                                crate::regex::js_string_match_all_value(s_ptr, pattern_val);
+                            if result_ptr.is_null() {
+                                return f64::from_bits(JSValue::null().bits());
+                            }
+                            return f64::from_bits(JSValue::pointer(result_ptr as *mut u8).bits());
+                        }
                         // Extract regex handle from the arg value. RegExp
                         // values are NaN-boxed pointers; pass through the
                         // pointer extraction the same way the HIR-level
                         // StringMatch path does.
-                        let regex_jsval = JSValue::from_bits(regex_val.to_bits());
+                        let regex_jsval = JSValue::from_bits(pattern_val.to_bits());
                         if !regex_jsval.is_pointer() {
                             return f64::from_bits(JSValue::null().bits());
                         }
                         let regex_ptr = regex_jsval.as_pointer::<crate::regex::RegExpHeader>();
-                        let result_ptr = if method_name == "match" {
-                            crate::regex::js_string_match(s_ptr, regex_ptr)
-                        } else {
-                            crate::regex::js_string_match_all(s_ptr, regex_ptr)
-                        };
+                        let result_ptr = crate::regex::js_string_match(s_ptr, regex_ptr);
                         if result_ptr.is_null() {
                             return f64::from_bits(JSValue::null().bits());
                         }
@@ -2491,6 +2495,12 @@ pub unsafe extern "C" fn js_native_call_method(
                     method_name,
                 );
             }
+            if (*obj).class_id == crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID {
+                return crate::regex::dispatch_regexp_string_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
             // #2874: lazy iterator-helper objects (`Iterator.from(x)` and the
             // chain it produces: `.map`/`.filter`/`.take`/`.drop`/`.flatMap`/
             // `.toArray`/`.forEach`/`.reduce`/`.some`/`.every`/`.find`/`.next`).
@@ -2983,6 +2993,12 @@ pub unsafe extern "C" fn js_native_call_method(
             }
             if (*obj).class_id == crate::string::STRING_ITERATOR_CLASS_ID {
                 return crate::string::dispatch_string_iterator_method(
+                    obj as *mut ObjectHeader,
+                    method_name,
+                );
+            }
+            if (*obj).class_id == crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID {
+                return crate::regex::dispatch_regexp_string_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,
                 );

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -16,8 +16,13 @@ use crate::value::js_nanbox_string;
 use crate::object::ObjectHeader;
 
 mod grammar;
+mod match_all;
 mod replace_fn;
 use grammar::{has_invalid_repeated_quantifier, js_regex_to_rust};
+pub use match_all::{
+    dispatch_regexp_string_iterator_method, js_string_match_all, js_string_match_all_value,
+    REGEXP_STRING_ITERATOR_CLASS_ID,
+};
 use replace_fn::call_replace_callback;
 pub use replace_fn::{js_string_replace_all_string_fn, js_string_replace_string_fn};
 
@@ -198,6 +203,13 @@ fn throw_replace_all_non_global_regex() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+fn throw_match_all_non_global_regex() -> ! {
+    let message = b"String.prototype.matchAll called with a non-global RegExp argument";
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 fn set_exec_array_metadata(arr: *mut ArrayHeader, input: &str, index: f64) {
     if arr.is_null() {
         return;
@@ -209,6 +221,22 @@ fn set_exec_array_metadata(arr: *mut ArrayHeader, input: &str, index: f64) {
     let input_str = js_string_from_str(input);
     let input_value = js_nanbox_string(input_str as i64);
     crate::array::js_array_set_string_key(arr, input_key, input_value);
+}
+
+fn char_index_to_byte(s: &str, char_index: usize) -> usize {
+    if char_index == 0 {
+        return 0;
+    }
+    for (idx, (byte, _)) in s.char_indices().enumerate() {
+        if idx == char_index {
+            return byte;
+        }
+    }
+    s.len()
+}
+
+fn byte_index_to_char_index(s: &str, byte_index: usize) -> f64 {
+    s[..byte_index.min(s.len())].chars().count() as f64
 }
 
 #[inline]
@@ -610,75 +638,6 @@ pub extern "C" fn js_string_match(
                 }
             }
         }
-    }
-}
-
-/// Find all matches in a string, each with capture groups
-/// string.matchAll(regex) -> Array<Array<string>> (array of match arrays)
-#[no_mangle]
-pub extern "C" fn js_string_match_all(
-    s: *const StringHeader,
-    re: *const RegExpHeader,
-) -> *mut ArrayHeader {
-    if !is_valid_ptr(s) || !is_valid_regex_ptr(re) {
-        // Return empty array, not null (matchAll never returns null)
-        return crate::array::js_array_alloc(0);
-    }
-
-    let str_data = string_as_str(s);
-
-    unsafe {
-        let regex = &*(*re).regex_ptr;
-
-        // Collect all captures
-        let all_caps: Vec<regex::Captures> = regex.captures_iter(str_data).collect();
-
-        if all_caps.is_empty() {
-            return crate::array::js_array_alloc(0);
-        }
-
-        // Create outer array (one entry per match)
-        let outer = crate::array::js_array_alloc(all_caps.len() as u32);
-        let scope = crate::gc::RuntimeHandleScope::new();
-        let outer_handle = scope.root_raw_mut_ptr(outer);
-        (*outer_handle.get_raw_mut_ptr::<ArrayHeader>()).length = all_caps.len() as u32;
-
-        for (i, caps) in all_caps.iter().enumerate() {
-            // Create inner array for this match (full match + capture groups)
-            let inner = crate::array::js_array_alloc(caps.len() as u32);
-            let inner_scope = crate::gc::RuntimeHandleScope::new();
-            let inner_handle = inner_scope.root_raw_mut_ptr(inner);
-            (*inner_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-
-            for (j, cap) in caps.iter().enumerate() {
-                if let Some(m) = cap {
-                    let str_ptr = js_string_from_str(m.as_str());
-                    let nanboxed = js_nanbox_string(str_ptr as i64);
-                    let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
-                    // GC_STORE_AUDIT(BARRIERED): regex nested capture slot uses the shared array slot-store helper.
-                    crate::array::store_array_slot(inner, j, nanboxed.to_bits());
-                } else {
-                    // Undefined capture group
-                    let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
-                    let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
-                    // GC_STORE_AUDIT(BARRIERED): regex unmatched nested capture slot uses the shared array slot-store helper.
-                    crate::array::store_array_slot(inner, j, undefined.to_bits());
-                }
-            }
-
-            // Store inner array as NaN-boxed POINTER_TAG in outer array slot —
-            // raw `inner as i64 -> f64::from_bits` would write a non-NaN-boxed
-            // double whose bits happen to alias the heap pointer; the codegen
-            // IndexGet path then reads `arr[i]` as a plain number and crashes
-            // when iterating with `for (const m of arr) m[1]`.
-            let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
-            let inner_boxed = crate::value::js_nanbox_pointer(inner as i64);
-            let outer = outer_handle.get_raw_mut_ptr::<ArrayHeader>();
-            // GC_STORE_AUDIT(BARRIERED): regex nested result slot uses the shared array slot-store helper.
-            crate::array::store_array_slot(outer, i, inner_boxed.to_bits());
-        }
-
-        outer_handle.get_raw_mut_ptr::<ArrayHeader>()
     }
 }
 

--- a/crates/perry-runtime/src/regex/match_all.rs
+++ b/crates/perry-runtime/src/regex/match_all.rs
@@ -1,0 +1,226 @@
+use regex::Regex;
+
+use super::{
+    byte_index_to_char_index, char_index_to_byte, is_valid_ptr, is_valid_regex_ptr, js_regexp_new,
+    js_string_from_str, set_exec_array_metadata, string_as_str, throw_match_all_non_global_regex,
+    RegExpHeader,
+};
+use crate::array::ArrayHeader;
+use crate::object::ObjectHeader;
+use crate::string::StringHeader;
+use crate::value::{
+    js_nanbox_get_pointer, js_nanbox_pointer, js_nanbox_string, JSValue, TAG_UNDEFINED,
+};
+
+/// Class id for `String.prototype.matchAll`'s RegExp String Iterator object.
+pub const REGEXP_STRING_ITERATOR_CLASS_ID: u32 = 0xFFFF_000A;
+
+fn build_match_all_groups(
+    regex: &Regex,
+    caps: &regex::Captures<'_>,
+    scope: &crate::gc::RuntimeHandleScope,
+) -> f64 {
+    let group_names: Vec<(&str, Option<regex::Match<'_>>)> = regex
+        .capture_names()
+        .enumerate()
+        .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
+        .collect();
+
+    if group_names.is_empty() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+
+    let groups_obj = crate::object::js_object_alloc(0, 0);
+    let groups_handle = scope.root_raw_mut_ptr(groups_obj);
+    for (name, m) in &group_names {
+        let val = if let Some(m) = m {
+            let str_ptr = js_string_from_str(m.as_str());
+            js_nanbox_string(str_ptr as i64)
+        } else {
+            f64::from_bits(TAG_UNDEFINED)
+        };
+        let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+        crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
+    }
+    let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+    js_nanbox_pointer(groups_obj as i64)
+}
+
+fn set_match_all_groups(arr: *mut ArrayHeader, groups_value: f64) {
+    let groups_key = js_string_from_str("groups");
+    crate::array::js_array_set_string_key(arr, groups_key, groups_value);
+}
+
+unsafe fn materialize_match_all_results(
+    s: *const StringHeader,
+    re: *const RegExpHeader,
+    start_char_index: usize,
+) -> *mut ArrayHeader {
+    if !is_valid_ptr(s) || !is_valid_regex_ptr(re) {
+        return crate::array::js_array_alloc(0);
+    }
+
+    let str_data = string_as_str(s);
+    let search_start = char_index_to_byte(str_data, start_char_index);
+    let search_str = &str_data[search_start..];
+    let regex = &*(*re).regex_ptr;
+    let all_caps: Vec<regex::Captures<'_>> = regex.captures_iter(search_str).collect();
+    let outer = crate::array::js_array_alloc(all_caps.len() as u32);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let outer_handle = scope.root_raw_mut_ptr(outer);
+    (*outer_handle.get_raw_mut_ptr::<ArrayHeader>()).length = all_caps.len() as u32;
+
+    for (i, caps) in all_caps.iter().enumerate() {
+        let inner = crate::array::js_array_alloc(caps.len() as u32);
+        let inner_handle = scope.root_raw_mut_ptr(inner);
+        (*inner_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
+
+        for (j, cap) in caps.iter().enumerate() {
+            let value = if let Some(m) = cap {
+                let str_ptr = js_string_from_str(m.as_str());
+                js_nanbox_string(str_ptr as i64)
+            } else {
+                f64::from_bits(TAG_UNDEFINED)
+            };
+            let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
+            crate::array::store_array_slot(inner, j, value.to_bits());
+        }
+
+        let match_index = caps
+            .get(0)
+            .map(|m| byte_index_to_char_index(str_data, search_start + m.start()))
+            .unwrap_or_else(|| start_char_index as f64);
+        let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
+        set_exec_array_metadata(inner, str_data, match_index);
+        let groups_value = build_match_all_groups(regex, caps, &scope);
+        set_match_all_groups(inner, groups_value);
+
+        let inner_boxed = js_nanbox_pointer(inner as i64);
+        let outer = outer_handle.get_raw_mut_ptr::<ArrayHeader>();
+        crate::array::store_array_slot(outer, i, inner_boxed.to_bits());
+    }
+
+    outer_handle.get_raw_mut_ptr::<ArrayHeader>()
+}
+
+unsafe fn alloc_regexp_string_iterator(matches: *mut ArrayHeader) -> *mut ObjectHeader {
+    let obj = crate::object::js_object_alloc(REGEXP_STRING_ITERATOR_CLASS_ID, 2);
+    crate::object::js_object_set_field(
+        obj,
+        0,
+        JSValue::from_bits(js_nanbox_pointer(matches as i64).to_bits()),
+    );
+    crate::object::js_object_set_field(obj, 1, JSValue::number(0.0));
+    crate::object::attach_iterator_prototype(obj, REGEXP_STRING_ITERATOR_CLASS_ID);
+    obj
+}
+
+fn match_all_pattern_to_regex(pattern_value: f64) -> *mut RegExpHeader {
+    let pattern_jsval = JSValue::from_bits(pattern_value.to_bits());
+    let pattern_ptr = if pattern_jsval.is_undefined() {
+        js_string_from_str("")
+    } else {
+        crate::value::js_jsvalue_to_string(pattern_value)
+    };
+    let flags_ptr = js_string_from_str("g");
+    js_regexp_new(
+        pattern_ptr as *const StringHeader,
+        flags_ptr as *const StringHeader,
+    )
+}
+
+/// `String.prototype.matchAll` returns a RegExp String Iterator object.
+#[no_mangle]
+pub extern "C" fn js_string_match_all_value(
+    s: *const StringHeader,
+    pattern_value: f64,
+) -> *mut ObjectHeader {
+    if !is_valid_ptr(s) {
+        let empty = crate::array::js_array_alloc(0);
+        return unsafe { alloc_regexp_string_iterator(empty) };
+    }
+
+    let pattern_jsval = JSValue::from_bits(pattern_value.to_bits());
+    let raw = if pattern_jsval.is_pointer() {
+        js_nanbox_get_pointer(pattern_value)
+    } else {
+        0
+    };
+    let (re, start_index) = if raw != 0 && is_valid_regex_ptr(raw as *const RegExpHeader) {
+        let re = raw as *const RegExpHeader;
+        unsafe {
+            if !(*re).global {
+                throw_match_all_non_global_regex();
+            }
+            (re, (*re).last_index as usize)
+        }
+    } else {
+        (
+            match_all_pattern_to_regex(pattern_value) as *const RegExpHeader,
+            0,
+        )
+    };
+
+    let matches = unsafe { materialize_match_all_results(s, re, start_index) };
+    unsafe { alloc_regexp_string_iterator(matches) }
+}
+
+/// Compatibility entry point for older call sites that already hold a RegExp.
+#[no_mangle]
+pub extern "C" fn js_string_match_all(
+    s: *const StringHeader,
+    re: *const RegExpHeader,
+) -> *mut ObjectHeader {
+    if !is_valid_regex_ptr(re) {
+        let empty = crate::array::js_array_alloc(0);
+        return unsafe { alloc_regexp_string_iterator(empty) };
+    }
+    unsafe {
+        if !(*re).global {
+            throw_match_all_non_global_regex();
+        }
+        let matches = materialize_match_all_results(s, re, (*re).last_index as usize);
+        alloc_regexp_string_iterator(matches)
+    }
+}
+
+unsafe fn regexp_string_iter_result(value: JSValue, done: bool) -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
+    let keys = crate::array::js_array_alloc(2);
+    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
+    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
+    crate::object::js_object_set_keys(obj, keys);
+    crate::object::js_object_set_field(obj, 0, value);
+    crate::object::js_object_set_field(obj, 1, JSValue::bool(done));
+    js_nanbox_pointer(obj as i64)
+}
+
+pub unsafe fn dispatch_regexp_string_iterator_method(
+    iter_obj: *mut ObjectHeader,
+    method_name: &str,
+) -> f64 {
+    match method_name {
+        "next" => {
+            let backing = f64::from_bits(crate::object::js_object_get_field(iter_obj, 0).bits());
+            let arr = js_nanbox_get_pointer(backing) as *const ArrayHeader;
+            let idx = f64::from_bits(crate::object::js_object_get_field(iter_obj, 1).bits()) as u32;
+            let len = if arr.is_null() {
+                0
+            } else {
+                crate::array::js_array_length(arr)
+            };
+            if idx >= len {
+                return regexp_string_iter_result(JSValue::undefined(), true);
+            }
+            crate::object::js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+            let elem = crate::array::js_array_get_f64(arr, idx);
+            regexp_string_iter_result(JSValue::from_bits(elem.to_bits()), false)
+        }
+        "Symbol.iterator" | "@@iterator" => js_nanbox_pointer(iter_obj as i64),
+        "return" | "throw" => regexp_string_iter_result(JSValue::undefined(), true),
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}

--- a/test-parity/expected/string-matchall-iterator.txt
+++ b/test-parity/expected/string-matchall-iterator.txt
@@ -1,0 +1,13 @@
+iter next type: function
+iter tag: [object RegExp String Iterator]
+iter self: true
+manual first done: false
+manual first value: 1|1|1|a1b2|true
+manual rest: [["2","2",3]]
+non-global: TypeError:String.prototype.matchAll called with a non-global RegExp argument
+string pattern: [["a",0],[".",1],["a",2]]
+undefined pattern: [["",0],["",1],["",2]]
+lastIndex seen: 2
+lastIndex after: 2
+named groups: x|x|0|xy
+dynamic dispatch: 9|9|1

--- a/test-parity/node-suite/globals/string-matchall-iterator.ts
+++ b/test-parity/node-suite/globals/string-matchall-iterator.ts
@@ -1,0 +1,51 @@
+function show(label: string, value: unknown) {
+  console.log(label + ": " + String(value));
+}
+
+function showError(label: string, fn: () => unknown) {
+  try {
+    fn();
+    show(label, "no-throw");
+  } catch (err: any) {
+    show(label, err?.name + ":" + err?.message);
+  }
+}
+
+const iter = "a1b2".matchAll(/(\d)/g);
+show("iter next type", typeof (iter as any).next);
+show("iter tag", Object.prototype.toString.call(iter));
+show("iter self", (iter as any)[Symbol.iterator]() === iter);
+
+const first = (iter as any).next();
+show("manual first done", first.done);
+show(
+  "manual first value",
+  [
+    first.value[0],
+    first.value[1],
+    first.value.index,
+    first.value.input,
+    first.value.groups === undefined,
+  ].join("|"),
+);
+show("manual rest", JSON.stringify(Array.from(iter, (m) => [m[0], m[1], m.index])));
+
+showError("non-global", () => "a".matchAll(/a/));
+show("string pattern", JSON.stringify(Array.from("a.a".matchAll("."), (m) => [m[0], m.index])));
+show(
+  "undefined pattern",
+  JSON.stringify(Array.from("ab".matchAll(undefined), (m) => [m[0], m.index])),
+);
+
+const startRe = /a/g;
+startRe.lastIndex = 2;
+show("lastIndex seen", Array.from("a_a".matchAll(startRe), (m) => m.index).join(","));
+show("lastIndex after", startRe.lastIndex);
+
+const named = Array.from("xy".matchAll(/(?<letter>[xy])/g))[0];
+show("named groups", [named[0], named.groups?.letter, named.index, named.input].join("|"));
+
+const dynamicInput: any = "z9";
+const dynamicIter = dynamicInput.matchAll(/(\d)/g);
+const dynamicFirst = dynamicIter.next().value;
+show("dynamic dispatch", [dynamicFirst[0], dynamicFirst[1], dynamicFirst.index].join("|"));


### PR DESCRIPTION
Closes #2845.

## What changed
- Reworked `String.prototype.matchAll` to return a RegExp String Iterator object instead of an eager array.
- Added iterator prototype wiring, `.next()` dispatch, self-iterability, `Object.prototype.toString` branding, and `Array.from`/spread support for the new iterator class.
- Preserved match array metadata (`index`, `input`, own `groups`) and honored the original RegExp `lastIndex` without mutating it.
- Added runtime validation for non-global RegExp arguments and support for string, non-RegExp, omitted, and `undefined` patterns through the RegExp-construction path.
- Updated codegen/type inference so `matchAll` stays dynamic/iterator-shaped instead of being treated as an array.

## Why this is batched
These changes are tightly coupled: the runtime entry point, iterator class dispatch, prototype roots, `Array.from` iterator recognition, and codegen return type all need to move together for Node-compatible `matchAll` behavior. Landing only one piece leaves either an ABI mismatch or an object that cannot be iterated correctly.

## Non-goals
- Broader RegExp flag parity beyond the existing runtime support.
- Sticky/unicode/indices behavior beyond what Perry's current RegExp engine already implements.
- Making `matchAll` lazy internally; this PR preserves the current materialized-match approach behind a spec-shaped iterator object.

## Validation
- `cargo check -p perry-runtime -p perry-codegen -p perry-hir -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `./scripts/check_file_size.sh`
- `timeout 900s ./run_parity_tests.sh --suite node-suite --module globals --filter string-matchall-iterator` (uses expected output because this local Node 22.22.1 build is not compiled with TypeScript-strip support)
