### PR TITLE
[codex] Expose basic Atomics operations

### DIFF
--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -368,6 +368,7 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "Math"
             | "JSON"
             | "Reflect"
+            | "Atomics"
             | "WebAssembly"
             | "performance"
             | "process"

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -271,7 +271,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         match property.as_str() {
                             "process" | "console" | "globalThis" | "performance" | "navigator"
                             | "crypto" | "localStorage" | "sessionStorage" => Some("object"),
-                            "Math" | "JSON" | "Reflect" => Some("object"),
+                            "Math" | "JSON" | "Reflect" | "Atomics" => Some("object"),
                             n if is_global_this_builtin_function_name(n) => Some("function"),
                             _ => None,
                         }

--- a/crates/perry-codegen/src/lower_call/atomics.rs
+++ b/crates/perry-codegen/src/lower_call/atomics.rs
@@ -1,0 +1,58 @@
+//! `Atomics.<op>(...)` namespace static calls.
+
+use anyhow::Result;
+use perry_hir::Expr;
+
+use crate::expr::{lower_expr, FnCtx};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, PTR};
+
+fn is_global_this_atomics_expr(e: &Expr) -> bool {
+    matches!(
+        e,
+        Expr::PropertyGet { object, property }
+            if property == "Atomics" && matches!(object.as_ref(), Expr::GlobalGet(_))
+    )
+}
+
+pub fn try_lower_atomics_static_call(
+    ctx: &mut FnCtx<'_>,
+    callee: &Expr,
+    args: &[Expr],
+) -> Result<Option<String>> {
+    let Expr::PropertyGet { object, property } = callee else {
+        return Ok(None);
+    };
+    if !is_global_this_atomics_expr(object) {
+        return Ok(None);
+    }
+
+    let (runtime_fn, arity) = match property.as_str() {
+        "load" => ("js_atomics_load", 2),
+        "store" => ("js_atomics_store", 3),
+        "add" => ("js_atomics_add", 3),
+        "sub" => ("js_atomics_sub", 3),
+        "exchange" => ("js_atomics_exchange", 3),
+        "compareExchange" => ("js_atomics_compare_exchange", 4),
+        _ => return Ok(None),
+    };
+
+    let undefined = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+    let mut lowered: Vec<String> = Vec::with_capacity(arity);
+    for i in 0..arity {
+        if let Some(arg) = args.get(i) {
+            lowered.push(lower_expr(ctx, arg)?);
+        } else {
+            lowered.push(undefined.clone());
+        }
+    }
+    for arg in args.iter().skip(arity) {
+        let _ = lower_expr(ctx, arg)?;
+    }
+
+    let mut call_args: Vec<(crate::types::LlvmType, &str)> = vec![(PTR, "null")];
+    for value in &lowered {
+        call_args.push((DOUBLE, value.as_str()));
+    }
+    Ok(Some(ctx.block().call(DOUBLE, runtime_fn, &call_args)))
+}

--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -31,6 +31,7 @@ use crate::expr::{variant_name, FnCtx};
 //   `native_module_dispatch.rs` (#1105 followup): per-branch
 //   extraction of the original `lower_call.rs`'s 4.3k-LOC body so
 //   every file in this directory stays under 2000 lines.
+mod atomics;
 mod buffer_intrinsic;
 mod builtin;
 mod closure_analysis;
@@ -139,6 +140,11 @@ pub(crate) fn lower_call(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> R
     // Namespace member call (#636) — `ns.foo(...)` where `ns` is an
     // ExternFuncRef namespace import.
     if let Some(v) = namespace_call::try_lower_namespace_member_call(ctx, callee, args)? {
+        return Ok(v);
+    }
+
+    // `Atomics.load(...)` / `Atomics.add(...)` and related namespace statics.
+    if let Some(v) = atomics::try_lower_atomics_static_call(ctx, callee, args)? {
         return Ok(v);
     }
 

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1545,6 +1545,22 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_math_sin", DOUBLE, &[DOUBLE]);
     module.declare_function("js_math_tan", DOUBLE, &[DOUBLE]);
 
+    // ========== Atomics ==========
+    module.declare_function("js_atomics_load", DOUBLE, &[PTR, DOUBLE, DOUBLE]);
+    module.declare_function("js_atomics_store", DOUBLE, &[PTR, DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_atomics_add", DOUBLE, &[PTR, DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_atomics_sub", DOUBLE, &[PTR, DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_atomics_exchange",
+        DOUBLE,
+        &[PTR, DOUBLE, DOUBLE, DOUBLE],
+    );
+    module.declare_function(
+        "js_atomics_compare_exchange",
+        DOUBLE,
+        &[PTR, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
+
     // ========== Number ==========
     module.declare_function("js_number_is_finite", DOUBLE, &[DOUBLE]);
 

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -122,6 +122,7 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
             | "Math"
             | "JSON"
             | "Reflect"
+            | "Atomics"
             // Test262 installs `globalThis.print`; bare `print(...)` must
             // resolve through the global object instead of the unknown-ident
             // numeric fallback.
@@ -299,6 +300,10 @@ pub(crate) fn is_builtin_static_function_member(namespace: &str, member: &str) -
                 | "set"
                 | "setPrototypeOf"
         ),
+        "Atomics" => matches!(
+            member,
+            "load" | "store" | "add" | "sub" | "exchange" | "compareExchange"
+        ),
         "WebAssembly" => matches!(
             member,
             "compile" | "compileStreaming" | "instantiate" | "instantiateStreaming" | "validate"
@@ -409,6 +414,12 @@ pub(crate) fn builtin_static_function_length(namespace: &str, member: &str) -> O
             | "has"
             | "setPrototypeOf" => 2,
             "getPrototypeOf" | "isExtensible" | "ownKeys" | "preventExtensions" => 1,
+            _ => return None,
+        },
+        "Atomics" => match member {
+            "load" => 2,
+            "store" | "add" | "sub" | "exchange" => 3,
+            "compareExchange" => 4,
             _ => return None,
         },
         "WebAssembly" => match member {

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -266,6 +266,14 @@ pub(crate) fn is_known_json_static_method(name: &str) -> bool {
     matches!(name, "parse" | "stringify" | "rawJSON" | "isRawJSON")
 }
 
+/// Names of `Atomics.<name>` static functions Perry's runtime implements.
+pub(crate) fn is_known_atomics_static_method(name: &str) -> bool {
+    matches!(
+        name,
+        "load" | "store" | "add" | "sub" | "exchange" | "compareExchange"
+    )
+}
+
 /// Names of `Number.<name>` static functions Perry's runtime implements.
 pub(crate) fn is_known_number_static_method(name: &str) -> bool {
     matches!(
@@ -294,6 +302,7 @@ pub(crate) fn is_known_namespace_static_function(obj_name: &str, prop_name: &str
         "Promise" => is_known_promise_static_method(prop_name),
         "Math" => is_known_math_static_method(prop_name),
         "JSON" => is_known_json_static_method(prop_name),
+        "Atomics" => is_known_atomics_static_method(prop_name),
         "Number" => is_known_number_static_method(prop_name),
         "String" => is_known_string_static_method(prop_name),
         // #2877: `ArrayBuffer.isView` is a real static function (folded to the

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1757,7 +1757,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     );
                     let receiver_is_namespace_value = matches!(
                         property.as_str(),
-                        "crypto" | "WebAssembly" | "localStorage" | "sessionStorage"
+                        "Atomics" | "crypto" | "WebAssembly" | "localStorage" | "sessionStorage"
                     );
                     let outer_is_websocket_static = property == "WebSocket"
                         && match &member.prop {

--- a/crates/perry-runtime/src/atomics.rs
+++ b/crates/perry-runtime/src/atomics.rs
@@ -1,0 +1,189 @@
+//! Minimal `Atomics` namespace operations for integer TypedArray views.
+
+use crate::closure::ClosureHeader;
+use crate::typedarray::{
+    clean_ta_ptr, js_typed_array_get, js_typed_array_length, js_typed_array_set,
+    lookup_typed_array_kind, TypedArrayHeader, KIND_INT16, KIND_INT32, KIND_INT8, KIND_UINT16,
+    KIND_UINT32, KIND_UINT8,
+};
+use crate::value::JSValue;
+
+fn throw_type_error(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn throw_range_error(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_rangeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn supported_integer_kind(kind: u8) -> bool {
+    matches!(
+        kind,
+        KIND_INT8 | KIND_UINT8 | KIND_INT16 | KIND_UINT16 | KIND_INT32 | KIND_UINT32
+    )
+}
+
+fn typed_array_arg(value: f64) -> (*mut TypedArrayHeader, u8) {
+    let js = JSValue::from_bits(value.to_bits());
+    if !js.is_pointer() {
+        throw_type_error(b"Atomics operation requires an integer typed array");
+    }
+    let ta = clean_ta_ptr(js.as_pointer::<TypedArrayHeader>());
+    if ta.is_null() {
+        throw_type_error(b"Atomics operation requires an integer typed array");
+    }
+    let Some(kind) = lookup_typed_array_kind(ta as usize) else {
+        throw_type_error(b"Atomics operation requires an integer typed array");
+    };
+    if !supported_integer_kind(kind) {
+        throw_type_error(b"Atomics operation requires an integer typed array");
+    }
+    (ta as *mut TypedArrayHeader, kind)
+}
+
+fn atomics_to_index(index: f64, length: i32) -> i32 {
+    let mut n = JSValue::from_bits(index.to_bits()).to_number();
+    if n.is_nan() {
+        n = 0.0;
+    }
+    if n < 0.0 || n > 9_007_199_254_740_991.0 {
+        throw_range_error(b"Invalid atomic access index");
+    }
+    let i = n.trunc();
+    if i >= length as f64 {
+        throw_range_error(b"Invalid atomic access index");
+    }
+    i as i32
+}
+
+fn numeric_arg(value: f64) -> f64 {
+    let js = JSValue::from_bits(value.to_bits());
+    let n = if js.is_any_string() {
+        let ptr = crate::value::js_get_string_pointer_unified(value)
+            as *const crate::string::StringHeader;
+        if ptr.is_null() {
+            f64::NAN
+        } else {
+            unsafe {
+                let len = (*ptr).byte_len as usize;
+                let data =
+                    (ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+                std::str::from_utf8(std::slice::from_raw_parts(data, len))
+                    .ok()
+                    .and_then(|s| s.trim().parse::<f64>().ok())
+                    .unwrap_or(f64::NAN)
+            }
+        }
+    } else {
+        js.to_number()
+    };
+    if n.is_finite() {
+        n.trunc()
+    } else {
+        0.0
+    }
+}
+
+fn coerce_for_kind(kind: u8, value: f64) -> f64 {
+    let n = numeric_arg(value);
+    match kind {
+        KIND_INT8 => (n as i32 as i8) as f64,
+        KIND_UINT8 => (n as i64).rem_euclid(256) as f64,
+        KIND_INT16 => (n as i32 as i16) as f64,
+        KIND_UINT16 => (n as i64).rem_euclid(65_536) as f64,
+        KIND_INT32 => (n as i32) as f64,
+        KIND_UINT32 => (n as i64 as u32) as f64,
+        _ => n,
+    }
+}
+
+fn slot(view: f64, index: f64) -> (*mut TypedArrayHeader, u8, i32) {
+    let (ta, kind) = typed_array_arg(view);
+    let idx = atomics_to_index(index, js_typed_array_length(ta));
+    (ta, kind, idx)
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_load(_closure: *const ClosureHeader, view: f64, index: f64) -> f64 {
+    let (ta, _, idx) = slot(view, index);
+    js_typed_array_get(ta, idx)
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_store(
+    _closure: *const ClosureHeader,
+    view: f64,
+    index: f64,
+    value: f64,
+) -> f64 {
+    let (ta, kind, idx) = slot(view, index);
+    js_typed_array_set(ta, idx, coerce_for_kind(kind, value));
+    js_typed_array_get(ta, idx)
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_add(
+    _closure: *const ClosureHeader,
+    view: f64,
+    index: f64,
+    value: f64,
+) -> f64 {
+    let (ta, kind, idx) = slot(view, index);
+    let previous = js_typed_array_get(ta, idx);
+    js_typed_array_set(
+        ta,
+        idx,
+        coerce_for_kind(kind, previous + numeric_arg(value)),
+    );
+    previous
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_sub(
+    _closure: *const ClosureHeader,
+    view: f64,
+    index: f64,
+    value: f64,
+) -> f64 {
+    let (ta, kind, idx) = slot(view, index);
+    let previous = js_typed_array_get(ta, idx);
+    js_typed_array_set(
+        ta,
+        idx,
+        coerce_for_kind(kind, previous - numeric_arg(value)),
+    );
+    previous
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_exchange(
+    _closure: *const ClosureHeader,
+    view: f64,
+    index: f64,
+    value: f64,
+) -> f64 {
+    let (ta, kind, idx) = slot(view, index);
+    let previous = js_typed_array_get(ta, idx);
+    js_typed_array_set(ta, idx, coerce_for_kind(kind, value));
+    previous
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_compare_exchange(
+    _closure: *const ClosureHeader,
+    view: f64,
+    index: f64,
+    expected: f64,
+    replacement: f64,
+) -> f64 {
+    let (ta, kind, idx) = slot(view, index);
+    let previous = js_typed_array_get(ta, idx);
+    if previous == coerce_for_kind(kind, expected) {
+        js_typed_array_set(ta, idx, coerce_for_kind(kind, replacement));
+    }
+    previous
+}

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -28,6 +28,7 @@ pub mod arena;
 pub mod array;
 pub mod async_context;
 pub mod async_hooks;
+pub mod atomics;
 pub mod bigint;
 pub mod r#box;
 pub mod buffer;

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2539,6 +2539,7 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                 "Math" => install_math_namespace(ns_obj),
                 "JSON" => install_json_namespace_members(ns_obj),
                 "Reflect" => install_reflect_namespace_members(ns_obj),
+                "Atomics" => install_atomics_namespace_members(ns_obj),
                 _ => {}
             }
             crate::value::js_nanbox_pointer(ns_obj as i64)
@@ -3357,6 +3358,27 @@ fn install_reflect_namespace_members(ns_obj: *mut ObjectHeader) {
     ];
     for (name, arity) in METHODS.iter().copied() {
         install_proto_method(ns_obj, name, noop, arity);
+    }
+}
+
+fn install_atomics_namespace_members(ns_obj: *mut ObjectHeader) {
+    for (name, func_ptr, arity) in [
+        ("load", crate::atomics::js_atomics_load as *const u8, 2),
+        ("store", crate::atomics::js_atomics_store as *const u8, 3),
+        ("add", crate::atomics::js_atomics_add as *const u8, 3),
+        ("sub", crate::atomics::js_atomics_sub as *const u8, 3),
+        (
+            "exchange",
+            crate::atomics::js_atomics_exchange as *const u8,
+            3,
+        ),
+        (
+            "compareExchange",
+            crate::atomics::js_atomics_compare_exchange as *const u8,
+            4,
+        ),
+    ] {
+        install_proto_method(ns_obj, name, func_ptr, arity);
     }
 }
 

--- a/crates/perry-runtime/src/object/global_this_tables.rs
+++ b/crates/perry-runtime/src/object/global_this_tables.rs
@@ -170,6 +170,7 @@ pub(crate) const GLOBAL_THIS_BUILTIN_NAMESPACES: &[&str] = &[
     "Math",
     "JSON",
     "Reflect",
+    "Atomics",
     "WebAssembly",
 ];
 

--- a/test-parity/node-suite/globals/atomics-basic.ts
+++ b/test-parity/node-suite/globals/atomics-basic.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+function show(label, value) {
+  console.log(label + ":" + String(value));
+}
+
+show("typeof Atomics", typeof Atomics);
+
+const sab = new SharedArrayBuffer(16);
+const i32 = new Int32Array(sab, 0, 4);
+
+show("load initial", Atomics.load(i32, 0));
+show("store", Atomics.store(i32, 0, 7));
+show("load after store", Atomics.load(i32, 0));
+show("add previous", Atomics.add(i32, 0, 5));
+show("load after add", Atomics.load(i32, 0));
+show("sub previous", Atomics.sub(i32, 0, 2));
+show("exchange previous", Atomics.exchange(i32, 0, 3));
+show("compareExchange hit", Atomics.compareExchange(i32, 0, 3, 9));
+show("compareExchange miss", Atomics.compareExchange(i32, 0, 3, 11));
+show("final", Atomics.load(i32, 0));


### PR DESCRIPTION
## Summary
- Expose the global `Atomics` namespace and static function metadata.
- Implement deterministic `load`, `store`, `add`, `sub`, `exchange`, and `compareExchange` for numeric integer TypedArray views.
- Add a focused Node parity fixture for `SharedArrayBuffer` + `Int32Array` Atomics operations.

## Notes
This is a focused first slice for #2876. `wait`/`notify`, BigInt Atomics, and full shared-memory aliasing beyond Perry's existing TypedArray view model are intentionally out of scope for this PR.

## Validation
- `npx -y node@25 --experimental-strip-types test-parity/node-suite/globals/atomics-basic.ts`
- `PATH=/root/.npm/_npx/8758e404b5eed2f3/node_modules/.bin:$PATH CARGO_BUILD_JOBS=1 PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter atomics-basic`
- `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-reserved-word-property-accessors/target-atomics-check cargo check -q -p perry-runtime -p perry-hir -p perry-codegen`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
