### PR TITLE
[codex] fix async_hooks snapshot callback validation

### DIFF
--- a/crates/perry-runtime/src/async_hooks.rs
+++ b/crates/perry-runtime/src/async_hooks.rs
@@ -1168,7 +1168,6 @@ extern "C" fn async_local_storage_snapshot_trampoline(
     callback_value: f64,
     rest: f64,
 ) -> f64 {
-    validate_bind_callback(callback_value);
     let snapshot_id = js_closure_get_capture_ptr(closure, 0) as usize;
     let this_arg = crate::object::js_implicit_this_get();
     run_with_context_snapshot(snapshot_id, || {

--- a/test-parity/node-suite/async_hooks/static-resource-helpers.ts
+++ b/test-parity/node-suite/async_hooks/static-resource-helpers.ts
@@ -1,0 +1,91 @@
+import asyncHooksDefault, * as async_hooks from "node:async_hooks";
+import {
+  AsyncLocalStorage,
+  AsyncResource,
+  asyncWrapProviders,
+  executionAsyncResource,
+} from "node:async_hooks";
+
+function summarizeError(error: any): string {
+  return `${error.name} ${error.code || "no-code"}`;
+}
+
+function probe(label: string, fn: () => any) {
+  try {
+    const value = fn();
+    console.log(label, "ok", value === undefined ? "undefined" : String(value));
+  } catch (error: any) {
+    console.log(label, summarizeError(error));
+  }
+}
+
+const als = new AsyncLocalStorage();
+
+console.log(
+  "static helper typeofs:",
+  typeof AsyncLocalStorage.bind,
+  typeof AsyncLocalStorage.snapshot,
+  typeof AsyncResource.bind,
+  typeof executionAsyncResource,
+  typeof async_hooks.executionAsyncResource,
+);
+console.log("instance helper absence:", typeof (als as any).bind, typeof (als as any).snapshot);
+console.log(
+  "provider sample:",
+  typeof asyncWrapProviders,
+  asyncWrapProviders.NONE,
+  asyncWrapProviders.DIRHANDLE,
+  asyncWrapProviders.PROMISE,
+  Object.keys(asyncWrapProviders).slice(0, 3).join("|"),
+);
+
+const boundFromAls = als.run("ctx", () =>
+  AsyncLocalStorage.bind((a: number, b: number) => `${als.getStore()}:${a + b}`),
+);
+console.log("als bind:", typeof boundFromAls, boundFromAls(2, 3), String(als.getStore()));
+
+const snapshotRunner = als.run("snap", () => AsyncLocalStorage.snapshot());
+console.log(
+  "als snapshot:",
+  typeof snapshotRunner,
+  snapshotRunner((a: string, b: string) => `${als.getStore()}:${a}:${b}`, "x", "y"),
+  String(als.getStore()),
+);
+
+probe("als bind bad", () => AsyncLocalStorage.bind(0 as any));
+probe("als snapshot bad", () => snapshotRunner(0 as any));
+
+const staticBoundResource = AsyncResource.bind(
+  function (this: any, value: number) {
+    return `${this && this.tag}:${value}`;
+  },
+  "StaticProbe",
+);
+console.log(
+  "resource static bind:",
+  typeof staticBoundResource,
+  staticBoundResource.call({ tag: "recv" }, 7),
+);
+probe("resource static bind bad", () => AsyncResource.bind(0 as any));
+
+const resource = new AsyncResource("ScopeProbe");
+console.log(
+  "execution resource objects:",
+  typeof executionAsyncResource(),
+  typeof resource.runInAsyncScope(() => executionAsyncResource()),
+  typeof async_hooks.executionAsyncResource(),
+);
+
+const capturedExecutionAsyncResource = async_hooks.executionAsyncResource;
+console.log(
+  "captured executionAsyncResource:",
+  typeof capturedExecutionAsyncResource,
+  typeof capturedExecutionAsyncResource(),
+);
+
+console.log(
+  "default helpers:",
+  typeof asyncHooksDefault.executionAsyncResource,
+  typeof asyncHooksDefault.asyncWrapProviders,
+  asyncHooksDefault.asyncWrapProviders.NONE,
+);


### PR DESCRIPTION
Refs #2013

## Summary
- Align the callback validation path used by the function returned from `AsyncLocalStorage.snapshot()`.
- Add a focused `node-suite/async_hooks/static-resource-helpers` fixture covering the static helper surface and this validation difference.

## Root Cause
Perry prevalidated the snapshot runner callback with the same `ERR_INVALID_ARG_TYPE` path used by `AsyncLocalStorage.bind()` and `AsyncResource.bind()`. Node lets the snapshot runner reach the callback invocation path, which throws a plain `TypeError` with no `code` for a non-callable callback.

## Why This Cut
The static helper surface is already mostly present on current main, but the callback error shape was still observably different. The new fixture keeps that narrow validation behavior covered alongside the related static exports and namespace/default helper surface.

## Non-Goals
- Broader async lifecycle fidelity.
- `createHook` callback ordering behavior.
- Unrelated `AsyncResource` validation tails.

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `env CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= CARGO_PROFILE_RELEASE_LTO=false CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 CARGO_PROFILE_RELEASE_OPT_LEVEL=1 CARGO_PROFILE_RELEASE_PACKAGE_PERRY_RUNTIME_OPT_LEVEL=1 CARGO_PROFILE_RELEASE_PACKAGE_PERRY_STDLIB_OPT_LEVEL=1 PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module async_hooks --filter static-resource-helpers`
- `env CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= CARGO_PROFILE_RELEASE_LTO=false CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 CARGO_PROFILE_RELEASE_OPT_LEVEL=1 CARGO_PROFILE_RELEASE_PACKAGE_PERRY_RUNTIME_OPT_LEVEL=1 CARGO_PROFILE_RELEASE_PACKAGE_PERRY_STDLIB_OPT_LEVEL=1 PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module async_hooks`
- `env CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-timers-promises-validation/target CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check -p perry-runtime`
