### PR TITLE
[codex] honor child_process AbortSignal options

### DIFF
--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -36,6 +36,7 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     } else {
         cp_undefined()
     };
+    let abort_signal = cp_read_abort_signal(opts_val);
 
     // Launch interpreter: options.execPath → $PERRY_FORK_EXECPATH → "node".
     let exec_path = cp_value_to_string(cp_get_field(opts_val, b"execPath"))
@@ -141,6 +142,8 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
         advanced,
         timeout,
         kill_signal,
+        abort_signal,
+        opts_val,
     );
     if !launched {
         // Spawn failure: emit a deferred `error`, leave `connected` false.
@@ -173,6 +176,8 @@ fn fork_launch(
     advanced: bool,
     timeout: Option<Duration>,
     kill_signal: i32,
+    abort_signal: Option<f64>,
+    opts_val: f64,
 ) -> bool {
     use std::os::unix::io::AsRawFd;
     use std::os::unix::net::UnixStream;
@@ -210,7 +215,7 @@ fn fork_launch(
             cp_set_field(cp, b"connected", TAG_TRUE_F64);
             let channel = crate::object::js_object_alloc(0, 0);
             cp_set_field(cp, b"channel", cp_box_ptr(channel as *const u8));
-            reactor::cp_register_live_child(
+            let handle = reactor::cp_register_live_child(
                 cp,
                 stdout_obj,
                 stderr_obj,
@@ -221,6 +226,7 @@ fn fork_launch(
                 timeout,
                 kill_signal,
             );
+            reactor::cp_install_abort_signal(handle, abort_signal, opts_val);
             true
         }
         Err(_) => false,
@@ -237,11 +243,13 @@ fn fork_launch(
     advanced: bool,
     timeout: Option<Duration>,
     kill_signal: i32,
+    abort_signal: Option<f64>,
+    opts_val: f64,
 ) -> bool {
     let _ = advanced;
     match command.spawn() {
         Ok(child) => {
-            reactor::cp_register_live_child(
+            let handle = reactor::cp_register_live_child(
                 cp,
                 stdout_obj,
                 stderr_obj,
@@ -252,6 +260,7 @@ fn fork_launch(
                 timeout,
                 kill_signal,
             );
+            reactor::cp_install_abort_signal(handle, abort_signal, opts_val);
             true
         }
         Err(_) => false,

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -560,6 +560,7 @@ pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64,
     // sit in the `arg1` slot, so the encoding is read from there. When `arg1`
     // is the callback the lookup no-ops and the default applies.
     let mode = cp_read_output_mode(arg1, true);
+    let abort_signal = cp_read_abort_signal(arg1);
 
     if cmd_ptr.is_null() {
         let empty = cp_box_output(b"", &mode);
@@ -576,6 +577,21 @@ pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64,
         let cmd_bytes = std::slice::from_raw_parts(data_ptr, len);
         String::from_utf8_lossy(cmd_bytes).into_owned()
     };
+
+    if abort_signal.is_some_and(cp_abort_signal_is_aborted) {
+        let stdout_box = cp_box_output(b"", &mode);
+        if cb.is_null() {
+            return stdout_box;
+        }
+        let stderr_box = cp_box_output(b"", &mode);
+        crate::closure::js_closure_call3(
+            cb,
+            cp_abort_error(Some(&cmd_str)),
+            stdout_box,
+            stderr_box,
+        );
+        return f64::from_bits(TAG_UNDEFINED_BITS);
+    }
 
     // `exec` always runs through the shell. The options object sits in the
     // `arg1` slot (`exec(cmd, options, cb)`); when `arg1` is the callback
@@ -637,6 +653,7 @@ pub extern "C" fn js_child_process_exec(cmd_ptr: *const StringHeader, arg1: f64,
 const CP_SHAPE_ID: u32 = 0x7FFF_FD00;
 const CP_READABLE_SHAPE_ID: u32 = 0x7FFF_FD40;
 const CP_WRITABLE_SHAPE_ID: u32 = 0x7FFF_FD80;
+const CP_ABORT_ERROR_CLASS_ID: u32 = 0x7FFF_FDC0;
 
 #[inline]
 fn cp_undefined() -> f64 {
@@ -1525,6 +1542,29 @@ pub(super) fn cp_read_argv0(opts_val: f64) -> Option<String> {
     cp_value_to_string(cp_get_field(opts_val, b"argv0"))
 }
 
+pub(super) fn cp_read_abort_signal(opts_val: f64) -> Option<f64> {
+    if cp_object_ptr(opts_val).is_none() {
+        return None;
+    }
+    let signal = cp_get_field(opts_val, b"signal");
+    if JSValue::from_bits(signal.to_bits()).is_undefined() {
+        return None;
+    }
+    if crate::url::abort::abort_signal_ptr_from_value(signal).is_some() {
+        return Some(signal);
+    }
+    let message = format!(
+        "The \"options.signal\" property must be an instance of AbortSignal. Received {}",
+        crate::fs::validate::describe_received(signal)
+    );
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+}
+
+pub(super) fn cp_abort_signal_is_aborted(signal: f64) -> bool {
+    crate::url::abort::abort_signal_ptr_from_value(signal)
+        .is_some_and(|ptr| crate::url::js_abort_signal_is_aborted(ptr) != 0)
+}
+
 pub(super) fn cp_spawnargs_argv0(default: &str, opts_val: f64) -> String {
     cp_read_argv0(opts_val).unwrap_or_else(|| default.to_string())
 }
@@ -1859,6 +1899,24 @@ fn cp_make_range_error(message: &str, extra: &[(&str, f64)]) -> f64 {
     )
 }
 
+pub(super) fn cp_abort_error(cmd: Option<&str>) -> f64 {
+    crate::object::js_register_class_extends_error(CP_ABORT_ERROR_CLASS_ID);
+    let obj = crate::object::js_object_alloc(CP_ABORT_ERROR_CLASS_ID, 4);
+    let set = |key: &str, value: f64| {
+        let kp = js_string_from_bytes(key.as_ptr(), key.len() as u32);
+        js_object_set_field_by_name(obj, kp, value);
+    };
+    set("code", cp_box_string("ABORT_ERR"));
+    set("name", cp_box_string("AbortError"));
+    set("message", cp_box_string("The operation was aborted"));
+    if let Some(cmd) = cmd {
+        set("cmd", cp_box_string(cmd));
+    }
+    let hidden = crate::object::PropertyAttrs::new(true, false, true);
+    crate::object::set_property_attrs(obj as usize, "message".to_string(), hidden);
+    cp_box_ptr(obj as *const u8)
+}
+
 /// `[null, stdout, stderr]` — the Node `output` array shared by spawnSync and
 /// the execSync throw error.
 fn cp_output_array(stdout: f64, stderr: f64) -> f64 {
@@ -2074,6 +2132,22 @@ pub extern "C" fn js_child_process_exec_file(
     let arg_strs = cp_args_from_value(args_val);
     // execFile defaults to utf8 (callback stdout/stderr are strings).
     let mode = cp_read_output_mode(opts_val, true);
+    let abort_signal = cp_read_abort_signal(opts_val);
+
+    if abort_signal.is_some_and(cp_abort_signal_is_aborted) {
+        let stdout_box = cp_box_output(b"", &mode);
+        if cb.is_null() {
+            return stdout_box;
+        }
+        let stderr_box = cp_box_output(b"", &mode);
+        crate::closure::js_closure_call3(
+            cb,
+            cp_abort_error(Some(&cp_file_cmd_display(&file_str, &arg_strs))),
+            stdout_box,
+            stderr_box,
+        );
+        return f64::from_bits(TAG_UNDEFINED_BITS);
+    }
 
     // `cwd`/`env` come from the options slot; when `opts_val` is the callback
     // (`execFile(file, args, cb)`) it's a closure, so the helper no-ops.

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -80,6 +80,8 @@ enum CpEvent {
     /// Timeout expired; terminate the live child with this signal on the main
     /// thread so JS-visible `killed` is updated with the same event ordering.
     Timeout { handle: u64, signal: i32 },
+    /// `AbortSignal` attached through `options.signal` fired.
+    Abort { handle: u64 },
 }
 
 static CP_EVENT_QUEUE: Mutex<Vec<CpEvent>> = Mutex::new(Vec::new());
@@ -108,6 +110,12 @@ struct LiveChild {
     /// #2130: whether the IPC channel uses V8 structured-clone framing
     /// (`serialization: 'advanced'`) rather than newline-delimited JSON.
     ipc_advanced: bool,
+    /// NaN-boxed AbortSignal value for listener cleanup/GC rooting.
+    abort_signal_bits: u64,
+    /// NaN-boxed abort-listener closure value for listener cleanup/GC rooting.
+    abort_listener_bits: u64,
+    /// Signal number used when `options.signal` aborts this child.
+    abort_kill_signal: i32,
 }
 
 static CP_LIVE: Mutex<Option<HashMap<u64, LiveChild>>> = Mutex::new(None);
@@ -133,6 +141,18 @@ fn cp_queue_lock() -> std::sync::MutexGuard<'static, Vec<CpEvent>> {
 fn cp_push_event(ev: CpEvent) {
     cp_queue_lock().push(ev);
     crate::event_pump::js_notify_main_thread();
+}
+
+#[inline]
+fn libc_sigterm() -> i32 {
+    #[cfg(unix)]
+    {
+        libc::SIGTERM
+    }
+    #[cfg(not(unix))]
+    {
+        15
+    }
 }
 
 /// Spawn a reader thread that streams `pipe` to the event queue until EOF.
@@ -312,6 +332,9 @@ pub(super) fn cp_register_live_child(
                 closed: false,
                 ipc_send,
                 ipc_advanced,
+                abort_signal_bits: 0,
+                abort_listener_bits: 0,
+                abort_kill_signal: libc_sigterm(),
             },
         );
     }
@@ -336,6 +359,92 @@ pub(super) fn cp_register_live_child(
     // Wake the loop so 'spawn' fires on the next tick.
     crate::event_pump::js_notify_main_thread();
     handle
+}
+
+extern "C" fn cp_abort_listener(closure: *const ClosureHeader) -> f64 {
+    let handle = js_closure_get_capture_ptr(closure, 0) as u64;
+    cp_push_event(CpEvent::Abort { handle });
+    cp_undefined()
+}
+
+pub(super) fn cp_install_abort_signal(handle: u64, signal: Option<f64>, opts_val: f64) {
+    let Some(signal) = signal else {
+        return;
+    };
+    let Some(signal_ptr) = crate::url::abort::abort_signal_ptr_from_value(signal) else {
+        return;
+    };
+
+    let listener = js_closure_alloc(cp_abort_listener as *const u8, 1);
+    js_closure_set_capture_ptr(listener, 0, handle as i64);
+    let listener_val = cp_box_ptr(listener as *const u8);
+    let kill_signal = cp_read_abort_kill_signal(opts_val);
+
+    if let Some(map) = cp_live_lock().as_mut() {
+        if let Some(lc) = map.get_mut(&handle) {
+            lc.abort_signal_bits = signal.to_bits();
+            lc.abort_listener_bits = listener_val.to_bits();
+            lc.abort_kill_signal = kill_signal;
+        }
+    }
+
+    if crate::url::js_abort_signal_is_aborted(signal_ptr) != 0 {
+        cp_push_event(CpEvent::Abort { handle });
+    } else {
+        crate::url::js_abort_signal_add_listener(signal_ptr, cp_box_string("abort"), listener_val);
+    }
+}
+
+fn cp_read_abort_kill_signal(opts_val: f64) -> i32 {
+    if cp_object_ptr(opts_val).is_none() {
+        return libc_sigterm();
+    }
+    let signal = cp_get_field(opts_val, b"killSignal");
+    if JSValue::from_bits(signal.to_bits()).is_undefined() {
+        return libc_sigterm();
+    }
+    cp_signal_number_from_value(signal)
+}
+
+fn cp_signal_number_from_value(signal: f64) -> i32 {
+    #[cfg(unix)]
+    {
+        cp_parse_signal(signal)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = signal;
+        libc_sigterm()
+    }
+}
+
+fn cp_take_abort_fields(handle: u64) -> Option<(u64, i32, u64, u64)> {
+    let mut guard = cp_live_lock();
+    let lc = guard.as_mut()?.get_mut(&handle)?;
+    let fields = (
+        lc.cp_bits,
+        lc.abort_kill_signal,
+        lc.abort_signal_bits,
+        lc.abort_listener_bits,
+    );
+    lc.abort_signal_bits = 0;
+    lc.abort_listener_bits = 0;
+    Some(fields)
+}
+
+fn cp_cleanup_abort_listener(signal_bits: u64, listener_bits: u64) {
+    if signal_bits == 0 || listener_bits == 0 {
+        return;
+    }
+    let signal = f64::from_bits(signal_bits);
+    let Some(signal_ptr) = crate::url::abort::abort_signal_ptr_from_value(signal) else {
+        return;
+    };
+    crate::url::js_abort_signal_remove_listener(
+        signal_ptr,
+        cp_box_string("abort"),
+        f64::from_bits(listener_bits),
+    );
 }
 
 /// `child.send(message)` — serialize `message` to JSON (main thread) and write
@@ -448,6 +557,7 @@ pub extern "C" fn js_child_process_spawn_streams(
     } else {
         cp_undefined()
     };
+    let abort_signal = cp_read_abort_signal(opts_val);
 
     // stdout/stderr Readable + stdin Writable sub-objects.
     let stdout_obj = cp_build_readable();
@@ -508,7 +618,7 @@ pub extern "C" fn js_child_process_spawn_streams(
 
     match command.spawn() {
         Ok(child) => {
-            cp_register_live_child(
+            let handle = cp_register_live_child(
                 cp,
                 stdout_obj,
                 stderr_obj,
@@ -519,6 +629,7 @@ pub extern "C" fn js_child_process_spawn_streams(
                 timeout,
                 kill_signal,
             );
+            cp_install_abort_signal(handle, abort_signal, opts_val);
         }
         Err(e) => {
             // Spawn failure (e.g. ENOENT): Node emits a single `error` event and
@@ -556,6 +667,7 @@ pub(super) extern "C" fn cp_emit_spawn_error(closure: *const ClosureHeader) -> f
 
 pub(super) fn cp_register_reactor_arities() {
     crate::closure::js_register_closure_arity(cp_emit_spawn_error as *const u8, 0);
+    crate::closure::js_register_closure_arity(cp_abort_listener as *const u8, 0);
 }
 
 // ============================================================================
@@ -689,12 +801,25 @@ fn cp_reactor_pump_inner() {
                     cp_set_field(f64::from_bits(cp_bits), b"killed", TAG_TRUE_F64);
                 }
             }
+            CpEvent::Abort { handle } => {
+                let Some((cp_bits, kill_signal, signal_bits, listener_bits)) =
+                    cp_take_abort_fields(handle)
+                else {
+                    continue;
+                };
+                cp_cleanup_abort_listener(signal_bits, listener_bits);
+                if cp_live_kill_signal(handle, kill_signal) {
+                    let cp = f64::from_bits(cp_bits);
+                    cp_set_field(cp, b"killed", TAG_TRUE_F64);
+                    cp_emit(cp, "error", &[cp_abort_error(None)]);
+                }
+            }
         }
     }
 
     // --- Phase B: emit `exit`+`close` once a child has exited AND both
     // streams have hit EOF, so all `data`/`end` have already fired. ---
-    let to_close: Vec<(u64, u64, Option<i32>, Option<i32>)> = {
+    let to_close: Vec<(u64, u64, Option<i32>, Option<i32>, u64, u64)> = {
         let mut guard = cp_live_lock();
         let mut out = Vec::new();
         if let Some(map) = guard.as_mut() {
@@ -705,14 +830,24 @@ fn cp_reactor_pump_inner() {
                 if let Some((code, signal)) = lc.exited {
                     if !lc.stdout_open && !lc.stderr_open {
                         lc.closed = true;
-                        out.push((*h, lc.cp_bits, code, signal));
+                        out.push((
+                            *h,
+                            lc.cp_bits,
+                            code,
+                            signal,
+                            lc.abort_signal_bits,
+                            lc.abort_listener_bits,
+                        ));
+                        lc.abort_signal_bits = 0;
+                        lc.abort_listener_bits = 0;
                     }
                 }
             }
         }
         out
     };
-    for (handle, cp_bits, code, signal) in to_close {
+    for (handle, cp_bits, code, signal, abort_signal_bits, abort_listener_bits) in to_close {
+        cp_cleanup_abort_listener(abort_signal_bits, abort_listener_bits);
         let cp = f64::from_bits(cp_bits);
         let code_f = code.map(|c| c as f64).unwrap_or(TAG_NULL_F64);
         let signal_f = signal
@@ -804,6 +939,63 @@ pub(super) fn cp_live_kill(handle: u64, signal: f64) -> bool {
     cp_live_kill_signum(handle, cp_signal_from_value(signal)).is_some()
 }
 
+fn cp_live_kill_signal(handle: u64, signum: i32) -> bool {
+    let pid = {
+        let guard = cp_live_lock();
+        match guard.as_ref().and_then(|map| map.get(&handle)) {
+            // Skip if already reaped — the pid may have been recycled by the OS.
+            Some(lc) if lc.exited.is_none() => lc.pid,
+            _ => return false,
+        }
+    };
+    #[cfg(unix)]
+    {
+        unsafe { libc::kill(pid, signum) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (pid, signum);
+        false
+    }
+}
+
+/// Map a JS `kill` signal argument to a Unix signal number. Default / no-arg
+/// (`undefined` or the `0.0` padding) → `SIGTERM`.
+#[cfg(unix)]
+fn cp_parse_signal(signal: f64) -> i32 {
+    const SIGTERM: i32 = libc::SIGTERM;
+    if JSValue::from_bits(signal.to_bits()).is_undefined() {
+        return SIGTERM;
+    }
+    if let Some(name) = cp_value_to_string(signal) {
+        return cp_signal_number(&name).unwrap_or(SIGTERM);
+    }
+    if signal.is_finite() {
+        let n = signal as i32;
+        // 0 is the "no-arg" padding sentinel — treat as the default SIGTERM.
+        return if n == 0 { SIGTERM } else { n };
+    }
+    SIGTERM
+}
+
+/// Inverse of `super::cp_signal_name` for the common signals.
+#[cfg(unix)]
+fn cp_signal_number(name: &str) -> Option<i32> {
+    Some(match name {
+        "SIGHUP" => libc::SIGHUP,
+        "SIGINT" => libc::SIGINT,
+        "SIGQUIT" => libc::SIGQUIT,
+        "SIGABRT" => libc::SIGABRT,
+        "SIGKILL" => libc::SIGKILL,
+        "SIGTERM" => libc::SIGTERM,
+        "SIGUSR1" => libc::SIGUSR1,
+        "SIGUSR2" => libc::SIGUSR2,
+        "SIGSTOP" => libc::SIGSTOP,
+        "SIGCONT" => libc::SIGCONT,
+        _ => return None,
+    })
+}
+
 // ============================================================================
 // Event-loop integration hooks (wired from lib.rs / gc/mod.rs).
 // ============================================================================
@@ -824,6 +1016,12 @@ pub(crate) fn cp_reactor_scan_roots_mut(visitor: &mut crate::gc::RuntimeRootVisi
     if let Some(map) = cp_live_lock().as_mut() {
         for lc in map.values_mut() {
             visitor.visit_nanbox_u64_slot(&mut lc.cp_bits);
+            if lc.abort_signal_bits != 0 {
+                visitor.visit_nanbox_u64_slot(&mut lc.abort_signal_bits);
+            }
+            if lc.abort_listener_bits != 0 {
+                visitor.visit_nanbox_u64_slot(&mut lc.abort_listener_bits);
+            }
         }
     }
 }

--- a/test-parity/node-suite/child_process/async/abort-signal.ts
+++ b/test-parity/node-suite/child_process/async/abort-signal.ts
@@ -1,0 +1,94 @@
+import { exec, execFile, fork, spawn } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function valueText(value) {
+  return value === null ? "null" : value === undefined ? "undefined" : String(value);
+}
+
+function errSummary(err) {
+  if (!err) return "null";
+  return [
+    valueText(err.name),
+    valueText(err.code),
+    Object.keys(err).join(","),
+    valueText(err.cmd),
+  ].join("|");
+}
+
+function close(child) {
+  return new Promise((resolve) => child.on("close", (code, signal) => resolve([code, signal])));
+}
+
+function invalidSignal(label, start) {
+  try {
+    const child = start();
+    console.log(`${label} invalid: ok`);
+    child?.kill?.();
+  } catch (err) {
+    console.log(`${label} invalid:`, err.name, err.code);
+  }
+}
+
+function execWithAbort(label, run) {
+  return new Promise((resolve) => {
+    const controller = new AbortController();
+    controller.abort();
+    run(controller.signal, (err, stdout, stderr) => {
+      console.log(`${label} err:`, errSummary(err));
+      console.log(`${label} stdout:`, JSON.stringify(String(stdout)));
+      console.log(`${label} stderr:`, JSON.stringify(String(stderr)));
+      resolve();
+    });
+  });
+}
+
+async function liveAbort(label, child) {
+  const events = [];
+  child.on("spawn", () => {
+    events.push(`spawn:${valueText(child.killed)}:${valueText(child.signalCode)}`);
+  });
+  child.on("error", (err) => {
+    events.push(`error:${errSummary(err)}:${valueText(child.killed)}:${valueText(child.signalCode)}`);
+  });
+  child.on("exit", (code, signal) => {
+    events.push(`exit:${valueText(code)}:${valueText(signal)}:${valueText(child.killed)}:${valueText(child.signalCode)}`);
+  });
+  const [code, signal] = await close(child);
+  events.push(`close:${valueText(code)}:${valueText(signal)}:${valueText(child.killed)}:${valueText(child.signalCode)}`);
+  console.log(`${label}:`, events.join(">"));
+}
+
+invalidSignal("spawn", () => spawn("node", ["-e", ""], { signal: {} }));
+invalidSignal("exec", () => exec("node -e \"\"", { signal: {} }, () => {}));
+invalidSignal("execFile", () => execFile("node", ["-e", ""], { signal: {} }, () => {}));
+
+await execWithAbort("exec aborted", (signal, cb) =>
+  exec("sleep 1; printf exec-after", { signal, encoding: "utf8" }, cb)
+);
+await execWithAbort("execFile aborted", (signal, cb) =>
+  execFile("sh", ["-c", "sleep 1; printf execfile-after"], { signal, encoding: "utf8" }, cb)
+);
+
+const spawnController = new AbortController();
+const spawned = spawn("node", ["-e", "setTimeout(() => {}, 1000)"], {
+  signal: spawnController.signal,
+});
+setTimeout(() => spawnController.abort(), 25);
+await liveAbort("spawn aborted", spawned);
+
+const childFile = join(tmpdir(), `perry-fork-abort-${process.pid}.js`);
+writeFileSync(childFile, "setTimeout(() => {}, 1000);");
+const forkController = new AbortController();
+const forked = fork(childFile, [], {
+  execArgv: [],
+  execPath: "node",
+  signal: forkController.signal,
+  stdio: ["ignore", "ignore", "ignore", "ipc"],
+});
+setTimeout(() => forkController.abort(), 25);
+await liveAbort("fork aborted", forked);
+try {
+  unlinkSync(childFile);
+} catch {}


### PR DESCRIPTION
## Summary

Implements the focused `node:child_process` AbortSignal option slice for the child-process paths Perry already supports.

Linked issues: #2555, #2130.

## Behavior Cluster

- Validates `options.signal` for `spawn()`, `fork()`, `exec()`, and `execFile()` and throws `TypeError [ERR_INVALID_ARG_TYPE]` for non-AbortSignal values.
- Handles pre-aborted buffered `exec()` / `execFile()` calls with `AbortError [ABORT_ERR]` callback errors and empty stdout/stderr output.
- Wires live `spawn()` / `fork()` AbortSignal listeners into the existing child-process reactor so aborts kill the child, mark `child.killed`, emit `error` with `AbortError [ABORT_ERR]`, and then surface the normal `exit` / `close` signal metadata.
- Roots and removes abort listeners from live child state so natural child exit cleans up the listener.

These issues are batched because they share the same `child_process` option parsing, AbortSignal validation, and live subprocess lifecycle path. Keeping them together covers the observable async/live AbortSignal behavior without mixing in unrelated stdio/fd/platform option work.

## Tests Added

- `test-parity/node-suite/child_process/async/abort-signal.ts`
  - invalid `options.signal` validation for `spawn`, `exec`, and `execFile`
  - pre-aborted buffered `exec` / `execFile` callback errors
  - abort-after-spawn lifecycle for live `spawn` and `fork`

## Validation

- Node v26.3.0 oracle for `abort-signal.ts`
- Pre-fix focused parity failure: `abort-signal` failed because Perry accepted invalid `options.signal`
- Focused parity pass: `./run_parity_tests.sh --suite node-suite --module child_process --filter abort-signal`
  - report: `/root/perry-worktrees/perry-node-child-process-abort-signal/test-parity/reports/parity_report_20260603_151145.json`
- Full curated child_process parity pass: `./run_parity_tests.sh --suite node-suite --module child_process`
  - report: `/root/perry-worktrees/perry-node-child-process-abort-signal/test-parity/reports/parity_report_20260603_151201.json`
- `CARGO_TARGET_DIR=/tmp/perry-child-abort-check cargo check -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known Limitations / Non-goals

- Buffered `exec()` / `execFile()` remain Perry's existing synchronous callback model; this PR covers pre-aborted callback behavior, not mid-run JS timer-driven aborts while the call is blocked.
- No numeric fd sharing, custom stream handle routing, uid/gid, detached/platform flag work, or broad option validation beyond `options.signal`.
- Sync APIs are intentionally not changed; Node ignores pre-aborted `signal` for sync child_process helpers.
