### PR TITLE
[codex] retire CI-env parity fixture skips

### DIFF
--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -74,6 +74,32 @@ run_with_timeout() {
     fi
 }
 
+wait_for_tcp_port() {
+    local host=$1
+    local port=$2
+    local attempts=$3
+    local delay=${4:-0.1}
+    python3 - "$host" "$port" "$attempts" "$delay" <<'PY'
+import socket
+import sys
+import time
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+attempts = int(sys.argv[3])
+delay = float(sys.argv[4])
+
+for _ in range(attempts):
+    try:
+        with socket.create_connection((host, port), timeout=0.2):
+            sys.exit(0)
+    except OSError:
+        time.sleep(delay)
+
+sys.exit(1)
+PY
+}
+
 # ── TLS-upgrade companion server (issue #275) ──────────────────────────────
 # Spawned once per test_net_upgrade_tls* test; killed immediately after.
 # Uses a self-signed cert; test calls upgradeToTLS(host, verify=0) so cert
@@ -82,14 +108,19 @@ run_with_timeout() {
 TLS_UPGRADE_SERVER_PID=""
 
 start_tls_upgrade_server() {
-    python3 "$SCRIPT_DIR/test-files/test_net_upgrade_tls_server.py" --port 17892 &
+    local server_script="$SCRIPT_DIR/test-files/test_net_upgrade_tls_server.py"
+    if ! command -v python3 &>/dev/null; then
+        echo -e "${YELLOW}WARN${NC}  python3 not found — test_net_upgrade_tls will fail parity" >&2
+        return 1
+    fi
+    if [[ ! -f "$server_script" ]]; then
+        echo -e "${YELLOW}WARN${NC}  $server_script not found — test_net_upgrade_tls will fail parity" >&2
+        return 1
+    fi
+    python3 "$server_script" --port 17892 &
     TLS_UPGRADE_SERVER_PID=$!
     # Wait up to 3 s for the port to open.
-    local i
-    for i in $(seq 1 30); do
-        nc -z 127.0.0.1 17892 2>/dev/null && return 0
-        sleep 0.1
-    done
+    wait_for_tcp_port 127.0.0.1 17892 30 0.1 && return 0
     echo -e "${YELLOW}WARN${NC}  TLS-upgrade server did not come up in time (pid $TLS_UPGRADE_SERVER_PID)" >&2
     return 1
 }
@@ -355,13 +386,9 @@ start_echo_server() {
     ECHO_SERVER_PID=$!
     # Poll up to 5 s (50 × 100 ms) for the server to accept connections.
     local ready=0
-    for _i in $(seq 1 50); do
-        if nc -z 127.0.0.1 17891 2>/dev/null; then
-            ready=1
-            break
-        fi
-        sleep 0.1
-    done
+    if wait_for_tcp_port 127.0.0.1 17891 50 0.1; then
+        ready=1
+    fi
     if [[ $ready -eq 1 ]]; then
         echo "Echo server started on 127.0.0.1:17891 (PID $ECHO_SERVER_PID)"
     else

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -8,30 +8,6 @@
       "reason": "Free-text explanation. Keep the most-actionable signal first \u2014 what changes the verdict (a fixture, a Perry fix, a Node spec change)."
     }
   },
-  "test_issue_422_socket_connect": {
-    "issue": "1634",
-    "added": "2026-05-15",
-    "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). #422 closed (net.Socket connect/error events + factory). The test passes locally with an echo server running but fails on Linux CI because no echo fixture server runs. Environmental \u2014 needs a CI-side fixture, not a Perry fix."
-  },
-  "test_net_min": {
-    "issue": "1634",
-    "added": "2026-05-15",
-    "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
-  },
-  "test_net_socket": {
-    "issue": "1634",
-    "added": "2026-05-15",
-    "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 needs a CI-side fixture, not a Perry fix."
-  },
-  "test_net_upgrade_tls": {
-    "issue": "1634",
-    "added": "2026-05-15",
-    "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test needs a TLS-capable echo server fixture; not available on CI. Environmental \u2014 needs a CI-side fixture."
-  },
   "test_parity_dns": {
     "issue": "793",
     "added": "2026-05-15",
@@ -97,18 +73,6 @@
     "added": "2026-05-15",
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:zlib` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
-  "test_sock_write_map": {
-    "issue": "1634",
-    "added": "2026-05-15",
-    "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Net test passes locally with an echo server running, fails on Linux CI (no echo fixture server). Environmental \u2014 issue #91 dispatch fix landed in v0.5.581 and is no longer the cause; needs a CI-side fixture."
-  },
-  "test_ramda_sum": {
-    "issue": "1634",
-    "added": "2026-05-18",
-    "category": "ci-env",
-    "reason": "Tracked in #1634 (parity CI environment fixtures). Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list \u2014 the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
   },
   "node-suite/stream/web/abort-during-pipeto": {
     "issue": "1545",


### PR DESCRIPTION
## Linked issues

- Closes #1634

## Summary

This PR retires the stale `ci-env` known-failure entries owned by #1634. The legacy top-level net fixtures already have local companion servers, but readiness polling depended on runner `nc`; the Ramda-named fixture is now a self-contained mini-reproducer and no longer imports the package.

Changes:
- add a `wait_for_tcp_port` helper in `run_parity_tests.sh` that probes local TCP readiness with Python sockets instead of runner `nc`;
- apply that helper to both the top-level echo server and the per-test TLS-upgrade server;
- add missing Python/script guardrails to the TLS-upgrade helper;
- remove all #1634 `ci-env` entries from `test-parity/known_failures.json`.

## Why this batch

These entries share the same stale CI-environment classification. The net entries are companion-server lifecycle checks, and `test_ramda_sum` has since become a self-contained runtime mini-reproducer rather than an npm-install fixture. Keeping them together closes the #1634 skip-list cleanup without mixing runtime behavior changes.

## Validation

- `bash -n run_parity_tests.sh`
- `jq empty test-parity/known_failures.json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- Node v26 focused parity filters, all 1 pass / 0 parity fail / 0 compile fail:
  - `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --filter test_issue_422_socket_connect'`
  - `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --filter test_net_min'`
  - `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --filter test_net_socket'`
  - `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --filter test_net_upgrade_tls'`
  - `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --filter test_sock_write_map'`
  - `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --filter test_ramda_sum'`

## Known limitations

The TLS-upgrade fixture still uses its stored expected-output path because Node exits nonzero for this Perry-specific helper shape; the Perry expected-output comparison passes. Module-inventory and stream/web known-failure entries are unchanged.

## Non-goals

No Node runtime behavior, net stdlib behavior, npm package installation, module-inventory skips, or stream/web behavior are changed here.