### PR TITLE
fix(hir): module-level var assigned inside a closure no longer re-localized (var hoisting, #4450)

### DIFF
--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -836,6 +836,23 @@ pub(crate) fn predeclare_implicit_assignment_targets(
 
     let mut stmts = Vec::new();
     for name in names {
+        // Inside a closure (scope_depth > 0), an assignment to a name that
+        // resolves to a MODULE-LEVEL binding (e.g. a `var` declared later at
+        // module scope) must NOT be re-declared as a closure-local: doing so
+        // emits a localizing `Let <id> = undefined` that makes codegen treat
+        // the id as a closure-local instead of the module var's global slot, so
+        // the write never reaches the module binding the post-declaration read
+        // uses (`var f = function(){ later = 5 }; var later; f();` → undefined).
+        // The assignment resolves to the module var via the global-slot path; no
+        // hoist Let is needed. A closure-local shadow (`function(){ var x; … }`)
+        // has its own non-module id and is unaffected.
+        if ctx.scope_depth > 0 {
+            if let Some(id) = ctx.lookup_local(&name) {
+                if ctx.module_level_ids.contains(&id) {
+                    continue;
+                }
+            }
+        }
         let mut assigned = false;
         if !ctx.pre_registered_module_var_decls.contains(&name)
             && expr_reads_name_before_assignment(expr, &name, &mut assigned)


### PR DESCRIPTION
## Summary

Closes #4450. A closure (or function declaration) that assigns to a **module-level `var` declared later** in the module lost the write — the value read back as `undefined`:

```js
var f = function () { later = 5; }; var later; f(); console.log(later);   // was undefined → 5
function g() { later = 7; }         var later; g(); console.log(later);   // was undefined → 7
```

## Root cause

When lowering the closure body, `predeclare_implicit_assignment_targets` sees `later = 5`. Because `later` is a pre-registered module `var`, it reused the module var's `LocalId` but **still emitted a localizing `Let <id> = undefined` inside the closure body**. That makes codegen treat the id as a closure-local (a fresh per-call slot) instead of the module var's global slot, so the write never reached the module binding the post-declaration read uses. (The existing `pre_registered_module_vars` machinery handled the *resolution* but this localizing `Let` defeated it — hence the bug surviving for the write-before-declaration case.)

## Fix

In `predeclare_implicit_assignment_targets`, when running inside a closure (`scope_depth > 0`) and the name resolves to a **module-level binding** (`module_level_ids`), skip the hoist `Let` — the assignment resolves to the module var's global slot. A closure-local shadow (`function(){ var x; … }`) has its own non-module id and is unaffected.

## Verification (clean main vs fix)

| category | main | fix |
|---|---|---|
| built-ins/Date | 44 | **33** (−11) |
| language/statements/variable | 18 | 18 |
| language/expressions/assignment | 5 | 5 |
| built-ins/Function | 220 | 220 |
| built-ins/Array/prototype/reduce | 91 | 91 |

−11 Date (the setter `arg-to-number` cases declare their `valueOf`-recording vars after the arg object), **zero regressions**. Edge cases verified Node-identical in both `PERRY_NO_AUTO_OPTIMIZE` and default builds: var-declared-before, closure-local `var` (stays local), `let` module var, module var with initializer. `cargo test -p perry-runtime --lib`: 983 passed.
