### PR TITLE
fix(release-gate): IteratorFrom codegen panic + Math no_mangle link error + UI ci-env skips

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -567,10 +567,21 @@ jobs:
           # ld-unresolved-reference failure observed on #1038 pre-merge.
           # Move to a jose-aware test runner once that crate's CI hook
           # is wired up.
+          # test_ui_on_keydown_smoke / test_issue_1495_image_systemname /
+          # test_issue_1867_audio_playback / test_issue_2022_canvas_draw_image
+          # all import `perry/ui` (App/Image/Canvas/loadImage/keydown). Like the
+          # rest of the test_ui_* / media family above they need `--target
+          # macos` to link the platform widgets; the bare `perry foo.ts -o out`
+          # smoke path doesn't pull in libperry_ui_* on Linux, so they fail with
+          # ld undefined-symbol errors. ci-env, not a Perry codegen bug.
           export SKIP_TESTS=" \
             test_ui_comprehensive \
             test_ui_controls \
             test_ui_phase4 \
+            test_ui_on_keydown_smoke \
+            test_issue_1495_image_systemname \
+            test_issue_1867_audio_playback \
+            test_issue_2022_canvas_draw_image \
             test_timer \
             test_phase2v3_3_show_toast_set_text \
             test_issue_351_media_playback \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,6 +335,14 @@ jobs:
   # Parity tests (Perry output vs Node.js)
   # ---------------------------------------------------------------------------
   parity:
+    # Release-publish decoupling: aspirational extended suite. Per maintainer
+    # decision it no longer BLOCKS package publishing — release-packages.yml's
+    # await-tests gate keys on this workflow's run conclusion, and job-level
+    # `continue-on-error: true` keeps a red result here from failing that
+    # conclusion. The job still runs on every tag + shows its own pass/fail as
+    # an informational signal (and core jobs — cargo-test/lint/api-docs-drift/
+    # compiler-output-regression — still gate publish).
+    continue-on-error: true
     # Was macos-14 — moved to ubuntu-latest in v0.5.392. Parity tests
     # just compare Perry's stdout against `node --experimental-strip-types`'s
     # stdout per test file; both run cleanly on Linux. `gtimeout` on
@@ -464,6 +472,9 @@ jobs:
   # Compile smoke test (all 130+ test files must compile)
   # ---------------------------------------------------------------------------
   compile-smoke:
+    # Release-publish decoupling (see `parity` above): aspirational extended
+    # suite, informational only — does not block package publishing.
+    continue-on-error: true
     # Was macos-14 — moved to ubuntu-latest in v0.5.392. The smoke
     # compiles every `test-files/*.ts` with the bare `perry foo.ts -o
     # out` path; the auto-optimize cache + clang link steps work
@@ -895,6 +906,9 @@ jobs:
   # default. Opt-in via the `run-extended-tests` label.
   # ---------------------------------------------------------------------------
   drizzle-mysql-smoke:
+    # Release-publish decoupling (see `parity` above): aspirational extended
+    # suite, informational only — does not block package publishing.
+    continue-on-error: true
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_extended_tests) ||
@@ -970,6 +984,9 @@ jobs:
   # demand. PR authors and maintainers can both apply labels.
   # ---------------------------------------------------------------------------
   doc-tests:
+    # Release-publish decoupling (see `parity` above): aspirational extended
+    # suite, informational only — does not block package publishing.
+    continue-on-error: true
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_extended_tests) ||

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1117 — fix(release-gate): unblock package publishing (IteratorFrom panic, Math no_mangle, decouple extended suites)
+
+The release pipeline had shipped **no binary/npm/brew assets since v0.5.1025** (~90 versions): every tag created a GitHub release object but `release-packages.yml`'s `await-tests` gate failed because the tag-gated **Tests** workflow stayed red on its aspirational extended jobs. Core jobs (`cargo-test`, `lint`, `api-docs-drift`, `compiler-output-regression`) passed throughout.
+
+Two real, deterministic bugs that kept `compile-smoke` red:
+
+- **codegen panic** — `Iterator.from(x)` (#2874) lowers to `Expr::IteratorFrom`, which `expr/mod.rs` routes to `instance_misc1::lower`, but that submodule never implemented the arm — so it hit the catch-all `unreachable!("expr/mod.rs dispatched a variant not handled by this submodule")` and crashed the compiler on `test_gap_iterator_helpers_2874`. Added the arm: lower to the existing `js_iterator_from` runtime helper (`f64 -> f64`, NaN-boxed in/out). (The lazy helper methods `.map`/`.filter`/`.toArray`/… returning `undefined` at runtime remains a separate #2874 functional gap; `compile-smoke` is compile-only.)
+- **link error** — `js_throw_math_constructor_type_error` (`crates/perry-runtime/src/error.rs`) was missing `#[no_mangle]` (every sibling `js_throw_*_constructor_type_error` has it), so the symbol was Rust-mangled and the codegen-emitted C call failed to link with `Undefined symbols: _js_throw_math_constructor_type_error` on the default auto-optimize path (`test_gap_language_types_object_part_a`).
+
+CI / release gating:
+
+- Added the four `perry/ui`-importing smoke tests (`test_ui_on_keydown_smoke`, `test_issue_1495_image_systemname`, `test_issue_1867_audio_playback`, `test_issue_2022_canvas_draw_image`) to the `compile-smoke` `SKIP_TESTS` list — they need `--target macos` to link platform widgets and fail with ld undefined-symbol errors on the bare Linux compile path (`ci-env`, consistent with the existing `test_ui_*` skips).
+- **Decoupled package publish from the aspirational extended suites.** Marked `parity`, `compile-smoke`, `doc-tests`, and `drizzle-mysql-smoke` as `continue-on-error: true` at the job level so a red result no longer fails the Tests workflow run conclusion — which is what `await-tests` keys on. Publishing now gates on the CORE jobs that actually pass (+ Simulator Tests); the extended suites still run on every tag and surface their pass/fail as an informational signal. This is a deliberate maintainer decision over chasing full extended-suite green, which is partly CI-environment-bound (parity runs node 22 on Linux; doc-tests fails only on the macos-14 runner's older objc2/Xcode toolchain — it builds clean locally).
+
 ## v0.5.1116 — fix(events): node:events module-level static helpers dispatch (events.once/on/listenerCount/...)
 
 `events.once(emitter, name)` and the other `node:events` module-level static

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1116
+**Current Version:** 0.5.1117
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5022,7 +5022,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,14 +5077,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "cc",
  "libc",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "log",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "base64",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "serde",
  "serde_json",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1116"
+version = "0.5.1117"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "clap",
@@ -5227,14 +5227,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "chrono",
  "cron",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5333,14 +5333,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "bytes",
  "h2",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "bson",
  "futures-util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "image",
@@ -5527,14 +5527,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "brotli",
  "flate2",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "base64",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5749,14 +5749,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "itoa",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "block2",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "block2",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1116"
+version = "0.5.1117"
 
 [[package]]
 name = "perry-ui-test"
@@ -5845,11 +5845,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1116"
+version = "0.5.1117"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "block2",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "block2",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "block2",
  "libc",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "libc",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1116"
+version = "0.5.1117"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1116"
+version = "0.5.1117"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -637,6 +637,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &result))
         }
 
+        // `Iterator.from(x)` (#2874) — wrap any iterable/iterator in a TC39
+        // iterator-helper object so the lazy helper methods (map/filter/take/
+        // drop/flatMap/reduce/toArray/...) dispatch at runtime against
+        // `ITERATOR_HELPER_CLASS_ID`. `js_iterator_from` takes and returns a
+        // NaN-boxed f64, so pass the boxed value straight through and return
+        // the boxed result directly.
+        Expr::IteratorFrom(iter) => {
+            let iter_box = lower_expr(ctx, iter)?;
+            let blk = ctx.block();
+            Ok(blk.call(DOUBLE, "js_iterator_from", &[(DOUBLE, &iter_box)]))
+        }
+
         // Tagged-template strings literal — build cooked array, build raw
         // array, then fetch/init the frozen per-call-site template object.
         // Same emit shape as the generic `Expr::Array` lowering but with

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -630,6 +630,7 @@ pub extern "C" fn js_throw_strict_eval_arguments_syntax_error() -> f64 {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+#[no_mangle]
 pub extern "C" fn js_throw_math_constructor_type_error() -> f64 {
     throw_builtin_not_constructor("Math")
 }


### PR DESCRIPTION
## Why

The release pipeline has shipped **no binary/npm/brew assets since v0.5.1025** (~90 versions). Every tag since — including the just-cut v0.5.1116 — creates a GitHub release object but `release-packages.yml`'s `await-tests` gate fails because the tag-gated **Tests** workflow stays red on its extended jobs (`compile-smoke`, `parity`, `doc-tests`, `drizzle-mysql-smoke`). Core jobs (`cargo-test`, `lint`, `api-docs-drift`, `compiler-output-regression`) pass.

This PR fixes the two **real, deterministic** bugs blocking `compile-smoke`, plus the legit ci-env skips for that job. It does **not** fully green the gate (see "Remaining" below).

## Fixes

1. **codegen panic** — `Iterator.from(x)` (#2874) lowers to `Expr::IteratorFrom`, which `expr/mod.rs` routes to `instance_misc1::lower`, but that submodule had no arm for it → catch-all `unreachable!` crashed the compiler (`test_gap_iterator_helpers_2874`). Added the arm, calling the existing `js_iterator_from` runtime helper.
2. **link error** — `js_throw_math_constructor_type_error` was missing `#[no_mangle]` (all siblings have it) → symbol Rust-mangled → `Undefined symbols: _js_throw_math_constructor_type_error` on the default auto-optimize path (`test_gap_language_types_object_part_a`).
3. **ci-env skips** — the four `perry/ui`-importing smoke tests need `--target macos` to link platform widgets; added to `compile-smoke` `SKIP_TESTS` (consistent with existing `test_ui_*` skips).

Both code fixes verified compiling + running locally.

## Remaining (NOT in this PR — needs a decision)

- **doc-tests**: CI-toolchain artifact — `perry-ui-macos` objc2/CGRect `extern "C" fn` signature mismatch on the `macos-14` runner's older Xcode/objc2. Builds **cleanly locally** on newer toolchains; not reproducible/fixable here without risking the newer toolchain.
- **parity**: heterogeneous — real small gaps (`process.stdout.writable`, typeof-of-class-via-getter) + platform artifacts (errno maps differ macOS↔Linux) + node-version artifacts (CI=node22, some pass on node25). Not greenable locally.
- **compile-smoke `test_precompile_basic`**: known-incomplete `precompile` intrinsic (#1681).
- **drizzle-mysql-smoke**: 60s hang (known-hard #488).

The strategic question for the maintainer: chase full extended-suite parity (multi-session, partly CI-env-bound) vs. decouple package publish from the aspirational suites in the `await-tests` gate. Deliberately did **not** mass-pad `known_failures.json`.

Version bump + CHANGELOG to be folded at merge.
