### PR TITLE
Preserve with references for delete

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -453,6 +453,61 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // dynamic key. Anything else is a no-op stub returning true.
         Expr::Delete(operand) => {
             match operand.as_ref() {
+                Expr::WithGet {
+                    object,
+                    property,
+                    fallback,
+                } => {
+                    let obj = lower_expr(ctx, object)?;
+                    let (_key_box, key_raw) = emit_with_key(ctx, property);
+                    let has = ctx.block().call(
+                        I32,
+                        "js_with_has_binding",
+                        &[(DOUBLE, &obj), (I64, &key_raw)],
+                    );
+                    let has_bool = ctx.block().icmp_ne(I32, &has, "0");
+
+                    let hit_idx = ctx.new_block("with.delete.hit");
+                    let miss_idx = ctx.new_block("with.delete.miss");
+                    let merge_idx = ctx.new_block("with.delete.merge");
+                    let hit_label = ctx.block_label(hit_idx);
+                    let miss_label = ctx.block_label(miss_idx);
+                    let merge_label = ctx.block_label(merge_idx);
+                    ctx.block().cond_br(&has_bool, &hit_label, &miss_label);
+
+                    ctx.current_block = hit_idx;
+                    let deleted = ctx.block().call(
+                        I32,
+                        "js_with_delete_binding",
+                        &[(DOUBLE, &obj), (I64, &key_raw)],
+                    );
+                    let deleted_bit = ctx.block().icmp_ne(I32, &deleted, "0");
+                    let hit_tagged = ctx.block().select(
+                        crate::types::I1,
+                        &deleted_bit,
+                        I64,
+                        crate::nanbox::TAG_TRUE_I64,
+                        crate::nanbox::TAG_FALSE_I64,
+                    );
+                    let hit = ctx.block().bitcast_i64_to_double(&hit_tagged);
+                    let hit_after = ctx.block().label.clone();
+                    if !ctx.block().is_terminated() {
+                        ctx.block().br(&merge_label);
+                    }
+
+                    ctx.current_block = miss_idx;
+                    let fallback_delete = Expr::Delete(fallback.clone());
+                    let miss = lower_expr(ctx, &fallback_delete)?;
+                    let miss_after = ctx.block().label.clone();
+                    if !ctx.block().is_terminated() {
+                        ctx.block().br(&merge_label);
+                    }
+
+                    ctx.current_block = merge_idx;
+                    Ok(ctx
+                        .block()
+                        .phi(DOUBLE, &[(&hit, &hit_after), (&miss, &miss_after)]))
+                }
                 // #1344: `delete process.env.X` must unset the real OS
                 // environment, not just the cached env dict — reads lower to
                 // `EnvGet` → `js_getenv_value` → `std::env::var`, so a generic

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -56,6 +56,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function("js_with_has_binding", I32, &[DOUBLE, I64]);
     module.declare_function("js_with_get_binding", DOUBLE, &[DOUBLE, I64]);
     module.declare_function("js_with_set_binding", DOUBLE, &[DOUBLE, I64, DOUBLE, I32]);
+    module.declare_function("js_with_delete_binding", I32, &[DOUBLE, I64]);
     module.declare_function("js_pod_scalar_write_compatible", I32, &[DOUBLE, I32]);
     module.declare_function(
         "js_typed_feedback_register_site",

--- a/crates/perry-runtime/src/object/with_env.rs
+++ b/crates/perry-runtime/src/object/with_env.rs
@@ -87,3 +87,9 @@ pub extern "C" fn js_with_set_binding(
     js_object_set_field_by_name(ptr, key, value);
     value
 }
+
+#[no_mangle]
+pub extern "C" fn js_with_delete_binding(bindings: f64, key: *const StringHeader) -> i32 {
+    let ptr = object_ptr(bindings);
+    js_object_delete_field(ptr, key)
+}

--- a/reference/deepwiki/c262-with-delete-reference-preservation.md
+++ b/reference/deepwiki/c262-with-delete-reference-preservation.md
@@ -1,0 +1,14 @@
+# DeepWiki Response
+
+Repository: `tc39/ecma262`
+Question: For ECMAScript Reference records under dynamic scope, how do with environment records preserve identifier references across assignment, and how does the delete operator interact with object environment bindings when PutValue happens later? Please point to the relevant spec algorithms for WithEnvironmentRecord/ObjectEnvironmentRecord, GetIdentifierReference, Delete, and PutValue.
+Search: https://deepwiki.com/search/for-ecmascript-reference-recor_b7a4e8b5-405a-44b8-a545-f438b6f4dc33
+
+**Question**: For ECMAScript Reference records under dynamic scope, how do with environment records preserve identifier references across assignment, and how does the delete operator interact with object environment bindings when PutValue happens later? Please point to the relevant spec algorithms for WithEnvironmentRecord/ObjectEnvironmentRecord, GetIdentifierReference, Delete, and PutValue.
+
+I cannot answer your question about ECMAScript Reference records, dynamic scope, environment records, and the `delete` operator. The provided codebase context for the `tc39/ecma262` repository primarily contains information about the TC39 proposal process, contributing to the ECMAScript specification, and repository maintenance. It does not include the actual ECMAScript specification algorithms or detailed technical definitions of core language concepts like `WithEnvironmentRecord`, `ObjectEnvironmentRecord`, `GetIdentifierReference`, `Delete`, or `PutValue`. Therefore, I do not have the necessary information to explain how these concepts interact as you've described.
+
+Wiki pages you might want to explore:
+- [TC39 Proposal Process (tc39/ecma262)](/wiki/tc39/ecma262#3)
+
+View this search on DeepWiki: https://deepwiki.com/search/for-ecmascript-reference-recor_b7a4e8b5-405a-44b8-a545-f438b6f4dc33

--- a/tests/test_c262_with_parity.sh
+++ b/tests/test_c262_with_parity.sh
@@ -35,6 +35,15 @@ function makeWithReader() {
 
 check("arrow captures with object environment", makeWithReader()() === 10);
 
+var deleteResult = false;
+var deleteScope = { deleteTarget: 1 };
+with (deleteScope) {
+  deleteResult = delete deleteTarget;
+}
+
+check("with delete identifier returns true", deleteResult === true);
+check("with delete identifier removes object binding", !("deleteTarget" in deleteScope));
+
 var count = 0;
 var scope = { x: 1 };
 with (scope) {


### PR DESCRIPTION
## Summary
- Preserve lowered `with` identifier references for `delete` instead of treating them as non-reference values.
- Add a focused runtime helper for deleting a binding from a `with` object.
- Add a c262 with-parity regression covering `delete` inside a `with` block.
- Save the requested DeepWiki reference for ECMA-262 with environment/reference/delete semantics.

## Root Cause
`delete deleteTarget` inside `with (obj)` lowers the identifier as `WithGet`. The delete lowering previously did not treat `WithGet` as a Reference, so it returned true without deleting the object binding. This keeps the dynamic-scope reference live through delete lowering: if the with-object has the binding, delete it there; otherwise fall back to deleting the outer reference.

## Verification
- `cargo fmt --check` passed.
- `cargo check -p perry-runtime -p perry-codegen -p perry` passed.
- `CARGO_BUILD_JOBS=1 cargo build -p perry` passed.
- `PERRY_BIN=/Users/andrew/.codex/worktrees/0c38/perry-2/target/debug/perry tests/test_c262_with_parity.sh` passed: `PASS c262 with parity`.
- Direct reduced Test262 delete case passed using Node and Perry: `vendor/test262/test/language/expressions/delete/11.4.1-4.a-6.js` with `node_status=0`, `compile_status=0`, `perry_status=0`.

## Notes
- Initial release/broader c262 runs hit ENOSPC and then were intentionally narrowed to the focused with/delete proof path to avoid repeated optimized auto-runtime builds.
- `vendor/test262/test/language/expressions/assignment/S11.13.1_A5_T2.js` was not used as Perry parity evidence because the local Node 24 harness also failed it (`scope.x === 2. Actual: undefined`).
- Broader computed assignment order, prototype/super set semantics, arrow binding, and addition coercion issues are intentionally out of scope.
