### PR TITLE
[codex] Support typed array own properties

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -654,6 +654,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ))
         }
         Expr::Uint8ArrayGet { array, index } => {
+            if !is_numeric_expr(ctx, index) {
+                let a = lower_expr(ctx, array)?;
+                let key = lower_expr(ctx, index)?;
+                let blk = ctx.block();
+                let handle = unbox_to_i64(blk, &a);
+                return Ok(blk.call(
+                    DOUBLE,
+                    "js_typed_array_index_get_dynamic",
+                    &[(I64, &handle), (DOUBLE, &key)],
+                ));
+            }
             let value = lower_uint8array_get_i32(ctx, array, index)?;
             let reason = buffer_access_materialization_reason(ctx, array);
             Ok(materialize_js_value(ctx, value, reason))
@@ -668,6 +679,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             index,
             value,
         } => {
+            if !is_numeric_expr(ctx, index) {
+                let a = lower_expr(ctx, array)?;
+                let key = lower_expr(ctx, index)?;
+                let val = lower_expr(ctx, value)?;
+                let blk = ctx.block();
+                let handle = unbox_to_i64(blk, &a);
+                let result = blk.call(
+                    DOUBLE,
+                    "js_typed_array_index_set_dynamic",
+                    &[(I64, &handle), (DOUBLE, &key), (DOUBLE, &val)],
+                );
+                if ctx.discard_expr_value {
+                    return Ok(double_literal(0.0));
+                }
+                return Ok(result);
+            }
             if let Some(store) =
                 lower_buffer_store(ctx, array, index, value, BufferAccessSpec::uint8array_set())?
             {

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -68,6 +68,13 @@ fn is_width_tracked_typed_array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool
     )
 }
 
+fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
+    matches!(
+        receiver_class_name(ctx, object).as_deref(),
+        Some("Uint8Array")
+    )
+}
+
 fn lower_guarded_array_index_get(
     ctx: &mut FnCtx<'_>,
     arr_box: &str,
@@ -476,6 +483,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     vec!["typed_array_fallback=untracked_or_unproven".to_string()],
                 );
                 return Ok(result);
+            }
+            if is_uint8array_receiver(ctx, object) && !is_numeric_expr(ctx, index) {
+                let arr_box = lower_expr(ctx, object)?;
+                let key_box = lower_expr(ctx, index)?;
+                let blk = ctx.block();
+                let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                let arr_i64 = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                return Ok(blk.call(
+                    DOUBLE,
+                    "js_typed_array_index_get_dynamic",
+                    &[(I64, &arr_i64), (DOUBLE, &key_box)],
+                ));
             }
             // Scalar-replaced array literal: `arr[k]` where arr was bound to
             // `[...]` and never escaped, and k is a compile-time index in

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -71,6 +71,13 @@ fn is_width_tracked_typed_array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool
     )
 }
 
+fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
+    matches!(
+        receiver_class_name(ctx, object).as_deref(),
+        Some("Uint8Array")
+    )
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::IndexSet {
@@ -150,6 +157,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     vec!["typed_array_fallback=untracked_or_unproven".to_string()],
                 );
                 return Ok(val_double);
+            }
+            if is_uint8array_receiver(ctx, object) && !is_numeric_expr(ctx, index) {
+                let arr_box = lower_expr(ctx, object)?;
+                let idx_double = lower_expr(ctx, index)?;
+                let val_double = lower_expr(ctx, value)?;
+                let blk = ctx.block();
+                let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                let arr_i64 = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                return Ok(blk.call(
+                    DOUBLE,
+                    "js_typed_array_index_set_dynamic",
+                    &[
+                        (I64, &arr_i64),
+                        (DOUBLE, &idx_double),
+                        (DOUBLE, &val_double),
+                    ],
+                ));
             }
             // Issue #637 / hono r2 followup: `arr[stringKey] = val` where
             // the index is statically string-typed (e.g. `for (const i in

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -27,7 +27,8 @@ use crate::native_value::{
 #[allow(unused_imports)]
 use crate::type_analysis::{
     compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
+    is_numeric_expr, is_numeric_typed_array_class, is_set_expr, is_string_expr,
+    is_url_search_params_expr, receiver_class_name,
 };
 #[allow(unused_imports)]
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
@@ -164,25 +165,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &arr_handle))
         }
 
-        // Buffer / Uint8Array `.length` — INLINE for locals with a
-        // pre-computed `buffer_data_slots` entry. Length lives 8 bytes
-        // before the data start (BufferHeader). The slot is populated
-        // by `Stmt::Let` for `const x = Buffer.alloc(N)` / `new
-        // Uint8Array(N)` whose binding doesn't escape — same locals
-        // that get the GEP-based fast path in `Expr::Uint8ArrayGet`.
-        // Marked `!invariant.load` so LICM can hoist the read out of
-        // tight inner loops like image_conv's FNV-1a hash:
-        //
-        //   for (let i = 0; i < dst.length; i++)
-        //
-        // Without this, `dst.length` falls through to the GC-type
-        // gate below — Buffer/Uint8Array have no GC header (they're
-        // `std::alloc`'d), so `gc_type` reads garbage, `has_length`
-        // is false, and every iteration calls `js_value_length_f64`
-        // (function call into the side-table registry). v0.5.83's
-        // `is_array || is_string` guard intentionally routes Buffers
-        // through that slow path for safety, but the buffer-data-slot
-        // path proves the receiver shape at compile time.
+        // TypedArray `.length` can be shadowed by an own property, so use
+        // the runtime length helper before the Buffer/Uint8Array inline path.
+        Expr::PropertyGet { object, property }
+            if property == "length"
+                && receiver_class_name(ctx, object)
+                    .as_deref()
+                    .is_some_and(is_numeric_typed_array_class) =>
+        {
+            let recv_box = lower_expr(ctx, object)?;
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_value_length_f64", &[(DOUBLE, &recv_box)]))
+        }
+
         Expr::PropertyGet { object, property }
             if property == "length"
                 && matches!(object.as_ref(), Expr::LocalGet(id)

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -105,6 +105,11 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_typed_array_index_get_dynamic", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_typed_array_at", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_typed_array_set", VOID, &[I64, I32, DOUBLE]);
+    module.declare_function(
+        "js_typed_array_index_set_dynamic",
+        DOUBLE,
+        &[I64, DOUBLE, DOUBLE],
+    );
     module.declare_function("js_uint8array_get", I32, &[I64, I32]);
     module.declare_function("js_uint8array_set", VOID, &[I64, I32, I32]);
     module.declare_function("js_native_arena_alloc", I64, &[I64]);

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -631,7 +631,7 @@ pub(crate) fn is_bigint_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     }
 }
 
-fn is_numeric_typed_array_class(name: &str) -> bool {
+pub(crate) fn is_numeric_typed_array_class(name: &str) -> bool {
     matches!(
         name,
         "Int8Array"

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -273,6 +273,7 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::perf_hooks::scan_perf_entries_roots_mut);
     gc_register_mutable_root_scanner(crate::v8::scan_v8_promise_hook_roots_mut);
     gc_register_mutable_root_scanner(crate::typed_feedback::scan_typed_feedback_roots_mut);
+    gc_register_mutable_root_scanner(crate::typedarray_props::scan_typed_array_own_props_roots_mut);
     gc_register_mutable_root_scanner(transition_cache_mutable_root_scanner);
     gc_register_mutable_root_scanner(crate::object::scan_object_cache_roots_mut);
     gc_register_mutable_root_scanner(crate::object::scan_arguments_object_roots_mut);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -98,6 +98,7 @@ pub mod timer;
 pub mod typed_feedback;
 pub mod typedarray;
 pub mod typedarray_half;
+pub(crate) mod typedarray_props;
 pub mod typedarray_view;
 pub mod url;
 pub mod v8;

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -28,6 +28,14 @@ pub extern "C" fn js_object_delete_field(
         return 1;
     }
     unsafe {
+        if let Some(addr) =
+            crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
+        {
+            return crate::typedarray_props::typed_array_delete_own_property(
+                addr as *mut crate::typedarray::TypedArrayHeader,
+                key,
+            );
+        }
         if let Some(result) = super::arguments_object_before_delete(obj, key) {
             return result;
         }

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -169,6 +169,17 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             super::TypedArrayOwnIndex::NotTypedArray => {}
         }
 
+        if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+            let key_str = crate::builtins::js_string_coerce(key_value);
+            if key_str.is_null() {
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            }
+            return crate::typedarray_props::typed_array_get_own_property_descriptor(
+                addr as *const crate::typedarray::TypedArrayHeader,
+                key_str,
+            );
+        }
+
         if let Some(class_id) = class_ref_id(obj_value) {
             let method_name = metadata_key_to_string(key_value);
             if let Some(method_name) = method_name {
@@ -571,7 +582,7 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
 
 /// Build a `{ value, writable, enumerable, configurable }` data descriptor
 /// object. Shared by the string-primitive descriptor path (#2818).
-unsafe fn build_data_descriptor(
+pub(crate) unsafe fn build_data_descriptor(
     value: f64,
     writable: bool,
     enumerable: bool,
@@ -593,7 +604,7 @@ unsafe fn build_data_descriptor(
     f64::from_bits((desc as u64) | 0x7FFD_0000_0000_0000)
 }
 
-unsafe fn build_accessor_descriptor(
+pub(crate) unsafe fn build_accessor_descriptor(
     get: f64,
     set: f64,
     enumerable: bool,
@@ -686,6 +697,13 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
         }
         if let Some(str_value) = boxed_string_payload(obj_value) {
             return boxed_string_own_property_names(obj_value, str_value);
+        }
+        if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+            let result = crate::typedarray_props::typed_array_own_property_names(
+                addr as *const crate::typedarray::TypedArrayHeader,
+                false,
+            );
+            return f64::from_bits((result as u64) | 0x7FFD_0000_0000_0000);
         }
         if let Some(class_id) = class_ref_id(obj_value) {
             let is_prototype_ref = super::class_prototype_ref_id(obj_value).is_some();

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -951,6 +951,14 @@ pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
             return arr;
         }
     }
+    if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(value) {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_property_names(
+                addr as *const crate::typedarray::TypedArrayHeader,
+                true,
+            )
+        };
+    }
     if jv.is_pointer() {
         let ptr = jv.as_pointer::<u8>() as usize;
         if ptr > 0 && ptr < 0x100000 {
@@ -967,6 +975,14 @@ pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
                 }
             }
             return crate::array::js_array_alloc(0);
+        }
+        if crate::typedarray::lookup_typed_array_kind(ptr).is_some() {
+            return unsafe {
+                crate::typedarray_props::typed_array_own_property_names(
+                    ptr as *const crate::typedarray::TypedArrayHeader,
+                    true,
+                )
+            };
         }
         if crate::closure::is_closure_ptr(ptr) {
             return js_closure_dynamic_keys(ptr);
@@ -1099,8 +1115,22 @@ pub extern "C" fn js_object_values_value(value: f64) -> *mut ArrayHeader {
         }
         return out;
     }
+    if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(value) {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_enumerable_values(
+                addr as *const crate::typedarray::TypedArrayHeader,
+            )
+        };
+    }
     if jv.is_pointer() {
         let ptr = jv.as_pointer::<u8>() as usize;
+        if crate::typedarray::lookup_typed_array_kind(ptr).is_some() {
+            return unsafe {
+                crate::typedarray_props::typed_array_own_enumerable_values(
+                    ptr as *const crate::typedarray::TypedArrayHeader,
+                )
+            };
+        }
         if crate::closure::is_closure_ptr(ptr) {
             return js_closure_dynamic_values(ptr);
         }
@@ -1137,8 +1167,22 @@ pub extern "C" fn js_object_entries_value(value: f64) -> *mut ArrayHeader {
         }
         return out;
     }
+    if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(value) {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_enumerable_entries(
+                addr as *const crate::typedarray::TypedArrayHeader,
+            )
+        };
+    }
     if jv.is_pointer() {
         let ptr = jv.as_pointer::<u8>() as usize;
+        if crate::typedarray::lookup_typed_array_kind(ptr).is_some() {
+            return unsafe {
+                crate::typedarray_props::typed_array_own_enumerable_entries(
+                    ptr as *const crate::typedarray::TypedArrayHeader,
+                )
+            };
+        }
         if crate::closure::is_closure_ptr(ptr) {
             return js_closure_dynamic_entries(ptr);
         }
@@ -1258,6 +1302,24 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
             obj
         }
     };
+    if let Some(addr) =
+        crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
+    {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_property_names(
+                addr as *const crate::typedarray::TypedArrayHeader,
+                true,
+            )
+        };
+    }
+    if crate::typedarray::lookup_typed_array_kind(stripped as usize).is_some() {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_property_names(
+                stripped as *const crate::typedarray::TypedArrayHeader,
+                true,
+            )
+        };
+    }
     if crate::closure::is_closure_ptr(stripped as usize) {
         let props = crate::closure::closure_dynamic_props_snapshot(stripped as usize);
         let out = crate::array::js_array_alloc(props.len() as u32);
@@ -1402,6 +1464,31 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
 /// Returns an array of the object's field values
 #[no_mangle]
 pub extern "C" fn js_object_values(obj: *const ObjectHeader) -> *mut ArrayHeader {
+    let stripped = {
+        let bits = obj as u64;
+        let top16 = bits >> 48;
+        if top16 == 0x7FFD || top16 >= 0x7FF8 {
+            (bits & 0x0000_FFFF_FFFF_FFFF) as *const ObjectHeader
+        } else {
+            obj
+        }
+    };
+    if let Some(addr) =
+        crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
+    {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_enumerable_values(
+                addr as *const crate::typedarray::TypedArrayHeader,
+            )
+        };
+    }
+    if crate::typedarray::lookup_typed_array_kind(stripped as usize).is_some() {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_enumerable_values(
+                stripped as *const crate::typedarray::TypedArrayHeader,
+            )
+        };
+    }
     if obj.is_null() || !is_valid_obj_ptr(obj as *const u8) {
         // Issue #893: defensive sibling of `js_object_entries` —
         // see that function's comment for the rationale.
@@ -1442,6 +1529,31 @@ pub extern "C" fn js_object_values(obj: *const ObjectHeader) -> *mut ArrayHeader
 /// Returns an array where each element is a 2-element array [key, value]
 #[no_mangle]
 pub extern "C" fn js_object_entries(obj: *const ObjectHeader) -> *mut ArrayHeader {
+    let stripped = {
+        let bits = obj as u64;
+        let top16 = bits >> 48;
+        if top16 == 0x7FFD || top16 >= 0x7FF8 {
+            (bits & 0x0000_FFFF_FFFF_FFFF) as *const ObjectHeader
+        } else {
+            obj
+        }
+    };
+    if let Some(addr) =
+        crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
+    {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_enumerable_entries(
+                addr as *const crate::typedarray::TypedArrayHeader,
+            )
+        };
+    }
+    if crate::typedarray::lookup_typed_array_kind(stripped as usize).is_some() {
+        return unsafe {
+            crate::typedarray_props::typed_array_own_enumerable_entries(
+                stripped as *const crate::typedarray::TypedArrayHeader,
+            )
+        };
+    }
     if obj.is_null() || !is_valid_obj_ptr(obj as *const u8) {
         // Issue #893 lineage: chalk's `Object.entries(ansiStyles)` passed a
         // value whose unboxed low-48 bits weren't a real heap pointer
@@ -1596,6 +1708,33 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
 
     let obj_addr = obj_val.bits() & 0x0000_FFFF_FFFF_FFFF;
     if obj_addr >= 0x10000 {
+        if crate::typedarray::lookup_typed_array_kind(obj_addr as usize).is_some() {
+            let ta = obj_addr as *const crate::typedarray::TypedArrayHeader;
+            if key_val.is_any_string() {
+                let key_str =
+                    crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+                let present =
+                    unsafe { crate::typedarray_props::typed_array_has_own_property(ta, key_str) };
+                return if present { nanbox_true } else { nanbox_false };
+            }
+            if key_val.is_int32() {
+                let index = key_val.as_int32();
+                let present = unsafe { index >= 0 && (index as u32) < (*ta).length };
+                return if present { nanbox_true } else { nanbox_false };
+            }
+            if key_val.is_number() {
+                let f = f64::from_bits(key_val.bits());
+                let present = unsafe {
+                    f.is_finite()
+                        && f >= 0.0
+                        && f.fract() == 0.0
+                        && f <= i32::MAX as f64
+                        && (f as u32) < (*ta).length
+                };
+                return if present { nanbox_true } else { nanbox_false };
+            }
+            return nanbox_false;
+        }
         let obj_ptr = obj_addr as *mut ObjectHeader;
         unsafe {
             if !obj_ptr.is_null() && (*obj_ptr).class_id == NATIVE_MODULE_CLASS_ID {
@@ -1881,6 +2020,73 @@ pub extern "C" fn js_object_get_field_by_name(
                 return JSValue::from_bits(v.to_bits());
             }
         }
+    }
+    if let Some(addr) =
+        crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
+    {
+        if !key.is_null() {
+            unsafe {
+                let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let key_len = (*key).byte_len as usize;
+                let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+                let ta = addr as *const crate::typedarray::TypedArrayHeader;
+                if let Some(value) =
+                    crate::typedarray_props::typed_array_get_own_property_value(ta, key)
+                {
+                    return JSValue::from_bits(value.to_bits());
+                }
+                if let Some(kind) = crate::typedarray::lookup_typed_array_kind(addr) {
+                    let elem_size = crate::typedarray::elem_size_for_kind(kind);
+                    match key_bytes {
+                        b"length" => {
+                            let len = crate::typedarray::js_typed_array_length(ta);
+                            return JSValue::number(len as f64);
+                        }
+                        b"byteLength" => {
+                            let len = crate::typedarray::js_typed_array_length(ta);
+                            return JSValue::number((len as usize * elem_size) as f64);
+                        }
+                        b"buffer" => {
+                            let buf = crate::typedarray::typed_array_to_array_buffer(ta);
+                            if buf.is_null() {
+                                return JSValue::undefined();
+                            }
+                            return JSValue::from_bits(
+                                crate::value::js_nanbox_pointer(buf as i64).to_bits(),
+                            );
+                        }
+                        b"byteOffset" => return JSValue::number(0.0),
+                        b"BYTES_PER_ELEMENT" => return JSValue::number(elem_size as f64),
+                        _ => {}
+                    }
+                } else {
+                    let buf = addr as *const crate::buffer::BufferHeader;
+                    match key_bytes {
+                        b"length" | b"byteLength" => {
+                            return JSValue::number(crate::buffer::js_buffer_length(buf) as f64);
+                        }
+                        b"buffer" | b"parent" => {
+                            let alias = crate::buffer::buffer_backing_array_buffer(addr);
+                            return JSValue::from_bits(
+                                crate::value::js_nanbox_pointer(alias as i64).to_bits(),
+                            );
+                        }
+                        b"byteOffset" | b"offset" => {
+                            let offset = crate::buffer::buffer_byte_offset(addr);
+                            return JSValue::number(offset as f64);
+                        }
+                        b"BYTES_PER_ELEMENT" => return JSValue::number(1.0),
+                        b"constructor" => {
+                            let ctor =
+                                super::js_get_global_this_builtin_value(b"Uint8Array".as_ptr(), 10);
+                            return JSValue::from_bits(ctor.to_bits());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        return JSValue::undefined();
     }
     // #2128: a plain JS number value (a finite double or canonical NaN —
     // anything `JSValue::is_number` returns true for *minus* the raw-I64
@@ -2667,6 +2873,11 @@ pub extern "C" fn js_object_get_field_by_name(
                 let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
                 let ta = obj as *const crate::typedarray::TypedArrayHeader;
                 let elem_size = crate::typedarray::elem_size_for_kind(kind);
+                if let Some(value) =
+                    crate::typedarray_props::typed_array_get_own_property_value(ta, key)
+                {
+                    return JSValue::from_bits(value.to_bits());
+                }
                 match key_bytes {
                     b"length" => {
                         let len = crate::typedarray::js_typed_array_length(ta);
@@ -4061,6 +4272,10 @@ pub extern "C" fn js_object_get_field_ic_miss(
         // inspect GC/object metadata, so mirror js_object_get_field_by_name's
         // buffer-first dispatch here.
         if crate::buffer::is_registered_buffer(obj as usize) {
+            let value = js_object_get_field_by_name(obj, key);
+            return f64::from_bits(value.bits());
+        }
+        if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
             let value = js_object_get_field_by_name(obj, key);
             return f64::from_bits(value.bits());
         }

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -180,6 +180,19 @@ pub extern "C" fn js_object_set_field_by_name(
     key: *const crate::StringHeader,
     value: f64,
 ) {
+    if let Some(addr) =
+        crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
+    {
+        unsafe {
+            crate::typedarray_props::typed_array_set_own_property(
+                addr as *mut crate::typedarray::TypedArrayHeader,
+                key,
+                value,
+            );
+        }
+        return;
+    }
+
     // Issue #618-followup: detect INT32-tagged class ref (top16 == 0x7FFE).
     // Drizzle's `((SQL2) => { SQL2.Aliased = Aliased; })(SQL)` pattern sets
     // a static property on an imported class — Perry stores classes as
@@ -306,6 +319,16 @@ pub extern "C" fn js_object_set_field_by_name(
             }
         }
         return;
+    }
+    unsafe {
+        if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
+            crate::typedarray_props::typed_array_set_own_property(
+                obj as *mut crate::typedarray::TypedArrayHeader,
+                key,
+                value,
+            );
+            return;
+        }
     }
     unsafe {
         if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 && string_key_eq(key, b"length") {

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -54,6 +54,9 @@ unsafe fn describe_value_for_type_error(value: f64) -> String {
 /// `Object.create` accepts as a descriptor / properties bag? (#2817)
 /// Functions/closures count as objects too.
 pub(crate) unsafe fn value_is_object_like(value: f64) -> bool {
+    if crate::typedarray_props::typed_array_addr_from_value(value).is_some() {
+        return true;
+    }
     let jv = crate::value::JSValue::from_bits(value.to_bits());
     if !jv.is_pointer() {
         // Module-level raw-I64 object pointers (top16 == 0) — accept if it
@@ -104,14 +107,15 @@ unsafe fn registered_buffer_index_own_property_present(
         return None;
     }
 
-    Some(
-        super::has_own_helpers::str_from_string_header(key_str)
-            .and_then(super::canonical_array_index)
-            .is_some_and(|idx| {
-                let buf = raw_buffer_addr as *const crate::buffer::BufferHeader;
-                idx < (*buf).length as u32
-            }),
-    )
+    // Only answer for canonical *index* keys here. Non-index keys (e.g.
+    // `length` or user-defined expandos on a typed array) are owned by the
+    // `typedarray_props` registry — returning `Some(false)` for them would
+    // shadow that check (`typed_array_has_own_property`) and wrongly report
+    // a defined own property as absent. Fall through with `None` instead.
+    let idx = super::has_own_helpers::str_from_string_header(key_str)
+        .and_then(super::canonical_array_index)?;
+    let buf = raw_buffer_addr as *const crate::buffer::BufferHeader;
+    Some(idx < (*buf).length as u32)
 }
 
 /// Validate a property descriptor object per ES `ToPropertyDescriptor`
@@ -567,6 +571,14 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
             return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
         }
 
+        if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+            let present = crate::typedarray_props::typed_array_has_own_property(
+                addr as *const crate::typedarray::TypedArrayHeader,
+                key_str,
+            );
+            return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+        }
+
         // #3655: functions/closures carry built-in own `name`/`length`
         // (and `prototype` for constructors) plus any user-attached props.
         // Route them here instead of through `extract_obj_ptr`/`own_key_present`,
@@ -584,6 +596,13 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
                 let present = super::has_own_helpers::str_from_string_header(key_str)
                     .map(|k| super::has_own_helpers::closure_own_key_present(ptr, k))
                     .unwrap_or(false);
+                return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+            }
+            if crate::typedarray::lookup_typed_array_kind(ptr).is_some() {
+                let present = crate::typedarray_props::typed_array_has_own_property(
+                    ptr as *const crate::typedarray::TypedArrayHeader,
+                    key_str,
+                );
                 return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
             }
             if ptr >= crate::gc::GC_HEADER_SIZE + 0x1000
@@ -683,8 +702,12 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
             return f64::from_bits(if is_length { TAG_FALSE } else { TAG_TRUE });
         }
 
-        if let Some(present) = registered_buffer_index_own_property_present(obj_value, key_str) {
-            return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+        if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+            let enumerable = crate::typedarray_props::typed_array_property_is_enumerable(
+                addr as *const crate::typedarray::TypedArrayHeader,
+                key_str,
+            );
+            return f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE });
         }
 
         // #3655: functions/closures. Built-in `name`/`length`/`prototype` are
@@ -704,6 +727,13 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
                 let enumerable = super::get_property_attrs(ptr, key_name)
                     .map(|attrs| attrs.enumerable())
                     .unwrap_or(true);
+                return f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE });
+            }
+            if crate::typedarray::lookup_typed_array_kind(ptr).is_some() {
+                let enumerable = crate::typedarray_props::typed_array_property_is_enumerable(
+                    ptr as *const crate::typedarray::TypedArrayHeader,
+                    key_str,
+                );
                 return f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE });
             }
         }
@@ -1035,6 +1065,30 @@ pub extern "C" fn js_object_define_property(
             return obj_value;
         }
 
+        if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+            let key_str = crate::builtins::js_string_coerce(key_value);
+            if key_str.is_null() {
+                return obj_value;
+            }
+            let key_rust: Option<String> = {
+                let name_ptr =
+                    (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_len = (*key_str).byte_len as usize;
+                let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
+                std::str::from_utf8(name_bytes).ok().map(|s| s.to_string())
+            };
+            if let Some(ref key_name) = key_rust {
+                return crate::typedarray_props::typed_array_define_own_property(
+                    obj_value,
+                    addr as *mut crate::typedarray::TypedArrayHeader,
+                    key_str,
+                    key_name,
+                    descriptor_value,
+                );
+            }
+            return obj_value;
+        }
+
         let obj = extract_obj_ptr(obj_value);
         if obj.is_null() {
             return obj_value;
@@ -1126,6 +1180,18 @@ pub extern "C" fn js_object_define_property(
             let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
             std::str::from_utf8(name_bytes).ok().map(|s| s.to_string())
         };
+        if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
+            if let Some(ref key_name) = key_rust {
+                return crate::typedarray_props::typed_array_define_own_property(
+                    obj_value,
+                    obj as *mut crate::typedarray::TypedArrayHeader,
+                    key_str,
+                    key_name,
+                    descriptor_value,
+                );
+            }
+            return obj_value;
+        }
         if let Some(result) = super::define_array_property(
             obj,
             obj_value,

--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -43,6 +43,11 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
     if raw < 0x1000 {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
+    if let Some(value) =
+        unsafe { crate::typedarray_props::typed_array_get_numeric_index(raw as usize, idx) }
+    {
+        return value;
+    }
     if crate::buffer::is_registered_buffer(raw as usize) {
         let idx_i32 = idx as i32;
         let byte_val =
@@ -148,6 +153,10 @@ pub extern "C" fn js_object_set_index_polymorphic(obj_handle: i64, idx: f64, val
         return;
     }
     let idx_i32 = idx as i32;
+
+    if unsafe { crate::typedarray_props::typed_array_set_numeric_index(raw as usize, idx, value) } {
+        return;
+    }
 
     if unsafe { arguments_object_set_index(raw as *mut ObjectHeader, idx_i32 as u32, value) } {
         return;

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -1,6 +1,4 @@
-//! TypedArray support: Int8Array, Uint8Array, Int16Array, Uint16Array,
-//! Int32Array, Uint32Array, Float32Array, Float64Array, BigInt64Array,
-//! BigUint64Array.
+//! TypedArray support for all JS typed-array element kinds.
 //!
 //! Each TypedArrayHeader stores its element kind + size and a contiguous
 //! data region. Element-level read/write goes through `js_typed_array_get`
@@ -153,9 +151,11 @@ pub fn register_typed_array(ptr: *const TypedArrayHeader, kind: u8) {
 }
 
 pub fn unregister_typed_array(ptr: *const TypedArrayHeader) {
+    let owner = ptr as usize;
     TYPED_ARRAY_REGISTRY.with(|r| {
-        r.borrow_mut().remove(&(ptr as usize));
+        r.borrow_mut().remove(&owner);
     });
+    crate::typedarray_props::typed_array_clear_own_props(owner);
 }
 
 /// Returns Some(kind) if the (already-stripped) address is a registered
@@ -898,57 +898,7 @@ pub extern "C" fn js_typed_array_get(ta: *const TypedArrayHeader, index: i32) ->
 ///   * a numeric (non-string) key → integer-indexed element read.
 #[no_mangle]
 pub extern "C" fn js_typed_array_index_get_dynamic(ta: *const TypedArrayHeader, key: f64) -> f64 {
-    let jsval = crate::value::JSValue::from_bits(key.to_bits());
-    if jsval.is_string() || jsval.is_short_string() {
-        let key_ptr =
-            crate::value::js_get_string_pointer_unified(key) as *const crate::string::StringHeader;
-        if key_ptr.is_null() {
-            return f64::from_bits(crate::value::TAG_UNDEFINED);
-        }
-        if let Some(idx) = canonical_typed_array_index(key_ptr) {
-            return js_typed_array_get(ta, idx);
-        }
-        return crate::object::js_object_get_field_by_name_f64(
-            ta as *const crate::object::ObjectHeader,
-            key_ptr,
-        );
-    }
-    // Numeric key — INT32 tag or plain double (defensive: codegen only routes
-    // string-typed keys here, but type erasure can let a number flow in).
-    let num = if jsval.is_int32() {
-        jsval.as_int32() as f64
-    } else if !key.is_nan() {
-        key
-    } else {
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
-    };
-    if !num.is_finite() || num < 0.0 || num.fract() != 0.0 || num > i32::MAX as f64 {
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
-    }
-    js_typed_array_get(ta, num as i32)
-}
-
-/// Canonical numeric array-index parse for a TypedArray string key. Returns
-/// `Some(idx)` only when `key` is the canonical decimal form of a
-/// non-negative integer in `[0, i32::MAX]` (no leading zeros, sign, or
-/// fractional part) — a CanonicalNumericIndexString that is a valid integer
-/// index. Mirrors the array string-key dispatch in `js_array_set_string_key`.
-fn canonical_typed_array_index(key: *const crate::string::StringHeader) -> Option<i32> {
-    let key_str = unsafe {
-        let len = (*key).byte_len as usize;
-        if len == 0 {
-            return None;
-        }
-        let data = (key as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
-        let bytes = std::slice::from_raw_parts(data, len);
-        std::str::from_utf8(bytes).ok()?
-    };
-    let idx = key_str.parse::<u32>().ok()?;
-    if idx.to_string() == key_str && idx <= i32::MAX as u32 {
-        Some(idx as i32)
-    } else {
-        None
-    }
+    unsafe { crate::typedarray_props::typed_array_index_get_dynamic(ta as usize, key) }
 }
 
 // #2063: force-keep the dynamic-key getter under LTO / auto-optimize. Like

--- a/crates/perry-runtime/src/typedarray_props.rs
+++ b/crates/perry-runtime/src/typedarray_props.rs
@@ -1,0 +1,827 @@
+use std::cell::RefCell;
+
+use crate::array::ArrayHeader;
+use crate::closure::ClosureHeader;
+use crate::typedarray::{
+    js_typed_array_get, js_typed_array_set, lookup_typed_array_kind, TypedArrayHeader,
+};
+
+thread_local! {
+    static TYPED_ARRAY_OWN_PROPS: RefCell<crate::fast_hash::PtrHashMap<usize, Vec<TypedArrayOwnProp>>> =
+        RefCell::new(crate::fast_hash::new_ptr_hash_map());
+}
+
+#[derive(Clone)]
+struct TypedArrayOwnProp {
+    key: String,
+    value: f64,
+    is_data: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TypedArrayStringKeyKind {
+    InBoundsIndex(u32),
+    IntegerIndex,
+    Ordinary,
+}
+
+#[derive(Clone, Copy)]
+enum TypedArrayOwnerKind {
+    TypedArray,
+    Uint8ArrayBuffer,
+}
+
+fn typed_array_owner_kind(owner: usize) -> Option<TypedArrayOwnerKind> {
+    if lookup_typed_array_kind(owner).is_some() {
+        Some(TypedArrayOwnerKind::TypedArray)
+    } else if crate::buffer::is_uint8array_buffer(owner) {
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    } else {
+        None
+    }
+}
+
+unsafe fn typed_array_owner_length(owner: usize) -> u32 {
+    match typed_array_owner_kind(owner) {
+        Some(TypedArrayOwnerKind::TypedArray) => (*(owner as *const TypedArrayHeader)).length,
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer) => {
+            crate::buffer::js_buffer_length(owner as *const crate::buffer::BufferHeader) as u32
+        }
+        None => 0,
+    }
+}
+
+unsafe fn typed_array_owner_get(owner: usize, index: u32) -> f64 {
+    match typed_array_owner_kind(owner) {
+        Some(TypedArrayOwnerKind::TypedArray) => {
+            js_typed_array_get(owner as *const TypedArrayHeader, index as i32)
+        }
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer) => {
+            crate::buffer::js_buffer_get(owner as *const crate::buffer::BufferHeader, index as i32)
+                as f64
+        }
+        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    }
+}
+
+unsafe fn typed_array_owner_set(owner: usize, index: u32, value: f64) {
+    match typed_array_owner_kind(owner) {
+        Some(TypedArrayOwnerKind::TypedArray) => {
+            js_typed_array_set(owner as *mut TypedArrayHeader, index as i32, value);
+        }
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer) => {
+            crate::buffer::js_buffer_set(
+                owner as *mut crate::buffer::BufferHeader,
+                index as i32,
+                value as i32,
+            );
+        }
+        None => {}
+    }
+}
+
+pub(crate) fn typed_array_clear_own_props(owner: usize) {
+    TYPED_ARRAY_OWN_PROPS.with(|m| {
+        m.borrow_mut().remove(&owner);
+    });
+}
+
+pub(crate) fn typed_array_addr_from_value(value: f64) -> Option<usize> {
+    let jsval = crate::value::JSValue::from_bits(value.to_bits());
+    let valid_addr = |addr: usize| {
+        (addr > 0x10000 && addr <= crate::value::POINTER_MASK as usize && addr & 0x7 == 0)
+            .then_some(addr)
+            .filter(|addr| typed_array_owner_kind(*addr).is_some())
+    };
+    if jsval.is_pointer() {
+        return valid_addr(jsval.as_pointer::<u8>() as usize);
+    }
+    let bits = value.to_bits();
+    if let Some(addr) = valid_addr(bits as usize) {
+        return Some(addr);
+    }
+    if value.is_finite() && value.fract() == 0.0 && value > 0.0 {
+        return valid_addr(value as usize);
+    }
+    None
+}
+
+unsafe fn string_header_str<'a>(key: *const crate::string::StringHeader) -> Option<&'a str> {
+    if key.is_null() || (key as usize) < 0x10000 {
+        return None;
+    }
+    let len = (*key).byte_len as usize;
+    let data = (key as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+    std::str::from_utf8(std::slice::from_raw_parts(data, len)).ok()
+}
+
+fn unsigned_canonical_index(name: &str) -> Option<u32> {
+    if name == "0" {
+        return Some(0);
+    }
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || bytes[0] == b'0' || !bytes.iter().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let idx = name.parse::<u32>().ok()?;
+    if idx.to_string() == name {
+        Some(idx)
+    } else {
+        None
+    }
+}
+
+fn is_canonical_numeric_index_name(name: &str) -> bool {
+    if matches!(name, "-0" | "NaN" | "Infinity" | "-Infinity") {
+        return true;
+    }
+    let Ok(value) = name.parse::<f64>() else {
+        return false;
+    };
+    if !value.is_finite() {
+        return false;
+    }
+    if value.fract() == 0.0 && value.abs() <= i64::MAX as f64 {
+        format!("{}", value as i64) == name
+    } else {
+        format!("{value}") == name
+    }
+}
+
+fn typed_array_string_key_kind(name: &str, len: u32) -> TypedArrayStringKeyKind {
+    if let Some(index) = unsigned_canonical_index(name) {
+        if index < len && index <= i32::MAX as u32 {
+            TypedArrayStringKeyKind::InBoundsIndex(index)
+        } else {
+            TypedArrayStringKeyKind::IntegerIndex
+        }
+    } else if is_canonical_numeric_index_name(name) {
+        TypedArrayStringKeyKind::IntegerIndex
+    } else {
+        TypedArrayStringKeyKind::Ordinary
+    }
+}
+
+fn typed_array_value(ta: *const TypedArrayHeader) -> f64 {
+    crate::value::js_nanbox_pointer(ta as i64)
+}
+
+fn invoke_typed_array_accessor_getter(get_bits: u64, receiver: f64) -> f64 {
+    let closure = (get_bits & crate::value::POINTER_MASK) as *const ClosureHeader;
+    if closure.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let prev = crate::object::js_implicit_this_set(receiver);
+    let result = crate::closure::js_closure_call0(closure);
+    crate::object::js_implicit_this_set(prev);
+    result
+}
+
+fn invoke_typed_array_accessor_setter(set_bits: u64, receiver: f64, value: f64) {
+    let closure = (set_bits & crate::value::POINTER_MASK) as *const ClosureHeader;
+    if closure.is_null() {
+        return;
+    }
+    let prev = crate::object::js_implicit_this_set(receiver);
+    crate::closure::js_closure_call1(closure, value);
+    crate::object::js_implicit_this_set(prev);
+}
+
+fn barrier_typed_array_own_props(owner: usize, props: &mut [TypedArrayOwnProp]) {
+    for prop in props.iter_mut().filter(|prop| prop.is_data) {
+        crate::gc::runtime_write_barrier_external_slot(
+            owner,
+            &mut prop.value as *mut f64 as usize,
+            prop.value.to_bits(),
+        );
+    }
+}
+
+fn upsert_typed_array_own_prop(owner: usize, key: String, value: f64, is_data: bool) {
+    TYPED_ARRAY_OWN_PROPS.with(|m| {
+        let mut map = m.borrow_mut();
+        let props = map.entry(owner).or_default();
+        if let Some(prop) = props.iter_mut().find(|prop| prop.key == key) {
+            prop.value = value;
+            prop.is_data = is_data;
+        } else {
+            props.push(TypedArrayOwnProp {
+                key,
+                value,
+                is_data,
+            });
+        }
+        barrier_typed_array_own_props(owner, props);
+    });
+}
+
+fn remove_typed_array_own_prop(owner: usize, key: &str) -> bool {
+    TYPED_ARRAY_OWN_PROPS.with(|m| {
+        let mut map = m.borrow_mut();
+        let Some(props) = map.get_mut(&owner) else {
+            return false;
+        };
+        let Some(index) = props.iter().position(|prop| prop.key == key) else {
+            return false;
+        };
+        props.remove(index);
+        if props.is_empty() {
+            map.remove(&owner);
+        }
+        true
+    })
+}
+
+fn typed_array_own_prop_snapshot(owner: usize, key: &str) -> Option<TypedArrayOwnProp> {
+    TYPED_ARRAY_OWN_PROPS.with(|m| {
+        m.borrow()
+            .get(&owner)
+            .and_then(|props| props.iter().find(|prop| prop.key == key).cloned())
+    })
+}
+
+fn typed_array_has_ordinary_own_prop(owner: usize, key: &str) -> bool {
+    TYPED_ARRAY_OWN_PROPS.with(|m| {
+        m.borrow()
+            .get(&owner)
+            .is_some_and(|props| props.iter().any(|prop| prop.key == key))
+    })
+}
+
+unsafe fn descriptor_has(desc_ptr: *mut crate::object::ObjectHeader, name: &[u8]) -> bool {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::object::own_key_present(desc_ptr, key)
+}
+
+unsafe fn descriptor_read(
+    desc_ptr: *mut crate::object::ObjectHeader,
+    name: &[u8],
+) -> crate::JSValue {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::object::js_object_get_field_by_name(desc_ptr as *const crate::object::ObjectHeader, key)
+}
+
+unsafe fn descriptor_bool(desc_ptr: *mut crate::object::ObjectHeader, name: &[u8]) -> Option<bool> {
+    if !descriptor_has(desc_ptr, name) {
+        return None;
+    }
+    let value = descriptor_read(desc_ptr, name);
+    Some(crate::value::js_is_truthy(f64::from_bits(value.bits())) != 0)
+}
+
+fn throw_typed_array_define_error(message: String) -> ! {
+    throw_type_error(message.as_bytes())
+}
+
+#[cold]
+fn throw_type_error(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+pub(crate) unsafe fn typed_array_define_own_property(
+    obj_value: f64,
+    ta: *mut TypedArrayHeader,
+    key: *const crate::string::StringHeader,
+    key_name: &str,
+    descriptor_value: f64,
+) -> f64 {
+    if ta.is_null() {
+        return obj_value;
+    }
+    let owner = ta as usize;
+    let len = typed_array_owner_length(owner);
+    let desc_ptr = crate::object::extract_obj_ptr(descriptor_value);
+    if desc_ptr.is_null() {
+        return obj_value;
+    }
+    match typed_array_string_key_kind(key_name, len) {
+        TypedArrayStringKeyKind::InBoundsIndex(index) => {
+            let has_accessor = descriptor_has(desc_ptr, b"get") || descriptor_has(desc_ptr, b"set");
+            let writable = descriptor_bool(desc_ptr, b"writable");
+            let enumerable = descriptor_bool(desc_ptr, b"enumerable");
+            let configurable = descriptor_bool(desc_ptr, b"configurable");
+            if has_accessor
+                || writable.is_some_and(|value| !value)
+                || enumerable.is_some_and(|value| !value)
+                || configurable.is_some_and(|value| !value)
+            {
+                throw_typed_array_define_error(format!("Cannot redefine property: {key_name}"));
+            }
+            if descriptor_has(desc_ptr, b"value") {
+                let value = descriptor_read(desc_ptr, b"value");
+                typed_array_owner_set(owner, index, f64::from_bits(value.bits()));
+            }
+            obj_value
+        }
+        TypedArrayStringKeyKind::IntegerIndex => {
+            throw_type_error(b"Invalid typed array index");
+        }
+        TypedArrayStringKeyKind::Ordinary => {
+            let has_get = descriptor_has(desc_ptr, b"get");
+            let has_set = descriptor_has(desc_ptr, b"set");
+            let has_accessor = has_get || has_set;
+            if has_accessor {
+                let get_field = descriptor_read(desc_ptr, b"get");
+                let set_field = descriptor_read(desc_ptr, b"set");
+                let get_bits = if !has_get || get_field.is_undefined() {
+                    0
+                } else {
+                    crate::closure::clone_closure_rebind_this(get_field.bits(), obj_value)
+                };
+                let set_bits = if !has_set || set_field.is_undefined() {
+                    0
+                } else {
+                    crate::closure::clone_closure_rebind_this(set_field.bits(), obj_value)
+                };
+                crate::object::set_accessor_descriptor(
+                    owner,
+                    key_name.to_string(),
+                    crate::object::AccessorDescriptor {
+                        get: get_bits,
+                        set: set_bits,
+                    },
+                );
+                upsert_typed_array_own_prop(
+                    owner,
+                    key_name.to_string(),
+                    f64::from_bits(crate::value::TAG_UNDEFINED),
+                    false,
+                );
+            } else {
+                crate::object::clear_accessor_descriptor(owner, key_name);
+                let value = if descriptor_has(desc_ptr, b"value") {
+                    let value = descriptor_read(desc_ptr, b"value");
+                    f64::from_bits(value.bits())
+                } else {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                };
+                upsert_typed_array_own_prop(owner, key_name.to_string(), value, true);
+            }
+            let writable = descriptor_bool(desc_ptr, b"writable").unwrap_or(has_accessor);
+            let enumerable = descriptor_bool(desc_ptr, b"enumerable").unwrap_or(false);
+            let configurable = descriptor_bool(desc_ptr, b"configurable").unwrap_or(false);
+            crate::object::set_property_attrs(
+                owner,
+                key_name.to_string(),
+                crate::object::PropertyAttrs::new(writable, enumerable, configurable),
+            );
+            let _ = key;
+            obj_value
+        }
+    }
+}
+
+pub(crate) unsafe fn typed_array_set_own_property(
+    ta: *mut TypedArrayHeader,
+    key: *const crate::string::StringHeader,
+    value: f64,
+) -> bool {
+    if ta.is_null() || key.is_null() {
+        return false;
+    }
+    let Some(name) = string_header_str(key) else {
+        return false;
+    };
+    let owner = ta as usize;
+    typed_array_set_property_by_name(owner, name, value)
+}
+
+pub(crate) unsafe fn typed_array_set_property_by_name(
+    owner: usize,
+    name: &str,
+    value: f64,
+) -> bool {
+    if typed_array_owner_kind(owner).is_none() {
+        return false;
+    }
+    match typed_array_string_key_kind(name, typed_array_owner_length(owner)) {
+        TypedArrayStringKeyKind::InBoundsIndex(index) => {
+            typed_array_owner_set(owner, index, value);
+            true
+        }
+        TypedArrayStringKeyKind::IntegerIndex => true,
+        TypedArrayStringKeyKind::Ordinary => {
+            if let Some(acc) = crate::object::get_accessor_descriptor(owner, name) {
+                if acc.set != 0 {
+                    invoke_typed_array_accessor_setter(
+                        acc.set,
+                        typed_array_value(owner as *const TypedArrayHeader),
+                        value,
+                    );
+                }
+                return true;
+            }
+            if typed_array_has_ordinary_own_prop(owner, name) {
+                if let Some(attrs) = crate::object::get_property_attrs(owner, name) {
+                    if !attrs.writable() {
+                        return true;
+                    }
+                }
+            } else {
+                crate::object::set_property_attrs(
+                    owner,
+                    name.to_string(),
+                    crate::object::PropertyAttrs::new(true, true, true),
+                );
+            }
+            upsert_typed_array_own_prop(owner, name.to_string(), value, true);
+            true
+        }
+    }
+}
+
+pub(crate) unsafe fn typed_array_set_numeric_index(owner: usize, index: f64, value: f64) -> bool {
+    if typed_array_owner_kind(owner).is_none() {
+        return false;
+    }
+    if !index.is_finite() || index.fract() != 0.0 || index < 0.0 || index > u32::MAX as f64 {
+        return true;
+    }
+    let index = index as u32;
+    if index < typed_array_owner_length(owner) {
+        typed_array_owner_set(owner, index, value);
+    }
+    true
+}
+
+pub(crate) unsafe fn typed_array_get_own_property_value(
+    ta: *const TypedArrayHeader,
+    key: *const crate::string::StringHeader,
+) -> Option<f64> {
+    if ta.is_null() || key.is_null() {
+        return None;
+    }
+    let name = string_header_str(key)?;
+    let owner = ta as usize;
+    typed_array_get_property_value_by_name(owner, name)
+}
+
+pub(crate) unsafe fn typed_array_get_property_value_by_name(
+    owner: usize,
+    name: &str,
+) -> Option<f64> {
+    if typed_array_owner_kind(owner).is_none() {
+        return None;
+    }
+    match typed_array_string_key_kind(name, typed_array_owner_length(owner)) {
+        TypedArrayStringKeyKind::InBoundsIndex(index) => Some(typed_array_owner_get(owner, index)),
+        TypedArrayStringKeyKind::IntegerIndex => Some(f64::from_bits(crate::value::TAG_UNDEFINED)),
+        TypedArrayStringKeyKind::Ordinary => {
+            let prop = typed_array_own_prop_snapshot(owner, name)?;
+            if prop.is_data {
+                return Some(prop.value);
+            }
+            let Some(acc) = crate::object::get_accessor_descriptor(owner, name) else {
+                return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+            };
+            if acc.get == 0 {
+                Some(f64::from_bits(crate::value::TAG_UNDEFINED))
+            } else {
+                Some(invoke_typed_array_accessor_getter(
+                    acc.get,
+                    typed_array_value(owner as *const TypedArrayHeader),
+                ))
+            }
+        }
+    }
+}
+
+pub(crate) unsafe fn typed_array_get_numeric_index(owner: usize, index: f64) -> Option<f64> {
+    typed_array_owner_kind(owner)?;
+    if !index.is_finite() || index.fract() != 0.0 || index < 0.0 || index > u32::MAX as f64 {
+        return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+    }
+    let index = index as u32;
+    if index < typed_array_owner_length(owner) {
+        Some(typed_array_owner_get(owner, index))
+    } else {
+        Some(f64::from_bits(crate::value::TAG_UNDEFINED))
+    }
+}
+
+pub(crate) unsafe fn typed_array_index_get_dynamic(owner_bits: usize, key: f64) -> f64 {
+    let Some(owner) = typed_array_addr_from_value(f64::from_bits(owner_bits as u64)) else {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    };
+    let jsval = crate::value::JSValue::from_bits(key.to_bits());
+    if jsval.is_string() || jsval.is_short_string() {
+        let key_ptr =
+            crate::value::js_get_string_pointer_unified(key) as *const crate::string::StringHeader;
+        if key_ptr.is_null() {
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+        if let Some(value) =
+            typed_array_get_own_property_value(owner as *const TypedArrayHeader, key_ptr)
+        {
+            return value;
+        }
+        return crate::object::js_object_get_field_by_name_f64(
+            owner as *const crate::object::ObjectHeader,
+            key_ptr,
+        );
+    }
+    if jsval.is_int32() {
+        return typed_array_get_numeric_index(owner, jsval.as_int32() as f64)
+            .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+    }
+    if key.is_finite() {
+        return typed_array_get_numeric_index(owner, key)
+            .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[no_mangle]
+pub extern "C" fn js_typed_array_index_set_dynamic(
+    ta: *mut TypedArrayHeader,
+    key: f64,
+    value: f64,
+) -> f64 {
+    unsafe {
+        let Some(owner) = typed_array_addr_from_value(f64::from_bits(ta as u64)) else {
+            return value;
+        };
+        let jsval = crate::value::JSValue::from_bits(key.to_bits());
+        if jsval.is_string() || jsval.is_short_string() {
+            let key_ptr = crate::value::js_get_string_pointer_unified(key)
+                as *const crate::string::StringHeader;
+            if let Some(name) = string_header_str(key_ptr) {
+                typed_array_set_property_by_name(owner, name, value);
+            }
+            return value;
+        }
+        if jsval.is_int32() {
+            typed_array_set_numeric_index(owner, jsval.as_int32() as f64, value);
+        } else if key.is_finite() {
+            typed_array_set_numeric_index(owner, key, value);
+        }
+        value
+    }
+}
+
+#[used]
+static KEEP_JS_TYPED_ARRAY_INDEX_SET_DYNAMIC: extern "C" fn(
+    *mut TypedArrayHeader,
+    f64,
+    f64,
+) -> f64 = js_typed_array_index_set_dynamic;
+
+pub(crate) unsafe fn typed_array_has_own_property(
+    ta: *const TypedArrayHeader,
+    key: *const crate::string::StringHeader,
+) -> bool {
+    if ta.is_null() || key.is_null() {
+        return false;
+    }
+    let Some(name) = string_header_str(key) else {
+        return false;
+    };
+    let owner = ta as usize;
+    match typed_array_string_key_kind(name, typed_array_owner_length(owner)) {
+        TypedArrayStringKeyKind::InBoundsIndex(_) => true,
+        TypedArrayStringKeyKind::IntegerIndex => false,
+        TypedArrayStringKeyKind::Ordinary => typed_array_has_ordinary_own_prop(owner, name),
+    }
+}
+
+pub(crate) unsafe fn typed_array_property_is_enumerable(
+    ta: *const TypedArrayHeader,
+    key: *const crate::string::StringHeader,
+) -> bool {
+    if ta.is_null() || key.is_null() {
+        return false;
+    }
+    let Some(name) = string_header_str(key) else {
+        return false;
+    };
+    let owner = ta as usize;
+    match typed_array_string_key_kind(name, typed_array_owner_length(owner)) {
+        TypedArrayStringKeyKind::InBoundsIndex(_) => true,
+        TypedArrayStringKeyKind::IntegerIndex => false,
+        TypedArrayStringKeyKind::Ordinary => {
+            if !typed_array_has_ordinary_own_prop(owner, name) {
+                return false;
+            }
+            crate::object::get_property_attrs(owner, name)
+                .map(|attrs| attrs.enumerable())
+                .unwrap_or(true)
+        }
+    }
+}
+
+fn typed_array_non_index_keys(owner: usize, enumerable_only: bool) -> Vec<String> {
+    let mut keys = TYPED_ARRAY_OWN_PROPS.with(|m| {
+        m.borrow()
+            .get(&owner)
+            .map(|props| {
+                props
+                    .iter()
+                    .filter_map(|prop| {
+                        if enumerable_only {
+                            let enumerable = crate::object::get_property_attrs(owner, &prop.key)
+                                .map(|attrs| attrs.enumerable())
+                                .unwrap_or(true);
+                            if !enumerable {
+                                return None;
+                            }
+                        }
+                        Some(prop.key.clone())
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    });
+    for key in crate::object::accessor_descriptor_keys_for_obj(owner) {
+        if keys.iter().any(|existing| existing == &key) {
+            continue;
+        }
+        if enumerable_only {
+            let enumerable = crate::object::get_property_attrs(owner, &key)
+                .map(|attrs| attrs.enumerable())
+                .unwrap_or(false);
+            if !enumerable {
+                continue;
+            }
+        }
+        keys.push(key);
+    }
+    keys
+}
+
+pub(crate) unsafe fn typed_array_own_property_names(
+    ta: *const TypedArrayHeader,
+    enumerable_only: bool,
+) -> *mut ArrayHeader {
+    if ta.is_null() {
+        return crate::array::js_array_alloc(0);
+    }
+    let owner = ta as usize;
+    let len = typed_array_owner_length(owner);
+    let names = typed_array_non_index_keys(owner, enumerable_only);
+    let mut result = crate::array::js_array_alloc(len.saturating_add(names.len() as u32));
+    for i in 0..len {
+        let name = i.to_string();
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        result = crate::array::js_array_push(result, crate::JSValue::string_ptr(key));
+    }
+    for name in names {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        result = crate::array::js_array_push(result, crate::JSValue::string_ptr(key));
+    }
+    result
+}
+
+pub(crate) unsafe fn typed_array_own_enumerable_values(
+    ta: *const TypedArrayHeader,
+) -> *mut ArrayHeader {
+    if ta.is_null() {
+        return crate::array::js_array_alloc(0);
+    }
+    let owner = ta as usize;
+    let len = typed_array_owner_length(owner);
+    let names = typed_array_non_index_keys(owner, true);
+    let mut result = crate::array::js_array_alloc(len.saturating_add(names.len() as u32));
+    for i in 0..len {
+        result = crate::array::js_array_push_f64(result, typed_array_owner_get(owner, i));
+    }
+    for name in names {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        if let Some(value) = typed_array_get_own_property_value(ta, key) {
+            result = crate::array::js_array_push_f64(result, value);
+        }
+    }
+    result
+}
+
+pub(crate) unsafe fn typed_array_own_enumerable_entries(
+    ta: *const TypedArrayHeader,
+) -> *mut ArrayHeader {
+    if ta.is_null() {
+        return crate::array::js_array_alloc(0);
+    }
+    let owner = ta as usize;
+    let len = typed_array_owner_length(owner);
+    let names = typed_array_non_index_keys(owner, true);
+    let mut result = crate::array::js_array_alloc(len.saturating_add(names.len() as u32));
+    for i in 0..len {
+        let pair = crate::array::js_array_alloc(2);
+        let name = i.to_string();
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let pair = crate::array::js_array_push(pair, crate::JSValue::string_ptr(key));
+        let pair = crate::array::js_array_push(
+            pair,
+            crate::JSValue::number(typed_array_owner_get(owner, i)),
+        );
+        result = crate::array::js_array_push(result, crate::JSValue::array_ptr(pair));
+    }
+    for name in names {
+        let pair = crate::array::js_array_alloc(2);
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let value = typed_array_get_own_property_value(ta, key)
+            .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+        let pair = crate::array::js_array_push(pair, crate::JSValue::string_ptr(key));
+        let pair = crate::array::js_array_push(pair, crate::JSValue::from_bits(value.to_bits()));
+        result = crate::array::js_array_push(result, crate::JSValue::array_ptr(pair));
+    }
+    result
+}
+
+pub(crate) unsafe fn typed_array_get_own_property_descriptor(
+    ta: *const TypedArrayHeader,
+    key: *const crate::string::StringHeader,
+) -> f64 {
+    if ta.is_null() || key.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let Some(name) = string_header_str(key) else {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    };
+    let owner = ta as usize;
+    match typed_array_string_key_kind(name, typed_array_owner_length(owner)) {
+        TypedArrayStringKeyKind::InBoundsIndex(index) => crate::object::build_data_descriptor(
+            typed_array_owner_get(owner, index),
+            true,
+            true,
+            true,
+        ),
+        TypedArrayStringKeyKind::IntegerIndex => f64::from_bits(crate::value::TAG_UNDEFINED),
+        TypedArrayStringKeyKind::Ordinary => {
+            let Some(prop) = typed_array_own_prop_snapshot(owner, name) else {
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            };
+            let attrs = crate::object::get_property_attrs(owner, name)
+                .unwrap_or(crate::object::PropertyAttrs::new(prop.is_data, true, true));
+            if !prop.is_data {
+                if let Some(acc) = crate::object::get_accessor_descriptor(owner, name) {
+                    let get = if acc.get == 0 {
+                        f64::from_bits(crate::value::TAG_UNDEFINED)
+                    } else {
+                        f64::from_bits(acc.get)
+                    };
+                    let set = if acc.set == 0 {
+                        f64::from_bits(crate::value::TAG_UNDEFINED)
+                    } else {
+                        f64::from_bits(acc.set)
+                    };
+                    return crate::object::build_accessor_descriptor(
+                        get,
+                        set,
+                        attrs.enumerable(),
+                        attrs.configurable(),
+                    );
+                }
+            }
+            crate::object::build_data_descriptor(
+                prop.value,
+                attrs.writable(),
+                attrs.enumerable(),
+                attrs.configurable(),
+            )
+        }
+    }
+}
+
+pub(crate) unsafe fn typed_array_delete_own_property(
+    ta: *mut TypedArrayHeader,
+    key: *const crate::string::StringHeader,
+) -> i32 {
+    if ta.is_null() || key.is_null() {
+        return 1;
+    }
+    let Some(name) = string_header_str(key) else {
+        return 1;
+    };
+    let owner = ta as usize;
+    match typed_array_string_key_kind(name, typed_array_owner_length(owner)) {
+        TypedArrayStringKeyKind::InBoundsIndex(_) => 0,
+        TypedArrayStringKeyKind::IntegerIndex => 1,
+        TypedArrayStringKeyKind::Ordinary => {
+            if !typed_array_has_ordinary_own_prop(owner, name) {
+                return 1;
+            }
+            if let Some(attrs) = crate::object::get_property_attrs(owner, name) {
+                if !attrs.configurable() {
+                    return 0;
+                }
+            }
+            remove_typed_array_own_prop(owner, name);
+            crate::object::clear_accessor_descriptor(owner, name);
+            crate::object::clear_property_attrs(owner, name);
+            1
+        }
+    }
+}
+
+pub(crate) fn scan_typed_array_own_props_roots_mut(
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+) {
+    TYPED_ARRAY_OWN_PROPS.with(|m| {
+        for props in m.borrow_mut().values_mut() {
+            for prop in props.iter_mut().filter(|prop| prop.is_data) {
+                visitor.visit_nanbox_f64_slot(&mut prop.value);
+            }
+        }
+    });
+}

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -90,6 +90,11 @@ pub extern "C" fn js_value_length_f64(value: f64) -> f64 {
         if handle < heap_min || handle >= 0x8000_0000_0000 {
             return 0.0;
         }
+        if let Some(value) = unsafe {
+            crate::typedarray_props::typed_array_get_property_value_by_name(handle, "length")
+        } {
+            return value;
+        }
         if crate::buffer::is_registered_buffer(handle) {
             let buf = handle as *const crate::buffer::BufferHeader;
             return unsafe { (*buf).length as f64 };
@@ -162,6 +167,11 @@ pub extern "C" fn js_value_length_f64(value: f64) -> f64 {
     let raw_heap_min: u64 = 0x200_0000_0000;
     if top16 == 0 && bits >= raw_heap_min && bits < 0x8000_0000_0000 {
         let handle = bits as usize;
+        if let Some(value) = unsafe {
+            crate::typedarray_props::typed_array_get_property_value_by_name(handle, "length")
+        } {
+            return value;
+        }
         if crate::buffer::is_registered_buffer(handle) {
             let buf = handle as *const crate::buffer::BufferHeader;
             return unsafe { (*buf).length as f64 };

--- a/test-parity/expected/typedarray-own-properties.txt
+++ b/test-parity/expected/typedarray-own-properties.txt
@@ -1,0 +1,11 @@
+define length ok
+own length {"read":1,"tail":4,"desc":{"value":1,"writable":false,"enumerable":false,"configurable":false},"names":["0","1","2","length"],"keys":["0","1","2"],"hasOwn":true,"enumerable":false}
+define foo ok
+ordinary props {"foo":5,"fooDesc":{"value":5,"writable":false,"enumerable":false,"configurable":false},"bar":7,"barDesc":{"value":7,"writable":true,"enumerable":true,"configurable":true},"names":["0","1","2","length","foo","bar"],"keys":["0","1","2","bar"]}
+accessor prop {"accRead":11,"getterCalls":1,"seen":88,"accDesc":{"get":"function","set":"function","enumerable":true,"configurable":true},"seenDesc":{"value":88,"writable":true,"enumerable":true,"configurable":true},"keys":["0","1","2","bar","acc","seen"]}
+non canonical key {"value":9,"names":["0","1","00"],"keys":["0","1","00"]}
+define index ok
+index props {"zero":9,"one":8,"zeroDesc":{"value":9,"writable":true,"enumerable":true,"configurable":true},"names":["0","1"],"keys":["0","1"]}
+define oob index TypeError
+define negative index TypeError
+invalid index state {"negativeDesc":null,"names":["0","1"]}

--- a/test-parity/node-suite/globals/typedarray-own-properties.ts
+++ b/test-parity/node-suite/globals/typedarray-own-properties.ts
@@ -1,0 +1,119 @@
+function descriptorShape(obj: any, key: string) {
+  const desc = Object.getOwnPropertyDescriptor(obj, key);
+  if (!desc) {
+    return null;
+  }
+  const out: Record<string, unknown> = {};
+  if ("value" in desc) {
+    out.value = desc.value;
+    out.writable = desc.writable;
+  }
+  if ("get" in desc) {
+    out.get = typeof desc.get;
+    out.set = typeof desc.set;
+  }
+  out.enumerable = desc.enumerable;
+  out.configurable = desc.configurable;
+  return out;
+}
+
+function attempt(label: string, fn: () => void) {
+  try {
+    fn();
+    console.log(label, "ok");
+  } catch (error: any) {
+    console.log(label, error.name);
+  }
+}
+
+function show(label: string, value: unknown) {
+  console.log(label, JSON.stringify(value));
+}
+
+const ta: any = new Uint8Array([2, 3, 4]);
+
+attempt("define length", () => {
+  Object.defineProperty(ta, "length", { value: 1 });
+});
+show("own length", {
+  read: ta.length,
+  tail: ta[2],
+  desc: descriptorShape(ta, "length"),
+  names: Object.getOwnPropertyNames(ta),
+  keys: Object.keys(ta),
+  hasOwn: Object.prototype.hasOwnProperty.call(ta, "length"),
+  enumerable: Object.prototype.propertyIsEnumerable.call(ta, "length"),
+});
+
+attempt("define foo", () => {
+  Object.defineProperty(ta, "foo", { value: 5 });
+});
+ta.bar = 7;
+show("ordinary props", {
+  foo: ta.foo,
+  fooDesc: descriptorShape(ta, "foo"),
+  bar: ta.bar,
+  barDesc: descriptorShape(ta, "bar"),
+  names: Object.getOwnPropertyNames(ta),
+  keys: Object.keys(ta),
+});
+
+let getterCalls = 0;
+Object.defineProperty(ta, "acc", {
+  get() {
+    getterCalls++;
+    return this.length + 10;
+  },
+  set(value: number) {
+    this.seen = value;
+  },
+  enumerable: true,
+  configurable: true,
+});
+const accRead = ta.acc;
+ta.acc = 88;
+show("accessor prop", {
+  accRead,
+  getterCalls,
+  seen: ta.seen,
+  accDesc: descriptorShape(ta, "acc"),
+  seenDesc: descriptorShape(ta, "seen"),
+  keys: Object.keys(ta),
+});
+
+const nonCanonical: any = new Uint8Array([1, 2]);
+Object.defineProperty(nonCanonical, "00", {
+  value: 9,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+show("non canonical key", {
+  value: nonCanonical["00"],
+  names: Object.getOwnPropertyNames(nonCanonical),
+  keys: Object.keys(nonCanonical),
+});
+
+const indexed: any = new Uint8Array([5, 6]);
+attempt("define index", () => {
+  Object.defineProperty(indexed, "0", { value: 9 });
+});
+indexed["1"] = 8;
+show("index props", {
+  zero: indexed[0],
+  one: indexed[1],
+  zeroDesc: descriptorShape(indexed, "0"),
+  names: Object.getOwnPropertyNames(indexed),
+  keys: Object.keys(indexed),
+});
+attempt("define oob index", () => {
+  Object.defineProperty(indexed, "2", { value: 10 });
+});
+attempt("define negative index", () => {
+  Object.defineProperty(indexed, "-1", { value: 10 });
+});
+show("invalid index state", {
+  negative: indexed["-1"],
+  negativeDesc: descriptorShape(indexed, "-1"),
+  names: Object.getOwnPropertyNames(indexed),
+});


### PR DESCRIPTION
## Summary

Fixes #4349.

This adds typed-array own-property support for Perry's Integer-Indexed exotic objects while preserving element-slot behavior for canonical numeric indices. The change introduces a typed-array own-property side table, routes Object/descriptor/reflection helpers through it, and updates codegen paths that previously lowered Uint8Array string indexes through numeric element access.

## Why This PR Cut

This is a focused runtime/codegen compatibility slice for one typed-array object-model gap. It was not batched with unrelated Node modules because the implementation touches a shared object/descriptor/indexing path and has enough reflection and codegen surface to stand alone safely.

## Behavior Covered

- `Object.defineProperty(ta, "length", { value })` creates an own property that shadows `.length` reads without changing the indexed element length.
- Ordinary named data/accessor properties on typed arrays are stored, assigned, enumerated, described, and deleted through typed-array-aware paths.
- Integer-index descriptors continue to expose element descriptors and enforce typed-array numeric-index define restrictions.
- `Uint8Array` string index reads/writes route through dynamic typed-array lookup instead of accidental numeric element access.
- Reflection order keeps integer indices first, then non-index own properties.

## Tests

Added `test-parity/node-suite/globals/typedarray-own-properties.ts` plus an expected-output fallback because the local system Node is Node 22 and does not support the TypeScript-strip flag used by the parity runner.

Validation run:

- `NODE26_BIN=$(npm exec --yes --package=node@26 -- node -e 'console.log(process.execPath)'); "$NODE26_BIN" --experimental-strip-types --no-warnings test-parity/node-suite/globals/typedarray-own-properties.ts`
- `./run_parity_tests.sh --suite node-suite --module globals --filter typedarray-own-properties`
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `git diff --check HEAD`
- `cargo check -p perry-runtime -p perry-codegen` (passed earlier in the slice with existing warnings; not rerun after the final no-conflict rebase because unrelated release builds were active in other worktrees)

## Known Limitations / Non-Goals

- This does not attempt a broad rewrite of Perry's descriptor invariants outside typed-array own-property behavior.
- Detached ArrayBuffer semantics remain out of scope for Perry's current typed-array model.
