### PR TITLE
fix(inline): #945 restore scalar method inlining for PutValueSet constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1113 — fix(inline): #945 restore scalar method inlining for PutValueSet constructors
+
+#4126 ("assignment PutValue descriptor semantics") changed `this.field = x`
+constructor stores to lower as `Expr::PutValueSet` instead of
+`Expr::PropertySet`. Three scalar-replacement / escape analyses only
+special-cased `PropertySet{object:This}`, so **every class whose constructor
+assigns a field** was treated as method-shadowing / `this`-escaping. That
+broadly disabled both method inlining and scalar replacement: the
+`run_issue_945_scalar_method_ir_guard.sh` compile-smoke guard regressed (a
+trivial `new C(); obj.getValue()` allocated + dispatched instead of folding to
+a scalar field read), and a large batch of parity tests regressed with it.
+
+Fixes, all mirroring the existing `PropertySet{object:This}` handling:
+- `perry-transform/src/inline/analysis.rs`
+  `construction_expr_can_affect_method_lookup`: add a `PutValueSet{target:This}`
+  arm so a plain field store isn't treated as a method-lookup shadow (restores
+  `method_lookup_safe = true`).
+- `perry-codegen/src/collectors/this_as_value.rs` `expr_uses_this_as_value`: add
+  a `PutValueSet` arm (target+receiver = `This`, string key) so a field store
+  isn't counted as materializing `this` as a value (restores non-escaping
+  scalar replacement).
+- `perry-transform/src/inline/exact_receivers.rs`
+  `invalidate_exact_receivers_for_expr`: add `PutValueSet` to the
+  fact-invalidating write set so an `obj.method = X` override at a use site
+  still suppresses inlining of the overridden method (#945 unsafe variants).
+
+`collectors/escape_check.rs` already grew a `PutValueSet` arm in #4126, so no
+change was needed there. Also tags two doc-example fences with `,no-test`
+(`getting-started/project-config.md`, `ui/on-frame.md`) so the repo-wide
+markdown-fence doc lint passes.
+
 ## v0.5.1112 — release: cut v0.5.1112
 
 Distribution release tagging the accumulated work since `v0.5.1028` (1198

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1112
+**Current Version:** 0.5.1113
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5022,7 +5022,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,14 +5077,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "cc",
  "libc",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "log",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "base64",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "serde",
  "serde_json",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1112"
+version = "0.5.1113"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "clap",
@@ -5227,14 +5227,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "chrono",
  "cron",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5333,14 +5333,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "bytes",
  "h2",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "bson",
  "futures-util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "image",
@@ -5527,14 +5527,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "brotli",
  "flate2",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "base64",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5749,14 +5749,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "itoa",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "block2",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "block2",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1112"
+version = "0.5.1113"
 
 [[package]]
 name = "perry-ui-test"
@@ -5845,11 +5845,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1112"
+version = "0.5.1113"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "block2",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "block2",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "block2",
  "libc",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "libc",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1112"
+version = "0.5.1113"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1112"
+version = "0.5.1113"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/collectors/this_as_value.rs
+++ b/crates/perry-codegen/src/collectors/this_as_value.rs
@@ -228,6 +228,41 @@ pub fn expr_uses_this_as_value(e: &perry_hir::Expr, fields: &HashSet<String>) ->
             };
             obj_unsafe || expr_uses_this_as_value(value, fields)
         }
+        // #4126 lowers `this.field = x` ctor stores as `PutValueSet` (with
+        // `target` and `receiver` both `Expr::This`) instead of `PropertySet`.
+        // Mirror the `PropertySet { object: This }` rule: a plain field store
+        // is the safe, scalar-replaceable pattern — only a `this.<method>`
+        // write or a `this` materialized in the value counts as this-as-value.
+        // Without this, every field-assigning constructor marks its class as
+        // using `this` as a value, forcing all instances onto the heap path
+        // (regressed scalar replacement / #945).
+        Expr::PutValueSet {
+            target,
+            key,
+            value,
+            receiver,
+            ..
+        } => {
+            let target_unsafe = if matches!(target.as_ref(), Expr::This) {
+                match key.as_ref() {
+                    Expr::String(property) => !fields.contains(property),
+                    // Computed/dynamic key — can't prove it's a plain field.
+                    _ => true,
+                }
+            } else {
+                expr_uses_this_as_value(target, fields)
+            };
+            // For an ordinary `this.f = v` store the receiver mirrors the
+            // (safe) `This` target; don't double-count it as this-as-value.
+            let receiver_unsafe = if matches!(target.as_ref(), Expr::This)
+                && matches!(receiver.as_ref(), Expr::This)
+            {
+                false
+            } else {
+                expr_uses_this_as_value(receiver, fields)
+            };
+            target_unsafe || receiver_unsafe || expr_uses_this_as_value(value, fields)
+        }
         Expr::PropertyUpdate {
             object, property, ..
         } => {

--- a/crates/perry-transform/src/inline/analysis.rs
+++ b/crates/perry-transform/src/inline/analysis.rs
@@ -442,6 +442,32 @@ pub fn construction_expr_can_affect_method_lookup(
                     setter_names,
                 )
         }
+        // #4126 changed `this.field = x` ctor assignments to lower as
+        // `PutValueSet` (PutValue descriptor semantics) instead of
+        // `PropertySet`. Mirror the `PropertySet { object: This }` arm so a
+        // plain field store doesn't get treated as a method-lookup shadow —
+        // otherwise every class whose constructor assigns a field disables
+        // method inlining + scalar replacement (regressed #945).
+        Expr::PutValueSet {
+            target, key, value, ..
+        } if matches!(target.as_ref(), Expr::This) => {
+            match key.as_ref() {
+                Expr::String(k) => {
+                    k == method_name
+                        || setter_names.contains(k)
+                        || construction_expr_can_affect_method_lookup(
+                            value,
+                            method_name,
+                            data_fields,
+                            getter_names,
+                            setter_names,
+                        )
+                }
+                // Computed/dynamic key — can't prove which property is
+                // written, so conservatively treat it as lookup-affecting.
+                _ => true,
+            }
+        }
         Expr::LocalSet(_, value) => construction_expr_can_affect_method_lookup(
             value,
             method_name,

--- a/crates/perry-transform/src/inline/exact_receivers.rs
+++ b/crates/perry-transform/src/inline/exact_receivers.rs
@@ -112,6 +112,11 @@ pub fn invalidate_exact_receivers_for_expr(expr: &Expr, facts: &mut ExactReceive
         | Expr::NewDynamic { .. }
         | Expr::ObjectAssign { .. }
         | Expr::PropertySet { .. }
+        // #4126 lowers property assignments as `PutValueSet`; an
+        // `obj.method = X` write at a use site must invalidate the
+        // exact-receiver facts (same as PropertySet) so a subsequently
+        // overridden method isn't wrongly inlined (#945 unsafe variants).
+        | Expr::PutValueSet { .. }
         | Expr::PropertyUpdate { .. }
         | Expr::IndexSet { .. }
         | Expr::IndexUpdate { .. }

--- a/docs/src/getting-started/project-config.md
+++ b/docs/src/getting-started/project-config.md
@@ -93,7 +93,7 @@ writeFileSync(new URL("../generated/validator.cjs", import.meta.url), moduleCode
 
 Then import the generated validator like any other module:
 
-```ts
+```ts,no-test
 import validate from "./generated/validator.cjs";
 if (!validate(input)) throw new Error("invalid config");
 ```

--- a/docs/src/ui/on-frame.md
+++ b/docs/src/ui/on-frame.md
@@ -6,7 +6,7 @@ real-time data visualizations, or custom `Canvas` transitions — where you
 need a frame-aligned tick with an accurate timestamp instead of
 `setInterval(cb, 16)`.
 
-```typescript
+```typescript,no-test
 import { onFrame, cancelFrame } from "perry/ui";
 
 function loop(timestampMs: number, deltaMs: number) {


### PR DESCRIPTION
## Problem

`#4126` ("assignment PutValue descriptor semantics") changed `this.field = x`
constructor stores to lower as `Expr::PutValueSet` instead of `Expr::PropertySet`.
Three scalar-replacement / escape analyses only special-cased
`PropertySet{object:This}`, so **every class whose constructor assigns a field**
was treated as method-shadowing / `this`-escaping — broadly disabling method
inlining *and* scalar replacement.

Symptoms:
- The tag-gated `compile-smoke` job's `run_issue_945_scalar_method_ir_guard.sh`
  regressed: a trivial `new C(); obj.getValue()` allocated + dispatched instead
  of folding to a scalar field read.
- A batch of parity tests regressed alongside it.

## Fix

All three mirror the existing `PropertySet{object:This}` handling:

- **`inline/analysis.rs`** `construction_expr_can_affect_method_lookup`: add a
  `PutValueSet{target:This}` arm so a plain field store isn't a method-lookup
  shadow (restores `method_lookup_safe = true`).
- **`collectors/this_as_value.rs`** `expr_uses_this_as_value`: add a `PutValueSet`
  arm (target+receiver = `This`, string key) so a field store isn't counted as
  materializing `this` as a value (restores non-escaping scalar replacement).
- **`inline/exact_receivers.rs`** `invalidate_exact_receivers_for_expr`: add
  `PutValueSet` to the fact-invalidating write set so an `obj.method = X`
  override at a use site still suppresses inlining of the overridden method
  (the #945 *unsafe* variants).

`collectors/escape_check.rs` already grew a `PutValueSet` arm in #4126, so no
change was needed there.

Also tags two doc-example fences with `,no-test` so the repo-wide markdown-fence
doc lint passes.

## Verification

- `run_issue_945_scalar_method_ir_guard.sh` → **PASS** (both safe + unsafe variants).
- Doc-fence lint → **clean**.
- Full local parity sweep: this fix **clears ~40 previously-failing parity tests**
  with **no regressions** (the two suspected regressions were A/B-verified as
  pre-existing on `main`).
