### PR TITLE
[codex] print inspector open banner

### DIFF
--- a/crates/perry-runtime/src/node_inspector.rs
+++ b/crates/perry-runtime/src/node_inspector.rs
@@ -528,6 +528,7 @@ pub extern "C" fn js_node_inspector_open(port: f64, host: f64, _wait: f64) -> f6
     let host = string_to_rust(host).unwrap_or_else(|| "127.0.0.1".to_string());
     let port = allocate_endpoint_port(port);
     let uuid = next_uuid();
+    let url = format!("ws://{host}:{port}/{uuid}");
     if let Ok(mut endpoint) = INSPECTOR_ENDPOINT.lock() {
         if endpoint.active {
             throw_node_error(
@@ -540,6 +541,8 @@ pub extern "C" fn js_node_inspector_open(port: f64, host: f64, _wait: f64) -> f6
         endpoint.port = port;
         endpoint.uuid = uuid;
     }
+    eprintln!("Debugger listening on {url}");
+    eprintln!("For help, see: https://nodejs.org/learn/getting-started/debugging");
     endpoint_handle()
 }
 


### PR DESCRIPTION
## Summary
- emit the Node-style `Debugger listening on ...` stderr line after a successful `inspector.open()`
- emit the matching Node help URL line using the generated inspector endpoint URL
- keep the existing inspector endpoint/session/network fixtures green

Refs #812.

## Validation
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target cargo check -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module inspector --filter endpoint` - 1 pass, 0 fail (`test-parity/reports/parity_report_20260604_070451.json`)
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module inspector` - 3 pass, 0 fail (`test-parity/reports/parity_report_20260604_070508.json`)
