### PR TITLE
fix(runtime): route for-await async generator values

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -1035,6 +1035,11 @@ impl JsEmitter {
                 self.emit_expr(val);
                 self.output.push(')');
             }
+            Expr::ForAwaitToArray(val) => {
+                self.output.push_str("Array.fromAsync(");
+                self.emit_expr(val);
+                self.output.push(')');
+            }
             Expr::ArrayFromMapped {
                 iterable,
                 map_fn,

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -396,6 +396,7 @@ pub fn check_escapes_in_expr(
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
         | Expr::ForOfToArray(operand)
+        | Expr::ForAwaitToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::FinalizationRegistryNew(operand)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -255,6 +255,7 @@ fn collect_used_new_fields_in_expr(
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
         | Expr::ForOfToArray(operand)
+        | Expr::ForAwaitToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::FinalizationRegistryNew(operand)

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1114,6 +1114,7 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
         | Expr::ForOfToArray(operand)
+        | Expr::ForAwaitToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::QueueMicrotask(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -237,6 +237,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
         | Expr::ForOfToArray(operand)
+        | Expr::ForAwaitToArray(operand)
         | Expr::WeakRefNew(operand)
         | Expr::WeakRefDeref(operand)
         | Expr::QueueMicrotask(operand)

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -574,6 +574,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 .block()
                 .call(DOUBLE, "js_for_of_to_array", &[(DOUBLE, &v)]))
         }
+        Expr::ForAwaitToArray(o) => {
+            let v = lower_expr(ctx, o)?;
+            let undefined = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_array_from_async",
+                &[(DOUBLE, &v), (DOUBLE, &undefined), (DOUBLE, &undefined)],
+            ))
+        }
         Expr::WeakRefDeref(o) => {
             // `ref.deref()` — returns the wrapped target (or undefined if
             // collected; GC never clears the stub slot, so always returns

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1581,6 +1581,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::IteratorToArray(..)
         | Expr::GetIterator(..)
         | Expr::ForOfToArray(..)
+        | Expr::ForAwaitToArray(..)
         | Expr::WeakRefDeref(..)
         | Expr::Uint8ArrayNew(..)
         | Expr::Uint8ArrayLength(..)

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2108,6 +2108,11 @@ pub enum Expr {
     /// else drives its `[Symbol.iterator]`. Without it the index loop read
     /// `.length` off a raw Map/Set handle (→ 0) and iterated zero times.
     ForOfToArray(Box<Expr>),
+    /// Materialize an untyped `for await...of` receiver into a plain Array.
+    /// This routes through the async-iterator protocol first, then falls back
+    /// to the existing array/array-like behavior used by `Array.fromAsync`.
+    /// The lowering wraps this in `Await` before the index loop reads it.
+    ForAwaitToArray(Box<Expr>),
     /// Array.from(iterable, mapFn, thisArg?) -> Array
     /// Creates a new array by applying mapFn to each element of the iterable.
     /// `this_arg` (#2773) binds `this` inside a non-arrow mapFn.

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -982,7 +982,11 @@ pub(crate) fn lower_stmt_for_of(
     } else if is_iterable_typed_array {
         Expr::ArrayFrom(Box::new(arr_expr))
     } else if needs_runtime_iterator {
-        Expr::ForOfToArray(Box::new(arr_expr))
+        if for_of_stmt.is_await {
+            Expr::Await(Box::new(Expr::ForAwaitToArray(Box::new(arr_expr))))
+        } else {
+            Expr::ForOfToArray(Box::new(arr_expr))
+        }
     } else {
         arr_expr
     };

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1351,6 +1351,8 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 }
             } else if is_iterable_typed_array {
                 Expr::ArrayFrom(Box::new(arr_expr))
+            } else if needs_runtime_iterator && for_of_stmt.is_await {
+                Expr::Await(Box::new(Expr::ForAwaitToArray(Box::new(arr_expr))))
             } else if needs_runtime_iterator {
                 Expr::ForOfToArray(Box::new(arr_expr))
             } else {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -553,6 +553,7 @@ impl SH for Expr {
             Expr::IteratorToArray(e) => { tag(h, 398); e.as_ref().hash(h); }
             Expr::GetIterator(e) => { tag(h, 11238); e.as_ref().hash(h); }
             Expr::ForOfToArray(e) => { tag(h, 11243); e.as_ref().hash(h); }
+            Expr::ForAwaitToArray(e) => { tag(h, 12501); e.as_ref().hash(h); }
             Expr::ArrayFromMapped { iterable, map_fn, this_arg } => { tag(h, 399); iterable.as_ref().hash(h); map_fn.as_ref().hash(h); this_arg.is_some().hash(h); if let Some(t) = this_arg { t.as_ref().hash(h); } }
             Expr::ParseInt { string, radix } => { tag(h, 400); string.as_ref().hash(h); radix.hash(h); }
             Expr::ParseFloat(e) => { tag(h, 401); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -244,6 +244,7 @@ where
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)
         | Expr::ForOfToArray(v)
+        | Expr::ForAwaitToArray(v)
         | Expr::ObjectRest { object: v, .. }
         | Expr::ProxyRevoke(v)
         | Expr::ReflectOwnKeys(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -245,6 +245,7 @@ where
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)
         | Expr::ForOfToArray(v)
+        | Expr::ForAwaitToArray(v)
         | Expr::ObjectRest { object: v, .. }
         | Expr::ProxyRevoke(v)
         | Expr::ReflectOwnKeys(v)

--- a/test-parity/node-suite/globals/async-generator-for-await-variable.ts
+++ b/test-parity/node-suite/globals/async-generator-for-await-variable.ts
@@ -1,0 +1,45 @@
+async function* letters() {
+  yield "a";
+  await Promise.resolve();
+  yield "b";
+}
+
+const collect = async (label: string, iterable: AsyncIterable<unknown>) => {
+  const values: string[] = [];
+  for await (const value of iterable) {
+    values.push(String(value));
+    if (values.length > 4) {
+      values.push("guard");
+      break;
+    }
+  }
+  console.log(`${label}:`, values.join(","));
+};
+
+await collect("direct", letters());
+
+const held = letters();
+await collect("variable", held);
+
+const runner = {
+  async *run(prefix: string) {
+    yield `${prefix}1`;
+    await Promise.resolve();
+    yield `${prefix}2`;
+  },
+};
+await collect("method result", runner.run("m"));
+
+const custom = {
+  async *[Symbol.asyncIterator]() {
+    yield "s1";
+    yield Promise.resolve("s2");
+  },
+};
+await collect("custom async iterable", custom);
+
+const promised: unknown[] = [];
+for await (const value of [Promise.resolve(1), 2]) {
+  promised.push(value);
+}
+console.log("array promises:", promised.join(","));


### PR DESCRIPTION
Refs #4405

## Summary
- adds a `ForAwaitToArray` HIR materialization path for untyped `for await...of` receivers
- routes that path through the existing `js_array_from_async` collector, so async-generator values held in variables or returned from methods use async-iterator/`.next()` semantics instead of the sync `for...of` array fallback
- keeps the existing `for await` array fast path intact, including awaiting array elements
- adds a focused parity fixture covering direct async-generator calls, variable-held async generators, async-generator method results, custom async iterables, and arrays of promises

## Why Batched
The variable-held and method-result cases fail for the same reason: after the direct named async-generator call special case is missed, lowering falls through to the untyped `for...of` materializer. A single async materializer fixes both without changing the direct named-call path.

## Non-Goals
- broader async generator scheduling rewrites
- Promise/microtask ordering changes outside the existing `Array.fromAsync` collector
- adding `[Symbol.asyncIterator]` shape metadata to Perry async-generator objects
- unrelated `for await` stream/timer special paths

## Validation
- Node 26 oracle for `test-parity/node-suite/globals/async-generator-for-await-variable.ts` matched Perry direct output
- `CARGO_TARGET_DIR=/tmp/perry-async-generator-for-await-check cargo check -p perry-hir -p perry-codegen -p perry-codegen-js` passed
- `cargo build -p perry-runtime -p perry-stdlib -p perry --release` passed
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter async-generator-for-await-variable` passed: 1 pass / 0 fail
- same harness with `--filter generator` passed: 6 pass / 0 fail
- same harness with `--filter array-from-async` passed: 1 pass / 0 fail
- `cargo fmt -p perry-hir -p perry-codegen -p perry-codegen-js -- --check` passed
- `git diff --check HEAD` passed
- `git diff --cached --check` passed
- `jq empty test-parity/known_failures.json` passed
- `./scripts/check_file_size.sh` passed
