### PR TITLE
fix(regex): make exec/match .groups a real own property (#4475)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1615,10 +1615,17 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 }
             }
         }
-        // RegExpExecArray.index / .groups — receiver is a local that holds the result
-        // of regex.exec(...). The runtime stores the most recent exec metadata in
-        // thread-locals which RegExpExecIndex/Groups read.
-        if prop_name == "index" || prop_name == "groups" {
+        // RegExpExecArray.index — receiver is a local that holds the result of
+        // regex.exec(...). The runtime stores the most recent exec index in a
+        // thread-local which RegExpExecIndex reads.
+        //
+        // `.groups` is deliberately NOT folded here: the runtime now attaches
+        // the named-capture object as a real own property on the result array
+        // (see regex.rs::set_exec_array_groups), so a generic PropertyGet reads
+        // the per-result value. That keeps `m.groups` correct after an
+        // intervening match on another regex, where a thread-local would be
+        // clobbered.
+        if prop_name == "index" {
             // Strip non-null assertion (m1! → m1)
             let inner = match member.obj.as_ref() {
                 ast::Expr::TsNonNull(nn) => nn.expr.as_ref(),
@@ -1626,11 +1633,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
             };
             if let ast::Expr::Ident(ident) = inner {
                 if ctx.regex_exec_locals.contains(&ident.sym.to_string()) {
-                    return Ok(if prop_name == "index" {
-                        Expr::RegExpExecIndex
-                    } else {
-                        Expr::RegExpExecGroups
-                    });
+                    return Ok(Expr::RegExpExecIndex);
                 }
             }
         }

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1434,20 +1434,25 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                         ast::MemberProp::Ident(ident) => {
                             let prop_name = ident.sym.to_string();
                             // Mirror the eager-fold from
-                            // `expr_member::lower_member` for `m.index` /
-                            // `m.groups` when `m` is a tracked
+                            // `expr_member::lower_member` for `m.index`
+                            // when `m` is a tracked
                             // regex.exec()/string.match() result. The
                             // standard `lower_member` fires when the
-                            // AST is `m.groups`; for the optional-chain
-                            // form `m?.groups` SWC routes here, the
+                            // AST is `m.index`; for the optional-chain
+                            // form `m?.index` SWC routes here, the
                             // `member.obj` has already been lowered to
                             // `LocalGet(...)`, so `lower_member`'s
                             // `ast::Expr::Ident` check fails. Intercept
                             // here so the optional-chain shape also
-                            // resolves to the thread-local groups
-                            // object instead of a generic property
-                            // read that returns undefined.
-                            if (prop_name == "groups" || prop_name == "index")
+                            // resolves to the thread-local index value.
+                            //
+                            // `.groups` is intentionally left as a generic
+                            // PropertyGet: the runtime attaches the
+                            // named-capture object as a real own property on
+                            // the result array (regex.rs::set_exec_array_groups),
+                            // so it survives an intervening match on another
+                            // regex (a thread-local would be clobbered).
+                            if prop_name == "index"
                                 && match member.obj.as_ref() {
                                     ast::Expr::Ident(ident) => {
                                         ctx.regex_exec_locals.contains(&ident.sym.to_string())
@@ -1461,11 +1466,7 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                                     _ => false,
                                 }
                             {
-                                if prop_name == "groups" {
-                                    Expr::RegExpExecGroups
-                                } else {
-                                    Expr::RegExpExecIndex
-                                }
+                                Expr::RegExpExecIndex
                             } else {
                                 Expr::PropertyGet {
                                     object: Box::new(obj_expr.clone()),

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -223,6 +223,28 @@ fn set_exec_array_metadata(arr: *mut ArrayHeader, input: &str, index: f64) {
     crate::array::js_array_set_string_key(arr, input_key, input_value);
 }
 
+/// Attach the `groups` own property to a regex match-result array.
+///
+/// Mirrors `set_exec_array_metadata` for `index`/`input`: the result of
+/// `regex.exec(s)` / `s.match(regex)` carries `groups` as a real own property
+/// so reads stay correct under aliasing and interleaved matches — a stored
+/// `m.groups` survives a later `re2.exec(...)`, instead of resolving through a
+/// single most-recent-match thread-local (`LAST_EXEC_GROUPS`). Per ECMA-262
+/// RegExpBuiltinExec, `groups` is the named-capture object when the pattern
+/// has named groups, else `undefined`.
+fn set_exec_array_groups(arr: *mut ArrayHeader, groups_obj: *mut ObjectHeader) {
+    if arr.is_null() {
+        return;
+    }
+    let groups_key = js_string_from_str("groups");
+    let value = if groups_obj.is_null() {
+        f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+    } else {
+        crate::value::js_nanbox_pointer(groups_obj as i64)
+    };
+    crate::array::js_array_set_string_key(arr, groups_key, value);
+}
+
 fn char_index_to_byte(s: &str, char_index: usize) -> usize {
     if char_index == 0 {
         return 0;
@@ -520,6 +542,12 @@ pub extern "C" fn js_string_match(
                             }
                         }
                         LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+                        // fancy-regex path doesn't extract named groups; mirror
+                        // the thread-local (`undefined`) on the result object.
+                        set_exec_array_groups(
+                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                            ptr::null_mut(),
+                        );
                         return arr_handle.get_raw_mut_ptr::<ArrayHeader>();
                     }
                     _ => {
@@ -626,8 +654,16 @@ pub extern "C" fn js_string_match(
                             *g.borrow_mut() =
                                 groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>()
                         });
+                        set_exec_array_groups(
+                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                            groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+                        );
                     } else {
                         LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+                        set_exec_array_groups(
+                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                            ptr::null_mut(),
+                        );
                     }
 
                     arr_handle.get_raw_mut_ptr::<ArrayHeader>()
@@ -1073,6 +1109,12 @@ pub extern "C" fn js_regexp_exec(
                     );
                     LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = match_char_offset as f64);
                     LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+                    // fancy-regex path doesn't extract named groups; mirror the
+                    // thread-local (`undefined`) on the result object.
+                    set_exec_array_groups(
+                        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                        ptr::null_mut(),
+                    );
                     return Some(arr_handle.get_raw_mut_ptr::<ArrayHeader>());
                 }
                 return Some(ptr::null_mut()); // fancy-regex tried but no match
@@ -1139,36 +1181,42 @@ pub extern "C" fn js_regexp_exec(
                     .collect();
 
                 if !group_names.is_empty() {
-                    let mut packed_keys: Vec<u8> = Vec::new();
-                    for (name, _) in &group_names {
-                        packed_keys.extend_from_slice(name.as_bytes());
-                        packed_keys.push(0);
-                    }
-                    let groups_obj = crate::object::js_object_alloc_with_shape(
-                        0x7FFF_FE00,
-                        group_names.len() as u32,
-                        packed_keys.as_ptr(),
-                        packed_keys.len() as u32,
-                    );
+                    // Allocate a fresh per-result object (and shape) via
+                    // `js_object_alloc(0, 0)` + by-name setters, NOT a shared
+                    // `js_object_alloc_with_shape(const_id)`. A fixed interned
+                    // shape id makes a later match with different named captures
+                    // inherit the prior call's key names (e.g. `(?<x>…)` then
+                    // `(?<z>…)` exposing `.x` on the second result). This mirrors
+                    // the fix already applied to the `js_string_match` path.
+                    let groups_obj = crate::object::js_object_alloc(0, 0);
                     let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-                    for (idx, (_, m)) in group_names.iter().enumerate() {
+                    for (name, m) in &group_names {
                         let val = if let Some(m) = m {
                             let str_ptr = js_string_from_str(m.as_str());
-                            let nanboxed = js_nanbox_string(str_ptr as i64);
-                            crate::value::JSValue::from_bits(nanboxed.to_bits())
+                            js_nanbox_string(str_ptr as i64)
                         } else {
-                            crate::value::JSValue::undefined()
+                            f64::from_bits(TAG_UNDEFINED)
                         };
+                        let key_ptr =
+                            crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
                         let groups_obj =
                             groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-                        crate::object::js_object_set_field(groups_obj, idx as u32, val);
+                        crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
                     }
                     LAST_EXEC_GROUPS.with(|g| {
                         *g.borrow_mut() =
                             groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>()
                     });
+                    set_exec_array_groups(
+                        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                        groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+                    );
                 } else {
                     LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+                    set_exec_array_groups(
+                        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                        ptr::null_mut(),
+                    );
                 }
 
                 arr_handle.get_raw_mut_ptr::<ArrayHeader>()

--- a/test-parity/node-suite/globals/regexp-named-groups-aliasing.ts
+++ b/test-parity/node-suite/globals/regexp-named-groups-aliasing.ts
@@ -1,0 +1,55 @@
+// Named-capture `.groups` must be a real own property on each exec/match
+// result, not a single most-recent-match thread-local. A stored groups object
+// (or a `.groups` read on a stored result) has to survive a later match on a
+// different regex, and two results with different named captures must not
+// share a shape. Regression for the `.groups` aliasing bug.
+
+function show(label: string, value: any) {
+  console.log(label + " = " + String(value));
+}
+
+// Inline read off the call result.
+show("inline", /(?<y>\d{4})/.exec("2024")?.groups?.y);
+
+// Stored result, immediate read (also checks .index / .input regressions).
+const m = /(?<year>\d{4})-(?<month>\d{2})/.exec("2024-05");
+show("stored.year", m?.groups?.year);
+show("stored.month", m?.groups?.month);
+show("stored.index", m?.index);
+show("stored.input", m?.input);
+show("stored[1]", m?.[1]);
+
+// Aliased groups object survives a later exec on another regex.
+const a = /(?<x>\d)/.exec("7");
+const aGroups = a?.groups;
+const b = /(?<z>\d)/.exec("9");
+show("aliased.x", (aGroups as any)?.x);
+show("later.z", b?.groups?.z);
+show("later.index", b?.index);
+
+// string.match() carries groups too.
+show("match.year", "2024-05".match(/(?<year>\d{4})/)?.groups?.year);
+
+// No named groups -> groups is undefined (not an empty object).
+const plain = /(\d+)/.exec("42");
+show("plain.groups", String(plain?.groups));
+show("plain[1]", plain?.[1]);
+
+// matchAll yields independent per-match groups.
+const all = [..."2024 2025".matchAll(/(?<y>\d{4})/g)];
+show("all[0].y", all[0]?.groups?.y);
+show("all[1].y", all[1]?.groups?.y);
+
+// Two regexes interleaved in a loop.
+const reDigit = /(?<d>\d)/;
+const reAlpha = /(?<c>[a-z])/;
+let out = "";
+for (const s of ["1x", "2y"]) {
+  const rd = reDigit.exec(s);
+  const ra = reAlpha.exec(s);
+  out += (rd?.groups?.d ?? "?") + (ra?.groups?.c ?? "?") + ",";
+}
+show("loop", out);
+
+// No match -> null.
+show("nomatch", String(/(?<q>z)/.exec("abc")));


### PR DESCRIPTION
Fixes #4475.

## Problem

Named-capture `.groups` on a `RegExp.exec()` / `String.match()` result was resolved through the `LAST_EXEC_GROUPS` thread-local via an HIR fold, so a stored groups object — or a `.groups` read on a stored result — returned `undefined` once another regex ran in between:

```ts
const a = /(?<x>\d)/.exec("7");
const ag = a?.groups;
const b = /(?<z>\d)/.exec("9");
ag?.x;        // Node: 7   was: undefined
b?.groups?.z; // Node: 9   was: undefined
```

The `js_regexp_exec` path also built its groups object with a fixed interned shape id (`js_object_alloc_with_shape(0x7FFF_FE00, …)`), the same bug already fixed on the `js_string_match` path — so two results with different named captures could share a shape.

## Fix

- **Attach `groups` as a real own property** on each exec/match result array (`set_exec_array_groups`, mirroring `set_exec_array_metadata` for `index`/`input`). It's `undefined` when the pattern has no named groups, per ECMA-262 RegExpBuiltinExec.
- **Per-result shape** for the exec-path groups object (`js_object_alloc(0, 0)` + by-name setters) instead of a shared interned shape.
- **Stop folding `.groups`** to `Expr::RegExpExecGroups` in HIR lowering so it reads the per-result property. `.index` folding is unchanged.

## Verification

- New parity fixture `test-parity/node-suite/globals/regexp-named-groups-aliasing.ts` — **PASS (100%)** via `run_parity_tests.sh`.
- Verified identical-to-Node for inline / stored / aliased / interleaved-loop / `matchAll` / `match` / no-named-groups / no-match cases.
- `cargo test -p perry-runtime regex` → 10/10 pass.