### PR TITLE
[codex] add WebCrypto ChaCha20-Poly1305

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -1021,6 +1032,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1051,6 +1075,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout 0.1.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -5672,6 +5697,7 @@ dependencies = [
  "bson",
  "bytes",
  "cbc",
+ "chacha20poly1305",
  "chrono",
  "clap",
  "cron 0.16.0",
@@ -6146,6 +6172,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6538,7 +6575,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -98,7 +98,12 @@ thread_local! {
     static SECRET_KEY_REGISTRY: RefCell<PtrHashSet<usize>> = RefCell::new(new_ptr_hash_set());
     /// Buffers that should behave as WebCrypto CryptoKey values. Metadata is
     /// numeric to keep perry-runtime independent from perry-stdlib enums:
-    /// algo: 1 HMAC, 2 AES-GCM, 3 AES-KW, 4 AES-CBC, 5 AES-CTR, 6 HKDF, 7 PBKDF2
+    /// algo: 1 HMAC, 2 AES-GCM, 3 AES-KW, 4 AES-CBC, 5 AES-CTR, 6 HKDF,
+    ///       7 PBKDF2, 8 ECDSA, 9 ECDH, 10 Ed25519, 11 X25519,
+    ///       12 RSASSA-PKCS1-v1_5, 13 RSA-OAEP, 14 RSA-PSS,
+    ///       15 ECDSA P-384, 16 ECDH P-384, 17 ECDSA P-521,
+    ///       18 ECDH P-521, 19 Argon2d, 20 Argon2i, 21 Argon2id,
+    ///       22 ChaCha20-Poly1305
     /// hash: 1 SHA-1, 2 SHA-256, 3 SHA-384, 4 SHA-512
     /// kind: 1 secret, 2 private, 3 public
     /// extractable: WebCrypto CryptoKey.extractable
@@ -365,7 +370,7 @@ fn default_crypto_key_usages(algo: u8, kind: u8) -> u32 {
 
     match (algo, kind) {
         (1, 1) => SIGN | VERIFY,
-        (2 | 4 | 5, 1) => ENCRYPT | DECRYPT | WRAP_KEY | UNWRAP_KEY,
+        (2 | 4 | 5 | 22, 1) => ENCRYPT | DECRYPT | WRAP_KEY | UNWRAP_KEY,
         (3, 1) => WRAP_KEY | UNWRAP_KEY,
         (6 | 7 | 19 | 20 | 21, 1) => DERIVE_KEY | DERIVE_BITS,
         (8 | 10 | 12 | 14 | 15 | 17, 2) => SIGN,

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -286,6 +286,7 @@ unsafe fn secret_to_crypto_key(addr: usize, algorithm_bits: f64) -> f64 {
         "AES-CTR" => 5,
         "HKDF" => 6,
         "PBKDF2" => 7,
+        "CHACHA20-POLY1305" => 15,
         _ => return f64::from_bits(JSValue::undefined().bits()),
     };
     let hash_name = object_field_string_value(algorithm_bits, b"hash")

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -87,6 +87,7 @@ fn crypto_key_algorithm_name(algo: u8) -> &'static str {
         19 => "Argon2d",
         20 => "Argon2i",
         21 => "Argon2id",
+        22 => "ChaCha20-Poly1305",
         _ => "",
     }
 }

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -219,7 +219,7 @@ bundled-mongodb = ["dep:mongodb", "dep:bson", "dep:futures-util", "async-runtime
 # bindings so the well-known flip (#466 Phase 4 step 2) can route them
 # to perry-ext-bcrypt / perry-ext-argon2 without taking the rest of
 # the crypto surface offline.
-crypto = ["dep:sha2", "dep:sha1", "dep:sha3", "dep:rsa-sha1", "dep:md-5", "dep:hex", "dep:hmac", "dep:aes", "dep:cbc", "dep:ecb", "dep:ctr", "dep:scrypt", "dep:pbkdf2", "dep:base64", "dep:x25519-dalek", "dep:ed25519-dalek", "dep:aes-gcm", "dep:ghash", "dep:aes-kw", "dep:hkdf", "dep:p256", "dep:p384", "dep:p521", "dep:x509-cert", "async-runtime", "ids", "bundled-bcrypt", "bundled-argon2", "bundled-jsonwebtoken", "bundled-ethers"]
+crypto = ["dep:sha2", "dep:sha1", "dep:sha3", "dep:rsa-sha1", "dep:md-5", "dep:hex", "dep:hmac", "dep:aes", "dep:cbc", "dep:ecb", "dep:ctr", "dep:scrypt", "dep:pbkdf2", "dep:base64", "dep:x25519-dalek", "dep:ed25519-dalek", "dep:aes-gcm", "dep:chacha20poly1305", "dep:ghash", "dep:aes-kw", "dep:hkdf", "dep:p256", "dep:p384", "dep:p521", "dep:x509-cert", "async-runtime", "ids", "bundled-bcrypt", "bundled-argon2", "bundled-jsonwebtoken", "bundled-ethers"]
 bundled-bcrypt = ["dep:bcrypt", "async-runtime"]
 bundled-argon2 = ["dep:argon2", "async-runtime"]
 bundled-jsonwebtoken = ["dep:jsonwebtoken", "dep:p256", "dep:rsa", "dep:spki"]
@@ -383,6 +383,7 @@ base64 = { version = "0.22", optional = true }
 x25519-dalek = { version = "2.0", features = ["static_secrets"], optional = true }
 ed25519-dalek = { version = "2.1", optional = true }
 aes-gcm = { version = "0.10", optional = true }
+chacha20poly1305 = { version = "0.10", optional = true }
 ghash = { version = "0.5", optional = true }
 # AES-KW (RFC 3394) — used by `crypto.subtle.wrapKey` / `unwrapKey`
 # when the wrap algorithm is `{ name: 'AES-KW' }`. Gated under the

--- a/crates/perry-stdlib/src/webcrypto/aes.rs
+++ b/crates/perry-stdlib/src/webcrypto/aes.rs
@@ -146,6 +146,54 @@ pub(super) fn aes_gcm_decrypt(
     }
 }
 
+pub(super) fn chacha20_poly1305_encrypt(
+    key: &[u8],
+    iv: &[u8],
+    aad: &[u8],
+    plaintext: &[u8],
+) -> Option<Vec<u8>> {
+    use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+    use chacha20poly1305::{ChaCha20Poly1305, Nonce};
+
+    if key.len() != 32 || iv.len() != 12 {
+        return None;
+    }
+    let cipher = ChaCha20Poly1305::new_from_slice(key).ok()?;
+    cipher
+        .encrypt(
+            Nonce::from_slice(iv),
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .ok()
+}
+
+pub(super) fn chacha20_poly1305_decrypt(
+    key: &[u8],
+    iv: &[u8],
+    aad: &[u8],
+    ciphertext: &[u8],
+) -> Option<Vec<u8>> {
+    use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+    use chacha20poly1305::{ChaCha20Poly1305, Nonce};
+
+    if key.len() != 32 || iv.len() != 12 {
+        return None;
+    }
+    let cipher = ChaCha20Poly1305::new_from_slice(key).ok()?;
+    cipher
+        .decrypt(
+            Nonce::from_slice(iv),
+            Payload {
+                msg: ciphertext,
+                aad,
+            },
+        )
+        .ok()
+}
+
 pub(super) type Aes128CbcEnc = Encryptor<Aes128>;
 pub(super) type Aes192CbcEnc = Encryptor<Aes192>;
 pub(super) type Aes256CbcEnc = Encryptor<Aes256>;
@@ -306,6 +354,32 @@ pub(super) unsafe fn extract_aes_gcm_args(
     Some((key_bytes, iv, aad, data_bytes))
 }
 
+pub(super) unsafe fn extract_chacha20_poly1305_args(
+    algo_bits: u64,
+    key_bits: u64,
+    data_bits: u64,
+) -> Option<(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>)> {
+    let algo_name = extract_algo_name(algo_bits)?;
+    if !algo_name.eq_ignore_ascii_case("ChaCha20-Poly1305") {
+        return None;
+    }
+    let iv = object_field_bytes(algo_bits, b"iv")?;
+    if let Some(tag_length) = object_field_number(algo_bits, b"tagLength") {
+        if tag_length != 128 {
+            return None;
+        }
+    }
+    let aad = object_field_bytes(algo_bits, b"additionalData").unwrap_or_default();
+    let key_addr = strip_ptr(key_bits);
+    let mat = lookup_crypto_key(key_addr)?;
+    if mat.algo != KeyAlgo::ChaCha20Poly1305 {
+        return None;
+    }
+    let key_bytes = bytes_from_jsvalue(key_bits);
+    let data_bytes = bytes_from_jsvalue(data_bits);
+    Some((key_bytes, iv, aad, data_bytes))
+}
+
 /// `crypto.subtle.encrypt({ name: "AES-GCM", iv, additionalData? }, key, data)`
 /// → Promise<Uint8Array>
 #[no_mangle]
@@ -427,6 +501,44 @@ pub unsafe extern "C" fn js_webcrypto_encrypt(
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
         };
         let ciphertext = match aes_ctr_apply(&key, &counter, length, &data) {
+            Some(c) => c,
+            None => return reject_with_dom_exception("OperationError", "The operation failed"),
+        };
+        return resolve_with_bytes(&ciphertext);
+    }
+    if algo_name.eq_ignore_ascii_case("ChaCha20-Poly1305") {
+        let key_addr = strip_ptr(key_bits.to_bits());
+        let mat = match lookup_crypto_key(key_addr) {
+            Some(m) => m,
+            None => {
+                return reject_with_dom_exception(
+                    "InvalidAccessError",
+                    "Key is not a valid CryptoKey",
+                )
+            }
+        };
+        if mat.algo != KeyAlgo::ChaCha20Poly1305 {
+            return reject_with_dom_exception(
+                "InvalidAccessError",
+                "The requested operation is not valid for the provided key",
+            );
+        }
+        if let Err((name, message)) = require_usage(
+            mat,
+            USAGE_ENCRYPT,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
+        let (key, iv, aad, data) = match extract_chacha20_poly1305_args(
+            algo_bits.to_bits(),
+            key_bits.to_bits(),
+            data_bits.to_bits(),
+        ) {
+            Some(t) => t,
+            None => return reject_with_dom_exception("OperationError", "The operation failed"),
+        };
+        let ciphertext = match chacha20_poly1305_encrypt(&key, &iv, &aad, &data) {
             Some(c) => c,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
         };
@@ -588,6 +700,44 @@ pub unsafe extern "C" fn js_webcrypto_decrypt(
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
         };
         let plaintext = match aes_ctr_apply(&key, &counter, length, &data) {
+            Some(p) => p,
+            None => return reject_with_dom_exception("OperationError", "The operation failed"),
+        };
+        return resolve_with_bytes(&plaintext);
+    }
+    if algo_name.eq_ignore_ascii_case("ChaCha20-Poly1305") {
+        let key_addr = strip_ptr(key_bits.to_bits());
+        let mat = match lookup_crypto_key(key_addr) {
+            Some(m) => m,
+            None => {
+                return reject_with_dom_exception(
+                    "InvalidAccessError",
+                    "Key is not a valid CryptoKey",
+                )
+            }
+        };
+        if mat.algo != KeyAlgo::ChaCha20Poly1305 {
+            return reject_with_dom_exception(
+                "InvalidAccessError",
+                "The requested operation is not valid for the provided key",
+            );
+        }
+        if let Err((name, message)) = require_usage(
+            mat,
+            USAGE_DECRYPT,
+            "The requested operation is not valid for the provided key",
+        ) {
+            return reject_with_dom_exception(name, message);
+        }
+        let (key, iv, aad, data) = match extract_chacha20_poly1305_args(
+            algo_bits.to_bits(),
+            key_bits.to_bits(),
+            data_bits.to_bits(),
+        ) {
+            Some(t) => t,
+            None => return reject_with_dom_exception("OperationError", "The operation failed"),
+        };
+        let plaintext = match chacha20_poly1305_decrypt(&key, &iv, &aad, &data) {
             Some(p) => p,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
         };

--- a/crates/perry-stdlib/src/webcrypto/jwk.rs
+++ b/crates/perry-stdlib/src/webcrypto/jwk.rs
@@ -90,6 +90,8 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
         (KeyAlgo::AesCbc, HashAlgo::Sha256, KeyKind::Secret)
     } else if algo_upper == "AES-CTR" && (format_lower == "raw" || format_lower == "jwk") {
         (KeyAlgo::AesCtr, HashAlgo::Sha256, KeyKind::Secret)
+    } else if algo_upper == "CHACHA20-POLY1305" && format_lower == "jwk" {
+        (KeyAlgo::ChaCha20Poly1305, HashAlgo::Sha256, KeyKind::Secret)
     } else if algo_upper == "ECDSA" && (format_lower == "raw" || format_lower == "jwk") {
         let curve = match object_field_string(algo_bits.to_bits(), b"namedCurve")
             .and_then(|c| parse_ec_named_curve(&c))
@@ -193,6 +195,9 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     } else {
         bytes_from_jsvalue(key_bits.to_bits())
     };
+    if key_algo == KeyAlgo::ChaCha20Poly1305 && key_bytes.len() != 32 {
+        return reject_with_dom_exception("DataError", "Invalid key length");
+    }
     if key_bytes.is_empty()
         && !matches!(
             key_algo,
@@ -298,6 +303,12 @@ pub unsafe extern "C" fn js_webcrypto_export_key(format_bits: f64, key_bits: f64
     if !mat.extractable {
         return reject_with_dom_exception("InvalidAccessError", "key is not extractable");
     }
+    if format_lower == "raw" && mat.algo == KeyAlgo::ChaCha20Poly1305 {
+        return reject_with_dom_exception(
+            "NotSupportedError",
+            "Unable to export ChaCha20-Poly1305 secret key using raw format",
+        );
+    }
     if format_lower == "raw" && mat.kind == KeyKind::Private {
         return reject_with_dom_exception("OperationError", "The operation failed");
     }
@@ -337,11 +348,21 @@ pub unsafe extern "C" fn js_webcrypto_export_key(format_bits: f64, key_bits: f64
     if format_lower == "jwk" {
         if mat.kind == KeyKind::Secret {
             let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&key_bytes);
-            let obj = js_object_alloc(0, 2);
+            let obj = js_object_alloc(
+                0,
+                if mat.algo == KeyAlgo::ChaCha20Poly1305 {
+                    3
+                } else {
+                    2
+                },
+            );
             if obj.is_null() {
                 return reject_with_dom_exception("OperationError", "The operation failed");
             }
             set_object_string_field(obj, b"kty", "oct");
+            if mat.algo == KeyAlgo::ChaCha20Poly1305 {
+                set_object_string_field(obj, b"alg", "C20P");
+            }
             set_object_string_field(obj, b"k", &encoded);
             return resolve_with_bits(JSValue::pointer(obj as *const u8).bits());
         }
@@ -490,7 +511,12 @@ pub(super) unsafe fn jwk_import_key_bytes(
     }
     if matches!(
         key_algo,
-        KeyAlgo::Hmac | KeyAlgo::AesGcm | KeyAlgo::AesKw | KeyAlgo::AesCbc | KeyAlgo::AesCtr
+        KeyAlgo::Hmac
+            | KeyAlgo::AesGcm
+            | KeyAlgo::AesKw
+            | KeyAlgo::AesCbc
+            | KeyAlgo::AesCtr
+            | KeyAlgo::ChaCha20Poly1305
     ) {
         if kty != "oct" {
             return None;

--- a/crates/perry-stdlib/src/webcrypto/keys.rs
+++ b/crates/perry-stdlib/src/webcrypto/keys.rs
@@ -389,6 +389,38 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         return resolve_with_bits(JSValue::pointer(buf as *const u8).bits());
     }
 
+    if algo_upper == "CHACHA20-POLY1305" {
+        let usages = match validate_key_usages(
+            KeyAlgo::ChaCha20Poly1305,
+            KeyKind::Secret,
+            usages_bits.to_bits(),
+            false,
+            "Usages cannot be empty when creating a key.",
+            "Unsupported key usage for a ChaCha20-Poly1305 key",
+        ) {
+            Ok(u) => u,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
+        let mut key_bytes = vec![0u8; 32];
+        use rand::RngCore;
+        rand::rngs::OsRng.fill_bytes(&mut key_bytes);
+        let buf = alloc_uint8array_from_slice(&key_bytes);
+        if buf.is_null() {
+            return reject_with_dom_exception("OperationError", "The operation failed");
+        }
+        register_crypto_key(
+            buf as usize,
+            CryptoKeyMaterial::new(
+                KeyAlgo::ChaCha20Poly1305,
+                HashAlgo::Sha256,
+                KeyKind::Secret,
+                extractable,
+                usages,
+            ),
+        );
+        return resolve_with_bits(JSValue::pointer(buf as *const u8).bits());
+    }
+
     if algo_upper != "AES-GCM"
         && algo_upper != "AES-KW"
         && algo_upper != "AES-CBC"

--- a/crates/perry-stdlib/src/webcrypto/supports.rs
+++ b/crates/perry-stdlib/src/webcrypto/supports.rs
@@ -27,6 +27,7 @@ unsafe fn supports_generate_key(algorithm_bits: u64, algorithm: &str) -> bool {
     let object_form = algorithm_is_object(algorithm_bits);
     match algorithm {
         "ED25519" | "X25519" => true,
+        "CHACHA20-POLY1305" => true,
         "HMAC" | "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" => object_form,
         "ECDSA" | "ECDH" => {
             object_form
@@ -41,8 +42,8 @@ unsafe fn supports_generate_key(algorithm_bits: u64, algorithm: &str) -> bool {
 
 unsafe fn supports_import_key(algorithm_bits: u64, algorithm: &str) -> bool {
     match algorithm {
-        "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" | "PBKDF2" | "HKDF" | "ARGON2D"
-        | "ARGON2I" | "ARGON2ID" | "ED25519" | "X25519" => true,
+        "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" | "CHACHA20-POLY1305" | "PBKDF2" | "HKDF"
+        | "ARGON2D" | "ARGON2I" | "ARGON2ID" | "ED25519" | "X25519" => true,
         "HMAC" => algorithm_is_object(algorithm_bits),
         "ECDSA" | "ECDH" => algorithm_curve(algorithm_bits)
             .as_deref()
@@ -61,6 +62,7 @@ fn supports_export_key(algorithm: &str) -> bool {
             | "AES-CBC"
             | "AES-CTR"
             | "AES-KW"
+            | "CHACHA20-POLY1305"
             | "ECDSA"
             | "ECDH"
             | "ED25519"
@@ -97,7 +99,16 @@ pub unsafe extern "C" fn js_webcrypto_supports(
         "SIGN" | "VERIFY" => {
             matches!(algorithm.as_str(), "HMAC" | "ED25519" | "RSASSA-PKCS1-V1_5")
         }
-        "ENCRYPT" | "DECRYPT" => algorithm == "RSA-OAEP",
+        "ENCRYPT" | "DECRYPT" => {
+            algorithm == "RSA-OAEP"
+                || (algorithm == "CHACHA20-POLY1305"
+                    && object_field_bytes(algorithm_bits.to_bits(), b"iv")
+                        .map(|iv| iv.len() == 12)
+                        .unwrap_or(false)
+                    && object_field_number(algorithm_bits.to_bits(), b"tagLength")
+                        .map(|tag_length| tag_length == 128)
+                        .unwrap_or(true))
+        }
         "GENERATEKEY" => supports_generate_key(algorithm_bits.to_bits(), &algorithm),
         "IMPORTKEY" => supports_import_key(algorithm_bits.to_bits(), &algorithm),
         "EXPORTKEY" => supports_export_key(&algorithm),

--- a/crates/perry-stdlib/src/webcrypto/util.rs
+++ b/crates/perry-stdlib/src/webcrypto/util.rs
@@ -111,6 +111,7 @@ pub(super) enum KeyAlgo {
     AesKw,
     AesCbc,
     AesCtr,
+    ChaCha20Poly1305,
     EcdsaP256,
     EcdhP256,
     EcdsaP384,
@@ -297,6 +298,7 @@ fn runtime_algo_id(algo: KeyAlgo) -> u8 {
         KeyAlgo::Argon2d => 19,
         KeyAlgo::Argon2i => 20,
         KeyAlgo::Argon2id => 21,
+        KeyAlgo::ChaCha20Poly1305 => 22,
     }
 }
 
@@ -348,6 +350,7 @@ pub(super) fn lookup_crypto_key(buf_addr: usize) -> Option<CryptoKeyMaterial> {
                 19 => KeyAlgo::Argon2d,
                 20 => KeyAlgo::Argon2i,
                 21 => KeyAlgo::Argon2id,
+                22 => KeyAlgo::ChaCha20Poly1305,
                 _ => return None,
             };
             let hash = match hash {
@@ -555,9 +558,10 @@ pub(super) fn argon2_key_algo(name: &str) -> Option<KeyAlgo> {
 pub(super) fn supported_usages(algo: KeyAlgo, kind: KeyKind) -> u32 {
     match (algo, kind) {
         (KeyAlgo::Hmac, KeyKind::Secret) => USAGE_SIGN | USAGE_VERIFY,
-        (KeyAlgo::AesGcm | KeyAlgo::AesCbc | KeyAlgo::AesCtr, KeyKind::Secret) => {
-            USAGE_ENCRYPT | USAGE_DECRYPT | USAGE_WRAP_KEY | USAGE_UNWRAP_KEY
-        }
+        (
+            KeyAlgo::AesGcm | KeyAlgo::AesCbc | KeyAlgo::AesCtr | KeyAlgo::ChaCha20Poly1305,
+            KeyKind::Secret,
+        ) => USAGE_ENCRYPT | USAGE_DECRYPT | USAGE_WRAP_KEY | USAGE_UNWRAP_KEY,
         (KeyAlgo::AesKw, KeyKind::Secret) => USAGE_WRAP_KEY | USAGE_UNWRAP_KEY,
         (
             KeyAlgo::Hkdf

--- a/test-parity/node-suite/crypto/webcrypto/chacha20-poly1305.ts
+++ b/test-parity/node-suite/crypto/webcrypto/chacha20-poly1305.ts
@@ -1,0 +1,95 @@
+import * as crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+(process as any).emitWarning = () => undefined;
+
+const subtle = crypto.subtle;
+const enc = new TextEncoder();
+const iv = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+const aad = enc.encode("chacha aad");
+const data = enc.encode("chacha payload");
+
+function supports(label: string, op: string, algorithm: AlgorithmIdentifier) {
+  console.log(`${label}:`, SubtleCrypto.supports(op as any, algorithm as any));
+}
+
+async function rejectName(label: string, promise: Promise<unknown>) {
+  try {
+    await promise;
+    console.log(`${label}: no reject`);
+  } catch (error: any) {
+    console.log(`${label}:`, error?.name ?? "");
+  }
+}
+
+supports("supports generate string", "generateKey", "ChaCha20-Poly1305");
+supports("supports import string", "importKey", "ChaCha20-Poly1305");
+supports("supports export string", "exportKey", "ChaCha20-Poly1305");
+supports("supports encrypt string", "encrypt", "ChaCha20-Poly1305");
+supports("supports encrypt iv", "encrypt", { name: "ChaCha20-Poly1305", iv } as any);
+supports("supports decrypt iv", "decrypt", { name: "ChaCha20-Poly1305", iv } as any);
+supports("supports encrypt tag96", "encrypt", { name: "ChaCha20-Poly1305", iv, tagLength: 96 } as any);
+supports("supports encrypt iv8", "encrypt", { name: "ChaCha20-Poly1305", iv: new Uint8Array(8) } as any);
+
+const key = await subtle.generateKey(
+  { name: "ChaCha20-Poly1305", length: 256 } as any,
+  true,
+  ["encrypt", "decrypt"],
+);
+console.log("key:", key.type, key.extractable, JSON.stringify(key.algorithm), key.usages.join(","));
+
+const ciphertext = new Uint8Array(
+  await subtle.encrypt({ name: "ChaCha20-Poly1305", iv, additionalData: aad } as any, key, data),
+);
+console.log("ciphertext len:", ciphertext.length);
+
+const plaintext = await subtle.decrypt(
+  { name: "ChaCha20-Poly1305", iv, additionalData: aad } as any,
+  key,
+  ciphertext,
+);
+console.log("plaintext:", Buffer.from(plaintext).toString());
+
+await rejectName(
+  "wrong aad",
+  subtle.decrypt({ name: "ChaCha20-Poly1305", iv, additionalData: enc.encode("bad") } as any, key, ciphertext),
+);
+await rejectName(
+  "bad tag length",
+  subtle.encrypt({ name: "ChaCha20-Poly1305", iv, tagLength: 96 } as any, key, data),
+);
+
+const wrongKey = await subtle.generateKey("ChaCha20-Poly1305" as any, true, ["decrypt"]);
+await rejectName(
+  "wrong key",
+  subtle.decrypt({ name: "ChaCha20-Poly1305", iv, additionalData: aad } as any, wrongKey, ciphertext),
+);
+
+const limited = await subtle.generateKey("ChaCha20-Poly1305" as any, false, ["encrypt"]);
+console.log("limited:", limited.type, limited.extractable, JSON.stringify(limited.algorithm), limited.usages.join(","));
+await rejectName(
+  "limited decrypt",
+  subtle.decrypt({ name: "ChaCha20-Poly1305", iv } as any, limited, ciphertext),
+);
+await rejectName(
+  "bad usage",
+  subtle.generateKey("ChaCha20-Poly1305" as any, true, ["sign" as any]),
+);
+await rejectName(
+  "empty usages",
+  subtle.generateKey("ChaCha20-Poly1305" as any, true, []),
+);
+
+const jwk = await subtle.exportKey("jwk", key) as JsonWebKey;
+console.log("jwk:", jwk.kty, jwk.alg, typeof jwk.k, Boolean(jwk.k && jwk.k.length > 0));
+const imported = await subtle.importKey("jwk", jwk, "ChaCha20-Poly1305" as any, true, ["encrypt", "decrypt"]);
+console.log("imported:", imported.type, imported.extractable, JSON.stringify(imported.algorithm), imported.usages.join(","));
+const importedCt = await subtle.encrypt({ name: "ChaCha20-Poly1305", iv } as any, imported, data);
+const importedPt = await subtle.decrypt({ name: "ChaCha20-Poly1305", iv } as any, imported, importedCt);
+console.log("imported plaintext:", Buffer.from(importedPt).toString());
+
+await rejectName("raw export", subtle.exportKey("raw", key));
+await rejectName(
+  "raw import",
+  subtle.importKey("raw", new Uint8Array(32), "ChaCha20-Poly1305" as any, true, ["encrypt"]),
+);


### PR DESCRIPTION
## Summary
- add WebCrypto `ChaCha20-Poly1305` secret key generation and CryptoKey metadata
- support `subtle.encrypt()` / `subtle.decrypt()` with 12-byte `iv`, optional `additionalData`, and 128-bit tags
- wire JWK import/export, raw export rejection, `SubtleCrypto.supports()` contexts, and a focused Node parity fixture

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/webcrypto/chacha20-poly1305.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-chacha-check cargo check -p perry-stdlib --no-default-features --features crypto`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH ./run_parity_tests.sh --suite node-suite --module crypto --filter chacha20-poly1305` (report `test-parity/reports/parity_report_20260604_002342.json`)
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH ./run_parity_tests.sh --suite node-suite --module crypto --filter subtle-supports` (report `test-parity/reports/parity_report_20260604_002002.json`)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Note
- `crypto/webcrypto/cryptokey-usages-extractable` still has an unrelated existing mismatch under Node 26: Perry reports `InvalidAccessException` for non-extractable export while Node reports `InvalidAccessError`. I left that to the separate non-extractable WebCrypto work already in flight.