### PR TITLE
fix(node/zlib): return buffers from one-shot codecs

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1977,7 +1977,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0"), ZLIB_OPTIONS_PARAM],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -1985,7 +1985,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0")],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -1993,7 +1993,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0"), ZLIB_OPTIONS_PARAM],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2001,7 +2001,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0")],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2027,7 +2027,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::Any,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2035,7 +2035,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::Any,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2043,7 +2043,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::Any,
+        TypeSpec::Buffer,
     ),
     // `crc32(data, seed?)` — `seed` is the running CRC from a prior chunk
     // so callers can stream a long input. Dispatch declares 2 args; mirror
@@ -2141,7 +2141,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2149,7 +2149,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_str("p0")],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2174,7 +2174,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0"), ZLIB_OPTIONS_PARAM],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",
@@ -2182,7 +2182,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         false,
         None,
         &[p_any("p0"), ZLIB_OPTIONS_PARAM],
-        TypeSpec::String,
+        TypeSpec::Buffer,
     ),
     method_sig(
         "zlib",

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -32,6 +32,7 @@ use crate::type_analysis::{
 #[allow(unused_imports)]
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
+use super::arrays_finds::lower_buffer_index_get_i32;
 #[allow(unused_imports)]
 use super::{
     buffer_access_materialization_reason, buffer_alias_metadata_suffix, can_lower_expr_as_i32,
@@ -71,7 +72,7 @@ fn is_width_tracked_typed_array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool
 fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     matches!(
         receiver_class_name(ctx, object).as_deref(),
-        Some("Uint8Array")
+        Some("Buffer" | "Uint8Array")
     )
 }
 
@@ -530,6 +531,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     "js_typed_array_index_get_dynamic",
                     &[(I64, &arr_i64), (DOUBLE, &key_box)],
                 ));
+            }
+            if is_uint8array_receiver(ctx, object) && is_numeric_expr(ctx, index) {
+                let value = lower_buffer_index_get_i32(ctx, object, index)?;
+                let reason = buffer_access_materialization_reason(ctx, object);
+                return Ok(materialize_js_value(ctx, value, reason));
             }
             // Scalar-replaced array literal: `arr[k]` where arr was bound to
             // `[...]` and never escaped, and k is a compile-time index in

--- a/crates/perry-ext-zlib/src/lib.rs
+++ b/crates/perry-ext-zlib/src/lib.rs
@@ -2,14 +2,16 @@
 //! deflate, inflate. Sync + async variants.
 //!
 //! First binary-bytes wrapper port under #466 Phase 5 — exercises
-//! perry-ffi's `read_bytes` / `alloc_bytes` helpers (added in
+//! perry-ffi's byte-reading / Buffer allocation helpers (added in
 //! v0.5.x alongside the JsValue surface). Compressed payloads
 //! aren't valid UTF-8, so the wrapper can't go through the
 //! standard `read_string` / `alloc_string` path.
 
 use flate2::read::{GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder};
 use flate2::Compression;
-use perry_ffi::{alloc_bytes, spawn_blocking, JsPromise, JsValue, Promise, StringHeader};
+use perry_ffi::{
+    alloc_buffer, spawn_blocking, BufferHeader, JsPromise, JsValue, Promise, StringHeader,
+};
 use std::io::Read;
 
 // #1843 — Transform-stream objects (`createGzip`/`createDeflate`/… with
@@ -83,12 +85,12 @@ fn inflate_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
 /// `opts` is the raw NaN-boxed options value (or `undefined`); an out-of-range
 /// `{ level }` throws `RangeError` before any compression runs (#2935).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut BufferHeader {
     stream::js_zlib_validate_options(opts, 9); // gzip needs windowBits >= 9 (#3662)
     stream::js_zlib_validate_buffer_arg(data_bits); // options validate before the buffer
     let level = stream::compression_from_opts(opts);
     match stream::read_input_from_bits(data_bits).map(|d| gzip_bytes_with(&d, level)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -99,10 +101,10 @@ pub unsafe extern "C" fn js_zlib_gzip_sync(data_bits: i64, opts: f64) -> *mut St
 ///
 /// `data_bits` is the raw NaN-box bit pattern of the data argument (#2935).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut BufferHeader {
     stream::js_zlib_validate_buffer_arg(data_bits); // #3662
     match stream::read_input_from_bits(data_bits).map(|d| gunzip_bytes(&d)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -115,12 +117,12 @@ pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut StringHeade
 /// the raw NaN-boxed options value. An out-of-range `{ level }` throws
 /// `RangeError` before any compression runs (#2935).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut BufferHeader {
     stream::js_zlib_validate_options(opts, 8); // deflate accepts windowBits >= 8 (#3662)
     stream::js_zlib_validate_buffer_arg(data_bits);
     let level = stream::compression_from_opts(opts);
     match stream::read_input_from_bits(data_bits).map(|d| deflate_bytes_with(&d, level)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -131,10 +133,10 @@ pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut
 ///
 /// `data_bits` is the raw NaN-box bit pattern of the data argument (#2935).
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_inflate_sync(data_bits: i64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_inflate_sync(data_bits: i64) -> *mut BufferHeader {
     stream::js_zlib_validate_buffer_arg(data_bits); // #3662
     match stream::read_input_from_bits(data_bits).map(|d| inflate_bytes(&d)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -158,14 +160,8 @@ where
 
     spawn_blocking(move || match op(&data) {
         Ok(out) => {
-            // Compressed payloads aren't valid UTF-8. perry-stdlib's
-            // existing zlib NaN-boxes the result as POINTER_TAG so
-            // the runtime never tries to read it as a string —
-            // TS-side `Buffer` / typed-array consumers see it as
-            // an opaque pointer with raw bytes underneath. Same
-            // trick here.
-            let bytes_handle = alloc_bytes(&out);
-            promise.resolve(JsValue::from_object_ptr(bytes_handle.as_raw()));
+            let bytes_handle = alloc_buffer(&out);
+            promise.resolve(JsValue::from_object_ptr(bytes_handle));
         }
         Err(e) => promise.reject_string(&format!("{} error: {}", label, e)),
     });

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -18,9 +18,8 @@
 //! registered after `.write()` still fire and `.pipe()` can forward chunks.
 
 use perry_ffi::{
-    alloc_buffer, alloc_bytes, alloc_string, gc_register_mutable_root_scanner_named,
-    notify_main_thread, BufferHeader, GcRootVisitor, JsClosure, JsValue, RawClosureHeader,
-    StringHeader,
+    alloc_buffer, alloc_string, gc_register_mutable_root_scanner_named, notify_main_thread,
+    BufferHeader, GcRootVisitor, JsClosure, JsValue, RawClosureHeader, StringHeader,
 };
 use std::collections::HashMap;
 use std::io::{Read, Write};
@@ -139,10 +138,10 @@ pub(crate) unsafe fn compression_from_opts(opts: f64) -> Compression {
 /// # Safety
 /// `data_bits` must be the raw NaN-box bit pattern of the data argument.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_bits: i64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_bits: i64) -> *mut BufferHeader {
     js_zlib_validate_buffer_arg(data_bits);
     match read_input_from_bits(data_bits) {
-        Some(d) => alloc_bytes(&brotli_compress_bytes(&d)).as_raw(),
+        Some(d) => alloc_buffer(&brotli_compress_bytes(&d)),
         None => std::ptr::null_mut(),
     }
 }
@@ -152,10 +151,10 @@ pub unsafe extern "C" fn js_zlib_brotli_compress_sync(data_bits: i64) -> *mut St
 /// # Safety
 /// `data_bits` must be the raw NaN-box bit pattern of the data argument.
 #[no_mangle]
-pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_bits: i64) -> *mut StringHeader {
+pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_bits: i64) -> *mut BufferHeader {
     js_zlib_validate_buffer_arg(data_bits);
     match read_input_from_bits(data_bits).map(|d| brotli_decompress_bytes(&d)) {
-        Some(Ok(out)) => alloc_bytes(&out).as_raw(),
+        Some(Ok(out)) => alloc_buffer(&out),
         _ => std::ptr::null_mut(),
     }
 }
@@ -197,7 +196,7 @@ where
         return raw;
     };
     perry_ffi::spawn_blocking(move || match op(&data) {
-        Ok(out) => promise.resolve(JsValue::from_object_ptr(alloc_bytes(&out).as_raw())),
+        Ok(out) => promise.resolve(JsValue::from_object_ptr(alloc_buffer(&out))),
         Err(e) => promise.reject_string(&format!("{} error: {}", label, e)),
     });
     raw

--- a/test-parity/node-suite/zlib/validation/one-shot-return-buffers.ts
+++ b/test-parity/node-suite/zlib/validation/one-shot-return-buffers.ts
@@ -1,0 +1,28 @@
+import * as zlib from "node:zlib";
+
+const input = Buffer.from("buffer-shape");
+
+const cases: Array<[string, Buffer]> = [
+  ["gzip", zlib.gzipSync(input)],
+  ["gunzip", zlib.gunzipSync(zlib.gzipSync(input))],
+  ["deflate", zlib.deflateSync(input)],
+  ["inflate", zlib.inflateSync(zlib.deflateSync(input))],
+  ["deflateRaw", zlib.deflateRawSync(input)],
+  ["inflateRaw", zlib.inflateRawSync(zlib.deflateRawSync(input))],
+  ["unzip-gzip", zlib.unzipSync(zlib.gzipSync(input))],
+  ["unzip-deflate", zlib.unzipSync(zlib.deflateSync(input))],
+  ["brotliCompress", zlib.brotliCompressSync(input)],
+  ["brotliDecompress", zlib.brotliDecompressSync(zlib.brotliCompressSync(input))],
+  ["zstdCompress", zlib.zstdCompressSync(input)],
+  ["zstdDecompress", zlib.zstdDecompressSync(zlib.zstdCompressSync(input))],
+];
+
+for (const [label, value] of cases) {
+  console.log(
+    `${label}:`,
+    Buffer.isBuffer(value),
+    value instanceof Uint8Array,
+    typeof value.length,
+    typeof value[0],
+  );
+}


### PR DESCRIPTION
## Linked issues

- Part of #2013

## Summary

This PR fixes a zlib one-shot byte-shape cluster where compressed or decompressed outputs were typed/materialized as string-ish or generic pointer values instead of Node-compatible `Buffer` values.

Changes:

- Return `BufferHeader` allocations from external zlib sync one-shots (`gzipSync`, `gunzipSync`, `deflateSync`, `inflateSync`) and Brotli one-shots.
- Resolve async one-shot zlib/Brotli promises with runtime Buffers instead of byte strings.
- Mark byte-returning zlib manifest entries as `TypeSpec::Buffer`, including raw/unzip/Brotli/Zstd entries that already return byte buffers at runtime.
- Lower numeric indexing on statically known `Buffer`/`Uint8Array` receivers through the runtime byte accessor so `buf[0]` sees real bytes.
- Add `node-suite/zlib/validation/one-shot-return-buffers` to assert Buffer identity, Uint8Array inheritance, length shape, and numeric indexing shape across the sync one-shot byte-returning APIs.

## Why this cut

The failing zlib cases shared the same surface: one-shot codec outputs needed to behave like Node Buffers for byte indexing, round trips, unzip auto-detection, and re-use as zlib inputs. This keeps stream object methods, invalid compressed payload error semantics, and gzip multi-member semantics as separate follow-up cuts.

## Verification

- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target cargo check -p perry-codegen -p perry-api-manifest -p perry-ext-zlib`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target cargo test -p perry-api-manifest`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib --filter magic-bytes'` → 1 pass / 0 fail / 0 compile fail
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib --filter one-shot-return-buffers'` → 1 pass / 0 fail / 0 compile fail
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib'` → 48 pass / 10 fail / 0 compile fail

Baseline before this cut on `2e0551cb9`: zlib was 24 pass / 33 fail / 0 compile fail. The remaining 10 failures are invalid payload throw behavior, gzip multi-member handling, stream instance methods/round trip, and callback-required output details.

## Non-goals

- Implement zlib transform stream instance methods or stream round trips.
- Normalize invalid compressed payload throw/error details.
- Implement gzip multi-member concatenation semantics.
- Broaden #2013 beyond this zlib one-shot Buffer/materialization cluster.
