### PR TITLE
fix(crypto): check x509 private keys

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -491,6 +491,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
             | "checkEmail"
             | "checkIP"
             | "verify"
+            | "checkPrivateKey"
     ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_x509_method(handle, method_name, &args);
@@ -2256,6 +2257,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             | "checkEmail"
             | "checkIP"
             | "verify"
+            | "checkPrivateKey"
     ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_x509_property(handle, property_name);

--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -657,6 +657,38 @@ unsafe fn x509_asymmetric_key_meta(value: f64) -> Option<(u8, u8)> {
     perry_runtime::buffer::asymmetric_key_meta(ptr as usize)
 }
 
+enum X509PkeyKind {
+    Public,
+    Private(u8),
+    Secret,
+}
+
+unsafe fn x509_pkey_kind(value: f64) -> Option<X509PkeyKind> {
+    let bits = value.to_bits();
+    let js = JSValue::from_bits(bits);
+    if js.is_any_string() && (bits >> 48) as u16 == 0x7FFF {
+        let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+        if !ptr.is_null() && (ptr as usize) >= 0x1000 {
+            return perry_runtime::buffer::asymmetric_key_meta(ptr as usize).map(
+                |(kind, asym_type)| {
+                    if kind == 2 {
+                        X509PkeyKind::Private(asym_type)
+                    } else {
+                        X509PkeyKind::Public
+                    }
+                },
+            );
+        }
+    }
+    if js.is_pointer() {
+        let addr = bits & 0x0000_FFFF_FFFF_FFFF;
+        if addr >= 0x1000 && perry_runtime::buffer::is_secret_key(addr as usize) {
+            return Some(X509PkeyKind::Secret);
+        }
+    }
+    None
+}
+
 fn throw_x509_pkey_type_error(value: f64) -> ! {
     let message = format!(
         "The \"pkey\" argument must be an instance of KeyObject. Received {}",
@@ -670,6 +702,16 @@ fn throw_x509_pkey_value_error(kind: u8) -> ! {
         "PrivateKeyObject {}"
     } else {
         "KeyObject {}"
+    };
+    let message = format!("The argument 'pkey' is invalid. Received {received}");
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE")
+}
+
+fn throw_x509_pkey_value_error_typed(kind: X509PkeyKind) -> ! {
+    let received = match kind {
+        X509PkeyKind::Public => "PublicKeyObject {}",
+        X509PkeyKind::Private(_) => "PrivateKeyObject {}",
+        X509PkeyKind::Secret => "SecretKeyObject {}",
     };
     let message = format!("The argument 'pkey' is invalid. Received {received}");
     perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE")
@@ -715,6 +757,41 @@ unsafe fn x509_verify_value(handle: &X509Handle, args: &[f64]) -> f64 {
         None => return js_bool(false),
     };
     js_bool(verify_rsa_data(alg, public_key, &tbs_der, &signature))
+}
+
+unsafe fn x509_check_private_key_value(handle: &X509Handle, args: &[f64]) -> f64 {
+    let key_value = args
+        .first()
+        .copied()
+        .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+    let kind = match x509_pkey_kind(key_value) {
+        Some(kind) => kind,
+        None => throw_x509_pkey_type_error(key_value),
+    };
+    let X509PkeyKind::Private(asym_type) = kind else {
+        throw_x509_pkey_value_error_typed(kind);
+    };
+    if asym_type != 1 {
+        return js_bool(false);
+    }
+
+    let pem = match crypto_key_input_to_private_pem(key_value.to_bits()) {
+        Some(pem) => pem,
+        None => return js_bool(false),
+    };
+    let private_key = match parse_rsa_private_key_pem(&pem) {
+        Some(key) => key,
+        None => return js_bool(false),
+    };
+    let cert_public_key = match x509_rsa_public_key(&handle.cert) {
+        Some((_, key)) => key,
+        None => return js_bool(false),
+    };
+    let private_public_key = RsaPublicKey::from(&private_key);
+    js_bool(
+        cert_public_key.n() == private_public_key.n()
+            && cert_public_key.e() == private_public_key.e(),
+    )
 }
 
 fn throw_x509_parse_error(message: &str) -> ! {
@@ -818,6 +895,7 @@ pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
             | "checkEmail"
             | "checkIP"
             | "verify"
+            | "checkPrivateKey"
     ) {
         return dispatch_x509_method_property(handle, property);
     }
@@ -907,6 +985,7 @@ pub unsafe fn dispatch_x509_method(handle: i64, method: &str, args: &[f64]) -> f
             None => nanbox_undefined(),
         },
         "verify" => x509_verify_value(h, args),
+        "checkPrivateKey" => x509_check_private_key_value(h, args),
         _ => nanbox_undefined(),
     }
 }
@@ -936,6 +1015,7 @@ pub unsafe fn dispatch_x509_method_property(handle: i64, property: &str) -> f64 
         "checkEmail" => b"checkEmail",
         "checkIP" => b"checkIP",
         "verify" => b"verify",
+        "checkPrivateKey" => b"checkPrivateKey",
         _ => return nanbox_undefined(),
     };
     let this_f64 =

--- a/test-parity/node-suite/crypto/x509/check-private-key.ts
+++ b/test-parity/node-suite/crypto/x509/check-private-key.ts
@@ -1,0 +1,111 @@
+import {
+  X509Certificate,
+  createPrivateKey,
+  createPublicKey,
+  createSecretKey,
+} from "node:crypto";
+
+const certPem = `-----BEGIN CERTIFICATE-----
+MIIDJTCCAg2gAwIBAgIUaMxORuQo1GE1YB4X0JyXV5+QyLYwDQYJKoZIhvcNAQEL
+BQAwIjEgMB4GA1UEAwwXcGVycnktY2hlY2stcHJpdmF0ZS1rZXkwHhcNMjYwNjAz
+MjEyNzExWhcNMjcwNjAzMjEyNzExWjAiMSAwHgYDVQQDDBdwZXJyeS1jaGVjay1w
+cml2YXRlLWtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXLyH7X
+dord0t4IjFy0T2/qR4mkZK4jtIs+Nwh8QuKi8egpGdsjOTVMXz3/n9QFs4J9SRLw
+dkP7e0JBh6KRbcJYm+JrML1rHPKg8xfoTxDlHmhaV1IWgSAhOEOb9vW9zKJX7TNv
+4rrcLAL7f96GNkdmtpJ87x+uyGmLSBu0dzp0LXCXfObNaE7L8piaItPs96chesLD
+V3zD+nTMbASD2UAykGdP2HfZ/Xymn+a6A2jzjAoRpSqPVrGndzIbDKBEzK4A5l2/
+qBA0b91flxgicjyD2WBZDbNCf1Ha35El908XMAjE4ybw4zT0sRtnzgf34nHvVf6o
+93cqSnYks3wafasCAwEAAaNTMFEwHQYDVR0OBBYEFOzo1OmXkR/IdelThccEsUWM
+3cUHMB8GA1UdIwQYMBaAFOzo1OmXkR/IdelThccEsUWM3cUHMA8GA1UdEwEB/wQF
+MAMBAf8wDQYJKoZIhvcNAQELBQADggEBAH/hIHVvB8JEhXmGjTSPu+4x12umPTTX
+NSDhYvvQ6DPR+P/Id3y8V5QKiMrKdT4RasrRDalLgoqcicUpXutFgm07krkiY+RZ
+6luvV3EwyWOPjj6Hu6VQ5DTyQAJGNI52UIico5ZrKHswXIdr7BRBHiRpK7FQaXPy
+p6PMilT1x+Zyw0v3p7nonWIf+OnKkeW8Dhz/al6qDWLDr1Q57rZsvN0oN7720cCy
+AtnD73wFNNU/PJVDa2JTv0mihRbSqZYiDq4V7qIX2HPRTbEBc3NsLYn4WPwE+01f
+QdMcKC/JQOCYA6+Ylbwjg41IxxO9TYzmvu2DCsiJMT6l4MHxV1JOrYY=
+-----END CERTIFICATE-----`;
+
+const matchingPrivatePem = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCly8h+13aK3dLe
+CIxctE9v6keJpGSuI7SLPjcIfELiovHoKRnbIzk1TF89/5/UBbOCfUkS8HZD+3tC
+QYeikW3CWJviazC9axzyoPMX6E8Q5R5oWldSFoEgIThDm/b1vcyiV+0zb+K63CwC
++3/ehjZHZraSfO8frshpi0gbtHc6dC1wl3zmzWhOy/KYmiLT7PenIXrCw1d8w/p0
+zGwEg9lAMpBnT9h32f18pp/mugNo84wKEaUqj1axp3cyGwygRMyuAOZdv6gQNG/d
+X5cYInI8g9lgWQ2zQn9R2t+RJfdPFzAIxOMm8OM09LEbZ84H9+Jx71X+qPd3Kkp2
+JLN8Gn2rAgMBAAECggEABapeihMTznABFixFm59fvYvMcQQompjGwSFZoRUZ9gOq
+b4wEAayE9nDLKmOzUvv04+cjGZ4U9ILB9gQmPeRpU0RS41xVWIux/AqK9AywsvuZ
+W+iGZlw1gmMQOKM6P7CCLyQBC4ptvYPrjxiICJMehLcaUwwo4bTHzW+Agc3bayhi
+FosFLUuwmtEMKgzb7PVfGccH5XrPD/N1bJeztLz7svzXP2tAbLBc1l7jjHbnD/I5
+K/cRhplGy2q0/xOP5VFUUnOQTuJUIkDWTXzLibT2RgnTxmkRjHTRDTmre2CAZB2w
+kYXwN5SQPDM0tBxw7oWNQY7c8xc9cvMctTH5/fJMGQKBgQDPL8edqtqmowtQo5PT
+fAeYmt/Rsxtuq+tDxB/6mQtJ3kigh/BnpLXmruktPAT2r4IT/gXpeZtLCIvMQvZJ
+mZdaI1HV80h4tToaCMdee8Pk+6p1Usbu33I/zo21Gjl6WKvDYa3/9b5eWatKWQxN
+s88BjpiTXJDl0s//Ocxg+wqmKQKBgQDM25O4GocHkk0CT3Exlgwds7UYSOcBIme7
+MxaaosakTgTjNiKWf0LHVKiYaAMfCA6E4rHitZsCYReBWYDmXKvGINg+X/2OSBAM
+So15FQZc5k2cCdD/C8jCgj9PfvwPnEam+/b3mDeDOeLRbrjjf3xLPfld/Mc/DxzG
+xWITEfm3swKBgANzxFu4MRR9uv6I+zmW43mDex8/YMGjU7Q5XF8MlceRUJx8J2FS
+uUUyvOfoDB0gJ4a1wNt3D0NczReGNhxb1s3FsONjvl1kh6dPZiMI5Oa32stBqdbp
+Gjo98taFrVeAirwisIeHTLi9vcDrYu0YheZ8vcYW0MNDk/uotuMWy8KhAoGADKgQ
+Q1KYPxaB3X+s/aRIkVk1+g8e/onyoLUyU1F1Nld/o84HawbnyErps6jRcIxd4UXk
+OZ6Aui/ndN1jwle9YRtMYOYrUywOmcPNY8qxvvGXn+lXWTqQJ7xGTxIIXqqIDu8I
+PhnQbDIaWlgd4ihRNJDapDzmznWPkJRHT+hPZlMCgYA1EJzs1y+bEkRgyh44eGop
+xB4WLkP9Fv1z0Q/cRHrVS4DBiO2nqsh5jBux59eGR6HdHH9kZ4hvyqLg+KgoFZaU
+TbwGGgfn0yeoyy5wni25k4wIugYueWWXzQYM0WijTIliDTipEfMRmNc3RZsq3GKA
+dyEbgft/SQsR7nBGwoxl0A==
+-----END PRIVATE KEY-----`;
+
+const otherPrivatePem = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC5U6mL6SiGtANk
+mAp7DoyZZrBeaCb4jqn8bAXAvXLrUsGnHY/YfFpIs0BgMI8+mpj/HJt48KUMW1h/
+z2/3SXkU2TS7WqZXqsE7ycMuTctZJaxXaOnzvzAqa5cP+DzDUE6mTIpz8o7WEVBd
+TIdZQg0vtD9yHVRfzmuPo753319s7TrhjKBX3xxvCkBbu/CNRr+059/cRoQvR7ef
+thwMIFKL+zx44z9kT36uND13RcOvb7BQEAfpFTY3ddl0AOujJZd0kWpOeSwRrxPP
+HB1K/uG3BSGbaHyVbKsXIker45hGMMb43lvj4MVEeK1FMPLIskqOxa9NTDkbNc23
+ffidVn9dAgMBAAECggEAI9GOKtro+MPxBe+20trYhMuKmeyCX7bfFsjgAcT74YyQ
+nhaCF0LNhlCSyCSKgvyJRoFGcUT9eVpsS+ORTdeW/dcPMIjQLpBzoXUY8qmZfETi
+PtCpqvEQQ5qgyzbcs5khYlXXypoeTjRxdl7UqAUynD43pvwRMyUnt87bgLqc7GXH
+ABUCRXi3FenshHTV57hp1Hh95xwgSUCe5gJPlQZo6d2swheQ77dUvtJoAGqvHM9N
+/pxbNCdZoIb5/PjVAOsd52R7uChxnd40qgya+uA7zAEbhGviOWyRRFHEkQO/RopN
+/vg0ZbHid28+ZX6ijsHKV7GKbKGv76ka0uCccITowQKBgQDpGfxhMk5Mu371d3UD
+CqGbhfrmwSYOwBxys7fTxytFYx34nR1Q4j9RF4uV/nTLerBuMmVNw602PxYyJHP8
+0afMsT3xwP/a0gjl8jwt0KbAFy+gjpoHxer1DNFcF7DQg3UKlMVnn8QDsvezfds3
+N6Umf9Dl5G0o19yd5CeNIcpPIQKBgQDLiD4scSoWvVszzaTZocNlWGGxZWFy2Ye7
+BV+yTGpJDHn6H8ajcxd5lo3/7ZSUQPIsVyjWDAKjGA/kL8r7Aq6YNzJiMlcTInK4
+yWBA0Q3p8FXkiX0lNEL+PuI3ycAot1U0sLE8LZeAy+N3X7F9Fk3dKMcg0V51/LDN
+CRl/hNuUvQKBgQCQ/EvBPOP80CZAkYOjV6p7LJOJkZuVUyKeqW/udpRQfTz4FOlW
+FNNjIez9Z57HrVEtyYS/ILWM5yJsH8ZQ+yqOo7Ouueep+Df2pnuN15jQI9vI1smx
+igYBU26pBEdC+nEDGtPKB1KJJnjxGJgQOTkswBVz2GeZHuKnBnEfVGQcYQKBgQCa
+z7nC4hzKiSNrBtuCMlnGp3A/l8aErlNgfNjqbNdXUucgyrSztKJBeLPv3A1squ3J
+rk5AaYhD99R2k6fIP6T/4NQw/utegZBTX9EX3CvCKm2a1L1c5CCk9L3rA0lnbvOf
+jVpyVJdtfyg4r4/4flOhihfUrYw1IIx2mJpNdYfz3QKBgEhh1kKJh7kUU4z5sHYa
+9qXScx4F//4gtE6J3q9c6xgrxANXskmHOIFY+ajMZs4kGrPG6UROUHQnBcHGJlWK
+tHc5rn0ius/pdKK/WIyNPm8vN3FtxZAW7PNa5Sewv6L5Jt63TDTK1RD/9mXZHkmH
+vbM9JUcwJ+eE0bDv+9fWIZkM
+-----END PRIVATE KEY-----`;
+
+const cert = new X509Certificate(certPem);
+const matchingPrivate = createPrivateKey(matchingPrivatePem);
+const otherPrivate = createPrivateKey(otherPrivatePem);
+const publicKey = createPublicKey(matchingPrivate);
+const secretKey = createSecretKey(Buffer.alloc(16));
+
+function report(label: string, fn: () => unknown) {
+  try {
+    console.log(`${label}:`, fn());
+  } catch (err: any) {
+    console.log(
+      `${label}: err`,
+      err.name,
+      err.code ?? "",
+      String(err.message).includes("KeyObject"),
+    );
+  }
+}
+
+console.log("typeof checkPrivateKey:", typeof cert["checkPrivateKey"]);
+report("matching private", () => cert["checkPrivateKey"](matchingPrivate));
+report("other private", () => cert["checkPrivateKey"](otherPrivate));
+report("public key", () => cert["checkPrivateKey"](publicKey));
+report("secret key", () => cert["checkPrivateKey"](secretKey));
+report("missing", () => cert["checkPrivateKey"]());
+report("string", () => cert["checkPrivateKey"](matchingPrivatePem as any));


### PR DESCRIPTION
## Summary
- adds bound `X509Certificate#checkPrivateKey(privateKey)` dispatch and property exposure
- validates `pkey` as a KeyObject and rejects public/secret KeyObjects with Node-shaped `ERR_INVALID_ARG_VALUE`
- compares RSA certificate public keys against the public key derived from a private KeyObject surrogate
- returns `true` for the matching RSA private key and `false` for mismatched RSA or unsupported non-RSA private keys
- adds focused Node/Perry parity coverage for success, mismatch, and validation behavior

## Non-goals
- `checkIssued()`
- `issuerCertificate`
- `infoAccess`
- `verify()` covered by separate draft PR #4300
- non-RSA private-key matching

## Validation
- `cargo fmt --all --check`
- `npm exec --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/x509/check-private-key.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-private-key-check cargo check -p perry-stdlib --no-default-features --features crypto`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-private-key-build cargo build -p perry --release`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-private-key-build cargo build -p perry-runtime -p perry-stdlib --release`
- direct Perry run of `test-parity/node-suite/crypto/x509/check-private-key.ts`
- `PATH=<node26-bin>:$PATH CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-private-key-build PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-private-key-build/release PERRY_NO_AUTO_OPTIMIZE=1 PERRY_GEN_GC=0 ./run_parity_tests.sh --suite node-suite --module crypto --filter x509/check-private-key`
- `git diff --check`
- `./scripts/check_file_size.sh`
