### PR TITLE
[codex] Add deterministic Atomics.waitAsync

### DIFF
--- a/crates/perry-codegen/src/lower_call/atomics.rs
+++ b/crates/perry-codegen/src/lower_call/atomics.rs
@@ -40,6 +40,7 @@ pub fn try_lower_atomics_static_call(
         "compareExchange" => ("js_atomics_compare_exchange", 4),
         "notify" => ("js_atomics_notify", 3),
         "wait" => ("js_atomics_wait", 4),
+        "waitAsync" => ("js_atomics_wait_async", 4),
         _ => return Ok(None),
     };
 

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1570,6 +1570,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
         DOUBLE,
         &[PTR, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
+    module.declare_function(
+        "js_atomics_wait_async",
+        DOUBLE,
+        &[PTR, DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
 
     // ========== Number ==========
     module.declare_function("js_number_is_finite", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -314,6 +314,7 @@ pub(crate) fn is_builtin_static_function_member(namespace: &str, member: &str) -
                 | "compareExchange"
                 | "notify"
                 | "wait"
+                | "waitAsync"
         ),
         "WebAssembly" => matches!(
             member,
@@ -434,6 +435,7 @@ pub(crate) fn builtin_static_function_length(namespace: &str, member: &str) -> O
             "compareExchange" => 4,
             "notify" => 3,
             "wait" => 4,
+            "waitAsync" => 4,
             _ => return None,
         },
         "WebAssembly" => match member {

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -282,6 +282,7 @@ pub(crate) fn is_known_atomics_static_method(name: &str) -> bool {
             | "compareExchange"
             | "notify"
             | "wait"
+            | "waitAsync"
     )
 }
 

--- a/crates/perry-runtime/src/atomics.rs
+++ b/crates/perry-runtime/src/atomics.rs
@@ -17,6 +17,10 @@ fn string_value(bytes: &[u8]) -> f64 {
     crate::value::js_nanbox_string(ptr as i64)
 }
 
+fn object_key(bytes: &[u8]) -> *const crate::StringHeader {
+    crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+}
+
 fn throw_type_error(message: &[u8]) -> ! {
     let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = crate::error::js_typeerror_new(msg);
@@ -371,6 +375,33 @@ fn int32_slot(view: f64, index: f64) -> (AtomicView, i32) {
     (view, idx)
 }
 
+fn wait_async_result(async_value: bool, value: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj = crate::object::js_object_alloc(0, 2);
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    let value_handle = scope.root_nanbox_f64(value);
+
+    let async_key = object_key(b"async");
+    let async_key_handle = scope.root_string_ptr(async_key);
+    crate::object::js_object_set_field_by_name(
+        obj_handle.get_raw_mut_ptr(),
+        async_key_handle.get_raw_const_ptr(),
+        nanbox_bool(async_value),
+    );
+
+    let value_key = object_key(b"value");
+    let value_key_handle = scope.root_string_ptr(value_key);
+    crate::object::js_object_set_field_by_name(
+        obj_handle.get_raw_mut_ptr(),
+        value_key_handle.get_raw_const_ptr(),
+        value_handle.get_nanbox_f64(),
+    );
+
+    crate::value::js_nanbox_pointer(
+        obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>() as i64
+    )
+}
+
 fn atomics_bitwise(view: f64, index: f64, value: f64, op: impl FnOnce(u64, u64) -> u64) -> f64 {
     let (view, idx) = slot(view, index);
     if view.is_bigint() {
@@ -571,4 +602,28 @@ pub extern "C" fn js_atomics_wait(
 
     let _ = number_arg(timeout);
     string_value(b"timed-out")
+}
+
+#[no_mangle]
+pub extern "C" fn js_atomics_wait_async(
+    _closure: *const ClosureHeader,
+    view: f64,
+    index: f64,
+    expected: f64,
+    timeout: f64,
+) -> f64 {
+    let (view, idx) = int32_slot(view, index);
+    let expected = coerce_for_kind(KIND_INT32, expected);
+    let timeout = number_arg(timeout);
+    if view.get_numeric(idx) != expected {
+        return wait_async_result(false, string_value(b"not-equal"));
+    }
+    if timeout <= 0.0 {
+        return wait_async_result(false, string_value(b"timed-out"));
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let timed_out = scope.root_nanbox_f64(string_value(b"timed-out"));
+    let promise = crate::promise::js_promise_resolved(timed_out.get_nanbox_f64());
+    wait_async_result(true, crate::value::js_nanbox_pointer(promise as i64))
 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3602,6 +3602,11 @@ fn install_atomics_namespace_members(ns_obj: *mut ObjectHeader) {
         ),
         ("notify", crate::atomics::js_atomics_notify as *const u8, 3),
         ("wait", crate::atomics::js_atomics_wait as *const u8, 4),
+        (
+            "waitAsync",
+            crate::atomics::js_atomics_wait_async as *const u8,
+            4,
+        ),
     ] {
         install_proto_method(ns_obj, name, func_ptr, arity);
     }

--- a/test-parity/node-suite/globals/atomics-wait-async.ts
+++ b/test-parity/node-suite/globals/atomics-wait-async.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+function show(label, value) {
+  console.log(label + ":" + String(value));
+}
+
+function showErr(label, fn) {
+  try {
+    fn();
+    show(label, "ok");
+  } catch (err) {
+    show(label, err.name);
+  }
+}
+
+const sab = new SharedArrayBuffer(8);
+const i32 = new Int32Array(sab, 0, 2);
+
+show("typeof waitAsync", typeof Atomics.waitAsync);
+show("waitAsync length", Atomics.waitAsync.length);
+
+const mismatch = Atomics.waitAsync(i32, 0, 1, 0);
+show("mismatch keys", Object.keys(mismatch).join("|"));
+show("mismatch async", mismatch.async);
+show("mismatch value", mismatch.value);
+
+const zero = Atomics.waitAsync(i32, 0, 0, 0);
+show("zero async", zero.async);
+show("zero value", zero.value);
+
+const negative = Atomics.waitAsync(i32, 0, 0, -1);
+show("negative async", negative.async);
+show("negative value", negative.value);
+
+showErr("waitAsync uint8 shared", () => Atomics.waitAsync(new Uint8Array(sab, 0, 8), 0, 0, 0));
+showErr("waitAsync oob", () => Atomics.waitAsync(i32, 99, 0, 0));


### PR DESCRIPTION
## Summary

Adds a deterministic `Atomics.waitAsync` slice for Int32 typed-array views:

- exposes `Atomics.waitAsync` on the Atomics namespace with `.length === 4`
- wires direct static-call lowering to a new `js_atomics_wait_async` runtime entry point
- returns Node-compatible immediate result objects for nonblocking cases:
  - `{ async: false, value: "not-equal" }` when the stored value does not match
  - `{ async: false, value: "timed-out" }` for zero/negative timeout
- adds focused Node-suite parity coverage for method metadata, result shape/key order, immediate values, and receiver/index validation

This is a scoped follow-up for #2876. Full waiter queues, notify wake scheduling, delayed timeout settlement, and BigInt waitAsync behavior remain out of scope.

## Validation

- Node oracle: `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/atomics-wait-async.ts`
- Pre-fix focused parity reproduced the gap: Perry reported `typeof waitAsync:undefined` in `test-parity/reports/parity_report_20260604_134002.json`
- Focused parity after rebasing onto `origin/main`: `PERRY_NO_CACHE=1 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/atomics-waitasync npm exec --yes --package=node@26 -- ./run_parity_tests.sh --suite node-suite --module globals --filter atomics-wait-async` PASS, report `test-parity/reports/parity_report_20260604_140356.json`
- Broader Atomics filter: `--filter atomics` passed the new `atomics-wait-async` fixture; existing `atomics-wait-notify` remains a receiver-constructor mismatch, report `test-parity/reports/parity_report_20260604_140721.json`
- `CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/atomics-waitasync cargo check --release -p perry-runtime -p perry-codegen -p perry-hir`
- `rustfmt --edition 2021 --check crates/perry-runtime/src/atomics.rs crates/perry-runtime/src/object/global_this.rs crates/perry-codegen/src/lower_call/atomics.rs crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs crates/perry-hir/src/analysis/builtins.rs crates/perry-hir/src/lower/array_fold.rs`
- `git diff --check HEAD~1..HEAD`
- `./scripts/check_file_size.sh`