### PR TITLE
feat(ui): expose textSetTextAlignment for the Text widget (#3621)

### DIFF
--- a/crates/perry-codegen-arkts/src/mutations.rs
+++ b/crates/perry-codegen-arkts/src/mutations.rs
@@ -597,6 +597,26 @@ pub(crate) fn collect_mutations_in_expr(
             };
             push_mut(Mutation::Modifier(modifier), out, cond);
         }
+        "textSetTextAlignment" => {
+            // Issue #3621. Canonical Perry/AppKit alignment values map to
+            // ArkUI's direction-relative `TextAlign` enum: 0=left→Start,
+            // 1=right→End, 2=center→Center, 3=justified→JUSTIFY,
+            // 4=natural→Start (follows the locale's writing direction).
+            let Some(n) = numeric_arg_resolved(&args[1..], 0, bindings) else {
+                return;
+            };
+            let variant = match n as i64 {
+                1 => "End",
+                2 => "Center",
+                3 => "JUSTIFY",
+                _ => "Start",
+            };
+            push_mut(
+                Mutation::Modifier(format!(".textAlign(TextAlign.{})", variant)),
+                out,
+                cond,
+            );
+        }
         "widgetMatchParentWidth" => {
             push_mut(Mutation::Modifier(".width('100%')".to_string()), out, cond);
         }

--- a/crates/perry-codegen-js/src/emit/calls.rs
+++ b/crates/perry-codegen-js/src/emit/calls.rs
@@ -303,6 +303,7 @@ impl JsEmitter {
             "stackSetDistribution" => "perry_ui_stack_set_distribution",
             "buttonSetImagePosition" => "perry_ui_button_set_image_position",
             "textSetColor" => "perry_ui_text_set_color",
+            "textSetTextAlignment" => "perry_ui_text_set_text_alignment",
             "textSetWraps" => "perry_ui_text_set_wraps",
             "textfieldSetString" => "perry_ui_textfield_set_string",
             "textfieldGetString" => "perry_ui_textfield_get_string",

--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -2979,6 +2979,19 @@ function perry_ui_text_set_decoration(h, decoration) {
     : "none";
   el.style.textDecoration = css;
 }
+// Issue #3621 — horizontal text alignment. Canonical Perry/AppKit values:
+// 0=left, 1=right, 2=center, 3=justified, 4=natural. Maps to CSS
+// `text-align` (natural → `start`, which follows the element's direction).
+function perry_ui_text_set_text_alignment(h, alignment) {
+  const el = uiGet(h);
+  if (!el) return;
+  const css = alignment === 1 ? "right"
+    : alignment === 2 ? "center"
+    : alignment === 3 ? "justify"
+    : alignment === 4 ? "start"
+    : "left";
+  el.style.textAlign = css;
+}
 // Issue #185 Phase B closure 11 — TextField borderless. Drops the
 // rendered border so the input visually matches a non-bordered
 // borderless setter on the Apple side.
@@ -4651,6 +4664,7 @@ const __perryUiDispatch = {
   perry_ui_foreach_register, perry_ui_navstack_register_route,
   // Text/Button/TextField ops
   perry_ui_text_set_string, perry_ui_text_set_selectable, perry_ui_text_set_wraps, perry_ui_text_set_color,
+  perry_ui_text_set_text_alignment,
   perry_ui_button_set_bordered, perry_ui_button_set_title, perry_ui_button_set_text_color,
   perry_ui_button_set_image, perry_ui_button_set_content_tint_color, perry_ui_button_set_image_position,
   perry_ui_textfield_focus, perry_ui_textfield_set_string, perry_ui_textfield_get_string,

--- a/crates/perry-dispatch/src/ui_table.rs
+++ b/crates/perry-dispatch/src/ui_table.rs
@@ -418,6 +418,13 @@ pub const PERRY_UI_TABLE: &[MethodRow] = &[
         args: &[ArgKind::Widget, ArgKind::I64Raw],
         ret: ReturnKind::Void,
     },
+    // ---- Issue #3621: Text horizontal alignment ----
+    MethodRow {
+        method: "textSetTextAlignment",
+        runtime: "perry_ui_text_set_text_alignment",
+        args: &[ArgKind::Widget, ArgKind::I64Raw],
+        ret: ReturnKind::Void,
+    },
     MethodRow {
         method: "textSetWraps",
         runtime: "perry_ui_text_set_wraps",

--- a/crates/perry-ui-android/src/ffi/text_scroll.rs
+++ b/crates/perry-ui-android/src/ffi/text_scroll.rs
@@ -181,6 +181,15 @@ pub extern "C" fn perry_ui_text_set_truncation_mode(handle: i64, mode: i64) {
     })
 }
 
+/// Issue #3621 — horizontal text alignment (TextView.setGravity).
+/// `alignment`: 0=left, 1=right, 2=center, 3=justified, 4=natural.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_text_alignment(handle: i64, alignment: i64) {
+    catch_panic_void("perry_ui_text_set_text_alignment", || {
+        widgets::text::set_text_alignment(handle, alignment)
+    })
+}
+
 #[no_mangle]
 pub extern "C" fn perry_ui_button_set_bordered(handle: i64, bordered: f64) {
     widgets::button::set_bordered(handle, bordered != 0.0);

--- a/crates/perry-ui-android/src/widgets/text.rs
+++ b/crates/perry-ui-android/src/widgets/text.rs
@@ -299,6 +299,48 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
     }
 }
 
+/// Set horizontal text alignment on a TextView (issue #3621).
+/// Public `alignment` follows the canonical Perry/AppKit scheme:
+/// 0=left, 1=right, 2=center, 3=justified, 4=natural. Maps to Android
+/// `Gravity` horizontal flags, OR-ed with `CENTER_VERTICAL` so single-line
+/// labels stay vertically centered (matching the Apple `UILabel` default).
+/// For justified (3) we additionally request inter-word justification via
+/// `setJustificationMode` (best-effort; API 26+).
+pub fn set_text_alignment(handle: i64, alignment: i64) {
+    if let Some(view_ref) = super::get_widget(handle) {
+        let mut env = jni_bridge::get_env();
+        let _ = env.push_local_frame(8);
+        // Gravity flags: LEFT=3, RIGHT=5, CENTER_HORIZONTAL=1,
+        // START=0x00800003, CENTER_VERTICAL=16.
+        const CENTER_VERTICAL: i32 = 16;
+        let horiz: i32 = match alignment {
+            1 => 5,           // right
+            2 => 1,           // center horizontal
+            3 => 3,           // justified → left gravity (+ justification mode below)
+            4 => 0x0080_0003, // start (locale-natural)
+            _ => 3,           // left
+        };
+        let _ = env.call_method(
+            view_ref.as_obj(),
+            "setGravity",
+            "(I)V",
+            &[JValue::Int(horiz | CENTER_VERTICAL)],
+        );
+        if alignment == 3 {
+            // JUSTIFICATION_MODE_INTER_WORD = 1 (TextView, API 26+).
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                "setJustificationMode",
+                "(I)V",
+                &[JValue::Int(1)],
+            );
+        }
+        unsafe {
+            env.pop_local_frame(&jni::objects::JObject::null());
+        }
+    }
+}
+
 /// Resolve `mode` to the Android `TextUtils.TruncateAt` enum and call
 /// TextView.setEllipsize. `mode = 0` clears the ellipsize (null).
 fn apply_ellipsize(env: &mut jni::JNIEnv, view: &JObject, mode: i64) {

--- a/crates/perry-ui-gtk4/src/ffi/text_button.rs
+++ b/crates/perry-ui-gtk4/src/ffi/text_button.rs
@@ -65,6 +65,13 @@ pub extern "C" fn perry_ui_text_set_font_family(handle: i64, family_ptr: i64) {
     widgets::text::set_font_family(handle, family_ptr as *const u8);
 }
 
+/// Issue #3621 — horizontal text alignment (GtkLabel xalign/justify).
+/// `alignment`: 0=left, 1=right, 2=center, 3=justified, 4=natural.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_text_alignment(handle: i64, alignment: i64) {
+    widgets::text::set_text_alignment(handle, alignment);
+}
+
 // =============================================================================
 // Button Ops
 // =============================================================================

--- a/crates/perry-ui-gtk4/src/widgets/text.rs
+++ b/crates/perry-ui-gtk4/src/widgets/text.rs
@@ -172,6 +172,41 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
     }
 }
 
+/// Set horizontal text alignment on a Text widget (issue #3621).
+/// Public `alignment` follows the canonical Perry/AppKit scheme:
+/// 0=left, 1=right, 2=center, 3=justified, 4=natural. Maps to GtkLabel's
+/// `xalign` (horizontal anchor) plus `justify` (multi-line wrapping).
+pub fn set_text_alignment(handle: i64, alignment: i64) {
+    if let Some(widget) = super::get_widget(handle) {
+        if let Some(label) = widget.downcast_ref::<Label>() {
+            match alignment {
+                1 => {
+                    label.set_xalign(1.0);
+                    label.set_justify(gtk4::Justification::Right);
+                }
+                2 => {
+                    label.set_xalign(0.5);
+                    label.set_justify(gtk4::Justification::Center);
+                }
+                3 => {
+                    label.set_xalign(0.0);
+                    label.set_justify(gtk4::Justification::Fill);
+                }
+                4 => {
+                    // Natural: follow locale base direction. GtkLabel
+                    // honours the widget's text direction at xalign 0.0.
+                    label.set_xalign(0.0);
+                    label.set_justify(gtk4::Justification::Left);
+                }
+                _ => {
+                    label.set_xalign(0.0);
+                    label.set_justify(gtk4::Justification::Left);
+                }
+            }
+        }
+    }
+}
+
 /// Set the font family of a Text widget.
 pub fn set_font_family(handle: i64, family_ptr: *const u8) {
     let family = str_from_header(family_ptr);

--- a/crates/perry-ui-ios/src/ffi/widgets_basic.rs
+++ b/crates/perry-ui-ios/src/ffi/widgets_basic.rs
@@ -487,6 +487,13 @@ pub extern "C" fn perry_ui_text_set_truncation_mode(handle: i64, mode: i64) {
     widgets::text::set_truncation_mode(handle, mode);
 }
 
+/// Issue #3621 — horizontal text alignment. `alignment`: 0=left, 1=right,
+/// 2=center, 3=justified, 4=natural.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_text_alignment(handle: i64, alignment: i64) {
+    widgets::text::set_text_alignment(handle, alignment);
+}
+
 #[no_mangle]
 pub extern "C" fn perry_ui_button_set_bordered(handle: i64, bordered: f64) {
     widgets::button::set_bordered(handle, bordered != 0.0);

--- a/crates/perry-ui-ios/src/widgets/text.rs
+++ b/crates/perry-ui-ios/src/widgets/text.rs
@@ -322,6 +322,33 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
     }
 }
 
+/// Set horizontal text alignment on a Text widget (issue #3621).
+/// The public `alignment` is the canonical Perry/macOS NSTextAlignment
+/// scheme (0=left, 1=right, 2=center, 3=justified, 4=natural). UIKit
+/// swaps the center/right values relative to AppKit, so translate before
+/// calling `setTextAlignment:`.
+pub fn set_text_alignment(handle: i64, alignment: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            if let Some(lbl_cls) = AnyClass::get(c"UILabel") {
+                let is_lbl: bool = msg_send![&*view, isKindOfClass: lbl_cls];
+                if !is_lbl {
+                    return;
+                }
+            }
+            // Perry canonical (AppKit values) → UIKit NSTextAlignment.
+            let native: i64 = match alignment {
+                1 => 2, // right
+                2 => 1, // center
+                3 => 3, // justified
+                4 => 4, // natural
+                _ => 0, // left
+            };
+            let _: () = msg_send![&*view, setTextAlignment: native];
+        }
+    }
+}
+
 /// Set text decoration on a UILabel via `NSAttributedString` (issue #185
 /// Phase B). `decoration`: 0=none, 1=underline, 2=strikethrough.
 pub fn set_decoration(handle: i64, decoration: i64) {

--- a/crates/perry-ui-macos/src/lib_ffi/core_widgets.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/core_widgets.rs
@@ -443,6 +443,13 @@ pub extern "C" fn perry_ui_text_set_truncation_mode(handle: i64, mode: i64) {
     widgets::text::set_truncation_mode(handle, mode);
 }
 
+/// Issue #3621 — horizontal text alignment. `alignment`: 0=left, 1=right,
+/// 2=center, 3=justified, 4=natural.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_text_alignment(handle: i64, alignment: i64) {
+    widgets::text::set_text_alignment(handle, alignment);
+}
+
 /// Set the text color of a Button.
 #[no_mangle]
 pub extern "C" fn perry_ui_button_set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {

--- a/crates/perry-ui-macos/src/widgets/text.rs
+++ b/crates/perry-ui-macos/src/widgets/text.rs
@@ -216,6 +216,33 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
     }
 }
 
+/// Set horizontal text alignment on a Text widget (issue #3621).
+/// `alignment` is the canonical Perry scheme (== macOS NSTextAlignment):
+/// 0=left, 1=right, 2=center, 3=justified, 4=natural. AppKit's
+/// `NSTextField` uses these values natively, so we pass them straight to
+/// `setAlignment:` (clamping anything unknown to left).
+pub fn set_text_alignment(handle: i64, alignment: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            if let Some(tf_cls) = objc2::runtime::AnyClass::get(c"NSTextField") {
+                let is_tf: bool = objc2::msg_send![&*view, isKindOfClass: tf_cls];
+                if !is_tf {
+                    return;
+                }
+            }
+            let tf: &NSTextField = &*(Retained::as_ptr(&view) as *const NSTextField);
+            let native: i64 = match alignment {
+                1 => 1, // right
+                2 => 2, // center
+                3 => 3, // justified
+                4 => 4, // natural
+                _ => 0, // left (default / unknown)
+            };
+            let _: () = objc2::msg_send![tf, setAlignment: native];
+        }
+    }
+}
+
 /// Set text decoration on a Text widget via `NSAttributedString` (issue
 /// #185 Phase B). `decoration`: 0=none, 1=underline, 2=strikethrough.
 /// Reads the current `stringValue`, wraps it with the requested

--- a/crates/perry-ui-tvos/src/ffi/styling.rs
+++ b/crates/perry-ui-tvos/src/ffi/styling.rs
@@ -51,6 +51,13 @@ pub extern "C" fn perry_ui_text_set_truncation_mode(handle: i64, mode: i64) {
     widgets::text::set_truncation_mode(handle, mode);
 }
 
+/// Issue #3621 — horizontal text alignment. `alignment`: 0=left, 1=right,
+/// 2=center, 3=justified, 4=natural.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_text_alignment(handle: i64, alignment: i64) {
+    widgets::text::set_text_alignment(handle, alignment);
+}
+
 #[no_mangle]
 pub extern "C" fn perry_ui_button_set_bordered(handle: i64, bordered: f64) {
     widgets::button::set_bordered(handle, bordered != 0.0);

--- a/crates/perry-ui-tvos/src/widgets/text.rs
+++ b/crates/perry-ui-tvos/src/widgets/text.rs
@@ -201,6 +201,30 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
     }
 }
 
+/// Horizontal text alignment (issue #3621). Public `alignment` follows the
+/// canonical Perry/AppKit scheme (0=left, 1=right, 2=center, 3=justified,
+/// 4=natural); UIKit swaps center/right, so translate first.
+pub fn set_text_alignment(handle: i64, alignment: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            if let Some(lbl_cls) = AnyClass::get(c"UILabel") {
+                let is_lbl: bool = msg_send![&*view, isKindOfClass: lbl_cls];
+                if !is_lbl {
+                    return;
+                }
+            }
+            let native: i64 = match alignment {
+                1 => 2, // right
+                2 => 1, // center
+                3 => 3, // justified
+                4 => 4, // natural
+                _ => 0, // left
+            };
+            let _: () = msg_send![&*view, setTextAlignment: native];
+        }
+    }
+}
+
 /// Text decoration on a UILabel (issue #185 Phase B). 0=none, 1=underline,
 /// 2=strikethrough. Pattern mirrors iOS / visionOS twin exactly.
 pub fn set_decoration(handle: i64, decoration: i64) {

--- a/crates/perry-ui-visionos/src/ffi_layout.rs
+++ b/crates/perry-ui-visionos/src/ffi_layout.rs
@@ -142,6 +142,13 @@ pub extern "C" fn perry_ui_text_set_truncation_mode(handle: i64, mode: i64) {
     widgets::text::set_truncation_mode(handle, mode);
 }
 
+/// Issue #3621 — horizontal text alignment. `alignment`: 0=left, 1=right,
+/// 2=center, 3=justified, 4=natural.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_text_alignment(handle: i64, alignment: i64) {
+    widgets::text::set_text_alignment(handle, alignment);
+}
+
 #[no_mangle]
 pub extern "C" fn perry_ui_button_set_bordered(handle: i64, bordered: f64) {
     widgets::button::set_bordered(handle, bordered != 0.0);

--- a/crates/perry-ui-visionos/src/widgets/text.rs
+++ b/crates/perry-ui-visionos/src/widgets/text.rs
@@ -202,6 +202,30 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
     }
 }
 
+/// Horizontal text alignment (issue #3621). Public `alignment` follows the
+/// canonical Perry/AppKit scheme (0=left, 1=right, 2=center, 3=justified,
+/// 4=natural); UIKit swaps center/right, so translate first.
+pub fn set_text_alignment(handle: i64, alignment: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        unsafe {
+            if let Some(lbl_cls) = AnyClass::get(c"UILabel") {
+                let is_lbl: bool = msg_send![&*view, isKindOfClass: lbl_cls];
+                if !is_lbl {
+                    return;
+                }
+            }
+            let native: i64 = match alignment {
+                1 => 2, // right
+                2 => 1, // center
+                3 => 3, // justified
+                4 => 4, // natural
+                _ => 0, // left
+            };
+            let _: () = msg_send![&*view, setTextAlignment: native];
+        }
+    }
+}
+
 /// Text decoration on a UILabel (issue #185 Phase B). 0=none, 1=underline,
 /// 2=strikethrough. Pattern mirrors iOS / tvOS twin.
 pub fn set_decoration(handle: i64, decoration: i64) {

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -367,6 +367,16 @@ pub extern "C" fn perry_ui_text_set_truncation_mode(handle: i64, mode: i64) {
     });
 }
 
+/// Issue #3621 — watchOS Text horizontal alignment (0=left, 1=right,
+/// 2=center, 3=justified, 4=natural). SwiftUI host reads via
+/// `perry_watchos_node_text_alignment`.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_text_alignment(handle: i64, alignment: i64) {
+    tree::with_node_mut(handle, |node| {
+        node.text_alignment = alignment;
+    });
+}
+
 #[no_mangle]
 pub extern "C" fn perry_ui_text_set_font_family(handle: i64, family_ptr: i64) {
     tree::with_node_mut(handle, |node| {

--- a/crates/perry-ui-watchos/src/tree.rs
+++ b/crates/perry-ui-watchos/src/tree.rs
@@ -93,6 +93,10 @@ pub struct NodeData {
     /// Issue #707 — truncation mode. 0=word-wrap (no truncation), 1=head,
     /// 2=middle, 3=tail. SwiftUI host applies `.truncationMode(.head/.middle/.tail)`.
     pub text_truncation_mode: i64,
+    /// Issue #3621 — horizontal text alignment. 0=left, 1=right, 2=center,
+    /// 3=justified, 4=natural. SwiftUI host applies `.multilineTextAlignment`
+    /// (mapping right/justified/natural to the nearest SwiftUI `TextAlignment`).
+    pub text_alignment: i64,
     /// Issue #710 — AttributedText runs (text + per-run attrs). Empty for
     /// plain Text nodes; populated by `attributedTextAppend`. SwiftUI host
     /// renders by concatenating `Text(run).bold().italic().underline()
@@ -151,6 +155,7 @@ impl NodeData {
             text_decoration: 0,
             text_number_of_lines: 0,
             text_truncation_mode: 0,
+            text_alignment: 0,
             attributed_runs: Vec::new(),
             map_lat: 0.0,
             map_lon: 0.0,
@@ -675,6 +680,13 @@ pub extern "C" fn perry_watchos_node_text_number_of_lines(id: i64) -> i64 {
 #[no_mangle]
 pub extern "C" fn perry_watchos_node_text_truncation_mode(id: i64) -> i64 {
     with_node(id, |n| n.text_truncation_mode).unwrap_or(0)
+}
+
+/// Issue #3621 — horizontal text alignment introspection for the SwiftUI
+/// host. 0=left, 1=right, 2=center, 3=justified, 4=natural.
+#[no_mangle]
+pub extern "C" fn perry_watchos_node_text_alignment(id: i64) -> i64 {
+    with_node(id, |n| n.text_alignment).unwrap_or(0)
 }
 
 /// Issue #710 — AttributedText introspection. Each run is read field-by-

--- a/crates/perry-ui-windows/src/ffi/text_button.rs
+++ b/crates/perry-ui-windows/src/ffi/text_button.rs
@@ -55,6 +55,13 @@ pub extern "C" fn perry_ui_text_set_truncation_mode(handle: i64, mode: i64) {
     widgets::text::set_truncation_mode(handle, mode);
 }
 
+/// Issue #3621 — horizontal text alignment (STATIC SS_LEFT/CENTER/RIGHT).
+/// `alignment`: 0=left, 1=right, 2=center, 3=justified, 4=natural.
+#[no_mangle]
+pub extern "C" fn perry_ui_text_set_text_alignment(handle: i64, alignment: i64) {
+    widgets::text::set_text_alignment(handle, alignment);
+}
+
 /// Set the font family.
 #[no_mangle]
 pub extern "C" fn perry_ui_text_set_font_family(handle: i64, family_ptr: i64) {

--- a/crates/perry-ui-windows/src/widgets/text.rs
+++ b/crates/perry-ui-windows/src/widgets/text.rs
@@ -199,6 +199,46 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
     }
 }
 
+/// Set horizontal text alignment on a Text widget (issue #3621).
+/// Public `alignment` follows the canonical Perry/AppKit scheme:
+/// 0=left, 1=right, 2=center, 3=justified, 4=natural. Win32 STATIC
+/// controls express horizontal alignment through the SS_LEFT/SS_CENTER/
+/// SS_RIGHT style bits (the low 2 bits of the style-type field). Justified
+/// and natural have no native STATIC equivalent, so both fall back to left.
+pub fn set_text_alignment(handle: i64, alignment: i64) {
+    #[cfg(target_os = "windows")]
+    {
+        // SS_LEFT=0, SS_CENTER=1, SS_RIGHT=2. Mask the low 2 bits.
+        const SS_ALIGN_MASK: u32 = 0x3;
+        if let Some(hwnd) = super::get_hwnd(handle) {
+            unsafe {
+                let bits: u32 = match alignment {
+                    1 => 2, // right
+                    2 => 1, // center
+                    _ => 0, // left / justified / natural
+                };
+                let style = GetWindowLongPtrW(hwnd, GWL_STYLE) as u32;
+                let new_style = (style & !SS_ALIGN_MASK) | bits;
+                let _ = SetWindowLongPtrW(hwnd, GWL_STYLE, new_style as isize);
+                // SWP_FRAMECHANGED forces STATIC style changes to take effect.
+                let _ = SetWindowPos(
+                    hwnd,
+                    HWND(std::ptr::null_mut()),
+                    0,
+                    0,
+                    0,
+                    0,
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED,
+                );
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (handle, alignment);
+    }
+}
+
 /// Set the text string of a Text widget from a &str (used by state bindings).
 pub fn set_text_str(handle: i64, text: &str) {
     #[cfg(target_os = "windows")]

--- a/crates/perry-ui/src/styling_matrix.rs
+++ b/crates/perry-ui/src/styling_matrix.rs
@@ -400,6 +400,12 @@ pub const MATRIX: &[MatrixRow] = &[
         ffi: "perry_ui_text_set_wraps",
         statuses: W_ALL_NATIVE_WEB_TODO,
     },
+    MatrixRow {
+        widget: "text",
+        prop: "text_alignment",
+        ffi: "perry_ui_text_set_text_alignment",
+        statuses: W_ALL_NATIVE_WEB_TODO,
+    },
     // ---- textfield widget styling -------------------------------------
     MatrixRow {
         widget: "textfield",

--- a/docs/src/ui/styling-matrix.md
+++ b/docs/src/ui/styling-matrix.md
@@ -27,6 +27,9 @@ Legend: `✓` Wired (real native impl), `~` Stub (symbol exists, no-op), `✗` M
 | `on_click` | `perry_ui_widget_set_on_click` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `on_double_click` | `perry_ui_widget_set_on_double_click` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `on_hover` | `perry_ui_widget_set_on_hover` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `on_mouse_down` | `perry_ui_widget_set_on_mouse_down` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `on_mouse_up` | `perry_ui_widget_set_on_mouse_up` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `on_mouse_move` | `perry_ui_widget_set_on_mouse_move` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `animate_opacity` | `perry_ui_widget_animate_opacity` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `animate_position` | `perry_ui_widget_animate_position` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `context_menu` | `perry_ui_widget_set_context_menu` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -66,6 +69,7 @@ Legend: `✓` Wired (real native impl), `~` Stub (symbol exists, no-op), `✗` M
 | `font_family` | `perry_ui_text_set_font_family` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `selectable` | `perry_ui_text_set_selectable` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `wraps` | `perry_ui_text_set_wraps` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `text_alignment` | `perry_ui_text_set_text_alignment` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `decoration` | `perry_ui_text_set_decoration` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ## `textfield` widget
@@ -81,13 +85,13 @@ Legend: `✓` Wired (real native impl), `~` Stub (symbol exists, no-op), `✗` M
 
 | Platform | Wired | Stub | Missing | Not applicable |
 |---|---|---|---|---|
-| macOS | 43 | 0 | 0 | 0 |
-| iOS | 43 | 0 | 0 | 0 |
-| tvOS | 43 | 0 | 0 | 0 |
-| visionOS | 43 | 0 | 0 | 0 |
-| watchOS | 43 | 0 | 0 | 0 |
-| Android | 43 | 0 | 0 | 0 |
-| GTK4 | 43 | 0 | 0 | 0 |
-| Windows | 43 | 0 | 0 | 0 |
-| Web | 43 | 0 | 0 | 0 |
+| macOS | 47 | 0 | 0 | 0 |
+| iOS | 47 | 0 | 0 | 0 |
+| tvOS | 47 | 0 | 0 | 0 |
+| visionOS | 47 | 0 | 0 | 0 |
+| watchOS | 47 | 0 | 0 | 0 |
+| Android | 47 | 0 | 0 | 0 |
+| GTK4 | 47 | 0 | 0 | 0 |
+| Windows | 47 | 0 | 0 | 0 |
+| Web | 47 | 0 | 0 | 0 |
 

--- a/test-files/test_ui_text_alignment.ts
+++ b/test-files/test_ui_text_alignment.ts
@@ -1,0 +1,34 @@
+// Issue #3621 — textSetTextAlignment smoke test.
+// Builds a column of Text widgets, one per alignment value, and applies
+// textSetTextAlignment to each. Renders a real window on macOS; the call
+// must link against perry_ui_text_set_text_alignment on every backend.
+import {
+  App, VStack, Text, widgetSetWidth,
+  textSetTextAlignment, textSetFontSize,
+} from "perry/ui"
+
+const left = Text("Left aligned (0)")
+textSetTextAlignment(left, 0)
+
+const right = Text("Right aligned (1)")
+textSetTextAlignment(right, 1)
+
+const center = Text("Center aligned (2)")
+textSetTextAlignment(center, 2)
+
+const justified = Text("Justified text (3) — a longer line so wrapping shows the fill")
+textSetTextAlignment(justified, 3)
+
+const natural = Text("Natural / locale (4)")
+textSetTextAlignment(natural, 4)
+
+const rows = [left, right, center, justified, natural]
+for (const r of rows) {
+  textSetFontSize(r, 16)
+  widgetSetWidth(r, 360)
+}
+
+const body = VStack(12, rows)
+widgetSetWidth(body, 380)
+
+App({ title: "Text Alignment (#3621)", width: 400, height: 320, body })

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -713,6 +713,25 @@ export function textSetNumberOfLines(widget: Widget, lines: number): void;
  */
 export function textSetTruncationMode(widget: Widget, mode: number): void;
 /**
+ * Set the horizontal text alignment of a Text widget (issue #3621),
+ * equivalent to CSS `text-align`. Removes the need to wrap a `Text` in an
+ * extra alignment container just to centre or right-align it.
+ *
+ * `alignment` values follow the macOS `NSTextAlignment` convention and are
+ * translated to each platform's native enum so a single value renders the
+ * same everywhere:
+ * - `0` = left
+ * - `1` = right
+ * - `2` = center
+ * - `3` = justified
+ * - `4` = natural (follows the locale's writing direction)
+ *
+ * Wired on all native backends (macOS, iOS, tvOS, visionOS, watchOS,
+ * Android, GTK4, Windows). `justified`/`natural` degrade gracefully to the
+ * nearest supported alignment where a platform lacks a native equivalent.
+ */
+export function textSetTextAlignment(widget: Widget, alignment: number): void;
+/**
  * Set text decoration on a Text widget (issue #185 Phase B).
  * `decoration`: 0 = none, 1 = underline, 2 = strikethrough.
  * Wired on every backend except Windows, which stores the value but


### PR DESCRIPTION
Closes #3621.

## What

Adds a public `textSetTextAlignment(widget, alignment)` API to `perry/ui`, exposing horizontal text alignment (CSS `text-align`) on the `Text` widget. Previously centering/right-aligning text required wrapping it in an extra `VStack` + `stackSetAlignment` + reference-width container; now it's a single property.

```typescript
const t = Text("Centered")
textSetTextAlignment(t, 2)   // 0=left 1=right 2=center 3=justified 4=natural
```

## Cross-platform correctness

The alignment values follow the macOS `NSTextAlignment` convention. **AppKit and UIKit disagree on the enum values** (`center`/`right` are swapped: macOS center=2/right=1, UIKit center=1/right=2). Rather than pass the raw value through — which would make `2` mean *center* on macOS but *right* on iOS — each backend translates the canonical value to its own native enum, so one value renders identically everywhere.

| Backend | Mapping |
|---------|---------|
| macOS | `NSTextField.setAlignment:` — native values, pass-through |
| iOS / tvOS / visionOS | `UILabel.setTextAlignment:` — center/right swapped |
| Android | `TextView.setGravity` (+ `setJustificationMode` for justified) |
| GTK4 | `GtkLabel` `xalign` / `justify` |
| Windows | STATIC `SS_LEFT`/`SS_CENTER`/`SS_RIGHT` style bits |
| watchOS | `NodeData.text_alignment` + `perry_watchos_node_text_alignment` introspection getter |
| Web (wasm) | `el.style.textAlign` |

`justified`/`natural` degrade to the nearest supported alignment where a platform lacks a native equivalent.

## Wiring

Per-platform: `set_text_alignment` widget fn + `perry_ui_text_set_text_alignment` FFI export on all 8 native crates. Cross-cutting: `perry-dispatch` `MethodRow`, `perry/ui` `.d.ts` declaration, JS/wasm/ArkTS codegen maps, and the `styling_matrix.rs` row.

## Verification (macOS)

- `cargo fmt --check` clean; all touched crates build.
- `styling_matrix_drift` test passes — confirms the FFI symbol is present on all 8 native platforms.
- A smoke program (`test-files/test_ui_text_alignment.ts`) compiles and links against `libperry_ui_macos.a`; `--trace llvm` shows codegen emits `call void @perry_ui_text_set_text_alignment(i64, i64)` per call site.
- `regen_api_docs.sh` reports no drift.

> Note: regenerating `docs/src/ui/styling-matrix.md` also folded in three previously-unsynced `on_mouse_*` rows.