### PR TITLE
fix(runtime): caller/arguments poison pill throws for all functions

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2700,8 +2700,18 @@ pub extern "C" fn js_object_get_field_by_name(
                 if crate::closure::closure_is_key_deleted(obj as usize, name_str) {
                     return JSValue::undefined();
                 }
+                // ECMAScript "poison pill": reading `caller` / `arguments` off a
+                // strict-mode function throws a TypeError (the %ThrowTypeError%
+                // accessor on `Function.prototype`). Perry has no sloppy mode —
+                // all TS/JS it compiles is strict — so this applies to every
+                // function (declarations, expressions, methods, classes, arrows,
+                // bound and built-in closures), matching `node`'s strict-mode
+                // behavior. A `delete fn.caller` (handled above) still wins, and a
+                // genuine own data prop of that name takes precedence so the rare
+                // `Object.defineProperty(fn, "caller", …)` round-trips.
                 if matches!(name_str, "caller" | "arguments")
-                    && crate::closure::closure_is_arrow(obj as *const crate::closure::ClosureHeader)
+                    && crate::closure::closure_get_dynamic_prop(obj as usize, name_str).to_bits()
+                        == crate::value::TAG_UNDEFINED
                 {
                     crate::fs::validate::throw_type_error_with_code(
                         "Restricted function property access",
@@ -3016,10 +3026,15 @@ pub extern "C" fn js_object_get_field_by_name(
                     if crate::closure::closure_is_key_deleted(obj as usize, name_str) {
                         return JSValue::undefined();
                     }
+                    // ECMAScript "poison pill" — see the matching arm in
+                    // `js_object_get_field_by_name`. Reading `caller`/`arguments`
+                    // off any strict-mode function throws a TypeError; Perry has
+                    // no sloppy mode, so this covers every function. A genuine own
+                    // data prop of that name still wins.
                     if matches!(name_str, "caller" | "arguments")
-                        && crate::closure::closure_is_arrow(
-                            obj as *const crate::closure::ClosureHeader,
-                        )
+                        && crate::closure::closure_get_dynamic_prop(obj as usize, name_str)
+                            .to_bits()
+                            == crate::value::TAG_UNDEFINED
                     {
                         crate::fs::validate::throw_type_error_with_code(
                             "Restricted function property access",


### PR DESCRIPTION
## What

Reading `caller` or `arguments` off a function now throws a `TypeError` (the
ECMAScript "poison pill" / `%ThrowTypeError%` accessor on `Function.prototype`)
for **all** functions, not just arrow functions.

Perry already threw for arrows (added in "Fix c262 arrow environment parity"),
but ordinary function declarations/expressions, methods, classes, bound and
built-in closures fell through to `undefined`. Since Perry compiles TypeScript —
which is always strict — every function it produces is a strict function, so the
poison pill applies uniformly, matching `node`'s strict-mode behavior.

## Why

20 test262 `built-ins/Function/*gs.js` cases assert `assert.throws(TypeError, () => fn.caller)`
(and `.arguments`). They run with `"use strict"` (test262 `onlyStrict`), where Node
throws and Perry returned `undefined`.

## Verification

- 19/20 of the targeted `built-ins/Function` caller/arguments tests now pass.
  The 20th (`15.3.5.4_2-11gs`) requires runtime `eval("…")`, which is an unrelated
  structural limitation (Perry can't dynamically eval source), not this change.
- Both `PERRY_NO_AUTO_OPTIMIZE=1` and the default (auto-optimize) build throw
  identically.
- Sanity: the `arguments` **local** binding inside a function, `fn.name`,
  `fn.length`, arrow calls, and `delete fn.caller` (still reads `undefined`) are
  unaffected. A genuine own data property of that name still takes precedence.
- `cargo test --release -p perry-runtime --lib` green.
- No `built-ins/Function` regressions; no other category increased.

## Scope / notes

- Applied to both closure field-get paths (`js_object_get_field_by_name` and the
  `GC_TYPE_CLOSURE` fast path).
- A no-`import`/`export` `.ts` file run by `node --experimental-strip-types` is
  treated as **sloppy CommonJS**, where Node returns `null` for `fn.caller`;
  Perry (always strict) throws. This strict-vs-sloppy divergence is inherent to
  Perry having no sloppy mode and matches real strict ES modules. node-core has no
  genuine function-value `.caller`/`.arguments` reads, so no node-core impact.

## Net measurement

`built-ins/Function` uncapped: **243 → 220 failures** (−23). 25 caller/arguments
tests fixed; 2 (`15.3.5.4_2-7gs`, `-9gs`) now show as a `diff` only because they
use `new Function("return gNonStrict()")` — Node's Function-constructor scoping
throws `ReferenceError` (Node fails the test too), while Perry now correctly throws
the spec `TypeError`. Not real regressions; the Node oracle itself rejects them.
`cargo test -p perry-runtime --lib`: 979 passed, 0 failed.
