### PR TITLE
feat(runtime): implement DataView getBigInt64/setBigInt64/getBigUint64/setBigUint64 (#4365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1119 — feat(runtime): implement DataView getBigInt64/setBigInt64/getBigUint64/setBigUint64 (#4365)
+
+`DataView.prototype.getBigInt64`/`setBigInt64`/`getBigUint64`/`setBigUint64` were unimplemented — `DataViewKind::from_method_suffix` didn't recognize the `"BigInt64"`/`"BigUint64"` suffixes, so the method names never routed to the DataView dispatch: reads returned `undefined` and setters silently no-op'd.
+
+- **`buffer/dataview.rs`** — add `BigInt64`/`BigUint64` to `DataViewKind` (width 8) and `from_method_suffix`. The `get` arms read the raw 8 bytes (endian-aware) and return a NaN-boxed BigInt (`js_bigint_from_i64`/`js_bigint_from_u64`). The `set` path runs `ToBigInt` (a Number throws `TypeError: Cannot convert <n> to a BigInt`, Boolean/String coerce, BigInt passes through) via the new `to_bigint_raw_or_throw`, then writes the BigInt's low 64 bits — bypassing the numeric `to_number`/ToIntN wrap the integer kinds use.
+- **`object/dataview_proto_thunks.rs`** — register `get`/`setBigInt64` + `get`/`setBigUint64` thunks and prototype-table rows so they are reflectable (`typeof DataView.prototype.getBigInt64 === "function"`) and `.call`-able.
+- **`object/buffer_dispatch.rs`** — add the four names to the buffer-method gate so instance calls reach `dispatch_buffer_method`.
+
+Verified byte-for-byte against `node --experimental-strip-types`: signed/unsigned round-trip, negative + u64-max values, big/little endian, Boolean coercion, Number→`TypeError`, out-of-bounds `RangeError`, prototype reflection, `.call` dispatch, and the non-DataView-receiver brand check. Numeric DataView accessors are unchanged. Follow-up to #4356 (#4364); reuses the same BigInt limb box/unbox helpers. New fixture: `test-parity/node-suite/buffer/dataview/bigint-accessors.ts`.
+
 ## v0.5.1118 — fix(runtime): round-trip BigInt64Array/BigUint64Array elements as BigInt (#4356)
 
 `BigInt64Array`/`BigUint64Array` element reads and writes coerced through `f64`, so values round-tripped as **Numbers** instead of **BigInts** and large/non-representable bigints were silently truncated: `const b = new BigInt64Array(2); b[0] = 5n; b[0]` yielded `0` (typeof Number) instead of `5n`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1118
+**Current Version:** 0.5.1119
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5022,7 +5022,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,14 +5077,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "cc",
  "libc",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "log",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "base64",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "serde",
  "serde_json",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1118"
+version = "0.5.1119"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "clap",
@@ -5227,14 +5227,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "chrono",
  "cron",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5333,14 +5333,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "bytes",
  "h2",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "bson",
  "futures-util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "image",
@@ -5527,14 +5527,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "brotli",
  "flate2",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "base64",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5749,14 +5749,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "itoa",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "block2",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "block2",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1118"
+version = "0.5.1119"
 
 [[package]]
 name = "perry-ui-test"
@@ -5845,11 +5845,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1118"
+version = "0.5.1119"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "block2",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "block2",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "block2",
  "libc",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "libc",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1118"
+version = "0.5.1119"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1118"
+version = "0.5.1119"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/buffer/dataview.rs
+++ b/crates/perry-runtime/src/buffer/dataview.rs
@@ -28,6 +28,8 @@ pub enum DataViewKind {
     Uint32,
     Float32,
     Float64,
+    BigInt64,
+    BigUint64,
 }
 
 impl DataViewKind {
@@ -37,8 +39,15 @@ impl DataViewKind {
             DataViewKind::Int8 | DataViewKind::Uint8 => 1,
             DataViewKind::Int16 | DataViewKind::Uint16 => 2,
             DataViewKind::Int32 | DataViewKind::Uint32 | DataViewKind::Float32 => 4,
-            DataViewKind::Float64 => 8,
+            DataViewKind::Float64 | DataViewKind::BigInt64 | DataViewKind::BigUint64 => 8,
         }
+    }
+
+    /// Is this a BigInt-valued accessor (`getBigInt64`/`setBigUint64`/…)? Those
+    /// read/write a NaN-boxed BigInt rather than a Number.
+    #[inline]
+    fn is_bigint(self) -> bool {
+        matches!(self, DataViewKind::BigInt64 | DataViewKind::BigUint64)
     }
 
     /// Map a `get*`/`set*` method name (without the `get`/`set` prefix) to a
@@ -53,6 +62,8 @@ impl DataViewKind {
             "Uint32" => DataViewKind::Uint32,
             "Float32" => DataViewKind::Float32,
             "Float64" => DataViewKind::Float64,
+            "BigInt64" => DataViewKind::BigInt64,
+            "BigUint64" => DataViewKind::BigUint64,
             _ => return None,
         })
     }
@@ -177,6 +188,24 @@ pub fn js_data_view_get(buf_f64: f64, offset_value: f64, kind: DataViewKind, lit
                     f64::from_be_bytes(b)
                 }
             }
+            DataViewKind::BigInt64 => {
+                let b = read_bytes::<8>(buf, offset);
+                let v = if little {
+                    i64::from_le_bytes(b)
+                } else {
+                    i64::from_be_bytes(b)
+                };
+                crate::value::js_nanbox_bigint(crate::bigint::js_bigint_from_i64(v) as i64)
+            }
+            DataViewKind::BigUint64 => {
+                let b = read_bytes::<8>(buf, offset);
+                let v = if little {
+                    u64::from_le_bytes(b)
+                } else {
+                    u64::from_be_bytes(b)
+                };
+                crate::value::js_nanbox_bigint(crate::bigint::js_bigint_from_u64(v) as i64)
+            }
         }
     }
 }
@@ -193,9 +222,23 @@ pub fn js_data_view_set(
 ) -> f64 {
     let buf = unbox_buffer_ptr(buf_f64.to_bits()) as *mut BufferHeader;
     let offset = to_byte_offset(offset_value);
+    if kind.is_bigint() {
+        // SetViewValue for a BigInt accessor: `ToBigInt(value)` (a Number throws
+        // `TypeError`) runs before the bounds check, then the raw 8 bytes are
+        // stored with the requested endianness (both kinds share the bit layout).
+        let raw = to_bigint_raw_or_throw(value);
+        let b = if little {
+            raw.to_le_bytes()
+        } else {
+            raw.to_be_bytes()
+        };
+        unsafe { write_bytes(buf, offset, &b) };
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
     let n = to_number(value);
     unsafe {
         match kind {
+            DataViewKind::BigInt64 | DataViewKind::BigUint64 => unreachable!(),
             DataViewKind::Int8 | DataViewKind::Uint8 => {
                 // ToUint8 / ToInt8 wrap to the same byte; store identically.
                 let byte = wrap_to_u64(n, 8) as u8;
@@ -254,4 +297,55 @@ fn wrap_to_u64(n: f64, bits: u32) -> u64 {
     let modulus = 1i128 << bits;
     let reduced = (truncated as i128).rem_euclid(modulus);
     reduced as u64
+}
+
+/// `ToBigInt(value)` for a `setBigInt64`/`setBigUint64` write, returning the
+/// BigInt's low 64 bits (the only ones an 8-byte slot holds; both signed and
+/// unsigned share the bit layout). Per the ECMAScript `ToBigInt` operation, a
+/// Number (incl. a NaN-boxed int32), `undefined`, `null`, and Symbols are NOT
+/// convertible and throw a `TypeError`; BigInt passes through, Boolean and
+/// String coerce.
+fn to_bigint_raw_or_throw(value: f64) -> u64 {
+    use crate::value::JSValue;
+    let jsval = JSValue::from_bits(value.to_bits());
+    let bi: *const crate::bigint::BigIntHeader = if jsval.is_bigint() {
+        jsval.as_bigint_ptr() as *const crate::bigint::BigIntHeader
+    } else if jsval.is_bool() {
+        crate::bigint::js_bigint_from_i64(if jsval.as_bool() { 1 } else { 0 })
+    } else if jsval.is_any_string() {
+        // StringToBigInt (a malformed numeric string throws SyntaxError).
+        crate::bigint::js_bigint_from_f64(value)
+    } else {
+        throw_bigint_conversion_type_error(value);
+    };
+    let bi = crate::bigint::clean_bigint_ptr(bi);
+    if bi.is_null() {
+        return 0;
+    }
+    unsafe { (*bi).limbs[0] }
+}
+
+/// Throw `TypeError: Cannot convert <x> to a BigInt`, matching Node's
+/// `ToBigInt` rejection text for a DataView BigInt setter.
+#[cold]
+fn throw_bigint_conversion_type_error(value: f64) -> ! {
+    use crate::value::JSValue;
+    let jsval = JSValue::from_bits(value.to_bits());
+    let label = if jsval.is_undefined() {
+        "undefined".to_string()
+    } else if jsval.is_null() {
+        "null".to_string()
+    } else if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
+        "a Symbol value".to_string()
+    } else if jsval.is_int32() {
+        jsval.as_int32().to_string()
+    } else {
+        format!("{value}")
+    };
+    let msg = format!("Cannot convert {label} to a BigInt");
+    let err = crate::error::js_typeerror_new(crate::string::js_string_from_bytes(
+        msg.as_ptr(),
+        msg.len() as u32,
+    ));
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -182,6 +182,13 @@ pub fn is_buffer_method_name(name: &str) -> bool {
             | "setUint32"
             | "setFloat32"
             | "setFloat64"
+            // #4365: DataView BigInt64/BigUint64 accessors (8-byte BigInt
+            // read/write). Route through `dispatch_buffer_method` like the
+            // other DataView numeric methods.
+            | "getBigInt64"
+            | "getBigUint64"
+            | "setBigInt64"
+            | "setBigUint64"
     )
 }
 

--- a/crates/perry-runtime/src/object/dataview_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/dataview_proto_thunks.rs
@@ -162,6 +162,8 @@ dataview_get_thunk!(dv_get_int32, "Int32");
 dataview_get_thunk!(dv_get_uint32, "Uint32");
 dataview_get_thunk!(dv_get_float32, "Float32");
 dataview_get_thunk!(dv_get_float64, "Float64");
+dataview_get_thunk!(dv_get_bigint64, "BigInt64");
+dataview_get_thunk!(dv_get_biguint64, "BigUint64");
 
 dataview_set_thunk!(dv_set_int8, "Int8");
 dataview_set_thunk!(dv_set_uint8, "Uint8");
@@ -171,6 +173,8 @@ dataview_set_thunk!(dv_set_int32, "Int32");
 dataview_set_thunk!(dv_set_uint32, "Uint32");
 dataview_set_thunk!(dv_set_float32, "Float32");
 dataview_set_thunk!(dv_set_float64, "Float64");
+dataview_set_thunk!(dv_set_bigint64, "BigInt64");
+dataview_set_thunk!(dv_set_biguint64, "BigUint64");
 
 /// Install the `DataView.prototype` accessors + numeric methods. Called from
 /// `global_this::populate_builtin_prototype_methods`'s `"DataView"` arm.
@@ -217,6 +221,8 @@ pub(crate) fn install_dataview_proto_methods(proto_obj: *mut ObjectHeader) {
         ("getUint32", dv_get_uint32 as *const u8),
         ("getFloat32", dv_get_float32 as *const u8),
         ("getFloat64", dv_get_float64 as *const u8),
+        ("getBigInt64", dv_get_bigint64 as *const u8),
+        ("getBigUint64", dv_get_biguint64 as *const u8),
     ];
     for (name, ptr) in gets.iter().copied() {
         install_proto_method_rest_with_length(proto_obj, name, ptr, 1, 1);
@@ -233,6 +239,8 @@ pub(crate) fn install_dataview_proto_methods(proto_obj: *mut ObjectHeader) {
         ("setUint32", dv_set_uint32 as *const u8),
         ("setFloat32", dv_set_float32 as *const u8),
         ("setFloat64", dv_set_float64 as *const u8),
+        ("setBigInt64", dv_set_bigint64 as *const u8),
+        ("setBigUint64", dv_set_biguint64 as *const u8),
     ];
     for (name, ptr) in sets.iter().copied() {
         // `install_proto_method_rest` registers spec_length == call_fixed_arity.

--- a/test-parity/node-suite/buffer/dataview/bigint-accessors.ts
+++ b/test-parity/node-suite/buffer/dataview/bigint-accessors.ts
@@ -1,0 +1,64 @@
+// #4365 — DataView.prototype.getBigInt64 / setBigInt64 / getBigUint64 /
+// setBigUint64. Reads return a `bigint`; writes ToBigInt-coerce the value (a
+// Number throws TypeError), store the raw 8 bytes with the requested
+// endianness (big-endian default), and the methods are reflectable on the
+// prototype and invokable via `.call`.
+
+const dv = new DataView(new ArrayBuffer(64));
+
+// Signed round-trip incl. negative + full-width unsigned (would truncate f64).
+dv.setBigInt64(0, -5n);
+console.log("i64:", dv.getBigInt64(0), typeof dv.getBigInt64(0));
+dv.setBigUint64(8, 18446744073709551615n);
+console.log("u64max:", dv.getBigUint64(8));
+
+// Endianness: default big-endian, explicit little-endian flag.
+dv.setBigInt64(16, 1n, true);
+console.log("le/be:", dv.getBigInt64(16, true), dv.getBigInt64(16, false));
+dv.setBigInt64(24, -1n, false);
+console.log("be -1:", dv.getBigInt64(24, false), dv.getBigUint64(24, false));
+
+// Boolean coerces via ToBigInt (true -> 1n).
+dv.setBigUint64(32, true as unknown as bigint);
+console.log("bool:", dv.getBigUint64(32));
+
+// A Number is not convertible: ToBigInt throws a TypeError, no write.
+try {
+  dv.setBigInt64(40, 7 as unknown as bigint);
+  console.log("number: no throw");
+} catch (e) {
+  const err = e as Error;
+  console.log("number:", err.name, "-", err.message);
+}
+
+// Out-of-bounds byte offset → RangeError (8-byte access past the buffer end).
+try {
+  dv.getBigInt64(60);
+  console.log("oob-get: no throw");
+} catch (e) {
+  console.log("oob-get:", (e as Error).name);
+}
+try {
+  dv.setBigUint64(60, 1n);
+  console.log("oob-set: no throw");
+} catch (e) {
+  console.log("oob-set:", (e as Error).name);
+}
+
+// Reflectable on the prototype, callable via `.call`.
+console.log(
+  "proto:",
+  typeof DataView.prototype.getBigInt64,
+  typeof DataView.prototype.setBigUint64,
+);
+const dv2 = new DataView(new ArrayBuffer(8));
+DataView.prototype.setBigInt64.call(dv2, 0, 42n);
+console.log("call:", DataView.prototype.getBigInt64.call(dv2, 0));
+
+// Brand check: invoking on a non-DataView receiver throws a TypeError.
+try {
+  DataView.prototype.getBigInt64.call({} as DataView, 0);
+  console.log("brand: no throw");
+} catch (e) {
+  console.log("brand:", (e as Error).name);
+}


### PR DESCRIPTION
## Summary

Fixes #4365. `DataView.prototype.getBigInt64` / `setBigInt64` / `getBigUint64` / `setBigUint64` were unimplemented — `DataViewKind::from_method_suffix` didn't recognize the `"BigInt64"`/`"BigUint64"` suffixes, so the method names never routed to the DataView dispatch: reads returned `undefined` and setters silently no-op'd.

```ts
const dv = new DataView(new ArrayBuffer(16));
dv.setBigInt64(0, -5n);
console.log(dv.getBigInt64(0), typeof dv.getBigInt64(0));
// before: undefined undefined   →  now: -5n bigint  (Node-identical)
```

## Changes

- **`buffer/dataview.rs`** — add `BigInt64`/`BigUint64` to `DataViewKind` (width 8) and `from_method_suffix`. The `get` arms read the raw 8 bytes (endian-aware) and return a **NaN-boxed BigInt** (`js_bigint_from_i64`/`js_bigint_from_u64`). The `set` path runs **`ToBigInt`** (a Number throws `TypeError`, Boolean/String coerce, BigInt passes through) via the new `to_bigint_raw_or_throw`, then writes the BigInt's low 64 bits — bypassing the numeric `to_number`/ToIntN wrap the integer kinds use.
- **`object/dataview_proto_thunks.rs`** — register `get`/`setBigInt64` + `get`/`setBigUint64` thunks and prototype-table rows, so they are reflectable (`typeof DataView.prototype.getBigInt64 === "function"`) and `.call`-able.
- **`object/buffer_dispatch.rs`** — add the four names to the buffer-method gate so instance calls reach `dispatch_buffer_method`.

## Verification

Byte-for-byte against `node --experimental-strip-types` for: signed/unsigned round-trip, negative + u64-max values, big/little endian, Boolean coercion, Number→`TypeError`, out-of-bounds `RangeError`, prototype reflection, `.call` dispatch, and the non-DataView-receiver brand check. Numeric DataView accessors are unchanged; `cargo fmt --check` clean and `cargo test -p perry-runtime` (buffer/stream suites) passes. New fixture: `test-parity/node-suite/buffer/dataview/bigint-accessors.ts`.

Follow-up to #4356 (BigInt64Array element round-trip, PR #4364); reuses the same BigInt limb box/unbox helpers.
