### PR TITLE
[codex] dispatch crypto getFips callable exports

### DIFF
--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -320,6 +320,7 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
         "generatePrime" | "generatePrimeSync" => js_crypto_generate_prime_sync(arg(0), arg(1)),
         "checkPrime" if args_len >= 3 => js_crypto_check_prime_async(arg(0), arg(1), arg(2)),
         "checkPrime" | "checkPrimeSync" => js_crypto_check_prime_sync(arg(0), arg(1)),
+        "getFips" => 0.0,
         "setFips" => undefined,
         "secureHeapUsed" => pointer_value(js_crypto_secure_heap_used() as *mut u8),
         "hkdf" => js_crypto_hkdf_async_alg(
@@ -628,6 +629,15 @@ mod tests {
             perry_runtime::exception::js_clear_exception();
             true
         }
+    }
+
+    #[test]
+    fn crypto_native_dispatch_get_fips_matches_default_node_mode() {
+        let method = b"getFips";
+        let result = unsafe {
+            js_crypto_native_dispatch(method.as_ptr(), method.len(), std::ptr::null(), 0)
+        };
+        assert_eq!(result.to_bits(), 0.0f64.to_bits());
     }
 
     #[test]


### PR DESCRIPTION
Refs #3955.

## Summary
- route the stdlib crypto native dispatcher's `getFips` callable export to Node's default non-FIPS value `0`
- cover the dispatcher path used by named imports and detached callable exports with a focused unit test

## Why
Direct `crypto.getFips()` already lowers statically to `0`, but callable export dispatch did not have a `getFips` arm. That made `import { getFips } from "node:crypto"; getFips()` diverge from Node's default FIPS-disabled behavior.

## Validation
- `NODE26_BIN=$(npm exec --yes --package=node@26 -- node -e 'console.log(process.execPath)'); "$NODE26_BIN" --experimental-strip-types --no-warnings test-parity/node-suite/crypto/inventory/fips-api.ts`
- `cargo build -p perry -p perry-stdlib`
- `cargo build -p perry-runtime`
- `PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=$PWD/target/debug target/debug/perry compile --no-cache test-parity/node-suite/crypto/inventory/fips-api.ts -o /root/perry-worktrees/.tmp-node-crypto-fips/fips-api && /root/perry-worktrees/.tmp-node-crypto-fips/fips-api`
- `cargo test -p perry-stdlib crypto_native_dispatch_get_fips_matches_default_node_mode -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`