### PR TITLE
[codex] resolve dynamic import literal-union params

### DIFF
--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1104,7 +1104,7 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         Expr::String(_) | Expr::WtfString(_) => true,
         Expr::LocalGet(id) => {
             match ctx.local_types.get(id) {
-                Some(HirType::String) => true,
+                Some(HirType::String | HirType::StringLiteral(_)) => true,
                 // Union(String, Null/Void) — nullable strings are still
                 // strings at runtime when non-null. The ?. and != null
                 // guard paths lower the non-null case through the string
@@ -1112,7 +1112,9 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
                 // toUpperCase()` fell through to the generic path and
                 // returned undefined.
                 Some(HirType::Union(members)) => {
-                    members.iter().any(|m| matches!(m, HirType::String))
+                    members
+                        .iter()
+                        .any(|m| matches!(m, HirType::String | HirType::StringLiteral(_)))
                 }
                 _ => false,
             }

--- a/crates/perry-codegen/src/typed_shape.rs
+++ b/crates/perry-codegen/src/typed_shape.rs
@@ -3,6 +3,7 @@ use perry_types::Type;
 pub(crate) fn type_is_pointer_bearing(ty: &Type) -> bool {
     match ty {
         Type::String
+        | Type::StringLiteral(_)
         | Type::BigInt
         | Type::Symbol
         | Type::Array(_)

--- a/crates/perry-hir/src/dynamic_import.rs
+++ b/crates/perry-hir/src/dynamic_import.rs
@@ -17,8 +17,9 @@
 //! `resolved_path` is the driver's job (it owns the module resolver).
 //! Here we only fold the JS-level path *string*.
 
-use crate::ir::{BinaryOp, Export, Expr, Function, Module, Stmt};
+use crate::ir::{BinaryOp, Export, Expr, Function, Module, Param, Stmt};
 use crate::walker::walk_expr_children;
+use perry_types::Type;
 use std::borrow::Borrow;
 use std::collections::HashSet;
 
@@ -291,6 +292,223 @@ pub fn collect_module_const_locals<'a>(
         consts.remove(&id);
     }
     consts
+}
+
+/// #1674: collect function/closure parameters whose declared type is a finite
+/// set of string literals. These locals can safely seed dynamic `import()`
+/// candidate sets even though their runtime value is not constant.
+pub fn collect_dynamic_import_param_literals(
+    module: &Module,
+) -> std::collections::HashMap<u32, Vec<String>> {
+    use std::collections::HashMap;
+    let mut out: HashMap<u32, Vec<String>> = HashMap::new();
+
+    let mut funcs: Vec<&Function> = module.functions.iter().collect();
+    let mut init_exprs: Vec<&Expr> = Vec::new();
+    for cls in &module.classes {
+        if let Some(ctor) = &cls.constructor {
+            funcs.push(ctor);
+        }
+        funcs.extend(cls.methods.iter());
+        funcs.extend(cls.getters.iter().map(|(_, f)| f));
+        funcs.extend(cls.setters.iter().map(|(_, f)| f));
+        funcs.extend(cls.static_methods.iter());
+        for field in cls.fields.iter().chain(cls.static_fields.iter()) {
+            if let Some(init) = &field.init {
+                init_exprs.push(init);
+            }
+        }
+    }
+    for g in &module.globals {
+        if let Some(init) = &g.init {
+            init_exprs.push(init);
+        }
+    }
+
+    for func in funcs {
+        collect_param_literal_sets(&func.params, &mut out);
+        for stmt in &func.body {
+            collect_param_literal_sets_stmt(stmt, &mut out);
+        }
+        for p in &func.params {
+            if let Some(default) = &p.default {
+                collect_param_literal_sets_expr(default, &mut out);
+            }
+        }
+    }
+    for stmt in &module.init {
+        collect_param_literal_sets_stmt(stmt, &mut out);
+    }
+    for expr in init_exprs {
+        collect_param_literal_sets_expr(expr, &mut out);
+    }
+
+    out
+}
+
+fn collect_param_literal_sets(
+    params: &[Param],
+    out: &mut std::collections::HashMap<u32, Vec<String>>,
+) {
+    for param in params {
+        if let Some(paths) = string_literal_type_set(&param.ty) {
+            out.insert(param.id, paths);
+        }
+    }
+}
+
+fn string_literal_type_set(ty: &Type) -> Option<Vec<String>> {
+    let mut out = Vec::new();
+    collect_string_literal_type_set(ty, &mut out)?;
+    if out.is_empty() {
+        return None;
+    }
+    Some(out)
+}
+
+fn collect_string_literal_type_set(ty: &Type, out: &mut Vec<String>) -> Option<()> {
+    match ty {
+        Type::StringLiteral(s) => {
+            if !out.contains(s) {
+                out.push(s.clone());
+            }
+            Some(())
+        }
+        Type::Union(types) => {
+            for ty in types {
+                collect_string_literal_type_set(ty, out)?;
+            }
+            Some(())
+        }
+        _ => None,
+    }
+}
+
+fn collect_param_literal_sets_stmt(
+    stmt: &Stmt,
+    out: &mut std::collections::HashMap<u32, Vec<String>>,
+) {
+    collect_param_literal_sets_from_frames(&mut vec![ParamFrame::Stmt(stmt)], out);
+}
+
+fn collect_param_literal_sets_expr(
+    expr: &Expr,
+    out: &mut std::collections::HashMap<u32, Vec<String>>,
+) {
+    collect_param_literal_sets_from_frames(&mut vec![ParamFrame::Expr(expr)], out);
+}
+
+enum ParamFrame<'a> {
+    Stmt(&'a Stmt),
+    Expr(&'a Expr),
+}
+
+fn collect_param_literal_sets_from_frames(
+    stack: &mut Vec<ParamFrame<'_>>,
+    out: &mut std::collections::HashMap<u32, Vec<String>>,
+) {
+    while let Some(frame) = stack.pop() {
+        match frame {
+            ParamFrame::Stmt(stmt) => match stmt {
+                Stmt::Let { init: Some(e), .. }
+                | Stmt::Expr(e)
+                | Stmt::Throw(e)
+                | Stmt::Return(Some(e)) => {
+                    stack.push(ParamFrame::Expr(e));
+                }
+                Stmt::Let { init: None, .. } | Stmt::Return(None) => {}
+                Stmt::If {
+                    condition,
+                    then_branch,
+                    else_branch,
+                } => {
+                    if let Some(else_branch) = else_branch {
+                        push_param_stmt_slice(stack, else_branch);
+                    }
+                    push_param_stmt_slice(stack, then_branch);
+                    stack.push(ParamFrame::Expr(condition));
+                }
+                Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                    push_param_stmt_slice(stack, body);
+                    stack.push(ParamFrame::Expr(condition));
+                }
+                Stmt::For {
+                    init,
+                    condition,
+                    update,
+                    body,
+                } => {
+                    push_param_stmt_slice(stack, body);
+                    if let Some(update) = update {
+                        stack.push(ParamFrame::Expr(update));
+                    }
+                    if let Some(condition) = condition {
+                        stack.push(ParamFrame::Expr(condition));
+                    }
+                    if let Some(init) = init {
+                        stack.push(ParamFrame::Stmt(init.as_ref()));
+                    }
+                }
+                Stmt::Labeled { body, .. } => {
+                    stack.push(ParamFrame::Stmt(body.as_ref()));
+                }
+                Stmt::Try {
+                    body,
+                    catch,
+                    finally,
+                } => {
+                    if let Some(finally) = finally {
+                        push_param_stmt_slice(stack, finally);
+                    }
+                    if let Some(catch) = catch {
+                        push_param_stmt_slice(stack, &catch.body);
+                    }
+                    push_param_stmt_slice(stack, body);
+                }
+                Stmt::Switch {
+                    discriminant,
+                    cases,
+                } => {
+                    for case in cases.iter().rev() {
+                        push_param_stmt_slice(stack, &case.body);
+                        if let Some(test) = &case.test {
+                            stack.push(ParamFrame::Expr(test));
+                        }
+                    }
+                    stack.push(ParamFrame::Expr(discriminant));
+                }
+                Stmt::Break
+                | Stmt::Continue
+                | Stmt::LabeledBreak(_)
+                | Stmt::LabeledContinue(_)
+                | Stmt::PreallocateBoxes(_) => {}
+            },
+            ParamFrame::Expr(expr) => {
+                if let Expr::Closure { params, body, .. } = expr {
+                    collect_param_literal_sets(params, out);
+                    push_param_stmt_slice(stack, body);
+                    for param in params {
+                        if let Some(default) = &param.default {
+                            stack.push(ParamFrame::Expr(default));
+                        }
+                    }
+                }
+                let mut children = Vec::new();
+                walk_expr_children(expr, &mut |child| {
+                    children.push(child);
+                });
+                for child in children.into_iter().rev() {
+                    stack.push(ParamFrame::Expr(child));
+                }
+            }
+        }
+    }
+}
+
+fn push_param_stmt_slice<'a>(stack: &mut Vec<ParamFrame<'a>>, stmts: &'a [Stmt]) {
+    for stmt in stmts.iter().rev() {
+        stack.push(ParamFrame::Stmt(stmt));
+    }
 }
 
 /// Collect `const x = <init>` bindings reachable from `stmt` into `out`,
@@ -669,6 +887,16 @@ pub fn resolve_import_path_with_consts<V: Borrow<Expr>>(
     consts: &std::collections::HashMap<u32, V>,
     visiting: &mut std::collections::HashSet<u32>,
 ) -> Resolution {
+    let params: std::collections::HashMap<u32, Vec<String>> = std::collections::HashMap::new();
+    resolve_import_path_with_consts_and_params(arg, consts, &params, visiting)
+}
+
+pub fn resolve_import_path_with_consts_and_params<V: Borrow<Expr>>(
+    arg: &Expr,
+    consts: &std::collections::HashMap<u32, V>,
+    param_literals: &std::collections::HashMap<u32, Vec<String>>,
+    visiting: &mut std::collections::HashSet<u32>,
+) -> Resolution {
     match arg {
         Expr::String(s) => Resolution::Set(vec![s.clone()]),
         Expr::Conditional {
@@ -676,8 +904,18 @@ pub fn resolve_import_path_with_consts<V: Borrow<Expr>>(
             else_expr,
             ..
         } => {
-            let a = resolve_import_path_with_consts(then_expr, consts, visiting);
-            let b = resolve_import_path_with_consts(else_expr, consts, visiting);
+            let a = resolve_import_path_with_consts_and_params(
+                then_expr,
+                consts,
+                param_literals,
+                visiting,
+            );
+            let b = resolve_import_path_with_consts_and_params(
+                else_expr,
+                consts,
+                param_literals,
+                visiting,
+            );
             a.merge(b)
         }
         // Template literal — desugared to `Binary(Add, ...)` chains by
@@ -697,7 +935,12 @@ pub fn resolve_import_path_with_consts<V: Borrow<Expr>>(
             // Unresolved.
             let mut sets: Vec<Vec<String>> = Vec::with_capacity(parts.len());
             for p in &parts {
-                match resolve_import_path_with_consts(p, consts, visiting) {
+                match resolve_import_path_with_consts_and_params(
+                    p,
+                    consts,
+                    param_literals,
+                    visiting,
+                ) {
                     Resolution::Set(v) => sets.push(v),
                     Resolution::Unresolved(r) => return Resolution::Unresolved(r),
                 }
@@ -733,14 +976,22 @@ pub fn resolve_import_path_with_consts<V: Borrow<Expr>>(
                 );
             }
             let resolved = if let Some(init) = consts.get(id) {
-                resolve_import_path_with_consts(init.borrow(), consts, visiting)
+                resolve_import_path_with_consts_and_params(
+                    init.borrow(),
+                    consts,
+                    param_literals,
+                    visiting,
+                )
+            } else if let Some(paths) = param_literals.get(id) {
+                Resolution::Set(paths.clone())
             } else {
                 Resolution::Unresolved(
                     "path argument references a binding that is not statically \
                      resolvable to a literal (supported: string literals, ternaries, \
                      template literals over resolvable locals, and `const`/never-\
-                     reassigned `let` bindings initialized to a resolvable value; a \
-                     binding reassigned anywhere falls back here)"
+                     reassigned `let` bindings initialized to a resolvable value, \
+                     plus parameters annotated with finite string-literal unions; \
+                     broad or mixed parameter types fall back here)"
                         .to_string(),
                 )
             };
@@ -1010,6 +1261,75 @@ mod tests {
         let mut visiting = std::collections::HashSet::new();
         let r = resolve_import_path_with_consts(&arg, &consts, &mut visiting);
         assert!(matches!(r, Resolution::Unresolved(_)));
+    }
+
+    #[test]
+    fn resolve_param_string_literal_union() {
+        let arg = Expr::LocalGet(42);
+        let consts: std::collections::HashMap<u32, Expr> = std::collections::HashMap::new();
+        let mut params = std::collections::HashMap::new();
+        params.insert(42, vec!["./a.ts".to_string(), "./b.ts".to_string()]);
+        let mut visiting = std::collections::HashSet::new();
+        match resolve_import_path_with_consts_and_params(&arg, &consts, &params, &mut visiting) {
+            Resolution::Set(v) => assert_eq!(v, vec!["./a.ts", "./b.ts"]),
+            Resolution::Unresolved(reason) => panic!("expected Set, got Unresolved: {reason}"),
+        }
+    }
+
+    #[test]
+    fn collect_param_string_literal_union_from_function() {
+        let mut m = Module::new("t");
+        m.functions.push(Function {
+            id: 1,
+            name: "load".to_string(),
+            type_params: Vec::new(),
+            params: vec![
+                Param {
+                    id: 42,
+                    name: "specifier".to_string(),
+                    ty: Type::Union(vec![
+                        Type::StringLiteral("./a.ts".to_string()),
+                        Type::StringLiteral("./b.ts".to_string()),
+                    ]),
+                    default: None,
+                    decorators: Vec::new(),
+                    is_rest: false,
+                    arguments_object: None,
+                },
+                Param {
+                    id: 43,
+                    name: "broad".to_string(),
+                    ty: Type::Union(vec![
+                        Type::StringLiteral("./c.ts".to_string()),
+                        Type::String,
+                    ]),
+                    default: None,
+                    decorators: Vec::new(),
+                    is_rest: false,
+                    arguments_object: None,
+                },
+            ],
+            return_type: Type::Any,
+            body: Vec::new(),
+            is_async: true,
+            is_generator: false,
+            is_strict: false,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: Vec::new(),
+            was_plain_async: false,
+            was_unrolled: false,
+        });
+
+        let params = collect_dynamic_import_param_literals(&m);
+        assert_eq!(
+            params.get(&42),
+            Some(&vec!["./a.ts".to_string(), "./b.ts".to_string()])
+        );
+        assert!(
+            !params.contains_key(&43),
+            "mixed literal/broad string unions are not finite"
+        );
     }
 
     #[test]

--- a/crates/perry-hir/src/lib.rs
+++ b/crates/perry-hir/src/lib.rs
@@ -30,9 +30,10 @@ pub use audit::{audit_module, AuditManifest, ModuleAudit};
 pub use capability::{audit_module_capabilities, CapabilityPolicy, CapabilityViolation};
 pub use deferral::{arm_deferral_sink, disarm_deferral_sink, try_defer_refusal, DeferredRefusal};
 pub use dynamic_import::{
-    collect_module_const_locals, detect_top_level_await, dynamic_import_glob_pattern,
-    flatten_exports, for_each_dynamic_import, for_each_dynamic_import_mut, for_each_worker_new,
-    for_each_worker_new_mut, resolve_import_path, resolve_import_path_with_consts, FlatExport,
+    collect_dynamic_import_param_literals, collect_module_const_locals, detect_top_level_await,
+    dynamic_import_glob_pattern, flatten_exports, for_each_dynamic_import,
+    for_each_dynamic_import_mut, for_each_worker_new, for_each_worker_new_mut, resolve_import_path,
+    resolve_import_path_with_consts, resolve_import_path_with_consts_and_params, FlatExport,
     Resolution, DYNAMIC_IMPORT_PATH_CAP,
 };
 pub use egress::{audit_module_egress, EgressRefusalReason, EgressViolation};

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -1388,7 +1388,7 @@ pub(crate) fn extract_ts_type_with_ctx(
         // Literal types: "foo", 42, true
         TsLitType(lit) => match &lit.lit {
             ast::TsLit::Number(_) => Type::Number,
-            ast::TsLit::Str(_) => Type::String,
+            ast::TsLit::Str(s) => Type::StringLiteral(s.value.as_str().unwrap_or("").to_string()),
             ast::TsLit::Bool(_) => Type::Boolean,
             ast::TsLit::BigInt(_) => Type::BigInt,
             ast::TsLit::Tpl(_) => Type::String,

--- a/crates/perry-hir/src/monomorph/mangle.rs
+++ b/crates/perry-hir/src/monomorph/mangle.rs
@@ -31,6 +31,7 @@ pub(crate) fn mangle_type(ty: &Type) -> String {
         Type::Int32 => "i32".to_string(),
         Type::BigInt => "bigint".to_string(),
         Type::String => "str".to_string(),
+        Type::StringLiteral(_) => "str".to_string(),
         Type::Symbol => "sym".to_string(),
         Type::Array(elem) => format!("arr_{}", mangle_type(elem)),
         Type::Tuple(elems) => {

--- a/crates/perry-hir/src/stable_hash/types.rs
+++ b/crates/perry-hir/src/stable_hash/types.rs
@@ -17,6 +17,10 @@ impl SH for Type {
             Type::Int32 => tag(hh, 4),
             Type::BigInt => tag(hh, 5),
             Type::String => tag(hh, 6),
+            Type::StringLiteral(s) => {
+                tag(hh, 20);
+                s.hash(hh);
+            }
             Type::Symbol => tag(hh, 7),
             Type::Array(t) => {
                 tag(hh, 8);

--- a/crates/perry-types/src/lib.rs
+++ b/crates/perry-types/src/lib.rs
@@ -34,6 +34,9 @@ pub enum Type {
     BigInt,
     /// String type
     String,
+    /// String literal type (e.g. `"./a.ts"`). Most runtime/type-analysis
+    /// paths treat this as `String`; AOT-only analyses can inspect the value.
+    StringLiteral(String),
     /// Symbol type
     Symbol,
     /// Array type with element type
@@ -128,6 +131,7 @@ impl Type {
                 | Type::Int32
                 | Type::BigInt
                 | Type::String
+                | Type::StringLiteral(_)
                 | Type::Symbol
         )
     }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -733,6 +733,7 @@ fn collect_module_one(
     // the resolver can follow `import(localStringVar)` and
     // `` import(`./prefix_${localStringVar}.ts`) `` paths transitively.
     let module_const_locals = perry_hir::collect_module_const_locals(&hir_module);
+    let dynamic_param_literals = perry_hir::collect_dynamic_import_param_literals(&hir_module);
     let mut dynamic_path_sets: Vec<Vec<String>> = Vec::new();
     perry_hir::for_each_dynamic_import(&hir_module, &mut |expr| {
         if let perry_hir::Expr::DynamicImport { paths, arg } = expr {
@@ -741,9 +742,10 @@ fn collect_module_one(
                 return;
             }
             let mut visiting: std::collections::HashSet<u32> = std::collections::HashSet::new();
-            match perry_hir::resolve_import_path_with_consts(
+            match perry_hir::resolve_import_path_with_consts_and_params(
                 arg.as_ref(),
                 &module_const_locals,
+                &dynamic_param_literals,
                 &mut visiting,
             ) {
                 perry_hir::Resolution::Set(set) => {
@@ -823,9 +825,10 @@ fn collect_module_one(
                 return;
             }
             let mut visiting: std::collections::HashSet<u32> = std::collections::HashSet::new();
-            match perry_hir::resolve_import_path_with_consts(
+            match perry_hir::resolve_import_path_with_consts_and_params(
                 filename.as_ref(),
                 &module_const_locals,
+                &dynamic_param_literals,
                 &mut visiting,
             ) {
                 perry_hir::Resolution::Set(set) => {

--- a/test-parity/node-suite/module/loader/dynamic-import-param-union.ts
+++ b/test-parity/node-suite/module/loader/dynamic-import-param-union.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+async function load(
+  specifier:
+    | "./fixtures/dynamic-param/one.ts"
+    | "./fixtures/dynamic-param/two.ts",
+) {
+  const mod = await import(specifier);
+  return `${mod.name}:${mod.value}`;
+}
+
+async function loadByName(name: "one" | "two") {
+  const mod = await import(`./fixtures/dynamic-param/${name}.ts`);
+  return `${mod.name}:${mod.value}`;
+}
+
+console.log("param one:", await load("./fixtures/dynamic-param/one.ts"));
+console.log("param two:", await load("./fixtures/dynamic-param/two.ts"));
+console.log("template one:", await loadByName("one"));
+console.log("template two:", await loadByName("two"));

--- a/test-parity/node-suite/module/loader/fixtures/dynamic-param/one.ts
+++ b/test-parity/node-suite/module/loader/fixtures/dynamic-param/one.ts
@@ -1,0 +1,2 @@
+export const name = "one";
+export const value = "param-a";

--- a/test-parity/node-suite/module/loader/fixtures/dynamic-param/two.ts
+++ b/test-parity/node-suite/module/loader/fixtures/dynamic-param/two.ts
@@ -1,0 +1,2 @@
+export const name = "two";
+export const value = "param-b";


### PR DESCRIPTION
Part of #1674.

## Scope
- Preserve inline TypeScript string literal type values in HIR as `StringLiteral` while keeping runtime/codegen treatment equivalent to `String`.
- Collect function and closure parameters annotated with finite all-string-literal union types.
- Feed those parameter candidate sets into dynamic `import()` and `new Worker()` path resolution alongside existing const/local resolution.
- Add Node parity coverage for direct `import(specifier)` and template interpolation over a literal-union parameter.

## Non-goals
- Type alias expansion beyond what existing lowering already provides.
- Mixed or broad string unions such as `"./a.ts" | string`.
- Later assignment/reaching-definition analysis.
- Package/bare wildcard imports or unbounded glob discovery.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/module/loader/dynamic-import-param-union.ts`
- `CARGO_TARGET_DIR=/tmp/perry-param-union-check cargo check -p perry-hir -p perry-codegen -p perry -p perry-runtime`
- `CARGO_TARGET_DIR=/tmp/perry-param-union-check cargo test -p perry-hir dynamic_import -- --nocapture`
- `CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-param-union-build cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- Direct Perry compile/run of `test-parity/node-suite/module/loader/dynamic-import-param-union.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-param-union-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module module --filter dynamic-import-param-union'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-param-union-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module module --filter dynamic-import'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
