### PR TITLE
fix(runtime): honor Date toJSON ToPrimitive and reject builtin method new

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -35,6 +35,14 @@ thread_local! {
         std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
+fn is_non_constructable_builtin_function_value(value: f64) -> bool {
+    super::native_module::builtin_closure_is_non_constructable_value(value)
+}
+
+fn throw_non_constructable_builtin_function() -> ! {
+    super::object_ops::throw_object_type_error(b"Function is not a constructor")
+}
+
 pub(crate) fn class_mark_key_deleted(class_id: u32, key: &str) {
     if class_id == 0 {
         return;
@@ -1210,6 +1218,9 @@ pub unsafe extern "C" fn js_new_function_construct(
         let arr_box = f64::from_bits(0x7FFD_0000_0000_0000 | (a as u64 & 0x0000_FFFF_FFFF_FFFF));
         return crate::proxy::js_proxy_construct(func_value, arr_box, func_value);
     }
+    if is_non_constructable_builtin_function_value(func_value) {
+        throw_non_constructable_builtin_function();
+    }
     if let Some((module, method)) = bound_native_callable_module_and_method(func_value) {
         if module == "sqlite"
             && matches!(
@@ -1849,6 +1860,11 @@ pub unsafe extern "C" fn js_new_function_construct_with_new_target(
     }
     if !is_callable_function_value(func_value) {
         return js_new_function_construct(func_value, args_ptr, args_len);
+    }
+    if is_non_constructable_builtin_function_value(func_value)
+        || is_non_constructable_builtin_function_value(nt)
+    {
+        throw_non_constructable_builtin_function();
     }
     if is_arrow_function_value(func_value) {
         crate::fs::validate::throw_type_error_with_code(

--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -102,7 +102,7 @@ extern "C" fn date_to_json(_closure: *const crate::closure::ClosureHeader) -> f6
     let tv = if crate::date::is_date_value(this) {
         crate::date::date_cell_timestamp(this)
     } else {
-        match unsafe { crate::value::ordinary_to_primitive_number_for_add(this) } {
+        match unsafe { crate::value::to_primitive_number(this) } {
             crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => p,
             // A plain object's default `"[object Object]"` is a String, never a
             // Number, so step 3 (non-finite Number → null) never fires; fall
@@ -150,6 +150,11 @@ extern "C" fn date_to_json(_closure: *const crate::closure::ClosureHeader) -> f6
             0,
         )
     }
+}
+
+#[cfg(test)]
+pub(crate) fn test_date_to_json_current_this() -> f64 {
+    date_to_json(std::ptr::null())
 }
 
 // --- Date constructor static methods (Date.now / Date.parse / Date.UTC) ---

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3282,6 +3282,7 @@ fn install_constructor_static_with_call_arity(
     }
     super::native_module::set_bound_native_closure_name(closure, name);
     super::native_module::set_builtin_closure_length(closure as usize, spec_length);
+    super::native_module::set_builtin_closure_non_constructable(closure as usize);
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
     let value = crate::value::js_nanbox_pointer(closure as i64);
     js_object_set_field_by_name(ctor as *mut ObjectHeader, key, value);
@@ -3551,6 +3552,7 @@ pub(super) fn install_proto_method(
     // can't distinguish `map` (1) from `slice` (2). Read back by the `.length`
     // value-accessor and `getOwnPropertyDescriptor`.
     super::native_module::set_builtin_closure_length(closure as usize, arity);
+    super::native_module::set_builtin_closure_non_constructable(closure as usize);
     let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
     let value = crate::value::js_nanbox_pointer(closure as i64);
     js_object_set_field_by_name(proto_obj, key, value);
@@ -3612,6 +3614,7 @@ pub(super) fn install_proto_method_rest_with_length(
     crate::closure::js_register_closure_rest(func_ptr, call_fixed_arity);
     super::native_module::set_bound_native_closure_name(closure, method_name);
     super::native_module::set_builtin_closure_length(closure as usize, spec_length);
+    super::native_module::set_builtin_closure_non_constructable(closure as usize);
     let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
     let value = crate::value::js_nanbox_pointer(closure as i64);
     js_object_set_field_by_name(proto_obj, key, value);

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -4655,6 +4655,13 @@ thread_local! {
     /// the spec count. #3143.
     static BUILTIN_CLOSURE_LENGTH: std::cell::RefCell<std::collections::HashMap<usize, u32>> =
         std::cell::RefCell::new(std::collections::HashMap::new());
+
+    /// Built-in method closures are callable but lack ECMAScript
+    /// `[[Construct]]`. Track the installed closure values so the dynamic
+    /// `new` / `Reflect.construct` paths can reject them without changing
+    /// ordinary user closures or global constructor closures.
+    static BUILTIN_CLOSURE_NON_CONSTRUCTABLE: std::cell::RefCell<std::collections::HashSet<usize>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
 }
 
 /// Record the spec `.length` for a built-in prototype-method closure. See
@@ -4669,6 +4676,28 @@ pub(crate) fn set_builtin_closure_length(closure: usize, length: u32) {
 /// closure, or `None` if this closure isn't one. See [`BUILTIN_CLOSURE_LENGTH`].
 pub(crate) fn builtin_closure_length(closure: usize) -> Option<u32> {
     BUILTIN_CLOSURE_LENGTH.with(|m| m.borrow().get(&closure).copied())
+}
+
+pub(crate) fn set_builtin_closure_non_constructable(closure: usize) {
+    BUILTIN_CLOSURE_NON_CONSTRUCTABLE.with(|m| {
+        m.borrow_mut().insert(closure);
+    });
+}
+
+pub(crate) fn builtin_closure_is_non_constructable(closure: usize) -> bool {
+    BUILTIN_CLOSURE_NON_CONSTRUCTABLE.with(|m| m.borrow().contains(&closure))
+}
+
+pub(crate) fn builtin_closure_is_non_constructable_value(value: f64) -> bool {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+    let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
+    if ptr.is_null() {
+        return false;
+    }
+    builtin_closure_is_non_constructable(ptr as usize)
 }
 
 /// Whitelist of (module, property) pairs for which property-read should

--- a/crates/perry-runtime/src/object/primitive_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/primitive_proto_thunks.rs
@@ -135,6 +135,7 @@ fn primitive_proto_method_closure_value(method_name: &str, func_ptr: *const u8, 
     crate::closure::js_register_closure_arity(func_ptr, arity);
     super::native_module::set_bound_native_closure_name(closure, method_name);
     super::native_module::set_builtin_closure_length(closure as usize, arity);
+    super::native_module::set_builtin_closure_non_constructable(closure as usize);
     super::set_builtin_property_attrs(
         closure as usize,
         "name".to_string(),

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -2,6 +2,7 @@
 #![cfg(test)]
 
 use super::*;
+use std::os::raw::c_int;
 
 fn test_global_this_builtin_constructor_value(name: &str) -> f64 {
     let closure_ptr = crate::closure::js_closure_alloc(
@@ -39,6 +40,207 @@ fn js_string_to_rust(value: JSValue) -> String {
         let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
         let bytes = std::slice::from_raw_parts(data, (*ptr).byte_len as usize);
         std::str::from_utf8(bytes).unwrap().to_string()
+    }
+}
+
+fn catch_js<F: FnOnce() -> f64>(f: F) -> Result<f64, f64> {
+    let env = crate::exception::js_try_push();
+    let jumped = unsafe { crate::ffi::setjmp::setjmp(env as *mut c_int) };
+    if jumped == 0 {
+        let result = f();
+        crate::exception::js_try_end();
+        Ok(result)
+    } else {
+        crate::exception::js_try_end();
+        let err = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        Err(err)
+    }
+}
+
+unsafe fn installed_builtin_method(ctor_name: &str, method_name: &str) -> f64 {
+    let global_ptr = js_object_alloc(0, 0);
+    super::global_this::populate_global_this_builtins(global_ptr);
+    let ctor_key = crate::string::js_string_from_bytes(ctor_name.as_ptr(), ctor_name.len() as u32);
+    let ctor = js_object_get_field_by_name(global_ptr, ctor_key);
+    assert!(
+        ctor.is_pointer(),
+        "{ctor_name} constructor should be installed"
+    );
+
+    let prototype_key = crate::string::js_string_from_bytes(b"prototype".as_ptr(), 9);
+    let prototype = js_object_get_field_by_name(
+        ctor.as_pointer::<crate::closure::ClosureHeader>() as *const ObjectHeader,
+        prototype_key,
+    );
+    assert!(
+        prototype.is_pointer(),
+        "{ctor_name}.prototype should be installed"
+    );
+
+    let method_key =
+        crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+    let method = js_object_get_field_by_name(prototype.as_pointer::<ObjectHeader>(), method_key);
+    assert!(
+        method.is_pointer(),
+        "{ctor_name}.prototype.{method_name} should be a function value"
+    );
+    f64::from_bits(method.bits())
+}
+
+extern "C" fn symbol_to_primitive_nan(
+    _closure: *const crate::closure::ClosureHeader,
+    hint: f64,
+) -> f64 {
+    let hint_value = JSValue::from_bits(hint.to_bits());
+    assert_eq!(js_string_to_rust(hint_value), "number");
+    f64::NAN
+}
+
+extern "C" fn value_of_finite(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    1.0
+}
+
+extern "C" fn symbol_to_primitive_this_object(
+    _closure: *const crate::closure::ClosureHeader,
+    hint: f64,
+) -> f64 {
+    let hint_value = JSValue::from_bits(hint.to_bits());
+    assert_eq!(js_string_to_rust(hint_value), "number");
+    crate::object::js_implicit_this_get()
+}
+
+extern "C" fn to_iso_string_sentinel(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    let string = crate::string::js_string_from_bytes(b"iso".as_ptr(), 3);
+    crate::value::js_nanbox_string(string as i64)
+}
+
+#[test]
+fn date_to_json_number_hint_honors_symbol_to_primitive() {
+    unsafe {
+        let receiver = js_object_alloc(0, 0);
+        let receiver_value = crate::value::js_nanbox_pointer(receiver as i64);
+
+        let to_primitive =
+            crate::closure::js_closure_alloc(symbol_to_primitive_nan as *const u8, 0);
+        crate::closure::js_register_closure_arity(symbol_to_primitive_nan as *const u8, 1);
+        let sym = crate::symbol::well_known_symbol("toPrimitive");
+        let sym_value =
+            f64::from_bits(crate::value::POINTER_TAG | (sym as u64 & crate::value::POINTER_MASK));
+        crate::symbol::js_object_set_symbol_property(
+            receiver_value,
+            sym_value,
+            crate::value::js_nanbox_pointer(to_primitive as i64),
+        );
+
+        let value_of = crate::closure::js_closure_alloc(value_of_finite as *const u8, 0);
+        crate::closure::js_register_closure_arity(value_of_finite as *const u8, 0);
+        let value_of_key = crate::string::js_string_from_bytes(b"valueOf".as_ptr(), 7);
+        js_object_set_field_by_name(
+            receiver,
+            value_of_key,
+            crate::value::js_nanbox_pointer(value_of as i64),
+        );
+
+        let prev_this = js_implicit_this_set(receiver_value);
+        let result = catch_js(crate::object::date_proto_thunks::test_date_to_json_current_this);
+        js_implicit_this_set(prev_this);
+
+        let result = result.expect("Date.prototype.toJSON should not throw");
+        assert!(
+            JSValue::from_bits(result.to_bits()).is_null(),
+            "@@toPrimitive returning NaN must make Date.prototype.toJSON return null"
+        );
+    }
+}
+
+#[test]
+fn date_to_json_symbol_to_primitive_object_result_throws() {
+    unsafe {
+        let receiver = js_object_alloc(0, 0);
+        let receiver_value = crate::value::js_nanbox_pointer(receiver as i64);
+
+        let to_primitive =
+            crate::closure::js_closure_alloc(symbol_to_primitive_this_object as *const u8, 0);
+        crate::closure::js_register_closure_arity(symbol_to_primitive_this_object as *const u8, 1);
+        let sym = crate::symbol::well_known_symbol("toPrimitive");
+        let sym_value =
+            f64::from_bits(crate::value::POINTER_TAG | (sym as u64 & crate::value::POINTER_MASK));
+        crate::symbol::js_object_set_symbol_property(
+            receiver_value,
+            sym_value,
+            crate::value::js_nanbox_pointer(to_primitive as i64),
+        );
+
+        let to_iso = crate::closure::js_closure_alloc(to_iso_string_sentinel as *const u8, 0);
+        crate::closure::js_register_closure_arity(to_iso_string_sentinel as *const u8, 0);
+        let to_iso_key = crate::string::js_string_from_bytes(b"toISOString".as_ptr(), 11);
+        js_object_set_field_by_name(
+            receiver,
+            to_iso_key,
+            crate::value::js_nanbox_pointer(to_iso as i64),
+        );
+
+        let prev_this = js_implicit_this_set(receiver_value);
+        let result = catch_js(crate::object::date_proto_thunks::test_date_to_json_current_this);
+        js_implicit_this_set(prev_this);
+
+        assert!(
+            result.is_err(),
+            "@@toPrimitive returning an object must throw before toISOString"
+        );
+    }
+}
+
+#[test]
+fn builtin_prototype_methods_reject_dynamic_new() {
+    unsafe {
+        for (ctor, method) in [
+            ("Date", "toJSON"),
+            ("Array", "map"),
+            ("Object", "hasOwnProperty"),
+        ] {
+            let method_value = installed_builtin_method(ctor, method);
+            let result = catch_js(|| js_new_function_construct(method_value, std::ptr::null(), 0));
+            assert!(
+                result.is_err(),
+                "{ctor}.prototype.{method} should not be constructable"
+            );
+
+            let args = crate::array::js_array_alloc(0);
+            let args_value = crate::value::js_nanbox_pointer(args as i64);
+            let result = catch_js(|| {
+                crate::proxy::js_reflect_construct(
+                    method_value,
+                    args_value,
+                    f64::from_bits(crate::value::TAG_UNDEFINED),
+                )
+            });
+            assert!(
+                result.is_err(),
+                "{ctor}.prototype.{method} should not be a Reflect.construct target"
+            );
+        }
+
+        let ordinary = crate::closure::js_closure_alloc(value_of_finite as *const u8, 0);
+        crate::closure::js_register_closure_arity(value_of_finite as *const u8, 0);
+        let ordinary_value = crate::value::js_nanbox_pointer(ordinary as i64);
+        let result = catch_js(|| js_new_function_construct(ordinary_value, std::ptr::null(), 0));
+        assert!(result.is_ok(), "ordinary closures remain constructable");
+
+        let args = crate::array::js_array_alloc(0);
+        let args_value = crate::value::js_nanbox_pointer(args as i64);
+        let result = catch_js(|| {
+            crate::proxy::js_reflect_construct(
+                ordinary_value,
+                args_value,
+                f64::from_bits(crate::value::TAG_UNDEFINED),
+            )
+        });
+        assert!(
+            result.is_ok(),
+            "ordinary closures remain Reflect.construct targets"
+        );
     }
 }
 

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1091,6 +1091,10 @@ fn is_callable_function(value: f64) -> bool {
     false
 }
 
+fn is_constructor_function(value: f64) -> bool {
+    is_callable_function(value) && !crate::object::builtin_closure_is_non_constructable_value(value)
+}
+
 /// Forward a `[[Call]]` to `target` (the default behavior when a proxy has no
 /// `apply` trap). If `target` is itself a proxy, recurse so its own trap chain
 /// runs; otherwise invoke the target through the canonical value-call path with
@@ -1189,7 +1193,7 @@ fn forward_construct(target: f64, args_array: f64, new_target: f64) -> f64 {
     if lookup(target).is_some() {
         return js_proxy_construct(target, args_array, new_target);
     }
-    if !is_callable_function(target) {
+    if !is_constructor_function(target) {
         return throw_type_error("target is not a constructor");
     }
     let buf = create_list_from_array_like(args_array);
@@ -1276,7 +1280,7 @@ fn array_from_args(args: &[f64]) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_reflect_construct(target: f64, args_like: f64, new_target: f64) -> f64 {
-    if !is_callable_function(target) {
+    if !is_constructor_function(target) {
         return throw_type_error("target is not a constructor");
     }
     let nt = if new_target.to_bits() == TAG_UNDEFINED {
@@ -1284,7 +1288,7 @@ pub extern "C" fn js_reflect_construct(target: f64, args_like: f64, new_target: 
     } else {
         new_target
     };
-    if !is_callable_function(nt) {
+    if !is_constructor_function(nt) {
         return throw_type_error("newTarget is not a constructor");
     }
     let args = create_list_from_array_like(args_like);

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -109,7 +109,8 @@ pub use dyn_index::{js_dyn_index_get, js_dyn_index_set, js_is_undefined_or_bare_
 
 // ----- to-string conversion helpers -----
 pub(crate) use to_string::{
-    coerce_validate_radix, ordinary_to_primitive_number_for_add, OrdinaryToPrimitiveOutcome,
+    coerce_validate_radix, ordinary_to_primitive_number_for_add, to_primitive_number,
+    OrdinaryToPrimitiveOutcome,
 };
 pub use to_string::{
     js_ensure_string_ptr, js_jsvalue_to_string, js_jsvalue_to_string_radix,

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -95,6 +95,83 @@ pub(crate) enum OrdinaryToPrimitiveOutcome {
     TypeError,
 }
 
+enum CustomToPrimitiveOutcome {
+    Absent,
+    Primitive(f64),
+    TypeError,
+}
+
+fn is_primitive_value(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    jsval.is_any_string()
+        || jsval.is_number()
+        || jsval.is_int32()
+        || jsval.is_bool()
+        || jsval.is_null()
+        || jsval.is_undefined()
+        || jsval.is_bigint()
+        || ((value.to_bits() & 0xFFFF_0000_0000_0000) == POINTER_TAG
+            && crate::symbol::is_registered_symbol((value.to_bits() & POINTER_MASK) as usize))
+}
+
+/// `ToPrimitive(O, "number"|"default")`: consult a user
+/// `[Symbol.toPrimitive]("number")` method first, then fall back to the
+/// ordinary `valueOf`/`toString` order.
+pub(crate) unsafe fn to_primitive_number(value: f64) -> OrdinaryToPrimitiveOutcome {
+    if is_primitive_value(value) {
+        return OrdinaryToPrimitiveOutcome::Primitive(value);
+    }
+
+    match custom_to_primitive_number(value) {
+        CustomToPrimitiveOutcome::Absent => {}
+        CustomToPrimitiveOutcome::Primitive(p) => return OrdinaryToPrimitiveOutcome::Primitive(p),
+        CustomToPrimitiveOutcome::TypeError => return OrdinaryToPrimitiveOutcome::TypeError,
+    }
+
+    ordinary_to_primitive_number_for_add(value)
+}
+
+unsafe fn custom_to_primitive_number(value: f64) -> CustomToPrimitiveOutcome {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+    let to_primitive = crate::symbol::well_known_symbol("toPrimitive");
+    let sym_value = f64::from_bits(POINTER_TAG | (to_primitive as u64 & POINTER_MASK));
+    let method =
+        crate::symbol::js_object_get_symbol_property(value_handle.get_nanbox_f64(), sym_value);
+    let method_jsv = JSValue::from_bits(method.to_bits());
+    if method_jsv.is_undefined() || method_jsv.is_null() {
+        return CustomToPrimitiveOutcome::Absent;
+    }
+
+    let method_bits = method.to_bits();
+    if (method_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
+        return CustomToPrimitiveOutcome::TypeError;
+    }
+    let method_ptr = (method_bits & POINTER_MASK) as usize;
+    if !crate::closure::is_closure_ptr(method_ptr) {
+        return CustomToPrimitiveOutcome::TypeError;
+    }
+
+    let method_handle = scope.root_nanbox_f64(method);
+    let hint_ptr = crate::string::js_string_from_bytes(b"number".as_ptr(), 6);
+    let hint_handle = scope.root_string_ptr(hint_ptr);
+    let hint = f64::from_bits(
+        STRING_TAG
+            | (hint_handle.get_raw_const_ptr::<crate::string::StringHeader>() as u64
+                & POINTER_MASK),
+    );
+    let receiver = value_handle.get_nanbox_f64();
+    let prev_this = crate::object::js_implicit_this_set(receiver);
+    let result = crate::closure::js_native_call_value(method_handle.get_nanbox_f64(), &hint, 1);
+    crate::object::js_implicit_this_set(prev_this);
+
+    if is_primitive_value(result) {
+        CustomToPrimitiveOutcome::Primitive(result)
+    } else {
+        CustomToPrimitiveOutcome::TypeError
+    }
+}
+
 /// `OrdinaryToPrimitive(O, "number"|"default")` for addition. The method
 /// order is `valueOf` then `toString`; Perry synthesizes the usual inherited
 /// defaults for boxed primitives, arrays, and plain objects because those


### PR DESCRIPTION
Closes #4452.

Summary
- Add a number-hint ToPrimitive helper for Date.prototype.toJSON that checks obj[Symbol.toPrimitive]("number") before ordinary valueOf / toString fallback.
- Treat non-primitive custom @@toPrimitive results as conversion errors so toJSON throws before invoking toISOString.
- Mark installed builtin prototype/static method closures as callable but non-constructable, then reject them through dynamic new and Reflect.construct while keeping ordinary closures constructable.
- Add runtime tests for Date.prototype.toJSON custom primitive behavior and builtin prototype methods used as constructors.

Why these are batched
Both changes close the same Node compatibility cluster around builtin method callability: Date.prototype.toJSON needs the correct abstract conversion path, and builtin prototype methods need the same callable-but-not-constructor shape observed by new and Reflect.construct.

Non-goals
- Does not implement a broader Date.prototype.toJSON Invoke(O, "toISOString") rewrite beyond the existing thunk behavior.
- Does not change global constructor-call semantics.
- Does not address unrelated Date parser/formatter behavior.

Validation
- cargo test -q -p perry-runtime date_to_json --lib
- cargo test -q -p perry-runtime builtin_prototype_methods_reject_dynamic_new --lib
- cargo test -q -p perry-runtime --lib -- --test-threads=1
- cargo check -q -p perry-runtime --lib
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh
- jq empty test-parity/known_failures.json

Also ran cargo test -q -p perry-runtime --lib with default parallelism; it still fails only the existing shared-state-sensitive tests array::tests::test_array_exotic_descriptors_and_global_prototype_identity and object::native_module_stream::tests::stream_constructors_expose_static_method_values (982 passed, 2 failed). Top-level Perry binary/parity execution was not run because current main has a known build-cache/link-cache build break in the perry binary path.