### PR TITLE
[codex] expose X509 extension metadata

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -2213,6 +2213,8 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             | "fingerprint"
             | "fingerprint256"
             | "fingerprint512"
+            | "subjectAltName"
+            | "keyUsage"
             | "ca"
             | "raw"
             | "toString"

--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -98,9 +98,87 @@ pub(super) fn x509_colon_hex(bytes: &[u8]) -> String {
         .join(":")
 }
 
+fn x509_find_extension<'a>(
+    cert: &'a x509_cert::Certificate,
+    oid: &str,
+) -> Option<&'a x509_cert::ext::Extension> {
+    cert.tbs_certificate
+        .extensions
+        .as_ref()?
+        .iter()
+        .find(|ext| ext.extn_id.to_string() == oid)
+}
+
+fn x509_format_general_name(name: &x509_cert::ext::pkix::name::GeneralName) -> Option<String> {
+    use x509_cert::ext::pkix::name::GeneralName;
+
+    match name {
+        GeneralName::DnsName(value) => Some(format!("DNS:{}", value.as_str())),
+        GeneralName::Rfc822Name(value) => Some(format!("email:{}", value.as_str())),
+        GeneralName::UniformResourceIdentifier(value) => Some(format!("URI:{}", value.as_str())),
+        GeneralName::IpAddress(value) => {
+            let bytes = value.as_bytes();
+            match bytes.len() {
+                4 => Some(format!(
+                    "IP Address:{}.{}.{}.{}",
+                    bytes[0], bytes[1], bytes[2], bytes[3]
+                )),
+                16 => {
+                    let segments: Vec<String> = bytes
+                        .chunks_exact(2)
+                        .map(|chunk| {
+                            let segment = u16::from_be_bytes([chunk[0], chunk[1]]);
+                            format!("{:x}", segment)
+                        })
+                        .collect();
+                    Some(format!("IP Address:{}", segments.join(":")))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn x509_subject_alt_name(cert: &x509_cert::Certificate) -> Option<String> {
+    use x509_cert::der::Decode;
+
+    let ext = x509_find_extension(cert, "2.5.29.17")?;
+    let san = x509_cert::ext::pkix::SubjectAltName::from_der(ext.extn_value.as_bytes()).ok()?;
+    let names: Vec<String> = san.0.iter().filter_map(x509_format_general_name).collect();
+    if names.is_empty() {
+        None
+    } else {
+        Some(names.join(", "))
+    }
+}
+
+fn x509_extended_key_usage(cert: &x509_cert::Certificate) -> Option<Vec<String>> {
+    use x509_cert::der::Decode;
+
+    let ext = x509_find_extension(cert, "2.5.29.37")?;
+    let key_usage =
+        x509_cert::ext::pkix::ExtendedKeyUsage::from_der(ext.extn_value.as_bytes()).ok()?;
+    let usages: Vec<String> = key_usage.0.iter().map(|oid| oid.to_string()).collect();
+    if usages.is_empty() {
+        None
+    } else {
+        Some(usages)
+    }
+}
+
 fn x509_string_f64(s: &str) -> f64 {
     let ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
     f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+unsafe fn x509_string_array_f64(items: &[String]) -> f64 {
+    let mut arr = perry_runtime::js_array_alloc(items.len() as u32);
+    for item in items {
+        let s = js_string_from_bytes(item.as_ptr(), item.len() as u32);
+        arr = perry_runtime::js_array_push(arr, JSValue::string_ptr(s));
+    }
+    nanbox_ptr(arr)
 }
 
 fn x509_time_millis(time: &x509_cert::time::Time) -> f64 {
@@ -265,6 +343,14 @@ pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
             let digest = Sha512::digest(&h.der);
             x509_string_f64(&x509_colon_hex(&digest))
         }
+        "subjectAltName" => match x509_subject_alt_name(&h.cert) {
+            Some(value) => x509_string_f64(&value),
+            None => nanbox_undefined(),
+        },
+        "keyUsage" => match x509_extended_key_usage(&h.cert) {
+            Some(values) => x509_string_array_f64(&values),
+            None => nanbox_undefined(),
+        },
         "ca" => {
             // BasicConstraints (id-ce 2.5.29.19) cA flag.
             let is_ca = x509_basic_constraints_ca(&h.cert);

--- a/test-parity/node-suite/crypto/x509/extension-metadata.ts
+++ b/test-parity/node-suite/crypto/x509/extension-metadata.ts
@@ -1,0 +1,33 @@
+import { X509Certificate } from "node:crypto";
+
+const pem = `-----BEGIN CERTIFICATE-----
+MIIEEDCCAvigAwIBAgIUSXW0OKKEkcMY0kWj2AXQh+WVEWEwDQYJKoZIhvcNAQEL
+BQAwSTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQ4wDAYDVQQKDAVQZXJyeTEd
+MBsGA1UEAwwUcGVycnktZXh0ZW5zaW9uLnRlc3QwHhcNMjYwNjAzMTAwMTM4WhcN
+MjcwNjAzMTAwMTM4WjBJMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExDjAMBgNV
+BAoMBVBlcnJ5MR0wGwYDVQQDDBRwZXJyeS1leHRlbnNpb24udGVzdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKFD+QNwqsoE5dEnFVP/3zMQq5CAya+y
+vskPkxapgwYPhyW86Hr23oUwqazBi3B4Q5KuYXmnQYfJnM+d+pniDO9YGbBX8ao8
+Xb2fKC2BQP3t8JzCr56u6c0ob0MWuLpB51A4Fj56D/kfHthUet8Z2plYKyyUPUsB
+XZibgxx9COwi+NN4FsT0rDz8Vtgr3ssHPDcEZi9XTSqeooIv3Wsm2oCRhkuplqbe
+Dd7Wm5rUpwZiR5ahsmP0G1qgwA55Exs++kijL3+Qg1C5MpLqYAE927TsfIqNxijy
+ScaNCiUB7YxhVB3bRF+5G1KMfwBxkfEfKZ1nB0k6rpXXPlxSZ1giLxECAwEAAaOB
+7zCB7DCBlAYDVR0RBIGMMIGJghRwZXJyeS1leHRlbnNpb24udGVzdIIYd3d3LnBl
+cnJ5LWV4dGVuc2lvbi50ZXN0hwR/AAABhxAAAAAAAAAAAAAAAAAAAAABgRphZG1p
+bkBwZXJyeS1leHRlbnNpb24udGVzdIYjaHR0cHM6Ly9wZXJyeS1leHRlbnNpb24u
+dGVzdC9zdGF0dXMwJwYDVR0lBCAwHgYIKwYBBQUHAwEGCCsGAQUFBwMCBggrBgEF
+BQcDAzALBgNVHQ8EBAMCBaAwHQYDVR0OBBYEFJxWlUjxxiBuCawipcrkJX8MJi+C
+MA0GCSqGSIb3DQEBCwUAA4IBAQAKrCMj6C6qVPZcpCVUZT7Ez1/v2ewTBo/r5UnH
+j3V2u7//9F9JE7w+iuljUcZuuyVG67DqFynhbpTu5FDlHbbMDmmNcF6XNZ0PUk+N
+ROm2v3W7WAKvToyuGJAs+cQrd4JL2r3/CGNk5lkh0Q7LF1ZPtxUvIEWMKvg/tVu2
+VJ6ezkG2NJt4xbgu7v/FuJnPD1LXn3gogk8bMn52DbRQFs24Jtb6Ods+ptecRokp
+hQEUyxl4qRwtjtKdbE63O80yaZS+hK00zwdTkaKgddWgGEn2nI2E1fBXjBZz5JB/
+0va/LS/0Zxi1rpJIIkybLVdENUaQRJXUZeYjmO2oWQQXHSqo
+-----END CERTIFICATE-----`;
+
+const cert = new X509Certificate(pem);
+
+console.log("subjectAltName:", cert["subjectAltName"]);
+console.log("keyUsage array:", Array.isArray(cert["keyUsage"]));
+console.log("keyUsage:", JSON.stringify(cert["keyUsage"]));
+console.log("infoAccess undefined:", cert["infoAccess"] === undefined);


### PR DESCRIPTION
## Summary

Refs #2563.

Adds a focused X509Certificate extension-metadata slice:

- exposes `X509Certificate#subjectAltName` for deterministic DNS/IP/email/URI SAN entries
- exposes `X509Certificate#keyUsage` as Node 26-shaped Extended Key Usage OID arrays
- keeps absent extension properties returning `undefined`
- adds an embedded extension-bearing certificate parity fixture

## Scope

The implementation decodes the existing parsed X509 handle's extensions with RustCrypto `x509-cert` types and routes the two new properties through the handle property dispatcher.

This intentionally follows the Node 26 observed `keyUsage` shape for Extended Key Usage OIDs, not a broader Basic Key Usage flag surface.

## Non-goals

Still intentionally outside this slice: `checkHost()` / `checkEmail()` / `checkIP()`, certificate/key verification, `publicKey`, `issuerCertificate`, `infoAccess`, and `toLegacyObject()`.

## Verification

- `npm exec --package=node@26 -- node test-parity/node-suite/crypto/x509/extension-metadata.ts`
- `CARGO_TARGET_DIR=/tmp/perry-node-x509-check-target cargo check -p perry-stdlib --no-default-features --features crypto`
- `CARGO_TARGET_DIR=/tmp/perry-node-x509-check-target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter extension-metadata'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/tmp/perry-node-x509-check-target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter x509'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
