### PR TITLE
fix(runtime): DataView offset RangeError carries real constructor/prototype chain

### DIFF
--- a/crates/perry-runtime/src/buffer/numeric.rs
+++ b/crates/perry-runtime/src/buffer/numeric.rs
@@ -93,25 +93,16 @@ pub(super) fn throw_out_of_range() -> ! {
 /// here (no `code` property), message
 /// `"Offset is outside the bounds of the DataView"` — see #2878.
 pub(super) fn throw_dataview_offset_out_of_bounds() -> ! {
-    static REGISTER_RANGE_ERROR: std::sync::Once = std::sync::Once::new();
-    REGISTER_RANGE_ERROR.call_once(|| {
-        crate::object::js_register_class_extends_error(crate::error::CLASS_ID_RANGE_ERROR);
-    });
-    let obj = crate::object::js_object_alloc(crate::error::CLASS_ID_RANGE_ERROR, 4);
-    let set = |key: &[u8], value: f64| {
-        let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
-        crate::object::js_object_set_field_by_name(obj, key_ptr, value);
-    };
-    let str_val = |s: &[u8]| -> f64 {
-        let ptr = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-        f64::from_bits(crate::JSValue::string_ptr(ptr).bits())
-    };
-    set(b"name", str_val(b"RangeError"));
-    set(
-        b"message",
-        str_val(b"Offset is outside the bounds of the DataView"),
-    );
-    crate::exception::js_throw(crate::value::js_nanbox_pointer(obj as i64))
+    // Use the standard `RangeError` constructor (same path as `new RangeError`)
+    // so the thrown error carries the real prototype chain — `.constructor`,
+    // `Error.prototype` methods, etc. The previous hand-rolled `js_object_alloc`
+    // produced an error where `instanceof RangeError` held but `.constructor` was
+    // `undefined`, which crashed test262's `assert.throws` (`err.constructor.name`).
+    // Node throws a plain `RangeError` here with no `code` property (#2878).
+    const MSG: &[u8] = b"Offset is outside the bounds of the DataView";
+    let msg = crate::string::js_string_from_bytes(MSG.as_ptr(), MSG.len() as u32);
+    let err = crate::error::js_rangeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
 fn throw_buffer_out_of_bounds() -> ! {


### PR DESCRIPTION
## What

`DataView.prototype.{get,set}*` out-of-bounds offset errors now carry the real
`RangeError` prototype chain. `throw_dataview_offset_out_of_bounds` hand-rolled the
error via `js_object_alloc(CLASS_ID_RANGE_ERROR, …)` and set `name`/`message` as own
properties. That gave an object where `instanceof RangeError` held but
`.constructor` was `undefined`. Switched to `js_rangeerror_new` — the same path
`new RangeError(msg)` uses — so `.constructor`, `Error.prototype` methods, etc. all
resolve.

## Why

```ts
const dv = new DataView(new ArrayBuffer(12), 0);
try { dv.getFloat32(-1); } catch (e) { console.log(e.constructor.name); }
// Node: "RangeError"   Perry (before): TypeError: Cannot read properties of undefined (reading 'name')
```

test262's `assert.throws` reads `err.constructor.name` on the no-match path, so the
broken `.constructor` turned a *correctly-thrown* `RangeError` into a spurious crash
across the `built-ins/DataView/prototype/*/negative-byteoffset-throws.js` and
`return-abrupt-*` cases.

## Verification

- Repro above now prints `RangeError` byte-identical to `node --experimental-strip-types`.
- `instanceof RangeError`/`instanceof Error` still hold; `.name` still `"RangeError"`;
  Node throws a plain `RangeError` here with no `code`, matching (#2878).
- `built-ins/DataView` radar: **108 → 97 failures** (−11), no new failures.
- `cargo test --release -p perry-runtime --lib` green.

## Out of scope (revealed, not regressed)

The fix exposes a deeper, separate DataView gap: `getX`/`setX` don't apply
`ToIndex(byteOffset)` coercion in spec order — a Symbol byteOffset should throw
`TypeError` (Perry throws `RangeError`) and a throwing `valueOf` should propagate
before the bounds check. ~44 remaining `built-ins/DataView` failures
("Expected a TypeError but got a RangeError", "valueOf Expected a Test262Error").
Tracked for a follow-up.
