### PR TITLE
[codex] fix generator function constructor lookups

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2474,6 +2474,26 @@ pub extern "C" fn js_object_get_field_by_name(
                 if val.to_bits() != crate::value::TAG_UNDEFINED {
                     return JSValue::from_bits(val.to_bits());
                 }
+                if name_str == "constructor" {
+                    if let Some(ctor) =
+                        crate::object::generator_function_constructor_of(obj as usize)
+                    {
+                        return JSValue::from_bits(ctor.to_bits());
+                    }
+                }
+                if name_str == "prototype" {
+                    if let Some(proto) =
+                        crate::object::generator_function_prototype_of(obj as usize)
+                    {
+                        return JSValue::from_bits(proto.to_bits());
+                    }
+                    let func_value = crate::value::js_nanbox_pointer(obj as i64);
+                    if let Some(proto) =
+                        super::ordinary_function_prototype_value_for_read(func_value)
+                    {
+                        return JSValue::from_bits(proto.to_bits());
+                    }
+                }
                 if name_str == "length" {
                     let closure_value = crate::value::js_nanbox_pointer(obj as i64);
                     if let Some(arity) =

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1695,17 +1695,15 @@ pub(crate) fn generator_function_proto_of(closure_ptr: usize) -> Option<f64> {
 /// `g.constructor` for a generator-function closure `g` → `%GeneratorFunction%`
 /// / `%AsyncGeneratorFunction%`. `None` for non-generator closures. (#3664)
 pub(crate) fn generator_function_constructor_of(closure_ptr: usize) -> Option<f64> {
-    let kind = closure_generator_kind(closure_ptr)?;
-    ensure_generator_intrinsics();
-    let slot = match kind {
-        GeneratorKind::Sync => {
-            crate::object::GENERATOR_FUNCTION_INTRINSIC_PTR.load(Ordering::Acquire)
-        }
-        GeneratorKind::Async => {
-            crate::object::ASYNC_GENERATOR_FUNCTION_INTRINSIC_PTR.load(Ordering::Acquire)
-        }
-    };
-    intrinsic_pointer_value(slot)
+    let proto = generator_function_proto_of(closure_ptr)?;
+    let proto_ptr = crate::value::js_nanbox_get_pointer(proto) as *const ObjectHeader;
+    if proto_ptr.is_null() {
+        return None;
+    }
+    let key =
+        crate::string::js_string_from_bytes(b"constructor".as_ptr(), "constructor".len() as u32);
+    let value = js_object_get_field_by_name(proto_ptr, key);
+    Some(f64::from_bits(value.bits()))
 }
 
 /// `g.prototype` for a generator-function closure `g`: a lazily-created object


### PR DESCRIPTION
## Summary
- route early closure property reads for generator functions through the generator constructor/prototype helpers
- make `g.constructor` resolve via the `%Generator%` / `%AsyncGenerator%` prototype's `constructor` property, matching `Object.getPrototypeOf(g).constructor`

## Root Cause
`js_object_get_field_by_name` had an early `is_closure_ptr` fast path that returned `undefined` for `constructor`/`prototype` before the later `GC_TYPE_CLOSURE` branch could apply the existing generator intrinsic handling. That made `g.constructor.name` fail even though the generator intrinsic tower and `Object.getPrototypeOf(g).constructor` were present.

## Validation
- `cargo check -p perry-runtime`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module globals --filter generator-intrinsics'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module globals --filter generator-prototype'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module util --filter generator-predicates'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
