### PR TITLE
[codex] honor child_process argv0 option

### DIFF
--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -67,9 +67,10 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     let stdin_obj = cp_build_writable();
     let stdio_kinds = cp_read_stdio(opts_val, 3);
 
-    // spawnargs = [execPath, ...execArgv, module, ...args] (matches Node).
+    // spawnargs = [argv0 ?? execPath, ...execArgv, module, ...args] (matches Node).
     let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + exec_argv.len() + 2) as u32);
-    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&exec_path));
+    let argv0 = cp_spawnargs_argv0(&exec_path, opts_val);
+    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&argv0));
     for a in &exec_argv {
         spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(a));
     }
@@ -123,6 +124,7 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     command.args(&exec_argv);
     command.arg(&module);
     command.args(&arg_strs);
+    cp_apply_argv0(&mut command, opts_val);
     cp_apply_options(&mut command, opts_val);
     cp_apply_live_stdio(&mut command, &stdio_kinds);
 

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -1321,7 +1321,8 @@ fn cp_args_from_value(value: f64) -> Vec<String> {
 }
 
 // ============================================================================
-// Spawn / exec options: `cwd`, `env`, `shell`, sync buffered I/O — #1780/#2555
+// Spawn / exec options: `cwd`, `env`, `shell`, `argv0`, sync buffered I/O —
+// #1780/#2555
 // ============================================================================
 //
 // These helpers read the common, host-portable options off a NaN-boxed options
@@ -1376,6 +1377,32 @@ fn cp_apply_options(command: &mut Command, opts_val: f64) {
                 command.env(&key, cp_coerce_string(v));
             }
         }
+    }
+}
+
+pub(super) fn cp_read_argv0(opts_val: f64) -> Option<String> {
+    if cp_object_ptr(opts_val).is_none() {
+        return None;
+    }
+    cp_value_to_string(cp_get_field(opts_val, b"argv0"))
+}
+
+pub(super) fn cp_spawnargs_argv0(default: &str, opts_val: f64) -> String {
+    cp_read_argv0(opts_val).unwrap_or_else(|| default.to_string())
+}
+
+pub(super) fn cp_apply_argv0(command: &mut Command, opts_val: f64) {
+    let Some(argv0) = cp_read_argv0(opts_val) else {
+        return;
+    };
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.arg0(argv0);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (command, argv0);
     }
 }
 
@@ -1481,6 +1508,7 @@ fn cp_build_command(cmd: &str, args: &[String], opts_val: f64) -> Command {
         c
     };
 
+    cp_apply_argv0(&mut command, opts_val);
     cp_apply_options(&mut command, opts_val);
     command
 }
@@ -1839,6 +1867,7 @@ pub extern "C" fn js_child_process_exec_file_sync(
     let arg_strs = cp_args_from_value(args_val);
     let mut command = Command::new(&file_str);
     command.args(&arg_strs);
+    cp_apply_argv0(&mut command, opts_val);
     cp_apply_options(&mut command, opts_val);
     let run_options = cp_read_run_options(opts_val);
     let run = cp_run_to_completion(command, &run_options);

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -439,9 +439,10 @@ pub extern "C" fn js_child_process_spawn_streams(
     let stdin_obj = cp_build_writable();
     let stdio_kinds = cp_read_stdio(opts_val, 3);
 
-    // spawnargs = [command, ...args]
+    // spawnargs = [argv0 ?? command, ...args]
     let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + 1) as u32);
-    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&cmd_str));
+    let argv0 = cp_spawnargs_argv0(&cmd_str, opts_val);
+    spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(&argv0));
     for a in &arg_strs {
         spawnargs = crate::array::js_array_push_f64(spawnargs, cp_box_string(a));
     }

--- a/test-parity/node-suite/child_process/async/argv0.ts
+++ b/test-parity/node-suite/child_process/async/argv0.ts
@@ -1,0 +1,73 @@
+import { execFileSync, fork, spawn, spawnSync } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function nodeArgv0Code(expected: string) {
+  return `console.log(process.argv0 === ${JSON.stringify(expected)} ? "match" : process.argv0)`;
+}
+
+function trim(value: unknown) {
+  return String(value).trim();
+}
+
+async function runSpawn() {
+  const child = spawn("node", ["-e", nodeArgv0Code("perry-spawn-argv0")], {
+    argv0: "perry-spawn-argv0",
+  });
+  let stdout = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  const status = await new Promise((resolve) => child.on("close", resolve));
+  console.log("spawn argv0:", trim(stdout));
+  console.log("spawn status:", status);
+  console.log("spawnargs first:", child.spawnargs[0]);
+  console.log("spawnargs second:", child.spawnargs[1]);
+}
+
+function runSpawnSync() {
+  const result = spawnSync("node", ["-e", nodeArgv0Code("perry-spawnsync-argv0")], {
+    argv0: "perry-spawnsync-argv0",
+    encoding: "utf8",
+  });
+  console.log("spawnSync argv0:", trim(result.stdout));
+  console.log("spawnSync status:", result.status);
+}
+
+function runExecFileSync() {
+  const stdout = execFileSync("node", ["-e", nodeArgv0Code("perry-execfile-sync-argv0")], {
+    argv0: "perry-execfile-sync-argv0",
+    encoding: "utf8",
+  });
+  console.log("execFileSync argv0:", trim(stdout));
+}
+
+async function runFork() {
+  const childFile = join(tmpdir(), `perry-fork-argv0-${process.pid}.js`);
+  writeFileSync(
+    childFile,
+    "if (process.send) process.send({ argv0: process.argv0 });",
+  );
+
+  const child = fork(childFile, ["child-arg"], {
+    argv0: "perry-fork-argv0",
+    execArgv: [],
+    execPath: "node",
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  });
+  const message = await new Promise<any>((resolve) => child.on("message", resolve));
+  const status = await new Promise((resolve) => child.on("close", resolve));
+  console.log("fork argv0:", message.argv0);
+  console.log("fork status:", status);
+  console.log("fork spawnargs first:", child.spawnargs[0]);
+  console.log("fork spawnargs second suffix:", child.spawnargs[1].endsWith(".js"));
+  try {
+    unlinkSync(childFile);
+  } catch {}
+}
+
+await runSpawn();
+runSpawnSync();
+runExecFileSync();
+await runFork();


### PR DESCRIPTION
Refs #2555.

## Summary
- read `options.argv0` for the Node-compatible child_process paths where Node 26 exposes it
- apply Unix `CommandExt::arg0` for live `spawn()`, `fork()`, `spawnSync()`, and `execFileSync()` launches
- update live `ChildProcess.spawnargs[0]` for `spawn()` and `fork()` so it reflects `argv0` instead of the executable when provided
- add parity coverage for child-visible `process.argv0`, live `spawnargs`, sync spawn, sync execFile, and fork IPC

## Scope Notes
This is intentionally limited to deterministic `argv0` behavior. It does not change async `exec` / `execFile` or shell `exec` paths, because Node 26 does not expose custom `argv0` there in the probed behavior. It also does not address numeric fd sharing, custom stream handles, AbortSignal/killSignal, uid/gid/detached/platform flags, or broad option validation.

## Validation
- Pre-fix: `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-child-process-stdio-inherit/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter argv0'` failed with `spawn argv0: node` vs Node `match`.
- `npm exec --package=node@26 -- node --experimental-strip-types test-parity/node-suite/child_process/async/argv0.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-child-process-stdio-inherit/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter argv0'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-child-process-stdio-inherit/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-child-process-stdio-inherit/target cargo check -p perry-runtime`
