### PR TITLE
fix(runtime): support typedarray buffer default length

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -870,8 +870,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // compile-time-constant numeric lengths, or `js_typed_array_new(kind, val)`
         // for runtime-dispatched arguments (which inspects the NaN-box tag to
         // distinguish a numeric length from a source-array pointer).
-        // Result is a raw pointer bitcast to f64 (no NaN-box tag) — the runtime
-        // formatter and `js_array_*` dispatch helpers detect it via TYPED_ARRAY_REGISTRY.
+        // Result is a normal POINTER_TAG JS value. Element/property fast paths
+        // mask off the tag before consulting TYPED_ARRAY_REGISTRY, and runtime
+        // consumers such as Atomics require the value to satisfy is_pointer().
         Expr::TypedArrayNew { kind, arg } => {
             let kind_str = (*kind as i32).to_string();
             match arg {
@@ -882,7 +883,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         "js_typed_array_new_empty",
                         &[(I32, &kind_str), (I32, &zero)],
                     );
-                    Ok(ctx.block().bitcast_i64_to_double(&p))
+                    Ok(nanbox_pointer_inline(ctx.block(), &p))
                 }
                 Some(arg_expr) => match arg_expr.as_ref() {
                     // Literal integer length: `new Int32Array(3)`. A negative
@@ -895,7 +896,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             "js_typed_array_new_empty",
                             &[(I32, &kind_str), (I32, &len_str)],
                         );
-                        Ok(ctx.block().bitcast_i64_to_double(&p))
+                        Ok(nanbox_pointer_inline(ctx.block(), &p))
                     }
                     // Literal float that is a non-negative integer: `new Int32Array(3.0)`.
                     Expr::Number(f) if f.fract() == 0.0 && *f >= 0.0 && *f < (i32::MAX as f64) => {
@@ -905,7 +906,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             "js_typed_array_new_empty",
                             &[(I32, &kind_str), (I32, &len_str)],
                         );
-                        Ok(ctx.block().bitcast_i64_to_double(&p))
+                        Ok(nanbox_pointer_inline(ctx.block(), &p))
                     }
                     // Non-literal: dispatch at runtime based on the NaN-box tag.
                     // `js_typed_array_new` detects POINTER_TAG → copy from array,
@@ -918,7 +919,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             "js_typed_array_new",
                             &[(I32, &kind_str), (DOUBLE, &val_box)],
                         );
-                        Ok(blk.bitcast_i64_to_double(&p))
+                        Ok(nanbox_pointer_inline(blk, &p))
                     }
                 },
             }

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -742,6 +742,12 @@ pub extern "C" fn js_typed_array_new(kind: i32, val: f64) -> *mut TypedArrayHead
                 raw_addr as *const TypedArrayHeader,
             );
         }
+        if crate::buffer::is_registered_buffer(raw_addr)
+            && crate::buffer::is_any_array_buffer(raw_addr)
+        {
+            let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+            return crate::typedarray_view::js_typed_array_view(kind, val, undefined, undefined);
+        }
         return js_typed_array_new_from_array(kind, arr);
     }
     if top16 == 0x7FFE {

--- a/test-parity/node-suite/globals/typedarray-buffer-default-length.ts
+++ b/test-parity/node-suite/globals/typedarray-buffer-default-length.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+function show(label, value) {
+  console.log(label + ":" + String(value));
+}
+
+function showErr(label, fn) {
+  try {
+    fn();
+    console.log(label + ":NO_THROW");
+  } catch (err) {
+    console.log(label + ":" + err.name);
+  }
+}
+
+const sab = new SharedArrayBuffer(16);
+const i32Full = new Int32Array(sab);
+show("sab full length", i32Full.length);
+show("sab full byteLength", i32Full.byteLength);
+show("sab full byteOffset", i32Full.byteOffset);
+show("sab full first", i32Full[0]);
+show("sab atomics wait not equal", Atomics.wait(i32Full, 0, 1, 0));
+show("sab atomics notify default", Atomics.notify(i32Full, 0));
+
+const i32Offset = new Int32Array(sab, 4);
+show("sab offset length", i32Offset.length);
+show("sab offset byteLength", i32Offset.byteLength);
+
+const ab = new ArrayBuffer(10);
+const u16Offset = new Uint16Array(ab, 2);
+show("ab offset length", u16Offset.length);
+show("ab offset byteLength", u16Offset.byteLength);
+
+showErr("full misaligned byteLength", () => new Int32Array(new ArrayBuffer(10)));
+showErr("offset misaligned", () => new Int32Array(new SharedArrayBuffer(16), 2));
+showErr("offset oob", () => new Int32Array(new SharedArrayBuffer(16), 20));


### PR DESCRIPTION
## Summary

- Route one-argument non-Uint8 TypedArray constructors with ArrayBuffer/SharedArrayBuffer inputs through the existing view-constructor validation path, so omitted length consumes the remaining bytes.
- Return `TypedArrayNew` values as normal pointer-tagged JS values, preserving typed-array registry lookup while letting runtime consumers like `Atomics.wait`/`Atomics.notify` recognize the constructed Int32Array.
- Add a focused globals fixture for ArrayBuffer/SAB default lengths, misaligned/OOB RangeErrors, and Atomics use of the default-length SAB view.

## Why batched

These are the same constructor/default-length/view validation path. The Atomics neighbor exposed that the constructed default-length Int32Array also needs to be brand-visible to runtime APIs that require a JS pointer value.

## Non-goals

- Backing-store aliasing or true `byteOffset` identity for copied Perry views.
- Detached/resizable ArrayBuffer behavior.
- Atomics wait scheduling or `waitAsync` behavior.
- Broader typed-array prototype descriptor work.

## Validation

- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH node test-parity/node-suite/globals/typedarray-buffer-default-length.ts`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 target/release/perry test-parity/node-suite/globals/typedarray-buffer-default-length.ts -o /tmp/perry_typedarray_buffer_default_length && /tmp/perry_typedarray_buffer_default_length`
- `cargo check -p perry-codegen -p perry-runtime`
- `cargo build -p perry-runtime -p perry-stdlib -p perry --release`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter typedarray-buffer-default-length` (PASS 1/0, report `test-parity/reports/parity_report_20260604_151146.json`)
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter atomics-wait-notify` (PASS 1/0, report `test-parity/reports/parity_report_20260604_151158.json`)
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/node/bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter typedarray` (PASS 5/0, report `test-parity/reports/parity_report_20260604_151209.json`)
- `cargo fmt -p perry-runtime -p perry-codegen -- --check`
- `git diff --check HEAD^ HEAD`
- `git diff --cached --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`