### PR TITLE
feat(runtime): implement BigInt.asIntN / BigInt.asUintN

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -212,6 +212,33 @@ pub(crate) fn lower_native_method_call(
         }
     }
 
+    // `BigInt.asIntN(bits, x)` / `BigInt.asUintN(bits, x)` (#bigint statics).
+    // Lowered to a receiver-less NativeMethodCall on the "bigint" module; emit
+    // a direct call to the runtime entry (ToIndex + BigInt brand check +
+    // two's-complement wrap).
+    if module == "bigint" && object.is_none() {
+        let runtime = match method {
+            "asIntN" => Some("js_bigint_as_int_n_call"),
+            "asUintN" => Some("js_bigint_as_uint_n_call"),
+            _ => None,
+        };
+        if let Some(runtime) = runtime {
+            let bits = if let Some(a) = args.first() {
+                lower_expr(ctx, a)?
+            } else {
+                crate::nanbox::double_literal(0.0)
+            };
+            let value = if let Some(a) = args.get(1) {
+                lower_expr(ctx, a)?
+            } else {
+                crate::nanbox::double_literal(0.0)
+            };
+            return Ok(ctx
+                .block()
+                .call(DOUBLE, runtime, &[(DOUBLE, &bits), (DOUBLE, &value)]));
+        }
+    }
+
     if module == "jsonwebtoken" && method == "sign" && object.is_none() {
         return lower_jsonwebtoken_sign(ctx, args);
     }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -671,6 +671,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_versions", DOUBLE, &[]);
     module.declare_function("js_process_memory_usage", DOUBLE, &[]);
     // node:v8 (#3137/#3138/#3142).
+    module.declare_function("js_bigint_as_int_n_call", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_bigint_as_uint_n_call", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_v8_serialize", DOUBLE, &[DOUBLE]);
     module.declare_function("js_v8_deserialize", DOUBLE, &[DOUBLE]);
     module.declare_function("js_v8_get_heap_statistics", DOUBLE, &[]);

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -948,6 +948,31 @@ pub(super) fn try_module_static_methods(
                 }
             }
 
+            // `BigInt.asIntN(bits, x)` / `BigInt.asUintN(bits, x)`. Bare `BigInt`
+            // in member position lowers to `globalThis`, so a direct
+            // `BigInt.asIntN(...)` call would read `globalThis.asIntN`
+            // (undefined → "value is not a function"). Route to the runtime via
+            // a receiver-less NativeMethodCall. (The statics are also installed
+            // on the BigInt ctor closure for the `const B = BigInt; B.asIntN`
+            // value path.)
+            if obj_ident.sym.as_ref() == "BigInt" {
+                if let ast::MemberProp::Ident(method_ident) = &member.prop {
+                    let m = method_ident.sym.as_ref();
+                    if m == "asIntN" || m == "asUintN" {
+                        let mut it = args.into_iter();
+                        let bits = it.next().unwrap_or(Expr::Undefined);
+                        let value = it.next().unwrap_or(Expr::Undefined);
+                        return Ok(Ok(Expr::NativeMethodCall {
+                            module: "bigint".to_string(),
+                            class_name: None,
+                            object: None,
+                            method: m.to_string(),
+                            args: vec![bits, value],
+                        }));
+                    }
+                }
+            }
+
             // Check for Number.methodName() static calls
             if obj_ident.sym.as_ref() == "Number" {
                 if let ast::MemberProp::Ident(method_ident) = &member.prop {

--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -1305,6 +1305,71 @@ fn subtract_limbs(a: &mut [u64; BIGINT_LIMBS], b: &[u64; BIGINT_LIMBS]) {
     }
 }
 
+/// Mask a 1024-bit two's-complement limb array down to its low `bits` bits,
+/// zeroing everything at or above bit index `bits`. `bits >= BIGINT_BITS`
+/// leaves the value unchanged.
+fn mask_low_bits(mut limbs: [u64; BIGINT_LIMBS], bits: usize) -> [u64; BIGINT_LIMBS] {
+    if bits >= BIGINT_BITS {
+        return limbs;
+    }
+    let full_limbs = bits / 64;
+    let rem = bits % 64;
+    for (i, l) in limbs.iter_mut().enumerate() {
+        if i < full_limbs {
+            // keep
+        } else if i == full_limbs && rem != 0 {
+            *l &= (1u64 << rem) - 1;
+        } else {
+            *l = 0;
+        }
+    }
+    limbs
+}
+
+/// `BigInt.asUintN(bits, bigint)` — wrap `value` to a `bits`-wide UNSIGNED
+/// integer: `value mod 2^bits`, always non-negative. (`asUintN(0, x)` → 0n.)
+#[no_mangle]
+pub extern "C" fn js_bigint_as_uint_n(bits: u32, value: *const BigIntHeader) -> *mut BigIntHeader {
+    let limbs = bigint_limbs_or_zero(value);
+    let masked = mask_low_bits(limbs, bits as usize);
+    bigint_alloc_with_limbs(masked)
+}
+
+/// `BigInt.asIntN(bits, bigint)` — wrap `value` to a `bits`-wide SIGNED
+/// two's-complement integer: `value mod 2^bits`, then interpret the top bit
+/// (bit `bits-1`) as the sign and sign-extend. (`asIntN(0, x)` → 0n.)
+#[no_mangle]
+pub extern "C" fn js_bigint_as_int_n(bits: u32, value: *const BigIntHeader) -> *mut BigIntHeader {
+    let bits = bits as usize;
+    if bits == 0 {
+        return bigint_alloc_with_limbs(ZERO_LIMBS);
+    }
+    if bits >= BIGINT_BITS {
+        // No truncation possible within our width; value already two's-complement.
+        return bigint_alloc_with_limbs(bigint_limbs_or_zero(value));
+    }
+    let mut masked = mask_low_bits(bigint_limbs_or_zero(value), bits);
+    // If the sign bit (bit bits-1) is set, sign-extend: set all bits >= bits-1.
+    let sign_limb = (bits - 1) / 64;
+    let sign_pos = (bits - 1) % 64;
+    let sign_set = (masked[sign_limb] >> sign_pos) & 1 == 1;
+    if sign_set {
+        // Set every bit from `bits` upward to 1 (two's-complement negative).
+        let full_limbs = bits / 64;
+        let rem = bits % 64;
+        for (i, l) in masked.iter_mut().enumerate() {
+            if i < full_limbs {
+                // low full limbs: keep
+            } else if i == full_limbs && rem != 0 {
+                *l |= !((1u64 << rem) - 1);
+            } else if i >= full_limbs {
+                *l = u64::MAX;
+            }
+        }
+    }
+    bigint_alloc_with_limbs(masked)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2844,6 +2844,50 @@ extern "C" fn number_is_integer_thunk(
     crate::builtins::js_number_is_integer(value)
 }
 
+/// Shared helper for `BigInt.asIntN`/`asUintN` thunks: coerce `bits` via
+/// ToIndex (throws RangeError on negative / non-integer) and extract the
+/// BigInt pointer from `value` (throws TypeError if not a BigInt). Diverges
+/// (`!`) on bad input, matching Node's throw semantics.
+fn bigint_as_n_args(bits_arg: f64, value_arg: f64) -> (u32, *const crate::bigint::BigIntHeader) {
+    // ToIndex(bits): non-negative integer; Node throws RangeError otherwise.
+    if !bits_arg.is_finite() || bits_arg < 0.0 || bits_arg.fract() != 0.0 {
+        crate::fs::validate::throw_range_error_with_code(
+            "The number of bits is invalid (must be a non-negative integer)",
+        );
+    }
+    let jv = JSValue::from_bits(value_arg.to_bits());
+    if !jv.is_bigint() {
+        crate::fs::validate::throw_type_error_with_code(
+            "Cannot convert value to a BigInt",
+            "ERR_INVALID_ARG_TYPE",
+        );
+    }
+    (
+        bits_arg as u32,
+        jv.as_bigint_ptr() as *const crate::bigint::BigIntHeader,
+    )
+}
+
+extern "C" fn bigint_as_int_n_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    bits: f64,
+    value: f64,
+) -> f64 {
+    let (bits, ptr) = bigint_as_n_args(bits, value);
+    let r = crate::bigint::js_bigint_as_int_n(bits, ptr);
+    f64::from_bits(crate::value::js_nanbox_bigint(r as i64).to_bits())
+}
+
+extern "C" fn bigint_as_uint_n_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    bits: f64,
+    value: f64,
+) -> f64 {
+    let (bits, ptr) = bigint_as_n_args(bits, value);
+    let r = crate::bigint::js_bigint_as_uint_n(bits, ptr);
+    f64::from_bits(crate::value::js_nanbox_bigint(r as i64).to_bits())
+}
+
 extern "C" fn number_is_safe_integer_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
@@ -3143,6 +3187,17 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 ctor,
                 "parseInt",
                 number_parse_int_thunk as *const u8,
+                2,
+                false,
+            );
+        }
+        "BigInt" => {
+            // BigInt.asIntN(bits, bigint) / asUintN(bits, bigint) — spec length 2.
+            install_constructor_static(ctor, "asIntN", bigint_as_int_n_thunk as *const u8, 2, false);
+            install_constructor_static(
+                ctor,
+                "asUintN",
+                bigint_as_uint_n_thunk as *const u8,
                 2,
                 false,
             );

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2872,6 +2872,18 @@ pub(crate) fn bigint_as_n_dispatch(bits_arg: f64, value_arg: f64, signed: bool) 
     f64::from_bits(crate::value::js_nanbox_bigint(r as i64).to_bits())
 }
 
+/// FFI entry for the codegen-lowered `BigInt.asIntN(bits, x)` direct call.
+#[no_mangle]
+pub extern "C" fn js_bigint_as_int_n_call(bits: f64, value: f64) -> f64 {
+    bigint_as_n_dispatch(bits, value, true)
+}
+
+/// FFI entry for the codegen-lowered `BigInt.asUintN(bits, x)` direct call.
+#[no_mangle]
+pub extern "C" fn js_bigint_as_uint_n_call(bits: f64, value: f64) -> f64 {
+    bigint_as_n_dispatch(bits, value, false)
+}
+
 extern "C" fn bigint_as_int_n_thunk(
     _closure: *const crate::closure::ClosureHeader,
     bits: f64,
@@ -3193,7 +3205,13 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
         }
         "BigInt" => {
             // BigInt.asIntN(bits, bigint) / asUintN(bits, bigint) — spec length 2.
-            install_constructor_static(ctor, "asIntN", bigint_as_int_n_thunk as *const u8, 2, false);
+            install_constructor_static(
+                ctor,
+                "asIntN",
+                bigint_as_int_n_thunk as *const u8,
+                2,
+                false,
+            );
             install_constructor_static(
                 ctor,
                 "asUintN",

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2844,12 +2844,12 @@ extern "C" fn number_is_integer_thunk(
     crate::builtins::js_number_is_integer(value)
 }
 
-/// Shared helper for `BigInt.asIntN`/`asUintN` thunks: coerce `bits` via
-/// ToIndex (throws RangeError on negative / non-integer) and extract the
-/// BigInt pointer from `value` (throws TypeError if not a BigInt). Diverges
-/// (`!`) on bad input, matching Node's throw semantics.
-fn bigint_as_n_args(bits_arg: f64, value_arg: f64) -> (u32, *const crate::bigint::BigIntHeader) {
-    // ToIndex(bits): non-negative integer; Node throws RangeError otherwise.
+/// Shared impl for `BigInt.asIntN`/`asUintN` (both the ctor-static thunks and
+/// the `("bigint", ...)` native-module dispatch). Coerces `bits` via ToIndex
+/// (RangeError on negative/non-integer), brand-checks `value` is a BigInt
+/// (TypeError otherwise), and returns the NaN-boxed result. `signed` selects
+/// asIntN vs asUintN. Diverges (`!`) on bad input, matching Node.
+pub(crate) fn bigint_as_n_dispatch(bits_arg: f64, value_arg: f64, signed: bool) -> f64 {
     if !bits_arg.is_finite() || bits_arg < 0.0 || bits_arg.fract() != 0.0 {
         crate::fs::validate::throw_range_error_with_code(
             "The number of bits is invalid (must be a non-negative integer)",
@@ -2862,10 +2862,14 @@ fn bigint_as_n_args(bits_arg: f64, value_arg: f64) -> (u32, *const crate::bigint
             "ERR_INVALID_ARG_TYPE",
         );
     }
-    (
-        bits_arg as u32,
-        jv.as_bigint_ptr() as *const crate::bigint::BigIntHeader,
-    )
+    let bits = bits_arg as u32;
+    let ptr = jv.as_bigint_ptr() as *const crate::bigint::BigIntHeader;
+    let r = if signed {
+        crate::bigint::js_bigint_as_int_n(bits, ptr)
+    } else {
+        crate::bigint::js_bigint_as_uint_n(bits, ptr)
+    };
+    f64::from_bits(crate::value::js_nanbox_bigint(r as i64).to_bits())
 }
 
 extern "C" fn bigint_as_int_n_thunk(
@@ -2873,9 +2877,7 @@ extern "C" fn bigint_as_int_n_thunk(
     bits: f64,
     value: f64,
 ) -> f64 {
-    let (bits, ptr) = bigint_as_n_args(bits, value);
-    let r = crate::bigint::js_bigint_as_int_n(bits, ptr);
-    f64::from_bits(crate::value::js_nanbox_bigint(r as i64).to_bits())
+    bigint_as_n_dispatch(bits, value, true)
 }
 
 extern "C" fn bigint_as_uint_n_thunk(
@@ -2883,9 +2885,7 @@ extern "C" fn bigint_as_uint_n_thunk(
     bits: f64,
     value: f64,
 ) -> f64 {
-    let (bits, ptr) = bigint_as_n_args(bits, value);
-    let r = crate::bigint::js_bigint_as_uint_n(bits, ptr);
-    f64::from_bits(crate::value::js_nanbox_bigint(r as i64).to_bits())
+    bigint_as_n_dispatch(bits, value, false)
 }
 
 extern "C" fn number_is_safe_integer_thunk(

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1327,6 +1327,8 @@ pub(crate) unsafe fn dispatch_native_module_method(
         ("util", "isAnyArrayBuffer") => {
             bool_tag(crate::buffer::is_any_array_buffer(ptr_addr(arg(0))))
         }
+        ("bigint", "asIntN") => crate::object::bigint_as_n_dispatch(arg(0), arg(1), true),
+        ("bigint", "asUintN") => crate::object::bigint_as_n_dispatch(arg(0), arg(1), false),
         ("util", "isArrayBufferView") => crate::object::js_util_types_is_array_buffer_view(arg(0)),
         ("util", "isTypedArray") => bool_tag(typed_kind(arg(0)).is_some()),
         ("util", "isUint8Array") => {


### PR DESCRIPTION
## What

Implements `BigInt.asIntN(bits, value)` and `BigInt.asUintN(bits, value)`, which
were entirely missing (`typeof BigInt.asIntN` was `number`; calling threw
"value is not a function").

## Why

`built-ins/BigInt` test262 cluster. Both statics are standard and were unwired
end-to-end.

## How (4 layers)

1. **Runtime** (`bigint.rs`): `js_bigint_as_int_n` / `js_bigint_as_uint_n` —
   two's-complement bit-masking on the 1024-bit limb array (mask low `bits`
   bits; for asIntN, sign-extend when bit `bits-1` is set).
2. **Ctor statics** (`global_this.rs`): installed on the BigInt constructor so
   the value path (`const B = BigInt; B.asIntN(...)`) works, plus
   `bigint_as_n_dispatch` (ToIndex(bits) + BigInt brand check) shared by the
   thunks and the FFI entries.
3. **HIR lowering** (`module_static.rs`): bare `BigInt` in member position
   lowers to `globalThis`, so a *direct* `BigInt.asIntN(...)` would read
   `globalThis.asIntN` (undefined). Route it to a receiver-less
   `NativeMethodCall` on the `"bigint"` module.
4. **Codegen** (`native/mod.rs` + FFI decls): emit a direct call to
   `js_bigint_as_int_n_call` / `js_bigint_as_uint_n_call`.

## Verification

- **test262 `built-ins/BigInt`: 32 → 27** (−5, no regressions).
- Byte-identical to `node --experimental-strip-types` (both build modes) on the
  call path: `asIntN(4,9n)=-7n`, `asUintN(8,-1n)=255n`, `asIntN(64, 2^64+1)=1n`,
  `asUintN(0,x)=0n`, plus RangeError(negative bits) / TypeError(non-BigInt value).
- `perry-runtime` suite: 977/977. fmt + file-size clean. Rebased on main.

## Known follow-ups (out of scope)

- `typeof BigInt.asIntN` still reports `number` — the bare value-READ (not call)
  path still resolves via globalThis. (Calls work; this is reflection-only.)
- 6 spec-coercion edges remain: `bits-toindex` (ToIndex of non-number bits),
  `bigint-tobigint` (ToBigInt of the value arg), `order-of-steps`. These need
  context-aware ToBigInt/ToIndex coercion; the current impl validates strictly.
