### PR TITLE
[codex] recognize error constructors for dynamic instanceof

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -705,6 +705,13 @@ pub(super) fn identify_global_builtin_constructor(func_value: f64) -> Option<&'s
             || func_ptr == global_this_string_thunk as *const u8 as usize
             || func_ptr == global_this_number_thunk as *const u8 as usize
             || func_ptr == global_this_boolean_thunk as *const u8 as usize
+            || func_ptr == error_constructor_call_thunk as *const u8 as usize
+            || func_ptr == type_error_constructor_call_thunk as *const u8 as usize
+            || func_ptr == range_error_constructor_call_thunk as *const u8 as usize
+            || func_ptr == reference_error_constructor_call_thunk as *const u8 as usize
+            || func_ptr == syntax_error_constructor_call_thunk as *const u8 as usize
+            || func_ptr == eval_error_constructor_call_thunk as *const u8 as usize
+            || func_ptr == uri_error_constructor_call_thunk as *const u8 as usize
             || func_ptr == webcrypto_illegal_constructor_thunk as *const u8 as usize
             || func_ptr
                 == crate::messaging::js_message_channel_constructor_call_error as *const u8

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -336,49 +336,49 @@ fn error_constructor_call(kind: u32, message: f64) -> f64 {
     crate::value::js_nanbox_pointer(error as i64)
 }
 
-extern "C" fn error_constructor_call_thunk(
+pub(crate) extern "C" fn error_constructor_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     message: f64,
 ) -> f64 {
     error_constructor_call(crate::error::ERROR_KIND_ERROR, message)
 }
 
-extern "C" fn type_error_constructor_call_thunk(
+pub(crate) extern "C" fn type_error_constructor_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     message: f64,
 ) -> f64 {
     error_constructor_call(crate::error::ERROR_KIND_TYPE_ERROR, message)
 }
 
-extern "C" fn range_error_constructor_call_thunk(
+pub(crate) extern "C" fn range_error_constructor_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     message: f64,
 ) -> f64 {
     error_constructor_call(crate::error::ERROR_KIND_RANGE_ERROR, message)
 }
 
-extern "C" fn reference_error_constructor_call_thunk(
+pub(crate) extern "C" fn reference_error_constructor_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     message: f64,
 ) -> f64 {
     error_constructor_call(crate::error::ERROR_KIND_REFERENCE_ERROR, message)
 }
 
-extern "C" fn syntax_error_constructor_call_thunk(
+pub(crate) extern "C" fn syntax_error_constructor_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     message: f64,
 ) -> f64 {
     error_constructor_call(crate::error::ERROR_KIND_SYNTAX_ERROR, message)
 }
 
-extern "C" fn eval_error_constructor_call_thunk(
+pub(crate) extern "C" fn eval_error_constructor_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     message: f64,
 ) -> f64 {
     error_constructor_call(crate::error::ERROR_KIND_EVAL_ERROR, message)
 }
 
-extern "C" fn uri_error_constructor_call_thunk(
+pub(crate) extern "C" fn uri_error_constructor_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     message: f64,
 ) -> f64 {


### PR DESCRIPTION
## Summary

Recognizes global Error constructor thunks in the dynamic `instanceof` path.

## Root Cause

Rebound Error constructors such as `const E = EvalError` already constructed the right error kind, but `identify_global_builtin_constructor()` did not accept the dedicated Error subclass constructor thunks. As a result, `err instanceof E` could not recover `E` as `EvalError` / `URIError` and returned false even though static `err instanceof EvalError` passed.

## Impact

Dynamic and rebound `instanceof` checks now work for `Error`, `TypeError`, `RangeError`, `ReferenceError`, `SyntaxError`, `EvalError`, and `URIError` constructor values.

## Validation

- `cargo fmt --check`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter error-eval-uri-constructors'`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals'`
