### PR TITLE
fix(compile): repair main build break from #4434 x #4436 collision

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -5387,13 +5387,22 @@ pub fn run_with_parse_cache(
     if let Some(path) = &wasm_host_lib {
         build_cache_runtime_inputs.push(path.clone());
     }
+    // #4434×#4436 merge fixup: `write_manifest_after_success` (added by the
+    // link-cache fingerprint work) takes `&[String]`, but `obj_fingerprints`
+    // carries `Option<String>` (None for objects that can't be fingerprinted,
+    // e.g. well-known archives — those are validated separately through
+    // `build_cache_runtime_inputs`). Flatten None to an empty fingerprint.
+    let obj_fingerprints_for_manifest: Vec<String> = obj_fingerprints
+        .iter()
+        .map(|f| f.clone().unwrap_or_default())
+        .collect();
     build_cache_probe.write_manifest_after_success(
         &mut build_cache_stats,
         &ctx,
         &exe_path,
         target.as_deref(),
         &compiled_features,
-        &obj_fingerprints,
+        &obj_fingerprints_for_manifest,
         &build_cache_runtime_inputs,
     );
 

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -204,6 +204,11 @@ impl BuildCacheProbe {
             link_cache_stats: Some(LinkCacheStats {
                 linked: false,
                 skipped: true,
+                // A build-cache hit performs no linking, so no object
+                // fingerprints were used or hashed (#4434×#4436 merge fixup).
+                object_fingerprints_used: 0,
+                object_files_hashed: 0,
+                external_inputs_hashed: 0,
             }),
             build_cache_stats: Some(BuildCacheStats {
                 hit: true,


### PR DESCRIPTION
## Summary

**Main build break.** `crates/perry` does not compile on `main` HEAD — `#4434` (object fingerprints for link cache) and `#4436` (no-op build cache) merged without mutual rebase:

```
error[E0063]: missing fields `external_inputs_hashed`, `object_files_hashed` and
  `object_fingerprints_used` in initializer of `compile::types::LinkCacheStats`
  --> build_cache.rs:204  (compile_result_for_hit)
error[E0308]: mismatched types  &Vec<Option<String>> vs &[String]
  --> compile.rs:5396  (write_manifest_after_success call)
```

This fails `cargo-test`, `compiler-output-regression`, and `api-docs-drift` on **every open PR** (they all build the `perry` binary).

## Fix

- `compile_result_for_hit`: a build-cache *hit* performs no linking, so the three new `LinkCacheStats` fields are `0`.
- Call site: `obj_fingerprints` is `Vec<Option<String>>` (`None` for objects that can't be fingerprinted — well-known archives, which are validated separately via `build_cache_runtime_inputs`). Flatten `None` → empty fingerprint to match the `&[String]` signature.

## Validation

`cargo build --release -p perry` (bin **and** `--tests`) now compiles. No behavior change beyond making the two collided features coexist.
