### PR TITLE
fix(hir): bind class-expression vars as class refs, not undefined locals

### DIFF
--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -298,6 +298,31 @@ pub fn lower_module_with_class_id_types_seed_and_entry(
     )
 }
 
+/// #4461: true when a `var/let/const X = class { ... }` declarator binds an
+/// identifier to a class *expression* (unwrapping `paren`/`as`/`!`/type-
+/// assertion layers that esbuild/rollup dist bundles emit). Such bindings are
+/// lowered to a class named after the binding in `stmt.rs`, so they must not be
+/// pre-registered as module-level locals (which would shadow the class ref).
+fn decl_init_is_class_expr(decl: &ast::VarDeclarator) -> bool {
+    if !matches!(decl.name, ast::Pat::Ident(_)) {
+        return false;
+    }
+    let mut e = match &decl.init {
+        Some(init) => init.as_ref(),
+        None => return false,
+    };
+    loop {
+        match e {
+            ast::Expr::Paren(p) => e = &p.expr,
+            ast::Expr::TsAs(a) => e = &a.expr,
+            ast::Expr::TsNonNull(n) => e = &n.expr,
+            ast::Expr::TsTypeAssertion(a) => e = &a.expr,
+            ast::Expr::Class(_) => return true,
+            _ => return false,
+        }
+    }
+}
+
 /// Issue #668: superset of the `_seed_and_entry` wrapper that also accepts
 /// `is_external_module`. Callers in `crates/perry/src/commands/compile/`
 /// pass `true` when the source file lives under any `node_modules/` segment
@@ -461,6 +486,18 @@ pub fn lower_module_full(
         };
         if let Some(var_decl) = var_decl {
             for decl in &var_decl.decls {
+                // #4461: `var X = class { ... }` is lowered as a class
+                // expression bound to the name `X` (see stmt.rs) — the class
+                // itself takes the role of the value referenced by name, and
+                // no `Stmt::Let` is ever emitted for `X`. Pre-registering `X`
+                // as a module-level local here would shadow that class with a
+                // never-assigned local, so a value read of `X` (`typeof X`,
+                // `X.staticMethod`, passing `X` around) resolved to the
+                // undefined local instead of the class ref. Skip the local so
+                // `Ident("X")` lowers to `Expr::ClassRef("X")`.
+                if decl_init_is_class_expr(decl) {
+                    continue;
+                }
                 if let ast::Pat::Ident(ident) = &decl.name {
                     let name = ident.id.sym.to_string();
                     if ctx.lookup_local(&name).is_none() {

--- a/test-files/test_gap_4461_class_expr_var_value.ts
+++ b/test-files/test_gap_4461_class_expr_var_value.ts
@@ -1,0 +1,50 @@
+// Issue #4461: a class EXPRESSION bound to a variable — `var X = class {...}`
+// / `const X = class l {...}` — must be a usable value when referenced by
+// name, not just a `new X()` target. Perry pre-registered the binding as a
+// module-level local that was never assigned (the class-expression lowering
+// emits no `Stmt::Let` for it), so a value read of `X` (`typeof X`,
+// `X.staticMethod`, passing `X` around) resolved to the undefined local
+// instead of the class ref. Common in minified npm dist bundles
+// (esbuild/rollup emit `var Cls = class name {...}` then reference `Cls`),
+// which blocked `marked` (`g.parser = b.parse` where `b = class l { static
+// parse(){} }`).
+
+// Bare value read: typeof and a static-method call off the binding.
+var B = class l {
+  static parse(e: any) { return "parsed:" + e; }
+  parse(e: any) { return e; }
+};
+console.log("typeof B =", typeof B);
+console.log("new B works:", typeof new B());
+console.log(B.parse(1));
+
+// marked's actual shape: a static-only method read off the binding as a
+// VALUE (not a direct call) and stashed on an object.
+var b = class l {
+  static parse(e: any) { return "parse:" + e; }
+};
+const g: any = {};
+g.parser = b.parse;
+console.log(g.parser(5));
+
+// const class expression with a self-binding name used inside methods.
+const Node2 = class _Node {
+  v: number;
+  constructor(v: number) { this.v = v; }
+  clone() { return new _Node(this.v + 1); }
+  static make(v: number) { return new _Node(v); }
+};
+console.log(typeof Node2);
+console.log(new Node2(1).clone().v);
+console.log(Node2.make(9).v);
+
+// Pass the binding around as a first-class value.
+function callNew(C: any) { return new C(); }
+var Empty = class { ok() { return "ok"; } };
+console.log(callNew(Empty).ok());
+
+// Regression guard: an ordinary `var` initialised with a non-class value is
+// still a real, reassignable local.
+var n = 42;
+n = n + 1;
+console.log(n);


### PR DESCRIPTION
## Summary

Fixes #4461. A class **expression** bound to a variable — `var X = class {...}` / `const X = class l {...}` — compiled fine as a `new X()` target but read as `undefined` when referenced as a value: `typeof X`, `X.staticMethod`, or passing `X` around.

### Root cause

`stmt.rs` lowers `var X = class {...}` to a class named after the binding and intentionally emits **no** `Stmt::Let` for `X` (the class itself plays the role of the value referenced by name). But the module-level var pre-registration in `lower_module_full` (`lower_module_fn.rs`) still ran for that declarator and defined `X` as a local that was **never assigned**. Since `lookup_local` is consulted before `lookup_class` when lowering an identifier, a value read of `X` resolved to the undefined local — `Ident("X")` never reached the `Expr::ClassRef("X")` arm.

### Fix

Skip the module-local pre-registration for declarators whose initializer is a class expression (unwrapping `paren`/`as`/`!`/type-assertion layers that esbuild/rollup dist bundles emit). `Ident("X")` then lowers to `Expr::ClassRef("X")`, which `typeof` already folds to `"function"` and which carries the constructor/static identity. `new X()` and `X.staticMethod(...)` already worked via class registration and are unchanged.

This is the common minified-bundle shape (`var Cls = class name {...}` then `Cls` referenced as a value) and unblocks the `marked` dependency (`g.parser = b.parse` where `b = class l { static parse(){} }`) for the Hono SSR site.

## Test

Added `test-files/test_gap_4461_class_expr_var_value.ts`, byte-identical to `node --experimental-strip-types`. Covers `typeof`, static-method call, static-method-as-value (`g.parser = b.parse`), self-binding-name (`class _Node`) methods/statics, passing the binding to a function, and a regression guard that an ordinary `var n = 42; n = n + 1` stays a real reassignable local.

Verified no regressions across the existing `test_gap_class*` / `test_class*` suite (the two pre-existing failures there — `test_class_field_layout`, `test_class_static_iife` — also fail on `main` and are unrelated). `cargo test -p perry-hir` green; `cargo fmt --check` clean.

## Note / follow-up (out of scope)

When a class declares **both** a static and an instance method of the same name, reading that method off the class as a *value* (`Plain.parse` where `Plain` has both) resolves to the instance method instead of the static. This is a **pre-existing** codegen bug that affects plain `class` declarations equally (not introduced here); `marked`'s actual shape is static-only and works. Worth a separate issue.