### PR TITLE
fix(compile): reconcile build_cache with expanded LinkCacheStats

### DIFF
--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -68,7 +68,7 @@ struct BuildCacheManifest {
     sources: Vec<FileFingerprint>,
     config_inputs: Vec<FileFingerprint>,
     runtime_inputs: Vec<FileFingerprint>,
-    object_fingerprints: Vec<String>,
+    object_fingerprints: Vec<Option<String>>,
     native_modules: usize,
     js_modules: usize,
     output: FileFingerprint,
@@ -204,6 +204,9 @@ impl BuildCacheProbe {
             link_cache_stats: Some(LinkCacheStats {
                 linked: false,
                 skipped: true,
+                object_fingerprints_used: 0,
+                object_files_hashed: 0,
+                external_inputs_hashed: 0,
             }),
             build_cache_stats: Some(BuildCacheStats {
                 hit: true,
@@ -219,7 +222,7 @@ impl BuildCacheProbe {
         output_path: &Path,
         target: Option<&str>,
         compiled_features: &[String],
-        object_fingerprints: &[String],
+        object_fingerprints: &[Option<String>],
         runtime_inputs: &[PathBuf],
     ) {
         if std::env::var("PERRY_DISABLE_BUILD_CACHE").ok().as_deref() == Some("1") {
@@ -286,7 +289,7 @@ impl BuildCacheProbe {
         output_path: &Path,
         target: Option<&str>,
         compiled_features: &[String],
-        object_fingerprints: &[String],
+        object_fingerprints: &[Option<String>],
         runtime_inputs: &[PathBuf],
     ) -> Result<BuildCacheManifest, String> {
         let sources = ctx


### PR DESCRIPTION
## Summary

`main` (`e81a28e0f`) does not compile. #4436 (native no-op build cache) and #4434 (object-fingerprint link cache) landed in parallel and collided:

- `build_cache.rs` built `LinkCacheStats { linked, skipped }` (2 fields), but #4434 expanded the struct to 5 fields → **E0063**.
- `write_manifest_after_success` / `build_manifest` took `object_fingerprints: &[String]`, but callers now pass `Vec<Option<String>>` (#4434) → **E0308**.

This blocks CI on every open PR until fixed.

## Fix

- Add the three zeroed fingerprint-stat fields (`object_fingerprints_used`, `object_files_hashed`, `external_inputs_hashed`) to the cache-hit `LinkCacheStats` literal.
- Thread `Option<String>` object fingerprints through `write_manifest_after_success`, `build_manifest`, and the `BuildCacheManifest` struct.

## Validation

- `cargo build --release -p perry-runtime -p perry-stdlib -p perry` — clean.
- `cargo test --release -p perry link_cache` — 14 passed.
- `cargo fmt --all -- --check` — clean.