### PR TITLE
fix(runtime): align Atomics.waitAsync receivers

### DIFF
--- a/crates/perry-runtime/src/atomics.rs
+++ b/crates/perry-runtime/src/atomics.rs
@@ -154,24 +154,6 @@ fn atomics_view_arg(value: f64) -> AtomicView {
     throw_type_error(b"Atomics operation requires an integer typed array");
 }
 
-fn atomics_int32_view_arg(value: f64) -> AtomicView {
-    let js = JSValue::from_bits(value.to_bits());
-    if !js.is_pointer() {
-        throw_type_error(b"Atomics wait/notify requires an Int32Array");
-    }
-    let raw = clean_ta_ptr(js.as_pointer::<TypedArrayHeader>()) as usize;
-    if raw == 0 {
-        throw_type_error(b"Atomics wait/notify requires an Int32Array");
-    }
-    if lookup_typed_array_kind(raw) == Some(KIND_INT32) {
-        return AtomicView::TypedArray {
-            ptr: raw as *mut TypedArrayHeader,
-            kind: KIND_INT32,
-        };
-    }
-    throw_type_error(b"Atomics wait/notify requires an Int32Array");
-}
-
 fn atomics_wait_notify_view_arg(value: f64) -> AtomicView {
     let js = JSValue::from_bits(value.to_bits());
     if !js.is_pointer() {
@@ -394,12 +376,6 @@ fn typed_array_set_bigint_bits(ta: *mut TypedArrayHeader, index: i32, value: u64
 
 fn slot(view: f64, index: f64) -> (AtomicView, i32) {
     let view = atomics_view_arg(view);
-    let idx = atomics_to_index(index, view.length());
-    (view, idx)
-}
-
-fn int32_slot(view: f64, index: f64) -> (AtomicView, i32) {
-    let view = atomics_int32_view_arg(view);
     let idx = atomics_to_index(index, view.length());
     (view, idx)
 }
@@ -660,10 +636,28 @@ pub extern "C" fn js_atomics_wait_async(
     expected: f64,
     timeout: f64,
 ) -> f64 {
-    let (view, idx) = int32_slot(view, index);
-    let expected = coerce_for_kind(KIND_INT32, expected);
+    let (view, idx) = wait_notify_slot(view, index);
+    if !view.has_shared_backing() {
+        throw_type_error(b"Atomics.waitAsync requires a shared typed array");
+    }
+    let kind = view.kind();
+    let expected_bigint_bits = if kind == KIND_BIGINT64 {
+        bigint_bits(expected)
+    } else {
+        0
+    };
+    let expected_i32 = if kind == KIND_BIGINT64 {
+        0.0
+    } else {
+        coerce_for_kind(KIND_INT32, expected)
+    };
     let timeout = number_arg(timeout);
-    if view.get_numeric(idx) != expected {
+    let mismatched = if kind == KIND_BIGINT64 {
+        view.get_bigint_bits(idx) != expected_bigint_bits
+    } else {
+        view.get_numeric(idx) != expected_i32
+    };
+    if mismatched {
         return wait_async_result(false, string_value(b"not-equal"));
     }
     if timeout <= 0.0 {

--- a/test-parity/node-suite/globals/atomics-wait-async.ts
+++ b/test-parity/node-suite/globals/atomics-wait-async.ts
@@ -13,7 +13,9 @@ function showErr(label, fn) {
 }
 
 const sab = new SharedArrayBuffer(8);
+const ab = new ArrayBuffer(8);
 const i32 = new Int32Array(sab, 0, 2);
+const localI32 = new Int32Array(ab, 0, 2);
 
 show("typeof waitAsync", typeof Atomics.waitAsync);
 show("waitAsync length", Atomics.waitAsync.length);
@@ -32,4 +34,28 @@ show("negative async", negative.async);
 show("negative value", negative.value);
 
 showErr("waitAsync uint8 shared", () => Atomics.waitAsync(new Uint8Array(sab, 0, 8), 0, 0, 0));
+showErr("waitAsync i32 nonshared", () => Atomics.waitAsync(localI32, 0, 0, 0));
 showErr("waitAsync oob", () => Atomics.waitAsync(i32, 99, 0, 0));
+
+const bigSab = new SharedArrayBuffer(16);
+const bigAb = new ArrayBuffer(16);
+const bigI64 = new BigInt64Array(bigSab, 0, 2);
+const localBigI64 = new BigInt64Array(bigAb, 0, 2);
+const bigU64 = new BigUint64Array(bigSab, 0, 2);
+
+const bigMismatch = Atomics.waitAsync(bigI64, 0, 1n, 0);
+show("big mismatch keys", Object.keys(bigMismatch).join("|"));
+show("big mismatch async", bigMismatch.async);
+show("big mismatch value", bigMismatch.value);
+
+const bigZero = Atomics.waitAsync(bigI64, 0, 0n, 0);
+show("big zero async", bigZero.async);
+show("big zero value", bigZero.value);
+
+const bigNegative = Atomics.waitAsync(bigI64, 0, 0n, -1);
+show("big negative async", bigNegative.async);
+show("big negative value", bigNegative.value);
+
+showErr("waitAsync big number expected", () => Atomics.waitAsync(bigI64, 0, 0, 0));
+showErr("waitAsync big nonshared", () => Atomics.waitAsync(localBigI64, 0, 0n, 0));
+showErr("waitAsync biguint shared", () => Atomics.waitAsync(bigU64, 0, 0n, 0));


### PR DESCRIPTION
Refs #2876.

## Summary
- route `Atomics.waitAsync()` through the shared Int32Array/BigInt64Array wait receiver path instead of the old Int32-only helper
- reject non-shared typed-array waitAsync receivers before returning an immediate result
- extend the Atomics waitAsync parity fixture for non-shared Int32Array, BigInt64Array immediate results, BigInt expected-value validation, non-shared BigInt64Array, and BigUint64Array rejection

## Validation
- Reproduced pre-fix Perry failure: BigInt64Array `Atomics.waitAsync()` threw `TypeError: Atomics wait/notify requires an Int32Array`
- Direct Node 26 vs Perry debug output diff for all Atomics fixtures: `atomics-basic`, `atomics-bitwise`, `atomics-bigint`, `atomics-wait-notify`, `atomics-wait-notify-receivers`, `atomics-wait-async`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-builtin-namespace-method-values-20260604/target CARGO_BUILD_JOBS=1 RUSTFLAGS="-Awarnings" cargo check -q -p perry-runtime --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`