### PR TITLE
fix(release): unblock publish build matrix — gtk4 + android cross-host UI crates (v0.5.1120)

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -138,6 +138,10 @@ jobs:
   build:
     needs: await-tests
     strategy:
+      # Don't let one platform's build failure cancel the others (mirrors
+      # build-cross). A broken cross-host target should not strand the
+      # binaries that did build — partial publish beats no publish.
+      fail-fast: false
       matrix:
         include:
           - os: macos-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1120 — fix(release): unblock the publish build matrix (gtk4 + android cross-host UI crates)
+
+v0.5.1117 fixed the `await-tests` gate (publishing resumed after ~90 dark versions) but `release-packages` still concluded failure and skipped npm/brew/apt/winget — a second, separate breakage in the **cross-host UI crates**, which `cargo-test` excludes (so no PR CI catches them):
+
+- **perry-ui-gtk4** (`widgets/canvas.rs`) called `gtk4::gdk::cairo::set_source_pixbuf(cr, …)`, but in gdk4 0.9 `set_source_pixbuf` is the `GdkCairoContextExt` trait method on the cairo `Context` (`fn set_source_pixbuf(&self, pixbuf, x, y)`), in scope via `gtk4::prelude::*`. Changed to `cr.set_source_pixbuf(&scaled, *dx, *dy)`. This broke the **linux-gnu** primary build (the gtk4 lib is bundled into the Linux tarball), which — with the build matrix lacking `fail-fast: false` — cancelled the macOS/Windows/linux-arm builds and skipped every publish leg (they `needs: build`).
+- **perry-runtime** `fs/mod.rs` bound `_path_str_for_log` but the `#[cfg(target_os = "android")]` debug-log block referenced `path_str_for_log` (no underscore) — a name mismatch only the android cross-build compiled. Fixed the reference.
+- **release-packages.yml**: added `fail-fast: false` to the primary `build` matrix (mirrors `build-cross`) so one platform's failure no longer cancels the rest — partial publish beats no publish.
+
+Note: the gtk4/android crates can't be compiled on the macOS dev host (no GTK/NDK toolchain); fixes were validated against the cached `gdk4-0.9.6` trait signature and the exact name mismatch. Follow-up worth filing: cross-host UI crates have no PR CI coverage, so they rot silently between releases.
+
 ## v0.5.1119 — feat(runtime): implement DataView getBigInt64/setBigInt64/getBigUint64/setBigUint64 (#4365)
 
 `DataView.prototype.getBigInt64`/`setBigInt64`/`getBigUint64`/`setBigUint64` were unimplemented — `DataViewKind::from_method_suffix` didn't recognize the `"BigInt64"`/`"BigUint64"` suffixes, so the method names never routed to the DataView dispatch: reads returned `undefined` and setters silently no-op'd.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1119
+**Current Version:** 0.5.1120
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5022,7 +5022,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "base64",
@@ -5077,14 +5077,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "cc",
  "libc",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "log",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "base64",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "serde",
  "serde_json",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1119"
+version = "0.5.1120"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "clap",
@@ -5227,14 +5227,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "chrono",
  "cron",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5333,14 +5333,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "bytes",
  "h2",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "bson",
  "futures-util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "image",
@@ -5527,14 +5527,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "brotli",
  "flate2",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "base64",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5749,14 +5749,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "itoa",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "block2",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "block2",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1119"
+version = "0.5.1120"
 
 [[package]]
 name = "perry-ui-test"
@@ -5845,11 +5845,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1119"
+version = "0.5.1120"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "block2",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "block2",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "block2",
  "libc",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "libc",
@@ -5910,7 +5910,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1119"
+version = "0.5.1120"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1119"
+version = "0.5.1120"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -212,7 +212,7 @@ pub extern "C" fn js_fs_read_file_sync_options(
             extern "C" {
                 fn __android_log_print(prio: i32, tag: *const u8, fmt: *const u8, ...) -> i32;
             }
-            let c_path = std::ffi::CString::new(path_str_for_log).unwrap_or_default();
+            let c_path = std::ffi::CString::new(_path_str_for_log).unwrap_or_default();
             __android_log_print(
                 3,
                 b"PerryFS\0".as_ptr(),

--- a/crates/perry-ui-gtk4/src/widgets/canvas.rs
+++ b/crates/perry-ui-gtk4/src/widgets/canvas.rs
@@ -300,7 +300,10 @@ pub fn create(width: f64, height: f64) -> i64 {
                                     )
                                     .unwrap_or(src);
                                 cr.save().ok();
-                                gtk4::gdk::cairo::set_source_pixbuf(cr, &scaled, *dx, *dy);
+                                // gdk4's `GdkCairoContextExt::set_source_pixbuf` (in scope via
+                                // `gtk4::prelude::*`) — a method on the cairo Context, not a free
+                                // function under `gtk4::gdk::cairo`.
+                                cr.set_source_pixbuf(&scaled, *dx, *dy);
                                 cr.paint().ok();
                                 cr.restore().ok();
                             }


### PR DESCRIPTION
## Why

v0.5.1117 fixed the `await-tests` gate — publishing resumed after ~90 dark versions — but `release-packages` still concluded failure and skipped npm/brew/apt/winget. Cause: a **second, separate** breakage in the **cross-host UI crates**, which `cargo-test` excludes, so no PR CI catches them.

## Fixes

- **perry-ui-gtk4** `widgets/canvas.rs`: `gtk4::gdk::cairo::set_source_pixbuf(cr, …)` → `cr.set_source_pixbuf(&scaled, *dx, *dy)`. In gdk4 0.9, `set_source_pixbuf` is the `GdkCairoContextExt` trait method on the cairo `Context` (in scope via `gtk4::prelude::*`), not a free function. This broke the **linux-gnu** primary build (gtk4 is bundled into the Linux tarball).
- **perry-runtime** `fs/mod.rs`: the `#[cfg(target_os = "android")]` debug-log block referenced `path_str_for_log`, but the binding is `_path_str_for_log`. Matched the name (only the android cross-build compiled it).
- **release-packages.yml**: `fail-fast: false` on the primary `build` matrix (mirrors `build-cross`) so one platform's failure no longer cancels the rest / skips the publish legs.

## Verification

gtk4/android can't be compiled on the macOS dev host (no GTK/NDK). Validated against the cached `gdk4-0.9.6` trait signature and the exact android name mismatch; host `perry-runtime`/`perry` builds clean. Required checks (`cargo-test` etc.) don't exercise these crates — the real validation is the tag's `release-packages` build.

Follow-up worth filing: cross-host UI crates have no PR CI coverage and rot silently between releases.

Targets v0.5.1120 (main moved to 1119 under me; 1118 already taken).
