### PR TITLE
Fix escaped hyphen regex class translation

### DIFF
--- a/crates/perry-runtime/src/regex/grammar.rs
+++ b/crates/perry-runtime/src/regex/grammar.rs
@@ -90,8 +90,12 @@ fn is_regex_identity_escape(ch: char) -> bool {
     )
 }
 
-fn push_escaped_literal(out: &mut String, ch: char) {
+fn push_escaped_literal(out: &mut String, ch: char, in_class: bool) {
     match ch {
+        '-' if in_class => {
+            out.push('\\');
+            out.push(ch);
+        }
         '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '\\' => {
             out.push('\\');
             out.push(ch);
@@ -257,7 +261,7 @@ pub(super) fn js_regex_to_rust(pattern: &str) -> String {
                     }
                 }
                 ch if is_regex_identity_escape(ch) => {
-                    push_escaped_literal(&mut result, ch);
+                    push_escaped_literal(&mut result, ch, in_class);
                     i += 2;
                 }
                 // Pass through all other backslash sequences as-is. (An escaped

--- a/test-parity/node-suite/globals/regexp-character-class-escaped-hyphen.ts
+++ b/test-parity/node-suite/globals/regexp-character-class-escaped-hyphen.ts
@@ -1,0 +1,19 @@
+const patterns = [
+  "[\\-]",
+  "[a\\- ]",
+  "[a-z]",
+  "[:]",
+  "[ ]",
+  "[a-z ]",
+  "[:\\- ]",
+  " {0,3}\\|?(?:[:\\- ]*\\|)+[\\:\\- ]*\\n",
+];
+
+for (const pattern of patterns) {
+  try {
+    const regex = new RegExp(pattern);
+    console.log("OK  /" + pattern + "/ " + regex.test("-"));
+  } catch (error: any) {
+    console.log("FAIL /" + pattern + "/ -> " + error.message);
+  }
+}


### PR DESCRIPTION
## Summary
- preserve escaped hyphen as a literal while translating JavaScript character classes to Rust regex syntax
- add a Node parity fixture covering minimal escaped-hyphen classes and the marked table delimiter pattern

## Validation
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-webcrypto-cryptokey-property-exposure-20260604/target cargo check -q -p perry-runtime --lib
- RUSTFLAGS='-Awarnings' cargo build --release -q -p perry-runtime
- npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/regexp-character-class-escaped-hyphen.ts
- PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 /root/perry-worktrees/perry-node-webcrypto-cryptokey-property-exposure-20260604/target/debug/perry run test-parity/node-suite/globals/regexp-character-class-escaped-hyphen.ts
- diff -u /tmp/node_regex_escaped_hyphen.out /tmp/perry_regex_escaped_hyphen.out
- git diff --check
- ./scripts/check_file_size.sh

Closes #4425
