### PR TITLE
fix(stream/web): reject direct abort while locked

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -1001,7 +1001,7 @@ unsafe fn js_readable_stream_cancel_inner(
         return promise;
     }
     if let Some(writable_id) = transform_writable_for_readable(id) {
-        let _ = js_writable_stream_abort(writable_id as f64, reason);
+        let _ = js_writable_stream_abort_inner(writable_id as f64, reason, true);
     }
     if cb != 0 {
         js_closure_call1(cb as *const ClosureHeader, reason);
@@ -2026,23 +2026,41 @@ pub unsafe extern "C" fn js_writable_stream_close(stream_handle: f64) -> *mut Pr
 
 #[no_mangle]
 pub unsafe extern "C" fn js_writable_stream_abort(stream_handle: f64, reason: f64) -> *mut Promise {
+    js_writable_stream_abort_inner(stream_handle, reason, false)
+}
+
+unsafe fn js_writable_stream_abort_inner(
+    stream_handle: f64,
+    reason: f64,
+    allow_locked: bool,
+) -> *mut Promise {
     let promise = js_promise_new();
     let id = stream_handle as usize;
     let reason_bits = reason.to_bits();
+    let mut locked_reject = false;
     let (cb, closed_p, close_request) = {
         let mut g = WRITABLE_STREAMS.lock().unwrap();
         match g.get_mut(&id) {
             Some(s) => {
-                s.state = WritableState::Errored;
-                s.error_value = reason_bits;
-                let close_request = s.close_request_promise;
-                s.close_request_promise = std::ptr::null_mut();
-                s.close_started = false;
-                (s.abort_cb, s.closed_promise, close_request)
+                if !allow_locked && s.writer_handle.is_some() {
+                    locked_reject = true;
+                    (0, std::ptr::null_mut(), std::ptr::null_mut())
+                } else {
+                    s.state = WritableState::Errored;
+                    s.error_value = reason_bits;
+                    let close_request = s.close_request_promise;
+                    s.close_request_promise = std::ptr::null_mut();
+                    s.close_started = false;
+                    (s.abort_cb, s.closed_promise, close_request)
+                }
             }
             None => (0, std::ptr::null_mut(), std::ptr::null_mut()),
         }
     };
+    if locked_reject {
+        reject_type_error(promise, "Invalid state: WritableStream is locked");
+        return promise;
+    }
     if cb != 0 {
         js_closure_call1(cb as *const ClosureHeader, reason);
     }
@@ -2558,7 +2576,7 @@ pub unsafe extern "C" fn js_writer_abort(writer_handle: f64, reason: f64) -> *mu
             return p;
         }
     };
-    js_writable_stream_abort(stream_id as f64, reason)
+    js_writable_stream_abort_inner(stream_id as f64, reason, true)
 }
 
 #[no_mangle]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -67,11 +67,5 @@
     "added": "2026-05-18",
     "category": "ci-env",
     "reason": "Tracked in #1634 (parity CI environment fixtures). Ramda npm-package fixture failure on Linux CI; observed on #1038's CI run pre-merge. Companion to the existing test_ramda_user_import skip in the compile-smoke list \u2014 the parity harness can't npm-install ramda. File a CI-side fixture issue if/when this matters for sweep coverage."
-  },
-  "node-suite/stream/web/abort-during-pipeto": {
-    "issue": "1545",
-    "added": "2026-05-24",
-    "category": "bug-open",
-    "reason": "node:stream/web: ws.abort() during active pipeTo \u2014 pipeTo Promise doesn't reject. Flips to PASS when #1545 lands."
   }
 }

--- a/test-parity/node-suite/stream/web/abort-during-pipeto.ts
+++ b/test-parity/node-suite/stream/web/abort-during-pipeto.ts
@@ -1,17 +1,45 @@
 import { ReadableStream, WritableStream } from "node:stream/web";
-// Aborting the writable side during an active pipeTo — pipeTo rejects.
+
+// Direct WritableStream.abort() is rejected while pipeTo owns the destination
+// writer lock. The pipe itself still completes once the source closes.
 const rs = new ReadableStream({
-  pull(c) { setTimeout(() => c.enqueue("x"), 30); },
+  start(c) {
+    setTimeout(() => {
+      c.enqueue("x");
+      c.close();
+    }, 30);
+  },
 });
 const ws = new WritableStream({ write() {} });
-const p = rs.pipeTo(ws);
-setTimeout(() => {
-  ws.abort("stop").catch(() => {});
-}, 5);
-let rejected = false;
-try {
-  await p;
-} catch {
-  rejected = true;
-}
-console.log("pipeTo rejected after abort:", rejected);
+const pipe = rs.pipeTo(ws).then(
+  () => "resolved",
+  (e: any) => `rejected ${e?.name || e}`,
+);
+
+console.log("locked during pipe:", rs.locked, ws.locked);
+
+const abortResult = new Promise<string>((resolve) => {
+  setTimeout(async () => {
+    try {
+      await ws.abort("stop");
+      resolve("resolved");
+    } catch (e: any) {
+      resolve(`${e?.name} ${e?.message}`);
+    }
+  }, 5);
+});
+
+console.log("direct abort during pipe:", await abortResult);
+console.log("pipe result:", await pipe);
+console.log("locked after pipe:", rs.locked, ws.locked);
+
+let sinkAbortReason = "unset";
+const writerStream = new WritableStream({
+  abort(reason) {
+    sinkAbortReason = String(reason);
+  },
+});
+const writer = writerStream.getWriter();
+await writer.abort("writer-stop");
+console.log("writer abort reason:", sinkAbortReason);
+console.log("writer stream locked:", writerStream.locked);


### PR DESCRIPTION
## Summary
- Aligns direct `WritableStream.abort(reason)` with Node when the writable is locked by `ReadableStream.pipeTo()` or another writer.
- Keeps `WritableStreamDefaultWriter.abort(reason)` and internal transform/readable cancellation paths using the underlying abort operation while bypassing the public locked-stream guard.
- Reworks `node-suite/stream/web/abort-during-pipeto` into a stable Node 26 oracle and removes its stale known-failure entry.

## Issues
- Helps #1545

## Cluster rationale
This is one Web Streams abort/lock lifecycle cut: direct stream abort, writer-owned abort, and `pipeTo()` destination locking share the same writable stream lock invariant. The PR stays out of unrelated Web Streams lifecycle and iterator work already covered by neighboring PRs.

## Tests
- `cargo check -p perry-stdlib`
- `cargo build -p perry-stdlib --release`
- `cargo build -p perry-runtime -p perry-stdlib -p perry --release`
- `NO_COLOR=1 FORCE_COLOR=0 npx --yes node@26 test-parity/node-suite/stream/web/abort-during-pipeto.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/release/perry compile test-parity/node-suite/stream/web/abort-during-pipeto.ts -o /tmp/perry-abort-during-pipeto --debug-symbols --no-cache && /tmp/perry-abort-during-pipeto`
- `npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream/web --filter abort-during-pipeto'`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream/web --filter abort-during-pipeto'`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream/web --filter pipe-to'`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream/web --filter writer'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Known limitations / non-goals
- Does not implement broader Web Streams abort propagation, BYOB reader behavior, strategy size accounting, or backpressure changes.
- Does not cover classic `node:stream` lifecycle options.
- The first cold auto-optimized harness run hit the existing object-file link race after rebuilding auto artifacts; rerunning the same focused default harness passed, and direct default auto compile/run also passed.