### PR TITLE
fix(runtime): Array.prototype read-only methods accept array-like receivers

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1226,6 +1226,25 @@ pub(super) fn try_builtin_prototype_method_apply_call(
         call.args.iter().skip(1).cloned().collect()
     };
 
+    // `Array.prototype.<m>.call(arrayLike, ...)` — when `<m>` is a known
+    // read-only Array method, this is an explicit, unambiguous request to run
+    // the Array algorithm on a *generic array-like* receiver (a plain object
+    // with `length` + indexed keys; ECMA-262 §23.1.3). The default synthesized
+    // `(thisArg).<m>(...)` member call below only routes to the Array runtime
+    // helper when the receiver is statically array-typed; for an Any/object
+    // receiver it lowers to a dynamic method lookup that finds no `map`/`reduce`
+    // field and throws "value is not a function". Build the dedicated
+    // `Expr::Array*` variant directly so the receiver flows to `js_array_*`
+    // regardless of its static type — the runtime materializes the array-like
+    // (see `normalize_array_receiver`). Only the read-only/returning methods are
+    // handled here; mutators and unsupported shapes fall through to the member
+    // call below (unchanged behavior).
+    if let Some(folded) =
+        try_arraylike_receiver_method(ctx, method_prop.sym.as_ref(), &this_arg.expr, &rest_args)?
+    {
+        return Ok(Some(folded));
+    }
+
     // Synthesize `(thisArg).<method>(rest_args)`: use the resolved method
     // name, make the receiver the real `thisArg`, drop the `.apply`/`.call`
     // wrapper, and re-dispatch.
@@ -1238,6 +1257,176 @@ pub(super) fn try_builtin_prototype_method_apply_call(
     synth_call.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(synth_member)));
     synth_call.args = rest_args;
     Ok(Some(super::lower_call(ctx, &synth_call)?))
+}
+
+/// Build a dedicated `Expr::Array*` HIR variant for `Array.prototype.<m>.call`
+/// / `.apply` on a *generic array-like* receiver, bypassing the receiver-type
+/// gate that the normal member-call fast path applies. `receiver` is the
+/// `thisArg`; `rest_args` are the post-`thisArg` positional arguments (already
+/// expanded from the `.apply` array if applicable).
+///
+/// Returns `Some(expr)` for a supported read-only/returning method, or `None`
+/// for mutators / unsupported methods (caller falls back to the synthesized
+/// member call). The chosen set mirrors the runtime methods that route through
+/// `normalize_array_receiver`.
+fn try_arraylike_receiver_method(
+    ctx: &mut LoweringContext,
+    method: &str,
+    receiver: &ast::Expr,
+    rest_args: &[ast::ExprOrSpread],
+) -> Result<Option<Expr>> {
+    // Any spread in the positional args defeats static argument expansion.
+    if rest_args.iter().any(|a| a.spread.is_some()) {
+        return Ok(None);
+    }
+    // Only fold the read-only/returning methods. Bail early for everything else
+    // (mutators, flat, etc.) BEFORE lowering the receiver, so unrelated shapes
+    // keep the existing member-call behavior with no side effects.
+    let supported = matches!(
+        method,
+        "map"
+            | "filter"
+            | "forEach"
+            | "find"
+            | "findIndex"
+            | "findLast"
+            | "findLastIndex"
+            | "some"
+            | "every"
+            | "flatMap"
+            | "reduce"
+            | "reduceRight"
+            | "indexOf"
+            | "lastIndexOf"
+            | "includes"
+            | "slice"
+            | "at"
+            | "join"
+    );
+    if !supported {
+        return Ok(None);
+    }
+    // Materialize the array-like receiver into a REAL array up front via
+    // `Expr::ArrayFrom` (→ `js_array_from_value` → `js_array_clone`, which has
+    // the array-like `{length, 0:…}` detection). This makes EVERY downstream
+    // method see a genuine `ArrayHeader` — crucial for the methods whose codegen
+    // is INLINED (e.g. `forEach` reads `(*arr).length` + `arr[i]` directly
+    // rather than calling `js_array_forEach`), which the runtime-side
+    // `normalize_array_receiver` can't reach. For a real-array receiver this
+    // clones (correct; the read-only methods don't mutate the receiver), and
+    // for null/undefined `js_array_from_value` throws a TypeError to match Node.
+    // The receiver (`thisArg`) lowers before the positional args, matching
+    // source order.
+    let array_src = lower_expr(ctx, receiver)?;
+    let array = Box::new(Expr::ArrayFrom(Box::new(array_src)));
+    // Lower a positional argument by index, if present.
+    let mut arg = |ctx: &mut LoweringContext, i: usize| -> Result<Option<Box<Expr>>> {
+        match rest_args.get(i) {
+            Some(a) => Ok(Some(Box::new(lower_expr(ctx, &a.expr)?))),
+            None => Ok(None),
+        }
+    };
+    // Callback-taking methods require the callback argument to be present.
+    macro_rules! cb_method {
+        ($variant:ident) => {{
+            let Some(cb) = arg(ctx, 0)? else {
+                return Ok(None);
+            };
+            Ok(Some(Expr::$variant {
+                array,
+                callback: cb,
+            }))
+        }};
+    }
+    match method {
+        "map" => cb_method!(ArrayMap),
+        "filter" => cb_method!(ArrayFilter),
+        "forEach" => cb_method!(ArrayForEach),
+        "find" => cb_method!(ArrayFind),
+        "findIndex" => cb_method!(ArrayFindIndex),
+        "findLast" => cb_method!(ArrayFindLast),
+        "findLastIndex" => cb_method!(ArrayFindLastIndex),
+        "some" => cb_method!(ArraySome),
+        "every" => cb_method!(ArrayEvery),
+        "flatMap" => cb_method!(ArrayFlatMap),
+        "reduce" => {
+            let Some(cb) = arg(ctx, 0)? else {
+                return Ok(None);
+            };
+            let initial = arg(ctx, 1)?;
+            Ok(Some(Expr::ArrayReduce {
+                array,
+                callback: cb,
+                initial,
+            }))
+        }
+        "reduceRight" => {
+            let Some(cb) = arg(ctx, 0)? else {
+                return Ok(None);
+            };
+            let initial = arg(ctx, 1)?;
+            Ok(Some(Expr::ArrayReduceRight {
+                array,
+                callback: cb,
+                initial,
+            }))
+        }
+        "indexOf" => {
+            let Some(value) = arg(ctx, 0)? else {
+                return Ok(None);
+            };
+            let from_index = arg(ctx, 1)?;
+            Ok(Some(Expr::ArrayIndexOf {
+                array,
+                value,
+                from_index,
+            }))
+        }
+        "lastIndexOf" => {
+            let Some(value) = arg(ctx, 0)? else {
+                return Ok(None);
+            };
+            let from_index = arg(ctx, 1)?;
+            Ok(Some(Expr::ArrayLastIndexOf {
+                array,
+                value,
+                from_index,
+            }))
+        }
+        "includes" => {
+            let Some(value) = arg(ctx, 0)? else {
+                return Ok(None);
+            };
+            let from_index = arg(ctx, 1)?;
+            Ok(Some(Expr::ArrayIncludes {
+                array,
+                value,
+                from_index,
+            }))
+        }
+        "slice" => {
+            // `slice()` with no args copies from index 0.
+            let start = match arg(ctx, 0)? {
+                Some(s) => s,
+                None => Box::new(Expr::Integer(0)),
+            };
+            let end = arg(ctx, 1)?;
+            Ok(Some(Expr::ArraySlice { array, start, end }))
+        }
+        "at" => {
+            let index = match arg(ctx, 0)? {
+                Some(i) => i,
+                None => Box::new(Expr::Integer(0)),
+            };
+            Ok(Some(Expr::ArrayAt { array, index }))
+        }
+        "join" => {
+            let separator = arg(ctx, 0)?;
+            Ok(Some(Expr::ArrayJoin { array, separator }))
+        }
+        // Unreachable: `supported` gate above filters to exactly these arms.
+        _ => Ok(None),
+    }
 }
 
 /// #3144: if `init` is a value-read of a builtin prototype method whose

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -464,6 +464,74 @@ pub(crate) fn clean_arr_ptr_mut(arr: *mut ArrayHeader) -> *mut ArrayHeader {
     clean_arr_ptr(arr as *const ArrayHeader) as *mut ArrayHeader
 }
 
+/// Normalize an Array.prototype method receiver into a real ArrayHeader.
+///
+/// `Array.prototype.<method>.call(arrayLike, ...)` lets a *generic array-like
+/// object* — a plain object with a `length` property and indexed keys, e.g.
+/// `{length: 3, 0: "a", 1: "b", 2: "c"}` — stand in for a real Array
+/// (ECMA-262 §23.1.3, every method's ToObject(this)/LengthOfArrayLike steps).
+///
+/// The read-only Array methods (`map`/`filter`/`reduce`/`slice`/`indexOf`/…)
+/// all start with `clean_arr_ptr(arr)` and then dereference the result as if it
+/// were a real ArrayHeader (reading `(*arr).length` + the inline element
+/// buffer). When the receiver is a plain object, `clean_arr_ptr` either nulls
+/// it (TypeError downstream) or — if the object's first u32s happen to pass the
+/// length<=capacity sanity bound — reads the `ObjectHeader` field_count / inline
+/// f64 slots as garbage elements (e.g. `8.48e-314`).
+///
+/// This helper detects the array-like case via the GC header `obj_type`
+/// (`GC_TYPE_OBJECT` == plain object) and materializes it into a real array via
+/// `js_array_from_arraylike` (which ToLength-coerces `length` and reads indexed
+/// keys `"0".."len-1"`). For genuine arrays (`GC_TYPE_ARRAY`), lazy arrays,
+/// typed arrays, buffers, and null/garbage it delegates straight to
+/// `clean_arr_ptr` — so the real-array hot path pays nothing beyond one
+/// already-warm GC-header byte read and a single integer compare.
+///
+/// Returns a pointer that is safe to dereference as an `ArrayHeader`, or null
+/// (preserving the existing empty-result / TypeError-at-call-site behavior).
+#[inline(always)]
+pub(crate) fn normalize_array_receiver(arr: *const ArrayHeader) -> *const ArrayHeader {
+    // Strip a NaN-box tag (if present) to recover the raw heap address so we
+    // can probe the GC header. Mirrors the tag-strip in clean_arr_ptr /
+    // flat_clone's array-like detection.
+    let bits = arr as u64;
+    let raw_addr = if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    };
+    if raw_addr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+        // Hot path first: read the GC-header obj_type byte. A genuine Array is
+        // GC_TYPE_ARRAY and falls straight through to `clean_arr_ptr` — the
+        // only added cost for `[1,2,3].map(...)` etc. is this one byte read and
+        // an integer compare (the registry lookups below are reached ONLY for a
+        // plain-object receiver, never for real arrays).
+        let obj_type = unsafe {
+            let hdr = (raw_addr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                as *const crate::gc::GcHeader;
+            (*hdr).obj_type
+        };
+        if obj_type == crate::gc::GC_TYPE_OBJECT
+            // Guard out registered typed arrays / buffers that (theoretically)
+            // carry a plain-object GC tag — those have their own delegation arms
+            // in the callers and must not be materialized as array-likes.
+            && crate::typedarray::lookup_typed_array_kind(raw_addr).is_none()
+            && !crate::buffer::is_registered_buffer(raw_addr)
+        {
+            // Generic array-like object receiver
+            // (`Array.prototype.<m>.call({length, 0:…}, …)`): materialize
+            // `length` + indexed keys into a real array and operate on that.
+            return unsafe {
+                crate::array::js_array_from_arraylike(
+                    raw_addr as *const crate::object::ObjectHeader,
+                )
+            } as *const ArrayHeader;
+        }
+    }
+    // Real array / lazy array / typed array / null / garbage: existing path.
+    clean_arr_ptr(arr)
+}
+
 /// Array header - precedes the elements in memory
 #[repr(C)]
 pub struct ArrayHeader {

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -16,7 +16,7 @@ fn array_receiver_value(arr: *const ArrayHeader) -> f64 {
 /// Returns nothing (void)
 #[no_mangle]
 pub extern "C" fn js_array_forEach(arr: *const ArrayHeader, callback: *const ClosureHeader) {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return;
     }
@@ -50,7 +50,7 @@ pub extern "C" fn js_array_map(
     arr: *const ArrayHeader,
     callback: *const ClosureHeader,
 ) -> *mut ArrayHeader {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return js_array_alloc(0);
     }
@@ -107,7 +107,7 @@ pub extern "C" fn js_array_map(
 /// effects without allocating or filling the result array.
 #[no_mangle]
 pub extern "C" fn js_array_map_discard(arr: *const ArrayHeader, callback: *const ClosureHeader) {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return;
     }
@@ -130,7 +130,7 @@ pub extern "C" fn js_array_filter(
     arr: *const ArrayHeader,
     callback: *const ClosureHeader,
 ) -> *mut ArrayHeader {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return js_array_alloc(0);
     }
@@ -167,7 +167,7 @@ pub extern "C" fn js_array_filter(
 /// Returns the element as f64, or f64::NAN (undefined) if not found
 #[no_mangle]
 pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const ClosureHeader) -> f64 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
@@ -203,7 +203,7 @@ pub extern "C" fn js_array_findIndex(
     arr: *const ArrayHeader,
     callback: *const ClosureHeader,
 ) -> i32 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return -1;
     }
@@ -238,7 +238,7 @@ pub extern "C" fn js_array_find_last(
     arr: *const ArrayHeader,
     callback: *const ClosureHeader,
 ) -> f64 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
@@ -269,7 +269,7 @@ pub extern "C" fn js_array_find_last_index(
     arr: *const ArrayHeader,
     callback: *const ClosureHeader,
 ) -> i32 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return -1;
     }
@@ -298,7 +298,7 @@ pub extern "C" fn js_array_find_last_index(
 /// at - element access supporting negative indices (arr.at(-1) = last)
 #[no_mangle]
 pub extern "C" fn js_array_at(arr: *const ArrayHeader, index: f64) -> f64 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
@@ -347,7 +347,7 @@ pub extern "C" fn js_array_at(arr: *const ArrayHeader, index: f64) -> f64 {
 pub extern "C" fn js_array_some(arr: *const ArrayHeader, callback: *const ClosureHeader) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return f64::from_bits(TAG_FALSE);
     }
@@ -380,7 +380,7 @@ pub extern "C" fn js_array_some(arr: *const ArrayHeader, callback: *const Closur
 pub extern "C" fn js_array_every(arr: *const ArrayHeader, callback: *const ClosureHeader) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return f64::from_bits(TAG_TRUE);
     }
@@ -414,7 +414,7 @@ pub extern "C" fn js_array_flatMap(
     arr: *const ArrayHeader,
     callback: *const ClosureHeader,
 ) -> *mut ArrayHeader {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return js_array_alloc(0);
     }
@@ -464,7 +464,7 @@ pub extern "C" fn js_array_reduce(
     has_initial: i32,
     initial: f64,
 ) -> f64 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         if has_initial != 0 {
             return initial;
@@ -533,7 +533,7 @@ pub extern "C" fn js_array_join(
     use crate::string::{js_string_from_bytes, StringHeader};
     use crate::value::JSValue;
 
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return crate::string::js_string_from_bytes(b"".as_ptr(), 0);
     }
@@ -737,7 +737,7 @@ pub extern "C" fn js_array_to_locale_string(
     locales: f64,
     options: f64,
 ) -> *mut crate::string::StringHeader {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return crate::string::js_string_from_bytes(b"".as_ptr(), 0);
     }

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -101,10 +101,11 @@ pub(crate) use self::header::{
     array_named_property_set, array_numeric_raw_f64_get, array_numeric_raw_f64_push_inbounds,
     array_numeric_raw_f64_set_inbounds, canonicalize_array_numeric_store_value, clean_arr_ptr,
     clean_arr_ptr_mut, clear_array_numeric_layout, clear_array_numeric_layout_ptr,
-    gc_element_slot_range, mark_array_layout_unknown, note_array_slot, note_array_slot_layout_only,
-    rebuild_array_layout, rebuild_array_layout_exact, refresh_array_numeric_layout,
-    replay_array_growth_write_barriers, set_array_numeric_layout, store_array_slot,
-    transfer_array_numeric_layout, value_bits_to_number, NumericArrayLayout, MIN_ARRAY_CAPACITY,
+    gc_element_slot_range, mark_array_layout_unknown, normalize_array_receiver, note_array_slot,
+    note_array_slot_layout_only, rebuild_array_layout, rebuild_array_layout_exact,
+    refresh_array_numeric_layout, replay_array_growth_write_barriers, set_array_numeric_layout,
+    store_array_slot, transfer_array_numeric_layout, value_bits_to_number, NumericArrayLayout,
+    MIN_ARRAY_CAPACITY,
 };
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/array/reduce_right.rs
+++ b/crates/perry-runtime/src/array/reduce_right.rs
@@ -11,7 +11,7 @@ pub extern "C" fn js_array_reduce_right(
     has_initial: i32,
     initial: f64,
 ) -> f64 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         if has_initial != 0 {
             return initial;

--- a/crates/perry-runtime/src/array/search.rs
+++ b/crates/perry-runtime/src/array/search.rs
@@ -3,7 +3,7 @@ use super::*;
 
 #[no_mangle]
 pub extern "C" fn js_array_indexOf_f64(arr: *const ArrayHeader, value: f64) -> i32 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return -1;
     }
@@ -74,7 +74,7 @@ pub extern "C" fn js_array_indexOf_jsvalue(
     from_index: f64,
     has_from: i32,
 ) -> i32 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return -1;
     }
@@ -120,7 +120,7 @@ pub extern "C" fn js_array_last_index_of_jsvalue(
     from_index: f64,
     has_from: i32,
 ) -> i32 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return -1;
     }
@@ -223,7 +223,7 @@ pub extern "C" fn js_array_includes_jsvalue(
     from_index: f64,
     has_from: i32,
 ) -> i32 {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return 0;
     }

--- a/crates/perry-runtime/src/array/splice_slice.rs
+++ b/crates/perry-runtime/src/array/splice_slice.rs
@@ -152,7 +152,7 @@ pub extern "C" fn js_array_slice(
     start: i32,
     end: i32,
 ) -> *mut ArrayHeader {
-    let arr = clean_arr_ptr(arr);
+    let arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return js_array_alloc(0);
     }


### PR DESCRIPTION
## What

`Array.prototype.<method>.call(arrayLikeObject, ...)` now works for the read-only
/ returning Array methods (map, filter, forEach, find, findIndex, findLast,
findLastIndex, some, every, flatMap, reduce, reduceRight, indexOf, lastIndexOf,
includes, slice, at, join). Previously these treated a generic array-like object
receiver as a raw ArrayHeader and read garbage or threw TypeError.

## Why

The single largest test262 cluster: ~1,618 `built-ins/Array` failures, spread
evenly across every prototype method — one shared root cause: array-like object
receivers weren't materialized into real arrays.

## How

Two orthogonal fixes:
1. **HIR (primary):** `try_builtin_prototype_method_apply_call` rewrote
   `Array.prototype.map.call(like, fn)` → `like.map(fn)`, which for an
   `Any`/object receiver lowered to a dynamic lookup that found no `map` and threw
   "value is not a function". Now, for a known read-only method, the receiver is
   materialized via `Expr::ArrayFrom` (→ `js_array_from_value`/`js_array_clone`,
   which already detect `{length, 0:…}` array-likes) before building the dedicated
   array-method node. This also fixes inlined-codegen methods (e.g. `forEach`).
2. **Runtime (defense-in-depth):** `normalize_array_receiver` replaces
   `clean_arr_ptr` at the read-only method entries. It reads the GC-header
   `obj_type`; ONLY `GC_TYPE_OBJECT` (a plain array-like) is materialized via
   `js_array_from_arraylike`. Real arrays (`GC_TYPE_ARRAY`) fall straight through
   — one warm header read + an int compare, no materialization — so
   `[1,2,3].map(...)` is not regressed.

## Verification

- **test262 `built-ins/Array`: 1618 → 1161** (503 fixed; net **−457**).
- **Byte-identical to `node --experimental-strip-types`** under BOTH
  `PERRY_NO_AUTO_OPTIMIZE=1` and default auto-optimize: array-like map/indexOf/
  reduce/slice/join/includes, real-array map/filter/reduce/slice/indexOf, for-of,
  spread, TypedArray `.map`, chained filter→map→reduce.
- `perry-runtime` suite: 974/974.
- fmt + file-size gates clean. Rebased on current main.

## Known: 46 newly-surfaced (pre-existing) failures → #4230

The correct materialization exposes ~46 pre-existing latent bugs the old
garbage-read path masked. **Confirmed identical on clean `main`** (not
regressions): Array iteration doesn't skip holes (`[1,,3].map` calls cb 3× vs
Node's 2×) and `[].find()` returns `NaN` vs `undefined`. Tracked in #4230 for a
dedicated hole-skipping pass (which would recover these 46 + fix real sparse
arrays). Net effect of this PR remains strongly positive (−457).

## Scope

Mutators (push/pop/shift/unshift/splice/sort/reverse/fill/copyWithin) and
`concat` are intentionally NOT changed — they need spec write-back / have
different array-like semantics; left for a follow-up.
