### PR TITLE
[codex] wire node core subset radar

### DIFF
--- a/.github/workflows/node-core-subset.yml
+++ b/.github/workflows/node-core-subset.yml
@@ -1,0 +1,112 @@
+name: Node Core Subset Radar
+
+on:
+  workflow_dispatch:
+    inputs:
+      apis:
+        description: "Optional space-separated API list, e.g. 'path url buffer'"
+        required: false
+        default: ""
+      max_per_api:
+        description: "Maximum upstream Node tests to sample per API; 0 means no cap"
+        required: false
+        default: "25"
+  schedule:
+    # Advisory nightly compatibility radar. It uploads a report but does not
+    # gate merges or releases.
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: node-core-subset-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  node-core-subset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      NODE_CORE_APIS: ${{ github.event_name == 'workflow_dispatch' && inputs.apis || '' }}
+      NODE_CORE_MAX_PER_API: ${{ github.event_name == 'workflow_dispatch' && inputs.max_per_api || '25' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-perry"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Sparse checkout pinned Node.js tests
+        run: |
+          set -euo pipefail
+          node_ref="$(cat test-compat/node-core/pinned-version.txt)"
+          git clone --no-checkout --depth 1 --branch "$node_ref" \
+            --filter=blob:none https://github.com/nodejs/node vendor/nodejs
+          git -C vendor/nodejs sparse-checkout set test/parallel test/common test/fixtures
+          git -C vendor/nodejs checkout
+
+      - name: Build Perry release binary
+        run: cargo build --release -p perry -p perry-runtime -p perry-stdlib
+
+      - name: Run Node core subset radar
+        run: |
+          set -euo pipefail
+          args=(
+            --root vendor/nodejs
+            --report test-compat/node-core/report.json
+            --max-per-api "$NODE_CORE_MAX_PER_API"
+          )
+          if [[ -n "$NODE_CORE_APIS" ]]; then
+            read -r -a requested_apis <<< "$NODE_CORE_APIS"
+            args+=(--api "${requested_apis[@]}")
+          fi
+          scripts/node_core_subset.py "${args[@]}"
+
+      - name: Write radar summary
+        if: always()
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          report_path = Path("test-compat/node-core/report.json")
+          if not report_path.exists():
+              print("## Node Core Subset Radar")
+              print("")
+              print("No report was generated.")
+              raise SystemExit(0)
+
+          report = json.loads(report_path.read_text())
+          print("## Node Core Subset Radar")
+          print("")
+          print(f"Node corpus: `{report.get('node_pinned', '')}`")
+          print(f"Node runtime: `{report.get('node_runtime', '')}`")
+          print(f"Parity: `{report.get('parity_pct', 0)}%` over `{report.get('judged', 0)}` judged tests")
+          print("")
+          print("| api | pass | diff | runtime-fail | compile-fail | node-skip |")
+          print("| --- | ---: | ---: | ---: | ---: | ---: |")
+          for api, counts in sorted(report.get("per_api", {}).items()):
+              print(
+                  f"| {api} | {counts.get('pass', 0)} | {counts.get('diff', 0)} | "
+                  f"{counts.get('runtime-fail', 0)} | {counts.get('compile-fail', 0)} | "
+                  f"{counts.get('node-skip', 0)} |"
+              )
+          PY
+
+      - name: Upload radar report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: node-core-subset-report
+          path: test-compat/node-core/report.json
+          if-no-files-found: warn

--- a/test-compat/node-core/README.md
+++ b/test-compat/node-core/README.md
@@ -105,12 +105,23 @@ timeout is bumped automatically (override with `--compile-timeout`). Restrict
 the sweep with `--api` to keep it tractable. The report records which mode
 produced the numbers (`"auto_optimize": true|false`).
 
-## What a CI job would do
+## CI workflow
+
+`.github/workflows/node-core-subset.yml` runs this radar as an advisory
+nightly job and as a manual `workflow_dispatch` job.
+
+The workflow:
 
 1. Sparse-checks-out `nodejs/node` at `pinned-version.txt`.
-2. Builds Perry, runs `scripts/node_core_subset.py`.
-3. Uploads `report.json` as an artifact.
-4. **Advisory** (non-required) — signal, not gating. Threshold-based
-   gating can be added once the baseline is stable across a few runs.
+2. Builds Perry's release binary.
+3. Runs `scripts/node_core_subset.py` with a bounded per-API sample cap
+   (`max_per_api`, default 25; use 0 for no cap).
+4. Writes a Markdown table to the Actions step summary.
+5. Uploads `test-compat/node-core/report.json` as an artifact.
+
+Manual dispatch also accepts an optional space-separated `apis` list such as
+`path url buffer` for a focused run. The workflow is intentionally
+non-required: it is a compatibility radar, not a merge gate. Threshold-based
+gating can be added once the baseline is stable across a few runs.
 
 Part of #793. Companion to #799 (Test262).


### PR DESCRIPTION
## Linked issues

- Closes part of #800

## Behavior cluster summary

This wires the existing Node core subset radar into CI as an advisory compatibility signal:

- adds `.github/workflows/node-core-subset.yml`
- sparse-checks out the pinned Node.js test corpus from `test-compat/node-core/pinned-version.txt`
- builds Perry's release binary and runs `scripts/node_core_subset.py`
- supports manual focused runs through a space-separated `apis` input and `max_per_api`
- writes a Markdown summary table to the Actions step summary
- uploads `test-compat/node-core/report.json` as an artifact
- updates `test-compat/node-core/README.md` with the workflow entrypoint

## Why these changes are batched

The runner already existed; this PR adds the missing workflow and documentation together so the radar has a durable scheduled/manual entrypoint and users can find how to run focused subsets.

## Tests and checks

- parsed `.github/workflows/node-core-subset.yml` with local YAML loader
- `python3 -m py_compile scripts/node_core_subset.py`
- `scripts/node_core_subset.py --help`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo fmt --all -- --check`

## Known limitations

- I did not run the full Node-core subset sweep locally because it requires a release build plus upstream corpus execution, and an unrelated release/http build was already active in the shared workspace.
- The workflow is intentionally advisory and non-required. Threshold/gating policy can be added after several stable reports establish a baseline.

## Non-goals

- Changing radar bucket semantics.
- Expanding the Node common shim.
- Fixing runtime/API failures that the radar reports.
- Making the job a required merge or release gate.
