### PR TITLE
[codex] expose subtle encapsulation method surface

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -378,6 +378,28 @@ pub(crate) fn lower_native_method_call(
         return Ok(ctx.block().call(DOUBLE, runtime, &[(DOUBLE, &input)]));
     }
 
+    if module == "crypto.subtle"
+        && object.is_none()
+        && matches!(
+            method,
+            "encapsulateBits" | "decapsulateBits" | "encapsulateKey" | "decapsulateKey"
+        )
+    {
+        for arg in args {
+            let _ = lower_expr(ctx, arg)?;
+        }
+        let runtime = match method {
+            "encapsulateBits" => "js_webcrypto_encapsulate_bits_unimplemented",
+            "decapsulateBits" => "js_webcrypto_decapsulate_bits_unimplemented",
+            "encapsulateKey" => "js_webcrypto_encapsulate_key_unimplemented",
+            "decapsulateKey" => "js_webcrypto_decapsulate_key_unimplemented",
+            _ => unreachable!(),
+        };
+        let present = args.len().to_string();
+        let promise = ctx.block().call(I64, runtime, &[(I64, &present)]);
+        return Ok(nanbox_pointer_inline(ctx.block(), &promise));
+    }
+
     // `perry/ui.App({ title, width, height, body, icon? })` — minimum-viable
     // dispatch so a perry/ui app actually launches an NSApplication and
     // shows a window. Pre-v0.5.10 this fell into the receiver-less early-

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -525,6 +525,10 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
         I64,
         &[DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
+    module.declare_function("js_webcrypto_encapsulate_bits_unimplemented", I64, &[I64]);
+    module.declare_function("js_webcrypto_decapsulate_bits_unimplemented", I64, &[I64]);
+    module.declare_function("js_webcrypto_encapsulate_key_unimplemented", I64, &[I64]);
+    module.declare_function("js_webcrypto_decapsulate_key_unimplemented", I64, &[I64]);
     // `zlib.createBrotliDecompress(options?)` — axios feature-check
     // shim. Returns a registered Buffer-shaped handle (NaN-boxed at
     // the call site).

--- a/crates/perry-hir/src/capability.rs
+++ b/crates/perry-hir/src/capability.rs
@@ -287,7 +287,7 @@ fn required_capability(expr: &Expr) -> Option<(&'static str, &'static str)> {
         // hard-coded above).
         Expr::NativeMethodCall { module, .. } => match module.as_str() {
             "child_process" => ("proc:exec", "child_process.<call>"),
-            "crypto" => ("crypto", "crypto.<call>"),
+            "crypto" | "crypto.subtle" => ("crypto", "crypto.<call>"),
             "fs" => ("fs:read", "fs.<call>"),
             _ => return None,
         },

--- a/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
+++ b/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
@@ -254,6 +254,16 @@ pub(super) fn try_web_crypto_subtle(
                                             usages: Box::new(usages),
                                         }));
                                     }
+                                    "encapsulateBits" | "decapsulateBits" | "encapsulateKey"
+                                    | "decapsulateKey" => {
+                                        return Ok(Ok(Expr::NativeMethodCall {
+                                            module: "crypto.subtle".to_string(),
+                                            class_name: None,
+                                            object: None,
+                                            method: method.to_string(),
+                                            args,
+                                        }));
+                                    }
                                     _ => {
                                         // Unsupported subtle method —
                                         // fail loudly. The supported

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2969,6 +2969,45 @@ extern "C" fn subtle_crypto_supports_thunk(
     }
 }
 
+fn subtle_crypto_dispatch_rest(method: &'static str, rest: f64) -> f64 {
+    let args = global_this_rest_array_values(rest);
+    let ptr = crate::value::JS_NATIVE_WEBCRYPTO_DISPATCH.load(Ordering::SeqCst);
+    if ptr.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let dispatch: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64 =
+        unsafe { std::mem::transmute(ptr) };
+    unsafe { dispatch(method.as_ptr(), method.len(), args.as_ptr(), args.len()) }
+}
+
+extern "C" fn subtle_crypto_encapsulate_bits_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    subtle_crypto_dispatch_rest("encapsulateBits", rest)
+}
+
+extern "C" fn subtle_crypto_decapsulate_bits_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    subtle_crypto_dispatch_rest("decapsulateBits", rest)
+}
+
+extern "C" fn subtle_crypto_encapsulate_key_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    subtle_crypto_dispatch_rest("encapsulateKey", rest)
+}
+
+extern "C" fn subtle_crypto_decapsulate_key_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    subtle_crypto_dispatch_rest("decapsulateKey", rest)
+}
+
 /// Install a single callable static method on a constructor closure as a
 /// `{ writable: true, enumerable: false, configurable: true }` data property
 /// (matching Node's descriptors for built-in statics). `has_rest` registers
@@ -4000,6 +4039,49 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                     proto_obj,
                     name,
                     cryptokey_property_getter_thunk as *const u8,
+                );
+            }
+            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+        }
+        "SubtleCrypto" => {
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "encapsulateBits",
+                subtle_crypto_encapsulate_bits_thunk as *const u8,
+                2,
+                0,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "decapsulateBits",
+                subtle_crypto_decapsulate_bits_thunk as *const u8,
+                3,
+                0,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "encapsulateKey",
+                subtle_crypto_encapsulate_key_thunk as *const u8,
+                5,
+                0,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "decapsulateKey",
+                subtle_crypto_decapsulate_key_thunk as *const u8,
+                6,
+                0,
+            );
+            for name in [
+                "encapsulateBits",
+                "decapsulateBits",
+                "encapsulateKey",
+                "decapsulateKey",
+            ] {
+                super::set_builtin_property_attrs(
+                    proto_obj as usize,
+                    name.to_string(),
+                    super::PropertyAttrs::new(true, true, true),
                 );
             }
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -3546,6 +3546,10 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("crypto", "Cipheriv" | "Decipheriv") => Some(4),
         ("crypto", "KeyObject") => Some(2),
         ("crypto.KeyObject", "from") => Some(1),
+        ("crypto.subtle", "encapsulateBits") => Some(2),
+        ("crypto.subtle", "decapsulateBits") => Some(3),
+        ("crypto.subtle", "encapsulateKey") => Some(5),
+        ("crypto.subtle", "decapsulateKey") => Some(6),
         // #2706/#2716 and #2694: crypto module-level callable exports.
         ("crypto", "DiffieHellman") => Some(4),
         ("crypto", "DiffieHellmanGroup") => Some(1),
@@ -5131,7 +5135,11 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
                     | "decrypt"
                     | "generateKey"
                     | "wrapKey"
-                    | "unwrapKey",
+                    | "unwrapKey"
+                    | "encapsulateBits"
+                    | "decapsulateBits"
+                    | "encapsulateKey"
+                    | "decapsulateKey",
             )
             | ("buffer.Buffer", "from")
             | ("buffer.Buffer", "alloc")

--- a/crates/perry-stdlib/src/webcrypto.rs
+++ b/crates/perry-stdlib/src/webcrypto.rs
@@ -9,6 +9,7 @@
 //! re-exported only inside this module for sibling shards.
 mod aes;
 mod digest;
+mod encapsulation;
 mod hmac;
 mod jwk;
 mod kdf;
@@ -21,8 +22,8 @@ mod wrap;
 #[allow(unused_imports)]
 // Private imports keep sibling modules able to share `pub(super)` helpers.
 use self::{
-    aes::*, digest::*, hmac::*, jwk::*, kdf::*, key_object::*, keys::*, supports::*, util::*,
-    wrap::*,
+    aes::*, digest::*, encapsulation::*, hmac::*, jwk::*, kdf::*, key_object::*, keys::*,
+    supports::*, util::*, wrap::*,
 };
 
 // Public re-exports preserve the parent module surface for FFI entry points.
@@ -104,6 +105,22 @@ pub unsafe extern "C" fn js_webcrypto_native_dispatch(
             js_webcrypto_key_object_to_crypto_key(arg(0), arg(1), arg(2), arg(3))
         }
         "supports" if args_len >= 2 => js_webcrypto_supports(arg(0), arg(1), arg(2)),
+        "encapsulateBits" => promise_to_value(encapsulation_method_dispatch(
+            "encapsulateBits",
+            2,
+            args_len,
+        )),
+        "decapsulateBits" => promise_to_value(encapsulation_method_dispatch(
+            "decapsulateBits",
+            3,
+            args_len,
+        )),
+        "encapsulateKey" => {
+            promise_to_value(encapsulation_method_dispatch("encapsulateKey", 5, args_len))
+        }
+        "decapsulateKey" => {
+            promise_to_value(encapsulation_method_dispatch("decapsulateKey", 6, args_len))
+        }
         _ => undefined,
     }
 }

--- a/crates/perry-stdlib/src/webcrypto/encapsulation.rs
+++ b/crates/perry-stdlib/src/webcrypto/encapsulation.rs
@@ -1,0 +1,65 @@
+use perry_runtime::{js_promise_rejected, js_string_from_bytes, JSValue, Promise};
+
+use super::util::reject_with_dom_exception;
+
+unsafe fn reject_type_error_with_code(message: String, code: &'static str) -> *mut Promise {
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    perry_runtime::node_submodules::register_error_code_pub(msg, code);
+    let err = perry_runtime::error::js_typeerror_new(msg);
+    let err_val = f64::from_bits(JSValue::pointer(err as *const u8).bits());
+    js_promise_rejected(err_val)
+}
+
+unsafe fn reject_missing_args(method: &str, required: usize, present: usize) -> *mut Promise {
+    reject_type_error_with_code(
+        format!(
+            "Failed to execute '{method}' on 'SubtleCrypto': {required} arguments required, but only {present} present."
+        ),
+        "ERR_MISSING_ARGS",
+    )
+}
+
+/// Node 24+ exposes WebCrypto encapsulation method names even when callers use
+/// them for feature detection. Perry does not implement ML-KEM execution yet,
+/// but the surface should be explicit instead of falling through as `undefined`.
+pub(super) unsafe fn encapsulation_method_dispatch(
+    method: &str,
+    required_args: usize,
+    present_args: usize,
+) -> *mut Promise {
+    if present_args < required_args {
+        return reject_missing_args(method, required_args, present_args);
+    }
+    reject_with_dom_exception(
+        "NotSupportedError",
+        "Unsupported WebCrypto encapsulation algorithm",
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_webcrypto_encapsulate_bits_unimplemented(
+    present_args: i64,
+) -> *mut Promise {
+    encapsulation_method_dispatch("encapsulateBits", 2, present_args.max(0) as usize)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_webcrypto_decapsulate_bits_unimplemented(
+    present_args: i64,
+) -> *mut Promise {
+    encapsulation_method_dispatch("decapsulateBits", 3, present_args.max(0) as usize)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_webcrypto_encapsulate_key_unimplemented(
+    present_args: i64,
+) -> *mut Promise {
+    encapsulation_method_dispatch("encapsulateKey", 5, present_args.max(0) as usize)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_webcrypto_decapsulate_key_unimplemented(
+    present_args: i64,
+) -> *mut Promise {
+    encapsulation_method_dispatch("decapsulateKey", 6, present_args.max(0) as usize)
+}

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -1769,6 +1769,7 @@ fn collect_module_finish(
             || hir_debug.contains("WebCryptoGenerateKey")
             || hir_debug.contains("WebCryptoWrapKey")
             || hir_debug.contains("WebCryptoUnwrapKey")
+            || hir_debug.contains("module: \"crypto.subtle\"")
             // `globalThis.crypto` / bare `crypto` now materializes the
             // WebCrypto singleton. Its `randomUUID` property dispatches
             // through perry-stdlib's crypto bridge when called via a

--- a/test-parity/node-suite/crypto/webcrypto/subtle-encapsulation-methods.ts
+++ b/test-parity/node-suite/crypto/webcrypto/subtle-encapsulation-methods.ts
@@ -1,0 +1,61 @@
+import { webcrypto } from "node:crypto";
+
+(process as any).emitWarning = () => undefined;
+
+const subtle = webcrypto.subtle;
+
+const descriptorShape = (desc: any) => ({
+  enumerable: desc?.enumerable,
+  configurable: desc?.configurable,
+  writable: "writable" in desc ? desc.writable : undefined,
+  value: typeof desc?.value,
+});
+
+async function rejection(label: string, promise: Promise<any>) {
+  try {
+    await promise;
+    console.log(`${label}: no reject`);
+  } catch (error: any) {
+    console.log(`${label}:`, error.name, error.code ?? "", error.message);
+  }
+}
+
+function directMissingCall(name: string): Promise<any> {
+  switch (name) {
+    case "encapsulateBits":
+      return subtle.encapsulateBits();
+    case "decapsulateBits":
+      return subtle.decapsulateBits();
+    case "encapsulateKey":
+      return subtle.encapsulateKey();
+    case "decapsulateKey":
+      return subtle.decapsulateKey();
+    default:
+      throw new Error(`unexpected method ${name}`);
+  }
+}
+
+for (const name of [
+  "encapsulateBits",
+  "decapsulateBits",
+  "encapsulateKey",
+  "decapsulateKey",
+] as const) {
+  const protoDesc = Object.getOwnPropertyDescriptor(SubtleCrypto.prototype, name);
+  const ownDesc = Object.getOwnPropertyDescriptor(subtle, name);
+  const fn = (subtle as any)[name];
+  console.log(
+    `${name} shape:`,
+    typeof fn,
+    fn.name,
+    fn.length,
+    !!ownDesc,
+    JSON.stringify(descriptorShape(protoDesc)),
+  );
+  const ret = fn.call(subtle);
+  console.log(`${name} missing returns promise:`, ret instanceof Promise);
+  await rejection(`${name} missing`, ret);
+  const directRet = directMissingCall(name);
+  console.log(`${name} direct missing returns promise:`, directRet instanceof Promise);
+  await rejection(`${name} direct missing`, directRet);
+}


### PR DESCRIPTION
Part of #2518.

## Scope
- Exposes `SubtleCrypto.prototype.encapsulateBits`, `decapsulateBits`, `encapsulateKey`, and `decapsulateKey` with Node-shaped callable method names, lengths, and enumerable/writable/configurable descriptors.
- Routes direct `crypto.subtle` calls plus captured/dynamic `crypto.subtle` method calls through the WebCrypto dispatcher instead of surfacing `undefined`.
- Matches Node 26 missing-argument behavior by returning a rejected Promise with `TypeError [ERR_MISSING_ARGS]` and the WebIDL-style message.
- Returns an explicit unsupported WebCrypto rejection for non-missing encapsulation execution paths rather than silently missing the method.

## Non-goals
- Implementing ML-KEM encapsulation/decapsulation execution.
- Advertising ML-KEM support through `SubtleCrypto.supports()`.
- Changing P-384/P-521 WebCrypto support, which is tracked separately.

## Validation
- `npm exec --yes --package=node@26 -- node test-parity/node-suite/crypto/webcrypto/subtle-encapsulation-methods.ts`
- `CARGO_TARGET_DIR=/tmp/perry-webcrypto-encap-check cargo check -p perry-hir -p perry-codegen -p perry-runtime -p perry-stdlib`
- Direct Perry compile/run of `test-parity/node-suite/crypto/webcrypto/subtle-encapsulation-methods.ts` with `PERRY_NO_AUTO_OPTIMIZE=1`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-encap-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter subtle-encapsulation-methods'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-encap-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter subtle-supports'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-encap-build npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter global-webcrypto-globals'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
