### PR TITLE
fix(node): implement WebCrypto ML-KEM encapsulation

### DIFF
--- a/crates/perry-stdlib/src/webcrypto/encapsulation.rs
+++ b/crates/perry-stdlib/src/webcrypto/encapsulation.rs
@@ -1,4 +1,6 @@
-use super::util::*;
+use super::*;
+use ml_kem::kem::Decapsulate;
+use rand::RngCore;
 
 unsafe fn reject_type_error_with_code(message: &str, code: &'static str) -> *mut Promise {
     let msg = perry_runtime::js_string_from_bytes(message.as_ptr(), message.len() as u32);
@@ -19,31 +21,369 @@ unsafe fn reject_unsupported_algorithm() -> *mut Promise {
     reject_with_dom_exception("NotSupportedError", "Unrecognized algorithm name")
 }
 
-unsafe fn encapsulation_stub(method: &str, required: usize, args_len: usize) -> *mut Promise {
+unsafe fn check_required_args(
+    method: &str,
+    required: usize,
+    args_len: usize,
+) -> Option<*mut Promise> {
     if args_len < required {
-        return reject_missing_args(method, required, args_len);
+        return Some(reject_missing_args(method, required, args_len));
     }
-    reject_unsupported_algorithm()
+    None
 }
 
-pub unsafe fn js_webcrypto_encapsulate_bits(
-    _args_ptr: *const f64,
-    args_len: usize,
+unsafe fn nth_arg(args_ptr: *const f64, args_len: usize, index: usize) -> f64 {
+    if args_ptr.is_null() || index >= args_len {
+        f64::from_bits(JSValue::undefined().bits())
+    } else {
+        *args_ptr.add(index)
+    }
+}
+
+fn ml_kem_encapsulate(algo: KeyAlgo, public_der: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    let public_bytes = ml_kem_public_bytes_from_der(algo, public_der)?;
+    let mut random = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut random);
+    let m = ml_kem::B32::try_from(random.as_slice()).ok()?;
+    match algo {
+        KeyAlgo::MlKem512 => {
+            let public =
+                ml_kem::Key::<ml_kem::EncapsulationKey512>::try_from(public_bytes.as_slice())
+                    .ok()?;
+            let key = ml_kem::EncapsulationKey512::new(&public).ok()?;
+            let (ciphertext, shared) = key.encapsulate_deterministic(&m);
+            Some((ciphertext.as_slice().to_vec(), shared.as_slice().to_vec()))
+        }
+        KeyAlgo::MlKem768 => {
+            let public =
+                ml_kem::Key::<ml_kem::EncapsulationKey768>::try_from(public_bytes.as_slice())
+                    .ok()?;
+            let key = ml_kem::EncapsulationKey768::new(&public).ok()?;
+            let (ciphertext, shared) = key.encapsulate_deterministic(&m);
+            Some((ciphertext.as_slice().to_vec(), shared.as_slice().to_vec()))
+        }
+        KeyAlgo::MlKem1024 => {
+            let public =
+                ml_kem::Key::<ml_kem::EncapsulationKey1024>::try_from(public_bytes.as_slice())
+                    .ok()?;
+            let key = ml_kem::EncapsulationKey1024::new(&public).ok()?;
+            let (ciphertext, shared) = key.encapsulate_deterministic(&m);
+            Some((ciphertext.as_slice().to_vec(), shared.as_slice().to_vec()))
+        }
+        _ => None,
+    }
+}
+
+fn ml_kem_decapsulate(algo: KeyAlgo, private_der: &[u8], ciphertext: &[u8]) -> Option<Vec<u8>> {
+    let (seed_bytes, _) = ml_kem_private_seed_and_public_from_der(algo, private_der)?;
+    let seed = ml_kem::Seed::try_from(seed_bytes.as_slice()).ok()?;
+    match algo {
+        KeyAlgo::MlKem512 => {
+            let private = ml_kem::DecapsulationKey512::from_seed(seed);
+            let ct: ml_kem::ml_kem_512::Ciphertext = ciphertext.try_into().ok()?;
+            Some(private.decapsulate(&ct).as_slice().to_vec())
+        }
+        KeyAlgo::MlKem768 => {
+            let private = ml_kem::DecapsulationKey768::from_seed(seed);
+            let ct: ml_kem::ml_kem_768::Ciphertext = ciphertext.try_into().ok()?;
+            Some(private.decapsulate(&ct).as_slice().to_vec())
+        }
+        KeyAlgo::MlKem1024 => {
+            let private = ml_kem::DecapsulationKey1024::from_seed(seed);
+            let ct: ml_kem::ml_kem_1024::Ciphertext = ciphertext.try_into().ok()?;
+            Some(private.decapsulate(&ct).as_slice().to_vec())
+        }
+        _ => None,
+    }
+}
+
+unsafe fn ml_kem_algo_arg(algo_bits: u64) -> Result<KeyAlgo, *mut Promise> {
+    let Some(name) = extract_algo_name(algo_bits) else {
+        return Err(reject_unsupported_algorithm());
+    };
+    ml_kem_key_algo_from_name(&name.to_ascii_uppercase())
+        .ok_or_else(|| reject_unsupported_algorithm())
+}
+
+unsafe fn key_material_arg(
+    key_bits: u64,
+    algo: KeyAlgo,
+    expected_kind: KeyKind,
+    usage: u32,
+    usage_message: &'static str,
+    invalid_type_message: &'static str,
+) -> Result<Vec<u8>, *mut Promise> {
+    let key_addr = strip_ptr(key_bits);
+    let Some(mat) = lookup_crypto_key(key_addr) else {
+        return Err(reject_type_error_with_code(
+            invalid_type_message,
+            "ERR_INVALID_ARG_TYPE",
+        ));
+    };
+    if mat.algo != algo {
+        return Err(reject_with_dom_exception(
+            "InvalidAccessError",
+            "key algorithm mismatch",
+        ));
+    }
+    if mat.kind != expected_kind {
+        return Err(reject_with_dom_exception(
+            "InvalidAccessError",
+            "The requested operation is not valid for the provided key",
+        ));
+    }
+    if let Err((name, message)) = require_usage(mat, usage, usage_message) {
+        return Err(reject_with_dom_exception(name, message));
+    }
+    Ok(bytes_from_jsvalue(key_bits))
+}
+
+unsafe fn object_with_two_buffers(
+    first_name: &[u8],
+    first_bytes: &[u8],
+    second_name: &[u8],
+    second_bytes: &[u8],
 ) -> *mut Promise {
-    encapsulation_stub("encapsulateBits", 2, args_len)
+    let first = alloc_uint8array_from_slice(first_bytes);
+    let second = alloc_uint8array_from_slice(second_bytes);
+    if first.is_null() || second.is_null() {
+        return reject_with_dom_exception("OperationError", "The operation failed");
+    }
+    let obj = js_object_alloc(0, 2);
+    if obj.is_null() {
+        return reject_with_dom_exception("OperationError", "The operation failed");
+    }
+    let first_key =
+        perry_runtime::js_string_from_bytes(first_name.as_ptr(), first_name.len() as u32);
+    let second_key =
+        perry_runtime::js_string_from_bytes(second_name.as_ptr(), second_name.len() as u32);
+    js_object_set_field_by_name(
+        obj,
+        first_key,
+        f64::from_bits(JSValue::pointer(first as *const u8).bits()),
+    );
+    js_object_set_field_by_name(
+        obj,
+        second_key,
+        f64::from_bits(JSValue::pointer(second as *const u8).bits()),
+    );
+    resolve_with_bits(JSValue::pointer(obj as *const u8).bits())
 }
 
-pub unsafe fn js_webcrypto_decapsulate_bits(
-    _args_ptr: *const f64,
-    args_len: usize,
+unsafe fn import_shared_secret_key(
+    key_bytes: &[u8],
+    algo_bits: u64,
+    extractable_bits: u64,
+    usages_bits: u64,
+) -> Result<*mut BufferHeader, *mut Promise> {
+    let extractable = bool_from_jsvalue(extractable_bits);
+    let Some(name) = extract_algo_name(algo_bits) else {
+        return Err(reject_with_dom_exception(
+            "NotSupportedError",
+            "Unrecognized algorithm name",
+        ));
+    };
+    let (key_algo, hash) = match name.to_ascii_uppercase().as_str() {
+        "HMAC" => {
+            let hash = match extract_hmac_hash(algo_bits) {
+                Some(h) => h,
+                None => {
+                    return Err(reject_with_dom_exception(
+                        "OperationError",
+                        "The operation failed",
+                    ))
+                }
+            };
+            (KeyAlgo::Hmac, hash)
+        }
+        "AES-GCM" => (KeyAlgo::AesGcm, HashAlgo::Sha256),
+        "AES-KW" => (KeyAlgo::AesKw, HashAlgo::Sha256),
+        "AES-CBC" => (KeyAlgo::AesCbc, HashAlgo::Sha256),
+        "AES-CTR" => (KeyAlgo::AesCtr, HashAlgo::Sha256),
+        "AES-OCB" => (KeyAlgo::AesOcb, HashAlgo::Sha256),
+        _ => {
+            return Err(reject_with_dom_exception(
+                "OperationError",
+                "The operation failed",
+            ))
+        }
+    };
+    let usages = match validate_key_usages(
+        key_algo,
+        KeyKind::Secret,
+        usages_bits,
+        false,
+        "Usages cannot be empty when importing a secret key.",
+        "Unsupported key usage for the requested algorithm",
+    ) {
+        Ok(u) => u,
+        Err((name, message)) => return Err(reject_with_dom_exception(name, message)),
+    };
+    let buf = alloc_uint8array_from_slice(key_bytes);
+    if buf.is_null() {
+        return Err(reject_with_dom_exception(
+            "OperationError",
+            "The operation failed",
+        ));
+    }
+    register_crypto_key(
+        buf as usize,
+        CryptoKeyMaterial::new(key_algo, hash, KeyKind::Secret, extractable, usages),
+    );
+    Ok(buf)
+}
+
+unsafe fn object_with_ciphertext_and_key(
+    ciphertext: &[u8],
+    key: *mut BufferHeader,
 ) -> *mut Promise {
-    encapsulation_stub("decapsulateBits", 3, args_len)
+    let ciphertext_buf = alloc_uint8array_from_slice(ciphertext);
+    if ciphertext_buf.is_null() || key.is_null() {
+        return reject_with_dom_exception("OperationError", "The operation failed");
+    }
+    let obj = js_object_alloc(0, 2);
+    if obj.is_null() {
+        return reject_with_dom_exception("OperationError", "The operation failed");
+    }
+    let ciphertext_key = perry_runtime::js_string_from_bytes(b"ciphertext".as_ptr(), 10);
+    let shared_key = perry_runtime::js_string_from_bytes(b"sharedKey".as_ptr(), 9);
+    js_object_set_field_by_name(
+        obj,
+        ciphertext_key,
+        f64::from_bits(JSValue::pointer(ciphertext_buf as *const u8).bits()),
+    );
+    js_object_set_field_by_name(
+        obj,
+        shared_key,
+        f64::from_bits(JSValue::pointer(key as *const u8).bits()),
+    );
+    resolve_with_bits(JSValue::pointer(obj as *const u8).bits())
 }
 
-pub unsafe fn js_webcrypto_encapsulate_key(_args_ptr: *const f64, args_len: usize) -> *mut Promise {
-    encapsulation_stub("encapsulateKey", 5, args_len)
+pub unsafe fn js_webcrypto_encapsulate_bits(args_ptr: *const f64, args_len: usize) -> *mut Promise {
+    if let Some(promise) = check_required_args("encapsulateBits", 2, args_len) {
+        return promise;
+    }
+    let algo = match ml_kem_algo_arg(nth_arg(args_ptr, args_len, 0).to_bits()) {
+        Ok(algo) => algo,
+        Err(promise) => return promise,
+    };
+    let public_bits = nth_arg(args_ptr, args_len, 1).to_bits();
+    let public_bytes = match key_material_arg(
+        public_bits,
+        algo,
+        KeyKind::Public,
+        USAGE_ENCAPSULATE_BITS,
+        "encapsulationKey does not have encapsulateBits usage",
+        "Failed to execute 'encapsulateBits' on 'SubtleCrypto': 2nd argument is not of type CryptoKey.",
+    ) {
+        Ok(bytes) => bytes,
+        Err(promise) => return promise,
+    };
+    let (ciphertext, shared) = match ml_kem_encapsulate(algo, &public_bytes) {
+        Some(result) => result,
+        None => return reject_with_dom_exception("OperationError", "The operation failed"),
+    };
+    object_with_two_buffers(b"sharedKey", &shared, b"ciphertext", &ciphertext)
 }
 
-pub unsafe fn js_webcrypto_decapsulate_key(_args_ptr: *const f64, args_len: usize) -> *mut Promise {
-    encapsulation_stub("decapsulateKey", 6, args_len)
+pub unsafe fn js_webcrypto_decapsulate_bits(args_ptr: *const f64, args_len: usize) -> *mut Promise {
+    if let Some(promise) = check_required_args("decapsulateBits", 3, args_len) {
+        return promise;
+    }
+    let algo = match ml_kem_algo_arg(nth_arg(args_ptr, args_len, 0).to_bits()) {
+        Ok(algo) => algo,
+        Err(promise) => return promise,
+    };
+    let private_bits = nth_arg(args_ptr, args_len, 1).to_bits();
+    let private_bytes = match key_material_arg(
+        private_bits,
+        algo,
+        KeyKind::Private,
+        USAGE_DECAPSULATE_BITS,
+        "decapsulationKey does not have decapsulateBits usage",
+        "Failed to execute 'decapsulateBits' on 'SubtleCrypto': 2nd argument is not of type CryptoKey.",
+    ) {
+        Ok(bytes) => bytes,
+        Err(promise) => return promise,
+    };
+    let ciphertext = bytes_from_jsvalue(nth_arg(args_ptr, args_len, 2).to_bits());
+    let shared = match ml_kem_decapsulate(algo, &private_bytes, &ciphertext) {
+        Some(shared) => shared,
+        None => return reject_with_dom_exception("OperationError", "The operation failed"),
+    };
+    resolve_with_bytes(&shared)
+}
+
+pub unsafe fn js_webcrypto_encapsulate_key(args_ptr: *const f64, args_len: usize) -> *mut Promise {
+    if let Some(promise) = check_required_args("encapsulateKey", 5, args_len) {
+        return promise;
+    }
+    let algo = match ml_kem_algo_arg(nth_arg(args_ptr, args_len, 0).to_bits()) {
+        Ok(algo) => algo,
+        Err(promise) => return promise,
+    };
+    let public_bits = nth_arg(args_ptr, args_len, 1).to_bits();
+    let public_bytes = match key_material_arg(
+        public_bits,
+        algo,
+        KeyKind::Public,
+        USAGE_ENCAPSULATE_KEY,
+        "encapsulationKey does not have encapsulateKey usage",
+        "Failed to execute 'encapsulateKey' on 'SubtleCrypto': 2nd argument is not of type CryptoKey.",
+    ) {
+        Ok(bytes) => bytes,
+        Err(promise) => return promise,
+    };
+    let (ciphertext, shared) = match ml_kem_encapsulate(algo, &public_bytes) {
+        Some(result) => result,
+        None => return reject_with_dom_exception("OperationError", "The operation failed"),
+    };
+    let shared_key = match import_shared_secret_key(
+        &shared,
+        nth_arg(args_ptr, args_len, 2).to_bits(),
+        nth_arg(args_ptr, args_len, 3).to_bits(),
+        nth_arg(args_ptr, args_len, 4).to_bits(),
+    ) {
+        Ok(key) => key,
+        Err(promise) => return promise,
+    };
+    object_with_ciphertext_and_key(&ciphertext, shared_key)
+}
+
+pub unsafe fn js_webcrypto_decapsulate_key(args_ptr: *const f64, args_len: usize) -> *mut Promise {
+    if let Some(promise) = check_required_args("decapsulateKey", 6, args_len) {
+        return promise;
+    }
+    let algo = match ml_kem_algo_arg(nth_arg(args_ptr, args_len, 0).to_bits()) {
+        Ok(algo) => algo,
+        Err(promise) => return promise,
+    };
+    let private_bits = nth_arg(args_ptr, args_len, 1).to_bits();
+    let private_bytes = match key_material_arg(
+        private_bits,
+        algo,
+        KeyKind::Private,
+        USAGE_DECAPSULATE_KEY,
+        "decapsulationKey does not have decapsulateKey usage",
+        "Failed to execute 'decapsulateKey' on 'SubtleCrypto': 2nd argument is not of type CryptoKey.",
+    ) {
+        Ok(bytes) => bytes,
+        Err(promise) => return promise,
+    };
+    let ciphertext = bytes_from_jsvalue(nth_arg(args_ptr, args_len, 2).to_bits());
+    let shared = match ml_kem_decapsulate(algo, &private_bytes, &ciphertext) {
+        Some(shared) => shared,
+        None => return reject_with_dom_exception("OperationError", "The operation failed"),
+    };
+    let shared_key = match import_shared_secret_key(
+        &shared,
+        nth_arg(args_ptr, args_len, 3).to_bits(),
+        nth_arg(args_ptr, args_len, 4).to_bits(),
+        nth_arg(args_ptr, args_len, 5).to_bits(),
+    ) {
+        Ok(key) => key,
+        Err(promise) => return promise,
+    };
+    resolve_with_bits(JSValue::pointer(shared_key as *const u8).bits())
 }

--- a/crates/perry-stdlib/src/webcrypto/supports.rs
+++ b/crates/perry-stdlib/src/webcrypto/supports.rs
@@ -126,6 +126,10 @@ pub unsafe extern "C" fn js_webcrypto_supports(
         "GENERATEKEY" => supports_generate_key(algorithm_bits.to_bits(), &algorithm),
         "IMPORTKEY" => supports_import_key(algorithm_bits.to_bits(), &algorithm),
         "EXPORTKEY" => supports_export_key(&algorithm),
+        "ENCAPSULATEBITS" | "DECAPSULATEBITS" => matches!(
+            algorithm.as_str(),
+            "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024"
+        ),
         _ => false,
     };
     js_bool(supported)

--- a/test-parity/node-suite/crypto/webcrypto/mlkem-encapsulation.ts
+++ b/test-parity/node-suite/crypto/webcrypto/mlkem-encapsulation.ts
@@ -1,0 +1,95 @@
+import { webcrypto } from "node:crypto";
+import { Buffer } from "node:buffer";
+
+(process as any).emitWarning = () => undefined;
+
+const subtle = webcrypto.subtle;
+const variants = [
+  ["ML-KEM-512", 768],
+  ["ML-KEM-768", 1088],
+  ["ML-KEM-1024", 1568],
+] as const;
+
+const sameBytes = (a: ArrayBuffer | Uint8Array, b: ArrayBuffer | Uint8Array) =>
+  Buffer.from(a).equals(Buffer.from(b));
+
+const rejectName = async (label: string, fn: () => Promise<unknown>) => {
+  try {
+    await fn();
+    console.log(`${label}: ok`);
+  } catch (error: any) {
+    console.log(`${label}:`, error.name);
+  }
+};
+
+for (const [algorithm, ciphertextLength] of variants) {
+  console.log(`algorithm: ${algorithm}`);
+  console.log("supports encapsulateBits:", SubtleCrypto.supports("encapsulateBits", algorithm));
+  console.log("supports decapsulateBits:", SubtleCrypto.supports("decapsulateBits", algorithm));
+  console.log("supports encapsulateKey:", SubtleCrypto.supports("encapsulateKey", algorithm));
+  console.log("supports decapsulateKey:", SubtleCrypto.supports("decapsulateKey", algorithm));
+
+  const pair = await subtle.generateKey(
+    { name: algorithm },
+    true,
+    ["encapsulateBits", "decapsulateBits", "encapsulateKey", "decapsulateKey"],
+  );
+
+  const bits = await (subtle as any).encapsulateBits(algorithm, pair.publicKey);
+  const recoveredBits = await (subtle as any).decapsulateBits(
+    algorithm,
+    pair.privateKey,
+    bits.ciphertext,
+  );
+  console.log(
+    "bits shape:",
+    Object.keys(bits).join("|"),
+    bits.sharedKey.byteLength,
+    bits.ciphertext.byteLength,
+    bits.ciphertext.byteLength === ciphertextLength,
+    sameBytes(recoveredBits, bits.sharedKey),
+  );
+
+  const keyResult = await (subtle as any).encapsulateKey(
+    algorithm,
+    pair.publicKey,
+    { name: "AES-GCM", length: 128 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+  const decapsulatedKey = await (subtle as any).decapsulateKey(
+    algorithm,
+    pair.privateKey,
+    keyResult.ciphertext,
+    { name: "AES-GCM", length: 128 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+  const encapsulatedRaw = await subtle.exportKey("raw", keyResult.sharedKey);
+  const decapsulatedRaw = await subtle.exportKey("raw", decapsulatedKey);
+  console.log(
+    "key shape:",
+    Object.keys(keyResult).join("|"),
+    keyResult.ciphertext.byteLength,
+    keyResult.ciphertext.byteLength === ciphertextLength,
+    (encapsulatedRaw as ArrayBuffer).byteLength,
+    (decapsulatedRaw as ArrayBuffer).byteLength,
+    sameBytes(encapsulatedRaw, decapsulatedRaw),
+  );
+
+  const noPublicUsage = await subtle.generateKey({ name: algorithm }, true, ["decapsulateBits"]);
+  const noPrivateUsage = await subtle.generateKey(
+    { name: algorithm },
+    true,
+    ["encapsulateBits", "decapsulateKey"],
+  );
+  await rejectName("encapsulate no usage", () =>
+    (subtle as any).encapsulateBits(algorithm, noPublicUsage.publicKey),
+  );
+  await rejectName("decapsulate no usage", () =>
+    (subtle as any).decapsulateBits(algorithm, noPrivateUsage.privateKey, bits.ciphertext),
+  );
+  await rejectName("bad ciphertext", () =>
+    (subtle as any).decapsulateBits(algorithm, pair.privateKey, new Uint8Array(7)),
+  );
+}

--- a/test-parity/node-suite/crypto/webcrypto/subtle-supports.ts
+++ b/test-parity/node-suite/crypto/webcrypto/subtle-supports.ts
@@ -60,6 +60,8 @@ for (const [label, op, algorithm] of [
   ["wrap aes ocb false", "wrapKey", "AES-OCB"],
   ["sign kmac false", "sign", "KMAC128"],
   ["derive x448 false", "deriveBits", "X448"],
+  ["encapsulateBits mlkem", "encapsulateBits", "ML-KEM-768"],
+  ["decapsulateBits mlkem", "decapsulateBits", "ML-KEM-768"],
   ["encapsulateKey mlkem false", "encapsulateKey", "ML-KEM-768"],
 ] as const) {
   console.log(`${label}:`, SubtleCrypto.supports(op, algorithm as any));


### PR DESCRIPTION
## Summary
- Implements WebCrypto ML-KEM encapsulation and decapsulation for ML-KEM-512, ML-KEM-768, and ML-KEM-1024.
- Adds `subtle.encapsulateBits`, `subtle.decapsulateBits`, `subtle.encapsulateKey`, and `subtle.decapsulateKey` behavior over existing DER-backed ML-KEM `CryptoKey` material.
- Updates `SubtleCrypto.supports()` so ML-KEM bit encapsulation reports supported while key encapsulation support remains false to match Node 26.

## Issues
- Closes #2518
- Helps #2013

## Cluster rationale
This is one WebCrypto ML-KEM encapsulation method cluster: all four methods share the same public/private key validation, ML-KEM variant dispatch, ciphertext/shared-secret shapes, and WebCrypto error behavior.

## Tests
- `cargo check -p perry-stdlib --no-default-features --features crypto`
- `cargo build --release`
- `NO_COLOR=1 FORCE_COLOR=0 npx --yes node@26 test-parity/node-suite/crypto/webcrypto/mlkem-encapsulation.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry compile test-parity/node-suite/crypto/webcrypto/mlkem-encapsulation.ts -o /tmp/perry-mlkem-encapsulation --debug-symbols --no-cache && /tmp/perry-mlkem-encapsulation`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry compile test-parity/node-suite/crypto/webcrypto/subtle-supports.ts -o /tmp/perry-subtle-supports --debug-symbols --no-cache && /tmp/perry-subtle-supports`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry compile test-parity/node-suite/crypto/webcrypto/encapsulation-method-surface.ts -o /tmp/perry-encap-surface --debug-symbols --no-cache && /tmp/perry-encap-surface`
- `git diff --check origin/main..HEAD`
- `rustfmt --check crates/perry-stdlib/src/webcrypto/encapsulation.rs crates/perry-stdlib/src/webcrypto/supports.rs`
- `./scripts/check_file_size.sh`

## Known limitations / non-goals
- The new fixture avoids CryptoKey metadata display; broader CryptoKey metadata/key material surfaces are covered separately.
- `SubtleCrypto.supports()` intentionally keeps `encapsulateKey` and `decapsulateKey` false to match Node 26 despite the methods being callable.
- This does not add a generic KEM framework beyond the three ML-KEM variants.
- `cargo fmt --all -- --check` still reports an unrelated pre-existing formatting diff in `crates/perry-stdlib/src/webcrypto/jwk.rs`; the touched Rust files pass `rustfmt --check`.