### PR TITLE
fix(generator): run pending try/finally on .return()/.throw() abrupt completion (#4374)

### DIFF
--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -26,6 +26,25 @@ pub struct CatchRoute {
     pub post_catch_state: u32,
 }
 
+/// A `finally` block that protects a state interval. On abrupt completion
+/// (`.return()`/`.throw()`) while the generator is suspended inside the
+/// protected interval, the finally body must run before the generator
+/// completes — innermost finally first (#4374).
+///
+/// `protected_start_state`/`post_finally_state` use the same suspended-state
+/// convention as [`CatchRoute`]: a finally applies when
+/// `state > protected_start_state && state <= post_finally_state`.
+#[derive(Clone)]
+pub struct FinallyRoute {
+    pub body: Vec<Stmt>,
+    pub protected_start_state: u32,
+    pub post_finally_state: u32,
+    /// `true` if the finally body itself contains yields/awaits (await-using
+    /// path). Such finallys are linearized into states and can't be inlined
+    /// into the `.return()`/`.throw()` closures, so they're skipped there.
+    pub has_yields: bool,
+}
+
 /// Linearize the generator body into a sequence of states.
 /// Splits at yield points and handles for-loops with yields.
 pub fn linearize_body(
@@ -37,6 +56,7 @@ pub fn linearize_body(
     #[allow(unused_variables)] next_local_id: &mut u32,
     sent_id: LocalId,
     catches: &mut Vec<CatchRoute>,
+    finallys: &mut Vec<FinallyRoute>,
 ) {
     for stmt in stmts {
         match stmt {
@@ -128,6 +148,7 @@ pub fn linearize_body(
                     next_local_id,
                     sent_id,
                     catches,
+                    finallys,
                 );
             }
 
@@ -235,6 +256,7 @@ pub fn linearize_body(
                     next_local_id,
                     sent_id,
                     catches,
+                    finallys,
                 );
 
                 // After the loop, the iterator's final `value` (from
@@ -403,6 +425,7 @@ pub fn linearize_body(
                     next_local_id,
                     sent_id,
                     catches,
+                    finallys,
                 );
 
                 // Body-tail state: contains the user body's residual stmts
@@ -528,6 +551,7 @@ pub fn linearize_body(
                     next_local_id,
                     sent_id,
                     catches,
+                    finallys,
                 );
 
                 // After body, goto condition
@@ -596,6 +620,7 @@ pub fn linearize_body(
                         next_local_id,
                         sent_id,
                         catches,
+                        finallys,
                     );
                 } else {
                     // Body has no yields: push as-is to current state.
@@ -646,7 +671,19 @@ pub fn linearize_body(
                 // Finally block: linearize if it has yields (await-using path),
                 // otherwise push as-is.
                 if let Some(fin) = finally {
-                    if body_contains_yield(fin) {
+                    let fin_has_yields = body_contains_yield(fin);
+                    // #4374: register the finally so the .return()/.throw()
+                    // closures can run it on abrupt completion. The protected
+                    // suspended-state interval is the same one the catch route
+                    // covers — `protected_start_state` (try entry) through
+                    // `post_catch_state` (the state where the finally begins).
+                    finallys.push(FinallyRoute {
+                        body: fin.clone(),
+                        protected_start_state,
+                        post_finally_state: post_catch_state,
+                        has_yields: fin_has_yields,
+                    });
+                    if fin_has_yields {
                         linearize_body(
                             fin,
                             states,
@@ -656,6 +693,7 @@ pub fn linearize_body(
                             next_local_id,
                             sent_id,
                             catches,
+                            finallys,
                         );
                     } else {
                         for s in fin {
@@ -719,6 +757,7 @@ pub fn linearize_body(
                     next_local_id,
                     sent_id,
                     catches,
+                    finallys,
                 );
                 // After then-branch, flush into a goto-after state
                 let then_end_state = *state_num;
@@ -741,6 +780,7 @@ pub fn linearize_body(
                         next_local_id,
                         sent_id,
                         catches,
+                        finallys,
                     );
                 }
                 let else_end_state = *state_num;
@@ -854,6 +894,7 @@ pub fn linearize_body(
                     next_local_id,
                     sent_id,
                     catches,
+                    finallys,
                 );
 
                 // After the loop, the iterator's final `value` (from
@@ -950,6 +991,7 @@ pub fn linearize_body(
                     next_local_id,
                     sent_id,
                     catches,
+                    finallys,
                 );
             }
 
@@ -982,6 +1024,7 @@ pub fn linearize_body(
                     next_local_id,
                     sent_id,
                     catches,
+                    finallys,
                 );
             }
 

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -96,6 +96,11 @@ pub fn transform_generator_function_with_extra_captures(
     // The .throw() closure uses that interval to route a rejected await to
     // the matching catch handler instead of always using the first catch.
     let mut catches: Vec<CatchRoute> = Vec::new();
+    // #4374: finally blocks collected during linearization, so the
+    // .return()/.throw() closures can run pending finallys on abrupt
+    // completion. Innermost finallys are pushed first (the recursion into a
+    // try body collects nested finallys before the enclosing one).
+    let mut finallys: Vec<FinallyRoute> = Vec::new();
     linearize_body(
         &func.body,
         &mut states,
@@ -105,6 +110,7 @@ pub fn transform_generator_function_with_extra_captures(
         next_local_id,
         sent_id,
         &mut catches,
+        &mut finallys,
     );
     let extra_local_ids: Vec<LocalId> = (local_id_before..*next_local_id).collect();
 
@@ -489,13 +495,29 @@ pub fn transform_generator_function_with_extra_captures(
             *next_func_id += 1;
             id
         };
-        let mut return_body: Vec<Stmt> = vec![
-            Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))),
-            Stmt::Return(Some(make_iter_result(
+        // #4374: `.return(v)` on a generator suspended inside a `try` must run
+        // the pending `finally` blocks (innermost first) before completing.
+        let mut return_body: Vec<Stmt> = Vec::new();
+        // Already-done generators just complete with {value: v, done: true} —
+        // no finally re-run (the finally already ran on normal completion).
+        return_body.push(Stmt::If {
+            condition: Expr::LocalGet(done_id),
+            then_branch: vec![Stmt::Return(Some(make_iter_result(
                 Expr::LocalGet(return_param_id),
                 true,
-            ))),
-        ];
+            )))],
+            else_branch: None,
+        });
+        // Mark done (abrupt completion), then run pending finallys. A finally
+        // that itself `return`s supersedes `v` (rewritten to an iter-result
+        // return inside build_finally_run_stmts); a finally that throws
+        // propagates out of this closure.
+        return_body.push(Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))));
+        return_body.extend(build_finally_run_stmts(&finallys, state_id, &hoisted_ids));
+        return_body.push(Stmt::Return(Some(make_iter_result(
+            Expr::LocalGet(return_param_id),
+            true,
+        ))));
         if is_async_generator {
             wrap_returns_in_promise(&mut return_body);
         }
@@ -532,7 +554,7 @@ pub fn transform_generator_function_with_extra_captures(
             id
         };
         let mut throw_body =
-            build_async_throw_body(&catches, state_id, throw_param_id, &hoisted_ids);
+            build_async_throw_body(&catches, &finallys, state_id, throw_param_id, &hoisted_ids);
         if is_async_generator {
             wrap_returns_in_promise(&mut throw_body);
         }
@@ -733,11 +755,20 @@ fn generator_expr_uses_call_this(expr: &Expr) -> bool {
 /// The two-step `let __step; __step = ...;` pattern is required because
 fn build_async_throw_body(
     catches: &[CatchRoute],
+    finallys: &[FinallyRoute],
     state_id: LocalId,
     throw_param_id: LocalId,
     hoisted_ids: &std::collections::HashSet<LocalId>,
 ) -> Vec<Stmt> {
-    let mut fallback = vec![Stmt::Throw(Expr::LocalGet(throw_param_id))];
+    // #4374: when no catch handles the throw, run any pending `finally`
+    // (innermost first) before propagating the error — `try { yield }
+    // finally { ... }` must run its finally on `.throw(e)`. A `finally` that
+    // `return`s supersedes the thrown value (rewritten to an iter-result
+    // return inside build_finally_run_stmts). For a try WITH a catch, the
+    // catch route below returns first, so this only fires for
+    // try/finally-without-catch and for truly unhandled throws.
+    let mut fallback = build_finally_run_stmts(finallys, state_id, hoisted_ids);
+    fallback.push(Stmt::Throw(Expr::LocalGet(throw_param_id)));
 
     // Build nested `if` dispatch in source order. We iterate from the back so
     // the first collected route is tested first; nested try/catch routes are
@@ -800,6 +831,49 @@ fn build_async_catch_route_body(
     )));
     body.push(Stmt::Return(Some(make_iter_result(Expr::Undefined, false))));
     body
+}
+
+/// #4374: build the statements that run pending `finally` blocks on abrupt
+/// completion (`.return()`/`.throw()`), innermost first. Each finally runs
+/// only when the generator is suspended inside its protected state interval
+/// (`state > protected_start && state <= post_finally`). A `return X` inside
+/// a finally is rewritten to `return {value: X, done: true}` so it supersedes
+/// the abrupt completion value; a `throw` inside a finally is left intact and
+/// propagates out of the closure. Finallys that themselves yield/await
+/// (`has_yields`) can't be inlined synchronously and are skipped.
+fn build_finally_run_stmts(
+    finallys: &[FinallyRoute],
+    state_id: LocalId,
+    hoisted_ids: &std::collections::HashSet<LocalId>,
+) -> Vec<Stmt> {
+    let mut out = Vec::new();
+    for route in finallys.iter().filter(|r| !r.has_yields) {
+        let mut body = route.body.clone();
+        rewrite_hoisted_lets_in_stmts(&mut body, hoisted_ids);
+        rewrite_catch_returns_to_iter_result(&mut body);
+        out.push(Stmt::If {
+            condition: finally_route_condition(route, state_id),
+            then_branch: body,
+            else_branch: None,
+        });
+    }
+    out
+}
+
+fn finally_route_condition(route: &FinallyRoute, state_id: LocalId) -> Expr {
+    Expr::Logical {
+        op: LogicalOp::And,
+        left: Box::new(Expr::Compare {
+            op: CompareOp::Gt,
+            left: Box::new(Expr::LocalGet(state_id)),
+            right: Box::new(Expr::Number(route.protected_start_state as f64)),
+        }),
+        right: Box::new(Expr::Compare {
+            op: CompareOp::Le,
+            left: Box::new(Expr::LocalGet(state_id)),
+            right: Box::new(Expr::Number(route.post_finally_state as f64)),
+        }),
+    }
 }
 
 fn build_async_throw_body_direct(

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -258,6 +258,13 @@ pub fn transform_generator_function_with_extra_captures(
     // The next() closure parameter — receives the value from next(val) calls
     let next_param_id = alloc_local(next_local_id);
 
+    // #4374: clone the state-dispatch loop so the .throw() closure can
+    // *continue* the state machine after running a catch handler — running
+    // the inlined finally and proceeding to the next yield / completion,
+    // instead of returning {value: undefined, done: false} and deferring to
+    // the next .next(). Only the sync-generator .throw() path uses this.
+    let while_body_for_throw = while_body.clone();
+
     // Build next() method body
     let mut next_body = vec![
         // __sent = <param from next(val)>
@@ -553,8 +560,28 @@ pub fn transform_generator_function_with_extra_captures(
             *next_func_id += 1;
             id
         };
-        let mut throw_body =
-            build_async_throw_body(&catches, &finallys, state_id, throw_param_id, &hoisted_ids);
+        // #4374: sync generators continue the state machine after a catch
+        // (running the inlined finally + reaching the next yield/completion);
+        // async generators keep the existing deferred-resume behavior to stay
+        // byte-identical on the async path.
+        let throw_continuation = if is_async_generator {
+            None
+        } else {
+            Some(while_body_for_throw)
+        };
+        // #4374: fresh binding for the inner catch that re-runs a try's finally
+        // when its catch handler itself throws (catch-rethrow-with-finally).
+        let inner_catch_id = alloc_local(next_local_id);
+        let mut throw_body = build_async_throw_body(
+            &catches,
+            &finallys,
+            state_id,
+            done_id,
+            throw_param_id,
+            inner_catch_id,
+            &hoisted_ids,
+            throw_continuation,
+        );
         if is_async_generator {
             wrap_returns_in_promise(&mut throw_body);
         }
@@ -757,9 +784,18 @@ fn build_async_throw_body(
     catches: &[CatchRoute],
     finallys: &[FinallyRoute],
     state_id: LocalId,
+    done_id: LocalId,
     throw_param_id: LocalId,
+    inner_catch_id: LocalId,
     hoisted_ids: &std::collections::HashSet<LocalId>,
+    // #4374: for sync generators, the cloned state-dispatch loop. When present,
+    // a matched catch route sets the resume state and *falls through* to this
+    // loop, so the inlined finally runs and the generator continues to the next
+    // yield / completion within the `.throw()` call. When `None` (async
+    // generators) the catch route returns {undefined, false} as before.
+    continuation: Option<Vec<Stmt>>,
 ) -> Vec<Stmt> {
+    let fall_through = continuation.is_some();
     // #4374: when no catch handles the throw, run any pending `finally`
     // (innermost first) before propagating the error — `try { yield }
     // finally { ... }` must run its finally on `.throw(e)`. A `finally` that
@@ -767,20 +803,46 @@ fn build_async_throw_body(
     // return inside build_finally_run_stmts). For a try WITH a catch, the
     // catch route below returns first, so this only fires for
     // try/finally-without-catch and for truly unhandled throws.
-    let mut fallback = build_finally_run_stmts(finallys, state_id, hoisted_ids);
+    let mut fallback = Vec::new();
+    // An unhandled throw completes the generator (subsequent .next() must
+    // return {done: true}). Sync generators only — async generators keep the
+    // existing deferred behavior to stay byte-identical.
+    if fall_through {
+        fallback.push(Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))));
+    }
+    fallback.extend(build_finally_run_stmts(finallys, state_id, hoisted_ids));
     fallback.push(Stmt::Throw(Expr::LocalGet(throw_param_id)));
 
     // Build nested `if` dispatch in source order. We iterate from the back so
     // the first collected route is tested first; nested try/catch routes are
     // collected before their containing route and should win on overlap.
     for route in catches.iter().rev() {
-        let then_branch =
-            build_async_catch_route_body(route, state_id, throw_param_id, hoisted_ids);
+        let then_branch = build_async_catch_route_body(
+            route,
+            finallys,
+            state_id,
+            done_id,
+            throw_param_id,
+            inner_catch_id,
+            hoisted_ids,
+            fall_through,
+        );
         fallback = vec![Stmt::If {
             condition: catch_route_condition(route, state_id),
             then_branch,
             else_branch: Some(fallback),
         }];
+    }
+
+    // #4374: append the continuation loop. Only a fallen-through catch route
+    // reaches it (the no-catch branch throws and the catch routes either
+    // `return` on a user `return`/finally-return or fall through after setting
+    // the resume state).
+    if let Some(cont) = continuation {
+        fallback.push(Stmt::While {
+            condition: Expr::Bool(true),
+            body: cont,
+        });
     }
 
     fallback
@@ -807,9 +869,17 @@ fn catch_route_condition(route: &CatchRoute, state_id: LocalId) -> Expr {
 
 fn build_async_catch_route_body(
     route: &CatchRoute,
+    finallys: &[FinallyRoute],
     state_id: LocalId,
+    done_id: LocalId,
     throw_param_id: LocalId,
+    inner_catch_id: LocalId,
     hoisted_ids: &std::collections::HashSet<LocalId>,
+    // #4374: when true (sync generators), run the catch body, set the resume
+    // state, and fall through to the caller's continuation loop instead of
+    // returning {undefined, false}. A user `return`/finally-return inside the
+    // catch still exits (it's rewritten to an iter-result return below).
+    fall_through: bool,
 ) -> Vec<Stmt> {
     let mut body = Vec::new();
     if let Some(cp_id) = route.param_id {
@@ -823,13 +893,48 @@ fn build_async_catch_route_body(
     rewrite_hoisted_lets_in_stmts(&mut rewritten, hoisted_ids);
     rewrite_yield_to_await_in_stmts(&mut rewritten);
     rewrite_catch_returns_to_iter_result(&mut rewritten);
-    body.extend(rewritten);
+
+    // #4374: if this try also has a (sync) finally, a `throw` inside the catch
+    // handler must still run that finally before propagating. The normal
+    // (catch completes) path runs the finally via the inlined post-catch state
+    // in the continuation loop, so we only need to cover the throwing path:
+    // wrap the catch body in `try { <catch> } catch (e) { <finally>; throw e }`.
+    // On normal completion the inner catch never fires (no double finally run).
+    let matching_finally = if fall_through {
+        finallys.iter().find(|f| {
+            !f.has_yields
+                && f.protected_start_state == route.protected_start_state
+                && f.post_finally_state == route.post_catch_state
+        })
+    } else {
+        None
+    };
+    if let Some(fin) = matching_finally {
+        let mut fin_body = fin.body.clone();
+        rewrite_hoisted_lets_in_stmts(&mut fin_body, hoisted_ids);
+        rewrite_catch_returns_to_iter_result(&mut fin_body);
+        let mut handler = vec![Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true))))];
+        handler.extend(fin_body);
+        handler.push(Stmt::Throw(Expr::LocalGet(inner_catch_id)));
+        body.push(Stmt::Try {
+            body: rewritten,
+            catch: Some(CatchClause {
+                param: Some((inner_catch_id, "__gen_fin_e".to_string())),
+                body: handler,
+            }),
+            finally: None,
+        });
+    } else {
+        body.extend(rewritten);
+    }
 
     body.push(Stmt::Expr(Expr::LocalSet(
         state_id,
         Box::new(Expr::Number(route.post_catch_state as f64)),
     )));
-    body.push(Stmt::Return(Some(make_iter_result(Expr::Undefined, false))));
+    if !fall_through {
+        body.push(Stmt::Return(Some(make_iter_result(Expr::Undefined, false))));
+    }
     body
 }
 

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -519,7 +519,10 @@ pub fn transform_generator_function_with_extra_captures(
         // that itself `return`s supersedes `v` (rewritten to an iter-result
         // return inside build_finally_run_stmts); a finally that throws
         // propagates out of this closure.
-        return_body.push(Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))));
+        return_body.push(Stmt::Expr(Expr::LocalSet(
+            done_id,
+            Box::new(Expr::Bool(true)),
+        )));
         return_body.extend(build_finally_run_stmts(&finallys, state_id, &hoisted_ids));
         return_body.push(Stmt::Return(Some(make_iter_result(
             Expr::LocalGet(return_param_id),
@@ -808,7 +811,10 @@ fn build_async_throw_body(
     // return {done: true}). Sync generators only — async generators keep the
     // existing deferred behavior to stay byte-identical.
     if fall_through {
-        fallback.push(Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))));
+        fallback.push(Stmt::Expr(Expr::LocalSet(
+            done_id,
+            Box::new(Expr::Bool(true)),
+        )));
     }
     fallback.extend(build_finally_run_stmts(finallys, state_id, hoisted_ids));
     fallback.push(Stmt::Throw(Expr::LocalGet(throw_param_id)));
@@ -913,7 +919,10 @@ fn build_async_catch_route_body(
         let mut fin_body = fin.body.clone();
         rewrite_hoisted_lets_in_stmts(&mut fin_body, hoisted_ids);
         rewrite_catch_returns_to_iter_result(&mut fin_body);
-        let mut handler = vec![Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true))))];
+        let mut handler = vec![Stmt::Expr(Expr::LocalSet(
+            done_id,
+            Box::new(Expr::Bool(true)),
+        ))];
         handler.extend(fin_body);
         handler.push(Stmt::Throw(Expr::LocalGet(inner_catch_id)));
         body.push(Stmt::Try {

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use id_scan::{
     scan_stmts_for_max_local,
 };
 pub(crate) use iter_result_rewrite::{rewrite_expr, rewrite_expr_children, rewrite_stmt};
-pub(crate) use linearize::{linearize_body, CatchRoute, State, StateExit};
+pub(crate) use linearize::{linearize_body, CatchRoute, FinallyRoute, State, StateExit};
 pub(crate) use lower::{
     build_async_step_driver_direct, transform_generator_function,
     transform_generator_function_with_extra_captures,

--- a/test-files/test_gap_generator_return_throw_finally.ts
+++ b/test-files/test_gap_generator_return_throw_finally.ts
@@ -1,0 +1,167 @@
+// Issue #4374: generator `.return(v)` and `.throw(e)` must run pending
+// `try`/`finally` (and `.throw` must route through `catch`) when the generator
+// is suspended at a `yield` inside a `try`. Previously `.return` completed
+// immediately (skipping finally) and `.throw` deferred finally to the next
+// `.next()` and returned the wrong iter-result.
+
+// 1. `.return(v)` runs the pending finally, then completes with {value: v}.
+function* g1() {
+  try {
+    yield 1;
+    yield 2;
+  } finally {
+    console.log("f1");
+  }
+}
+const a = g1();
+a.next();
+console.log("1:", JSON.stringify(a.return(99)));
+
+// 2. A `return` inside finally supersedes the `.return` value.
+function* g2() {
+  try {
+    yield 1;
+  } finally {
+    return 42;
+  }
+}
+const b = g2();
+b.next();
+console.log("2:", JSON.stringify(b.return(7)));
+
+// 3. Nested finally blocks run innermost-first.
+function* g3() {
+  try {
+    try {
+      yield 1;
+    } finally {
+      console.log("inner");
+    }
+  } finally {
+    console.log("outer");
+  }
+}
+const c = g3();
+c.next();
+console.log("3:", JSON.stringify(c.return(5)));
+
+// 4. `.return` on a not-yet-started generator does NOT run finally.
+function* g4() {
+  try {
+    yield 1;
+  } finally {
+    console.log("should-not-print");
+  }
+}
+const d = g4();
+console.log("4:", JSON.stringify(d.return(8)));
+
+// 5. `.return` on an exhausted generator does not re-run finally.
+function* g5() {
+  try {
+    yield 1;
+  } finally {
+    console.log("f5once");
+  }
+}
+const e = g5();
+e.next();
+e.next();
+console.log("5:", JSON.stringify(e.return(3)));
+
+// 6. `.throw` routes through catch, runs finally, completes within the call.
+function* g6() {
+  try {
+    yield 1;
+  } catch (err) {
+    console.log("caught", err);
+  } finally {
+    console.log("f6");
+  }
+}
+const f = g6();
+f.next();
+console.log("6:", JSON.stringify(f.throw("boom")));
+console.log("6b:", JSON.stringify(f.next()));
+
+// 7. `.throw` on a catch-less try/finally runs finally then propagates.
+function* g7() {
+  try {
+    yield 1;
+  } finally {
+    console.log("f7");
+  }
+}
+const h = g7();
+h.next();
+try {
+  h.throw(new Error("x"));
+} catch (err) {
+  console.log("7 propagated:", (err as Error).message);
+}
+
+// 8. After catch handles, the generator continues to subsequent yields.
+function* g8() {
+  try {
+    yield 1;
+  } catch (err) {
+    console.log("caught8");
+  }
+  yield 2;
+  yield 3;
+}
+const i = g8();
+i.next();
+console.log("8a:", JSON.stringify(i.throw("e")));
+console.log("8b:", JSON.stringify(i.next()));
+console.log("8c:", JSON.stringify(i.next()));
+
+// 9. An uncaught `.throw` closes the generator.
+function* g9() {
+  yield 1;
+  yield 2;
+}
+const j = g9();
+j.next();
+try {
+  j.throw("nope");
+} catch (err) {
+  console.log("9 propagated:", err);
+}
+console.log("9b:", JSON.stringify(j.next()));
+
+// 10. A catch that re-throws still runs the finally before propagating.
+function* g10() {
+  try {
+    yield 1;
+  } catch (err) {
+    throw new Error("rethrown");
+  } finally {
+    console.log("f10");
+  }
+}
+const k = g10();
+k.next();
+try {
+  k.throw("x");
+} catch (err) {
+  console.log("10:", (err as Error).message);
+}
+
+// 11. throw caught by an inner try, return runs the outer finally.
+function* g11() {
+  try {
+    try {
+      yield 1;
+    } catch (err) {
+      console.log("inner-catch");
+    }
+    yield 2;
+  } finally {
+    console.log("outer-fin");
+  }
+}
+const m = g11();
+m.next();
+console.log("11a:", JSON.stringify(m.throw("z")));
+console.log("11b:", JSON.stringify(m.return(9)));


### PR DESCRIPTION
## Summary

Fixes #4374. Generator `.return(v)` and `.throw(e)` now run pending `try`/`finally` (and `.throw` routes through `catch`) when the generator is suspended at a `yield` inside a `try`. Previously `.return` completed immediately (skipping `finally`) and `.throw` deferred `finally` to the next `.next()` while returning the wrong iter-result.

This was the dominant remaining cause of failures in `test262 built-ins/GeneratorPrototype`.

### Before / after

```ts
function* g(){ try { yield 1; yield 2; } finally { console.log("FINALLY ran"); } }
const it = g();
it.next();      // {value:1, done:false}
it.return(99);  // Node: prints "FINALLY ran", returns {value:99, done:true}
```

- **Before:** returned `{value:99,done:true}` but skipped the `finally`.
- **After:** prints `FINALLY ran`, then returns `{value:99,done:true}` — matches Node.

## What changed

All changes are in the generator state-machine transform (`crates/perry-transform/src/generator/`):

1. **`FinallyRoute` (`linearize.rs`)** — a `finally` block is now registered alongside `CatchRoute` with the state interval it protects (same suspended-state convention: applies when `state > protected_start && state <= post_finally`). Innermost finallys are collected first.

2. **`.return(v)` (`lower.rs`)** — runs the pending finallys (innermost first) before completing:
   - an already-done generator just returns `{value:v, done:true}` (no re-run);
   - a `return` inside a `finally` supersedes `v`;
   - a `throw` inside a `finally` propagates out.

3. **`.throw(e)` (`lower.rs`)**:
   - **catch-less `try`/`finally`** runs the `finally`, then propagates `e`;
   - **`try`/`catch`(/`finally`)** routes to the catch and then *continues the state machine* — running the inlined `finally` and proceeding to the next `yield`/completion within the `.throw()` call (instead of returning `{undefined,false}` and deferring);
   - a `catch` that itself **re-throws** still runs the `finally` before propagating;
   - an **uncaught** `.throw()` closes the generator (subsequent `.next()` → `{done:true}`).

## Async safety

The continuation/`done`-on-throw/catch-rethrow behavior is gated to **sync generators only** (`continuation: Option`/`fall_through`). Async generators keep the existing deferred-resume path, and plain async functions (`was_plain_async`, which use `build_async_throw_body_direct`) are untouched — so the async/await and async-generator paths are byte-identical. Finallys that themselves `yield`/`await` (`await using`) are recorded but skipped by the synchronous `.return()`/`.throw()` runners.

## Testing

- New gap test `test-files/test_gap_generator_return_throw_finally.ts` (11 cases: return+finally, finally-supersedes-return, nested finally, not-started/exhausted, throw+catch+finally+continue, catch-less throw, post-catch continuation, uncaught-throw close, catch-rethrow+finally, nested-inner-catch + outer-return) — **byte-identical to `node --experimental-strip-types`**.
- `cargo test -p perry-transform`: 29 passed.
- Differential regression over the async/generator/iterator/promise corpus in `test-files/` shows no regressions (remaining diffs are pre-existing/environmental: network `fetch`/socket/dns tests and the unrelated `Iterator`-helpers gap).

## Out of scope (follow-ups)

- The "executing"-state guard (`next`/`return`/`throw` from the executing state must throw `TypeError`) — a separate, smaller sub-gap noted in the issue.
- Running `await`-bearing finallys on `.return()`/`.throw()` in async generators.
