### PR TITLE
test(parity): unskip sqlite inventory

### DIFF
--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -44,12 +44,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:net` socket-layer surface not implemented (Server/Socket classes, BlockList, SocketAddress). Classification helpers landed via #811. Tracker for surface coverage; flips to PASS as each API lands."
   },
-  "test_parity_sqlite": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:sqlite` (Node 22.5+ built-in) surface not implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_stream": {
     "issue": "793",
     "added": "2026-05-15",


### PR DESCRIPTION
## Summary
- remove the stale `test_parity_sqlite` known-failure entry
- keep the existing SQLite parity fixtures active now that the Node 26 surface passes cleanly

Fixes #4387.

## Validation
- `jq empty test-parity/known_failures.json`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/http2-refused npm exec --yes --package=node@26 -- bash -lc 'node --version; ./run_parity_tests.sh --suite parity --filter test_parity_sqlite'`
  - Node `v26.3.0`
  - Parity Pass: 8 / Fail 0 / Compile Fail 0 / Skipped 0
