### PR TITLE
[codex] support asymmetric KeyObject toCryptoKey

### DIFF
--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -34,9 +34,10 @@ pub use header::{
     asymmetric_key_meta, buffer_ab_alias, buffer_alloc, buffer_backing_array_buffer,
     buffer_byte_offset, buffer_data, buffer_data_mut, crypto_key_meta, ensure_buffer_ab_alias,
     is_any_array_buffer, is_array_buffer, is_data_view, is_registered_buffer, is_secret_key,
-    is_shared_array_buffer, is_uint8array_buffer, mark_as_array_buffer, mark_as_asymmetric_key,
-    mark_as_crypto_key, mark_as_data_view, mark_as_secret_key, mark_as_shared_array_buffer,
-    mark_as_uint8array, register_buffer, resolve_buffer_ab_alias, set_buffer_ab_alias,
+    is_shared_array_buffer, is_uint8array_buffer, js_buffer_mark_as_crypto_key_external,
+    mark_as_array_buffer, mark_as_asymmetric_key, mark_as_crypto_key, mark_as_data_view,
+    mark_as_secret_key, mark_as_shared_array_buffer, mark_as_uint8array, register_buffer,
+    resolve_buffer_ab_alias, set_buffer_ab_alias,
 };
 
 // ---- Re-exports: Buffer.from / alloc / concat (FFI) ----

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -3145,6 +3145,7 @@ pub extern "C" fn js_object_get_field_by_name(
                     let static_name: Option<&'static [u8]> = match key_bytes {
                         b"export" => Some(b"export"),
                         b"equals" => Some(b"equals"),
+                        b"toCryptoKey" => Some(b"toCryptoKey"),
                         _ => None,
                     };
                     if let Some(name) = static_name {

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1475,6 +1475,28 @@ pub unsafe extern "C" fn js_native_call_method(
                     let eq = crate::string::js_string_equals(s_ptr, other_ptr) != 0;
                     return f64::from_bits(JSValue::bool(eq).bits());
                 }
+                "toCryptoKey" if crate::buffer::asymmetric_key_meta(s_ptr as usize).is_some() => {
+                    let ptr = crate::value::JS_NATIVE_CRYPTO_DISPATCH
+                        .load(std::sync::atomic::Ordering::SeqCst);
+                    if ptr.is_null() {
+                        return f64::from_bits(JSValue::undefined().bits());
+                    }
+                    let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
+                        std::mem::transmute(ptr);
+                    let undefined = f64::from_bits(JSValue::undefined().bits());
+                    let mut call_args = Vec::with_capacity(4);
+                    call_args.push(object_handle.get_nanbox_f64());
+                    call_args.push(arg_at(0).unwrap_or(undefined));
+                    call_args.push(arg_at(1).unwrap_or(undefined));
+                    call_args.push(arg_at(2).unwrap_or(undefined));
+                    let method = b"keyObjectToCryptoKey";
+                    return dispatch(
+                        method.as_ptr(),
+                        method.len(),
+                        call_args.as_ptr(),
+                        call_args.len(),
+                    );
+                }
                 "at" => {
                     return crate::string::js_string_at(s_ptr, arg_i32(0));
                 }

--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -316,6 +316,7 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
         "generateKeySync" => {
             pointer_value(js_crypto_generate_key_sync(str_ptr(0), arg(1)) as *mut u8)
         }
+        "keyObjectToCryptoKey" => js_crypto_keyobject_to_crypto_key(arg(0), arg(1), arg(2), arg(3)),
         "generatePrime" if args_len >= 3 => js_crypto_generate_prime_async(arg(0), arg(1), arg(2)),
         "generatePrime" | "generatePrimeSync" => js_crypto_generate_prime_sync(arg(0), arg(1)),
         "checkPrime" if args_len >= 3 => js_crypto_check_prime_async(arg(0), arg(1), arg(2)),

--- a/crates/perry-stdlib/src/crypto/sign.rs
+++ b/crates/perry-stdlib/src/crypto/sign.rs
@@ -376,6 +376,259 @@ pub unsafe extern "C" fn js_crypto_create_public_key_value(key_bits: f64) -> *mu
     ptr
 }
 
+const KO_USAGE_ENCRYPT: u32 = 1 << 0;
+const KO_USAGE_DECRYPT: u32 = 1 << 1;
+const KO_USAGE_SIGN: u32 = 1 << 2;
+const KO_USAGE_VERIFY: u32 = 1 << 3;
+const KO_USAGE_DERIVE_KEY: u32 = 1 << 4;
+const KO_USAGE_DERIVE_BITS: u32 = 1 << 5;
+const KO_USAGE_WRAP_KEY: u32 = 1 << 6;
+const KO_USAGE_UNWRAP_KEY: u32 = 1 << 7;
+
+unsafe fn keyobject_string_value(value: &str) -> f64 {
+    let ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+unsafe fn throw_keyobject_dom_exception(name: &str, message: &str) -> ! {
+    let err = perry_runtime::event_target::js_dom_exception_new(
+        keyobject_string_value(message),
+        keyobject_string_value(name),
+    );
+    perry_runtime::exception::js_throw(perry_runtime::value::js_nanbox_pointer(err as i64))
+}
+
+unsafe fn throw_keyobject_usage_type_error() -> ! {
+    perry_runtime::fs::validate::throw_type_error_with_code(
+        "Value cannot be converted to sequence.",
+        "ERR_INVALID_ARG_TYPE",
+    )
+}
+
+unsafe fn keyobject_algorithm_name(bits: u64) -> Option<String> {
+    string_from_jsvalue(bits).or_else(|| object_field_string(bits, b"name"))
+}
+
+fn keyobject_hash_id(name: &str) -> Option<u8> {
+    let normalized = name
+        .chars()
+        .filter(|ch| *ch != '-')
+        .flat_map(char::to_uppercase)
+        .collect::<String>();
+    match normalized.as_str() {
+        "SHA1" => Some(1),
+        "SHA256" => Some(2),
+        "SHA384" => Some(3),
+        "SHA512" => Some(4),
+        _ => None,
+    }
+}
+
+unsafe fn keyobject_algorithm_hash(bits: u64) -> Option<u8> {
+    let hash_bits = object_field_bits(bits, b"hash")?;
+    if let Some(hash) = string_from_jsvalue(hash_bits) {
+        return keyobject_hash_id(&hash);
+    }
+    object_field_string(hash_bits, b"name").and_then(|hash| keyobject_hash_id(&hash))
+}
+
+unsafe fn keyobject_named_curve_is_p256(bits: u64) -> bool {
+    let Some(curve) = object_field_string(bits, b"namedCurve") else {
+        return false;
+    };
+    let upper = curve.to_ascii_uppercase();
+    matches!(upper.as_str(), "P-256" | "PRIME256V1" | "SECP256R1")
+}
+
+fn keyobject_usage_bit(name: &str) -> Option<u32> {
+    match name {
+        "encrypt" => Some(KO_USAGE_ENCRYPT),
+        "decrypt" => Some(KO_USAGE_DECRYPT),
+        "sign" => Some(KO_USAGE_SIGN),
+        "verify" => Some(KO_USAGE_VERIFY),
+        "deriveKey" => Some(KO_USAGE_DERIVE_KEY),
+        "deriveBits" => Some(KO_USAGE_DERIVE_BITS),
+        "wrapKey" => Some(KO_USAGE_WRAP_KEY),
+        "unwrapKey" => Some(KO_USAGE_UNWRAP_KEY),
+        _ => None,
+    }
+}
+
+unsafe fn keyobject_usage_bits(bits: u64) -> Option<u32> {
+    if perry_runtime::array::js_array_is_array(f64::from_bits(bits)).to_bits()
+        != JSValue::bool(true).bits()
+    {
+        return None;
+    }
+    let arr_addr = bits & 0x0000_FFFF_FFFF_FFFF;
+    if arr_addr < 0x1000 {
+        return None;
+    }
+    let arr = arr_addr as *const perry_runtime::ArrayHeader;
+    let len = perry_runtime::array::js_array_length(arr);
+    let mut usages = 0u32;
+    for i in 0..len {
+        let item = perry_runtime::array::js_array_get(arr, i);
+        let name = string_from_jsvalue(item.bits())?;
+        usages |= keyobject_usage_bit(&name)?;
+    }
+    Some(usages)
+}
+
+fn keyobject_supported_usages(algo_id: u8, kind_id: u8) -> u32 {
+    match (algo_id, kind_id) {
+        (8 | 12 | 14, 2) => KO_USAGE_SIGN,
+        (8 | 12 | 14, 3) => KO_USAGE_VERIFY,
+        (9, 2) => KO_USAGE_DERIVE_KEY | KO_USAGE_DERIVE_BITS,
+        (9, 3) => 0,
+        (13, 2) => KO_USAGE_DECRYPT | KO_USAGE_UNWRAP_KEY,
+        (13, 3) => KO_USAGE_ENCRYPT | KO_USAGE_WRAP_KEY,
+        _ => 0,
+    }
+}
+
+unsafe fn keyobject_validate_usages(algo_name: &str, algo_id: u8, kind_id: u8, bits: u64) -> u32 {
+    let usages = match keyobject_usage_bits(bits) {
+        Some(usages) => usages,
+        None => throw_keyobject_usage_type_error(),
+    };
+    let supported = keyobject_supported_usages(algo_id, kind_id);
+    if usages & !supported != 0 {
+        let article = if algo_name.starts_with("RSA") || algo_name.starts_with("RSASSA") {
+            "an"
+        } else {
+            "a"
+        };
+        let message = format!("Unsupported key usage for {article} {algo_name} key");
+        throw_keyobject_dom_exception("SyntaxError", &message);
+    }
+    if usages == 0 && kind_id == 2 {
+        throw_keyobject_dom_exception(
+            "SyntaxError",
+            "Usages cannot be empty when importing a private key.",
+        );
+    }
+    usages
+}
+
+fn keyobject_rsa_der(pem: &str, kind_id: u8) -> Option<Vec<u8>> {
+    use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey};
+
+    if kind_id == 2 {
+        return parse_rsa_private_key_pem(pem)
+            .and_then(|key| key.to_pkcs8_der().ok().map(|der| der.as_bytes().to_vec()));
+    }
+    parse_rsa_public_key_pem(pem).and_then(|key| {
+        key.to_public_key_der()
+            .ok()
+            .map(|der| der.as_bytes().to_vec())
+    })
+}
+
+fn keyobject_p256_bytes(pem: &str, kind_id: u8) -> Option<Vec<u8>> {
+    if kind_id == 2 {
+        return parse_p256_signing_key_pem(pem).map(|key| key.to_bytes().as_slice().to_vec());
+    }
+    parse_p256_verifying_key_pem(pem).map(|key| key.to_encoded_point(false).as_bytes().to_vec())
+}
+
+/// Private runtime hook for asymmetric `KeyObject#toCryptoKey()`.
+///
+/// The runtime owns method dispatch for string-backed KeyObject surrogates,
+/// while stdlib owns key parsing and DER/SEC1 encoding. The receiver arrives
+/// as `key_bits`; the remaining args match Node's
+/// `toCryptoKey(algorithm, extractable, keyUsages)`.
+#[no_mangle]
+pub unsafe extern "C" fn js_crypto_keyobject_to_crypto_key(
+    key_bits: f64,
+    algorithm_bits: f64,
+    extractable_bits: f64,
+    usages_bits: f64,
+) -> f64 {
+    let key_ptr = perry_runtime::js_get_string_pointer_unified(key_bits) as *const StringHeader;
+    if key_ptr.is_null() || (key_ptr as usize) < 0x1000 {
+        throw_keyobject_dom_exception("InvalidAccessError", "Key is not a valid KeyObject");
+    }
+    let Some((asym_kind_id, asym_type)) =
+        perry_runtime::buffer::asymmetric_key_meta(key_ptr as usize)
+    else {
+        throw_keyobject_dom_exception("InvalidAccessError", "Key is not a valid KeyObject");
+    };
+    let crypto_kind_id = if asym_kind_id == 2 { 2 } else { 3 };
+
+    let Some(algo_name) = keyobject_algorithm_name(algorithm_bits.to_bits()) else {
+        throw_keyobject_dom_exception("NotSupportedError", "Unrecognized algorithm name");
+    };
+    let upper = algo_name.to_ascii_uppercase();
+    let (algo_id, hash_id) = match upper.as_str() {
+        "RSASSA-PKCS1-V1_5" => (12, keyobject_algorithm_hash(algorithm_bits.to_bits())),
+        "RSA-OAEP" => (13, keyobject_algorithm_hash(algorithm_bits.to_bits())),
+        "RSA-PSS" => (14, keyobject_algorithm_hash(algorithm_bits.to_bits())),
+        "ECDSA" if keyobject_named_curve_is_p256(algorithm_bits.to_bits()) => (8, Some(2)),
+        "ECDH" if keyobject_named_curve_is_p256(algorithm_bits.to_bits()) => (9, Some(2)),
+        "ECDSA" | "ECDH" => {
+            throw_keyobject_dom_exception("DataError", "Named curve mismatch");
+        }
+        _ => throw_keyobject_dom_exception("NotSupportedError", "Unrecognized algorithm name"),
+    };
+    let Some(hash_id) = hash_id else {
+        perry_runtime::fs::validate::throw_type_error_with_code(
+            "Failed to normalize algorithm: missing hash",
+            "ERR_MISSING_OPTION",
+        );
+    };
+
+    if (matches!(algo_id, 12 | 13 | 14) && asym_type != 1)
+        || (matches!(algo_id, 8 | 9) && asym_type != 2)
+    {
+        throw_keyobject_dom_exception("DataError", "Key algorithm mismatch");
+    }
+
+    let usages = keyobject_validate_usages(
+        crypto_key_algorithm_name_for_id(algo_id),
+        algo_id,
+        crypto_kind_id,
+        usages_bits.to_bits(),
+    );
+    let pem = match String::from_utf8(bytes_from_ptr(key_ptr as i64)) {
+        Ok(pem) => pem,
+        Err(_) => throw_keyobject_dom_exception("DataError", "Key data is invalid"),
+    };
+    let key_bytes = if asym_type == 1 {
+        keyobject_rsa_der(&pem, crypto_kind_id)
+    } else {
+        keyobject_p256_bytes(&pem, crypto_kind_id)
+    };
+    let Some(key_bytes) = key_bytes else {
+        throw_keyobject_dom_exception("OperationError", "The operation failed");
+    };
+
+    let buf = alloc_buffer_from_slice(&key_bytes);
+    if buf.is_null() {
+        throw_keyobject_dom_exception("OperationError", "The operation failed");
+    }
+    perry_runtime::buffer::js_buffer_mark_as_crypto_key_external(
+        buf as usize,
+        algo_id,
+        hash_id,
+        crypto_kind_id,
+        u8::from(js_truthy(extractable_bits)),
+        usages,
+    );
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}
+
+fn crypto_key_algorithm_name_for_id(algo_id: u8) -> &'static str {
+    match algo_id {
+        8 => "ECDSA",
+        9 => "ECDH",
+        12 => "RSASSA-PKCS1-v1_5",
+        13 => "RSA-OAEP",
+        14 => "RSA-PSS",
+        _ => "",
+    }
+}
+
 /// crypto.generateKeyPairSync("rsa", options) -> { publicKey, privateKey }.
 ///
 /// This covers the high-value Node/Bun shape where `publicKeyEncoding` and

--- a/test-parity/node-suite/crypto/key-object/asymmetric-to-cryptokey.ts
+++ b/test-parity/node-suite/crypto/key-object/asymmetric-to-cryptokey.ts
@@ -1,0 +1,99 @@
+import * as crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+function describeCryptoKey(label: string, key: CryptoKey) {
+  const algorithm = key.algorithm as any;
+  console.log(`${label} type:`, key.type);
+  console.log(`${label} extractable:`, key.extractable);
+  console.log(`${label} alg name:`, algorithm.name);
+  console.log(`${label} alg detail:`, algorithm.hash?.name ?? algorithm.namedCurve ?? "none");
+  console.log(`${label} usages:`, JSON.stringify(key.usages));
+  console.log(`${label} instanceof:`, key instanceof CryptoKey);
+}
+
+function reportThrow(label: string, fn: () => unknown) {
+  try {
+    const value = fn();
+    console.log(`${label}:`, String(value));
+  } catch (error) {
+    const err = error as any;
+    console.log(`${label}:`, `${err.name} ${err.code ?? ""}`.trim());
+  }
+}
+
+const rsa = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+const ec = crypto.generateKeyPairSync("ec", {
+  namedCurve: "prime256v1",
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+const rsaPrivate = crypto.createPrivateKey(rsa.privateKey);
+const rsaPublic = crypto.createPublicKey(rsaPrivate);
+const ecPrivate = crypto.createPrivateKey(ec.privateKey);
+const ecPublic = crypto.createPublicKey(ecPrivate);
+const data = new TextEncoder().encode("asymmetric KeyObject toCryptoKey");
+
+const rsaSignKey = (rsaPrivate as any).toCryptoKey(
+  { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+  true,
+  ["sign"],
+);
+const rsaVerifyKey = (rsaPublic as any).toCryptoKey(
+  { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+  true,
+  ["verify"],
+);
+describeCryptoKey("rsa private", rsaSignKey);
+describeCryptoKey("rsa public", rsaVerifyKey);
+const rsaSignature = await crypto.webcrypto.subtle.sign("RSASSA-PKCS1-v1_5", rsaSignKey, data);
+console.log("rsa sig len:", Buffer.from(rsaSignature).length);
+console.log(
+  "rsa verify ok:",
+  await crypto.webcrypto.subtle.verify("RSASSA-PKCS1-v1_5", rsaVerifyKey, rsaSignature, data),
+);
+
+const rsaEncryptKey = (rsaPublic as any).toCryptoKey(
+  { name: "RSA-OAEP", hash: "SHA-256" },
+  false,
+  ["encrypt"],
+);
+const rsaDecryptKey = (rsaPrivate as any).toCryptoKey(
+  { name: "RSA-OAEP", hash: "SHA-256" },
+  false,
+  ["decrypt"],
+);
+describeCryptoKey("rsa oaep public", rsaEncryptKey);
+const ciphertext = await crypto.webcrypto.subtle.encrypt({ name: "RSA-OAEP" }, rsaEncryptKey, data);
+console.log("rsa oaep ct len:", Buffer.from(ciphertext).length);
+console.log(
+  "rsa oaep pt:",
+  Buffer.from(await crypto.webcrypto.subtle.decrypt({ name: "RSA-OAEP" }, rsaDecryptKey, ciphertext)).toString(),
+);
+
+const ecSignKey = (ecPrivate as any).toCryptoKey(
+  { name: "ECDSA", namedCurve: "P-256" },
+  true,
+  ["sign"],
+);
+const ecVerifyKey = (ecPublic as any).toCryptoKey(
+  { name: "ECDSA", namedCurve: "P-256" },
+  true,
+  ["verify"],
+);
+describeCryptoKey("ec private", ecSignKey);
+describeCryptoKey("ec public", ecVerifyKey);
+const ecSignature = await crypto.webcrypto.subtle.sign({ name: "ECDSA", hash: "SHA-256" }, ecSignKey, data);
+console.log("ec sig len:", Buffer.from(ecSignature).length);
+console.log(
+  "ec verify ok:",
+  await crypto.webcrypto.subtle.verify({ name: "ECDSA", hash: "SHA-256" }, ecVerifyKey, ecSignature, data),
+);
+
+reportThrow("rsa private verify usage", () =>
+  (rsaPrivate as any).toCryptoKey({ name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" }, true, ["verify"]),
+);


### PR DESCRIPTION
Refs #2565.

## Summary
- expose `toCryptoKey` on string-backed asymmetric `KeyObject` surrogates
- add a crypto dispatcher bridge that converts RSA and P-256 EC KeyObject PEM material into CryptoKey-backed buffers
- validate Node-style algorithm, extractability, and key usage inputs for RSA signing, RSA-OAEP, RSA-PSS, ECDSA, and ECDH shapes
- add Node 26 parity coverage for RSA sign/verify, RSA-OAEP encrypt/decrypt, EC P-256 sign/verify, CryptoKey properties, and bad usage errors

This is batched because the method exposure, stdlib conversion hook, CryptoKey metadata registration, and parity fixture are one KeyObject method surface.

## Validation
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-keyobject-asymmetric-tocryptokey/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter asymmetric-to-cryptokey'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-keyobject-asymmetric-tocryptokey/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter key-object'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-keyobject-asymmetric-tocryptokey/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter rsassa-pkcs1-sign-verify'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-keyobject-asymmetric-tocryptokey/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter rsa-oaep-encrypt-decrypt'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-keyobject-asymmetric-tocryptokey/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter ecdsa-p256-sign-verify'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-keyobject-asymmetric-tocryptokey/target cargo check -p perry-runtime`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-keyobject-asymmetric-tocryptokey/target cargo check -p perry-stdlib --no-default-features --features crypto`

## Known Limits
- Ed25519 and X25519 asymmetric KeyObject conversion are still out of scope here.
- Encrypted PEM/DER input expansion is out of scope.
- Broader WebCrypto algorithm support and X509 publicKey graph expansion are separate issue slices.
