### PR TITLE
fix(crypto): add WebCrypto KMAC support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,6 +3777,15 @@ dependencies = [
 
 [[package]]
 name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
@@ -5753,7 +5762,9 @@ dependencies = [
  "sha1 0.10.6",
  "sha1 0.11.0",
  "sha2 0.11.0",
- "sha3",
+ "sha3 0.10.9",
+ "sha3 0.11.0",
+ "sha3-utils",
  "spki",
  "sqlx",
  "thiserror 1.0.69",
@@ -7437,12 +7448,31 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3-utils"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e0bf98cc082cbe077f06a707c94ca15796d046cc4cd2593167b5730a6727be"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -103,7 +103,7 @@ thread_local! {
     ///       12 RSASSA-PKCS1-v1_5, 13 RSA-OAEP, 14 RSA-PSS,
     ///       15 ECDSA P-384, 16 ECDH P-384, 17 ECDSA P-521,
     ///       18 ECDH P-521, 19 Argon2d, 20 Argon2i, 21 Argon2id,
-    ///       22 ChaCha20-Poly1305
+    ///       22 ChaCha20-Poly1305, 23 KMAC128, 24 KMAC256
     /// hash: 1 SHA-1, 2 SHA-256, 3 SHA-384, 4 SHA-512
     /// kind: 1 secret, 2 private, 3 public
     /// extractable: WebCrypto CryptoKey.extractable
@@ -370,6 +370,7 @@ fn default_crypto_key_usages(algo: u8, kind: u8) -> u32 {
 
     match (algo, kind) {
         (1, 1) => SIGN | VERIFY,
+        (23 | 24, 1) => SIGN | VERIFY,
         (2 | 4 | 5 | 22, 1) => ENCRYPT | DECRYPT | WRAP_KEY | UNWRAP_KEY,
         (3, 1) => WRAP_KEY | UNWRAP_KEY,
         (6 | 7 | 19 | 20 | 21, 1) => DERIVE_KEY | DERIVE_BITS,

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -287,6 +287,8 @@ unsafe fn secret_to_crypto_key(addr: usize, algorithm_bits: f64) -> f64 {
         "HKDF" => 6,
         "PBKDF2" => 7,
         "CHACHA20-POLY1305" => 15,
+        "KMAC128" => 23,
+        "KMAC256" => 24,
         _ => return f64::from_bits(JSValue::undefined().bits()),
     };
     let hash_name = object_field_string_value(algorithm_bits, b"hash")

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -88,6 +88,8 @@ fn crypto_key_algorithm_name(algo: u8) -> &'static str {
         20 => "Argon2i",
         21 => "Argon2id",
         22 => "ChaCha20-Poly1305",
+        23 => "KMAC128",
+        24 => "KMAC256",
         _ => "",
     }
 }
@@ -106,7 +108,7 @@ fn crypto_key_algorithm_has_hash(algo: u8) -> bool {
 }
 
 fn crypto_key_algorithm_has_length(algo: u8) -> bool {
-    matches!(algo, 1 | 2 | 3 | 4 | 5)
+    matches!(algo, 1 | 2 | 3 | 4 | 5 | 21 | 22)
 }
 
 fn crypto_key_named_curve(algo: u8) -> Option<&'static str> {

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -219,7 +219,7 @@ bundled-mongodb = ["dep:mongodb", "dep:bson", "dep:futures-util", "async-runtime
 # bindings so the well-known flip (#466 Phase 4 step 2) can route them
 # to perry-ext-bcrypt / perry-ext-argon2 without taking the rest of
 # the crypto surface offline.
-crypto = ["dep:sha2", "dep:sha1", "dep:sha3", "dep:rsa-sha1", "dep:md-5", "dep:hex", "dep:hmac", "dep:aes", "dep:cbc", "dep:ecb", "dep:ctr", "dep:scrypt", "dep:pbkdf2", "dep:base64", "dep:x25519-dalek", "dep:ed25519-dalek", "dep:aes-gcm", "dep:chacha20poly1305", "dep:ghash", "dep:aes-kw", "dep:hkdf", "dep:p256", "dep:p384", "dep:p521", "dep:x509-cert", "async-runtime", "ids", "bundled-bcrypt", "bundled-argon2", "bundled-jsonwebtoken", "bundled-ethers"]
+crypto = ["dep:sha2", "dep:sha1", "dep:sha3", "dep:sha3_010", "dep:sha3-utils", "dep:rsa-sha1", "dep:md-5", "dep:hex", "dep:hmac", "dep:aes", "dep:cbc", "dep:ecb", "dep:ctr", "dep:scrypt", "dep:pbkdf2", "dep:base64", "dep:x25519-dalek", "dep:ed25519-dalek", "dep:aes-gcm", "dep:chacha20poly1305", "dep:ghash", "dep:aes-kw", "dep:hkdf", "dep:p256", "dep:p384", "dep:p521", "dep:x509-cert", "async-runtime", "ids", "bundled-bcrypt", "bundled-argon2", "bundled-jsonwebtoken", "bundled-ethers"]
 bundled-bcrypt = ["dep:bcrypt", "async-runtime"]
 bundled-argon2 = ["dep:argon2", "async-runtime"]
 bundled-jsonwebtoken = ["dep:jsonwebtoken", "dep:p256", "dep:rsa", "dep:spki"]
@@ -358,6 +358,8 @@ rusqlite = { version = "0.32.1", features = ["bundled", "column_decltype", "limi
 sha2 = { version = "0.11", optional = true }
 sha1 = { version = "0.11", optional = true }
 sha3 = { version = "0.11", optional = true }
+sha3_010 = { package = "sha3", version = "0.10", optional = true, default-features = false }
+sha3-utils = { version = "0.5", optional = true }
 rsa-sha1 = { package = "sha1", version = "0.10", optional = true }
 md-5 = { version = "0.11", optional = true }
 hex = { version = "0.4", optional = true }

--- a/crates/perry-stdlib/src/webcrypto/hmac.rs
+++ b/crates/perry-stdlib/src/webcrypto/hmac.rs
@@ -43,6 +43,39 @@ pub unsafe extern "C" fn js_webcrypto_sign(
             Some(s) => s,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
         }
+    } else if algo_upper == "KMAC128" || algo_upper == "KMAC256" {
+        let key_algo = if algo_upper == "KMAC128" {
+            KeyAlgo::Kmac128
+        } else {
+            KeyAlgo::Kmac256
+        };
+        if mat.algo != key_algo || mat.kind != KeyKind::Secret {
+            return reject_with_dom_exception(
+                "InvalidAccessError",
+                "Unable to use this key to sign",
+            );
+        }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_SIGN, "Unable to use this key to sign")
+        {
+            return reject_with_dom_exception(name, message);
+        }
+        let output_length = match kmac_output_length(algo_bits.to_bits()) {
+            Ok(length) => length,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
+        let customization =
+            object_field_bytes(algo_bits.to_bits(), b"customization").unwrap_or_else(Vec::new);
+        match compute_kmac(
+            key_algo,
+            &key_bytes,
+            &customization,
+            &data_bytes,
+            output_length,
+        ) {
+            Some(s) => s,
+            None => return reject_with_dom_exception("OperationError", "The operation failed"),
+        }
     } else if algo_upper == "ECDSA" {
         if !is_ecdsa_key_algo(mat.algo) || mat.kind != KeyKind::Private {
             return reject_with_dom_exception(
@@ -195,6 +228,43 @@ pub unsafe extern "C" fn js_webcrypto_verify(
             return reject_with_dom_exception(name, message);
         }
         let expected_sig = match compute_hmac(mat.hash, &key_bytes, &data_bytes) {
+            Some(s) => s,
+            None => return reject_with_dom_exception("OperationError", "The operation failed"),
+        };
+        constant_time_eq(&expected_sig, &provided_sig)
+    } else if algo_upper == "KMAC128" || algo_upper == "KMAC256" {
+        let key_algo = if algo_upper == "KMAC128" {
+            KeyAlgo::Kmac128
+        } else {
+            KeyAlgo::Kmac256
+        };
+        if mat.algo != key_algo || mat.kind != KeyKind::Secret {
+            return reject_with_dom_exception(
+                "InvalidAccessError",
+                "Unable to use this key to verify",
+            );
+        }
+        if let Err((name, message)) =
+            require_usage(mat, USAGE_VERIFY, "Unable to use this key to verify")
+        {
+            return reject_with_dom_exception(name, message);
+        }
+        let output_length = match kmac_output_length(algo_bits.to_bits()) {
+            Ok(length) => length,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
+        if output_length == 0 {
+            return resolve_with_bool(false);
+        }
+        let customization =
+            object_field_bytes(algo_bits.to_bits(), b"customization").unwrap_or_else(Vec::new);
+        let expected_sig = match compute_kmac(
+            key_algo,
+            &key_bytes,
+            &customization,
+            &data_bytes,
+            output_length,
+        ) {
             Some(s) => s,
             None => return reject_with_dom_exception("OperationError", "The operation failed"),
         };
@@ -362,6 +432,16 @@ pub(super) fn number_from_bits(bits: u64) -> Option<u32> {
     } else {
         None
     }
+}
+
+unsafe fn kmac_output_length(algo_bits: u64) -> Result<u32, (&'static str, &'static str)> {
+    let Some(length) = object_field_number(algo_bits, b"outputLength") else {
+        return Err(("TypeError", "KmacParams.outputLength is required"));
+    };
+    if length % 8 != 0 {
+        return Err(("NotSupportedError", "Unsupported KmacParams outputLength"));
+    }
+    Ok(length)
 }
 
 pub(super) unsafe fn ecdh_shared_secret_bytes(

--- a/crates/perry-stdlib/src/webcrypto/jwk.rs
+++ b/crates/perry-stdlib/src/webcrypto/jwk.rs
@@ -46,6 +46,14 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
         }
     };
     let algo_upper = algo_name.to_ascii_uppercase();
+    if (algo_upper == "KMAC128" || algo_upper == "KMAC256") && format_lower == "raw" {
+        let message = if algo_upper == "KMAC128" {
+            "Unable to import KMAC128 using raw format"
+        } else {
+            "Unable to import KMAC256 using raw format"
+        };
+        return reject_with_dom_exception("NotSupportedError", message);
+    }
     let (key_algo, hash, kind) = if algo_upper == "HMAC"
         && (format_lower == "raw" || format_lower == "jwk")
     {
@@ -77,6 +85,10 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
             return reject_with_dom_exception("SyntaxError", message);
         }
         (argon_algo, HashAlgo::Sha256, KeyKind::Secret)
+    } else if algo_upper == "KMAC128" && format_lower == "jwk" {
+        (KeyAlgo::Kmac128, HashAlgo::Sha256, KeyKind::Secret)
+    } else if algo_upper == "KMAC256" && format_lower == "jwk" {
+        (KeyAlgo::Kmac256, HashAlgo::Sha256, KeyKind::Secret)
     } else if algo_upper == "AES-GCM" && (format_lower == "raw" || format_lower == "jwk") {
         // AES-GCM: 128, 192, or 256-bit keys. We accept any length
         // here and let encrypt/decrypt fail loudly on mismatch.
@@ -176,6 +188,8 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
         KeyAlgo::Argon2d => "Unsupported key usage for a Argon2d key",
         KeyAlgo::Argon2i => "Unsupported key usage for a Argon2i key",
         KeyAlgo::Argon2id => "Unsupported key usage for a Argon2id key",
+        KeyAlgo::Kmac128 => "Unsupported key usage for KMAC128 key",
+        KeyAlgo::Kmac256 => "Unsupported key usage for KMAC256 key",
         _ => "Unsupported key usage for the requested algorithm",
     };
     let usages = match validate_key_usages(
@@ -197,6 +211,9 @@ pub unsafe extern "C" fn js_webcrypto_import_key(
     };
     if key_algo == KeyAlgo::ChaCha20Poly1305 && key_bytes.len() != 32 {
         return reject_with_dom_exception("DataError", "Invalid key length");
+    }
+    if key_bytes.is_empty() && matches!(key_algo, KeyAlgo::Kmac128 | KeyAlgo::Kmac256) {
+        return reject_with_dom_exception("DataError", "Zero-length key is not supported");
     }
     if key_bytes.is_empty()
         && !matches!(
@@ -312,6 +329,15 @@ pub unsafe extern "C" fn js_webcrypto_export_key(format_bits: f64, key_bits: f64
     if format_lower == "raw" && mat.kind == KeyKind::Private {
         return reject_with_dom_exception("OperationError", "The operation failed");
     }
+    if format_lower == "raw" && matches!(mat.algo, KeyAlgo::Kmac128 | KeyAlgo::Kmac256) {
+        let name = if mat.algo == KeyAlgo::Kmac128 {
+            "KMAC128"
+        } else {
+            "KMAC256"
+        };
+        let message = format!("Unable to export {name} secret key using raw format");
+        return reject_with_dom_exception("NotSupportedError", &message);
+    }
     if format_lower == "jwk"
         && mat.kind != KeyKind::Secret
         && !matches!(
@@ -348,14 +374,15 @@ pub unsafe extern "C" fn js_webcrypto_export_key(format_bits: f64, key_bits: f64
     if format_lower == "jwk" {
         if mat.kind == KeyKind::Secret {
             let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&key_bytes);
-            let obj = js_object_alloc(
-                0,
-                if mat.algo == KeyAlgo::ChaCha20Poly1305 {
-                    3
-                } else {
-                    2
-                },
-            );
+            let field_count = if matches!(
+                mat.algo,
+                KeyAlgo::ChaCha20Poly1305 | KeyAlgo::Kmac128 | KeyAlgo::Kmac256
+            ) {
+                3
+            } else {
+                2
+            };
+            let obj = js_object_alloc(0, field_count);
             if obj.is_null() {
                 return reject_with_dom_exception("OperationError", "The operation failed");
             }
@@ -364,6 +391,11 @@ pub unsafe extern "C" fn js_webcrypto_export_key(format_bits: f64, key_bits: f64
                 set_object_string_field(obj, b"alg", "C20P");
             }
             set_object_string_field(obj, b"k", &encoded);
+            if mat.algo == KeyAlgo::Kmac128 {
+                set_object_string_field(obj, b"alg", "K128");
+            } else if mat.algo == KeyAlgo::Kmac256 {
+                set_object_string_field(obj, b"alg", "K256");
+            }
             return resolve_with_bits(JSValue::pointer(obj as *const u8).bits());
         }
         if matches!(
@@ -512,6 +544,8 @@ pub(super) unsafe fn jwk_import_key_bytes(
     if matches!(
         key_algo,
         KeyAlgo::Hmac
+            | KeyAlgo::Kmac128
+            | KeyAlgo::Kmac256
             | KeyAlgo::AesGcm
             | KeyAlgo::AesKw
             | KeyAlgo::AesCbc
@@ -520,6 +554,18 @@ pub(super) unsafe fn jwk_import_key_bytes(
     ) {
         if kty != "oct" {
             return None;
+        }
+        if let Some(alg) = object_field_string(obj_bits, b"alg") {
+            let expected_alg = match key_algo {
+                KeyAlgo::Kmac128 => Some("K128"),
+                KeyAlgo::Kmac256 => Some("K256"),
+                _ => None,
+            };
+            if let Some(expected) = expected_alg {
+                if alg != expected {
+                    return None;
+                }
+            }
         }
         let k = object_field_string(obj_bits, b"k")?;
         return base64::engine::general_purpose::URL_SAFE_NO_PAD

--- a/crates/perry-stdlib/src/webcrypto/keys.rs
+++ b/crates/perry-stdlib/src/webcrypto/keys.rs
@@ -421,6 +421,70 @@ pub unsafe extern "C" fn js_webcrypto_generate_key(
         return resolve_with_bits(JSValue::pointer(buf as *const u8).bits());
     }
 
+    if algo_upper == "KMAC128" || algo_upper == "KMAC256" {
+        let key_algo = if algo_upper == "KMAC128" {
+            KeyAlgo::Kmac128
+        } else {
+            KeyAlgo::Kmac256
+        };
+        let bad_message = if key_algo == KeyAlgo::Kmac128 {
+            "Unsupported key usage for KMAC128 key"
+        } else {
+            "Unsupported key usage for KMAC256 key"
+        };
+        let usages = match validate_key_usages(
+            key_algo,
+            KeyKind::Secret,
+            usages_bits.to_bits(),
+            false,
+            "Usages cannot be empty when creating a key.",
+            bad_message,
+        ) {
+            Ok(u) => u,
+            Err((name, message)) => return reject_with_dom_exception(name, message),
+        };
+        let default_length = if key_algo == KeyAlgo::Kmac128 {
+            128
+        } else {
+            256
+        };
+        let bit_len = if string_from_jsvalue(algo_bits.to_bits()).is_some() {
+            default_length
+        } else {
+            object_field_number(algo_bits.to_bits(), b"length").unwrap_or(default_length)
+        };
+        if bit_len == 0 {
+            return reject_with_dom_exception(
+                "OperationError",
+                "KmacKeyGenParams.length cannot be 0",
+            );
+        }
+        if bit_len % 8 != 0 {
+            return reject_with_dom_exception(
+                "NotSupportedError",
+                "Unsupported KmacKeyGenParams.length",
+            );
+        }
+        let mut key_bytes = vec![0u8; (bit_len / 8) as usize];
+        use rand::RngCore;
+        rand::rngs::OsRng.fill_bytes(&mut key_bytes);
+        let buf = alloc_uint8array_from_slice(&key_bytes);
+        if buf.is_null() {
+            return reject_with_dom_exception("OperationError", "The operation failed");
+        }
+        register_crypto_key(
+            buf as usize,
+            CryptoKeyMaterial::new(
+                key_algo,
+                HashAlgo::Sha256,
+                KeyKind::Secret,
+                extractable,
+                usages,
+            ),
+        );
+        return resolve_with_bits(JSValue::pointer(buf as *const u8).bits());
+    }
+
     if algo_upper != "AES-GCM"
         && algo_upper != "AES-KW"
         && algo_upper != "AES-CBC"

--- a/crates/perry-stdlib/src/webcrypto/supports.rs
+++ b/crates/perry-stdlib/src/webcrypto/supports.rs
@@ -26,7 +26,7 @@ unsafe fn algorithm_curve(bits: u64) -> Option<String> {
 unsafe fn supports_generate_key(algorithm_bits: u64, algorithm: &str) -> bool {
     let object_form = algorithm_is_object(algorithm_bits);
     match algorithm {
-        "ED25519" | "X25519" => true,
+        "ED25519" | "X25519" | "KMAC128" | "KMAC256" => true,
         "CHACHA20-POLY1305" => true,
         "HMAC" | "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" => object_form,
         "ECDSA" | "ECDH" => {
@@ -43,7 +43,7 @@ unsafe fn supports_generate_key(algorithm_bits: u64, algorithm: &str) -> bool {
 unsafe fn supports_import_key(algorithm_bits: u64, algorithm: &str) -> bool {
     match algorithm {
         "AES-GCM" | "AES-CBC" | "AES-CTR" | "AES-KW" | "CHACHA20-POLY1305" | "PBKDF2" | "HKDF"
-        | "ARGON2D" | "ARGON2I" | "ARGON2ID" | "ED25519" | "X25519" => true,
+        | "ARGON2D" | "ARGON2I" | "ARGON2ID" | "ED25519" | "X25519" | "KMAC128" | "KMAC256" => true,
         "HMAC" => algorithm_is_object(algorithm_bits),
         "ECDSA" | "ECDH" => algorithm_curve(algorithm_bits)
             .as_deref()
@@ -67,6 +67,8 @@ fn supports_export_key(algorithm: &str) -> bool {
             | "ECDH"
             | "ED25519"
             | "X25519"
+            | "KMAC128"
+            | "KMAC256"
             | "RSA-OAEP"
             | "RSA-PSS"
             | "RSASSA-PKCS1-V1_5"

--- a/crates/perry-stdlib/src/webcrypto/util.rs
+++ b/crates/perry-stdlib/src/webcrypto/util.rs
@@ -123,6 +123,8 @@ pub(super) enum KeyAlgo {
     RsaOaep,
     RsassaPkcs1,
     RsaPss,
+    Kmac128,
+    Kmac256,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -299,6 +301,8 @@ fn runtime_algo_id(algo: KeyAlgo) -> u8 {
         KeyAlgo::Argon2i => 20,
         KeyAlgo::Argon2id => 21,
         KeyAlgo::ChaCha20Poly1305 => 22,
+        KeyAlgo::Kmac128 => 23,
+        KeyAlgo::Kmac256 => 24,
     }
 }
 
@@ -351,6 +355,8 @@ pub(super) fn lookup_crypto_key(buf_addr: usize) -> Option<CryptoKeyMaterial> {
                 20 => KeyAlgo::Argon2i,
                 21 => KeyAlgo::Argon2id,
                 22 => KeyAlgo::ChaCha20Poly1305,
+                23 => KeyAlgo::Kmac128,
+                24 => KeyAlgo::Kmac256,
                 _ => return None,
             };
             let hash = match hash {
@@ -558,6 +564,7 @@ pub(super) fn argon2_key_algo(name: &str) -> Option<KeyAlgo> {
 pub(super) fn supported_usages(algo: KeyAlgo, kind: KeyKind) -> u32 {
     match (algo, kind) {
         (KeyAlgo::Hmac, KeyKind::Secret) => USAGE_SIGN | USAGE_VERIFY,
+        (KeyAlgo::Kmac128 | KeyAlgo::Kmac256, KeyKind::Secret) => USAGE_SIGN | USAGE_VERIFY,
         (
             KeyAlgo::AesGcm | KeyAlgo::AesCbc | KeyAlgo::AesCtr | KeyAlgo::ChaCha20Poly1305,
             KeyKind::Secret,
@@ -757,6 +764,59 @@ pub(super) fn compute_hmac(hash: HashAlgo, key: &[u8], data: &[u8]) -> Option<Ve
             Some(mac.finalize().into_bytes().to_vec())
         }
     }
+}
+
+pub(super) fn compute_kmac(
+    algo: KeyAlgo,
+    key: &[u8],
+    customization: &[u8],
+    data: &[u8],
+    output_bits: u32,
+) -> Option<Vec<u8>> {
+    if output_bits % 8 != 0 {
+        return None;
+    }
+    let mut out = vec![0u8; (output_bits / 8) as usize];
+    match algo {
+        KeyAlgo::Kmac128 => {
+            use sha3_010::digest::{core_api::CoreProxy, ExtendableOutput, Update, XofReader};
+            let core = <sha3_010::CShake128 as CoreProxy>::Core::new_with_function_name(
+                b"KMAC",
+                customization,
+            );
+            let mut cshake = sha3_010::CShake128::from_core(core);
+            for item in sha3_utils::bytepad::<168, _>([sha3_utils::encode_string(key)]) {
+                Update::update(&mut cshake, item.as_bytes());
+            }
+            Update::update(&mut cshake, data);
+            Update::update(
+                &mut cshake,
+                sha3_utils::right_encode(output_bits as usize).as_bytes(),
+            );
+            let mut reader = cshake.finalize_xof();
+            XofReader::read(&mut reader, &mut out);
+        }
+        KeyAlgo::Kmac256 => {
+            use sha3_010::digest::{core_api::CoreProxy, ExtendableOutput, Update, XofReader};
+            let core = <sha3_010::CShake256 as CoreProxy>::Core::new_with_function_name(
+                b"KMAC",
+                customization,
+            );
+            let mut cshake = sha3_010::CShake256::from_core(core);
+            for item in sha3_utils::bytepad::<136, _>([sha3_utils::encode_string(key)]) {
+                Update::update(&mut cshake, item.as_bytes());
+            }
+            Update::update(&mut cshake, data);
+            Update::update(
+                &mut cshake,
+                sha3_utils::right_encode(output_bits as usize).as_bytes(),
+            );
+            let mut reader = cshake.finalize_xof();
+            XofReader::read(&mut reader, &mut out);
+        }
+        _ => return None,
+    }
+    Some(out)
 }
 
 pub(super) fn generate_p256_signing_key() -> Option<P256EcdsaSigningKey> {

--- a/test-parity/node-suite/crypto/webcrypto/kmac.ts
+++ b/test-parity/node-suite/crypto/webcrypto/kmac.ts
@@ -1,0 +1,104 @@
+import * as crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+(process as any).emitWarning = () => undefined;
+
+const data = new TextEncoder().encode("kmac payload");
+
+function b64u(bytes: number[]) {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+async function logReject(label: string, promise: Promise<unknown>) {
+  let rejected = false;
+  let name = "";
+  try {
+    await promise;
+  } catch (error: any) {
+    rejected = true;
+    name = error?.name ?? "";
+  }
+  console.log(`${label}:`, rejected, name);
+}
+
+async function logKmac(label: string, algorithm: any, key: CryptoKey, payload = data) {
+  const sig = await crypto.subtle.sign(algorithm, key, payload);
+  console.log(`${label} len:`, Buffer.from(sig).length);
+  console.log(`${label} hex:`, Buffer.from(sig).toString("hex"));
+  console.log(`${label} verify ok:`, await crypto.subtle.verify(algorithm, key, sig, payload));
+  console.log(
+    `${label} verify bad data:`,
+    await crypto.subtle.verify(algorithm, key, sig, new TextEncoder().encode("bad payload")),
+  );
+  return sig;
+}
+
+async function main() {
+  for (const op of ["generateKey", "importKey", "exportKey", "sign", "verify"] as const) {
+    console.log(`supports ${op} KMAC128:`, SubtleCrypto.supports(op, "KMAC128"));
+    console.log(`supports ${op} KMAC256:`, SubtleCrypto.supports(op, "KMAC256"));
+  }
+
+  const generated128 = await crypto.subtle.generateKey({ name: "KMAC128", length: 16 }, true, ["sign", "verify"]);
+  console.log(
+    "generated128:",
+    generated128.type,
+    generated128.algorithm.name,
+    (generated128.algorithm as any).length,
+    generated128.extractable,
+    generated128.usages.join(","),
+  );
+
+  const generated256 = await crypto.subtle.generateKey("KMAC256", false, ["sign"]);
+  console.log(
+    "generated256:",
+    generated256.type,
+    generated256.algorithm.name,
+    (generated256.algorithm as any).length,
+    generated256.extractable,
+    generated256.usages.join(","),
+  );
+
+  const jwk128 = {
+    kty: "oct",
+    alg: "K128",
+    k: b64u([1, 2, 3, 4, 5, 6, 7, 8]),
+    ext: true,
+    key_ops: ["sign", "verify"],
+  };
+  const key128 = await crypto.subtle.importKey("jwk", jwk128, "KMAC128", true, ["sign", "verify"]);
+  const exported128: any = await crypto.subtle.exportKey("jwk", key128);
+  console.log("jwk128 key:", key128.type, key128.algorithm.name, (key128.algorithm as any).length, key128.usages.join(","));
+  console.log("jwk128 export:", exported128.kty, exported128.alg, exported128.k === jwk128.k);
+  await logKmac("kmac128", { name: "KMAC128", outputLength: 128 }, key128);
+  await logKmac("kmac128 custom", { name: "KMAC128", outputLength: 64, customization: new Uint8Array([1, 2, 3]) }, key128);
+
+  const jwk256 = {
+    kty: "oct",
+    alg: "K256",
+    k: b64u([9, 8, 7, 6, 5, 4, 3, 2, 1]),
+    ext: true,
+    key_ops: ["sign", "verify"],
+  };
+  const key256 = await crypto.subtle.importKey("jwk", jwk256, "KMAC256", true, ["sign", "verify"]);
+  const exported256: any = await crypto.subtle.exportKey("jwk", key256);
+  console.log("jwk256 key:", key256.type, key256.algorithm.name, (key256.algorithm as any).length, key256.usages.join(","));
+  console.log("jwk256 export:", exported256.kty, exported256.alg, exported256.k === jwk256.k);
+  await logKmac("kmac256", { name: "KMAC256", outputLength: 256 }, key256);
+  await logKmac("kmac256 custom", { name: "KMAC256", outputLength: 128, customization: new Uint8Array([4, 5]) }, key256);
+
+  const emptySig = await crypto.subtle.sign({ name: "KMAC128", outputLength: 0 }, key128, data);
+  console.log("kmac128 zero len:", Buffer.from(emptySig).length);
+  console.log("kmac128 zero verify:", await crypto.subtle.verify({ name: "KMAC128", outputLength: 0 }, key128, emptySig, data));
+
+  await logReject("kmac128 raw import", crypto.subtle.importKey("raw", new Uint8Array(8), "KMAC128", true, ["sign"]));
+  await logReject("kmac256 raw import", crypto.subtle.importKey("raw", new Uint8Array(8), "KMAC256", true, ["sign"]));
+  await logReject("kmac128 raw export", crypto.subtle.exportKey("raw", key128));
+  await logReject("kmac128 empty usages", crypto.subtle.generateKey("KMAC128", true, []));
+  await logReject("kmac128 bad usage", crypto.subtle.generateKey("KMAC128", true, ["encrypt" as any]));
+  await logReject("kmac128 bad key length", crypto.subtle.generateKey({ name: "KMAC128", length: 7 }, true, ["sign"]));
+  await logReject("kmac128 zero key", crypto.subtle.importKey("jwk", { kty: "oct", alg: "K128", k: "", ext: true, key_ops: ["sign"] }, "KMAC128", true, ["sign"]));
+  await logReject("kmac128 bad output", crypto.subtle.sign({ name: "KMAC128", outputLength: 7 }, key128, data));
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add WebCrypto KMAC128/KMAC256 secret CryptoKey metadata, generation, JWK import/export, and raw-format rejection
- implement KMAC sign/verify with outputLength and optional customization using cSHAKE/SP800-185 encoding
- add Node 26 parity coverage for supports(), metadata, deterministic JWK vectors, validation, and raw/JWK behavior

Part of #2518.

## Validation
- npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/crypto/webcrypto/kmac.ts
- CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-webcrypto-kmac-check cargo check -p perry-stdlib --no-default-features --features crypto
- PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter kmac
- PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" ./run_parity_tests.sh --suite node-suite --module crypto --filter subtle-supports
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh