### PR TITLE
[codex] Align util.aborted signal validation

### DIFF
--- a/crates/perry-runtime/src/util_abort.rs
+++ b/crates/perry-runtime/src/util_abort.rs
@@ -39,6 +39,10 @@ fn invalid_signal_error(signal: f64) -> f64 {
     )
 }
 
+fn invalid_aborted_signal_error() -> f64 {
+    type_error_value("signal is not of type AbortSignal.", "ERR_INVALID_ARG_TYPE")
+}
+
 fn invalid_resource_error(resource: f64) -> f64 {
     type_error_value(
         &format!(
@@ -86,7 +90,7 @@ extern "C" fn aborted_resolve_listener(closure: *const ClosureHeader) -> f64 {
 pub extern "C" fn js_util_aborted(signal: f64, resource: f64) -> f64 {
     let signal_ptr = match crate::url::abort::abort_signal_ptr_from_value(signal) {
         Some(signal_ptr) => signal_ptr,
-        None => return rejected_promise(invalid_signal_error(signal)),
+        None => return rejected_promise(invalid_aborted_signal_error()),
     };
     if !is_object_resource(resource) {
         return rejected_promise(invalid_resource_error(resource));

--- a/test-parity/node-suite/util/abort-helpers.ts
+++ b/test-parity/node-suite/util/abort-helpers.ts
@@ -81,6 +81,9 @@ source.abort("later");
 console.log("signal after source abort:", signal.aborted, signal.reason);
 
 await rejected("invalid aborted signal", () => aborted(undefined, {}));
+await rejected("invalid aborted signal null", () => aborted(null, {}));
+await rejected("invalid aborted signal object", () => aborted({}, {}));
+await rejected("invalid aborted signal number", () => aborted(1, {}));
 await rejected("invalid aborted resource", () =>
   aborted(new AbortController().signal, undefined),
 );


### PR DESCRIPTION
## Summary

- Fixes the `node:util` `aborted(signal, resource)` invalid-signal rejection message to match Node 26's WebIDL-style `signal is not of type AbortSignal.` text.
- Keeps `transferableAbortSignal()` on the existing detailed `AbortSignal` instance-validator message.
- Extends `node-suite/util/abort-helpers` to cover undefined, null, object, and number invalid-signal inputs.

## Linked Issue

- Part of #3146. This is a narrow remaining validation-message tail; broader runtime validation and `util.inspect` proxy rendering are out of scope.

## Why This Cut

Current `node-suite --module util` has a concrete `abort-helpers` mismatch for `aborted(undefined, {})`, while the rest of the helper behavior already matches Node. The fix is isolated to the util AbortSignal helper runtime path and does not touch unrelated util formatting or child_process AbortSignal option handling.

## Validation

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/util/abort-helpers.ts`
- Direct Perry fixture diff against the Node oracle: `target/release/perry test-parity/node-suite/util/abort-helpers.ts -o /tmp/perry_util_abort_after && /tmp/perry_util_abort_after`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module util --filter abort-helpers'` -> 1 pass / 0 fail / 0 compile fail\n- `cargo build --release --quiet -p perry -p perry-runtime`\n- `cargo fmt --all -- --check`\n- `git diff --check`\n- `./scripts/check_file_size.sh`\n\n## Non-goals\n\n- `util.inspect` proxy/default rendering.\n- Child-process AbortSignal option semantics.\n- Other broad #3146 validation leaves.