### PR TITLE
[codex] expose subtle encapsulation method surface

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -3351,6 +3351,13 @@ pub extern "C" fn js_object_get_field_by_name(
                         return JSValue::from_bits(value.to_bits());
                     }
                 }
+                if module_name == "crypto.subtle" {
+                    if let Some(value) =
+                        super::global_this::subtle_crypto_method_value(property_name)
+                    {
+                        return JSValue::from_bits(value.to_bits());
+                    }
+                }
                 // Issue #894: parity with the direct-NativeModuleRef
                 // fast path (`js_native_module_property_by_name`). For
                 // (module, prop) pairs whose property-read should

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -498,6 +498,28 @@ pub(crate) fn webcrypto_method_value(property_name: &str) -> Option<f64> {
     Some(crate::value::js_nanbox_pointer(closure as i64))
 }
 
+fn subtle_crypto_method_spec(property_name: &str) -> Option<(*const u8, u32)> {
+    match property_name {
+        "encapsulateBits" => Some((subtle_crypto_encapsulate_bits_thunk as *const u8, 2)),
+        "decapsulateBits" => Some((subtle_crypto_decapsulate_bits_thunk as *const u8, 3)),
+        "encapsulateKey" => Some((subtle_crypto_encapsulate_key_thunk as *const u8, 5)),
+        "decapsulateKey" => Some((subtle_crypto_decapsulate_key_thunk as *const u8, 6)),
+        _ => None,
+    }
+}
+
+pub(crate) fn subtle_crypto_method_value(property_name: &str) -> Option<f64> {
+    let (func_ptr, length) = subtle_crypto_method_spec(property_name)?;
+    crate::closure::js_register_closure_rest(func_ptr, 0);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+    }
+    super::native_module::set_bound_native_closure_name(closure, property_name);
+    super::native_module::set_builtin_closure_length(closure as usize, length);
+    Some(crate::value::js_nanbox_pointer(closure as i64))
+}
+
 pub(crate) extern "C" fn global_this_array_thunk(
     _closure: *const crate::closure::ClosureHeader,
     rest: f64,
@@ -2969,6 +2991,78 @@ extern "C" fn subtle_crypto_supports_thunk(
     }
 }
 
+fn is_subtle_crypto_this(value: f64) -> bool {
+    let js_value = crate::value::JSValue::from_bits(value.to_bits());
+    if !js_value.is_pointer() {
+        return false;
+    }
+    let obj = js_value.as_pointer::<ObjectHeader>();
+    !obj.is_null()
+        && unsafe { (*obj).class_id } == super::native_module::NATIVE_MODULE_CLASS_ID
+        && unsafe { super::native_module::read_native_module_name(obj) }
+            .is_some_and(|name| name == "crypto.subtle")
+}
+
+fn rejected_type_error_with_code_promise(message: &str, code: &'static str) -> f64 {
+    let reason = crate::fs::validate::build_type_error_with_code_value(message, code);
+    let promise = crate::promise::js_promise_rejected(reason);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+fn subtle_crypto_dispatch_rest(method_name: &str, rest: f64) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    if !is_subtle_crypto_this(this_value) {
+        return rejected_type_error_with_code_promise(
+            "Value of \"this\" must be of type SubtleCrypto",
+            "ERR_INVALID_THIS",
+        );
+    }
+
+    let args = global_this_rest_array_values(rest);
+    let ptr = crate::value::JS_NATIVE_WEBCRYPTO_DISPATCH.load(Ordering::SeqCst);
+    if ptr.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
+        unsafe { std::mem::transmute(ptr) };
+    unsafe {
+        dispatch(
+            method_name.as_ptr(),
+            method_name.len(),
+            args.as_ptr(),
+            args.len(),
+        )
+    }
+}
+
+extern "C" fn subtle_crypto_encapsulate_bits_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    subtle_crypto_dispatch_rest("encapsulateBits", rest)
+}
+
+extern "C" fn subtle_crypto_decapsulate_bits_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    subtle_crypto_dispatch_rest("decapsulateBits", rest)
+}
+
+extern "C" fn subtle_crypto_encapsulate_key_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    subtle_crypto_dispatch_rest("encapsulateKey", rest)
+}
+
+extern "C" fn subtle_crypto_decapsulate_key_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    subtle_crypto_dispatch_rest("decapsulateKey", rest)
+}
+
 /// Install a single callable static method on a constructor closure as a
 /// `{ writable: true, enumerable: false, configurable: true }` data property
 /// (matching Node's descriptors for built-in statics). `has_rest` registers
@@ -4004,6 +4098,33 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             }
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
+        "SubtleCrypto" => {
+            for (name, func_ptr, length) in [
+                (
+                    "encapsulateBits",
+                    subtle_crypto_encapsulate_bits_thunk as *const u8,
+                    2,
+                ),
+                (
+                    "decapsulateBits",
+                    subtle_crypto_decapsulate_bits_thunk as *const u8,
+                    3,
+                ),
+                (
+                    "encapsulateKey",
+                    subtle_crypto_encapsulate_key_thunk as *const u8,
+                    5,
+                ),
+                (
+                    "decapsulateKey",
+                    subtle_crypto_decapsulate_key_thunk as *const u8,
+                    6,
+                ),
+            ] {
+                install_webcrypto_proto_method_rest_with_length(proto_obj, name, func_ptr, length);
+            }
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
         "Error" | "TypeError" | "RangeError" | "SyntaxError" | "ReferenceError"
         | "AggregateError" | "EvalError" | "URIError" => {
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
@@ -4130,6 +4251,20 @@ fn install_webcrypto_proto_method(
     arity: u32,
 ) {
     install_proto_method(proto_obj, method_name, func_ptr, arity);
+    super::set_builtin_property_attrs(
+        proto_obj as usize,
+        method_name.to_string(),
+        super::PropertyAttrs::new(true, true, true),
+    );
+}
+
+fn install_webcrypto_proto_method_rest_with_length(
+    proto_obj: *mut ObjectHeader,
+    method_name: &str,
+    func_ptr: *const u8,
+    length: u32,
+) {
+    install_proto_method_rest_with_length(proto_obj, method_name, func_ptr, length, 0);
     super::set_builtin_property_attrs(
         proto_obj as usize,
         method_name.to_string(),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -3162,6 +3162,11 @@ pub unsafe extern "C" fn js_native_module_property_by_name(
             return value;
         }
     }
+    if module_name == "crypto.subtle" {
+        if let Some(value) = super::global_this::subtle_crypto_method_value(property_name) {
+            return value;
+        }
+    }
 
     // #3687: `node:cluster` is a singleton EventEmitter. Its EventEmitter
     // method surface is exposed ONLY on the default import (the distinct
@@ -5611,6 +5616,11 @@ pub extern "C" fn js_native_module_bind_method(
 
     if module_name == "crypto.webcrypto" {
         if let Some(value) = super::global_this::webcrypto_method_value(property_name) {
+            return value;
+        }
+    }
+    if module_name == "crypto.subtle" {
+        if let Some(value) = super::global_this::subtle_crypto_method_value(property_name) {
             return value;
         }
     }

--- a/crates/perry-stdlib/src/webcrypto.rs
+++ b/crates/perry-stdlib/src/webcrypto.rs
@@ -9,6 +9,7 @@
 //! re-exported only inside this module for sibling shards.
 mod aes;
 mod digest;
+mod encapsulation;
 mod hmac;
 mod jwk;
 mod kdf;
@@ -21,12 +22,14 @@ mod wrap;
 #[allow(unused_imports)]
 // Private imports keep sibling modules able to share `pub(super)` helpers.
 use self::{
-    aes::*, digest::*, hmac::*, jwk::*, kdf::*, key_object::*, keys::*, supports::*, util::*,
-    wrap::*,
+    aes::*, digest::*, encapsulation::*, hmac::*, jwk::*, kdf::*, key_object::*, keys::*,
+    supports::*, util::*, wrap::*,
 };
 
 // Public re-exports preserve the parent module surface for FFI entry points.
-pub use self::{aes::*, digest::*, hmac::*, jwk::*, kdf::*, keys::*, supports::*, wrap::*};
+pub use self::{
+    aes::*, digest::*, encapsulation::*, hmac::*, jwk::*, kdf::*, keys::*, supports::*, wrap::*,
+};
 
 /// Dispatcher for captured/dynamic `crypto.subtle.*` calls. Static
 /// `crypto.subtle.method(...)` call sites still lower directly in codegen;
@@ -104,6 +107,10 @@ pub unsafe extern "C" fn js_webcrypto_native_dispatch(
             js_webcrypto_key_object_to_crypto_key(arg(0), arg(1), arg(2), arg(3))
         }
         "supports" if args_len >= 2 => js_webcrypto_supports(arg(0), arg(1), arg(2)),
+        "encapsulateBits" => promise_to_value(js_webcrypto_encapsulate_bits(args_ptr, args_len)),
+        "decapsulateBits" => promise_to_value(js_webcrypto_decapsulate_bits(args_ptr, args_len)),
+        "encapsulateKey" => promise_to_value(js_webcrypto_encapsulate_key(args_ptr, args_len)),
+        "decapsulateKey" => promise_to_value(js_webcrypto_decapsulate_key(args_ptr, args_len)),
         _ => undefined,
     }
 }

--- a/crates/perry-stdlib/src/webcrypto/encapsulation.rs
+++ b/crates/perry-stdlib/src/webcrypto/encapsulation.rs
@@ -1,0 +1,49 @@
+use super::util::*;
+
+unsafe fn reject_type_error_with_code(message: &str, code: &'static str) -> *mut Promise {
+    let msg = perry_runtime::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    perry_runtime::node_submodules::register_error_code_pub(msg, code);
+    let err = perry_runtime::error::js_typeerror_new(msg);
+    let value = f64::from_bits(JSValue::pointer(err as *const u8).bits());
+    perry_runtime::js_promise_rejected(value)
+}
+
+unsafe fn reject_missing_args(method: &str, required: usize, present: usize) -> *mut Promise {
+    let message = format!(
+        "Failed to execute '{method}' on 'SubtleCrypto': {required} arguments required, but only {present} present."
+    );
+    reject_type_error_with_code(&message, "ERR_MISSING_ARGS")
+}
+
+unsafe fn reject_unsupported_algorithm() -> *mut Promise {
+    reject_with_dom_exception("NotSupportedError", "Unrecognized algorithm name")
+}
+
+unsafe fn encapsulation_stub(method: &str, required: usize, args_len: usize) -> *mut Promise {
+    if args_len < required {
+        return reject_missing_args(method, required, args_len);
+    }
+    reject_unsupported_algorithm()
+}
+
+pub unsafe fn js_webcrypto_encapsulate_bits(
+    _args_ptr: *const f64,
+    args_len: usize,
+) -> *mut Promise {
+    encapsulation_stub("encapsulateBits", 2, args_len)
+}
+
+pub unsafe fn js_webcrypto_decapsulate_bits(
+    _args_ptr: *const f64,
+    args_len: usize,
+) -> *mut Promise {
+    encapsulation_stub("decapsulateBits", 3, args_len)
+}
+
+pub unsafe fn js_webcrypto_encapsulate_key(_args_ptr: *const f64, args_len: usize) -> *mut Promise {
+    encapsulation_stub("encapsulateKey", 5, args_len)
+}
+
+pub unsafe fn js_webcrypto_decapsulate_key(_args_ptr: *const f64, args_len: usize) -> *mut Promise {
+    encapsulation_stub("decapsulateKey", 6, args_len)
+}

--- a/test-parity/node-suite/crypto/webcrypto/encapsulation-method-surface.ts
+++ b/test-parity/node-suite/crypto/webcrypto/encapsulation-method-surface.ts
@@ -1,0 +1,67 @@
+import { webcrypto } from "node:crypto";
+
+// Node 26 marks these WebCrypto helpers as experimental. Keep the fixture
+// focused on stdout API parity.
+(process as any).emitWarning = () => undefined;
+
+const subtle = webcrypto.subtle as any;
+
+const descriptorShape = (desc: any) => ({
+  enumerable: desc?.enumerable,
+  configurable: desc?.configurable,
+  writable: "writable" in desc ? desc.writable : undefined,
+  value: typeof desc?.value,
+});
+
+const rejectionShape = async (label: string, fn: () => Promise<any>) => {
+  try {
+    const result = fn();
+    console.log(`${label} promise:`, !!result && typeof (result as any).then === "function");
+    await result;
+    console.log(`${label}: resolved`);
+  } catch (error: any) {
+    console.log(`${label}:`, error.name, error.code ?? "");
+  }
+};
+
+const rejectionName = async (label: string, fn: () => Promise<any>) => {
+  try {
+    const result = fn();
+    console.log(`${label} promise:`, !!result && typeof (result as any).then === "function");
+    await result;
+    console.log(`${label}: resolved`);
+  } catch (error: any) {
+    console.log(`${label}:`, error.name);
+  }
+};
+
+for (const [name, length] of [
+  ["encapsulateBits", 2],
+  ["decapsulateBits", 3],
+  ["encapsulateKey", 5],
+  ["decapsulateKey", 6],
+] as const) {
+  const fn = subtle[name];
+  const protoDesc = Object.getOwnPropertyDescriptor(SubtleCrypto.prototype, name);
+
+  console.log(`${name} typeof:`, typeof fn);
+  console.log(`${name} name:`, fn?.name);
+  console.log(`${name} length:`, fn?.length);
+  console.log(`${name} desc:`, JSON.stringify(descriptorShape(protoDesc)));
+  console.log(`${name} own desc missing:`, Object.getOwnPropertyDescriptor(subtle, name) === undefined);
+  await rejectionShape(`${name} direct missing`, () => subtle[name]());
+  await rejectionShape(`${name} captured missing`, () => fn.call(subtle));
+  await rejectionShape(`${name} bare invalid this`, () => fn());
+  console.log(`${name} expected length:`, length);
+}
+
+const aesKey = await webcrypto.subtle.generateKey(
+  { name: "AES-GCM", length: 128 },
+  true,
+  ["encrypt", "decrypt"],
+);
+
+await rejectionName(
+  "encapsulateBits unsupported algorithm",
+  () => subtle.encapsulateBits("AES-GCM", aesKey),
+);


### PR DESCRIPTION
## Summary

Refs #2518.

This PR adds the WebCrypto `SubtleCrypto` encapsulation method surface:

- exposes `encapsulateBits`, `decapsulateBits`, `encapsulateKey`, and `decapsulateKey` on `SubtleCrypto.prototype`
- routes `crypto.subtle` namespace property reads and captured method calls to callable runtime thunks
- matches Node 26 method `name`, `length`, descriptor shape, Promise-returning missing-argument rejections, and captured-call `ERR_INVALID_THIS`
- adds explicit unsupported-operation stubs so reached execution paths reject with `NotSupportedError` instead of falling through as missing methods

## Why batched

The four helpers share the same `SubtleCrypto` prototype installation, `crypto.subtle` namespace property-read path, captured-call receiver validation, and stdlib WebCrypto dispatch surface. Splitting them would duplicate the runtime plumbing and leave the method family in a partially reflective state.

## Tests

Added `test-parity/node-suite/crypto/webcrypto/encapsulation-method-surface.ts`, covering:

- method presence on `crypto.webcrypto.subtle`
- `SubtleCrypto.prototype` descriptor shape
- method `name` and `length`
- direct and captured omitted-argument Promise rejections
- bare captured-call `ERR_INVALID_THIS`
- explicit unsupported algorithm rejection

## Validation

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/webcrypto/encapsulation-method-surface.ts`
- `cargo check -p perry-runtime -p perry-stdlib`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter encapsulation-method-surface'`
  - report: `/root/perry-worktrees/perry-node-crypto-subtle-encapsulate-surface/test-parity/reports/parity_report_20260603_192724.json`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter global-webcrypto-globals'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter subtle-supports'`
- `CARGO_TARGET_DIR=/tmp/perry-subtle-encapsulation-crypto-check cargo check -p perry-stdlib --no-default-features --features crypto`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations

This does not implement ML-KEM encapsulation or decapsulation. Calls that reach the new execution stubs reject explicitly as unsupported.

## Non-goals

- no ML-KEM key generation or shared-secret implementation
- no changes to `SubtleCrypto.supports()` reporting
- no P-384/P-521, Ed448/X448, AES-OCB, ChaCha20-Poly1305, KMAC, or Argon2 WebCrypto algorithm work
