### PR TITLE
[codex] add WebCrypto Argon2 KDF support

### DIFF
--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -367,7 +367,7 @@ fn default_crypto_key_usages(algo: u8, kind: u8) -> u32 {
         (1, 1) => SIGN | VERIFY,
         (2 | 4 | 5, 1) => ENCRYPT | DECRYPT | WRAP_KEY | UNWRAP_KEY,
         (3, 1) => WRAP_KEY | UNWRAP_KEY,
-        (6 | 7, 1) => DERIVE_KEY | DERIVE_BITS,
+        (6 | 7 | 19 | 20 | 21, 1) => DERIVE_KEY | DERIVE_BITS,
         (8 | 10 | 12 | 14 | 15 | 17, 2) => SIGN,
         (8 | 10 | 12 | 14 | 15 | 17, 3) => VERIFY,
         (9 | 11 | 16 | 18, 2) => DERIVE_KEY | DERIVE_BITS,

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -84,6 +84,9 @@ fn crypto_key_algorithm_name(algo: u8) -> &'static str {
         14 => "RSA-PSS",
         15 | 17 => "ECDSA",
         16 | 18 => "ECDH",
+        19 => "Argon2d",
+        20 => "Argon2i",
+        21 => "Argon2id",
         _ => "",
     }
 }

--- a/crates/perry-stdlib/src/webcrypto/hmac.rs
+++ b/crates/perry-stdlib/src/webcrypto/hmac.rs
@@ -368,7 +368,10 @@ pub(super) unsafe fn ecdh_shared_secret_bytes(
     algo_bits: u64,
     base_key_bits: u64,
 ) -> Option<Vec<u8>> {
-    let algo_name = extract_algo_name(algo_bits)?;
+    let algo_name = match extract_algo_name(algo_bits) {
+        Some(name) => name,
+        None => return None,
+    };
     let algo_upper = algo_name.to_ascii_uppercase();
     if algo_upper != "ECDH" && algo_upper != "X25519" {
         return None;
@@ -487,44 +490,174 @@ pub(super) fn pbkdf2_derive(
     }
 }
 
+fn argon2_algorithm_kind(algo: KeyAlgo) -> Option<argon2::Algorithm> {
+    match algo {
+        KeyAlgo::Argon2d => Some(argon2::Algorithm::Argon2d),
+        KeyAlgo::Argon2i => Some(argon2::Algorithm::Argon2i),
+        KeyAlgo::Argon2id => Some(argon2::Algorithm::Argon2id),
+        _ => None,
+    }
+}
+
+unsafe fn argon2_derive(
+    algo_bits: u64,
+    base_mat: CryptoKeyMaterial,
+    base_key: &[u8],
+    byte_len: usize,
+) -> Result<Option<Vec<u8>>, (&'static str, &'static str)> {
+    let algo_name = match extract_algo_name(algo_bits) {
+        Some(name) => name,
+        None => return Ok(None),
+    };
+    let requested = match argon2_key_algo(&algo_name) {
+        Some(algo) => algo,
+        None => return Ok(None),
+    };
+    if base_mat.algo != requested {
+        return Err(("InvalidAccessError", "Key algorithm mismatch"));
+    }
+    if byte_len < 4 {
+        return Err(("OperationError", "length must be >= 32"));
+    }
+
+    let nonce = match object_field_bytes(algo_bits, b"nonce") {
+        Some(bytes) => bytes,
+        None => {
+            return Err((
+                "TypeError",
+                "Failed to normalize algorithm: passed algorithm cannot be converted to 'Argon2Params' because 'nonce' is required in 'Argon2Params'.",
+            ))
+        }
+    };
+    if nonce.len() < 8 {
+        return Err(("OperationError", "nonce must be at least 8 bytes"));
+    }
+    let parallelism = match object_field_number(algo_bits, b"parallelism") {
+        Some(value) => value,
+        None => {
+            return Err((
+                "TypeError",
+                "Failed to normalize algorithm: passed algorithm cannot be converted to 'Argon2Params' because 'parallelism' is required in 'Argon2Params'.",
+            ))
+        }
+    };
+    if parallelism == 0 || parallelism > 0xFF_FFFF {
+        return Err(("OperationError", "parallelism must be > 0 and <= 16777215"));
+    }
+    let memory = match object_field_number(algo_bits, b"memory") {
+        Some(value) => value,
+        None => {
+            return Err((
+                "TypeError",
+                "Failed to normalize algorithm: passed algorithm cannot be converted to 'Argon2Params' because 'memory' is required in 'Argon2Params'.",
+            ))
+        }
+    };
+    if memory < parallelism.saturating_mul(8).max(8) {
+        return Err((
+            "OperationError",
+            "memory must be at least 8 times the degree of parallelism",
+        ));
+    }
+    let passes = match object_field_number(algo_bits, b"passes") {
+        Some(value) => value,
+        None => {
+            return Err((
+                "TypeError",
+                "Failed to normalize algorithm: passed algorithm cannot be converted to 'Argon2Params' because 'passes' is required in 'Argon2Params'.",
+            ))
+        }
+    };
+    if passes == 0 {
+        return Err(("OperationError", "passes must be > 0"));
+    }
+    let version = object_field_number(algo_bits, b"version").unwrap_or(0x13);
+    if version != 0x13 {
+        return Err(("OperationError", "version must be 0x13"));
+    }
+
+    let associated_data = object_field_bytes(algo_bits, b"associatedData").unwrap_or_default();
+    let secret = object_field_bytes(algo_bits, b"secretValue").unwrap_or_default();
+
+    let mut builder = argon2::ParamsBuilder::new();
+    builder
+        .m_cost(memory)
+        .t_cost(passes)
+        .p_cost(parallelism)
+        .output_len(byte_len);
+    if !associated_data.is_empty() {
+        let data = argon2::AssociatedData::new(&associated_data)
+            .map_err(|_| ("OperationError", "The operation failed"))?;
+        builder.data(data);
+    }
+    let params = builder
+        .build()
+        .map_err(|_| ("OperationError", "The operation failed"))?;
+    let algorithm = argon2_algorithm_kind(requested)
+        .ok_or(("NotSupportedError", "Unrecognized algorithm name"))?;
+    let argon = if secret.is_empty() {
+        argon2::Argon2::new(algorithm, argon2::Version::V0x13, params)
+    } else {
+        argon2::Argon2::new_with_secret(&secret, algorithm, argon2::Version::V0x13, params)
+            .map_err(|_| ("OperationError", "The operation failed"))?
+    };
+    let mut out = vec![0u8; byte_len];
+    argon
+        .hash_password_into(base_key, &nonce, &mut out)
+        .map_err(|_| ("OperationError", "The operation failed"))?;
+    Ok(Some(out))
+}
+
 pub(super) unsafe fn kdf_derive_bytes(
     algo_bits: u64,
     base_key_bits: u64,
     byte_len: usize,
-) -> Option<Vec<u8>> {
-    let algo_name = extract_algo_name(algo_bits)?;
+) -> Result<Option<Vec<u8>>, (&'static str, &'static str)> {
+    let algo_name = match extract_algo_name(algo_bits) {
+        Some(name) => name,
+        None => return Ok(None),
+    };
     let algo_upper = algo_name.to_ascii_uppercase();
     let base_key_addr = strip_ptr(base_key_bits);
-    let base_mat = lookup_crypto_key(base_key_addr)?;
+    let base_mat = match lookup_crypto_key(base_key_addr) {
+        Some(mat) => mat,
+        None => return Ok(None),
+    };
     if base_mat.kind != KeyKind::Secret {
-        return None;
+        return Ok(None);
     }
     let base_key = bytes_from_jsvalue(base_key_bits);
+    if let Some(bytes) = argon2_derive(algo_bits, base_mat, &base_key, byte_len)? {
+        return Ok(Some(bytes));
+    }
     let mut out = vec![0u8; byte_len];
     if algo_upper == "HKDF" {
         if base_mat.algo != KeyAlgo::Hkdf {
-            return None;
+            return Ok(None);
         }
         let hash = extract_algorithm_hash(algo_bits, base_mat.hash);
         let salt = object_field_bytes(algo_bits, b"salt").unwrap_or_default();
         let info = object_field_bytes(algo_bits, b"info").unwrap_or_default();
         if hkdf_expand(hash, &base_key, &salt, &info, &mut out) {
-            return Some(out);
+            return Ok(Some(out));
         }
-        return None;
+        return Ok(None);
     }
     if algo_upper == "PBKDF2" {
         if base_mat.algo != KeyAlgo::Pbkdf2 {
-            return None;
+            return Ok(None);
         }
         let hash = extract_algorithm_hash(algo_bits, base_mat.hash);
         let salt = object_field_bytes(algo_bits, b"salt").unwrap_or_default();
-        let iterations = object_field_number(algo_bits, b"iterations")?;
+        let iterations = match object_field_number(algo_bits, b"iterations") {
+            Some(value) => value,
+            None => return Ok(None),
+        };
         if iterations == 0 {
-            return None;
+            return Ok(None);
         }
         pbkdf2_derive(hash, &base_key, &salt, iterations, &mut out);
-        return Some(out);
+        return Ok(Some(out));
     }
-    None
+    Ok(None)
 }

--- a/crates/perry-stdlib/src/webcrypto/jwk.rs
+++ b/crates/perry-stdlib/src/webcrypto/jwk.rs
@@ -30,6 +30,7 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     };
     let format_lower = format.to_ascii_lowercase();
     if format_lower != "raw"
+        && format_lower != "raw-secret"
         && format_lower != "spki"
         && format_lower != "pkcs8"
         && format_lower != "jwk"
@@ -59,6 +60,23 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     } else if algo_upper == "PBKDF2" && format_lower == "raw" {
         let hash = extract_algorithm_hash(algo_bits.to_bits(), HashAlgo::Sha256);
         (KeyAlgo::Pbkdf2, hash, KeyKind::Secret)
+    } else if let Some(argon_algo) = argon2_key_algo(&algo_name) {
+        if format_lower != "raw-secret" {
+            return reject_with_dom_exception(
+                "NotSupportedError",
+                "Unsupported algorithm for the given key format",
+            );
+        }
+        if extractable {
+            let message = match argon_algo {
+                KeyAlgo::Argon2d => "Argon2d keys are not extractable",
+                KeyAlgo::Argon2i => "Argon2i keys are not extractable",
+                KeyAlgo::Argon2id => "Argon2id keys are not extractable",
+                _ => unreachable!(),
+            };
+            return reject_with_dom_exception("SyntaxError", message);
+        }
+        (argon_algo, HashAlgo::Sha256, KeyKind::Secret)
     } else if algo_upper == "AES-GCM" && (format_lower == "raw" || format_lower == "jwk") {
         // AES-GCM: 128, 192, or 256-bit keys. We accept any length
         // here and let encrypt/decrypt fail loudly on mismatch.
@@ -151,10 +169,12 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     } else {
         "Usages cannot be empty when importing a private key."
     };
-    let bad_message = if key_algo == KeyAlgo::Hmac {
-        "Unsupported key usage for HMAC key"
-    } else {
-        "Unsupported key usage for the requested algorithm"
+    let bad_message = match key_algo {
+        KeyAlgo::Hmac => "Unsupported key usage for HMAC key",
+        KeyAlgo::Argon2d => "Unsupported key usage for a Argon2d key",
+        KeyAlgo::Argon2i => "Unsupported key usage for a Argon2i key",
+        KeyAlgo::Argon2id => "Unsupported key usage for a Argon2id key",
+        _ => "Unsupported key usage for the requested algorithm",
     };
     let usages = match validate_key_usages(
         key_algo,
@@ -173,7 +193,16 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     } else {
         bytes_from_jsvalue(key_bits.to_bits())
     };
-    if key_bytes.is_empty() && !matches!(key_algo, KeyAlgo::Hkdf | KeyAlgo::Pbkdf2) {
+    if key_bytes.is_empty()
+        && !matches!(
+            key_algo,
+            KeyAlgo::Hkdf
+                | KeyAlgo::Pbkdf2
+                | KeyAlgo::Argon2d
+                | KeyAlgo::Argon2i
+                | KeyAlgo::Argon2id
+        )
+    {
         return reject_with_dom_exception("DataError", "Key data is empty or could not be read");
     }
     if is_ec_key_algo(key_algo) {

--- a/crates/perry-stdlib/src/webcrypto/kdf.rs
+++ b/crates/perry-stdlib/src/webcrypto/kdf.rs
@@ -16,11 +16,14 @@ pub unsafe extern "C" fn js_webcrypto_derive_bits(
             return reject_with_dom_exception("InvalidAccessError", "Key is not a valid CryptoKey")
         }
     };
-    if let Err((name, message)) = require_usage(
-        base_mat,
-        USAGE_DERIVE_BITS,
-        "The requested operation is not valid for the provided key",
-    ) {
+    let algo_name = extract_algo_name(algo_bits.to_bits()).unwrap_or_default();
+    let is_argon2 = argon2_key_algo(&algo_name).is_some();
+    let usage_message = if is_argon2 {
+        "baseKey does not have deriveBits usage"
+    } else {
+        "The requested operation is not valid for the provided key"
+    };
+    if let Err((name, message)) = require_usage(base_mat, USAGE_DERIVE_BITS, usage_message) {
         return reject_with_dom_exception(name, message);
     }
     let bit_len = match number_from_bits(length_bits.to_bits()) {
@@ -28,11 +31,21 @@ pub unsafe extern "C" fn js_webcrypto_derive_bits(
         None => return reject_with_dom_exception("OperationError", "The operation failed"),
     };
     if bit_len % 8 != 0 {
-        return reject_with_dom_exception("OperationError", "The operation failed");
+        let message = if is_argon2 {
+            "length must be a multiple of 8"
+        } else {
+            "The operation failed"
+        };
+        return reject_with_dom_exception("OperationError", message);
+    }
+    if is_argon2 && bit_len < 32 {
+        return reject_with_dom_exception("OperationError", "length must be >= 32");
     }
     let byte_len = (bit_len / 8) as usize;
-    if let Some(bytes) = kdf_derive_bytes(algo_bits.to_bits(), base_key_bits.to_bits(), byte_len) {
-        return resolve_with_bytes(&bytes);
+    match kdf_derive_bytes(algo_bits.to_bits(), base_key_bits.to_bits(), byte_len) {
+        Ok(Some(bytes)) => return resolve_with_bytes(&bytes),
+        Ok(None) => {}
+        Err((name, message)) => return reject_with_dom_exception(name, message),
     }
     let shared = match ecdh_shared_secret_bytes(algo_bits.to_bits(), base_key_bits.to_bits()) {
         Some(s) => s,
@@ -67,11 +80,14 @@ pub unsafe extern "C" fn js_webcrypto_derive_key(
             return reject_with_dom_exception("InvalidAccessError", "Key is not a valid CryptoKey")
         }
     };
-    if let Err((name, message)) = require_usage(
-        base_mat,
-        USAGE_DERIVE_KEY,
-        "The requested operation is not valid for the provided key",
-    ) {
+    let algo_name = extract_algo_name(algo_bits.to_bits()).unwrap_or_default();
+    let is_argon2 = argon2_key_algo(&algo_name).is_some();
+    let usage_message = if is_argon2 {
+        "baseKey does not have deriveKey usage"
+    } else {
+        "The requested operation is not valid for the provided key"
+    };
+    if let Err((name, message)) = require_usage(base_mat, USAGE_DERIVE_KEY, usage_message) {
         return reject_with_dom_exception(name, message);
     }
     let extractable = bool_from_jsvalue(extractable_bits.to_bits());
@@ -122,28 +138,31 @@ pub unsafe extern "C" fn js_webcrypto_derive_key(
         Err((name, message)) => return reject_with_dom_exception(name, message),
     };
     let byte_len = (bit_len / 8) as usize;
-    let key_bytes = if let Some(bytes) =
-        kdf_derive_bytes(algo_bits.to_bits(), base_key_bits.to_bits(), byte_len)
-    {
-        bytes
-    } else {
-        let shared = match ecdh_shared_secret_bytes(algo_bits.to_bits(), base_key_bits.to_bits()) {
-            Some(s) => s,
-            None => {
-                if ecdh_public_private_curve_mismatch(algo_bits.to_bits(), base_key_bits.to_bits())
-                {
-                    return reject_with_dom_exception(
-                        "InvalidAccessError",
-                        "The requested operation is not valid for the provided key",
-                    );
-                }
+    let key_bytes = match kdf_derive_bytes(algo_bits.to_bits(), base_key_bits.to_bits(), byte_len) {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => {
+            let shared =
+                match ecdh_shared_secret_bytes(algo_bits.to_bits(), base_key_bits.to_bits()) {
+                    Some(s) => s,
+                    None => {
+                        if ecdh_public_private_curve_mismatch(
+                            algo_bits.to_bits(),
+                            base_key_bits.to_bits(),
+                        ) {
+                            return reject_with_dom_exception(
+                                "InvalidAccessError",
+                                "The requested operation is not valid for the provided key",
+                            );
+                        }
+                        return reject_with_dom_exception("OperationError", "The operation failed");
+                    }
+                };
+            if byte_len > shared.len() {
                 return reject_with_dom_exception("OperationError", "The operation failed");
             }
-        };
-        if byte_len > shared.len() {
-            return reject_with_dom_exception("OperationError", "The operation failed");
+            shared[..byte_len].to_vec()
         }
-        shared[..byte_len].to_vec()
+        Err((name, message)) => return reject_with_dom_exception(name, message),
     };
     let buf = alloc_uint8array_from_slice(&key_bytes);
     if buf.is_null() {

--- a/crates/perry-stdlib/src/webcrypto/supports.rs
+++ b/crates/perry-stdlib/src/webcrypto/supports.rs
@@ -41,9 +41,8 @@ unsafe fn supports_generate_key(algorithm_bits: u64, algorithm: &str) -> bool {
 
 unsafe fn supports_import_key(algorithm_bits: u64, algorithm: &str) -> bool {
     match algorithm {
-        "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" | "PBKDF2" | "HKDF" | "ED25519" | "X25519" => {
-            true
-        }
+        "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" | "PBKDF2" | "HKDF" | "ARGON2D"
+        | "ARGON2I" | "ARGON2ID" | "ED25519" | "X25519" => true,
         "HMAC" => algorithm_is_object(algorithm_bits),
         "ECDSA" | "ECDH" => algorithm_curve(algorithm_bits)
             .as_deref()

--- a/crates/perry-stdlib/src/webcrypto/util.rs
+++ b/crates/perry-stdlib/src/webcrypto/util.rs
@@ -104,6 +104,9 @@ pub(super) enum KeyAlgo {
     Hmac,
     Hkdf,
     Pbkdf2,
+    Argon2d,
+    Argon2i,
+    Argon2id,
     AesGcm,
     AesKw,
     AesCbc,
@@ -291,6 +294,9 @@ fn runtime_algo_id(algo: KeyAlgo) -> u8 {
         KeyAlgo::EcdhP384 => 16,
         KeyAlgo::EcdsaP521 => 17,
         KeyAlgo::EcdhP521 => 18,
+        KeyAlgo::Argon2d => 19,
+        KeyAlgo::Argon2i => 20,
+        KeyAlgo::Argon2id => 21,
     }
 }
 
@@ -339,6 +345,9 @@ pub(super) fn lookup_crypto_key(buf_addr: usize) -> Option<CryptoKeyMaterial> {
                 16 => KeyAlgo::EcdhP384,
                 17 => KeyAlgo::EcdsaP521,
                 18 => KeyAlgo::EcdhP521,
+                19 => KeyAlgo::Argon2d,
+                20 => KeyAlgo::Argon2i,
+                21 => KeyAlgo::Argon2id,
                 _ => return None,
             };
             let hash = match hash {
@@ -534,6 +543,15 @@ pub(super) fn usage_bit(name: &str) -> Option<u32> {
     }
 }
 
+pub(super) fn argon2_key_algo(name: &str) -> Option<KeyAlgo> {
+    match name.to_ascii_uppercase().as_str() {
+        "ARGON2D" => Some(KeyAlgo::Argon2d),
+        "ARGON2I" => Some(KeyAlgo::Argon2i),
+        "ARGON2ID" => Some(KeyAlgo::Argon2id),
+        _ => None,
+    }
+}
+
 pub(super) fn supported_usages(algo: KeyAlgo, kind: KeyKind) -> u32 {
     match (algo, kind) {
         (KeyAlgo::Hmac, KeyKind::Secret) => USAGE_SIGN | USAGE_VERIFY,
@@ -541,7 +559,14 @@ pub(super) fn supported_usages(algo: KeyAlgo, kind: KeyKind) -> u32 {
             USAGE_ENCRYPT | USAGE_DECRYPT | USAGE_WRAP_KEY | USAGE_UNWRAP_KEY
         }
         (KeyAlgo::AesKw, KeyKind::Secret) => USAGE_WRAP_KEY | USAGE_UNWRAP_KEY,
-        (KeyAlgo::Hkdf | KeyAlgo::Pbkdf2, KeyKind::Secret) => USAGE_DERIVE_KEY | USAGE_DERIVE_BITS,
+        (
+            KeyAlgo::Hkdf
+            | KeyAlgo::Pbkdf2
+            | KeyAlgo::Argon2d
+            | KeyAlgo::Argon2i
+            | KeyAlgo::Argon2id,
+            KeyKind::Secret,
+        ) => USAGE_DERIVE_KEY | USAGE_DERIVE_BITS,
         (
             KeyAlgo::EcdsaP256
             | KeyAlgo::EcdsaP384

--- a/test-parity/node-suite/crypto/webcrypto/argon2-kdf.ts
+++ b/test-parity/node-suite/crypto/webcrypto/argon2-kdf.ts
@@ -1,0 +1,105 @@
+import * as crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+(process as any).emitWarning = () => {};
+
+const password = new TextEncoder().encode("password");
+const nonce = Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8]);
+
+function hex(value: ArrayBuffer | Uint8Array): string {
+  return Buffer.from(value instanceof Uint8Array ? value : new Uint8Array(value)).toString("hex");
+}
+
+async function reportError(label: string, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn();
+    console.log(`${label}: ok`);
+  } catch (error: any) {
+    console.log(`${label}: ${error.name}: ${error.message}`);
+  }
+}
+
+async function runAlgorithm(name: "Argon2d" | "Argon2i" | "Argon2id"): Promise<void> {
+  console.log(`${name} supports import:`, crypto.subtle.constructor.supports("importKey", name));
+  console.log(`${name} supports deriveBits:`, crypto.subtle.constructor.supports("deriveBits", name));
+  console.log(`${name} supports deriveKey:`, crypto.subtle.constructor.supports("deriveKey", name));
+
+  const params = { name, nonce, memory: 8, passes: 1, parallelism: 1 };
+  const key = await crypto.subtle.importKey("raw-secret", password, name, false, [
+    "deriveBits",
+    "deriveKey",
+  ]);
+  console.log(
+    `${name} key:`,
+    key.algorithm.name,
+    key.type,
+    key.extractable,
+    key.usages.join(","),
+  );
+
+  const bits = await crypto.subtle.deriveBits(params, key, 128);
+  console.log(`${name} bits128:`, hex(bits));
+
+  const derivedKey = await crypto.subtle.deriveKey(
+    params,
+    key,
+    { name: "AES-GCM", length: 128 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+  console.log(
+    `${name} derived key:`,
+    derivedKey.algorithm.name,
+    (derivedKey.algorithm as any).length,
+    derivedKey.extractable,
+    derivedKey.usages.join(","),
+  );
+  console.log(`${name} derived raw:`, hex(await crypto.subtle.exportKey("raw", derivedKey)));
+}
+
+await runAlgorithm("Argon2d");
+await runAlgorithm("Argon2i");
+await runAlgorithm("Argon2id");
+
+await reportError("extractable argon2 key", () =>
+  crypto.subtle.importKey("raw-secret", password, "Argon2id", true, ["deriveBits"]),
+);
+await reportError("invalid argon2 usage", () =>
+  crypto.subtle.importKey("raw-secret", password, "Argon2id", false, ["encrypt"]),
+);
+
+const deriveOnlyKey = await crypto.subtle.importKey("raw-secret", password, "Argon2id", false, [
+  "deriveKey",
+]);
+await reportError("deriveBits missing usage", () =>
+  crypto.subtle.deriveBits(
+    { name: "Argon2id", nonce, memory: 8, passes: 1, parallelism: 1 },
+    deriveOnlyKey,
+    128,
+  ),
+);
+
+const bitsOnlyKey = await crypto.subtle.importKey("raw-secret", password, "Argon2id", false, [
+  "deriveBits",
+]);
+await reportError("algorithm mismatch", () =>
+  crypto.subtle.deriveBits(
+    { name: "Argon2i", nonce, memory: 8, passes: 1, parallelism: 1 },
+    bitsOnlyKey,
+    128,
+  ),
+);
+await reportError("short nonce", () =>
+  crypto.subtle.deriveBits(
+    { name: "Argon2id", nonce: new Uint8Array(7), memory: 8, passes: 1, parallelism: 1 },
+    bitsOnlyKey,
+    128,
+  ),
+);
+await reportError("low memory", () =>
+  crypto.subtle.deriveBits(
+    { name: "Argon2id", nonce, memory: 7, passes: 1, parallelism: 1 },
+    bitsOnlyKey,
+    128,
+  ),
+);


### PR DESCRIPTION
## Summary
- add WebCrypto raw-secret import support for Argon2d, Argon2i, and Argon2id keys
- implement Argon2 deriveBits/deriveKey handling with nonce, memory, passes, parallelism, version, associatedData, and secretValue params
- update CryptoKey runtime metadata IDs and usages so the added KDF algorithms do not collide with existing EC, Ed25519, X25519, and RSA keys
- add a Node parity fixture covering support probes, deterministic Argon2 vectors, derived AES keys, and validation errors

## Validation
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-argon2-baseline npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter argon2-kdf'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-argon2-baseline npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter jwk-ecdh-p256'`
- `PERRY_NO_AUTO_OPTIMIZE=1 CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-argon2-baseline npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter webcrypto'` (54 pass / 2 known adjacent parity fails: `cryptokey-usages-extractable`, `jwk-wrap-unwrap`; covered by #4302)
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-argon2-check cargo check -p perry-stdlib --no-default-features --features crypto`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Refs #2518