### PR TITLE
fix(console): skip sparse table holes

### DIFF
--- a/crates/perry-runtime/src/builtins/table.rs
+++ b/crates/perry-runtime/src/builtins/table.rs
@@ -465,7 +465,9 @@ pub extern "C" fn js_console_table_with_properties(value: f64, properties: f64) 
                 let mut rows: Vec<Vec<String>> = Vec::with_capacity(length);
                 for i in 0..length {
                     let elem = *data_ptr.add(i);
-                    if JSValue::from_bits(elem.to_bits()).is_undefined() {
+                    if elem.to_bits() == crate::value::TAG_HOLE
+                        || JSValue::from_bits(elem.to_bits()).is_undefined()
+                    {
                         continue;
                     }
                     rows.push(vec![i.to_string(), format_table_cell(elem)]);


### PR DESCRIPTION
## Summary
- skip raw sparse-array hole slots in primitive-array console.table rows
- keep holes out of the rendered table instead of formatting the sentinel as NaN

## Root Cause
The primitive-array console.table path iterated raw array storage. Sparse holes are stored as Perry's internal hole sentinel, which then reached cell formatting and printed as NaN instead of being treated as an absent element.

## Validation
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module console --filter sparse-array'` -> 1 pass / 0 fail
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module console --filter table'` -> 12 pass / 0 fail
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module console'` -> 117 pass / 2 fail; remaining failures are pre-existing non-table cases: method-binding and proxy-getters
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-node-current-main-scan-20260603b cargo check -p perry-runtime` -> pass with existing warnings
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Refs #812