### PR TITLE
[codex] honor spawnSync stdio result shape

### DIFF
--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -36,8 +36,8 @@ use std::sync::{
 };
 
 use sync_run::{
-    cp_read_async_run_options, cp_read_run_options, cp_run_to_completion, CpRun, CpRunError,
-    CpRunOptions,
+    cp_read_async_run_options, cp_read_run_options, cp_read_spawn_sync_run_options,
+    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
 };
 
 use crate::closure::{
@@ -435,17 +435,21 @@ pub extern "C" fn js_child_process_spawn_sync(
     // unless `shell` is set).
     let arg_strs = unsafe { cp_read_arg_strings(args_ptr as i64) };
     let command = cp_build_command(&cmd_str, &arg_strs, opts_val);
-    let run_options = cp_read_run_options(opts_val);
+    let run_options = cp_read_spawn_sync_run_options(opts_val);
     let run = cp_run_to_completion(command, &run_options);
 
     let spawn_failed_before_pid = run.spawn_error.is_some() && run.pid.is_none();
     let stdout_box = if spawn_failed_before_pid {
         cp_undefined()
+    } else if !run.stdout_piped {
+        TAG_NULL_F64
     } else {
         cp_box_output(&run.stdout, &mode)
     };
     let stderr_box = if spawn_failed_before_pid {
         cp_undefined()
+    } else if !run.stderr_piped {
+        TAG_NULL_F64
     } else {
         cp_box_output(&run.stderr, &mode)
     };

--- a/crates/perry-runtime/src/child_process/sync_run.rs
+++ b/crates/perry-runtime/src/child_process/sync_run.rs
@@ -6,7 +6,7 @@ use crate::value::JSValue;
 
 use super::{
     cp_decode_status, cp_get_field, cp_io_error_code, cp_object_ptr, cp_read_kill_signal,
-    cp_value_to_bytes, CpExit, CP_SIGTERM,
+    cp_read_stdio, cp_value_to_bytes, CpExit, CpStdio, CP_SIGTERM,
 };
 
 const CP_DEFAULT_MAX_BUFFER: usize = 1024 * 1024;
@@ -17,6 +17,7 @@ pub(super) struct CpRunOptions {
     timeout: Option<Duration>,
     kill_signal: i32,
     pub(super) max_buffer: usize,
+    stdio: [CpStdio; 3],
 }
 
 impl Default for CpRunOptions {
@@ -26,6 +27,7 @@ impl Default for CpRunOptions {
             timeout: None,
             kill_signal: CP_SIGTERM,
             max_buffer: CP_DEFAULT_MAX_BUFFER,
+            stdio: [CpStdio::Pipe; 3],
         }
     }
 }
@@ -99,6 +101,19 @@ pub(super) fn cp_read_run_options(opts_val: f64) -> CpRunOptions {
     options
 }
 
+/// Read spawnSync options, including the stdio capture policy used to shape
+/// `stdout`/`stderr`/`output`.
+pub(super) fn cp_read_spawn_sync_run_options(opts_val: f64) -> CpRunOptions {
+    let mut options = cp_read_run_options(opts_val);
+    let stdio = cp_read_stdio(opts_val, 3);
+    options.stdio = [
+        stdio.first().copied().unwrap_or(CpStdio::Pipe),
+        stdio.get(1).copied().unwrap_or(CpStdio::Pipe),
+        stdio.get(2).copied().unwrap_or(CpStdio::Pipe),
+    ];
+    options
+}
+
 /// Read async buffered limits. Unlike the sync helpers, async `exec` and
 /// `execFile` do not have a documented `input` option, so only timing and
 /// buffer limits are consumed here.
@@ -146,6 +161,8 @@ impl CpRunError {
 pub(super) struct CpRun {
     pub(super) stdout: Vec<u8>,
     pub(super) stderr: Vec<u8>,
+    pub(super) stdout_piped: bool,
+    pub(super) stderr_piped: bool,
     pub(super) code: Option<i32>,
     pub(super) signal: Option<i32>,
     pub(super) pid: Option<u32>,
@@ -161,23 +178,36 @@ impl CpRun {
     }
 }
 
-/// Spawn `command` with piped stdout/stderr (and a closed stdin so children
-/// that read stdin see EOF instead of blocking), run it to completion, and
-/// capture stdout/stderr/exit/pid. Used by the synchronous + buffered-callback
-/// entry points.
+/// Spawn `command`, run it to completion, and capture the configured stdio.
+/// Piped stdin without input is closed so children that read stdin see EOF
+/// instead of blocking. Used by synchronous + buffered-callback entry points.
 pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions) -> CpRun {
-    if options.input.is_some() {
-        command.stdin(Stdio::piped());
-    } else {
-        command.stdin(Stdio::null());
-    }
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
+    let stdin_piped = matches!(options.stdio[0], CpStdio::Pipe) && options.input.is_some();
+    let stdout_piped = matches!(options.stdio[1], CpStdio::Pipe);
+    let stderr_piped = matches!(options.stdio[2], CpStdio::Pipe);
+    command.stdin(match options.stdio[0] {
+        CpStdio::Pipe if options.input.is_some() => Stdio::piped(),
+        CpStdio::Pipe | CpStdio::Ignore => Stdio::null(),
+        CpStdio::Inherit => Stdio::inherit(),
+        CpStdio::Fd(fd) => super::cp_stdio_from_fd(fd),
+    });
+    command.stdout(match options.stdio[1] {
+        CpStdio::Pipe => Stdio::piped(),
+        CpStdio::Ignore => Stdio::null(),
+        CpStdio::Inherit => Stdio::inherit(),
+        CpStdio::Fd(fd) => super::cp_stdio_from_fd(fd),
+    });
+    command.stderr(match options.stdio[2] {
+        CpStdio::Pipe => Stdio::piped(),
+        CpStdio::Ignore => Stdio::null(),
+        CpStdio::Inherit => Stdio::inherit(),
+        CpStdio::Fd(fd) => super::cp_stdio_from_fd(fd),
+    });
     match command.spawn() {
         Ok(mut child) => {
             let pid = child.id();
-            if let Some(input) = &options.input {
-                if let Some(mut stdin) = child.stdin.take() {
+            if stdin_piped {
+                if let (Some(input), Some(mut stdin)) = (&options.input, child.stdin.take()) {
                     let _ = stdin.write_all(input);
                 }
             }
@@ -187,8 +217,8 @@ pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions)
                 Ok(o) => {
                     let CpExit { code, signal } = cp_decode_status(&o.status);
                     if run_error.is_none()
-                        && (o.stdout.len() > options.max_buffer
-                            || o.stderr.len() > options.max_buffer)
+                        && ((stdout_piped && o.stdout.len() > options.max_buffer)
+                            || (stderr_piped && o.stderr.len() > options.max_buffer))
                     {
                         run_error = Some(CpRunError::MaxBuffer);
                     }
@@ -199,6 +229,8 @@ pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions)
                     CpRun {
                         stdout: o.stdout,
                         stderr: o.stderr,
+                        stdout_piped,
+                        stderr_piped,
                         code,
                         signal,
                         pid: Some(pid),
@@ -209,6 +241,8 @@ pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions)
                 Err(e) => CpRun {
                     stdout: Vec::new(),
                     stderr: Vec::new(),
+                    stdout_piped,
+                    stderr_piped,
                     code: None,
                     signal: None,
                     pid: Some(pid),
@@ -220,6 +254,8 @@ pub(super) fn cp_run_to_completion(mut command: Command, options: &CpRunOptions)
         Err(e) => CpRun {
             stdout: Vec::new(),
             stderr: Vec::new(),
+            stdout_piped,
+            stderr_piped,
             code: None,
             signal: None,
             pid: None,

--- a/test-parity/node-suite/child_process/sync/spawn-sync-stdio.ts
+++ b/test-parity/node-suite/child_process/sync/spawn-sync-stdio.ts
@@ -1,0 +1,57 @@
+import { spawnSync } from "node:child_process";
+
+function slot(value: any): string {
+  if (value === null) return "null";
+  if (Buffer.isBuffer(value)) return `buffer:${value.toString("utf8")}`;
+  return `${typeof value}:${String(value)}`;
+}
+
+function report(label: string, result: any) {
+  console.log(`${label} status:`, result.status);
+  console.log(`${label} stdout:`, slot(result.stdout));
+  console.log(`${label} stderr:`, slot(result.stderr));
+  console.log(`${label} output:`, result.output.map(slot).join("|"));
+}
+
+report(
+  "default pipe",
+  spawnSync("sh", ["-c", "printf out; printf err >&2"], { encoding: "utf8" }),
+);
+
+report(
+  "all ignore",
+  spawnSync("sh", ["-c", "printf ignored; printf ignored-err >&2"], {
+    encoding: "utf8",
+    stdio: "ignore",
+  }),
+);
+
+report(
+  "all inherit",
+  spawnSync("sh", ["-c", "exit 0"], { encoding: "utf8", stdio: "inherit" }),
+);
+
+report(
+  "stdin pipe outputs ignored",
+  spawnSync("cat", [], {
+    encoding: "utf8",
+    input: "input ignored by stdout",
+    stdio: ["pipe", "ignore", "ignore"],
+  }),
+);
+
+report(
+  "stdin ignore outputs pipe",
+  spawnSync("sh", ["-c", "printf out2; printf err2 >&2"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }),
+);
+
+report(
+  "mixed capture",
+  spawnSync("sh", ["-c", "printf out3; printf err3 >&2"], {
+    encoding: "utf8",
+    stdio: ["ignore", "ignore", "pipe"],
+  }),
+);


### PR DESCRIPTION
## Summary
- Teach `spawnSync()` to read the existing child_process stdio option subset for sync execution.
- Return `null` for `stdout`, `stderr`, and `output` slots when stdout/stderr are `ignore` or `inherit` instead of boxing empty captures.
- Add a Node parity fixture for default pipe, string stdio, and mixed array stdio result shapes.

## Validation
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter spawn-sync-stdio'`
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process'` (18 pass, 0 fail, 0 compile fail)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`