### PR TITLE
[codex] cover dynamic import local candidates

### DIFF
--- a/test-parity/node-suite/module/loader/dynamic-import-local-candidates.ts
+++ b/test-parity/node-suite/module/loader/dynamic-import-local-candidates.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+async function loadFromLet(flag: boolean) {
+  let specifier = flag
+    ? "./fixtures/dynamic-local-a.ts"
+    : "./fixtures/dynamic-local-b.ts";
+  const mod = await import(specifier);
+  return mod.value;
+}
+
+async function loadFromTemplate(flag: boolean) {
+  let name = flag ? "a" : "b";
+  let specifier = `./fixtures/dynamic-local-${name}.ts`;
+  const mod = await import(specifier);
+  return mod.templateValue;
+}
+
+console.log("let true:", await loadFromLet(true));
+console.log("let false:", await loadFromLet(false));
+console.log("template true:", await loadFromTemplate(true));
+console.log("template false:", await loadFromTemplate(false));

--- a/test-parity/node-suite/module/loader/fixtures/dynamic-local-a.ts
+++ b/test-parity/node-suite/module/loader/fixtures/dynamic-local-a.ts
@@ -1,0 +1,2 @@
+export const value = "local-a";
+export const templateValue = "template-a";

--- a/test-parity/node-suite/module/loader/fixtures/dynamic-local-b.ts
+++ b/test-parity/node-suite/module/loader/fixtures/dynamic-local-b.ts
@@ -1,0 +1,2 @@
+export const value = "local-b";
+export const templateValue = "template-b";


### PR DESCRIPTION
## Summary

Part of #1674.

This adds end-to-end Node parity coverage for dynamic `import()` specifiers stored in never-reassigned local `let` bindings with finite literal candidate sets.

- covers `let specifier = flag ? "./a" : "./b"; await import(specifier)` inside a function
- covers a transitive template-literal case where a never-reassigned local candidate feeds another local specifier
- adds two tiny fixture target modules so both dispatch branches are executed at runtime

The resolver support is already present on current `main`; this PR locks the behavior in the parity suite.

## Non-goals

- no compiler/runtime behavior changes
- no template-glob/context-module wildcard expansion coverage in this cut
- no function-parameter type narrowing or later-assignment reaching-definition analysis

## Validation

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/module/loader/dynamic-import-local-candidates.ts`
- `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/tmp/perry-dynamic-import-build cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `PERRY_NO_AUTO_OPTIMIZE=1 /tmp/perry-dynamic-import-build/release/perry test-parity/node-suite/module/loader/dynamic-import-local-candidates.ts -o /tmp/perry_dynamic_import_local && /tmp/perry_dynamic_import_local`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/tmp/perry-dynamic-import-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module module --filter dynamic-import-local-candidates'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/tmp/perry-dynamic-import-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module module --filter dynamic-import'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
