### PR TITLE
fix(android): use a tls-model flag form the active rustc accepts (#1529 follow-up)

### DIFF
--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1304,7 +1304,8 @@ pub(super) fn build_geisterhand_libs(target: Option<&str>, format: OutputFormat)
     // model doesn't crash at load. (RUSTFLAGS scopes to the cross target,
     // so host build-scripts/proc-macros are unaffected.)
     if matches!(target, Some("android") | Some("android-x86_64")) {
-        cargo_cmd.env("RUSTFLAGS", "-C tls-model=global-dynamic");
+        let tls_flag = super::optimized_libs::android_global_dynamic_tls_rustflag(&mut cargo_cmd);
+        cargo_cmd.env("RUSTFLAGS", tls_flag);
     }
 
     let status = cargo_cmd

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -1265,7 +1265,9 @@ pub(super) fn build_and_run_link(
                 (
                     "libperry_ui_android.a",
                     // #1529 — TLS model must be global-dynamic for the dlopen'd cdylib.
-                    "RUSTFLAGS=\"-C tls-model=global-dynamic\" cargo build --release -p perry-ui-android --target aarch64-linux-android",
+                    // `tls-model` is `-Z`-gated on the toolchains we ship against, so
+                    // RUSTC_BOOTSTRAP=1 lets the gated flag through on a stable rustc.
+                    "RUSTC_BOOTSTRAP=1 RUSTFLAGS=\"-Z tls-model=global-dynamic\" cargo build --release -p perry-ui-android --target aarch64-linux-android",
                 )
             } else if is_linux {
                 (
@@ -1446,9 +1448,12 @@ pub(super) fn build_and_run_link(
                     // relocations are baked into the dlopen'd `libperry_app.so`, so an
                     // Initial-Executable model (rustc's android default) crashes at load.
                     if is_android {
+                        let tls_flag = super::optimized_libs::android_global_dynamic_tls_rustflag(
+                            &mut cargo_cmd,
+                        );
                         cargo_cmd.env(
                             "CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS",
-                            "-C link-arg=-Wl,-z,max-page-size=16384 -C tls-model=global-dynamic",
+                            format!("-C link-arg=-Wl,-z,max-page-size=16384 {tls_flag}"),
                         );
                     }
 

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -21,6 +21,34 @@ use crate::OutputFormat;
 use super::library_search::{find_harmonyos_sdk, harmonyos_cross_env};
 use super::{find_perry_workspace_root, rust_target_triple, CompilationContext};
 
+/// (#1529) Android's `libperry_app.so` is loaded via `dlopen`, so its TLS
+/// relocations must use the global-dynamic model — the aarch64-linux-android
+/// default (Initial-Executable) crashes at load with
+/// `TLS symbol "(null)" ... using IE access model`. The model is selected by a
+/// `tls-model` rustc flag, but that flag is exposed as a stable `-C` codegen
+/// option on some toolchains and is still nightly-gated (`-Z`) on others.
+/// Passing the `-C` form to a toolchain that only knows the `-Z` form aborts
+/// *every* Android build with `error: unknown codegen option: tls-model`.
+/// (This slipped past CI because release CI builds the runtime libs with plain
+/// `cargo build` and never compiles a full Android app through this path.)
+///
+/// Probe the active rustc and return the spelling it accepts. When only the
+/// `-Z` form is available, also set `RUSTC_BOOTSTRAP=1` on `cmd` so the gated
+/// flag is honored on a stable toolchain without requiring a nightly install.
+pub(crate) fn android_global_dynamic_tls_rustflag(cmd: &mut Command) -> &'static str {
+    let c_form_supported = Command::new("rustc")
+        .args(["-C", "help"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains("tls-model"))
+        .unwrap_or(false);
+    if c_form_supported {
+        "-C tls-model=global-dynamic"
+    } else {
+        cmd.env("RUSTC_BOOTSTRAP", "1");
+        "-Z tls-model=global-dynamic"
+    }
+}
+
 pub struct OptimizedLibs {
     /// Path to the rebuilt `libperry_runtime.a` (or `perry_runtime.lib`).
     /// `None` means "fall back to the prebuilt one in target/release/".
@@ -691,7 +719,7 @@ pub(super) fn build_optimized_libs(
     // cdylib. Force global-dynamic so the dynamic linker can resolve TLS
     // slots after the process has started.
     if matches!(target, Some("android") | Some("android-x86_64")) {
-        rustflags.push("-C tls-model=global-dynamic");
+        rustflags.push(android_global_dynamic_tls_rustflag(&mut cargo_cmd));
     }
     if !rustflags.is_empty() {
         cargo_cmd.env("RUSTFLAGS", rustflags.join(" "));


### PR DESCRIPTION
## Problem

Compiling **any** Android app (`perry compile … --target android`, e.g. via Perry Hub) aborts during the native-library build with:

```
error: failed to run `rustc` to learn about target-specific information
  process didn't exit successfully: `rustc - … -C tls-model=global-dynamic --target aarch64-linux-android …`
  error: unknown codegen option: `tls-model`
Error: Failed to build native library crate for <pkg>
```

## Root cause

`#1529` forces the global-dynamic TLS model for Android (the `dlopen`'d `libperry_app.so` crashes at load under the default Initial-Executable model). It does so by injecting `-C tls-model=global-dynamic` into `RUSTFLAGS` at four sites:

- `compile/link/mod.rs` — the user's native-library crate build (`CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS`)
- `compile/optimized_libs.rs` — the optimized runtime/stdlib rebuild
- `compile/library_search.rs` — the cross runtime/stdlib build
- `compile/link/mod.rs` — the `perry-ui-android` build hint

But `tls-model` is a **stable `-C` codegen option on some toolchains and still `-Z`-gated (nightly) on others**. On the latter, the `-C` form is rejected outright with `unknown codegen option: tls-model`, so every Android app build fails.

### Why CI didn't catch it

`release-packages.yml` builds the runtime/stdlib bundles with plain `cargo build -p perry-runtime …` (no `tls-model` flag) and **never compiles a full Android app through the native-library link path** that injects the flag. So the broken path is exercised only by real Android builds (Perry Hub / `perry publish android`), not CI.

## Fix

Add `android_global_dynamic_tls_rustflag()`: probe `rustc -C help` and

- emit `-C tls-model=global-dynamic` when the toolchain exposes it (unchanged behavior), else
- fall back to `-Z tls-model=global-dynamic` **and set `RUSTC_BOOTSTRAP=1`** on the cargo invocation, so the gated flag is honored on a *stable* toolchain without requiring a nightly install.

Applied at all four sites. No behavior change on toolchains where the `-C` form already works.

## Validation

- Reproduced on a Linux builder (rustup stable 1.94.0/1.96.0 and nightly 1.98 all reject `-C tls-model`; only `-Z tls-model` is accepted — confirmed `rustc -C help` lists no `tls-model`).
- `cargo check -p perry` passes locally (Finished in ~31s, no new warnings/errors in the changed files). Recommend a real Android build in CI to confirm the runtime TLS fix end-to-end.

Discovered while bringing up Android builds for `bloom/jump` on a freshly-migrated Hub builder.
