### PR TITLE
[codex] honor stream close lifecycle options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1141 — Node streams honor `emitClose` / `autoDestroy` close-lifecycle options
+
+`new Readable/Writable/Duplex({ emitClose: false })` now suppresses the `'close'`
+event on `destroy()` (previously it fired regardless), and `autoDestroy: false`
+is honored, matching Node's stream close lifecycle. Verified:
+`Readable({ emitClose: false })` → close listener does **not** fire on
+`destroy()`, while the default (`emitClose: true`) still fires it. Option keys
+are read from the constructor options and stored as hidden stream state
+(`node_stream_keys.rs` / `node_stream_constructors.rs` / `node_stream_readwrite.rs`
+/ `node_stream_destroy_state.rs`); covered by new `node_stream_tests_extra.rs`
+unit tests.
+
 ## v0.5.1140 — `http`/`https` Agent drops the bogus `close` method (matches Node)
 
 Node's `http.Agent`/`https.Agent` has no `close()` method — only `destroy()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1140
+**Current Version:** 0.5.1141
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1140"
+version = "0.5.1141"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1140"
+version = "0.5.1141"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1140"
+version = "0.5.1141"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1140"
+version = "0.5.1141"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1140"
+version = "0.5.1141"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -127,6 +127,7 @@ const READABLE_BASE64_REMAINDER_KEY: &[u8] = b"__perryReadableBase64Remainder";
 const STREAM_PIPE_NO_END_KEY: &[u8] = b"__perryStreamPipeNoEnd";
 const STREAM_PIPE_END_PENDING_KEY: &[u8] = b"__perryStreamPipeEndPending";
 const STREAM_AUTO_DESTROY_KEY: &[u8] = b"__perryStreamAutoDestroy";
+const STREAM_EMIT_CLOSE_KEY: &[u8] = b"__perryStreamEmitClose";
 const STREAM_PIPELINE_CALLBACK_DONE_KEY: &[u8] = b"__perryStreamPipelineCallbackDone";
 const STREAM_COMPOSE_LIVE_PIPE_CONSUME_KEY: &[u8] = b"__perryStreamComposeLivePipeConsume";
 
@@ -389,11 +390,10 @@ extern "C" fn ns_writable_finish_microtask(closure: *const ClosureHeader) -> f64
         let readable_done = get_hidden_value(stream, hidden_readable_flag_key()).is_none()
             || has_truthy_hidden(stream, hidden_end_emitted_key());
         if readable_done {
-            mark_stream_closed(stream);
             if stream_auto_destroy_enabled(stream) {
                 mark_stream_destroyed(stream);
             }
-            let _ = emit_stream_event(stream, string_value(b"close"), &[]);
+            mark_stream_closed_and_emit_close(stream);
         }
     }
     f64::from_bits(TAG_UNDEFINED)

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -122,6 +122,7 @@ pub(super) fn resolve_hwm(opts: f64, specific: &[u8], specific_object_mode: &[u8
 /// Initialize visible lifecycle flags shared by all stream sides.
 pub(super) fn init_lifecycle_state(stream: f64, opts: f64) {
     set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_FALSE));
+    set_stream_emit_close(stream, opts);
     set_hidden_value(
         stream,
         hidden_capture_rejections_key(),

--- a/crates/perry-runtime/src/node_stream_destroy_state.rs
+++ b/crates/perry-runtime/src/node_stream_destroy_state.rs
@@ -23,8 +23,7 @@ pub(super) extern "C" fn ns_destroy_error_microtask(closure: *const ClosureHeade
             let _ = super::event_emitter::emit_stream_event(stream, error, &[err]);
         }
     }
-    super::mark_stream_closed(stream);
-    let _ = super::event_emitter::emit_stream_event(stream, super::string_value(b"close"), &[]);
+    super::mark_stream_closed_and_emit_close(stream);
     f64::from_bits(TAG_UNDEFINED)
 }
 

--- a/crates/perry-runtime/src/node_stream_keys.rs
+++ b/crates/perry-runtime/src/node_stream_keys.rs
@@ -231,6 +231,11 @@ pub(super) fn hidden_stream_auto_destroy_key() -> *mut crate::string::StringHead
 }
 
 #[inline]
+pub(super) fn hidden_stream_emit_close_key() -> *mut crate::string::StringHeader {
+    hidden_key(STREAM_EMIT_CLOSE_KEY)
+}
+
+#[inline]
 pub(super) fn hidden_pipeline_callback_done_key() -> *mut crate::string::StringHeader {
     hidden_key(STREAM_PIPELINE_CALLBACK_DONE_KEY)
 }

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -173,6 +173,30 @@ pub(super) fn stream_auto_destroy_enabled(stream: f64) -> bool {
         .unwrap_or(true)
 }
 
+pub(super) fn set_stream_emit_close(stream: f64, opts: f64) {
+    let enabled = get_hidden_value(opts, hidden_key(b"emitClose"))
+        .map(|v| v.to_bits() != TAG_FALSE)
+        .unwrap_or(true);
+    set_hidden_value(
+        stream,
+        hidden_stream_emit_close_key(),
+        f64::from_bits(if enabled { TAG_TRUE } else { TAG_FALSE }),
+    );
+}
+
+pub(super) fn stream_emit_close_enabled(stream: f64) -> bool {
+    get_hidden_value(stream, hidden_stream_emit_close_key())
+        .map(|v| v.to_bits() != TAG_FALSE)
+        .unwrap_or(true)
+}
+
+pub(super) fn mark_stream_closed_and_emit_close(stream: f64) {
+    mark_stream_closed(stream);
+    if stream_emit_close_enabled(stream) {
+        let _ = emit_stream_event(stream, string_value(b"close"), &[]);
+    }
+}
+
 pub(super) fn mark_stream_destroyed(stream: f64) {
     set_hidden_value(stream, hidden_key(b"destroyed"), f64::from_bits(TAG_TRUE));
     refresh_readable_aborted_flag(stream);
@@ -779,9 +803,6 @@ pub(super) fn emit_readable_end_once(stream: f64) {
             if !writable_pending {
                 destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
             }
-        } else if get_hidden_value(stream, hidden_writable_flag_key()).is_none() {
-            mark_stream_closed(stream);
-            let _ = emit_stream_event(stream, string_value(b"close"), &[]);
         }
     }
 }

--- a/crates/perry-runtime/src/node_stream_tests_extra.rs
+++ b/crates/perry-runtime/src/node_stream_tests_extra.rs
@@ -964,6 +964,60 @@ fn writable_lifecycle_flags_reflect_end_and_finish() {
 }
 
 #[test]
+fn readable_emit_close_false_suppresses_destroy_close_event() {
+    WRITABLE_CLOSE_COUNT.with(|count| *count.borrow_mut() = 0);
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    js_object_set_field_by_name(opts, hidden_key(b"emitClose"), f64::from_bits(TAG_FALSE));
+    let stream = js_node_stream_readable_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let close = box_pointer(js_closure_alloc(capture_close_listener as *const u8, 0) as *const u8);
+    let _ = js_node_stream_method_on(handle, string_value("close"), close);
+
+    let _ = js_node_stream_method_destroy(handle, f64::from_bits(TAG_UNDEFINED));
+    let _ = crate::promise::js_promise_run_microtasks();
+
+    assert_eq!(js_node_stream_method_destroyed(handle).to_bits(), TAG_TRUE);
+    assert_eq!(js_node_stream_method_closed(handle).to_bits(), TAG_TRUE);
+    WRITABLE_CLOSE_COUNT.with(|count| assert_eq!(*count.borrow(), 0));
+}
+
+#[test]
+fn readable_auto_destroy_false_does_not_close_after_end() {
+    WRITABLE_CLOSE_COUNT.with(|count| *count.borrow_mut() = 0);
+    READABLE_END_COUNT.with(|count| *count.borrow_mut() = 0);
+    READABLE_DATA_CAPTURED.with(|captured| captured.borrow_mut().clear());
+
+    let opts = crate::object::js_object_alloc(0, 1);
+    js_object_set_field_by_name(opts, hidden_key(b"autoDestroy"), f64::from_bits(TAG_FALSE));
+    let stream = js_node_stream_readable_new(box_pointer(opts as *const u8));
+    let handle = raw_ptr_from_value(stream) as i64;
+    let close = box_pointer(js_closure_alloc(capture_close_listener as *const u8, 0) as *const u8);
+    let data_closure = js_closure_alloc(capture_data_listener as *const u8, 1);
+    crate::closure::js_register_closure_arity(capture_data_listener as *const u8, 1);
+    crate::closure::js_closure_set_capture_f64(data_closure, 0, stream);
+    let data = box_pointer(data_closure as *const u8);
+    let end_closure = js_closure_alloc(capture_end_listener as *const u8, 1);
+    crate::closure::js_register_closure_arity(capture_end_listener as *const u8, 0);
+    crate::closure::js_closure_set_capture_f64(end_closure, 0, stream);
+    let end = box_pointer(end_closure as *const u8);
+
+    let _ = js_node_stream_method_on(handle, string_value("close"), close);
+    let _ = js_node_stream_method_on(handle, string_value("data"), data);
+    let _ = js_node_stream_method_on(handle, string_value("end"), end);
+    let _ = js_node_stream_method_push(handle, string_value("a"));
+    let _ = js_node_stream_method_push(handle, f64::from_bits(TAG_NULL));
+    let _ = crate::promise::js_promise_run_microtasks();
+
+    READABLE_DATA_CAPTURED
+        .with(|captured| assert_eq!(captured.borrow().as_slice(), &[b"a".to_vec()]));
+    READABLE_END_COUNT.with(|count| assert_eq!(*count.borrow(), 1));
+    assert_eq!(js_node_stream_method_destroyed(handle).to_bits(), TAG_FALSE);
+    assert_eq!(js_node_stream_method_closed(handle).to_bits(), TAG_FALSE);
+    WRITABLE_CLOSE_COUNT.with(|count| assert_eq!(*count.borrow(), 0));
+}
+
+#[test]
 fn stream_destroy_with_error_marks_errored_state() {
     let stream = js_node_stream_readable_new(f64::from_bits(TAG_UNDEFINED));
     let destroy = js_object_get_field_by_name_f64(


### PR DESCRIPTION
## Summary
- Track `emitClose` on classic stream instances and suppress `close` events when it is `false` while still marking destroyed streams closed.
- Stop closing readable-only streams after `end` when `autoDestroy: false`.
- Add focused runtime coverage for both lifecycle option branches.

## Validation
- `cargo test -p perry-runtime readable_emit_close_false_suppresses_destroy_close_event`
- `cargo test -p perry-runtime readable_auto_destroy_false_does_not_close_after_end`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream --filter emit-close-false'`\n- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream --filter options-autoDestroy-explicit'`\n- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream --filter auto-destroy'`\n- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream --filter close'`