### PR TITLE
[codex] fix Node Web Storage globals

### DIFF
--- a/crates/perry-runtime/src/web_storage.rs
+++ b/crates/perry-runtime/src/web_storage.rs
@@ -30,12 +30,23 @@ pub extern "C" fn storage_constructor_illegal(_closure: *const ClosureHeader) ->
     throw_error("Illegal constructor")
 }
 
-extern "C" fn storage_global_getter(_closure: *const ClosureHeader) -> f64 {
+extern "C" fn storage_global_setter(_closure: *const ClosureHeader, _value: f64) -> f64 {
     f64::from_bits(TAG_UNDEFINED)
 }
 
-extern "C" fn storage_global_setter(_closure: *const ClosureHeader, _value: f64) -> f64 {
-    f64::from_bits(TAG_UNDEFINED)
+extern "C" fn storage_local_global_getter(_closure: *const ClosureHeader) -> f64 {
+    storage_global_value(StorageKind::Local)
+}
+
+extern "C" fn storage_session_global_getter(_closure: *const ClosureHeader) -> f64 {
+    storage_global_value(StorageKind::Session)
+}
+
+extern "C" fn storage_length_getter(_closure: *const ClosureHeader) -> f64 {
+    let Some(kind) = receiver_kind() else {
+        return throw_type_error("Illegal invocation");
+    };
+    with_store(kind, |store| store.len() as f64)
 }
 
 extern "C" fn storage_get_item(_closure: *const ClosureHeader, key: f64) -> f64 {
@@ -151,6 +162,15 @@ fn storage_key_impl(kind: StorageKind, index: f64) -> f64 {
     })
 }
 
+fn storage_global_value(kind: StorageKind) -> f64 {
+    let obj = storage_object(kind);
+    if obj.is_null() {
+        f64::from_bits(TAG_UNDEFINED)
+    } else {
+        crate::value::js_nanbox_pointer(obj as i64)
+    }
+}
+
 fn storage_clear_impl(kind: StorageKind) -> f64 {
     with_store_mut(kind, |store| {
         let keys: Vec<String> = store.keys().cloned().collect();
@@ -245,11 +265,11 @@ fn install_method(proto: *mut ObjectHeader, name: &str, func_ptr: *const u8, ari
 }
 
 fn install_storage_length_accessor(proto: *mut ObjectHeader) {
-    let getter = crate::closure::js_closure_alloc(storage_global_getter as *const u8, 0);
+    let getter = crate::closure::js_closure_alloc(storage_length_getter as *const u8, 0);
     if getter.is_null() {
         return;
     }
-    crate::closure::js_register_closure_arity(storage_global_getter as *const u8, 0);
+    crate::closure::js_register_closure_arity(storage_length_getter as *const u8, 0);
     crate::object::set_bound_native_closure_name(getter, "get length");
     crate::object::js_object_set_field_by_name(
         proto,
@@ -325,9 +345,16 @@ fn set_global_storage_property(global: *mut ObjectHeader, name: &str, value: *mu
         PropertyAttrs::new(true, true, true),
     );
 
-    let getter = crate::closure::js_closure_alloc(storage_global_getter as *const u8, 0);
+    let getter_fn = match name {
+        "localStorage" => storage_local_global_getter as *const u8,
+        _ => storage_session_global_getter as *const u8,
+    };
+    let getter = crate::closure::js_closure_alloc(getter_fn, 0);
     let setter = crate::closure::js_closure_alloc(storage_global_setter as *const u8, 0);
     if !getter.is_null() && !setter.is_null() {
+        crate::closure::js_register_closure_arity(getter_fn, 0);
+        crate::closure::js_register_closure_arity(storage_global_setter as *const u8, 1);
+        crate::object::set_bound_native_closure_name(getter, name);
         crate::object::set_builtin_accessor_descriptor(
             global as usize,
             name.to_string(),
@@ -412,6 +439,7 @@ fn update_length(kind: StorageKind, len: usize) {
 }
 
 fn update_length_on_obj(obj: *mut ObjectHeader, len: usize) {
+    crate::object::clear_property_attrs(obj as usize, "length");
     crate::object::js_object_set_field_by_name(obj, string("length"), len as f64);
     crate::object::set_builtin_property_attrs(
         obj as usize,

--- a/test-parity/node-suite/globals/storage-globals.ts
+++ b/test-parity/node-suite/globals/storage-globals.ts
@@ -41,6 +41,12 @@ show("same storage globals", localStorage === sessionStorage);
 globalDesc("Storage desc", "Storage");
 globalDesc("localStorage desc", "localStorage");
 globalDesc("sessionStorage desc", "sessionStorage");
+const localDesc: any = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+const sessionDesc: any = Object.getOwnPropertyDescriptor(globalThis, "sessionStorage");
+show(
+  "descriptor getters",
+  (localDesc.get.call(g) === localStorage) + "/" + (sessionDesc.get.call(g) === sessionStorage),
+);
 
 for (const name of ["clear", "getItem", "key", "removeItem", "setItem"]) {
   const fn = (Storage.prototype as any)[name];


### PR DESCRIPTION
## Summary

Fixes #812.

- Return the rooted `localStorage` and `sessionStorage` objects from the reflected global descriptor getters instead of `undefined`.
- Give `Storage.prototype.length` its own receiver-aware getter so it keeps the existing illegal-invocation behavior.
- Allow internal storage mutations to refresh the readonly `length` data slot by clearing and restoring attrs around the update.
- Extend `globals/storage-globals` with descriptor getter coverage.

## Root Cause

The Web Storage globals installed reflectable accessor descriptors, but the shared getter stub always returned `undefined`. After exposing the actual storage objects through the descriptor getters, storage mutations also hit an existing internal update path that wrote to the readonly `length` property through normal property assignment and threw.

## Known Limit

This keeps the existing in-memory/process-local Web Storage behavior. It does not change persistence or flag handling.

## Validation

- `npm exec --package=node@26 -- node --experimental-webstorage --localstorage-file=/tmp/perry_web_storage_parity.sqlite test-parity/node-suite/globals/storage-globals.ts`
- Manual Perry compile/run for `globals/storage-globals`, then `diff -u /tmp/perry_storage_node.out /tmp/perry_storage_run.out` clean
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-web-storage-globals npm exec --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter storage-globals'` -> pass, report `test-parity/reports/parity_report_20260604_040722.json`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/node-web-storage-globals cargo check -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`