### PR TITLE
[codex] Skip sparse array holes in iteration methods

### DIFF
--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -528,11 +528,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         // -------- arr.forEach(callback) — invoke callback for side effects --------
-        // We don't actually iterate; just lower the callback for side
-        // effects (so closures get auto-collected) and return undefined.
         Expr::ArrayForEach { array, callback } => {
-            // Lower as: for (let i = 0; i < arr.length; i++)
-            //              callback(arr[i], i);
             let arr_box = lower_expr(ctx, array)?;
             let cb_box = lower_expr(ctx, callback)?;
             let blk = ctx.block();
@@ -540,53 +536,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // #4091: throw TypeError for a non-callable callback before iterating
             // (validated up front so even an empty array throws, per spec).
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            // Load length (null-guarded).
-            let len_i32 = blk.safe_load_i32_from_ptr(&arr_handle);
-            // Loop: for i = 0; i < len; i++
-            let cond_idx = ctx.new_block("foreach.cond");
-            let body_idx = ctx.new_block("foreach.body");
-            let exit_idx = ctx.new_block("foreach.exit");
-            let cond_lbl = ctx.block_label(cond_idx);
-            let body_lbl = ctx.block_label(body_idx);
-            let exit_lbl = ctx.block_label(exit_idx);
-            // i alloca — hoisted to the entry block so the loop body
-            // (which lives in its own basic blocks) is dominated by
-            // the slot definition even if this forEach is itself
-            // lowered from inside a nested if-arm.
-            let i_slot = ctx.func.alloca_entry(I32);
-            ctx.block().store(I32, "0", &i_slot);
-            ctx.block().br(&cond_lbl);
-            // cond: i < len
-            ctx.current_block = cond_idx;
-            let i_val = ctx.block().load(I32, &i_slot);
-            let cmp = ctx.block().icmp_slt(I32, &i_val, &len_i32);
-            ctx.block().cond_br(&cmp, &body_lbl, &exit_lbl);
-            // body: callback(arr[i], i)
-            ctx.current_block = body_idx;
-            let i_cur = ctx.block().load(I32, &i_slot);
-            let elem = ctx.block().call(
-                DOUBLE,
-                "js_array_get_f64",
-                &[(I64, &arr_handle), (I32, &i_cur)],
-            );
-            let i_f64 = ctx.block().sitofp(I32, &i_cur, DOUBLE);
-            ctx.block().call(
-                DOUBLE,
-                "js_closure_call3",
-                &[
-                    (I64, &cb_handle),
-                    (DOUBLE, &elem),
-                    (DOUBLE, &i_f64),
-                    (DOUBLE, &arr_box),
-                ],
-            );
-            // i++
-            let i_next = ctx.block().add(I32, &i_cur, "1");
-            ctx.block().store(I32, &i_next, &i_slot);
-            ctx.block().br(&cond_lbl);
-            // exit
-            ctx.current_block = exit_idx;
-            Ok(double_literal(0.0))
+            blk.call_void("js_array_forEach", &[(I64, &arr_handle), (I64, &cb_handle)]);
+            Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
 
         // -------- Object.getOwnPropertyDescriptor(obj, key) --------

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -12,6 +12,32 @@ fn array_receiver_value(arr: *const ArrayHeader) -> f64 {
     f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits())
 }
 
+#[inline(always)]
+unsafe fn array_elements_ptr(arr: *const ArrayHeader) -> *const f64 {
+    (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64
+}
+
+#[inline(always)]
+fn undefined_value() -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[inline(always)]
+unsafe fn present_array_element(elements_ptr: *const f64, index: usize) -> Option<f64> {
+    let element = *elements_ptr.add(index);
+    (element.to_bits() != crate::value::TAG_HOLE).then_some(element)
+}
+
+#[inline(always)]
+unsafe fn array_element_get_value(elements_ptr: *const f64, index: usize) -> f64 {
+    let element = *elements_ptr.add(index);
+    if element.to_bits() == crate::value::TAG_HOLE {
+        undefined_value()
+    } else {
+        element
+    }
+}
+
 /// forEach - call callback(element, index) for each element
 /// Returns nothing (void)
 #[no_mangle]
@@ -29,11 +55,13 @@ pub extern "C" fn js_array_forEach(arr: *const ArrayHeader, callback: *const Clo
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
 
         let arr_value = array_receiver_value(arr);
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
             // JS forEach passes (element, index, array). The callback
             // dispatch path supports call3 safely, so bound native
             // methods like `array.forEach(console.log)` can observe the
@@ -64,16 +92,18 @@ pub extern "C" fn js_array_map(
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
 
-        // Allocate result array with same capacity
-        let result = js_array_alloc(length);
+        // Allocate at the source length so skipped sparse slots remain holes.
+        let result = js_array_alloc_with_length(length);
         let result_elements =
             (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
         let arr_value = array_receiver_value(arr);
 
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
             // JS .map() callback receives (element, index, array).
             let mapped = js_closure_call3(callback, element, i as f64, arr_value);
             // GC_STORE_AUDIT(INIT): map result is unpublished; slot layout is noted immediately below.
@@ -95,9 +125,7 @@ pub extern "C" fn js_array_map(
             } else {
                 note_array_slot(result, i, mapped_bits);
             }
-            (*result).length = (i + 1) as u32;
         }
-        (*result).length = length;
 
         result
     }
@@ -113,11 +141,13 @@ pub extern "C" fn js_array_map_discard(arr: *const ArrayHeader, callback: *const
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
 
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
             let _ = js_closure_call3(callback, element, i as f64, arr_value);
         }
     }
@@ -142,7 +172,7 @@ pub extern "C" fn js_array_filter(
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
 
         // Allocate result array with same capacity (might be smaller)
         let mut result = js_array_alloc(length);
@@ -151,7 +181,9 @@ pub extern "C" fn js_array_filter(
         // separate `result_len` counter that used to live here was dead.
 
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
             let keep = js_closure_call3(callback, element, i as f64, arr_value);
             // Proper truthy check: handles NaN-boxed booleans (TAG_FALSE != 0.0 but is falsy)
             if crate::value::js_is_truthy(keep) != 0 {
@@ -164,7 +196,7 @@ pub extern "C" fn js_array_filter(
 }
 
 /// find - find first element that matches callback(element) => true
-/// Returns the element as f64, or f64::NAN (undefined) if not found
+/// Returns the element as f64, or undefined if not found.
 #[no_mangle]
 pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const ClosureHeader) -> f64 {
     let arr = clean_arr_ptr(arr);
@@ -179,11 +211,11 @@ pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const Closur
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
 
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let element = array_element_get_value(elements_ptr, i);
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             // Proper truthy check: handles NaN-boxed booleans
             if crate::value::js_is_truthy(result) != 0 {
@@ -191,8 +223,8 @@ pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const Closur
             }
         }
 
-        // Not found - return undefined (NaN)
-        f64::NAN
+        // Not found
+        undefined_value()
     }
 }
 
@@ -215,11 +247,11 @@ pub extern "C" fn js_array_findIndex(
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
 
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let element = array_element_get_value(elements_ptr, i);
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             // Proper truthy check: handles NaN-boxed booleans
             if crate::value::js_is_truthy(result) != 0 {
@@ -250,10 +282,10 @@ pub extern "C" fn js_array_find_last(
     }
     unsafe {
         let length = (*arr).length as usize;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
         for i in (0..length).rev() {
-            let element = *elements_ptr.add(i);
+            let element = array_element_get_value(elements_ptr, i);
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             if crate::value::js_is_truthy(result) != 0 {
                 return element;
@@ -282,10 +314,10 @@ pub extern "C" fn js_array_find_last_index(
     }
     unsafe {
         let length = (*arr).length as usize;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
         for i in (0..length).rev() {
-            let element = *elements_ptr.add(i);
+            let element = array_element_get_value(elements_ptr, i);
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             if crate::value::js_is_truthy(result) != 0 {
                 return i as i32;
@@ -336,8 +368,8 @@ pub extern "C" fn js_array_at(arr: *const ArrayHeader, index: f64) -> f64 {
         if idx < 0 || idx >= length {
             return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
-        *elements_ptr.add(idx as usize)
+        let elements_ptr = array_elements_ptr(arr);
+        array_element_get_value(elements_ptr, idx as usize)
     }
 }
 
@@ -359,11 +391,13 @@ pub extern "C" fn js_array_some(arr: *const ArrayHeader, callback: *const Closur
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
 
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             if crate::value::js_is_truthy(result) != 0 {
                 return f64::from_bits(TAG_TRUE);
@@ -392,11 +426,13 @@ pub extern "C" fn js_array_every(arr: *const ArrayHeader, callback: *const Closu
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
 
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             if crate::value::js_is_truthy(result) == 0 {
                 return f64::from_bits(TAG_FALSE);
@@ -420,13 +456,15 @@ pub extern "C" fn js_array_flatMap(
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
 
         let mut result = js_array_alloc(length);
         let arr_value = array_receiver_value(arr);
 
         for i in 0..length as usize {
-            let element = *elements_ptr.add(i);
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
             let mapped = js_closure_call3(callback, element, i as f64, arr_value);
             // Check if the mapped value is an array (pointer-tagged)
             let bits = mapped.to_bits();
@@ -440,7 +478,9 @@ pub extern "C" fn js_array_flatMap(
                         .add(std::mem::size_of::<ArrayHeader>())
                         as *const f64;
                     for j in 0..sub_len as usize {
-                        let sub_element = *sub_elements.add(j);
+                        let Some(sub_element) = present_array_element(sub_elements, j) else {
+                            continue;
+                        };
                         result = js_array_push_f64(result, sub_element);
                     }
                 }
@@ -483,8 +523,8 @@ pub extern "C" fn js_array_reduce(
         );
     }
     unsafe {
-        let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let length = (*arr).length as usize;
+        let elements_ptr = array_elements_ptr(arr);
 
         if length == 0 {
             if has_initial != 0 {
@@ -498,13 +538,24 @@ pub extern "C" fn js_array_reduce(
         let (mut accumulator, start_idx) = if has_initial != 0 {
             (initial, 0)
         } else {
-            // Use first element as initial
-            (*elements_ptr, 1)
+            let mut seed = None;
+            for i in 0..length {
+                if let Some(element) = present_array_element(elements_ptr, i) {
+                    seed = Some((element, i + 1));
+                    break;
+                }
+            }
+            match seed {
+                Some(seed) => seed,
+                None => throw_reduce_of_empty(),
+            }
         };
 
         let arr_value = array_receiver_value(arr);
-        for i in start_idx..length as usize {
-            let element = *elements_ptr.add(i);
+        for i in start_idx..length {
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
             // Spec callback is `(accumulator, currentValue, currentIndex, array)`.
             accumulator = js_closure_call4(callback, accumulator, element, i as f64, arr_value);
         }

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -238,8 +238,8 @@ pub extern "C" fn js_array_pop_f64(arr: *mut ArrayHeader) -> f64 {
 
 /// Set the length of an array, JS-spec style.
 ///
-/// Closes #304: `arr.length = N` must truncate when N < length and pad with
-/// `undefined` when N > length. Pre-fix Perry routed this through the generic
+/// Closes #304: `arr.length = N` must truncate when N < length and create holes
+/// when N > length. Pre-fix Perry routed this through the generic
 /// `js_object_set_field_by_name(obj, "length", N)` path which silently set a
 /// new "length" property on the array's hidden object dispatch but never
 /// touched the `ArrayHeader.length` field — so `arr.length` still read back
@@ -261,39 +261,30 @@ pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
     unsafe {
         let cur = (*arr).length;
         if n < cur {
-            // Truncate: clear elements at indices [n..cur) to TAG_UNDEFINED so
+            // Truncate: clear elements at indices [n..cur) to TAG_HOLE so
             // any code that resurrects the slot via `arr[i]` reads `undefined`,
             // not stale data. The capacity stays unchanged — JS doesn't
             // require Perry to release the underlying buffer here, and growing
             // back via `push` would just re-overwrite these slots anyway.
-            const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
-            let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
             for i in n..cur {
-                // GC_STORE_AUDIT(BARRIERED): length truncation sentinel is immediately recorded via note_array_slot.
-                std::ptr::write(elements_ptr.add(i as usize), TAG_UNDEFINED_F64);
-                note_array_slot(arr, i as usize, TAG_UNDEFINED_F64.to_bits());
+                note_array_slot(arr, i as usize, crate::value::TAG_HOLE);
             }
             (*arr).length = n;
             refresh_array_numeric_layout(arr);
         } else if n > cur {
-            // Extend: pad with TAG_UNDEFINED. Past-capacity extensions go
+            // Extend: pad with TAG_HOLE. Past-capacity extensions go
             // through `js_array_grow` which installs a forwarding pointer at
             // the OLD location (issue #233 mechanism), so the caller's stale
             // pointer transparently follows the chain to the resized buffer
             // on the next access — no callsite-side writeback needed.
-            const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
             let target = if n > (*arr).capacity {
                 js_array_grow(arr, n)
             } else {
                 arr
             };
             if !target.is_null() {
-                let elements_ptr =
-                    (target as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
                 for i in cur..n {
-                    // GC_STORE_AUDIT(BARRIERED): length extension sentinel is immediately recorded via note_array_slot.
-                    std::ptr::write(elements_ptr.add(i as usize), TAG_UNDEFINED_F64);
-                    note_array_slot(target, i as usize, TAG_UNDEFINED_F64.to_bits());
+                    note_array_slot(target, i as usize, crate::value::TAG_HOLE);
                 }
                 (*target).length = n;
             }
@@ -303,7 +294,7 @@ pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
 }
 
 /// Delete an element from an array by index, creating a "hole".
-/// Sets the element to undefined without changing the array length.
+/// Clears the element without changing the array length.
 /// Matches JavaScript `delete arr[index]` semantics.
 /// Returns 1 (true) on success, 0 (false) on failure.
 #[no_mangle]
@@ -323,11 +314,7 @@ pub extern "C" fn js_array_delete(arr: *mut ArrayHeader, index: u32) -> i32 {
         if index >= length {
             return 1; // delete on out-of-bounds always returns true in JS
         }
-        const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
-        let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-        // GC_STORE_AUDIT(BARRIERED): delete sentinel is immediately recorded via note_array_slot.
-        std::ptr::write(elements_ptr.add(index as usize), TAG_UNDEFINED_F64);
-        note_array_slot(arr, index as usize, TAG_UNDEFINED_F64.to_bits());
+        note_array_slot(arr, index as usize, crate::value::TAG_HOLE);
         1
     }
 }

--- a/crates/perry-runtime/src/array/reduce_right.rs
+++ b/crates/perry-runtime/src/array/reduce_right.rs
@@ -3,6 +3,17 @@ use super::*;
 use crate::array::throw_reduce_of_empty;
 use crate::closure::{js_closure_call4, ClosureHeader};
 
+#[inline(always)]
+unsafe fn array_elements_ptr(arr: *const ArrayHeader) -> *const f64 {
+    (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64
+}
+
+#[inline(always)]
+unsafe fn present_array_element(elements_ptr: *const f64, index: usize) -> Option<f64> {
+    let element = *elements_ptr.add(index);
+    (element.to_bits() != crate::value::TAG_HOLE).then_some(element)
+}
+
 /// `arr.reduceRight(callback, initial?)` — reduce from right to left
 #[no_mangle]
 pub extern "C" fn js_array_reduce_right(
@@ -29,7 +40,7 @@ pub extern "C" fn js_array_reduce_right(
     }
     unsafe {
         let length = (*arr).length as usize;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
 
         if length == 0 {
             if has_initial != 0 {
@@ -43,13 +54,25 @@ pub extern "C" fn js_array_reduce_right(
         let (mut accumulator, start_idx) = if has_initial != 0 {
             (initial, length)
         } else {
-            (*elements_ptr.add(length - 1), length - 1)
+            let mut seed = None;
+            for i in (0..length).rev() {
+                if let Some(element) = present_array_element(elements_ptr, i) {
+                    seed = Some((element, i));
+                    break;
+                }
+            }
+            match seed {
+                Some(seed) => seed,
+                None => throw_reduce_of_empty(),
+            }
         };
 
         let arr_value = f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits());
         if start_idx > 0 {
             for i in (0..start_idx).rev() {
-                let element = *elements_ptr.add(i);
+                let Some(element) = present_array_element(elements_ptr, i) else {
+                    continue;
+                };
                 // Spec callback `(accumulator, currentValue, currentIndex, array)`.
                 accumulator = js_closure_call4(callback, accumulator, element, i as f64, arr_value);
             }

--- a/crates/perry-runtime/src/array/search.rs
+++ b/crates/perry-runtime/src/array/search.rs
@@ -1,6 +1,32 @@
 //! indexOf / includes — both f64 and JSValue variants.
 use super::*;
 
+#[inline(always)]
+unsafe fn array_elements_ptr(arr: *const ArrayHeader) -> *const f64 {
+    (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64
+}
+
+#[inline(always)]
+fn undefined_value() -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[inline(always)]
+unsafe fn present_array_element(elements_ptr: *const f64, index: usize) -> Option<f64> {
+    let element = *elements_ptr.add(index);
+    (element.to_bits() != crate::value::TAG_HOLE).then_some(element)
+}
+
+#[inline(always)]
+unsafe fn array_element_get_value(elements_ptr: *const f64, index: usize) -> f64 {
+    let element = *elements_ptr.add(index);
+    if element.to_bits() == crate::value::TAG_HOLE {
+        undefined_value()
+    } else {
+        element
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_array_indexOf_f64(arr: *const ArrayHeader, value: f64) -> i32 {
     let arr = clean_arr_ptr(arr);
@@ -9,10 +35,13 @@ pub extern "C" fn js_array_indexOf_f64(arr: *const ArrayHeader, value: f64) -> i
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
 
         for i in 0..length as usize {
-            if *elements_ptr.add(i) == value {
+            let Some(element) = present_array_element(elements_ptr, i) else {
+                continue;
+            };
+            if element == value {
                 return i as i32;
             }
         }
@@ -97,9 +126,11 @@ pub extern "C" fn js_array_indexOf_jsvalue(
             Some(s) => s,
             None => return -1,
         };
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
         for i in start..length {
-            let element = *elements_ptr.add(i as usize);
+            let Some(element) = present_array_element(elements_ptr, i as usize) else {
+                continue;
+            };
             if crate::value::js_jsvalue_equals(element, value) == 1 {
                 return i as i32;
             }
@@ -164,7 +195,7 @@ pub extern "C" fn js_array_last_index_of_jsvalue(
         if length == 0 {
             return -1;
         }
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
 
         // Determine the start index. Without an explicit fromIndex, start at
         // the last element. With one, apply ToIntegerOrInfinity + clamping
@@ -190,7 +221,10 @@ pub extern "C" fn js_array_last_index_of_jsvalue(
 
         let mut i = start;
         while i >= 0 {
-            let element = *elements_ptr.add(i as usize);
+            let Some(element) = present_array_element(elements_ptr, i as usize) else {
+                i -= 1;
+                continue;
+            };
             if crate::value::js_jsvalue_equals(element, value) == 1 {
                 return i as i32;
             }
@@ -248,14 +282,14 @@ pub extern "C" fn js_array_includes_jsvalue(
             Some(s) => s,
             None => return 0,
         };
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let elements_ptr = array_elements_ptr(arr);
 
         // `Array.prototype.includes` uses SameValueZero (ECMA-262 §23.1.3.16),
         // which differs from === in one place: NaN equals NaN. Routing
         // through `js_jsvalue_same_value_zero` preserves the `indexOf(NaN) ===
         // -1` / `includes(NaN) === true` split.
         for i in start..length {
-            let element = *elements_ptr.add(i as usize);
+            let element = array_element_get_value(elements_ptr, i as usize);
             if crate::value::js_jsvalue_same_value_zero(element, value) == 1 {
                 return 1;
             }

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -829,8 +829,12 @@ fn test_numeric_array_layout_length_and_delete_transitions() {
     assert_eq!(
         js_array_is_numeric_f64_layout(arr),
         0,
-        "extension pads with undefined and must downgrade numeric layout"
+        "extension creates holes and must downgrade numeric layout"
     );
+    unsafe {
+        assert_eq!(raw_slot_bits(arr, 2), crate::value::TAG_HOLE);
+        assert_eq!(raw_slot_bits(arr, 3), crate::value::TAG_HOLE);
+    }
     assert_eq!(
         crate::gc::test_layout_pointer_slot_count(arr as usize, 4),
         Some(0)
@@ -845,8 +849,11 @@ fn test_numeric_array_layout_length_and_delete_transitions() {
     assert_eq!(
         js_array_is_numeric_f64_layout(dense),
         0,
-        "delete creates an undefined slot and downgrades dense numeric layout"
+        "delete creates a hole and downgrades dense numeric layout"
     );
+    unsafe {
+        assert_eq!(raw_slot_bits(dense, 0), crate::value::TAG_HOLE);
+    }
 }
 
 #[test]

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -201,7 +201,6 @@ pub extern "C" fn js_object_delete_field(
 }
 
 /// Delete a field from an object using a dynamic key (could be string or number index)
-/// For arrays, this sets the element to undefined
 /// Returns 1 if successful, 0 otherwise
 #[no_mangle]
 pub extern "C" fn js_object_delete_dynamic(obj: *mut ObjectHeader, key: f64) -> i32 {
@@ -218,17 +217,11 @@ pub extern "C" fn js_object_delete_dynamic(obj: *mut ObjectHeader, key: f64) -> 
         return js_object_delete_field(obj, key_str);
     }
 
-    // If the key is a number, treat as array index
-    if key_val.is_number() {
-        let index = key_val.as_number() as usize;
-        // Try to treat it as an array and set the element to undefined
-        // This is a simplified implementation - real JS delete on arrays
-        // creates a hole (sparse array), but we just set to undefined
-        let arr = obj as *mut crate::array::ArrayHeader;
-        let len = crate::array::js_array_length(arr) as usize;
-        if index < len {
-            crate::array::js_array_set(arr, index as u32, JSValue::undefined());
-            return 1;
+    let property_key = unsafe { js_to_property_key(key) };
+    if unsafe { crate::symbol::js_is_symbol(property_key) } == 0 {
+        let key_str = crate::value::js_jsvalue_to_string(property_key);
+        if !key_str.is_null() {
+            return js_object_delete_field(obj, key_str as *const crate::StringHeader);
         }
     }
 

--- a/test-parity/node-suite/globals/array-sparse-iteration.ts
+++ b/test-parity/node-suite/globals/array-sparse-iteration.ts
@@ -1,0 +1,156 @@
+function show(label: string, value: any) {
+  console.log(label + ":", String(value));
+}
+
+function expectThrowName(label: string, fn: () => any) {
+  try {
+    fn();
+    show(label, "no throw");
+  } catch (err: any) {
+    show(label, err.name);
+  }
+}
+
+const sparse: any[] = [1, , 3];
+
+const forEachCalls: string[] = [];
+sparse.forEach((value, index, array) => {
+  forEachCalls.push(index + ":" + String(value) + ":" + String(array === sparse));
+});
+show("forEach calls", forEachCalls.join("|"));
+
+const mapCalls: string[] = [];
+const mapped = sparse.map((value, index, array) => {
+  mapCalls.push(index + ":" + String(value) + ":" + String(array === sparse));
+  return value * 10;
+});
+show("map calls", mapCalls.join("|"));
+show("map length", mapped.length);
+show("map has1", 1 in mapped);
+show("map join", mapped.join("|"));
+
+const filterCalls: string[] = [];
+const filtered = sparse.filter((value, index) => {
+  filterCalls.push(index + ":" + String(value));
+  return true;
+});
+show("filter calls", filterCalls.join("|"));
+show("filter join", filtered.join("|"));
+
+const someCalls: string[] = [];
+show("some result", sparse.some((value, index) => {
+  someCalls.push(index + ":" + String(value));
+  return index === 1;
+}));
+show("some calls", someCalls.join("|"));
+
+const everyCalls: string[] = [];
+show("every result", sparse.every((value, index) => {
+  everyCalls.push(index + ":" + String(value));
+  return index !== 1;
+}));
+show("every calls", everyCalls.join("|"));
+
+const flatMapCalls: string[] = [];
+const flatMapped = sparse.flatMap((value, index) => {
+  flatMapCalls.push(index + ":" + String(value));
+  return [value, , value + 10];
+});
+show("flatMap calls", flatMapCalls.join("|"));
+show("flatMap length", flatMapped.length);
+show("flatMap join", flatMapped.join("|"));
+
+const reduceCalls: string[] = [];
+const reduced = [, 2, , 4].reduce((acc, value, index) => {
+  reduceCalls.push(index + ":" + String(value));
+  return String(acc) + "|" + index + ":" + String(value);
+});
+show("reduce result", reduced);
+show("reduce calls", reduceCalls.join("|"));
+
+const reduceInitCalls: string[] = [];
+const reducedInit = [, 2, , 4].reduce((acc, value, index) => {
+  reduceInitCalls.push(index + ":" + String(value));
+  return String(acc) + "|" + index + ":" + String(value);
+}, "init");
+show("reduce init result", reducedInit);
+show("reduce init calls", reduceInitCalls.join("|"));
+
+const reduceRightCalls: string[] = [];
+const reducedRight = [1, , 3, ,].reduceRight((acc, value, index) => {
+  reduceRightCalls.push(index + ":" + String(value));
+  return String(acc) + "|" + index + ":" + String(value);
+});
+show("reduceRight result", reducedRight);
+show("reduceRight calls", reduceRightCalls.join("|"));
+
+const holes = new Array(2);
+let reduceHoleCalls = 0;
+show("reduce holes init", holes.reduce((acc: string) => {
+  reduceHoleCalls++;
+  return acc;
+}, "seed"));
+show("reduce holes init calls", reduceHoleCalls);
+expectThrowName("reduce holes no init", () => holes.reduce((acc: any, value: any) => acc || value));
+
+const findCalls: string[] = [];
+const found = sparse.find((value, index) => {
+  findCalls.push(index + ":" + String(value));
+  return index === 1;
+});
+show("find found undefined", found === undefined);
+show("find calls", findCalls.join("|"));
+
+const findIndexCalls: string[] = [];
+show("findIndex hole", sparse.findIndex((value, index) => {
+  findIndexCalls.push(index + ":" + String(value));
+  return value === undefined;
+}));
+show("findIndex calls", findIndexCalls.join("|"));
+
+const findLastCalls: string[] = [];
+const foundLast = sparse.findLast((value, index) => {
+  findLastCalls.push(index + ":" + String(value));
+  return value === undefined;
+});
+show("findLast found undefined", foundLast === undefined);
+show("findLast calls", findLastCalls.join("|"));
+
+const findLastIndexCalls: string[] = [];
+show("findLastIndex hole", sparse.findLastIndex((value, index) => {
+  findLastIndexCalls.push(index + ":" + String(value));
+  return value === undefined;
+}));
+show("findLastIndex calls", findLastIndexCalls.join("|"));
+
+show("indexOf undefined", sparse.indexOf(undefined));
+show("lastIndexOf undefined", sparse.lastIndexOf(undefined));
+show("includes undefined", sparse.includes(undefined));
+show("holes includes undefined", new Array(2).includes(undefined));
+
+let emptyFindCalls = 0;
+show("empty find undefined", [].find(() => {
+  emptyFindCalls++;
+  return true;
+}) === undefined);
+show("empty find calls", emptyFindCalls);
+
+const deleted: any[] = [1, 2, 3];
+delete deleted[1];
+const deletedCalls: string[] = [];
+deleted.map((value, index) => {
+  deletedCalls.push(index + ":" + String(value));
+  return value;
+});
+show("delete has1", 1 in deleted);
+show("delete map calls", deletedCalls.join("|"));
+
+const extended: any[] = [1];
+extended.length = 3;
+const extendedCalls: string[] = [];
+extended.forEach((value, index) => {
+  extendedCalls.push(index + ":" + String(value));
+});
+show("length extend has1", 1 in extended);
+show("length extend calls", extendedCalls.join("|"));
+show("at hole undefined", extended.at(1) === undefined);


### PR DESCRIPTION
Closes #4230.

## Summary
- Skip `TAG_HOLE` slots for array methods that should ignore sparse holes: `forEach`, `map`, `filter`, `some`, `every`, `flatMap`, `reduce`, `reduceRight`, `indexOf`, and `lastIndexOf`.
- Preserve sparse holes when deleting array elements, extending/truncating length, and producing `map` results.
- Keep `find`/`findIndex`/`findLast`/`findLastIndex` visiting holes as `undefined`, make `includes` treat holes as `undefined`, and return the real `undefined` sentinel for empty `find`.
- Route optimized `forEach` lowering through the sparse-aware runtime helper.
- Add a Node parity fixture covering sparse iteration, search, delete, length extension, and `at`.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-runtime -p perry-codegen`
- `cargo test -p perry-runtime array:: --lib`
- `timeout 900s env PERRY_NO_CACHE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-array-sparse-iteration/target npm exec --package=node@25 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module globals --filter array-sparse-iteration'` (Node v25.9.0, `PASS node-suite/globals/array-sparse-iteration`; report `test-parity/reports/parity_report_20260603_085139.json`)