### PR TITLE
fix(runtime): ToIndex(byteOffset) coercion in DataView get/set

### DIFF
--- a/crates/perry-runtime/src/buffer/dataview.rs
+++ b/crates/perry-runtime/src/buffer/dataview.rs
@@ -74,20 +74,25 @@ fn throw_dataview_oob() -> ! {
 }
 
 #[inline]
+/// `ToIndex(byteOffset)` for `GetViewValue`/`SetViewValue`: ToNumber →
+/// ToIntegerOrInfinity → range-check `[0, 2^53-1]`. A Symbol or object byteOffset
+/// is coerced through the full ToNumber (`js_number_coerce` throws a TypeError on
+/// a Symbol and runs an object's `valueOf`/`toString`); a BigInt throws a
+/// TypeError (ToIndex uses ToNumber, which — unlike `Number()` — rejects BigInt);
+/// a negative or `> 2^53-1` integer (including ±Infinity) throws a RangeError.
+/// Previously this used the bare `JSValue::to_number()`, which silently produced
+/// `NaN`/`0` for those cases — so a Symbol didn't throw, `valueOf` never ran, and
+/// negative/Infinity offsets only surfaced (if at all) as a later bounds error.
 fn to_byte_offset(value: f64) -> i64 {
-    let n = crate::value::JSValue::from_bits(value.to_bits()).to_number();
-    if n.is_nan() {
-        0
-    } else if !n.is_finite() {
-        // ±Infinity → out of any finite buffer range; surfaced as OOB later.
-        if n > 0.0 {
-            i64::MAX
-        } else {
-            i64::MIN
-        }
-    } else {
-        n.trunc() as i64
+    if crate::value::JSValue::from_bits(value.to_bits()).is_bigint() {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
     }
+    let n = crate::builtins::js_number_coerce(value);
+    let i = if n.is_nan() { 0.0 } else { n.trunc() };
+    if i < 0.0 || i > 9_007_199_254_740_991.0 {
+        throw_dataview_oob();
+    }
+    i as i64
 }
 
 #[inline]


### PR DESCRIPTION
## What

`DataView.prototype.{get,set}*` now apply `ToIndex(byteOffset)` per spec instead of
a lossy numeric cast. `to_byte_offset` used the bare `JSValue::to_number()`, which:
- returned `NaN`→`0` for strings/objects (no `valueOf` call) and Symbols (no throw),
- never range-checked, so negative / `> 2^53-1` / `±Infinity` offsets only sometimes
  surfaced as a later bounds error.

Now: full `ToNumber` (`js_number_coerce` — throws `TypeError` on a Symbol, runs an
object's `valueOf`/`toString`, parses strings), an explicit `TypeError` on a BigInt
(ToIndex uses ToNumber, which rejects BigInt), then `ToIntegerOrInfinity` (NaN→0,
truncate) and a `RangeError` for `< 0` or `> 2^53-1` (including ±Infinity).

For `set*`, byteOffset is coerced before the value (`SetViewValue` step order), so a
throwing-`valueOf` byteOffset throws before value conversion.

## Why

~40 test262 `built-ins/DataView/prototype/*` cases:
`return-abrupt-from-tonumber-byteoffset[-symbol]`, `toindex-byteoffset[-toprimitive]`,
`*/index-is-out-of-range` (Infinity), `index-check-before-value-conversion`, etc.

## Verification

Byte-identical to `node --experimental-strip-types`, both `PERRY_NO_AUTO_OPTIMIZE=1`
and default build:

```
dv.getUint8("1")            => 99   (was 0)
dv.getUint8({valueOf:()=>1})=> 99   (valueOf ran; was 0)
dv.getFloat32(Symbol())     => throws TypeError   (was no-throw)
dv.getFloat32({valueOf throws}) => propagates, valueOf-before-value
dv.getUint8(1n)             => throws TypeError   (was 0)
dv.getFloat32(-1 / Infinity)=> throws RangeError
dv.getFloat32(0.9)/setFloat32(0,1.5) => valid offsets unchanged
```

- `built-ins/DataView` radar: with this fix on top of #4458, the category drops
  to **38 failures** (from ~108 on `main` before either DataView fix); this fix
  clears the byteOffset coercion cluster (Symbol/valueOf/string/object/BigInt/
  ±Infinity). Remaining 38 are mostly the analogous *value*-arg coercion and
  resizable-buffer/descriptor cases — separate follow-ups.
- `cargo test --release -p perry-runtime --lib` green.
- Depends on the RangeError-constructor fix (#4458) so the thrown RangeError is
  catchable by `assert.throws`.
