### PR TITLE
test(timers): normalize immediate timeout ordering fixtures

### DIFF
--- a/test-parity/node-suite/timers/immediate/cross-clear-noop.ts
+++ b/test-parity/node-suite/timers/immediate/cross-clear-noop.ts
@@ -8,4 +8,5 @@ const timeout: any = setTimeout(() => events.push("timeout"), 1);
 clearImmediate(timeout as any);
 
 await new Promise<void>((resolve) => setTimeout(() => resolve(), 20));
-console.log(events.join(","));
+console.log("events length:", events.length);
+console.log("events sorted:", events.slice().sort().join(","));

--- a/test-parity/node-suite/timers/ordering/immediate-vs-timeout-main.ts
+++ b/test-parity/node-suite/timers/ordering/immediate-vs-timeout-main.ts
@@ -2,4 +2,5 @@ const events: string[] = [];
 setImmediate(() => events.push("immediate"));
 setTimeout(() => events.push("timeout"), 0);
 await new Promise(resolve => setTimeout(resolve, 30));
-console.log("events:", events.join(","));
+console.log("events length:", events.length);
+console.log("events sorted:", events.slice().sort().join(","));


### PR DESCRIPTION
Refs #800.

## Summary
- normalize `timers/ordering/immediate-vs-timeout-main` to assert both callbacks ran without depending on top-level `setImmediate` vs `setTimeout(..., 0)` order
- normalize `timers/immediate/cross-clear-noop` the same way, since that fixture is about cross-clear no-op behavior rather than phase ordering

## Validation
- `cargo fmt --all -- --check`
- `git diff --check HEAD`
- `./scripts/check_file_size.sh`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" timeout 600 ./run_parity_tests.sh --suite node-suite --module timers --filter immediate-vs-timeout-main`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" timeout 600 ./run_parity_tests.sh --suite node-suite --module timers --filter cross-clear-noop`
- pre-rebase: `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" timeout 1200 ./run_parity_tests.sh --suite node-suite --module timers` (90/90 pass)

Note: a post-rebase full timers rerun exited before fixture output, so the rebased branch was revalidated with the two changed focused filters above.