### PR TITLE
[codex] fix uncurried hasOwnProperty on builtin prototypes

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1037,15 +1037,7 @@ extern "C" fn object_prototype_has_own_property_thunk(
     key: f64,
 ) -> f64 {
     let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
-    unsafe {
-        super::js_native_call_method(
-            this_value,
-            b"hasOwnProperty".as_ptr() as *const i8,
-            "hasOwnProperty".len(),
-            &key as *const f64,
-            1,
-        )
-    }
+    super::object_ops::js_object_has_own(this_value, key)
 }
 
 extern "C" fn object_prototype_property_is_enumerable_thunk(

--- a/test-parity/node-suite/globals/function-call-bind-builtin-prototypes.ts
+++ b/test-parity/node-suite/globals/function-call-bind-builtin-prototypes.ts
@@ -1,0 +1,15 @@
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+const isEnumerable = Function.prototype.call.bind(Object.prototype.propertyIsEnumerable);
+
+function show(label: string, value: unknown) {
+  console.log(label, typeof value, String(value));
+}
+
+show("plain own", hasOwn({ a: 1 }, "a"));
+show("array proto push", hasOwn(Array.prototype, "push"));
+show("math abs", hasOwn(Math, "abs"));
+show("object proto toString", hasOwn(Object.prototype, "toString"));
+show("error proto message", hasOwn(Error.prototype, "message"));
+
+show("object proto toString enumerable", isEnumerable(Object.prototype, "toString"));
+show("error proto message enumerable", isEnumerable(Error.prototype, "message"));


### PR DESCRIPTION
## Summary
- route `Object.prototype.hasOwnProperty` thunk calls directly through `js_object_has_own`
- add a globals parity fixture for `Function.prototype.call.bind(Object.prototype.hasOwnProperty)` on builtin prototype receivers

Fixes #4276.

## Root Cause
The uncurried `Function.prototype.call.bind(Object.prototype.hasOwnProperty)` path eventually invokes the installed `Object.prototype.hasOwnProperty` thunk with `IMPLICIT_THIS` set to the requested receiver. That thunk re-entered `js_native_call_method(this, "hasOwnProperty", ...)`. For receivers like `Object.prototype` and `Error.prototype`, the method tower found the receiver own `hasOwnProperty` field first and recursed until the depth guard returned an object.

Calling `js_object_has_own` directly matches the existing HIR rewrite for `Object.prototype.hasOwnProperty.call(obj, key)` and avoids the recursive method lookup.

## Why this cluster
This PR is limited to one receiver dispatch path: `Function.prototype.call.bind(method)` forwarding the call receiver into an `Object.prototype` builtin thunk. Error descriptor shape work stays on the separate descriptor-focused branch.

## Validation
- `npm exec --yes --package=node@26 -- node --version` (`v26.3.0`)
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter function-call-bind-builtin-prototypes'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter builtin-constructor-own-name-length'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter reflective-builtins'`
- `cargo check -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`