### PR TITLE
[codex] Preserve lexical new.target for arrows

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1405,7 +1405,6 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::Bool(..)
         | Expr::Undefined
         | Expr::Null
-        | Expr::NewTarget
         | Expr::Void(..)
         | Expr::TypeOf(..)
         | Expr::String(..)

--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -440,6 +440,7 @@ fn rewrite_async_closures_in_expr(
             captures,
             mutable_captures,
             captures_this,
+            captures_new_target,
             enclosing_class,
             is_strict,
             is_async,
@@ -470,6 +471,7 @@ fn rewrite_async_closures_in_expr(
                 // AND `await` silently halts (the step closure has
                 // captures_this=false and Expr::This doesn't lower).
                 let owned_captures_this = *captures_this;
+                let owned_captures_new_target = *captures_new_target;
                 let owned_enclosing_class = enclosing_class.clone();
                 let new_body = crate::generator::transform_plain_async_closure_body(
                     owned_body,
@@ -477,6 +479,7 @@ fn rewrite_async_closures_in_expr(
                     &owned_captures,
                     &owned_mutable_captures,
                     owned_captures_this,
+                    owned_captures_new_target,
                     owned_enclosing_class,
                     *is_strict,
                     next_local_id,

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -16,6 +16,7 @@ pub fn transform_generator_function(
         &[],
         &[],
         false,
+        false,
         None,
     );
 }
@@ -38,6 +39,7 @@ pub fn transform_generator_function_with_extra_captures(
     extra_captures: &[LocalId],
     extra_mutable_captures: &[LocalId],
     captures_this: bool,
+    captures_new_target: bool,
     enclosing_class: Option<String>,
 ) {
     // Generator bodies run later inside synthesized step closures, so direct
@@ -467,6 +469,7 @@ pub fn transform_generator_function_with_extra_captures(
             next_local_id,
             next_func_id,
             captures_this,
+            captures_new_target,
             enclosing_class.clone(),
             func.is_strict,
         );
@@ -878,6 +881,7 @@ pub fn build_async_step_driver_direct(
     next_local_id: &mut u32,
     next_func_id: &mut u32,
     captures_this: bool,
+    captures_new_target: bool,
     enclosing_class: Option<String>,
     is_strict: bool,
 ) -> Vec<Stmt> {
@@ -1128,7 +1132,7 @@ pub fn build_async_step_driver_direct(
         captures: step_captures,
         mutable_captures: step_mut_captures,
         captures_this,
-        captures_new_target: false,
+        captures_new_target,
         enclosing_class: enclosing_class.clone(),
         is_arrow: false,
         is_strict,

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -133,6 +133,7 @@ pub fn transform_generators(module: &mut Module) {
                     &[],
                     &[],
                     true,
+                    false,
                     Some(class.name.clone()),
                 );
             }
@@ -161,6 +162,7 @@ pub fn transform_generators(module: &mut Module) {
                     &[],
                     &[],
                     true,
+                    false,
                     Some(class.name.clone()),
                 );
             }
@@ -357,6 +359,7 @@ fn transform_generator_closures_in_stmts(
                             captures,
                             mutable_captures,
                             *captures_this,
+                            false,
                             enclosing_class.clone(),
                         );
                         *body = synth.body;
@@ -394,6 +397,7 @@ pub fn transform_plain_async_closure_body(
     outer_captures: &[LocalId],
     outer_mutable_captures: &[LocalId],
     outer_captures_this: bool,
+    outer_captures_new_target: bool,
     outer_enclosing_class: Option<String>,
     is_strict: bool,
     next_local_id: &mut LocalId,
@@ -430,6 +434,7 @@ pub fn transform_plain_async_closure_body(
         outer_captures,
         outer_mutable_captures,
         outer_captures_this,
+        outer_captures_new_target,
         outer_enclosing_class,
     );
     synth.body

--- a/test-parity/node-suite/globals/arrow-newtarget-capture.ts
+++ b/test-parity/node-suite/globals/arrow-newtarget-capture.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+
+function show(label, value) {
+  console.log(label + ":" + value);
+}
+
+function syncArrowFactory() {
+  return () => new.target;
+}
+
+function asyncArrowFactory() {
+  return async () => new.target;
+}
+
+function asyncAwaitArrowFactory() {
+  return async () => {
+    await Promise.resolve();
+    return new.target;
+  };
+}
+
+function ordinaryFactory() {
+  return function () {
+    return new.target;
+  };
+}
+
+async function main() {
+  const SyncCtor = function SyncCtor() {};
+  const AsyncCtor = function AsyncCtor() {};
+  const AsyncAwaitCtor = function AsyncAwaitCtor() {};
+  const OrdinaryCtor = function OrdinaryCtor() {};
+
+  const syncValue = Reflect.construct(syncArrowFactory, [], SyncCtor)();
+  const asyncValue = await Reflect.construct(asyncArrowFactory, [], AsyncCtor)();
+  const asyncAwaitValue = await Reflect.construct(asyncAwaitArrowFactory, [], AsyncAwaitCtor)();
+  const ordinaryValue = Reflect.construct(ordinaryFactory, [], OrdinaryCtor)();
+
+  show("sync arrow new.target", syncValue && syncValue.name);
+  show("async arrow new.target", asyncValue && asyncValue.name);
+  show("async await arrow new.target", asyncAwaitValue && asyncAwaitValue.name);
+  show("ordinary function own new.target", ordinaryValue === undefined);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Route `Expr::NewTarget` through the stack-aware lowerer so arrow closures can read captured lexical `new.target` values.
- Propagate `captures_new_target` into synthesized async step closures, including awaited async arrows.
- Add a Node parity fixture for sync arrows, async arrows, awaited async arrows, and ordinary function `new.target` behavior.

Addresses the async/arrow `new.target` portion of #3568.

## Validation
- `npm exec --package=node@25 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module globals --filter arrow-newtarget-capture'` (Node v25.9.0, 1 pass / 0 fail)
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-generator-prototype-identity/target cargo check -p perry-codegen -p perry-transform`
