### PR TITLE
fix(build): repair perry binary broken by #4434/#4436 rebase race

### DIFF
--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -204,6 +204,9 @@ impl BuildCacheProbe {
             link_cache_stats: Some(LinkCacheStats {
                 linked: false,
                 skipped: true,
+                object_fingerprints_used: 0,
+                object_files_hashed: 0,
+                external_inputs_hashed: 0,
             }),
             build_cache_stats: Some(BuildCacheStats {
                 hit: true,
@@ -219,7 +222,7 @@ impl BuildCacheProbe {
         output_path: &Path,
         target: Option<&str>,
         compiled_features: &[String],
-        object_fingerprints: &[String],
+        object_fingerprints: &[Option<String>],
         runtime_inputs: &[PathBuf],
     ) {
         if std::env::var("PERRY_DISABLE_BUILD_CACHE").ok().as_deref() == Some("1") {
@@ -242,12 +245,24 @@ impl BuildCacheProbe {
             stats.reason = "js-modules".to_string();
             return;
         }
+        // Objects whose fingerprint isn't a trusted proxy for the linked bytes
+        // (bitcode-merged or freshly compiled `.ll`→`.o`) arrive as `None`. We
+        // can't soundly re-validate those on a later run, so refuse to store the
+        // manifest rather than risk a false cache hit.
+        let Some(object_fingerprints) = object_fingerprints
+            .iter()
+            .cloned()
+            .collect::<Option<Vec<String>>>()
+        else {
+            stats.reason = "object-fingerprint-missing".to_string();
+            return;
+        };
         let manifest = match self.build_manifest(
             ctx,
             output_path,
             target,
             compiled_features,
-            object_fingerprints,
+            &object_fingerprints,
             runtime_inputs,
         ) {
             Ok(manifest) => manifest,


### PR DESCRIPTION
## What

Repairs the `perry` binary, which does not compile on `main` (`cargo build -p perry`
fails with `E0063` + `E0308`). The lib crates build, so the `cargo-test` gate on
individual PRs passed — but the binary is broken at the current `main` HEAD.

## Root cause — rebase race between #4434 and #4436

- **#4434** (`Use object fingerprints for link cache`) added three fields to
  `LinkCacheStats` (`object_fingerprints_used`, `object_files_hashed`,
  `external_inputs_hashed`) and changed `obj_fingerprints` to
  `Vec<Option<String>>`.
- **#4436** (`Add native compile no-op build cache`) was branched before #4434 and
  merged after it without rebasing. It constructs `LinkCacheStats { linked, skipped }`
  (now missing 3 fields) and passes `&obj_fingerprints` (`&Vec<Option<String>>`) to
  `write_manifest_after_success(&[String])`.

Each PR compiled against its own base; together they don't.

## Fix

- `compile_result_for_hit`: initialize the three new `LinkCacheStats` count fields
  to `0` (a cache hit does no hashing/linking work).
- `write_manifest_after_success`: take `&[Option<String>]`. A `None` fingerprint
  marks an object whose hash isn't a trusted proxy for the linked bytes
  (bitcode-merged or freshly compiled `.ll`→`.o`, per #4434's own comment), so it
  can't be re-validated on a later run — refuse to store the manifest
  (`reason = "object-fingerprint-missing"`) rather than risk a false cache hit.
  When all fingerprints are present, unwrap to `Vec<String>` and proceed as before.

## Verification

- `cargo build --release -p perry` now succeeds (was E0063/E0308).
- Smoke: `perry` compiles + runs a `.ts` correctly.
- No behavior change on the success path; the only new outcome is that a build
  whose objects lack trusted fingerprints skips the no-op build cache (sound;
  better than an unverifiable hit).
