### PR TITLE
fix(crypto): check x509 issuers

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -492,6 +492,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
             | "checkIP"
             | "verify"
             | "checkPrivateKey"
+            | "checkIssued"
     ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_x509_method(handle, method_name, &args);
@@ -2258,6 +2259,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             | "checkIP"
             | "verify"
             | "checkPrivateKey"
+            | "checkIssued"
     ) && with_handle::<crate::crypto::X509Handle, bool, _>(handle, |_| true).unwrap_or(false)
     {
         return crate::crypto::dispatch_x509_property(handle, property_name);

--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -423,6 +423,63 @@ fn x509_info_access(cert: &x509_cert::Certificate) -> Option<String> {
     }
 }
 
+fn x509_handle_arg(value: f64) -> Option<i64> {
+    let bits = value.to_bits();
+    if (bits & 0xFFFF_0000_0000_0000) != 0x7FFD_0000_0000_0000 {
+        return None;
+    }
+    let handle = (bits & 0x0000_FFFF_FFFF_FFFF) as i64;
+    crate::common::handle::with_handle::<X509Handle, bool, _>(handle, |_| true)
+        .unwrap_or(false)
+        .then_some(handle)
+}
+
+fn x509_throw_certificate_arg(value: f64) -> ! {
+    let message = format!(
+        "The \"otherCert\" argument must be an instance of X509Certificate. Received {}",
+        perry_runtime::fs::validate::describe_received(value)
+    );
+    perry_runtime::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn x509_name_der(name: &x509_cert::name::Name) -> Option<Vec<u8>> {
+    use x509_cert::der::Encode;
+
+    name.to_der().ok()
+}
+
+fn x509_check_issued_value(cert: &x509_cert::Certificate, issuer: &x509_cert::Certificate) -> bool {
+    use x509_cert::der::Encode;
+
+    let Some(issuer_name) = x509_name_der(&cert.tbs_certificate.issuer) else {
+        return false;
+    };
+    let Some(subject_name) = x509_name_der(&issuer.tbs_certificate.subject) else {
+        return false;
+    };
+    if issuer_name != subject_name {
+        return false;
+    }
+
+    let Some(alg) = x509_rsa_signature_digest(cert) else {
+        return false;
+    };
+    let Some((_, public_key)) = x509_rsa_public_key(issuer) else {
+        return false;
+    };
+    let Some(signature_bytes) = cert.signature.as_bytes() else {
+        return false;
+    };
+    let Ok(signature) = RsaPkcs1v15Signature::try_from(signature_bytes) else {
+        return false;
+    };
+    let Ok(tbs_der) = cert.tbs_certificate.to_der() else {
+        return false;
+    };
+
+    verify_rsa_data(alg, public_key, &tbs_der, &signature)
+}
+
 fn x509_string_f64(s: &str) -> f64 {
     let ptr = js_string_from_bytes(s.as_ptr(), s.len() as u32);
     f64::from_bits(JSValue::string_ptr(ptr).bits())
@@ -896,6 +953,7 @@ pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
             | "checkIP"
             | "verify"
             | "checkPrivateKey"
+            | "checkIssued"
     ) {
         return dispatch_x509_method_property(handle, property);
     }
@@ -986,6 +1044,22 @@ pub unsafe fn dispatch_x509_method(handle: i64, method: &str, args: &[f64]) -> f
         },
         "verify" => x509_verify_value(h, args),
         "checkPrivateKey" => x509_check_private_key_value(h, args),
+        "checkIssued" => {
+            let value = args
+                .first()
+                .copied()
+                .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+            let Some(other_handle) = x509_handle_arg(value) else {
+                x509_throw_certificate_arg(value);
+            };
+            let cert = h.cert.clone();
+            let Some(other_cert) =
+                get_handle_mut::<X509Handle>(other_handle).map(|other| other.cert.clone())
+            else {
+                x509_throw_certificate_arg(value);
+            };
+            js_bool(x509_check_issued_value(&cert, &other_cert))
+        }
         _ => nanbox_undefined(),
     }
 }
@@ -1016,6 +1090,7 @@ pub unsafe fn dispatch_x509_method_property(handle: i64, property: &str) -> f64 
         "checkIP" => b"checkIP",
         "verify" => b"verify",
         "checkPrivateKey" => b"checkPrivateKey",
+        "checkIssued" => b"checkIssued",
         _ => return nanbox_undefined(),
     };
     let this_f64 =

--- a/test-parity/node-suite/crypto/x509/check-issued.ts
+++ b/test-parity/node-suite/crypto/x509/check-issued.ts
@@ -1,0 +1,111 @@
+import { X509Certificate } from "node:crypto";
+
+const caPem = `-----BEGIN CERTIFICATE-----
+MIIDHzCCAgegAwIBAgIUQi4LftjxMHG8l96kJMCrdmH7dkIwDQYJKoZIhvcNAQEL
+BQAwHzEdMBsGA1UEAwwUUGVycnkgQ2hlY2tJc3N1ZWQgQ0EwHhcNMjYwNjAzMjE1
+OTA4WhcNMjYwNzAzMjE1OTA4WjAfMR0wGwYDVQQDDBRQZXJyeSBDaGVja0lzc3Vl
+ZCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ2pr0DRJ7do6ng6
+eAOkIybAGfatMgiXWcBfS3ZxO8+RHPR60EKn0lcxud/nHapvS8WRGapBYExUlOoL
+nsuMDkvWUBqpqyy3OrZLOO+CQPMWmhY0xYrGllonHBE+3+pZfoBsEpXQ/7sUPvD5
+I731f2mmYF2G7SXqTFDm9WNOJGXSLwLRCNjTSlNihUP627ZgK1X+i/nLgTLiQwqp
+hsAtG1ujkxFwuvUsae8rIFAtogplJPj4UQPPezooXXECqINY5B32GRMREQL7aQYG
+ZojY5V9GTDzQgeUudjbmeIBH9eL6ybI/D9cgtAygHSdvENP5CoMRT2f93bCRKKsP
+TgiFw28CAwEAAaNTMFEwHQYDVR0OBBYEFBjxMj66h75tO2CGim8oUKv2akoMMB8G
+A1UdIwQYMBaAFBjxMj66h75tO2CGim8oUKv2akoMMA8GA1UdEwEB/wQFMAMBAf8w
+DQYJKoZIhvcNAQELBQADggEBAJqCiHK2WUuE0pp/uPlldyjX+WyRxAtxgbsJq1nr
+n2qLF3ge/vB4O9jFo2AgTFP1hLQPi9CCIO6bdhEfKPZd+CVifH7Jnp/Vd7YLinEF
+//FFnTWr7c2acyV0BceRihxyO+y6qSZ+PMrU1o+sIEuRcZ3uN+APNIJPt9gX0kub
+uUIXdOx5MzT7kWRyAGsaGvvRL9sQzn07HtflVlqBvZzOctb6NqlOoe2Tbqa+9bri
+2mjMobcGZCTQaAiVFjqTgv/XHeCebrCm4nyh9NJXGmZWvgvk8V8d3QMigGmOb+ly
+MY9Q2hHYbEL2N1HqHf/GflaHo1f3KDJ3pAoVJGeWqR2vmN4=
+-----END CERTIFICATE-----`;
+
+const leafPem = `-----BEGIN CERTIFICATE-----
+MIIDOTCCAiGgAwIBAgIUTl4ecABfreE+pEbhAEs/WhytnmUwDQYJKoZIhvcNAQEL
+BQAwHzEdMBsGA1UEAwwUUGVycnkgQ2hlY2tJc3N1ZWQgQ0EwHhcNMjYwNjAzMjE1
+OTA4WhcNMjYwNzAzMjE1OTA4WjAhMR8wHQYDVQQDDBZQZXJyeSBDaGVja0lzc3Vl
+ZCBMZWFmMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsFRGYmE16b5g
+o8cZgI3YRwwL4fhMrFUHQZj4QYhghumHaLQL01doaJumZcfaopfhEGUvNgqMG03R
+WfgJGavWy/i6HpNKXtpyd8N8Tmo2mBjHVu5oYAU7obcudHJCWN4JpPQkIjYbikHh
+B/nBfv5dq5AFhqmo5kyc62MVgY8ZXWdGIJbCoRymzEZX4lY1ogFZscGGdSqZY3pB
+DXD7OaVtDdLtpm1XGHpGs6ACZXc/QLXZt4ZVKr+AK3OoW6PGu1mVvJ2+tDdDVcJH
+lnwQ8oUlGQXJQNIjMcEHqzdu7ul2RqxE3qJDLrehRR0i3eEcg7s5WAPQ5dlUm3cx
+8NFt/SoWRQIDAQABo2swaTAJBgNVHRMEAjAAMBwGA1UdEQQVMBOCEWxlYWYuZXhh
+bXBsZS50ZXN0MB0GA1UdDgQWBBQY6Fn3W6PnVu0YquyzvKWImxLjKDAfBgNVHSME
+GDAWgBQY8TI+uoe+bTtghopvKFCr9mpKDDANBgkqhkiG9w0BAQsFAAOCAQEAFPlc
+qWsMX4yXZ5n942QVCX6Uxr9yhu+8kJAPLnyISGJm/ojIbUh2DwmZvdy4Wc64U+mM
+2UJvmYRiU+SDGTt6gD//x1l5L74Iz+0fAWKjvupmzOqw9sb5FOgCmcwsCN/z0Pwf
+9kcCdlbdGXS+Y8yKkh+qrCMAj7FZfdrTDJrzSbtKmd+Fie4Zb94NytHrovrqXfey
+rir8gdDVjpHP1Pyc/Avlj7+QWqYR2O/EICWzuPB0YSVrQVH1lQAFS8agO+E9VnUn
+SHyGvXHoE4VIWi65wJG2pos8VGTrrVTOhUhpux1VCjO1FEWj/D344azquXG6r3lw
+opbYuZtZ9lpEQiO/WA==
+-----END CERTIFICATE-----`;
+
+const otherPem = `-----BEGIN CERTIFICATE-----
+MIIDJTCCAg2gAwIBAgIUDBgkXCbbRWU2zy0qDM/I0Oiq+RMwDQYJKoZIhvcNAQEL
+BQAwIjEgMB4GA1UEAwwXUGVycnkgQ2hlY2tJc3N1ZWQgT3RoZXIwHhcNMjYwNjAz
+MjE1OTA4WhcNMjYwNzAzMjE1OTA4WjAiMSAwHgYDVQQDDBdQZXJyeSBDaGVja0lz
+c3VlZCBPdGhlcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK41DqfH
+yQ1YRNL9YT0QXLMxTkH8njuAVfHMQIJJouClyK4Bc6lnUhnjGxZh1HRZaCeaw4J6
+GTOWFLp0mB7YtDvZuiIlc0rDrZWwWza51BQ/Iiv0N5jOo2OAa68E2Wa0hhsS0Mgt
+S455C7wgwQldL9DFbukqgpa9w99jSrB5ACO0zSMo8lSEivDH1sv5v3NLazB/vc3c
+ZKF4gspIP9IG4R6dTLePsrlVniYMGHozZ0C9b1kwyXK2S8dkKbIg9PIe8asxMiao
+FOT0ICpivL9vyA/FhAfkHhmutA4rMn3iaTOMm5TfMrg4I87LjmnDphnRxX/7XZmF
+ne1k+H0j6sWMgocCAwEAAaNTMFEwHQYDVR0OBBYEFLfswwqBNB0gkdP323wNKOG2
+MGn/MB8GA1UdIwQYMBaAFLfswwqBNB0gkdP323wNKOG2MGn/MA8GA1UdEwEB/wQF
+MAMBAf8wDQYJKoZIhvcNAQELBQADggEBADeWDZ/zwCmEo/Ygt7ZgWSVuO9hJXgDe
+Zdea+jAlCOjOaK4+0fZGOnqygSiOMTLYrSECqYVHD69nEUFt2fi3hvzMz6tGTAJf
+kXUvSszhJ2UIKg0kiYDESh31ITaa4SZHEa3vCe9C6rLbTIVCP7C37pDx5a2PqjSO
+S3426Zk1BzEE+KlzX/Hm/W1It3ksPd/FUI267E5CWbiMNiAqfSN23aPTOireXm61
+buIOpVetw9H6FIC9B/lRzbDcOMQs37Gv4XPO8V4gxFrg2x3gpwIAYIdPcAm9eocu
+FjHBbd4lY/WjIKqVM9Pl+qo/4zY3puhe58Mu18URB8EKkSIjbsy3LAI=
+-----END CERTIFICATE-----`;
+
+const sameSubjectPem = `-----BEGIN CERTIFICATE-----
+MIIDHzCCAgegAwIBAgIUa7SBI0jI5P05I1xvb0BcUG7sIIAwDQYJKoZIhvcNAQEL
+BQAwHzEdMBsGA1UEAwwUUGVycnkgQ2hlY2tJc3N1ZWQgQ0EwHhcNMjYwNjAzMjE1
+OTI5WhcNMjYwNzAzMjE1OTI5WjAfMR0wGwYDVQQDDBRQZXJyeSBDaGVja0lzc3Vl
+ZCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ+DtArETPvkXsAR
+QvaU1Pucr2edMNGRl2hcnIkVKsMuZWSakz0f0bWCfjvWkbEn7bo2S0ge6S04i7aa
+5v9f0lasHnDJon2p+baShW7tIZomW7iR7NfFmSn/ve7KHIo6e9S+kWkmdhL2aP3N
+EVcwS46jHYGzf1CkpdMw1AYE2Pg+AvBBQkqwKFCiUtndnhF5hJcIXYOHgHgj2ODN
+8jFKlXQ+I9vHTLmo9Z1K253yuqejODtwEJf9cSDIWN0ThluS/blwB1p/2WEj+aAK
+LCj6gj5ZXVIiRWwlcIPpdVZkNd/zkUdvhxAKGWITCcZLrXz8WKnoCrGnFAlukjkm
+q+QibpkCAwEAAaNTMFEwHQYDVR0OBBYEFO7fegjhiDHaCKJ8tsQq1iiKzM16MB8G
+A1UdIwQYMBaAFO7fegjhiDHaCKJ8tsQq1iiKzM16MA8GA1UdEwEB/wQFMAMBAf8w
+DQYJKoZIhvcNAQELBQADggEBAD01tYjbKarpqeJjMEK/fSmHOJm1WIKNZBg3BREq
+Mo4MDmMd0OIKZgC8pyTfHrAnp6eCtJ3r4P0weFyHsOhKZQxijy7KXBJWXWEnei/8
+xZ+Pg90iSJj4QLijpBrTOSeewXBFuSCSjiq5LwoPPW/C45dhaGVkp2/SEZ3iiWFc
+Q4b/ifZX9LEOHh0zx1TtpQGwSS+oKuozFojxHL0WqEQiyAxQq0ksv9lRqpZBkGfy
+T7EJP4HEFUnlV5p1Sr8tlG1PeLOnXNQtIFt05B9ujOklQPFGoeudj3pMs+YPEC8l
+9TROOIf7UZ0ph3Mwq+n98b1dD7YmInT2mQevK8oTr8Mze5g=
+-----END CERTIFICATE-----`;
+
+const ca = new X509Certificate(caPem);
+const leaf = new X509Certificate(leafPem);
+const other = new X509Certificate(otherPem);
+const sameSubject = new X509Certificate(sameSubjectPem);
+
+function report(label: string, fn: () => unknown) {
+  try {
+    console.log(`${label}:`, fn());
+  } catch (err) {
+    const e = err as Error & { code?: string };
+    console.log(
+      `${label}: err`,
+      e.constructor.name,
+      e.code || "",
+      e.message.includes("X509Certificate"),
+    );
+  }
+}
+
+console.log("typeof checkIssued:", typeof leaf["checkIssued"]);
+report("leaf issued by ca", () => leaf["checkIssued"](ca));
+report("leaf issued by leaf", () => leaf["checkIssued"](leaf));
+report("ca self issued", () => ca["checkIssued"](ca));
+report("ca issued by leaf", () => ca["checkIssued"](leaf));
+report("leaf issued by other", () => leaf["checkIssued"](other));
+report("leaf issued by same subject", () => leaf["checkIssued"](sameSubject));
+report("other self issued", () => other["checkIssued"](other));
+report("string arg", () => leaf["checkIssued"]("bad" as any));


### PR DESCRIPTION
## Linked Issues

- Part of #2563

## Summary

- Implements `X509Certificate.prototype.checkIssued(otherCert)` for Perry's Node-compatible X509 handle path.
- Validates `otherCert` as an `X509Certificate` handle and throws `ERR_INVALID_ARG_TYPE` for non-certificate arguments.
- Checks issuer/subject DER equality and verifies the signed TBS certificate with the candidate issuer's RSA public key for SHA-256/384/512 RSA certificate signatures.
- Adds parity coverage for CA-issued leaf certificates, self-issued certificates, wrong issuers, same-subject wrong-key issuers, and non-certificate argument validation.

## Why This Cut

This is a focused #2563 X509 method slice. It shares the existing X509 handle dispatch, certificate parsing, and RSA verification helpers without mixing in unrelated remaining X509 properties like `infoAccess` or `issuerCertificate`.

## Tests

- `npm exec --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/x509/check-issued.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-issued-check cargo check -p perry-stdlib --no-default-features --features crypto`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-issued-before cargo build -p perry -p perry-runtime -p perry-stdlib --release`
- `PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-issued-before/release PERRY_NO_AUTO_OPTIMIZE=1 PERRY_GEN_GC=0 /root/perry-worktrees/.build-targets/perry-x509-check-issued-before/release/perry run test-parity/node-suite/crypto/x509/check-issued.ts`
- `PATH=<node26-bin>:$PATH CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-issued-before PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/perry-x509-check-issued-before/release PERRY_NO_AUTO_OPTIMIZE=1 PERRY_GEN_GC=0 ./run_parity_tests.sh --suite node-suite --module crypto --filter x509/check-issued`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known Limitations

- This covers RSA certificate signatures using SHA-256, SHA-384, and SHA-512. Unsupported key/signature families currently return `false`.
- The test uses bracket property access, matching the existing X509 fixtures while the separate dot-property fast-path issue #1583 remains open.
- Node's `undefined`/`null` argument paths currently throw internal-state TypeErrors without an error code; this slice covers the stable public `ERR_INVALID_ARG_TYPE` validation for non-X509 arguments.

## Non-Goals

- `X509Certificate.prototype.verify(publicKey)`
- `X509Certificate.prototype.checkPrivateKey(privateKey)`
- `X509Certificate.prototype.infoAccess`
- `X509Certificate.prototype.issuerCertificate`
