### PR TITLE
fix(runtime): ToNumber/ToInteger(Symbol|BigInt) throw TypeError at numeric coercion sites

### DIFF
--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -383,6 +383,18 @@ pub extern "C" fn js_number_coerce(value: f64) -> f64 {
         let ptr = jsval.as_bigint_ptr();
         crate::bigint::js_bigint_to_f64(ptr)
     } else if jsval.is_pointer() {
+        // ECMA-262 ToNumber(Symbol) is a TypeError (§7.1.4). Symbols are
+        // NaN-boxed with POINTER_TAG, so they would otherwise fall through to
+        // the object/toPrimitive path below and stringify to "Symbol(...)" or
+        // produce NaN. Throw before any of the pointer-shape handling. This
+        // covers both explicit `Number(sym)` and the implicit arithmetic
+        // ToNumber the codegen routes here (`sym * 2`, `-sym`, etc.). BigInt is
+        // intentionally NOT thrown here: `Number(1n)` converts (handled in the
+        // is_bigint arm above); the arithmetic-throws-on-BigInt rule lives at
+        // the arithmetic call sites (see dynamic_arith.rs both_bigint_or_throw).
+        if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
+            crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a number");
+        }
         let id = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64;
         // #2089: a Date is a NaN-boxed pointer to a `DateCell`. `Number(date)`
         // / `+date` / `date - other` coerce to the millisecond timestamp.

--- a/crates/perry-runtime/src/string/format.rs
+++ b/crates/perry-runtime/src/string/format.rs
@@ -336,42 +336,49 @@ fn fmt_fixed_int(value: f64, dp: usize) -> Option<*mut StringHeader> {
 pub extern "C" fn js_number_to_precision(value: f64, precision: f64) -> *mut StringHeader {
     let s = if is_undefined_arg(precision) {
         format_number_for_js(value)
-    } else if value.is_nan() {
-        "NaN".to_string()
-    } else if value.is_infinite() {
-        if value > 0.0 {
-            "Infinity".to_string()
-        } else {
-            "-Infinity".to_string()
-        }
     } else {
+        // ECMA-262 §21.1.3.5: `p = ? ToIntegerOrInfinity(precision)` (step 3)
+        // runs *before* the non-finite check on x (step 4). A Symbol/abrupt
+        // precision must therefore throw even when x is NaN/±Infinity — e.g.
+        // `Number.prototype.toPrecision(Symbol())`, whose [[NumberData]] is +0
+        // but which V8 also exercises with non-finite receivers (test262
+        // built-ins/Number/prototype/toPrecision/return-abrupt-*-symbol).
         let p_number = to_integer_or_infinity(precision);
-        if p_number < 1.0 || p_number > 100.0 {
-            throw_number_format_range_error("toPrecision() argument must be between 1 and 100");
-        }
-        let p = p_number as usize;
-        if value == 0.0 {
-            // 0.toPrecision(3) = "0.00"
-            if p == 1 {
-                "0".to_string()
+        if value.is_nan() {
+            "NaN".to_string()
+        } else if value.is_infinite() {
+            if value > 0.0 {
+                "Infinity".to_string()
             } else {
-                format!("0.{}", "0".repeat(p - 1))
+                "-Infinity".to_string()
             }
+        } else if p_number < 1.0 || p_number > 100.0 {
+            throw_number_format_range_error("toPrecision() argument must be between 1 and 100");
         } else {
-            // Find the decimal exponent: floor(log10(|x|))
-            let abs = value.abs();
-            let exp = abs.log10().floor() as i32;
-            // JS uses exponential notation when exp < -6 or exp >= precision
-            if exp < -6 || exp >= p as i32 {
-                // Exponential: precision-1 digits after decimal, e+/-exp
-                let mantissa_digits = p.saturating_sub(1);
-                let formatted = format!("{:.*e}", mantissa_digits, value);
-                // Rust's "{:e}" format produces "1.23e4"; JS uses "1.23e+4"
-                fix_exponent_format(&formatted)
+            let p = p_number as usize;
+            if value == 0.0 {
+                // 0.toPrecision(3) = "0.00"
+                if p == 1 {
+                    "0".to_string()
+                } else {
+                    format!("0.{}", "0".repeat(p - 1))
+                }
             } else {
-                // Fixed: precision - exp - 1 digits after decimal
-                let dp = (p as i32 - exp - 1).max(0) as usize;
-                format!("{:.prec$}", value, prec = dp)
+                // Find the decimal exponent: floor(log10(|x|))
+                let abs = value.abs();
+                let exp = abs.log10().floor() as i32;
+                // JS uses exponential notation when exp < -6 or exp >= precision
+                if exp < -6 || exp >= p as i32 {
+                    // Exponential: precision-1 digits after decimal, e+/-exp
+                    let mantissa_digits = p.saturating_sub(1);
+                    let formatted = format!("{:.*e}", mantissa_digits, value);
+                    // Rust's "{:e}" format produces "1.23e4"; JS uses "1.23e+4"
+                    fix_exponent_format(&formatted)
+                } else {
+                    // Fixed: precision - exp - 1 digits after decimal
+                    let dp = (p as i32 - exp - 1).max(0) as usize;
+                    format!("{:.prec$}", value, prec = dp)
+                }
             }
         }
     };
@@ -382,25 +389,40 @@ pub extern "C" fn js_number_to_precision(value: f64, precision: f64) -> *mut Str
 /// Format a number in exponential notation (Number.prototype.toExponential).
 #[no_mangle]
 pub extern "C" fn js_number_to_exponential(value: f64, decimals: f64) -> *mut StringHeader {
-    let s = if value.is_nan() {
-        "NaN".to_string()
-    } else if value.is_infinite() {
-        if value > 0.0 {
-            "Infinity".to_string()
+    let s = if is_undefined_arg(decimals) {
+        if value.is_nan() {
+            "NaN".to_string()
+        } else if value.is_infinite() {
+            if value > 0.0 {
+                "Infinity".to_string()
+            } else {
+                "-Infinity".to_string()
+            }
         } else {
-            "-Infinity".to_string()
+            fix_exponent_format(&format!("{:e}", value))
         }
-    } else if is_undefined_arg(decimals) {
-        fix_exponent_format(&format!("{:e}", value))
     } else {
+        // ECMA-262 §21.1.3.2: `f = ? ToIntegerOrInfinity(fractionDigits)`
+        // (step 2) runs *before* the non-finite check on x (step 3), so a
+        // Symbol/abrupt fractionDigits throws even when x is NaN/±Infinity
+        // (test262 .../toExponential/return-abrupt-tointeger-*-symbol).
         let dp_number = to_integer_or_infinity(decimals);
-        if !(0.0..=100.0).contains(&dp_number) {
+        if value.is_nan() {
+            "NaN".to_string()
+        } else if value.is_infinite() {
+            if value > 0.0 {
+                "Infinity".to_string()
+            } else {
+                "-Infinity".to_string()
+            }
+        } else if !(0.0..=100.0).contains(&dp_number) {
             throw_number_format_range_error("toExponential() argument must be between 0 and 100");
+        } else {
+            let dp = dp_number as usize;
+            // Rust's `{:e}` produces e.g. "1.23e4"; JS expects "1.23e+4"
+            let formatted = format!("{:.*e}", dp, value);
+            fix_exponent_format(&formatted)
         }
-        let dp = dp_number as usize;
-        // Rust's `{:e}` produces e.g. "1.23e4"; JS expects "1.23e+4"
-        let formatted = format!("{:.*e}", dp, value);
-        fix_exponent_format(&formatted)
     };
     let bytes = s.as_bytes();
     js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -535,6 +535,17 @@ fn jsvalue_to_f64(v: f64) -> f64 {
     if !(0x7FFA..0x8000).contains(&top16) {
         return v;
     }
+    // ECMA-262 IntegerIndexedElementSet on a non-bigint view performs
+    // ToNumber on the value. ToNumber(Symbol) and ToNumber(BigInt) are both
+    // TypeErrors (§7.1.4). Bigint views never reach here (js_typed_array_set
+    // routes ToBigInt separately), so a BigInt at this point is being written
+    // into a numeric view and must throw. Symbols are POINTER_TAG.
+    if top16 == 0x7FFA {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
+    }
+    if top16 == 0x7FFD && unsafe { crate::symbol::js_is_symbol(v) } != 0 {
+        crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a number");
+    }
     // INT32 tag
     if top16 == 0x7FFE {
         let n = (bits & 0xFFFF_FFFF) as i32;
@@ -727,6 +738,16 @@ pub extern "C" fn js_typed_array_new_empty(kind: i32, length: i32) -> *mut Typed
 pub extern "C" fn js_typed_array_new(kind: i32, val: f64) -> *mut TypedArrayHeader {
     let bits = val.to_bits();
     let top16 = (bits >> 48) as u16;
+    // `new TA(arg)` with a non-object arg performs ToIndex(arg) = ToNumber(arg)
+    // for the length. ToNumber(BigInt) and ToNumber(Symbol) are TypeErrors
+    // (§7.1.4), so `new Int8Array(5n)` / `new Int8Array(Symbol())` must throw
+    // rather than yielding an empty (BigInt) or garbage-copied (Symbol) array.
+    if top16 == 0x7FFA {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
+    }
+    if top16 == 0x7FFD && unsafe { crate::symbol::js_is_symbol(val) } != 0 {
+        crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a number");
+    }
     if top16 == 0x7FFD {
         // POINTER_TAG — existing array pointer; copy its elements.
         let arr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::array::ArrayHeader;


### PR DESCRIPTION
## Summary

`ToNumber(Symbol)` and `ToNumber(BigInt)` are both **TypeErrors** in ECMAScript (§7.1.4). In Perry only the `+` operator enforced this — the other numeric-coercion sites each have their own `ToNumber` and silently produced `NaN`/garbage:

```ts
const s = Symbol();
Number(s)            // was NaN          → now TypeError
(s as any) * 2       // was NaN          → now TypeError
new Int8Array(s as any)   // was garbage → now TypeError
new Int8Array(5n as any)  // was empty   → now TypeError
const a = new Int8Array(3); a[0] = s as any;  // was silent → now TypeError
Number.prototype.toPrecision(s)               // was no-throw → now TypeError
```

This is one spec rule across several scattered coercion sites. The fix adds the missing guard at each **shared** runtime entry point — all additive throws, no normal path changes.

## Changes

- **`builtins/numbers.rs` `js_number_coerce`** — a Symbol throws before the pointer/`toPrimitive` path. This is the function codegen routes through for `Number(sym)` *and* for arithmetic on a non-numeric operand (`expr/binary.rs` / `expr/unary.rs` fallback), so explicit and implicit `ToNumber` both match Node now. **BigInt is intentionally left converting here** (`Number(1n)` is allowed); the arithmetic-throws-on-BigInt rule already lives at the arithmetic call sites (`dynamic_arith.rs` `both_bigint_or_throw`).
- **`string/format.rs` `toPrecision` / `toExponential`** — `ToIntegerOrInfinity(arg)` (which routes through `js_number_coerce`) now runs *before* the non-finite check on the receiver, matching the spec step order, so a Symbol argument throws even when `x` is `NaN`/`±Infinity` (e.g. `Number.prototype.toPrecision(Symbol())`, whose `[[NumberData]]` is `+0`).
- **`typedarray/mod.rs`** — `jsvalue_to_f64` (element store on a numeric view) and `js_typed_array_new` (the length argument) throw on Symbol and BigInt. BigInt views are unaffected: `js_typed_array_set` routes `ToBigInt` separately before reaching these.

## Verification

- **Node-identical** in both the default (`PERRY_NO_CACHE=1`) and `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 PERRY_ALLOW_UNIMPLEMENTED=1` builds for all cases above, plus regression spot-checks (`5*3`, `Number("0x1f")`, `Number([5])`, `new Int8Array([1,2,300])`, `c[0]=1.5`, `big[0]=7n`, `(123.456).toPrecision(4)`).
- `cargo test --release -p perry-runtime --lib` — **979 passed**.
- test262 `built-ins/Number` real parity **71.5% → 73.3%** (the `js_number_coerce` guard plus the `toPrecision`/`toExponential` ordering fix).

## Not in scope (follow-up)

`Math.*` argument coercion (`Math.abs(Symbol())` etc.) is a separate, scattered codegen change — the ~35 `Expr::Math*` arms emit LLVM intrinsics / `js_math_*` directly on the raw operand across 4 files. Filing a granular follow-up rather than bundling that risk here.
