### PR TITLE
[codex] align fs symlink callback and stats arity

### DIFF
--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -2172,6 +2172,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(DOUBLE, &p), (DOUBLE, &options)],
                     ))
                 }
+                "symlink" if args.len() >= 2 => {
+                    let target = lower_expr(ctx, &args[0])?;
+                    let path = lower_expr(ctx, &args[1])?;
+                    let arg2 = if args.len() >= 3 {
+                        lower_expr(ctx, &args[2])?
+                    } else {
+                        double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                    };
+                    let arg3 = if args.len() >= 4 {
+                        lower_expr(ctx, &args[3])?
+                    } else {
+                        double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                    };
+                    Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_fs_symlink_callback",
+                        &[
+                            (DOUBLE, &target),
+                            (DOUBLE, &path),
+                            (DOUBLE, &arg2),
+                            (DOUBLE, &arg3),
+                        ],
+                    ))
+                }
                 "rmdirSync" if !args.is_empty() => {
                     let p = lower_expr(ctx, &args[0])?;
                     let options = if args.len() >= 2 {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -402,6 +402,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_fs_glob_sync_options", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_fs_link_sync", I32, &[DOUBLE, DOUBLE]);
     module.declare_function("js_fs_symlink_sync", I32, &[DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_fs_symlink_callback",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
     module.declare_function("js_fs_readlink_sync", I64, &[DOUBLE]);
     module.declare_function("js_fs_readlink_sync_options", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_fs_readlink_dispatch", DOUBLE, &[DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -83,6 +83,23 @@ fn callback_or_arg3(arg2: f64, arg3: f64) -> *const ClosureHeader {
     }
 }
 
+fn callback_or_symlink_type_arg(arg2: f64, arg3: f64) -> *const ClosureHeader {
+    let fourth = extract_closure_ptr(arg3);
+    if !fourth.is_null() {
+        return fourth;
+    }
+    if !is_undefined_value(arg3) {
+        return required_callback(arg3);
+    }
+
+    let third = extract_closure_ptr(arg2);
+    if !third.is_null() {
+        third
+    } else {
+        required_callback(arg2)
+    }
+}
+
 fn callback_from_options_arg(options: f64, callback: f64) -> *const ClosureHeader {
     let cb = extract_closure_ptr(callback);
     if !cb.is_null() {
@@ -591,7 +608,7 @@ pub extern "C" fn js_fs_symlink_callback(
     arg3: f64,
 ) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
-    let cb = callback_or_arg3(arg2, arg3);
+    let cb = callback_or_symlink_type_arg(arg2, arg3);
     unsafe {
         match crate::fs::js_fs_symlink_result(from_value, to_value) {
             Ok(()) => call_cb0(cb),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -3693,7 +3693,7 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("fs", "ReadStream" | "WriteStream") => Some(2),
         ("fs", "Utf8Stream") => Some(0),
         ("fs", "Dir" | "Dirent") => Some(3),
-        ("fs", "Stats") => Some(14),
+        ("fs", "Stats") => Some(18),
         ("fs", "mkdtempDisposableSync") => Some(2),
         ("fs", "openAsBlob") => Some(1),
         ("fs", "_toUnixTimestamp") => Some(1),


### PR DESCRIPTION
## Summary

This is a narrow `node:fs` parity cut.

- Preserve the optional `type` slot when lowering direct `fs.symlink(target, path, type, callback)` calls so missing-callback validation reports the provided third argument, matching Node's `Received type string ('file')` behavior for `fs.symlink(target, path, "file")`.
- Align the native callable export metadata for `fs.Stats.length` from `14` to `18` so namespace/default export surfaces match Node 26.

## Context

A full FS parity sweep had two deterministic non-watch mismatches: callback argument validation for `fs.symlink` and `Stats.length` in `fs/imports/namespace-exports`. The symlink mismatch was partly runtime validation and partly codegen: the direct native call lowering dropped the optional third argument before the runtime callback helper could validate it.

Related: #2013 for the validation surface.

## Validation

- `cargo build -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all && cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- Direct Node 26/Perry output diffs for:
  - `test-parity/node-suite/fs/callbacks/arg-validation.ts`
  - `test-parity/node-suite/fs/imports/namespace-exports.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module fs --filter callbacks/arg-validation'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module fs --filter imports/namespace-exports'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module fs'` -> 170 pass / 3 fail; remaining failures are watcher delivery/promise timing cases outside this cut
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module fs --filter watch/watchfile-delivery'` -> pass on focused rerun
- `cargo test -p perry-runtime symlink --lib`
- `cargo test -p perry-codegen fs --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Non-Goals

- `fs.watch` / `fs.promises.watch` async iterator, abort, and delivery timing behavior
- Broader FS API behavior beyond this validation/export surface
