### PR TITLE
[codex] consume HTTP upgrade WebSocket frames in parity fixture

### DIFF
--- a/test-parity/node-suite/http/server/upgrade-websocket.ts
+++ b/test-parity/node-suite/http/server/upgrade-websocket.ts
@@ -26,12 +26,18 @@ function unmaskedTextFrame(text: string) {
   return Buffer.concat([Buffer.from([0x81, payload.length]), payload]);
 }
 
-function readServerTextFrame(buf: Buffer) {
-  const start = buf.indexOf(Buffer.from([0x81]));
-  if (start < 0 || start + 2 > buf.length) return "";
-  const len = buf[start + 1] & 0x7f;
-  if (start + 2 + len > buf.length) return "";
-  return buf.slice(start + 2, start + 2 + len).toString("utf8");
+function readServerFrame(buf: Buffer) {
+  if (buf.length < 2) return null;
+  const opcode = buf[0] & 0x0f;
+  const len = buf[1] & 0x7f;
+  if (len >= 126) return null;
+  const frameLength = 2 + len;
+  if (buf.length < frameLength) return null;
+  return {
+    opcode,
+    text: opcode === 1 ? buf.slice(2, frameLength).toString("utf8") : "",
+    bytes: frameLength,
+  };
 }
 
 function readClientTextFrame(frame: Buffer) {
@@ -107,11 +113,15 @@ client.on("data", (chunk: Buffer) => {
     pending = pending.slice(marker + 4);
     client.write(maskedTextFrame("hello"));
   }
-  const text = readServerTextFrame(pending);
-  if (text) {
-    console.log("client-frame:", text);
-    client.end();
-    server.close();
+  while (pending.length > 0) {
+    const frame = readServerFrame(pending);
+    if (!frame) break;
+    pending = pending.slice(frame.bytes);
+    if (frame.text) {
+      console.log("client-frame:", frame.text);
+      client.end();
+      server.close();
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- Parse server WebSocket frames from the raw client receive buffer instead of repeatedly searching the whole buffer for the first text frame.
- Consume non-text control frames so a Perry WebSocket `close()` frame does not cause the fixture to log the already-consumed echo frame twice.

## Validation
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-http-upgrade-websocket-tail/target npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module http --filter upgrade-websocket'`\n- `git diff --check HEAD~1..HEAD`\n- `./scripts/check_file_size.sh`