### PR TITLE
fix(runtime): implement TypedArray integer-indexed [[DefineOwnProperty]]

### DIFF
--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -58,6 +58,7 @@ mod property_key;
 pub(crate) mod prototype_chain;
 mod prototype_helpers;
 mod reflect_support;
+mod typed_array_define;
 mod typed_array_proto_thunks;
 mod util_types;
 mod websocket_global;
@@ -101,6 +102,7 @@ pub(crate) use primitive_proto_thunks::primitive_proto_method_value;
 pub use property_key::*;
 pub(crate) use prototype_helpers::*;
 pub(crate) use reflect_support::*;
+pub(crate) use typed_array_define::{typed_array_define_own_property, TypedArrayDefineOutcome};
 pub use util_types::*;
 pub use with_env::*;
 

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -852,6 +852,17 @@ pub extern "C" fn js_object_define_property(
         }
         validate_property_descriptor(descriptor_value);
 
+        // TypedArrays are Integer-Indexed exotic objects: a canonical numeric
+        // index key bypasses ordinary define entirely (validate the index, then
+        // either write the element or reject with a TypeError).
+        match super::typed_array_define_own_property(obj_value, key_value, descriptor_value) {
+            super::TypedArrayDefineOutcome::Defined => return obj_value,
+            super::TypedArrayDefineOutcome::Rejected => {
+                throw_object_type_error(b"Cannot redefine property")
+            }
+            super::TypedArrayDefineOutcome::NotTypedArray => {}
+        }
+
         // #2159: when the receiver is a class-ref (`Class.prototype` evaluates
         // back to the class itself in Perry — see `class_ref_id` /
         // `js_object_get_own_property_descriptor`'s class-ref arm), route the

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -101,6 +101,40 @@ pub(crate) fn obj_value_attrs(value: f64, key: f64) -> Option<(bool, bool)> {
     }
 }
 
+#[inline]
+fn reflect_bool(b: bool) -> f64 {
+    f64::from_bits(crate::value::JSValue::bool(b).bits())
+}
+
+/// Ordinary (non-proxy) `Reflect.defineProperty` `[[DefineOwnProperty]]`,
+/// reporting success as a NaN-boxed boolean. Shared by `crate::proxy`'s
+/// `Reflect.defineProperty` entry point (both the no-trap and direct paths).
+pub(crate) fn reflect_define_property(obj: f64, key: f64, descriptor: f64) -> f64 {
+    // TypedArrays are Integer-Indexed exotic objects: a canonical numeric index
+    // key returns true/false here rather than going through the ordinary object
+    // machinery (which would mishandle in-bounds element writes and treats the
+    // view as non-extensible).
+    match unsafe { super::typed_array_define_own_property(obj, key, descriptor) } {
+        super::TypedArrayDefineOutcome::Defined => return reflect_bool(true),
+        super::TypedArrayDefineOutcome::Rejected => return reflect_bool(false),
+        super::TypedArrayDefineOutcome::NotTypedArray => {}
+    }
+    let has_own = obj_value_has_own_key(obj, key);
+    // Redefining a non-configurable existing property fails.
+    if has_own {
+        if let Some((_writable, configurable)) = obj_value_attrs(obj, key) {
+            if !configurable {
+                return reflect_bool(false);
+            }
+        }
+    } else if obj_value_no_extend(obj) {
+        // Defining a brand-new property on a non-extensible object fails.
+        return reflect_bool(false);
+    }
+    super::js_object_define_property(obj, key, descriptor);
+    reflect_bool(true)
+}
+
 unsafe fn key_to_rust_string(value: f64) -> Option<String> {
     let key_str = crate::builtins::js_string_coerce(value);
     if key_str.is_null() {

--- a/crates/perry-runtime/src/object/typed_array_define.rs
+++ b/crates/perry-runtime/src/object/typed_array_define.rs
@@ -1,0 +1,229 @@
+//! Integer-Indexed exotic `[[DefineOwnProperty]]` for TypedArrays
+//! (`Object.defineProperty` / `Reflect.defineProperty` on a typed array).
+//!
+//! Per the ECMAScript spec, a TypedArray is an Integer-Indexed exotic object:
+//! defining a property whose key is a *CanonicalNumericIndexString* does NOT go
+//! through the ordinary object machinery. Instead the index is validated
+//! against the view's length and the descriptor is constrained to a writable,
+//! enumerable, configurable data property; a valid in-bounds value descriptor
+//! writes the element, and everything else is rejected (`Reflect.defineProperty`
+//! returns `false`; `Object.defineProperty` throws a `TypeError`).
+//!
+//! Keys that are NOT canonical numeric index strings (`"length"`, `"foo"`,
+//! `"1.0"`, `"+1"`, symbols, …) fall through to ordinary `[[DefineOwnProperty]]`
+//! — this module reports `NotTypedArray` for those so the caller keeps its
+//! existing behavior.
+//!
+//! Detached `ArrayBuffer`s are not modeled in Perry, so `IsValidIntegerIndex`
+//! here never observes a detached backing store; the detached-buffer test262
+//! cases remain out of scope.
+
+use super::*;
+
+/// Outcome of the TypedArray exotic `[[DefineOwnProperty]]` check.
+pub(crate) enum TypedArrayDefineOutcome {
+    /// Receiver isn't a TypedArray, or the key isn't a canonical numeric index
+    /// — fall back to ordinary `[[DefineOwnProperty]]`.
+    NotTypedArray,
+    /// The integer-indexed branch rejected the definition (`false` / `TypeError`).
+    Rejected,
+    /// The integer-indexed branch accepted (and applied) the definition (`true`).
+    Defined,
+}
+
+/// Resolve the raw heap address behind a NaN-boxed value (pointer tag or a bare
+/// in-range pointer carried as raw bits).
+#[inline]
+fn value_addr(value: f64) -> usize {
+    let bits = value.to_bits();
+    if (bits >> 48) >= 0x7FF8 {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else {
+        bits as usize
+    }
+}
+
+/// If `value` is a TypedArray view, return `(addr, is_uint8_buffer, length)`.
+/// `is_uint8_buffer` distinguishes the `BufferHeader`-backed `Uint8Array`
+/// representation from the `TypedArrayHeader`-backed kinds.
+fn typed_array_view_info(value: f64) -> Option<(usize, bool, u32)> {
+    let addr = value_addr(value);
+    if addr < 0x1000 {
+        return None;
+    }
+    if crate::buffer::is_uint8array_buffer(addr) {
+        let len = crate::buffer::js_buffer_length(addr as *const crate::buffer::BufferHeader);
+        return Some((addr, true, len.max(0) as u32));
+    }
+    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let len = crate::typedarray::js_typed_array_length(
+            addr as *const crate::typedarray::TypedArrayHeader,
+        );
+        return Some((addr, false, len.max(0) as u32));
+    }
+    None
+}
+
+/// `CanonicalNumericIndexString(key)` — returns the numeric value when `key` is
+/// the canonical string form of a Number (so `ToString(ToNumber(key)) == key`),
+/// else `None`. `"-0"` is canonical (mapping to `-0`).
+fn canonical_numeric_index(key: &str) -> Option<f64> {
+    if key == "-0" {
+        return Some(-0.0);
+    }
+    // ToNumber(String) — mirror the element-store string coercion: trim, then
+    // parse as an IEEE double (parse failure → NaN).
+    let n = key.trim().parse::<f64>().unwrap_or(f64::NAN);
+    // Round-trip through JS `ToString(Number)` to confirm canonicality.
+    let rendered = number_to_js_string(n);
+    if rendered.as_deref() == Some(key) {
+        Some(n)
+    } else {
+        None
+    }
+}
+
+/// `ToString(Number)` rendered to an owned Rust string via the runtime's
+/// number formatter (so `1e+21`, `NaN`, `Infinity` match JS output exactly).
+fn number_to_js_string(n: f64) -> Option<String> {
+    let s = crate::string::js_number_to_string(n);
+    if s.is_null() {
+        return None;
+    }
+    unsafe {
+        let len = (*s).byte_len as usize;
+        let data = (s as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        std::str::from_utf8(std::slice::from_raw_parts(data, len))
+            .ok()
+            .map(|s| s.to_string())
+    }
+}
+
+/// `IsValidIntegerIndex(O, index)` minus the detached-buffer check (not modeled):
+/// integral, not `-0`, and in `[0, length)`.
+fn is_valid_integer_index(index: f64, length: u32) -> bool {
+    if !index.is_finite() || index.fract() != 0.0 {
+        return false;
+    }
+    if index == 0.0 && index.is_sign_negative() {
+        return false; // -0
+    }
+    index >= 0.0 && index < length as f64
+}
+
+/// Is the descriptor's `name` field present and falsy (`{ name: false }`)?
+unsafe fn field_present_and_false(desc: *mut ObjectHeader, name: &[u8]) -> bool {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    if !own_key_present(desc, key) {
+        return false;
+    }
+    let v = js_object_get_field_by_name(desc as *const ObjectHeader, key);
+    crate::value::js_is_truthy(f64::from_bits(v.bits())) == 0
+}
+
+/// Is the descriptor's `name` field present (regardless of value)?
+unsafe fn field_present(desc: *mut ObjectHeader, name: &[u8]) -> bool {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    own_key_present(desc, key)
+}
+
+/// TypedArray Integer-Indexed `[[DefineOwnProperty]]`. See module docs.
+///
+/// `key_value` and `descriptor_value` are the raw NaN-boxed arguments. The
+/// caller must have already validated that `descriptor_value` is an object.
+pub(crate) unsafe fn typed_array_define_own_property(
+    obj_value: f64,
+    key_value: f64,
+    descriptor_value: f64,
+) -> TypedArrayDefineOutcome {
+    let Some((addr, is_buf, length)) = typed_array_view_info(obj_value) else {
+        return TypedArrayDefineOutcome::NotTypedArray;
+    };
+
+    // Only String keys can be canonical numeric index strings. Symbols (and any
+    // non-string key) fall through to ordinary define.
+    if crate::symbol::js_is_symbol(key_value) != 0 {
+        return TypedArrayDefineOutcome::NotTypedArray;
+    }
+    let key_str_ptr = crate::builtins::js_string_coerce(key_value);
+    if key_str_ptr.is_null() {
+        return TypedArrayDefineOutcome::NotTypedArray;
+    }
+    let key = {
+        let name_ptr = (key_str_ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_len = (*key_str_ptr).byte_len as usize;
+        match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+            Ok(s) => s.to_string(),
+            Err(_) => return TypedArrayDefineOutcome::NotTypedArray,
+        }
+    };
+
+    let Some(numeric_index) = canonical_numeric_index(&key) else {
+        // Not a canonical numeric index → ordinary define handles it.
+        return TypedArrayDefineOutcome::NotTypedArray;
+    };
+
+    // Canonical numeric index → integer-indexed branch. From here every path
+    // returns Rejected or Defined; we never fall back to ordinary define.
+    if !is_valid_integer_index(numeric_index, length) {
+        return TypedArrayDefineOutcome::Rejected;
+    }
+
+    let desc = extract_obj_ptr(descriptor_value);
+    if desc.is_null() {
+        // Descriptor isn't ObjectHeader-backed; nothing constrains the index, so
+        // accept with no element write (matches an all-default data descriptor).
+        return TypedArrayDefineOutcome::Defined;
+    }
+
+    // A valid integer index requires a configurable, enumerable, writable data
+    // descriptor. Any field that contradicts that rejects the definition.
+    if field_present_and_false(desc, b"configurable") {
+        return TypedArrayDefineOutcome::Rejected;
+    }
+    if field_present_and_false(desc, b"enumerable") {
+        return TypedArrayDefineOutcome::Rejected;
+    }
+    if field_present(desc, b"get") || field_present(desc, b"set") {
+        return TypedArrayDefineOutcome::Rejected; // accessor descriptor
+    }
+    if field_present_and_false(desc, b"writable") {
+        return TypedArrayDefineOutcome::Rejected;
+    }
+
+    // If the descriptor carries a value, perform IntegerIndexedElementSet. The
+    // ToNumber coercion may run user `valueOf` (and throw) before the write.
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    if own_key_present(desc, value_key) {
+        let value_field = js_object_get_field_by_name(desc as *const ObjectHeader, value_key);
+        let value = f64::from_bits(value_field.bits());
+        // Object values coerce via OrdinaryToPrimitive(number) first, running a
+        // user `valueOf`/`toString` (which may throw). The resulting primitive is
+        // fed to the per-kind element store, which re-coerces it numerically.
+        let primitive = if crate::value::JSValue::from_bits(value.to_bits()).is_pointer() {
+            match crate::value::ordinary_to_primitive_number_for_add(value) {
+                crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => p,
+                _ => f64::NAN,
+            }
+        } else {
+            value
+        };
+        let idx = numeric_index as u32;
+        if is_buf {
+            let n = crate::value::JSValue::from_bits(primitive.to_bits()).to_number();
+            crate::buffer::js_buffer_set(
+                addr as *mut crate::buffer::BufferHeader,
+                idx as i32,
+                n as i32,
+            );
+        } else {
+            crate::typedarray::js_typed_array_set(
+                addr as *mut crate::typedarray::TypedArrayHeader,
+                idx as i32,
+                primitive,
+            );
+        }
+    }
+
+    TypedArrayDefineOutcome::Defined
+}

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1524,27 +1524,9 @@ pub extern "C" fn js_reflect_define_property(obj: f64, key: f64, descriptor: f64
             return coerce_trap_bool(trap_result);
         }
         // No trap — define on the underlying target with ordinary semantics.
-        return reflect_ordinary_define(target, key, descriptor);
+        return crate::object::reflect_define_property(target, key, descriptor);
     }
-    reflect_ordinary_define(obj, key, descriptor)
-}
-
-/// Ordinary (non-proxy) `[[DefineOwnProperty]]` reporting success as a boolean.
-fn reflect_ordinary_define(obj: f64, key: f64, descriptor: f64) -> f64 {
-    let has_own = crate::object::obj_value_has_own_key(obj, key);
-    // Redefining a non-configurable existing property fails.
-    if has_own {
-        if let Some((_writable, configurable)) = crate::object::obj_value_attrs(obj, key) {
-            if !configurable {
-                return nanbox_bool(false);
-            }
-        }
-    } else if crate::object::obj_value_no_extend(obj) {
-        // Defining a brand-new property on a non-extensible object fails.
-        return nanbox_bool(false);
-    }
-    crate::object::js_object_define_property(obj, key, descriptor);
-    nanbox_bool(true)
+    crate::object::reflect_define_property(obj, key, descriptor)
 }
 
 /// `Reflect.getPrototypeOf(obj)` — shares the actual prototype lookup with


### PR DESCRIPTION
## Summary

Implements the ECMAScript **Integer-Indexed exotic `[[DefineOwnProperty]]`** for TypedArrays, so `Object.defineProperty` / `Reflect.defineProperty` with a canonical numeric-index key behave per spec instead of routing through ordinary `[[DefineOwnProperty]]` (which treated every TypedArray as non-extensible and rejected all index defines).

Part of the parity-to-95% roadmap (#4315), cluster **B / TypedArray deep semantics**.

## Root cause

A TypedArray is an Integer-Indexed exotic object. For a key that is a *CanonicalNumericIndexString*, `[[DefineOwnProperty]]` must:
- validate the index with `IsValidIntegerIndex` (integral, not `-0`, in `[0, length)`),
- reject (`false` / `TypeError`) accessor descriptors and any `configurable:false` / `enumerable:false` / `writable:false`,
- otherwise perform `IntegerIndexedElementSet` and return `true`.

Perry instead sent these through the ordinary object path, where TypedArrays are seen as non-extensible — so `Reflect.defineProperty(ta, "0", {value:1})` returned `false` and never wrote the element, and `Object.defineProperty` threw `"object is not extensible"`.

## Fix

New `crates/perry-runtime/src/object/typed_array_define.rs` implements the algorithm (CanonicalNumericIndexString via a `ToString(ToNumber(key)) == key` round-trip, `IsValidIntegerIndex`, descriptor constraints, and `IntegerIndexedElementSet` covering both the `BufferHeader`-backed `Uint8Array` and `TypedArrayHeader`-backed representations). Object-valued descriptors run `valueOf`/`toString` before the write. Non-canonical keys (`"length"`, `"foo"`, `"1.0"`, `"+1"`) and symbols return `NotTypedArray` and keep the existing ordinary-define behavior.

Wired into both entry points:
- `js_object_define_property` — throws `TypeError` on rejection.
- `Reflect.defineProperty` — returns `false` on rejection (the shared `reflect_ordinary_define` body moved from `proxy.rs` into `object/reflect_support.rs`, which also keeps both files under the 2000-line cap).

Detached `ArrayBuffer`s are not modeled in Perry, so the detached-buffer cases are out of scope.

## Results

`test262 built-ins/TypedArrayConstructors/internals/DefineOwnProperty`: **40 → 24 failures** (16 fixed), measured uncapped via `scripts/parity_gap_report.py`. **No new failures.**

Verified byte-identical to `node --experimental-strip-types` in **both** `PERRY_NO_AUTO_OPTIMIZE=1` and default builds for: valid index set, out-of-bounds / negative / `-0` / non-integer index rejection, accessor-descriptor rejection, `configurable/enumerable/writable:false` rejection, and `Uint8Array` ToUint8 element store (`value:300 → 44`). Regression-checked plain-object / array `defineProperty`, frozen-object rejection, and normal TA element writes — all unchanged.

`cargo test --release -p perry-runtime --lib`: **977 passed, 0 failed.**

## Remaining (separate pre-existing gaps, out of scope)

The 24 still-failing cases are blocked by independent gaps, not this define path:
- **BigInt typed-array element storage** (15) — `bigTA[i] = 5n` already reads/writes `0` (a Number) on `main`; the side-effect assertions compare against `0n`/`1n`.
- **TypedArray expando properties** — `Object.defineProperty(ta, "1.0", …)` (ordinary, non-index) is not supported.
- **Integer-indexed `[[GetOwnProperty]]`** — `Object.getOwnPropertyDescriptor(ta, "0")` returns `undefined`, failing `verifyProperty` steps.
- **Detached buffers** and float NaN-canonicalization precision.

These are good follow-up issues; happy to file them.
