### PR TITLE
[codex] Preserve BigInt typed array elements

### DIFF
--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -64,6 +64,8 @@ fn is_width_tracked_typed_array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool
                 | "Float16Array"
                 | "Float32Array"
                 | "Float64Array"
+                | "BigInt64Array"
+                | "BigUint64Array"
         )
     )
 }

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -97,6 +97,7 @@ pub mod text;
 pub mod timer;
 pub mod typed_feedback;
 pub mod typedarray;
+pub mod typedarray_bigint;
 pub mod typedarray_half;
 pub mod typedarray_view;
 pub mod url;

--- a/crates/perry-runtime/src/typedarray.rs
+++ b/crates/perry-runtime/src/typedarray.rs
@@ -569,32 +569,35 @@ fn jsvalue_to_f64(v: f64) -> f64 {
     f64::NAN
 }
 
-/// Store a number into the typed array slot, performing the per-kind cast.
+/// Store a JS value into the typed array slot, performing the per-kind cast.
 unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64) {
     let kind = (*ta).kind;
+    let number = if matches!(kind, KIND_BIGINT64 | KIND_BIGUINT64) {
+        value
+    } else {
+        jsvalue_to_f64(value)
+    };
     let elem_size = (*ta).elem_size as usize;
     let base = data_ptr_mut(ta);
     let off = idx * elem_size;
     match kind {
         KIND_INT8 => {
-            let v = value as i32 as i8;
+            let v = number as i32 as i8;
             *(base.add(off) as *mut i8) = v;
         }
         KIND_UINT8 => {
-            let mut v = value as i64;
+            let mut v = number as i64;
             v = v.rem_euclid(256);
             *base.add(off) = v as u8;
         }
         KIND_UINT8_CLAMPED => {
-            // ToUint8Clamp: NaN → 0, v ≤ 0 → 0, v ≥ 255 → 255,
-            // otherwise round-half-to-even then clamp.
-            let byte = if value.is_nan() || value <= 0.0 {
+            let byte = if number.is_nan() || number <= 0.0 {
                 0u8
-            } else if value >= 255.0 {
+            } else if number >= 255.0 {
                 255u8
             } else {
-                let f = value.floor();
-                let frac = value - f;
+                let f = number.floor();
+                let frac = number - f;
                 let rounded = if frac > 0.5 {
                     f + 1.0
                 } else if frac < 0.5 {
@@ -609,42 +612,43 @@ unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64) {
             *base.add(off) = byte;
         }
         KIND_INT16 => {
-            let v = value as i32 as i16;
+            let v = number as i32 as i16;
             *(base.add(off) as *mut i16) = v;
         }
         KIND_UINT16 => {
-            let mut v = value as i64;
+            let mut v = number as i64;
             v = v.rem_euclid(65536);
             *(base.add(off) as *mut u16) = v as u16;
         }
         KIND_INT32 => {
-            let v = value as i32;
+            let v = number as i32;
             *(base.add(off) as *mut i32) = v;
         }
         KIND_UINT32 => {
-            let v = value as i64 as u32;
+            let v = number as i64 as u32;
             *(base.add(off) as *mut u32) = v;
         }
         KIND_FLOAT16 => {
-            *(base.add(off) as *mut u16) = f64_to_f16_bits(value);
+            *(base.add(off) as *mut u16) = f64_to_f16_bits(number);
         }
         KIND_FLOAT32 => {
-            *(base.add(off) as *mut f32) = value as f32;
+            *(base.add(off) as *mut f32) = number as f32;
         }
         KIND_FLOAT64 => {
-            *(base.add(off) as *mut f64) = value;
+            *(base.add(off) as *mut f64) = number;
         }
         KIND_BIGINT64 => {
-            *(base.add(off) as *mut i64) = value as i64;
+            *(base.add(off) as *mut i64) =
+                crate::typedarray_bigint::bigint64_element_bits(value) as i64;
         }
         KIND_BIGUINT64 => {
-            *(base.add(off) as *mut u64) = value as u64;
+            *(base.add(off) as *mut u64) = crate::typedarray_bigint::bigint64_element_bits(value);
         }
         _ => {}
     }
 }
 
-/// Load a slot, returning a plain f64 (numeric, not NaN-boxed).
+/// Load a slot as the JS element value.
 unsafe fn load_at(ta: *const TypedArrayHeader, idx: usize) -> f64 {
     let kind = (*ta).kind;
     let elem_size = (*ta).elem_size as usize;
@@ -660,8 +664,8 @@ unsafe fn load_at(ta: *const TypedArrayHeader, idx: usize) -> f64 {
         KIND_FLOAT16 => f16_bits_to_f64(*(base.add(off) as *const u16)),
         KIND_FLOAT32 => *(base.add(off) as *const f32) as f64,
         KIND_FLOAT64 => *(base.add(off) as *const f64),
-        KIND_BIGINT64 => *(base.add(off) as *const i64) as f64,
-        KIND_BIGUINT64 => *(base.add(off) as *const u64) as f64,
+        KIND_BIGINT64 => crate::typedarray_bigint::box_bigint64(*(base.add(off) as *const i64)),
+        KIND_BIGUINT64 => crate::typedarray_bigint::box_biguint64(*(base.add(off) as *const u64)),
         _ => 0.0,
     }
 }
@@ -817,11 +821,9 @@ pub extern "C" fn js_typed_array_new_from_array(
     }
     unsafe {
         let len = (*arr).length;
-        // Snapshot source values via the canonical accessor BEFORE allocating:
-        // `typed_array_alloc` may GC and free/move an unrooted cloned source
-        // (`.of/.from` path), and the raw inline read mis-read it (#871).
+        // Snapshot before allocating: `typed_array_alloc` may GC (#871).
         let vals: Vec<f64> = (0..len)
-            .map(|i| jsvalue_to_f64(crate::array::js_array_get_f64(arr, i)))
+            .map(|i| crate::array::js_array_get_f64(arr, i))
             .collect();
         let ta = typed_array_alloc(kind, len);
         for (i, v) in vals.iter().enumerate() {
@@ -988,17 +990,11 @@ pub extern "C" fn js_typed_array_set(ta: *mut TypedArrayHeader, index: i32, valu
         if index < 0 || index as u32 >= (*ta).length {
             return;
         }
-        store_at(ta, index as usize, jsvalue_to_f64(value));
+        store_at(ta, index as usize, value);
     }
 }
 
-/// Collect the elements of a `TypedArray.prototype.set` source value into a
-/// `Vec<f64>` (numeric, not NaN-boxed). Handles three source shapes:
-///   - another typed array (read via its per-kind `load_at`),
-///   - a plain `Array` (each element coerced through `jsvalue_to_f64`),
-///   - an array-like object (`{ length, 0, 1, … }`).
-/// Returns `None` for null/undefined (caller throws TypeError) and an empty
-/// vec for unrecognized non-iterable values (Node coerces those to length 0).
+/// Collect `TypedArray.prototype.set` source values before mutating target.
 unsafe fn collect_typed_array_set_source(source_value: f64) -> Option<Vec<f64>> {
     let v = crate::value::JSValue::from_bits(source_value.to_bits());
     if v.is_null() || v.is_undefined() {
@@ -1037,9 +1033,7 @@ unsafe fn collect_typed_array_set_source(source_value: f64) -> Option<Vec<f64>> 
             let len = crate::array::js_array_length(arr) as usize;
             let mut out = Vec::with_capacity(len);
             for i in 0..len {
-                out.push(jsvalue_to_f64(crate::array::js_array_get_f64(
-                    arr, i as u32,
-                )));
+                out.push(crate::array::js_array_get_f64(arr, i as u32));
             }
             return Some(out);
         }
@@ -1058,7 +1052,7 @@ unsafe fn collect_typed_array_set_source(source_value: f64) -> Option<Vec<f64>> 
                 let key = i.to_string();
                 let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
                 let field = crate::object::js_object_get_field_by_name(obj, key_ptr);
-                out.push(jsvalue_to_f64(f64::from_bits(field.bits())));
+                out.push(f64::from_bits(field.bits()));
             }
             return Some(out);
         }
@@ -1395,7 +1389,7 @@ pub extern "C" fn js_typed_array_with(
         let out = typed_array_alloc(kind, len as u32);
         for i in 0..len {
             if i as i64 == idx {
-                store_at(out, i, jsvalue_to_f64(value));
+                store_at(out, i, value);
             } else {
                 store_at(out, i, load_at(ta, i));
             }
@@ -1470,8 +1464,8 @@ pub extern "C" fn js_typed_array_find_last_index(
 // this file and the generic array helpers use.
 
 /// `ta.map(cb)` — returns a NEW TypedArray of the SAME kind (per spec, not a
-/// plain Array). Each result is coerced back to the element type via the same
-/// `jsvalue_to_f64` path `ta[i] = v` uses.
+/// plain Array). Each result is coerced back to the element type through
+/// `store_at`, matching `ta[i] = v`.
 #[no_mangle]
 pub extern "C" fn js_typed_array_map(
     ta: *const TypedArrayHeader,
@@ -1489,7 +1483,7 @@ pub extern "C" fn js_typed_array_map(
         for i in 0..len {
             let v = load_at(ta, i);
             let r = crate::closure::js_closure_call3(callback, v, i as f64, recv);
-            store_at(out, i, jsvalue_to_f64(r));
+            store_at(out, i, r);
         }
         out
     }
@@ -1890,7 +1884,6 @@ pub extern "C" fn js_typed_array_fill(
     }
     unsafe {
         let len = (*ta).length as isize;
-        let v = jsvalue_to_f64(value);
         let norm = |x: f64, default: isize| -> isize {
             let mut n = if x.is_nan() { default } else { x as isize };
             if n < 0 {
@@ -1902,7 +1895,7 @@ pub extern "C" fn js_typed_array_fill(
         let e = if has_end != 0 { norm(end, len) } else { len };
         let mut i = s;
         while i < e {
-            store_at(ta, i as usize, v);
+            store_at(ta, i as usize, value);
             i += 1;
         }
         ta

--- a/crates/perry-runtime/src/typedarray_bigint.rs
+++ b/crates/perry-runtime/src/typedarray_bigint.rs
@@ -1,0 +1,62 @@
+use crate::bigint::{clean_bigint_ptr, js_bigint_from_f64, js_bigint_from_i64, js_bigint_from_u64};
+use crate::value::{js_nanbox_bigint, js_nanbox_pointer, JSValue};
+
+#[cold]
+fn throw_type_error(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(js_nanbox_pointer(err as i64))
+}
+
+#[inline]
+unsafe fn gc_payload_type(addr: usize) -> Option<u8> {
+    if addr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    let header_addr = addr - crate::gc::GC_HEADER_SIZE;
+    if matches!(
+        crate::arena::classify_heap_space(header_addr),
+        crate::arena::HeapSpace::Unknown
+    ) {
+        return None;
+    }
+    let header = header_addr as *const crate::gc::GcHeader;
+    let obj_type = (*header).obj_type;
+    crate::gc::gc_type_info(obj_type).map(|_| obj_type)
+}
+
+pub(crate) fn bigint64_element_bits(value: f64) -> u64 {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_number() || jsval.is_int32() {
+        throw_type_error(b"Cannot convert value to a BigInt");
+    }
+    let ptr = if jsval.is_bigint() {
+        jsval.as_bigint_ptr()
+    } else if jsval.is_pointer() {
+        let ptr = jsval.as_pointer::<crate::bigint::BigIntHeader>();
+        let addr = ptr as usize;
+        unsafe {
+            if gc_payload_type(addr) != Some(crate::gc::GC_TYPE_BIGINT) {
+                throw_type_error(b"Cannot convert object to a BigInt");
+            }
+        }
+        ptr
+    } else {
+        js_bigint_from_f64(value)
+    };
+    let ptr = clean_bigint_ptr(ptr);
+    if ptr.is_null() {
+        throw_type_error(b"Cannot convert value to a BigInt");
+    }
+    unsafe { (*ptr).limbs[0] }
+}
+
+#[inline]
+pub(crate) fn box_bigint64(value: i64) -> f64 {
+    js_nanbox_bigint(js_bigint_from_i64(value) as i64)
+}
+
+#[inline]
+pub(crate) fn box_biguint64(value: u64) -> f64 {
+    js_nanbox_bigint(js_bigint_from_u64(value) as i64)
+}

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -117,6 +117,15 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         let byte_val = crate::buffer::js_buffer_get(buf, idx_i32);
         return byte_val as f64;
     }
+    if crate::typedarray::lookup_typed_array_kind(raw_ptr).is_some() {
+        if idx_i32 < 0 {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        return crate::typedarray::js_typed_array_get(
+            raw_ptr as *const crate::typedarray::TypedArrayHeader,
+            idx_i32,
+        );
+    }
     if raw_ptr >= crate::gc::GC_HEADER_SIZE {
         let gc_hdr = unsafe {
             (raw_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader

--- a/test-parity/expected/typedarray-bigint-elements.txt
+++ b/test-parity/expected/typedarray-bigint-elements.txt
@@ -1,0 +1,18 @@
+signed direct bigint:5|bigint:-1|bigint:-9223372036854775808
+signed accessors bigint:-1 bigint:-9223372036854775808 bigint:5
+unsigned direct bigint:5|bigint:18446744073709551615|bigint:0
+signed number write TypeError
+unsigned number write TypeError
+after direct rejects bigint:5 bigint:5
+define values bigint:42 bigint:18446744073709551614 bigint:42 true true true
+define number value TypeError
+after define reject bigint:-1
+from array bigint:1|bigint:-2|bigint:3|bigint:1
+from number array TypeError
+set values bigint:3|bigint:-4|bigint:5|bigint:6
+set number source TypeError
+after set reject bigint:3|bigint:-4|bigint:5|bigint:6
+fill bigint bigint:3|bigint:7|bigint:7|bigint:6
+fill number TypeError
+after fill reject bigint:3|bigint:7|bigint:7|bigint:6
+copy unsigned bigint:5|bigint:18446744073709551614|bigint:0

--- a/test-parity/node-suite/globals/typedarray-bigint-elements.ts
+++ b/test-parity/node-suite/globals/typedarray-bigint-elements.ts
@@ -1,0 +1,83 @@
+function cell(value: any): string {
+  return typeof value + ":" + String(value);
+}
+
+function list(values: any): string {
+  const out = [];
+  for (let i = 0; i < values.length; i++) {
+    out.push(cell(values[i]));
+  }
+  return out.join("|");
+}
+
+function attempt(label: string, fn: () => void) {
+  try {
+    fn();
+    console.log(label, "ok");
+  } catch (err: any) {
+    console.log(label, err && err.name);
+  }
+}
+
+const signed = new BigInt64Array(3);
+signed[0] = 5n;
+signed[1] = -1n;
+signed[2] = 9223372036854775808n;
+console.log("signed direct", list(signed));
+console.log("signed accessors", cell(signed[1]), cell(signed["2" as any]), cell(signed.at(0)));
+
+const unsigned = new BigUint64Array(3);
+unsigned[0] = 5n;
+unsigned[1] = -1n;
+unsigned[2] = 18446744073709551616n;
+console.log("unsigned direct", list(unsigned));
+
+attempt("signed number write", () => {
+  (signed as any)[0] = 1;
+});
+attempt("unsigned number write", () => {
+  (unsigned as any)[0] = 1;
+});
+console.log("after direct rejects", cell(signed[0]), cell(unsigned[0]));
+
+Object.defineProperty(signed, "0", { value: 42n });
+Object.defineProperty(unsigned, "1", { value: -2n });
+const desc = Object.getOwnPropertyDescriptor(signed, "0") as any;
+console.log(
+  "define values",
+  cell(signed[0]),
+  cell(unsigned[1]),
+  cell(desc.value),
+  desc.writable,
+  desc.enumerable,
+  desc.configurable,
+);
+attempt("define number value", () => {
+  Object.defineProperty(signed, "1", { value: 1 });
+});
+console.log("after define reject", cell(signed[1]));
+
+const fromArray = new BigInt64Array([1n, -2n, "3" as any, true as any]);
+console.log("from array", list(fromArray));
+attempt("from number array", () => {
+  new BigInt64Array([1 as any]);
+});
+
+const setTarget = new BigInt64Array(4);
+setTarget.set([3n, -4n]);
+setTarget.set(new BigInt64Array([5n, 6n]), 2);
+console.log("set values", list(setTarget));
+attempt("set number source", () => {
+  setTarget.set([1 as any], 1);
+});
+console.log("after set reject", list(setTarget));
+
+setTarget.fill(7n, 1, 3);
+console.log("fill bigint", list(setTarget));
+attempt("fill number", () => {
+  setTarget.fill(1 as any);
+});
+console.log("after fill reject", list(setTarget));
+
+const copiedUnsigned = new BigUint64Array(unsigned);
+console.log("copy unsigned", list(copiedUnsigned));


### PR DESCRIPTION
## Summary
Fixes #4356.

BigInt64Array and BigUint64Array element storage now preserves JS BigInt values instead of converting through f64. The shared typed-array store path now performs Number conversion only for numeric typed arrays and uses strict BigInt conversion for 64-bit BigInt typed arrays, rejecting Number inputs with TypeError. Loads box signed and unsigned 64-bit slots back into BigInt values.

The same raw-value path is used for constructors, set, with, map, fill, defineProperty side effects, and dynamic any typed-array index reads.

## Why This Cut
This is a single runtime storage/read issue with one codegen/runtime fallback touch for BigInt typed array index reads. Keeping it together gives one parity fixture that covers direct, dynamic, and reflective entry points without mixing unrelated typed-array work.

## Tests
- node oracle captured in test-parity/expected/typedarray-bigint-elements.txt because local Node v22.22.1 is not compiled with TypeScript stripping support
- cargo check -p perry-runtime -p perry-codegen
- ./run_parity_tests.sh --suite node-suite --module globals --filter typedarray-bigint-elements
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh

## Notes
- Non-goal: full object-to-primitive ToBigInt support for arbitrary objects remains outside this fix. Existing primitive BigInt inputs, strings, booleans, and number rejection are covered.
