### PR TITLE
fix(generator): make try/catch real in the sync generator state machine (#4438 B2)

### DIFF
--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -24,6 +24,19 @@ pub struct CatchRoute {
     pub body: Vec<Stmt>,
     pub protected_start_state: u32,
     pub post_catch_state: u32,
+    /// #4438: upper bound of the protected suspended-state interval for routing
+    /// a thrown error into this catch. Covers the try-body states (and the
+    /// post-last-yield happy landing state) but EXCLUDES the catch's own states,
+    /// so a `throw` executing inside the catch propagates to an enclosing
+    /// handler instead of re-entering this one. For sync generators the catch
+    /// body is linearized into the state machine (`catch_entry_state`); async
+    /// generators still inline `body` into the `.throw()` closure and ignore
+    /// these two fields.
+    pub protected_end_state: u32,
+    /// #4438: first state of the linearized catch body. `Some` for sync
+    /// generators (runtime throws + `.throw()` route here); `None` when the
+    /// catch was not linearized into states.
+    pub catch_entry_state: Option<u32>,
 }
 
 /// A `finally` block that protects a state interval. On abrupt completion
@@ -587,17 +600,22 @@ pub fn linearize_body(
                 );
             }
 
-            // Try-catch containing yield(s) — linearize the try body directly and
-            // stash the catch body so the .throw() closure can inline it.
-            // Limitations: no per-state exception handler tracking, so only the
-            // first catch encountered will run on .throw(). Catches themselves
-            // must not yield — they run to completion inside the throw closure.
+            // Try-catch/finally containing yield(s) — linearize the try body and
+            // the catch body into states (#4438) so a `throw` during dispatch is
+            // routed to the catch and a `yield` inside the catch suspends.
+            //
+            // #4438: the guard must also fire when the yield lives ONLY in the
+            // catch body (e.g. `try { throw } catch (e) { yield }`). Pre-fix that
+            // fell into the catch-all, which emitted the whole `Stmt::Try`
+            // literally and the catch's `yield` hit the codegen
+            // `Expr::Yield => double_literal(0.0)` arm and was swallowed.
             Stmt::Try {
                 body,
                 catch,
                 finally,
             } if body_contains_yield(body)
-                || finally.as_ref().is_some_and(|f| body_contains_yield(f)) =>
+                || finally.as_ref().is_some_and(|f| body_contains_yield(f))
+                || catch.as_ref().is_some_and(|c| body_contains_yield(&c.body)) =>
             {
                 let protected_start_state = *state_num;
 
@@ -629,31 +647,74 @@ pub fn linearize_body(
                     }
                 }
 
-                // Issue #621: if the try has a catch handler, split the
+                // Issue #621 / #4438: if the try has a catch handler, split the
                 // post-await happy-path continuation (currently in `current`)
-                // from the post-try-catch continuation. Stmts that follow
-                // the LAST yield in the try body should only run on the
-                // happy path; the throw path runs the catch body and then
-                // resumes at the stmts AFTER the try/catch. Without this
-                // split, both paths land in the same state and the catch
-                // path incorrectly runs the post-await stmts.
-                if catch.is_some() {
-                    if !current.is_empty() {
-                        let happy_state = *state_num;
-                        *state_num += 1;
-                        let goto_target = *state_num;
-                        states.push(State {
-                            num: happy_state,
-                            body: std::mem::take(current),
-                            exit: StateExit::Goto(goto_target),
-                        });
-                    }
-                }
-                let post_catch_state = *state_num;
-
-                // Stash the catch so transform_generator_function can inline it
-                // into the .throw() closure later.
+                // from the catch and post-try-catch continuations, and linearize
+                // the catch body into its own states.
+                //
+                // Pre-#4438 the catch body was stashed and only inlined into the
+                // `.throw()` closure, so the catch handler did not exist in the
+                // normal `.next()` dispatch at all. Two consequences:
+                //   (a) a runtime `throw` executing inside the try during a plain
+                //       `.next()` was never caught — it propagated out of next();
+                //   (b) a `yield` inside the catch was swallowed (it was rewritten
+                //       to an `await` in the throw closure).
+                // Now the catch body is real states. The happy path skips them;
+                // runtime throws (via the dispatch-loop try/catch in lower.rs) and
+                // `.throw()` route into `catch_entry_state` for sync generators.
+                let post_catch_state;
                 if let Some(catch_clause) = catch {
+                    // Flush the happy-path tail (post-last-yield-in-try code) as
+                    // its own landing state. The last yield inside the try resumes
+                    // here on a normal `.next()`; it must skip the catch states.
+                    let happy_state = *state_num;
+                    *state_num += 1;
+                    let happy_idx = states.len();
+                    states.push(State {
+                        num: happy_state,
+                        body: std::mem::take(current),
+                        exit: StateExit::Goto(0), // patched to post_catch below
+                    });
+                    // Throws while suspended in the try body (states
+                    // protected_start..=happy_state) route to the catch. Catch
+                    // states (> happy_state) are EXCLUDED so a `throw` inside the
+                    // catch escapes to an enclosing handler, not back into here.
+                    let protected_end_state = happy_state;
+
+                    // Linearize the catch body into states.
+                    let catch_entry_state = *state_num;
+                    let mut catch_current = Vec::new();
+                    if body_contains_yield(&catch_clause.body) {
+                        linearize_body(
+                            &catch_clause.body,
+                            states,
+                            &mut catch_current,
+                            state_num,
+                            state_id,
+                            next_local_id,
+                            sent_id,
+                            catches,
+                            finallys,
+                        );
+                    } else {
+                        for s in &catch_clause.body {
+                            catch_current.push(s.clone());
+                        }
+                    }
+                    // The catch tail falls through to the code after try/catch.
+                    let catch_tail_state = *state_num;
+                    *state_num += 1;
+                    let catch_tail_idx = states.len();
+                    states.push(State {
+                        num: catch_tail_state,
+                        body: std::mem::take(&mut catch_current),
+                        exit: StateExit::Goto(0), // patched below
+                    });
+
+                    post_catch_state = *state_num;
+                    states[happy_idx].exit = StateExit::Goto(post_catch_state);
+                    states[catch_tail_idx].exit = StateExit::Goto(post_catch_state);
+
                     let (param_id, param_name) = catch_clause
                         .param
                         .as_ref()
@@ -665,7 +726,11 @@ pub fn linearize_body(
                         body: catch_clause.body.clone(),
                         protected_start_state,
                         post_catch_state,
+                        protected_end_state,
+                        catch_entry_state: Some(catch_entry_state),
                     });
+                } else {
+                    post_catch_state = *state_num;
                 }
 
                 // Finally block: linearize if it has yields (await-using path),

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -265,6 +265,37 @@ pub fn transform_generator_function_with_extra_captures(
     // the next .next(). Only the sync-generator .throw() path uses this.
     let while_body_for_throw = while_body.clone();
 
+    // #4438: for sync generators, wrap the dispatch loop body in a real
+    // try/catch so a `throw` *executing inside a try block during a normal
+    // .next()* is caught and routed to the matching catch's linearized states
+    // (or, when no catch matches, runs any pending `finally` and completes the
+    // generator before propagating). Pre-#4438 the catch handler existed only
+    // in the .throw() closure, so such a throw escaped uncaught.
+    let has_state_based_catch = catches.iter().any(|r| r.catch_entry_state.is_some());
+    let has_inlineable_finally = finallys.iter().any(|r| !r.has_yields);
+    let wrap_dispatch = !is_async_generator && (has_state_based_catch || has_inlineable_finally);
+    let dispatch_body = if wrap_dispatch {
+        let disp_err_id = alloc_local(next_local_id);
+        let handler = build_dispatch_catch_handler(
+            &catches,
+            &finallys,
+            state_id,
+            done_id,
+            disp_err_id,
+            &hoisted_ids,
+        );
+        vec![Stmt::Try {
+            body: while_body,
+            catch: Some(CatchClause {
+                param: Some((disp_err_id, "__gen_disp_err".to_string())),
+                body: handler,
+            }),
+            finally: None,
+        }]
+    } else {
+        while_body
+    };
+
     // Build next() method body
     let mut next_body = vec![
         // __sent = <param from next(val)>
@@ -281,7 +312,7 @@ pub fn transform_generator_function_with_extra_captures(
         // while (true) { if-chain }
         Stmt::While {
             condition: Expr::Bool(true),
-            body: while_body,
+            body: dispatch_body,
         },
     ];
     if is_async_generator {
@@ -823,18 +854,40 @@ fn build_async_throw_body(
     // the first collected route is tested first; nested try/catch routes are
     // collected before their containing route and should win on overlap.
     for route in catches.iter().rev() {
-        let then_branch = build_async_catch_route_body(
-            route,
-            finallys,
-            state_id,
-            done_id,
-            throw_param_id,
-            inner_catch_id,
-            hoisted_ids,
-            fall_through,
-        );
+        // #4438: sync generators route the thrown error into the catch's
+        // linearized states (set the catch param + jump to `catch_entry_state`,
+        // then fall through to the appended continuation loop, which dispatches
+        // the catch body — so a `yield` inside the catch actually suspends).
+        // Async generators (and any route without a linearized catch) keep the
+        // legacy inline-the-catch-body behavior.
+        let state_based = fall_through && route.catch_entry_state.is_some();
+        let then_branch = if state_based {
+            let mut b = Vec::new();
+            if let Some(cp_id) = route.param_id {
+                b.push(Stmt::Expr(Expr::LocalSet(
+                    cp_id,
+                    Box::new(Expr::LocalGet(throw_param_id)),
+                )));
+            }
+            b.push(Stmt::Expr(Expr::LocalSet(
+                state_id,
+                Box::new(Expr::Number(route.catch_entry_state.unwrap() as f64)),
+            )));
+            b
+        } else {
+            build_async_catch_route_body(
+                route,
+                finallys,
+                state_id,
+                done_id,
+                throw_param_id,
+                inner_catch_id,
+                hoisted_ids,
+                fall_through,
+            )
+        };
         fallback = vec![Stmt::If {
-            condition: catch_route_condition(route, state_id),
+            condition: catch_route_condition(route, state_id, state_based, false),
             then_branch,
             else_branch: Some(fallback),
         }];
@@ -854,23 +907,97 @@ fn build_async_throw_body(
     fallback
 }
 
-fn catch_route_condition(route: &CatchRoute, state_id: LocalId) -> Expr {
+fn catch_route_condition(
+    route: &CatchRoute,
+    state_id: LocalId,
+    state_based: bool,
+    inclusive_lower: bool,
+) -> Expr {
     // Awaited rejection re-enters after the yield state has advanced to its
     // resume/post state, so lifted catch ownership is open on the start state
     // and closed on the post-catch state.
+    //
+    // #4438: for sync state-based routing the upper bound is
+    // `protected_end_state` (the post-last-yield-in-try happy landing state),
+    // which EXCLUDES the catch's own states — a throw inside the catch must
+    // escape to an enclosing handler, not re-enter this one. The legacy inline
+    // (async) path keeps `post_catch_state` as before.
+    //
+    // `inclusive_lower` selects `>=` vs `>` on the start state. The runtime
+    // dispatch wrapper (a `throw` *executing* inside a try) uses `>=`: a throw
+    // in the try's first state runs at exactly `protected_start_state`. The
+    // `.throw()`-injection path uses `>`: it only fires while *suspended* at a
+    // yield, whose resume state is already `> protected_start_state`, and a
+    // yield sitting just before the try (state == protected_start) is outside
+    // the try and must not be caught.
+    let upper = if state_based {
+        route.protected_end_state
+    } else {
+        route.post_catch_state
+    };
+    let lower_op = if inclusive_lower {
+        CompareOp::Ge
+    } else {
+        CompareOp::Gt
+    };
     Expr::Logical {
         op: LogicalOp::And,
         left: Box::new(Expr::Compare {
-            op: CompareOp::Gt,
+            op: lower_op,
             left: Box::new(Expr::LocalGet(state_id)),
             right: Box::new(Expr::Number(route.protected_start_state as f64)),
         }),
         right: Box::new(Expr::Compare {
             op: CompareOp::Le,
             left: Box::new(Expr::LocalGet(state_id)),
-            right: Box::new(Expr::Number(route.post_catch_state as f64)),
+            right: Box::new(Expr::Number(upper as f64)),
         }),
     }
+}
+
+/// #4438: build the catch handler for the sync-generator dispatch loop. When a
+/// `throw` executes inside a try during a normal `.next()` dispatch, route the
+/// error to the matching catch's linearized states (set the catch param, jump
+/// to `catch_entry_state`, and `continue` the dispatch loop so the catch body
+/// runs — including any `yield` inside it). When no catch owns the current
+/// state, run any pending `finally`, complete the generator, and rethrow.
+fn build_dispatch_catch_handler(
+    catches: &[CatchRoute],
+    finallys: &[FinallyRoute],
+    state_id: LocalId,
+    done_id: LocalId,
+    err_id: LocalId,
+    hoisted_ids: &std::collections::HashSet<LocalId>,
+) -> Vec<Stmt> {
+    let mut fallback = vec![Stmt::Expr(Expr::LocalSet(
+        done_id,
+        Box::new(Expr::Bool(true)),
+    ))];
+    fallback.extend(build_finally_run_stmts(finallys, state_id, hoisted_ids));
+    fallback.push(Stmt::Throw(Expr::LocalGet(err_id)));
+    for route in catches.iter().rev() {
+        let Some(entry) = route.catch_entry_state else {
+            continue;
+        };
+        let mut then_branch = Vec::new();
+        if let Some(cp_id) = route.param_id {
+            then_branch.push(Stmt::Expr(Expr::LocalSet(
+                cp_id,
+                Box::new(Expr::LocalGet(err_id)),
+            )));
+        }
+        then_branch.push(Stmt::Expr(Expr::LocalSet(
+            state_id,
+            Box::new(Expr::Number(entry as f64)),
+        )));
+        then_branch.push(Stmt::Continue);
+        fallback = vec![Stmt::If {
+            condition: catch_route_condition(route, state_id, true, true),
+            then_branch,
+            else_branch: Some(fallback),
+        }];
+    }
+    fallback
 }
 
 fn build_async_catch_route_body(
@@ -1000,7 +1127,7 @@ fn build_async_throw_body_direct(
     let mut fallback = vec![Stmt::Throw(Expr::LocalGet(throw_param_id))];
 
     for route in catches.into_iter().rev() {
-        let condition = catch_route_condition(&route, state_id);
+        let condition = catch_route_condition(&route, state_id, false, false);
         let then_branch = build_async_catch_route_body_direct(
             route,
             state_id,


### PR DESCRIPTION
## Summary

Addresses the **B2** slice of #4438 (generator `.throw()`/`.return()` try/finally
edge cases): makes a generator's **`try`/`catch` real in the state machine** for
sync generators.

### Root cause (deeper than the issue's framing)

The issue described B2 as "continuation-cloning edge cases in `linearize.rs`",
but probing showed the catch handler was **entirely absent from the normal
`.next()` dispatch** — it existed only inside the `.throw()` closure. Two
consequences, both visible in test262:

- **(a)** a `throw` *executing* inside a `try` during a plain `.next()` was never
  caught — it propagated straight out of `next()` (the `[object] escaped`
  failures);
- **(b)** a `yield` inside a `catch` was swallowed — it was rewritten to an
  `await` in the throw closure (`catch (e) { yield e }` lost the yield).

### Fix

- **`linearize.rs`** — linearize the `catch` body into its own states (the guard
  now also fires when the yield lives only in the catch). The happy path skips
  the catch states; the catch's own states are excluded from the protected
  interval so a throw inside the catch escapes to an enclosing handler.
- **`lower.rs`** — for sync generators, wrap the dispatch loop body in a real
  `try/catch` that routes a thrown error to the matching catch's
  `catch_entry_state` (or runs pending `finally` + completes the generator when
  unhandled). `.throw()` routes the same way and falls through to the
  continuation loop, so a `yield` inside the catch suspends correctly. The
  runtime-throw path uses an inclusive lower bound (`>=`) since a throw in a
  try's first state runs at exactly `protected_start`.

Async generators are untouched: the linearized catch states are dead code on the
async path (it still inlines the catch body in `.throw()`), so behavior is
byte-identical.

### Results

test262 `GeneratorPrototype/{throw,return}/try-*`: **15 → 21 pass** (all
try/catch cases). Broader sweep of every try-containing generator test:
**0 regressions, 17 newly-fixed** — the 6 GeneratorPrototype cases plus 11
`language/expressions/yield` `yield*`-delegation error-handling tests
(`star-rhs-iter-*-err`, `from-catch`, `rhs-unresolvable`).

### Out of scope (remaining B2 — separate follow-up)

The 6 still-failing cases all involve a **yielding `finally`** (`finally { yield
N }`), which needs a completion-record mechanism to thread abrupt completion
through the finally's states and re-raise afterward. Tracked as the remaining
B2-finally work under #4438.
