### PR TITLE
[codex] add parity matrix trend gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -440,12 +440,23 @@ jobs:
           fi
           echo "All ${TOTAL} failures are known/triaged."
 
+      - name: Generate parity matrix trend
+        run: |
+          python3 scripts/parity_matrix_trend.py \
+            --check \
+            --output-json test-parity/reports/parity_matrix_latest.json \
+            --output-md test-parity/reports/parity_matrix_latest.md
+          cat test-parity/reports/parity_matrix_latest.md >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload parity report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: parity-report
-          path: test-parity/reports/latest.json
+          path: |
+            test-parity/reports/latest.json
+            test-parity/reports/parity_matrix_latest.json
+            test-parity/reports/parity_matrix_latest.md
 
       # Capture per-test compile stderr written by run_parity_tests.sh into
       # `test-parity/output/*.compile_error.log` so the long-tail

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -391,8 +391,14 @@ echo ""
 REPORT_FILE="$REPORT_DIR/parity_report_$(date +%Y%m%d_%H%M%S).json"
 LATEST_REPORT="$REPORT_DIR/latest.json"
 
-# Start JSON array for test results
-TEST_RESULTS="[]"
+# Compact per-test records consumed by scripts/parity_matrix_trend.py.
+declare -a TEST_RESULTS=()
+
+record_result() {
+    local test_id=$1
+    local status=$2
+    TEST_RESULTS+=("{\"id\":\"$test_id\",\"status\":\"$status\"}")
+}
 
 declare -a TEST_FILES=()
 case "$TEST_SUITE" in
@@ -471,6 +477,7 @@ for test_file in "${TEST_FILES[@]}"; do
     if should_skip "$test_name"; then
         echo -e "${YELLOW}SKIP${NC}  $test_id (async/timer test)"
         ((SKIPPED++))
+        record_result "$test_id" "skipped"
         continue
     fi
 
@@ -504,6 +511,7 @@ for test_file in "${TEST_FILES[@]}"; do
         if ! has_expected_output "$test_name"; then
             echo -e "${YELLOW}SKIP${NC}  $test_id (Node.js error: exit $node_exit)"
             ((NODE_FAIL++))
+            record_result "$test_id" "node_fail"
             [[ -n "$local_server_pid" ]] && stop_tls_upgrade_server
             continue
         fi
@@ -540,6 +548,7 @@ for test_file in "${TEST_FILES[@]}"; do
         echo -e "${RED}FAIL${NC}  $test_id (compile error)"
         ((COMPILE_FAIL++))
         COMPILE_FAILURES+=("$test_id")
+        record_result "$test_id" "compile_fail"
         echo "" > "$perry_output_file"
         # Persist the actual compile stderr so CI artifacts can be inspected
         # to diagnose long-tail compile failures (e.g. the macOS-14 SDK gap
@@ -578,7 +587,7 @@ for test_file in "${TEST_FILES[@]}"; do
             echo -e "${RED}FAIL${NC}  $test_id (expected-output mismatch)"
             ((PARITY_FAIL++))
             PARITY_FAILURES+=("$test_id")
-            status="fail"
+            status="parity_fail"
             echo "       Expected exit: $expected_exit"
             echo "       Perry exit:    $perry_exit"
             echo "       Expected: $(cat "$EXPECTED_DIR/${test_name}.txt" | head -1)"
@@ -598,13 +607,15 @@ for test_file in "${TEST_FILES[@]}"; do
             echo -e "${RED}FAIL${NC}  $test_id (output mismatch)"
             ((PARITY_FAIL++))
             PARITY_FAILURES+=("$test_id")
-            status="fail"
+            status="parity_fail"
 
             # Show diff for failures (first few lines)
             echo "       Node.js:    $(echo "$node_output" | head -1)"
             echo "       Perry:  $(echo "$perry_output" | head -1)"
         fi
     fi
+
+    record_result "$test_id" "$status"
 
     # Stop any per-test companion server that was started for this test.
     [[ -n "$local_server_pid" ]] && stop_tls_upgrade_server
@@ -651,6 +662,8 @@ if [[ ${#COMPILE_FAILURES[@]} -gt 0 ]]; then
     echo ""
 fi
 
+RESULTS_JSON=$(printf '%s\n' "${TEST_RESULTS[@]}" | paste -sd, -)
+
 # Generate JSON report
 cat > "$REPORT_FILE" << EOF
 {
@@ -669,7 +682,8 @@ cat > "$REPORT_FILE" << EOF
 ,
     "compile": [$(printf '"%s",' "${COMPILE_FAILURES[@]}" | sed 's/,$//')]
 
-  }
+  },
+  "results": [${RESULTS_JSON}]
 }
 EOF
 

--- a/scripts/parity_matrix_trend.py
+++ b/scripts/parity_matrix_trend.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Build and check the per-module parity matrix trend artifact (#812).
+
+The parity runner compares Perry output with Node output per test and writes
+`test-parity/reports/latest.json`. This script narrows that report to the
+top-level `test_parity_<module>` matrix, computes per-module line/diff counts
+from the captured output files, and checks the result against a committed
+baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REPORT = REPO_ROOT / "test-parity" / "reports" / "latest.json"
+DEFAULT_KNOWN = REPO_ROOT / "test-parity" / "known_failures.json"
+DEFAULT_BASELINE = REPO_ROOT / "test-parity" / "parity_matrix_baseline.json"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "test-parity" / "output"
+DEFAULT_JSON = REPO_ROOT / "test-parity" / "reports" / "parity_matrix_latest.json"
+DEFAULT_MARKDOWN = REPO_ROOT / "test-parity" / "reports" / "parity_matrix_latest.md"
+
+FAIL_STATUSES = {"parity_fail", "compile_fail", "node_fail"}
+
+
+@dataclass
+class ModuleRecord:
+    module: str
+    test_id: str
+    status: str
+    known: bool
+    node_lines: int | None
+    perry_lines: int | None
+    diff_lines: int | None
+
+
+def load_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def normalize_status(status: str) -> str:
+    if status == "fail":
+        return "parity_fail"
+    return status
+
+
+def module_from_test_id(test_id: str) -> str | None:
+    prefix = "test_parity_"
+    if not test_id.startswith(prefix):
+        return None
+    return test_id[len(prefix):]
+
+
+def safe_test_id(test_id: str) -> str:
+    return test_id.replace("/", "__")
+
+
+def read_lines(path: Path) -> list[str] | None:
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8", errors="replace").splitlines()
+
+
+def diff_line_count(node_lines: list[str] | None, perry_lines: list[str] | None) -> int | None:
+    if node_lines is None or perry_lines is None:
+        return None
+    diff = difflib.unified_diff(node_lines, perry_lines, n=0, lineterm="")
+    count = 0
+    for line in diff:
+        if line.startswith(("+++", "---", "@@")):
+            continue
+        if line.startswith(("+", "-")):
+            count += 1
+    return count
+
+
+def known_failures(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    data = load_json(path)
+    return {key for key in data if key != "_schema"}
+
+
+def report_results(report: dict) -> list[dict[str, str]]:
+    results = report.get("results")
+    if isinstance(results, list):
+        out: list[dict[str, str]] = []
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            test_id = item.get("id")
+            status = item.get("status")
+            if isinstance(test_id, str) and isinstance(status, str):
+                out.append({"id": test_id, "status": normalize_status(status)})
+        return out
+
+    # Backward compatibility for reports generated before run_parity_tests.sh
+    # started emitting the `results` array. This can only describe failures.
+    out = []
+    failures = report.get("failures", {})
+    for test_id in failures.get("parity", []) or []:
+        if test_id:
+            out.append({"id": test_id, "status": "parity_fail"})
+    for test_id in failures.get("compile", []) or []:
+        if test_id:
+            out.append({"id": test_id, "status": "compile_fail"})
+    return out
+
+
+def build_records(report: dict, known: set[str], output_dir: Path) -> list[ModuleRecord]:
+    records: list[ModuleRecord] = []
+    seen: set[str] = set()
+    for result in report_results(report):
+        test_id = result["id"]
+        module = module_from_test_id(test_id)
+        if module is None or test_id in seen:
+            continue
+        seen.add(test_id)
+        safe = safe_test_id(test_id)
+        node_lines = read_lines(output_dir / "node" / f"{safe}.txt")
+        perry_lines = read_lines(output_dir / "perry" / f"{safe}.txt")
+        records.append(ModuleRecord(
+            module=module,
+            test_id=test_id,
+            status=result["status"],
+            known=test_id in known,
+            node_lines=None if node_lines is None else len(node_lines),
+            perry_lines=None if perry_lines is None else len(perry_lines),
+            diff_lines=diff_line_count(node_lines, perry_lines),
+        ))
+    return sorted(records, key=lambda record: record.module)
+
+
+def load_baseline(path: Path) -> dict:
+    if not path.exists():
+        return {"modules": {}}
+    data = load_json(path)
+    if not isinstance(data.get("modules"), dict):
+        raise ValueError(f"{path} must contain a top-level modules object")
+    return data
+
+
+def allowed_statuses(config: dict | None) -> set[str]:
+    if config is None:
+        return {"pass"}
+    raw = config.get("allowed_statuses", ["pass"])
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise ValueError("allowed_statuses must be a string array")
+    return set(raw) | {"pass"}
+
+
+def check_records(records: list[ModuleRecord], baseline: dict) -> list[str]:
+    problems: list[str] = []
+    modules = baseline.get("modules", {})
+
+    for record in records:
+        config = modules.get(record.module)
+        if record.status in FAIL_STATUSES and not record.known:
+            problems.append(
+                f"{record.test_id}: {record.status} is not listed in known_failures.json"
+            )
+
+        allowed = allowed_statuses(config)
+        if record.status not in allowed:
+            problems.append(
+                f"{record.test_id}: status {record.status} is outside baseline "
+                f"allowed statuses {sorted(allowed)}"
+            )
+
+        max_diff = 0 if config is None else config.get("max_diff_lines", 0)
+        if max_diff is not None and not isinstance(max_diff, int):
+            raise ValueError(f"{record.module}.max_diff_lines must be an integer or null")
+        if (
+            isinstance(max_diff, int)
+            and record.diff_lines is not None
+            and record.diff_lines > max_diff
+        ):
+            problems.append(
+                f"{record.test_id}: diff_lines {record.diff_lines} exceeds baseline {max_diff}"
+            )
+
+    return problems
+
+
+def write_json(path: Path, records: list[ModuleRecord], problems: list[str], source: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    failing = [record for record in records if record.status in FAIL_STATUSES]
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "source_report": str(source),
+        "summary": {
+            "modules": len(records),
+            "passing": sum(1 for record in records if record.status == "pass"),
+            "failing": len(failing),
+            "known_failures": sum(1 for record in failing if record.known),
+            "problems": len(problems),
+        },
+        "modules": [asdict(record) for record in records],
+        "problems": problems,
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def markdown_table(records: list[ModuleRecord], problems: list[str]) -> str:
+    lines = [
+        "# Parity Matrix Trend",
+        "",
+        "| module | status | known | node_lines | perry_lines | diff_lines |",
+        "| --- | --- | --- | ---: | ---: | ---: |",
+    ]
+    for record in records:
+        def fmt(value: int | None) -> str:
+            return "" if value is None else str(value)
+
+        lines.append(
+            f"| {record.module} | {record.status} | "
+            f"{'yes' if record.known else 'no'} | "
+            f"{fmt(record.node_lines)} | {fmt(record.perry_lines)} | "
+            f"{fmt(record.diff_lines)} |"
+        )
+    if problems:
+        lines.extend(["", "## Problems", ""])
+        lines.extend(f"- {problem}" for problem in problems)
+    return "\n".join(lines) + "\n"
+
+
+def write_markdown(path: Path, records: list[ModuleRecord], problems: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(markdown_table(records, problems), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--known", type=Path, default=DEFAULT_KNOWN)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--output-md", type=Path, default=DEFAULT_MARKDOWN)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = load_json(args.report)
+    known = known_failures(args.known)
+    baseline = load_baseline(args.baseline)
+    records = build_records(report, known, args.output_dir)
+    problems = check_records(records, baseline) if args.check else []
+
+    write_json(args.output_json, records, problems, args.report)
+    write_markdown(args.output_md, records, problems)
+    sys.stdout.write(markdown_table(records, problems))
+
+    if args.check and problems:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test-parity/parity_matrix_baseline.json
+++ b/test-parity/parity_matrix_baseline.json
@@ -1,0 +1,75 @@
+{
+  "_schema": {
+    "description": "Baseline for scripts/parity_matrix_trend.py. Modules absent from `modules` must pass with zero diff lines. Entries here are existing module-inventory gaps that may fail until their top-level parity smoke tests are retired or narrowed.",
+    "max_diff_lines": "Integer maximum accepted unified-diff changed-line count, or null when the current broad inventory test has not been converted to an exact diff baseline yet.",
+    "allowed_statuses": "Statuses accepted for the module. `pass` is always accepted as an improvement."
+  },
+  "modules": {
+    "dns": {
+      "test_id": "test_parity_dns",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "dns_promises": {
+      "test_id": "test_parity_dns_promises",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "http": {
+      "test_id": "test_parity_http",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "http2": {
+      "test_id": "test_parity_http2",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "https": {
+      "test_id": "test_parity_https",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "net": {
+      "test_id": "test_parity_net",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "sqlite": {
+      "test_id": "test_parity_sqlite",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "stream": {
+      "test_id": "test_parity_stream",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "stream_web": {
+      "test_id": "test_parity_stream_web",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "tls": {
+      "test_id": "test_parity_tls",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    },
+    "zlib": {
+      "test_id": "test_parity_zlib",
+      "issue": "812",
+      "allowed_statuses": ["pass", "parity_fail", "compile_fail"],
+      "max_diff_lines": null
+    }
+  }
+}

--- a/tests/test_parity_matrix_trend.py
+++ b/tests/test_parity_matrix_trend.py
@@ -1,0 +1,129 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "parity_matrix_trend.py"
+
+
+class ParityMatrixTrendTests(unittest.TestCase):
+    def write_json(self, path: Path, data: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def write_output(self, root: Path, test_id: str, node: str, perry: str) -> None:
+        safe = test_id.replace("/", "__")
+        node_path = root / "output" / "node" / f"{safe}.txt"
+        perry_path = root / "output" / "perry" / f"{safe}.txt"
+        node_path.parent.mkdir(parents=True, exist_ok=True)
+        perry_path.parent.mkdir(parents=True, exist_ok=True)
+        node_path.write_text(node, encoding="utf-8")
+        perry_path.write_text(perry, encoding="utf-8")
+
+    def run_checker(self, root: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--report",
+                str(root / "report.json"),
+                "--known",
+                str(root / "known_failures.json"),
+                "--baseline",
+                str(root / "baseline.json"),
+                "--output-dir",
+                str(root / "output"),
+                "--output-json",
+                str(root / "matrix.json"),
+                "--output-md",
+                str(root / "matrix.md"),
+                "--check",
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+    def test_known_baselined_failure_passes(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self.write_json(root / "report.json", {
+                "results": [
+                    {"id": "test_parity_path", "status": "pass"},
+                    {"id": "test_parity_zlib", "status": "parity_fail"},
+                ],
+                "failures": {"parity": ["test_parity_zlib"], "compile": []},
+            })
+            self.write_json(root / "known_failures.json", {
+                "test_parity_zlib": {"category": "module-inventory", "reason": "known"}
+            })
+            self.write_json(root / "baseline.json", {
+                "modules": {
+                    "zlib": {
+                        "allowed_statuses": ["pass", "parity_fail"],
+                        "max_diff_lines": 4,
+                    }
+                }
+            })
+            self.write_output(root, "test_parity_path", "ok\n", "ok\n")
+            self.write_output(root, "test_parity_zlib", "node\n", "perry\n")
+
+            result = self.run_checker(root)
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+            matrix = json.loads((root / "matrix.json").read_text(encoding="utf-8"))
+            self.assertEqual(matrix["summary"]["modules"], 2)
+            zlib = next(item for item in matrix["modules"] if item["module"] == "zlib")
+            self.assertTrue(zlib["known"])
+            self.assertEqual(zlib["diff_lines"], 2)
+
+    def test_new_untriaged_failure_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self.write_json(root / "report.json", {
+                "results": [{"id": "test_parity_path", "status": "parity_fail"}],
+                "failures": {"parity": ["test_parity_path"], "compile": []},
+            })
+            self.write_json(root / "known_failures.json", {})
+            self.write_json(root / "baseline.json", {"modules": {}})
+            self.write_output(root, "test_parity_path", "node\n", "perry\n")
+
+            result = self.run_checker(root)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("test_parity_path", result.stdout)
+            self.assertIn("not listed in known_failures.json", result.stdout)
+
+    def test_diff_lines_regression_fails_even_for_known_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self.write_json(root / "report.json", {
+                "results": [{"id": "test_parity_zlib", "status": "parity_fail"}],
+                "failures": {"parity": ["test_parity_zlib"], "compile": []},
+            })
+            self.write_json(root / "known_failures.json", {
+                "test_parity_zlib": {"category": "module-inventory", "reason": "known"}
+            })
+            self.write_json(root / "baseline.json", {
+                "modules": {
+                    "zlib": {
+                        "allowed_statuses": ["pass", "parity_fail"],
+                        "max_diff_lines": 1,
+                    }
+                }
+            })
+            self.write_output(root, "test_parity_zlib", "node\n", "perry\n")
+
+            result = self.run_checker(root)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("diff_lines 2 exceeds baseline 1", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked issues

- Closes part of #812

## Behavior cluster summary

This adds the CI/reporting slice for the Node parity matrix:

- `run_parity_tests.sh` now emits compact per-test `results` records in `latest.json`.
- `scripts/parity_matrix_trend.py` builds a per-module matrix for top-level `test_parity_<module>` runs, including status, known-failure state, Node/Perry line counts, and unified-diff changed-line counts.
- `test-parity/parity_matrix_baseline.json` seeds the current module-inventory gaps while treating any absent module as must-pass with zero diff lines.
- The existing parity CI job now checks the matrix, writes JSON/Markdown artifacts, and appends the table to the Actions step summary.

## Why these changes are batched

The report gate needs all three pieces to be useful: the runner has to expose per-test status, the checker has to convert that into a module trend, and CI has to publish/fail on the artifact. Keeping them together avoids a dead script or an unused report field.

## Tests and checks

- `python3 -m unittest tests.test_parity_matrix_trend`
- `bash -n run_parity_tests.sh`
- `python3 -m py_compile scripts/parity_matrix_trend.py tests/test_parity_matrix_trend.py`
- `jq empty test-parity/parity_matrix_baseline.json`
- local YAML parse of `.github/workflows/test.yml`
- `./scripts/check_file_size.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

## Known limitations

- I did not run the full parity suite locally because an unrelated `cargo build --release -p perry -p perry-runtime -p perry-stdlib` job was already active in the shared workspace; starting another full parity run would have kicked off a competing release build.
- Existing module-inventory entries use `max_diff_lines: null` until a full CI/release parity run records exact diff baselines. New untriaged module failures still fail immediately.

## Non-goals

- Importing upstream Node core tests (#800).
- Changing Node module runtime behavior.
- Editing existing `known_failures.json` module-inventory rows.
