### PR TITLE
[codex] Honor function accessor properties

### DIFF
--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -305,6 +305,22 @@ pub extern "C" fn js_value_is_closure(value_bits: i64) -> i32 {
 /// Get a dynamic property stored on a closure.
 /// Returns TAG_UNDEFINED if not found.
 pub fn closure_get_dynamic_prop(ptr: usize, prop: &str) -> f64 {
+    if let Some(acc) = crate::object::get_accessor_descriptor(ptr, prop) {
+        if acc.get == 0 {
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+        let closure =
+            (acc.get & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
+        if closure.is_null() {
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+        let receiver = crate::value::js_nanbox_pointer(ptr as i64);
+        let prev = crate::object::js_implicit_this_set(receiver);
+        let result = crate::closure::js_closure_call0(closure);
+        crate::object::js_implicit_this_set(prev);
+        return result;
+    }
+
     if let Ok(props) = get_closure_props().lock() {
         if let Some(closure_props) = props.get(&ptr) {
             if let Some(&val) = closure_props.get(prop) {

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -219,6 +219,26 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                     let registered = super::get_property_attrs(ptr, name);
                     let writable_default = registered.map(|a| a.writable());
                     let configurable_default = registered.map(|a| a.configurable()).unwrap_or(true);
+                    if let Some(acc) = super::get_accessor_descriptor(ptr, name) {
+                        let attrs =
+                            registered.unwrap_or(super::PropertyAttrs::new(false, false, false));
+                        let get = if acc.get == 0 {
+                            f64::from_bits(crate::value::TAG_UNDEFINED)
+                        } else {
+                            f64::from_bits(acc.get)
+                        };
+                        let set = if acc.set == 0 {
+                            f64::from_bits(crate::value::TAG_UNDEFINED)
+                        } else {
+                            f64::from_bits(acc.set)
+                        };
+                        return build_accessor_descriptor(
+                            get,
+                            set,
+                            attrs.enumerable(),
+                            attrs.configurable(),
+                        );
+                    }
                     let resolved: Option<(f64, bool, bool, bool)> = match name {
                         "length" => {
                             let closure_value = crate::value::js_nanbox_pointer(ptr as i64);
@@ -780,6 +800,15 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                         continue;
                     }
                     names.push(name);
+                }
+                for name in super::accessor_descriptor_keys_for_obj(ptr) {
+                    if matches!(name.as_str(), "length" | "name" | "prototype") {
+                        continue;
+                    }
+                    if crate::closure::closure_is_key_deleted(ptr, &name) {
+                        continue;
+                    }
+                    push_unique_name(&mut names, name);
                 }
                 if has_prototype {
                     names.push("prototype".to_string());

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -985,14 +985,30 @@ pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
 }
 
 fn closure_dynamic_enumerable_props(ptr: usize) -> Vec<(String, f64)> {
-    crate::closure::closure_dynamic_props_snapshot(ptr)
+    let mut props = crate::closure::closure_dynamic_props_snapshot(ptr)
         .into_iter()
         .filter(|(name, _)| {
             get_property_attrs(ptr, name)
                 .map(|attrs| attrs.enumerable())
                 .unwrap_or(true)
         })
-        .collect()
+        .collect::<Vec<_>>();
+    for name in super::accessor_descriptor_keys_for_obj(ptr) {
+        if props.iter().any(|(existing, _)| existing == &name) {
+            continue;
+        }
+        if crate::closure::closure_is_key_deleted(ptr, &name) {
+            continue;
+        }
+        if get_property_attrs(ptr, &name)
+            .map(|attrs| attrs.enumerable())
+            .unwrap_or(false)
+        {
+            let value = crate::closure::closure_get_dynamic_prop(ptr, &name);
+            props.push((name, value));
+        }
+    }
+    props
 }
 
 fn js_closure_dynamic_keys(ptr: usize) -> *mut ArrayHeader {

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -15,6 +15,9 @@ pub(crate) fn closure_own_key_present(ptr: usize, key: &str) -> bool {
     if crate::closure::closure_is_key_deleted(ptr, key) {
         return false;
     }
+    if super::get_accessor_descriptor(ptr, key).is_some() {
+        return true;
+    }
     match key {
         // Always-present built-in function slots.
         "name" | "length" => true,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -597,6 +597,18 @@ pub(crate) fn get_accessor_descriptor(obj: usize, key: &str) -> Option<AccessorD
     ACCESSOR_DESCRIPTORS.with(|m| m.borrow().get(&(obj, key.to_string())).copied())
 }
 
+pub(crate) fn accessor_descriptor_keys_for_obj(obj: usize) -> Vec<String> {
+    ACCESSOR_DESCRIPTORS.with(|m| {
+        let mut keys = m
+            .borrow()
+            .keys()
+            .filter_map(|(owner, key)| (*owner == obj).then(|| key.clone()))
+            .collect::<Vec<_>>();
+        keys.sort();
+        keys
+    })
+}
+
 /// #2766: resolve an accessor *getter* closure for `(value, key)` if one is
 /// installed (e.g. an object-literal `get x() {…}` or
 /// `Object.defineProperty(obj, k, { get })`). Returns the NaN-boxed getter

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -66,8 +66,7 @@ pub(crate) fn obj_value_has_own_key(value: f64, key: f64) -> bool {
             let Some(key_name) = key_to_rust_string(key) else {
                 return false;
             };
-            return crate::closure::closure_has_own_dynamic_prop(obj_addr, &key_name)
-                || matches!(key_name.as_str(), "length" | "name" | "prototype");
+            return super::has_own_helpers::closure_own_key_present(obj_addr, &key_name);
         }
         let key_str = crate::builtins::js_string_coerce(key);
         if key_str.is_null() {

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -147,6 +147,63 @@ fn closure_name_can_be_redefined_with_define_property() {
     }
 }
 
+extern "C" fn closure_accessor_getter(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    4.0
+}
+
+#[test]
+fn closure_accessor_define_property_is_own_and_invoked() {
+    crate::closure::test_clear_closure_side_tables();
+    let closure = crate::closure::js_closure_alloc(
+        crate::object::global_this_builtin_noop_thunk as *const u8,
+        0,
+    );
+    assert!(!closure.is_null());
+    let getter = crate::closure::js_closure_alloc(closure_accessor_getter as *const u8, 0);
+    assert!(!getter.is_null());
+
+    let caller_key = crate::string::js_string_from_bytes(b"caller".as_ptr(), 6);
+    let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
+    let configurable_key = crate::string::js_string_from_bytes(b"configurable".as_ptr(), 12);
+    let descriptor = js_object_alloc(0, 0);
+    assert!(!descriptor.is_null());
+    js_object_set_field_by_name(
+        descriptor,
+        get_key,
+        crate::value::js_nanbox_pointer(getter as i64),
+    );
+    js_object_set_field_by_name(
+        descriptor,
+        configurable_key,
+        f64::from_bits(crate::value::TAG_TRUE),
+    );
+
+    let closure_value = crate::value::js_nanbox_pointer(closure as i64);
+    let key_value = f64::from_bits(JSValue::string_ptr(caller_key).bits());
+    let descriptor_value = crate::value::js_nanbox_pointer(descriptor as i64);
+    js_object_define_property(closure_value, key_value, descriptor_value);
+
+    assert!(super::has_own_helpers::closure_own_key_present(
+        closure as usize,
+        "caller"
+    ));
+    let value = js_object_get_field_by_name(closure as *const ObjectHeader, caller_key);
+    assert!(value.is_number());
+    assert_eq!(value.as_number(), 4.0);
+
+    let own_descriptor = js_object_get_own_property_descriptor(closure_value, key_value);
+    let own_descriptor_obj =
+        crate::value::js_nanbox_get_pointer(own_descriptor) as *const crate::object::ObjectHeader;
+    assert_eq!(
+        js_object_get_field_by_name(own_descriptor_obj, get_key).bits(),
+        crate::value::js_nanbox_pointer(getter as i64).to_bits()
+    );
+    assert_eq!(
+        js_object_get_field_by_name(own_descriptor_obj, configurable_key).bits(),
+        crate::value::TAG_TRUE
+    );
+}
+
 #[test]
 fn test_object_alloc_and_fields() {
     let obj = js_object_alloc(1, 3);

--- a/test-parity/node-suite/globals/async-function-forbidden-props.ts
+++ b/test-parity/node-suite/globals/async-function-forbidden-props.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+
+const missing = Symbol("missing");
+
+function show(label, value) {
+  console.log(label + ":" + String(value));
+}
+
+async function asyncDecl() {
+  show("async own caller", asyncDecl.hasOwnProperty("caller"));
+  show("async own arguments", asyncDecl.hasOwnProperty("arguments"));
+}
+
+function ownValueProbe() {
+  function inner() {
+    return inner.hasOwnProperty("caller") ? inner.caller : missing;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(inner, "caller");
+  if (descriptor && descriptor.configurable) {
+    Object.defineProperty(inner, "caller", { value: 1 });
+  }
+
+  const result = inner();
+  show("own value caller", result === missing ? "missing" : result);
+}
+
+function ownGetterProbe() {
+  function inner() {
+    return inner.hasOwnProperty("caller") ? inner.caller : missing;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(inner, "caller");
+  if (descriptor && descriptor.configurable) {
+    Object.defineProperty(inner, "caller", {
+      get() {
+        return 2;
+      },
+    });
+  }
+
+  const result = inner();
+  show("own getter caller", result === missing ? "missing" : result);
+}
+
+function userDefinedCallerProbe() {
+  function inner() {}
+  Object.defineProperty(inner, "caller", { value: 3, configurable: true });
+  show("defined caller own", inner.hasOwnProperty("caller"));
+  show("defined caller value", inner.caller);
+}
+
+function userDefinedCallerAccessorProbe() {
+  function inner() {}
+  Object.defineProperty(inner, "caller", {
+    get() {
+      return 4;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  show("defined caller getter own", inner.hasOwnProperty("caller"));
+  show("defined caller getter value", inner.caller);
+  show("defined caller getter names", Object.getOwnPropertyNames(inner).includes("caller"));
+  show("defined caller getter keys", Object.keys(inner).join(","));
+  show("defined caller getter values", Object.values(inner).join(","));
+}
+
+async function main() {
+  await asyncDecl();
+  ownValueProbe();
+  ownGetterProbe();
+  userDefinedCallerProbe();
+  userDefinedCallerAccessorProbe();
+}
+
+main();


### PR DESCRIPTION
## Summary
- Honor function accessor descriptors installed with `Object.defineProperty` on closure/function objects, including `caller`.
- Surface closure accessor keys through `hasOwnProperty`, own property descriptors, `Object.getOwnPropertyNames`, `Object.keys`, and `Object.values`.
- Add a globals parity fixture covering async `caller`/`arguments` absence plus user-defined `caller` data/accessor behavior.

## Root Cause
Function/closure objects stored accessor descriptors in the generic descriptor side table, but closure property lookup and ownership/enumeration paths only checked dynamic data properties and built-in function slots.

## Validation
- `cargo fmt --all -- --check`
- `npm exec --package=node@25 -- node --experimental-strip-types test-parity/node-suite/globals/async-function-forbidden-props.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-async-caller-callee-tail/target cargo test -q -p perry-runtime closure_accessor_define_property_is_own_and_invoked --lib`
- `timeout 900s env PERRY_NO_CACHE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-async-caller-callee-tail/target npm exec --package=node@25 -- bash -lc "node --version; ./run_parity_tests.sh --suite node-suite --module globals --filter async-function-forbidden-props"`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-async-caller-callee-tail/target cargo check -q -p perry-runtime`
- `git diff --check`
- `./scripts/check_file_size.sh`

Part of #3568.