### PR TITLE
[codex] expose request AbortSignal on http IncomingMessage

### DIFF
--- a/crates/perry-ext-http-server/src/handle_dispatch.rs
+++ b/crates/perry-ext-http-server/src/handle_dispatch.rs
@@ -98,6 +98,7 @@ extern "C" {
     fn js_node_http_im_complete(handle: i64) -> i32;
     fn js_node_http_im_aborted(handle: i64) -> i32;
     fn js_node_http_im_destroyed(handle: i64) -> i32;
+    fn js_node_http_im_signal(handle: i64) -> f64;
     fn js_node_http_im_remote_address(handle: i64) -> *mut StringHeader;
     fn js_node_http_im_remote_port(handle: i64) -> f64;
     fn js_node_http_im_pause(handle: i64);
@@ -483,7 +484,7 @@ pub unsafe extern "C" fn js_ext_http_incoming_message_dispatch_method(
             json_string_value_empty_object(js_node_http_im_trailers_distinct_json(handle))
         }
         "__get_socket" | "socket" | "__get_connection" | "connection" => self_ref,
-        "__get_signal" | "signal" => undef,
+        "__get_signal" | "signal" => js_node_http_im_signal(handle),
         "__get_remoteAddress" | "remoteAddress" => {
             string_ptr_value(js_node_http_im_remote_address(handle))
         }
@@ -687,7 +688,7 @@ pub unsafe extern "C" fn js_ext_http_incoming_message_dispatch_property(
         "aborted" => bool_value(js_node_http_im_aborted(handle) != 0),
         "destroyed" => bool_value(js_node_http_im_destroyed(handle) != 0),
         "socket" | "connection" => handle_to_pointer_f64(handle),
-        "signal" => undef,
+        "signal" => js_node_http_im_signal(handle),
         "remoteAddress" => string_ptr_value(js_node_http_im_remote_address(handle)),
         "remotePort" => js_node_http_im_remote_port(handle),
         _ => undef,

--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -138,6 +138,8 @@ fn scan_http_server_roots(visitor: &mut GcRootVisitor<'_>) {
     });
     iter_handles_of_mut::<IncomingMessage, _>(|im| {
         scan_listener_roots(&mut im.listeners, visitor);
+        visitor.visit_nanbox_f64_slot(&mut im.signal_controller);
+        visitor.visit_nanbox_f64_slot(&mut im.signal);
     });
     iter_handles_of_mut::<ServerResponse, _>(|sr| {
         scan_listener_roots(&mut sr.listeners, visitor);
@@ -197,9 +199,21 @@ mod tests {
         perry_runtime::arena::arena_alloc_gc(32, 8, perry_runtime::gc::GC_TYPE_STRING) as i64
     }
 
+    fn young_gc_value() -> f64 {
+        f64::from_bits(
+            crate::types::POINTER_TAG | (young_gc_root() as u64 & crate::types::PTR_MASK),
+        )
+    }
+
     fn assert_rewritten(before: i64, after: i64) {
         assert_ne!(after, before);
         assert!(perry_runtime::arena::pointer_in_nursery(after as usize));
+    }
+
+    fn assert_nanbox_rewritten(before: f64, after: f64) {
+        assert_ne!(after.to_bits(), before.to_bits());
+        let ptr = after.to_bits() & crate::types::PTR_MASK;
+        assert!(perry_runtime::arena::pointer_in_nursery(ptr as usize));
     }
 
     fn listener_map(event: &str, cb: i64) -> HashMap<String, Vec<i64>> {
@@ -349,6 +363,10 @@ mod tests {
             1234,
         );
         incoming.listeners = listener_map("data", incoming_listener);
+        let incoming_signal_controller = young_gc_value();
+        let incoming_signal = young_gc_value();
+        incoming.signal_controller = incoming_signal_controller;
+        incoming.signal = incoming_signal;
         let incoming_handle = register_handle(incoming);
 
         let response_listener = young_gc_root();
@@ -376,6 +394,8 @@ mod tests {
 
             let incoming = get_handle::<IncomingMessage>(incoming_handle).expect("incoming");
             assert_rewritten(incoming_listener, incoming.listeners["data"][0]);
+            assert_nanbox_rewritten(incoming_signal_controller, incoming.signal_controller);
+            assert_nanbox_rewritten(incoming_signal, incoming.signal);
 
             let response = get_handle::<ServerResponse>(response_handle).expect("response");
             assert_rewritten(response_listener, response.listeners["finish"][0]);

--- a/crates/perry-ext-http-server/src/request.rs
+++ b/crates/perry-ext-http-server/src/request.rs
@@ -74,6 +74,12 @@ pub struct IncomingMessage {
     /// Trailers placeholder — Node populates after `'end'`. We hand
     /// back an empty object until trailing-headers support lands.
     pub trailers: HashMap<String, String>,
+    /// Lazily-created AbortController/AbortSignal pair backing
+    /// `req.signal`.
+    pub signal_controller: f64,
+    pub signal: f64,
+    /// True once `'close'` has fired.
+    pub close_emitted: bool,
 }
 
 impl IncomingMessage {
@@ -104,6 +110,53 @@ impl IncomingMessage {
             paused: false,
             encoding: None,
             trailers: HashMap::new(),
+            signal_controller: f64::from_bits(crate::types::TAG_UNDEFINED),
+            signal: f64::from_bits(crate::types::TAG_UNDEFINED),
+            close_emitted: false,
+        }
+    }
+}
+
+extern "C" {
+    fn js_abort_controller_new() -> *mut perry_ffi::ObjectHeader;
+    fn js_abort_controller_signal(
+        controller: *mut perry_ffi::ObjectHeader,
+    ) -> *mut perry_ffi::ObjectHeader;
+    fn js_abort_controller_abort(controller: *mut perry_ffi::ObjectHeader);
+}
+
+fn is_undefined(value: f64) -> bool {
+    JsValue::from_bits(value.to_bits()).is_undefined()
+}
+
+fn object_value<T>(ptr: *mut T) -> f64 {
+    if ptr.is_null() {
+        f64::from_bits(crate::types::TAG_UNDEFINED)
+    } else {
+        f64::from_bits(JsValue::from_object_ptr(ptr).bits())
+    }
+}
+
+fn ensure_signal(im: &mut IncomingMessage) -> f64 {
+    if !is_undefined(im.signal) {
+        return im.signal;
+    }
+
+    unsafe {
+        let controller = js_abort_controller_new();
+        let signal = js_abort_controller_signal(controller);
+        im.signal_controller = object_value(controller);
+        im.signal = object_value(signal);
+    }
+    im.signal
+}
+
+fn abort_signal(im: &mut IncomingMessage) {
+    let controller =
+        JsValue::from_bits(im.signal_controller.to_bits()).as_pointer::<perry_ffi::ObjectHeader>();
+    if !controller.is_null() {
+        unsafe {
+            js_abort_controller_abort(controller);
         }
     }
 }
@@ -250,6 +303,14 @@ pub extern "C" fn js_node_http_im_destroyed(handle: i64) -> i32 {
         .unwrap_or(0)
 }
 
+/// `req.signal` — lazily-created AbortSignal for the request lifetime.
+#[no_mangle]
+pub extern "C" fn js_node_http_im_signal(handle: i64) -> f64 {
+    get_handle_mut::<IncomingMessage>(handle)
+        .map(ensure_signal)
+        .unwrap_or_else(|| f64::from_bits(crate::types::TAG_UNDEFINED))
+}
+
 /// `req.socket.remoteAddress` — peer IP as a dotted string.
 #[no_mangle]
 pub extern "C" fn js_node_http_im_remote_address(handle: i64) -> *mut StringHeader {
@@ -321,14 +382,12 @@ pub extern "C" fn js_node_http_im_resume(handle: i64) {
 /// `req.destroy()` — mark destroyed and fire `'close'`.
 #[no_mangle]
 pub extern "C" fn js_node_http_im_destroy(handle: i64) {
-    let close_listeners;
     if let Some(im) = get_handle_mut::<IncomingMessage>(handle) {
         im.destroyed = true;
-        close_listeners = im.listeners.get("close").cloned().unwrap_or_default();
     } else {
         return;
     }
-    emit_no_arg_to_listeners(&close_listeners);
+    close_incoming_message(handle);
 }
 
 /// `req.on(event, cb)` — register a listener. For `'data'` and `'end'`
@@ -520,6 +579,25 @@ pub(crate) fn emit_no_arg_to_listeners(listeners: &[i64]) {
             }
         }
     }
+}
+
+/// Mark the request as closed, abort `req.signal`, and fire `'close'` once.
+pub(crate) fn close_incoming_message(handle: i64) {
+    let close_listeners;
+    if let Some(im) = get_handle_mut::<IncomingMessage>(handle) {
+        if im.close_emitted {
+            return;
+        }
+        im.close_emitted = true;
+        close_listeners = im.listeners.get("close").cloned().unwrap_or_default();
+        if !close_listeners.is_empty() {
+            ensure_signal(im);
+        }
+        abort_signal(im);
+    } else {
+        return;
+    }
+    emit_no_arg_to_listeners(&close_listeners);
 }
 
 // ============================================================================

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -24,8 +24,8 @@ use perry_ffi::{
 
 use crate::ensure_gc_scanner_registered;
 use crate::request::{
-    alloc_incoming_message, emit_no_arg_to_listeners, handle_to_pointer_f64, with_implicit_this,
-    IncomingMessage,
+    alloc_incoming_message, close_incoming_message, emit_no_arg_to_listeners,
+    handle_to_pointer_f64, with_implicit_this, IncomingMessage,
 };
 use crate::response::{
     alloc_server_response_for_request, HyperResponseShape, ResponseBody, ServerResponse,
@@ -1019,6 +1019,7 @@ fn process_pending(pending: HttpPendingRequest) {
     }
 
     // Free the per-request handles.
+    close_incoming_message(pending.request_handle);
     perry_ffi::drop_handle(pending.request_handle);
     perry_ffi::drop_handle(pending.response_handle);
 }

--- a/test-parity/node-suite/http/server/message-surfaces.ts
+++ b/test-parity/node-suite/http/server/message-surfaces.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 
 const server = http.createServer((req: any, res: any) => {
+  const signal = req.signal;
   console.log(
     "req method types:",
     [
@@ -11,6 +12,13 @@ const server = http.createServer((req: any, res: any) => {
       typeof req.signal,
     ].join("|"),
   );
+  console.log(
+    "req signal:",
+    [typeof signal, signal === req.signal, signal.aborted, typeof signal.reason].join("|"),
+  );
+  req.on("close", () => {
+    console.log("req close signal:", req.signal.aborted);
+  });
   console.log(
     "req meta:",
     [


### PR DESCRIPTION
Refs #2132.

## Summary
- Expose a cached `IncomingMessage#signal` AbortSignal for server-side `node:http` request handles.
- Abort the cached signal and fire request `close` once before the per-request handle is dropped.
- Keep the cached signal/controller reachable through the HTTP extension GC root scanner.
- Extend the `server/message-surfaces` parity fixture to cover signal identity, initial aborted state, and close-time aborted state.

## Scope
This is limited to the request AbortSignal surface that was failing in `server/message-surfaces`. It does not address the remaining `server/upgrade-websocket` output mismatch or broader byte-level HTTP response/header diffs.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/http/server/message-surfaces.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-byte-diff-tail/target cargo test -p perry-ext-http-server gc_mutable_scanner_rewrites_server_wrapper_and_request_response_roots -- --nocapture`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-byte-diff-tail/target npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module http --filter message-surfaces'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-byte-diff-tail/target cargo check -p perry-ext-http-server`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-byte-diff-tail/target npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module http'` now reports `Parity Pass: 16`, `Parity Fail: 1`, `Compile Fail: 0`; the remaining failure is `node-suite/http/server/upgrade-websocket` and is out of scope here.
