### PR TITLE
Add native compile no-op build cache

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -20,6 +20,7 @@ mod app_metadata;
 mod apple_info_plist;
 mod audit_manifest;
 mod bootstrap;
+mod build_cache;
 mod bundle_apple;
 mod bundle_ios;
 mod cjs_wrap;
@@ -55,6 +56,7 @@ use bootstrap::{
     maybe_init_type_checker, rerun_collect_with_class_field_types, run_native_instance_fixups,
     run_post_collect_preflight,
 };
+use build_cache::BuildCacheProbe;
 use bundle_apple::{bundle_for_tvos, bundle_for_visionos, bundle_for_watchos};
 use bundle_ios::build_ios_app_bundle;
 use collect_modules::collect_modules;
@@ -285,11 +287,6 @@ pub fn run_with_parse_cache(
         }
     }
 
-    match format {
-        OutputFormat::Text => println!("Collecting modules..."),
-        OutputFormat::Json => {}
-    }
-
     // Canonicalize the input path first so its `.parent()` is an absolute directory.
     // Without this, a bare filename like `perry demo.ts` produced `Path::new("").parent()`
     // → fallback `"."`, and the walk-up loops below (package.json + perry.toml discovery)
@@ -306,6 +303,22 @@ pub fn run_with_parse_cache(
 
     let mut ctx = CompilationContext::new(project_root.clone());
     ctx.cache_root = object_cache_project_root(&args.input, &project_root);
+
+    let build_cache_probe = BuildCacheProbe::new(&args, &project_root, &ctx.cache_root);
+    let mut build_cache_stats = build_cache_probe.probe();
+    if build_cache_stats.hit {
+        if let OutputFormat::Json = format {
+            build_cache_probe.print_json_hit(&build_cache_stats)?;
+        } else if verbose > 0 {
+            println!("Build cache hit: {}", build_cache_stats.reason);
+        }
+        return Ok(build_cache_probe.compile_result_for_hit());
+    }
+
+    match format {
+        OutputFormat::Text => println!("Collecting modules..."),
+        OutputFormat::Json => {}
+    }
 
     // Tier 2.x: package.json + perry.toml + i18n + google_auth config
     // loading lifted into compile/host_config.rs::apply_pkg_and_toml_config.
@@ -4672,6 +4685,7 @@ pub fn run_with_parse_cache(
             is_dylib,
             codegen_cache_stats,
             link_cache_stats: None,
+            build_cache_stats: None,
         });
     }
 
@@ -4838,6 +4852,7 @@ pub fn run_with_parse_cache(
             is_dylib: true,
             codegen_cache_stats,
             link_cache_stats: None,
+            build_cache_stats: None,
         });
     }
 
@@ -4899,6 +4914,7 @@ pub fn run_with_parse_cache(
             is_dylib: true,
             codegen_cache_stats,
             link_cache_stats: None,
+            build_cache_stats: None,
         });
     }
 
@@ -5274,6 +5290,10 @@ pub fn run_with_parse_cache(
                     "output": exe_path.to_string_lossy(),
                     "native_modules": ctx.native_modules.len(),
                     "js_modules": ctx.js_modules.len(),
+                    "build_cache": {
+                        "hit": false,
+                        "miss_reason": build_cache_stats.reason,
+                    },
                     "codegen_cache": codegen_cache,
                     "link_cache": {
                         "linked": link_cache_stats.linked,
@@ -5342,6 +5362,25 @@ pub fn run_with_parse_cache(
         write_link_cache_manifest(&link_cache_status, &exe_path);
     }
 
+    let mut build_cache_runtime_inputs = Vec::new();
+    build_cache_runtime_inputs.push(runtime_lib.clone());
+    if let Some(path) = &stdlib_lib_resolved {
+        build_cache_runtime_inputs.push(path.clone());
+    }
+    build_cache_runtime_inputs.extend(optimized_libs.well_known_libs.iter().cloned());
+    if let Some(path) = &wasm_host_lib {
+        build_cache_runtime_inputs.push(path.clone());
+    }
+    build_cache_probe.write_manifest_after_success(
+        &mut build_cache_stats,
+        &ctx,
+        &exe_path,
+        target.as_deref(),
+        &compiled_features,
+        &obj_fingerprints,
+        &build_cache_runtime_inputs,
+    );
+
     emit_attestation_sidecar(&ctx, &exe_path, format);
 
     print_binary_size(format, &exe_path);
@@ -5358,6 +5397,7 @@ pub fn run_with_parse_cache(
         is_dylib,
         codegen_cache_stats,
         link_cache_stats: Some(link_cache_status.stats()),
+        build_cache_stats: Some(build_cache_stats),
     })
 }
 

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -1,0 +1,590 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use super::{BuildCacheStats, CompilationContext, CompileArgs, CompileResult, LinkCacheStats};
+
+const BUILD_CACHE_MANIFEST_VERSION: u32 = 1;
+
+const BUILD_CACHE_ENV_VARS: &[&str] = &[
+    "PATH",
+    "LIB",
+    "LIBPATH",
+    "LIBRARY_PATH",
+    "LD_LIBRARY_PATH",
+    "DYLD_LIBRARY_PATH",
+    "SDKROOT",
+    "PKG_CONFIG_PATH",
+    "PKG_CONFIG_LIBDIR",
+    "PKG_CONFIG_SYSROOT_DIR",
+    "PERRY_LINUX_SYSROOT",
+    "PERRY_WINDOWS_SYSROOT",
+    "PERRY_IOS_SYSROOT",
+    "PERRY_MACOS_SYSROOT",
+    "PERRY_TVOS_SYSROOT",
+    "PERRY_VISIONOS_SYSROOT",
+    "ANDROID_NDK_HOME",
+    "OHOS_SDK_HOME",
+    "HARMONYOS_SDK_HOME",
+    "PERRY_DEBUG_INIT",
+    "PERRY_DEBUG_SYMBOLS",
+    "PERRY_LLVM_CLANG",
+    "PERRY_WRITE_BARRIERS",
+    "PERRY_SHADOW_STACK",
+    "PERRY_DISABLE_BUFFER_FAST_PATH",
+    "PERRY_VERIFY_NATIVE_REGIONS",
+    "PERRY_UNBOXED_OBJECT_FIELDS",
+    "PERRY_NO_AUTO_OPTIMIZE",
+    "PERRY_DISABLE_WELL_KNOWN",
+];
+
+#[derive(Debug, Clone)]
+pub(super) struct BuildCacheProbe {
+    args_key: String,
+    manifest_path: PathBuf,
+    output_path: PathBuf,
+    target_name: String,
+    input_path: PathBuf,
+    project_root: PathBuf,
+    cache_root: PathBuf,
+    eligible: Result<(), String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct BuildCacheManifest {
+    version: u32,
+    perry_version: String,
+    perry_build_id: FileFingerprint,
+    args_key: String,
+    env: Vec<EnvFingerprint>,
+    input_path: String,
+    output_path: String,
+    target: String,
+    compiled_features: Vec<String>,
+    sources: Vec<FileFingerprint>,
+    config_inputs: Vec<FileFingerprint>,
+    runtime_inputs: Vec<FileFingerprint>,
+    object_fingerprints: Vec<String>,
+    native_modules: usize,
+    js_modules: usize,
+    output: FileFingerprint,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct FileFingerprint {
+    path: String,
+    size: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct EnvFingerprint {
+    name: String,
+    value: Option<String>,
+}
+
+impl BuildCacheProbe {
+    pub(super) fn new(args: &CompileArgs, project_root: &Path, cache_root: &Path) -> Self {
+        let output_path = default_output_path(args);
+        let output_identity = absolute_identity(&output_path);
+        let manifest_name = format!("{}.json", short_hash(output_identity.as_bytes()));
+        let manifest_path = cache_root
+            .join(".perry-cache")
+            .join("build")
+            .join(args.target.as_deref().unwrap_or("native"))
+            .join(manifest_name);
+        let eligible = eligibility(args, project_root);
+        Self {
+            args_key: args_key(args, &output_path),
+            manifest_path,
+            output_path,
+            target_name: args.target.clone().unwrap_or_else(|| "native".to_string()),
+            input_path: args.input.clone(),
+            project_root: project_root.to_path_buf(),
+            cache_root: cache_root.to_path_buf(),
+            eligible,
+        }
+    }
+
+    pub(super) fn probe(&self) -> BuildCacheStats {
+        if std::env::var("PERRY_DISABLE_BUILD_CACHE").ok().as_deref() == Some("1") {
+            return miss("disabled-by-env");
+        }
+        if let Err(reason) = &self.eligible {
+            return miss(reason);
+        }
+        let raw = match fs::read_to_string(&self.manifest_path) {
+            Ok(raw) => raw,
+            Err(_) => return miss("manifest-missing"),
+        };
+        let manifest = match serde_json::from_str::<BuildCacheManifest>(&raw) {
+            Ok(manifest) => manifest,
+            Err(_) => return miss("manifest-invalid"),
+        };
+        if manifest.version != BUILD_CACHE_MANIFEST_VERSION {
+            return miss("manifest-version");
+        }
+        if manifest.perry_version != env!("CARGO_PKG_VERSION") {
+            return miss("perry-version");
+        }
+        if manifest.args_key != self.args_key {
+            return miss("args");
+        }
+        if manifest.env != current_env() {
+            return miss("env");
+        }
+        if manifest.input_path != absolute_identity(&self.input_path) {
+            return miss("input-path");
+        }
+        if manifest.output_path != absolute_identity(&self.output_path) {
+            return miss("output-path");
+        }
+        if file_fingerprint_from_str(&manifest.perry_build_id.path).ok()
+            != Some(manifest.perry_build_id.clone())
+        {
+            return miss("perry-build-id");
+        }
+        if verify_files(&manifest.sources).is_err() {
+            return miss("source");
+        }
+        if verify_files(&manifest.config_inputs).is_err() {
+            return miss("config");
+        }
+        if verify_files(&manifest.runtime_inputs).is_err() {
+            return miss("runtime-input");
+        }
+        if file_fingerprint(&self.output_path).ok() != Some(manifest.output.clone()) {
+            return miss("output");
+        }
+        BuildCacheStats {
+            hit: true,
+            reason: "manifest-match".to_string(),
+        }
+    }
+
+    pub(super) fn print_json_hit(&self, stats: &BuildCacheStats) -> Result<()> {
+        let manifest = fs::read_to_string(&self.manifest_path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<BuildCacheManifest>(&raw).ok());
+        let (native_modules, js_modules) = manifest
+            .as_ref()
+            .map(|m| (m.native_modules, m.js_modules))
+            .unwrap_or((0, 0));
+        let result = serde_json::json!({
+            "success": true,
+            "output": self.output_path.to_string_lossy(),
+            "native_modules": native_modules,
+            "js_modules": js_modules,
+            "build_cache": {
+                "hit": stats.hit,
+                "miss_reason": serde_json::Value::Null,
+                "reason": stats.reason,
+            },
+            "codegen_cache": serde_json::Value::Null,
+            "link_cache": {
+                "linked": false,
+                "skipped": true,
+            },
+        });
+        println!("{}", serde_json::to_string(&result)?);
+        Ok(())
+    }
+
+    pub(super) fn compile_result_for_hit(&self) -> CompileResult {
+        CompileResult {
+            output_path: self.output_path.clone(),
+            target: self.target_name.clone(),
+            bundle_id: None,
+            is_dylib: false,
+            codegen_cache_stats: None,
+            link_cache_stats: Some(LinkCacheStats {
+                linked: false,
+                skipped: true,
+            }),
+            build_cache_stats: Some(BuildCacheStats {
+                hit: true,
+                reason: "manifest-match".to_string(),
+            }),
+        }
+    }
+
+    pub(super) fn write_manifest_after_success(
+        &self,
+        stats: &mut BuildCacheStats,
+        ctx: &CompilationContext,
+        output_path: &Path,
+        target: Option<&str>,
+        compiled_features: &[String],
+        object_fingerprints: &[String],
+        runtime_inputs: &[PathBuf],
+    ) {
+        if std::env::var("PERRY_DISABLE_BUILD_CACHE").ok().as_deref() == Some("1") {
+            stats.reason = "disabled-by-env".to_string();
+            return;
+        }
+        if let Err(reason) = &self.eligible {
+            stats.reason = reason.clone();
+            return;
+        }
+        if ctx.needs_ui || ctx.needs_geisterhand || ctx.needs_plugins || ctx.needs_wasm_runtime {
+            stats.reason = "complex-runtime".to_string();
+            return;
+        }
+        if !ctx.native_libraries.is_empty() {
+            stats.reason = "native-libraries".to_string();
+            return;
+        }
+        if !ctx.js_modules.is_empty() {
+            stats.reason = "js-modules".to_string();
+            return;
+        }
+        let manifest = match self.build_manifest(
+            ctx,
+            output_path,
+            target,
+            compiled_features,
+            object_fingerprints,
+            runtime_inputs,
+        ) {
+            Ok(manifest) => manifest,
+            Err(reason) => {
+                stats.reason = reason;
+                return;
+            }
+        };
+        let Some(parent) = self.manifest_path.parent() else {
+            stats.reason = "manifest-parent".to_string();
+            return;
+        };
+        if fs::create_dir_all(parent).is_err() {
+            stats.reason = "manifest-dir".to_string();
+            return;
+        }
+        let bytes = match serde_json::to_vec_pretty(&manifest) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                stats.reason = "manifest-serialize".to_string();
+                return;
+            }
+        };
+        let tmp = self.manifest_path.with_extension("json.tmp");
+        if fs::write(&tmp, bytes).is_ok() && fs::rename(&tmp, &self.manifest_path).is_ok() {
+            stats.reason = "stored".to_string();
+        } else {
+            let _ = fs::remove_file(&tmp);
+            stats.reason = "manifest-write".to_string();
+        }
+    }
+
+    fn build_manifest(
+        &self,
+        ctx: &CompilationContext,
+        output_path: &Path,
+        target: Option<&str>,
+        compiled_features: &[String],
+        object_fingerprints: &[String],
+        runtime_inputs: &[PathBuf],
+    ) -> Result<BuildCacheManifest, String> {
+        let sources = ctx
+            .native_modules
+            .keys()
+            .map(|path| file_fingerprint(path.as_path()))
+            .collect::<std::io::Result<Vec<_>>>()
+            .map_err(|_| "source-fingerprint".to_string())?;
+        let config_inputs = config_inputs_for(&sources, &self.project_root, &self.cache_root)
+            .into_iter()
+            .map(|path| file_fingerprint(path.as_path()))
+            .collect::<std::io::Result<Vec<_>>>()
+            .map_err(|_| "config-fingerprint".to_string())?;
+        let runtime_inputs = runtime_inputs
+            .iter()
+            .filter(|p| p.exists())
+            .map(|path| file_fingerprint(path.as_path()))
+            .collect::<std::io::Result<Vec<_>>>()
+            .map_err(|_| "runtime-fingerprint".to_string())?;
+        Ok(BuildCacheManifest {
+            version: BUILD_CACHE_MANIFEST_VERSION,
+            perry_version: env!("CARGO_PKG_VERSION").to_string(),
+            perry_build_id: current_perry_fingerprint().map_err(|_| "perry-fingerprint")?,
+            args_key: self.args_key.clone(),
+            env: current_env(),
+            input_path: absolute_identity(&self.input_path),
+            output_path: absolute_identity(output_path),
+            target: target.unwrap_or("native").to_string(),
+            compiled_features: compiled_features.to_vec(),
+            sources,
+            config_inputs,
+            runtime_inputs,
+            object_fingerprints: object_fingerprints.to_vec(),
+            native_modules: ctx.native_modules.len(),
+            js_modules: ctx.js_modules.len(),
+            output: file_fingerprint(output_path).map_err(|_| "output-fingerprint".to_string())?,
+        })
+    }
+}
+
+fn miss(reason: &str) -> BuildCacheStats {
+    BuildCacheStats {
+        hit: false,
+        reason: reason.to_string(),
+    }
+}
+
+fn eligibility(args: &CompileArgs, project_root: &Path) -> Result<(), String> {
+    if args.no_cache {
+        return Err("no-cache".to_string());
+    }
+    if args.no_link {
+        return Err("no-link".to_string());
+    }
+    if args.output_type != "executable" {
+        return Err("library-output".to_string());
+    }
+    if matches!(
+        args.target.as_deref(),
+        Some("web")
+            | Some("wasm")
+            | Some("ios-widget")
+            | Some("ios-widget-simulator")
+            | Some("watchos-widget")
+            | Some("watchos-widget-simulator")
+            | Some("android-widget")
+            | Some("wearos-tile")
+    ) {
+        return Err("non-native-target".to_string());
+    }
+    if args.bundle_extensions.is_some() {
+        return Err("bundle-extensions".to_string());
+    }
+    if args.enable_wasm_runtime {
+        return Err("wasm-runtime".to_string());
+    }
+    if args.type_check {
+        return Err("type-check".to_string());
+    }
+    if args.print_hir || args.trace.is_some() || args.focus.is_some() {
+        return Err("diagnostic-mode".to_string());
+    }
+    if args.verify_native_regions || args.emit_attest || args.emit_sandbox {
+        return Err("sidecar-or-verify".to_string());
+    }
+    if std::env::var("PERRY_NO_CACHE").ok().as_deref() == Some("1") {
+        return Err("no-cache-env".to_string());
+    }
+    if has_resource_copy_side_effects(project_root) {
+        return Err("resource-dirs".to_string());
+    }
+    if package_has_unknown_build_hooks(project_root) {
+        return Err("package-codegen".to_string());
+    }
+    if entry_uses_precompile(&args.input) {
+        return Err("precompile".to_string());
+    }
+    Ok(())
+}
+
+fn package_has_unknown_build_hooks(project_root: &Path) -> bool {
+    let pkg = project_root.join("package.json");
+    if pkg.exists() {
+        let Ok(raw) = fs::read_to_string(pkg) else {
+            return true;
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            return true;
+        };
+        if json.pointer("/perry/codegen").is_some() || json.pointer("/perry/i18n").is_some() {
+            return true;
+        }
+    }
+
+    let toml = project_root.join("perry.toml");
+    if toml.exists() {
+        let Ok(raw) = fs::read_to_string(toml) else {
+            return true;
+        };
+        if raw.contains("codegen") || raw.contains("i18n") {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn has_resource_copy_side_effects(project_root: &Path) -> bool {
+    ["logo", "assets", "resources", "images"]
+        .into_iter()
+        .any(|name| project_root.join(name).exists())
+}
+
+fn entry_uses_precompile(input: &Path) -> bool {
+    fs::read_to_string(input)
+        .map(|src| src.contains("precompile("))
+        .unwrap_or(true)
+}
+
+fn args_key(args: &CompileArgs, output_path: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hash_field(&mut hasher, "args-debug", &format!("{args:?}"));
+    hash_field(&mut hasher, "input", &absolute_identity(&args.input));
+    hash_field(&mut hasher, "output", &absolute_identity(output_path));
+    hash_field(
+        &mut hasher,
+        "target",
+        args.target.as_deref().unwrap_or("native"),
+    );
+    hash_field(&mut hasher, "output-type", &args.output_type);
+    hash_field(
+        &mut hasher,
+        "features",
+        args.features.as_deref().unwrap_or(""),
+    );
+    hex::encode(hasher.finalize())
+}
+
+fn default_output_path(args: &CompileArgs) -> PathBuf {
+    if let Some(output) = &args.output {
+        return output.clone();
+    }
+    let raw_stem = args
+        .input
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("output");
+    let stem = crate::commands::sanitize::sanitize_for_linker_argv(raw_stem);
+    if matches!(args.target.as_deref(), Some("windows"))
+        || (args.target.is_none() && cfg!(target_os = "windows"))
+    {
+        PathBuf::from(format!("{stem}.exe"))
+    } else {
+        PathBuf::from(stem)
+    }
+}
+
+fn current_env() -> Vec<EnvFingerprint> {
+    BUILD_CACHE_ENV_VARS
+        .iter()
+        .map(|name| EnvFingerprint {
+            name: (*name).to_string(),
+            value: std::env::var_os(name).map(|v| v.to_string_lossy().into_owned()),
+        })
+        .collect()
+}
+
+fn current_perry_fingerprint() -> std::io::Result<FileFingerprint> {
+    let exe = std::env::current_exe()?;
+    file_fingerprint(&exe)
+}
+
+fn config_inputs_for(
+    sources: &[FileFingerprint],
+    project_root: &Path,
+    cache_root: &Path,
+) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    for name in ["package.json", "perry.toml", "tsconfig.json", "perry.lock"] {
+        let path = project_root.join(name);
+        if path.exists() {
+            out.insert(path);
+        }
+        let path = cache_root.join(name);
+        if path.exists() {
+            out.insert(path);
+        }
+    }
+    for source in sources {
+        let mut dir = PathBuf::from(&source.path);
+        dir.pop();
+        loop {
+            for name in ["package.json", "perry.toml"] {
+                let candidate = dir.join(name);
+                if candidate.exists() {
+                    out.insert(candidate);
+                }
+            }
+            if dir == project_root || !dir.pop() {
+                break;
+            }
+        }
+    }
+    out
+}
+
+fn verify_files(files: &[FileFingerprint]) -> Result<(), ()> {
+    for expected in files {
+        if file_fingerprint_from_str(&expected.path).map_err(|_| ())? != *expected {
+            return Err(());
+        }
+    }
+    Ok(())
+}
+
+fn file_fingerprint_from_str(path: &str) -> std::io::Result<FileFingerprint> {
+    file_fingerprint(Path::new(path))
+}
+
+fn file_fingerprint(path: &Path) -> std::io::Result<FileFingerprint> {
+    let path_identity = absolute_identity(path);
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut size = 0_u64;
+    let mut buf = [0_u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        size += n as u64;
+        hasher.update(&buf[..n]);
+    }
+    Ok(FileFingerprint {
+        path: path_identity,
+        size,
+        sha256: hex::encode(hasher.finalize()),
+    })
+}
+
+fn absolute_identity(path: &Path) -> String {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    if let Ok(canonical) = absolute.canonicalize() {
+        return canonical.to_string_lossy().into_owned();
+    }
+
+    absolute
+        .parent()
+        .and_then(|parent| {
+            let file_name = absolute.file_name()?;
+            Some(
+                parent
+                    .canonicalize()
+                    .unwrap_or_else(|_| parent.to_path_buf())
+                    .join(file_name),
+            )
+        })
+        .unwrap_or(absolute)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn hash_field(hasher: &mut Sha256, name: &str, value: &str) {
+    hasher.update(name.as_bytes());
+    hasher.update([0]);
+    hasher.update(value.as_bytes());
+    hasher.update([0xff]);
+}
+
+fn short_hash(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let hex = hex::encode(hasher.finalize());
+    hex[..16].to_string()
+}

--- a/crates/perry/src/commands/compile/targets.rs
+++ b/crates/perry/src/commands/compile/targets.rs
@@ -383,6 +383,7 @@ pub(super) fn compile_for_ios_widget(
         is_dylib: false,
         codegen_cache_stats: None,
         link_cache_stats: None,
+        build_cache_stats: None,
     })
 }
 
@@ -635,6 +636,7 @@ pub(super) fn compile_for_watchos_widget(
         is_dylib: false,
         codegen_cache_stats: None,
         link_cache_stats: None,
+        build_cache_stats: None,
     })
 }
 
@@ -969,6 +971,7 @@ pub(super) fn compile_for_android_widget(
         is_dylib: false,
         codegen_cache_stats: None,
         link_cache_stats: None,
+        build_cache_stats: None,
     })
 }
 
@@ -1221,6 +1224,7 @@ pub(super) fn compile_for_wearos_tile(
         is_dylib: false,
         codegen_cache_stats: None,
         link_cache_stats: None,
+        build_cache_stats: None,
     })
 }
 
@@ -1380,6 +1384,7 @@ pub(super) fn compile_for_web(
         is_dylib: false,
         codegen_cache_stats: None,
         link_cache_stats: None,
+        build_cache_stats: None,
     })
 }
 
@@ -1529,5 +1534,6 @@ pub(super) fn compile_for_wasm(
         is_dylib: false,
         codegen_cache_stats: None,
         link_cache_stats: None,
+        build_cache_stats: None,
     })
 }

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
 use perry_hir::{Module as HirModule, ModuleKind};
+use serde::{Deserialize, Serialize};
 
 use crate::OutputFormat;
 
@@ -32,12 +33,22 @@ pub struct CompileResult {
     /// executable linker path.
     #[allow(dead_code)]
     pub link_cache_stats: Option<LinkCacheStats>,
+    /// Native executable build-level no-op status. `Some` for native executable
+    /// compile attempts; `None` for targets that bypass the native linker path.
+    #[allow(dead_code)]
+    pub build_cache_stats: Option<BuildCacheStats>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LinkCacheStats {
     pub linked: bool,
     pub skipped: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BuildCacheStats {
+    pub hit: bool,
+    pub reason: String,
 }
 
 // Helpers moved to sub-modules:

--- a/crates/perry/tests/native_link_cache.rs
+++ b/crates/perry/tests/native_link_cache.rs
@@ -8,16 +8,27 @@ fn perry_bin() -> PathBuf {
 }
 
 fn compile_json(project: &Path, entry: &Path, output: &Path) -> Value {
-    let out = Command::new(perry_bin())
-        .current_dir(project)
+    compile_json_with_env(project, entry, output, &[])
+}
+
+fn compile_json_with_env(
+    project: &Path,
+    entry: &Path,
+    output: &Path,
+    envs: &[(&str, &str)],
+) -> Value {
+    let mut cmd = Command::new(perry_bin());
+    cmd.current_dir(project)
         .arg("--format")
         .arg("json")
         .arg("compile")
         .arg(entry)
         .arg("-o")
-        .arg(output)
-        .output()
-        .expect("run perry compile");
+        .arg(output);
+    for (name, value) in envs {
+        cmd.env(name, value);
+    }
+    let out = cmd.output().expect("run perry compile");
 
     assert!(
         out.status.success(),
@@ -55,6 +66,15 @@ fn assert_skipped(result: &Value) {
     assert_eq!(result["link_cache"]["skipped"], true, "{result}");
 }
 
+fn assert_build_cache_hit(result: &Value) {
+    assert_eq!(result["build_cache"]["hit"], true, "{result}");
+}
+
+fn assert_build_cache_miss(result: &Value, reason: &str) {
+    assert_eq!(result["build_cache"]["hit"], false, "{result}");
+    assert_eq!(result["build_cache"]["miss_reason"], reason, "{result}");
+}
+
 #[test]
 fn native_compile_skips_link_on_identical_second_build() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -84,13 +104,37 @@ fn native_compile_skips_link_on_identical_second_build() {
 
     let first = compile_json(project, &entry, &output);
     assert_linked(&first);
+    assert_build_cache_miss(&first, "manifest-missing");
     let first_bytes = fs::read(&output).expect("first output");
     assert_eq!(run_binary(&output).trim(), "42");
 
     let second = compile_json(project, &entry, &output);
     assert_skipped(&second);
+    assert_build_cache_hit(&second);
     assert_eq!(fs::read(&output).expect("second output"), first_bytes);
     assert_eq!(run_binary(&output).trim(), "42");
+
+    fs::write(
+        project.join("package.json"),
+        "{\"name\":\"link-cache-test\",\"version\":\"1.0.1\"}\n",
+    )
+    .unwrap();
+    let config_changed = compile_json(project, &entry, &output);
+    assert_build_cache_miss(&config_changed, "config");
+    assert_eq!(run_binary(&output).trim(), "42");
+
+    let env_changed = compile_json_with_env(project, &entry, &output, &[("PERRY_DEBUG_INIT", "1")]);
+    assert_linked(&env_changed);
+    assert_build_cache_miss(&env_changed, "env");
+
+    let env_restored = compile_json(project, &entry, &output);
+    assert_linked(&env_restored);
+    assert_build_cache_miss(&env_restored, "env");
+    assert_eq!(run_binary(&output).trim(), "42");
+
+    let warm_again = compile_json(project, &entry, &output);
+    assert_skipped(&warm_again);
+    assert_build_cache_hit(&warm_again);
 
     fs::write(
         src.join("util.ts"),
@@ -99,10 +143,12 @@ fn native_compile_skips_link_on_identical_second_build() {
     .unwrap();
     let changed = compile_json(project, &entry, &output);
     assert_linked(&changed);
+    assert_build_cache_miss(&changed, "source");
     assert_eq!(run_binary(&output).trim(), "41");
 
     fs::remove_file(&output).unwrap();
     let missing_output = compile_json(project, &entry, &output);
     assert_linked(&missing_output);
+    assert_build_cache_miss(&missing_output, "output");
     assert!(output.exists());
 }


### PR DESCRIPTION
## Summary

Adds a conservative build-level no-op manifest for unchanged native executable `perry compile` runs. On a manifest hit, Perry now verifies the output and recorded inputs before returning ahead of module collection, parsing/lowering, object-cache work, linker command setup, and link-cache hashing.

The fast path is deliberately narrow: it skips for no-cache/no-link, non-executable outputs, web/wasm/widget targets, diagnostics/type-check/HIR tracing modes, sidecar/verification modes, resource-copy side effects, package codegen/i18n hooks, `precompile(` usage, native libraries, JS modules, and complex native runtimes.

Manifest inputs include Perry version and executable fingerprint, canonical input/output identity, target/options key, selected link-affecting env, source graph fingerprints, config fingerprints, runtime/link input fingerprints, object fingerprints, module counts, and output fingerprint.

## Verification

- `cargo fmt --all -- --check` passed.
- `cargo test -p perry --test native_link_cache` passed: 1 passed, 0 failed.
- `cargo test -p perry link_cache` passed: 10 unit tests passed, 0 failed; native integration test filtered out for that name filter.
- `cargo build -p perry --release` passed.

Focused release smoke under `target/noop-smoke-release` with 201 native modules:

- First compile: `build_cache.hit=false`, `miss_reason=manifest-missing`, `codegen_cache.misses=201`, `link_cache.linked=true`, wall `3.96s`.
- Unchanged compile with `PERRY_DISABLE_BUILD_CACHE=1`: `build_cache.hit=false`, `miss_reason=disabled-by-env`, `codegen_cache.hits=201`, `link_cache.skipped=true`, wall `1.00s`.
- Unchanged compile with build cache enabled: `build_cache.hit=true`, `reason=manifest-match`, `codegen_cache=null`, `link_cache.skipped=true`, wall `0.10s`.
- Compiled binary output: `19900`.

## Remaining Gaps

This PR does not attempt a full build manifest for package codegen/i18n/native-library/JS-module/resource-copy/UI/plugin/wasm-runtime cases. Those remain conservative misses until their generated inputs and side effects are separately fingerprinted.
