### PR TITLE
fix(http2): align refused session property shape

### DIFF
--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -104,6 +104,7 @@ pub struct Http2SecureServer {
 
 pub struct Http2SessionHandle {
     pub session_type: i32,
+    pub connected: bool,
     pub encrypted: bool,
     pub alpn_protocol: String,
     pub connecting: bool,
@@ -345,6 +346,7 @@ fn call3(callback: i64, arg0: f64, arg1: f64, arg2: f64) {
 fn register_server_session(server_handle: i64) -> i64 {
     let session_handle = register_handle(Http2SessionHandle {
         session_type: 0,
+        connected: true,
         encrypted: false,
         alpn_protocol: "h2c".to_string(),
         connecting: false,
@@ -1069,12 +1071,13 @@ pub unsafe extern "C" fn js_node_http2_connect(
     }
     let session_handle = register_handle(Http2SessionHandle {
         session_type: 1,
+        connected: false,
         encrypted: false,
         alpn_protocol: "h2c".to_string(),
         connecting: true,
         closed: false,
         destroyed: false,
-        pending_settings_ack: true,
+        pending_settings_ack: false,
         authority: host_port,
         local_settings: Http2SettingsState::default(),
         remote_settings: Http2SettingsState::default(),
@@ -1127,7 +1130,9 @@ pub unsafe extern "C" fn js_node_http2_connect(
                 *slot = Some(sender);
             }
             if let Some(session) = get_handle_mut::<Http2SessionHandle>(session_handle) {
+                session.connected = true;
                 session.connecting = false;
+                session.pending_settings_ack = true;
             }
             push_h2_event(Http2PendingEvent::ClientConnect { session_handle });
             let _ = connection.await;
@@ -1636,11 +1641,15 @@ pub unsafe extern "C" fn js_ext_http2_session_dispatch_property(
         "type" => get_handle::<Http2SessionHandle>(handle)
             .map(|s| s.session_type as f64)
             .unwrap_or(0.0),
-        "encrypted" => bool_value(
-            get_handle::<Http2SessionHandle>(handle)
-                .map(|s| s.encrypted)
-                .unwrap_or(false),
-        ),
+        "encrypted" => get_handle::<Http2SessionHandle>(handle)
+            .map(|s| {
+                if s.connected {
+                    bool_value(s.encrypted)
+                } else {
+                    undef
+                }
+            })
+            .unwrap_or(undef),
         "connecting" => bool_value(
             get_handle::<Http2SessionHandle>(handle)
                 .map(|s| s.connecting)
@@ -1657,7 +1666,13 @@ pub unsafe extern "C" fn js_ext_http2_session_dispatch_property(
                 .unwrap_or(false),
         ),
         "alpnProtocol" => get_handle::<Http2SessionHandle>(handle)
-            .map(|s| string_value(&s.alpn_protocol))
+            .map(|s| {
+                if s.connected {
+                    string_value(&s.alpn_protocol)
+                } else {
+                    undef
+                }
+            })
             .unwrap_or(undef),
         "pendingSettingsAck" => bool_value(
             get_handle::<Http2SessionHandle>(handle)

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -1909,6 +1909,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
                 | "closed"
                 | "destroyed"
                 | "alpnProtocol"
+                | "pendingSettingsAck"
                 | "localSettings"
                 | "remoteSettings"
                 | "state"

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -26,12 +26,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_http2": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:http2` surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_https": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary

- track whether HTTP/2 sessions have reached a successful connection before exposing `alpnProtocol` and `encrypted`
- keep refused plaintext client sessions Node-shaped with undefined `alpnProtocol` / `encrypted` and boolean `pendingSettingsAck`
- remove `test_parity_http2` from known failures now that the top-level inventory probe passes

Fixes #4382.

## Validation

- Node 26.3.0 oracle for refused and connected plaintext sessions
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/http2-refused cargo check -p perry-ext-http-server -p perry-stdlib`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/http2-refused npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite parity --filter test_parity_http2'`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/http2-refused npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite node-suite --module http2'`
- `jq empty test-parity/known_failures.json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
