### PR TITLE
fix(date): expose instance method values

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -34,8 +34,8 @@ use crate::type_analysis::{
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
 use super::property_get_names::{
-    is_headers_method_name, is_http_client_request_method_name, is_net_native_method_value,
-    is_url_pattern_data_property,
+    is_builtin_prototype_method_value, is_date_prototype_method_name, is_headers_method_name,
+    is_http_client_request_method_name, is_net_native_method_value, is_url_pattern_data_property,
 };
 #[allow(unused_imports)]
 use super::{
@@ -100,16 +100,27 @@ fn lower_class_method_bind(
     ))
 }
 
-fn is_primitive_builtin_proto_method(builtin_name: &str, method_name: &str) -> bool {
-    match builtin_name {
-        "Number" => matches!(
-            method_name,
-            "toExponential" | "toFixed" | "toLocaleString" | "toPrecision" | "toString" | "valueOf"
-        ),
-        "Boolean" | "Symbol" => matches!(method_name, "toString" | "valueOf"),
-        "BigInt" => matches!(method_name, "toString" | "valueOf"),
-        _ => false,
-    }
+fn lower_builtin_prototype_method_value(
+    ctx: &mut FnCtx<'_>,
+    builtin_name: &str,
+    method_name: &str,
+) -> String {
+    let builtin_idx = ctx.strings.intern(builtin_name);
+    let builtin_bytes_global = format!("@{}", ctx.strings.entry(builtin_idx).bytes_global);
+    let builtin_len = builtin_name.len().to_string();
+    let method_idx = ctx.strings.intern(method_name);
+    let method_bytes_global = format!("@{}", ctx.strings.entry(method_idx).bytes_global);
+    let method_len = method_name.len().to_string();
+    ctx.block().call(
+        DOUBLE,
+        "js_builtin_prototype_method_value",
+        &[
+            (PTR, &builtin_bytes_global),
+            (I64, &builtin_len),
+            (PTR, &method_bytes_global),
+            (I64, &method_len),
+        ],
+    )
 }
 
 fn builtin_prototype_method_read<'a>(
@@ -136,7 +147,7 @@ fn builtin_prototype_method_read<'a>(
     if !matches!(global_object.as_ref(), Expr::GlobalGet(_)) {
         return None;
     }
-    is_primitive_builtin_proto_method(builtin_name, property)
+    is_builtin_prototype_method_value(builtin_name, property)
         .then_some((builtin_name.as_str(), property))
 }
 
@@ -454,24 +465,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if let Some((builtin_name, method_name)) =
                 builtin_prototype_method_read(object, property)
             {
-                let builtin_idx = ctx.strings.intern(builtin_name);
-                let builtin_bytes_global =
-                    format!("@{}", ctx.strings.entry(builtin_idx).bytes_global);
-                let builtin_len = builtin_name.len().to_string();
-                let method_idx = ctx.strings.intern(method_name);
-                let method_bytes_global =
-                    format!("@{}", ctx.strings.entry(method_idx).bytes_global);
-                let method_len = method_name.len().to_string();
-                return Ok(ctx.block().call(
-                    DOUBLE,
-                    "js_builtin_prototype_method_value",
-                    &[
-                        (PTR, &builtin_bytes_global),
-                        (I64, &builtin_len),
-                        (PTR, &method_bytes_global),
-                        (I64, &method_len),
-                    ],
+                return Ok(lower_builtin_prototype_method_value(
+                    ctx,
+                    builtin_name,
+                    method_name,
                 ));
+            }
+            if is_date_prototype_method_name(property)
+                && (matches!(object.as_ref(), Expr::DateNew(_))
+                    || matches!(receiver_class_name(ctx, object).as_deref(), Some("Date")))
+            {
+                return Ok(lower_builtin_prototype_method_value(ctx, "Date", property));
             }
             // date-fns `constructFrom(date, value)` reads `date.constructor`
             // to clone Dates without naming Date directly. Perry stores

--- a/crates/perry-codegen/src/expr/property_get_names.rs
+++ b/crates/perry-codegen/src/expr/property_get_names.rs
@@ -114,6 +114,70 @@ pub(super) fn is_net_native_method_value(class_name: &str, name: &str) -> bool {
     }
 }
 
+pub(super) fn is_date_prototype_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "getTime"
+            | "valueOf"
+            | "getFullYear"
+            | "getMonth"
+            | "getDate"
+            | "getHours"
+            | "getMinutes"
+            | "getSeconds"
+            | "getMilliseconds"
+            | "getDay"
+            | "getUTCFullYear"
+            | "getUTCMonth"
+            | "getUTCDate"
+            | "getUTCHours"
+            | "getUTCMinutes"
+            | "getUTCSeconds"
+            | "getUTCMilliseconds"
+            | "getUTCDay"
+            | "getTimezoneOffset"
+            | "getYear"
+            | "setTime"
+            | "setFullYear"
+            | "setMonth"
+            | "setDate"
+            | "setHours"
+            | "setMinutes"
+            | "setSeconds"
+            | "setMilliseconds"
+            | "setYear"
+            | "setUTCFullYear"
+            | "setUTCMonth"
+            | "setUTCDate"
+            | "setUTCHours"
+            | "setUTCMinutes"
+            | "setUTCSeconds"
+            | "setUTCMilliseconds"
+            | "toDateString"
+            | "toISOString"
+            | "toJSON"
+            | "toLocaleDateString"
+            | "toLocaleString"
+            | "toLocaleTimeString"
+            | "toString"
+            | "toTimeString"
+            | "toUTCString"
+    )
+}
+
+pub(super) fn is_builtin_prototype_method_value(builtin_name: &str, method_name: &str) -> bool {
+    match builtin_name {
+        "Number" => matches!(
+            method_name,
+            "toExponential" | "toFixed" | "toLocaleString" | "toPrecision" | "toString" | "valueOf"
+        ),
+        "Boolean" | "Symbol" => matches!(method_name, "toString" | "valueOf"),
+        "BigInt" => matches!(method_name, "toString" | "valueOf"),
+        "Date" => is_date_prototype_method_name(method_name),
+        _ => false,
+    }
+}
+
 pub(super) fn is_url_pattern_data_property(name: &str) -> bool {
     matches!(
         name,

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -464,10 +464,9 @@ unsafe fn bind_closure_value_to_receiver(value: JSValue, receiver: f64) -> JSVal
     JSValue::from_bits(crate::closure::clone_closure_rebind_this(bits, receiver))
 }
 
-unsafe fn primitive_builtin_prototype_property(
+unsafe fn builtin_prototype_property_value(
     builtin_name: &[u8],
     key: *const crate::StringHeader,
-    receiver: f64,
 ) -> Option<JSValue> {
     if key.is_null() {
         return None;
@@ -491,7 +490,30 @@ unsafe fn primitive_builtin_prototype_property(
     if value.is_undefined() {
         return None;
     }
+    Some(value)
+}
+
+unsafe fn primitive_builtin_prototype_property(
+    builtin_name: &[u8],
+    key: *const crate::StringHeader,
+    receiver: f64,
+) -> Option<JSValue> {
+    let value = builtin_prototype_property_value(builtin_name, key)?;
     Some(bind_closure_value_to_receiver(value, receiver))
+}
+
+unsafe fn date_cell_property_value(key: *const crate::StringHeader) -> Option<JSValue> {
+    if key.is_null() {
+        return None;
+    }
+    let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let key_len = (*key).byte_len as usize;
+    let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+    if key_bytes == b"constructor" {
+        let v = js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
+        return Some(JSValue::from_bits(v.to_bits()));
+    }
+    builtin_prototype_property_value(b"Date", key)
 }
 
 unsafe fn string_index_value(str_value: f64, key: *const crate::StringHeader) -> Option<JSValue> {
@@ -2219,8 +2241,9 @@ pub extern "C" fn js_object_get_field_by_name(
     // read as a value) must NOT fall through to the object-deref path below —
     // the cell is far smaller than an `ObjectHeader`, so reading its
     // `keys_array`/field slots would deref unmapped memory. Resolve the few
-    // meaningful reads here and return `undefined` for everything else
-    // (matching property reads on the old value-type Date). `obj` may arrive
+    // meaningful reads here and return `undefined` for everything else.
+    // Prototype method reads are resolved from `Date.prototype` so `d.getTime`
+    // has the same identity as `Date.prototype.getTime`. `obj` may arrive
     // NaN-boxed (top16 == 0x7FFD) or as a raw-I64 pointer (top16 == 0).
     {
         let bits = obj as u64;
@@ -2235,13 +2258,8 @@ pub extern "C" fn js_object_get_field_by_name(
         if addr != 0 && crate::date::is_date_cell_addr(addr) {
             if !key.is_null() {
                 unsafe {
-                    let key_ptr =
-                        (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-                    let key_len = (*key).byte_len as usize;
-                    let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
-                    if key_bytes == b"constructor" {
-                        let v = js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
-                        return JSValue::from_bits(v.to_bits());
+                    if let Some(v) = date_cell_property_value(key) {
+                        return v;
                     }
                 }
             }
@@ -4391,6 +4409,14 @@ pub extern "C" fn js_object_get_field_ic_miss(
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
     if (obj as usize) < 0x10000 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    if crate::date::is_date_cell_addr(obj as usize) {
+        unsafe {
+            if let Some(value) = date_cell_property_value(key) {
+                return f64::from_bits(value.bits());
+            }
+        }
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
     // When accessors are active anywhere in the program, skip the cache

--- a/test-parity/node-suite/globals/date-method-values.ts
+++ b/test-parity/node-suite/globals/date-method-values.ts
@@ -1,0 +1,62 @@
+const d = new Date(0);
+
+function log(label: string, value: unknown) {
+  console.log(`${label}:`, String(value));
+}
+
+function logErrorName(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(`${label}: no-error`);
+  } catch (err) {
+    console.log(`${label}:`, (err as Error).name);
+  }
+}
+
+const opaque: any = d;
+const typedGetTime = d.getTime;
+const typedToISOString = d.toISOString;
+const typedToJSON = d.toJSON;
+const getTime = opaque.getTime;
+const getTimeByIndex = opaque["getTime"];
+const toISOString = opaque.toISOString;
+const toJSON = opaque.toJSON;
+const setTime = opaque.setTime;
+const valueOf = opaque.valueOf;
+
+log("typed typeof getTime", typeof typedGetTime);
+log("typed typeof toISOString", typeof typedToISOString);
+log("typed typeof toJSON", typeof typedToJSON);
+log("typed getTime identity", typedGetTime === Date.prototype.getTime);
+log("typed toISOString identity", typedToISOString === Date.prototype.toISOString);
+log("typed toJSON identity", typedToJSON === Date.prototype.toJSON);
+log("typed getTime call", typedGetTime.call(d));
+log("typed toISOString call", typedToISOString.call(d));
+log("typed toJSON call", typedToJSON.call(d));
+
+log("opaque typeof getTime", typeof getTime);
+log("opaque typeof toISOString", typeof toISOString);
+log("opaque typeof toJSON", typeof toJSON);
+log("getTime identity", getTime === Date.prototype.getTime);
+log("getTime index identity", getTimeByIndex === Date.prototype.getTime);
+log("toISOString identity", toISOString === Date.prototype.toISOString);
+log("toJSON identity", toJSON === Date.prototype.toJSON);
+log("valueOf identity", valueOf === Date.prototype.valueOf);
+log("getTime call", getTime.call(d));
+log("getTime index call", getTimeByIndex.call(d));
+log("toISOString call", toISOString.call(d));
+log("toJSON call", toJSON.call(d));
+log("valueOf call", valueOf.call(d));
+
+const originalGetTime = Date.prototype.getTime;
+(Date.prototype as any).getTime = function () {
+  return 77;
+};
+const overriddenGetTime = opaque.getTime;
+log("overridden getTime identity", overriddenGetTime === Date.prototype.getTime);
+log("overridden getTime call", overriddenGetTime.call(d));
+Date.prototype.getTime = originalGetTime;
+
+log("setTime call", setTime.call(d, 1234));
+log("after setTime", d.getTime());
+logErrorName("new toJSON", () => new opaque.toJSON());


### PR DESCRIPTION
## Summary

Fixes #4481.

`Date` instances are `DateCell` pointers, so reading a method value like
`d.getTime` was not traversing the `Date.prototype` method table. Direct calls
such as `d.getTime()` still worked because codegen lowers those to Date
intrinsics, but extracted methods read as `undefined`.

This PR:

- returns `Date.prototype` method values for known-Date property reads in
  codegen, preserving identity such as `d.getTime === Date.prototype.getTime`;
- mirrors that resolution in the runtime DateCell field-get paths for opaque /
  `any` receivers and bracket reads;
- keeps `date.constructor` on the existing global `Date` constructor path;
- adds parity coverage for typed Date reads, opaque reads, bracket reads,
  extracted `.call`, prototype override behavior, setter extraction, and
  `new d.toJSON()` TypeError behavior.

## Validation

- Reproduced pre-fix Perry output: `typeof d.getTime` / `toISOString` /
  `toJSON` were `undefined`, and extracted `.call` failed.
- Node 26 vs Perry diff is empty for
  `test-parity/node-suite/globals/date-method-values.ts` with
  `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_NO_CACHE=1`.
- `cargo build -p perry`
- `cargo check -q -p perry-runtime --lib`
- `cargo check -q -p perry-codegen --lib`
- `cargo test -q -p perry-runtime date_to_json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
