### PR TITLE
fix(util): wrap default proxy inspection

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -1084,11 +1084,12 @@ unsafe fn format_buffer_value(buf_ptr: *const crate::buffer::BufferHeader) -> St
 fn format_proxy_value(value: f64, depth: usize, json: bool) -> String {
     let target = crate::proxy::js_proxy_target(value);
     if !inspect_show_proxy() {
-        return if json {
+        let target_str = if json {
             format_jsvalue_for_json(target, depth)
         } else {
             format_jsvalue(target, depth)
         };
+        return format!("Proxy({target_str})");
     }
 
     let handler = crate::proxy::js_proxy_handler(value);


### PR DESCRIPTION
## Summary
- render default Proxy inspection as `Proxy(<target>)` instead of unwrapping to the bare target
- preserve `showProxy: true` rendering as `Proxy [ <target>, <handler> ]`

## Root Cause
Perry's shared proxy formatter returned the formatted target directly when `showProxy` was false. Node still keeps a lightweight `Proxy(...)` wrapper in default `util.inspect`, `console.log`, and `%O` formatting; it only includes the handler when `showProxy` is true.

## Validation
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module util --filter inspect/proxy-getters-weak'` -> 1 pass / 0 fail
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module console --filter proxy-getters'` -> 1 pass / 0 fail
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module util --filter inspect'` -> 15 pass / 0 fail
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module console --filter output'` -> 30 pass / 0 fail
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/perry-node-current-main-scan-20260603b cargo check -p perry-runtime` -> pass with existing warnings
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Refs #812