### PR TITLE
Fix default parameter TDZ for later bindings

### DIFF
--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -487,6 +487,7 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
     // remaining params are the real runtime ones. (`fn_decl` already has its
     // own param-lowering site that needs the same fix — handled below.)
     let mut params = Vec::new();
+    let mut default_param_pats: Vec<ast::Pat> = Vec::new();
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
     for param in &fn_expr.function.params {
         let param_name = get_pat_name(&param.pat)?;
@@ -494,22 +495,25 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
             // TS `this:` annotation — skip; it's type-only.
             continue;
         }
-        let param_default = get_param_default(ctx, &param.pat)?;
         let is_rest = is_rest_param(&param.pat);
         let param_id = ctx.define_local(param_name.clone(), Type::Any);
         params.push(Param {
             id: param_id,
             name: param_name,
             ty: Type::Any,
-            default: param_default,
+            default: None,
             decorators: Vec::new(),
             is_rest,
             arguments_object: None,
         });
+        default_param_pats.push(param.pat.clone());
         // Track destructuring patterns to generate extraction statements
         if is_destructuring_pattern(&param.pat) {
             destructuring_params.push((param_id, param.pat.clone()));
         }
+    }
+    for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {
+        param.default = get_param_default(ctx, pat)?;
     }
 
     // #677: synthesize `arguments` for non-arrow function expressions when the

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -173,6 +173,7 @@ fn lower_method_prop(
     let scope_mark = ctx.enter_scope();
     ctx.enter_strict_mode(true);
     let mut params = Vec::new();
+    let mut default_param_pats: Vec<ast::Pat> = Vec::new();
     for param in method.function.params.iter() {
         let param_name = get_pat_name(&param.pat)?;
         // TypeScript's `this: T` is a TYPE-only marker (SWC emits it as a
@@ -188,17 +189,20 @@ fn lower_method_prop(
             continue;
         }
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
-        let param_default = get_param_default(ctx, &param.pat)?;
         let param_id = ctx.define_local(param_name.clone(), param_type.clone());
         params.push(Param {
             id: param_id,
             name: param_name,
             ty: param_type,
-            default: param_default,
+            default: None,
             decorators: Vec::new(),
             is_rest: is_rest_param(&param.pat),
             arguments_object: None,
         });
+        default_param_pats.push(param.pat.clone());
+    }
+    for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {
+        param.default = get_param_default(ctx, pat)?;
     }
     let return_type = method
         .function

--- a/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
@@ -63,27 +63,31 @@ pub(super) fn lower_nested_fn_decl(
     // it has no runtime existence (see the sibling site above for
     // the full rationale).
     let mut params = Vec::new();
+    let mut default_param_pats: Vec<ast::Pat> = Vec::new();
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
     for param in &fn_decl.function.params {
         let param_name = get_pat_name(&param.pat)?;
         if param_name == "this" {
             continue;
         }
-        let param_default = get_param_default(ctx, &param.pat)?;
         let is_rest = is_rest_param(&param.pat);
         let param_id = ctx.define_local(param_name.clone(), Type::Any);
         params.push(Param {
             id: param_id,
             name: param_name,
             ty: Type::Any,
-            default: param_default,
+            default: None,
             decorators: Vec::new(),
             is_rest,
             arguments_object: None,
         });
+        default_param_pats.push(param.pat.clone());
         if is_destructuring_pattern(&param.pat) {
             destructuring_params.push((param_id, param.pat.clone()));
         }
+    }
+    for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {
+        param.default = get_param_default(ctx, pat)?;
     }
 
     // #677: synthesize `arguments` for nested function decls.

--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -479,6 +479,7 @@ pub fn lower_class_method_with_name(
     // rather than reading from a synthetic `__obj_destruct_*` local that the
     // method body can't reach by name.
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
+    let mut default_param_pats: Vec<ast::Pat> = Vec::new();
     for param in &method.function.params {
         let param_name = get_pat_name(&param.pat)?;
         // TypeScript's `this: T` is a TYPE-only marker (SWC emits it as a
@@ -492,18 +493,18 @@ pub fn lower_class_method_with_name(
             continue;
         }
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
-        let param_default = get_param_default(ctx, &param.pat)?;
         let is_rest = is_rest_param(&param.pat);
         let param_id = ctx.define_local(param_name.clone(), param_type.clone());
         params.push(Param {
             id: param_id,
             name: param_name,
             ty: param_type,
-            default: param_default,
+            default: None,
             decorators: lower_decorators(ctx, &param.decorators),
             is_rest,
             arguments_object: None,
         });
+        default_param_pats.push(param.pat.clone());
         // Mirror the lower_fn_decl shape: an `Assign` pattern can wrap a
         // destructure (e.g. `({ a } = {}) => ...`). Unwrap before testing.
         let inner_pat = if let ast::Pat::Assign(assign) = &param.pat {
@@ -514,6 +515,9 @@ pub fn lower_class_method_with_name(
         if is_destructuring_pattern(inner_pat) {
             destructuring_params.push((param_id, inner_pat.clone()));
         }
+    }
+    for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {
+        param.default = get_param_default(ctx, pat)?;
     }
 
     // #677: synthesize `arguments` if the method body references it.

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -108,6 +108,7 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
     // prefix=undefined` — which breaks `Function.prototype.{call,apply}` on
     // FnDecls that use TS `this:` annotations.
     let mut params = Vec::new();
+    let mut default_param_pats: Vec<ast::Pat> = Vec::new();
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
     for param in fn_decl.function.params.iter() {
         let param_name = get_pat_name(&param.pat)?;
@@ -115,18 +116,18 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
             continue;
         }
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
-        let param_default = get_param_default(ctx, &param.pat)?;
         let param_id = ctx.define_local(param_name.clone(), param_type.clone());
         let is_rest = is_rest_param(&param.pat);
         params.push(Param {
             id: param_id,
             name: param_name,
             ty: param_type,
-            default: param_default,
+            default: None,
             decorators: lower_decorators(ctx, &param.decorators),
             is_rest,
             arguments_object: None,
         });
+        default_param_pats.push(param.pat.clone());
         // Track destructuring patterns (or an Assign wrapping one) for extraction stmts
         let inner_pat = if let ast::Pat::Assign(assign) = &param.pat {
             assign.left.as_ref()
@@ -136,6 +137,9 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
         if is_destructuring_pattern(inner_pat) {
             destructuring_params.push((param_id, inner_pat.clone()));
         }
+    }
+    for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {
+        param.default = get_param_default(ctx, pat)?;
     }
 
     // If the body references `arguments`, append the hidden raw-arguments input.

--- a/crates/perry-hir/src/lower_decl/helpers.rs
+++ b/crates/perry-hir/src/lower_decl/helpers.rs
@@ -12,10 +12,12 @@ use crate::analysis::*;
 use crate::destructuring::*;
 use crate::ir::*;
 use crate::lower::{
-    collect_for_of_pattern_leaves, emit_for_of_pattern_binding, lower_expr, LoweringContext,
+    collect_for_of_pattern_leaves, emit_for_of_pattern_binding, lower_expr,
+    throw_reference_error_expr, LoweringContext,
 };
 use crate::lower_patterns::*;
 use crate::lower_types::*;
+use crate::walker::walk_expr_children_mut;
 
 fn strip_for_await_expr_wrappers(mut expr: &ast::Expr) -> &ast::Expr {
     loop {
@@ -163,21 +165,18 @@ pub fn init_is_webassembly_instantiate(expr: &ast::Expr) -> bool {
 
 pub fn build_default_param_stmts(params: &[Param]) -> Vec<Stmt> {
     let mut out: Vec<Stmt> = Vec::new();
-    for param in params {
+    for (idx, param) in params.iter().enumerate() {
         if param.is_rest {
             continue;
         }
         let Some(default_expr) = param.default.as_ref() else {
             continue;
         };
-        let mut default_refs = Vec::new();
-        let mut visited_closures = std::collections::HashSet::new();
-        crate::analysis::collect_local_refs_expr(
-            default_expr,
-            &mut default_refs,
-            &mut visited_closures,
-        );
-        let default_reads_own_param = default_refs.contains(&param.id);
+        let tdz_param_ids: std::collections::HashSet<LocalId> = params[idx..]
+            .iter()
+            .filter(|p| p.arguments_object.is_none())
+            .map(|p| p.id)
+            .collect();
         let default_is_throw_helper = matches!(
             default_expr,
             Expr::Call { callee, .. }
@@ -201,22 +200,67 @@ pub fn build_default_param_stmts(params: &[Param]) -> Vec<Stmt> {
                 left: Box::new(Expr::LocalGet(param.id)),
                 right: Box::new(Expr::Undefined),
             },
-            then_branch: if default_reads_own_param {
-                vec![Stmt::Throw(Expr::ReferenceErrorNew(Box::new(
-                    Expr::String("Cannot access parameter in its own initializer".to_string()),
-                )))]
-            } else if default_is_throw_helper || default_is_eval_syntax_error {
+            then_branch: if default_is_throw_helper || default_is_eval_syntax_error {
                 vec![Stmt::Throw(default_expr.clone())]
             } else {
+                let mut default_value = default_expr.clone();
+                rewrite_default_param_tdz_refs(&mut default_value, &tdz_param_ids);
                 vec![Stmt::Expr(Expr::LocalSet(
                     param.id,
-                    Box::new(default_expr.clone()),
+                    Box::new(default_value),
                 ))]
             },
             else_branch: None,
         });
     }
     out
+}
+
+fn rewrite_default_param_tdz_refs(
+    expr: &mut Expr,
+    tdz_param_ids: &std::collections::HashSet<LocalId>,
+) {
+    match expr {
+        Expr::LocalGet(id) if tdz_param_ids.contains(id) => {
+            *expr = throw_reference_error_expr("js_throw_reference_error_unresolved_get");
+            return;
+        }
+        Expr::LocalSet(id, value) if tdz_param_ids.contains(id) => {
+            rewrite_default_param_tdz_refs(value, tdz_param_ids);
+            let value = std::mem::replace(value.as_mut(), Expr::Undefined);
+            *expr = Expr::Sequence(vec![
+                value,
+                throw_reference_error_expr("js_throw_reference_error_unresolved_assignment"),
+            ]);
+            return;
+        }
+        Expr::Update { id, .. } | Expr::ArrayPop(id) | Expr::ArrayShift(id)
+            if tdz_param_ids.contains(id) =>
+        {
+            *expr = throw_reference_error_expr("js_throw_reference_error_unresolved_get");
+            return;
+        }
+        Expr::ArrayPush { array_id, .. }
+        | Expr::ArrayPushSpread { array_id, .. }
+        | Expr::ArrayUnshift { array_id, .. }
+        | Expr::ArraySplice { array_id, .. }
+        | Expr::ArrayCopyWithin { array_id, .. }
+            if tdz_param_ids.contains(array_id) =>
+        {
+            *expr = throw_reference_error_expr("js_throw_reference_error_unresolved_get");
+            return;
+        }
+        Expr::SetAdd { set_id, .. } if tdz_param_ids.contains(set_id) => {
+            *expr = throw_reference_error_expr("js_throw_reference_error_unresolved_get");
+            return;
+        }
+        Expr::Closure { .. } => return,
+        _ => {}
+    }
+
+    walk_expr_children_mut(expr, &mut |child| {
+        rewrite_default_param_tdz_refs(child, tdz_param_ids)
+    });
 }
 
 /// Detect the computed key `[Symbol.iterator]` in a class method / object

--- a/crates/perry-hir/src/lower_decl/private_members.rs
+++ b/crates/perry-hir/src/lower_decl/private_members.rs
@@ -42,21 +42,22 @@ pub fn lower_private_method(
     // Issue #572 — private methods follow the same destructure-extraction shape
     // as public methods.
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
+    let mut default_param_pats: Vec<ast::Pat> = Vec::new();
     for param in &method.function.params {
         let param_name = get_pat_name(&param.pat)?;
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
-        let param_default = get_param_default(ctx, &param.pat)?;
         let is_rest = is_rest_param(&param.pat);
         let param_id = ctx.define_local(param_name.clone(), param_type.clone());
         params.push(Param {
             id: param_id,
             name: param_name,
             ty: param_type,
-            default: param_default,
+            default: None,
             decorators: Vec::new(),
             is_rest,
             arguments_object: None,
         });
+        default_param_pats.push(param.pat.clone());
         let inner_pat = if let ast::Pat::Assign(assign) = &param.pat {
             assign.left.as_ref()
         } else {
@@ -65,6 +66,9 @@ pub fn lower_private_method(
         if is_destructuring_pattern(inner_pat) {
             destructuring_params.push((param_id, inner_pat.clone()));
         }
+    }
+    for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {
+        param.default = get_param_default(ctx, pat)?;
     }
 
     // #677: synthesize `arguments` if the private method body references it.

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -67,6 +67,18 @@ fn is_number_literal(expr: &Expr, expected: f64) -> bool {
     }
 }
 
+fn expr_is_reference_error_throw_helper(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Call { callee, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::ExternFuncRef { name, .. }
+                    if name.starts_with("js_throw_reference_error_")
+            )
+    )
+}
+
 #[test]
 fn assignment_named_evaluation_names_bare_identifier_rhs_functions() {
     let module = lower_src(
@@ -194,9 +206,73 @@ fn arrow_default_parameter_self_reference_throws_reference_error() {
             callee.as_ref(),
             Expr::ExternFuncRef { name, .. } if name.starts_with("js_throw_")
         ),
+        [Stmt::Expr(Expr::LocalSet(_, value))] => expr_is_reference_error_throw_helper(value),
         _ => false,
     };
     assert!(throws_reference_error, "{then_branch:?}");
+}
+
+#[test]
+fn default_parameter_later_binding_throws_reference_error() {
+    let module = lower_src("var f = (x = y, y = 1) => { return x; };");
+    let Expr::Closure { body, .. } = top_level_init(&module, "f") else {
+        panic!("expected arrow closure");
+    };
+    let Some(Stmt::If { then_branch, .. }) = body.first() else {
+        panic!("expected default-parameter guard, got {body:?}");
+    };
+
+    assert!(
+        matches!(
+            then_branch.as_slice(),
+            [Stmt::Expr(Expr::LocalSet(_, value))]
+                if expr_is_reference_error_throw_helper(value)
+        ),
+        "{then_branch:?}"
+    );
+}
+
+#[test]
+fn function_default_parameter_later_binding_shadows_outer_binding() {
+    let module = lower_src(
+        r#"
+        var y = 2;
+        function f(x = y, y = 1) { return x; }
+        "#,
+    );
+    let f = function(&module, "f");
+    let Some(Stmt::If { then_branch, .. }) = f.body.first() else {
+        panic!("expected default-parameter guard, got {:?}", f.body);
+    };
+
+    assert!(
+        matches!(
+            then_branch.as_slice(),
+            [Stmt::Expr(Expr::LocalSet(_, value))]
+                if expr_is_reference_error_throw_helper(value)
+        ),
+        "{then_branch:?}"
+    );
+}
+
+#[test]
+fn default_parameter_nested_closure_can_capture_later_binding() {
+    let module = lower_src("var f = (x = () => y, y = 1) => { return x; };");
+    let Expr::Closure { body, .. } = top_level_init(&module, "f") else {
+        panic!("expected arrow closure");
+    };
+    let Some(Stmt::If { then_branch, .. }) = body.first() else {
+        panic!("expected default-parameter guard, got {body:?}");
+    };
+
+    assert!(
+        matches!(
+            then_branch.as_slice(),
+            [Stmt::Expr(Expr::LocalSet(_, value))]
+                if matches!(value.as_ref(), Expr::Closure { .. })
+        ),
+        "{then_branch:?}"
+    );
 }
 
 #[test]

--- a/reference/deepwiki/default-parameter-tdz-ecma262.md
+++ b/reference/deepwiki/default-parameter-tdz-ecma262.md
@@ -1,0 +1,237 @@
+# DeepWiki Response
+
+Repository: `tc39/ecma262`
+Question: For ECMAScript function calls with non-simple/default parameter lists, how are function parameter environments created and initialized? In particular, how should default parameter initializers resolve references to later parameters or body lexical declarations, and what ReferenceError / TDZ ordering follows from FunctionDeclarationInstantiation? Please cite the relevant specification sections/algorithms.
+Search: https://deepwiki.com/search/for-ecmascript-function-calls_71815d43-14fe-4545-950f-376916ae9f67
+
+**Question**: For ECMAScript function calls with non-simple/default parameter lists, how are function parameter environments created and initialized? In particular, how should default parameter initializers resolve references to later parameters or body lexical declarations, and what ReferenceError / TDZ ordering follows from FunctionDeclarationInstantiation? Please cite the relevant specification sections/algorithms.
+
+I cannot answer your question about how ECMAScript function parameter environments are created and initialized, or how default parameter initializers resolve references, or the `ReferenceError` / TDZ ordering from `FunctionDeclarationInstantiation` .
+
+The provided codebase context for `tc39/ecma262` primarily discusses the TC39 proposal process, contribution guidelines, and repository structure [1](#ref-q1-1)  [2](#ref-q1-2)  [3](#ref-q1-3) . It does not contain the detailed ECMAScript specification text or algorithms that would describe the internal mechanisms of function parameter environment creation, initialization, or `FunctionDeclarationInstantiation` . To answer your question, I would need access to the actual ECMAScript Language Specification document, which is not present in the provided snippets .
+
+Wiki pages you might want to explore:
+- [TC39 Proposal Process (tc39/ecma262)](/wiki/tc39/ecma262#3)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-ecmascript-function-calls_71815d43-14fe-4545-950f-376916ae9f67
+
+## References
+
+<a id="ref-q1-1"></a>
+### [1] `CONTRIBUTING.md:1-60`
+Source: [tc39/ecma262 @ bdfd596f](https://github.com/tc39/ecma262/blob/bdfd596f/CONTRIBUTING.md#L1-L60)
+
+```markdown
+# Contributing to ECMAScript
+
+Contributors to ECMAScript and TC39 are expected to follow our [Code of Conduct](https://tc39.es/code-of-conduct/).
+
+**Please do not open issues or pull requests in this repository to suggest new features.** See the [new feature proposals](#new-feature-proposals) section below for more details.
+
+If you are not an Ecma member, any non-trivial contributions require signing a legal agreement with Ecma. See the section "Required Legal Agreements" below for details.
+
+## Issues and Pull Requests
+
+Issues and PRs in the ecma262 repository are appropriate for minor modifications to the existing specification, for example to fix typos, clarify wording, or correct accidental changes introduced by earlier commits. New features use the feature request process described below. 
+
+To file an issue, go to the ecma262 [issues page](https://github.com/tc39/ecma262/issues). From there, [search](https://guides.github.com/features/issues/) in the existing issues to see if an issue already exists to track your problem. If so, add a comment to the existing issue; otherwise, [file a new issue](https://help.github.com/articles/creating-an-issue/) documenting the problem.
+
+To make a pull request (PR), [fork](https://help.github.com/articles/fork-a-repo/) the [ecma262](https://github.com/tc39/ecma262) repository, apply changes to `spec.html`, and upload it to your fork on GitHub, using the web interface to file a pull request. Locally, to see how your change renders in HTML, run `npm install && npm run build` to build `spec.html` into an actual HTML file.
+
+Commits in pull requests should have a first line which starts with a tag, followed by a colon, indicating which type of patch they are:
+  * Normative: any changes that affect behavior required to correctly evaluate some ECMAScript source text (such as a script or module)
+  * Editorial: any non-normative changes to spec text including typo fixes, changes to the document style, etc.
+  * Markup: non-visible changes to markup in the spec
+  * Meta: changes to documents about this repository (e.g. readme.md or contributing.md) and other supporting documents or scripts (e.g. `package.json`, design documents, etc.)
+
+If changes in the upstream `main` branch cause your PR to have conflicts, you should rebase your branch to `main` and force-push it to your repo (rather than doing a merge commit).
+
+### Downstream dependencies
+
+If you are changing the signature or behavior of an existing construct, please check if this affects downstream dependencies (searching for the construct's name is sufficient) and if needed file an issue:
+
+* [Web IDL](https://heycam.github.io/webidl/) — [file an issue](https://github.com/heycam/webidl/issues/new)
+* [HTML Standard](https://html.spec.whatwg.org/) — [file an issue](https://github.com/whatwg/html/issues/new)
+* [ECMAScript Intl API](https://tc39.es/ecma402/) - [file an issue](https://github.com/tc39/ecma402/issues/new)
+* [WebAssembly](https://webassembly.github.io/spec/) - [file an issue](https://github.com/WebAssembly/spec/issues/new)
+
+## New feature proposals
+
+TC39 is open to accepting new feature requests for ECMAScript, referred to as "proposals". Proposals go through a four-stage process which is documented in the [TC39 process document](https://tc39.es/process-document/).
+
+Feature requests for future versions of ECMAScript should not be made in this repository. Instead, they are developed in separate GitHub repositories, which are then merged into the main repository once they have received "Stage 4".
+
+### Creating a new proposal
+
+To make a feature request, document the problem and a sketch of the solution with others in the community, including TC39 members. One place to do this is the [TC39 Discourse](https://es.discourse.group/); another is the [Matrix chat room][].
+
+Your goal will be to convince others that your proposal is a useful addition to the language and recruit TC39 members to help turn your request into a proposal and shepherd it into the language. Once a proposal is introduced to the committee, new features are considered by the committee according to the [TC39 process document](https://tc39.es/process-document/).
+
+You can look at [existing proposals](https://github.com/tc39/proposals/) for examples of how proposals are structured, and some delegates use [this template](https://github.com/tc39/template-for-proposals) when creating repositories for their proposals. Proposals need to have a repository and be moved to the TC39 org on GitHub once they reach Stage 1.
+
+### TC39 meetings and champions
+
+If you have a new proposal you want to get into the language, you first need a TC39 "champion": a member of the committee who will make the case for the proposal at [in-person TC39 meetings](https://github.com/tc39/agendas#agendas) and help it move through the process. If you are a TC39 member, you can be a champion; otherwise, find a TC39 member to work with for this (e.g., through the [TC39 discussion group](https://es.discourse.group/) or the [Matrix chat room][]). Proposals may have multiple champions (a "champion group").
+
+TC39 meets six times a year, mostly in the United States, to discuss proposals. It is possible for members to join meetings remotely. At meetings, we discuss ways to resolve issues and feature requests. We spend most of the time considering proposals and advancing them through the stage process. Meetings follow an agenda which is developed in the [agendas GitHub repository](https://github.com/tc39/agendas/). After the meeting, notes are published in the [notes GitHub repository](https://github.com/tc39/tc39-notes/). To advance your proposal towards inclusion in the final specification, ensure that it is included on the agenda for an upcoming meeting and propose advancement at that time.
+
+### Helping with existing proposals
+
+TC39 is currently considering adding several new features to the language. These proposals are linked from [the proposals repository](https://github.com/tc39/proposals). There are many ways to help with existing proposals:
+  * File issues in the individual proposal repository to provide constructive criticism and feedback.
+  * Make PRs against proposals, e.g., to clarify explanations of the motivation and use cases in `README.md`, or to fix issues in the proposal's specification text.
+  * Talk about what you think of the proposal, including sharing thoughts with the champion.
+  * Blog, tweet, give talks, etc about proposals to get more awareness and programmer feedback about them.
+```
+
+<a id="ref-q1-2"></a>
+### [2] `FAQ.md:1-102`
+Source: [tc39/ecma262 @ bdfd596f](https://github.com/tc39/ecma262/blob/bdfd596f/FAQ.md#L1-L102)
+
+```markdown
+# Frequently Asked Questions
+
+An index of frequently asked questions regarding all things ECMA-262.
+
+# Process Questions
+
+##### What is the process for proposing a new feature?
+
+New features start life as a proposal to the [TC39](#what-is-a-tc39) committee and must be championed (or co-championed) by at least one member of the committee. Once the proposal is raised at a committee meeting, it will become a Stage 0 proposal and move along from there. For more details on how proposal stages work, check out the [proposal process document][proposal-process-document].
+
+If you would like to contribute, please check out [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md).
+
+##### What is a "TC39"?
+
+TC39 stands for "Technical Committee 39" and is the committee responsible for iterating on and evolving the ECMAScript language specification. The committee generally meets around 6 times a year to discuss progress on pending proposals and collectively work on moving forward with changes to the spec.
+
+##### Why can't we remove feature X?
+
+Changes to ECMAScript must carefully consider the state of the world using the previous version of the language. This includes a large percentage of the web. As a result, in order to remove a feature from ECMAScript, TC39 must be able to show that the feature is used almost never (and thus can be removed). Going through this exercise is extremely difficult and sometimes impossible -- so in general ECMAScript *very* rarely removes features.
+
+Because the web is so large, even features that behave in a way that's surprising and potentially lead to bugs are often relied upon by real programs. Therefore, only actual use data, and not a sense of whether some feature is correct or useful, can guide TC39 in potentially changing existing behavior.
+
+# Feature Questions
+
+### Arrow Functions
+
+##### Why isn't there a `->` version of arrow functions?
+
+The motivation for `=>` was to address the oft-fired footgun of dynamic `this` bindings. Additionally, having two forms of arrows is confusing; So only one form was added.
+
+### Destructuring
+
+##### Why isn't the object property destructuring syntax flipped the other way?
+
+(i.e. `let {x: y} = {x: 42}` vs `let {y: x} = {x: 42}`)
+
+In all other object patterns in the language, the syntax to the left of the colon represents the "structure" of an object; So having destructuring patterns match this convention was most consistent.
+
+More fundamentally, however, flipping the syntax the other way would produce a grammar that requires infinite lookahead to properly disambiguate.
+
+### Modules
+
+##### Why don't `import` statements use real destructuring syntax?
+
+[`import` statements create an alias of a remote binding](#why-are-imported-module-bindings-aliased-instead-of-copied), they do not create a new local binding. First-class destructuring, however, allows for the creation of new bindings from substructures of objects and arrays. As a result first-class destructuring was not a good fit for the `import` statement.
+
+##### Why are imported module bindings aliased instead of copied?
+
+The biggest reason for this is that it allows cyclic module dependencies to work.
+
+For example, consider the following contrived scenario:
+
+```javascript
+// Even.js
+import {isOdd} from "./Odd.js";
+
+export function isEven(num) {
+  if (num === 0) {
+    return true;
+  } else {
+    return isOdd(num - 1);
+  }
+}
+```
+
+```javascript
+// Odd.js
+import {isEven} from "./Even.js";
+
+export function isOdd(num) {
+  if (num === 0) {
+    return false;
+  } else {
+    return isEven(num - 1);
+  }
+}
+```
+
+```javascript
+// main.js
+import {isOdd} from "./Odd";
+
+isOdd(2);
+```
+
+The list of operations that execute will go something like the following:
+
+1. Note that **main.js** has a named import called `isOdd` that comes from **Odd.js**
+2. Begin loading **Odd.js**.
+3. Once **Odd.js** has loaded, note that it has a named export called `isOdd` and a named import called `isEven` that comes from **Even.js**.
+4. Create an empty binding called `isOdd` for **Odd.js**'s exports.
+5. Begin loading **Even.js**.
+6. Once **Even.js** has loaded, note that it has a named export called `isEven` and a named import called `isOdd` that comes from **Odd.js**.
+7. Create an empty binding called `isEven` for **Even.js**'s exports.
+8. Now that all of the dependencies of **Even.js** have loaded, begin evaluating it with a variable called `isOdd` aliased to the (currently empty) `isOdd` binding we created in step 4.
+9. As we evaluate the `export function isEven() { ... }` statement in **Even.js**, fill in the value for the `isEven` binding created in step 7.
+10. Now that all of the dependencies of **Odd.js** have loaded, begin evaluating it with a variable called `isEven` aliased to the (no longer empty) `isEven` binding we created in step 9.
+11. As we evaluate the `export function isOdd() { ... }` statement in **Odd.js**, fill in the value for the `isOdd` binding created in step 4. Note that this now "fills in" the value for the alias to this binding noted in step 8.
+
+If the exported bindings were copied between **Even.js** and **Odd.js** rather than aliased, the body of `isEven` would have received a copy of the uninitialized value for `isOdd`.
+
+[proposal-process-document]: https://tc39.es/process-document/
+```
+
+<a id="ref-q1-3"></a>
+### [3] `README.md:1-36`
+Source: [tc39/ecma262 @ bdfd596f](https://github.com/tc39/ecma262/blob/bdfd596f/README.md#L1-L36)
+
+```markdown
+
+ECMAScript
+====
+
+## This repo
+
+This repository contains the source for the current draft of ECMA-262,
+the ECMAScript® Language Specification.
+
+This source is processed to obtain a human-readable version,
+which you can view [here](https://tc39.es/ecma262/).
+
+If you want to explore how the specification was written, you can also view the source with its history in [searchfox](https://searchfox.org/ecma262/source/spec.html).
+
+## Current Proposals
+
+Proposals follow [the TC39 process](https://tc39.es/process-document/) and are tracked in the [proposals repository](https://github.com/tc39/proposals).
+
+* [Finished Proposals](https://github.com/tc39/proposals/blob/HEAD/finished-proposals.md)
+* [Active Proposals](https://github.com/tc39/proposals)
+* [Stage 1 Proposals](https://github.com/tc39/proposals/blob/HEAD/stage-1-proposals.md)
+* [Stage 0 Proposals](https://github.com/tc39/proposals/blob/HEAD/stage-0-proposals.md)
+* [Inactive Proposals](https://github.com/tc39/proposals/blob/HEAD/inactive-proposals.md)
+
+### Contributing New Proposals
+
+Please see [Contributing to ECMAScript](/CONTRIBUTING.md) for the most up-to-date information on contributing proposals to this standard.
+
+## Developing the Specification
+
+After cloning, do `npm install` to set up your environment. You can then do `npm run build` to build the spec or `npm run watch` to set up a continuous build. The results will appear in the `out` directory, which you can use `npm run clean` to delete.
+
+## Community
+
+* [ES discourse](https://es.discourse.group/): Forum for ECMAScript discussion and questions
+* [Matrix](https://github.com/tc39/how-we-work/blob/HEAD/matrix-guide.md): Chat
+```

--- a/test-files/test_gap_default_param_tdz.ts
+++ b/test-files/test_gap_default_param_tdz.ts
@@ -1,0 +1,38 @@
+function assert(cond: boolean, msg: string) {
+  if (!cond) {
+    throw new Error(msg);
+  }
+}
+
+function assertReferenceError(fn: () => unknown, msg: string) {
+  let threw = false;
+  try {
+    fn();
+  } catch (err) {
+    threw = err instanceof ReferenceError;
+  }
+  assert(threw, msg);
+}
+
+let outer = 2;
+
+function laterParam(a = b, b = 1) {
+  return a;
+}
+
+function laterParamShadowsOuter(a = outer, outer = 1) {
+  return a;
+}
+
+const arrowLaterParam = (a = b, b = 1) => a;
+const closureDefault = (a = () => b, b = 1) => a();
+
+assertReferenceError(() => laterParam(), "function default must TDZ-read later param");
+assertReferenceError(
+  () => laterParamShadowsOuter(),
+  "later param must shadow outer binding during default evaluation",
+);
+assertReferenceError(() => arrowLaterParam(), "arrow default must TDZ-read later param");
+assert(closureDefault() === 1, "nested closure default should not TDZ-read early");
+
+console.log("default param TDZ ok");


### PR DESCRIPTION
## Summary
- make default parameter initializers resolve against the full parameter binding environment so later parameters shadow outer names
- rewrite direct reads/writes of the current-or-later parameter slots inside default initializers to ReferenceError throw helpers while preserving nested closure defaults
- add focused c262 parity regressions and a runtime-facing gap test for default-parameter TDZ
- save the requested DeepWiki tc39/ecma262 reference at reference/deepwiki/default-parameter-tdz-ecma262.md

## Focused verification
- `cargo test -p perry-hir --test c262_parity` -> passed, 15/15
- `git diff --check` -> clean

## Test262/c262 notes
- Direct Test262 path execution was not available in this worktree because `vendor/test262` is not present; `test-compat/test262` only contains the harness metadata files here.
- A release `cargo build --release -p perry -p perry-runtime -p perry-stdlib` was attempted after the coordinator freed disk space, but it spent ~17 minutes in final project compile/link and had not emitted `target/release/perry`; I cancelled it to avoid blocking this scoped PR.

## Fixed path/reason pairs
- `crates/perry-hir/tests/c262_parity.rs::default_parameter_later_binding_throws_reference_error`: arrow default `x = y` now treats later `y` as TDZ and emits ReferenceError helper.
- `crates/perry-hir/tests/c262_parity.rs::function_default_parameter_later_binding_shadows_outer_binding`: function default `x = y, y = 1` now shadows an outer `y` with the later parameter binding and emits ReferenceError helper.
- `crates/perry-hir/tests/c262_parity.rs::default_parameter_nested_closure_can_capture_later_binding`: closure-valued defaults such as `x = () => y` are not eagerly rewritten; the later parameter can be read when the closure runs after initialization.

## Remaining related work
- Full direct Test262/c262 slice should be rerun once a pinned `vendor/test262` checkout and release Perry binary are available in the worktree.
- This PR intentionally does not address arrow special bindings, with/delete, prototype assignment, or addition coercion.
