### PR TITLE
fix(hir): reject globalThis Symbol BigInt constructors

### DIFF
--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -263,8 +263,14 @@ fn is_fetch_constructor_name(name: &str) -> bool {
 }
 
 fn is_global_object_expr(ctx: &LoweringContext, expr: &Expr) -> bool {
-    matches!(expr, Expr::GlobalGet(_))
-        || matches!(expr, Expr::LocalGet(id) if ctx.global_this_aliases.contains(id))
+    match expr {
+        Expr::GlobalGet(_) => true,
+        Expr::LocalGet(id) => ctx.global_this_aliases.contains(id),
+        Expr::PropertyGet { object, property } => {
+            property == "globalThis" && matches!(object.as_ref(), Expr::GlobalGet(_))
+        }
+        _ => false,
+    }
 }
 
 pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> Result<Expr> {
@@ -1676,7 +1682,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 .transpose()?
                 .unwrap_or_default();
             if let Expr::PropertyGet { object, property } = callee.as_ref() {
-                if matches!(object.as_ref(), Expr::GlobalGet(_))
+                if is_global_object_expr(ctx, object.as_ref())
                     && matches!(property.as_str(), "Symbol" | "BigInt" | "Math")
                 {
                     return Ok(nonconstructable_builtin_throw_expr(property, args));

--- a/test-features/feature_matrix.md
+++ b/test-features/feature_matrix.md
@@ -12,7 +12,7 @@ Summary: 19/22 probes pass across 14 categories.
 | async | await-order | PASS | async/await-order:a:4\|b:6 |
 | classes | inheritance | PASS | class:hi perry! |
 | classes | mixin-expression | PASS | classes/mixin-expression:tag:base |
-| classes | private-static-fields | DIFF | Node `classes/private-static-fields:2,2` vs Perry `classes/private-static-fields:NaN,NaN` |
+| classes | private-static-fields | RUNTIME-FAIL | Perry exit 1: TypeError: Cannot read properties of undefined (reading '#total') |
 | closures | basic | PASS | closure:15:22 |
 | closures | captured-mutation | PASS | closures/captured-mutation:6,12 |
 | collections | map-set | PASS | map-set:2:2,4 |
@@ -29,7 +29,7 @@ Summary: 19/22 probes pass across 14 categories.
 | syntax | destructuring-defaults | PASS | syntax/destructuring-defaults:a:2,n2:0 |
 | syntax | optional-call | PASS | optional:0:7:skip |
 | syntax | optional-nullish | PASS | syntax/optional-nullish:fallback,ok |
-| typed-arrays | uint8array-basic | DIFF | Node `typed-array:3:1,9,3:1` vs Perry `typed-array:3:undefined:undefined` |
+| typed-arrays | uint8array-basic | DIFF | Node `typed-array:3:1,9,3:1` vs Perry `typed-array:3:undefined:1` |
 
 ## Categories
 

--- a/test-features/probes/classes/private-static-fields.ts
+++ b/test-features/probes/classes/private-static-fields.ts
@@ -1,0 +1,16 @@
+class Counter {
+  #value = 1;
+  static #total = 1;
+
+  next() {
+    this.#value += 1;
+    return this.#value;
+  }
+
+  static next() {
+    this.#total += 1;
+    return this.#total;
+  }
+}
+
+console.log(`classes/private-static-fields:${new Counter().next()},${Counter.next()}`);


### PR DESCRIPTION
## Summary
- Recognize reified `globalThis` value reads as the global object in dynamic `new` lowering.
- Route `new (globalThis.Symbol as any)(...)` and `new (globalThis.BigInt as any)(...)` through the existing nonconstructable TypeError helpers while preserving argument evaluation.
- Keep the same guard working for known `globalThis` aliases and `Math`.
- Restore the missing `classes/private-static-fields` feature-matrix probe and refresh generated matrix rows so CI can run the configured matrix.

## Tests
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module globals --filter symbol-bigint-new-throws`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module globals --filter symbol`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" ./run_parity_tests.sh --suite node-suite --module globals --filter bigint`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" python3 scripts/gen_feature_matrix.py --check --node-bin node --perry-bin target/release/perry --report .feature-matrix/feature_matrix.json --generated-output .feature-matrix/feature_matrix.md`
- `cargo build --release --quiet -p perry -p perry-runtime -p perry-stdlib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Refs #3146