### PR TITLE
fix(regex): keep escaped hyphen `\-` literal inside a character class (#4425)

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -1885,4 +1885,24 @@ mod tests {
 
         assert_eq!(string_as_str(result), "hell0 w0rld");
     }
+
+    #[test]
+    fn escaped_hyphen_in_class_stays_literal() {
+        // #4425: `\-` inside a character class is always a literal hyphen. The
+        // Rust `regex` crate reads a bare `-` flanked by members as a range
+        // operator, so the escape must be preserved or `[a\- ]` translates to
+        // the invalid range `[a- ]`.
+        assert_eq!(js_regex_to_rust(r"[a\- ]"), r"[a\- ]");
+        assert_eq!(js_regex_to_rust(r"[:\- ]"), r"[:\- ]");
+        assert_eq!(js_regex_to_rust(r"[\-]"), r"[\-]");
+        // Outside a class a hyphen carries no range meaning, so it stays bare.
+        assert_eq!(js_regex_to_rust(r"a\-b"), "a-b");
+
+        // The patterns that crashed `marked` at module-init must now compile.
+        for pat in [r"[a\- ]", r"[:\- ]", r" {0,3}\|?(?:[:\- ]*\|)+[\:\- ]*\n"] {
+            let flags = make_string("");
+            let re = js_regexp_new(make_string(pat), flags);
+            assert!(!re.is_null(), "pattern failed to construct: {pat}");
+        }
+    }
 }

--- a/crates/perry-runtime/src/regex/grammar.rs
+++ b/crates/perry-runtime/src/regex/grammar.rs
@@ -257,7 +257,18 @@ pub(super) fn js_regex_to_rust(pattern: &str) -> String {
                     }
                 }
                 ch if is_regex_identity_escape(ch) => {
-                    push_escaped_literal(&mut result, ch);
+                    // Inside a character class an escaped hyphen `\-` is always a
+                    // literal hyphen, but the Rust `regex` crate reads a bare `-`
+                    // flanked by members as a range operator (so `[a\- ]` would
+                    // become the invalid range `[a- ]`). Keep the escape so it
+                    // stays a literal regardless of position. `marked`'s GFM
+                    // table-delimiter regex `[:\- ]` relies on this.
+                    if in_class && ch == '-' {
+                        result.push('\\');
+                        result.push('-');
+                    } else {
+                        push_escaped_literal(&mut result, ch);
+                    }
                     i += 2;
                 }
                 // Pass through all other backslash sequences as-is. (An escaped


### PR DESCRIPTION
## Summary

Fixes #4425. An escaped hyphen `\-` inside a JS character class is always a literal hyphen, but Perry's regex translator emitted a bare `-` for it via `push_escaped_literal`. The Rust `regex` crate then read a `-` flanked by members as a **range operator**, so `[a\- ]` translated to the invalid range `[a- ]` (`a` 0x61 → space 0x20) and `new RegExp` threw `invalid pattern`.

`[\-]` (sole member) worked because there was nothing to form a range with; `[a-z]` worked because it's a valid range. Only `\-` *flanked by other members* hit the bug.

## Fix

In `js_regex_to_rust` (`crates/perry-runtime/src/regex/grammar.rs`), when inside a character class, preserve the escape for `\-` so it stays a literal hyphen regardless of position. Outside a class a hyphen carries no range meaning, so it's still emitted bare.

## Verification

The issue's repro now reports `OK` for every pattern, including `marked`'s GFM table-delimiter regex:

```
OK   /[\-]/
OK   /[a\- ]/
OK   /[a-z]/
OK   /[:]/
OK   /[ ]/
OK   /[a-z ]/
OK   /[:\- ]/
OK   / {0,3}\|?(?:[:\- ]*\|)+[\:\- ]*\n/
```

Behavioral check confirms literal-hyphen semantics — `/[a\- ]/` matches `-`, `a`, and space, but not `z`.

Added a runtime regression test (`escaped_hyphen_in_class_stays_literal`) covering both the translation output and that the previously-crashing patterns construct. All 9 `regex::` tests pass; `cargo fmt --check` clean.

This unblocks a native build of `marked` (#4362 fixed codegen+link; this was the last blocker — the binary now boots instead of throwing on module-init regex).