### PR TITLE
[codex] Expose WebCrypto CryptoKey metadata getters

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -27,7 +27,7 @@ const CRYPTO_USAGE_DECAPSULATE_BITS: u32 = 1 << 9;
 const CRYPTO_USAGE_ENCAPSULATE_KEY: u32 = 1 << 10;
 const CRYPTO_USAGE_DECAPSULATE_KEY: u32 = 1 << 11;
 
-unsafe fn crypto_key_property_value(addr: usize, key_bytes: &[u8]) -> Option<JSValue> {
+pub(crate) unsafe fn crypto_key_property_value(addr: usize, key_bytes: &[u8]) -> Option<JSValue> {
     let (algo, hash, kind, extractable, usages) = crate::buffer::crypto_key_meta(addr)?;
     match key_bytes {
         b"algorithm" => Some(crypto_key_algorithm_value(addr, algo, hash)),
@@ -38,6 +38,10 @@ unsafe fn crypto_key_property_value(addr: usize, key_bytes: &[u8]) -> Option<JSV
             _ => "secret",
         })),
         b"usages" => Some(crypto_key_usages_value(usages)),
+        b"constructor" => {
+            let ctor = super::js_get_global_this_builtin_value(b"CryptoKey".as_ptr(), 9);
+            Some(JSValue::from_bits(ctor.to_bits()))
+        }
         _ => None,
     }
 }
@@ -2043,6 +2047,9 @@ pub extern "C" fn js_object_get_field_by_name(
                 let key_len = (*key).byte_len as usize;
                 let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
                 let ta = addr as *const crate::typedarray::TypedArrayHeader;
+                if let Some(value) = crypto_key_property_value(addr, key_bytes) {
+                    return value;
+                }
                 if let Some(value) =
                     crate::typedarray_props::typed_array_get_own_property_value(ta, key)
                 {

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -492,10 +492,52 @@ extern "C" fn webcrypto_subtle_getter_thunk(_closure: *const crate::closure::Clo
     super::native_module::subtle_crypto_namespace()
 }
 
-extern "C" fn cryptokey_property_getter_thunk(
+fn cryptokey_receiver_addr() -> Option<usize> {
+    let this_bits = IMPLICIT_THIS.with(|c| c.get());
+    let this_jsv = crate::value::JSValue::from_bits(this_bits);
+    let raw = if this_jsv.is_pointer() {
+        (this_bits & crate::value::POINTER_MASK) as usize
+    } else if this_bits >> 48 == 0 && this_bits > 0x10000 {
+        this_bits as usize
+    } else {
+        return None;
+    };
+    crate::buffer::crypto_key_meta(raw).map(|_| raw)
+}
+
+fn cryptokey_brand_error() -> ! {
+    super::object_ops::throw_object_type_error(
+        b"Value of CryptoKey getter must be an instance of CryptoKey",
+    )
+}
+
+fn cryptokey_property_getter(key: &[u8]) -> f64 {
+    let addr = cryptokey_receiver_addr().unwrap_or_else(|| cryptokey_brand_error());
+    unsafe {
+        super::crypto_key_property_value(addr, key)
+            .map(|value| f64::from_bits(value.bits()))
+            .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED))
+    }
+}
+
+extern "C" fn cryptokey_algorithm_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
-    f64::from_bits(crate::value::TAG_UNDEFINED)
+    cryptokey_property_getter(b"algorithm")
+}
+
+extern "C" fn cryptokey_extractable_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    cryptokey_property_getter(b"extractable")
+}
+
+extern "C" fn cryptokey_type_getter_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    cryptokey_property_getter(b"type")
+}
+
+extern "C" fn cryptokey_usages_getter_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    cryptokey_property_getter(b"usages")
 }
 
 pub(crate) fn webcrypto_method_value(property_name: &str) -> Option<f64> {
@@ -4221,12 +4263,16 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "CryptoKey" => {
-            for name in ["algorithm", "extractable", "type", "usages"] {
-                install_webcrypto_proto_getter(
-                    proto_obj,
-                    name,
-                    cryptokey_property_getter_thunk as *const u8,
-                );
+            for (name, func_ptr) in [
+                ("algorithm", cryptokey_algorithm_getter_thunk as *const u8),
+                (
+                    "extractable",
+                    cryptokey_extractable_getter_thunk as *const u8,
+                ),
+                ("type", cryptokey_type_getter_thunk as *const u8),
+                ("usages", cryptokey_usages_getter_thunk as *const u8),
+            ] {
+                install_webcrypto_proto_getter(proto_obj, name, func_ptr);
             }
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }

--- a/test-parity/node-suite/crypto/webcrypto/mlkem-key-material.ts
+++ b/test-parity/node-suite/crypto/webcrypto/mlkem-key-material.ts
@@ -21,6 +21,21 @@ const rejectName = async (label: string, fn: () => Promise<unknown>) => {
   }
 };
 
+const cryptoKeyGetterNames = ["algorithm", "type", "extractable", "usages"] as const;
+type CryptoKeyGetterName = typeof cryptoKeyGetterNames[number];
+
+const cryptoKeyGetter = (name: CryptoKeyGetterName) =>
+  Object.getOwnPropertyDescriptor(CryptoKey.prototype, name)!.get!;
+
+const cryptoKeyGetterBrand = (name: CryptoKeyGetterName) => {
+  try {
+    cryptoKeyGetter(name).call({});
+    return "ok";
+  } catch (error: any) {
+    return error.name;
+  }
+};
+
 for (const algorithm of variants) {
   console.log(`algorithm: ${algorithm}`);
   console.log("supports generate:", SubtleCrypto.supports("generateKey", algorithm));
@@ -32,6 +47,24 @@ for (const algorithm of variants) {
   console.log("generated type:", pair.publicKey.type, pair.privateKey.type);
   console.log("generated usages:", JSON.stringify(pair.publicKey.usages), JSON.stringify(pair.privateKey.usages));
   console.log("generated extractable:", pair.publicKey.extractable, pair.privateKey.extractable);
+  console.log("generated instance:", pair.publicKey instanceof CryptoKey, pair.privateKey instanceof CryptoKey);
+  console.log(
+    "generated ctor:",
+    pair.publicKey.constructor === CryptoKey,
+    pair.privateKey.constructor === CryptoKey,
+  );
+  const descriptorAlgorithm = cryptoKeyGetter("algorithm").call(pair.publicKey) as any;
+  console.log(
+    "descriptor getters:",
+    descriptorAlgorithm.name,
+    cryptoKeyGetter("type").call(pair.privateKey),
+    cryptoKeyGetter("extractable").call(pair.publicKey),
+    JSON.stringify(cryptoKeyGetter("usages").call(pair.publicKey)),
+  );
+  console.log(
+    "descriptor brands:",
+    cryptoKeyGetterNames.map(cryptoKeyGetterBrand).join(","),
+  );
 
   const spki = await subtle.exportKey("spki", pair.publicKey);
   const pkcs8 = await subtle.exportKey("pkcs8", pair.privateKey);


### PR DESCRIPTION
## Summary
Refs #2518.

- Resolve registered WebCrypto `CryptoKey` metadata before the early Uint8Array/Buffer property fallback, so direct reads of `algorithm`, `type`, `extractable`, `usages`, and `constructor` surface CryptoKey state.
- Replace the no-op `CryptoKey.prototype` accessors with per-property getters that read the registered key metadata from the receiver and throw `TypeError` for non-CryptoKey receivers.
- Extend `mlkem-key-material` parity coverage for generated/imported ML-KEM CryptoKeys, constructor identity, descriptor getter calls, and getter brand errors.

## Why Batched
These behaviors share the same runtime CryptoKey metadata dispatch path: generated/imported ML-KEM keys were already registered as CryptoKeys, but property reads could be shadowed by buffer/typed-array handling or no-op prototype accessors.

## Validation
- `node test-parity/node-suite/crypto/webcrypto/mlkem-key-material.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 target/release/perry test-parity/node-suite/crypto/webcrypto/mlkem-key-material.ts -o /tmp/perry_mlkem_key_material_after2 && /tmp/perry_mlkem_key_material_after2`
- `cargo check -p perry-runtime`
- `cargo build -p perry-runtime -p perry-stdlib -p perry --release`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module crypto/webcrypto --filter mlkem-key-material` (passed; rerun twice after one intermittent ML-KEM DER export mismatch)
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module crypto/webcrypto --filter subtle-supports`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module crypto/webcrypto --filter cryptokey-usages-extractable`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 ./run_parity_tests.sh --suite node-suite --module crypto/webcrypto --filter hmac-generate-key`
- `cargo fmt -p perry-runtime -- --check`
- `git diff --check HEAD^ HEAD`
- `git diff --cached --check`
- `jq empty test-parity/known_failures.json`
- `./scripts/check_file_size.sh`

## Non-Goals
- No new ML-KEM encapsulate/decapsulate execution.
- No new key-material formats.
- No changes to other WebCrypto algorithms or top-level `node:crypto` KEM APIs.