### PR TITLE
[codex] brand value-called TypedArray prototype methods

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1514,11 +1514,12 @@ fn install_typed_array_iterator_symbol(proto_obj: *mut ObjectHeader) {
     if proto_obj.is_null() {
         return;
     }
-    install_proto_method(
+    install_proto_method_with_receiver_brand(
         proto_obj,
         "values",
         global_this_builtin_noop_thunk as *const u8,
         0,
+        "TypedArray",
     );
     unsafe {
         let values_key = crate::string::js_string_from_bytes(b"values".as_ptr(), 6);
@@ -3479,6 +3480,45 @@ fn install_noop_proto_methods(proto_obj: *mut ObjectHeader, methods: &[(&str, u3
     }
 }
 
+fn record_proto_method_receiver_brand(value: f64, brand: &'static str) {
+    let jsv = crate::value::JSValue::from_bits(value.to_bits());
+    if !jsv.is_pointer() {
+        return;
+    }
+    let raw = (value.to_bits() & crate::value::POINTER_MASK) as usize;
+    if raw != 0 {
+        super::native_module::set_builtin_closure_receiver_brand(raw, brand);
+    }
+}
+
+fn install_proto_method_with_receiver_brand(
+    proto_obj: *mut ObjectHeader,
+    method_name: &str,
+    func_ptr: *const u8,
+    arity: u32,
+    brand: &'static str,
+) -> f64 {
+    let value = install_proto_method(proto_obj, method_name, func_ptr, arity);
+    record_proto_method_receiver_brand(value, brand);
+    value
+}
+
+fn install_noop_proto_methods_with_receiver_brand(
+    proto_obj: *mut ObjectHeader,
+    methods: &[(&str, u32)],
+    brand: &'static str,
+) {
+    for (name, arity) in methods.iter().copied() {
+        install_proto_method_with_receiver_brand(
+            proto_obj,
+            name,
+            global_this_builtin_noop_thunk as *const u8,
+            arity,
+            brand,
+        );
+    }
+}
+
 extern "C" fn url_pattern_test_thunk(
     _closure: *const crate::closure::ClosureHeader,
     input: f64,
@@ -4116,7 +4156,7 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
         "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
         | "Int32Array" | "Uint32Array" | "Float16Array" | "Float32Array" | "Float64Array"
         | "BigInt64Array" | "BigUint64Array" => {
-            install_noop_proto_methods(
+            install_noop_proto_methods_with_receiver_brand(
                 proto_obj,
                 &[
                     ("at", 1),
@@ -4151,6 +4191,7 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                     ("values", 0),
                     ("with", 2),
                 ],
+                "TypedArray",
             );
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -380,6 +380,31 @@ pub(crate) fn throw_object_to_locale_string_nullish_receiver() -> ! {
     throw_type_error_message(b"Object.prototype.toLocaleString called on null or undefined")
 }
 
+#[inline]
+fn raw_receiver_addr(value: f64) -> Option<usize> {
+    let bits = value.to_bits();
+    let jsval = JSValue::from_bits(bits);
+    if jsval.is_pointer() {
+        return Some((bits & crate::value::POINTER_MASK) as usize);
+    }
+    if bits >> 48 == 0 && bits > 0x10000 {
+        return Some(bits as usize);
+    }
+    None
+}
+
+fn is_typed_array_or_uint8array_receiver(value: f64) -> bool {
+    let Some(raw) = raw_receiver_addr(value) else {
+        return false;
+    };
+    crate::typedarray::lookup_typed_array_kind(raw).is_some()
+        || crate::buffer::is_registered_buffer(raw)
+}
+
+fn throw_typed_array_incompatible_receiver() -> ! {
+    throw_type_error_message(b"Method %TypedArray%.prototype called on incompatible receiver")
+}
+
 fn throw_object_to_string_not_function() -> ! {
     crate::error::js_throw_type_error_not_a_function(
         std::ptr::null(),
@@ -829,6 +854,13 @@ pub(crate) unsafe fn try_dispatch_value_called_proto_method(
     let name_hdr = crate::builtins::js_string_coerce(name_val);
     let name = super::has_own_helpers::str_from_string_header(name_hdr)?;
     let receiver = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    if matches!(
+        super::native_module::builtin_closure_receiver_brand(closure as usize),
+        Some("TypedArray")
+    ) && !is_typed_array_or_uint8array_receiver(receiver)
+    {
+        throw_typed_array_incompatible_receiver();
+    }
     Some(js_native_call_method(
         receiver,
         name.as_ptr() as *const i8,

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -4597,6 +4597,12 @@ thread_local! {
     /// the spec count. #3143.
     static BUILTIN_CLOSURE_LENGTH: std::cell::RefCell<std::collections::HashMap<usize, u32>> =
         std::cell::RefCell::new(std::collections::HashMap::new());
+
+    /// Internal receiver brand for noop-backed builtin prototype methods.
+    /// This lets reflective calls distinguish same-named methods such as
+    /// `Array.prototype.map` and `Uint8Array.prototype.map`.
+    static BUILTIN_CLOSURE_RECEIVER_BRAND: std::cell::RefCell<std::collections::HashMap<usize, &'static str>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
 /// Record the spec `.length` for a built-in prototype-method closure. See
@@ -4611,6 +4617,16 @@ pub(crate) fn set_builtin_closure_length(closure: usize, length: u32) {
 /// closure, or `None` if this closure isn't one. See [`BUILTIN_CLOSURE_LENGTH`].
 pub(crate) fn builtin_closure_length(closure: usize) -> Option<u32> {
     BUILTIN_CLOSURE_LENGTH.with(|m| m.borrow().get(&closure).copied())
+}
+
+pub(crate) fn set_builtin_closure_receiver_brand(closure: usize, brand: &'static str) {
+    BUILTIN_CLOSURE_RECEIVER_BRAND.with(|m| {
+        m.borrow_mut().insert(closure, brand);
+    });
+}
+
+pub(crate) fn builtin_closure_receiver_brand(closure: usize) -> Option<&'static str> {
+    BUILTIN_CLOSURE_RECEIVER_BRAND.with(|m| m.borrow().get(&closure).copied())
 }
 
 /// Whitelist of (module, property) pairs for which property-read should

--- a/test-parity/node-suite/globals/typedarray-prototype-method-brand.ts
+++ b/test-parity/node-suite/globals/typedarray-prototype-method-brand.ts
@@ -1,0 +1,32 @@
+// %TypedArray%.prototype methods are not generic Array helpers: extracted
+// calls must validate that `this` is a TypedArray receiver.
+
+function show(label: string, fn: () => unknown): void {
+  try {
+    console.log(label + ":", String(fn()));
+  } catch (err) {
+    console.log(label + ":", (err as Error).name);
+  }
+}
+
+const map = Uint16Array.prototype.map;
+const mapped: any = map.call(new Uint16Array([1, 2]), (value: number) => value * 2);
+console.log("map typed:", mapped instanceof Uint16Array, mapped.length);
+show("map array receiver", () => map.call([1, 2] as any, (value: number) => value * 2));
+
+const filter = Int8Array.prototype.filter;
+const filtered: any = filter.call(new Int8Array([-1, 2, 3]), (value: number) => value > 0);
+console.log("filter typed:", filtered instanceof Int8Array, filtered.length);
+show("filter array receiver", () => filter.call([1, 2] as any, (value: number) => value > 1));
+
+const reduce = Float32Array.prototype.reduce;
+console.log(
+  "reduce typed:",
+  reduce.call(new Float32Array([1.5, 2.5]), (acc: number, value: number) => acc + value, 0),
+);
+show("reduce array receiver", () =>
+  reduce.call([1, 2] as any, (acc: number, value: number) => acc + value, 0)
+);
+
+const generic = Array.prototype.map.call({ 0: 3, 1: 4, length: 2 }, (value: number) => value + 1);
+console.log("array prototype generic:", generic.join("|"));


### PR DESCRIPTION
## Summary
- tracks an internal receiver brand for noop-backed `%TypedArray%.prototype` method closures
- rejects extracted TypedArray prototype calls on plain-array receivers while preserving valid TypedArray and Buffer/Uint8Array receivers
- adds a Node parity fixture covering extracted `map`/`filter`/`reduce` and a control for generic `Array.prototype.map` borrowing

## Why
The TypedArray prototype methods are installed through the same noop-backed native closure path as Array methods. When a method like `Uint16Array.prototype.map` is extracted and invoked with `.call(...)`, the runtime redispatch could treat it like the same-named Array helper and accept a plain array receiver. Node requires these `%TypedArray%.prototype` methods to brand-check their receiver first.

Refs #4315.

## Validation
- Node 26 oracle for `test-parity/node-suite/globals/typedarray-prototype-method-brand.ts`
- direct Perry release run of `test-parity/node-suite/globals/typedarray-prototype-method-brand.ts`
- `./run_parity_tests.sh --suite node-suite --module globals --filter typedarray-prototype-method-brand`
- `./run_parity_tests.sh --suite node-suite --module globals --filter typedarray`
- `cargo fmt --all --check`
- `cargo check -p perry-runtime`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `git diff --check`
- `./scripts/check_file_size.sh`
