### PR TITLE
[codex] Support asymmetric KeyObject toCryptoKey

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -106,8 +106,6 @@ fn crypto_key_algorithm_has_length(algo: u8) -> bool {
 fn crypto_key_named_curve(algo: u8) -> Option<&'static str> {
     match algo {
         8 | 9 => Some("P-256"),
-        10 => Some("Ed25519"),
-        11 => Some("X25519"),
         _ => None,
     }
 }
@@ -3161,6 +3159,7 @@ pub extern "C" fn js_object_get_field_by_name(
                     let static_name: Option<&'static [u8]> = match key_bytes {
                         b"export" => Some(b"export"),
                         b"equals" => Some(b"equals"),
+                        b"toCryptoKey" => Some(b"toCryptoKey"),
                         _ => None,
                     };
                     if let Some(name) = static_name {

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1452,6 +1452,29 @@ pub unsafe extern "C" fn js_native_call_method(
                 }
             };
             match method_name {
+                "toCryptoKey" if crate::buffer::asymmetric_key_meta(s_ptr as usize).is_some() => {
+                    let ptr = crate::value::JS_NATIVE_WEBCRYPTO_DISPATCH
+                        .load(std::sync::atomic::Ordering::SeqCst);
+                    if ptr.is_null() {
+                        return f64::from_bits(JSValue::undefined().bits());
+                    }
+                    let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
+                        std::mem::transmute(ptr);
+                    let key_value = f64::from_bits(JSValue::string_ptr(s_ptr as *mut _).bits());
+                    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+                    let dispatch_args = [
+                        key_value,
+                        arg_at(0).unwrap_or(undefined),
+                        arg_at(1).unwrap_or(undefined),
+                        arg_at(2).unwrap_or(undefined),
+                    ];
+                    return dispatch(
+                        b"keyObjectToCryptoKey".as_ptr(),
+                        "keyObjectToCryptoKey".len(),
+                        dispatch_args.as_ptr(),
+                        dispatch_args.len(),
+                    );
+                }
                 "export" if crate::buffer::asymmetric_key_meta(s_ptr as usize).is_some() => {
                     // Minimal asymmetric KeyObject-surrogate export surface.
                     // The native crypto layer stores PEM-backed RSA/EC keys

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -19,7 +19,7 @@ mod keys;
 mod prime;
 mod random;
 mod sign;
-mod util;
+pub(crate) mod util;
 mod x509;
 
 #[allow(unused_imports)]

--- a/crates/perry-stdlib/src/crypto/util.rs
+++ b/crates/perry-stdlib/src/crypto/util.rs
@@ -113,7 +113,7 @@ pub(super) fn normalize_sign_algorithm(algorithm: &[u8]) -> Option<RsaDigestKind
     }
 }
 
-pub(super) fn parse_rsa_private_key_pem(pem: &str) -> Option<RsaPrivateKey> {
+pub(crate) fn parse_rsa_private_key_pem(pem: &str) -> Option<RsaPrivateKey> {
     use rsa::pkcs1::DecodeRsaPrivateKey;
     use rsa::pkcs8::DecodePrivateKey;
 
@@ -140,7 +140,7 @@ pub(super) fn rsa_private_key_to_pem(private_key: &RsaPrivateKey) -> Option<Stri
         .map(|pem| pem.to_string())
 }
 
-pub(super) fn parse_rsa_public_key_pem(pem: &str) -> Option<RsaPublicKey> {
+pub(crate) fn parse_rsa_public_key_pem(pem: &str) -> Option<RsaPublicKey> {
     use rsa::pkcs1::DecodeRsaPublicKey;
     use rsa::pkcs8::DecodePublicKey;
 
@@ -161,13 +161,13 @@ pub(super) fn rsa_public_key_to_pem(public_key: &RsaPublicKey) -> Option<String>
         .map(|pem| pem.to_string())
 }
 
-pub(super) fn parse_p256_signing_key_pem(pem: &str) -> Option<P256EcdsaSigningKey> {
+pub(crate) fn parse_p256_signing_key_pem(pem: &str) -> Option<P256EcdsaSigningKey> {
     use p256::pkcs8::DecodePrivateKey;
 
     P256EcdsaSigningKey::from_pkcs8_pem(pem).ok()
 }
 
-pub(super) fn parse_p256_verifying_key_pem(pem: &str) -> Option<p256::ecdsa::VerifyingKey> {
+pub(crate) fn parse_p256_verifying_key_pem(pem: &str) -> Option<p256::ecdsa::VerifyingKey> {
     use p256::pkcs8::{DecodePrivateKey, DecodePublicKey};
 
     p256::ecdsa::VerifyingKey::from_public_key_pem(pem)
@@ -196,7 +196,7 @@ pub(super) fn ed25519_public_surrogate(key: &ed25519_dalek::VerifyingKey) -> Str
     format!("{ED25519_PUBLIC_PREFIX}{public}")
 }
 
-pub(super) fn parse_ed25519_private_surrogate(value: &str) -> Option<ed25519_dalek::SigningKey> {
+pub(crate) fn parse_ed25519_private_surrogate(value: &str) -> Option<ed25519_dalek::SigningKey> {
     let rest = value.strip_prefix(ED25519_PRIVATE_PREFIX)?;
     let secret_b64 = rest.split('.').next()?;
     let secret = base64::engine::general_purpose::URL_SAFE_NO_PAD
@@ -206,7 +206,7 @@ pub(super) fn parse_ed25519_private_surrogate(value: &str) -> Option<ed25519_dal
     Some(ed25519_dalek::SigningKey::from_bytes(&secret))
 }
 
-pub(super) fn parse_ed25519_public_surrogate(value: &str) -> Option<ed25519_dalek::VerifyingKey> {
+pub(crate) fn parse_ed25519_public_surrogate(value: &str) -> Option<ed25519_dalek::VerifyingKey> {
     if let Some(private) = parse_ed25519_private_surrogate(value) {
         return Some(private.verifying_key());
     }
@@ -228,7 +228,7 @@ pub(super) fn x25519_public_surrogate(public: &[u8; 32]) -> String {
     format!("{X25519_PUBLIC_PREFIX}{encoded}")
 }
 
-pub(super) fn parse_x25519_private_surrogate(value: &str) -> Option<[u8; 32]> {
+pub(crate) fn parse_x25519_private_surrogate(value: &str) -> Option<[u8; 32]> {
     let rest = value.strip_prefix(X25519_PRIVATE_PREFIX)?;
     let secret = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(rest.as_bytes())
@@ -236,7 +236,7 @@ pub(super) fn parse_x25519_private_surrogate(value: &str) -> Option<[u8; 32]> {
     secret.as_slice().try_into().ok()
 }
 
-pub(super) fn parse_x25519_public_surrogate(value: &str) -> Option<[u8; 32]> {
+pub(crate) fn parse_x25519_public_surrogate(value: &str) -> Option<[u8; 32]> {
     if let Some(secret) = parse_x25519_private_surrogate(value) {
         let secret = x25519_dalek::StaticSecret::from(secret);
         let public = x25519_dalek::PublicKey::from(&secret);

--- a/crates/perry-stdlib/src/webcrypto.rs
+++ b/crates/perry-stdlib/src/webcrypto.rs
@@ -12,6 +12,7 @@ mod digest;
 mod hmac;
 mod jwk;
 mod kdf;
+mod key_object;
 mod keys;
 mod supports;
 mod util;
@@ -19,7 +20,10 @@ mod wrap;
 
 #[allow(unused_imports)]
 // Private imports keep sibling modules able to share `pub(super)` helpers.
-use self::{aes::*, digest::*, hmac::*, jwk::*, kdf::*, keys::*, supports::*, util::*, wrap::*};
+use self::{
+    aes::*, digest::*, hmac::*, jwk::*, kdf::*, key_object::*, keys::*, supports::*, util::*,
+    wrap::*,
+};
 
 // Public re-exports preserve the parent module surface for FFI entry points.
 pub use self::{aes::*, digest::*, hmac::*, jwk::*, kdf::*, keys::*, supports::*, wrap::*};
@@ -96,6 +100,9 @@ pub unsafe extern "C" fn js_webcrypto_native_dispatch(
             arg(5),
             arg(6),
         )),
+        "keyObjectToCryptoKey" if args_len >= 4 => {
+            js_webcrypto_key_object_to_crypto_key(arg(0), arg(1), arg(2), arg(3))
+        }
         "supports" if args_len >= 2 => js_webcrypto_supports(arg(0), arg(1), arg(2)),
         _ => undefined,
     }

--- a/crates/perry-stdlib/src/webcrypto/key_object.rs
+++ b/crates/perry-stdlib/src/webcrypto/key_object.rs
@@ -1,0 +1,178 @@
+use super::*;
+
+use crate::crypto::util::{
+    parse_ed25519_private_surrogate, parse_ed25519_public_surrogate, parse_p256_signing_key_pem,
+    parse_p256_verifying_key_pem, parse_rsa_private_key_pem, parse_rsa_public_key_pem,
+    parse_x25519_private_surrogate, parse_x25519_public_surrogate,
+};
+
+unsafe fn throw_type_error(message: &str) -> ! {
+    let msg = perry_runtime::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = perry_runtime::error::js_typeerror_new(msg);
+    perry_runtime::exception::js_throw(perry_runtime::value::js_nanbox_pointer(err as i64))
+}
+
+unsafe fn throw_dom_exception(name: &str, message: &str) -> ! {
+    let obj = js_object_alloc(0, 3);
+    if obj.is_null() {
+        throw_type_error(message);
+    }
+    let name_key = perry_runtime::js_string_from_bytes(b"name".as_ptr(), 4);
+    let message_key = perry_runtime::js_string_from_bytes(b"message".as_ptr(), 7);
+    let stack_key = perry_runtime::js_string_from_bytes(b"stack".as_ptr(), 5);
+    let name_str = perry_runtime::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let message_str = perry_runtime::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let empty_str = perry_runtime::js_string_from_bytes(b"".as_ptr(), 0);
+    js_object_set_field_by_name(
+        obj,
+        name_key,
+        f64::from_bits(JSValue::string_ptr(name_str).bits()),
+    );
+    js_object_set_field_by_name(
+        obj,
+        message_key,
+        f64::from_bits(JSValue::string_ptr(message_str).bits()),
+    );
+    js_object_set_field_by_name(
+        obj,
+        stack_key,
+        f64::from_bits(JSValue::string_ptr(empty_str).bits()),
+    );
+    perry_runtime::exception::js_throw(perry_runtime::value::js_nanbox_pointer(obj as i64))
+}
+
+unsafe fn require_hash(algo_bits: u64) -> HashAlgo {
+    let hash_bits = object_field_bits(algo_bits, b"hash").unwrap_or_else(|| {
+        throw_type_error("KeyObject.toCryptoKey algorithm.hash is required");
+    });
+    extract_hash_algo(hash_bits).unwrap_or_else(|| {
+        throw_dom_exception(
+            "NotSupportedError",
+            "Unrecognized hash name for KeyObject.toCryptoKey",
+        );
+    })
+}
+
+unsafe fn require_p256_curve(algo_bits: u64) {
+    let curve = object_field_string(algo_bits, b"namedCurve").unwrap_or_else(|| {
+        throw_type_error("KeyObject.toCryptoKey algorithm.namedCurve is required");
+    });
+    match curve.to_ascii_lowercase().as_str() {
+        "p-256" | "prime256v1" | "secp256r1" => {}
+        _ => throw_dom_exception("DataError", "Named curve does not match the key"),
+    }
+}
+
+unsafe fn require_extractable(bits: u64) -> bool {
+    match bits {
+        TAG_TRUE => true,
+        TAG_FALSE => false,
+        _ => throw_type_error("KeyObject.toCryptoKey extractable must be a boolean"),
+    }
+}
+
+unsafe fn require_usage_sequence(bits: u64) {
+    let is_array =
+        JSValue::from_bits(perry_runtime::js_array_is_array(f64::from_bits(bits)).to_bits());
+    if !is_array.is_bool() || !is_array.as_bool() {
+        throw_type_error("KeyObject.toCryptoKey keyUsages must be an array");
+    }
+}
+
+unsafe fn key_material(value: &str, kind: KeyKind, asym_type: u8) -> Vec<u8> {
+    match (asym_type, kind) {
+        (1, KeyKind::Private) => parse_rsa_private_key_pem(value)
+            .and_then(|key| key.to_pkcs8_der().ok().map(|der| der.as_bytes().to_vec())),
+        (1, KeyKind::Public) => parse_rsa_public_key_pem(value).and_then(|key| {
+            key.to_public_key_der()
+                .ok()
+                .map(|der| der.as_bytes().to_vec())
+        }),
+        (2, KeyKind::Private) => {
+            parse_p256_signing_key_pem(value).map(|key| key.to_bytes().as_slice().to_vec())
+        }
+        (2, KeyKind::Public) => parse_p256_verifying_key_pem(value)
+            .map(|key| key.to_encoded_point(false).as_bytes().to_vec()),
+        (3, KeyKind::Private) => {
+            parse_ed25519_private_surrogate(value).map(|key| key.to_bytes().to_vec())
+        }
+        (3, KeyKind::Public) => {
+            parse_ed25519_public_surrogate(value).map(|key| key.to_bytes().to_vec())
+        }
+        (4, KeyKind::Private) => parse_x25519_private_surrogate(value).map(|key| key.to_vec()),
+        (4, KeyKind::Public) => parse_x25519_public_surrogate(value).map(|key| key.to_vec()),
+        _ => None,
+    }
+    .unwrap_or_else(|| throw_dom_exception("DataError", "The key data is invalid"))
+}
+
+unsafe fn select_key_algorithm(algo_bits: u64, asym_type: u8) -> (KeyAlgo, HashAlgo) {
+    let name = extract_algo_name(algo_bits).unwrap_or_else(|| {
+        throw_dom_exception(
+            "NotSupportedError",
+            "Unrecognized algorithm name for KeyObject.toCryptoKey",
+        );
+    });
+    let upper = name.to_ascii_uppercase();
+    match (asym_type, upper.as_str()) {
+        (1, "RSASSA-PKCS1-V1_5") => (KeyAlgo::RsassaPkcs1, require_hash(algo_bits)),
+        (1, "RSA-OAEP") => (KeyAlgo::RsaOaep, require_hash(algo_bits)),
+        (1, "RSA-PSS") => (KeyAlgo::RsaPss, require_hash(algo_bits)),
+        (2, "ECDSA") => {
+            require_p256_curve(algo_bits);
+            (KeyAlgo::EcdsaP256, HashAlgo::Sha256)
+        }
+        (2, "ECDH") => {
+            require_p256_curve(algo_bits);
+            (KeyAlgo::EcdhP256, HashAlgo::Sha256)
+        }
+        (3, "ED25519") => (KeyAlgo::Ed25519, HashAlgo::Sha256),
+        (4, "X25519") => (KeyAlgo::X25519, HashAlgo::Sha256),
+        _ => throw_dom_exception(
+            "NotSupportedError",
+            "The requested algorithm is not supported for this key",
+        ),
+    }
+}
+
+pub(super) unsafe fn js_webcrypto_key_object_to_crypto_key(
+    key_bits: f64,
+    algorithm_bits: f64,
+    extractable_bits: f64,
+    usages_bits: f64,
+) -> f64 {
+    let key_addr = strip_ptr(key_bits.to_bits());
+    let (runtime_kind, asym_type) = perry_runtime::buffer::asymmetric_key_meta(key_addr)
+        .unwrap_or_else(|| throw_type_error("KeyObject.toCryptoKey receiver is not a KeyObject"));
+    let kind = match runtime_kind {
+        1 => KeyKind::Public,
+        2 => KeyKind::Private,
+        _ => throw_type_error("KeyObject.toCryptoKey receiver is not an asymmetric KeyObject"),
+    };
+    let key_string = string_from_jsvalue(key_bits.to_bits())
+        .unwrap_or_else(|| throw_type_error("KeyObject.toCryptoKey receiver is not a KeyObject"));
+    let extractable = require_extractable(extractable_bits.to_bits());
+    require_usage_sequence(usages_bits.to_bits());
+    let (key_algo, hash) = select_key_algorithm(algorithm_bits.to_bits(), asym_type);
+    let usages = match validate_key_usages(
+        key_algo,
+        kind,
+        usages_bits.to_bits(),
+        matches!(kind, KeyKind::Public),
+        "Usages cannot be empty when creating a key.",
+        "Unsupported key usage for the requested key",
+    ) {
+        Ok(usages) => usages,
+        Err((name, message)) => throw_dom_exception(name, message),
+    };
+    let bytes = key_material(&key_string, kind, asym_type);
+    let buf = alloc_uint8array_from_slice(&bytes);
+    if buf.is_null() {
+        throw_dom_exception("OperationError", "The operation failed");
+    }
+    register_crypto_key(
+        buf as usize,
+        CryptoKeyMaterial::new(key_algo, hash, kind, extractable, usages),
+    );
+    f64::from_bits(JSValue::pointer(buf as *const u8).bits())
+}

--- a/test-parity/node-suite/crypto/key-object/asymmetric-to-cryptokey.ts
+++ b/test-parity/node-suite/crypto/key-object/asymmetric-to-cryptokey.ts
@@ -1,0 +1,143 @@
+import * as crypto from "node:crypto";
+
+const subtle = crypto.webcrypto.subtle;
+const data = new TextEncoder().encode("keyobject asymmetric toCryptoKey");
+
+function summary(key: CryptoKey): string {
+  const algorithm = key.algorithm as EcKeyAlgorithm & RsaHashedKeyAlgorithm;
+  const detail = algorithm.hash
+    ? `${algorithm.name}/${algorithm.hash.name}`
+    : algorithm.namedCurve
+      ? `${algorithm.name}/${algorithm.namedCurve}`
+      : algorithm.name;
+  return [
+    key instanceof CryptoKey,
+    key.constructor === CryptoKey,
+    key.type,
+    key.extractable,
+    detail,
+    key.usages.join(","),
+  ].join("|");
+}
+
+function errorName(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(`${label}: ok`);
+  } catch (err: any) {
+    console.log(`${label}: ${err.name}`);
+  }
+}
+
+const rsaPem = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+const rsaPrivate = crypto.createPrivateKey(rsaPem.privateKey);
+const rsaPublic = crypto.createPublicKey(rsaPrivate);
+const rsaSign = (rsaPrivate as any).toCryptoKey(
+  { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+  false,
+  ["sign"],
+) as CryptoKey;
+const rsaVerify = (rsaPublic as any).toCryptoKey(
+  { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+  true,
+  ["verify"],
+) as CryptoKey;
+console.log("rsa sign summary:", summary(rsaSign));
+console.log("rsa verify summary:", summary(rsaVerify));
+const rsaSignature = await subtle.sign("RSASSA-PKCS1-v1_5", rsaSign, data);
+console.log(
+  "rsa verify:",
+  await subtle.verify("RSASSA-PKCS1-v1_5", rsaVerify, rsaSignature, data),
+);
+
+const rsaEncrypt = (rsaPublic as any).toCryptoKey(
+  { name: "RSA-OAEP", hash: "SHA-256" },
+  true,
+  ["encrypt", "wrapKey"],
+) as CryptoKey;
+const rsaDecrypt = (rsaPrivate as any).toCryptoKey(
+  { name: "RSA-OAEP", hash: "SHA-256" },
+  false,
+  ["decrypt", "unwrapKey"],
+) as CryptoKey;
+console.log("rsa oaep summary:", summary(rsaEncrypt));
+const ciphertext = await subtle.encrypt("RSA-OAEP", rsaEncrypt, data);
+const plaintext = await subtle.decrypt("RSA-OAEP", rsaDecrypt, ciphertext);
+console.log("rsa oaep plaintext:", Buffer.from(plaintext).toString());
+
+const ecPem = crypto.generateKeyPairSync("ec", {
+  namedCurve: "prime256v1",
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+const ecPrivate = crypto.createPrivateKey(ecPem.privateKey);
+const ecPublic = crypto.createPublicKey(ecPrivate);
+const ecdsaSign = (ecPrivate as any).toCryptoKey(
+  { name: "ECDSA", namedCurve: "P-256" },
+  false,
+  ["sign"],
+) as CryptoKey;
+const ecdsaVerify = (ecPublic as any).toCryptoKey(
+  { name: "ECDSA", namedCurve: "P-256" },
+  true,
+  ["verify"],
+) as CryptoKey;
+console.log("ecdsa sign summary:", summary(ecdsaSign));
+const ecSignature = await subtle.sign({ name: "ECDSA", hash: "SHA-256" }, ecdsaSign, data);
+console.log(
+  "ecdsa verify:",
+  await subtle.verify({ name: "ECDSA", hash: "SHA-256" }, ecdsaVerify, ecSignature, data),
+);
+
+const peer = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+const ecdhPrivate = (ecPrivate as any).toCryptoKey(
+  { name: "ECDH", namedCurve: "P-256" },
+  false,
+  ["deriveBits"],
+) as CryptoKey;
+const ecdhPublic = (peer.publicKey as any).toCryptoKey(
+  { name: "ECDH", namedCurve: "P-256" },
+  true,
+  [],
+) as CryptoKey;
+console.log("ecdh private summary:", summary(ecdhPrivate));
+const derived = await subtle.deriveBits({ name: "ECDH", public: ecdhPublic }, ecdhPrivate, 128);
+console.log("ecdh bits length:", Buffer.from(derived).length);
+
+const ed = crypto.generateKeyPairSync("ed25519");
+const edSign = (ed.privateKey as any).toCryptoKey({ name: "Ed25519" }, false, ["sign"]);
+const edVerify = (ed.publicKey as any).toCryptoKey("Ed25519", true, ["verify"]);
+console.log("ed verify summary:", summary(edVerify));
+const edSignature = await subtle.sign("Ed25519", edSign, data);
+console.log("ed verify:", await subtle.verify("Ed25519", edVerify, edSignature, data));
+
+const x = crypto.generateKeyPairSync("x25519");
+const xPrivate = (x.privateKey as any).toCryptoKey({ name: "X25519" }, false, ["deriveBits"]);
+const xPublic = (x.publicKey as any).toCryptoKey("X25519", true, []);
+console.log("x25519 public summary:", summary(xPublic));
+const xBits = await subtle.deriveBits({ name: "X25519", public: xPublic }, xPrivate, 128);
+console.log("x25519 bits length:", Buffer.from(xBits).length);
+
+errorName("rsa wrong usage", () =>
+  (rsaPublic as any).toCryptoKey(
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    true,
+    ["sign"],
+  )
+);
+errorName("rsa missing usages", () =>
+  (rsaPublic as any).toCryptoKey(
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    true,
+  )
+);
+errorName("ec curve mismatch", () =>
+  (ecPublic as any).toCryptoKey({ name: "ECDSA", namedCurve: "P-384" }, true, ["verify"])
+);
+errorName("unknown algorithm", () =>
+  (rsaPublic as any).toCryptoKey("AES-GCM", true, ["encrypt"])
+);


### PR DESCRIPTION
## Summary
- Expose `KeyObject#toCryptoKey` on asymmetric KeyObject surrogates.
- Convert RSA, P-256 EC, Ed25519, and X25519 stored key material into WebCrypto-backed `CryptoKey` values with Node-shaped metadata and usage validation.
- Add parity coverage for asymmetric `toCryptoKey` sign/verify, encrypt/decrypt, deriveBits, and validation errors.

Refs #2565

## Validation
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-compat-crypto-keyobject-tocryptokey/target cargo check -p perry-runtime -p perry-stdlib`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-compat-crypto-keyobject-tocryptokey/target npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module crypto --filter asymmetric-to-cryptokey'`\n- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-compat-crypto-keyobject-tocryptokey/target npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module crypto --filter key-object'`\n- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-compat-crypto-keyobject-tocryptokey/target npm exec --yes --package=node@26 -- bash -lc 'for filter in rsa-oaep rsassa rsa-pss-sign-verify ecdsa-p256-sign-verify ecdh-p256-derive-bits ed25519-sign-verify x25519-derive-bits; do ./run_parity_tests.sh --suite node-suite --module crypto --filter "$filter"; done'`