### PR TITLE
[codex] reject invalid dns promises rrtype

### DIFF
--- a/crates/perry-runtime/src/dns.rs
+++ b/crates/perry-runtime/src/dns.rs
@@ -497,12 +497,16 @@ fn throw_invalid_dns_order(value: f64) -> ! {
     crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE");
 }
 
-fn throw_invalid_name(value: f64) -> ! {
+fn invalid_name_error(value: f64) -> f64 {
     let message = format!(
         "The \"name\" argument must be of type string. Received {}",
         crate::fs::validate::describe_received(value)
     );
-    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    type_error_value(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_invalid_name(value: f64) -> ! {
+    throw_error_value(invalid_name_error(value));
 }
 
 fn throw_invalid_callback(value: f64) -> ! {
@@ -513,42 +517,46 @@ fn throw_invalid_callback(value: f64) -> ! {
     crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
 }
 
-fn throw_invalid_rrtype_type(value: f64) -> ! {
+fn invalid_rrtype_type_error(value: f64) -> f64 {
     let message = format!(
         "The \"rrtype\" argument must be of type string. Received {}",
         crate::fs::validate::describe_received(value)
     );
-    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
+    type_error_value(&message, "ERR_INVALID_ARG_TYPE")
 }
 
-fn throw_invalid_rrtype_value(value: f64) -> ! {
+fn invalid_rrtype_value_error(value: f64) -> f64 {
     let message = format!(
         "The argument 'rrtype' is invalid. Received {}",
         invalid_arg_value_received(value)
     );
-    crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE");
+    type_error_value(&message, "ERR_INVALID_ARG_VALUE")
+}
+
+fn parse_record_kind_result(value: f64) -> Result<RecordKind, f64> {
+    let Some(rrtype) = js_string_to_rust(value) else {
+        return Err(invalid_rrtype_type_error(value));
+    };
+    match rrtype.as_str() {
+        "A" => Ok(RecordKind::A),
+        "AAAA" => Ok(RecordKind::Aaaa),
+        "ANY" => Ok(RecordKind::Any),
+        "CAA" => Ok(RecordKind::Caa),
+        "CNAME" => Ok(RecordKind::Cname),
+        "MX" => Ok(RecordKind::Mx),
+        "NAPTR" => Ok(RecordKind::Naptr),
+        "NS" => Ok(RecordKind::Ns),
+        "PTR" => Ok(RecordKind::Ptr),
+        "SOA" => Ok(RecordKind::Soa),
+        "SRV" => Ok(RecordKind::Srv),
+        "TLSA" => Ok(RecordKind::Tlsa),
+        "TXT" => Ok(RecordKind::Txt),
+        _ => Err(invalid_rrtype_value_error(value)),
+    }
 }
 
 fn parse_record_kind(value: f64) -> RecordKind {
-    let Some(rrtype) = js_string_to_rust(value) else {
-        throw_invalid_rrtype_type(value);
-    };
-    match rrtype.as_str() {
-        "A" => RecordKind::A,
-        "AAAA" => RecordKind::Aaaa,
-        "ANY" => RecordKind::Any,
-        "CAA" => RecordKind::Caa,
-        "CNAME" => RecordKind::Cname,
-        "MX" => RecordKind::Mx,
-        "NAPTR" => RecordKind::Naptr,
-        "NS" => RecordKind::Ns,
-        "PTR" => RecordKind::Ptr,
-        "SOA" => RecordKind::Soa,
-        "SRV" => RecordKind::Srv,
-        "TLSA" => RecordKind::Tlsa,
-        "TXT" => RecordKind::Txt,
-        _ => throw_invalid_rrtype_value(value),
-    }
+    parse_record_kind_result(value).unwrap_or_else(|error| throw_error_value(error))
 }
 
 pub(crate) fn dns_set_default_result_order_value(value: f64) -> f64 {
@@ -935,19 +943,22 @@ fn callback_record_args(args: i64, default_kind: Option<RecordKind>) -> (String,
     }
 }
 
-fn promise_record_args(args: i64, default_kind: Option<RecordKind>) -> (String, RecordKind) {
+fn promise_record_args(
+    args: i64,
+    default_kind: Option<RecordKind>,
+) -> Result<(String, RecordKind), f64> {
     let name_value = arg(args, 0);
     let Some(name) = js_string_to_rust(name_value) else {
-        throw_invalid_name(name_value);
+        return Err(invalid_name_error(name_value));
     };
-    let kind = default_kind.unwrap_or_else(|| {
-        if args_len(args) < 2 {
-            RecordKind::A
-        } else {
-            parse_record_kind(arg(args, 1))
-        }
-    });
-    (name, kind)
+    let kind = if let Some(kind) = default_kind {
+        kind
+    } else if args_len(args) < 2 {
+        RecordKind::A
+    } else {
+        parse_record_kind_result(arg(args, 1))?
+    };
+    Ok((name, kind))
 }
 
 fn callback_reverse_args(args: i64) -> (String, f64) {
@@ -1002,7 +1013,10 @@ fn promise_rejected_value(reason: f64) -> f64 {
 }
 
 fn dns_promise_resolve(args: i64, default_kind: Option<RecordKind>) -> f64 {
-    let (name, kind) = promise_record_args(args, default_kind);
+    let (name, kind) = match promise_record_args(args, default_kind) {
+        Ok(parsed) => parsed,
+        Err(error) => return promise_rejected_value(error),
+    };
     promise_value(resolve_records(kind, &name))
 }
 


### PR DESCRIPTION
Refs #812

## Summary
- make `node:dns/promises.resolve(hostname, rrtype)` convert invalid `rrtype` validation errors into rejected Promises
- keep callback `node:dns.resolve(...)` validation on its synchronous throwing path
- keep scope limited to deterministic DNS validation; no external DNS IO or inventory cleanup

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/dns/resolve/localhost.ts`
- baseline Perry direct run reproduced the uncaught invalid-rrtype throw before the fix
- `CARGO_TARGET_DIR=/tmp/perry-main-scan-target npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module dns --filter resolve/localhost'`\n- `CARGO_TARGET_DIR=/tmp/perry-main-scan-target npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module dns'`\n- `CARGO_TARGET_DIR=/tmp/perry-main-scan-target cargo check -p perry-runtime`\n- `cargo fmt --all -- --check`\n- `git diff --check`\n- `./scripts/check_file_size.sh`