### PR TITLE
[codex] Reify builtin namespace method values

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1787,6 +1787,25 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                                     | "values"
                             )
                         );
+                    // #4437: value reads such as `JSON.stringify` /
+                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` need the
+                    // reified namespace/constructor receiver. Direct calls still
+                    // take the intrinsic path this reroute-undo protects.
+                    let outer_static_member = match &member.prop {
+                        ast::MemberProp::Ident(p) => Some(p.sym.as_ref()),
+                        ast::MemberProp::Computed(c) => match c.expr.as_ref() {
+                            ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str(),
+                            _ => None,
+                        },
+                        ast::MemberProp::PrivateName(_) => None,
+                    };
+                    let outer_is_reified_builtin_static_value = !member_is_call_callee
+                        && matches!(property.as_str(), "JSON" | "Reflect" | "BigInt" | "Symbol")
+                        && outer_static_member
+                            .map(|member| {
+                                crate::analysis::is_builtin_static_function_member(property, member)
+                            })
+                            .unwrap_or(false);
                     // Non-callee `console.log` reads need the namespace
                     // receiver; the property-only GlobalGet path collides
                     // with detached `Math.log`.
@@ -1796,6 +1815,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         && !receiver_is_namespace_value
                         && !outer_is_websocket_static
                         && !outer_is_reified_object_static_value
+                        && !outer_is_reified_builtin_static_value
                         && !receiver_is_detached_console_read
                     {
                         object_expr = Expr::GlobalGet(0);

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3052,6 +3052,71 @@ extern "C" fn bigint_as_uint_n_thunk(
     bigint_as_n_dispatch(bits, value, false)
 }
 
+extern "C" fn json_parse_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    text: f64,
+    reviver: f64,
+) -> f64 {
+    let text_ptr = crate::value::js_get_string_pointer_unified(text) as *const crate::StringHeader;
+    let reviver_value = JSValue::from_bits(reviver.to_bits());
+    let parsed = unsafe {
+        if reviver_value.is_pointer()
+            && crate::closure::is_closure_ptr(reviver_value.as_pointer::<u8>() as usize)
+        {
+            crate::json::js_json_parse_with_reviver(
+                text_ptr,
+                reviver_value.as_pointer::<crate::closure::ClosureHeader>() as i64,
+            )
+        } else {
+            crate::json::js_json_parse(text_ptr)
+        }
+    };
+    f64::from_bits(parsed.bits())
+}
+
+extern "C" fn json_stringify_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+    replacer: f64,
+    space: f64,
+) -> f64 {
+    f64::from_bits(unsafe { crate::json::js_json_stringify_full(value, replacer, space) as u64 })
+}
+
+extern "C" fn json_raw_json_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    text: f64,
+) -> f64 {
+    unsafe { crate::json::js_json_raw_json(text) }
+}
+
+extern "C" fn json_is_raw_json_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    unsafe { crate::json::js_json_is_raw_json(value) }
+}
+
+extern "C" fn reflect_apply_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    target: f64,
+    this_arg: f64,
+    args: f64,
+) -> f64 {
+    crate::proxy::js_reflect_apply(target, this_arg, args)
+}
+
+extern "C" fn symbol_for_thunk(_closure: *const crate::closure::ClosureHeader, key: f64) -> f64 {
+    unsafe { crate::symbol::js_symbol_for(key) }
+}
+
+extern "C" fn symbol_key_for_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    symbol: f64,
+) -> f64 {
+    unsafe { crate::symbol::js_symbol_key_for(symbol) }
+}
+
 extern "C" fn number_is_safe_integer_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
@@ -3457,6 +3522,10 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 false,
             );
         }
+        "Symbol" => {
+            install_constructor_static(ctor, "for", symbol_for_thunk as *const u8, 1, false);
+            install_constructor_static(ctor, "keyFor", symbol_key_for_thunk as *const u8, 1, false);
+        }
         "ArrayBuffer" => {
             install_constructor_static(
                 ctor,
@@ -3633,19 +3702,17 @@ pub(super) fn install_proto_method_rest_with_length(
     value
 }
 
-/// #4139: reify the `JSON` namespace's own methods for reflection parity. See
-/// `install_math_namespace` for the rationale (call sites are codegen
-/// intrinsics; these no-op-backed fields exist only for reflection).
+/// #4139/#4437: reify the `JSON` namespace's own methods for reflection parity
+/// and detached value calls. Direct call sites are still codegen intrinsics.
 fn install_json_namespace_members(ns_obj: *mut ObjectHeader) {
-    let noop = global_this_builtin_noop_thunk as *const u8;
-    const METHODS: &[(&str, u32)] = &[
-        ("parse", 2),
-        ("stringify", 3),
-        ("rawJSON", 1),
-        ("isRawJSON", 1),
+    const METHODS: &[(&str, *const u8, u32)] = &[
+        ("parse", json_parse_thunk as *const u8, 2),
+        ("stringify", json_stringify_thunk as *const u8, 3),
+        ("rawJSON", json_raw_json_thunk as *const u8, 1),
+        ("isRawJSON", json_is_raw_json_thunk as *const u8, 1),
     ];
-    for (name, arity) in METHODS.iter().copied() {
-        install_proto_method(ns_obj, name, noop, arity);
+    for (name, func_ptr, arity) in METHODS.iter().copied() {
+        install_proto_method(ns_obj, name, func_ptr, arity);
     }
 }
 
@@ -3653,23 +3720,23 @@ fn install_json_namespace_members(ns_obj: *mut ObjectHeader) {
 /// See `install_math_namespace` for the rationale.
 fn install_reflect_namespace_members(ns_obj: *mut ObjectHeader) {
     let noop = global_this_builtin_noop_thunk as *const u8;
-    const METHODS: &[(&str, u32)] = &[
-        ("defineProperty", 3),
-        ("deleteProperty", 2),
-        ("apply", 3),
-        ("construct", 2),
-        ("get", 2),
-        ("getOwnPropertyDescriptor", 2),
-        ("getPrototypeOf", 1),
-        ("has", 2),
-        ("isExtensible", 1),
-        ("ownKeys", 1),
-        ("preventExtensions", 1),
-        ("set", 3),
-        ("setPrototypeOf", 2),
+    let methods = [
+        ("defineProperty", noop, 3),
+        ("deleteProperty", noop, 2),
+        ("apply", reflect_apply_thunk as *const u8, 3),
+        ("construct", noop, 2),
+        ("get", noop, 2),
+        ("getOwnPropertyDescriptor", noop, 2),
+        ("getPrototypeOf", noop, 1),
+        ("has", noop, 2),
+        ("isExtensible", noop, 1),
+        ("ownKeys", noop, 1),
+        ("preventExtensions", noop, 1),
+        ("set", noop, 3),
+        ("setPrototypeOf", noop, 2),
     ];
-    for (name, arity) in METHODS.iter().copied() {
-        install_proto_method(ns_obj, name, noop, arity);
+    for (name, func_ptr, arity) in methods {
+        install_proto_method(ns_obj, name, func_ptr, arity);
     }
 }
 

--- a/test-parity/node-suite/globals/builtin-namespace-method-values.ts
+++ b/test-parity/node-suite/globals/builtin-namespace-method-values.ts
@@ -1,0 +1,55 @@
+function show(label: string, value: any) {
+  console.log(label, "typeof", typeof value);
+  console.log(label, "names", Object.getOwnPropertyNames(value).join("|"));
+  console.log(
+    label,
+    "own",
+    Object.prototype.hasOwnProperty.call(value, "length"),
+    Object.prototype.hasOwnProperty.call(value, "name"),
+  );
+  console.log(
+    label,
+    "meta",
+    typeof value === "function" ? value.name : "<not-function>",
+    typeof value === "function" ? value.length : "<not-function>",
+  );
+}
+
+const mathAbs = Math.abs;
+const objectKeys = Object.keys;
+const jsonStringify = JSON.stringify;
+const reflectApply = Reflect.apply;
+const bigintAsIntN = BigInt.asIntN;
+const symbolFor = Symbol.for;
+
+show("Math.abs", mathAbs);
+show("Object.keys", objectKeys);
+show("JSON.stringify", jsonStringify);
+show("Reflect.apply", reflectApply);
+show("BigInt.asIntN", bigintAsIntN);
+show("Symbol.for", symbolFor);
+
+console.log(
+  "Math.abs call",
+  typeof mathAbs === "function" ? mathAbs(-5) : "<not-function>",
+);
+console.log(
+  "Object.keys call",
+  typeof objectKeys === "function" ? objectKeys({ b: 2, a: 1 }).join("|") : "<not-function>",
+);
+console.log(
+  "JSON.stringify call",
+  typeof jsonStringify === "function" ? jsonStringify({ a: 1 }) : "<not-function>",
+);
+console.log(
+  "Reflect.apply call",
+  typeof reflectApply === "function" ? reflectApply(Math.max, null, [3, 7]) : "<not-function>",
+);
+console.log(
+  "BigInt.asIntN call",
+  typeof bigintAsIntN === "function" ? bigintAsIntN(4, 31n).toString() : "<not-function>",
+);
+console.log(
+  "Symbol.for call",
+  typeof symbolFor === "function" ? String(symbolFor("perry.issue4437")) : "<not-function>",
+);


### PR DESCRIPTION
Fixes #4437.

## Summary

- Keep the reified receiver for value-position reads of built-in static methods on `JSON`, `Reflect`, `BigInt`, and `Symbol`.
- Install callable runtime function values for the JSON methods, `Reflect.apply`, and `Symbol.for` / `Symbol.keyFor`.
- Add a parity fixture covering function metadata and detached calls for existing working namespaces plus the affected built-ins.

## Validation

- `CARGO_BUILD_JOBS=1 RUSTFLAGS='-Awarnings' cargo build -q -p perry -p perry-runtime`
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/builtin-namespace-method-values.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1 PERRY_ALLOW_UNIMPLEMENTED=1 target/debug/perry test-parity/node-suite/globals/builtin-namespace-method-values.ts`
- `diff -u /tmp/perry4437-node.current.out /tmp/perry4437-perry.current.run.out`
- Node/Perry focused fixture result: 30 stdout lines each, 0 stderr lines each, empty diff.
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json test-parity/threshold.json test-parity/parity_matrix_baseline.json`
- `./scripts/check_file_size.sh`
- `git diff --check`
