### PR TITLE
[codex] honor child_process detached process groups

### DIFF
--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -126,6 +126,7 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     command.args(&arg_strs);
     cp_apply_argv0(&mut command, opts_val);
     cp_apply_options(&mut command, opts_val);
+    cp_apply_detached(&mut command, opts_val);
     cp_apply_live_stdio(&mut command, &stdio_kinds);
 
     let launched = fork_launch(cp, stdout_obj, stderr_obj, stdin_obj, command, advanced);

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -1410,6 +1410,43 @@ pub(super) fn cp_apply_argv0(command: &mut Command, opts_val: f64) {
     }
 }
 
+fn cp_option_detached(opts_val: f64) -> bool {
+    if cp_object_ptr(opts_val).is_none() {
+        return false;
+    }
+    cp_get_field(opts_val, b"detached").to_bits() == TAG_TRUE_F64.to_bits()
+}
+
+pub(super) fn cp_apply_detached(command: &mut Command, opts_val: f64) {
+    if !cp_option_detached(opts_val) {
+        return;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x00000008 | 0x00000200);
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = command;
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum CpStdio {
     Pipe,
@@ -1519,6 +1556,7 @@ fn cp_build_command(cmd: &str, args: &[String], opts_val: f64) -> Command {
 
     cp_apply_argv0(&mut command, opts_val);
     cp_apply_options(&mut command, opts_val);
+    cp_apply_detached(&mut command, opts_val);
     command
 }
 

--- a/test-parity/node-suite/child_process/async/detached-process-group.ts
+++ b/test-parity/node-suite/child_process/async/detached-process-group.ts
@@ -1,0 +1,75 @@
+import { fork, spawn, spawnSync } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (process.platform === "win32") {
+  console.log("detached unix skipped:", true);
+  process.exit(0);
+}
+
+const shellGroupScript =
+  'pid=$$; pgid=$(ps -o pgid= -p "$$" | tr -d " "); printf "%s:%s\\n" "$pid" "$pgid"';
+
+function pgidMatchesPid(line: string): boolean {
+  const [pid, pgid] = line.trim().split(":");
+  return pid.length > 0 && pid === pgid;
+}
+
+function closeCode(child: any): Promise<number | null> {
+  return new Promise((resolve) => child.on("close", (code: number | null) => resolve(code)));
+}
+
+async function runSpawn() {
+  const child = spawn("sh", ["-c", shellGroupScript], {
+    detached: true,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  let stdout = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+  });
+  const code = await closeCode(child);
+  console.log("spawn detached same pgid:", pgidMatchesPid(stdout));
+  console.log("spawn detached close:", code);
+}
+
+function runSpawnSync() {
+  const result = spawnSync("sh", ["-c", shellGroupScript], {
+    detached: true,
+    encoding: "utf8",
+  });
+  console.log("spawnSync detached same pgid:", pgidMatchesPid(result.stdout));
+  console.log("spawnSync detached status:", result.status);
+}
+
+async function runFork() {
+  const childFile = join(tmpdir(), `perry-fork-detached-${process.pid}.js`);
+  writeFileSync(
+    childFile,
+    `
+const { execFileSync } = require("node:child_process");
+const pid = String(process.pid);
+const pgid = execFileSync("ps", ["-o", "pgid=", "-p", pid], { encoding: "utf8" }).trim();
+if (process.send) process.send({ same: pid === pgid, connected: process.connected === true });
+`,
+  );
+
+  const child = fork(childFile, [], {
+    detached: true,
+    execArgv: [],
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  });
+  const message: any = await new Promise((resolve) => child.on("message", resolve));
+  const code = await closeCode(child);
+  console.log("fork detached same pgid:", message.same);
+  console.log("fork detached connected:", message.connected);
+  console.log("fork detached close:", code);
+  try {
+    unlinkSync(childFile);
+  } catch {}
+}
+
+await runSpawn();
+runSpawnSync();
+await runFork();


### PR DESCRIPTION
## Summary
- add a child_process parity fixture for `detached: true` process-group behavior across `spawn`, `spawnSync`, and `fork`
- wire `options.detached === true` into shared spawn/spawnSync command construction
- apply the same detached setup to the fork command path before launching IPC-enabled children

## Root Cause
Perry already exposed the documented child_process option surface, but the live and sync command builders ignored `options.detached`. On Unix, Node makes a detached child the leader of a new session and process group, so the child shell's process group ID should match its PID. Perry left children in the parent process group.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/child_process/async/detached-process-group.ts`
- Baseline check before the fix: focused parity reported `Node.js: spawn detached same pgid: true` and `Perry: spawn detached same pgid: false`
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter detached-process-group'` (1 pass, 0 compile failures)
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process'` (18 pass, 0 compile failures)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Covers the `detached` option slice of #2555.