### PR TITLE
[codex] Add optional TTY PTY parity runner

### DIFF
--- a/test-parity/node-suite/tty/README.md
+++ b/test-parity/node-suite/tty/README.md
@@ -3,3 +3,13 @@
 Focused Node.js-compatible cases for Perry's `node:tty` surface.
 
 These tests avoid requiring a real interactive TTY. They exercise stable CI-safe semantics from Node's tty tests: import shapes, `isatty()` false cases, stdio TTY/dimension shape, constructor export shape, and color-helper behavior.
+
+## Optional PTY-backed coverage
+
+Interactive terminal behavior lives outside the default parity suite. Run it explicitly with:
+
+```sh
+PERRY_RUN_TTY_INTERACTIVE_TESTS=1 ./test-parity/run_tty_interactive_tests.sh
+```
+
+The runner uses `script(1)` to allocate a pseudo-terminal, skips cleanly when `script(1)` or a usable PTY is unavailable, and normalizes terminal control sequences before comparing Node and Perry output. It supports the util-linux `script -q -e -c <cmd> /dev/null` form and the BSD/macOS `script -q /dev/null sh -c <cmd>` form. Use `PERRY_TTY_PTY_COLS` and `PERRY_TTY_PTY_ROWS` to override the default `80x24` PTY size.

--- a/test-parity/run_tty_interactive_tests.sh
+++ b/test-parity/run_tty_interactive_tests.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Optional PTY-backed node:tty parity runner.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/tty-pty-smoke.ts"
+OUTPUT_DIR="$SCRIPT_DIR/output/tty-interactive"
+REPORT_DIR="$SCRIPT_DIR/reports"
+PERRY_BIN="${PERRY_BIN:-$ROOT_DIR/target/release/perry}"
+NODE_BIN="${NODE_BIN:-node}"
+COLS="${PERRY_TTY_PTY_COLS:-80}"
+ROWS="${PERRY_TTY_PTY_ROWS:-24}"
+
+if [[ "${PERRY_RUN_TTY_INTERACTIVE_TESTS:-0}" != "1" ]]; then
+    echo "SKIP tty interactive PTY tests (set PERRY_RUN_TTY_INTERACTIVE_TESTS=1 to run)"
+    exit 0
+fi
+
+if ! command -v script >/dev/null 2>&1; then
+    echo "SKIP tty interactive PTY tests (script(1) not found)"
+    exit 0
+fi
+
+if ! command -v "$NODE_BIN" >/dev/null 2>&1; then
+    echo "FAIL tty interactive PTY tests (NODE_BIN not found: $NODE_BIN)"
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR/node" "$OUTPUT_DIR/perry" "$REPORT_DIR"
+
+quote_arg() {
+    printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\\\''/g")"
+}
+
+detect_script_style() {
+    local probe
+    probe=$(mktemp)
+    if script -q -e -c "printf __perry_tty_script_ok__" /dev/null >"$probe" 2>&1; then
+        if grep -q "__perry_tty_script_ok__" "$probe"; then
+            rm -f "$probe"
+            echo "util-linux"
+            return 0
+        fi
+    fi
+    if script -q /dev/null sh -c "printf __perry_tty_script_ok__" >"$probe" 2>&1; then
+        if grep -q "__perry_tty_script_ok__" "$probe"; then
+            rm -f "$probe"
+            echo "bsd"
+            return 0
+        fi
+    fi
+    rm -f "$probe"
+    return 1
+}
+
+SCRIPT_STYLE="$(detect_script_style || true)"
+if [[ -z "$SCRIPT_STYLE" ]]; then
+    echo "SKIP tty interactive PTY tests (script(1) could not allocate a usable PTY)"
+    exit 0
+fi
+
+run_under_pty() {
+    local outfile=$1
+    local command=$2
+    local setup="stty cols $COLS rows $ROWS 2>/dev/null || true"
+    if [[ "$SCRIPT_STYLE" == "util-linux" ]]; then
+        script -q -e -c "$setup; $command" /dev/null >"$outfile" 2>&1
+    else
+        script -q /dev/null sh -c "$setup; $command" >"$outfile" 2>&1
+    fi
+}
+
+normalize_output() {
+    perl -0pe 's/\r//g; s/\e\][^\a]*(?:\a|\e\\)//g; s/\e\[[0-?]*[ -\/]*[@-~]//g; s/\e[()][A-Za-z0-9]//g;' |
+        sed '/^Script started/d;/^Script done/d'
+}
+
+echo "Running optional tty interactive PTY parity (script style: $SCRIPT_STYLE, size: ${COLS}x${ROWS})"
+
+if [[ ! -x "$PERRY_BIN" ]]; then
+    echo "Building Perry compiler..."
+    cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib
+fi
+
+perry_binary="/tmp/perry_tty_pty_smoke"
+echo "Compiling fixture with Perry..."
+env PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE="${PERRY_NO_AUTO_OPTIMIZE:-1}" \
+    "$PERRY_BIN" "$FIXTURE" -o "$perry_binary"
+
+node_raw="$OUTPUT_DIR/node/tty-pty-smoke.raw.txt"
+perry_raw="$OUTPUT_DIR/perry/tty-pty-smoke.raw.txt"
+node_out="$OUTPUT_DIR/node/tty-pty-smoke.txt"
+perry_out="$OUTPUT_DIR/perry/tty-pty-smoke.txt"
+
+node_cmd="env FORCE_COLOR=0 NO_COLOR=1 NODE_DISABLE_COLORS=1 TERM=xterm-256color $(quote_arg "$NODE_BIN") --experimental-strip-types $(quote_arg "$FIXTURE")"
+perry_cmd="env TERM=xterm-256color $(quote_arg "$perry_binary")"
+
+set +e
+run_under_pty "$node_raw" "$node_cmd"
+node_status=$?
+run_under_pty "$perry_raw" "$perry_cmd"
+perry_status=$?
+set -e
+
+normalize_output <"$node_raw" >"$node_out"
+normalize_output <"$perry_raw" >"$perry_out"
+
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+report="$REPORT_DIR/tty_interactive_report_$(date -u +"%Y%m%d_%H%M%S").json"
+diff_status=0
+diff -u "$node_out" "$perry_out" || diff_status=$?
+
+if [[ $node_status -eq 0 && $perry_status -eq 0 && $diff_status -eq 0 ]]; then
+    cat >"$report" <<EOF
+{
+  "generated_at": "$generated_at",
+  "suite": "tty-interactive",
+  "script_style": "$SCRIPT_STYLE",
+  "pty_size": { "columns": $COLS, "rows": $ROWS },
+  "node_exit": $node_status,
+  "perry_exit": $perry_status,
+  "summary": { "parity_pass": 1, "parity_fail": 0, "compile_fail": 0, "skipped": 0 },
+  "fixtures": ["test-parity/fixtures/tty-pty-smoke.ts"]
+}
+EOF
+    echo "PASS tty-interactive/tty-pty-smoke"
+    echo "Report saved to: $report"
+else
+    cat >"$report" <<EOF
+{
+  "generated_at": "$generated_at",
+  "suite": "tty-interactive",
+  "script_style": "$SCRIPT_STYLE",
+  "pty_size": { "columns": $COLS, "rows": $ROWS },
+  "node_exit": $node_status,
+  "perry_exit": $perry_status,
+  "summary": { "parity_pass": 0, "parity_fail": 1, "compile_fail": 0, "skipped": 0 },
+  "fixtures": ["test-parity/fixtures/tty-pty-smoke.ts"]
+}
+EOF
+    echo "FAIL tty-interactive/tty-pty-smoke"
+    echo "Report saved to: $report"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `test-parity/run_tty_interactive_tests.sh` as an opt-in PTY-backed parity runner for `node:tty` interactive behavior.
- Keep the default parity suite deterministic: the runner exits with a clear skip unless `PERRY_RUN_TTY_INTERACTIVE_TESTS=1` is set.
- Detect usable `script(1)` support for util-linux and BSD/macOS forms, configure a deterministic PTY size, normalize terminal control sequences, and compare Node vs Perry output for the existing `tty-pty-smoke.ts` fixture.
- Document the optional runner in the `node:tty` suite README.

## Issue Scope
Covers #1271's requested optional PTY-backed harness without changing the regular non-interactive `node:tty` suite.

## Validation
- `bash -n test-parity/run_tty_interactive_tests.sh`
- `./test-parity/run_tty_interactive_tests.sh` -> skipped by default with a clear reason
- `NODE_BIN=$(npm exec --yes --package=node@26 -- node -p 'process.execPath') PERRY_RUN_TTY_INTERACTIVE_TESTS=1 ./test-parity/run_tty_interactive_tests.sh` -> `PASS tty-interactive/tty-pty-smoke`, report `test-parity/reports/tty_interactive_report_20260603_080132.json`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module tty'` -> Node v26.3.0, 32 pass / 0 fail, report `test-parity/reports/parity_report_20260603_075920.json`
- `git diff --check`
- `./scripts/check_file_size.sh`
