### PR TITLE
[codex] honor child_process numeric stdio fds

### DIFF
--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -1626,9 +1626,27 @@ pub(super) enum CpStdio {
     Pipe,
     Ignore,
     Inherit,
+    Fd(i32),
 }
 
 fn cp_stdio_kind(value: f64) -> CpStdio {
+    let js_value = JSValue::from_bits(value.to_bits());
+    let fd = if js_value.is_int32() {
+        Some(js_value.as_int32())
+    } else if js_value.is_number() {
+        let n = js_value.as_number();
+        if n.is_finite() && n >= 0.0 && n.fract() == 0.0 && n <= i32::MAX as f64 {
+            Some(n as i32)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    if let Some(fd) = fd {
+        return CpStdio::Fd(fd);
+    }
+
     match cp_value_to_string(value).as_deref() {
         Some("ignore") => CpStdio::Ignore,
         Some("inherit") => CpStdio::Inherit,
@@ -1636,8 +1654,8 @@ fn cp_stdio_kind(value: f64) -> CpStdio {
     }
 }
 
-/// Read the deterministic live-stdio subset: `pipe` (default), `ignore`, and
-/// `inherit`. Other Node forms (numeric fds, custom streams) intentionally
+/// Read the deterministic live-stdio subset: `pipe` (default), `ignore`,
+/// `inherit`, and numeric fd entries. Custom stream handles intentionally
 /// remain in #2555.
 pub(super) fn cp_read_stdio(opts_val: f64, fds: usize) -> Vec<CpStdio> {
     let mut out = vec![CpStdio::Pipe; fds];
@@ -1646,6 +1664,14 @@ pub(super) fn cp_read_stdio(opts_val: f64, fds: usize) -> Vec<CpStdio> {
     }
 
     let stdio = cp_get_field(opts_val, b"stdio");
+    if let Some(arr) = cp_array_ptr(stdio) {
+        let n = crate::array::js_array_length(arr).min(fds as u32);
+        for i in 0..n {
+            out[i as usize] = cp_stdio_kind(crate::array::js_array_get_f64(arr, i));
+        }
+        return out;
+    }
+
     if let Some(s) = cp_value_to_string(stdio) {
         match s.as_str() {
             "ignore" => out.fill(CpStdio::Ignore),
@@ -1654,21 +1680,13 @@ pub(super) fn cp_read_stdio(opts_val: f64, fds: usize) -> Vec<CpStdio> {
         }
         return out;
     }
-
-    let Some(arr) = cp_array_ptr(stdio) else {
-        return out;
-    };
-    let n = crate::array::js_array_length(arr).min(fds as u32);
-    for i in 0..n {
-        out[i as usize] = cp_stdio_kind(crate::array::js_array_get_f64(arr, i));
-    }
     out
 }
 
 pub(super) fn cp_stdio_js_value(kind: CpStdio, pipe_obj: f64) -> f64 {
     match kind {
         CpStdio::Pipe => pipe_obj,
-        CpStdio::Ignore | CpStdio::Inherit => TAG_NULL_F64,
+        CpStdio::Ignore | CpStdio::Inherit | CpStdio::Fd(_) => TAG_NULL_F64,
     }
 }
 
@@ -1677,10 +1695,31 @@ pub(super) fn cp_apply_live_stdio(command: &mut Command, stdio: &[CpStdio]) {
         CpStdio::Pipe => Stdio::piped(),
         CpStdio::Ignore => Stdio::null(),
         CpStdio::Inherit => Stdio::inherit(),
+        CpStdio::Fd(fd) => cp_stdio_from_fd(fd),
     };
     command.stdin(to_stdio(stdio.first().copied().unwrap_or(CpStdio::Pipe)));
     command.stdout(to_stdio(stdio.get(1).copied().unwrap_or(CpStdio::Pipe)));
     command.stderr(to_stdio(stdio.get(2).copied().unwrap_or(CpStdio::Pipe)));
+}
+
+#[cfg(unix)]
+fn cp_stdio_from_fd(fd: i32) -> Stdio {
+    use std::os::fd::FromRawFd;
+
+    if let Some(file) = crate::fs::try_clone_registered_fd(fd) {
+        return Stdio::from(file);
+    }
+
+    let dup_fd = unsafe { libc::dup(fd) };
+    if dup_fd < 0 {
+        return Stdio::null();
+    }
+    unsafe { Stdio::from_raw_fd(dup_fd) }
+}
+
+#[cfg(not(unix))]
+fn cp_stdio_from_fd(_fd: i32) -> Stdio {
+    Stdio::null()
 }
 
 /// Default shell for `{ shell: true }` (`shell: "<path>"` overrides it).

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -74,6 +74,10 @@ pub(crate) fn fd_is_registered(fd: i32) -> bool {
     FD_REGISTRY.with(|r| r.borrow().contains_key(&fd))
 }
 
+pub(crate) fn try_clone_registered_fd(fd: i32) -> Option<fs::File> {
+    FD_REGISTRY.with(|r| r.borrow().get(&fd).and_then(|file| file.try_clone().ok()))
+}
+
 pub(crate) fn filehandle_object_fd(value: f64) -> Option<i32> {
     let bits = value.to_bits();
     if (bits & !POINTER_MASK) != POINTER_TAG {

--- a/test-parity/node-suite/child_process/async/stdio-fd.ts
+++ b/test-parity/node-suite/child_process/async/stdio-fd.ts
@@ -1,0 +1,75 @@
+import { fork, spawn } from "node:child_process";
+import { closeSync, openSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function slot(value: any): string {
+  return value === null ? "null" : typeof value;
+}
+
+function report(label: string, child: any) {
+  console.log(`${label} props:`, slot(child.stdin), slot(child.stdout), slot(child.stderr));
+  console.log(`${label} stdio:`, child.stdio.map(slot).join(","));
+}
+
+function close(child: any): Promise<number | null> {
+  return new Promise((resolve) => child.on("close", (code: number | null) => resolve(code)));
+}
+
+function readTrim(path: string): string {
+  return readFileSync(path, "utf8").trim();
+}
+
+const base = join(tmpdir(), `perry-stdio-fd-${process.pid}`);
+const outPath = `${base}-out.txt`;
+const errPath = `${base}-err.txt`;
+const forkOutPath = `${base}-fork-out.txt`;
+const forkErrPath = `${base}-fork-err.txt`;
+const childFile = `${base}-child.js`;
+
+writeFileSync(outPath, "");
+writeFileSync(errPath, "");
+writeFileSync(forkOutPath, "");
+writeFileSync(forkErrPath, "");
+writeFileSync(
+  childFile,
+  [
+    "process.stdout.write('fork-out');",
+    "process.stderr.write('fork-err');",
+    "process.on('message', () => { if (process.send) process.send({ ok: true }); process.exit(0); });",
+  ].join(""),
+);
+
+const outFd = openSync(outPath, "w");
+const errFd = openSync(errPath, "w");
+const fromFds = spawn("sh", ["-c", "printf fd-out; printf fd-err >&2"], {
+  stdio: ["ignore", outFd, errFd],
+});
+report("spawn fd", fromFds);
+console.log("spawn fd close:", await close(fromFds));
+closeSync(outFd);
+closeSync(errFd);
+console.log("spawn fd stdout file:", readTrim(outPath));
+console.log("spawn fd stderr file:", readTrim(errPath));
+
+const forkOutFd = openSync(forkOutPath, "w");
+const forkErrFd = openSync(forkErrPath, "w");
+const forked = fork(childFile, [], { stdio: ["ignore", forkOutFd, forkErrFd, "ipc"] });
+report("fork fd", forked);
+console.log("fork channel:", typeof forked.channel);
+const message: any = await new Promise((resolve) => {
+  forked.on("message", resolve);
+  forked.send({ ping: true });
+});
+console.log("fork ipc:", message.ok);
+console.log("fork fd close:", await close(forked));
+closeSync(forkOutFd);
+closeSync(forkErrFd);
+console.log("fork fd stdout file:", readTrim(forkOutPath));
+console.log("fork fd stderr file:", readTrim(forkErrPath));
+
+for (const path of [outPath, errPath, forkOutPath, forkErrPath, childFile]) {
+  try {
+    unlinkSync(path);
+  } catch {}
+}


### PR DESCRIPTION
## Summary

This adds live `child_process` support for numeric fd entries in `spawn()` and `fork()` stdio arrays. Valid fd entries are routed to duplicated parent file descriptors, while the JS-visible `stdin`/`stdout`/`stderr` properties and `child.stdio[]` slots match Node by exposing `null` for those entries.

The change also parses array stdio forms before string forms so mixed arrays such as `["ignore", outFd, errFd]` are not accidentally interpreted as strings, and keeps fork IPC behavior intact for `["ignore", outFd, errFd, "ipc"]`.

Non-goals for this slice: custom stream handles, invalid-fd validation/error shape, sync stdio fd forms, numeric stdin coverage, AbortSignal/killSignal timeout behavior, uid/gid, detached/platform flags, and broad option validation.

## Validation

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/child_process/async/stdio-fd.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter stdio-fd'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter stdio-ignore'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter stdio-inherit'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process'` (18/18)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/tmp/perry-child-stdio-fd-check cargo check -p perry-runtime` (passes with existing warnings)
