### PR TITLE
fix(release): build Apple cross-libs on the arm64 mac job only (v0.5.1121)

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -284,7 +284,13 @@ jobs:
       # suffix so the bottle can ship both side-by-side. tvOS/visionOS/
       # watchOS are Tier-3 (need nightly + -Zbuild-std) and out of scope.
       - name: Build iOS cross-compile libraries (macOS)
-        if: runner.os == 'macOS'
+        # Only on the arm64 mac job. These iOS/Apple cross-libs are aarch64 and
+        # identical regardless of host, so building them on the x86_64 mac runner
+        # is redundant — and the macos-15 x86_64 runner fails `libsqlite3-sys`
+        # bindgen on the iOS target (libclang/SDK env). The macOS staging step
+        # copies these libs only `if [ -f ]`, so the x86_64 bottle degrades
+        # gracefully; the arm64 bottle + the build-cross tarballs still ship them.
+        if: runner.os == 'macOS' && matrix.target == 'aarch64-apple-darwin'
         run: |
           for triple in aarch64-apple-ios aarch64-apple-ios-sim; do
             cargo build --release --target "$triple" -p perry-runtime
@@ -303,7 +309,8 @@ jobs:
       # `apple_class_lib_name` already maps each `--target` to the correct
       # variant (covered by the `handles_other_class_suffixes` unit test).
       - name: Build tvOS/visionOS/watchOS cross-compile libraries (macOS)
-        if: runner.os == 'macOS'
+        # arm64 mac job only — same rationale as the iOS step above.
+        if: runner.os == 'macOS' && matrix.target == 'aarch64-apple-darwin'
         run: |
           set -e
           # Format: "<platform>:<device-triple>:<sim-triple>"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1121 — fix(release): build Apple cross-libs on the arm64 mac job only (unblocks npm/brew/apt/winget publish)
+
+v0.5.1120 fixed the gtk4 + android build-matrix breakage (both verified green on the real toolchains) and published 34 assets, but `release-packages` still concluded failure and skipped the package-manager publish legs (`npm-publish`/`homebrew`/`apt`/`winget`, which `needs: build` = every primary build). The lone remaining failure was `build (macos-15, x86_64-apple-darwin)`: its "Build iOS cross-compile libraries (macOS)" step panicked in `libsqlite3-sys` build.rs — `could not run bindgen on header sqlite3/sqlite3.h` — a libclang/SDK issue on the macos-15 x86_64 runner. The macos-14 arm64 runner built the identical iOS aarch64 libs fine; the failure was masked in earlier releases by the build matrix's (now-removed) fail-fast.
+
+Fix: gate the "Build iOS cross-compile libraries (macOS)" and "Build tvOS/visionOS/watchOS cross-compile libraries (macOS)" steps to `matrix.target == 'aarch64-apple-darwin'`. These Apple cross-libs are aarch64 and host-independent, so building them on the x86_64 mac job was pure redundancy. The macOS staging step copies them only `if [ -f ]`, so the x86_64 (Intel) bottle degrades gracefully — the arm64 bottle and the standalone `build-cross` `perry-cross-aarch64-apple-*` tarballs still ship every Apple cross-lib.
+
 ## v0.5.1120 — fix(release): unblock the publish build matrix (gtk4 + android cross-host UI crates)
 
 v0.5.1117 fixed the `await-tests` gate (publishing resumed after ~90 dark versions) but `release-packages` still concluded failure and skipped npm/brew/apt/winget — a second, separate breakage in the **cross-host UI crates**, which `cargo-test` excludes (so no PR CI catches them):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1120
+**Current Version:** 0.5.1121
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "base64",
@@ -5252,14 +5252,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "cc",
  "libc",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "base64",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "serde",
  "serde_json",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1120"
+version = "0.5.1121"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "clap",
@@ -5402,14 +5402,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5492,7 +5492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5508,14 +5508,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5532,7 +5532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "bytes",
  "h2",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5588,7 +5588,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5607,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "bson",
  "futures-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5676,7 +5676,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5693,7 +5693,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "image",
@@ -5702,14 +5702,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5748,7 +5748,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "brotli",
  "flate2",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "base64",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5932,14 +5932,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "itoa",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "block2",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "block2",
@@ -6020,7 +6020,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1120"
+version = "0.5.1121"
 
 [[package]]
 name = "perry-ui-test"
@@ -6028,11 +6028,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1120"
+version = "0.5.1121"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "block2",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "block2",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "block2",
  "libc",
@@ -6077,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "libc",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1120"
+version = "0.5.1121"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1120"
+version = "0.5.1121"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
v0.5.1120 published 34 assets but skipped npm/brew/apt/winget — the only failing build was macos-15 x86_64, whose iOS-cross step panicked in libsqlite3-sys bindgen (libclang/SDK issue on that runner). The Apple cross-libs are aarch64/host-independent and already built on the arm64 mac job, so gate the iOS + tvOS/visionOS cross-compile steps to matrix.target == 'aarch64-apple-darwin'. macOS staging copies them only if present, so the Intel bottle degrades gracefully. YAML-only + version bump. See CHANGELOG v0.5.1121.