### PR TITLE
fix(console): preserve detached console methods

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1787,10 +1787,16 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                                     | "values"
                             )
                         );
+                    // Non-callee `console.log` reads need the namespace
+                    // receiver; the property-only GlobalGet path collides
+                    // with detached `Math.log`.
+                    let receiver_is_detached_console_read =
+                        property == "console" && !member_is_call_callee;
                     if !outer_is_prototype_or_proto
                         && !receiver_is_namespace_value
                         && !outer_is_websocket_static
                         && !outer_is_reified_object_static_value
+                        && !receiver_is_detached_console_read
                     {
                         object_expr = Expr::GlobalGet(0);
                     }

--- a/test-parity/node-suite/console/console-class/method-binding.ts
+++ b/test-parity/node-suite/console/console-class/method-binding.ts
@@ -1,2 +1,6 @@
 const log = console.log;
+const mathLog = Math.log;
+
+console.log("console log equals Math.log:", log === mathLog);
+console.log("math log:", mathLog(Math.E));
 [1, 2, 3].forEach(log);


### PR DESCRIPTION
## Linked Issues

Part of #812.

## Behavior Cluster

This fixes the current console method-binding parity gap where a detached `console.log` value could be lowered through the property-only global path and collide with detached `Math.log`. As a result, `const log = console.log; [1, 2, 3].forEach(log);` did not print the Array.forEach callback arguments.

## Why This Cut

The failing behavior is a single lowering issue: non-callee `console.<method>` reads need to preserve the `console` namespace receiver so the existing native-module property-read path returns a bound console callable. This is intentionally separate from console.table sparse-array formatting and util.inspect Proxy formatting, which are covered by separate draft PRs.

## Tests Added

- Expanded `test-parity/node-suite/console/console-class/method-binding.ts` to assert detached `console.log` is distinct from detached `Math.log`, detached `Math.log` still computes normally, and `Array.forEach(log)` prints the `(value, index, array)` triple.

## Validation

- `npm exec --package=node@26 -- node test-parity/node-suite/console/console-class/method-binding.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-console-method-binding npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module console --filter console-class/method-binding'` (1 pass / 0 fail / 0 compile fail)
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-console-method-binding npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module console --filter console-class'` (11 pass / 0 fail / 0 compile fail)
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-console-method-binding cargo check -p perry-hir`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-console-method-binding cargo check -p perry-hir -p perry-codegen`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known Limitations

Full `node-suite/console` still depends on the separate draft PRs for console.table sparse holes and default Proxy inspection formatting when run from this branch's `origin/main` base.

## Non-Goals

- console.table sparse-array hole formatting
- util.inspect Proxy formatting
- broader console stream/error behavior
- Array iteration callback dispatch changes