### PR TITLE
[codex] Apply ToNumber to Math operands

### DIFF
--- a/crates/perry-codegen/src/expr/array_methods.rs
+++ b/crates/perry-codegen/src/expr/array_methods.rs
@@ -38,8 +38,8 @@ use super::{
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
+    lower_index_set_fast, lower_js_args_array, lower_math_operand, lower_object_literal,
+    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
     nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
     try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
     unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
@@ -268,7 +268,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ))
         }
         Expr::MathClz32(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_clz32", &[(DOUBLE, &v)]))
         }
         Expr::FsReadFileSync(p) => {

--- a/crates/perry-codegen/src/expr/math_simple.rs
+++ b/crates/perry-codegen/src/expr/math_simple.rs
@@ -38,8 +38,8 @@ use super::{
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
+    lower_index_set_fast, lower_js_args_array, lower_math_operand, lower_object_literal,
+    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
     nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
     try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
     unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
@@ -55,8 +55,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- Math.pow (special variant — separate from Binary::Pow) --------
         Expr::MathPow(base, exp) => {
-            let b = lower_expr(ctx, base)?;
-            let e = lower_expr(ctx, exp)?;
+            let b = lower_math_operand(ctx, base)?;
+            let e = lower_math_operand(ctx, exp)?;
             Ok(ctx
                 .block()
                 .call(DOUBLE, "js_math_pow", &[(DOUBLE, &b), (DOUBLE, &e)]))
@@ -77,8 +77,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // but no real hash/PRNG feeds those to imul, so we accept that minor
         // divergence rather than adding a compare-and-select gate per call.
         Expr::MathImul(a, b) => {
-            let av = lower_expr(ctx, a)?;
-            let bv = lower_expr(ctx, b)?;
+            let av = lower_math_operand(ctx, a)?;
+            let bv = lower_math_operand(ctx, b)?;
             let blk = ctx.block();
             let a_i64 = blk.fptosi(DOUBLE, &av, I64);
             let b_i64 = blk.fptosi(DOUBLE, &bv, I64);
@@ -194,21 +194,21 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         //
         // Uses LLVM intrinsics (llvm.sqrt.f64, llvm.floor.f64, etc.).
         Expr::MathSqrt(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "llvm.sqrt.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathFloor(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "llvm.floor.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathCeil(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "llvm.ceil.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathRound(operand) => {
             // JS Math.round: round-half-toward-positive-infinity. We
             // emulate via floor(x + 0.5) then fcopysign to preserve -0.
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             let blk = ctx.block();
             let half = blk.fadd(&v, "0.5");
             let floored = blk.call(DOUBLE, "llvm.floor.f64", &[(DOUBLE, &half)]);
@@ -219,23 +219,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ))
         }
         Expr::MathAbs(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "llvm.fabs.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathLog(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "llvm.log.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathLog2(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "llvm.log2.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathLog10(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "llvm.log10.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathLog1p(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "js_math_log1p", &[(DOUBLE, &v)]))
         }
         // Math.random — return 0.5 sentinel. Real impl needs a PRNG

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -38,8 +38,8 @@ use super::{
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
+    lower_index_set_fast, lower_js_args_array, lower_math_operand, lower_object_literal,
+    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
     nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
     try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
     unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
@@ -49,11 +49,11 @@ use super::{
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::MathFround(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "js_math_fround", &[(DOUBLE, &v)]))
         }
         Expr::MathF16round(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx
                 .block()
                 .call(DOUBLE, "js_math_f16round", &[(DOUBLE, &v)]))
@@ -563,7 +563,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- Math.cbrt --------
         Expr::MathCbrt(operand) => {
-            let v = lower_expr(ctx, operand)?;
+            let v = lower_math_operand(ctx, operand)?;
             Ok(ctx.block().call(DOUBLE, "js_math_cbrt", &[(DOUBLE, &v)]))
         }
 
@@ -824,13 +824,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 return Ok(double_literal(0.0));
             }
             if values.len() == 1 {
-                let v = lower_expr(ctx, &values[0])?;
+                let v = lower_math_operand(ctx, &values[0])?;
                 // Math.hypot(x) = |x|
                 return Ok(ctx.block().call(DOUBLE, "llvm.fabs.f64", &[(DOUBLE, &v)]));
             }
-            let mut acc = lower_expr(ctx, &values[0])?;
+            let mut acc = lower_math_operand(ctx, &values[0])?;
             for v in &values[1..] {
-                let rhs = lower_expr(ctx, v)?;
+                let rhs = lower_math_operand(ctx, v)?;
                 let blk = ctx.block();
                 acc = blk.call(DOUBLE, "js_math_hypot", &[(DOUBLE, &acc), (DOUBLE, &rhs)]);
             }

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1979,3 +1979,14 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         ),
     }
 }
+
+pub(crate) fn lower_math_operand(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
+    let raw = lower_expr(ctx, expr)?;
+    if is_numeric_expr(ctx, expr) {
+        Ok(raw)
+    } else {
+        Ok(ctx
+            .block()
+            .call(DOUBLE, "js_math_to_number", &[(DOUBLE, &raw)]))
+    }
+}

--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -38,8 +38,8 @@ use super::{
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
     lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
+    lower_index_set_fast, lower_js_args_array, lower_math_operand, lower_object_literal,
+    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
     nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
     try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
     unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
@@ -218,11 +218,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ))
         }
         Expr::MathExpm1(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_expm1", &[(DOUBLE, &v)]))
         }
         Expr::MathExp(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "llvm.exp.f64", &[(DOUBLE, &v)]))
         }
         Expr::DateSetUtcFullYear { date, args } => super::os_uri_dates::lower_date_setter(
@@ -348,45 +348,45 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- Math.sin/cos via LLVM intrinsics --------
         Expr::MathSin(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "llvm.sin.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathCos(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "llvm.cos.f64", &[(DOUBLE, &v)]))
         }
         // Hyperbolic + extra trig via runtime (uses Rust's f64 methods).
         Expr::MathSinh(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_sinh", &[(DOUBLE, &v)]))
         }
         Expr::MathCosh(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_cosh", &[(DOUBLE, &v)]))
         }
         Expr::MathTanh(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_tanh", &[(DOUBLE, &v)]))
         }
         Expr::MathTan(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_tan", &[(DOUBLE, &v)]))
         }
         Expr::MathAsin(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_asin", &[(DOUBLE, &v)]))
         }
         Expr::MathAcos(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_acos", &[(DOUBLE, &v)]))
         }
         Expr::MathAtan(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_atan", &[(DOUBLE, &v)]))
         }
         Expr::MathAtan2(y, x) => {
-            let y_v = lower_expr(ctx, y)?;
-            let x_v = lower_expr(ctx, x)?;
+            let y_v = lower_math_operand(ctx, y)?;
+            let x_v = lower_math_operand(ctx, x)?;
             Ok(ctx
                 .block()
                 .call(DOUBLE, "js_math_atan2", &[(DOUBLE, &y_v), (DOUBLE, &x_v)]))
@@ -423,15 +423,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::ProcessStdout => Ok(ctx.block().call(DOUBLE, "js_process_stdout", &[])),
         Expr::ProcessStderr => Ok(ctx.block().call(DOUBLE, "js_process_stderr", &[])),
         Expr::MathAsinh(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_asinh", &[(DOUBLE, &v)]))
         }
         Expr::MathAcosh(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_acosh", &[(DOUBLE, &v)]))
         }
         Expr::MathAtanh(o) => {
-            let v = lower_expr(ctx, o)?;
+            let v = lower_math_operand(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_math_atanh", &[(DOUBLE, &v)]))
         }
         Expr::DateSetUtcDate { date, args } => super::os_uri_dates::lower_date_setter(

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -492,6 +492,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // and prints as `<Buffer xx xx ...>`.
     module.declare_function("js_fs_read_file_binary", I64, &[DOUBLE]);
     module.declare_function("js_number_coerce", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_math_to_number", DOUBLE, &[DOUBLE]);
     module.declare_function("js_set_add", I64, &[I64, DOUBLE]);
     module.declare_function("js_set_has", I32, &[I64, DOUBLE]);
     module.declare_function("js_set_delete", I32, &[I64, DOUBLE]);

--- a/crates/perry-runtime/src/math.rs
+++ b/crates/perry-runtime/src/math.rs
@@ -2,6 +2,24 @@
 
 use rand::Rng;
 
+/// Math built-ins apply ECMAScript ToNumber, where Symbol and BigInt throw.
+/// `Number(1n)` is allowed in JavaScript, so this stays separate from the
+/// shared `js_number_coerce` helper used by the Number constructor.
+#[no_mangle]
+pub extern "C" fn js_math_to_number(value: f64) -> f64 {
+    let jsval = crate::value::JSValue::from_bits(value.to_bits());
+    if jsval.is_bigint() {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
+    }
+    if jsval.is_pointer() {
+        let ptr = (value.to_bits() & crate::value::POINTER_MASK) as usize;
+        if crate::symbol::is_registered_symbol(ptr) {
+            crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a number");
+        }
+    }
+    crate::builtins::js_number_coerce(value)
+}
+
 /// Math.pow(base, exponent) -> number
 #[no_mangle]
 pub extern "C" fn js_math_pow(base: f64, exp: f64) -> f64 {
@@ -228,7 +246,7 @@ pub extern "C" fn js_math_min_array(arr_ptr: i64) -> f64 {
     }
     let mut result = f64::INFINITY;
     for i in 0..len {
-        let num = crate::array::js_array_get_f64(arr, i as u32);
+        let num = js_math_to_number(crate::array::js_array_get_f64(arr, i as u32));
         if num.is_nan() {
             return f64::NAN;
         }
@@ -252,7 +270,7 @@ pub extern "C" fn js_math_max_array(arr_ptr: i64) -> f64 {
     }
     let mut result = f64::NEG_INFINITY;
     for i in 0..len {
-        let num = crate::array::js_array_get_f64(arr, i as u32);
+        let num = js_math_to_number(crate::array::js_array_get_f64(arr, i as u32));
         if num.is_nan() {
             return f64::NAN;
         }

--- a/test-parity/node-suite/globals/math-tonumber-coercion.ts
+++ b/test-parity/node-suite/globals/math-tonumber-coercion.ts
@@ -1,0 +1,42 @@
+function show(label: string, value: number): void {
+  if (Object.is(value, -0)) {
+    console.log(label, "-0");
+  } else if (Number.isNaN(value)) {
+    console.log(label, "NaN");
+  } else {
+    console.log(label, String(value));
+  }
+}
+
+function throwsTypeError(label: string, thunk: () => unknown): void {
+  try {
+    console.log(label, "value", thunk());
+  } catch (err: any) {
+    console.log(label, "throw", err instanceof TypeError, err.name);
+  }
+}
+
+const sym = Symbol("math");
+
+throwsTypeError("abs symbol", () => Math.abs(sym as any));
+throwsTypeError("sin bigint", () => Math.sin(5n as any));
+throwsTypeError("pow symbol", () => Math.pow(sym as any, 2));
+throwsTypeError("atan2 bigint", () => Math.atan2(1, 5n as any));
+throwsTypeError("fround symbol", () => Math.fround(sym as any));
+throwsTypeError("clz32 bigint", () => Math.clz32(5n as any));
+throwsTypeError("hypot symbol", () => Math.hypot(3, sym as any));
+throwsTypeError("min symbol", () => Math.min(1, sym as any));
+throwsTypeError("max bigint", () => Math.max(1, 5n as any));
+
+show("abs string", Math.abs("-5" as any));
+show("floor bool", Math.floor(true as any));
+show("ceil null", Math.ceil(null as any));
+show("sqrt string", Math.sqrt("16" as any));
+show("sin string", Math.sin("0" as any));
+show("pow strings", Math.pow("2" as any, "3" as any));
+show("imul strings", Math.imul("2" as any, "3" as any));
+show("fround true", Math.fround(true as any));
+show("clz32 string", Math.clz32("1" as any));
+show("hypot mixed", Math.hypot("3" as any, true as any));
+show("min mixed", Math.min("3" as any, true as any));
+show("max mixed", Math.max("3" as any, true as any));


### PR DESCRIPTION
## Summary
- Add a Math-specific `js_math_to_number` helper that rejects Symbol/BigInt operands and delegates ordinary coercions.
- Route generated `Math.*` operands through the helper while preserving statically numeric fast paths.
- Apply the same helper to `Math.min` and `Math.max` array runtime paths.
- Add a node-suite fixture covering Symbol/BigInt throws plus string, bool, and null coercions.

## Validation
- Reproduced Node/Perry mismatch before the fix: Node 26 threw TypeError for Symbol/BigInt Math operands; Perry returned raw Symbol/BigInt values on early paths and later segfaulted on a raw Symbol path.
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/math-tonumber-coercion.ts`
- Direct Perry compile/run of the same fixture with `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1`; Node/Perry diff was empty.
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-webcrypto-cryptokey-property-exposure-20260604/target cargo check -q -p perry-codegen --lib`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-webcrypto-cryptokey-property-exposure-20260604/target cargo check -q -p perry-runtime --lib`
- `RUSTFLAGS="-Awarnings" CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-webcrypto-cryptokey-property-exposure-20260604/target cargo build -q -p perry`
- `RUSTFLAGS="-Awarnings" CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-webcrypto-cryptokey-property-exposure-20260604/target cargo build -q -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Note: the full `run_parity_tests.sh` harness was not used because it hardcodes the release `target/release/perry`; direct Node/Perry fixture comparison used the debug CLI and rebuilt debug runtime archive instead.