### PR TITLE
[codex] Expose process.permission.drop

### DIFF
--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -394,6 +394,12 @@ struct ProcessFinalizationEntry {
     kind: ProcessFinalizationKind,
 }
 
+#[derive(Clone)]
+struct ProcessPermissionDrop {
+    scope: String,
+    reference: Option<String>,
+}
+
 thread_local! {
     static PROCESS_FINALIZATION_REGISTRY: RefCell<Vec<ProcessFinalizationEntry>> =
         RefCell::new(Vec::new());
@@ -407,6 +413,8 @@ thread_local! {
     static MODULE_LOADER_HOOKS: RefCell<Vec<ModuleLoaderHookEntry>> =
         const { RefCell::new(Vec::new()) };
     static MODULE_LOADER_HOOK_NEXT_ID: Cell<u64> = const { Cell::new(1) };
+    static PROCESS_PERMISSION_DROPS: RefCell<Vec<ProcessPermissionDrop>> =
+        const { RefCell::new(Vec::new()) };
     static MODULE_LOADER_NEXT_RESOLVE: Cell<*const crate::closure::ClosureHeader> =
         const { Cell::new(std::ptr::null()) };
     static MODULE_LOADER_NEXT_LOAD: Cell<*const crate::closure::ClosureHeader> =
@@ -920,7 +928,40 @@ fn permission_path_allowed(reference: &str, allowed: &[String]) -> bool {
     false
 }
 
+fn process_permission_is_dropped(scope: &str, reference: Option<&str>) -> bool {
+    PROCESS_PERMISSION_DROPS.with(|drops| {
+        drops.borrow().iter().any(|drop| {
+            if drop.scope != scope {
+                return false;
+            }
+            match (&drop.reference, reference) {
+                (None, _) => true,
+                (Some(drop_reference), Some(reference)) => {
+                    permission_path_allowed(reference, std::slice::from_ref(drop_reference))
+                }
+                _ => false,
+            }
+        })
+    })
+}
+
+fn process_permission_drop(scope: &str, reference: Option<String>) {
+    PROCESS_PERMISSION_DROPS.with(|drops| {
+        let mut drops = drops.borrow_mut();
+        if reference.is_none() {
+            drops.retain(|drop| drop.scope != scope);
+        }
+        drops.push(ProcessPermissionDrop {
+            scope: scope.to_string(),
+            reference,
+        });
+    });
+}
+
 fn process_permission_scope_allowed(scope: &str, reference: Option<&str>) -> bool {
+    if process_permission_is_dropped(scope, reference) {
+        return false;
+    }
     match scope {
         "fs.read" => {
             let allowed = process_permission_flag_values("--allow-fs-read");
@@ -974,6 +1015,26 @@ extern "C" fn process_permission_has_thunk(
     ))
 }
 
+extern "C" fn process_permission_drop_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    scope_value: f64,
+    reference_value: f64,
+) -> f64 {
+    let Some(scope) = module_value_to_string(scope_value) else {
+        throw_permission_arg_type("scope", scope_value);
+    };
+    let reference_js = JSValue::from_bits(reference_value.to_bits());
+    let reference = if reference_js.is_undefined() || reference_js.is_null() {
+        None
+    } else if let Some(reference) = module_value_to_string_or_buffer(reference_value) {
+        Some(reference)
+    } else {
+        throw_permission_arg_type("reference", reference_value);
+    };
+    process_permission_drop(&scope, reference);
+    undefined_value()
+}
+
 fn process_permission_value() -> Option<f64> {
     if !process_permission_enabled() {
         return None;
@@ -988,11 +1049,16 @@ fn process_permission_value() -> Option<f64> {
         return Some(cached);
     }
 
-    let obj = crate::object::js_object_alloc(0, 1);
+    let obj = crate::object::js_object_alloc(0, 2);
     module_set_field(
         obj,
         "has",
         module_function2("has", process_permission_has_thunk, 2),
+    );
+    module_set_field(
+        obj,
+        "drop",
+        module_function2("drop", process_permission_drop_thunk, 2),
     );
     let value = module_object_value(obj);
     CACHED_PERMISSION.with(|c| c.set(value));

--- a/test-parity/node-suite/process/permission/enabled-has.ts
+++ b/test-parity/node-suite/process/permission/enabled-has.ts
@@ -28,6 +28,8 @@ if (permission && typeof permission.has === "function") {
   console.log("permission names:", Object.getOwnPropertyNames(permission).join(","));
   console.log("has typeof:", typeof permission.has);
   console.log("has length:", permission.has.length);
+  console.log("drop typeof:", typeof permission.drop);
+  console.log("drop length:", permission.drop.length);
   console.log("fs.read:", permission.has("fs.read"));
   console.log("fs.read dot:", permission.has("fs.read", "."));
   console.log("fs.read buffer:", permission.has("fs.read", Buffer.from(".")));
@@ -36,6 +38,10 @@ if (permission && typeof permission.has === "function") {
   console.log("addon:", permission.has("addon"));
   console.log("addons:", permission.has("addons"));
   console.log("unknown:", permission.has("bad.scope"));
+  console.log("drop fs.read dot:", permission.drop("fs.read", "."));
+  console.log("fs.read dot after drop:", permission.has("fs.read", "."));
+  console.log("drop addon:", permission.drop("addon"));
+  console.log("addon after drop:", permission.has("addon"));
   showError("missing scope", () => permission.has());
   showError("bad scope type", () => permission.has(1 as any));
   showError("bad reference type", () => permission.has("fs.read", 1 as any));
@@ -44,6 +50,8 @@ if (permission && typeof permission.has === "function") {
   console.log("permission names: unavailable");
   console.log("has typeof: unavailable");
   console.log("has length: unavailable");
+  console.log("drop typeof: unavailable");
+  console.log("drop length: unavailable");
   console.log("fs.read: unavailable");
   console.log("fs.read dot: unavailable");
   console.log("fs.read buffer: unavailable");
@@ -52,6 +60,10 @@ if (permission && typeof permission.has === "function") {
   console.log("addon: unavailable");
   console.log("addons: unavailable");
   console.log("unknown: unavailable");
+  console.log("drop fs.read dot: unavailable");
+  console.log("fs.read dot after drop: unavailable");
+  console.log("drop addon: unavailable");
+  console.log("addon after drop: unavailable");
   console.log("missing scope: unavailable");
   console.log("bad scope type: unavailable");
   console.log("bad reference type: unavailable");


### PR DESCRIPTION
Links #2013.

## Summary
- add `process.permission.drop(scope, reference?)` alongside the existing `has()` surface when the permission model is enabled
- track dropped scopes/references in runtime state and have `has()` reflect dropped grants
- extend the focused process permission parity fixture to cover property order, `drop.length`, fs-read reference drops, addon drops, and existing argument errors

## Why This Slice
The current process permission gap is small and self-contained: Node exposes both `has` and `drop` on `process.permission`, while Perry only exposed `has`. Keeping this PR scoped to that missing method avoids mixing it with the separate pending `process.env` write/readback fix.

## Validation
- direct Node 26 oracle for `test-parity/node-suite/process/permission/enabled-has.ts`
- direct Perry release run of `enabled-has.ts` with `--permission --allow-fs-read=. --allow-addons`
- `./run_parity_tests.sh --suite node-suite --module process --filter permission/enabled-has`
- `./run_parity_tests.sh --suite node-suite --module process --filter process/permission`
- `cargo check -p perry-runtime`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Non-goals
- does not change broader process permission flag parsing
- does not fold in the separate `process.env` write/readback compatibility slice
