### PR TITLE
[codex] parse Function directive lookalikes as scripts

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -69,18 +69,19 @@ pub(crate) fn try_const_fold_function_construct(
     };
 
     let synth = format!("(function ({params_src}) {{\n{body_src}\n}});\n");
-    let module = perry_parser::parse_typescript(&synth, "<new Function body>").map_err(|e| {
-        anyhow::Error::new(LowerError::new(
-            format!(
-                "`{}` body is not valid JavaScript and cannot be compiled: {} \
+    let module =
+        perry_parser::parse_typescript(&synth, "<new Function body>.cjs").map_err(|e| {
+            anyhow::Error::new(LowerError::new(
+                format!(
+                    "`{}` body is not valid JavaScript and cannot be compiled: {} \
                  (#1679)\n  body: {:?}",
-                surface.label(),
-                e,
-                body_src,
-            ),
-            span,
-        ))
-    })?;
+                    surface.label(),
+                    e,
+                    body_src,
+                ),
+                span,
+            ))
+        })?;
 
     let fn_expr = extract_fn_expr(&module).ok_or_else(|| {
         anyhow::Error::new(LowerError::new(

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -446,6 +446,30 @@ fn module_strictness_uses_raw_directive_tokens() {
 }
 
 #[test]
+fn function_constructor_lookalike_directives_parse_as_sloppy_script_bodies() {
+    let module = lower_js_src(
+        r#"
+        const doubledSpace = Function("\"use  strict\"; var public = 1; return public;");
+        const escapedSpace = new Function("\"use\\x20strict\"; var yield = 2; return yield;");
+        const interrupted = new Function("var interface = 3; \"use strict\"; return interface;");
+        "#,
+    );
+
+    assert!(matches!(
+        top_level_init(&module, "doubledSpace"),
+        Expr::Closure { .. }
+    ));
+    assert!(matches!(
+        top_level_init(&module, "escapedSpace"),
+        Expr::Closure { .. }
+    ));
+    assert!(matches!(
+        top_level_init(&module, "interrupted"),
+        Expr::Closure { .. }
+    ));
+}
+
+#[test]
 fn sloppy_js_yield_identifier_arrow_parameters_lower() {
     let module = lower_js_src(
         r#"

--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -677,6 +677,32 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_js_lookalike_directives_keep_function_body_sloppy() {
+        let source = r#"
+            function doubledSpace() {
+                "use  strict";
+                var public = 1;
+                return public;
+            }
+            function escapedSpace() {
+                "use\x20strict";
+                var yield = 2;
+                return yield;
+            }
+            function interrupted() {
+                var interface = 3;
+                "use strict";
+                return interface;
+            }
+        "#;
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(source, "test.js", &mut cache).unwrap();
+
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
     fn test_parse_js_sloppy_escaped_contextual_identifiers() {
         let source = r#"
             var imp\u006Cements = 1;

--- a/test-parity/node-suite/globals/strict-directive/function-constructor-lookalikes.ts
+++ b/test-parity/node-suite/globals/strict-directive/function-constructor-lookalikes.ts
@@ -1,0 +1,15 @@
+// @ts-nocheck
+
+function show(label, value) {
+  console.log(label + ":" + String(value));
+}
+
+const doubledSpace = Function('"use  strict"; var public = 1; return public;');
+const uppercase = Function('"USE STRICT"; var package = 2; return package;');
+const escapedSpace = new Function('"use\\x20strict"; var yield = 3; return yield;');
+const interrupted = new Function('var interface = 4; "use strict"; return interface;');
+
+show("function doubled-space reserved", doubledSpace());
+show("function uppercase reserved", uppercase());
+show("new function escaped reserved", escapedSpace());
+show("new function interrupted reserved", interrupted());


### PR DESCRIPTION
## Summary

- Parse synthesized `Function(...)` / `new Function(...)` bodies with a `.cjs` parser identity so they use JS script semantics, independent of the repo/package ESM context.
- Add parser and HIR regressions for directive lookalikes (`"use  strict"`, `"use\x20strict"`, uppercase, interrupted prologue) followed by strict-only reserved identifiers.
- Add a node-suite fixture covering Function-constructor lookalike directive bodies.

## Linked Issues

- Refs #3570

## Why This Cut

This is the remaining parser/frontend tail after raw directive recognition landed in HIR. Direct `.js` parser input already accepts sloppy lookalikes; the failing path was Perry's synthesized Function-constructor parse, which used an extensionless filename and therefore went through module/strict parsing under package ESM contexts.

## Tests

- `cargo fmt --check`
- `cargo test -p perry-parser test_parse_js_lookalike_directives_keep_function_body_sloppy -- --nocapture`
- `cargo test -p perry-hir --test c262_parity function_constructor_lookalike_directives_parse_as_sloppy_script_bodies -- --nocapture`
- `cargo test -p perry-hir --test c262_parity strict -- --nocapture`
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/strict-directive/function-constructor-lookalikes.ts`

## Notes

I attempted the filtered node-suite harness for `strict-directive`, but it could not complete in this workspace because a concurrent release build held Cargo's global package cache/target locks. The focused Rust regression reproduces the pre-fix compile failure on `Function("\"use  strict\"; var public = 1; ...")` and passes with this change.

## Non-Goals

- Changing exact strict directive SyntaxError timing for AOT-folded `Function(...)` bodies.
- Broad runtime `eval(...)` semantics or unrelated strict-mode assignment/declaration behavior.
