### PR TITLE
fix(runtime): TypedArray integer-indexed [[GetOwnProperty]] descriptors

### DIFF
--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -155,6 +155,20 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
 
+        // TypedArrays are Integer-Indexed exotic objects: a canonical numeric
+        // index key resolves to the element as a writable/enumerable/
+        // configurable data property (valid index) or to no own property
+        // (out-of-bounds / invalid index), never the ordinary keys table.
+        match super::typed_array_own_index(obj_value, key_value) {
+            super::TypedArrayOwnIndex::Element(value) => {
+                return build_data_descriptor(value, true, true, true);
+            }
+            super::TypedArrayOwnIndex::OutOfBounds => {
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            }
+            super::TypedArrayOwnIndex::NotTypedArray => {}
+        }
+
         if let Some(class_id) = class_ref_id(obj_value) {
             let method_name = metadata_key_to_string(key_value);
             if let Some(method_name) = method_name {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -102,7 +102,10 @@ pub(crate) use primitive_proto_thunks::primitive_proto_method_value;
 pub use property_key::*;
 pub(crate) use prototype_helpers::*;
 pub(crate) use reflect_support::*;
-pub(crate) use typed_array_define::{typed_array_define_own_property, TypedArrayDefineOutcome};
+pub(crate) use typed_array_define::{
+    typed_array_define_own_property, typed_array_own_index, TypedArrayDefineOutcome,
+    TypedArrayOwnIndex,
+};
 pub use util_types::*;
 pub use with_env::*;
 

--- a/crates/perry-runtime/src/object/typed_array_define.rs
+++ b/crates/perry-runtime/src/object/typed_array_define.rs
@@ -127,6 +127,59 @@ unsafe fn field_present(desc: *mut ObjectHeader, name: &[u8]) -> bool {
     own_key_present(desc, key)
 }
 
+/// If `key_value` is a String key that is a CanonicalNumericIndexString, return
+/// its numeric value. Returns `None` for symbols, non-string keys, and strings
+/// that aren't canonical numeric indices (those go through ordinary semantics).
+unsafe fn canonical_index_for_key(key_value: f64) -> Option<f64> {
+    if crate::symbol::js_is_symbol(key_value) != 0 {
+        return None;
+    }
+    let key_str_ptr = crate::builtins::js_string_coerce(key_value);
+    if key_str_ptr.is_null() {
+        return None;
+    }
+    let name_ptr = (key_str_ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let name_len = (*key_str_ptr).byte_len as usize;
+    let key = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)).ok()?;
+    canonical_numeric_index(key)
+}
+
+/// Result of a TypedArray Integer-Indexed `[[GetOwnProperty]]`.
+pub(crate) enum TypedArrayOwnIndex {
+    /// Not a TypedArray, or the key isn't a canonical numeric index — fall back
+    /// to ordinary `[[GetOwnProperty]]`.
+    NotTypedArray,
+    /// Canonical numeric index but out of bounds / invalid — no own property.
+    OutOfBounds,
+    /// Valid in-bounds index — the element value (a NaN-boxed Number).
+    Element(f64),
+}
+
+/// TypedArray Integer-Indexed `[[GetOwnProperty]]`: resolves a canonical numeric
+/// index key to the element value (so `getOwnPropertyDescriptor(ta, "0")` yields
+/// a `{ value, writable, enumerable, configurable: true }` data descriptor).
+pub(crate) unsafe fn typed_array_own_index(obj_value: f64, key_value: f64) -> TypedArrayOwnIndex {
+    let Some((addr, is_buf, length)) = typed_array_view_info(obj_value) else {
+        return TypedArrayOwnIndex::NotTypedArray;
+    };
+    let Some(numeric_index) = canonical_index_for_key(key_value) else {
+        return TypedArrayOwnIndex::NotTypedArray;
+    };
+    if !is_valid_integer_index(numeric_index, length) {
+        return TypedArrayOwnIndex::OutOfBounds;
+    }
+    let idx = numeric_index as i32;
+    let value = if is_buf {
+        crate::buffer::js_buffer_get(addr as *const crate::buffer::BufferHeader, idx) as f64
+    } else {
+        crate::typedarray::js_typed_array_get(
+            addr as *const crate::typedarray::TypedArrayHeader,
+            idx,
+        )
+    };
+    TypedArrayOwnIndex::Element(value)
+}
+
 /// TypedArray Integer-Indexed `[[DefineOwnProperty]]`. See module docs.
 ///
 /// `key_value` and `descriptor_value` are the raw NaN-boxed arguments. The
@@ -140,26 +193,8 @@ pub(crate) unsafe fn typed_array_define_own_property(
         return TypedArrayDefineOutcome::NotTypedArray;
     };
 
-    // Only String keys can be canonical numeric index strings. Symbols (and any
-    // non-string key) fall through to ordinary define.
-    if crate::symbol::js_is_symbol(key_value) != 0 {
-        return TypedArrayDefineOutcome::NotTypedArray;
-    }
-    let key_str_ptr = crate::builtins::js_string_coerce(key_value);
-    if key_str_ptr.is_null() {
-        return TypedArrayDefineOutcome::NotTypedArray;
-    }
-    let key = {
-        let name_ptr = (key_str_ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-        let name_len = (*key_str_ptr).byte_len as usize;
-        match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
-            Ok(s) => s.to_string(),
-            Err(_) => return TypedArrayDefineOutcome::NotTypedArray,
-        }
-    };
-
-    let Some(numeric_index) = canonical_numeric_index(&key) else {
-        // Not a canonical numeric index → ordinary define handles it.
+    let Some(numeric_index) = canonical_index_for_key(key_value) else {
+        // Symbol / non-string / non-canonical key → ordinary define handles it.
         return TypedArrayDefineOutcome::NotTypedArray;
     };
 


### PR DESCRIPTION
## Summary

`Object.getOwnPropertyDescriptor(ta, i)` on a TypedArray returned **`undefined`** for every index, because the lookup routed through the ordinary keys table (TypedArrays store their elements in a separate backing buffer, not as ordinary own properties).

Per the ECMAScript **Integer-Indexed exotic `[[GetOwnProperty]]`**, a canonical numeric-index key must resolve to the element as a data property. Follow-up to #4353 (integer-indexed `[[DefineOwnProperty]]`), reusing the same canonical-index + view machinery. Part of #4315.

## Fix

Adds `typed_array_own_index` to `object/typed_array_define.rs` and a branch in `js_object_get_own_property_descriptor`:
- **valid in-bounds index** → `{ value, writable: true, enumerable: true, configurable: true }`,
- **out-of-bounds / non-integer / `-0`** → `undefined` (no own property),
- **symbols / non-canonical keys** → fall through to ordinary `[[GetOwnProperty]]` unchanged.

Covers both the `BufferHeader`-backed `Uint8Array` and `TypedArrayHeader`-backed kinds.

## Results

Verified byte-identical to `node --experimental-strip-types` in **both** `PERRY_NO_AUTO_OPTIMIZE=1` and default builds:

```
Object.getOwnPropertyDescriptor(new Int8Array([5,6]), "0")
  → {value:5, writable:true, enumerable:true, configurable:true}   // was: undefined
  "2"/"-1"/"0.5" → undefined                                       // out of bounds / invalid
new Uint8Array([10,20])["1"] descriptor → {value:20, …true}
```

Plain object / array descriptors unchanged. `cargo test --release -p perry-runtime --lib`: **977 passed, 0 failed.**

test262 `TypedArrayConstructors/internals`: `GetOwnProperty` 7→6, `DefineOwnProperty` 24→23 (the remaining cases are gated on separate pre-existing gaps — TA expando properties and BigInt element storage #4356 — not this path). No regressions.
