### PR TITLE
fix(codegen): disambiguate static method symbols

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -398,13 +398,12 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             )
             .with_context(|| format!("lowering constructor for '{}'", class.name))?;
         }
-        // Static methods compile as plain functions named
-        // `perry_static_<modprefix>__<class>__<method>` — no `this`
-        // parameter, no class_stack push.
+        // Static methods compile as ID-qualified plain functions with no
+        // `this` parameter and no class_stack push.
         for sm in &class.static_methods {
             compile_static_method(
                 llmod,
-                &class.name,
+                class,
                 sm,
                 func_names,
                 strings,
@@ -431,7 +430,7 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
         {
             compile_static_method(
                 llmod,
-                &class.name,
+                class,
                 &member.function,
                 func_names,
                 strings,

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -112,6 +112,21 @@ pub(super) fn scoped_fn_name(module_prefix: &str, hir_name: &str) -> String {
     format!("perry_fn_{}__{}", module_prefix, sanitize(hir_name))
 }
 
+pub(super) fn scoped_static_method_name(
+    module_prefix: &str,
+    class_id: u32,
+    class_name: &str,
+    method_name: &str,
+) -> String {
+    format!(
+        "perry_static_{}__{}__c{}__{}",
+        module_prefix,
+        sanitize(class_name),
+        class_id,
+        sanitize(method_name)
+    )
+}
+
 /// Walk a function body looking for `Return(Some(expr))` shapes that
 /// identify the function as a factory returning a class. Sets
 /// `*produced` to the resolved class name when the first qualifying
@@ -617,7 +632,10 @@ pub(super) fn init_static_fields_late(
             if !sm.name.starts_with("__perry_static_init_") {
                 continue;
             }
-            let key = (c.name.clone(), sm.name.clone());
+            let key = (
+                c.name.clone(),
+                crate::codegen::static_method_registry_key(&sm.name),
+            );
             // Skip if the init stream already invokes this block. The
             // typical class-decl path emits a `StaticMethodCall` for
             // each block; if we find one referencing this (class,

--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -12,7 +12,7 @@ use crate::stmt;
 use crate::strings::StringPool;
 use crate::types::{LlvmType, DOUBLE, I64};
 
-use super::helpers::sanitize;
+use super::helpers::scoped_static_method_name;
 use super::opts::CrossModuleCtx;
 
 fn node_stream_parent_kind(
@@ -536,12 +536,12 @@ pub(super) fn compile_method(
 
 /// Compile a static class method as a top-level LLVM function with
 /// no `this` parameter. Mostly identical to `compile_function` but
-/// the LLVM symbol name is `perry_static_<modprefix>__<class>__<method>`
-/// instead of `perry_fn_<modprefix>__<name>`.
+/// the LLVM symbol name is scoped by module, class id, class name, and
+/// method name instead of `perry_fn_<modprefix>__<name>`.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn compile_static_method(
     llmod: &mut LlModule,
-    class_name: &str,
+    class: &perry_hir::Class,
     f: &Function,
     func_names: &HashMap<u32, String>,
     strings: &mut StringPool,
@@ -559,12 +559,7 @@ pub(super) fn compile_static_method(
     closure_rest_params: &HashMap<u32, usize>,
     cross_module: &CrossModuleCtx,
 ) -> Result<()> {
-    let llvm_name = format!(
-        "perry_static_{}__{}__{}",
-        module_prefix,
-        sanitize(class_name),
-        sanitize(&f.name),
-    );
+    let llvm_name = scoped_static_method_name(module_prefix, class.id, &class.name, &f.name);
 
     let params: Vec<(LlvmType, String)> = f
         .params
@@ -615,10 +610,10 @@ pub(super) fn compile_static_method(
     let mut ctx = FnCtx {
         func: lf,
         module_slug: crate::expr::native_region_slug(strings.module_prefix()),
-        source_function: format!("{}.{}", class_name, f.name),
+        source_function: format!("{}.{}", class.name, f.name),
         source_function_slug: crate::expr::native_region_slug(&format!(
             "{}.{}",
-            class_name, f.name
+            class.name, f.name
         )),
         active_region_id: None,
         locals,
@@ -750,11 +745,11 @@ pub(super) fn compile_static_method(
     );
     if f.is_async {
         stmt::lower_async_rejecting_stmts(&mut ctx, &f.body).with_context(|| {
-            format!("lowering async body of static '{}::{}'", class_name, f.name)
+            format!("lowering async body of static '{}::{}'", class.name, f.name)
         })?;
     } else {
         stmt::lower_stmts(&mut ctx, &f.body)
-            .with_context(|| format!("lowering body of static '{}::{}'", class_name, f.name))?;
+            .with_context(|| format!("lowering body of static '{}::{}'", class.name, f.name))?;
     }
 
     if !ctx.block().is_terminated() {

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -60,7 +60,7 @@ use artifacts::{emit_module_artifacts, ModuleArtifactsCtx};
 use function::compile_function;
 use helpers::{
     collect_return_class, emit_buffer_alias_metadata, function_body_returns_generator_object,
-    sanitize, scoped_fn_name, scoped_method_name,
+    sanitize, scoped_fn_name, scoped_method_name, scoped_static_method_name,
 };
 
 // Collector and boxing-analysis walkers live in dedicated modules.
@@ -72,6 +72,10 @@ pub(super) fn spec_function_length(params: &[perry_hir::Param]) -> usize {
         .iter()
         .take_while(|p| !p.is_rest && p.default.is_none())
         .count()
+}
+
+pub(crate) fn static_method_registry_key(method_name: &str) -> String {
+    format!("__perry_static__{}", method_name)
 }
 
 /// Compile a Perry HIR module to an object file via LLVM IR.
@@ -944,10 +948,11 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         // with 2 scalar args while the signature expects (rest_array),
         // and `arguments.length` reads garbage / undefined.
         for sm in &cls.static_methods {
-            method_param_counts.insert((cls.name.clone(), sm.name.clone()), sm.params.len());
+            let key = static_method_registry_key(&sm.name);
+            method_param_counts.insert((cls.name.clone(), key.clone()), sm.params.len());
             let has_rest = sm.params.iter().any(|p| p.is_rest);
             if has_rest {
-                method_has_rest.insert((cls.name.clone(), sm.name.clone()), true);
+                method_has_rest.insert((cls.name.clone(), key), true);
             }
         }
     }
@@ -1593,6 +1598,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             .get(&c.name)
             .map(|s| s.as_str())
             .unwrap_or(c.name.as_str());
+        let class_symbol_id = class_ids.get(&c.name).copied().unwrap_or(c.id);
         for m in &c.methods {
             let llvm_name = scoped_method_name(class_prefix, mangle_class_name, &m.name);
             method_names.insert((c.name.clone(), m.name.clone()), llvm_name.clone());
@@ -1608,22 +1614,36 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         }
         for member in &c.computed_members {
             let llvm_name = if member.is_static {
-                format!(
-                    "perry_static_{}__{}__{}",
+                scoped_static_method_name(
                     class_prefix,
-                    sanitize(mangle_class_name),
-                    sanitize(&member.function.name),
+                    class_symbol_id,
+                    mangle_class_name,
+                    &member.function.name,
                 )
             } else {
                 scoped_method_name(class_prefix, mangle_class_name, &member.function.name)
             };
             method_names.insert(
-                (c.name.clone(), member.function.name.clone()),
+                (
+                    c.name.clone(),
+                    if member.is_static {
+                        static_method_registry_key(&member.function.name)
+                    } else {
+                        member.function.name.clone()
+                    },
+                ),
                 llvm_name.clone(),
             );
             for alias in &c.aliases {
                 method_names
-                    .entry((alias.clone(), member.function.name.clone()))
+                    .entry((
+                        alias.clone(),
+                        if member.is_static {
+                            static_method_registry_key(&member.function.name)
+                        } else {
+                            member.function.name.clone()
+                        },
+                    ))
                     .or_insert_with(|| llvm_name.clone());
             }
         }
@@ -1661,20 +1681,17 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 ),
             );
         }
-        // Static methods. Registered under their plain method name
-        // so `Counter.increment()` (StaticMethodCall) can look them
-        // up the same way as instance methods, but emitted as
-        // `perry_static_<modprefix>__<class>__<method>` (no `this`).
-        // The class/method names are sanitized so private methods
-        // (`#helper`) produce a valid LLVM identifier.
+        // Static methods. Registered under a static-only key so they do not
+        // collide with instance methods of the same class and name, and emitted
+        // with the class id so duplicate text class names stay distinct.
         for sm in &c.static_methods {
             method_names.insert(
-                (c.name.clone(), sm.name.clone()),
-                format!(
-                    "perry_static_{}__{}__{}",
+                (c.name.clone(), static_method_registry_key(&sm.name)),
+                scoped_static_method_name(
                     class_prefix,
-                    sanitize(mangle_class_name),
-                    sanitize(&sm.name),
+                    class_symbol_id,
+                    mangle_class_name,
+                    &sm.name,
                 ),
             );
         }
@@ -1777,19 +1794,22 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         }
         llmod.declare_function(&ctor_fn, VOID, &ctor_params);
 
-        // Cross-module static methods. Source module emits these as
-        // `perry_static_<source_prefix>__<class>__<method>` (no `this`
-        // receiver). Register them in `method_names` under the same
-        // (class, method) key the StaticMethodCall lowering looks up.
+        // Cross-module static methods. Source modules emit these as static
+        // functions with no `this` receiver, normally qualified by the source
+        // class id. Register them under the static-only key the lowering uses.
         for sm in &ic.static_method_names {
-            let llvm_fn = format!(
-                "perry_static_{}__{}__{}",
-                sanitize(src),
-                sanitize(&ic.name),
-                sanitize(sm),
-            );
+            let llvm_fn = if let Some(source_class_id) = ic.source_class_id {
+                scoped_static_method_name(&sanitize(src), source_class_id, &ic.name, sm)
+            } else {
+                format!(
+                    "perry_static_{}__{}__{}",
+                    sanitize(src),
+                    sanitize(&ic.name),
+                    sanitize(sm),
+                )
+            };
             method_names
-                .entry((effective_name.to_string(), sm.clone()))
+                .entry((effective_name.to_string(), static_method_registry_key(sm)))
                 .or_insert_with(|| llvm_fn.clone());
             // Declare conservatively with 6 double params; LLVM's direct-call
             // resolution doesn't require an exact arity match for declarations.

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -6,7 +6,7 @@ use crate::module::LlModule;
 use crate::strings::StringPool;
 use crate::types::{DOUBLE, I32, I64, PTR, VOID};
 
-use super::helpers::sanitize;
+use super::helpers::{sanitize, scoped_static_method_name};
 
 /// Emit the string pool into the module: byte-array constants, handle
 /// globals, and the `__perry_init_strings_<prefix>` function that
@@ -413,12 +413,7 @@ pub(super) fn emit_string_pool(
         // #1788: static methods are emitted as `perry_static_*` (no `this`
         // param). Collect them for the runtime CLASS_STATIC_METHODS table.
         for sm in &class.static_methods {
-            let llvm_name = format!(
-                "perry_static_{}__{}__{}",
-                module_prefix,
-                sanitize(class_name),
-                sanitize(&sm.name),
-            );
+            let llvm_name = scoped_static_method_name(module_prefix, cid, class_name, &sm.name);
             let has_rest = sm.params.last().map(|p| p.is_rest).unwrap_or(false);
             static_method_triples.push((
                 cid,

--- a/crates/perry-codegen/src/expr/static_field_meta.rs
+++ b/crates/perry-codegen/src/expr/static_field_meta.rs
@@ -163,9 +163,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let key_v = lower_expr(ctx, key_expr)?;
             if let Some(&class_id) = ctx.class_ids.get(class_name) {
                 if class_id != 0 {
-                    if let Some(llvm_name) =
-                        ctx.methods.get(&(class_name.clone(), method_name.clone()))
-                    {
+                    let registry_name = if *is_static {
+                        crate::codegen::static_method_registry_key(method_name)
+                    } else {
+                        method_name.clone()
+                    };
+                    if let Some(llvm_name) = ctx.methods.get(&(class_name.clone(), registry_name)) {
                         let func_ref = format!("@{}", llvm_name);
                         let func_i64 = ctx.block().ptrtoint(&func_ref, I64);
                         let cid_str = class_id.to_string();
@@ -200,7 +203,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 if class_id != 0 {
                     let getter_i64 = getter_name
                         .as_ref()
-                        .and_then(|name| ctx.methods.get(&(class_name.clone(), name.clone())))
+                        .and_then(|name| {
+                            let registry_name = if *is_static {
+                                crate::codegen::static_method_registry_key(name)
+                            } else {
+                                name.clone()
+                            };
+                            ctx.methods.get(&(class_name.clone(), registry_name))
+                        })
                         .map(|llvm_name| {
                             let func_ref = format!("@{}", llvm_name);
                             ctx.block().ptrtoint(&func_ref, I64)
@@ -208,7 +218,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         .unwrap_or_else(|| "0".to_string());
                     let setter_i64 = setter_name
                         .as_ref()
-                        .and_then(|name| ctx.methods.get(&(class_name.clone(), name.clone())))
+                        .and_then(|name| {
+                            let registry_name = if *is_static {
+                                crate::codegen::static_method_registry_key(name)
+                            } else {
+                                name.clone()
+                            };
+                            ctx.methods.get(&(class_name.clone(), registry_name))
+                        })
                         .map(|llvm_name| {
                             let func_ref = format!("@{}", llvm_name);
                             ctx.block().ptrtoint(&func_ref, I64)

--- a/crates/perry-codegen/src/expr/static_method.rs
+++ b/crates/perry-codegen/src/expr/static_method.rs
@@ -87,7 +87,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let signal_handle = blk.call(I64, "js_abort_signal_any", &[(I64, &arr_handle)]);
                 return Ok(nanbox_pointer_inline(blk, &signal_handle));
             }
-            let key = (class_name.clone(), method_name.clone());
+            let key = (
+                class_name.clone(),
+                crate::codegen::static_method_registry_key(method_name),
+            );
             if let Some(fn_name) = ctx.methods.get(&key).cloned() {
                 let mut lowered: Vec<String> = Vec::with_capacity(args.len());
                 for a in args {

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -871,8 +871,8 @@ pub fn try_lower_property_get_method_call(
     // Resolution: when the static receiver is `Expr::ClassRef`, walk
     // the class's own static methods plus its `extends_name` chain
     // looking for `property`. If found, emit a direct call to the
-    // `perry_static_<modprefix>__<class>__<method>` symbol with
-    // IMPLICIT_THIS bound to the ClassRef so `pipe`'s body's
+    // ID-qualified static method symbol with IMPLICIT_THIS bound to
+    // the ClassRef so `pipe`'s body's
     // `this` references the class. If nothing matches (Effect's
     // BigIntFromSelf case — its parent is an unnamed CallExpr so
     // perry's `extends_name` chain is empty), fall back to
@@ -987,7 +987,11 @@ pub fn try_lower_property_get_method_call(
                     .iter()
                     .find(|m| m.name == *property);
                 if let Some(sm) = sm {
-                    if let Some(fname) = ctx.methods.get(&(c.clone(), property.clone())).cloned() {
+                    let key = (
+                        c.clone(),
+                        crate::codegen::static_method_registry_key(property),
+                    );
+                    if let Some(fname) = ctx.methods.get(&key).cloned() {
                         let declared = sm.params.len();
                         let has_rest = sm.params.last().map(|p| p.is_rest).unwrap_or(false);
                         let is_synth_args = sm

--- a/crates/perry-codegen/tests/static_symbol_hygiene.rs
+++ b/crates/perry-codegen/tests/static_symbol_hygiene.rs
@@ -1,0 +1,230 @@
+use perry_codegen::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::{Class, Expr, Function, Module, ModuleInitKind, Stmt};
+use perry_types::Type;
+
+fn empty_opts() -> CompileOptions {
+    CompileOptions {
+        target: None,
+        is_entry_module: false,
+        non_entry_module_prefixes: Vec::new(),
+        import_function_prefixes: std::collections::HashMap::new(),
+        import_function_origin_names: std::collections::HashMap::new(),
+        import_function_v8_specifiers: std::collections::HashMap::new(),
+        import_function_node_submodule: std::collections::HashMap::new(),
+        namespace_node_submodules: std::collections::HashMap::new(),
+        namespace_v8_specifiers: std::collections::HashMap::new(),
+        namespace_member_prefixes: std::collections::HashMap::new(),
+        emit_ir_only: true,
+        verify_native_regions: false,
+        disable_buffer_fast_path: false,
+        namespace_imports: Vec::new(),
+        namespace_reexport_named_imports: std::collections::HashSet::new(),
+        imported_classes: Vec::new(),
+        imported_enums: Vec::new(),
+        imported_async_funcs: std::collections::HashSet::new(),
+        type_aliases: std::collections::HashMap::new(),
+        imported_func_param_counts: std::collections::HashMap::new(),
+        imported_func_has_rest: std::collections::HashSet::new(),
+        imported_func_synthetic_arguments: std::collections::HashSet::new(),
+        imported_func_return_types: std::collections::HashMap::new(),
+        imported_vars: std::collections::HashSet::new(),
+        output_type: "executable".to_string(),
+        needs_stdlib: false,
+        needs_ui: false,
+        needs_geisterhand: false,
+        geisterhand_port: 7676,
+        enabled_features: Vec::new(),
+        native_module_init_names: Vec::new(),
+        js_module_specifiers: Vec::new(),
+        bundled_extensions: Vec::new(),
+        native_library_functions: Vec::new(),
+        i18n_table: None,
+        fast_math: false,
+        fp_contract_mode: perry_codegen::FpContractMode::Off,
+        app_metadata: AppMetadata::default(),
+        namespace_entries: Vec::new(),
+        dynamic_import_path_to_prefix: std::collections::HashMap::new(),
+        deferred_module_prefixes: std::collections::HashSet::new(),
+        module_init_deps: Vec::new(),
+        is_dynamic_import_target: false,
+    }
+}
+
+fn static_method(id: u32, value: f64) -> Function {
+    Function {
+        id,
+        name: "lex".to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type: Type::Number,
+        body: vec![Stmt::Return(Some(Expr::Number(value)))],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+    }
+}
+
+fn instance_method(id: u32, value: f64) -> Function {
+    Function {
+        id,
+        name: "lex".to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type: Type::Number,
+        body: vec![Stmt::Return(Some(Expr::Number(value)))],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+    }
+}
+
+fn class_with_static(id: u32, value: f64) -> Class {
+    Class {
+        id,
+        name: "x".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        fields: Vec::new(),
+        constructor: None,
+        methods: Vec::new(),
+        getters: Vec::new(),
+        setters: Vec::new(),
+        computed_members: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: vec![static_method(id + 100, value)],
+        decorators: Vec::new(),
+        is_exported: false,
+        aliases: Vec::new(),
+    }
+}
+
+fn duplicate_static_module() -> Module {
+    Module {
+        name: "marked_symbol_hygiene.ts".to_string(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        classes: vec![class_with_static(11, 1.0), class_with_static(12, 2.0)],
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions: Vec::new(),
+        init: Vec::new(),
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+    }
+}
+
+fn class_with_instance_and_static_method() -> Module {
+    let mut class = class_with_static(11, 2.0);
+    class.methods.push(instance_method(301, 1.0));
+
+    Module {
+        name: "static_instance_symbol_hygiene.ts".to_string(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        classes: vec![class],
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions: Vec::new(),
+        init: Vec::new(),
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+    }
+}
+
+fn count(haystack: &str, needle: &str) -> usize {
+    haystack.match_indices(needle).count()
+}
+
+#[test]
+fn duplicate_class_static_methods_use_class_id_in_symbols() {
+    let ir = String::from_utf8(compile_module(&duplicate_static_module(), empty_opts()).unwrap())
+        .unwrap();
+
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_static_marked_symbol_hygiene_ts__x__c11__lex"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_static_marked_symbol_hygiene_ts__x__c12__lex"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_static_marked_symbol_hygiene_ts__x__lex"
+        ),
+        0
+    );
+}
+
+#[test]
+fn static_and_instance_methods_with_same_name_keep_distinct_symbols() {
+    let ir = String::from_utf8(
+        compile_module(&class_with_instance_and_static_method(), empty_opts()).unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_method_static_instance_symbol_hygiene_ts__x__lex"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_static_static_instance_symbol_hygiene_ts__x__c11__lex"
+        ),
+        1
+    );
+}


### PR DESCRIPTION
Fixes #4362.

## Summary
- Qualify generated static method symbols with the class id so repeated text class names do not emit duplicate LLVM function names.
- Keep JS static method registry keys separate from instance method keys to avoid static/instance same-name collisions.
- Add focused codegen IR regression tests for duplicate class static methods and static/instance same-name methods.

## Validation
- `cargo test -p perry-codegen --test static_symbol_hygiene`
- `cargo check -p perry-codegen`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry repro.ts -o repro` with `marked@18.0.4` now compiles and links; running the produced binary reaches a separate runtime regex parser error.
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
