### PR TITLE
fix(v8): align startCpuProfile arity

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -3663,8 +3663,14 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("http", "_connectionListener") => Some(1),
         ("module", "register" | "registerHooks") => Some(1),
         // #3904: modern V8 diagnostics/profiler exports (Node .length values).
-        ("v8", "getCppHeapStatistics" | "startCpuProfile") => Some(0),
-        ("v8", "getHeapSnapshot" | "isStringOneByteRepresentation" | "queryObjects") => Some(1),
+        ("v8", "getCppHeapStatistics") => Some(0),
+        (
+            "v8",
+            "getHeapSnapshot"
+            | "isStringOneByteRepresentation"
+            | "queryObjects"
+            | "startCpuProfile",
+        ) => Some(1),
         ("v8", "writeHeapSnapshot") => Some(2),
         // #3906: implemented top-level v8 helpers reachable as bound callables.
         ("v8", "serialize" | "deserialize") => Some(1),


### PR DESCRIPTION
## Summary
- align `node:v8` `startCpuProfile.length` with Node 26 by assigning the export arity `1`
- keep the existing callable/export behavior unchanged; this only corrects the native-module metadata used for `.length`

Tracks #812.

## Validation
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-v8-start-cpu-profile-length npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module v8 --filter exports/diagnostics-surface'` (1 pass, 0 fail, report `test-parity/reports/parity_report_20260604_022220.json`)
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-v8-start-cpu-profile-length npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module v8'` (4 pass, 0 fail, report `test-parity/reports/parity_report_20260604_022410.json`)
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-v8-start-cpu-profile-length cargo check -p perry-runtime` (passes with existing warnings)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Non-goals
- no real CPU profiler implementation changes
- no changes to other `node:v8` helper behavior