### PR TITLE
[codex] route dynamic TypedArray index access

### DIFF
--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -42,6 +42,16 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
     if raw_ptr < 0x10000 {
         return f64::from_bits(TAG_UNDEFINED);
     }
+    // TypedArrays carry element-typed storage, not boxed ArrayHeader slots.
+    // Probe the registry before any GC-header or raw ArrayHeader fallback so
+    // values whose static type was erased by callback methods still read via
+    // the per-kind accessor (`Uint16Array#map(...)[0]`, `(ta as any)[0]`).
+    if crate::typedarray::lookup_typed_array_kind(raw_ptr).is_some() {
+        return crate::typedarray::js_typed_array_index_get_dynamic(
+            raw_ptr as *const crate::typedarray::TypedArrayHeader,
+            index,
+        );
+    }
     // Issue #63 / #321 (Effect.runSync→fork SIGBUS): the raw-I64 fallback
     // above accepts arbitrary in-range bits — including denormal f64
     // payloads from non-pointer dataflow (e.g. effect's fiberRefs.ts loop
@@ -206,6 +216,19 @@ pub extern "C" fn js_dyn_index_set(obj: f64, index: f64, value: f64) -> f64 {
         return value;
     };
     if raw_ptr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return value;
+    }
+    if crate::typedarray::lookup_typed_array_kind(raw_ptr).is_some() {
+        if index.is_finite() {
+            let idx_i32 = index as i32;
+            if idx_i32 >= 0 && index == idx_i32 as f64 {
+                crate::typedarray::js_typed_array_set(
+                    raw_ptr as *mut crate::typedarray::TypedArrayHeader,
+                    idx_i32,
+                    value,
+                );
+            }
+        }
         return value;
     }
     // Mirror the #63/#321 guard on the get side: heuristic-derived

--- a/test-parity/node-suite/globals/typedarray-callback-result-indexes.ts
+++ b/test-parity/node-suite/globals/typedarray-callback-result-indexes.ts
@@ -1,0 +1,22 @@
+// TypedArray callback methods return TypedArrays with element-typed storage.
+// Index reads on the result must use the TypedArray accessor even when the
+// static type has been erased by the callback-method lowering.
+
+const mapped = new Uint16Array([1, 2]).map((value) => value * 2);
+console.log("map instance:", mapped instanceof Uint16Array);
+console.log("map indexes:", mapped[0], mapped[1]);
+const mappedAny: any = mapped;
+console.log("map any indexes:", mappedAny[0], mappedAny[1]);
+console.log("map from:", Array.from(mapped).join("|"));
+
+const filtered = new Int8Array([-1, 2, 3]).filter((value) => value > 0);
+console.log("filter instance:", filtered instanceof Int8Array);
+console.log("filter indexes:", filtered[0], filtered[1]);
+const filteredAny: any = filtered;
+console.log("filter any indexes:", filteredAny[0], filteredAny[1]);
+console.log("filter from:", Array.from(filtered).join("|"));
+
+const clampedAny: any = new Uint8ClampedArray([1, 2]);
+clampedAny[0] = 300;
+clampedAny[1] = -5;
+console.log("dynamic set clamp:", clampedAny[0], clampedAny[1], Array.from(clampedAny).join("|"));


### PR DESCRIPTION
Refs #4315.

## Summary
- route dynamic index reads on registered TypedArrays through the per-kind TypedArray accessor before the raw ArrayHeader fallback
- route dynamic numeric index writes on registered TypedArrays through the TypedArray setter so conversions and clamping are preserved
- add a parity fixture covering `map`/`filter` callback results, erased `any` indexing, and `Uint8ClampedArray` dynamic write coercion

## Validation
- Node 26 oracle for `test-parity/node-suite/globals/typedarray-callback-result-indexes.ts`
- direct Perry release run of `test-parity/node-suite/globals/typedarray-callback-result-indexes.ts`
- `./run_parity_tests.sh --suite node-suite --module globals --filter typedarray-callback-result-indexes`
- `./run_parity_tests.sh --suite node-suite --module globals --filter typedarray`
- `cargo fmt --all --check`
- `cargo check -p perry-runtime`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `git diff --check`
- `./scripts/check_file_size.sh`
