### PR TITLE
fix(date): reflective Date.prototype.toJSON.call(realDate) returns the ISO string

### DIFF
--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -131,7 +131,15 @@ extern "C" fn date_to_json(_closure: *const crate::closure::ClosureHeader) -> f6
             return f64::from_bits(crate::value::TAG_NULL);
         }
     }
-    // Step 4: Invoke(this, "toISOString").
+    // Step 4: Invoke(this, "toISOString"). For a real Date, dispatch straight
+    // to the runtime helper: `js_native_call_method` does not resolve the
+    // reflective `toISOString` on a `DateCell` receiver and would fall back to
+    // the generic `[object Object]` Object.prototype.toString. Other receivers
+    // (a plain object carrying its own `toISOString`) use the ordinary Invoke.
+    if crate::date::is_date_value(this) {
+        let s = crate::date::js_date_to_iso_string_or_throw(this);
+        return crate::value::js_nanbox_string(s as i64);
+    }
     let name = b"toISOString";
     unsafe {
         crate::object::js_native_call_method(


### PR DESCRIPTION
## Summary

`Date.prototype.toJSON.call(d)` on a **real Date** returned `"[object Object]"` instead of the ISO string. `date_to_json`'s step 4 invoked `toISOString` via `js_native_call_method`, which doesn't resolve the reflective `toISOString` on a `DateCell` receiver and fell back to `Object.prototype.toString`.

(The instance form `d.toJSON()` and `JSON.stringify(d)` already worked via separate paths — this was specific to the extracted/`.call` value form on a real Date.)

## Fix

In `date_to_json`, dispatch a real Date straight to `js_date_to_iso_string_or_throw` (the same helper the `toISOString` thunk uses); non-Date receivers keep the ordinary `Invoke`.

## Validation

Byte-identical to `node --experimental-strip-types` in **both** `PERRY_NO_AUTO_OPTIMIZE=1` and default builds:
```
Date.prototype.toJSON.call(new Date(0))          → "1970-01-01T00:00:00.000Z"  (was "[object Object]")
Date.prototype.toJSON.call(new Date(NaN))        → null
Date.prototype.toJSON.call({toISOString:()=>'X'})→ "X"
```
`cargo test -p perry-runtime --lib`: 979 passed, 0 failed.

## Scope note

This is a real correctness fix but moves the test262 count by 0 — no test262 case exercises `Date.prototype.toJSON.call(aRealDate)` directly (they use the instance form for real dates and custom objects for the reflective form). The remaining `built-ins/Date/prototype/toJSON/{invoke-arguments,invoke-abrupt,to-object}.js` failures are a **separate, deeper gap** in reflective `Invoke`/`js_native_call_method` on arbitrary receivers (accessor-property methods, primitive `ToObject` + prototype method lookup) — not addressed here.
