### PR TITLE
[codex] link net validation helpers in no-auto parity

### DIFF
--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -382,6 +382,14 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_net_socket_address_get_family",            OwnerKind::WellKnown("net")),
     ("js_net_socket_address_get_port",              OwnerKind::WellKnown("net")),
     ("js_net_socket_address_get_flowlabel",         OwnerKind::WellKnown("net")),
+    // #2013 — net validation rows whose runtime helpers live only in
+    // `perry-ext-net`. These calls can be emitted by native-table lowering,
+    // so they must independently flip the net well-known provider.
+    ("js_net_get_default_auto_select_family",       OwnerKind::WellKnown("net")),
+    ("js_net_set_default_auto_select_family",       OwnerKind::WellKnown("net")),
+    ("js_net_get_default_auto_select_family_attempt_timeout", OwnerKind::WellKnown("net")),
+    ("js_net_set_default_auto_select_family_attempt_timeout", OwnerKind::WellKnown("net")),
+    ("js_net_socket_set_timeout",                   OwnerKind::WellKnown("net")),
     // #1852 — chainable no-op option setters for Socket/Server.
     ("js_net_socket_noop_self",                     OwnerKind::WellKnown("net")),
     ("js_net_socket_get_type_of_service",           OwnerKind::WellKnown("net")),
@@ -602,6 +610,28 @@ mod tests {
                 _ => OwnerKind::WellKnown("http"),
             };
             assert_symbol_routes_to(symbol, owner);
+        }
+    }
+
+    /// #2013 regression: net validation fixtures emit provider-only
+    /// `perry-ext-net` symbols through native-table lowering. Each one must
+    /// route to the net well-known archive so `PERRY_NO_AUTO_OPTIMIZE=1`
+    /// compiles the fixtures instead of linking unresolved `js_net_*` calls.
+    #[test]
+    fn emitted_net_validation_external_symbols_route_to_net() {
+        let _guard = PROVIDER_TEST_LOCK
+            .lock()
+            .expect("provider test lock poisoned");
+        for symbol in [
+            "js_net_create_server",
+            "js_net_server_listen",
+            "js_net_get_default_auto_select_family",
+            "js_net_set_default_auto_select_family",
+            "js_net_get_default_auto_select_family_attempt_timeout",
+            "js_net_set_default_auto_select_family_attempt_timeout",
+            "js_net_socket_set_timeout",
+        ] {
+            assert_symbol_routes_to(symbol, OwnerKind::WellKnown("net"));
         }
     }
 }

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -362,9 +362,28 @@ if [[ -n "${PERRY_NO_AUTO_OPTIMIZE:-}" && "$TEST_SUITE" == "node-suite" ]]; then
             ;;
     esac
 fi
+needs_ext_net=0
+if [[ "$TEST_SUITE" == "node-suite" ]]; then
+    case "$MODULE_FILTER" in
+        ""|net|net/*)
+            # node-suite/net commonly runs with PERRY_NO_AUTO_OPTIMIZE=1.
+            # That path links prebuilt well-known archives, so build ext-net
+            # once up front instead of failing on unresolved js_net_* symbols.
+            needs_ext_net=1
+            ;;
+    esac
+fi
 if ! cargo build --release --quiet "${BUILD_PACKAGES[@]}" "${BUILD_FEATURES[@]}" 2>/dev/null; then
     echo -e "${RED}Failed to build compiler/runtime archives${NC}"
     exit 1
+fi
+if [[ "$needs_ext_net" -eq 1 ]]; then
+    echo "Building net extension (release)..."
+    ext_net_jobs="${CARGO_BUILD_JOBS:-1}"
+    if ! cargo build --release --quiet -p perry-ext-net -j "$ext_net_jobs" 2>/dev/null; then
+        echo -e "${RED}Failed to build net extension library${NC}"
+        exit 1
+    fi
 fi
 if [[ ! -x "$PERRY_BIN" ]]; then
     echo -e "${RED}Expected $PERRY_BIN after release build${NC}"


### PR DESCRIPTION
Refs #2013.

## Summary
- Route net validation helper FFIs (`getDefaultAutoSelectFamily*` and `socket.setTimeout`) through the codegen FFI provider registry so native-table emissions pull in `perry-ext-net`.
- Teach the parity runner to prebuild `perry-ext-net` for `node-suite/net` selections, so `PERRY_NO_AUTO_OPTIMIZE=1` has the well-known archive available on clean worktrees.
- Add an `ext_registry` regression test covering the net validation symbols plus existing create/listen rows.

## Verification
- `bash -n run_parity_tests.sh`
- `cargo test -p perry-codegen ext_registry::tests::emitted_net_validation_external_symbols_route_to_net -- --nocapture`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module net --filter validation`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-codegen -p perry`
- `cargo test -p perry-codegen ext_registry::tests -- --nocapture`
