### PR TITLE
[codex] Honor well-known archives in no-auto links

### DIFF
--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -377,6 +377,14 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_net_server_listener_count",                OwnerKind::WellKnown("net")),
     ("js_net_server_event_names",                   OwnerKind::WellKnown("net")),
 
+    // HTTP upgrade flows can surface a Perry WebSocket client handle through
+    // `node:http` without a source-level `import "ws"`. The codegen receiver
+    // rows still emit the ws client helper symbols, so those calls must flip
+    // the `ws` well-known wrapper onto the link line independently.
+    ("js_ws_send_client_i64",                       OwnerKind::WellKnown("ws")),
+    ("js_ws_close_client_i64",                      OwnerKind::WellKnown("ws")),
+    ("js_ws_on_client_i64",                         OwnerKind::WellKnown("ws")),
+
     // ── #1724: global Blob/File + URL object-URL helpers ──────────────
     // `new Blob([...])`, `new File([...], name)`, `URL.createObjectURL`,
     // `URL.revokeObjectURL`, and `resolveObjectURL` (node:buffer) are all
@@ -550,11 +558,14 @@ mod tests {
             "js_node_http_res_set_strict_content_length",
             "js_net_socket_listeners",
             "js_net_socket_raw_listeners",
+            "js_ws_on_client_i64",
+            "js_ws_send_client_i64",
+            "js_ws_close_client_i64",
         ] {
-            let owner = if symbol.starts_with("js_net_") {
-                OwnerKind::WellKnown("net")
-            } else {
-                OwnerKind::WellKnown("http")
+            let owner = match symbol {
+                symbol if symbol.starts_with("js_net_") => OwnerKind::WellKnown("net"),
+                symbol if symbol.starts_with("js_ws_") => OwnerKind::WellKnown("ws"),
+                _ => OwnerKind::WellKnown("http"),
             };
             assert_symbol_routes_to(symbol, owner);
         }

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4002,12 +4002,14 @@ pub fn run_with_parse_cache(
     // for this binary and rebuild perry-runtime + perry-stdlib in a
     // hash-keyed target dir. Both halves fall back to the prebuilt full
     // libraries if the rebuild fails or the workspace source isn't on
-    // disk. `--no-auto-optimize` disables the rebuild path entirely.
+    // disk. `--no-auto-optimize` disables runtime/stdlib rebuilds but
+    // still resolves prebuilt well-known wrapper archives whose symbols
+    // are absent from the full stdlib.
     //
     // The legacy `--minimal-stdlib` flag is now a no-op alias for
     // backward compat — auto-mode already does what it used to and more.
     let optimized_libs: OptimizedLibs = if args.no_auto_optimize {
-        OptimizedLibs::empty()
+        optimized_libs::resolve_no_auto_optimized_libs(&ctx, target.as_deref(), format, verbose)
     } else {
         build_optimized_libs(&ctx, target.as_deref(), &compiled_features, format, verbose)
     };

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -11,6 +11,7 @@
 //! use a hash-keyed target dir so consecutive runs with the same
 //! profile are no-ops after the first build.
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -55,6 +56,40 @@ impl OptimizedLibs {
     }
 }
 
+fn well_known_iteration_set(ctx: &CompilationContext) -> BTreeSet<String> {
+    let mut iteration_set: BTreeSet<String> = ctx.native_module_imports.iter().cloned().collect();
+    if ctx.uses_fetch && !iteration_set.contains("fetch") && !iteration_set.contains("node-fetch") {
+        iteration_set.insert("fetch".to_string());
+    }
+    iteration_set
+}
+
+/// Resolve only the prebuilt well-known wrapper archives.
+///
+/// Used when automatic runtime/stdlib specialization is disabled. The
+/// no-auto path still needs wrapper archives for FFI symbols that are not
+/// defined by the full prebuilt stdlib, such as the `perry-ext-http` server
+/// entry points recorded by the codegen FFI registry.
+pub(super) fn resolve_no_auto_optimized_libs(
+    ctx: &CompilationContext,
+    target: Option<&str>,
+    format: OutputFormat,
+    verbose: u8,
+) -> OptimizedLibs {
+    if matches!(format, OutputFormat::Text) && verbose > 0 {
+        eprintln!("  auto-optimize: skipped; using prebuilt target/release/libperry_*.a");
+    }
+    let well_known_libs = if std::env::var_os("PERRY_DISABLE_WELL_KNOWN").is_none() {
+        resolve_prebuilt_ext_libs(&well_known_iteration_set(ctx), target, format, verbose)
+    } else {
+        Vec::new()
+    };
+    OptimizedLibs {
+        well_known_libs,
+        ..OptimizedLibs::empty()
+    }
+}
+
 /// Rebuild perry-runtime + perry-stdlib in a single cargo invocation with
 /// the chosen Cargo features and panic mode, and return paths to the
 /// resulting archives. Both halves fall back to the prebuilt libraries
@@ -73,11 +108,7 @@ pub(super) fn build_optimized_libs(
     verbose: u8,
 ) -> OptimizedLibs {
     let use_well_known = std::env::var_os("PERRY_DISABLE_WELL_KNOWN").is_none();
-    let mut iteration_set: std::collections::BTreeSet<String> =
-        ctx.native_module_imports.iter().cloned().collect();
-    if ctx.uses_fetch && !iteration_set.contains("fetch") && !iteration_set.contains("node-fetch") {
-        iteration_set.insert("fetch".to_string());
-    }
+    let iteration_set = well_known_iteration_set(ctx);
 
     // `PERRY_NO_AUTO_OPTIMIZE=1` — opt out of the per-app feature-set
     // specialization and use the prebuilt `target/release/libperry_*.a`
@@ -96,21 +127,7 @@ pub(super) fn build_optimized_libs(
     // owned by `perry-ext-http`, and the full prebuilt stdlib does not
     // define those wrapper-only entry points.
     if std::env::var_os("PERRY_NO_AUTO_OPTIMIZE").is_some() {
-        if matches!(format, OutputFormat::Text) && verbose > 0 {
-            eprintln!(
-                "  auto-optimize: skipped (PERRY_NO_AUTO_OPTIMIZE=1); \
-                 using prebuilt target/release/libperry_*.a"
-            );
-        }
-        let well_known_libs = if use_well_known {
-            resolve_prebuilt_ext_libs(&iteration_set, target, format, verbose)
-        } else {
-            Vec::new()
-        };
-        return OptimizedLibs {
-            well_known_libs,
-            ..OptimizedLibs::empty()
-        };
+        return resolve_no_auto_optimized_libs(ctx, target, format, verbose);
     }
     // (compute_required_features + features_to_cargo_arg imported at module top)
     let mut features = compute_required_features(
@@ -1110,6 +1127,22 @@ fn binding_needs_shared_tokio(module: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock poisoned")
+    }
+
+    fn set_env_var(key: &str, value: Option<&str>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
 
     /// Closes #507. The well-known flip's "shared tokio" allowlist
     /// must match the set of perry-ext-* crates whose own
@@ -1138,5 +1171,79 @@ mod tests {
         // Defensive default: if a module isn't in the allowlist,
         // treat it as CPU-only (existing v0.5.586 behavior).
         assert!(!binding_needs_shared_tokio("definitely-not-a-real-package"));
+    }
+
+    #[test]
+    fn no_auto_still_resolves_prebuilt_well_known_archives() {
+        let _guard = env_lock();
+        let old_lib_dir = std::env::var("PERRY_LIB_DIR").ok();
+        let old_runtime_dir = std::env::var("PERRY_RUNTIME_DIR").ok();
+        let old_disable_well_known = std::env::var("PERRY_DISABLE_WELL_KNOWN").ok();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let http =
+            super::super::well_known::lookup_well_known("http").expect("http well-known binding");
+        let net =
+            super::super::well_known::lookup_well_known("net").expect("net well-known binding");
+        let ws = super::super::well_known::lookup_well_known("ws").expect("ws well-known binding");
+        let http_lib = dir
+            .path()
+            .join(super::super::well_known::ext_staticlib_filename(
+                &http.lib,
+                rust_target_triple(None),
+            ));
+        let net_lib = dir
+            .path()
+            .join(super::super::well_known::ext_staticlib_filename(
+                &net.lib,
+                rust_target_triple(None),
+            ));
+        let ws_lib = dir
+            .path()
+            .join(super::super::well_known::ext_staticlib_filename(
+                &ws.lib,
+                rust_target_triple(None),
+            ));
+        std::fs::write(&http_lib, b"!<arch>\n").expect("write fake http archive");
+        std::fs::write(&net_lib, b"!<arch>\n").expect("write fake net archive");
+        std::fs::write(&ws_lib, b"!<arch>\n").expect("write fake ws archive");
+
+        set_env_var(
+            "PERRY_LIB_DIR",
+            Some(dir.path().to_str().expect("utf8 temp path")),
+        );
+        set_env_var("PERRY_RUNTIME_DIR", None);
+        set_env_var("PERRY_DISABLE_WELL_KNOWN", None);
+
+        let mut ctx = CompilationContext::new(dir.path().to_path_buf());
+        ctx.native_module_imports.insert("http".to_string());
+        ctx.native_module_imports.insert("net".to_string());
+        ctx.native_module_imports.insert("ws".to_string());
+        let libs = resolve_no_auto_optimized_libs(&ctx, None, OutputFormat::Json, 0);
+
+        set_env_var("PERRY_LIB_DIR", old_lib_dir.as_deref());
+        set_env_var("PERRY_RUNTIME_DIR", old_runtime_dir.as_deref());
+        set_env_var(
+            "PERRY_DISABLE_WELL_KNOWN",
+            old_disable_well_known.as_deref(),
+        );
+
+        assert_eq!(libs.runtime, None);
+        assert_eq!(libs.stdlib, None);
+        assert!(
+            libs.well_known_libs.contains(&http_lib),
+            "expected no-auto well-known libs to include {http_lib:?}, got {:?}",
+            libs.well_known_libs
+        );
+        assert!(
+            libs.well_known_libs.contains(&net_lib),
+            "expected no-auto well-known libs to include {net_lib:?}, got {:?}",
+            libs.well_known_libs
+        );
+        assert!(
+            libs.well_known_libs.contains(&ws_lib),
+            "expected no-auto well-known libs to include {ws_lib:?}, got {:?}",
+            libs.well_known_libs
+        );
     }
 }


### PR DESCRIPTION
Addresses #3954.

## Summary
- Make the `--no-auto-optimize` compile path still resolve prebuilt well-known wrapper archives from the finalized native-module import set.
- Keep the `PERRY_NO_AUTO_OPTIMIZE=1` optimized-lib branch on the same no-auto resolver so env and CLI behavior match.
- Route HTTP upgrade WebSocket helper FFIs (`js_ws_*_client_i64`) to the `ws` well-known wrapper owner.
- Add focused coverage for no-auto archive resolution and HTTP-suite FFI owner routing.

## Root Cause
Current `main` no longer has the HTTP owner-table gap fixed by #4216, but the compile driver still returned `OptimizedLibs::empty()` whenever no-auto optimization was enabled. That skipped the prebuilt `perry-ext-http`, `perry-ext-net`, and `perry-ext-ws` archives even when codegen had recorded wrapper-owned FFI symbols after module collection.

## Non-Goals
This does not change HTTP response/body behavior or request validation semantics. The HTTP parity suite still has runtime/output mismatches; this cut is limited to eliminating the no-auto compile/link failure tail.

## Validation
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-validation-tail/target cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib -p perry-ext-http -p perry-ext-net -p perry-ext-ws` passed with existing warnings.
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-validation-tail/target cargo check -p perry -p perry-codegen` passed with existing warnings.
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-validation-tail/target cargo test -p perry no_auto_still_resolves_prebuilt_well_known_archives -- --nocapture` passed.
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-validation-tail/target cargo test -p perry-codegen emitted_http_suite_external_symbols_route_to_owners -- --nocapture` passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- `./scripts/check_file_size.sh` passed.
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-validation-tail/target npm exec --yes --package=node@26 -- bash -lc "node --version; ./run_parity_tests.sh --suite node-suite --module http --filter header-state-controls"` ran on Node v26.3.0 with `Compile Fail: 0`; it exits non-zero due the existing header-method output mismatch.
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-validation-tail/target npm exec --yes --package=node@26 -- bash -lc "node --version; ./run_parity_tests.sh --suite node-suite --module http"` ran on Node v26.3.0 with `Parity Pass: 5`, `Parity Fail: 12`, `Compile Fail: 0`, `Skipped: 0`; it exits non-zero due existing HTTP runtime/output mismatches.