### PR TITLE
fix(runtime): ToNumber(object) honors valueOf (OrdinaryToPrimitive number hint)

### DIFF
--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -417,13 +417,24 @@ pub extern "C" fn js_number_coerce(value: f64) -> f64 {
             // toPrimitive returned something different — re-coerce.
             return js_number_coerce(primitive);
         }
-        // No custom [Symbol.toPrimitive]: complete OrdinaryToPrimitive by
-        // stringifying the object and re-running ToNumber on the result
-        // (#2378). `js_jsvalue_to_string` handles arrays via join(",") and
-        // objects via their own/inherited toString, so `Number([])` → "" → 0,
-        // `Number([5])` → "5" → 5, and `Number({})` → "[object Object]" → NaN
-        // all match Node. The result is a string, so the recursive call lands
-        // in the string branch — no infinite pointer-branch recursion.
+        // No custom [Symbol.toPrimitive]: OrdinaryToPrimitive(O, "number") =
+        // try `valueOf` THEN `toString` (ES2024 §7.1.1.1). Previously this
+        // jumped straight to stringifying, so `Number({valueOf(){return 42}})`,
+        // `+obj`, `obj * 2` etc. wrongly gave NaN. Reuse the shared
+        // valueOf-first helper (the same one `+`/addition uses): a primitive
+        // result re-coerces; DefaultString/TypeError fall through to the
+        // stringify path (so `Number([5])` → "5" → 5, `Number({})` →
+        // "[object Object]" → NaN, `Number([])` → "" → 0 still match Node).
+        match unsafe { crate::value::ordinary_to_primitive_number_for_add(value) } {
+            crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => {
+                if p.to_bits() != value.to_bits() {
+                    return js_number_coerce(p);
+                }
+                return f64::NAN;
+            }
+            crate::value::OrdinaryToPrimitiveOutcome::TypeError
+            | crate::value::OrdinaryToPrimitiveOutcome::DefaultString => {}
+        }
         let str_ptr = crate::value::js_jsvalue_to_string(value);
         if str_ptr.is_null() {
             return f64::NAN;


### PR DESCRIPTION
## What

`ToNumber(object)` now performs the spec's OrdinaryToPrimitive with the
**number** hint — `valueOf` first, then `toString` — instead of jumping straight
to stringification. So an object with a custom `valueOf` coerces correctly:

```js
const o = { valueOf() { return 42; } };
+o            // was NaN → now 42
Number(o)     // was NaN → now 42
o * 2         // was NaN → now 84
o - 1         // was NaN → now 41
```

## Why

`js_number_coerce` (the canonical ToNumber backing `Number()`, unary `+`, and
numeric binary operators) checked `[Symbol.toPrimitive]` and then went directly
to `js_jsvalue_to_string` — skipping `valueOf` entirely. Any object relying on
`valueOf` for numeric coercion produced NaN. This is a core coercion path, so the
bug reached Number, Date constructor/setters, arithmetic, TypedArray indexing,
and more.

## How

Insert the existing, tested `ordinary_to_primitive_number_for_add`
(valueOf-then-toString, already used by `+`/addition) between the
`[Symbol.toPrimitive]` check and the stringify fallback. A primitive result
re-coerces; `DefaultString`/`TypeError` outcomes fall through to the existing
stringify path, so the established string-coercion cases are unchanged.

## Verification

Byte-identical to `node --experimental-strip-types`:
- Fixed: `+o`, `Number(o)`, `o*2`, `o-1` for a `{valueOf}` object.
- Unchanged (regression set): `Number([5])`→5, `Number([])`→0, `Number([1,2])`→NaN,
  `Number({})`→NaN, `Number('3.14')`→3.14, `+5`, `Number(true/null)`,
  `[Symbol.toPrimitive]` precedence, `valueOf`-wins-over-`toString` for `+`,
  `toString` for `String()`.
- `perry-runtime` suite: 977/977. fmt + file-size clean. Rebased on main.

## Note

Also unblocks object-valued Date arguments and is a prerequisite for several
Date/Number test262 cases that were failing purely on this coercion gap.
