### PR TITLE
Use object fingerprints for link cache

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -3898,7 +3898,7 @@ pub fn run_with_parse_cache(
 
     // Sequential print + obj_paths collection (output grouped, source
     // order preserved).
-    let mut obj_fingerprints: Vec<String> = Vec::new();
+    let mut obj_fingerprints: Vec<Option<String>> = Vec::new();
     for (obj_path, _, object_fingerprint) in to_write {
         match format {
             OutputFormat::Text => {
@@ -3911,7 +3911,7 @@ pub fn run_with_parse_cache(
             }
             OutputFormat::Json => {}
         }
-        obj_fingerprints.push(object_fingerprint);
+        obj_fingerprints.push(Some(object_fingerprint));
         obj_paths.push(obj_path);
     }
 
@@ -4309,6 +4309,7 @@ pub fn run_with_parse_cache(
             let stub_path = PathBuf::from("_perry_stubs.o");
             fs::write(&stub_path, &stub_bytes)?;
             obj_paths.push(stub_path);
+            obj_fingerprints.push(None);
         }
     }
 
@@ -4366,9 +4367,15 @@ pub fn run_with_parse_cache(
                             let _ = fs::remove_file(ll);
                         }
                     }
-                    // Replace obj_paths with the merged .o + any stubs
-                    obj_paths = vec![linked_obj];
-                    obj_paths.extend(stub_objs);
+                    // Replace obj_paths with the merged .o + any stubs.
+                    // The merged object is derived after codegen-cache
+                    // materialization, so the original per-module cache
+                    // fingerprints are no longer a trusted proxy for these
+                    // bytes.
+                    let mut linked_obj_paths = vec![linked_obj];
+                    linked_obj_paths.extend(stub_objs);
+                    obj_fingerprints = vec![None; linked_obj_paths.len()];
+                    obj_paths = linked_obj_paths;
                     true
                 }
                 Err(e) => {
@@ -4385,7 +4392,8 @@ pub fn run_with_parse_cache(
         // Fall back: compile any .ll files to .o via clang -c.
         eprintln!("  bitcode-link: runtime .bc not available, falling back to normal link");
         let mut new_obj_paths: Vec<PathBuf> = Vec::new();
-        for p in &obj_paths {
+        let mut new_obj_fingerprints: Vec<Option<String>> = Vec::new();
+        for (idx, p) in obj_paths.iter().enumerate() {
             if p.extension().and_then(|e| e.to_str()) == Some("ll") {
                 let ll_text = fs::read_to_string(p)?;
                 let obj_bytes =
@@ -4396,11 +4404,14 @@ pub fn run_with_parse_cache(
                     let _ = fs::remove_file(p);
                 }
                 new_obj_paths.push(obj_path);
+                new_obj_fingerprints.push(None);
             } else {
                 new_obj_paths.push(p.clone());
+                new_obj_fingerprints.push(obj_fingerprints.get(idx).cloned().unwrap_or(None));
             }
         }
         obj_paths = new_obj_paths;
+        obj_fingerprints = new_obj_fingerprints;
         false
     } else {
         false
@@ -4427,6 +4438,7 @@ pub fn run_with_parse_cache(
                     println!("Embedded JS bundle: {}", obj.display());
                 }
                 obj_paths.push(obj);
+                obj_fingerprints.push(None);
             }
             Err(e) => {
                 // Don't hard-fail — the on-disk `__perry_js_bundle.js`
@@ -4651,6 +4663,7 @@ pub fn run_with_parse_cache(
             let stub_path = PathBuf::from("_perry_failed_stubs.o");
             fs::write(&stub_path, &stub_bytes)?;
             obj_paths.push(stub_path);
+            obj_fingerprints.push(None);
         }
     }
 
@@ -5278,6 +5291,9 @@ pub fn run_with_parse_cache(
                     "link_cache": {
                         "linked": link_cache_stats.linked,
                         "skipped": link_cache_stats.skipped,
+                        "object_fingerprints_used": link_cache_stats.object_fingerprints_used,
+                        "object_files_hashed": link_cache_stats.object_files_hashed,
+                        "external_inputs_hashed": link_cache_stats.external_inputs_hashed,
                     },
                 });
                 println!("{}", serde_json::to_string(&result)?);

--- a/crates/perry/src/commands/compile/link/link_cache.rs
+++ b/crates/perry/src/commands/compile/link/link_cache.rs
@@ -54,9 +54,17 @@ impl LinkCacheStatus {
     }
 
     pub(in crate::commands::compile) fn stats(&self) -> LinkCacheStats {
+        let input_stats = self
+            .state
+            .as_ref()
+            .map(|state| state.stats)
+            .unwrap_or_default();
         LinkCacheStats {
             linked: self.linked,
             skipped: !self.linked,
+            object_fingerprints_used: input_stats.object_fingerprints_used,
+            object_files_hashed: input_stats.object_files_hashed,
+            external_inputs_hashed: input_stats.external_inputs_hashed,
         }
     }
 }
@@ -65,6 +73,14 @@ impl LinkCacheStatus {
 struct LinkCacheState {
     manifest_path: PathBuf,
     link_fingerprint: String,
+    stats: LinkCacheInputStats,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct LinkCacheInputStats {
+    object_fingerprints_used: usize,
+    object_files_hashed: usize,
+    external_inputs_hashed: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -85,6 +101,7 @@ struct LinkFingerprintContext<'a> {
     cwd: PathBuf,
     exe_path: &'a Path,
     obj_paths: &'a [PathBuf],
+    stats: LinkCacheInputStats,
     lib_dirs: Vec<SearchDir>,
     framework_dirs: Vec<SearchDir>,
     msvc_lib_dirs: Vec<SearchDir>,
@@ -126,13 +143,20 @@ pub(super) fn prepare_link_cache_status(
     target: Option<&str>,
     cmd: &Command,
     obj_paths: &[PathBuf],
-    _obj_fingerprints: &[String],
+    obj_fingerprints: &[Option<String>],
     exe_path: &Path,
 ) -> LinkCacheStatus {
     if std::env::var("PERRY_NO_LINK_CACHE").ok().as_deref() == Some("1") {
         return LinkCacheStatus::linked(None);
     }
-    let Some(state) = compute_link_cache_state(cache_root, target, cmd, obj_paths, exe_path) else {
+    let Some(state) = compute_link_cache_state(
+        cache_root,
+        target,
+        cmd,
+        obj_paths,
+        obj_fingerprints,
+        exe_path,
+    ) else {
         return LinkCacheStatus::linked(None);
     };
     let Ok(raw) = fs::read_to_string(&state.manifest_path) else {
@@ -161,6 +185,7 @@ fn compute_link_cache_state(
     target: Option<&str>,
     cmd: &Command,
     obj_paths: &[PathBuf],
+    obj_fingerprints: &[Option<String>],
     exe_path: &Path,
 ) -> Option<LinkCacheState> {
     let cwd = command_cwd(cmd);
@@ -176,20 +201,34 @@ fn compute_link_cache_state(
         feed_file_fingerprint_from(&mut hasher, "perry", &exe, &cwd)?;
     }
 
+    let mut stats = LinkCacheInputStats::default();
     for (idx, obj_path) in obj_paths.iter().enumerate() {
         feed_hash_field(&mut hasher, "object-index", &idx.to_string());
-        feed_file_fingerprint_from(&mut hasher, "object-file", obj_path, &cwd)?;
+        if let Some(fingerprint) = trusted_object_fingerprint(obj_path, obj_fingerprints.get(idx)) {
+            feed_hash_field(
+                &mut hasher,
+                "object-file",
+                &absolute_path_identity_from(obj_path, &cwd),
+            );
+            feed_hash_field(&mut hasher, "object-fingerprint", fingerprint);
+            stats.object_fingerprints_used += 1;
+        } else {
+            feed_file_fingerprint_from(&mut hasher, "object-file", obj_path, &cwd)?;
+            stats.object_files_hashed += 1;
+        }
     }
 
     let mut ctx = LinkFingerprintContext {
         cwd: cwd.clone(),
         exe_path,
         obj_paths,
+        stats,
         lib_dirs: library_path_search_dirs(cmd, &cwd),
         framework_dirs: default_framework_search_dirs(cmd, &cwd),
         msvc_lib_dirs: msvc_lib_search_dirs(cmd, &cwd),
     };
     feed_command_args(&mut hasher, cmd, &mut ctx)?;
+    let stats = ctx.stats;
 
     let link_fingerprint = hex::encode(hasher.finalize());
     let manifest_name = format!(
@@ -204,7 +243,20 @@ fn compute_link_cache_state(
     Some(LinkCacheState {
         manifest_path,
         link_fingerprint,
+        stats,
     })
+}
+
+fn trusted_object_fingerprint<'a>(
+    obj_path: &Path,
+    fingerprint: Option<&'a Option<String>>,
+) -> Option<&'a str> {
+    let fingerprint = fingerprint?.as_deref()?;
+    let metadata = fs::metadata(obj_path).ok()?;
+    if fingerprint.is_empty() || !metadata.is_file() || metadata.len() == 0 {
+        return None;
+    }
+    Some(fingerprint)
 }
 
 fn feed_effective_env(hasher: &mut Sha256, cmd: &Command) {
@@ -367,7 +419,7 @@ fn feed_explicit_file_arg(
     hasher: &mut Sha256,
     role: &str,
     path: &OsStr,
-    ctx: &LinkFingerprintContext<'_>,
+    ctx: &mut LinkFingerprintContext<'_>,
 ) -> Option<()> {
     let candidate = resolve_relative_path(Path::new(path), &ctx.cwd);
     if same_path_from(&candidate, ctx.exe_path, &ctx.cwd) {
@@ -387,7 +439,7 @@ fn feed_explicit_file_arg(
         return Some(());
     }
     if candidate.is_file() {
-        feed_file_fingerprint_from(hasher, role, &candidate, &ctx.cwd)
+        feed_external_file_fingerprint_from(hasher, role, &candidate, ctx)
     } else {
         feed_hash_field(hasher, role, &path.to_string_lossy());
         Some(())
@@ -398,10 +450,11 @@ fn feed_file_content_arg(
     hasher: &mut Sha256,
     role: &str,
     path: &OsStr,
-    ctx: &LinkFingerprintContext<'_>,
+    ctx: &mut LinkFingerprintContext<'_>,
 ) -> Option<()> {
     let candidate = resolve_relative_path(Path::new(path), &ctx.cwd);
     let (hash, size) = hash_file_with_size(&candidate).ok()?;
+    ctx.stats.external_inputs_hashed += 1;
     feed_hash_field(hasher, role, "<content-only>");
     feed_hash_field(hasher, "file-size", &size.to_string());
     feed_hash_field(hasher, "file-sha256", &hash);
@@ -411,11 +464,11 @@ fn feed_file_content_arg(
 fn feed_unix_library(
     hasher: &mut Sha256,
     name: &str,
-    ctx: &LinkFingerprintContext<'_>,
+    ctx: &mut LinkFingerprintContext<'_>,
 ) -> Option<()> {
     feed_hash_field(hasher, "library", name);
     if let Some(path) = resolve_unix_library(name, &ctx.lib_dirs) {
-        return feed_file_fingerprint_from(hasher, "library-file", &path, &ctx.cwd);
+        return feed_external_file_fingerprint_from(hasher, "library-file", &path, ctx);
     }
     if has_non_system_dir(&ctx.lib_dirs) {
         return None;
@@ -427,15 +480,15 @@ fn feed_unix_library(
 fn feed_msvc_library(
     hasher: &mut Sha256,
     name: &str,
-    ctx: &LinkFingerprintContext<'_>,
+    ctx: &mut LinkFingerprintContext<'_>,
 ) -> Option<()> {
     feed_hash_field(hasher, "msvc-library", name);
     let direct = resolve_relative_path(Path::new(name), &ctx.cwd);
     if direct.is_file() {
-        return feed_file_fingerprint_from(hasher, "msvc-library-file", &direct, &ctx.cwd);
+        return feed_external_file_fingerprint_from(hasher, "msvc-library-file", &direct, ctx);
     }
     if let Some(path) = resolve_msvc_library(name, &ctx.msvc_lib_dirs) {
-        return feed_file_fingerprint_from(hasher, "msvc-library-file", &path, &ctx.cwd);
+        return feed_external_file_fingerprint_from(hasher, "msvc-library-file", &path, ctx);
     }
     if has_non_system_dir(&ctx.msvc_lib_dirs) {
         return None;
@@ -444,10 +497,14 @@ fn feed_msvc_library(
     Some(())
 }
 
-fn feed_framework(hasher: &mut Sha256, name: &str, ctx: &LinkFingerprintContext<'_>) -> Option<()> {
+fn feed_framework(
+    hasher: &mut Sha256,
+    name: &str,
+    ctx: &mut LinkFingerprintContext<'_>,
+) -> Option<()> {
     feed_hash_field(hasher, "framework", name);
     if let Some(path) = resolve_framework(name, &ctx.framework_dirs) {
-        return feed_file_fingerprint_from(hasher, "framework-file", &path, &ctx.cwd);
+        return feed_external_file_fingerprint_from(hasher, "framework-file", &path, ctx);
     }
     if has_non_system_dir(&ctx.framework_dirs) {
         return None;
@@ -633,6 +690,17 @@ fn feed_hash_field(hasher: &mut Sha256, name: &str, value: &str) {
     hasher.update([0xff]);
 }
 
+fn feed_external_file_fingerprint_from(
+    hasher: &mut Sha256,
+    role: &str,
+    path: &Path,
+    ctx: &mut LinkFingerprintContext<'_>,
+) -> Option<()> {
+    feed_file_fingerprint_from(hasher, role, path, &ctx.cwd)?;
+    ctx.stats.external_inputs_hashed += 1;
+    Some(())
+}
+
 fn feed_file_fingerprint_from(
     hasher: &mut Sha256,
     role: &str,
@@ -777,21 +845,72 @@ mod tests {
     }
 
     fn write_manifest_for(project: &Path, cmd: &Command, output: &Path, obj_paths: &[PathBuf]) {
-        let first = prepare_link_cache_status(project, None, cmd, obj_paths, &[], output);
+        write_manifest_for_with_fingerprints(project, cmd, output, obj_paths, &[]);
+    }
+
+    fn write_manifest_for_with_fingerprints(
+        project: &Path,
+        cmd: &Command,
+        output: &Path,
+        obj_paths: &[PathBuf],
+        obj_fingerprints: &[Option<String>],
+    ) {
+        let first =
+            prepare_link_cache_status(project, None, cmd, obj_paths, obj_fingerprints, output);
         assert!(first.stats().linked);
         write_link_cache_manifest(&first, output);
     }
 
-    fn assert_skips(project: &Path, cmd: &Command, output: &Path, obj_paths: &[PathBuf]) {
+    fn assert_skips(
+        project: &Path,
+        cmd: &Command,
+        output: &Path,
+        obj_paths: &[PathBuf],
+    ) -> LinkCacheStats {
         let status = prepare_link_cache_status(project, None, cmd, obj_paths, &[], output);
         assert!(status.stats().skipped);
         assert!(!status.stats().linked);
+        status.stats()
     }
 
-    fn assert_links(project: &Path, cmd: &Command, output: &Path, obj_paths: &[PathBuf]) {
+    fn assert_links(
+        project: &Path,
+        cmd: &Command,
+        output: &Path,
+        obj_paths: &[PathBuf],
+    ) -> LinkCacheStats {
         let status = prepare_link_cache_status(project, None, cmd, obj_paths, &[], output);
         assert!(status.stats().linked);
         assert!(!status.stats().skipped);
+        status.stats()
+    }
+
+    fn assert_skips_with_fingerprints(
+        project: &Path,
+        cmd: &Command,
+        output: &Path,
+        obj_paths: &[PathBuf],
+        obj_fingerprints: &[Option<String>],
+    ) -> LinkCacheStats {
+        let status =
+            prepare_link_cache_status(project, None, cmd, obj_paths, obj_fingerprints, output);
+        assert!(status.stats().skipped);
+        assert!(!status.stats().linked);
+        status.stats()
+    }
+
+    fn assert_links_with_fingerprints(
+        project: &Path,
+        cmd: &Command,
+        output: &Path,
+        obj_paths: &[PathBuf],
+        obj_fingerprints: &[Option<String>],
+    ) -> LinkCacheStats {
+        let status =
+            prepare_link_cache_status(project, None, cmd, obj_paths, obj_fingerprints, output);
+        assert!(status.stats().linked);
+        assert!(!status.stats().skipped);
+        status.stats()
     }
 
     #[test]
@@ -822,6 +941,85 @@ mod tests {
 
         fs::write(&input, b"object-v2").unwrap();
         assert_links(project, &cmd, &output, &[input]);
+    }
+
+    #[test]
+    fn link_cache_uses_stable_object_fingerprints_without_hashing_object_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let input = project.join("main.o");
+        let output = project.join("app");
+        fs::write(&input, b"object-v1").unwrap();
+        fs::write(&output, b"binary-v1").unwrap();
+        let cmd = fake_link_command(project, &input, &output);
+        let objects = vec![input.clone()];
+        let fingerprints = vec![Some("perry-object-cache:fingerprint-v1".to_string())];
+
+        write_manifest_for_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+
+        fs::write(&input, b"object-v2-not-read-by-link-cache").unwrap();
+        let stats = assert_skips_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+        assert_eq!(stats.object_fingerprints_used, 1);
+        assert_eq!(stats.object_files_hashed, 0);
+    }
+
+    #[test]
+    fn link_cache_relinks_when_object_fingerprint_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let input = project.join("main.o");
+        let output = project.join("app");
+        fs::write(&input, b"object-v1").unwrap();
+        fs::write(&output, b"binary-v1").unwrap();
+        let cmd = fake_link_command(project, &input, &output);
+        let objects = vec![input.clone()];
+        let old_fingerprints = vec![Some("perry-object-cache:fingerprint-v1".to_string())];
+        let new_fingerprints = vec![Some("perry-object-cache:fingerprint-v2".to_string())];
+
+        write_manifest_for_with_fingerprints(project, &cmd, &output, &objects, &old_fingerprints);
+
+        let stats =
+            assert_links_with_fingerprints(project, &cmd, &output, &objects, &new_fingerprints);
+        assert_eq!(stats.object_fingerprints_used, 1);
+        assert_eq!(stats.object_files_hashed, 0);
+    }
+
+    #[test]
+    fn link_cache_relinks_when_fingerprinted_object_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let input = project.join("main.o");
+        let output = project.join("app");
+        fs::write(&input, b"object-v1").unwrap();
+        fs::write(&output, b"binary-v1").unwrap();
+        let cmd = fake_link_command(project, &input, &output);
+        let objects = vec![input.clone()];
+        let fingerprints = vec![Some("perry-object-cache:fingerprint-v1".to_string())];
+
+        write_manifest_for_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+
+        fs::remove_file(&input).unwrap();
+        assert_links_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+    }
+
+    #[test]
+    fn link_cache_hashes_truncated_fingerprinted_object() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let input = project.join("main.o");
+        let output = project.join("app");
+        fs::write(&input, b"object-v1").unwrap();
+        fs::write(&output, b"binary-v1").unwrap();
+        let cmd = fake_link_command(project, &input, &output);
+        let objects = vec![input.clone()];
+        let fingerprints = vec![Some("perry-object-cache:fingerprint-v1".to_string())];
+
+        write_manifest_for_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+
+        fs::write(&input, b"").unwrap();
+        let stats = assert_links_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+        assert_eq!(stats.object_fingerprints_used, 0);
+        assert_eq!(stats.object_files_hashed, 1);
     }
 
     #[test]
@@ -965,11 +1163,17 @@ mod tests {
         cmd.arg(&extra);
         let objects = vec![input.clone(), extra.clone()];
 
-        write_manifest_for(project, &cmd, &output, &objects);
-        assert_skips(project, &cmd, &output, &objects);
+        let fingerprints = vec![Some("perry-object-cache:main-v1".to_string()), None];
+
+        write_manifest_for_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+        let stats = assert_skips_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+        assert_eq!(stats.object_fingerprints_used, 1);
+        assert_eq!(stats.object_files_hashed, 1);
 
         fs::write(&extra, b"extra-v2").unwrap();
-        assert_links(project, &cmd, &output, &objects);
+        let stats = assert_links_with_fingerprints(project, &cmd, &output, &objects, &fingerprints);
+        assert_eq!(stats.object_fingerprints_used, 1);
+        assert_eq!(stats.object_files_hashed, 1);
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -226,7 +226,7 @@ pub(super) fn build_and_run_link(
     ctx: &CompilationContext,
     target: Option<&str>,
     obj_paths: &[PathBuf],
-    obj_fingerprints: &[String],
+    obj_fingerprints: &[Option<String>],
     compiled_features: &[String],
     runtime_lib: &Path,
     stdlib_lib: &Option<PathBuf>,

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -38,6 +38,9 @@ pub struct CompileResult {
 pub struct LinkCacheStats {
     pub linked: bool,
     pub skipped: bool,
+    pub object_fingerprints_used: usize,
+    pub object_files_hashed: usize,
+    pub external_inputs_hashed: usize,
 }
 
 // Helpers moved to sub-modules:


### PR DESCRIPTION
## Summary
- use trusted Perry-generated object fingerprints in native link-cache fingerprints instead of rereading/hashing those object bytes
- keep byte hashing for unknown objects and external inputs, with counters in JSON/status output
- preserve fallback behavior for missing/zero-byte objects and object-source changes

## Validation
- cargo fmt --all -- --check
- cargo test -p perry link_cache_ -- --nocapture
- cargo test -p perry --test native_link_cache -- --nocapture

## Smoke
Generated 20 imported modules plus main under target/ and ran target/debug/perry --format json compile from a fresh project cwd:
- cold: codegen hits=0 misses=21 stores=21; link_cache linked=true skipped=false object_fingerprints_used=21 object_files_hashed=0 external_inputs_hashed=1
- warm noop: codegen hits=21 misses=0 stores=0; link_cache linked=false skipped=true object_fingerprints_used=21 object_files_hashed=0 external_inputs_hashed=1
- one-module change: codegen hits=20 misses=1 stores=1; link_cache linked=true skipped=false object_fingerprints_used=21 object_files_hashed=0 external_inputs_hashed=1