### PR TITLE
fix(date): TimeClip, present-undefined ctor args, reflective toISOString/toJSON, Date statics

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -236,13 +236,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // minute?, second?, ms?)` in local time. dayjs's parseDate
                 // takes this branch with regex-captured string args — see
                 // js_date_new_local_components for the coercion path.
-                let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
                 let mut vals: Vec<String> = Vec::with_capacity(7);
                 for a in args.iter().take(7) {
                     vals.push(lower_expr(ctx, a)?);
                 }
+                // Pad *absent* trailing components with their ECMA-262 default
+                // literal (slot 2 `day` → 1, time slots 3-6 → 0) rather than
+                // `undefined`, so the runtime can run a plain ToNumber on every
+                // forwarded slot: a *present* `undefined` then coerces to NaN
+                // (Invalid Date), while a truly-omitted arg uses its default.
+                // Slots: 0 year, 1 month, 2 day, 3 hour, 4 min, 5 sec, 6 ms.
                 while vals.len() < 7 {
-                    vals.push(undef.clone());
+                    let default = if vals.len() == 2 { 1.0 } else { 0.0 };
+                    vals.push(double_literal(default));
                 }
                 let blk = ctx.block();
                 let call_args: Vec<(crate::types::LlvmType, &str)> =

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -297,7 +297,11 @@ pub extern "C" fn js_date_new_from_value(value: f64) -> f64 {
         // (rather than silently producing an Invalid Date from raw pointer bits).
         jsvalue_to_number(value)
     };
-    alloc_date_cell(result)
+    // `new Date(number)` applies TimeClip: `abs(t) > 8.64e15` → Invalid, and a
+    // fractional timestamp truncates toward zero (`new Date(123.9).getTime()`
+    // === 123). Copying another Date or parsing a string already yields an
+    // integral in-range value, so this is idempotent for those paths.
+    alloc_date_cell(time_clip(result))
 }
 
 /// Number of days from the civil date 1970-01-01 to `y-m-d` (m is 1-based,
@@ -329,6 +333,26 @@ fn make_utc_ms(year: i64, month0: i64, day: i64, hour: i64, min: i64, sec: i64, 
     let days = days_from_civil(norm_year, norm_month1, day);
     let secs = days * 86400 + hour * 3600 + min * 60 + sec;
     (secs * 1000 + ms) as f64
+}
+
+/// ECMA-262 `TimeClip(time)`: a constructed/derived millisecond time value is
+/// `NaN` when it is non-finite or `abs(t) > 8.64e15`, otherwise it is truncated
+/// toward zero (`ToIntegerOrInfinity`) with `-0` normalized to `+0`. Every
+/// public Date construction/`UTC`/setter result path funnels its computed time
+/// through this so out-of-range dates become Invalid and fractional inputs
+/// (`new Date(123.9)`) drop their fraction, matching Node.
+#[inline]
+pub(crate) fn time_clip(t: f64) -> f64 {
+    if !t.is_finite() || t.abs() > 8.64e15 {
+        return f64::NAN;
+    }
+    let i = t.trunc();
+    // Normalize -0 to +0 (TimeClip step 3: `ToInteger(time) + (+0)`).
+    if i == 0.0 {
+        0.0
+    } else {
+        i
+    }
 }
 
 /// Apply the ECMA-262 `0..=99 => 1900 + y` rebasing for an integral year
@@ -911,17 +935,21 @@ pub extern "C" fn js_date_utc(args_ptr: *const f64, argc: i32) -> f64 {
     let minute = get(4, 0.0);
     let second = get(5, 0.0);
     let ms = get(6, 0.0);
-    if year.is_nan()
-        || month.is_nan()
-        || day.is_nan()
-        || hour.is_nan()
-        || minute.is_nan()
-        || second.is_nan()
-        || ms.is_nan()
+    // MakeDay/MakeTime return NaN when any component is non-finite (`Infinity`,
+    // `-Infinity`, or `NaN`); a bare `is_nan` check would let `Infinity` through
+    // and saturate `as i64` to a bogus timestamp, so reject every non-finite
+    // component before assembling.
+    if !year.is_finite()
+        || !month.is_finite()
+        || !day.is_finite()
+        || !hour.is_finite()
+        || !minute.is_finite()
+        || !second.is_finite()
+        || !ms.is_finite()
     {
         return f64::NAN;
     }
-    make_utc_ms(
+    time_clip(make_utc_ms(
         year as i64,
         month as i64,
         day as i64,
@@ -929,7 +957,7 @@ pub extern "C" fn js_date_utc(args_ptr: *const f64, argc: i32) -> f64 {
         minute as i64,
         second as i64,
         ms as i64,
-    )
+    ))
 }
 
 /// Keepalive anchor for `js_date_utc` — codegen-only `#[no_mangle]` symbols
@@ -1067,7 +1095,7 @@ pub extern "C" fn js_date_apply_setter(
         } else {
             jsvalue_to_number(args[0])
         };
-        return date_cell_store(date, v);
+        return date_cell_store(date, time_clip(v));
     }
     // setYear (annexB): like setFullYear but rebases a truncated year in
     // `0..=99` to `1900 + y`, operates in local time, and has no UTC variant.
@@ -1165,34 +1193,28 @@ pub extern "C" fn js_date_new_local_components(
     second: f64,
     millisecond: f64,
 ) -> f64 {
-    fn coerce(v: f64, default: f64) -> f64 {
-        let bits = v.to_bits();
-        let tag = (bits >> 48) & 0xFFFF;
-        if tag == 0x7FFC && (bits & 0xFF) == 0x01 {
-            // undefined — optional trailing args take their default; a required
-            // leading `undefined` passes NaN (callers supply `default = NaN`).
-            default
-        } else {
-            // Everything else goes through ECMAScript ToNumber: strings parse,
-            // booleans/null coerce numerically, objects run a single valueOf,
-            // and Symbol/BigInt throw.
-            jsvalue_to_number(v)
-        }
-    }
-    let y = coerce(year, f64::NAN);
-    let m = coerce(month, f64::NAN);
-    let d = coerce(day, 1.0);
-    let h = coerce(hour, 0.0);
-    let mi = coerce(minute, 0.0);
-    let s = coerce(second, 0.0);
-    let ms = coerce(millisecond, 0.0);
-    if y.is_nan()
-        || m.is_nan()
-        || d.is_nan()
-        || h.is_nan()
-        || mi.is_nan()
-        || s.is_nan()
-        || ms.is_nan()
+    // Every argument codegen forwards is a *present* component: omitted
+    // trailing parameters are padded with their ECMA-262 default literal
+    // (`day = 1`, time fields = 0) at the call site, so here we run a plain
+    // ToNumber on each — a *present* `undefined` (e.g. `new Date(1899, 11,
+    // undefined)` or `DateValue(1899, 11)` where the wrapper forwards all seven
+    // params) coerces to NaN and produces an Invalid Date, matching Node.
+    let y = jsvalue_to_number(year);
+    let m = jsvalue_to_number(month);
+    let d = jsvalue_to_number(day);
+    let h = jsvalue_to_number(hour);
+    let mi = jsvalue_to_number(minute);
+    let s = jsvalue_to_number(second);
+    let ms = jsvalue_to_number(millisecond);
+    // MakeDay/MakeTime yield NaN for any non-finite component (Infinity as well
+    // as NaN), so reject all non-finite values before assembling.
+    if !y.is_finite()
+        || !m.is_finite()
+        || !d.is_finite()
+        || !h.is_finite()
+        || !mi.is_finite()
+        || !s.is_finite()
+        || !ms.is_finite()
     {
         return alloc_date_cell(f64::NAN);
     }
@@ -1212,7 +1234,7 @@ pub extern "C" fn js_date_new_local_components(
     );
     let local_secs = (local_ms as i64).div_euclid(1000);
     let (_, _, _, _, _, _, tz_offset) = timestamp_to_local_components(local_secs);
-    alloc_date_cell(local_ms - (tz_offset * 1000) as f64)
+    alloc_date_cell(time_clip(local_ms - (tz_offset * 1000) as f64))
 }
 
 // --- UTC getters: same impl as the regular getters since we store UTC internally ---
@@ -1366,12 +1388,13 @@ fn rebuild_with(
             cur_ms,
         )
     };
-    // If any provided override is NaN, the Date becomes Invalid.
+    // If any provided override is non-finite (NaN or ±Infinity), the Date
+    // becomes Invalid.
     for o in [year, month0, day, hour, minute, second, millisecond]
         .into_iter()
         .flatten()
     {
-        if o.is_nan() {
+        if !o.is_finite() {
             return date_cell_store(date, f64::NAN);
         }
     }
@@ -1384,7 +1407,9 @@ fn rebuild_with(
         second.map(|v| v as i64).unwrap_or(cs),
         millisecond.map(|v| v as i64).unwrap_or(cur_ms),
     );
-    date_cell_store(date, ms)
+    // TimeClip the rebuilt value: a setter that overflows ±8.64e15 makes the
+    // Date Invalid (`new Date(8.64e15).setHours(24)` → NaN).
+    date_cell_store(date, time_clip(ms))
 }
 
 // --- Local-time setters (#1187 / #2851) ---
@@ -1437,7 +1462,7 @@ fn rebuild_local_with(
         .into_iter()
         .flatten()
     {
-        if o.is_nan() {
+        if !o.is_finite() {
             return date_cell_store(date, f64::NAN);
         }
     }
@@ -1452,7 +1477,9 @@ fn rebuild_local_with(
     );
     let local_secs = (local_ms as i64).div_euclid(1000);
     let (_, _, _, _, _, _, tz_offset) = timestamp_to_local_components(local_secs);
-    date_cell_store(date, local_ms - (tz_offset * 1000) as f64)
+    // TimeClip after the local→UTC adjustment so an overflowing local setter
+    // (`new Date(8.64e15).setHours(24)`) makes the Date Invalid.
+    date_cell_store(date, time_clip(local_ms - (tz_offset * 1000) as f64))
 }
 
 // --- String-returning Date methods ---

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -731,8 +731,11 @@ pub extern "C" fn js_date_to_iso_string(timestamp: f64) -> *mut crate::StringHea
         return invalid_date_string();
     }
     let ts_ms = timestamp as i64;
-    let secs = ts_ms / 1000;
-    let millis = (ts_ms % 1000).unsigned_abs() as u32;
+    // Floor-divide so sub-epoch timestamps round toward -∞: `new Date(-1)` is
+    // `1969-12-31T23:59:59.999Z`, not `1970-01-01T00:00:00.001Z`. Truncating
+    // division (`/`, `%`) gave `secs = 0, millis = 1` for `-1`.
+    let secs = ts_ms.div_euclid(1000);
+    let millis = ts_ms.rem_euclid(1000) as u32;
 
     // Calculate date components from Unix timestamp
     // This is a simplified implementation - proper implementation would use chrono crate

--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -69,6 +69,81 @@ date_getter_thunk!(
     crate::date::js_date_get_timezone_offset
 );
 
+/// `Date.prototype.toISOString` reflective thunk. The instance fast path
+/// (`d.toISOString()`) is lowered by codegen straight to
+/// `js_date_to_iso_string_or_throw`, but the value form
+/// (`Date.prototype.toISOString.call(x)`) reaches here: brand-check `this`
+/// (TypeError on a non-Date receiver), then format-or-throw (RangeError when
+/// the time value is `NaN`).
+extern "C" fn date_to_iso_string(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    if !crate::date::is_date_value(this) {
+        super::object_ops::throw_object_type_error(b"this is not a Date object.");
+    }
+    let s = crate::date::js_date_to_iso_string_or_throw(this);
+    crate::value::js_nanbox_string(s as i64)
+}
+
+/// `Date.prototype.toJSON` reflective thunk. Unlike the getters this is a
+/// *generic* method — it is not brand-checked to Date. Per ECMA-262
+/// (`thisTimeValue` is NOT used): `ToObject(this)`, then `ToPrimitive(this,
+/// number)`; if that primitive is a Number and not finite, return `null`;
+/// otherwise return `Invoke(this, "toISOString")`. So it works for a real Date
+/// (Invalid → `null`), a plain object carrying its own `toISOString`, and a
+/// `Number(-Infinity)` wrapper (→ `null`).
+extern "C" fn date_to_json(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let jsv = crate::value::JSValue::from_bits(this.to_bits());
+    // ToObject(this): null / undefined throw a TypeError.
+    if jsv.is_undefined() || jsv.is_null() {
+        super::object_ops::throw_object_type_error(b"Cannot convert undefined or null to object");
+    }
+    // ToPrimitive(this, hint Number).
+    let tv = if crate::date::is_date_value(this) {
+        crate::date::date_cell_timestamp(this)
+    } else {
+        match unsafe { crate::value::ordinary_to_primitive_number_for_add(this) } {
+            crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => p,
+            // A plain object's default `"[object Object]"` is a String, never a
+            // Number, so step 3 (non-finite Number → null) never fires; fall
+            // through to the `toISOString` invocation.
+            crate::value::OrdinaryToPrimitiveOutcome::DefaultString => {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            }
+            crate::value::OrdinaryToPrimitiveOutcome::TypeError => {
+                super::object_ops::throw_object_type_error(
+                    b"Cannot convert object to primitive value",
+                )
+            }
+        }
+    };
+    // Step 3: if the primitive is a Number and is not finite, return null.
+    let tv_jsv = crate::value::JSValue::from_bits(tv.to_bits());
+    let as_num = if tv_jsv.is_int32() {
+        Some(((tv.to_bits() & 0xFFFF_FFFF) as u32 as i32) as f64)
+    } else if tv_jsv.is_number() {
+        Some(tv)
+    } else {
+        None
+    };
+    if let Some(n) = as_num {
+        if !n.is_finite() {
+            return f64::from_bits(crate::value::TAG_NULL);
+        }
+    }
+    // Step 4: Invoke(this, "toISOString").
+    let name = b"toISOString";
+    unsafe {
+        crate::object::js_native_call_method(
+            this,
+            name.as_ptr() as *const i8,
+            name.len(),
+            std::ptr::null(),
+            0,
+        )
+    }
+}
+
 /// Legacy `Date.prototype.getYear` — `getFullYear() - 1900` (NaN-preserving).
 extern "C" fn date_get_year(_closure: *const crate::closure::ClosureHeader) -> f64 {
     let fy = crate::date::js_date_get_full_year(require_date_timestamp());
@@ -111,6 +186,16 @@ pub(crate) fn install_date_proto_getters(proto_obj: *mut ObjectHeader) {
     for (name, ptr) in methods.iter().copied() {
         super::global_this::install_proto_method(proto_obj, name, ptr, 0);
     }
+    // String-returning / generic methods that also need real reflective thunks
+    // (overwriting their no-op entries). `toJSON` is generic (`.length === 1`),
+    // `toISOString` brand-checks `this` (`.length === 0`).
+    super::global_this::install_proto_method(
+        proto_obj,
+        "toISOString",
+        date_to_iso_string as *const u8,
+        0,
+    );
+    super::global_this::install_proto_method(proto_obj, "toJSON", date_to_json as *const u8, 1);
 }
 
 // --- Setters ---------------------------------------------------------------

--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -144,6 +144,63 @@ extern "C" fn date_to_json(_closure: *const crate::closure::ClosureHeader) -> f6
     }
 }
 
+// --- Date constructor static methods (Date.now / Date.parse / Date.UTC) ---
+//
+// The functional call forms are codegen intrinsics (`Expr::DateNow` /
+// `DateParse` / `DateUtc`), recognized at HIR lowering before any property
+// lookup, so these closures never intercept `Date.now()` etc. They exist only
+// so the statics are real own properties of the `Date` constructor — readable
+// as values (`const f = Date.UTC; f(...)`) and observable through reflection
+// (`Date.UTC.name === "UTC"`, `Date.UTC.length === 7`,
+// `getOwnPropertyDescriptor(Date, "UTC")`).
+
+/// `Date.now()` — current time in milliseconds.
+extern "C" fn date_now_static(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    crate::date::js_date_now()
+}
+
+/// `Date.parse(string)` — ToString the argument, then parse to a ms timestamp.
+extern "C" fn date_parse_static(_closure: *const crate::closure::ClosureHeader, arg: f64) -> f64 {
+    let s = crate::value::js_jsvalue_to_string(arg);
+    crate::date::js_date_parse(s as *const crate::string::StringHeader)
+}
+
+/// `Date.UTC(year, month?, day?, …)` — variadic; forwards to `js_date_utc`.
+extern "C" fn date_utc_static(_closure: *const crate::closure::ClosureHeader, rest: f64) -> f64 {
+    let vals = super::global_this::global_this_rest_array_values(rest);
+    crate::date::js_date_utc(vals.as_ptr(), vals.len() as i32)
+}
+
+/// Install `now` / `parse` / `UTC` as own data properties on the `Date`
+/// constructor closure. Called from `install_builtin_constructor_statics`.
+pub(crate) fn install_date_constructor_statics(ctor: *mut crate::closure::ClosureHeader) {
+    if ctor.is_null() {
+        return;
+    }
+    // (name, fn-ptr, spec `.length`, has_rest)
+    super::global_this::install_constructor_static(
+        ctor,
+        "now",
+        date_now_static as *const u8,
+        0,
+        false,
+    );
+    super::global_this::install_constructor_static(
+        ctor,
+        "parse",
+        date_parse_static as *const u8,
+        1,
+        false,
+    );
+    super::global_this::install_constructor_static(
+        ctor,
+        "UTC",
+        date_utc_static as *const u8,
+        7,
+        true,
+    );
+}
+
 /// Legacy `Date.prototype.getYear` — `getFullYear() - 1900` (NaN-preserving).
 extern "C" fn date_get_year(_closure: *const crate::closure::ClosureHeader) -> f64 {
     let fy = crate::date::js_date_get_full_year(require_date_timestamp());

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3204,7 +3204,7 @@ extern "C" fn subtle_crypto_decapsulate_key_thunk(
 /// `{ writable: true, enumerable: false, configurable: true }` data property
 /// (matching Node's descriptors for built-in statics). `has_rest` registers
 /// the func pointer as a rest-arg closure so trailing args arrive as an array.
-fn install_constructor_static(
+pub(super) fn install_constructor_static(
     ctor: *mut crate::closure::ClosureHeader,
     name: &str,
     func_ptr: *const u8,
@@ -3346,6 +3346,12 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
             );
             install_constructor_static(ctor, "from", array_from_thunk as *const u8, 1, false);
             install_constructor_static(ctor, "of", array_of_thunk as *const u8, 0, true);
+        }
+        "Date" => {
+            // `Date.now` / `Date.parse` / `Date.UTC` as real own data props
+            // (thunks live in `date_proto_thunks`). The functional calls are
+            // codegen intrinsics, so this only affects value reads + reflection.
+            date_proto_thunks::install_date_constructor_statics(ctor);
         }
         "Number" => {
             install_constructor_static(ctor, "isNaN", number_is_nan_thunk as *const u8, 1, false);


### PR DESCRIPTION
## Summary

Fixes a cluster of small, independent `Date` parity gaps in `built-ins/Date`
(test262). Net effect on the `built-ins/Date` radar: **125 → 87 failures
(38 fixed, 0 regressions)**.

## Changes

1. **TimeClip** — every Date construction / `Date.UTC` / `set*` result path now
   applies ECMA-262 `TimeClip`: timestamps with `|t| > 8.64e15` (or any
   non-finite component, e.g. `Infinity`, not just `NaN`) become Invalid, and a
   fractional timestamp truncates toward zero (`new Date(123.9).getTime() ===
   123`; `-0` normalizes to `+0`). Component checks switched from `is_nan` to
   `!is_finite` in `Date.UTC`, the local-components constructor, and the
   `set*` rebuild paths so `Infinity` components no longer saturate `as i64`.

2. **Present-`undefined` constructor args** — `new Date(y, m, d, …)` now pads
   only *absent* trailing components with their spec default (codegen forwards a
   *present* `undefined` unchanged, so it `ToNumber`s to `NaN` → Invalid Date).
   `DateValue(1899, 11)` where the wrapper forwards all seven params now yields
   `NaN`, matching Node (`S15.9.3.1_A6_T*`).

3. **Reflective `toISOString` / `toJSON`** — real brand-checked thunks replace
   the no-op entries. `Date.prototype.toISOString.call(x)` throws `TypeError`
   on a non-Date receiver and `RangeError` on an Invalid Date; `toJSON` runs the
   generic algorithm (`ToPrimitive(this, number)` → `null` on non-finite Number,
   else `Invoke(this, "toISOString")`) so it works for a real Date, a plain
   object carrying its own `toISOString`, and a `Number(-Infinity)` wrapper.

4. **`Date.now` / `Date.parse` / `Date.UTC` statics** — installed as real own
   data properties on the `Date` constructor (`{ writable, !enumerable,
   configurable }`). The functional calls remain codegen intrinsics, so this
   only affects value reads + reflection (fixes the `prop-desc` /
   property-presence cases). The static closures' own `.name` / `.length` reads
   remain `undefined`, which is a pre-existing cross-builtin reflection gap
   (`Array.isArray.name` is likewise `undefined`) and is left out of scope.

5. **`toISOString` floor-division** — sub-epoch timestamps now round toward −∞:
   `new Date(-1).toISOString() === "1969-12-31T23:59:59.999Z"` (was the
   truncating `1970-01-01T00:00:00.001Z`). Positive timestamps are unchanged.

## Validation

- `built-ins/Date` radar: 125 → 87 failures, **0 regressions**.
- `cargo test -p perry-runtime --lib`: 979 passed, 0 failed.
- Byte-identical to `node --experimental-strip-types` on a focused Date suite
  in **both** default and `PERRY_NO_AUTO_OPTIMIZE=1` builds.

## Out of scope (left failing)

- `toJSON` edge tests requiring getter-accessor method invocation + primitive→
  wrapper method lookup (`invoke-abrupt`, `invoke-arguments`, `to-object`).
- The cross-builtin `.name`/`.length` reflection-read gap on static-method
  closures (shared with `Array.isArray` etc.).
- `toUTCString` formatter (no runtime impl yet) and the negative-extended-year
  serialization.
