### PR TITLE
[codex] unskip sqlite inventory known failure

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -44,12 +44,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
   },
-  "test_parity_sqlite": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_stream": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary

- Remove the stale `test_parity_sqlite` entry from `test-parity/known_failures.json`.
- Leave sqlite runtime code, granular sqlite fixtures, and the parity matrix baseline unchanged.

## Linked Issues

- Closes #4387

## Why This Cut

#4387 records that the top-level `test_parity_sqlite` inventory probe and its split sqlite parity fixtures now pass on Node 26.3.0. This PR removes only the known-failure gate entry so future regressions in that inventory smoke are visible again.

## Tests

- `jq empty test-parity/known_failures.json`
- `jq 'has("test_parity_sqlite")' test-parity/known_failures.json` -> `false`\n- `python3 -m json.tool test-parity/known_failures.json >/tmp/perry_known_failures_check.json`\n- `git diff --check`\n\n## Notes\n\nI attempted to rerun the exact sqlite parity filter from #4387 in this workspace, but a separate long-running sqlite-enabled runtime archive build prevented the harness from reaching a fresh summary during this turn. The issue body has the full green Node 26.3.0 run for the same command and filter.\n\n## Non-Goals\n\n- SQLite runtime behavior changes.\n- Other module-inventory known-failure entries.\n- `test-parity/parity_matrix_baseline.json` changes.\n