### PR TITLE
fix(runtime): new on a primitive throws TypeError (not a constructor)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1207,6 +1207,24 @@ pub unsafe extern "C" fn js_new_function_construct(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    // `new <primitive>()` is a TypeError — a primitive is never a constructor
+    // (`new undefined()`, `new 5n()`, `new "s"()`, `new true()`). Checked via
+    // the unambiguous NaN-box tags only (NOT `is_number`, whose f64 range
+    // overlaps the raw-i64 pointer encoding of module-level objects). Without
+    // this, `new x.method()` where `x.method` reads back `undefined`, and other
+    // primitive callees, silently fell through to the empty-object fallback.
+    {
+        let jv = crate::value::JSValue::from_bits(func_value.to_bits());
+        if jv.is_undefined()
+            || jv.is_null()
+            || jv.is_bool()
+            || jv.is_int32()
+            || jv.is_any_string()
+            || jv.is_bigint()
+        {
+            super::object_ops::throw_object_type_error(b"is not a constructor");
+        }
+    }
     // #3656: `new p()` where `p` is a Proxy dispatches through its `construct`
     // trap (or forwards to the target). Reached when the compiler can't prove
     // the callee is a proxy statically (e.g. `new record.proxy()`). newTarget


### PR DESCRIPTION
## Summary

`new <primitive>()` must throw a `TypeError` ("X is not a constructor") — a primitive is never a constructor. Perry silently fell through to its empty-object fallback:
```
new undefined()  new 5n()  new "s"()  new true()   // Node: TypeError;  Perry: returned an object
```

## Fix

Guard `js_new_function_construct` on the **unambiguous primitive NaN-box tags** (undefined / null / bool / int32 / string / bigint). `is_number` is intentionally excluded because its f64 range overlaps the raw-i64 pointer encoding of module-level objects, so testing it could mis-fire on real object callees.

## Results

- Fixes `test262 built-ins/Date/prototype/toJSON/not-a-constructor.js` (its `new date.toJSON()` is effectively `new undefined()`).
- `built-ins/Function` **220 → 216**; `language/expressions/new` unchanged at 34 (no regression).
- Real constructors verified unaffected (`class`, `Date`, `Map`, user function, `Array`); Node-identical in both `PERRY_NO_AUTO_OPTIMIZE` and default builds; `cargo test -p perry-runtime --lib` 983 passed.

Spec-safe: a primitive can never satisfy `IsConstructor`, so this can only fix or be neutral — never break a conformant program.
