### PR TITLE
fix(date): honor @@toPrimitive(number) in Date.prototype.toJSON

### DIFF
--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -98,22 +98,32 @@ extern "C" fn date_to_json(_closure: *const crate::closure::ClosureHeader) -> f6
     if jsv.is_undefined() || jsv.is_null() {
         super::object_ops::throw_object_type_error(b"Cannot convert undefined or null to object");
     }
-    // ToPrimitive(this, hint Number).
+    // ToPrimitive(this, hint Number): consult `[Symbol.toPrimitive]("number")`
+    // first (called exactly once); only fall back to OrdinaryToPrimitive
+    // (valueOf/toString) when the object has no exotic `@@toPrimitive` —
+    // otherwise a custom @@toPrimitive must win and valueOf/toString must NOT
+    // run. `js_to_primitive` returns the receiver unchanged when no
+    // `@@toPrimitive` is present.
     let tv = if crate::date::is_date_value(this) {
         crate::date::date_cell_timestamp(this)
     } else {
-        match unsafe { crate::value::ordinary_to_primitive_number_for_add(this) } {
-            crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => p,
-            // A plain object's default `"[object Object]"` is a String, never a
-            // Number, so step 3 (non-finite Number → null) never fires; fall
-            // through to the `toISOString` invocation.
-            crate::value::OrdinaryToPrimitiveOutcome::DefaultString => {
-                f64::from_bits(crate::value::TAG_UNDEFINED)
-            }
-            crate::value::OrdinaryToPrimitiveOutcome::TypeError => {
-                super::object_ops::throw_object_type_error(
-                    b"Cannot convert object to primitive value",
-                )
+        let exotic = unsafe { crate::symbol::js_to_primitive(this, 1) };
+        if exotic.to_bits() != this.to_bits() {
+            exotic
+        } else {
+            match unsafe { crate::value::ordinary_to_primitive_number_for_add(this) } {
+                crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => p,
+                // A plain object's default `"[object Object]"` is a String, never
+                // a Number, so step 3 (non-finite Number → null) never fires;
+                // fall through to the `toISOString` invocation.
+                crate::value::OrdinaryToPrimitiveOutcome::DefaultString => {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                }
+                crate::value::OrdinaryToPrimitiveOutcome::TypeError => {
+                    super::object_ops::throw_object_type_error(
+                        b"Cannot convert object to primitive value",
+                    )
+                }
             }
         }
     };


### PR DESCRIPTION
## Summary

`Date.prototype.toJSON`'s step 2 — `ToPrimitive(O, hint Number)` — only ran `OrdinaryToPrimitive` (`valueOf`/`toString`) and ignored an exotic `[Symbol.toPrimitive]`. Per spec, a present `@@toPrimitive` must be called (with hint `"number"`) and win, and `valueOf`/`toString` must **not** run.

## Fix

Consult `crate::symbol::js_to_primitive(this, 1)` first (called exactly once; it returns the receiver unchanged when no `@@toPrimitive` exists), and fall back to `OrdinaryToPrimitive` only when there is no `@@toPrimitive`.

## Results

Fixes `test262 built-ins/Date/prototype/toJSON/to-primitive-symbol.js`:
```js
var obj = { [Symbol.toPrimitive](h){ /* h === "number" */ return 3.14; },
            toISOString(){ return result; },
            valueOf(){ throw }, toString(){ throw } };
Date.prototype.toJSON.call(obj) === result   // @@toPrimitive called once with "number"; valueOf/toString never run
```
All other `toJSON` cases still pass (`invoke-*`, `to-object`, `to-primitive-value-of`, `to-primitive-abrupt`). `cargo test -p perry-runtime --lib`: 980 passed; Node-identical in both build modes.

The lone remaining `toJSON` failure — `not-a-constructor.js` — is a separate cross-cutting gap (builtin method thunks report as constructable), tracked in #4452.
