### PR TITLE
[codex] Bind class expressions assigned to vars as values

### DIFF
--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -46,6 +46,65 @@ fn class_computed_member_registration_expr(class_name: &str, member: &ClassCompu
     }
 }
 
+fn emit_class_expression_value_binding(
+    ctx: &mut LoweringContext,
+    module: &mut Module,
+    bind_name: &str,
+    mutable: bool,
+    is_var: bool,
+) {
+    let ty = Type::Any;
+    let id = if ctx.scope_depth == 0
+        && ctx.inside_block_scope == 0
+        && ctx.pre_registered_module_vars.remove(bind_name)
+    {
+        ctx.pre_registered_module_var_decls.remove(bind_name);
+        let id = ctx
+            .lookup_local(bind_name)
+            .unwrap_or_else(|| ctx.define_local(bind_name.to_string(), ty.clone()));
+        if let Some((_, _, existing_ty)) =
+            ctx.locals.iter_mut().rev().find(|(_, lid, _)| *lid == id)
+        {
+            *existing_ty = ty.clone();
+        }
+        id
+    } else if is_var {
+        if let Some(id) = ctx
+            .locals
+            .iter()
+            .rev()
+            .find(|(name, id, _)| name == bind_name && ctx.var_hoisted_ids.contains(id))
+            .map(|(_, id, _)| *id)
+        {
+            if let Some((_, _, existing_ty)) =
+                ctx.locals.iter_mut().rev().find(|(_, lid, _)| *lid == id)
+            {
+                *existing_ty = ty.clone();
+            }
+            id
+        } else {
+            ctx.define_local(bind_name.to_string(), ty.clone())
+        }
+    } else {
+        ctx.define_local(bind_name.to_string(), ty.clone())
+    };
+
+    if is_var {
+        ctx.var_hoisted_ids.insert(id);
+    }
+    if !mutable {
+        ctx.mark_local_immutable(id);
+    }
+    ctx.register_let_class_alias(bind_name.to_string(), bind_name.to_string());
+    module.init.push(Stmt::Let {
+        id,
+        name: bind_name.to_string(),
+        ty,
+        mutable,
+        init: Some(Expr::ClassRef(bind_name.to_string())),
+    });
+}
+
 /// Recursively walk a destructuring pattern collecting every leaf identifier
 /// (and pre-defining each as a local). Used by the for-of binding pre-pass so
 /// the loop body can reference variables introduced by *nested* patterns like
@@ -604,9 +663,9 @@ pub(crate) fn lower_stmt(
                                     // (no-op lookup, but marks the binding as a class).
                                     ctx.class_expr_aliases
                                         .insert(bind_name.clone(), bind_name.clone());
-                                    // We intentionally DO NOT push a Stmt::Let for
-                                    // this binding — the class itself takes the
-                                    // role of a "static value" referenced by name.
+                                    emit_class_expression_value_binding(
+                                        ctx, module, &bind_name, mutable, is_var,
+                                    );
                                     continue;
                                 }
                             }

--- a/test-parity/node-suite/globals/class-expression-var-value.ts
+++ b/test-parity/node-suite/globals/class-expression-var-value.ts
@@ -1,0 +1,33 @@
+var B = class l {
+  static parse(e: any) {
+    return "parsed:" + e;
+  }
+  static selfType() {
+    return typeof l;
+  }
+  parse(e: any) {
+    return "instance:" + e;
+  }
+};
+
+const C = class {
+  static parse(e: any) {
+    return "const:" + e;
+  }
+  parse(e: any) {
+    return "const-instance:" + e;
+  }
+};
+
+const D = B;
+
+console.log("typeof B:", typeof B);
+console.log("B.parse:", B.parse(1));
+console.log("new B:", new B().parse(2));
+console.log("B inner self:", B.selfType());
+console.log("typeof C:", typeof C);
+console.log("C.parse:", C.parse(3));
+console.log("new C:", new C().parse(4));
+console.log("typeof D:", typeof D);
+console.log("D.parse:", D.parse(5));
+console.log("new D:", new D().parse(6));


### PR DESCRIPTION
## Summary

- emit a runtime value binding for `var` / `const` class-expression initializers handled by the special HIR class path
- preserve class alias bookkeeping for later `new` lowering and codegen static dispatch
- add a globals parity fixture covering `var`, `const`, static method reads, aliases, and constructor use

## Root Cause

`var B = class l { ... }` was lowered through a special HIR branch that registered the class under `B` and the inner name `l`, then skipped `Stmt::Let`. That preserved `new B()` and some static dispatch paths, but ordinary value reads such as `typeof B` had no local runtime binding and evaluated as `undefined`.

## Fix

The special class-expression branch now emits `Stmt::Let { init: ClassRef("B") }` for the outer binding, while mirroring the generic var-declaration bookkeeping: module pre-registered ids are reused, function-scoped `var` hoist ids are preserved, immutable bindings are marked, and the HIR class alias is registered.

## Validation

- reproduced pre-fix current-main behavior with the issue repro: `typeof B = undefined`, while `new B()` worked
- Node 26 oracle for `test-parity/node-suite/globals/class-expression-var-value.ts`
- patched Perry no-auto output matches the new fixture
- original issue repro now prints `typeof B = function`, `new B works: object`, `B.parse = parsed:1`
- `cargo check -q -p perry-hir -p perry-codegen`
- `cargo build -q -p perry`
- `cargo test -q -p perry-hir`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`