### PR TITLE
[codex] Refresh binary size baseline at v0.5.1122

### DIFF
--- a/benchmarks/binary-size-baseline.json
+++ b/benchmarks/binary-size-baseline.json
@@ -1,10 +1,10 @@
 {
-  "commit": "f7aaed1a",
-  "generated_at": "2026-05-22T02:22:21Z",
+  "commit": "efd9286b",
+  "generated_at": "2026-06-04T20:47:55Z",
   "sizes": {
-    "perry": 19054064,
-    "libperry_runtime": 42489880,
-    "libperry_stdlib": 225526744
+    "perry": 27385088,
+    "libperry_runtime": 60365288,
+    "libperry_stdlib": 263376488
   },
-  "_note": "Refreshed at v0.5.1021 after the v0.5.455 → v0.5.1021 release cycle (566 patch versions of accumulated runtime + stdlib + CLI work). perry +22.6% / libperry_runtime +34.0% vs the prior 7fd1c8b3 baseline — both above the 15% per-release threshold, which is meant for incremental drift, not multi-release catch-up gates (same pattern as the v0.5.455 refresh from 7fd1c8b3). libperry_stdlib +6.5%, within threshold. Production binaries are stripped by the linker; these .a/.bin sizes are the unstripped release-build artefacts used as a regression-trend signal, not a deployment-size measurement. Sizes captured from `cargo build --release` on the Regression Check macos-14 runner (aarch64-apple-darwin)."
+  "_note": "Refreshed at v0.5.1122 after the v0.5.1021 → v0.5.1122 release cycle. This interval added substantial Node/runtime compatibility surface across child_process, crypto/WebCrypto, fs, streams, DNS, Atomics, Date, TypedArray/DataView, EventEmitter, and native compile/link cache paths. Compared with the v0.5.1021 f7aaed1a baseline: perry +43.7%, libperry_runtime +42.1%, and libperry_stdlib +16.8%. Those deltas are above the 15% per-release threshold, which is meant for incremental drift rather than multi-release catch-up gates. Production binaries are stripped by the linker; these .a/.bin sizes are the unstripped release-build artefacts used as a regression-trend signal, not a deployment-size measurement. Sizes captured from `cargo build --release` on the Regression Check macos-14 runner (aarch64-apple-darwin), release run 26960786294, binary-sizes artifact for commit efd9286bfbb96e20be245bd3c6866cfa3220a2bf."
 }


### PR DESCRIPTION
## Summary

- refresh `benchmarks/binary-size-baseline.json` to the latest v0.5.1122 Regression Check release artefact sizes
- keep the existing 15% release hard-fail threshold unchanged
- document the compatibility-growth interval in the baseline note

## Root Cause

The binary-size gate was comparing v0.5.1122 release artefacts against a v0.5.1021 baseline. That interval added substantial runtime and stdlib compatibility surface across child_process, crypto/WebCrypto, fs, streams, DNS, Atomics, Date, TypedArrays/DataView, EventEmitter, and native compile/link cache paths. The release profile settings still use `strip = true` for binaries and intentionally unstripped static archive trend artefacts, so I did not find a build-profile regression.

## Evidence

Latest failing release artefact from Regression Check run 26960786294, commit `efd9286b` / v0.5.1122:

- `perry`: 27,385,088 bytes
- `libperry_runtime`: 60,365,288 bytes
- `libperry_stdlib`: 263,376,488 bytes

Same-day scheduled main artefact from run 26937387495, commit `c05bd5c`, was close and lower:

- `perry`: 26,888,944 bytes
- `libperry_runtime`: 58,729,288 bytes
- `libperry_stdlib`: 257,328,496 bytes

That points to stale baseline drift rather than a one-run anomaly.

## Validation

- downloaded the `binary-sizes-*` artefacts from runs 26960786294 and 26937387495
- replayed the workflow percentage comparison against the refreshed baseline: release +0.0%, nightly -1.8% / -2.7% / -2.3%, no regressions
- `jq empty benchmarks/binary-size-baseline.json`
- `git diff --check`
- `./scripts/check_file_size.sh`