### PR TITLE
[codex] Invoke module loader hooks for dynamic imports

### DIFF
--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -105,8 +105,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if paths.len() == 1 {
                 // Evaluate the arg for side effects (most are pure but
                 // a template literal with computed parts can have e.g.
-                // function calls); the result is discarded.
-                let _ = lower_expr(ctx, arg)?;
+                // function calls) and let registered module loader hooks
+                // observe/delegate the import. The statically known target
+                // still determines the namespace in Perry's compile-time graph.
+                let path_val = lower_expr(ctx, arg)?;
+                let _ = ctx.block().call(
+                    DOUBLE,
+                    "js_module_dynamic_import_apply_hooks",
+                    &[(DOUBLE, &path_val)],
+                );
                 let path = &paths[0];
                 let target_prefix = ctx.dynamic_import_path_to_prefix.get(path).cloned();
                 // #1671: a dynamic import of a known node-submodule
@@ -178,7 +185,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // successful compare resolves to its corresponding
             // namespace global. The final fallback emits a rejected
             // promise.
-            let path_val = lower_expr(ctx, arg)?;
+            let raw_path_val = lower_expr(ctx, arg)?;
+            let path_val = ctx.block().call(
+                DOUBLE,
+                "js_module_dynamic_import_apply_hooks",
+                &[(DOUBLE, &raw_path_val)],
+            );
             // Result phi slot: every successful match stores the
             // promise (NaN-boxed POINTER_TAG f64) here, then jumps to
             // a join block which loads and returns. Using an alloca

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1792,6 +1792,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_get_export", DOUBLE, &[I64, I64, I64]);
     module.declare_function("js_get_property", DOUBLE, &[DOUBLE, I64, I64]);
     module.declare_function("js_load_module", I64, &[I64, I64]);
+    module.declare_function("js_module_dynamic_import_apply_hooks", DOUBLE, &[DOUBLE]);
     module.declare_function(
         "js_native_call_method",
         DOUBLE,

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -343,6 +343,7 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::node_vm::scan_vm_roots_mut);
     gc_register_mutable_root_scanner(crate::tls::scan_tls_roots_mut);
     gc_register_mutable_root_scanner(crate::process::scan_process_finalization_roots_mut);
+    gc_register_mutable_root_scanner(crate::process::scan_process_module_loader_roots_mut);
     gc_register_mutable_root_scanner(crate::os::scan_process_event_listener_roots_mut);
     gc_register_mutable_root_scanner(crate::os::scan_process_stream_singleton_roots_mut);
     gc_register_mutable_root_scanner(crate::fs::scan_fs_stream_roots_mut);

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -373,6 +373,14 @@ fn module_set_field(obj: *mut crate::object::ObjectHeader, name: &str, value: f6
 type ModuleFunction1 = extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64;
 type ModuleFunction2 = extern "C" fn(*const crate::closure::ClosureHeader, f64, f64) -> f64;
 
+#[derive(Clone, Copy)]
+struct ModuleLoaderHookEntry {
+    id: u64,
+    resolve: f64,
+    load: f64,
+    active: bool,
+}
+
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum ProcessFinalizationKind {
     Exit,
@@ -396,18 +404,13 @@ thread_local! {
         const { Cell::new(std::ptr::null()) };
     static PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER_INSTALLED: Cell<bool> =
         const { Cell::new(false) };
-}
-
-extern "C" fn module_source_map_noop(_closure: *const crate::closure::ClosureHeader) -> f64 {
-    f64::from_bits(crate::value::TAG_UNDEFINED)
-}
-
-fn module_noop_function(name: &str) -> f64 {
-    let func_ptr = module_source_map_noop as *const u8;
-    crate::closure::js_register_closure_arity(func_ptr, 0);
-    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
-    crate::object::set_bound_native_closure_name(closure, name);
-    crate::value::js_nanbox_pointer(closure as i64)
+    static MODULE_LOADER_HOOKS: RefCell<Vec<ModuleLoaderHookEntry>> =
+        const { RefCell::new(Vec::new()) };
+    static MODULE_LOADER_HOOK_NEXT_ID: Cell<u64> = const { Cell::new(1) };
+    static MODULE_LOADER_NEXT_RESOLVE: Cell<*const crate::closure::ClosureHeader> =
+        const { Cell::new(std::ptr::null()) };
+    static MODULE_LOADER_NEXT_LOAD: Cell<*const crate::closure::ClosureHeader> =
+        const { Cell::new(std::ptr::null()) };
 }
 
 fn module_function1(name: &str, thunk: ModuleFunction1, length: u32) -> f64 {
@@ -608,6 +611,27 @@ pub fn scan_process_finalization_roots_mut(visitor: &mut crate::gc::RuntimeRootV
         }
     });
     PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER.with(|cell| {
+        let mut callback = cell.get();
+        if !callback.is_null() && visitor.visit_raw_const_ptr_slot(&mut callback) {
+            cell.set(callback);
+        }
+    });
+}
+
+pub fn scan_process_module_loader_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    MODULE_LOADER_HOOKS.with(|hooks| {
+        for entry in hooks.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut entry.resolve);
+            visitor.visit_nanbox_f64_slot(&mut entry.load);
+        }
+    });
+    MODULE_LOADER_NEXT_RESOLVE.with(|cell| {
+        let mut callback = cell.get();
+        if !callback.is_null() && visitor.visit_raw_const_ptr_slot(&mut callback) {
+            cell.set(callback);
+        }
+    });
+    MODULE_LOADER_NEXT_LOAD.with(|cell| {
         let mut callback = cell.get();
         if !callback.is_null() && visitor.visit_raw_const_ptr_slot(&mut callback) {
             cell.set(callback);
@@ -3471,6 +3495,9 @@ static KEEP_JS_MODULE_REGISTER: extern "C" fn(f64, f64, f64) -> f64 = js_module_
 #[used]
 static KEEP_JS_MODULE_REGISTER_HOOKS: extern "C" fn(f64) -> f64 = js_module_register_hooks;
 #[used]
+static KEEP_JS_MODULE_DYNAMIC_IMPORT_APPLY_HOOKS: extern "C" fn(f64) -> f64 =
+    js_module_dynamic_import_apply_hooks;
+#[used]
 static KEEP_JS_MODULE_MODULE_NEW: extern "C" fn(f64) -> f64 = js_module_module_new;
 #[used]
 static KEEP_JS_MODULE_FIND_PATH: extern "C" fn(f64, f64, f64) -> f64 = js_module_find_path;
@@ -4308,9 +4335,30 @@ fn module_hook_member(value: f64, name: &str) -> f64 {
     crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
 }
 
-fn module_hooks_deregister_prototype() -> *mut crate::object::ObjectHeader {
+extern "C" fn module_hooks_deregister(closure: *const crate::closure::ClosureHeader) -> f64 {
+    let id = js_closure_get_capture_f64(closure, 0) as u64;
+    MODULE_LOADER_HOOKS.with(|hooks| {
+        if let Some(entry) = hooks.borrow_mut().iter_mut().find(|entry| entry.id == id) {
+            entry.active = false;
+        }
+    });
+    module_undefined()
+}
+
+fn module_hooks_deregister_function(id: u64) -> f64 {
+    let func_ptr = module_hooks_deregister as *const u8;
+    crate::closure::js_register_closure_arity(func_ptr, 0);
+    crate::closure::js_register_closure_length(func_ptr, 0);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 1);
+    js_closure_set_capture_f64(closure, 0, id as f64);
+    crate::object::set_bound_native_closure_name(closure, "deregister");
+    crate::object::set_builtin_closure_length(closure as usize, 0);
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
+fn module_hooks_deregister_prototype(id: u64) -> *mut crate::object::ObjectHeader {
     let proto = crate::object::js_object_alloc(0, 1);
-    module_set_field(proto, "deregister", module_noop_function("deregister"));
+    module_set_field(proto, "deregister", module_hooks_deregister_function(id));
     crate::object::set_property_attrs(
         proto as usize,
         "deregister".to_string(),
@@ -4343,17 +4391,177 @@ pub extern "C" fn js_module_register_hooks(hooks: f64) -> f64 {
         load = module_hook_member(module_get_named_field(hooks_obj, "load"), "load");
     }
 
+    let id = MODULE_LOADER_HOOK_NEXT_ID.with(|next| {
+        let id = next.get();
+        next.set(id.saturating_add(1).max(1));
+        id
+    });
+    MODULE_LOADER_HOOKS.with(|hooks| {
+        hooks.borrow_mut().push(ModuleLoaderHookEntry {
+            id,
+            resolve,
+            load,
+            active: true,
+        });
+    });
+    crate::gc::runtime_write_barrier_root_nanbox(resolve.to_bits());
+    crate::gc::runtime_write_barrier_root_nanbox(load.to_bits());
+
     let handle = crate::object::js_object_alloc(0, 2);
     module_set_field(handle, "resolve", resolve);
     module_set_field(handle, "load", load);
 
-    let proto = module_hooks_deregister_prototype();
+    let proto = module_hooks_deregister_prototype(id);
     let proto_value = module_object_value(proto);
     crate::object::prototype_chain::object_set_static_prototype(
         handle as usize,
         proto_value.to_bits(),
     );
     module_object_value(handle)
+}
+
+extern "C" fn module_loader_next_resolve(
+    _closure: *const crate::closure::ClosureHeader,
+    specifier: f64,
+    _context: f64,
+) -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    module_set_field(obj, "url", specifier);
+    module_set_field(obj, "format", module_string_value("module-typescript"));
+    module_object_value(obj)
+}
+
+extern "C" fn module_loader_next_load(
+    _closure: *const crate::closure::ClosureHeader,
+    _url: f64,
+    _context: f64,
+) -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    module_set_field(obj, "format", module_string_value("module-typescript"));
+    module_set_field(obj, "source", module_string_value(""));
+    module_object_value(obj)
+}
+
+fn module_loader_callback(
+    slot: &'static std::thread::LocalKey<Cell<*const crate::closure::ClosureHeader>>,
+    name: &str,
+    func: extern "C" fn(*const crate::closure::ClosureHeader, f64, f64) -> f64,
+) -> f64 {
+    let ptr = slot.with(|cell| {
+        let existing = cell.get();
+        if !existing.is_null() {
+            return existing;
+        }
+        let func_ptr = func as *const u8;
+        crate::closure::js_register_closure_arity(func_ptr, 2);
+        crate::closure::js_register_closure_length(func_ptr, 2);
+        let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+        crate::object::set_bound_native_closure_name(closure, name);
+        crate::object::set_builtin_closure_length(closure as usize, 2);
+        cell.set(closure);
+        closure
+    });
+    crate::value::js_nanbox_pointer(ptr as i64)
+}
+
+fn module_loader_resolve_context() -> f64 {
+    let obj = crate::object::js_object_alloc(0, 1);
+    module_set_field(obj, "parentURL", module_string_value(""));
+    module_object_value(obj)
+}
+
+fn module_loader_load_context() -> f64 {
+    let obj = crate::object::js_object_alloc(0, 1);
+    module_set_field(obj, "format", module_string_value("module-typescript"));
+    module_object_value(obj)
+}
+
+fn module_loader_result_url(result: f64, fallback: f64) -> f64 {
+    let Some(obj) = module_object_ptr(result) else {
+        return fallback;
+    };
+    let url = module_get_named_field(obj, "url");
+    if module_value_to_string(url).is_some() {
+        url
+    } else {
+        fallback
+    }
+}
+
+/// Apply active synchronous `module.registerHooks()` callbacks to a dynamic
+/// import known to Perry's compile-time graph. This supports observable
+/// resolve/load callback participation and deregistration; arbitrary new
+/// runtime-loaded modules remain outside Perry's static import model.
+#[no_mangle]
+pub extern "C" fn js_module_dynamic_import_apply_hooks(specifier: f64) -> f64 {
+    let entries = MODULE_LOADER_HOOKS.with(|hooks| {
+        hooks
+            .borrow()
+            .iter()
+            .copied()
+            .filter(|entry| entry.active)
+            .collect::<Vec<_>>()
+    });
+    if entries.is_empty() {
+        return specifier;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let mut current = specifier;
+    for entry in entries {
+        if is_function_value(entry.resolve) {
+            let current_handle = scope.root_nanbox_f64(current);
+            let callback_handle = scope.root_nanbox_f64(entry.resolve);
+            let context_handle = scope.root_nanbox_f64(module_loader_resolve_context());
+            let next_handle = scope.root_nanbox_f64(module_loader_callback(
+                &MODULE_LOADER_NEXT_RESOLVE,
+                "nextResolve",
+                module_loader_next_resolve,
+            ));
+            let args = [
+                current_handle.get_nanbox_f64(),
+                context_handle.get_nanbox_f64(),
+                next_handle.get_nanbox_f64(),
+            ];
+            let result = unsafe {
+                crate::closure::js_native_call_value(
+                    callback_handle.get_nanbox_f64(),
+                    args.as_ptr(),
+                    args.len(),
+                )
+            };
+            let result_handle = scope.root_nanbox_f64(result);
+            current = module_loader_result_url(
+                result_handle.get_nanbox_f64(),
+                current_handle.get_nanbox_f64(),
+            );
+        }
+
+        if is_function_value(entry.load) {
+            let current_handle = scope.root_nanbox_f64(current);
+            let callback_handle = scope.root_nanbox_f64(entry.load);
+            let context_handle = scope.root_nanbox_f64(module_loader_load_context());
+            let next_handle = scope.root_nanbox_f64(module_loader_callback(
+                &MODULE_LOADER_NEXT_LOAD,
+                "nextLoad",
+                module_loader_next_load,
+            ));
+            let args = [
+                current_handle.get_nanbox_f64(),
+                context_handle.get_nanbox_f64(),
+                next_handle.get_nanbox_f64(),
+            ];
+            unsafe {
+                crate::closure::js_native_call_value(
+                    callback_handle.get_nanbox_f64(),
+                    args.as_ptr(),
+                    args.len(),
+                );
+            }
+        }
+    }
+
+    current
 }
 
 fn module_register_invalid_specifier(specifier: &str) -> bool {

--- a/test-parity/node-suite/module/loader/fixtures/loader-hook-first.ts
+++ b/test-parity/node-suite/module/loader/fixtures/loader-hook-first.ts
@@ -1,0 +1,1 @@
+export const value = "first";

--- a/test-parity/node-suite/module/loader/fixtures/loader-hook-second.ts
+++ b/test-parity/node-suite/module/loader/fixtures/loader-hook-second.ts
@@ -1,0 +1,1 @@
+export const value = "second";

--- a/test-parity/node-suite/module/loader/register-hooks-dynamic-import.ts
+++ b/test-parity/node-suite/module/loader/register-hooks-dynamic-import.ts
@@ -1,0 +1,32 @@
+import * as Module from "node:module";
+
+const calls: string[] = [];
+
+const handle = Module.registerHooks({
+  resolve(specifier: string, context: any, nextResolve: Function) {
+    calls.push(`resolve:${specifier}:${typeof context.parentURL}:${typeof nextResolve}`);
+    const result = nextResolve(specifier, context);
+    calls.push(`resolve-result:${typeof result.url}:${result.format ?? "none"}`);
+    return result;
+  },
+  load(url: string, context: any, nextLoad: Function) {
+    calls.push(`load:${typeof url}:${typeof context.format}:${typeof nextLoad}`);
+    const result = nextLoad(url, context);
+    calls.push(`load-result:${result.format ?? "none"}:${"source" in result}`);
+    return result;
+  },
+});
+
+const firstPath =
+  true ? "./fixtures/loader-hook-first.ts" : "./fixtures/loader-hook-second.ts";
+const first = await import(firstPath);
+console.log("first value:", first.value);
+console.log("calls after first:", calls.join("|"));
+
+handle.deregister();
+
+const secondPath =
+  false ? "./fixtures/loader-hook-first.ts" : "./fixtures/loader-hook-second.ts";
+const second = await import(secondPath);
+console.log("second value:", second.value);
+console.log("calls after deregister:", calls.join("|"));


### PR DESCRIPTION
## Summary
- Store active `Module.registerHooks({ resolve, load })` registrations and keep their callbacks rooted for GC.
- Invoke active synchronous resolve/load hooks during Perry's compile-time-resolved dynamic imports, including `nextResolve` / `nextLoad` delegation objects and string `url` propagation for known graph imports.
- Make each hook handle's `deregister()` disable future dynamic-import participation.
- Add a focused Node parity fixture that proves callbacks run before deregistration and stop running afterward.

## Issue Scope
- Completes the synchronous `registerHooks` callback/deregistration slice for #3125.
- Advances the shared module loader registration surface for #3261 with explicit staged behavior.
- These are batched because both issues exercise the `node:module` loader registration path around dynamic import participation.

## Known Limitations
- Perry still imports only modules present in its compile-time graph; arbitrary runtime-loaded modules remain outside this PR.
- Full async loader-thread customization for `Module.register()` remains staged separately.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo test -p perry-runtime js_module_dynamic_import_apply_hooks -- --nocapture` (0 matched, 975 filtered, ok)
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module module --filter loader'` (Node v26.3.0, 5 pass / 0 fail; `test-parity/reports/parity_report_20260603_073532.json`)
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module module'` (Node v26.3.0, 13 pass / 1 fail; unrelated current-main `node-suite/module/require/cjs-package/commonjs-require-shape`, covered by #4220; `test-parity/reports/parity_report_20260603_073844.json`)
