### PR TITLE
[codex] validate X509 checkIP inputs

### DIFF
--- a/crates/perry-stdlib/src/crypto/x509.rs
+++ b/crates/perry-stdlib/src/crypto/x509.rs
@@ -222,7 +222,12 @@ fn x509_check_ip_value(cert: &x509_cert::Certificate, ip: &str) -> Option<String
     use std::net::IpAddr;
     use x509_cert::ext::pkix::name::GeneralName;
 
-    let parsed = ip.parse::<IpAddr>().ok()?;
+    let parsed = ip.parse::<IpAddr>().unwrap_or_else(|_| {
+        perry_runtime::fs::validate::throw_type_error_with_code(
+            "Invalid IP",
+            "ERR_INVALID_ARG_VALUE",
+        )
+    });
     let san = x509_decoded_subject_alt_name(cert)?;
     san.0.iter().find_map(|general_name| {
         let GeneralName::IpAddress(value) = general_name else {
@@ -230,8 +235,8 @@ fn x509_check_ip_value(cert: &x509_cert::Certificate, ip: &str) -> Option<String
         };
         let bytes = value.as_bytes();
         match parsed {
-            IpAddr::V4(addr) if bytes == addr.octets().as_slice() => Some(addr.to_string()),
-            IpAddr::V6(addr) if bytes == addr.octets().as_slice() => Some(addr.to_string()),
+            IpAddr::V4(addr) if bytes == addr.octets().as_slice() => Some(ip.to_string()),
+            IpAddr::V6(addr) if bytes == addr.octets().as_slice() => Some(ip.to_string()),
             _ => None,
         }
     })

--- a/test-parity/node-suite/crypto/x509/check-ip-validation.ts
+++ b/test-parity/node-suite/crypto/x509/check-ip-validation.ts
@@ -1,0 +1,52 @@
+import { X509Certificate } from "node:crypto";
+
+const pem = `-----BEGIN CERTIFICATE-----
+MIIEEDCCAvigAwIBAgIUSXW0OKKEkcMY0kWj2AXQh+WVEWEwDQYJKoZIhvcNAQEL
+BQAwSTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMQ4wDAYDVQQKDAVQZXJyeTEd
+MBsGA1UEAwwUcGVycnktZXh0ZW5zaW9uLnRlc3QwHhcNMjYwNjAzMTAwMTM4WhcN
+MjcwNjAzMTAwMTM4WjBJMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExDjAMBgNV
+BAoMBVBlcnJ5MR0wGwYDVQQDDBRwZXJyeS1leHRlbnNpb24udGVzdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKFD+QNwqsoE5dEnFVP/3zMQq5CAya+y
+vskPkxapgwYPhyW86Hr23oUwqazBi3B4Q5KuYXmnQYfJnM+d+pniDO9YGbBX8ao8
+Xb2fKC2BQP3t8JzCr56u6c0ob0MWuLpB51A4Fj56D/kfHthUet8Z2plYKyyUPUsB
+XZibgxx9COwi+NN4FsT0rDz8Vtgr3ssHPDcEZi9XTSqeooIv3Wsm2oCRhkuplqbe
+Dd7Wm5rUpwZiR5ahsmP0G1qgwA55Exs++kijL3+Qg1C5MpLqYAE927TsfIqNxijy
+ScaNCiUB7YxhVB3bRF+5G1KMfwBxkfEfKZ1nB0k6rpXXPlxSZ1giLxECAwEAAaOB
+7zCB7DCBlAYDVR0RBIGMMIGJghRwZXJyeS1leHRlbnNpb24udGVzdIIYd3d3LnBl
+cnJ5LWV4dGVuc2lvbi50ZXN0hwR/AAABhxAAAAAAAAAAAAAAAAAAAAABgRphZG1p
+bkBwZXJyeS1leHRlbnNpb24udGVzdIYjaHR0cHM6Ly9wZXJyeS1leHRlbnNpb24u
+dGVzdC9zdGF0dXMwJwYDVR0lBCAwHgYIKwYBBQUHAwEGCCsGAQUFBwMCBggrBgEF
+BQcDAzALBgNVHQ8EBAMCBaAwHQYDVR0OBBYEFJxWlUjxxiBuCawipcrkJX8MJi+C
+MA0GCSqGSIb3DQEBCwUAA4IBAQAKrCMj6C6qVPZcpCVUZT7Ez1/v2ewTBo/r5UnH
+j3V2u7//9F9JE7w+iuljUcZuuyVG67DqFynhbpTu5FDlHbbMDmmNcF6XNZ0PUk+N
+ROm2v3W7WAKvToyuGJAs+cQrd4JL2r3/CGNk5lkh0Q7LF1ZPtxUvIEWMKvg/tVu2
+VJ6ezkG2NJt4xbgu7v/FuJnPD1LXn3gogk8bMn52DbRQFs24Jtb6Ods+ptecRokp
+hQEUyxl4qRwtjtKdbE63O80yaZS+hK00zwdTkaKgddWgGEn2nI2E1fBXjBZz5JB/
+0va/LS/0Zxi1rpJIIkybLVdENUaQRJXUZeYjmO2oWQQXHSqo
+-----END CERTIFICATE-----`;
+
+const cert = new X509Certificate(pem);
+
+function report(label: string, fn: () => unknown) {
+  try {
+    console.log(`${label}:`, fn());
+  } catch (err: any) {
+    console.log(`${label}:`, "err", err.name, err.code ?? "", err.message);
+  }
+}
+
+report("ipv4 exact", () => cert["checkIP"]("127.0.0.1"));
+report("ipv4 miss", () => cert["checkIP"]("127.0.0.2"));
+report("ipv6 compressed", () => cert["checkIP"]("::1"));
+report("ipv6 expanded", () => cert["checkIP"]("0:0:0:0:0:0:0:1"));
+report("ipv6 miss", () => cert["checkIP"]("0:0:0:0:0:0:0:2"));
+
+report("invalid dotted", () => cert["checkIP"]("999.0.0.1"));
+report("invalid padded", () => cert["checkIP"]("127.000.000.001"));
+report("invalid text", () => cert["checkIP"]("localhost"));
+report("invalid empty", () => cert["checkIP"](""));
+report("invalid spaced", () => cert["checkIP"](" 127.0.0.1 "));
+
+report("missing", () => cert["checkIP"]());
+report("number", () => cert["checkIP"](1 as any));
+report("object", () => cert["checkIP"]({} as any));


### PR DESCRIPTION
Refs #2563.

## Summary
- make `X509Certificate#checkIP(ip)` throw `TypeError [ERR_INVALID_ARG_VALUE]` with `Invalid IP` for invalid string IP values
- preserve the caller's valid IP spelling on successful matches instead of returning Rust's canonicalized address string
- add focused Node parity coverage for IPv4/IPv6 matches, valid non-matches, invalid string inputs, and non-string argument validation

## Validation
- Node 26 oracle for `test-parity/node-suite/crypto/x509/check-ip-validation.ts`
- direct Perry release run of `test-parity/node-suite/crypto/x509/check-ip-validation.ts`
- `./run_parity_tests.sh --suite node-suite --module crypto --filter x509/check-ip-validation`
- `./run_parity_tests.sh --suite node-suite --module crypto --filter x509`
- `cargo fmt --all --check`
- `cargo check -p perry-stdlib --no-default-features --features crypto`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `git diff --check`
- `./scripts/check_file_size.sh`
