### PR TITLE
[codex] Cache tagged-template objects per call site

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -20,7 +20,7 @@ use crate::lower_string_method::{
     lower_string_concat_chain, lower_string_self_append,
 };
 #[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::{double_literal, i64_literal, POINTER_MASK_I64};
 #[allow(unused_imports)]
 use crate::type_analysis::{
     compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
@@ -638,11 +638,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         // Tagged-template strings literal — build cooked array, build raw
-        // array, register the (cooked, raw) pair so subsequent `.raw`
-        // reads resolve via `js_template_raw`, return the cooked array.
+        // array, then fetch/init the frozen per-call-site template object.
         // Same emit shape as the generic `Expr::Array` lowering but with
-        // the side-table registration sandwiched in.
-        Expr::TaggedTemplateStrings { cooked, raw } => {
+        // the template-object initialization sandwiched in.
+        Expr::TaggedTemplateStrings {
+            site_id,
+            cooked,
+            raw,
+        } => {
             // Materialize cooked array — go through lower_array_literal so
             // SSO + GC + length-init logic stays in one place.
             let cooked_box = lower_array_literal(ctx, cooked)?;
@@ -654,10 +657,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let blk = ctx.block();
             let cooked_handle = unbox_to_i64(blk, &cooked_box);
             let raw_handle = unbox_to_i64(blk, &raw_box);
+            let site_id = i64_literal(*site_id);
             let registered = blk.call(
                 I64,
-                "js_tagged_template_register_raw",
-                &[(I64, &cooked_handle), (I64, &raw_handle)],
+                "js_tagged_template_get_or_init",
+                &[(I64, &site_id), (I64, &cooked_handle), (I64, &raw_handle)],
             );
             Ok(nanbox_pointer_inline(blk, &registered))
         }

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -21,6 +21,7 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // TaggedTemplate Evaluation step 5: `template[Symbol.raw]` returns
     // an array of raw strings).
     module.declare_function("js_tagged_template_register_raw", I64, &[I64, I64]);
+    module.declare_function("js_tagged_template_get_or_init", I64, &[I64, I64, I64]);
     module.declare_function("js_template_raw", I64, &[I64]);
     // Convenience alias for `js_array_alloc(0)`; emitted by lower_call's
     // `new Array()` no-arg branch. Issue #432: clang rejected

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2054,13 +2054,13 @@ pub enum Expr {
     IteratorFrom(Box<Expr>),
 
     /// Tagged-template strings literal — codegen builds the cooked-strings
-    /// array AND a parallel raw-strings array, registers the (cooked, raw)
-    /// pair via `js_tagged_template_register_raw`, and returns the cooked
-    /// pointer (NaN-boxed). The raw entries are always known at compile
-    /// time (each quasi's `.raw` text), so they're stored as `String` rather
-    /// than `Expr`. Used by `lower_tagged_tpl` for the non-`String.raw`
-    /// fast-path tag-function call.
+    /// array AND a parallel raw-strings array, then asks the runtime for the
+    /// cached frozen template object for this call site. The raw entries are
+    /// always known at compile time (each quasi's `.raw` text), so they're
+    /// stored as `String` rather than `Expr`. Used by `lower_tagged_tpl` for
+    /// the non-`String.raw` fast-path tag-function call.
     TaggedTemplateStrings {
+        site_id: u64,
         cooked: Vec<Expr>,
         raw: Vec<String>,
     },

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -14,6 +14,15 @@ use swc_ecma_ast as ast;
 use super::*;
 use crate::ir::*;
 
+fn stable_tagged_template_site_salt(source_file_path: &str) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in source_file_path.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h & 0xFFFF_FFFF
+}
+
 impl LoweringContext {
     // #854: single-arg constructor (delegates to `with_class_id_start`).
     // Currently only exercised from the `#[cfg(test)]` lowering tests, so it
@@ -27,6 +36,8 @@ impl LoweringContext {
         source_file_path: impl Into<String>,
         start_class_id: ClassId,
     ) -> Self {
+        let source_file_path = source_file_path.into();
+        let tagged_template_site_salt = stable_tagged_template_site_salt(&source_file_path);
         Self {
             next_local_id: 0,
             next_global_id: 0,
@@ -35,6 +46,8 @@ impl LoweringContext {
             next_enum_id: 0,
             next_interface_id: 0,
             next_type_alias_id: 0,
+            tagged_template_site_salt,
+            next_tagged_template_site_id: 0,
             locals: Vec::new(),
             globals: Vec::new(),
             functions: Vec::new(),
@@ -64,7 +77,7 @@ impl LoweringContext {
             current_class_member_is_static: false,
             object_super_home_stack: Vec::new(),
             extern_func_types: Vec::new(),
-            source_file_path: source_file_path.into(),
+            source_file_path,
             exportable_object_vars: HashSet::new(),
             pending_functions: Vec::new(),
             closure_display_names: HashMap::new(),
@@ -133,6 +146,12 @@ impl LoweringContext {
             is_external_module: false,
             optional_require_try_depth: 0,
         }
+    }
+
+    pub(crate) fn fresh_tagged_template_site_id(&mut self) -> u64 {
+        let local_id = self.next_tagged_template_site_id;
+        self.next_tagged_template_site_id = self.next_tagged_template_site_id.wrapping_add(1);
+        (self.tagged_template_site_salt << 32) | u64::from(local_id)
     }
 
     pub(crate) fn fresh_interface(&mut self) -> InterfaceId {

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1750,9 +1750,10 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
             // strings array carries the cooked text (escapes processed) AS
             // the array elements AND the raw text (escapes preserved) via
             // a thread-local side table populated at the call site —
-            // `TaggedTemplateStrings` codegen emits both arrays + a
-            // `js_tagged_template_register_raw` call so `strings.raw` reads
-            // can resolve via the matching `Expr::TemplateRaw` fold below.
+            // `TaggedTemplateStrings` codegen emits both arrays, then asks
+            // the runtime for the cached frozen template object so
+            // `strings.raw` reads can resolve via the matching
+            // `Expr::TemplateRaw` fold below.
             let cooked_strings: Vec<Expr> = tpl
                 .quasis
                 .iter()
@@ -1771,6 +1772,7 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 .map(|q| q.raw.as_ref().to_string())
                 .collect();
             let strings_array = Expr::TaggedTemplateStrings {
+                site_id: ctx.fresh_tagged_template_site_id(),
                 cooked: cooked_strings,
                 raw: raw_strings,
             };

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -35,6 +35,10 @@ pub struct LoweringContext {
     pub(crate) next_interface_id: InterfaceId,
     /// Counter for generating unique type alias IDs
     pub(crate) next_type_alias_id: TypeAliasId,
+    /// Deterministic per-module salt for tagged-template call-site cache keys.
+    pub(crate) tagged_template_site_salt: u64,
+    /// Counter for generating unique tagged-template call-site IDs.
+    pub(crate) next_tagged_template_site_id: u32,
     /// Current scope's local variables: name -> (id, type)
     pub(crate) locals: Vec<(String, LocalId, Type)>,
     /// LocalIds that represent immutable bindings (`const`, imports, and

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -612,7 +612,7 @@ impl SH for Expr {
             Expr::AsyncStepDone { value, step_closure, } => { tag(h, 442); value.as_ref().hash(h); step_closure.as_ref().hash(h); }
             Expr::CurrentStepClosure => tag(h, 443),
             Expr::AsyncFirstCall { step_closure } => { tag(h, 444); step_closure.as_ref().hash(h); }
-            Expr::TaggedTemplateStrings { cooked, raw } => { tag(h, 445); cooked.hash(h); raw.hash(h); }
+            Expr::TaggedTemplateStrings { site_id, cooked, raw } => { tag(h, 445); site_id.hash(h); cooked.hash(h); raw.hash(h); }
             Expr::TemplateRaw(e) => { tag(h, 446); e.as_ref().hash(h); }
             Expr::RegisterClassParentDynamic { class_name, parent_expr, } => { tag(h, 447); class_name.hash(h); parent_expr.as_ref().hash(h); }
             Expr::RegisterClassStaticSymbol { class_name, key_expr, value_expr, } => { tag(h, 12025); class_name.hash(h); key_expr.as_ref().hash(h); value_expr.as_ref().hash(h); }

--- a/crates/perry-hir/src/stable_hash/primitives.rs
+++ b/crates/perry-hir/src/stable_hash/primitives.rs
@@ -31,6 +31,12 @@ impl SH for u32 {
     }
 }
 
+impl SH for u64 {
+    fn hash<H: StableHasher>(&self, h: &mut H) {
+        h.write(&self.to_le_bytes());
+    }
+}
+
 impl SH for usize {
     fn hash<H: StableHasher>(&self, h: &mut H) {
         h.write(&(*self as u64).to_le_bytes());

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -16,6 +16,11 @@ thread_local! {
     static TEMPLATE_RAW_MAP: RefCell<HashMap<usize, *mut ArrayHeader>> =
         RefCell::new(HashMap::new());
 
+    /// Tagged-template template-object cache — maps a stable compile-time
+    /// call-site id to the frozen cooked/raw array pair for that site.
+    static TEMPLATE_OBJECT_CACHE: RefCell<HashMap<u64, (*mut ArrayHeader, *mut ArrayHeader)>> =
+        RefCell::new(HashMap::new());
+
     /// Own non-index properties for Array exotic objects.
     ///
     /// Perry's `ArrayHeader` intentionally stays compact: `length`,
@@ -40,6 +45,72 @@ pub enum NumericArrayLayout {
     RawF64 = 1,
 }
 
+#[inline]
+pub(crate) fn array_object_flags(arr: *const ArrayHeader) -> u16 {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() || (arr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return 0;
+    }
+    unsafe {
+        let gc_header =
+            (arr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+            (*gc_header)._reserved
+        } else {
+            0
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn array_is_frozen(arr: *const ArrayHeader) -> bool {
+    array_object_flags(arr) & crate::gc::OBJ_FLAG_FROZEN != 0
+}
+
+#[inline]
+pub(crate) fn array_is_sealed_or_no_extend(arr: *const ArrayHeader) -> bool {
+    array_object_flags(arr) & (crate::gc::OBJ_FLAG_SEALED | crate::gc::OBJ_FLAG_NO_EXTEND) != 0
+}
+
+unsafe fn mark_template_array_frozen(arr: *mut ArrayHeader) {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() || (arr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return;
+    }
+    let gc_header = (arr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
+    if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+        (*gc_header)._reserved |=
+            crate::gc::OBJ_FLAG_FROZEN | crate::gc::OBJ_FLAG_SEALED | crate::gc::OBJ_FLAG_NO_EXTEND;
+    }
+}
+
+unsafe fn register_template_raw_pair(cooked: *mut ArrayHeader, raw: *mut ArrayHeader) {
+    if cooked.is_null() || raw.is_null() {
+        return;
+    }
+    TEMPLATE_RAW_MAP.with(|m| {
+        m.borrow_mut().insert(cooked as usize, raw);
+    });
+}
+
+unsafe fn install_template_raw_property(
+    cooked_handle: &crate::gc::RuntimeHandle<'_>,
+    raw_handle: &crate::gc::RuntimeHandle<'_>,
+) {
+    let raw_key = crate::string::js_string_from_bytes(b"raw".as_ptr(), 3);
+    let cooked = cooked_handle.get_raw_mut_ptr::<ArrayHeader>();
+    let raw = raw_handle.get_raw_mut_ptr::<ArrayHeader>();
+    if cooked.is_null() || raw.is_null() {
+        return;
+    }
+    array_named_property_set(cooked, raw_key, crate::value::js_nanbox_pointer(raw as i64));
+    crate::object::set_property_attrs(
+        cooked as usize,
+        "raw".to_string(),
+        crate::object::PropertyAttrs::new(false, false, false),
+    );
+}
+
 /// Register the (cooked, raw) pair for a tagged-template call. Returns
 /// `cooked` (so the codegen can chain it inline into the call args).
 #[no_mangle]
@@ -47,13 +118,59 @@ pub extern "C" fn js_tagged_template_register_raw(
     cooked: *mut ArrayHeader,
     raw: *mut ArrayHeader,
 ) -> *mut ArrayHeader {
-    if !cooked.is_null() && !raw.is_null() {
-        TEMPLATE_RAW_MAP.with(|m| {
-            m.borrow_mut().insert(cooked as usize, raw);
-        });
+    let cooked = clean_arr_ptr_mut(cooked);
+    let raw = clean_arr_ptr_mut(raw);
+    unsafe {
+        register_template_raw_pair(cooked, raw);
     }
     cooked
 }
+
+/// Return the frozen template-strings object for a tagged-template call site,
+/// initializing the per-site cooked/raw pair on first evaluation.
+#[no_mangle]
+pub extern "C" fn js_tagged_template_get_or_init(
+    site_id: u64,
+    cooked: *mut ArrayHeader,
+    raw: *mut ArrayHeader,
+) -> *mut ArrayHeader {
+    if let Some(cached) = TEMPLATE_OBJECT_CACHE.with(|m| {
+        m.borrow()
+            .get(&site_id)
+            .map(|&(cached_cooked, _)| cached_cooked)
+    }) {
+        return cached;
+    }
+
+    let cooked = clean_arr_ptr_mut(cooked);
+    let raw = clean_arr_ptr_mut(raw);
+    if cooked.is_null() || raw.is_null() {
+        return cooked;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let cooked_handle = scope.root_raw_mut_ptr(cooked);
+    let raw_handle = scope.root_raw_mut_ptr(raw);
+    unsafe {
+        install_template_raw_property(&cooked_handle, &raw_handle);
+        let cooked = cooked_handle.get_raw_mut_ptr::<ArrayHeader>();
+        let raw = raw_handle.get_raw_mut_ptr::<ArrayHeader>();
+        mark_template_array_frozen(raw);
+        mark_template_array_frozen(cooked);
+        register_template_raw_pair(cooked, raw);
+        TEMPLATE_OBJECT_CACHE.with(|m| {
+            m.borrow_mut().insert(site_id, (cooked, raw));
+        });
+    }
+    cooked_handle.get_raw_mut_ptr::<ArrayHeader>()
+}
+
+#[used]
+static KEEP_TAGGED_TEMPLATE_GET_OR_INIT: extern "C" fn(
+    u64,
+    *mut ArrayHeader,
+    *mut ArrayHeader,
+) -> *mut ArrayHeader = js_tagged_template_get_or_init;
 
 /// Read the raw-strings array for a cooked array, or 0 if not a
 /// tagged-template strings array.
@@ -81,6 +198,13 @@ pub fn scan_template_raw_roots(mark: &mut dyn FnMut(f64)) {
 }
 
 pub fn scan_template_raw_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    TEMPLATE_OBJECT_CACHE.with(|m| {
+        let mut map = m.borrow_mut();
+        for (_, (cooked_ptr, raw_ptr)) in map.iter_mut() {
+            visitor.visit_raw_mut_ptr_slot(cooked_ptr);
+            visitor.visit_raw_mut_ptr_slot(raw_ptr);
+        }
+    });
     TEMPLATE_RAW_MAP.with(|m| {
         let mut map = m.borrow_mut();
         let mut moved = Vec::new();

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -237,6 +237,9 @@ pub extern "C" fn js_array_set_f64_unchecked(arr: *mut ArrayHeader, index: u32, 
     if arr.is_null() {
         return;
     }
+    if array_is_frozen(arr) {
+        return;
+    }
     unsafe {
         let length = (*arr).length;
         if index >= length {
@@ -257,6 +260,9 @@ pub extern "C" fn js_array_numeric_set_f64_unboxed(
     index: u32,
     value: f64,
 ) -> i32 {
+    if array_is_frozen(arr) {
+        return 0;
+    }
     unsafe {
         if array_numeric_raw_f64_set_inbounds(arr, index, value) {
             return 1;
@@ -289,6 +295,9 @@ pub extern "C" fn js_array_set_f64(arr: *mut ArrayHeader, index: u32, value: f64
             index as i32,
             value,
         );
+        return;
+    }
+    if array_is_frozen(arr) {
         return;
     }
     unsafe {
@@ -336,6 +345,10 @@ pub extern "C" fn js_array_set_f64_extend(
         );
         return arr;
     }
+    let flags = array_object_flags(arr);
+    let is_frozen = flags & crate::gc::OBJ_FLAG_FROZEN != 0;
+    let blocks_extension =
+        flags & (crate::gc::OBJ_FLAG_SEALED | crate::gc::OBJ_FLAG_NO_EXTEND) != 0;
     let scope = crate::gc::RuntimeHandleScope::new();
     let _arr_handle = scope.root_raw_mut_ptr(arr);
     let value_handle = scope.root_nanbox_f64(value);
@@ -348,12 +361,19 @@ pub extern "C" fn js_array_set_f64_extend(
 
         // If index is within bounds, just set it
         if index < length {
+            if is_frozen {
+                return arr;
+            }
             let value = canonicalize_array_numeric_store_value(arr, value);
             let value_bits = value.to_bits();
             let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
             // GC_STORE_AUDIT(BARRIERED): in-bounds extending set is immediately recorded via note_array_slot.
             ptr::write(elements_ptr.add(index as usize), value);
             note_array_slot(arr, index as usize, value_bits);
+            return arr;
+        }
+
+        if is_frozen || blocks_extension {
             return arr;
         }
 
@@ -463,6 +483,18 @@ pub extern "C" fn js_array_set_string_key(
             return js_array_set_f64_extend(arr, idx, value);
         }
     }
+    if array_is_frozen(arr) {
+        return arr;
+    }
+    let existing = unsafe { array_named_property_get(arr, key).is_some() };
+    if !existing && array_is_sealed_or_no_extend(arr) {
+        return arr;
+    }
+    if let Some(attrs) = crate::object::get_property_attrs(arr as usize, key_str) {
+        if !attrs.writable() {
+            return arr;
+        }
+    }
     // Non-numeric string key — fall through to object-property set on the
     // array's expando map. Arrays with named properties are rare but spec-
     // legal.
@@ -529,10 +561,7 @@ pub extern "C" fn js_array_set_index_or_string(
                 format!("{:.0}", n)
             };
             let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-            unsafe {
-                array_named_property_set(arr, key, value);
-            }
-            return arr;
+            return js_array_set_string_key(arr, key, value);
         }
     }
     arr

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -36,8 +36,9 @@ pub use self::from_concat::{js_array_concat_variadic, js_array_from_mapped, js_a
 pub(crate) use self::header::{array_has_arguments_object_flag, mark_array_as_arguments_object};
 pub use self::header::{
     js_array_clear_numeric_layout, js_array_is_numeric_f64_layout, js_array_mark_arguments_object,
-    js_array_mark_numeric_f64_layout, js_array_note_numeric_write, js_tagged_template_register_raw,
-    js_template_raw, scan_template_raw_roots, scan_template_raw_roots_mut, ArrayHeader,
+    js_array_mark_numeric_f64_layout, js_array_note_numeric_write, js_tagged_template_get_or_init,
+    js_tagged_template_register_raw, js_template_raw, scan_template_raw_roots,
+    scan_template_raw_roots_mut, ArrayHeader,
 };
 pub use self::immutable::{
     js_array_copy_within, js_array_to_reversed, js_array_to_sorted_default,
@@ -96,12 +97,13 @@ pub use self::splice_slice::{
 pub(crate) use self::alloc::array_length_from_property_value_or_throw;
 pub(crate) use self::alloc::{js_array_from_arraylike, js_array_from_string_codepoints};
 pub(crate) use self::header::{
-    array_byte_size, array_named_property_delete, array_named_property_get,
-    array_named_property_get_by_name, array_named_property_has, array_named_property_names,
-    array_named_property_set, array_numeric_raw_f64_get, array_numeric_raw_f64_push_inbounds,
-    array_numeric_raw_f64_set_inbounds, canonicalize_array_numeric_store_value, clean_arr_ptr,
-    clean_arr_ptr_mut, clear_array_numeric_layout, clear_array_numeric_layout_ptr,
-    gc_element_slot_range, mark_array_layout_unknown, normalize_array_receiver, note_array_slot,
+    array_byte_size, array_is_frozen, array_is_sealed_or_no_extend, array_named_property_delete,
+    array_named_property_get, array_named_property_get_by_name, array_named_property_has,
+    array_named_property_names, array_named_property_set, array_numeric_raw_f64_get,
+    array_numeric_raw_f64_push_inbounds, array_numeric_raw_f64_set_inbounds, array_object_flags,
+    canonicalize_array_numeric_store_value, clean_arr_ptr, clean_arr_ptr_mut,
+    clear_array_numeric_layout, clear_array_numeric_layout_ptr, gc_element_slot_range,
+    mark_array_layout_unknown, normalize_array_receiver, note_array_slot,
     note_array_slot_layout_only, rebuild_array_layout, rebuild_array_layout_exact,
     refresh_array_numeric_layout, replay_array_growth_write_barriers, set_array_numeric_layout,
     store_array_slot, transfer_array_numeric_layout, value_bits_to_number, NumericArrayLayout,

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -14,6 +14,9 @@ pub extern "C" fn js_array_grow(arr: *mut ArrayHeader, min_capacity: u32) -> *mu
     if arr.is_null() {
         return js_array_alloc(min_capacity);
     }
+    if array_is_sealed_or_no_extend(arr) || array_is_frozen(arr) {
+        return arr;
+    }
     let scope = crate::gc::RuntimeHandleScope::new();
     let arr_handle = scope.root_raw_mut_ptr(arr);
     unsafe {
@@ -102,6 +105,9 @@ pub extern "C" fn js_array_push_f64(arr: *mut ArrayHeader, value: f64) -> *mut A
     if arr.is_null() {
         return js_array_alloc(0);
     }
+    if array_is_sealed_or_no_extend(arr) || array_is_frozen(arr) {
+        return arr;
+    }
     unsafe {
         let length = (*arr).length;
         let capacity = (*arr).capacity;
@@ -134,6 +140,9 @@ pub extern "C" fn js_array_numeric_push_f64_unboxed(
     let arr = clean_arr_ptr_mut(arr);
     if arr.is_null() {
         return js_array_alloc(0);
+    }
+    if array_is_sealed_or_no_extend(arr) || array_is_frozen(arr) {
+        return arr;
     }
     unsafe {
         if array_numeric_raw_f64_push_inbounds(arr, value) {
@@ -222,6 +231,9 @@ pub extern "C" fn js_array_pop_f64(arr: *mut ArrayHeader) -> f64 {
     if arr.is_null() {
         return TAG_UNDEFINED_F64;
     }
+    if array_is_frozen(arr) {
+        return TAG_UNDEFINED_F64;
+    }
     unsafe {
         let length = (*arr).length;
         if length == 0 {
@@ -260,6 +272,13 @@ pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
     let _arr_handle = scope.root_raw_mut_ptr(arr);
     unsafe {
         let cur = (*arr).length;
+        let flags = array_object_flags(arr);
+        if flags & crate::gc::OBJ_FLAG_FROZEN != 0 {
+            return;
+        }
+        if flags & (crate::gc::OBJ_FLAG_SEALED | crate::gc::OBJ_FLAG_NO_EXTEND) != 0 && n != cur {
+            return;
+        }
         if n < cur {
             // Truncate: clear elements at indices [n..cur) to TAG_UNDEFINED so
             // any code that resurrects the slot via `arr[i]` reads `undefined`,
@@ -345,6 +364,9 @@ pub extern "C" fn js_array_shift_f64(arr: *mut ArrayHeader) -> f64 {
     if arr.is_null() {
         return TAG_UNDEFINED_F64;
     }
+    if array_is_frozen(arr) {
+        return TAG_UNDEFINED_F64;
+    }
     unsafe {
         let length = (*arr).length;
         if length == 0 {
@@ -370,6 +392,9 @@ pub extern "C" fn js_array_unshift_f64(arr: *mut ArrayHeader, value: f64) -> *mu
     let arr = clean_arr_ptr_mut(arr);
     if arr.is_null() {
         return js_array_alloc(0);
+    }
+    if array_is_sealed_or_no_extend(arr) || array_is_frozen(arr) {
+        return arr;
     }
     let scope = crate::gc::RuntimeHandleScope::new();
     let _arr_handle = scope.root_raw_mut_ptr(arr);
@@ -421,6 +446,9 @@ pub extern "C" fn js_array_unshift_variadic(
         return js_array_alloc(0);
     }
     if count == 0 {
+        return arr;
+    }
+    if array_is_sealed_or_no_extend(arr) || array_is_frozen(arr) {
         return arr;
     }
     let scope = crate::gc::RuntimeHandleScope::new();

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -341,10 +341,11 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                 let Some(ref name) = key_rust else {
                     return f64::from_bits(crate::value::TAG_UNDEFINED);
                 };
+                let is_frozen = crate::array::array_is_frozen(arr);
                 if name == "length" {
                     return build_data_descriptor(
                         crate::array::js_array_length(arr) as f64,
-                        true,
+                        !is_frozen,
                         false,
                         false,
                     );
@@ -352,7 +353,7 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                 if let Some(index) = super::canonical_array_index(name) {
                     if super::has_own_helpers::array_own_key_present(arr, key_str) {
                         let value = crate::array::js_array_get_f64(arr, index);
-                        return build_data_descriptor(value, true, true, true);
+                        return build_data_descriptor(value, !is_frozen, true, !is_frozen);
                     }
                     return f64::from_bits(crate::value::TAG_UNDEFINED);
                 }

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -361,6 +361,13 @@ pub extern "C" fn js_object_set_field_by_name(
                     return;
                 }
             }
+            if crate::array::array_is_frozen(arr) {
+                return;
+            }
+            let existing = crate::array::array_named_property_get(arr, key).is_some();
+            if !existing && crate::array::array_is_sealed_or_no_extend(arr) {
+                return;
+            }
             crate::array::array_named_property_set(arr, key, value);
             return;
         }

--- a/test-parity/expected/tagged-template-cache-freeze.txt
+++ b/test-parity/expected/tagged-template-cache-freeze.txt
@@ -1,0 +1,16 @@
+same: first
+raw same: true
+frozen: true|true
+extensible: false|false
+raw enumerable: false
+values: ["a\n","b","a\\n","b",2,null]
+value: 1
+same: true
+raw same: true
+frozen: true|true
+extensible: false|false
+raw enumerable: false
+values: ["a\n","b","a\\n","b",2,null]
+value: 2
+duplicate site same: first
+duplicate site same: false

--- a/test-parity/node-suite/globals/tagged-template-cache-freeze.ts
+++ b/test-parity/node-suite/globals/tagged-template-cache-freeze.ts
@@ -1,0 +1,64 @@
+let first: any;
+
+function show(label: string, value: unknown) {
+  console.log(label + ": " + String(value));
+}
+
+function tag(strings: TemplateStringsArray, value: unknown) {
+  show("same", first === undefined ? "first" : first === strings);
+  if (first === undefined) {
+    first = strings;
+  }
+  show("raw same", strings.raw === first.raw);
+  show("frozen", Object.isFrozen(strings) + "|" + Object.isFrozen(strings.raw));
+  show("extensible", Object.isExtensible(strings) + "|" + Object.isExtensible(strings.raw));
+  show("raw enumerable", Object.getOwnPropertyDescriptor(strings, "raw")?.enumerable);
+
+  try {
+    (strings as any)[0] = "x";
+  } catch {}
+  try {
+    (strings.raw as any)[0] = "x";
+  } catch {}
+  try {
+    (strings as any).length = 9;
+  } catch {}
+  try {
+    (strings as any).extra = "x";
+  } catch {}
+
+  show(
+    "values",
+    JSON.stringify([
+      strings[0],
+      strings[1],
+      strings.raw[0],
+      strings.raw[1],
+      strings.length,
+      (strings as any).extra,
+    ]),
+  );
+  show("value", value);
+}
+
+function call(value: unknown) {
+  tag`a\n${value}b`;
+}
+
+call(1);
+call(2);
+
+let duplicateSiteFirst: any;
+
+function duplicateSite(strings: TemplateStringsArray) {
+  show(
+    "duplicate site same",
+    duplicateSiteFirst === undefined ? "first" : duplicateSiteFirst === strings,
+  );
+  if (duplicateSiteFirst === undefined) {
+    duplicateSiteFirst = strings;
+  }
+}
+
+duplicateSite`same`;
+duplicateSite`same`;


### PR DESCRIPTION
Closes #2855.

## Summary
- assign stable HIR call-site ids to tagged template sites and route codegen through a runtime template-object cache
- freeze cooked/raw template arrays, install non-enumerable immutable `.raw`, and guard array mutation paths against frozen template objects
- add a focused Node parity fixture for call-site identity, `.raw`, frozen/extensible state, and mutation resistance

## Validation
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-runtime-tagged-template-cache/target cargo check -p perry-hir -p perry-codegen -p perry-runtime`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-runtime-tagged-template-cache/target npm exec --package=node@25 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module globals --filter tagged-template-cache-freeze'`\n