### PR TITLE
fix(runtime): pack rest params for zero-arg ctors and apply-dispatched methods (#4441)

### DIFF
--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -352,7 +352,7 @@ pub(super) fn emit_string_pool(
     // symbols for those live in the defining module's object file.
     // Each module's init registers its own classes; the linker
     // ensures all init functions run before main.
-    let mut method_triples: Vec<(u32, String, String, u32, bool)> = Vec::new();
+    let mut method_triples: Vec<(u32, String, String, u32, bool, bool)> = Vec::new();
     // #1788: (cid, static-method name, perry_static_* symbol, param_count,
     // has_rest). Registered into the runtime CLASS_STATIC_METHODS table so a
     // subclass whose parent is a class-expression value inherits the parent's
@@ -402,12 +402,23 @@ pub(super) fn emit_string_pool(
                 .last()
                 .map(|p| p.arguments_object.is_some())
                 .unwrap_or(false);
+            // A trailing user rest param (`method(a, ...rest)`) — distinct from
+            // the synthesized-`arguments` param above. The runtime needs this
+            // so an apply/dynamic dispatch (`recv.method(...spread)`) bundles
+            // the call args into the rest array instead of passing `rest =
+            // args[0]` as a scalar (marked's `this.use(...e)` blocker).
+            let has_rest = method
+                .params
+                .last()
+                .map(|p| p.is_rest && p.arguments_object.is_none())
+                .unwrap_or(false);
             method_triples.push((
                 cid,
                 method.name.clone(),
                 llvm_name,
                 method.params.len() as u32,
                 has_synth_args,
+                has_rest,
             ));
         }
         // #1788: static methods are emitted as `perry_static_*` (no `this`
@@ -442,7 +453,7 @@ pub(super) fn emit_string_pool(
         ));
     }
     method_triples.sort_unstable();
-    for (cid, method_name, llvm_name, param_count, has_synth_args) in method_triples {
+    for (cid, method_name, llvm_name, param_count, has_synth_args, has_rest) in method_triples {
         // The pre-intern pass before `emit_string_pool` ensured every
         // method name has a string pool entry; look it up here without
         // mutating the pool.
@@ -460,6 +471,7 @@ pub(super) fn emit_string_pool(
         let func_i64 = blk.ptrtoint(&func_ref, I64);
         let bytes_i64 = blk.ptrtoint(&bytes_global, I64);
         let has_synth_args_str = if has_synth_args { "1" } else { "0" };
+        let has_rest_str = if has_rest { "1" } else { "0" };
         blk.call_void(
             "js_register_class_method",
             &[
@@ -469,6 +481,7 @@ pub(super) fn emit_string_pool(
                 (I64, &func_i64),
                 (I64, &param_count.to_string()),
                 (I64, has_synth_args_str),
+                (I64, has_rest_str),
             ],
         );
     }

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1802,7 +1802,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function(
         "js_register_class_method",
         VOID,
-        &[I64, I64, I64, I64, I64, I64],
+        &[I64, I64, I64, I64, I64, I64, I64],
     );
     // #1787: register a class's standalone constructor so `new
     // <classObjectValue>()` can replay it on a dynamically-allocated instance.

--- a/crates/perry-hir/src/monomorph/defaults.rs
+++ b/crates/perry-hir/src/monomorph/defaults.rs
@@ -11,8 +11,20 @@ pub(crate) fn fill_default_arguments(module: &mut Module) {
     let mut ctor_defaults: HashMap<String, Vec<Option<Expr>>> = HashMap::new();
     for class in &module.classes {
         if let Some(ref ctor) = class.constructor {
-            let defaults: Vec<Option<Expr>> =
-                ctor.params.iter().map(|p| p.default.clone()).collect();
+            // Stop at a trailing rest parameter. `constructor(...e)` (or
+            // `constructor(a, b = 5, ...e)`) accepts zero or more trailing
+            // args, so the call-site padding below must never synthesize an
+            // `undefined` for the rest slot: doing so makes `new C()` collect
+            // `[undefined]` instead of `[]`, and any `e.forEach(...)` over that
+            // bogus element throws (marked's `new q` / hono's verb-method
+            // setup). Only the leading fixed params (which DO get default-fill
+            // checks prepended to the ctor body) are eligible for padding.
+            let defaults: Vec<Option<Expr>> = ctor
+                .params
+                .iter()
+                .take_while(|p| !p.is_rest)
+                .map(|p| p.default.clone())
+                .collect();
             ctor_defaults.insert(class.name.clone(), defaults);
         }
     }

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -1229,7 +1229,7 @@ unsafe fn format_object_as_json(
         // object's class chain when the instance lookup misses.
         let class_id = (*obj_ptr).class_id;
         if class_id != 0 {
-            if let Some((func_ptr, param_count, has_synthetic_arguments)) =
+            if let Some((func_ptr, param_count, has_synthetic_arguments, has_rest)) =
                 crate::object::lookup_class_method_in_chain(class_id, "__perry_inspect_custom__")
             {
                 let _guard = InspectCustomInspectGuard::new(false);
@@ -1245,6 +1245,7 @@ unsafe fn format_object_as_json(
                     args.len(),
                     param_count,
                     has_synthetic_arguments,
+                    has_rest,
                 );
                 let ret_jv = crate::value::JSValue::from_bits(ret.to_bits());
                 if ret_jv.is_any_string() {

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -125,5 +125,8 @@ pub(crate) unsafe fn replay_class_object_constructor(
         final_args.len(),
         total_params,
         false,
+        // Capture-forwarding constructor args are materialized positionally
+        // above (including any caps), so no trailing rest re-packing here.
+        false,
     );
 }

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -104,6 +104,10 @@ pub struct VTableMethodEntry {
     pub func_ptr: usize,
     pub param_count: u32,
     pub has_synthetic_arguments: bool,
+    /// Trailing user rest param (`method(a, ...rest)`). Distinct from
+    /// `has_synthetic_arguments`: the rest slot holds only the args from the
+    /// rest position onward, so apply/dynamic dispatch bundles them correctly.
+    pub has_rest: bool,
 }
 
 /// Per-class vtable with methods, getters, and setters
@@ -2620,6 +2624,7 @@ pub unsafe extern "C" fn js_register_class_method(
     func_ptr: i64,
     param_count: i64,
     has_synthetic_arguments: i64,
+    has_rest: i64,
 ) {
     let name = if name_ptr.is_null() || name_len <= 0 {
         return;
@@ -2645,6 +2650,7 @@ pub unsafe extern "C" fn js_register_class_method(
             func_ptr: func_ptr as usize,
             param_count: param_count as u32,
             has_synthetic_arguments: has_synthetic_arguments != 0,
+            has_rest: has_rest != 0,
         },
     );
     VTABLE_GEN.fetch_add(1, Ordering::Release);
@@ -2758,6 +2764,7 @@ struct VTableICEntry {
     func_ptr: usize,
     param_count: u32,
     has_synthetic_arguments: u32,
+    has_rest: u32,
 }
 
 const EMPTY_VTABLE_IC_ENTRY: VTableICEntry = VTableICEntry {
@@ -2768,6 +2775,7 @@ const EMPTY_VTABLE_IC_ENTRY: VTableICEntry = VTableICEntry {
     func_ptr: 0,
     param_count: 0,
     has_synthetic_arguments: 0,
+    has_rest: 0,
 };
 
 thread_local! {
@@ -2792,7 +2800,7 @@ fn vtable_ic_slot(class_id: u32, method_name_ptr: usize) -> usize {
 pub(crate) unsafe fn vtable_ic_lookup(
     class_id: u32,
     method_name_ptr: usize,
-) -> Option<(usize, u32, bool)> {
+) -> Option<(usize, u32, bool, bool)> {
     if method_name_ptr == 0 {
         return None;
     }
@@ -2809,6 +2817,7 @@ pub(crate) unsafe fn vtable_ic_lookup(
                 entry.func_ptr,
                 entry.param_count,
                 entry.has_synthetic_arguments != 0,
+                entry.has_rest != 0,
             ))
         } else {
             None
@@ -2823,6 +2832,7 @@ pub(crate) unsafe fn vtable_ic_insert(
     func_ptr: usize,
     param_count: u32,
     has_synthetic_arguments: bool,
+    has_rest: bool,
 ) {
     if method_name_ptr == 0 {
         return;
@@ -2839,6 +2849,7 @@ pub(crate) unsafe fn vtable_ic_insert(
             func_ptr,
             param_count,
             has_synthetic_arguments: if has_synthetic_arguments { 1 } else { 0 },
+            has_rest: if has_rest { 1 } else { 0 },
         };
     });
 }
@@ -2852,6 +2863,7 @@ pub(crate) unsafe fn call_vtable_method(
     args_len: usize,
     param_count: u32,
     has_synthetic_arguments: bool,
+    has_rest: bool,
 ) -> f64 {
     #[inline(always)]
     unsafe fn arg_or_nan(args_ptr: *const f64, args_len: usize, idx: usize) -> f64 {
@@ -2890,12 +2902,31 @@ pub(crate) unsafe fn call_vtable_method(
         }
     };
 
+    // A trailing param that is either the synthesized `arguments` object or a
+    // user rest param (`method(a, ...rest)`) needs the call-site args bundled
+    // into a JS array for that slot. Without this, an apply/dynamic dispatch
+    // (`recv.method(...spread)` via `js_native_call_method_apply`) passes the
+    // raw individual args and the callee reads `rest = args[0]` as a scalar —
+    // marked's `new Marked()` -> `this.use(...e)` hit exactly this, throwing
+    // `(number).forEach is not a function`. The synthesized-`arguments` slot
+    // holds ALL passed args; a user rest slot holds only args from the rest
+    // position onward (so `method(a, ...rest)` keeps `a` positional).
     let mut adjusted_args_storage: Option<Vec<f64>> = None;
-    let (call_args_ptr, call_args_len) = if has_synthetic_arguments {
+    let (call_args_ptr, call_args_len) = if has_synthetic_arguments || has_rest {
         let visible_params = (param_count as usize).saturating_sub(1);
-        let raw_args = crate::array::js_array_alloc_with_length(args_len as u32);
-        for i in 0..args_len {
-            crate::array::js_array_set_f64(raw_args, i as u32, arg_or_nan(args_ptr, args_len, i));
+        let pack_start = if has_synthetic_arguments {
+            0
+        } else {
+            visible_params.min(args_len)
+        };
+        let packed_len = args_len.saturating_sub(pack_start);
+        let raw_args = crate::array::js_array_alloc_with_length(packed_len as u32);
+        for (slot, i) in (pack_start..args_len).enumerate() {
+            crate::array::js_array_set_f64(
+                raw_args,
+                slot as u32,
+                arg_or_nan(args_ptr, args_len, i),
+            );
         }
         let raw_args_value = crate::value::js_nanbox_pointer(raw_args as i64);
         let mut args = Vec::with_capacity(param_count as usize);
@@ -3319,6 +3350,7 @@ pub unsafe extern "C" fn js_register_class_computed_method(
                 // metadata through this registration path (only `has_rest`),
                 // so they never receive a synthesized arguments object.
                 has_synthetic_arguments: false,
+                has_rest: has_rest != 0,
             },
         );
     }
@@ -3872,11 +3904,11 @@ pub(crate) fn get_parent_class_id(class_id: u32) -> Option<u32> {
 }
 
 /// Look up a method by name in the class vtable, walking the parent chain.
-/// Returns `Some((func_ptr, param_count, has_synthetic_arguments))` if found,
-/// `None` otherwise.
+/// Returns `Some((func_ptr, param_count, has_synthetic_arguments, has_rest))`
+/// if found, `None` otherwise.
 /// Used by `js_assimilate_thenable` (refs #586) and other runtime callers
 /// that need to probe a class for a method without invoking it.
-pub fn lookup_class_method_in_chain(class_id: u32, name: &str) -> Option<(usize, u32, bool)> {
+pub fn lookup_class_method_in_chain(class_id: u32, name: &str) -> Option<(usize, u32, bool, bool)> {
     let registry = CLASS_VTABLE_REGISTRY.read().unwrap();
     let reg = registry.as_ref()?;
     let mut cur = class_id;
@@ -3887,6 +3919,7 @@ pub fn lookup_class_method_in_chain(class_id: u32, name: &str) -> Option<(usize,
                     entry.func_ptr,
                     entry.param_count,
                     entry.has_synthetic_arguments,
+                    entry.has_rest,
                 ));
             }
         }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -144,7 +144,7 @@ pub unsafe extern "C" fn js_native_call_method_value(
                 let class_id = (bits & 0xFFFF_FFFF) as u32;
                 let is_prototype_ref = crate::object::class_prototype_ref_id(object).is_some();
                 if is_prototype_ref {
-                    if let Some((func_ptr, param_count, _has_rest)) =
+                    if let Some((func_ptr, param_count, has_rest)) =
                         lookup_class_symbol_method_in_chain(class_id, sym_key, false)
                     {
                         return call_vtable_method(
@@ -153,10 +153,11 @@ pub unsafe extern "C" fn js_native_call_method_value(
                             args_ptr,
                             args_len,
                             param_count,
-                            // Computed symbol methods track `has_rest`, not a
-                            // synthetic-arguments flag, and never synthesize an
-                            // `arguments` object — so pass `false`.
+                            // Computed symbol methods never synthesize an
+                            // `arguments` object, but DO carry a `has_rest`
+                            // flag for a trailing user rest param.
                             false,
+                            has_rest,
                         );
                     }
                 } else {
@@ -199,7 +200,7 @@ pub unsafe extern "C" fn js_native_call_method_value(
                     if !obj.is_null() && is_valid_obj_ptr(obj as *const u8) {
                         let class_id = js_object_get_class_id(obj);
                         if class_id != 0 {
-                            if let Some((func_ptr, param_count, _has_rest)) =
+                            if let Some((func_ptr, param_count, has_rest)) =
                                 lookup_class_symbol_method_in_chain(class_id, sym_key, false)
                             {
                                 let this_i64 = obj as i64;
@@ -210,8 +211,9 @@ pub unsafe extern "C" fn js_native_call_method_value(
                                     args_len,
                                     param_count,
                                     // Computed symbol methods never synthesize an
-                                    // `arguments` object.
+                                    // `arguments` object, but DO carry `has_rest`.
                                     false,
+                                    has_rest,
                                 );
                             }
                         }
@@ -1055,7 +1057,7 @@ pub unsafe extern "C" fn js_native_call_method(
     if (object.to_bits() >> 48) == 0x7FFE {
         let class_id = (object.to_bits() & 0xFFFF_FFFF) as u32;
         if crate::object::class_prototype_ref_id(object).is_some() {
-            if let Some((func_ptr, param_count, has_synthetic_arguments)) =
+            if let Some((func_ptr, param_count, has_synthetic_arguments, has_rest)) =
                 crate::object::class_registry::lookup_class_method_in_chain(class_id, method_name)
             {
                 return crate::object::class_registry::call_vtable_method(
@@ -1065,6 +1067,7 @@ pub unsafe extern "C" fn js_native_call_method(
                     args_len,
                     param_count,
                     has_synthetic_arguments,
+                    has_rest,
                 );
             }
         } else if class_id != 0
@@ -2717,7 +2720,7 @@ pub unsafe extern "C" fn js_native_call_method(
             // Vtable lookup for class instances — fast path via per-callsite IC
             let class_id = (*obj).class_id;
             if class_id != 0 {
-                if let Some((func_ptr, param_count, has_synthetic_arguments)) =
+                if let Some((func_ptr, param_count, has_synthetic_arguments, has_rest)) =
                     vtable_ic_lookup(class_id, method_name_ptr as usize)
                 {
                     let this_i64 = jsval.as_pointer::<u8>() as i64;
@@ -2728,6 +2731,7 @@ pub unsafe extern "C" fn js_native_call_method(
                         args_len,
                         param_count,
                         has_synthetic_arguments,
+                        has_rest,
                     );
                 }
                 if let Ok(registry) = CLASS_VTABLE_REGISTRY.read() {
@@ -2754,6 +2758,7 @@ pub unsafe extern "C" fn js_native_call_method(
                                         entry.func_ptr,
                                         entry.param_count,
                                         entry.has_synthetic_arguments,
+                                        entry.has_rest,
                                     );
                                     let this_i64 = jsval.as_pointer::<u8>() as i64;
                                     return call_vtable_method(
@@ -2763,6 +2768,7 @@ pub unsafe extern "C" fn js_native_call_method(
                                         args_len,
                                         entry.param_count,
                                         entry.has_synthetic_arguments,
+                                        entry.has_rest,
                                     );
                                 }
                             }
@@ -3158,7 +3164,7 @@ pub unsafe extern "C" fn js_native_call_method(
             // Vtable lookup — fast path via per-callsite IC
             let class_id = (*obj).class_id;
             if class_id != 0 {
-                if let Some((func_ptr, param_count, has_synthetic_arguments)) =
+                if let Some((func_ptr, param_count, has_synthetic_arguments, has_rest)) =
                     vtable_ic_lookup(class_id, method_name_ptr as usize)
                 {
                     let this_i64 = raw_bits as i64;
@@ -3169,6 +3175,7 @@ pub unsafe extern "C" fn js_native_call_method(
                         args_len,
                         param_count,
                         has_synthetic_arguments,
+                        has_rest,
                     );
                 }
                 if let Ok(registry) = CLASS_VTABLE_REGISTRY.read() {
@@ -3186,6 +3193,7 @@ pub unsafe extern "C" fn js_native_call_method(
                                         entry.func_ptr,
                                         entry.param_count,
                                         entry.has_synthetic_arguments,
+                                        entry.has_rest,
                                     );
                                     let this_i64 = raw_bits as i64;
                                     return call_vtable_method(
@@ -3195,6 +3203,7 @@ pub unsafe extern "C" fn js_native_call_method(
                                         args_len,
                                         entry.param_count,
                                         entry.has_synthetic_arguments,
+                                        entry.has_rest,
                                     );
                                 }
                             }
@@ -3949,6 +3958,7 @@ pub unsafe extern "C" fn js_native_call_method(
                                 args_len,
                                 entry.param_count,
                                 entry.has_synthetic_arguments,
+                                entry.has_rest,
                             );
                         }
                     }
@@ -4034,6 +4044,7 @@ pub unsafe extern "C" fn js_native_call_method(
                                         args_len,
                                         entry.param_count,
                                         entry.has_synthetic_arguments,
+                                        entry.has_rest,
                                     );
                                 }
                             }

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -854,7 +854,7 @@ unsafe fn define_class_prototype_method(target_cid: u32, name: &str, value_bits:
         if (*closure).type_tag == CLOSURE_MAGIC && (*closure).func_ptr == BOUND_METHOD_FUNC_PTR {
             let recv = crate::closure::js_closure_get_capture_f64(closure, 0);
             if let Some(source_cid) = super::class_ref_id(recv) {
-                if let Some((func_ptr, param_count, has_synthetic_arguments)) =
+                if let Some((func_ptr, param_count, has_synthetic_arguments, has_rest)) =
                     super::lookup_class_method_in_chain(source_cid, name)
                 {
                     let mut guard = CLASS_VTABLE_REGISTRY.write().unwrap();
@@ -873,6 +873,7 @@ unsafe fn define_class_prototype_method(target_cid: u32, name: &str, value_bits:
                             func_ptr,
                             param_count,
                             has_synthetic_arguments,
+                            has_rest,
                         },
                     );
                     drop(guard);

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -1123,7 +1123,7 @@ pub extern "C" fn js_assimilate_thenable(value: f64) -> f64 {
 
     // Probe the vtable chain for `then`. Bail out on plain objects (no class
     // method) so the await passes the original value through unchanged.
-    let (then_func_ptr, then_param_count, _then_has_synthetic_arguments) =
+    let (then_func_ptr, then_param_count, _then_has_synthetic_arguments, _then_has_rest) =
         match crate::object::lookup_class_method_in_chain(class_id, "then") {
             Some(p) => p,
             None => return value,

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -79,6 +79,7 @@ unsafe fn register_test_method(class_id: u32, name: &'static [u8]) {
         test_direct_method as *const () as usize as i64,
         1,
         0,
+        0,
     );
 }
 

--- a/crates/perry-runtime/src/util_mime.rs
+++ b/crates/perry-runtime/src/util_mime.rs
@@ -475,6 +475,9 @@ fn register_method(class_id: u32, name: &'static str, func_ptr: usize, param_cou
             func_ptr as i64,
             param_count,
             0,
+            // util.MIMEType/MIMEParams methods are fixed-arity natives — no
+            // trailing rest param.
+            0,
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes two latent **rest-parameter** bugs surfaced while compiling a Hono SSR site (#4441). The crash the issue reports — `Cannot read properties of undefined (reading 'forEach')` during module init — comes from the app's `marked` dependency (pulled in via `@skelpo/site-kit`), not from Hono itself; a bare `new Hono()` already works on `main`. Both bugs are general TypeScript-correctness issues with minimal standalone repros.

### Bug 1 — constructor rest param padded with a spurious `undefined`
`fill_default_arguments` (HIR `monomorph/defaults.rs`) padded `new C(...)` args up to the constructor's **full** param count, including a trailing rest param. So `new C()` with `constructor(...e)` produced `e = [undefined]` instead of `[]`, and any `e.forEach(...)` over that bogus element threw.

```ts
class Q { constructor(...e: any[]) { console.log(JSON.stringify(e)); } }
new Q();            // before: [null]   after: []
```

Fix: stop padding at the rest param (mirrors the existing call-site padding already done in `expr_call`). marked's `new Marked()` → `this.use(...e)` hit this.

### Bug 2 — apply-dispatched instance method bound its rest param to a scalar
`recv.method(...spread)` routes through `js_native_call_method_apply` → `call_vtable_method`, which only handled a synthesized `arguments` slot, never a **user rest param**. So `method(...args)` set `rest = args[0]` as a scalar (`(number).forEach is not a function`). Direct (non-spread) calls were already correct.

```ts
class Q { use(...e: any[]) { console.log(typeof e, JSON.stringify(e)); } }
new Q().use(...[1,2,3]);   // before: number 1   after: object [1,2,3]
```

Fix: the instance-method vtable now tracks `has_rest` (static methods already did), and `call_vtable_method` bundles the trailing call args into the rest array — packing only the args from the rest position onward, so `method(a, ...rest)` keeps `a` positional. Also fixes the `router.add(...routes[i])` class of failure noted in `call_spread.rs`.

## Verification
- Direct repros for both bugs now print the correct array.
- Smoke test covering inheritance, `method(base, ...rest)` via direct/spread/`.apply`/`.call`, and the `arguments` object — all correct and unchanged.
- `cargo fmt` clean. perry-runtime suite passes modulo pre-existing parallel-test flakiness (a different unrelated test fails each run — stream / url-path / typed-array-search — all pass in isolation).

## Follow-up (not in this PR)
The same SSR app has a further, independent blocker: `var X = class {...}` referenced as a value (`X.staticMethod`, `typeof X`) is `undefined` — class-expression bindings aren't materialized as runtime values (the `#740` area). marked's `g.parser = b.parse` hits this. Will file separately.