### PR TITLE
fix(crypto): expose x509 issuerCertificate surface

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -3280,6 +3280,9 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
     if export_module_name == "crypto" && property_name == "KeyObject" {
         attach_crypto_key_object_shape(closure_addr, value);
     }
+    if export_module_name == "crypto" && property_name == "X509Certificate" {
+        attach_crypto_x509_certificate_shape(closure_addr, value);
+    }
 
     // `PerformanceObserver.supportedEntryTypes` is a static array on the
     // constructor. `PerformanceObserver` is a function value (a bound-method
@@ -3549,6 +3552,7 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         // #3726: `crypto.Cipheriv` / `crypto.Decipheriv` constructor exports —
         // `(cipher, key, iv, options)` arity matches Node's length 4.
         ("crypto", "Cipheriv" | "Decipheriv") => Some(4),
+        ("crypto", "X509Certificate") => Some(1),
         ("crypto", "KeyObject") => Some(2),
         ("crypto.KeyObject", "from") => Some(1),
         // #2706/#2716 and #2694: crypto module-level callable exports.
@@ -4241,6 +4245,49 @@ fn attach_crypto_key_object_shape(closure_addr: usize, constructor_value: f64) {
         constructor.to_string(),
         super::PropertyAttrs::new(true, false, true),
     );
+
+    let proto_value = crate::value::js_nanbox_pointer(proto as i64);
+    crate::closure::closure_set_dynamic_prop(closure_addr, "prototype", proto_value);
+    super::set_builtin_property_attrs(
+        closure_addr,
+        "prototype".to_string(),
+        super::PropertyAttrs::new(true, false, false),
+    );
+}
+
+extern "C" fn x509_issuer_certificate_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+fn attach_crypto_x509_certificate_shape(closure_addr: usize, constructor_value: f64) {
+    let proto = js_object_alloc(0, 0);
+    if proto.is_null() {
+        return;
+    }
+    let constructor = "constructor";
+    let constructor_key =
+        crate::string::js_string_from_bytes(constructor.as_ptr(), constructor.len() as u32);
+    js_object_set_field_by_name(proto, constructor_key, constructor_value);
+    super::set_builtin_property_attrs(
+        proto as usize,
+        constructor.to_string(),
+        super::PropertyAttrs::new(true, false, true),
+    );
+
+    unsafe {
+        crate::closure::js_register_closure_arity(
+            x509_issuer_certificate_getter_thunk as *const u8,
+            0,
+        );
+        let getter =
+            crate::closure::js_closure_alloc(x509_issuer_certificate_getter_thunk as *const u8, 0);
+        if !getter.is_null() {
+            let getter_bits = crate::value::js_nanbox_pointer(getter as i64).to_bits();
+            super::object_ops::install_builtin_getter(proto, "issuerCertificate", getter_bits);
+        }
+    }
 
     let proto_value = crate::value::js_nanbox_pointer(proto as i64);
     crate::closure::closure_set_dynamic_prop(closure_addr, "prototype", proto_value);
@@ -5451,6 +5498,7 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             // callable functions so `typeof crypto.Cipheriv === "function"`.
             | ("crypto", "Cipheriv")
             | ("crypto", "Decipheriv")
+            | ("crypto", "X509Certificate")
             // #2565: public KeyObject constructor shape plus the supported
             // secret-key `KeyObject.from(CryptoKey)` static helper.
             | ("crypto", "KeyObject")

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -691,6 +691,10 @@ pub(crate) unsafe fn dispatch_native_module_method(
             "Class constructor KeyObject cannot be invoked without 'new'",
             "ERR_CONSTRUCT_CALL_REQUIRED",
         ),
+        ("crypto", "X509Certificate") => crate::fs::validate::throw_type_error_with_code(
+            "Class constructor X509Certificate cannot be invoked without 'new'",
+            "ERR_CONSTRUCT_CALL_REQUIRED",
+        ),
         ("crypto.KeyObject", "from") => {
             super::native_module_crypto_key_object::key_object_from(arg(0))
         }

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -2251,6 +2251,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             | "ca"
             | "raw"
             | "publicKey"
+            | "issuerCertificate"
             | "toString"
             | "toJSON"
             | "toLegacyObject"

--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -3,6 +3,7 @@ use super::*;
 pub struct X509Handle {
     der: Vec<u8>,
     cert: x509_cert::Certificate,
+    issuer_certificate: Option<Handle>,
 }
 
 /// Short attribute name for an X.500 DN OID, matching Node's subject /
@@ -851,6 +852,10 @@ unsafe fn x509_check_private_key_value(handle: &X509Handle, args: &[f64]) -> f64
     )
 }
 
+fn x509_handle_value(handle: Handle) -> f64 {
+    f64::from_bits(0x7FFD_0000_0000_0000u64 | ((handle as u64) & 0x0000_FFFF_FFFF_FFFF))
+}
+
 fn throw_x509_parse_error(message: &str) -> ! {
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = perry_runtime::error::js_error_new_with_message(msg);
@@ -935,8 +940,12 @@ pub unsafe extern "C" fn js_crypto_x509_new(input_ptr: i64) -> f64 {
         Ok(d) => d,
         Err(_) => throw_x509_parse_error("error:0680007B:asn1 encoding routines::header too long"),
     };
-    let handle: Handle = register_handle(X509Handle { der, cert });
-    f64::from_bits(0x7FFD_0000_0000_0000u64 | ((handle as u64) & 0x0000_FFFF_FFFF_FFFF))
+    let handle: Handle = register_handle(X509Handle {
+        der,
+        cert,
+        issuer_certificate: None,
+    });
+    x509_handle_value(handle)
 }
 
 /// Read-only property dispatch for an X509Certificate handle.
@@ -1012,6 +1021,10 @@ pub unsafe fn dispatch_x509_property(handle: i64, property: &str) -> f64 {
             f64::from_bits(0x7FFD_0000_0000_0000u64 | ((buf as u64) & 0x0000_FFFF_FFFF_FFFF))
         }
         "publicKey" => x509_public_key_value(h),
+        "issuerCertificate" => h
+            .issuer_certificate
+            .map(x509_handle_value)
+            .unwrap_or_else(nanbox_undefined),
         _ => nanbox_undefined(),
     }
 }

--- a/test-parity/node-suite/crypto/x509/issuer-certificate.ts
+++ b/test-parity/node-suite/crypto/x509/issuer-certificate.ts
@@ -1,0 +1,61 @@
+import * as crypto from "node:crypto";
+import { X509Certificate } from "node:crypto";
+
+const caPem = `-----BEGIN CERTIFICATE-----
+MIIDHzCCAgegAwIBAgIUQi4LftjxMHG8l96kJMCrdmH7dkIwDQYJKoZIhvcNAQEL
+BQAwHzEdMBsGA1UEAwwUUGVycnkgQ2hlY2tJc3N1ZWQgQ0EwHhcNMjYwNjAzMjE1
+OTA4WhcNMjYwNzAzMjE1OTA4WjAfMR0wGwYDVQQDDBRQZXJyeSBDaGVja0lzc3Vl
+ZCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJ2pr0DRJ7do6ng6
+eAOkIybAGfatMgiXWcBfS3ZxO8+RHPR60EKn0lcxud/nHapvS8WRGapBYExUlOoL
+nsuMDkvWUBqpqyy3OrZLOO+CQPMWmhY0xYrGllonHBE+3+pZfoBsEpXQ/7sUPvD5
+I731f2mmYF2G7SXqTFDm9WNOJGXSLwLRCNjTSlNihUP627ZgK1X+i/nLgTLiQwqp
+hsAtG1ujkxFwuvUsae8rIFAtogplJPj4UQPPezooXXECqINY5B32GRMREQL7aQYG
+ZojY5V9GTDzQgeUudjbmeIBH9eL6ybI/D9cgtAygHSdvENP5CoMRT2f93bCRKKsP
+TgiFw28CAwEAAaNTMFEwHQYDVR0OBBYEFBjxMj66h75tO2CGim8oUKv2akoMMB8G
+A1UdIwQYMBaAFBjxMj66h75tO2CGim8oUKv2akoMMA8GA1UdEwEB/wQFMAMBAf8w
+DQYJKoZIhvcNAQELBQADggEBAJqCiHK2WUuE0pp/uPlldyjX+WyRxAtxgbsJq1nr
+n2qLF3ge/vB4O9jFo2AgTFP1hLQPi9CCIO6bdhEfKPZd+CVifH7Jnp/Vd7YLinEF
+//FFnTWr7c2acyV0BceRihxyO+y6qSZ+PMrU1o+sIEuRcZ3uN+APNIJPt9gX0kub
+uUIXdOx5MzT7kWRyAGsaGvvRL9sQzn07HtflVlqBvZzOctb6NqlOoe2Tbqa+9bri
+2mjMobcGZCTQaAiVFjqTgv/XHeCebrCm4nyh9NJXGmZWvgvk8V8d3QMigGmOb+ly
+MY9Q2hHYbEL2N1HqHf/GflaHo1f3KDJ3pAoVJGeWqR2vmN4=
+-----END CERTIFICATE-----`;
+
+const leafPem = `-----BEGIN CERTIFICATE-----
+MIIDOTCCAiGgAwIBAgIUTl4ecABfreE+pEbhAEs/WhytnmUwDQYJKoZIhvcNAQEL
+BQAwHzEdMBsGA1UEAwwUUGVycnkgQ2hlY2tJc3N1ZWQgQ0EwHhcNMjYwNjAzMjE1
+OTA4WhcNMjYwNzAzMjE1OTA4WjAhMR8wHQYDVQQDDBZQZXJyeSBDaGVja0lzc3Vl
+ZCBMZWFmMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsFRGYmE16b5g
+o8cZgI3YRwwL4fhMrFUHQZj4QYhghumHaLQL01doaJumZcfaopfhEGUvNgqMG03R
+WfgJGavWy/i6HpNKXtpyd8N8Tmo2mBjHVu5oYAU7obcudHJCWN4JpPQkIjYbikHh
+B/nBfv5dq5AFhqmo5kyc62MVgY8ZXWdGIJbCoRymzEZX4lY1ogFZscGGdSqZY3pB
+DXD7OaVtDdLtpm1XGHpGs6ACZXc/QLXZt4ZVKr+AK3OoW6PGu1mVvJ2+tDdDVcJH
+lnwQ8oUlGQXJQNIjMcEHqzdu7ul2RqxE3qJDLrehRR0i3eEcg7s5WAPQ5dlUm3cx
+8NFt/SoWRQIDAQABo2swaTAJBgNVHRMEAjAAMBwGA1UdEQQVMBOCEWxlYWYuZXhh
+bXBsZS50ZXN0MB0GA1UdDgQWBBQY6Fn3W6PnVu0YquyzvKWImxLjKDAfBgNVHSME
+GDAWgBQY8TI+uoe+bTtghopvKFCr9mpKDDANBgkqhkiG9w0BAQsFAAOCAQEAFPlc
+qWsMX4yXZ5n942QVCX6Uxr9yhu+8kJAPLnyISGJm/ojIbUh2DwmZvdy4Wc64U+mM
+2UJvmYRiU+SDGTt6gD//x1l5L74Iz+0fAWKjvupmzOqw9sb5FOgCmcwsCN/z0Pwf
+9kcCdlbdGXS+Y8yKkh+qrCMAj7FZfdrTDJrzSbtKmd+Fie4Zb94NytHrovrqXfey
+rir8gdDVjpHP1Pyc/Avlj7+QWqYR2O/EICWzuPB0YSVrQVH1lQAFS8agO+E9VnUn
+SHyGvXHoE4VIWi65wJG2pos8VGTrrVTOhUhpux1VCjO1FEWj/D344azquXG6r3lw
+opbYuZtZ9lpEQiO/WA==
+-----END CERTIFICATE-----`;
+
+const ctor = crypto["X509Certificate"];
+const proto = ctor["prototype"];
+const desc = Object.getOwnPropertyDescriptor(proto, "issuerCertificate");
+const leaf = new X509Certificate(leafPem);
+const chainInput = new X509Certificate(`${leafPem}\n${caPem}`);
+
+console.log("module ctor type:", typeof ctor);
+console.log("prototype type:", typeof proto);
+console.log(
+  "prototype has issuerCertificate:",
+  Object.getOwnPropertyNames(proto).includes("issuerCertificate"),
+);
+console.log("descriptor get type:", typeof desc?.get);
+console.log("descriptor enumerable:", desc?.enumerable);
+console.log("descriptor configurable:", desc?.configurable);
+console.log("leaf issuer undefined:", leaf["issuerCertificate"] === undefined);
+console.log("chain input issuer undefined:", chainInput["issuerCertificate"] === undefined);


### PR DESCRIPTION
## Summary
- Exposes `crypto.X509Certificate` as a callable constructor value with a reflectable prototype.
- Adds a non-enumerable `issuerCertificate` prototype getter shape matching Node's standalone constructor surface.
- Routes `X509Certificate#issuerCertificate` through the X509 handle dispatch and returns `undefined` for constructor-created certificates without an issuer chain.
- Adds focused Node parity coverage for constructor/prototype reflection and standalone issuer behavior.

## Issue
Addresses part of #2563.

## Why batched this way
`issuerCertificate` is the remaining X509 property surface gap that can be handled independently from certificate-chain plumbing. This cut keeps the constructor-created certificate behavior Node-compatible while leaving a handle slot that future TLS/chain-backed X509 construction can populate.

## Known Limitations
- Constructor-created certificates do not carry issuer chains in Node, so this PR preserves `undefined` for both single-PEM and concatenated-PEM constructor inputs.
- This does not add chain-backed `InternalX509Certificate` objects for TLS peer certificate paths.
- Dynamic `new crypto.X509Certificate(...)` through a captured module property remains outside this cut; the existing lowered constructor path is unchanged.

## Validation
- `npm exec --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/x509/issuer-certificate.ts`
- Pre-fix Perry release binary failed the new fixture at `crypto.X509Certificate.prototype`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-issuer-certificate-check cargo check -p perry-runtime -p perry-stdlib --no-default-features --features crypto`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-issuer-certificate-build cargo build -p perry -p perry-runtime -p perry-stdlib --release`
- Direct Perry release run of `test-parity/node-suite/crypto/x509/issuer-certificate.ts`
- `./run_parity_tests.sh --suite node-suite --module crypto --filter x509/issuer-certificate`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
