### PR TITLE
fix(runtime): typed-array own-property fallback shadows secret-key buffer metadata (#4363 regression)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2099,7 +2099,15 @@ pub extern "C" fn js_object_get_field_by_name(
                 }
             }
         }
-        return JSValue::undefined();
+        // #4363 regression fix: a secret-key Uint8Array (KeyObject backing
+        // buffer) exposes `type` / `symmetricKeySize` / `asymmetricKey*`
+        // through the KeyObject metadata block later in this function. The
+        // typed-array own-property fallback must not shadow those with
+        // `undefined` — fall through for a secret-key buffer so the metadata
+        // block resolves them. Plain typed arrays keep the `undefined` result.
+        if !crate::buffer::is_secret_key(addr) {
+            return JSValue::undefined();
+        }
     }
     // #2128: a plain JS number value (a finite double or canonical NaN —
     // anything `JSValue::is_number` returns true for *minus* the raw-I64


### PR DESCRIPTION
## Summary

**Main regression fix.** `#4363` (typed array own properties) added a typed-array own-property block at the top of `js_object_get_field_by_name` that, for a `Uint8Array`-backed buffer, **`return JSValue::undefined()`** for any key it doesn't recognize. A `KeyObject`'s secret-key backing buffer *is* a Uint8Array, so its `type` / `symmetricKeySize` / `asymmetricKey*` metadata — resolved by the KeyObject block later in the same function — was shadowed and read back as `undefined`.

This is a **deterministic failure on `main` HEAD** (bisected to #4363): the unit test `object::field_get_set::buffer_ic_miss_tests::secret_key_buffer_metadata_survives_ic_miss_for_aes_sizes` fails, which fails the `cargo-test` gate on **every** open PR.

```
# on main (and #4363's parent passes):
test ...secret_key_buffer_metadata_survives_ic_miss_for_aes_sizes ... FAILED
panicked at field_get_set.rs: assertion `left == right` failed   (type read back as undefined, not "secret")
```

## Fix

Fall through to the KeyObject metadata block for a secret-key buffer instead of returning the typed-array `undefined` fallback. Plain typed arrays are unchanged (still return `undefined` for unknown keys).

## Validation

`cargo test --release -p perry-runtime --lib`: **979 passed, 0 failed** (was 979 passed, 1 failed). The AES test passes both alone and in the full suite.

Found while diagnosing why an unrelated PR's `cargo-test` was red — the failure was this pre-existing main regression, not that PR.
