### PR TITLE
fix(runtime): ToIndex(byteOffset/byteLength) coercion in DataView constructor

### DIFF
--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -706,7 +706,15 @@ fn dataview_to_index(value: f64, what: &str) -> i64 {
     if jv.is_undefined() {
         return 0;
     }
-    let n = jv.to_number();
+    // ToIndex → ToNumber: a BigInt throws a TypeError (ToNumber rejects it), and
+    // `js_number_coerce` is the full ToNumber — it throws a TypeError on a Symbol
+    // and runs an object's `valueOf`/`toString`. The bare `JSValue::to_number()`
+    // previously produced `NaN`→0 for those, so `new DataView(buf, Symbol())`
+    // didn't throw and a `valueOf` never ran.
+    if jv.is_bigint() {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
+    }
+    let n = crate::builtins::js_number_coerce(value);
     if n.is_nan() {
         // ToIntegerOrInfinity(NaN) = 0.
         return 0;


### PR DESCRIPTION
## What

The `new DataView(buffer, byteOffset?, byteLength?)` constructor now applies full
`ToIndex` (via `ToNumber`) to `byteOffset` and `byteLength` instead of the bare
`JSValue::to_number()`. A Symbol arg throws `TypeError`, an object's
`valueOf`/`toString` runs (throwing ones propagate), strings parse, and a BigInt
throws `TypeError` — previously all silently became `NaN`→`0`.

## Why

test262 `built-ins/DataView/return-abrupt-tonumber-{byteoffset,bytelength}[-symbol].js`
and `toindex-{byteoffset,bytelength}.js`.

## Verification

Byte-identical to `node --experimental-strip-types`, both build modes:

```
new DataView(buf, Symbol())            => throws TypeError   (was no-throw)
new DataView(buf, {valueOf:()=>2})     => .byteOffset 2; valueOf ran (was 0)
new DataView(buf, "2")                 => .byteOffset 2      (was 0)
```

- One-helper change (`dataview_to_index` in `buffer/from.rs`); the existing
  `RangeError` path already carries the real constructor (uses `js_rangeerror_new`).
- Completes the DataView argument-coercion family alongside #4458 / #4466 / #4470.
