### PR TITLE
fix(zlib): validate Brotli one-shot inputs

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/media.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/media.rs
@@ -413,14 +413,15 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         ret: NR_F64,
     },
     // `zlib.brotli{Compress,Decompress}Sync(data)` — one-shot Brotli via the
-    // `brotli` crate (already a `compression`-feature dep). #1843 cluster 2.
+    // `brotli` crate (already a `compression`-feature dep). Pass data as raw
+    // NaN-box bits so shared codec validation sees the original JS value.
     NativeModSig {
         module: "zlib",
         has_receiver: false,
         method: "brotliCompressSync",
         class_filter: None,
         runtime: "js_zlib_brotli_compress_sync",
-        args: &[NA_F64],
+        args: &[NA_JSV],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -429,7 +430,7 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
         method: "brotliDecompressSync",
         class_filter: None,
         runtime: "js_zlib_brotli_decompress_sync",
-        args: &[NA_F64],
+        args: &[NA_JSV],
         ret: NR_PTR,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -580,9 +580,10 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_zlib_unzip_sync", I64, &[DOUBLE]);
     module.declare_function("js_zlib_unzip", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_zlib_crc32", DOUBLE, &[DOUBLE, DOUBLE]);
-    // #1843 — Brotli one-shots (sync validates JS values; async queues callbacks).
-    module.declare_function("js_zlib_brotli_compress_sync", I64, &[DOUBLE]);
-    module.declare_function("js_zlib_brotli_decompress_sync", I64, &[DOUBLE]);
+    // Brotli sync one-shots take data as raw NaN-box bits for the same
+    // shared validation path as gzipSync/deflateSync.
+    module.declare_function("js_zlib_brotli_compress_sync", I64, &[I64]);
+    module.declare_function("js_zlib_brotli_decompress_sync", I64, &[I64]);
     module.declare_function("js_zlib_brotli_compress", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_zlib_brotli_decompress", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_zlib_zstd_compress_sync", I64, &[DOUBLE, DOUBLE]);

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -137,12 +137,11 @@ pub(crate) unsafe fn compression_from_opts(opts: f64) -> Compression {
 /// `zlib.brotliCompressSync(data)` -> Buffer.
 ///
 /// # Safety
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+/// `data_bits` must be the raw NaN-box bit pattern of the data argument.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_compress_sync(
-    data_ptr: *const StringHeader,
-) -> *mut StringHeader {
-    match read_input_bytes(data_ptr) {
+pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_bits: i64) -> *mut StringHeader {
+    js_zlib_validate_buffer_arg(data_bits);
+    match read_input_from_bits(data_bits) {
         Some(d) => alloc_bytes(&brotli_compress_bytes(&d)).as_raw(),
         None => std::ptr::null_mut(),
     }
@@ -151,12 +150,11 @@ pub unsafe extern "C" fn js_zlib_brotli_compress_sync(
 /// `zlib.brotliDecompressSync(data)` -> Buffer.
 ///
 /// # Safety
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+/// `data_bits` must be the raw NaN-box bit pattern of the data argument.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(
-    data_ptr: *const StringHeader,
-) -> *mut StringHeader {
-    match read_input_bytes(data_ptr).map(|d| brotli_decompress_bytes(&d)) {
+pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_bits: i64) -> *mut StringHeader {
+    js_zlib_validate_buffer_arg(data_bits);
+    match read_input_from_bits(data_bits).map(|d| brotli_decompress_bytes(&d)) {
         Some(Ok(out)) => alloc_bytes(&out).as_raw(),
         _ => std::ptr::null_mut(),
     }

--- a/crates/perry-stdlib/src/zlib.rs
+++ b/crates/perry-stdlib/src/zlib.rs
@@ -442,16 +442,16 @@ fn brotli_decompress_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
 /// `zlib.brotliCompressSync(data)` -> Buffer
 ///
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_value: f64) -> *mut BufferHeader {
-    let data = codec_bytes(data_value);
+pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_bits: i64) -> *mut BufferHeader {
+    let data = codec_bytes(f64::from_bits(data_bits as u64));
     let out = brotli_compress_bytes(&data);
     buffer_from_slice(&out)
 }
 
 /// `zlib.brotliDecompressSync(data)` -> Buffer
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_value: f64) -> *mut BufferHeader {
-    let data = codec_bytes(data_value);
+pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_bits: i64) -> *mut BufferHeader {
+    let data = codec_bytes(f64::from_bits(data_bits as u64));
     match brotli_decompress_bytes(&data) {
         Ok(out) => buffer_from_slice(&out),
         Err(e) => throw_zlib_error(&format!("brotli: {}", e)),
@@ -1321,8 +1321,12 @@ pub unsafe extern "C" fn js_zlib_native_dispatch(
         "deflateRawSync" => ptr_to_f64(js_zlib_deflate_raw_sync(arg(0)) as *const u8),
         "inflateRawSync" => ptr_to_f64(js_zlib_inflate_raw_sync(arg(0)) as *const u8),
         "unzipSync" => ptr_to_f64(js_zlib_unzip_sync(arg(0)) as *const u8),
-        "brotliCompressSync" => ptr_to_f64(js_zlib_brotli_compress_sync(arg(0)) as *const u8),
-        "brotliDecompressSync" => ptr_to_f64(js_zlib_brotli_decompress_sync(arg(0)) as *const u8),
+        "brotliCompressSync" => {
+            ptr_to_f64(js_zlib_brotli_compress_sync(arg(0).to_bits() as i64) as *const u8)
+        }
+        "brotliDecompressSync" => {
+            ptr_to_f64(js_zlib_brotli_decompress_sync(arg(0).to_bits() as i64) as *const u8)
+        }
         "zstdCompressSync" => ptr_to_f64(js_zlib_zstd_compress_sync(arg(0), arg(1)) as *const u8),
         "zstdDecompressSync" => {
             ptr_to_f64(js_zlib_zstd_decompress_sync(arg(0), arg(1)) as *const u8)


### PR DESCRIPTION
## Summary
- Pass `brotliCompressSync()` / `brotliDecompressSync()` data arguments as raw JS value bits through native dispatch, matching the existing gzip/deflate sync validation path.
- Update both bundled zlib and `perry-ext-zlib` Brotli sync entry points to validate non-string / non-BufferSource inputs before reading bytes.
- Preserve the dynamic zlib dispatcher by forwarding raw argument bits for Brotli sync calls.

## Issue / cut
Refs #2013.

This is one coherent zlib validation cut because direct codegen, bundled stdlib dispatch, and the no-auto external zlib wrapper all share the same exported Brotli sync symbols.

## Tests
- `cargo build --release --quiet -p perry-ext-zlib`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib --filter one-shot-invalid-data'`
- `cargo check -p perry-codegen -p perry-stdlib -p perry-ext-zlib`
- `cargo test -p perry-ext-zlib --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations / non-goals
- Broader zlib roundtrip return-shape work remains out of scope: an adjacent `roundtrip-ascii` run still fails for Brotli/gzip/deflate because compressed outputs are not yet accepted as BufferSource inputs on the next call; `raw/roundtrip-ascii` passed.
- This does not change async zlib callback/promisify behavior, stream behavior, compression output format, or invalid compressed payload errors.