### PR TITLE
[codex] add Effect advisory package smoke

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1033,6 +1033,58 @@ jobs:
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
+  # effect-basic-smoke: runs the tier-3 release fixture
+  # `tests/release/packages/effect-basic/` as the CI counterpart to #802.
+  #
+  # This is intentionally advisory: #802 asks for a live Effect compile/run
+  # signal even while broader Effect end-to-end compatibility remains in
+  # progress. Gated to tag pushes + opt-in, matching the named package smokes.
+  # ---------------------------------------------------------------------------
+  effect-basic-smoke:
+    continue-on-error: true
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_extended_tests) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-extended-tests'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-perry"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Build perry compiler
+        run: cargo build --release -p perry-runtime -p perry-stdlib -p perry
+
+      - name: Run Effect fixture
+        run: |
+          cd tests/release/packages/effect-basic
+          PERRY_EFFECT_BASIC_ADVISORY=1 PERRY_BIN="$GITHUB_WORKSPACE/target/release/perry" bash fixture.sh
+
+      - name: Upload Effect fixture logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: effect-basic-smoke-logs
+          path: |
+            tests/release/packages/effect-basic/install.log
+            tests/release/packages/effect-basic/perry-compile.log
+            tests/release/packages/effect-basic/perry-run.log
+            tests/release/packages/effect-basic/perry-out.txt
+            tests/release/packages/effect-basic/diff.log
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
   # Doc-example tests: compile + run every .ts under docs/examples/.
   # UI examples launch with PERRY_UI_TEST_MODE=1 so they auto-exit after one
   # frame. Gallery screenshots are diffed against per-OS baselines (advisory

--- a/tests/release/packages/README.md
+++ b/tests/release/packages/README.md
@@ -74,8 +74,11 @@ PERRY_TEST_SUMMARY_OUT=/tmp/x.json _harness.sh       # emit JSON summary
 The harness defines its own pass/fail/skip totals; downstream consumers
 (release_sweep tier 3) only care about the JSON summary.
 
-The `ink-link-smoke` fixture also has a named CI job in
-`.github/workflows/test.yml`. It runs on release tags, on manual dispatch with
-`run_extended_tests=true`, and on PRs with the `run-extended-tests` label. That
+The `effect-basic` and `ink-link-smoke` fixtures also have named CI jobs in
+`.github/workflows/test.yml`. They run on release tags, on manual dispatch with
+`run_extended_tests=true`, and on PRs with the `run-extended-tests` label. The
+Effect job opts into a currently advisory compile/run signal with
+`PERRY_EFFECT_BASIC_ADVISORY=1`; the default tier-3 sweep records it as SKIP so
+known Effect end-to-end gaps do not block unrelated package releases. The Ink
 job intentionally stops at compile/link plus symbol inspection; end-to-end Ink
 rendering remains tracked separately from the release fixture contract.

--- a/tests/release/packages/effect-basic/entry.ts
+++ b/tests/release/packages/effect-basic/entry.ts
@@ -1,0 +1,26 @@
+import { Effect } from "effect";
+
+const mapped = Effect.succeed(21).pipe(
+    Effect.map((value: number) => value * 2),
+);
+
+const program = Effect.gen(function* () {
+    const label = yield* Effect.succeed("effect");
+    const value = yield* mapped;
+    return `${label}:${value}`;
+});
+
+async function main() {
+    const asyncResult = await Effect.runPromise(program);
+    const syncResult = Effect.runSync(
+        Effect.succeed("sync").pipe(Effect.map((value: string) => `${value}:ok`)),
+    );
+
+    console.log(`runPromise=${asyncResult}`);
+    console.log(`runSync=${syncResult}`);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/tests/release/packages/effect-basic/expected.txt
+++ b/tests/release/packages/effect-basic/expected.txt
@@ -1,0 +1,2 @@
+runPromise=effect:42
+runSync=sync:ok

--- a/tests/release/packages/effect-basic/fixture.sh
+++ b/tests/release/packages/effect-basic/fixture.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")"
+. "$(dirname "$0")/../_fixture_lib.sh"
+
+NAME="effect-basic"
+
+if [[ "${1:-}" == "--__did-skip-marker" ]]; then
+    exit 1
+fi
+
+if [[ "${PERRY_EFFECT_BASIC_ADVISORY:-0}" != "1" ]]; then
+    fixture_skip "$NAME" "advisory #802 signal; set PERRY_EFFECT_BASIC_ADVISORY=1 to compile/run"
+fi
+
+fixture_setup "$NAME" || exit 1
+fixture_compile_run_diff "$NAME"

--- a/tests/release/packages/effect-basic/package-lock.json
+++ b/tests/release/packages/effect-basic/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "perry-release-fixture-effect-basic",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "perry-release-fixture-effect-basic",
+      "version": "0.0.0",
+      "dependencies": {
+        "effect": "3.21.2"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/effect": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
+      "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
+    }
+  }
+}

--- a/tests/release/packages/effect-basic/package.json
+++ b/tests/release/packages/effect-basic/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "perry-release-fixture-effect-basic",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tier-3 fixture: canonical Effect compile/run smoke for issue #802.",
+  "dependencies": {
+    "effect": "3.21.2"
+  },
+  "perry": {
+    "compilePackages": ["effect"],
+    "allow": {
+      "compilePackages": ["effect"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add an effect-basic release-package fixture pinned to effect 3.21.2 with a canonical succeed/map/gen program and runPromise/runSync execution.
- Keep the default tier-3 package harness non-blocking by recording the fixture as SKIP unless PERRY_EFFECT_BASIC_ADVISORY=1 is set.
- Add an opt-in, continue-on-error effect-basic-smoke job for release tags, manual extended runs, and PRs labeled run-extended-tests.

Closes #802.

## Validation
- Node 26 --experimental-strip-types entry.ts output matches expected.txt.
- PERRY_BIN=/root/perry-worktrees/perry-node-timers-promises-validation/target/release/perry ./tests/release/packages/_harness.sh --filter effect-basic exits 0 with one skipped fixture and zero failures.
- PERRY_EFFECT_BASIC_ADVISORY=1 with the same Perry binary compiles entry.ts, then fails at runtime with TypeError: Cannot read properties of undefined (reading prototype), which is the current live Effect signal.
- python3 YAML parse for .github/workflows/test.yml.
- jq empty on the fixture package files.
- bash -n tests/release/packages/effect-basic/fixture.sh.
- git diff --check.
- ./scripts/check_file_size.sh.