### PR TITLE
[codex] Cover reserved word parser contexts

### DIFF
--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -659,6 +659,54 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_js_sloppy_future_reserved_words() {
+        let source = r#"
+            var implements = "implements";
+            var interface = "interface";
+            var package = "package";
+            var private = "private";
+            var protected = "protected";
+            var public = "public";
+            var static = "static";
+        "#;
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(source, "test.js", &mut cache).unwrap();
+
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_parse_js_sloppy_escaped_contextual_identifiers() {
+        let source = r#"
+            var imp\u006Cements = 1;
+            var yie\u006Cd = 2;
+            var awa\u0069t = 3;
+        "#;
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(source, "test.js", &mut cache).unwrap();
+
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_parse_js_keyword_property_accessors() {
+        let source = r#"
+            var obj = { await: 0, yield: 1, static: 2, implements: 3 };
+            obj.await = "await";
+            obj.yield = "yield";
+            obj.static = "static";
+            obj.implements = "implements";
+        "#;
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(source, "test.js", &mut cache).unwrap();
+
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
     fn test_parse_ts_still_rejects_ts_syntax_errors() {
         let source = "let x: number = ;";
         let mut cache = SourceCache::new();

--- a/test-files/test_issue_3572_keyword_property_access.ts
+++ b/test-files/test_issue_3572_keyword_property_access.ts
@@ -1,0 +1,8 @@
+const obj: any = { await: 0, yield: 1, static: 2, implements: 3 };
+
+obj.await = "await";
+obj.yield = "yield";
+obj.static = "static";
+obj.implements = "implements";
+
+console.log("keyword-props", obj.await, obj.yield, obj.static, obj.implements);


### PR DESCRIPTION
## Summary
- Add parser regressions for sloppy `.js` future reserved words, escaped contextual identifiers, and keyword-named property accessors.
- Add a tracked runtime fixture for keyword property reads/writes such as `obj.await`.

## Notes
Current `main` already matches Node for the affected #3572 cases in focused probes; this PR locks that behavior in with coverage.

Closes #3572.

## Validation
- `CARGO_TARGET_DIR=/tmp/perry-reserved-word-contexts cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `CARGO_TARGET_DIR=/tmp/perry-reserved-word-contexts cargo test -p perry-parser test_parse_js -- --nocapture`
- `npm exec --yes --package=node@26 -- node test-files/test_issue_3572_keyword_property_access.ts`
- `/tmp/perry-reserved-word-contexts/release/perry compile --no-auto-optimize test-files/test_issue_3572_keyword_property_access.ts -o /tmp/perry_issue_3572_keyword_property_access && /tmp/perry_issue_3572_keyword_property_access`
- Node 26 local `.cjs` oracle for sloppy future-reserved/contextual identifiers matched Perry's compiled output.
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
