### PR TITLE
fix(runtime): ToIndex(bits) + ToBigInt(value) coercion in BigInt.asIntN/asUintN

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2952,20 +2952,69 @@ extern "C" fn number_is_integer_thunk(
 /// (RangeError on negative/non-integer), brand-checks `value` is a BigInt
 /// (TypeError otherwise), and returns the NaN-boxed result. `signed` selects
 /// asIntN vs asUintN. Diverges (`!`) on bad input, matching Node.
+/// `ToBigInt(value)` for `BigInt.asIntN`/`asUintN`'s second argument. BigInt
+/// passes through; Boolean → 0n/1n; String → StringToBigInt; an object is first
+/// reduced through ToPrimitive("number") (running its `valueOf`/`toString`) and
+/// re-coerced; a Number/undefined/null/Symbol throws a TypeError. The
+/// primitive cases reuse the same `to_bigint_for_store` helper that backs
+/// `BigInt64Array` element writes.
+fn bigint_to_bigint_arg(value: f64) -> f64 {
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_pointer() && !jv.is_bigint() {
+        // Array → ToPrimitive finds no `valueOf` override and falls to
+        // `Array.prototype.toString` = `join(",")`, then ToBigInt on that string
+        // (`[] => "" => 0n`, `[10n] => "10" => 10n`, `[1,2] => "1,2" => throws`).
+        // `js_to_primitive` doesn't apply array join, so handle it first —
+        // mirrors the array arm in `js_number_coerce`. #2378.
+        const TAG_TRUE_BITS: u64 = 0x7FFC_0000_0000_0004;
+        if crate::array::js_array_is_array(value).to_bits() == TAG_TRUE_BITS {
+            let arr_ptr = jv.as_pointer::<crate::array::ArrayHeader>();
+            let comma = crate::string::js_string_from_bytes(b",".as_ptr(), 1);
+            let joined = unsafe { crate::array::js_array_join(arr_ptr, comma) };
+            return bigint_to_bigint_arg(crate::value::js_nanbox_string(joined as i64));
+        }
+        // Object: ToPrimitive("number") then re-coerce. Try a custom
+        // [Symbol.toPrimitive] first, then OrdinaryToPrimitive
+        // (valueOf-before-toString). A primitive result recurses; anything
+        // unconvertible falls through to the TypeError in `to_bigint_for_store`.
+        let prim = unsafe { crate::symbol::js_to_primitive(value, 1) };
+        if prim.to_bits() != value.to_bits() {
+            return bigint_to_bigint_arg(prim);
+        }
+        if let crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) =
+            unsafe { crate::value::ordinary_to_primitive_number_for_add(value) }
+        {
+            if p.to_bits() != value.to_bits() {
+                return bigint_to_bigint_arg(p);
+            }
+        }
+    }
+    crate::typedarray::bigint::to_bigint_for_store(value)
+}
+
 pub(crate) fn bigint_as_n_dispatch(bits_arg: f64, value_arg: f64, signed: bool) -> f64 {
-    if !bits_arg.is_finite() || bits_arg < 0.0 || bits_arg.fract() != 0.0 {
+    // Step 1: `bits = ? ToIndex(bits)`. ToIndex = ToIntegerOrInfinity(ToNumber)
+    // with a `0 <= n <= 2^53-1` range check. `js_number_coerce` is the full
+    // ToNumber (strings, booleans, null/undefined, and objects via
+    // ToPrimitive("number") — so a `bits` object's `valueOf`/`toString` runs
+    // here, BEFORE `value` is touched, preserving the spec coercion order).
+    let bits_num = crate::builtins::js_number_coerce(bits_arg);
+    let bits_int = if bits_num.is_nan() {
+        0.0
+    } else {
+        bits_num.trunc()
+    };
+    if bits_int < 0.0 || bits_int > 9_007_199_254_740_991.0 {
         crate::fs::validate::throw_range_error_with_code(
             "The number of bits is invalid (must be a non-negative integer)",
         );
     }
-    let jv = JSValue::from_bits(value_arg.to_bits());
-    if !jv.is_bigint() {
-        crate::fs::validate::throw_type_error_with_code(
-            "Cannot convert value to a BigInt",
-            "ERR_INVALID_ARG_TYPE",
-        );
-    }
-    let bits = bits_arg as u32;
+    // Step 2: `bigint = ? ToBigInt(bigint)`. ToBigInt coerces BigInt / Boolean /
+    // String (and objects via ToPrimitive); a Number/undefined/null/Symbol
+    // throws a TypeError. Runs strictly after ToIndex(bits) above.
+    let value_bigint = bigint_to_bigint_arg(value_arg);
+    let jv = JSValue::from_bits(value_bigint.to_bits());
+    let bits = bits_int as u32;
     let ptr = jv.as_bigint_ptr() as *const crate::bigint::BigIntHeader;
     let r = if signed {
         crate::bigint::js_bigint_as_int_n(bits, ptr)

--- a/crates/perry-runtime/src/typedarray/bigint.rs
+++ b/crates/perry-runtime/src/typedarray/bigint.rs
@@ -51,7 +51,7 @@ pub(super) fn coerce_for_kind(dst_kind: u8, raw: f64) -> f64 {
 /// abstract operation, a Number (including a NaN-boxed int32), `undefined`,
 /// `null`, and Symbols are NOT convertible and throw a `TypeError`; only
 /// BigInt, Boolean, and String inputs coerce.
-pub(super) fn to_bigint_for_store(value: f64) -> f64 {
+pub(crate) fn to_bigint_for_store(value: f64) -> f64 {
     use crate::value::JSValue;
     let jsval = JSValue::from_bits(value.to_bits());
     if jsval.is_bigint() {

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -17,7 +17,7 @@ use crate::array::ArrayHeader;
 use crate::closure::ClosureHeader;
 use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
-mod bigint;
+pub(crate) mod bigint;
 mod format;
 pub use format::format_typed_array;
 


### PR DESCRIPTION
## What

`BigInt.asIntN(bits, value)` and `BigInt.asUintN(bits, value)` now coerce both
arguments per spec instead of inspecting them as raw NaN-boxed doubles:

- **`bits` → `ToIndex`** (`ToIntegerOrInfinity(ToNumber(bits))`, clamped to
  `0 … 2^53-1`). Previously `bits` was read as an `f64` and rejected unless it was
  already a finite non-negative integer, so valid inputs like `-0.9` (truncates to
  `0`), `NaN`/`undefined` (→ `0`), `"3"`, `3.9`, `[0]`, `{}` all spuriously threw
  `RangeError`.
- **`value` → `ToBigInt`** (BigInt passes through; Boolean → `0n`/`1n`; String →
  StringToBigInt; objects via ToPrimitive; Number/undefined/null/Symbol throw
  `TypeError`). Previously any non-BigInt threw `TypeError`, even the
  spec-coercible Boolean/String/object cases.

The two steps run in spec order (`ToIndex(bits)` fully, *then* `ToBigInt(value)`),
so a `bits` object's `valueOf` is observed before `value`'s.

## Why

test262 `built-ins/BigInt/{asIntN,asUintN}/{bits-toindex,order-of-steps}.js`.

## Verification

- `bits-toindex` and `order-of-steps` (both asIntN + asUintN = **4 tests**) now
  pass. Spot-checks match `node --experimental-strip-types` byte-for-byte in both
  `PERRY_NO_AUTO_OPTIMIZE=1` and the default (direct-call codegen) build:
  `asUintN(-0.9,1n)=0n`, `asIntN(4,100n)=4n`, `asUintN(NaN,5n)=0n`, `asUintN("3",10n)=2n`.
- `cargo test --release -p perry-runtime --lib` green.
- Reuses the existing `to_bigint_for_store` (the `BigInt64Array` element-write
  ToBigInt) for the primitive cases and `js_number_coerce` (the full ToNumber) for
  `bits`.

## Out of scope (pre-existing, not regressions)

- `bigint-tobigint.js` is still blocked by a separate bug: `[10n].join()` /
  `[10n].toString()` yields `"[object Object]"` (array stringification doesn't
  handle BigInt elements). Tracked for a follow-up.
- `bits-toindex-errors` / `bigint-tobigint-errors` / `*-toprimitive` assert
  `typeof BigInt.asUintN === "function"`, which fails because a bare builtin
  namespace method used as a value resolves to a leaked int (`typeof` → "number").
  That's the known namespace-member-as-value gap, unrelated to coercion.
