### PR TITLE
[codex] add deterministic Atomics wait notify

### DIFF
--- a/crates/perry-codegen/src/lower_call/atomics.rs
+++ b/crates/perry-codegen/src/lower_call/atomics.rs
@@ -29,6 +29,7 @@ pub fn try_lower_atomics_static_call(
 
     let (runtime_fn, arity) = match property.as_str() {
         "load" => ("js_atomics_load", 2),
+        "isLockFree" => ("js_atomics_is_lock_free", 1),
         "store" => ("js_atomics_store", 3),
         "add" => ("js_atomics_add", 3),
         "sub" => ("js_atomics_sub", 3),
@@ -37,6 +38,8 @@ pub fn try_lower_atomics_static_call(
         "xor" => ("js_atomics_xor", 3),
         "exchange" => ("js_atomics_exchange", 3),
         "compareExchange" => ("js_atomics_compare_exchange", 4),
+        "notify" => ("js_atomics_notify", 3),
+        "wait" => ("js_atomics_wait", 4),
         _ => return Ok(None),
     };
 

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1547,6 +1547,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
 
     // ========== Atomics ==========
     module.declare_function("js_atomics_load", DOUBLE, &[PTR, DOUBLE, DOUBLE]);
+    module.declare_function("js_atomics_is_lock_free", DOUBLE, &[PTR, DOUBLE]);
     module.declare_function("js_atomics_store", DOUBLE, &[PTR, DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_atomics_add", DOUBLE, &[PTR, DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_atomics_sub", DOUBLE, &[PTR, DOUBLE, DOUBLE, DOUBLE]);
@@ -1560,6 +1561,12 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     );
     module.declare_function(
         "js_atomics_compare_exchange",
+        DOUBLE,
+        &[PTR, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
+    module.declare_function("js_atomics_notify", DOUBLE, &[PTR, DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_atomics_wait",
         DOUBLE,
         &[PTR, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -303,6 +303,7 @@ pub(crate) fn is_builtin_static_function_member(namespace: &str, member: &str) -
         "Atomics" => matches!(
             member,
             "load"
+                | "isLockFree"
                 | "store"
                 | "add"
                 | "sub"
@@ -311,6 +312,8 @@ pub(crate) fn is_builtin_static_function_member(namespace: &str, member: &str) -
                 | "xor"
                 | "exchange"
                 | "compareExchange"
+                | "notify"
+                | "wait"
         ),
         "WebAssembly" => matches!(
             member,
@@ -426,8 +429,11 @@ pub(crate) fn builtin_static_function_length(namespace: &str, member: &str) -> O
         },
         "Atomics" => match member {
             "load" => 2,
+            "isLockFree" => 1,
             "store" | "add" | "sub" | "and" | "or" | "xor" | "exchange" => 3,
             "compareExchange" => 4,
+            "notify" => 3,
+            "wait" => 4,
             _ => return None,
         },
         "WebAssembly" => match member {

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -270,7 +270,18 @@ pub(crate) fn is_known_json_static_method(name: &str) -> bool {
 pub(crate) fn is_known_atomics_static_method(name: &str) -> bool {
     matches!(
         name,
-        "load" | "store" | "add" | "sub" | "and" | "or" | "xor" | "exchange" | "compareExchange"
+        "load"
+            | "isLockFree"
+            | "store"
+            | "add"
+            | "sub"
+            | "and"
+            | "or"
+            | "xor"
+            | "exchange"
+            | "compareExchange"
+            | "notify"
+            | "wait"
     )
 }
 

--- a/crates/perry-runtime/src/atomics.rs
+++ b/crates/perry-runtime/src/atomics.rs
@@ -8,6 +8,15 @@ use crate::typedarray::{
 };
 use crate::value::JSValue;
 
+fn nanbox_bool(value: bool) -> f64 {
+    f64::from_bits(JSValue::bool(value).bits())
+}
+
+fn string_value(bytes: &[u8]) -> f64 {
+    let ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    crate::value::js_nanbox_string(ptr as i64)
+}
+
 fn throw_type_error(message: &[u8]) -> ! {
     let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = crate::error::js_typeerror_new(msg);
@@ -94,6 +103,24 @@ fn atomics_view_arg(value: f64) -> AtomicView {
     throw_type_error(b"Atomics operation requires an integer typed array");
 }
 
+fn atomics_int32_view_arg(value: f64) -> AtomicView {
+    let js = JSValue::from_bits(value.to_bits());
+    if !js.is_pointer() {
+        throw_type_error(b"Atomics wait/notify requires an Int32Array");
+    }
+    let raw = clean_ta_ptr(js.as_pointer::<TypedArrayHeader>()) as usize;
+    if raw == 0 {
+        throw_type_error(b"Atomics wait/notify requires an Int32Array");
+    }
+    if lookup_typed_array_kind(raw) == Some(KIND_INT32) {
+        return AtomicView::TypedArray {
+            ptr: raw as *mut TypedArrayHeader,
+            kind: KIND_INT32,
+        };
+    }
+    throw_type_error(b"Atomics wait/notify requires an Int32Array");
+}
+
 fn atomics_to_index(index: f64, length: i32) -> i32 {
     let mut n = JSValue::from_bits(index.to_bits()).to_number();
     if n.is_nan() {
@@ -109,9 +136,9 @@ fn atomics_to_index(index: f64, length: i32) -> i32 {
     i as i32
 }
 
-fn numeric_arg(value: f64) -> f64 {
+fn number_arg(value: f64) -> f64 {
     let js = JSValue::from_bits(value.to_bits());
-    let n = if js.is_any_string() {
+    if js.is_any_string() {
         let ptr = crate::value::js_get_string_pointer_unified(value)
             as *const crate::string::StringHeader;
         if ptr.is_null() {
@@ -121,15 +148,23 @@ fn numeric_arg(value: f64) -> f64 {
                 let len = (*ptr).byte_len as usize;
                 let data =
                     (ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
-                std::str::from_utf8(std::slice::from_raw_parts(data, len))
-                    .ok()
-                    .and_then(|s| s.trim().parse::<f64>().ok())
-                    .unwrap_or(f64::NAN)
+                match std::str::from_utf8(std::slice::from_raw_parts(data, len)) {
+                    Ok(s) => match s.trim() {
+                        "Infinity" | "+Infinity" => f64::INFINITY,
+                        "-Infinity" => f64::NEG_INFINITY,
+                        other => other.parse::<f64>().unwrap_or(f64::NAN),
+                    },
+                    Err(_) => f64::NAN,
+                }
             }
         }
     } else {
         js.to_number()
-    };
+    }
+}
+
+fn numeric_arg(value: f64) -> f64 {
+    let n = number_arg(value);
     if n.is_finite() {
         n.trunc()
     } else {
@@ -172,6 +207,12 @@ fn slot(view: f64, index: f64) -> (AtomicView, i32) {
     (view, idx)
 }
 
+fn int32_slot(view: f64, index: f64) -> (AtomicView, i32) {
+    let view = atomics_int32_view_arg(view);
+    let idx = atomics_to_index(index, view.length());
+    (view, idx)
+}
+
 fn atomics_bitwise(view: f64, index: f64, value: f64, op: impl FnOnce(u32, u32) -> u32) -> f64 {
     let (view, idx) = slot(view, index);
     let kind = view.kind();
@@ -185,6 +226,12 @@ fn atomics_bitwise(view: f64, index: f64, value: f64, op: impl FnOnce(u32, u32) 
 pub extern "C" fn js_atomics_load(_closure: *const ClosureHeader, view: f64, index: f64) -> f64 {
     let (view, idx) = slot(view, index);
     view.get(idx)
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_is_lock_free(_closure: *const ClosureHeader, size: f64) -> f64 {
+    let n = number_arg(size);
+    nanbox_bool(n.is_finite() && n.trunc() == n && matches!(n as i32, 1 | 2 | 4 | 8))
 }
 
 #[no_mangle]
@@ -288,4 +335,34 @@ pub extern "C" fn js_atomics_compare_exchange(
         view.set(idx, coerce_for_kind(view.kind(), replacement));
     }
     previous
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_notify(
+    _closure: *const ClosureHeader,
+    view: f64,
+    index: f64,
+    count: f64,
+) -> f64 {
+    let (_view, _idx) = int32_slot(view, index);
+    let _ = numeric_arg(count);
+    0.0
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_wait(
+    _closure: *const ClosureHeader,
+    view: f64,
+    index: f64,
+    expected: f64,
+    timeout: f64,
+) -> f64 {
+    let (view, idx) = int32_slot(view, index);
+    let expected = coerce_for_kind(KIND_INT32, expected);
+    if view.get(idx) != expected {
+        return string_value(b"not-equal");
+    }
+
+    let _ = number_arg(timeout);
+    string_value(b"timed-out")
 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3365,6 +3365,11 @@ fn install_reflect_namespace_members(ns_obj: *mut ObjectHeader) {
 fn install_atomics_namespace_members(ns_obj: *mut ObjectHeader) {
     for (name, func_ptr, arity) in [
         ("load", crate::atomics::js_atomics_load as *const u8, 2),
+        (
+            "isLockFree",
+            crate::atomics::js_atomics_is_lock_free as *const u8,
+            1,
+        ),
         ("store", crate::atomics::js_atomics_store as *const u8, 3),
         ("add", crate::atomics::js_atomics_add as *const u8, 3),
         ("sub", crate::atomics::js_atomics_sub as *const u8, 3),
@@ -3381,6 +3386,8 @@ fn install_atomics_namespace_members(ns_obj: *mut ObjectHeader) {
             crate::atomics::js_atomics_compare_exchange as *const u8,
             4,
         ),
+        ("notify", crate::atomics::js_atomics_notify as *const u8, 3),
+        ("wait", crate::atomics::js_atomics_wait as *const u8, 4),
     ] {
         install_proto_method(ns_obj, name, func_ptr, arity);
     }

--- a/test-parity/node-suite/globals/atomics-wait-notify.ts
+++ b/test-parity/node-suite/globals/atomics-wait-notify.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+function show(label, value) {
+  console.log(label + ":" + String(value));
+}
+
+function showErr(label, fn) {
+  try {
+    show(label, fn());
+  } catch (err) {
+    console.log(label + ":" + err.name);
+  }
+}
+
+show("typeof isLockFree", typeof Atomics.isLockFree);
+show("typeof wait", typeof Atomics.wait);
+show("typeof notify", typeof Atomics.notify);
+show("isLockFree length", Atomics.isLockFree.length);
+show("wait length", Atomics.wait.length);
+show("notify length", Atomics.notify.length);
+
+for (const value of [undefined, NaN, -1, 0, 1, 2, 3, 4, 8, 16, "4", 4.9, Infinity]) {
+  show("isLockFree " + String(value), Atomics.isLockFree(value));
+}
+
+const sab = new SharedArrayBuffer(16);
+const i32 = new Int32Array(sab);
+
+show("wait not equal", Atomics.wait(i32, 0, 1, 0));
+show("wait zero timeout", Atomics.wait(i32, 0, 0, 0));
+show("wait negative timeout", Atomics.wait(i32, 0, 0, -1));
+show("notify default", Atomics.notify(i32, 0));
+show("notify zero", Atomics.notify(i32, 0, 0));
+show("notify string count", Atomics.notify(i32, 0, "2"));
+
+showErr("wait uint8 shared", () => Atomics.wait(new Uint8Array(sab), 0, 0, 0));
+showErr("notify uint8 shared", () => Atomics.notify(new Uint8Array(sab), 0));
+showErr("wait oob", () => Atomics.wait(i32, 99, 0, 0));
+showErr("notify oob", () => Atomics.notify(i32, 99));


### PR DESCRIPTION
Part of #2876.

## What changed
- Added `Atomics.isLockFree`, `Atomics.notify`, and deterministic nonblocking `Atomics.wait` runtime entry points for Int32 typed-array views.
- Wired the new Atomics methods into static-call lowering, FFI declarations, namespace installation, `typeof` recognition, and `.length` metadata.
- Added a Node-suite fixture for method presence/lengths, lock-free size results, immediate `wait` outcomes, no-waiter `notify`, Int32-only validation, and index range errors.

## Scope
This keeps the slice intentionally deterministic: `notify` reports zero waiters and `wait` covers immediate `not-equal` / `timed-out` paths. Full waiter queues, `waitAsync`, and BigInt Atomics remain out of scope.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/atomics-wait-notify.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-atomics-wait-notify/target cargo check -p perry-runtime -p perry-codegen -p perry-hir`
- `cargo fmt --all -- --check`
- `git diff --cached --check`
- `./scripts/check_file_size.sh`

Not completed locally: the focused parity runner release build was terminated before fixture execution, and a follow-up debug binary build was also terminated before producing `target/debug/perry`.