### PR TITLE
fix(runtime): stringify BigInt elements in Array.prototype.join

### DIFF
--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -695,6 +695,19 @@ pub extern "C" fn js_array_join(
                 } else {
                     result.push_str("[object Object]");
                 }
+            } else if jsvalue.is_bigint() {
+                // BigInt elements are NaN-boxed with BIGINT_TAG (not POINTER_TAG),
+                // so they bypass the pointer arm above and previously fell through
+                // to the `[object Object]` catch-all. ToString(BigInt) is the plain
+                // decimal digits with NO `n` suffix (`[10n].join() === "10"`).
+                let s_ptr = crate::bigint::js_bigint_to_string(jsvalue.as_bigint_ptr());
+                if !s_ptr.is_null() {
+                    let str_len = (*s_ptr).byte_len as usize;
+                    let str_data = (s_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+                    result.push_str(std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                        str_data, str_len,
+                    )));
+                }
             } else if jsvalue.is_number() {
                 let n = jsvalue.as_number();
                 if n.is_nan() {


### PR DESCRIPTION
## What

`Array.prototype.join` now stringifies BigInt elements correctly. A BigInt is
NaN-boxed with `BIGINT_TAG` (not `POINTER_TAG`), so it bypassed the pointer arm in
`js_array_join` and fell through to the `"[object Object]"` catch-all. Added an
`is_bigint()` arm that emits `ToString(BigInt)` — the plain decimal digits, no `n`
suffix.

This also fixes `Array.prototype.toString`, `String(array)`, and template-literal
interpolation of arrays, which all route through `join`.

## Why

`[10n].join()` returned `"[object Object]"` instead of `"10"`. Surfaced while
fixing `BigInt.asUintN`/`asIntN` ToBigInt coercion (sibling PR): test262
`built-ins/BigInt/{asIntN,asUintN}/bigint-tobigint.js` feeds `[10n]`/`["10"]`
through `ToBigInt` (→ `array.toString()` → BigInt parse), which silently corrupted.

## Verification

Byte-identical to `node --experimental-strip-types`, in both `PERRY_NO_AUTO_OPTIMIZE=1`
and the default (codegen `js_array_join_value`) build:

```
[1n,2n,3n].join("-")  => "1-2-3"
[1n,2n,3n].toString() => "1,2,3"
String([100n, -5n])   => "100,-5"
`${[7n,8n]}`          => "7,8"
[1, 2n, "x"].join(",")=> "1,2,x"
```

- `cargo test --release -p perry-runtime --lib` green.
- Purely additive: only the previously-`"[object Object]"` BigInt-element path
  changes; non-BigInt arrays are untouched.
