### PR TITLE
[codex] cover dynamic import glob candidates

### DIFF
--- a/test-parity/node-suite/module/loader/dynamic-import-glob-candidates.ts
+++ b/test-parity/node-suite/module/loader/dynamic-import-glob-candidates.ts
@@ -1,0 +1,8 @@
+// @ts-nocheck
+async function load(name: string) {
+  const mod = await import(`./fixtures/dynamic-glob/${name}.ts`);
+  return `${mod.name}:${mod.value}`;
+}
+
+console.log("glob alpha:", await load("alpha"));
+console.log("glob beta:", await load("beta"));

--- a/test-parity/node-suite/module/loader/fixtures/dynamic-glob/alpha.ts
+++ b/test-parity/node-suite/module/loader/fixtures/dynamic-glob/alpha.ts
@@ -1,0 +1,2 @@
+export const name = "alpha";
+export const value = "glob-a";

--- a/test-parity/node-suite/module/loader/fixtures/dynamic-glob/beta.ts
+++ b/test-parity/node-suite/module/loader/fixtures/dynamic-glob/beta.ts
@@ -1,0 +1,2 @@
+export const name = "beta";
+export const value = "glob-b";


### PR DESCRIPTION
Part of PerryTS/perry#1674.

## Scope
- Adds a Node parity fixture for directory-scoped dynamic import template literals.
- Covers finite candidate expansion through `import(`./fixtures/dynamic-glob/${name}.ts`)`.
- Includes two local fixture modules so the test verifies both discovered candidates compile and run.

## Non-goals
- No compiler/runtime changes.
- No package or bare-specifier wildcard support.
- No unbounded recursive glob behavior.
- No additional parameter type narrowing beyond the existing directory-scoped glob handling.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/module/loader/dynamic-import-glob-candidates.ts`
- `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-dynamic-import-glob-build cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `PERRY_NO_AUTO_OPTIMIZE=1 /root/perry-worktrees/.build-targets/perry-dynamic-import-glob-build/release/perry test-parity/node-suite/module/loader/dynamic-import-glob-candidates.ts -o /tmp/perry_dynamic_import_glob && /tmp/perry_dynamic_import_glob`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-dynamic-import-glob-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module module --filter dynamic-import-glob-candidates'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-dynamic-import-glob-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module module --filter dynamic-import'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
