### PR TITLE
[codex] honor sync exec stdio result shape

### DIFF
--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -37,7 +37,7 @@ use std::sync::{
 
 use sync_run::{
     cp_read_async_run_options, cp_read_run_options, cp_read_spawn_sync_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
+    cp_read_sync_stdio_run_options, cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
 };
 
 use crate::closure::{
@@ -393,13 +393,13 @@ pub extern "C" fn js_child_process_exec_sync(
     };
     cp_apply_options(&mut command, opts_val);
 
-    let run_options = cp_read_run_options(opts_val);
+    let run_options = cp_read_sync_stdio_run_options(opts_val);
     let run = cp_run_to_completion(command, &run_options);
-    let stdout_box = cp_box_output(&run.stdout, &mode);
+    let stdout_box = cp_box_run_output(&run.stdout, run.stdout_piped, &mode);
     if run.success() {
         return stdout_box;
     }
-    let stderr_box = cp_box_output(&run.stderr, &mode);
+    let stderr_box = cp_box_run_output(&run.stderr, run.stderr_piped, &mode);
     cp_sync_throw_error(&run, &cmd_str, stdout_box, stderr_box);
 }
 
@@ -1846,6 +1846,14 @@ fn cp_box_output(bytes: &[u8], mode: &CpOutput) -> f64 {
     }
 }
 
+fn cp_box_run_output(bytes: &[u8], piped: bool, mode: &CpOutput) -> f64 {
+    if piped {
+        cp_box_output(bytes, mode)
+    } else {
+        TAG_NULL_F64
+    }
+}
+
 /// Decoded exit disposition of a finished child.
 struct CpExit {
     /// Exit code when the child exited normally; `None` when killed by signal.
@@ -2239,14 +2247,14 @@ pub extern "C" fn js_child_process_exec_file_sync(
     command.args(&arg_strs);
     cp_apply_argv0(&mut command, opts_val);
     cp_apply_options(&mut command, opts_val);
-    let run_options = cp_read_run_options(opts_val);
+    let run_options = cp_read_sync_stdio_run_options(opts_val);
     let run = cp_run_to_completion(command, &run_options);
 
-    let stdout_box = cp_box_output(&run.stdout, &mode);
+    let stdout_box = cp_box_run_output(&run.stdout, run.stdout_piped, &mode);
     if run.success() {
         return stdout_box;
     }
-    let stderr_box = cp_box_output(&run.stderr, &mode);
+    let stderr_box = cp_box_run_output(&run.stderr, run.stderr_piped, &mode);
     cp_sync_throw_error(
         &run,
         &cp_file_cmd_display(&file_str, &arg_strs),

--- a/crates/perry-runtime/src/child_process/sync_run.rs
+++ b/crates/perry-runtime/src/child_process/sync_run.rs
@@ -114,6 +114,19 @@ pub(super) fn cp_read_spawn_sync_run_options(opts_val: f64) -> CpRunOptions {
     options
 }
 
+/// Read sync exec options, including explicit stdio policies that affect
+/// return and thrown-error output slots.
+pub(super) fn cp_read_sync_stdio_run_options(opts_val: f64) -> CpRunOptions {
+    let mut options = cp_read_run_options(opts_val);
+    let stdio = cp_read_stdio(opts_val, 3);
+    options.stdio = [
+        stdio.first().copied().unwrap_or(CpStdio::Pipe),
+        stdio.get(1).copied().unwrap_or(CpStdio::Pipe),
+        stdio.get(2).copied().unwrap_or(CpStdio::Pipe),
+    ];
+    options
+}
+
 /// Read async buffered limits. Unlike the sync helpers, async `exec` and
 /// `execFile` do not have a documented `input` option, so only timing and
 /// buffer limits are consumed here.

--- a/test-parity/node-suite/child_process/sync/sync-stdio.ts
+++ b/test-parity/node-suite/child_process/sync/sync-stdio.ts
@@ -1,0 +1,57 @@
+import { execFileSync, execSync } from "node:child_process";
+
+function slot(value: any): string {
+  if (value === null) return "null";
+  if (Buffer.isBuffer(value)) return `buffer:${value.toString("utf8")}`;
+  return `${typeof value}:${String(value)}`;
+}
+
+function reportValue(label: string, value: any) {
+  console.log(`${label} value:`, slot(value));
+}
+
+function reportThrow(label: string, action: () => any) {
+  try {
+    reportValue(label, action());
+  } catch (err: any) {
+    console.log(`${label} status:`, err.status);
+    console.log(`${label} stdout:`, slot(err.stdout));
+    console.log(`${label} stderr:`, slot(err.stderr));
+    console.log(`${label} output:`, err.output.map(slot).join("|"));
+  }
+}
+
+reportValue(
+  "execSync all ignore",
+  execSync("printf ignored; printf ignored-err >&2", {
+    encoding: "utf8",
+    stdio: "ignore",
+  }),
+);
+
+reportValue(
+  "execSync all inherit",
+  execSync("exit 0", { encoding: "utf8", stdio: "inherit" }),
+);
+
+reportThrow("execSync stdout ignore stderr pipe throw", () =>
+  execSync("printf out; printf err >&2; exit 7", {
+    encoding: "utf8",
+    stdio: ["ignore", "ignore", "pipe"],
+  }),
+);
+
+reportValue(
+  "execFileSync all ignore",
+  execFileSync("sh", ["-c", "printf ignored; printf ignored-err >&2"], {
+    encoding: "utf8",
+    stdio: "ignore",
+  }),
+);
+
+reportThrow("execFileSync stdout pipe stderr ignore throw", () =>
+  execFileSync("sh", ["-c", "printf out2; printf err2 >&2; exit 9"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }),
+);


### PR DESCRIPTION
## Summary
- Read explicit stdio options for `execSync()` and `execFileSync()` sync execution.
- Return `null` for non-piped stdout and preserve `null` stdout/stderr/output slots on thrown sync errors.
- Add a parity fixture for ignored/inherited sync stdio and mixed captured/null error output.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/child_process/sync/sync-stdio.ts`
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process --filter sync-stdio'`
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module child_process'` (18 pass, 0 fail, 0 compile fail)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`