### PR TITLE
[codex] fix re-exported class method prefixes

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -103,6 +103,63 @@ use super::progress::{ProgressSnapshot, VerboseProgress};
 mod types;
 pub use types::*;
 
+fn canonical_class_source_prefix(
+    class: &perry_hir::Class,
+    class_canonical_path: &HashMap<perry_hir::ClassId, String>,
+    project_root: &Path,
+    fallback_prefix: &str,
+) -> String {
+    class_canonical_path
+        .get(&class.id)
+        .map(|path| compute_module_prefix(path, project_root))
+        .unwrap_or_else(|| fallback_prefix.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_class_source_prefix_prefers_defining_path() {
+        let class = perry_hir::Class {
+            id: 7,
+            name: "Observable".to_string(),
+            type_params: Vec::new(),
+            extends: None,
+            extends_name: None,
+            native_extends: None,
+            extends_expr: None,
+            fields: Vec::new(),
+            constructor: None,
+            methods: Vec::new(),
+            getters: Vec::new(),
+            setters: Vec::new(),
+            static_fields: Vec::new(),
+            static_methods: Vec::new(),
+            computed_members: Vec::new(),
+            decorators: Vec::new(),
+            is_exported: true,
+            aliases: Vec::new(),
+        };
+        let project_root = PathBuf::from("/repo");
+        let mut class_canonical_path = HashMap::new();
+        class_canonical_path.insert(
+            class.id,
+            "/repo/node_modules/rxjs/src/internal/Observable.ts".to_string(),
+        );
+
+        assert_eq!(
+            canonical_class_source_prefix(
+                &class,
+                &class_canonical_path,
+                &project_root,
+                "node_modules_rxjs_src_index_ts",
+            ),
+            "node_modules_rxjs_src_internal_Observable_ts"
+        );
+    }
+}
+
 // `inject_ios_deeplinks`, `inject_google_auth_info_plist`, and
 // `lookup_bundle_id_from_info_plist` moved to `apple_info_plist.rs`.
 // `rust_target_triple` moved to `app_metadata.rs`.
@@ -2194,10 +2251,16 @@ pub fn run_with_parse_cache(
                                     imported_vars.insert(export_name.clone());
                                 }
                                 if let Some(class) = exported_classes.get(&key) {
+                                    let class_prefix = canonical_class_source_prefix(
+                                        class,
+                                        &class_canonical_path,
+                                        &ctx.project_root,
+                                        &origin_prefix,
+                                    );
                                     imported_classes.push(perry_codegen::ImportedClass {
                                         name: class.name.clone(),
                                         local_alias: None,
-                                        source_prefix: origin_prefix.clone(),
+                                        source_prefix: class_prefix,
                                         constructor_param_count: class
                                             .constructor
                                             .as_ref()
@@ -2382,10 +2445,16 @@ pub fn run_with_parse_cache(
                                         imported_vars.insert(export_name.clone());
                                     }
                                     if let Some(class) = exported_classes.get(&key) {
+                                        let class_prefix = canonical_class_source_prefix(
+                                            class,
+                                            &class_canonical_path,
+                                            &ctx.project_root,
+                                            &origin_prefix,
+                                        );
                                         imported_classes.push(perry_codegen::ImportedClass {
                                             name: class.name.clone(),
                                             local_alias: None,
-                                            source_prefix: origin_prefix.clone(),
+                                            source_prefix: class_prefix,
                                             constructor_param_count: class
                                                 .constructor
                                                 .as_ref()
@@ -2599,6 +2668,12 @@ pub fn run_with_parse_cache(
 
                     // Imported classes
                     if let Some(class) = exported_classes.get(&key) {
+                        let class_prefix = canonical_class_source_prefix(
+                            class,
+                            &class_canonical_path,
+                            &ctx.project_root,
+                            &effective_prefix,
+                        );
                         // Issue #665: when the user wrote `import X from "pkg"`
                         // and `pkg`'s default export is a class, the importer
                         // still registers `exported_name="default"` into
@@ -2625,7 +2700,7 @@ pub fn run_with_parse_cache(
                             imported_classes.push(perry_codegen::ImportedClass {
                                 name: class.name.clone(),
                                 local_alias: Some(exported_name.clone()),
-                                source_prefix: effective_prefix.clone(),
+                                source_prefix: class_prefix.clone(),
                                 constructor_param_count: class
                                     .constructor
                                     .as_ref()
@@ -2689,7 +2764,7 @@ pub fn run_with_parse_cache(
                             } else {
                                 None
                             },
-                            source_prefix: effective_prefix.clone(),
+                            source_prefix: class_prefix,
                             constructor_param_count: class
                                 .constructor
                                 .as_ref()

--- a/test-files/fixtures/issue_1021_rxjs_reexport_methods/index.ts
+++ b/test-files/fixtures/issue_1021_rxjs_reexport_methods/index.ts
@@ -1,0 +1,2 @@
+export { Observable } from "./internal/Observable.js";
+export { Subject } from "./internal/Subject.js";

--- a/test-files/fixtures/issue_1021_rxjs_reexport_methods/internal/Observable.ts
+++ b/test-files/fixtures/issue_1021_rxjs_reexport_methods/internal/Observable.ts
@@ -1,0 +1,11 @@
+export class Observable {
+  private value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+  subscribe(): string {
+    return "subscribe:" + this.value;
+  }
+}

--- a/test-files/fixtures/issue_1021_rxjs_reexport_methods/internal/Subject.ts
+++ b/test-files/fixtures/issue_1021_rxjs_reexport_methods/internal/Subject.ts
@@ -1,0 +1,17 @@
+import { Observable } from "../index.js";
+
+export class Subject extends Observable {
+  private closed = false;
+
+  error(message: string): string {
+    this.closed = true;
+    return "error:" + message;
+  }
+
+  next(value: string): string {
+    if (this.closed) {
+      return "closed";
+    }
+    return this.subscribe() + ":next:" + value;
+  }
+}

--- a/test-files/test_issue_1021_rxjs_reexport_methods.ts
+++ b/test-files/test_issue_1021_rxjs_reexport_methods.ts
@@ -1,0 +1,18 @@
+// Issue #1021 follow-up: RxJS-style barrels re-export classes from
+// `src/internal/*`, while consumers import from the package index. The
+// cross-module method metadata must keep the defining file's prefix, not
+// the barrel's prefix, or the link step references method symbols that no
+// module emitted.
+
+import { Observable, Subject } from "./fixtures/issue_1021_rxjs_reexport_methods/index.js";
+
+function read(obs: Observable): string {
+  return obs.subscribe();
+}
+
+const subject = new Subject("seed");
+
+console.log(read(new Observable("plain")));
+console.log(subject.next("value"));
+console.log(subject.error("boom"));
+console.log(subject.next("after"));


### PR DESCRIPTION
## Summary
- Canonicalize `ImportedClass.source_prefix` through the class defining path for namespace imports, namespace re-exports, and named imports.
- Keep existing barrel/effective prefixes for non-class import metadata while using the defining module prefix for class method symbols.
- Add an RxJS-style barrel regression where `Subject` imports `Observable` via the package index and inherited methods are exercised.

## Root Cause
`exported_classes` can map barrel names to class objects emitted from internal modules. The importer was storing the barrel/effective module prefix in `ImportedClass.source_prefix`, so generated call sites could reference method symbols with the barrel prefix instead of the module that emitted those methods.

## Validation
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `cargo test --release -p perry canonical_class_source_prefix_prefers_defining_path -- --nocapture`
- `./target/release/perry test-files/test_issue_1021_rxjs_reexport_methods.ts -o /tmp/perry_issue_1021_reexport_methods_after && /tmp/perry_issue_1021_reexport_methods_after`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Notes
I also tried the current `tests/release/packages/nestjs-hello` fixture with this branch. It now stops before link/codegen at the V8-free JS dependency gate for Express/Multer-side dependencies such as `tslib`, `uid`, `iterare`, `fast-safe-stringify`, `path-to-regexp`, `cors`, `express`, and `multer`, so this PR does not claim an end-to-end NestJS pass.
