### PR TITLE
fix(release): decouple aspirational smokes from publish gate (v0.5.1122)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -870,6 +870,12 @@ jobs:
   # entries for the workflow).
   # ---------------------------------------------------------------------------
   harmonyos-smoke:
+    # Aspirational smoke (informational) — must not block package publish.
+    # release-packages await-tests keys on this workflow's run conclusion;
+    # continue-on-error keeps a red result here from failing it (same as
+    # parity/compile-smoke/doc-tests/drizzle/effect-basic-smoke). Core jobs
+    # (cargo-test/lint/api-docs-drift/compiler-output-regression) still gate.
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -987,6 +993,8 @@ jobs:
   # `run-extended-tests` label or workflow dispatch.
   # ---------------------------------------------------------------------------
   ink-link-smoke:
+    # Aspirational smoke (informational) — see harmonyos-smoke. Does not block publish.
+    continue-on-error: true
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_extended_tests) ||

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1122 — fix(release): decouple aspirational platform/framework smokes from the publish gate
+
+v0.5.1121's publish was blocked at `await-tests` because the tag-gated **Tests** workflow concluded failure — but the only *core*-job failures were `cargo-test` (the `secret_key_buffer_metadata_survives_ic_miss_for_aes_sizes` regression from #4363 typed-array own-properties, since fixed on `main` by #4399) and `lint` (a transient rustup/curl network flake during toolchain setup). The v0.5.1121 tag predated #4399, so its `cargo-test` could never pass; this release re-tags from a `main` that includes the fix.
+
+To stop new aspirational smoke jobs from silently re-blocking publish (the recurring failure mode this whole pipeline-repair has hit), marked `harmonyos-smoke` and `ink-link-smoke` `continue-on-error: true` — joining `effect-basic-smoke` (already so) and the `parity`/`compile-smoke`/`doc-tests`/`drizzle-mysql-smoke` set. Package publish now effectively gates only on the four core jobs: `cargo-test`, `lint`, `api-docs-drift`, `compiler-output-regression` (+ Simulator Tests).
+
+Note: a more durable fix is to have `release-packages.yml`'s `await-tests` gate key on those core jobs' conclusions directly rather than the whole-workflow conclusion, so future aspirational jobs need no `continue-on-error` annotation. Tracked as a follow-up.
+
 ## v0.5.1121 — fix(release): build Apple cross-libs on the arm64 mac job only (unblocks npm/brew/apt/winget publish)
 
 v0.5.1120 fixed the gtk4 + android build-matrix breakage (both verified green on the real toolchains) and published 34 assets, but `release-packages` still concluded failure and skipped the package-manager publish legs (`npm-publish`/`homebrew`/`apt`/`winget`, which `needs: build` = every primary build). The lone remaining failure was `build (macos-15, x86_64-apple-darwin)`: its "Build iOS cross-compile libraries (macOS)" step panicked in `libsqlite3-sys` build.rs — `could not run bindgen on header sqlite3/sqlite3.h` — a libclang/SDK issue on the macos-15 x86_64 runner. The macos-14 arm64 runner built the identical iOS aarch64 libs fine; the failure was masked in earlier releases by the build matrix's (now-removed) fail-fast.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1121
+**Current Version:** 0.5.1122
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "base64",
@@ -5252,14 +5252,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "cc",
  "libc",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "base64",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "serde",
  "serde_json",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1121"
+version = "0.5.1122"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "clap",
@@ -5402,14 +5402,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5476,7 +5476,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5492,7 +5492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5508,14 +5508,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5532,7 +5532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "bytes",
  "h2",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5588,7 +5588,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5607,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "bson",
  "futures-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5676,7 +5676,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5693,7 +5693,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "image",
@@ -5702,14 +5702,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5748,7 +5748,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "brotli",
  "flate2",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "base64",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5932,14 +5932,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "itoa",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "block2",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "block2",
@@ -6020,7 +6020,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1121"
+version = "0.5.1122"
 
 [[package]]
 name = "perry-ui-test"
@@ -6028,11 +6028,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1121"
+version = "0.5.1122"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "block2",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "block2",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "block2",
  "libc",
@@ -6077,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "libc",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1121"
+version = "0.5.1122"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1121"
+version = "0.5.1122"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
v0.5.1121 blocked at await-tests because Tests failed on cargo-test (AES regression #4363, fixed on main by #4399 — 1121 tag predated it) + lint (network flake). Re-tag from main with #4399. Mark harmonyos-smoke + ink-link-smoke continue-on-error so aspirational smokes can't re-block publish; publish gates only on core jobs. test.yml + metadata only. See CHANGELOG v0.5.1122.