### PR TITLE
[codex] Prebuild HTTP no-auto parity archives

### DIFF
--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -357,7 +357,9 @@ if [[ -n "${PERRY_NO_AUTO_OPTIMIZE:-}" && "$TEST_SUITE" == "node-suite" ]]; then
         ""|http|http/*|https|https/*|http2|http2/*)
             # No-auto optimized links still consume prebuilt well-known ext archives
             # and need the matching stdlib pump hooks compiled into libperry_stdlib.a.
-            BUILD_PACKAGES+=(-p perry-ext-http)
+            # HTTP fixtures can also emit net + ws well-known owners via the codegen
+            # FFI registry, so build those wrappers too (#4373).
+            BUILD_PACKAGES+=(-p perry-ext-http -p perry-ext-net -p perry-ext-ws)
             BUILD_FEATURES+=(--features perry-stdlib/external-http-server-pump,perry-stdlib/external-http-client-pump)
             ;;
     esac


### PR DESCRIPTION
Fixes #3954

## Summary
- prebuild `perry-ext-http`, `perry-ext-net`, and `perry-ext-ws` in `run_parity_tests.sh` when `PERRY_NO_AUTO_OPTIMIZE` is set for `node-suite --module http`
- leave the compiler resolver and HTTP runtime unchanged; this only makes the prebuilt archives available for the existing no-auto link path
- convert the current no-auto HTTP module sweep from link-time compile failures into ordinary runtime parity results

## Why This Cut
The current #3954 failure mode is coherent at the harness/link boundary: HTTP fixtures can emit HTTP, net, and WS well-known FFI owners, but the no-auto parity harness only prebuilt the core `perry`, `perry-runtime`, and `perry-stdlib` archives. The compiler already records the needed owners; the missing piece was archive availability before the per-test compile loop.

## Tests
- `bash -n run_parity_tests.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- Before fix: `npm exec --yes --package=node@26 -- bash -lc 'node --version; PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module http'` reported 3 pass / 14 compile fail / 0 skipped
- After fix: same command reported 5 pass / 12 parity fail / 0 compile fail / 0 skipped

## Known Limitations / Non-goals
- This does not change HTTP runtime behavior. The remaining 12 HTTP failures are output mismatches and crashes in the existing HTTP behavior fixtures, not link failures.
- This keeps the trigger narrow to the no-auto `node-suite --module http` harness path.