### PR TITLE
fix(runtime): ToNumber(value) coercion in DataView set (Symbol/valueOf)

### DIFF
--- a/crates/perry-runtime/src/buffer/dataview.rs
+++ b/crates/perry-runtime/src/buffer/dataview.rs
@@ -95,9 +95,15 @@ fn to_byte_offset(value: f64) -> i64 {
     i as i64
 }
 
+/// `ToNumber(value)` for `SetViewValue` on a non-BigInt accessor. Uses the full
+/// ToNumber (`js_number_coerce`): a Symbol throws a TypeError, an object runs its
+/// `valueOf`/`toString`, strings parse. The bare `JSValue::to_number()` silently
+/// produced `NaN` for those, so `setFloat32(0, Symbol())` didn't throw and a
+/// throwing `valueOf` never ran. Runs after `ToIndex(byteOffset)` (SetViewValue
+/// step order). A BigInt accessor takes the `to_bigint_raw_or_throw` path instead.
 #[inline]
 fn to_number(value: f64) -> f64 {
-    crate::value::JSValue::from_bits(value.to_bits()).to_number()
+    crate::builtins::js_number_coerce(value)
 }
 
 /// Read `width` bytes starting at `offset` from a DataView's backing storage.


### PR DESCRIPTION
## What

`DataView.prototype.set*` (non-BigInt accessors) now apply full `ToNumber(value)`
instead of the bare `JSValue::to_number()`. A Symbol value throws a `TypeError`, an
object's `valueOf`/`toString` runs (and a throwing one propagates), and strings
parse — previously all of these silently became `NaN` and were stored without
error.

`SetViewValue` order is preserved: `ToIndex(byteOffset)` runs first (#4466), then
`ToNumber(value)`, then the bounds check. (BigInt accessors keep their existing
`ToBigInt` path.)

## Why

test262 `built-ins/DataView/prototype/set*/return-abrupt-from-tonumber-value[-symbol].js`
(9 accessors × 2 = ~18 cases).

## Verification

Byte-identical to `node --experimental-strip-types`, both `PERRY_NO_AUTO_OPTIMIZE=1`
and default build:

```
dv.setFloat32(0, Symbol())            => throws TypeError      (was no-throw)
dv.setFloat32(0, {valueOf throws})    => propagates; valueOf ran (was no-throw)
dv.setFloat32(0, "1.5")               => stores 1.5            (was 0/NaN)
```

- `cargo test --release -p perry-runtime --lib` green.
- One-line change to the `to_number` helper in `buffer/dataview.rs` (only used by
  `set`'s value path); valid numeric/boolean values unchanged.
