### PR TITLE
fix(runtime): round-trip BigInt64Array/BigUint64Array elements as BigInt (#4356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1118 — fix(runtime): round-trip BigInt64Array/BigUint64Array elements as BigInt (#4356)
+
+`BigInt64Array`/`BigUint64Array` element reads and writes coerced through `f64`, so values round-tripped as **Numbers** instead of **BigInts** and large/non-representable bigints were silently truncated: `const b = new BigInt64Array(2); b[0] = 5n; b[0]` yielded `0` (typeof Number) instead of `5n`.
+
+All fixes in `crates/perry-runtime/src/typedarray/`:
+
+- **`load_at`** — bigint kinds now return a NaN-boxed BigInt (`js_bigint_from_i64`/`js_bigint_from_u64`) instead of `raw as f64`, so element reads are real `bigint`s.
+- **`store_at`** — bigint kinds read the BigInt's raw low limb (`bigint::bigint_slot_bits`) rather than `value as i64` on an already-NaN-boxed pointer (which mapped to `0`).
+- **`js_typed_array_set`** — bigint views run `ToBigInt`: a Number throws `TypeError: Cannot convert <n> to a BigInt`, Boolean/String coerce, BigInt passes through; the raw value is stored (not `jsvalue_to_f64`'d).
+- **Construction-from-array** and **`TypedArray.prototype.set()`** — coerce per destination kind (`bigint::coerce_for_kind` → `ToBigInt` for bigint views), so `new BigInt64Array([1n, 2n])` and `ta.set([...])` keep real BigInt elements.
+- **`format_typed_value`** — render bigint elements from the raw limb, with the trailing `n` for the `console.log` inspect form and without it for `join`.
+
+The internal `load_at`→`store_at` data-movement helpers (`slice`, `reverse`, `copyWithin`, set-from-TA) round-trip the raw bits unchanged. The inline codegen element fast paths have no BigInt `BufferElem` variant, so bigint views always reach the runtime — a runtime-only fix covers the codegen path too. Unblocks the element-set side-effect assertions in the test262 `TypedArrayConstructors/internals/DefineOwnProperty/BigInt/` subdirectory. Verified byte-for-byte against `node --experimental-strip-types` for element get/set, negative + u64-max values, construction, `join`/inspect, in-place `reverse`, `slice`, `set()` from a typed array and a plain array, Boolean coercion, `Object`/`Reflect.defineProperty`, out-of-bounds rejection, and the Number→`TypeError`. New fixture: `test-parity/node-suite/bigint/typed-array/element-roundtrip.ts`.
+
+`DataView.prototype.getBigInt64`/`setBigInt64`/`getBigUint64`/`setBigUint64` (a distinct, previously-unimplemented feature) is tracked in #4365. Chained-method-result element indexing (`const x = ta.reverse(); x[0]`) and `String(ta)` read raw bytes — a pre-existing codegen/`toString` limitation that affects numeric typed arrays too, not bigint-specific.
+
+To keep `typedarray.rs` (already at the 2000-line file-size cap) under the limit, it was converted to a directory module: the BigInt element-coercion helpers moved to `typedarray/bigint.rs` and the Node-style display formatting to `typedarray/format.rs`.
+
 ## v0.5.1117 — fix(release-gate): unblock package publishing (IteratorFrom panic, Math no_mangle, decouple extended suites)
 
 The release pipeline had shipped **no binary/npm/brew assets since v0.5.1025** (~90 versions): every tag created a GitHub release object but `release-packages.yml`'s `await-tests` gate failed because the tag-gated **Tests** workflow stayed red on its aspirational extended jobs. Core jobs (`cargo-test`, `lint`, `api-docs-drift`, `compiler-output-regression`) passed throughout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1117
+**Current Version:** 0.5.1118
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5022,7 +5022,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,14 +5077,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "cc",
  "libc",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "log",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "base64",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "serde",
  "serde_json",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1117"
+version = "0.5.1118"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "clap",
@@ -5227,14 +5227,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "chrono",
  "cron",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5333,14 +5333,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "bytes",
  "h2",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "bson",
  "futures-util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "image",
@@ -5527,14 +5527,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "brotli",
  "flate2",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "base64",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5749,14 +5749,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "itoa",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "block2",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "block2",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1117"
+version = "0.5.1118"
 
 [[package]]
 name = "perry-ui-test"
@@ -5845,11 +5845,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1117"
+version = "0.5.1118"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "block2",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "block2",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "block2",
  "libc",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "libc",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1117"
+version = "0.5.1118"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1117"
+version = "0.5.1118"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/typedarray/bigint.rs
+++ b/crates/perry-runtime/src/typedarray/bigint.rs
@@ -1,0 +1,89 @@
+//! BigInt element coercion for `BigInt64Array` / `BigUint64Array` (#4356).
+//!
+//! These views store real BigInt values, so the element read/write path can't
+//! funnel them through `f64` like the numeric kinds. The helpers here bridge
+//! between a NaN-boxed JS value and the raw 64-bit slot bits:
+//!
+//!   - `bigint_slot_bits` — unbox a BigInt to the low limb to store.
+//!   - `to_bigint_for_store` — `ToBigInt(value)` for an element write
+//!     (a Number throws `TypeError`), returning a NaN-boxed BigInt.
+//!   - `coerce_for_kind` — pick `ToBigInt` vs `ToNumber` by destination kind
+//!     for the construction / `set()` paths.
+
+use super::{jsvalue_to_f64, throw_type_error, KIND_BIGINT64, KIND_BIGUINT64};
+
+/// Extract the low 64 bits to write into a `BigInt64`/`BigUint64` slot. The
+/// element-set path hands us an already-`ToBigInt`-coerced, NaN-boxed BigInt
+/// (so reads round-trip the raw bits); internal `load_at`→`store_at` copies do
+/// the same. A bare finite Number falls back to a truncating `as i64` cast so
+/// any legacy numeric caller keeps its old behavior rather than reading garbage.
+pub(super) fn bigint_slot_bits(value: f64) -> u64 {
+    let bits = value.to_bits();
+    if (bits >> 48) >= 0x7FF8 {
+        let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::bigint::BigIntHeader;
+        let cleaned = crate::bigint::clean_bigint_ptr(ptr);
+        if cleaned.is_null() {
+            return 0;
+        }
+        unsafe { (*cleaned).limbs[0] }
+    } else if value.is_finite() {
+        value as i64 as u64
+    } else {
+        0
+    }
+}
+
+/// Coerce a raw (NaN-boxed) source value to the representation `store_at`
+/// expects for `dst_kind`: a NaN-boxed BigInt for the bigint kinds (via
+/// `ToBigInt`), or a plain numeric f64 (via `ToNumber`) for every other kind.
+/// Used by the array/array-like construction and `set()` paths so a bigint view
+/// keeps real BigInt elements instead of `jsvalue_to_f64`-mangling them to NaN.
+pub(super) fn coerce_for_kind(dst_kind: u8, raw: f64) -> f64 {
+    if dst_kind == KIND_BIGINT64 || dst_kind == KIND_BIGUINT64 {
+        to_bigint_for_store(raw)
+    } else {
+        jsvalue_to_f64(raw)
+    }
+}
+
+/// `ToBigInt(value)` for a `BigInt64`/`BigUint64` element store, returning the
+/// value re-boxed as a NaN-boxed BigInt. Per the ECMAScript `ToBigInt`
+/// abstract operation, a Number (including a NaN-boxed int32), `undefined`,
+/// `null`, and Symbols are NOT convertible and throw a `TypeError`; only
+/// BigInt, Boolean, and String inputs coerce.
+pub(super) fn to_bigint_for_store(value: f64) -> f64 {
+    use crate::value::JSValue;
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_bigint() {
+        return value;
+    }
+    if jsval.is_bool() {
+        let n = if jsval.as_bool() { 1 } else { 0 };
+        return crate::value::js_nanbox_bigint(crate::bigint::js_bigint_from_i64(n) as i64);
+    }
+    if jsval.is_any_string() {
+        // StringToBigInt (a malformed numeric string throws SyntaxError).
+        let bi = crate::bigint::js_bigint_from_f64(value);
+        return crate::value::js_nanbox_bigint(bi as i64);
+    }
+    let label = bigint_unconvertible_label(value);
+    throw_type_error(format!("Cannot convert {label} to a BigInt").as_bytes());
+}
+
+/// Human-readable label for a value that `ToBigInt` rejects, matching Node's
+/// `Cannot convert <x> to a BigInt` TypeError text.
+fn bigint_unconvertible_label(value: f64) -> String {
+    use crate::value::JSValue;
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_undefined() {
+        "undefined".to_string()
+    } else if jsval.is_null() {
+        "null".to_string()
+    } else if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
+        "a Symbol value".to_string()
+    } else if jsval.is_int32() {
+        jsval.as_int32().to_string()
+    } else {
+        format!("{value}")
+    }
+}

--- a/crates/perry-runtime/src/typedarray/format.rs
+++ b/crates/perry-runtime/src/typedarray/format.rs
@@ -1,0 +1,84 @@
+//! Node-style display formatting for typed arrays (`console.log` / `join`).
+
+use super::bigint::bigint_slot_bits;
+use super::{
+    clean_ta_ptr, load_at, name_for_kind, TypedArrayHeader, KIND_BIGINT64, KIND_BIGUINT64,
+    KIND_FLOAT16, KIND_FLOAT32, KIND_FLOAT64,
+};
+
+/// Format a typed array Node-style: `Int32Array(N) [ a, b, c ]`. Used by
+/// `format_jsvalue` in builtins.rs.
+pub fn format_typed_array(ta: *const TypedArrayHeader) -> String {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() {
+        return "TypedArray(0) []".to_string();
+    }
+    unsafe {
+        let kind = (*ta).kind;
+        let len = (*ta).length as usize;
+        let name = name_for_kind(kind);
+        if len == 0 {
+            return format!("{}(0) []", name);
+        }
+        let mut s = format!("{}({}) [", name, len);
+        for i in 0..len {
+            if i == 0 {
+                s.push(' ');
+            } else {
+                s.push_str(", ");
+            }
+            let v = load_at(ta, i);
+            s.push_str(&format_typed_value(kind, v, true));
+        }
+        s.push_str(" ]");
+        s
+    }
+}
+
+/// Format a single typed-array element. `bigint_suffix` controls whether a
+/// `BigInt64`/`BigUint64` element renders with the trailing `n` (true for the
+/// `console.log` inspect form `BigInt64Array(1) [ 5n ]`, false for `join`,
+/// which calls plain `ToString` on each element → `"5"`).
+pub(super) fn format_typed_value(kind: u8, v: f64, bigint_suffix: bool) -> String {
+    match kind {
+        KIND_BIGINT64 => {
+            let n = bigint_slot_bits(v) as i64;
+            if bigint_suffix {
+                format!("{n}n")
+            } else {
+                format!("{n}")
+            }
+        }
+        KIND_BIGUINT64 => {
+            let n = bigint_slot_bits(v);
+            if bigint_suffix {
+                format!("{n}n")
+            } else {
+                format!("{n}")
+            }
+        }
+        KIND_FLOAT16 | KIND_FLOAT32 | KIND_FLOAT64 => {
+            // Match Node: integer-valued floats render with no decimal,
+            // others render via Rust's default Debug for f64.
+            if v.is_nan() {
+                "NaN".to_string()
+            } else if v.is_infinite() {
+                if v > 0.0 {
+                    "Infinity".to_string()
+                } else {
+                    "-Infinity".to_string()
+                }
+            } else if v == v.trunc() && v.abs() < 1e16 {
+                format!("{}", v as i64)
+            } else {
+                // Use Rust's default short formatting.
+                let s = format!("{}", v);
+                s
+            }
+        }
+        _ => {
+            // Integer types
+            format!("{}", v as i64)
+        }
+    }
+}

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -19,6 +19,10 @@ use crate::array::ArrayHeader;
 use crate::closure::ClosureHeader;
 use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
+mod bigint;
+mod format;
+pub use format::format_typed_array;
+
 // Element kind tags. Match the order used by HIR/codegen.
 pub const KIND_INT8: u8 = 0;
 pub const KIND_UINT8: u8 = 1;
@@ -635,10 +639,10 @@ unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64) {
             *(base.add(off) as *mut f64) = value;
         }
         KIND_BIGINT64 => {
-            *(base.add(off) as *mut i64) = value as i64;
+            *(base.add(off) as *mut i64) = bigint::bigint_slot_bits(value) as i64;
         }
         KIND_BIGUINT64 => {
-            *(base.add(off) as *mut u64) = value as u64;
+            *(base.add(off) as *mut u64) = bigint::bigint_slot_bits(value);
         }
         _ => {}
     }
@@ -660,8 +664,17 @@ unsafe fn load_at(ta: *const TypedArrayHeader, idx: usize) -> f64 {
         KIND_FLOAT16 => f16_bits_to_f64(*(base.add(off) as *const u16)),
         KIND_FLOAT32 => *(base.add(off) as *const f32) as f64,
         KIND_FLOAT64 => *(base.add(off) as *const f64),
-        KIND_BIGINT64 => *(base.add(off) as *const i64) as f64,
-        KIND_BIGUINT64 => *(base.add(off) as *const u64) as f64,
+        // BigInt kinds return a NaN-boxed BigInt (not a plain Number), so
+        // `ta[i]` round-trips as a `bigint`. The raw slot bits are the BigInt's
+        // low limb; widen via the signed/unsigned constructor for `> i64::MAX`.
+        KIND_BIGINT64 => {
+            let v = *(base.add(off) as *const i64);
+            crate::value::js_nanbox_bigint(crate::bigint::js_bigint_from_i64(v) as i64)
+        }
+        KIND_BIGUINT64 => {
+            let v = *(base.add(off) as *const u64);
+            crate::value::js_nanbox_bigint(crate::bigint::js_bigint_from_u64(v) as i64)
+        }
         _ => 0.0,
     }
 }
@@ -821,7 +834,7 @@ pub extern "C" fn js_typed_array_new_from_array(
         // `typed_array_alloc` may GC and free/move an unrooted cloned source
         // (`.of/.from` path), and the raw inline read mis-read it (#871).
         let vals: Vec<f64> = (0..len)
-            .map(|i| jsvalue_to_f64(crate::array::js_array_get_f64(arr, i)))
+            .map(|i| bigint::coerce_for_kind(kind, crate::array::js_array_get_f64(arr, i)))
             .collect();
         let ta = typed_array_alloc(kind, len);
         for (i, v) in vals.iter().enumerate() {
@@ -988,7 +1001,15 @@ pub extern "C" fn js_typed_array_set(ta: *mut TypedArrayHeader, index: i32, valu
         if index < 0 || index as u32 >= (*ta).length {
             return;
         }
-        store_at(ta, index as usize, jsvalue_to_f64(value));
+        let kind = (*ta).kind;
+        if kind == KIND_BIGINT64 || kind == KIND_BIGUINT64 {
+            // IntegerIndexedElementSet on a bigint view performs `ToBigInt` —
+            // a Number throws `TypeError`. Pass the NaN-boxed BigInt straight
+            // to `store_at` (NOT through `jsvalue_to_f64`, which maps it to NaN).
+            store_at(ta, index as usize, bigint::to_bigint_for_store(value));
+        } else {
+            store_at(ta, index as usize, jsvalue_to_f64(value));
+        }
     }
 }
 
@@ -999,7 +1020,7 @@ pub extern "C" fn js_typed_array_set(ta: *mut TypedArrayHeader, index: i32, valu
 ///   - an array-like object (`{ length, 0, 1, … }`).
 /// Returns `None` for null/undefined (caller throws TypeError) and an empty
 /// vec for unrecognized non-iterable values (Node coerces those to length 0).
-unsafe fn collect_typed_array_set_source(source_value: f64) -> Option<Vec<f64>> {
+unsafe fn collect_typed_array_set_source(source_value: f64, dst_kind: u8) -> Option<Vec<f64>> {
     let v = crate::value::JSValue::from_bits(source_value.to_bits());
     if v.is_null() || v.is_undefined() {
         return None;
@@ -1037,9 +1058,10 @@ unsafe fn collect_typed_array_set_source(source_value: f64) -> Option<Vec<f64>> 
             let len = crate::array::js_array_length(arr) as usize;
             let mut out = Vec::with_capacity(len);
             for i in 0..len {
-                out.push(jsvalue_to_f64(crate::array::js_array_get_f64(
-                    arr, i as u32,
-                )));
+                out.push(bigint::coerce_for_kind(
+                    dst_kind,
+                    crate::array::js_array_get_f64(arr, i as u32),
+                ));
             }
             return Some(out);
         }
@@ -1058,7 +1080,10 @@ unsafe fn collect_typed_array_set_source(source_value: f64) -> Option<Vec<f64>> 
                 let key = i.to_string();
                 let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
                 let field = crate::object::js_object_get_field_by_name(obj, key_ptr);
-                out.push(jsvalue_to_f64(f64::from_bits(field.bits())));
+                out.push(bigint::coerce_for_kind(
+                    dst_kind,
+                    f64::from_bits(field.bits()),
+                ));
             }
             return Some(out);
         }
@@ -1089,7 +1114,7 @@ pub extern "C" fn js_typed_array_set_from(
         0.0
     };
     unsafe {
-        let elems = match collect_typed_array_set_source(source_value) {
+        let elems = match collect_typed_array_set_source(source_value, (*ta).kind) {
             Some(e) => e,
             None => throw_type_error(b"Cannot convert undefined or null to object"),
         };
@@ -1725,35 +1750,6 @@ pub extern "C" fn js_typed_array_reduce_right(
     }
 }
 
-/// Format a typed array Node-style: `Int32Array(N) [ a, b, c ]`. Used by
-/// `format_jsvalue` in builtins.rs.
-pub fn format_typed_array(ta: *const TypedArrayHeader) -> String {
-    let ta = clean_ta_ptr(ta);
-    if ta.is_null() {
-        return "TypedArray(0) []".to_string();
-    }
-    unsafe {
-        let kind = (*ta).kind;
-        let len = (*ta).length as usize;
-        let name = name_for_kind(kind);
-        if len == 0 {
-            return format!("{}(0) []", name);
-        }
-        let mut s = format!("{}({}) [", name, len);
-        for i in 0..len {
-            if i == 0 {
-                s.push(' ');
-            } else {
-                s.push_str(", ");
-            }
-            let v = load_at(ta, i);
-            s.push_str(&format_typed_value(kind, v));
-        }
-        s.push_str(" ]");
-        s
-    }
-}
-
 // #3148: %TypedArray%.prototype join / slice / reverse / fill / subarray.
 // (reduce/reduceRight/copyWithin/set_from/findIndex live above — added separately.)
 /// `ta.join(sep?)` — Number→String each element (Node formatting), joined by
@@ -1786,7 +1782,7 @@ pub extern "C" fn js_typed_array_join(
             if i > 0 {
                 result.push_str(sep_str);
             }
-            result.push_str(&format_typed_value(kind, load_at(ta, i)));
+            result.push_str(&format::format_typed_value(kind, load_at(ta, i), false));
         }
         let ret = js_string_from_bytes(result.as_ptr(), result.len() as u32);
         std::hint::black_box(&result);
@@ -1943,34 +1939,10 @@ pub extern "C" fn js_typed_array_subarray(
     }
 }
 
-fn format_typed_value(kind: u8, v: f64) -> String {
-    match kind {
-        KIND_FLOAT16 | KIND_FLOAT32 | KIND_FLOAT64 => {
-            // Match Node: integer-valued floats render with no decimal,
-            // others render via Rust's default Debug for f64.
-            if v.is_nan() {
-                "NaN".to_string()
-            } else if v.is_infinite() {
-                if v > 0.0 {
-                    "Infinity".to_string()
-                } else {
-                    "-Infinity".to_string()
-                }
-            } else if v == v.trunc() && v.abs() < 1e16 {
-                format!("{}", v as i64)
-            } else {
-                // Use Rust's default short formatting.
-                let s = format!("{}", v);
-                s
-            }
-        }
-        _ => {
-            // Integer types
-            format!("{}", v as i64)
-        }
-    }
-}
-
+/// Format a single typed-array element. `bigint_suffix` controls whether a
+/// `BigInt64`/`BigUint64` element renders with the trailing `n` (true for the
+/// `console.log` inspect form `BigInt64Array(1) [ 5n ]`, false for `join`,
+/// which calls plain `ToString` on each element → `"5"`).
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/test-parity/node-suite/bigint/typed-array/element-roundtrip.ts
+++ b/test-parity/node-suite/bigint/typed-array/element-roundtrip.ts
@@ -1,0 +1,65 @@
+// #4356 — BigInt64Array / BigUint64Array element get/set must round-trip as
+// BigInt (not Number). Reads return a `bigint`, writes ToBigInt-coerce the
+// value (a Number throws TypeError), and the prototype/reflection surface
+// (join, inspect, set, slice, defineProperty) preserves the BigInt values.
+
+// Element write/read round-trip.
+const b = new BigInt64Array(2);
+b[0] = 5n;
+b[1] = 9n;
+console.log("get:", b[0], b[1], typeof b[0]);
+
+// Negative + BigUint64 full-width value (would truncate through f64).
+const s = new BigInt64Array(1);
+s[0] = -7n;
+console.log("neg:", s[0]);
+const u = new BigUint64Array(1);
+u[0] = 18446744073709551615n;
+console.log("u64max:", u[0]);
+
+// Construct from a BigInt array literal.
+const c = new BigInt64Array([10n, 20n, 30n]);
+console.log("ctor:", c[0], c[1], c[2]);
+
+// join (plain ToString — no trailing `n`) and inspect (with `n`).
+console.log("join:", c.join(","));
+console.log(c);
+
+// slice keeps BigInt elements (slice-result local is a tracked view).
+const sl = c.slice(1);
+console.log("slice:", sl.length, sl[0], sl[1]);
+
+// In-place reverse mutates the original view's slots.
+c.reverse();
+console.log("reverse:", c[0], c[1], c[2]);
+
+// set() from another typed array and from a plain array.
+const dstTa = new BigInt64Array(3);
+dstTa.set(new BigInt64Array([1n, 2n, 3n]));
+console.log("set-ta:", dstTa[0], dstTa[1], dstTa[2]);
+const dstArr = new BigInt64Array(3);
+dstArr.set([4n, 5n, 6n]);
+console.log("set-arr:", dstArr[0], dstArr[1], dstArr[2]);
+
+// Boolean coerces via ToBigInt (true -> 1n).
+const t = new BigUint64Array(1);
+(t as unknown as boolean[])[0] = true;
+console.log("bool:", t[0]);
+
+// defineProperty / Reflect.defineProperty drive IntegerIndexedElementSet.
+const d = new BigInt64Array([0n, 0n, 0n]);
+Reflect.defineProperty(d, "0", { value: 42n });
+Object.defineProperty(d, "1", { value: 43n });
+console.log("define:", d[0], d[1]);
+
+// Out-of-bounds canonical index → rejected (Reflect returns false).
+console.log("oob:", Reflect.defineProperty(d, "9", { value: 1n }), d[2]);
+
+// A Number value is not convertible: ToBigInt throws a TypeError, no write.
+try {
+  Object.defineProperty(d, "2", { value: 3 });
+  console.log("number-define: no throw");
+} catch (e) {
+  const err = e as Error;
+  console.log("number-define:", err.name, "-", err.message, "->", d[2]);
+}


### PR DESCRIPTION
## Summary

Fixes #4356. `BigInt64Array` / `BigUint64Array` element reads and writes coerced through `f64`, so values round-tripped as **Numbers** instead of **BigInts** — and large/non-representable bigints were silently truncated.

```ts
const b = new BigInt64Array(2);
b[0] = 5n; b[1] = 9n;
console.log(b[0], b[1]);   // before: 0 0   →  now: 5n 9n  (Node-identical)
```

## Changes (all in `crates/perry-runtime/src/typedarray.rs`)

- **`load_at`** — bigint kinds return a NaN-boxed `BigInt` (`js_bigint_from_i64`/`js_bigint_from_u64`) instead of `raw as f64`, so element reads are real `bigint`s.
- **`store_at`** — bigint kinds read the BigInt's raw low limb (`bigint_slot_bits`) rather than `value as i64` on an already-NaN-boxed pointer (which mapped to `0`).
- **`js_typed_array_set`** — bigint views run `ToBigInt`: a Number throws `TypeError: Cannot convert <n> to a BigInt`, Boolean/String coerce, BigInt passes through; the raw value is stored (not `jsvalue_to_f64`'d).
- **construction-from-array** and **`set()`** — coerce per destination kind (`ToBigInt` for bigint views), so `new BigInt64Array([1n,2n])` and `ta.set([...])` keep real BigInt elements.
- **`format_typed_value`** — render bigint elements from the raw limb, with the trailing `n` for the `console.log` inspect form and without it for `join`.

The internal `load_at`→`store_at` data-movement helpers (`slice`, `reverse`, `copyWithin`, set-from-TA) round-trip the raw bits unchanged.

## Impact

Unblocks the element-set side-effect assertions in the test262 `TypedArrayConstructors/internals/DefineOwnProperty/BigInt/` subdirectory (rejection logic from #4353 was already correct; the reads now yield BigInts).

## Verification

Byte-for-byte against `node --experimental-strip-types` for: element get/set, negative + u64-max values, construction-from-array, `join`/inspect formatting, in-place `reverse`, `slice`, `set()` from a typed array and from a plain array, Boolean coercion, `Object`/`Reflect.defineProperty`, out-of-bounds rejection, and the Number→`TypeError`. Numeric typed-array behavior is unchanged; `cargo fmt --check` clean and `cargo test -p perry-runtime typed` (57 tests) passes. New fixture: `test-parity/node-suite/bigint/typed-array/element-roundtrip.ts`.

## Out of scope (follow-ups)

- `DataView.prototype.getBigInt64`/`setBigInt64`/`getBigUint64`/`setBigUint64` are entirely unimplemented (return `undefined`) — a distinct missing feature spanning the DataView dispatch layers; tracked in #4365.
- Chained-method-result element indexing (`const x = ta.reverse(); x[0]`) reads raw bytes — a **pre-existing** codegen view-tracking limitation that affects numeric typed arrays too (not bigint-specific).
