### PR TITLE
[codex] honor child_process timeout killSignal

### DIFF
--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -18,6 +18,7 @@
 
 use super::*;
 use std::process::Command;
+use std::time::Duration;
 
 /// `child_process.fork(modulePath[, args][, options])`. `module_ptr`/`args_ptr`
 /// are raw (unboxed) `StringHeader` / `ArrayHeader` pointers; `opts_ptr` is a
@@ -66,6 +67,8 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     let stderr_obj = cp_build_readable();
     let stdin_obj = cp_build_writable();
     let stdio_kinds = cp_read_stdio(opts_val, 3);
+    let timeout = cp_read_timeout(opts_val);
+    let kill_signal = cp_read_kill_signal(opts_val);
 
     // spawnargs = [argv0 ?? execPath, ...execArgv, module, ...args] (matches Node).
     let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + exec_argv.len() + 2) as u32);
@@ -128,7 +131,16 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     cp_apply_options(&mut command, opts_val);
     cp_apply_live_stdio(&mut command, &stdio_kinds);
 
-    let launched = fork_launch(cp, stdout_obj, stderr_obj, stdin_obj, command, advanced);
+    let launched = fork_launch(
+        cp,
+        stdout_obj,
+        stderr_obj,
+        stdin_obj,
+        command,
+        advanced,
+        timeout,
+        kill_signal,
+    );
     if !launched {
         // Spawn failure: emit a deferred `error`, leave `connected` false.
         let msg = format!("fork failed: {exec_path}");
@@ -158,6 +170,8 @@ fn fork_launch(
     stdin_obj: f64,
     mut command: Command,
     advanced: bool,
+    timeout: Option<Duration>,
+    kill_signal: i32,
 ) -> bool {
     use std::os::unix::io::AsRawFd;
     use std::os::unix::net::UnixStream;
@@ -203,6 +217,8 @@ fn fork_launch(
                 child,
                 Some(parent_sock),
                 advanced,
+                timeout,
+                kill_signal,
             );
             true
         }
@@ -218,12 +234,22 @@ fn fork_launch(
     stdin_obj: f64,
     mut command: Command,
     advanced: bool,
+    timeout: Option<Duration>,
+    kill_signal: i32,
 ) -> bool {
     let _ = advanced;
     match command.spawn() {
         Ok(child) => {
             reactor::cp_register_live_child(
-                cp, stdout_obj, stderr_obj, stdin_obj, child, None, false,
+                cp,
+                stdout_obj,
+                stderr_obj,
+                stdin_obj,
+                child,
+                None,
+                false,
+                timeout,
+                kill_signal,
             );
             true
         }

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -800,7 +800,34 @@ fn cp_emit(target: f64, event: &str, args: &[f64]) -> bool {
     fired
 }
 
-fn cp_signal_name(sig: i32) -> &'static str {
+pub(super) const CP_SIGTERM: i32 = 15;
+
+#[cfg(unix)]
+pub(super) fn cp_signal_name(sig: i32) -> &'static str {
+    match sig {
+        x if x == libc::SIGHUP => "SIGHUP",
+        x if x == libc::SIGINT => "SIGINT",
+        x if x == libc::SIGQUIT => "SIGQUIT",
+        x if x == libc::SIGILL => "SIGILL",
+        x if x == libc::SIGTRAP => "SIGTRAP",
+        x if x == libc::SIGABRT => "SIGABRT",
+        x if x == libc::SIGBUS => "SIGBUS",
+        x if x == libc::SIGFPE => "SIGFPE",
+        x if x == libc::SIGKILL => "SIGKILL",
+        x if x == libc::SIGUSR1 => "SIGUSR1",
+        x if x == libc::SIGSEGV => "SIGSEGV",
+        x if x == libc::SIGUSR2 => "SIGUSR2",
+        x if x == libc::SIGPIPE => "SIGPIPE",
+        x if x == libc::SIGALRM => "SIGALRM",
+        x if x == libc::SIGTERM => "SIGTERM",
+        x if x == libc::SIGSTOP => "SIGSTOP",
+        x if x == libc::SIGCONT => "SIGCONT",
+        _ => "SIGTERM",
+    }
+}
+
+#[cfg(not(unix))]
+pub(super) fn cp_signal_name(sig: i32) -> &'static str {
     match sig {
         1 => "SIGHUP",
         2 => "SIGINT",
@@ -809,6 +836,74 @@ fn cp_signal_name(sig: i32) -> &'static str {
         11 => "SIGSEGV",
         15 => "SIGTERM",
         _ => "SIGTERM",
+    }
+}
+
+#[cfg(unix)]
+pub(super) fn cp_signal_number(name: &str) -> Option<i32> {
+    Some(match name {
+        "SIGHUP" => libc::SIGHUP,
+        "SIGINT" => libc::SIGINT,
+        "SIGQUIT" => libc::SIGQUIT,
+        "SIGILL" => libc::SIGILL,
+        "SIGTRAP" => libc::SIGTRAP,
+        "SIGABRT" => libc::SIGABRT,
+        "SIGBUS" => libc::SIGBUS,
+        "SIGFPE" => libc::SIGFPE,
+        "SIGKILL" => libc::SIGKILL,
+        "SIGUSR1" => libc::SIGUSR1,
+        "SIGSEGV" => libc::SIGSEGV,
+        "SIGUSR2" => libc::SIGUSR2,
+        "SIGPIPE" => libc::SIGPIPE,
+        "SIGALRM" => libc::SIGALRM,
+        "SIGTERM" => libc::SIGTERM,
+        "SIGSTOP" => libc::SIGSTOP,
+        "SIGCONT" => libc::SIGCONT,
+        _ => return None,
+    })
+}
+
+#[cfg(not(unix))]
+pub(super) fn cp_signal_number(_name: &str) -> Option<i32> {
+    None
+}
+
+pub(super) fn cp_signal_from_value(signal: f64) -> i32 {
+    let js = JSValue::from_bits(signal.to_bits());
+    if js.is_undefined() || js.is_null() {
+        return CP_SIGTERM;
+    }
+    if let Some(name) = cp_value_to_string(signal) {
+        return cp_signal_number(&name).unwrap_or(CP_SIGTERM);
+    }
+    if signal.is_finite() {
+        let n = signal as i32;
+        return if n == 0 { CP_SIGTERM } else { n };
+    }
+    CP_SIGTERM
+}
+
+pub(super) fn cp_read_kill_signal(opts_val: f64) -> i32 {
+    if cp_object_ptr(opts_val).is_none() {
+        return CP_SIGTERM;
+    }
+    cp_signal_from_value(cp_get_field(opts_val, b"killSignal"))
+}
+
+pub(super) fn cp_read_timeout(opts_val: f64) -> Option<std::time::Duration> {
+    if cp_object_ptr(opts_val).is_none() {
+        return None;
+    }
+    let value = cp_get_field(opts_val, b"timeout");
+    let js = JSValue::from_bits(value.to_bits());
+    if js.is_undefined() || js.is_null() {
+        return None;
+    }
+    let timeout = js.to_number();
+    if timeout.is_finite() && timeout > 0.0 {
+        Some(std::time::Duration::from_millis(timeout as u64))
+    } else {
+        None
     }
 }
 

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -31,6 +31,7 @@ use std::io::{Read, Write};
 use std::process::{Child, ChildStdin};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, PoisonError};
+use std::time::Duration;
 
 // Brings in the `cp_*` helpers, `CpFn`, `CP_SHAPE_ID`, the `TAG_*` consts, and
 // (since this is a descendant module) `mod.rs`'s `use` bindings such as
@@ -76,6 +77,9 @@ enum CpEvent {
     /// #1933: the IPC channel closed (child disconnected or exited) — flip
     /// `connected`/`channel` and emit `'disconnect'`.
     IpcClosed { handle: u64 },
+    /// Timeout expired; terminate the live child with this signal on the main
+    /// thread so JS-visible `killed` is updated with the same event ordering.
+    Timeout { handle: u64, signal: i32 },
 }
 
 static CP_EVENT_QUEUE: Mutex<Vec<CpEvent>> = Mutex::new(Vec::new());
@@ -177,6 +181,13 @@ fn cp_spawn_waiter(handle: u64, mut child: Child) {
     });
 }
 
+fn cp_spawn_timeout(handle: u64, timeout: Duration, signal: i32) {
+    std::thread::spawn(move || {
+        std::thread::sleep(timeout);
+        cp_push_event(CpEvent::Timeout { handle, signal });
+    });
+}
+
 /// IPC reader (#1933): read newline-delimited JSON from the parent socket and
 /// push each line for main-thread parse + `'message'` delivery. For
 /// `serialization: 'advanced'` (#2130) the framing is instead a 4-byte
@@ -256,6 +267,8 @@ pub(super) fn cp_register_live_child(
     mut child: Child,
     ipc: Option<IpcStream>,
     ipc_advanced: bool,
+    timeout: Option<Duration>,
+    kill_signal: i32,
 ) -> u64 {
     let pid = child.id();
     cp_set_field(cp, b"pid", pid as f64);
@@ -311,6 +324,9 @@ pub(super) fn cp_register_live_child(
         cp_spawn_reader(handle, e, true);
     }
     cp_spawn_waiter(handle, child);
+    if let Some(timeout) = timeout {
+        cp_spawn_timeout(handle, timeout, kill_signal);
+    }
     #[cfg(unix)]
     {
         if let Some(sock) = ipc {
@@ -438,6 +454,8 @@ pub extern "C" fn js_child_process_spawn_streams(
     let stderr_obj = cp_build_readable();
     let stdin_obj = cp_build_writable();
     let stdio_kinds = cp_read_stdio(opts_val, 3);
+    let timeout = cp_read_timeout(opts_val);
+    let kill_signal = cp_read_kill_signal(opts_val);
 
     // spawnargs = [argv0 ?? command, ...args]
     let mut spawnargs = crate::array::js_array_alloc((arg_strs.len() + 1) as u32);
@@ -490,7 +508,17 @@ pub extern "C" fn js_child_process_spawn_streams(
 
     match command.spawn() {
         Ok(child) => {
-            cp_register_live_child(cp, stdout_obj, stderr_obj, stdin_obj, child, None, false);
+            cp_register_live_child(
+                cp,
+                stdout_obj,
+                stderr_obj,
+                stdin_obj,
+                child,
+                None,
+                false,
+                timeout,
+                kill_signal,
+            );
         }
         Err(e) => {
             // Spawn failure (e.g. ENOENT): Node emits a single `error` event and
@@ -656,6 +684,11 @@ fn cp_reactor_pump_inner() {
                     }
                 }
             }
+            CpEvent::Timeout { handle, signal } => {
+                if let Some(cp_bits) = cp_live_kill_signum(handle, signal) {
+                    cp_set_field(f64::from_bits(cp_bits), b"killed", TAG_TRUE_F64);
+                }
+            }
         }
     }
 
@@ -739,66 +772,36 @@ pub(super) fn cp_live_stdin_close(handle: u64) {
     }
 }
 
+fn cp_live_kill_signum(handle: u64, signum: i32) -> Option<u64> {
+    let (pid, cp_bits) = {
+        let guard = cp_live_lock();
+        match guard.as_ref().and_then(|map| map.get(&handle)) {
+            // Skip if already reaped — the pid may have been recycled by the OS.
+            Some(lc) if lc.exited.is_none() => (lc.pid, lc.cp_bits),
+            _ => return None,
+        }
+    };
+    #[cfg(unix)]
+    {
+        if unsafe { libc::kill(pid, signum) == 0 } {
+            Some(cp_bits)
+        } else {
+            None
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (pid, signum, cp_bits);
+        None
+    }
+}
+
 /// Signal a live child. `signal` is the JS `kill([signal])` argument (a signal
 /// name string, a number, or — for the no-arg / default case — undefined or the
 /// `0.0` arg-padding, both treated as `SIGTERM`). Returns whether the signal
 /// was delivered.
 pub(super) fn cp_live_kill(handle: u64, signal: f64) -> bool {
-    let pid = {
-        let guard = cp_live_lock();
-        match guard.as_ref().and_then(|map| map.get(&handle)) {
-            // Skip if already reaped — the pid may have been recycled by the OS.
-            Some(lc) if lc.exited.is_none() => lc.pid,
-            _ => return false,
-        }
-    };
-    #[cfg(unix)]
-    {
-        let signum = cp_parse_signal(signal);
-        unsafe { libc::kill(pid, signum) == 0 }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        false
-    }
-}
-
-/// Map a JS `kill` signal argument to a Unix signal number. Default / no-arg
-/// (`undefined` or the `0.0` padding) → `SIGTERM`.
-#[cfg(unix)]
-fn cp_parse_signal(signal: f64) -> i32 {
-    const SIGTERM: i32 = libc::SIGTERM;
-    if JSValue::from_bits(signal.to_bits()).is_undefined() {
-        return SIGTERM;
-    }
-    if let Some(name) = cp_value_to_string(signal) {
-        return cp_signal_number(&name).unwrap_or(SIGTERM);
-    }
-    if signal.is_finite() {
-        let n = signal as i32;
-        // 0 is the "no-arg" padding sentinel — treat as the default SIGTERM.
-        return if n == 0 { SIGTERM } else { n };
-    }
-    SIGTERM
-}
-
-/// Inverse of `super::cp_signal_name` for the common signals.
-#[cfg(unix)]
-fn cp_signal_number(name: &str) -> Option<i32> {
-    Some(match name {
-        "SIGHUP" => libc::SIGHUP,
-        "SIGINT" => libc::SIGINT,
-        "SIGQUIT" => libc::SIGQUIT,
-        "SIGABRT" => libc::SIGABRT,
-        "SIGKILL" => libc::SIGKILL,
-        "SIGTERM" => libc::SIGTERM,
-        "SIGUSR1" => libc::SIGUSR1,
-        "SIGUSR2" => libc::SIGUSR2,
-        "SIGSTOP" => libc::SIGSTOP,
-        "SIGCONT" => libc::SIGCONT,
-        _ => return None,
-    })
+    cp_live_kill_signum(handle, cp_signal_from_value(signal)).is_some()
 }
 
 // ============================================================================

--- a/crates/perry-runtime/src/child_process/sync_run.rs
+++ b/crates/perry-runtime/src/child_process/sync_run.rs
@@ -5,16 +5,17 @@ use std::time::{Duration, Instant};
 use crate::value::JSValue;
 
 use super::{
-    cp_decode_status, cp_get_field, cp_io_error_code, cp_object_ptr, cp_value_to_bytes, CpExit,
+    cp_decode_status, cp_get_field, cp_io_error_code, cp_object_ptr, cp_read_kill_signal,
+    cp_value_to_bytes, CpExit, CP_SIGTERM,
 };
 
 const CP_DEFAULT_MAX_BUFFER: usize = 1024 * 1024;
-const CP_SIGTERM: i32 = 15;
 
 /// Options that affect buffered sync execution after the `Command` is built.
 pub(super) struct CpRunOptions {
     input: Option<Vec<u8>>,
     timeout: Option<Duration>,
+    kill_signal: i32,
     pub(super) max_buffer: usize,
 }
 
@@ -23,6 +24,7 @@ impl Default for CpRunOptions {
         Self {
             input: None,
             timeout: None,
+            kill_signal: CP_SIGTERM,
             max_buffer: CP_DEFAULT_MAX_BUFFER,
         }
     }
@@ -110,6 +112,8 @@ pub(super) fn cp_read_async_run_options(opts_val: f64) -> CpRunOptions {
 }
 
 fn cp_read_timing_and_buffer_options(opts_val: f64, options: &mut CpRunOptions) {
+    options.kill_signal = cp_read_kill_signal(opts_val);
+
     if let Some(timeout) = cp_read_option_number(opts_val, b"timeout") {
         if timeout > 0.0 {
             options.timeout = Some(Duration::from_millis(timeout as u64));
@@ -177,7 +181,8 @@ pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions)
                     let _ = stdin.write_all(input);
                 }
             }
-            let mut run_error = cp_wait_for_timeout(&mut child, options.timeout);
+            let mut run_error =
+                cp_wait_for_timeout(&mut child, options.timeout, options.kill_signal);
             match child.wait_with_output() {
                 Ok(o) => {
                     let CpExit { code, signal } = cp_decode_status(&o.status);
@@ -188,7 +193,7 @@ pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions)
                         run_error = Some(CpRunError::MaxBuffer);
                     }
                     let (code, signal) = match run_error {
-                        Some(CpRunError::Timeout) => (None, Some(CP_SIGTERM)),
+                        Some(CpRunError::Timeout) => (None, Some(options.kill_signal)),
                         _ => (code, signal),
                     };
                     CpRun {
@@ -227,6 +232,7 @@ pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions)
 fn cp_wait_for_timeout(
     child: &mut std::process::Child,
     timeout: Option<Duration>,
+    kill_signal: i32,
 ) -> Option<CpRunError> {
     let timeout = timeout?;
     let deadline = Instant::now() + timeout;
@@ -235,7 +241,7 @@ fn cp_wait_for_timeout(
             Ok(Some(_)) => return None,
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    cp_terminate_child(child);
+                    cp_terminate_child(child, kill_signal);
                     return Some(CpRunError::Timeout);
                 }
                 let remaining = deadline.saturating_duration_since(Instant::now());
@@ -246,10 +252,10 @@ fn cp_wait_for_timeout(
     }
 }
 
-fn cp_terminate_child(child: &mut std::process::Child) {
+fn cp_terminate_child(child: &mut std::process::Child, kill_signal: i32) {
     #[cfg(unix)]
     unsafe {
-        let _ = libc::kill(child.id() as i32, libc::SIGTERM);
+        let _ = libc::kill(child.id() as i32, kill_signal);
     }
     #[cfg(not(unix))]
     {

--- a/test-parity/node-suite/child_process/async/timeout-killsignal.ts
+++ b/test-parity/node-suite/child_process/async/timeout-killsignal.ts
@@ -1,0 +1,107 @@
+import { exec, execFile, execFileSync, fork, spawn, spawnSync } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function text(value: unknown): string {
+  return value === null ? "null" : value === undefined ? "undefined" : String(value);
+}
+
+function reportSpawnSync() {
+  const result = spawnSync("sh", ["-c", "sleep 1"], {
+    timeout: 50,
+    killSignal: "SIGKILL",
+    encoding: "utf8",
+  });
+  console.log("spawnSync status:", text(result.status));
+  console.log("spawnSync signal:", text(result.signal));
+  console.log("spawnSync error:", text(result.error?.code), text(result.error?.syscall));
+}
+
+function reportExecFileSync() {
+  try {
+    execFileSync("sh", ["-c", "sleep 1"], {
+      timeout: 50,
+      killSignal: "SIGKILL",
+      encoding: "utf8",
+    });
+    console.log("execFileSync no throw");
+  } catch (error: any) {
+    console.log("execFileSync caught:", error instanceof Error);
+    console.log("execFileSync code:", text(error.code));
+    console.log("execFileSync status:", text(error.status));
+    console.log("execFileSync signal:", text(error.signal));
+    console.log("execFileSync stdout:", JSON.stringify(String(error.stdout)));
+    console.log("execFileSync stderr:", JSON.stringify(String(error.stderr)));
+  }
+}
+
+function runBuffered(
+  label: string,
+  start: (callback: (error: any, stdout: unknown, stderr: unknown) => void) => void,
+) {
+  return new Promise<void>((resolve) => {
+    start((error, stdout, stderr) => {
+      console.log(`${label} error:`, error instanceof Error);
+      console.log(`${label} code:`, text(error?.code));
+      console.log(`${label} killed:`, text(error?.killed));
+      console.log(`${label} signal:`, text(error?.signal));
+      console.log(`${label} stdout:`, JSON.stringify(String(stdout)));
+      console.log(`${label} stderr:`, JSON.stringify(String(stderr)));
+      resolve();
+    });
+  });
+}
+
+function runLive(label: string, child: any) {
+  return new Promise<void>((resolve) => {
+    console.log(`${label} killed initial:`, child.killed);
+    child.on("exit", (code: number | null, signal: string | null) => {
+      console.log(`${label} exit:`, text(code), text(signal));
+      console.log(`${label} killed exit:`, child.killed);
+    });
+    child.on("close", (code: number | null, signal: string | null) => {
+      console.log(`${label} close:`, text(code), text(signal));
+      console.log(`${label} killed close:`, child.killed);
+      console.log(`${label} signalCode:`, text(child.signalCode));
+      resolve();
+    });
+  });
+}
+
+reportSpawnSync();
+reportExecFileSync();
+
+await runBuffered("exec", (callback) =>
+  exec("sleep 1", { timeout: 50, killSignal: "SIGKILL", encoding: "utf8" }, callback)
+);
+await runBuffered("execFile", (callback) =>
+  execFile(
+    "sh",
+    ["-c", "sleep 1"],
+    { timeout: 50, killSignal: "SIGKILL", encoding: "utf8" },
+    callback,
+  )
+);
+
+await runLive(
+  "spawn",
+  spawn("sh", ["-c", "sleep 1"], { timeout: 50, killSignal: "SIGKILL" }),
+);
+
+const childFile = join(tmpdir(), `perry-fork-timeout-killsignal-${process.pid}.js`);
+writeFileSync(childFile, "setInterval(() => {}, 1000);");
+
+await runLive(
+  "fork",
+  fork(childFile, [], {
+    timeout: 50,
+    killSignal: "SIGKILL",
+    execArgv: [],
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  }),
+);
+
+try {
+  unlinkSync(childFile);
+} catch {}


### PR DESCRIPTION
## Summary
- honor `options.killSignal` when timeout kills buffered `exec()` / `execFile()` and sync `spawnSync()` / `execSync()` / `execFileSync()` children
- add live `spawn()` / `fork()` timeout termination through the child-process reactor so `exit` / `close`, `killed`, and `signalCode` reflect the configured signal
- share child_process signal parsing/name reporting across `ChildProcess#kill()` and timeout paths
- add focused Node parity coverage for sync, buffered async, live spawn, and fork timeout termination with `SIGKILL`

## Scope
Refs #2555 and #2130. This is the deterministic timeout/killSignal child_process option slice only.

## Non-goals
AbortSignal lifecycle semantics, numeric fd sharing, custom stream handles, uid/gid, detached/platform flags, and broad child_process option validation remain follow-up work.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/child_process/async/timeout-killsignal.ts`
- `CARGO_TARGET_DIR=/tmp/perry-child-timeout-check cargo check -p perry-runtime`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/tmp/perry-node-child-process-timeout-killsignal npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter timeout-killsignal & pid=$!; while kill -0 "$pid" 2>/dev/null; do echo "[heartbeat] child_process timeout parity still running"; sleep 20; done; wait "$pid"'`
  - report: `/root/perry-worktrees/perry-node-child-process-timeout-killsignal/test-parity/reports/parity_report_20260603_142824.json`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/tmp/perry-node-child-process-timeout-killsignal npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process & pid=$!; while kill -0 "$pid" 2>/dev/null; do echo "[heartbeat] child_process full parity still running"; sleep 20; done; wait "$pid"'`
  - report: `/root/perry-worktrees/perry-node-child-process-timeout-killsignal/test-parity/reports/parity_report_20260603_142901.json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`