### PR TITLE
[codex] drop native proof file-size allowlist

### DIFF
--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -143,9 +143,6 @@ crates/perry-stdlib/src/sqlite.rs
 # non-byte reject, #2460 reserved-type reject) landed on main without a
 # split. Splitting per stream-kind family is tracked under #2472.
 crates/perry-stdlib/src/streams.rs
-# Native proof regression fixtures: intentionally broad golden tests that keep
-# related source snippets and assertions together for optimizer/codegen review.
-crates/perry-codegen/tests/native_proof_regressions.rs
 # Member-expression lowering tower (one big match over member/property/call
 # shapes, plus per-namespace literal builders). Crossed the limit at 2121 LOC
 # after #3161 inlined the full allowedNodeEnvironmentFlags string list into


### PR DESCRIPTION
## Summary

- remove the stale file-size allowlist entry for `crates/perry-codegen/tests/native_proof_regressions.rs`
- keep the gate rationale focused on files that are still over the threshold

## Why

`native_proof_regressions.rs` is now 1,945 lines on current `origin/main`, below the 2,000-line gate, so it no longer needs a deferred-exception entry.

## Validation

- `bash -n scripts/check_file_size.sh`
- `./scripts/check_file_size.sh`
- `git diff --check`

Refs #2657