### PR TITLE
[codex] align buffer File constructors and own indices

### DIFF
--- a/crates/perry-codegen/src/expr/v8_interop.rs
+++ b/crates/perry-codegen/src/expr/v8_interop.rs
@@ -252,6 +252,16 @@ pub(crate) fn emit_v8_member_method_call(
 ///     class name; the rest of the lower_new path resolves it via the
 ///     usual `ctx.classes` lookup, which contains imported classes
 ///     under their original (un-namespaced) names.
+fn is_global_object_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::GlobalGet(_) => true,
+        Expr::PropertyGet { object, property } if property == "globalThis" => {
+            is_global_object_expr(object)
+        }
+        _ => false,
+    }
+}
+
 pub(crate) fn try_static_class_name<'a>(callee: &'a Expr, ctx: &FnCtx<'_>) -> Option<&'a str> {
     match callee {
         Expr::ClassRef(name) => Some(name.as_str()),
@@ -267,7 +277,7 @@ pub(crate) fn try_static_class_name<'a>(callee: &'a Expr, ctx: &FnCtx<'_>) -> Op
         // breaks on the resulting instance.
         Expr::ExternFuncRef { name, .. } if ctx.class_ids.contains_key(name) => Some(name.as_str()),
         Expr::PropertyGet { object, property } => {
-            if matches!(object.as_ref(), Expr::GlobalGet(_)) {
+            if is_global_object_expr(object.as_ref()) {
                 return Some(property.as_str());
             }
             // Namespace import via local: `import * as ns from 'm'; new ns.Foo()`.

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -100,3 +100,16 @@ pub(super) unsafe fn array_own_key_present(
         (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const u64;
     std::ptr::read(elements.add(index as usize)) != crate::value::TAG_HOLE
 }
+
+pub(super) unsafe fn buffer_own_key_present(
+    buf: *const crate::buffer::BufferHeader,
+    key: *const crate::StringHeader,
+) -> bool {
+    let Some(key_name) = string_header_as_str(key) else {
+        return false;
+    };
+    let Some(index) = super::canonical_array_index(key_name) else {
+        return false;
+    };
+    index < (*buf).length
+}

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -3312,6 +3312,13 @@ pub unsafe extern "C" fn js_native_call_method(
                 // `is_valid_obj_ptr`-false fallthrough returned `true` for
                 // *every* key (so a deleted slot still looked present).
                 let raw = jsval.as_pointer::<u8>() as usize;
+                if crate::buffer::is_registered_buffer(raw) {
+                    let present = super::has_own_helpers::buffer_own_key_present(
+                        raw as *const crate::buffer::BufferHeader,
+                        key_str,
+                    );
+                    return f64::from_bits(JSValue::bool(present).bits());
+                }
                 if crate::closure::is_closure_ptr(raw) {
                     let present = super::has_own_helpers::str_from_string_header(key_str)
                         .map(|k| super::has_own_helpers::closure_own_key_present(raw, k))

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -540,6 +540,13 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
         // which would read `keys_array` off a closure (out of bounds).
         if obj_js.is_pointer() {
             let ptr = obj_js.as_pointer::<u8>() as usize;
+            if crate::buffer::is_registered_buffer(ptr) {
+                let present = super::has_own_helpers::buffer_own_key_present(
+                    ptr as *const crate::buffer::BufferHeader,
+                    key_str,
+                );
+                return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+            }
             if crate::closure::is_closure_ptr(ptr) {
                 let present = super::has_own_helpers::str_from_string_header(key_str)
                     .map(|k| super::has_own_helpers::closure_own_key_present(ptr, k))


### PR DESCRIPTION
## Summary

This closes the two deterministic `node:buffer` parity failures from the current sweep.

- Recognize `new globalThis.File(...)` as a statically-known global constructor shape, so it routes through the existing `File` built-in constructor instead of the dynamic-new placeholder.
- Treat in-range Buffer numeric indices as own properties for `hasOwnProperty` / `Object.hasOwn` paths, matching Node while preserving the existing enumerable index behavior.

## Context

The initial buffer sweep on fresh `origin/main` was 131 pass / 2 fail:

- `node-suite/buffer/blob-file/global-file`: `globalThis.File` identity was present, but `new globalThis.File(...)` fell through to dynamic construction and threw `TypeError: File is not a function`.
- `node-suite/buffer/properties/enumerable-indices`: `b.propertyIsEnumerable("1")` already matched Node, but `b.hasOwnProperty("0")` returned false for an in-range Buffer index.

After this patch, the full buffer sweep is 133 pass / 0 fail.

## Validation

- `cargo fmt --all && cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- Direct Node 26/Perry output diffs for:
  - `test-parity/node-suite/buffer/blob-file/global-file.ts`
  - `test-parity/node-suite/buffer/properties/enumerable-indices.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module buffer --filter blob-file/global-file'`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module buffer --filter properties/enumerable-indices'`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module buffer'` -> 133 pass / 0 fail
- `cargo test -p perry-runtime has_own --lib`
- `cargo test -p perry-codegen try_static_class_name --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
