### PR TITLE
[codex] honor raw use strict directives

### DIFF
--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -53,29 +53,15 @@ pub(crate) fn capture_function_source(
     ctx.closure_source_text.insert(func_id, src);
 }
 
-fn stmt_is_string_directive(stmt: &ast::Stmt) -> Option<&str> {
-    let ast::Stmt::Expr(expr_stmt) = stmt else {
-        return None;
-    };
-    let mut expr = expr_stmt.expr.as_ref();
-    while let ast::Expr::Paren(paren) = expr {
-        expr = paren.expr.as_ref();
-    }
-    let ast::Expr::Lit(ast::Lit::Str(s)) = expr else {
-        return None;
-    };
-    s.value.as_str()
-}
-
 fn block_has_use_strict(block: Option<&ast::BlockStmt>) -> bool {
     let Some(block) = block else {
         return false;
     };
     for stmt in &block.stmts {
-        let Some(directive) = stmt_is_string_directive(stmt) else {
+        let Some(directive) = super::string_directive_stmt_lit(stmt) else {
             break;
         };
-        if directive == "use strict" {
+        if super::is_raw_use_strict_directive(directive) {
             return true;
         }
     }

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -15,29 +15,15 @@ use swc_ecma_ast as ast;
 use super::*;
 use crate::ir::*;
 
-fn stmt_is_string_directive(stmt: &ast::Stmt) -> Option<&str> {
-    let ast::Stmt::Expr(expr_stmt) = stmt else {
-        return None;
-    };
-    let mut expr = expr_stmt.expr.as_ref();
-    while let ast::Expr::Paren(paren) = expr {
-        expr = paren.expr.as_ref();
-    }
-    let ast::Expr::Lit(ast::Lit::Str(s)) = expr else {
-        return None;
-    };
-    s.value.as_str()
-}
-
 fn module_has_strict_mode(ast_module: &ast::Module) -> bool {
     for item in &ast_module.body {
         match item {
             ast::ModuleItem::ModuleDecl(_) => return true,
             ast::ModuleItem::Stmt(stmt) => {
-                let Some(directive) = stmt_is_string_directive(stmt) else {
+                let Some(directive) = string_directive_stmt_lit(stmt) else {
                     break;
                 };
-                if directive == "use strict" {
+                if is_raw_use_strict_directive(directive) {
                     return true;
                 }
             }

--- a/crates/perry-hir/src/lower/misc.rs
+++ b/crates/perry-hir/src/lower/misc.rs
@@ -14,14 +14,27 @@ use swc_ecma_ast as ast;
 use super::*;
 use crate::ir::*;
 
-fn is_use_strict_directive_stmt(stmt: &ast::Stmt) -> Option<bool> {
+pub(crate) fn string_directive_stmt_lit(stmt: &ast::Stmt) -> Option<&ast::Str> {
     let ast::Stmt::Expr(expr_stmt) = stmt else {
         return None;
     };
     let ast::Expr::Lit(ast::Lit::Str(str_lit)) = expr_stmt.expr.as_ref() else {
         return None;
     };
-    Some(str_lit.value.as_str() == Some("use strict"))
+    Some(str_lit)
+}
+
+pub(crate) fn is_raw_use_strict_directive(str_lit: &ast::Str) -> bool {
+    // Directive recognition is based on the raw token text. The cooked string
+    // value would incorrectly treat escapes like "use\x20strict" as strict.
+    matches!(
+        str_lit.raw.as_ref().map(|raw| raw.as_ref()),
+        Some("\"use strict\"") | Some("'use strict'")
+    )
+}
+
+fn is_use_strict_directive_stmt(stmt: &ast::Stmt) -> Option<bool> {
+    string_directive_stmt_lit(stmt).map(is_raw_use_strict_directive)
 }
 
 pub(crate) fn stmt_list_starts_with_use_strict_directive(stmts: &[ast::Stmt]) -> bool {

--- a/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
@@ -1,28 +1,14 @@
 use super::*;
 
-fn stmt_is_string_directive(stmt: &ast::Stmt) -> Option<&str> {
-    let ast::Stmt::Expr(expr_stmt) = stmt else {
-        return None;
-    };
-    let mut expr = expr_stmt.expr.as_ref();
-    while let ast::Expr::Paren(paren) = expr {
-        expr = paren.expr.as_ref();
-    }
-    let ast::Expr::Lit(ast::Lit::Str(s)) = expr else {
-        return None;
-    };
-    s.value.as_str()
-}
-
 fn function_has_use_strict(func: &ast::Function) -> bool {
     let Some(block) = func.body.as_ref() else {
         return false;
     };
     for stmt in &block.stmts {
-        let Some(directive) = stmt_is_string_directive(stmt) else {
+        let Some(directive) = crate::lower::string_directive_stmt_lit(stmt) else {
             break;
         };
-        if directive == "use strict" {
+        if crate::lower::is_raw_use_strict_directive(directive) {
             return true;
         }
     }

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -14,29 +14,15 @@ use crate::lower_types::*;
 
 use super::*;
 
-fn stmt_is_string_directive(stmt: &ast::Stmt) -> Option<&str> {
-    let ast::Stmt::Expr(expr_stmt) = stmt else {
-        return None;
-    };
-    let mut expr = expr_stmt.expr.as_ref();
-    while let ast::Expr::Paren(paren) = expr {
-        expr = paren.expr.as_ref();
-    }
-    let ast::Expr::Lit(ast::Lit::Str(s)) = expr else {
-        return None;
-    };
-    s.value.as_str()
-}
-
 fn function_has_use_strict(func: &ast::Function) -> bool {
     let Some(block) = func.body.as_ref() else {
         return false;
     };
     for stmt in &block.stmts {
-        let Some(directive) = stmt_is_string_directive(stmt) else {
+        let Some(directive) = crate::lower::string_directive_stmt_lit(stmt) else {
             break;
         };
-        if directive == "use strict" {
+        if crate::lower::is_raw_use_strict_directive(directive) {
             return true;
         }
     }

--- a/crates/perry-hir/src/lower_decl/helpers.rs
+++ b/crates/perry-hir/src/lower_decl/helpers.rs
@@ -538,13 +538,10 @@ fn binding_pat_uses_arguments(pat: &ast::Pat) -> bool {
 
 pub fn body_has_use_strict(body: &[ast::Stmt]) -> bool {
     for stmt in body {
-        let ast::Stmt::Expr(expr_stmt) = stmt else {
+        let Some(directive) = crate::lower::string_directive_stmt_lit(stmt) else {
             return false;
         };
-        let ast::Expr::Lit(ast::Lit::Str(s)) = expr_stmt.expr.as_ref() else {
-            return false;
-        };
-        if s.value.as_str() == Some("use strict") {
+        if crate::lower::is_raw_use_strict_directive(directive) {
             return true;
         }
     }

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -391,6 +391,61 @@ fn sloppy_assignment_in_if_test_creates_storage_before_following_getvalue() {
 }
 
 #[test]
+fn strict_directive_recognition_requires_raw_use_strict_literal() {
+    let module = lower_js_src(
+        r#"
+        function exactDouble() { "use strict"; }
+        function exactSingle() { 'use strict'; }
+        function escapedHex() { "use\x20strict"; }
+        function escapedUnicode() { "use\u0020strict"; }
+        function doubleBackslash() { "use\\x20strict"; }
+        function trailing() { "use strict "; }
+        function parenthesized() { ("use strict"); }
+        function interrupted() { 0; "use strict"; }
+        function laterDirective() { "not strict"; "use strict"; }
+        "#,
+    );
+
+    let is_strict = |name: &str| function(&module, name).is_strict;
+    assert!(is_strict("exactDouble"));
+    assert!(is_strict("exactSingle"));
+    assert!(is_strict("laterDirective"));
+    assert!(!is_strict("escapedHex"));
+    assert!(!is_strict("escapedUnicode"));
+    assert!(!is_strict("doubleBackslash"));
+    assert!(!is_strict("trailing"));
+    assert!(!is_strict("parenthesized"));
+    assert!(!is_strict("interrupted"));
+}
+
+#[test]
+fn module_strictness_uses_raw_directive_tokens() {
+    let exact = lower_js_src(
+        r#"
+        "use strict";
+        function f() {}
+        "#,
+    );
+    assert!(function(&exact, "f").is_strict);
+
+    let escaped = lower_js_src(
+        r#"
+        "use\x20strict";
+        function f() {}
+        "#,
+    );
+    assert!(!function(&escaped, "f").is_strict);
+
+    let parenthesized = lower_js_src(
+        r#"
+        ("use strict");
+        function f() {}
+        "#,
+    );
+    assert!(!function(&parenthesized, "f").is_strict);
+}
+
+#[test]
 fn sloppy_js_yield_identifier_arrow_parameters_lower() {
     let module = lower_js_src(
         r#"

--- a/test-parity/node-suite/globals/strict-directive/package.json
+++ b/test-parity/node-suite/globals/strict-directive/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test-parity/node-suite/globals/strict-directive/strict-directive-raw.ts
+++ b/test-parity/node-suite/globals/strict-directive/strict-directive-raw.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+"use\x20strict";
+
+function show(label, value) {
+  console.log(label + ":" + String(value));
+}
+
+function exactDouble() {
+  "use strict";
+  return this === undefined;
+}
+
+function exactSingle() {
+  'use strict';
+  return this === undefined;
+}
+
+function escapedBody() {
+  "use\x20strict";
+  return this === globalThis;
+}
+
+function trailingBody() {
+  "use strict ";
+  return this === globalThis;
+}
+
+function parenthesizedBody() {
+  ("use strict");
+  return this === globalThis;
+}
+
+function interruptedBody() {
+  0;
+  "use strict";
+  return this === globalThis;
+}
+
+function nestedEscaped() {
+  function inner() {
+    "use\x20strict";
+    return this === globalThis;
+  }
+  return inner();
+}
+
+const exprExact = function () {
+  "use strict";
+  return this === undefined;
+};
+
+const exprEscaped = function () {
+  "use\x20strict";
+  return this === globalThis;
+};
+
+const arrowExact = () => {
+  "use strict";
+  return (function () {
+    return this === undefined;
+  })();
+};
+
+const arrowEscaped = () => {
+  "use\x20strict";
+  return (function () {
+    return this === globalThis;
+  })();
+};
+
+show("exact double strict", exactDouble());
+show("exact single strict", exactSingle());
+show("escaped body sloppy", escapedBody());
+show("trailing body sloppy", trailingBody());
+show("parenthesized body sloppy", parenthesizedBody());
+show("interrupted body sloppy", interruptedBody());
+show("nested escaped sloppy", nestedEscaped());
+show("expr exact strict", exprExact());
+show("expr escaped sloppy", exprEscaped());
+show("arrow exact strict", arrowExact());
+show("arrow escaped sloppy", arrowEscaped());


### PR DESCRIPTION
## Summary
- centralize directive-prologue string literal detection in HIR
- recognize `"use strict"` and `'use strict'` only from the raw string token, not the cooked value
- stop treating parenthesized string expressions as directives
- add HIR unit coverage and a CommonJS Node parity fixture for escaped, trailing-space, parenthesized, interrupted, nested, function-expression, and arrow strictness cases

## Root cause
Perry compared SWC's cooked `Str.value` against `use strict` in several lowering paths. That misclassified escaped literals like `"use\x20strict"` / `"use\u0020strict"` as strict directives, and some helper copies also unwrapped parentheses even though `("use strict")` is not a directive-prologue item.

## Scope
Refs #3570. This PR covers the raw directive-prologue recognition slice. Parser-level reserved-word cases from #3570 still fail before HIR lowering and are intentionally left for a separate parser-focused change.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/strict-directive/strict-directive-raw.ts`
- Pre-fix baseline proof failed on `origin/main`: `/root/perry-worktrees/perry-node-strict-directive-raw-base/test-parity/reports/parity_report_20260603_131734.json`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-strict-directive-raw/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter strict-directive-raw'` -> `/root/perry-worktrees/perry-node-strict-directive-raw/test-parity/reports/parity_report_20260603_132157.json`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-strict-directive-raw/target cargo test --release -p perry-hir strict_directive -- --nocapture`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-strict-directive-raw/target cargo test --release -p perry-hir module_strictness_uses_raw_directive_tokens -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-strict-directive-raw/target cargo check --release -p perry-hir`