### PR TITLE
[codex] honor child_process stdio inherit

### DIFF
--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -1383,17 +1383,19 @@ fn cp_apply_options(command: &mut Command, opts_val: f64) {
 pub(super) enum CpStdio {
     Pipe,
     Ignore,
+    Inherit,
 }
 
 fn cp_stdio_kind(value: f64) -> CpStdio {
     match cp_value_to_string(value).as_deref() {
         Some("ignore") => CpStdio::Ignore,
+        Some("inherit") => CpStdio::Inherit,
         _ => CpStdio::Pipe,
     }
 }
 
-/// Read the deterministic live-stdio subset: `pipe` (default) and `ignore`.
-/// Other Node forms (`inherit`, numeric fds, custom streams) intentionally
+/// Read the deterministic live-stdio subset: `pipe` (default), `ignore`, and
+/// `inherit`. Other Node forms (numeric fds, custom streams) intentionally
 /// remain in #2555.
 pub(super) fn cp_read_stdio(opts_val: f64, fds: usize) -> Vec<CpStdio> {
     let mut out = vec![CpStdio::Pipe; fds];
@@ -1403,8 +1405,10 @@ pub(super) fn cp_read_stdio(opts_val: f64, fds: usize) -> Vec<CpStdio> {
 
     let stdio = cp_get_field(opts_val, b"stdio");
     if let Some(s) = cp_value_to_string(stdio) {
-        if s == "ignore" {
-            out.fill(CpStdio::Ignore);
+        match s.as_str() {
+            "ignore" => out.fill(CpStdio::Ignore),
+            "inherit" => out.fill(CpStdio::Inherit),
+            _ => {}
         }
         return out;
     }
@@ -1422,7 +1426,7 @@ pub(super) fn cp_read_stdio(opts_val: f64, fds: usize) -> Vec<CpStdio> {
 pub(super) fn cp_stdio_js_value(kind: CpStdio, pipe_obj: f64) -> f64 {
     match kind {
         CpStdio::Pipe => pipe_obj,
-        CpStdio::Ignore => TAG_NULL_F64,
+        CpStdio::Ignore | CpStdio::Inherit => TAG_NULL_F64,
     }
 }
 
@@ -1430,6 +1434,7 @@ pub(super) fn cp_apply_live_stdio(command: &mut Command, stdio: &[CpStdio]) {
     let to_stdio = |kind: CpStdio| match kind {
         CpStdio::Pipe => Stdio::piped(),
         CpStdio::Ignore => Stdio::null(),
+        CpStdio::Inherit => Stdio::inherit(),
     };
     command.stdin(to_stdio(stdio.first().copied().unwrap_or(CpStdio::Pipe)));
     command.stdout(to_stdio(stdio.get(1).copied().unwrap_or(CpStdio::Pipe)));

--- a/test-parity/node-suite/child_process/async/stdio-inherit.ts
+++ b/test-parity/node-suite/child_process/async/stdio-inherit.ts
@@ -1,0 +1,47 @@
+import { fork, spawn } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function slot(value: any): string {
+  return value === null ? "null" : typeof value;
+}
+
+function report(label: string, child: any) {
+  console.log(`${label} props:`, slot(child.stdin), slot(child.stdout), slot(child.stderr));
+  console.log(`${label} stdio:`, child.stdio.map(slot).join(","));
+}
+
+function close(child: any): Promise<number | null> {
+  return new Promise((resolve) => child.on("close", (code: number | null) => resolve(code)));
+}
+
+const inherited = spawn("sh", ["-c", "exit 0"], { stdio: "inherit" });
+report("spawn inherit", inherited);
+console.log("spawn inherit close:", await close(inherited));
+
+const mixed = spawn("sh", ["-c", "cat >/dev/null"], {
+  stdio: ["pipe", "inherit", "inherit"],
+});
+report("spawn mixed inherit", mixed);
+mixed.stdin.end("mixed-input");
+console.log("spawn mixed inherit close:", await close(mixed));
+
+const childFile = join(tmpdir(), `perry-fork-stdio-inherit-${process.pid}.js`);
+writeFileSync(
+  childFile,
+  "process.on('message', () => { if (process.send) process.send({ ok: true }); process.exit(0); }); setTimeout(() => process.exit(0), 100);",
+);
+
+const forked = fork(childFile, [], { stdio: "inherit" });
+report("fork inherit", forked);
+console.log("fork channel:", typeof forked.channel);
+const message: any = await new Promise((resolve) => {
+  forked.on("message", resolve);
+  forked.send({ ping: true });
+});
+console.log("fork ipc:", message.ok);
+console.log("fork inherit close:", await close(forked));
+try {
+  unlinkSync(childFile);
+} catch {}


### PR DESCRIPTION
## Summary

Refs #2555.

Adds the next deterministic live child_process option slice: `spawn()` and `fork()` now honor `stdio: "inherit"` plus array entries set to `"inherit"`.

This maps inherited descriptors through to the OS child process while keeping Node-facing `stdin`, `stdout`, `stderr`, and `stdio[]` surfaces as `null` for inherited slots. `fork()` keeps its IPC channel behavior intact.

## Scope

- Extends the shared `CpStdio` parser with an `Inherit` kind.
- Applies inherited stdio through the existing live spawn/fork stdio helper.
- Adds a Node parity fixture for full inherit, mixed pipe/inherit, and fork IPC behavior.

Batching rationale: this is the same shared parser and live stdio application path used by the prior `ignore` option slice, so keeping the focused inherit semantics together avoids duplicating coverage around the same dispatch surface.

## Non-goals

Still intentionally outside this slice: numeric fd sharing, custom stream handles, async `exec`/`execFile` timeout and maxBuffer behavior, AbortSignal/killSignal, uid/gid/detached/platform flags, and broad option validation.

## Verification

- `npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter stdio-inherit'`
- `npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter stdio-ignore'`
- `npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process'`
- `cargo fmt --all -- --check`
- `cargo check -p perry-runtime`
- `git diff --check`
- `./scripts/check_file_size.sh`
