### PR TITLE
fix(crypto): expand x509 checkHost options

### DIFF
--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -175,7 +175,141 @@ fn x509_subject_common_names(cert: &x509_cert::Certificate) -> Vec<String> {
     names
 }
 
-fn x509_check_host_value(cert: &x509_cert::Certificate, name: &str) -> Option<String> {
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum X509HostSubject {
+    Default,
+    Always,
+    Never,
+}
+
+struct X509CheckHostOptions {
+    subject: X509HostSubject,
+    wildcards: bool,
+    partial_wildcards: bool,
+    multi_label_wildcards: bool,
+}
+
+impl Default for X509CheckHostOptions {
+    fn default() -> Self {
+        Self {
+            subject: X509HostSubject::Default,
+            wildcards: true,
+            partial_wildcards: true,
+            multi_label_wildcards: false,
+        }
+    }
+}
+
+unsafe fn x509_object_field(value: f64, name: &[u8]) -> Option<f64> {
+    let js = JSValue::from_bits(value.to_bits());
+    if !js.is_pointer() {
+        return None;
+    }
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    Some(f64::from_bits(
+        js_object_get_field_by_name(js.as_pointer::<ObjectHeader>(), key).bits(),
+    ))
+}
+
+unsafe fn x509_options_bool(opts: f64, name: &[u8], default: bool) -> bool {
+    let Some(value) = x509_object_field(opts, name) else {
+        return default;
+    };
+    let js = JSValue::from_bits(value.to_bits());
+    if js.is_bool() {
+        js.as_bool()
+    } else {
+        default
+    }
+}
+
+unsafe fn x509_check_host_options(args: &[f64]) -> X509CheckHostOptions {
+    let mut options = X509CheckHostOptions::default();
+    let opts = args
+        .get(1)
+        .copied()
+        .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+
+    if let Some(subject) =
+        x509_object_field(opts, b"subject").and_then(|value| string_from_jsvalue(value.to_bits()))
+    {
+        options.subject = match subject.as_str() {
+            "always" => X509HostSubject::Always,
+            "never" => X509HostSubject::Never,
+            _ => X509HostSubject::Default,
+        };
+    }
+
+    options.wildcards = x509_options_bool(opts, b"wildcards", true);
+    options.partial_wildcards = x509_options_bool(opts, b"partialWildcards", true);
+    options.multi_label_wildcards = x509_options_bool(opts, b"multiLabelWildcards", false);
+    options
+}
+
+fn x509_label_count(value: &str) -> usize {
+    value.split('.').filter(|label| !label.is_empty()).count()
+}
+
+fn x509_host_suffix_matches(host: &str, suffix: &str, options: &X509CheckHostOptions) -> bool {
+    if x509_label_count(suffix) < 2 {
+        return false;
+    }
+    if !host.ends_with(suffix) {
+        return false;
+    }
+    let prefix = &host[..host.len() - suffix.len()];
+    if !prefix.ends_with('.') {
+        return false;
+    }
+    let prefix = &prefix[..prefix.len() - 1];
+    if prefix.is_empty() {
+        return false;
+    }
+    options.multi_label_wildcards || !prefix.contains('.')
+}
+
+fn x509_dns_name_matches(candidate: &str, host: &str, options: &X509CheckHostOptions) -> bool {
+    let candidate = candidate.to_ascii_lowercase();
+    let host = host.to_ascii_lowercase();
+    if candidate == host {
+        return true;
+    }
+    if !options.wildcards {
+        return false;
+    }
+
+    if let Some(suffix) = candidate.strip_prefix("*.") {
+        return x509_host_suffix_matches(&host, suffix, options);
+    }
+
+    if !options.partial_wildcards {
+        return false;
+    }
+    let Some((candidate_label, candidate_suffix)) = candidate.split_once('.') else {
+        return false;
+    };
+    let Some((host_label, host_suffix)) = host.split_once('.') else {
+        return false;
+    };
+    if candidate_suffix != host_suffix || x509_label_count(candidate_suffix) < 2 {
+        return false;
+    }
+    let Some(star_index) = candidate_label.find('*') else {
+        return false;
+    };
+    if candidate_label[star_index + 1..].contains('*') {
+        return false;
+    }
+    let prefix = &candidate_label[..star_index];
+    let suffix = &candidate_label[star_index + 1..];
+    !host_label.is_empty() && host_label.starts_with(prefix) && host_label.ends_with(suffix)
+}
+
+fn x509_check_host_value(
+    cert: &x509_cert::Certificate,
+    name: &str,
+    options: &X509CheckHostOptions,
+) -> Option<String> {
     use x509_cert::ext::pkix::name::GeneralName;
 
     let mut saw_dns_san = false;
@@ -186,19 +320,21 @@ fn x509_check_host_value(cert: &x509_cert::Certificate, name: &str) -> Option<St
             };
             saw_dns_san = true;
             let candidate = value.as_str();
-            if candidate.eq_ignore_ascii_case(name) {
+            if x509_dns_name_matches(candidate, name, options) {
                 return Some(candidate.to_string());
             }
         }
     }
 
-    if saw_dns_san {
+    if options.subject == X509HostSubject::Never
+        || (saw_dns_san && options.subject != X509HostSubject::Always)
+    {
         return None;
     }
 
     x509_subject_common_names(cert)
         .into_iter()
-        .find(|candidate| candidate.eq_ignore_ascii_case(name))
+        .find(|candidate| x509_dns_name_matches(candidate, name, options))
 }
 
 fn x509_check_email_value(cert: &x509_cert::Certificate, email: &str) -> Option<String> {
@@ -490,7 +626,9 @@ pub unsafe fn dispatch_x509_method(handle: i64, method: &str, args: &[f64]) -> f
     match method {
         "toString" | "toJSON" => x509_string_f64(&x509_der_to_pem(&h.der)),
         "checkHost" => {
-            match x509_check_host_value(&h.cert, &x509_required_string_arg(args, "name")) {
+            let options = x509_check_host_options(args);
+            match x509_check_host_value(&h.cert, &x509_required_string_arg(args, "name"), &options)
+            {
                 Some(value) => x509_string_f64(&value),
                 None => nanbox_undefined(),
             }

--- a/test-parity/node-suite/crypto/x509/check-host-options.ts
+++ b/test-parity/node-suite/crypto/x509/check-host-options.ts
@@ -1,0 +1,80 @@
+import { X509Certificate } from "node:crypto";
+
+const sanPem = `-----BEGIN CERTIFICATE-----
+MIIDQTCCAimgAwIBAgIUdM+DrVg0qioOfxnnJUQ14DHSQcAwDQYJKoZIhvcNAQEL
+BQAwHjEcMBoGA1UEAwwTdW51c2VkLXN1YmplY3QudGVzdDAeFw0yNjA2MDMyMzAz
+MjhaFw0yNzA2MDMyMzAzMjhaMB4xHDAaBgNVBAMME3VudXNlZC1zdWJqZWN0LnRl
+c3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyPe7y2KXjojSt4kCi
+Cw4uLwKbM4P9pfG37XfJpPkMjOloI8dTKOlw5wUokg5wDYjZg3+4etfj3RyMyweo
+168rkbXZHC21v5zw34FWBthCj3bLl/B2KU76Ki0DrFSQ3XHmuMTzYieLhryewQfC
+5B2u7TINIuugFWXGh/9qB3WqJn4XAJ3V4POhy9sak52Cggb8gUKVOdm1rqiXP5Xa
+TioaTJqsXNrM7vJ01CioL50uBdkzrokqeZASd1/Ouo+iELPLARjmdgY1t0qsus4I
+cYsHYk6SjBQspUSut6WY1bU6DjaeiD7RaIhET1RUe8OC+uagIoMimNs1xHJlJzkt
+M/03AgMBAAGjdzB1MFQGA1UdEQRNMEuCDiouZXhhbXBsZS50ZXN0gg9mKi5wYXJ0
+aWFsLnRlc3SCFCoubXVsdGkuZXhhbXBsZS50ZXN0ghJleGFjdC5leGFtcGxlLnRl
+c3QwHQYDVR0OBBYEFMrzNiJDY7M2fpUFtLH5xvt9bHDdMA0GCSqGSIb3DQEBCwUA
+A4IBAQAbV7JZllcIGWs/QZIo6f3yVyA4dzmyKEG+7PIS+SPUi5h/R9+6h5+Ess1E
+7+n+IW5EP8UNq4kFJaoQRwNWRxiELUghxJKe96dsGah3NnkADTJv9hksw9x2GEtb
+0r9R20cFOb6pQxL/bvNHXWUkac+OSWUeG0/7ya/lhXKwy82BP0dC7bmsPyOmc9VF
+fDesTnn9TS09mCm5dIvrqx6Cv+oIyzsjm7bx4tWYGKr655r22Grmftr2hj0JQpjH
+sTpZDRKnqL+RSjqPykoAaHVgEOz87TwLbtnmxbTRVjaxC2nwm+08gQnvabO4PS6z
+JNYX4btmoYsWnMu+LjpBMYBf/TKz
+-----END CERTIFICATE-----`;
+
+const cnOnlyPem = `-----BEGIN CERTIFICATE-----
+MIIC4TCCAcmgAwIBAgIUT2Pmm498Rc/QLZlHprJ7h7ZJYoEwDQYJKoZIhvcNAQEL
+BQAwGTEXMBUGA1UEAwwOKi5jbi1vbmx5LnRlc3QwHhcNMjYwNjAzMjMwMzI4WhcN
+MjcwNjAzMjMwMzI4WjAZMRcwFQYDVQQDDA4qLmNuLW9ubHkudGVzdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBALv2ANRBWJHb71fTsCtCvUytHVmWrcz/
+0xTvNRFeStefuo1meXNljz6FkTiosqD2trmCA5SHfI11szHNH5c0P+8mTqzK/Z31
+t7c50SFQthyQv8uboUAqkh1ZLmsL7O0SHmAOd2GG7HxdV2tkEDGjIyx0OVnKTQC3
+WDYtfO0STDWo2UUBcBygbHvoJcIEd0G3e69oXXfspzNx4HaYXXDisbEWgpiKruiA
+6Oiifa/MCrDqhw3MImCo/a8ibZva5t0zhuSIpiKICFYSdspiRts4NAQ50O5INCtQ
+UgSxcT+zvyRxzyzLKBV8YmXI0VBrwZhyUHTIGis+6w9g6mYyHvYwTNECAwEAAaMh
+MB8wHQYDVR0OBBYEFIKyDAzP63MS4IJWvbkgJRZ8LiaYMA0GCSqGSIb3DQEBCwUA
+A4IBAQA+md3YqLinuVUbjUy9g9CVG9z4bChWsvvu9LL90RoM9UsN/hcdG2I0ra1O
+gLBYJFR8+z16k0MIaQTvmFjn6NbCwLuemVsG481IUbdR+imIcZJCvQ8vPm9qPZHp
+8zwiJpTbqlXdyc34Je7C7PtTBWfnVc2Kza4F+1TPbiBxNg1j2Xv204BnYV/ymy81
+pJ64kX2jHiglIGoNtroRW9XJtgT46IZKnBixyrvXI1LyQ4yRn/sW3zylzv2wRZ6+
+OgOV6qEP9MI/nkRxjjOhgd6OhtEw7Oii6WZe3EU4LoJRMGmM6o6gxT0pSmzUAtn9
+rwGNC7scODmtWIlD3dV3oVLxqAaD
+-----END CERTIFICATE-----`;
+
+const sanCert = new X509Certificate(sanPem);
+const cnOnlyCert = new X509Certificate(cnOnlyPem);
+
+function show(label: string, value: unknown) {
+  console.log(`${label}:`, value);
+}
+
+show("exact san", sanCert["checkHost"]("exact.example.test"));
+show("wildcard default", sanCert["checkHost"]("www.example.test"));
+show("wildcard false", sanCert["checkHost"]("www.example.test", { wildcards: false }));
+show("partial default", sanCert["checkHost"]("foo.partial.test"));
+show(
+  "partial false",
+  sanCert["checkHost"]("foo.partial.test", { partialWildcards: false }),
+);
+show("multi default", sanCert["checkHost"]("a.b.multi.example.test"));
+show(
+  "multi true",
+  sanCert["checkHost"]("a.b.multi.example.test", { multiLabelWildcards: true }),
+);
+show("subject default blocked", sanCert["checkHost"]("unused-subject.test"));
+show(
+  "subject always",
+  sanCert["checkHost"]("unused-subject.test", { subject: "always" }),
+);
+show(
+  "subject never exact san",
+  sanCert["checkHost"]("exact.example.test", { subject: "never" }),
+);
+show("cn wildcard default", cnOnlyCert["checkHost"]("www.cn-only.test"));
+show(
+  "cn wildcard false",
+  cnOnlyCert["checkHost"]("www.cn-only.test", { wildcards: false }),
+);
+show(
+  "cn subject never",
+  cnOnlyCert["checkHost"]("www.cn-only.test", { subject: "never" }),
+);


### PR DESCRIPTION
## Summary
- parse `X509Certificate#checkHost(name, options)` host-matching options for subject fallback and wildcard handling
- match DNS SAN entries in certificate order before subject CN fallback
- add parity coverage for wildcard, partial wildcard, multi-label wildcard, and `subject` option behavior

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/x509/check-host-options.ts`
- `PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/perry-x509-checkhost-options-build/release PERRY_NO_AUTO_OPTIMIZE=1 PERRY_GEN_GC=0 /root/perry-worktrees/.build-targets/perry-x509-checkhost-options-build/release/perry run test-parity/node-suite/crypto/x509/check-host-options.ts`
- `NODE26_BIN=$(npm exec --yes --package=node@26 -- node -e 'console.log(process.execPath)') && NODE26_DIR=$(dirname "$NODE26_BIN") && PATH="$NODE26_DIR:$PATH" CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-checkhost-options-build PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/perry-x509-checkhost-options-build/release PERRY_NO_AUTO_OPTIMIZE=1 PERRY_GEN_GC=0 ./run_parity_tests.sh --suite node-suite --module crypto --filter x509/check-host-options`
- `NODE26_BIN=$(npm exec --yes --package=node@26 -- node -e 'console.log(process.execPath)') && NODE26_DIR=$(dirname "$NODE26_BIN") && PATH="$NODE26_DIR:$PATH" CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-checkhost-options-build PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/perry-x509-checkhost-options-build/release PERRY_NO_AUTO_OPTIMIZE=1 PERRY_GEN_GC=0 ./run_parity_tests.sh --suite node-suite --module crypto --filter x509`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-checkhost-options-check cargo check -p perry-stdlib --no-default-features --features crypto`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-x509-checkhost-options-build cargo build -p perry -p perry-runtime -p perry-stdlib --release`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Refs #2563
