### PR TITLE
[codex] scope strict switch declarations

### DIFF
--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1303,6 +1303,7 @@ pub(crate) fn lower_stmt(
         ast::Stmt::Switch(switch_stmt) => {
             let discriminant = lower_expr(ctx, &switch_stmt.discriminant)?;
             let mut cases = Vec::new();
+            let switch_scope_mark = ctx.push_block_scope();
 
             for case in &switch_stmt.cases {
                 let test = case.test.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
@@ -1314,6 +1315,8 @@ pub(crate) fn lower_stmt(
 
                 cases.push(SwitchCase { test, body });
             }
+
+            ctx.pop_block_scope(switch_scope_mark);
 
             module.init.push(Stmt::Switch {
                 discriminant,

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -729,6 +729,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
         ast::Stmt::Switch(switch_stmt) => {
             let discriminant = lower_expr(ctx, &switch_stmt.discriminant)?;
             let mut cases = Vec::new();
+            let switch_scope_mark = ctx.push_block_scope();
 
             for case in &switch_stmt.cases {
                 let test = case.test.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
@@ -740,6 +741,8 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
 
                 cases.push(SwitchCase { test, body });
             }
+
+            ctx.pop_block_scope(switch_scope_mark);
 
             result.push(Stmt::Switch {
                 discriminant,

--- a/test-parity/node-suite/globals/strict-runtime-errors.ts
+++ b/test-parity/node-suite/globals/strict-runtime-errors.ts
@@ -1,0 +1,64 @@
+function runStrictCases() {
+  "use strict";
+
+  let rhsCount = 0;
+  try {
+    missingStrictTarget = (rhsCount += 1);
+    console.log("strict assignment:", "no throw");
+  } catch (error) {
+    console.log(
+      "strict assignment:",
+      error instanceof ReferenceError,
+      (error as Error).name,
+      rhsCount,
+      (globalThis as any).missingStrictTarget === undefined,
+    );
+  }
+
+  {
+    function blockScopedFunction() {
+      return "inside-block";
+    }
+    let blockScopedLet = "let-block";
+    console.log("block inside:", blockScopedFunction(), blockScopedLet);
+  }
+
+  try {
+    console.log("block outside fn:", blockScopedFunction());
+  } catch (error) {
+    console.log("block outside fn:", error instanceof ReferenceError, (error as Error).name);
+  }
+
+  try {
+    console.log("block outside let:", blockScopedLet);
+  } catch (error) {
+    console.log("block outside let:", error instanceof ReferenceError, (error as Error).name);
+  }
+
+  switch (1) {
+    case 1:
+      function switchScopedFunction() {
+        return "inside-switch";
+      }
+      let switchScopedLet = "let-switch";
+      var switchScopedVar = "var-switch";
+      console.log("switch inside:", switchScopedFunction(), switchScopedLet, switchScopedVar);
+      break;
+  }
+
+  try {
+    console.log("switch outside fn:", switchScopedFunction());
+  } catch (error) {
+    console.log("switch outside fn:", error instanceof ReferenceError, (error as Error).name);
+  }
+
+  try {
+    console.log("switch outside let:", switchScopedLet);
+  } catch (error) {
+    console.log("switch outside let:", error instanceof ReferenceError, (error as Error).name);
+  }
+
+  console.log("switch outside var:", switchScopedVar);
+}
+
+runStrictCases();


### PR DESCRIPTION
## Summary
- create one shared HIR block scope for each lowered `switch` case block in module and function-body paths
- prevent strict `let` and function declarations inside `switch` cases from leaking after the switch
- keep `var` declarations function-scoped through the existing `pop_block_scope` hoist preservation
- add focused Node parity coverage for strict unresolvable assignment, strict block declarations, strict switch declarations, and switch `var` hoisting

## Scope
Refs #3571. This is the strict runtime/scope error slice for switch lexical declaration leakage.

## Non-goals
Raw directive escape classification, reserved/contextual-word parsing, and broad Test262 harness import remain out of scope.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/strict-runtime-errors.ts`
- `CARGO_TARGET_DIR=/tmp/perry-strict-runtime-errors cargo check -p perry-hir`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/tmp/perry-strict-runtime-errors npm exec --yes --package=node@26 -- ./run_parity_tests.sh --suite node-suite --module globals --filter strict-runtime-errors`
  - report: `/root/perry-worktrees/perry-node-strict-runtime-errors/test-parity/reports/parity_report_20260603_152435.json`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/tmp/perry-strict-runtime-errors /tmp/perry-strict-runtime-errors/release/perry test-files/test_issue_3585_bindings.ts -o /tmp/perry_issue_3585_bindings_after_switch && /tmp/perry_issue_3585_bindings_after_switch`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`