### PR TITLE
fix(node/zlib): align one-shot buffers and callbacks

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1977,7 +1977,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0"), ZLIB_OPTIONS_PARAM],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -1985,7 +1985,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0")],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -1993,7 +1993,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0"), ZLIB_OPTIONS_PARAM],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2001,7 +2001,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0")],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2027,7 +2027,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::Any,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2035,7 +2035,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::Any,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2043,7 +2043,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::Any,
+        TypeSpec::Buffer,
     ),
     // `crc32(data, seed?)` — `seed` is the running CRC from a prior chunk
     // so callers can stream a long input. Dispatch declares 2 args; mirror
@@ -2141,7 +2141,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2149,7 +2149,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2174,7 +2174,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0"), ZLIB_OPTIONS_PARAM],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2182,7 +2182,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0"), ZLIB_OPTIONS_PARAM],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -32,6 +32,7 @@ use crate::type_analysis::{
 #[allow(unused_imports)]
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
+use super::arrays_finds::lower_buffer_index_get_i32;
 #[allow(unused_imports)]
 use super::{
     buffer_access_materialization_reason, buffer_alias_metadata_suffix, can_lower_expr_as_i32,
@@ -71,7 +72,7 @@ fn is_width_tracked_typed_array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool
 fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     matches!(
         receiver_class_name(ctx, object).as_deref(),
-        Some("Uint8Array")
+        Some("Buffer" | "Uint8Array")
     )
 }
 
@@ -530,6 +531,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     "js_typed_array_index_get_dynamic",
                     &[(I64, &arr_i64), (DOUBLE, &key_box)],
                 ));
+            }
+            if is_uint8array_receiver(ctx, object) && is_numeric_expr(ctx, index) {
+                let value = lower_buffer_index_get_i32(ctx, object, index)?;
+                let reason = buffer_access_materialization_reason(ctx, object);
+                return Ok(materialize_js_value(ctx, value, reason));
             }
             // Scalar-replaced array literal: `arr[k]` where arr was bound to
             // `[...]` and never escaped, and k is a compile-time index in

--- a/crates/perry-ext-zlib/src/lib.rs
+++ b/crates/perry-ext-zlib/src/lib.rs
@@ -1,15 +1,14 @@
 //! Native bindings for Node's `zlib` module — gzip, gunzip,
 //! deflate, inflate. Sync + async variants.
 //!
-//! First binary-bytes wrapper port under #466 Phase 5 — exercises
-//! perry-ffi's `read_bytes` / `alloc_bytes` helpers (added in
-//! v0.5.x alongside the JsValue surface). Compressed payloads
-//! aren't valid UTF-8, so the wrapper can't go through the
-//! standard `read_string` / `alloc_string` path.
+//! First binary-bytes wrapper port under #466 Phase 5 — reads input bytes from
+//! strings/Buffers and returns registered runtime Buffers. Compressed payloads
+//! aren't valid UTF-8, so the wrapper can't go through the standard
+//! `read_string` / `alloc_string` path.
 
 use flate2::read::{GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder};
 use flate2::Compression;
-use perry_ffi::{alloc_bytes, spawn_blocking, JsPromise, JsValue, Promise, StringHeader};
+use perry_ffi::{alloc_buffer, BufferHeader};
 use std::io::Read;
 
 // #1843 — Transform-stream objects (`createGzip`/`createDeflate`/… with
@@ -17,15 +16,6 @@ use std::io::Read;
 // module to keep this file under the 2000-line size gate.
 mod stream;
 pub use stream::*;
-
-unsafe fn read_input(ptr: *const StringHeader) -> Option<Vec<u8>> {
-    // #1843: route through the buffer-aware reader so `gzipSync` / `gunzipSync`
-    // / `deflateSync` / `inflateSync` accept real Buffers/Uint8Arrays (e.g.
-    // `gunzipSync(Buffer.concat(chunks))`, `gunzipSync(fs.readFileSync(...))`),
-    // not just StringHeader-shaped inputs. Falls back to the StringHeader path
-    // for JS strings / our own `alloc_bytes` outputs.
-    stream::read_input_bytes(ptr)
-}
 
 fn gzip_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
     gzip_bytes_with(data, Compression::default())
@@ -83,12 +73,12 @@ fn inflate_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
 /// `opts` is the raw NaN-boxed options value (or `undefined`); an out-of-range
 /// `{ level }` throws `RangeError` before any compression runs (#2935).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut BufferHeader {
     stream::js_zlib_validate_options(opts, 9); // gzip needs windowBits >= 9 (#3662)
     stream::js_zlib_validate_buffer_arg(data_bits); // options validate before the buffer
     let level = stream::compression_from_opts(opts);
     match stream::read_input_from_bits(data_bits).map(|d| gzip_bytes_with(&d, level)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -99,10 +89,10 @@ pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut St
 ///
 /// `data_bits` is the raw NaN-box bit pattern of the data argument (#2935).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut BufferHeader {
     stream::js_zlib_validate_buffer_arg(data_bits); // #3662
     match stream::read_input_from_bits(data_bits).map(|d| gunzip_bytes(&d)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -115,12 +105,12 @@ pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut StringHeade
 /// the raw NaN-boxed options value. An out-of-range `{ level }` throws
 /// `RangeError` before any compression runs (#2935).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut BufferHeader {
     stream::js_zlib_validate_options(opts, 8); // deflate accepts windowBits >= 8 (#3662)
     stream::js_zlib_validate_buffer_arg(data_bits);
     let level = stream::compression_from_opts(opts);
     match stream::read_input_from_bits(data_bits).map(|d| deflate_bytes_with(&d, level)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -131,10 +121,10 @@ pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut
 ///
 /// `data_bits` is the raw NaN-box bit pattern of the data argument (#2935).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_inflate_sync(data_bits: i64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_inflate_sync(data_bits: i64) -> *mut BufferHeader {
     stream::js_zlib_validate_buffer_arg(data_bits); // #3662
     match stream::read_input_from_bits(data_bits).map(|d| inflate_bytes(&d)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -142,74 +132,42 @@ pub unsafe extern "C" fn js_zlib_inflate_sync(data_bits: i64) -> *mut StringHead
 // `zlib.createBrotliDecompress` and the other `create*` Transform-stream
 // factories now live in `stream.rs` (returning real stream handles).
 
-// ── async variants ────────────────────────────────────────────
+// ── callback variants ─────────────────────────────────────────
 
-unsafe fn async_op<F>(data_ptr: *const StringHeader, label: &'static str, op: F) -> *mut Promise
-where
-    F: FnOnce(&[u8]) -> std::io::Result<Vec<u8>> + Send + 'static,
-{
-    let promise = JsPromise::new();
-    let raw = promise.as_raw();
-
-    let Some(data) = read_input(data_ptr) else {
-        promise.reject_string("Invalid input data");
-        return raw;
-    };
-
-    spawn_blocking(move || match op(&data) {
-        Ok(out) => {
-            // Compressed payloads aren't valid UTF-8. perry-stdlib's
-            // existing zlib NaN-boxes the result as POINTER_TAG so
-            // the runtime never tries to read it as a string —
-            // TS-side `Buffer` / typed-array consumers see it as
-            // an opaque pointer with raw bytes underneath. Same
-            // trick here.
-            let bytes_handle = alloc_bytes(&out);
-            promise.resolve(JsValue::from_object_ptr(bytes_handle.as_raw()));
-        }
-        Err(e) => promise.reject_string(&format!("{} error: {}", label, e)),
-    });
-    raw
-}
-
-/// `zlib.gzip(data) -> Promise<Buffer>`.
+/// `zlib.gzip(data, callback) -> undefined`.
 ///
 /// # Safety
-///
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+/// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_gzip(data_ptr: *const StringHeader) -> *mut Promise {
-    async_op(data_ptr, "Gzip", |b| gzip_bytes(b))
+pub unsafe extern "C" fn js_zlib_gzip(data_value: f64, callback_value: f64) {
+    stream::queue_one_shot_callback(data_value, callback_value, "Gzip", |b| gzip_bytes(b));
 }
 
-/// `zlib.gunzip(data) -> Promise<Buffer>`.
+/// `zlib.gunzip(data, callback) -> undefined`.
 ///
 /// # Safety
-///
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+/// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_gunzip(data_ptr: *const StringHeader) -> *mut Promise {
-    async_op(data_ptr, "Gunzip", |b| gunzip_bytes(b))
+pub unsafe extern "C" fn js_zlib_gunzip(data_value: f64, callback_value: f64) {
+    stream::queue_one_shot_callback(data_value, callback_value, "Gunzip", |b| gunzip_bytes(b));
 }
 
-/// `zlib.deflate(data) -> Promise<Buffer>`.
+/// `zlib.deflate(data, callback) -> undefined`.
 ///
 /// # Safety
-///
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+/// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_deflate(data_ptr: *const StringHeader) -> *mut Promise {
-    async_op(data_ptr, "Deflate", |b| deflate_bytes(b))
+pub unsafe extern "C" fn js_zlib_deflate(data_value: f64, callback_value: f64) {
+    stream::queue_one_shot_callback(data_value, callback_value, "Deflate", |b| deflate_bytes(b));
 }
 
-/// `zlib.inflate(data) -> Promise<Buffer>`.
+/// `zlib.inflate(data, callback) -> undefined`.
 ///
 /// # Safety
-///
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+/// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_inflate(data_ptr: *const StringHeader) -> *mut Promise {
-    async_op(data_ptr, "Inflate", |b| inflate_bytes(b))
+pub unsafe extern "C" fn js_zlib_inflate(data_value: f64, callback_value: f64) {
+    stream::queue_one_shot_callback(data_value, callback_value, "Inflate", |b| inflate_bytes(b));
 }
 
 #[cfg(test)]
@@ -235,16 +193,8 @@ mod tests {
         assert_eq!(decompressed, input);
     }
 
-    // The FFI-round-trip path (alloc_bytes(non_utf8_bytes) →
-    // js_string_from_bytes → compute_utf16_len with non-UTF-8
-    // input) hits a debug-mode-only `unsafe precondition` panic
-    // in std's char iteration. perry-runtime's
-    // `from_utf8_unchecked` works correctly in release mode (the
-    // utf16_len value is meaningless but the StringHeader payload
-    // is intact and the binary is recoverable through
-    // POINTER_TAG access). End-to-end TS smoke tests in release
-    // mode are the integration coverage; unit tests stay scoped
-    // to pure-Rust gzip / gunzip correctness above.
+    // End-to-end TS smoke tests cover the FFI Buffer allocation path.
+    // Unit tests stay scoped to pure-Rust gzip / gunzip correctness above.
     #[test]
     #[allow(dead_code)]
     fn _placeholder() {

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -18,9 +18,8 @@
 //! registered after `.write()` still fire and `.pipe()` can forward chunks.
 
 use perry_ffi::{
-    alloc_buffer, alloc_bytes, alloc_string, gc_register_mutable_root_scanner_named,
-    notify_main_thread, BufferHeader, GcRootVisitor, JsClosure, JsValue, RawClosureHeader,
-    StringHeader,
+    alloc_buffer, alloc_string, gc_register_mutable_root_scanner_named, notify_main_thread,
+    BufferHeader, GcRootVisitor, JsClosure, JsValue, RawClosureHeader, StringHeader,
 };
 use std::collections::HashMap;
 use std::io::{Read, Write};
@@ -40,6 +39,8 @@ const TRUE_BITS: u64 = 0x7FFC_0000_0000_0004;
 // perry-runtime `#[no_mangle]` symbols, resolved at final link (perry-runtime
 // is always linked). Mirrors perry-ext-net's extern usage.
 extern "C" {
+    fn js_register_aux_has_active(f: extern "C" fn() -> i32);
+    fn js_register_aux_pump(f: extern "C" fn() -> i32);
     fn js_buffer_is_buffer(ptr: i64) -> i32;
     fn js_get_string_pointer_unified(value: f64) -> i64;
     // #2935: resolve + validate a `{ level }` option to a flate2 level
@@ -68,6 +69,18 @@ extern "C" {
         args_ptr: *const f64,
         args_len: usize,
     ) -> f64;
+}
+
+extern "C" fn process_pending_aux() -> i32 {
+    unsafe { js_ext_zlib_process_pending() }
+}
+
+fn ensure_aux_pump_registered() {
+    static REGISTER: std::sync::Once = std::sync::Once::new();
+    REGISTER.call_once(|| unsafe {
+        js_register_aux_pump(process_pending_aux);
+        js_register_aux_has_active(js_ext_zlib_has_active_handles);
+    });
 }
 
 // ── Brotli one-shots (#1843 cluster 2) ───────────────────────────────────────
@@ -139,10 +152,10 @@ pub(crate) unsafe fn compression_from_opts(opts: f64) -> Compression {
 /// # Safety
 /// `data_bits` must be the raw NaN-box bit pattern of the data argument.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_bits: i64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_bits: i64) -> *mut BufferHeader {
     js_zlib_validate_buffer_arg(data_bits);
     match read_input_from_bits(data_bits) {
-        Some(d) => alloc_bytes(&brotli_compress_bytes(&d)).as_raw(),
+        Some(d) => alloc_buffer(&brotli_compress_bytes(&d)),
         None => std::ptr::null_mut(),
     }
 }
@@ -152,55 +165,34 @@ pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_bits: i64) -> *mut St
 /// # Safety
 /// `data_bits` must be the raw NaN-box bit pattern of the data argument.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_bits: i64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_bits: i64) -> *mut BufferHeader {
     js_zlib_validate_buffer_arg(data_bits);
     match read_input_from_bits(data_bits).map(|d| brotli_decompress_bytes(&d)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
 
-/// `zlib.brotliCompress(data)` -> Promise<Buffer>.
+/// `zlib.brotliCompress(data, callback)` -> undefined.
 ///
 /// # Safety
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
+/// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_compress(
-    data_ptr: *const StringHeader,
-) -> *mut perry_ffi::Promise {
-    brotli_async(data_ptr, "BrotliCompress", |b| Ok(brotli_compress_bytes(b)))
-}
-
-/// `zlib.brotliDecompress(data)` -> Promise<Buffer>.
-///
-/// # Safety
-/// `data_ptr` must be null or a Perry-runtime `StringHeader`.
-#[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_decompress(
-    data_ptr: *const StringHeader,
-) -> *mut perry_ffi::Promise {
-    brotli_async(data_ptr, "BrotliDecompress", |b| brotli_decompress_bytes(b))
-}
-
-unsafe fn brotli_async<F>(
-    data_ptr: *const StringHeader,
-    label: &'static str,
-    op: F,
-) -> *mut perry_ffi::Promise
-where
-    F: FnOnce(&[u8]) -> std::io::Result<Vec<u8>> + Send + 'static,
-{
-    let promise = perry_ffi::JsPromise::new();
-    let raw = promise.as_raw();
-    let Some(data) = read_input_bytes(data_ptr) else {
-        promise.reject_string("Invalid input data");
-        return raw;
-    };
-    perry_ffi::spawn_blocking(move || match op(&data) {
-        Ok(out) => promise.resolve(JsValue::from_object_ptr(alloc_bytes(&out).as_raw())),
-        Err(e) => promise.reject_string(&format!("{} error: {}", label, e)),
+pub unsafe extern "C" fn js_zlib_brotli_compress(data_value: f64, callback_value: f64) {
+    queue_one_shot_callback(data_value, callback_value, "BrotliCompress", |b| {
+        Ok(brotli_compress_bytes(b))
     });
-    raw
+}
+
+/// `zlib.brotliDecompress(data, callback)` -> undefined.
+///
+/// # Safety
+/// `data_value` and `callback_value` are raw NaN-boxed JS values.
+#[no_mangle]
+pub unsafe extern "C" fn js_zlib_brotli_decompress(data_value: f64, callback_value: f64) {
+    queue_one_shot_callback(data_value, callback_value, "BrotliDecompress", |b| {
+        brotli_decompress_bytes(b)
+    });
 }
 
 // ── stream codec ─────────────────────────────────────────────────────────────
@@ -384,6 +376,8 @@ enum ZlibEvent {
     /// `.flush(cb)` completion callback — invoked (0 args) after its flushed
     /// 'data' is delivered.
     Callback(i64),
+    /// `zlib.gzip(data, cb)` style one-shot completion callback.
+    OneShotCallback(i64, Result<Vec<u8>, String>),
 }
 
 struct Statics {
@@ -425,11 +419,14 @@ fn scan_zlib_roots(visitor: &mut GcRootVisitor<'_>) {
                 }
             }
         }
-        // `.flush(cb)` callbacks queued but not yet drained are referenced only
-        // here — root them too, same hazard as listeners.
+        // Queued callbacks are referenced only here — root them too, same
+        // hazard as listeners.
         for ev in s.pending.iter_mut() {
-            if let ZlibEvent::Callback(cb) = ev {
-                visitor.visit_i64_slot(cb);
+            match ev {
+                ZlibEvent::Callback(cb) | ZlibEvent::OneShotCallback(cb, _) => {
+                    visitor.visit_i64_slot(cb);
+                }
+                _ => {}
             }
         }
     }
@@ -523,6 +520,61 @@ unsafe fn make_buffer_f64(bytes: &[u8]) -> Option<f64> {
         return None;
     }
     Some(f64::from_bits(POINTER_TAG | (buf as u64 & POINTER_MASK)))
+}
+
+fn callback_ptr(value: f64) -> i64 {
+    let bits = value.to_bits();
+    if JsValue::from_bits(bits).is_pointer() {
+        (bits & POINTER_MASK) as i64
+    } else {
+        0
+    }
+}
+
+unsafe fn call_one_shot_callback(callback: i64, result: Result<Vec<u8>, String>) {
+    if callback == 0 {
+        return;
+    }
+    match result {
+        Ok(bytes) => {
+            let err = f64::from_bits(JsValue::NULL.bits());
+            let out = make_buffer_f64(&bytes)
+                .unwrap_or_else(|| f64::from_bits(JsValue::UNDEFINED.bits()));
+            let _ = JsClosure::from_raw(callback as *const RawClosureHeader).call2(err, out);
+        }
+        Err(msg) => {
+            let err = build_error_object(&msg);
+            let _ = JsClosure::from_raw(callback as *const RawClosureHeader)
+                .call2(err, f64::from_bits(JsValue::UNDEFINED.bits()));
+        }
+    }
+}
+
+pub(crate) unsafe fn queue_one_shot_callback<F>(
+    data_value: f64,
+    callback_value: f64,
+    label: &'static str,
+    op: F,
+) where
+    F: FnOnce(&[u8]) -> std::io::Result<Vec<u8>>,
+{
+    let data_bits = data_value.to_bits() as i64;
+    js_zlib_validate_buffer_arg(data_bits);
+    let result = match read_input_from_bits(data_bits) {
+        Some(data) => op(&data).map_err(|e| format!("{} error: {}", label, e)),
+        None => Err("Invalid input data".to_string()),
+    };
+    ensure_aux_pump_registered();
+    ensure_gc_scanner_registered();
+    statics()
+        .lock()
+        .unwrap()
+        .pending
+        .push(ZlibEvent::OneShotCallback(
+            callback_ptr(callback_value),
+            result,
+        ));
+    notify_main_thread();
 }
 
 unsafe fn event_name(value: f64) -> Option<String> {
@@ -888,6 +940,9 @@ pub unsafe extern "C" fn js_ext_zlib_process_pending() -> i32 {
                 if cb != 0 {
                     let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call0();
                 }
+            }
+            ZlibEvent::OneShotCallback(cb, result) => {
+                call_one_shot_callback(cb, result);
             }
             ZlibEvent::Error(id, msg) => {
                 let err_f64 = build_error_object(&msg);

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -4169,11 +4169,11 @@ declare module "zlib" {
   /** stdlib */
   export function brotliCompress(buffer: any, callback: any): void;
   /** stdlib */
-  export function brotliCompressSync(p0: string): string;
+  export function brotliCompressSync(p0: string): Buffer;
   /** stdlib */
   export function brotliDecompress(buffer: any, callback: any): void;
   /** stdlib */
-  export function brotliDecompressSync(p0: string): string;
+  export function brotliDecompressSync(p0: string): Buffer;
   /** stdlib */
   export function crc32(p0: string, seed?: number): number;
   /** stdlib */
@@ -4203,35 +4203,35 @@ declare module "zlib" {
   /** stdlib */
   export function deflateRaw(buffer: any, callback: any): void;
   /** stdlib */
-  export function deflateRawSync(p0: string): any;
+  export function deflateRawSync(p0: string): Buffer;
   /** stdlib */
-  export function deflateSync(p0: any, options?: any): string;
+  export function deflateSync(p0: any, options?: any): Buffer;
   /** stdlib */
   export function gunzip(buffer: any, callback: any): void;
   /** stdlib */
-  export function gunzipSync(p0: any): string;
+  export function gunzipSync(p0: any): Buffer;
   /** stdlib */
   export function gzip(buffer: any, callback: any): void;
   /** stdlib */
-  export function gzipSync(p0: any, options?: any): string;
+  export function gzipSync(p0: any, options?: any): Buffer;
   /** stdlib */
   export function inflate(buffer: any, callback: any): void;
   /** stdlib */
   export function inflateRaw(buffer: any, callback: any): void;
   /** stdlib */
-  export function inflateRawSync(p0: string): any;
+  export function inflateRawSync(p0: string): Buffer;
   /** stdlib */
-  export function inflateSync(p0: any): string;
+  export function inflateSync(p0: any): Buffer;
   /** stdlib */
   export function unzip(buffer: any, callback: any): void;
   /** stdlib */
-  export function unzipSync(p0: string): any;
+  export function unzipSync(p0: string): Buffer;
   /** stdlib */
   export function zstdCompress(buffer: any, callback: any): void;
   /** stdlib */
-  export function zstdCompressSync(p0: any, options?: any): string;
+  export function zstdCompressSync(p0: any, options?: any): Buffer;
   /** stdlib */
   export function zstdDecompress(buffer: any, callback: any): void;
   /** stdlib */
-  export function zstdDecompressSync(p0: any, options?: any): string;
+  export function zstdDecompressSync(p0: any, options?: any): Buffer;
 }

--- a/test-parity/node-suite/zlib/gzip/magic-bytes.ts
+++ b/test-parity/node-suite/zlib/gzip/magic-bytes.ts
@@ -1,6 +1,7 @@
 import { gzipSync } from "node:zlib";
 
 const compressed = gzipSync(Buffer.from("magic"));
+console.log("is buffer:", Buffer.isBuffer(compressed));
 console.log("magic 0:", compressed[0].toString(16));
 console.log("magic 1:", compressed[1].toString(16));
 console.log("method:", compressed[2]);

--- a/test-parity/node-suite/zlib/validation/one-shot-return-buffers.ts
+++ b/test-parity/node-suite/zlib/validation/one-shot-return-buffers.ts
@@ -1,0 +1,28 @@
+import * as zlib from "node:zlib";
+
+const input = Buffer.from("buffer-shape");
+
+const cases: Array<[string, Buffer]> = [
+  ["gzip", zlib.gzipSync(input)],
+  ["gunzip", zlib.gunzipSync(zlib.gzipSync(input))],
+  ["deflate", zlib.deflateSync(input)],
+  ["inflate", zlib.inflateSync(zlib.deflateSync(input))],
+  ["deflateRaw", zlib.deflateRawSync(input)],
+  ["inflateRaw", zlib.inflateRawSync(zlib.deflateRawSync(input))],
+  ["unzip-gzip", zlib.unzipSync(zlib.gzipSync(input))],
+  ["unzip-deflate", zlib.unzipSync(zlib.deflateSync(input))],
+  ["brotliCompress", zlib.brotliCompressSync(input)],
+  ["brotliDecompress", zlib.brotliDecompressSync(zlib.brotliCompressSync(input))],
+  ["zstdCompress", zlib.zstdCompressSync(input)],
+  ["zstdDecompress", zlib.zstdDecompressSync(zlib.zstdCompressSync(input))],
+];
+
+for (const [label, value] of cases) {
+  console.log(
+    `${label}:`,
+    Buffer.isBuffer(value),
+    value instanceof Uint8Array,
+    typeof value.length,
+    typeof value[0],
+  );
+}


### PR DESCRIPTION
## Linked issues

- Part of #2013

## Summary

This PR fixes the zlib one-shot byte-output cluster and the external callback pump path for no-auto builds.

Changes:

- Return registered runtime Buffers from external zlib sync one-shots (`gzipSync`, `gunzipSync`, `deflateSync`, `inflateSync`) and Brotli one-shots instead of binary string-shaped pointers.
- Resolve external async zlib/Brotli one-shot promises with runtime Buffers.
- Align external zlib callback one-shots with the native-table callback ABI and register aux pump/active-handle hooks so callback/promisified one-shots drain in no-auto builds.
- Mark byte-returning zlib manifest entries as `TypeSpec::Buffer`, including raw/unzip/Brotli/Zstd entries that already return byte buffers at runtime.
- Lower numeric indexing on statically known `Buffer`/`Uint8Array` receivers through the runtime byte accessor so `buf[0]` sees real bytes.
- Extend `zlib/gzip/magic-bytes` to assert `Buffer.isBuffer` and add `zlib/validation/one-shot-return-buffers` for direct Buffer identity, Uint8Array inheritance, length shape, and numeric indexing coverage across sync one-shot byte-returning APIs.

## Why this cut

These failures share the same zlib one-shot output/pump path: Node expects one-shot codec outputs to be Buffers that can be indexed, concatenated, passed back into zlib, and delivered through callback/promise APIs. Stream object methods, invalid compressed payload error semantics, and gzip multi-member semantics are kept as follow-up cuts.

## Verification

- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target cargo check -p perry-codegen -p perry-api-manifest -p perry-ext-zlib`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target cargo test -p perry-api-manifest`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib --filter magic-bytes'` → 1 pass / 0 fail / 0 compile fail
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib --filter one-shot-return-buffers'` → 1 pass / 0 fail / 0 compile fail
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib'` → 48 pass / 10 fail / 0 compile fail

Baseline before this zlib cut on `2e0551cb9`: 24 pass / 33 fail / 0 compile fail. The remaining 10 zlib failures are invalid payload throw behavior, gzip multi-member handling, stream instance methods/round trip, and callback-required output details.

## Non-goals

- Implement zlib transform stream instance methods or stream round trips.
- Normalize invalid compressed payload throw/error details.
- Implement gzip multi-member concatenation semantics.
- Broaden #2013 beyond this zlib one-shot Buffer/callback/materialization cluster.