### PR TITLE
[codex] match async resource apply undefined message

### DIFF
--- a/crates/perry-runtime/src/async_hooks.rs
+++ b/crates/perry-runtime/src/async_hooks.rs
@@ -765,7 +765,7 @@ fn render_apply_value(value: f64) -> String {
 fn describe_apply_type(value: f64) -> &'static str {
     let jv = JSValue::from_bits(value.to_bits());
     if jv.is_undefined() {
-        "a undefined"
+        "undefined"
     } else if jv.is_null() {
         "null"
     } else if jv.is_bool() {


### PR DESCRIPTION
## Summary

Matches Node's `AsyncResource.runInAsyncScope(undefined)` TypeError message for non-callable callbacks.

## Root Cause

The async_hooks `Function.prototype.apply` error formatter described `undefined` as `a undefined`, while V8 renders the type description as `undefined` with no article. Other value kinds already matched Node.

## Impact

The `node-suite/async_hooks/async-resource-validation` parity fixture now matches Node output exactly, bringing the async_hooks module to 100% parity on the current suite.

## Validation

- `cargo fmt --check`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module async_hooks --filter async-resource-validation'`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module async_hooks'`
