### PR TITLE
[codex] spread URLSearchParams entries

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -238,6 +238,23 @@ pub(crate) fn array_from_spread_value(value: f64) -> *mut ArrayHeader {
             raw_ptr as *const crate::typedarray::TypedArrayHeader,
         );
     }
+    if raw_ptr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+        let obj_type = unsafe {
+            let hdr =
+                (raw_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            (*hdr).obj_type
+        };
+        if obj_type == crate::gc::GC_TYPE_OBJECT {
+            let obj = raw_ptr as *mut crate::object::ObjectHeader;
+            if crate::url::try_read_as_search_params(obj).is_some() {
+                let boxed = crate::url::js_url_search_params_entries_arr(obj);
+                let ptr = crate::value::js_nanbox_get_pointer(boxed) as *mut ArrayHeader;
+                if !ptr.is_null() {
+                    return ptr;
+                }
+            }
+        }
+    }
     // A built-in iterator object (`arr.values()`, `map.entries()`, a String
     // iterator, …) IS already an iterator: drive `.next()` via the class-id
     // tower directly. These now inherit `[Symbol.iterator]` from the shared


### PR DESCRIPTION
## Summary
- teach strict array spread materialization to recognize URLSearchParams objects
- return the same `[key, value]` entries array used by URLSearchParams `Array.from` / `Object.fromEntries` handling
- fixes the residual `[...sp]` failure in `node-suite/url/search-params/iteration` while keeping the full URL module green

Refs #812. Follow-up to closed #1668.

## Validation
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target cargo check -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module url --filter iteration` - 1 pass, 0 fail (`test-parity/reports/parity_report_20260604_074223.json`)
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module url` - 67 pass, 0 fail (`test-parity/reports/parity_report_20260604_074237.json`)
