### PR TITLE
[codex] Align captured Object.assign value shape

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1768,9 +1768,29 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                             ast::MemberProp::Computed(_) => true,
                             _ => false,
                         };
+                    let outer_is_reified_object_static_value = property == "Object"
+                        && matches!(
+                            &member.prop,
+                            ast::MemberProp::Ident(p) if matches!(
+                                p.sym.as_ref(),
+                                "assign"
+                                    | "create"
+                                    | "defineProperty"
+                                    | "entries"
+                                    | "freeze"
+                                    | "fromEntries"
+                                    | "getOwnPropertyDescriptor"
+                                    | "getOwnPropertyNames"
+                                    | "getPrototypeOf"
+                                    | "hasOwn"
+                                    | "keys"
+                                    | "values"
+                            )
+                        );
                     if !outer_is_prototype_or_proto
                         && !receiver_is_namespace_value
                         && !outer_is_websocket_static
+                        && !outer_is_reified_object_static_value
                     {
                         object_expr = Expr::GlobalGet(0);
                     }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3103,7 +3103,14 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 1,
                 false,
             );
-            install_constructor_static(ctor, "assign", object_assign_thunk as *const u8, 1, true);
+            install_constructor_static_with_call_arity(
+                ctor,
+                "assign",
+                object_assign_thunk as *const u8,
+                2,
+                1,
+                true,
+            );
             install_constructor_static(ctor, "hasOwn", object_hasown_thunk as *const u8, 2, false);
         }
         "Array" => {

--- a/test-parity/node-suite/object/captured-object-assign.ts
+++ b/test-parity/node-suite/object/captured-object-assign.ts
@@ -1,0 +1,13 @@
+const assign = Object.assign;
+
+console.log("assign typeof:", typeof assign);
+console.log("assign name:", assign.name);
+console.log("assign length:", assign.length);
+
+const target: any = { base: 1 };
+const out: any = assign(target, { a: 2 }, { b: 3 });
+
+console.log("same target:", out === target);
+console.log("keys:", Object.keys(out).join(","));
+console.log("values:", [out.base, out.a, out.b].join(","));
+console.log("fresh copy:", JSON.stringify(assign({}, { x: 1 }, { y: 2 })));


### PR DESCRIPTION
## Linked issues

- Addresses #2564

## Summary

This PR aligns the captured `Object.assign` value shape with Node for the React-reconciler style pattern:

```ts
const assign = Object.assign;
assign({}, state, payload);
```

Current main already routes the captured call through the `Object.assign` alias-call rewrite, so the copy itself works. The value read still materializes as Perry's builtin sentinel, so `typeof assign`, `assign.name`, and `assign.length` are wrong. This keeps value reads for the already-reified `Object` statics on the real `Object` constructor closure, where the runtime has function-valued static properties installed.

It also corrects `Object.assign.length` to Node's value of `2` while preserving the runtime rest-argument call arity used by the assign thunk.

## Why this cut

The issue is specifically about a captured `Object.assign` alias used by React's HostRoot update queue. The HIR receiver-collapse fix and the existing runtime static metadata share the same behavior surface, so they belong in one small object-model PR. Broader React execution and other non-reified Object static values are intentionally left out.

## Tests

Added `node-suite/object/captured-object-assign` covering:

- `typeof Object.assign` after capture
- captured `name` and `length`
- target identity preservation
- multi-source copy output

Validation run locally with Node v26.3.0:

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/object/captured-object-assign.ts`
- Direct Perry-vs-Node output diff for `captured-object-assign`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module object --filter captured-object-assign'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module object --filter assign-coercion-errors'`
- `cargo fmt --all -- --check`
- `cargo check -p perry-hir -p perry-runtime`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations / non-goals

- Does not attempt a full React reconciler run.
- Does not add new runtime static values for Object methods that are not already reified on the constructor.
- Does not change the existing `Object.assign` copy/descriptor/proxy behavior beyond captured value shape and `length` metadata.
