### PR TITLE
[codex] align net socket type of service state

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -1295,6 +1295,15 @@ unsafe fn dispatch_net_socket(handle: i64, method: &str, args: &[f64]) -> f64 {
             crate::net::js_net_socket_destroy(handle);
             f64::from_bits(0x7FFC_0000_0000_0001)
         }
+        "getTypeOfService" => crate::net::js_net_socket_get_type_of_service(handle),
+        "setTypeOfService" => {
+            let value = args
+                .first()
+                .copied()
+                .unwrap_or(f64::from_bits(0x7FFC_0000_0000_0001));
+            crate::net::js_net_socket_set_type_of_service(handle, value);
+            f64::from_bits(0x7FFD_0000_0000_0000u64 | (handle as u64 & 0x0000_FFFF_FFFF_FFFF))
+        }
         "on" if args.len() >= 2 => {
             let event_ptr = unbox_to_i64(args[0]);
             let cb_ptr = unbox_to_i64(args[1]);

--- a/crates/perry-stdlib/src/net/mod.rs
+++ b/crates/perry-stdlib/src/net/mod.rs
@@ -150,6 +150,7 @@ struct SocketState {
     /// where the rx flows straight into the task.
     pending_rx: Option<mpsc::UnboundedReceiver<SocketCommand>>,
     is_open: bool,
+    type_of_service: u8,
 }
 
 enum SocketCommand {
@@ -536,6 +537,7 @@ pub unsafe extern "C" fn js_net_socket_alloc() -> i64 {
             cmd_tx: tx,
             pending_rx: Some(rx),
             is_open: false,
+            type_of_service: 0,
         },
     );
     NET_LISTENERS.lock().unwrap().insert(id, HashMap::new());
@@ -660,6 +662,7 @@ fn spawn_socket_task(host: String, port: u16, direct_tls: Option<(String, bool)>
             cmd_tx: tx,
             pending_rx: None,
             is_open: false,
+            type_of_service: 0,
         },
     );
     NET_LISTENERS.lock().unwrap().insert(id, HashMap::new());
@@ -875,6 +878,24 @@ pub unsafe extern "C" fn js_net_socket_destroy(handle: i64) {
     if let Some(s) = sockets.get(&handle) {
         let _ = s.cmd_tx.send(SocketCommand::Destroy);
     }
+}
+
+#[no_mangle]
+pub extern "C" fn js_net_socket_get_type_of_service(handle: i64) -> f64 {
+    NET_SOCKETS
+        .lock()
+        .ok()
+        .and_then(|sockets| sockets.get(&handle).map(|s| s.type_of_service as f64))
+        .unwrap_or(0.0)
+}
+
+#[no_mangle]
+pub extern "C" fn js_net_socket_set_type_of_service(handle: i64, tos: f64) -> i64 {
+    let tos = perry_runtime::net_validate::js_net_validate_tos(tos) as u8;
+    if let Some(s) = NET_SOCKETS.lock().unwrap().get_mut(&handle) {
+        s.type_of_service = tos;
+    }
+    handle
 }
 
 // ─── FFI: socket.on(event, callback) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds bundled `net.Socket` state for `getTypeOfService()` / `setTypeOfService()` so the fallback socket path matches Node and the existing external net implementation.

## Root Cause

The external net crate already stored and validated the socket TOS value, but the bundled `net.Socket` handle dispatcher returned `undefined` for the getter, did not preserve the value, and treated invalid setter inputs as successful no-ops.

## Impact

`new net.Socket()` now reports a default TOS of `0`, returns the socket from `setTypeOfService()`, preserves the assigned value, and throws Node-compatible validation errors for invalid `tos` values.

## Validation

- `cargo fmt --check`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module net --filter socket/type-of-service'`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module net'`
