### PR TITLE
[codex] expose X509Certificate publicKey

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -2217,6 +2217,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             | "keyUsage"
             | "ca"
             | "raw"
+            | "publicKey"
             | "toString"
             | "toJSON"
     ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)

--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -211,6 +211,32 @@ fn x509_der_to_pem(der: &[u8]) -> String {
     pem
 }
 
+fn x509_public_key_pem(spki_der: &[u8]) -> String {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(spki_der);
+    let mut pem = String::from("-----BEGIN PUBLIC KEY-----\n");
+    for chunk in b64.as_bytes().chunks(64) {
+        pem.push_str(std::str::from_utf8(chunk).unwrap_or(""));
+        pem.push('\n');
+    }
+    pem.push_str("-----END PUBLIC KEY-----\n");
+    pem
+}
+
+unsafe fn x509_public_key_value(handle: &X509Handle) -> f64 {
+    use x509_cert::der::Encode;
+
+    let spki_der = match handle.cert.tbs_certificate.subject_public_key_info.to_der() {
+        Ok(der) => der,
+        Err(_) => return nanbox_undefined(),
+    };
+    let pem = x509_public_key_pem(&spki_der);
+    let ptr = js_string_from_bytes(pem.as_ptr(), pem.len() as u32);
+    if let Some(asym_type) = classify_public_key_surrogate(&pem) {
+        mark_keyobject_string(ptr, KeyKind::Public, asym_type);
+    }
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
 fn throw_x509_parse_error(message: &str) -> ! {
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = perry_runtime::error::js_error_new_with_message(msg);
@@ -364,6 +390,7 @@ pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
             let buf = alloc_buffer_from_slice(&h.der);
             f64::from_bits(0x7FFD_0000_0000_0000u64 | ((buf as u64) & 0x0000_FFFF_FFFF_FFFF))
         }
+        "publicKey" => x509_public_key_value(h),
         _ => nanbox_undefined(),
     }
 }

--- a/test-parity/node-suite/crypto/x509/public-key.ts
+++ b/test-parity/node-suite/crypto/x509/public-key.ts
@@ -1,0 +1,36 @@
+import { KeyObject, X509Certificate } from "node:crypto";
+
+const pem = `-----BEGIN CERTIFICATE-----
+MIIDXzCCAkegAwIBAgIUICGaY01t7nWGtQ+QsMAicwoeRLUwDQYJKoZIhvcNAQEL
+BQAwPzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQ4wDAYDVQQKDAVQZXJyeTET
+MBEGA1UEAwwKcGVycnkudGVzdDAeFw0yNjA1MjMyMjM3NDZaFw0yNzA1MjMyMjM3
+NDZaMD8xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEOMAwGA1UECgwFUGVycnkx
+EzARBgNVBAMMCnBlcnJ5LnRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDSofrefQLAkx4k9mHYD/VrTLCkiPH7DP3RTmTD8UotAG+kv2+JQVIRWJOP
+/mJWC+ZnIVK7dCs8fqvsHS3HuU5BAYPQ4U7IyFyA48/ZBdsHECY6wuqhNW9yD5Pj
+x066iEFMckKKCNBP7gLX3rsrp4R5uWmvmK6lNqMgO4Xx8c3ae9xyxupUaS13fNzA
+inw5NNp7axLJm62llWMBOP+w2ZgQL4UmJDdxe5GI0q94ChHTU7uIr3DMOGAGWuoY
+zXLk8LeSwncgWn3CZZ4WpUxibNvhVG1pmZAbgeWB5GZboUMXd2a0Uyjq3EB2kYfx
+hPQYOp3obhEy1JtodmJHAlqYqG8vAgMBAAGjUzBRMB0GA1UdDgQWBBRB2mlHlpxU
+LohkBQ2NH8rRhV9hQDAfBgNVHSMEGDAWgBRB2mlHlpxULohkBQ2NH8rRhV9hQDAP
+BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCvghtILxg/BdFTS9ZA
+VarJrhSrEHSlJ2Bqp6v8BJmMpouU9heVhT24RdAx9nM46jZPem6Mt55ZQ+eyR7vK
+iC5T5yPWreaKEWnbS7YhxSTcLZOhMMZ4eah02f1lhYtiDF6u7p6zfY1HjZlJrbE4
+WNdOEcttJh8BTciSV2wuxD7iZNejN5L1wH+PATHTnuEuryksRhky4tOb7UiY7qkj
+M11jjUSojXBNqw754Na4vTz5hhjJo17NeB3hZw6N+r9flCGdTQZ4k02hx9+LbxcJ
+uVylGMusIXcohDauuPEBi/NXk0owHqF6uafjjW5lHK2CnsHKL8U0qHRdcKFJZ4Jx
+/gTV
+-----END CERTIFICATE-----`;
+
+const cert = new X509Certificate(pem);
+const key = cert["publicKey"];
+const exported = key.export({ type: "spki", format: "pem" }) as string;
+
+console.log("publicKey type:", key.type);
+console.log("publicKey asymmetric:", key.asymmetricKeyType);
+console.log("publicKey details type:", typeof key.asymmetricKeyDetails);
+console.log("publicKey instanceof:", key instanceof KeyObject);
+console.log("export starts:", exported.startsWith("-----BEGIN PUBLIC KEY-----\n"));
+console.log("export ends:", exported.endsWith("-----END PUBLIC KEY-----\n"));
+console.log("export line count:", exported.trimEnd().split("\n").length);
+console.log("equals repeated:", key.equals(cert["publicKey"]));


### PR DESCRIPTION
Refs #2563.

## Summary
- expose `X509Certificate#publicKey` through the existing X509 handle property dispatch
- encode the certificate SubjectPublicKeyInfo as `PUBLIC KEY` PEM
- mark the returned string as a public asymmetric KeyObject surrogate when Perry can classify the key type
- add Node 26 parity coverage for public KeyObject type/asymmetric type, `instanceof KeyObject`, PEM export delimiters, and `equals()` on repeated reads

## Scope Notes
This slice is limited to `publicKey` for currently supported public-key surrogate types such as RSA and P-256. It does not implement `checkHost()` / `checkEmail()` / `checkIP()`, certificate/key verification, `issuerCertificate`, `infoAccess`, `toLegacyObject()`, or the extension metadata handled by the separate draft PR.

## Validation
- Pre-fix: `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-x509-extension-metadata/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter public-key'` failed because `publicKey` was undefined.
- `npm exec --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/x509/public-key.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-x509-extension-metadata/target cargo check -p perry-stdlib --no-default-features --features crypto`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-x509-extension-metadata/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter public-key'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-x509-extension-metadata/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter x509'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-x509-extension-metadata/target npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter export-equals'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
