### PR TITLE
[codex] honor child_process uid gid options

### DIFF
--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -1325,14 +1325,14 @@ fn cp_args_from_value(value: f64) -> Vec<String> {
 }
 
 // ============================================================================
-// Spawn / exec options: `cwd`, `env`, `shell`, `argv0`, sync buffered I/O —
-// #1780/#2555
+// Spawn / exec options: `cwd`, `env`, `uid`, `gid`, `shell`, `argv0`, sync
+// buffered I/O — #1780/#2555
 // ============================================================================
 //
-// These helpers read the common, host-portable options off a NaN-boxed options
-// value and apply them to a `std::process::Command`. The sync buffered forms
-// also parse `{ input, timeout, maxBuffer }`; broader stdio routing remains
-// outside the current runtime surface.
+// These helpers read common options off a NaN-boxed options value and apply them
+// to a `std::process::Command`. The sync buffered forms also parse `{ input,
+// timeout, maxBuffer }`; broader stdio routing remains outside the current
+// runtime surface.
 
 /// Coerce any JS value to an owned Rust string — string fast-path, else
 /// `js_jsvalue_to_string`. Used for `env` values, which Node stringifies.
@@ -1347,8 +1347,45 @@ fn cp_coerce_string(value: f64) -> String {
     unsafe { cp_read_string_header(p as i64) }
 }
 
-/// Apply the host-portable `{ cwd, env }` options to `command`. `opts_val` is a
-/// NaN-boxed options object (or undefined/null/non-object — then a no-op). Node
+fn cp_read_uid_gid_option(opts_val: f64, key: &[u8]) -> Option<u32> {
+    let value = cp_get_field(opts_val, key);
+    let js_value = JSValue::from_bits(value.to_bits());
+    if js_value.is_undefined() || js_value.is_null() {
+        return None;
+    }
+    if !js_value.is_number() && !js_value.is_int32() {
+        return None;
+    }
+    let id = js_value.to_number();
+    if id.is_finite() && id >= 0.0 && id.fract() == 0.0 && id <= u32::MAX as f64 {
+        Some(id as u32)
+    } else {
+        None
+    }
+}
+
+fn cp_apply_uid_gid(command: &mut Command, opts_val: f64) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+
+        if let Some(gid) = cp_read_uid_gid_option(opts_val, b"gid") {
+            command.gid(gid);
+        }
+        if let Some(uid) = cp_read_uid_gid_option(opts_val, b"uid") {
+            command.uid(uid);
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (command, opts_val);
+    }
+}
+
+/// Apply shared command options to `command`. `cwd` and `env` are portable;
+/// `uid` and `gid` are applied on Unix targets. `opts_val` is a NaN-boxed
+/// options object (or undefined/null/non-object — then a no-op). Node
 /// semantics: `env` *replaces* the child's environment wholesale, so when an
 /// `env` object is provided we `env_clear()` first and skip keys whose value is
 /// `undefined`. #1780.
@@ -1382,6 +1419,8 @@ fn cp_apply_options(command: &mut Command, opts_val: f64) {
             }
         }
     }
+
+    cp_apply_uid_gid(command, opts_val);
 }
 
 pub(super) fn cp_read_argv0(opts_val: f64) -> Option<String> {

--- a/test-parity/node-suite/child_process/async/uid-gid.ts
+++ b/test-parity/node-suite/child_process/async/uid-gid.ts
@@ -1,0 +1,88 @@
+import { execFileSync, fork, spawn, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const forkExecPath = "/usr/bin/node";
+const canSetIds =
+  process.platform !== "win32" &&
+  typeof process.getuid === "function" &&
+  typeof process.getgid === "function" &&
+  process.getuid() === 0 &&
+  existsSync(forkExecPath);
+
+if (!canSetIds) {
+  console.log("uid gid skipped:", true);
+  process.exit(0);
+}
+
+const targetUid = 65534;
+const targetGid = 65534;
+const identityCode = 'console.log(`${process.getuid()}:${process.getgid()}`)';
+
+function closeCode(child: any): Promise<number | null> {
+  return new Promise((resolve) => child.on("close", (code: number | null) => resolve(code)));
+}
+
+async function runSpawn() {
+  const child = spawn("node", ["-e", identityCode], {
+    gid: targetGid,
+    uid: targetUid,
+  });
+  let stdout = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+  });
+  const code = await closeCode(child);
+  console.log("spawn uid gid:", stdout.trim());
+  console.log("spawn uid gid close:", code);
+}
+
+function runSpawnSync() {
+  const result = spawnSync("node", ["-e", identityCode], {
+    encoding: "utf8",
+    gid: targetGid,
+    uid: targetUid,
+  });
+  console.log("spawnSync uid gid:", result.stdout.trim());
+  console.log("spawnSync uid gid status:", result.status);
+}
+
+function runExecFileSync() {
+  const output = execFileSync("node", ["-e", identityCode], {
+    encoding: "utf8",
+    gid: targetGid,
+    uid: targetUid,
+  });
+  console.log("execFileSync uid gid:", output.trim());
+}
+
+async function runFork() {
+  const childFile = join(tmpdir(), `perry-fork-uid-gid-${process.pid}.js`);
+  writeFileSync(
+    childFile,
+    "if (process.send) process.send(`${process.getuid()}:${process.getgid()}`);",
+  );
+  chmodSync(childFile, 0o644);
+
+  const child = fork(childFile, [], {
+    cwd: tmpdir(),
+    execArgv: [],
+    execPath: forkExecPath,
+    gid: targetGid,
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+    uid: targetUid,
+  });
+  const message = await new Promise((resolve) => child.on("message", resolve));
+  const code = await closeCode(child);
+  console.log("fork uid gid:", message);
+  console.log("fork uid gid close:", code);
+  try {
+    unlinkSync(childFile);
+  } catch {}
+}
+
+await runSpawn();
+runSpawnSync();
+runExecFileSync();
+await runFork();


### PR DESCRIPTION
## Summary
- add child_process parity coverage for `uid`/`gid` across spawn, spawnSync, execFileSync, and fork when running as root
- apply numeric `uid` and `gid` options through the shared child_process command setup
- set `gid` before `uid` on Unix so dropped-privilege children observe the supplied identities

## Root Cause
Perry parsed common child_process options such as `cwd` and `env`, but ignored `uid` and `gid`. Node applies these IDs before exec, so root-launched children should observe the supplied IDs via `process.getuid()` and `process.getgid()`.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/child_process/async/uid-gid.ts`
- Baseline check before the fix: focused parity reported `Node.js: spawn uid gid: 65534:65534` and `Perry: spawn uid gid: 0:0`
- `npm exec --yes --package=node@26 -- bash -lc "./run_parity_tests.sh --suite node-suite --module child_process --filter uid-gid"`
- `npm exec --yes --package=node@26 -- bash -lc "./run_parity_tests.sh --suite node-suite --module child_process"`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Covers the `uid` / `gid` option slice of #2555.