### PR TITLE
Expose X509Certificate name checks

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -477,8 +477,10 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     }
 
     #[cfg(feature = "crypto")]
-    if matches!(method_name, "toString" | "toJSON")
-        && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
+    if matches!(
+        method_name,
+        "toString" | "toJSON" | "checkHost" | "checkEmail" | "checkIP"
+    ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_x509_method(handle, method_name, &args);
     }
@@ -2220,6 +2222,9 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             | "publicKey"
             | "toString"
             | "toJSON"
+            | "checkHost"
+            | "checkEmail"
+            | "checkIP"
     ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_x509_property(handle, property_name);

--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -29,41 +29,45 @@ pub(super) fn x509_attr_short_name(oid: &str) -> String {
 /// Format an X.500 `Name` the way Node's `cert.subject` / `cert.issuer`
 /// do: one `TYPE=value` per line, newline-joined, in encoding order.
 pub(super) fn x509_format_name(name: &x509_cert::name::Name) -> String {
-    use x509_cert::der::Encode;
     let mut lines: Vec<String> = Vec::new();
     for rdn in name.0.iter() {
         for atv in rdn.0.iter() {
             let oid = atv.oid.to_string();
-            // The value is an AttributeValue (ASN.1 Any); decode common
-            // string forms. Fall back to its UTF-8 lossy DER tail.
-            let value = atv
-                .value
-                .decode_as::<x509_cert::der::asn1::Utf8StringRef>()
-                .map(|s| s.as_str().to_string())
-                .or_else(|_| {
-                    atv.value
-                        .decode_as::<x509_cert::der::asn1::PrintableStringRef>()
-                        .map(|s| s.as_str().to_string())
-                })
-                .or_else(|_| {
-                    atv.value
-                        .decode_as::<x509_cert::der::asn1::Ia5StringRef>()
-                        .map(|s| s.as_str().to_string())
-                })
-                .unwrap_or_else(|_| {
-                    let bytes = atv.value.to_der().unwrap_or_default();
-                    // Skip the 2-byte tag+len header when present.
-                    let tail = if bytes.len() > 2 {
-                        &bytes[2..]
-                    } else {
-                        &bytes[..]
-                    };
-                    String::from_utf8_lossy(tail).to_string()
-                });
+            let value = x509_attr_value(atv);
             lines.push(format!("{}={}", x509_attr_short_name(&oid), value));
         }
     }
     lines.join("\n")
+}
+
+fn x509_attr_value(atv: &x509_cert::attr::AttributeTypeAndValue) -> String {
+    use x509_cert::der::Encode;
+
+    // The value is an AttributeValue (ASN.1 Any); decode common string forms.
+    // Fall back to its UTF-8 lossy DER tail.
+    atv.value
+        .decode_as::<x509_cert::der::asn1::Utf8StringRef>()
+        .map(|s| s.as_str().to_string())
+        .or_else(|_| {
+            atv.value
+                .decode_as::<x509_cert::der::asn1::PrintableStringRef>()
+                .map(|s| s.as_str().to_string())
+        })
+        .or_else(|_| {
+            atv.value
+                .decode_as::<x509_cert::der::asn1::Ia5StringRef>()
+                .map(|s| s.as_str().to_string())
+        })
+        .unwrap_or_else(|_| {
+            let bytes = atv.value.to_der().unwrap_or_default();
+            // Skip the 2-byte tag+len header when present.
+            let tail = if bytes.len() > 2 {
+                &bytes[2..]
+            } else {
+                &bytes[..]
+            };
+            String::from_utf8_lossy(tail).to_string()
+        })
 }
 
 /// Format an X.509 validity `Time` as Node does — `MMM D HH:MM:SS YYYY GMT`
@@ -141,16 +145,96 @@ fn x509_format_general_name(name: &x509_cert::ext::pkix::name::GeneralName) -> O
 }
 
 fn x509_subject_alt_name(cert: &x509_cert::Certificate) -> Option<String> {
-    use x509_cert::der::Decode;
-
-    let ext = x509_find_extension(cert, "2.5.29.17")?;
-    let san = x509_cert::ext::pkix::SubjectAltName::from_der(ext.extn_value.as_bytes()).ok()?;
+    let san = x509_decoded_subject_alt_name(cert)?;
     let names: Vec<String> = san.0.iter().filter_map(x509_format_general_name).collect();
     if names.is_empty() {
         None
     } else {
         Some(names.join(", "))
     }
+}
+
+fn x509_decoded_subject_alt_name(
+    cert: &x509_cert::Certificate,
+) -> Option<x509_cert::ext::pkix::SubjectAltName> {
+    use x509_cert::der::Decode;
+
+    let ext = x509_find_extension(cert, "2.5.29.17")?;
+    x509_cert::ext::pkix::SubjectAltName::from_der(ext.extn_value.as_bytes()).ok()
+}
+
+fn x509_subject_common_names(cert: &x509_cert::Certificate) -> Vec<String> {
+    let mut names = Vec::new();
+    for rdn in cert.tbs_certificate.subject.0.iter() {
+        for atv in rdn.0.iter() {
+            if atv.oid.to_string() == "2.5.4.3" {
+                names.push(x509_attr_value(atv));
+            }
+        }
+    }
+    names
+}
+
+fn x509_check_host_value(cert: &x509_cert::Certificate, name: &str) -> Option<String> {
+    use x509_cert::ext::pkix::name::GeneralName;
+
+    let mut saw_dns_san = false;
+    if let Some(san) = x509_decoded_subject_alt_name(cert) {
+        for general_name in san.0.iter() {
+            let GeneralName::DnsName(value) = general_name else {
+                continue;
+            };
+            saw_dns_san = true;
+            let candidate = value.as_str();
+            if candidate.eq_ignore_ascii_case(name) {
+                return Some(candidate.to_string());
+            }
+        }
+    }
+
+    if saw_dns_san {
+        return None;
+    }
+
+    x509_subject_common_names(cert)
+        .into_iter()
+        .find(|candidate| candidate.eq_ignore_ascii_case(name))
+}
+
+fn x509_check_email_value(cert: &x509_cert::Certificate, email: &str) -> Option<String> {
+    use x509_cert::ext::pkix::name::GeneralName;
+
+    let san = x509_decoded_subject_alt_name(cert)?;
+    san.0.iter().find_map(|general_name| {
+        let GeneralName::Rfc822Name(value) = general_name else {
+            return None;
+        };
+        let candidate = value.as_str();
+        if candidate == email {
+            Some(candidate.to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn x509_check_ip_value(cert: &x509_cert::Certificate, ip: &str) -> Option<String> {
+    use std::net::IpAddr;
+    use x509_cert::ext::pkix::name::GeneralName;
+
+    let parsed = ip.parse::<IpAddr>().ok()?;
+    let san = x509_decoded_subject_alt_name(cert)?;
+    san.0.iter().find_map(|general_name| {
+        let GeneralName::IpAddress(value) = general_name else {
+            return None;
+        };
+        let bytes = value.as_bytes();
+        match parsed {
+            IpAddr::V4(addr) if bytes == addr.octets().as_slice() => Some(addr.to_string()),
+            IpAddr::V6(addr) if bytes == addr.octets().as_slice() => Some(addr.to_string()),
+            _ => None,
+        }
+    })
 }
 
 fn x509_extended_key_usage(cert: &x509_cert::Certificate) -> Option<Vec<String>> {
@@ -329,7 +413,10 @@ pub unsafe extern "C" fn js_crypto_x509_new(input_ptr: i64) -> f64 {
 pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
     use sha1::Sha1;
     use sha2::{Digest, Sha256, Sha512};
-    if matches!(property, "toString" | "toJSON") {
+    if matches!(
+        property,
+        "toString" | "toJSON" | "checkHost" | "checkEmail" | "checkIP"
+    ) {
         return dispatch_x509_method_property(handle, property);
     }
     let h = match get_handle_mut::<X509Handle>(handle) {
@@ -395,21 +482,56 @@ pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
     }
 }
 
-pub unsafe fn dispatch_x509_method(handle: i64, method: &str, _args: &[f64]) -> f64 {
+pub unsafe fn dispatch_x509_method(handle: i64, method: &str, args: &[f64]) -> f64 {
     let h = match get_handle_mut::<X509Handle>(handle) {
         Some(h) => h,
         None => return nanbox_undefined(),
     };
     match method {
         "toString" | "toJSON" => x509_string_f64(&x509_der_to_pem(&h.der)),
+        "checkHost" => {
+            match x509_check_host_value(&h.cert, &x509_required_string_arg(args, "name")) {
+                Some(value) => x509_string_f64(&value),
+                None => nanbox_undefined(),
+            }
+        }
+        "checkEmail" => {
+            match x509_check_email_value(&h.cert, &x509_required_string_arg(args, "email")) {
+                Some(value) => x509_string_f64(&value),
+                None => nanbox_undefined(),
+            }
+        }
+        "checkIP" => match x509_check_ip_value(&h.cert, &x509_required_string_arg(args, "ip")) {
+            Some(value) => x509_string_f64(&value),
+            None => nanbox_undefined(),
+        },
         _ => nanbox_undefined(),
     }
+}
+
+unsafe fn x509_required_string_arg(args: &[f64], arg_name: &str) -> String {
+    let value = args
+        .first()
+        .copied()
+        .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+    if !JSValue::from_bits(value.to_bits()).is_any_string() {
+        let message = format!(
+            "The \"{}\" argument must be of type string. Received {}",
+            arg_name,
+            perry_runtime::fs::validate::describe_received(value)
+        );
+        perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    }
+    string_from_jsvalue(value.to_bits()).unwrap_or_default()
 }
 
 pub unsafe fn dispatch_x509_method_property(handle: i64, property: &str) -> f64 {
     let name_bytes: &'static [u8] = match property {
         "toString" => b"toString",
         "toJSON" => b"toJSON",
+        "checkHost" => b"checkHost",
+        "checkEmail" => b"checkEmail",
+        "checkIP" => b"checkIP",
         _ => return nanbox_undefined(),
     };
     let this_f64 =

--- a/test-parity/node-suite/crypto/x509/name-checks.ts
+++ b/test-parity/node-suite/crypto/x509/name-checks.ts
@@ -1,0 +1,83 @@
+import { X509Certificate } from "node:crypto";
+
+const sanPem = `-----BEGIN CERTIFICATE-----
+MIIEEDCCAvigAwIBAgIUSXW0OKKEkcMY0kWj2AXQh+WVEWEwDQYJKoZIhvcNAQEL
+BQAwSTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQ4wDAYDVQQKDAVQZXJyeTEd
+MBsGA1UEAwwUcGVycnktZXh0ZW5zaW9uLnRlc3QwHhcNMjYwNjAzMTAwMTM4WhcN
+MjcwNjAzMTAwMTM4WjBJMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExDjAMBgNV
+BAoMBVBlcnJ5MR0wGwYDVQQDDBRwZXJyeS1leHRlbnNpb24udGVzdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKFD+QNwqsoE5dEnFVP/3zMQq5CAya+y
+vskPkxapgwYPhyW86Hr23oUwqazBi3B4Q5KuYXmnQYfJnM+d+pniDO9YGbBX8ao8
+Xb2fKC2BQP3t8JzCr56u6c0ob0MWuLpB51A4Fj56D/kfHthUet8Z2plYKyyUPUsB
+XZibgxx9COwi+NN4FsT0rDz8Vtgr3ssHPDcEZi9XTSqeooIv3Wsm2oCRhkuplqbe
+Dd7Wm5rUpwZiR5ahsmP0G1qgwA55Exs++kijL3+Qg1C5MpLqYAE927TsfIqNxijy
+ScaNCiUB7YxhVB3bRF+5G1KMfwBxkfEfKZ1nB0k6rpXXPlxSZ1giLxECAwEAAaOB
+7zCB7DCBlAYDVR0RBIGMMIGJghRwZXJyeS1leHRlbnNpb24udGVzdIIYd3d3LnBl
+cnJ5LWV4dGVuc2lvbi50ZXN0hwR/AAABhxAAAAAAAAAAAAAAAAAAAAABgRphZG1p
+bkBwZXJyeS1leHRlbnNpb24udGVzdIYjaHR0cHM6Ly9wZXJyeS1leHRlbnNpb24u
+dGVzdC9zdGF0dXMwJwYDVR0lBCAwHgYIKwYBBQUHAwEGCCsGAQUFBwMCBggrBgEF
+BQcDAzALBgNVHQ8EBAMCBaAwHQYDVR0OBBYEFJxWlUjxxiBuCawipcrkJX8MJi+C
+MA0GCSqGSIb3DQEBCwUAA4IBAQAKrCMj6C6qVPZcpCVUZT7Ez1/v2ewTBo/r5UnH
+j3V2u7//9F9JE7w+iuljUcZuuyVG67DqFynhbpTu5FDlHbbMDmmNcF6XNZ0PUk+N
+ROm2v3W7WAKvToyuGJAs+cQrd4JL2r3/CGNk5lkh0Q7LF1ZPtxUvIEWMKvg/tVu2
+VJ6ezkG2NJt4xbgu7v/FuJnPD1LXn3gogk8bMn52DbRQFs24Jtb6Ods+ptecRokp
+hQEUyxl4qRwtjtKdbE63O80yaZS+hK00zwdTkaKgddWgGEn2nI2E1fBXjBZz5JB/
+0va/LS/0Zxi1rpJIIkybLVdENUaQRJXUZeYjmO2oWQQXHSqo
+-----END CERTIFICATE-----`;
+
+const cnOnlyPem = `-----BEGIN CERTIFICATE-----
+MIIDXzCCAkegAwIBAgIUICGaY01t7nWGtQ+QsMAicwoeRLUwDQYJKoZIhvcNAQEL
+BQAwPzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQ4wDAYDVQQKDAVQZXJyeTET
+MBEGA1UEAwwKcGVycnkudGVzdDAeFw0yNjA1MjMyMjM3NDZaFw0yNzA1MjMyMjM3
+NDZaMD8xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEOMAwGA1UECgwFUGVycnkx
+EzARBgNVBAMMCnBlcnJ5LnRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDSofrefQLAkx4k9mHYD/VrTLCkiPH7DP3RTmTD8UotAG+kv2+JQVIRWJOP
+/mJWC+ZnIVK7dCs8fqvsHS3HuU5BAYPQ4U7IyFyA48/ZBdsHECY6wuqhNW9yD5Pj
+x066iEFMckKKCNBP7gLX3rsrp4R5uWmvmK6lNqMgO4Xx8c3ae9xyxupUaS13fNzA
+inw5NNp7axLJm62llWMBOP+w2ZgQL4UmJDdxe5GI0q94ChHTU7uIr3DMOGAGWuoY
+zXLk8LeSwncgWn3CZZ4WpUxibNvhVG1pmZAbgeWB5GZboUMXd2a0Uyjq3EB2kYfx
+hPQYOp3obhEy1JtodmJHAlqYqG8vAgMBAAGjUzBRMB0GA1UdDgQWBBRB2mlHlpxU
+LohkBQ2NH8rRhV9hQDAfBgNVHSMEGDAWgBRB2mlHlpxULohkBQ2NH8rRhV9hQDAP
+BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCvghtILxg/BdFTS9ZA
+VarJrhSrEHSlJ2Bqp6v8BJmMpouU9heVhT24RdAx9nM46jZPem6Mt55ZQ+eyR7vK
+iC5T5yPWreaKEWnbS7YhxSTcLZOhMMZ4eah02f1lhYtiDF6u7p6zfY1HjZlJrbE4
+WNdOEcttJh8BTciSV2wuxD7iZNejN5L1wH+PATHTnuEuryksRhky4tOb7UiY7qkj
+M11jjUSojXBNqw754Na4vTz5hhjJo17NeB3hZw6N+r9flCGdTQZ4k02hx9+LbxcJ
+uVylGMusIXcohDauuPEBi/NXk0owHqF6uafjjW5lHK2CnsHKL8U0qHRdcKFJZ4Jx
+/gTV
+-----END CERTIFICATE-----`;
+
+const sanCert = new X509Certificate(sanPem);
+const cnOnlyCert = new X509Certificate(cnOnlyPem);
+
+function report(label: string, fn: () => unknown) {
+  try {
+    console.log(`${label}:`, fn());
+  } catch (err: any) {
+    console.log(`${label}:`, "err", err.name, err.code ?? "", err.message);
+  }
+}
+
+console.log("typeof checkHost:", typeof sanCert["checkHost"]);
+console.log("typeof checkEmail:", typeof sanCert["checkEmail"]);
+console.log("typeof checkIP:", typeof sanCert["checkIP"]);
+
+report("san host exact", () => sanCert["checkHost"]("perry-extension.test"));
+report("san host alt", () => sanCert["checkHost"]("www.perry-extension.test"));
+report("san host uppercase", () => sanCert["checkHost"]("PERRY-EXTENSION.TEST"));
+report("san host miss", () => sanCert["checkHost"]("missing.test"));
+
+report("san email exact", () => sanCert["checkEmail"]("admin@perry-extension.test"));
+report("san email uppercase", () => sanCert["checkEmail"]("ADMIN@PERRY-EXTENSION.TEST"));
+report("san email miss", () => sanCert["checkEmail"]("root@perry-extension.test"));
+
+report("san ip exact", () => sanCert["checkIP"]("127.0.0.1"));
+report("san ip miss", () => sanCert["checkIP"]("127.0.0.2"));
+
+report("cn host exact", () => cnOnlyCert["checkHost"]("perry.test"));
+report("cn host uppercase", () => cnOnlyCert["checkHost"]("PERRY.TEST"));
+report("cn host miss", () => cnOnlyCert["checkHost"]("www.perry.test"));
+
+report("checkHost missing", () => sanCert["checkHost"]());
+report("checkEmail missing", () => sanCert["checkEmail"]());
+report("checkIP missing", () => sanCert["checkIP"]());


### PR DESCRIPTION
## Summary

- Exposes bound `X509Certificate#checkHost()`, `checkEmail()`, and `checkIP()` on native X509 handles.
- Adds deterministic name matching for DNS SANs, CN fallback when no DNS SAN is present, RFC822 email SANs, and IP SANs.
- Validates each method's first argument as a JS string with Node-style `ERR_INVALID_ARG_TYPE` errors.
- Adds a focused Node 26 parity fixture for matching, non-matching, case behavior, CN fallback, IP matching, and missing-argument validation.

## Linked Issues

- Closes part of #2563

## Why This Cut

These methods share the same X509 certificate handle, SAN/CN decoding, native method binding, and dispatch paths. Keeping them together gives one coherent compatibility slice without mixing in separate certificate verification or legacy-object work.

## Tests

- `./run_parity_tests.sh --suite node-suite --module crypto --filter name-checks` with `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-x509-extension-metadata/target PERRY_NO_AUTO_OPTIMIZE=1` (pre-fix failure captured in `parity_report_20260603_122625.json`, post-fix pass in `parity_report_20260603_123136.json`)
- `./run_parity_tests.sh --suite node-suite --module crypto --filter x509` with the same environment (`parity_report_20260603_123150.json`)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known Limitations / Non-Goals

- Does not implement full wildcard/options/null-byte/invalid-IP error parity for these methods.
- Does not cover `verify()`, `checkIssued()`, `checkPrivateKey()`, `issuerCertificate`, `infoAccess`, or `toLegacyObject()`.
- Full `node:crypto` parity was not run; the full module is 223 fixtures and local disk was near capacity, so validation is focused on the affected X509 fixtures plus formatting/diff/file-size checks.
