### PR TITLE
Fix no-auto HTTP socket introspection link deps

### DIFF
--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -40,6 +40,7 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     "PERRY_UNBOXED_OBJECT_FIELDS",
     "PERRY_NO_AUTO_OPTIMIZE",
     "PERRY_DISABLE_WELL_KNOWN",
+    "PERRY_FORCE_WELL_KNOWN",
 ];
 
 #[derive(Debug, Clone)]

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -91,7 +91,19 @@ impl OptimizedLibs {
 }
 
 fn well_known_iteration_set(ctx: &CompilationContext) -> BTreeSet<String> {
-    ctx.native_module_imports.iter().cloned().collect()
+    let mut iteration_set: BTreeSet<String> = ctx.native_module_imports.iter().cloned().collect();
+    if let Ok(forced) = std::env::var("PERRY_FORCE_WELL_KNOWN") {
+        for module in forced.split(|ch: char| ch == ',' || ch == ';' || ch.is_whitespace()) {
+            let module = module.trim();
+            if module.is_empty() {
+                continue;
+            }
+            if super::well_known::lookup_well_known(module).is_some() {
+                iteration_set.insert(module.strip_prefix("node:").unwrap_or(module).to_string());
+            }
+        }
+    }
+    iteration_set
 }
 
 /// Resolve well-known wrapper archives without rebuilding runtime/stdlib.
@@ -1342,6 +1354,27 @@ mod tests {
         let modules = well_known_iteration_set(&ctx);
 
         assert!(modules.contains("node-fetch"));
+    }
+
+    #[test]
+    fn forced_well_known_env_extends_iteration_set() {
+        let _guard = env_lock();
+        let old_force_well_known = std::env::var("PERRY_FORCE_WELL_KNOWN").ok();
+
+        set_env_var(
+            "PERRY_FORCE_WELL_KNOWN",
+            Some("http, node:net ws definitely-not-real"),
+        );
+        let ctx = CompilationContext::new(std::env::current_dir().expect("cwd"));
+        let modules = well_known_iteration_set(&ctx);
+
+        set_env_var("PERRY_FORCE_WELL_KNOWN", old_force_well_known.as_deref());
+
+        assert!(modules.contains("http"));
+        assert!(modules.contains("net"));
+        assert!(modules.contains("ws"));
+        assert!(!modules.contains("node:net"));
+        assert!(!modules.contains("definitely-not-real"));
     }
 
     #[test]

--- a/test-parity/node-suite/http/agent/socket-event-introspection.ts
+++ b/test-parity/node-suite/http/agent/socket-event-introspection.ts
@@ -1,3 +1,5 @@
+// parity-env: PERRY_FORCE_WELL_KNOWN=http,net,ws
+//
 // Issue #2211 — EventEmitter introspection on a net.Socket. Tests in
 // the `test-http-agent-*` and `test-http-server-*` families call
 // `socket.listeners('timeout')`, `socket.eventNames()`,


### PR DESCRIPTION
## Summary
- Adds `PERRY_FORCE_WELL_KNOWN` so no-auto parity runs can request additional well-known archives that are not visible from import scanning alone.
- Includes the new env key in the build-cache fingerprint.
- Marks `node-suite/http/agent/socket-event-introspection` to link the HTTP/net/ws well-known archives under no-auto mode.

## Issue
- Supports one compile-failure slice of #2132: the HTTP socket introspection fixture imported `node:net`, but the no-auto prebuilt stdlib path also referenced HTTP extension symbols, leaving the link missing HTTP-related archives.

## Why This Batch
- This keeps the behavior change limited to link dependency selection for no-auto parity fixtures. It does not change HTTP runtime semantics.

## Tests
- `cargo test -p perry forced_well_known_env_extends_iteration_set -- --nocapture`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module http --filter socket-event-introspection`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module http` - 17 pass / 0 fail / 0 compile fail on the rebased branch
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib -p perry-ext-http -p perry-ext-net -p perry-ext-ws --features perry-stdlib/external-http-server-pump,perry-stdlib/external-http-client-pump`
- `cargo check -p perry`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known Limitations
- HTTPS/http2 inventory and broader HTTP runtime semantics are left untouched. This patch is only for no-auto well-known link dependency selection.