### PR TITLE
fix(runtime): isPrototypeOf + Reflect.set/getPrototypeOf/deleteProperty throw on non-object

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1010,6 +1010,15 @@ extern "C" fn object_prototype_is_prototype_of_thunk(
     value: f64,
 ) -> f64 {
     let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    // RequireObjectCoercible(this): `Object.prototype.isPrototypeOf.call(null)`
+    // / `.call(undefined)` must throw a TypeError (spec step 1), matching the
+    // sibling Object.prototype methods. Pre-fix this silently returned false.
+    let this_jsv = JSValue::from_bits(this_value.to_bits());
+    if this_jsv.is_null() || this_jsv.is_undefined() {
+        super::object_ops::throw_object_type_error(
+            b"Object.prototype.isPrototypeOf called on null or undefined",
+        );
+    }
     f64::from_bits(
         JSValue::bool(unsafe { super::js_object_is_prototype_of_value(this_value, value) }).bits(),
     )

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1365,6 +1365,11 @@ pub extern "C" fn js_reflect_set(target: f64, key: f64, value: f64) -> f64 {
     if lookup(target).is_some() {
         return js_proxy_set(target, key, value);
     }
+    // Reflect.set on a non-object target must throw TypeError (spec step 1),
+    // matching Reflect.has/get/etc. Pre-fix it silently returned false.
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("set");
+    }
     reflect_ordinary_set(target, key, value)
 }
 
@@ -1410,6 +1415,11 @@ pub extern "C" fn js_reflect_has(target: f64, key: f64) -> f64 {
 pub extern "C" fn js_reflect_delete(target: f64, key: f64) -> f64 {
     if lookup(target).is_some() {
         return js_proxy_delete(target, key);
+    }
+    // Reflect.deleteProperty on a non-object target must throw TypeError (spec
+    // step 1). Pre-fix it silently returned true.
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("deleteProperty");
     }
     reflect_ordinary_delete(target, key)
 }
@@ -1542,6 +1552,13 @@ fn reflect_ordinary_define(obj: f64, key: f64, descriptor: f64) -> f64 {
 /// including `null` for null-prototype objects, not the object itself.
 #[no_mangle]
 pub extern "C" fn js_reflect_get_prototype_of(obj: f64) -> f64 {
+    // Reflect.getPrototypeOf on a non-object target must throw TypeError (spec
+    // step 1). Note `Object.getPrototypeOf` is more lenient (ToObject-coerces
+    // primitives), so guard here before delegating. Proxies have a registered
+    // entry and are objects, so they pass this check and dispatch below.
+    if lookup(obj).is_none() && !reflect_value_is_object(obj) {
+        return reflect_non_object_typeerror("getPrototypeOf");
+    }
     crate::object::js_object_get_prototype_of(obj)
 }
 


### PR DESCRIPTION
## What

Four built-in methods now throw `TypeError` on a non-object / null-undefined
receiver-or-target, per spec, instead of silently succeeding:
- `Object.prototype.isPrototypeOf.call(null|undefined, ...)` → was returning false
- `Reflect.set(nonObject, ...)` → was returning false
- `Reflect.getPrototypeOf(nonObject)` → was returning null
- `Reflect.deleteProperty(nonObject, ...)` → was returning true

## Why

Part of the "Expected a TypeError to be thrown" cluster across `built-ins/Object`
and `built-ins/Reflect`. Each method's spec step 1 is a RequireObjectCoercible /
"target must be Object" check; these four were missing it while their siblings
(Reflect.has/get/ownKeys/defineProperty/isExtensible/…, and the other
Object.prototype methods) already had it.

## How

- `Object.prototype.isPrototypeOf` thunk: add the null/undefined `this` guard →
  `throw_object_type_error` (mirrors `error_prototype_to_string_thunk`).
- `Reflect.set` / `getPrototypeOf` / `deleteProperty`: add the existing
  `reflect_value_is_object` + `reflect_non_object_typeerror` guard already used by
  the sibling Reflect methods (proxies pass the check and dispatch normally).

## Verification

- Byte-identical to `node --experimental-strip-types`: all four throw on bad
  input; the exact test262 cases (`isPrototypeOf/{null,undefined}-this-and-object-arg-throws.js`)
  now PASS via the full harness; valid operations (`Reflect.set(o,...)`,
  `getPrototypeOf(o)`, `deleteProperty(o,...)`, valid `isPrototypeOf`) unchanged.
- `perry-runtime` suite: 977/977 (single-threaded).
- fmt + file-size gates clean. Rebased on current main.

## Scope

Targeted RequireObjectCoercible fixes. The broader `built-ins/Object` cluster
(Proxy invariants, per-method descriptor edges) remains for follow-up — these four
are the clean shared-shape subset.
