### PR TITLE
fix(date): Date instance methods readable as values (d.getTime / d.toJSON)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2243,6 +2243,28 @@ pub extern "C" fn js_object_get_field_by_name(
                         let v = js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
                         return JSValue::from_bits(v.to_bits());
                     }
+                    // A Date method read as a *value* (`const f = d.getTime`,
+                    // `typeof d.toISOString`, `d.toJSON === Date.prototype.toJSON`)
+                    // resolves to the same thunk installed on `Date.prototype`.
+                    // The `d.method()` call form is handled by codegen's fast
+                    // path and never reaches here, so this only affects value
+                    // reads. Unknown keys still return undefined.
+                    let date_ctor = js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
+                    let cv = JSValue::from_bits(date_ctor.to_bits());
+                    if cv.is_pointer() {
+                        let ctor_ptr = cv.as_pointer::<crate::closure::ClosureHeader>() as usize;
+                        let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+                        let pv = JSValue::from_bits(proto.to_bits());
+                        if pv.is_pointer() {
+                            let proto_ptr = pv.as_pointer::<ObjectHeader>();
+                            if !proto_ptr.is_null() {
+                                let m = js_object_get_field_by_name(proto_ptr, key);
+                                if !m.is_undefined() {
+                                    return JSValue::from_bits(m.bits());
+                                }
+                            }
+                        }
+                    }
                 }
             }
             return JSValue::undefined();


### PR DESCRIPTION
## Summary

Closes #4481. Reading a Date method off an **instance** returned `undefined`:
```js
const d = new Date();
typeof d.getTime          // was "undefined" → "function"
d.toJSON === Date.prototype.toJSON   // was false → true
const f = d.getTime; f.call(d);      // f was undefined → works
```
`DateCell` instances aren't `ObjectHeader`-backed, so the property-read path returned `undefined` for everything except `constructor` — only the `d.method()` *call* form worked (codegen fast path).

## Fix

The `DateCell` read path now resolves a method name to the same thunk installed on `Date.prototype` (identity preserved). Method extraction, `typeof`, and reflective comparisons now work; unknown keys still return `undefined`; the `d.method()` call fast path is unchanged.

## Results

Node-identical in **both** build modes: `typeof`/identity/extracted-`.call`, normal `d.getFullYear()`/`d.getTime()` still correct (no fast-path regression), and `new d.toJSON()` throws `TypeError` (now because `toJSON` is a non-constructable *function*, matching Node's reason — completing `built-ins/Date/prototype/toJSON/not-a-constructor.js`). `built-ins/Date` unchanged at 33 (no regression); `cargo test -p perry-runtime --lib` 983 passed.
