### PR TITLE
fix(crypto): verify x509 certificates with public keys

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -484,7 +484,13 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     #[cfg(feature = "crypto")]
     if matches!(
         method_name,
-        "toString" | "toJSON" | "toLegacyObject" | "checkHost" | "checkEmail" | "checkIP"
+        "toString"
+            | "toJSON"
+            | "toLegacyObject"
+            | "checkHost"
+            | "checkEmail"
+            | "checkIP"
+            | "verify"
     ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_x509_method(handle, method_name, &args);
@@ -2249,6 +2255,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             | "checkHost"
             | "checkEmail"
             | "checkIP"
+            | "verify"
     ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_x509_property(handle, property_name);

--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -510,6 +510,15 @@ fn x509_signature_algorithm_name(cert: &x509_cert::Certificate) -> Option<&'stat
     }
 }
 
+fn x509_rsa_signature_digest(cert: &x509_cert::Certificate) -> Option<RsaDigestKind> {
+    match cert.signature_algorithm.oid.to_string().as_str() {
+        "1.2.840.113549.1.1.11" => Some(RsaDigestKind::Sha256),
+        "1.2.840.113549.1.1.12" => Some(RsaDigestKind::Sha384),
+        "1.2.840.113549.1.1.13" => Some(RsaDigestKind::Sha512),
+        _ => None,
+    }
+}
+
 unsafe fn x509_name_legacy_object(name: &x509_cert::name::Name) -> f64 {
     let attr_count = name.0.iter().map(|rdn| rdn.0.len()).sum::<usize>() as u32;
     let obj = js_object_alloc(0, attr_count);
@@ -635,6 +644,79 @@ unsafe fn x509_to_legacy_object(handle: &X509Handle) -> f64 {
     nanbox_ptr(obj)
 }
 
+unsafe fn x509_asymmetric_key_meta(value: f64) -> Option<(u8, u8)> {
+    let bits = value.to_bits();
+    let js = JSValue::from_bits(bits);
+    if !js.is_any_string() || (bits >> 48) as u16 != 0x7FFF {
+        return None;
+    }
+    let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return None;
+    }
+    perry_runtime::buffer::asymmetric_key_meta(ptr as usize)
+}
+
+fn throw_x509_pkey_type_error(value: f64) -> ! {
+    let message = format!(
+        "The \"pkey\" argument must be an instance of KeyObject. Received {}",
+        perry_runtime::fs::validate::describe_received(value)
+    );
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_x509_pkey_value_error(kind: u8) -> ! {
+    let received = if kind == 2 {
+        "PrivateKeyObject {}"
+    } else {
+        "KeyObject {}"
+    };
+    let message = format!("The argument 'pkey' is invalid. Received {received}");
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE")
+}
+
+unsafe fn x509_verify_value(handle: &X509Handle, args: &[f64]) -> f64 {
+    use x509_cert::der::Encode;
+
+    let key_value = args
+        .first()
+        .copied()
+        .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+    let Some((kind, _asym_type)) = x509_asymmetric_key_meta(key_value) else {
+        throw_x509_pkey_type_error(key_value);
+    };
+    if kind != 1 {
+        throw_x509_pkey_value_error(kind);
+    }
+
+    let alg = match x509_rsa_signature_digest(&handle.cert) {
+        Some(alg) => alg,
+        None => return js_bool(false),
+    };
+    let pem = match crypto_key_input_to_public_pem(key_value.to_bits()) {
+        Some(pem) => pem,
+        None => return js_bool(false),
+    };
+    let public_key = match parse_rsa_public_key_pem(&pem) {
+        Some(key) => key,
+        None => return js_bool(false),
+    };
+    let tbs_der = match handle.cert.tbs_certificate.to_der() {
+        Ok(der) => der,
+        Err(_) => return js_bool(false),
+    };
+    let signature = match handle
+        .cert
+        .signature
+        .as_bytes()
+        .and_then(|bytes| RsaPkcs1v15Signature::try_from(bytes).ok())
+    {
+        Some(signature) => signature,
+        None => return js_bool(false),
+    };
+    js_bool(verify_rsa_data(alg, public_key, &tbs_der, &signature))
+}
+
 fn throw_x509_parse_error(message: &str) -> ! {
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = perry_runtime::error::js_error_new_with_message(msg);
@@ -729,7 +811,13 @@ pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
     use sha2::{Digest, Sha256, Sha512};
     if matches!(
         property,
-        "toString" | "toJSON" | "toLegacyObject" | "checkHost" | "checkEmail" | "checkIP"
+        "toString"
+            | "toJSON"
+            | "toLegacyObject"
+            | "checkHost"
+            | "checkEmail"
+            | "checkIP"
+            | "verify"
     ) {
         return dispatch_x509_method_property(handle, property);
     }
@@ -818,6 +906,7 @@ pub unsafe fn dispatch_x509_method(handle: i64, method: &str, args: &[f64]) -> f
             Some(value) => x509_string_f64(&value),
             None => nanbox_undefined(),
         },
+        "verify" => x509_verify_value(h, args),
         _ => nanbox_undefined(),
     }
 }
@@ -846,6 +935,7 @@ pub unsafe fn dispatch_x509_method_property(handle: i64, property: &str) -> f64 
         "checkHost" => b"checkHost",
         "checkEmail" => b"checkEmail",
         "checkIP" => b"checkIP",
+        "verify" => b"verify",
         _ => return nanbox_undefined(),
     };
     let this_f64 =

--- a/test-parity/node-suite/crypto/x509/verify-method.ts
+++ b/test-parity/node-suite/crypto/x509/verify-method.ts
@@ -1,0 +1,45 @@
+import { X509Certificate, generateKeyPairSync } from "node:crypto";
+
+const pem = `-----BEGIN CERTIFICATE-----
+MIIDXzCCAkegAwIBAgIUICGaY01t7nWGtQ+QsMAicwoeRLUwDQYJKoZIhvcNAQEL
+BQAwPzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQ4wDAYDVQQKDAVQZXJyeTET
+MBEGA1UEAwwKcGVycnkudGVzdDAeFw0yNjA1MjMyMjM3NDZaFw0yNzA1MjMyMjM3
+NDZaMD8xCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEOMAwGA1UECgwFUGVycnkx
+EzARBgNVBAMMCnBlcnJ5LnRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDSofrefQLAkx4k9mHYD/VrTLCkiPH7DP3RTmTD8UotAG+kv2+JQVIRWJOP
+/mJWC+ZnIVK7dCs8fqvsHS3HuU5BAYPQ4U7IyFyA48/ZBdsHECY6wuqhNW9yD5Pj
+x066iEFMckKKCNBP7gLX3rsrp4R5uWmvmK6lNqMgO4Xx8c3ae9xyxupUaS13fNzA
+inw5NNp7axLJm62llWMBOP+w2ZgQL4UmJDdxe5GI0q94ChHTU7uIr3DMOGAGWuoY
+zXLk8LeSwncgWn3CZZ4WpUxibNvhVG1pmZAbgeWB5GZboUMXd2a0Uyjq3EB2kYfx
+hPQYOp3obhEy1JtodmJHAlqYqG8vAgMBAAGjUzBRMB0GA1UdDgQWBBRB2mlHlpxU
+LohkBQ2NH8rRhV9hQDAfBgNVHSMEGDAWgBRB2mlHlpxULohkBQ2NH8rRhV9hQDAP
+BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCvghtILxg/BdFTS9ZA
+VarJrhSrEHSlJ2Bqp6v8BJmMpouU9heVhT24RdAx9nM46jZPem6Mt55ZQ+eyR7vK
+iC5T5yPWreaKEWnbS7YhxSTcLZOhMMZ4eah02f1lhYtiDF6u7p6zfY1HjZlJrbE4
+WNdOEcttJh8BTciSV2wuxD7iZNejN5L1wH+PATHTnuEuryksRhky4tOb7UiY7qkj
+M11jjUSojXBNqw754Na4vTz5hhjJo17NeB3hZw6N+r9flCGdTQZ4k02hx9+LbxcJ
+uVylGMusIXcohDauuPEBi/NXk0owHqF6uafjjW5lHK2CnsHKL8U0qHRdcKFJZ4Jx
+/gTV
+-----END CERTIFICATE-----`;
+
+const cert = new X509Certificate(pem);
+const other = generateKeyPairSync("rsa", { modulusLength: 2048 }).publicKey;
+
+function report(label: string, fn: () => unknown) {
+  try {
+    console.log(`${label}:`, fn());
+  } catch (err: any) {
+    console.log(
+      `${label}: err`,
+      err.name,
+      err.code ?? "",
+      String(err.message).includes("KeyObject"),
+    );
+  }
+}
+
+console.log("typeof verify:", typeof cert["verify"]);
+report("verify own public", () => cert["verify"](cert["publicKey"]));
+report("verify other public", () => cert["verify"](other));
+report("verify missing", () => cert["verify"]());
+report("verify string", () => cert["verify"]("bad" as any));


### PR DESCRIPTION
## Summary
- adds bound `X509Certificate#verify(publicKey)` dispatch and property exposure
- verifies RSA-signed certificates against public asymmetric `KeyObject` surrogates
- returns `false` for mismatched public keys and unsupported/non-RSA verification paths
- matches Node-shaped `pkey` validation for missing and non-`KeyObject` arguments

## Non-goals
- `checkIssued()`
- `checkPrivateKey()`
- `issuerCertificate`
- `infoAccess`
- non-RSA certificate verification
- legacy metadata compatibility

## Validation
- `cargo fmt --all --check`
- `npm exec --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/x509/verify-method.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-verify-check cargo check -p perry-stdlib --no-default-features --features crypto`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-verify-build cargo build -p perry --release`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-verify-build cargo build -p perry-runtime -p perry-stdlib --release`
- direct Perry run of `test-parity/node-suite/crypto/x509/verify-method.ts`
- `PATH=<node26-bin>:$PATH CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-verify-build PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/perry-x509-verify-build/release PERRY_NO_AUTO_OPTIMIZE=1 PERRY_GEN_GC=0 ./run_parity_tests.sh --suite node-suite --module crypto --filter x509/verify-method`
