### PR TITLE
fix(compile): build missing no-auto well-known archives

### DIFF
--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -12,7 +12,7 @@
 //! profile are no-ops after the first build.
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::commands::stdlib_features::{compute_required_features, features_to_cargo_arg};
@@ -64,12 +64,15 @@ fn well_known_iteration_set(ctx: &CompilationContext) -> BTreeSet<String> {
     iteration_set
 }
 
-/// Resolve only the prebuilt well-known wrapper archives.
+/// Resolve well-known wrapper archives without rebuilding runtime/stdlib.
 ///
 /// Used when automatic runtime/stdlib specialization is disabled. The
 /// no-auto path still needs wrapper archives for FFI symbols that are not
 /// defined by the full prebuilt stdlib, such as the `perry-ext-http` server
-/// entry points recorded by the codegen FFI registry.
+/// entry points recorded by the codegen FFI registry. Prefer already-built
+/// archives, but when the Perry workspace source is available, build a missing
+/// wrapper once in the caller's cargo target dir so fresh dev checkouts still
+/// link no-auto parity cases correctly.
 pub(super) fn resolve_no_auto_optimized_libs(
     ctx: &CompilationContext,
     target: Option<&str>,
@@ -1013,9 +1016,8 @@ pub(super) fn build_optimized_libs(
     }
 }
 
-/// #2532 — resolve the prebuilt `perry-ext-*` staticlibs a program needs
-/// when there is **no workspace source** to rebuild from (a released /
-/// out-of-tree install).
+/// #2532 / #3954 — resolve the `perry-ext-*` staticlibs a program needs
+/// while runtime/stdlib auto-specialization is disabled.
 ///
 /// The in-tree path strips the matching perry-stdlib feature and rebuilds
 /// stdlib so the ext lib and stdlib don't both define the same `_js_*`
@@ -1028,12 +1030,10 @@ pub(super) fn build_optimized_libs(
 /// duplicates (`js_http_*`) are never pulled because stdlib already resolves
 /// them.
 ///
-/// Each well-known lib is located through `find_library`, which honours the
-/// `PERRY_LIB_DIR` / `PERRY_RUNTIME_DIR` overrides and the exe-dir /
-/// Homebrew `../lib` probes — the same precedence the runtime/stdlib
-/// lookups already use, so a release tarball or `brew` bottle that ships
-/// the ext libs alongside `libperry_runtime.a` resolves them with no extra
-/// configuration.
+/// Each well-known lib is first located through `find_library`, which honours
+/// the `PERRY_LIB_DIR` / `PERRY_RUNTIME_DIR` overrides and the exe-dir /
+/// Homebrew `../lib` probes. If that fails in an in-tree dev checkout, build
+/// the missing wrapper crate once and link the resulting archive.
 fn resolve_prebuilt_ext_libs(
     iteration_set: &std::collections::BTreeSet<String>,
     target: Option<&str>,
@@ -1058,7 +1058,7 @@ fn resolve_prebuilt_ext_libs(
             Some(path) => {
                 if matches!(format, OutputFormat::Text) {
                     println!(
-                        "  well-known (out-of-tree): routing `{}` → {} ({})",
+                        "  well-known (no-auto): routing `{}` → {} ({})",
                         module,
                         path.display(),
                         binding.tracking.as_deref().unwrap_or("no tracking issue")
@@ -1067,18 +1067,136 @@ fn resolve_prebuilt_ext_libs(
                 libs.push(path);
             }
             None => {
+                if let Some(workspace_root) = find_perry_workspace_root() {
+                    if let Some(path) = build_missing_prebuilt_ext_lib(
+                        &workspace_root,
+                        binding,
+                        &filename,
+                        target,
+                        format,
+                        verbose,
+                    ) {
+                        libs.push(path);
+                        continue;
+                    }
+                }
                 if matches!(format, OutputFormat::Text) && verbose > 0 {
                     eprintln!(
-                        "  well-known (out-of-tree): `{}` not found for `{}` — install \
-                         Perry's bundled ext libs next to the perry binary or set \
-                         PERRY_LIB_DIR; the link will fail with unresolved `js_*` symbols.",
-                        filename, module
+                        "  well-known (no-auto): `{}` not found for `{}` — install \
+                         Perry's bundled ext libs next to the perry binary, set \
+                         PERRY_LIB_DIR, or build `{}`; the link will fail with \
+                         unresolved `js_*` symbols.",
+                        filename, module, binding.krate
                     );
                 }
             }
         }
     }
     libs
+}
+
+fn cargo_target_dir_for_workspace(workspace_root: &Path) -> PathBuf {
+    match std::env::var_os("CARGO_TARGET_DIR") {
+        Some(raw) if !raw.is_empty() => {
+            let path = PathBuf::from(raw);
+            if path.is_absolute() {
+                path
+            } else {
+                workspace_root.join(path)
+            }
+        }
+        _ => workspace_root.join("target"),
+    }
+}
+
+fn built_staticlib_path(workspace_root: &Path, filename: &str, target: Option<&str>) -> PathBuf {
+    let mut release_dir = cargo_target_dir_for_workspace(workspace_root);
+    if let Some(triple) = rust_target_triple(target) {
+        release_dir = release_dir.join(triple);
+    }
+    release_dir.join("release").join(filename)
+}
+
+fn build_missing_prebuilt_ext_lib(
+    workspace_root: &Path,
+    binding: &super::well_known::WellKnownBinding,
+    filename: &str,
+    target: Option<&str>,
+    format: OutputFormat,
+    verbose: u8,
+) -> Option<PathBuf> {
+    let crate_dir = workspace_root.join("crates").join(&binding.krate);
+    if !crate_dir.is_dir() {
+        if matches!(format, OutputFormat::Text) && verbose > 0 {
+            eprintln!(
+                "  well-known (no-auto): skipping `{}` — crate source not found at {}",
+                binding.krate,
+                crate_dir.display()
+            );
+        }
+        return None;
+    }
+
+    if matches!(format, OutputFormat::Text) {
+        println!(
+            "  well-known (no-auto): building missing `{}` from `{}`",
+            filename, binding.krate
+        );
+    }
+
+    let mut cargo_cmd = Command::new("cargo");
+    cargo_cmd
+        .current_dir(workspace_root)
+        .arg("build")
+        .arg("--release")
+        .arg("-p")
+        .arg(&binding.krate);
+    if let Some(triple) = rust_target_triple(target) {
+        cargo_cmd.arg("--target").arg(triple);
+    }
+
+    let status = match cargo_cmd.status() {
+        Ok(status) => status,
+        Err(err) => {
+            if matches!(format, OutputFormat::Text) && verbose > 0 {
+                eprintln!(
+                    "  well-known (no-auto): failed to spawn cargo for `{}` ({})",
+                    binding.krate, err
+                );
+            }
+            return None;
+        }
+    };
+    if !status.success() {
+        if matches!(format, OutputFormat::Text) && verbose > 0 {
+            eprintln!(
+                "  well-known (no-auto): cargo build for `{}` failed ({})",
+                binding.krate, status
+            );
+        }
+        return None;
+    }
+
+    let path = built_staticlib_path(workspace_root, filename, target);
+    if path.exists() {
+        if matches!(format, OutputFormat::Text) {
+            println!(
+                "  well-known (no-auto): routing `{}` → {}",
+                binding.package,
+                path.display()
+            );
+        }
+        return Some(path);
+    }
+
+    if matches!(format, OutputFormat::Text) && verbose > 0 {
+        eprintln!(
+            "  well-known (no-auto): cargo finished but `{}` was not produced at {}",
+            filename,
+            path.display()
+        );
+    }
+    None
 }
 
 /// True if this binding's wrapper crate has its own tokio dependency
@@ -1244,6 +1362,89 @@ mod tests {
             libs.well_known_libs.contains(&ws_lib),
             "expected no-auto well-known libs to include {ws_lib:?}, got {:?}",
             libs.well_known_libs
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn no_auto_builds_missing_well_known_archive_from_workspace_source() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = env_lock();
+        let old_path = std::env::var_os("PATH");
+        let old_cargo_target_dir = std::env::var_os("CARGO_TARGET_DIR");
+
+        let workspace = tempfile::tempdir().expect("tempdir");
+        for dir in [
+            "crates/perry-runtime",
+            "crates/perry-ui-geisterhand",
+            "crates/perry-ext-http",
+        ] {
+            std::fs::create_dir_all(workspace.path().join(dir)).expect("mkdir workspace marker");
+        }
+
+        let fake_bin = workspace.path().join("fake-bin");
+        std::fs::create_dir_all(&fake_bin).expect("mkdir fake bin");
+        let fake_cargo = fake_bin.join("cargo");
+        std::fs::write(
+            &fake_cargo,
+            r#"#!/bin/sh
+case "$*" in
+  *"-p perry-ext-http"*) ;;
+  *) exit 43 ;;
+esac
+mkdir -p "$CARGO_TARGET_DIR/release"
+printf '!<arch>\n' > "$CARGO_TARGET_DIR/release/libperry_ext_http.a"
+"#,
+        )
+        .expect("write fake cargo");
+        let mut perms = std::fs::metadata(&fake_cargo)
+            .expect("fake cargo metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_cargo, perms).expect("chmod fake cargo");
+
+        let target_dir = workspace.path().join("out-target");
+        let test_path = match old_path.as_ref() {
+            Some(path) => {
+                let mut paths = vec![fake_bin.clone()];
+                paths.extend(std::env::split_paths(path));
+                std::env::join_paths(paths).expect("join PATH")
+            }
+            None => fake_bin.clone().into_os_string(),
+        };
+        std::env::set_var("PATH", test_path);
+        std::env::set_var("CARGO_TARGET_DIR", &target_dir);
+
+        let binding =
+            super::super::well_known::lookup_well_known("http").expect("http well-known binding");
+        let filename = super::super::well_known::ext_staticlib_filename(
+            &binding.lib,
+            rust_target_triple(None),
+        );
+        let got = build_missing_prebuilt_ext_lib(
+            workspace.path(),
+            binding,
+            &filename,
+            None,
+            OutputFormat::Json,
+            0,
+        );
+
+        if let Some(path) = old_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+        if let Some(dir) = old_cargo_target_dir {
+            std::env::set_var("CARGO_TARGET_DIR", dir);
+        } else {
+            std::env::remove_var("CARGO_TARGET_DIR");
+        }
+
+        assert_eq!(
+            got.expect("missing archive should be built from workspace source"),
+            target_dir.join("release/libperry_ext_http.a")
         );
     }
 }


### PR DESCRIPTION
## Summary

- teach the `PERRY_NO_AUTO_OPTIMIZE=1` well-known resolver to keep using existing `perry-ext-*` archives when present, but build a missing wrapper archive from workspace source when available
- route the built archive from the caller's `CARGO_TARGET_DIR` into the no-auto link line
- add focused coverage with a fake `cargo` binary for the missing-archive fallback, alongside the existing prebuilt-archive resolver coverage

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `env CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo test -p perry optimized_libs::tests::no_auto -- --nocapture`
- `env CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check -p perry`
- `env CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= CARGO_PROFILE_RELEASE_LTO=false CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 CARGO_PROFILE_RELEASE_OPT_LEVEL=1 CARGO_PROFILE_RELEASE_PACKAGE_PERRY_RUNTIME_OPT_LEVEL=1 CARGO_PROFILE_RELEASE_PACKAGE_PERRY_STDLIB_OPT_LEVEL=1 PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module http --filter message-surfaces` -> 0 compile failures; remaining output mismatch
- `env CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= CARGO_PROFILE_RELEASE_LTO=false CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 CARGO_PROFILE_RELEASE_OPT_LEVEL=1 CARGO_PROFILE_RELEASE_PACKAGE_PERRY_RUNTIME_OPT_LEVEL=1 CARGO_PROFILE_RELEASE_PACKAGE_PERRY_STDLIB_OPT_LEVEL=1 PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module http` -> 5 pass / 12 output mismatch / 0 compile fail / 0 skipped, report `test-parity/reports/parity_report_20260604_090134.json`
