### PR TITLE
[codex] fix runtime async generator request queue

### DIFF
--- a/crates/perry-runtime/src/object/async_generator_queue.rs
+++ b/crates/perry-runtime/src/object/async_generator_queue.rs
@@ -1,0 +1,416 @@
+//! Request queue wrapper for lowered `async function*` instances.
+//!
+//! Perry lowers a generator call to an object with own `next` / `return` /
+//! `throw` closures. For async generators those closures already return
+//! promises, but calling a second method in the same stack used to resume the
+//! state machine synchronously. ECMAScript async generators queue requests:
+//! same-stack follow-up requests resume from the microtask queue.
+
+use super::{js_object_get_own_field_or_undef, js_object_set_field_by_name, ObjectHeader};
+use crate::closure::{
+    js_closure_alloc, js_closure_call1, js_closure_get_capture_f64, js_closure_get_capture_ptr,
+    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
+};
+use crate::promise::{
+    js_promise_attach_settle_listener, js_promise_new, js_promise_reject, js_promise_resolve,
+    js_value_is_promise, Promise, PromiseState,
+};
+use crate::value::{js_nanbox_get_pointer, js_nanbox_pointer, JSValue, TAG_UNDEFINED};
+use std::cell::RefCell;
+use std::collections::VecDeque;
+
+struct AsyncGeneratorRequest {
+    original: *const ClosureHeader,
+    arg: f64,
+    promise: *mut Promise,
+}
+
+struct AsyncGeneratorQueueState {
+    active: bool,
+    drain_scheduled: bool,
+    queue: VecDeque<AsyncGeneratorRequest>,
+}
+
+thread_local! {
+    static STATES: RefCell<Vec<AsyncGeneratorQueueState>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(crate) fn wrap_async_generator_instance(obj: *mut ObjectHeader) {
+    if obj.is_null() {
+        return;
+    }
+
+    let Some(next) = own_closure(obj, b"next") else {
+        return;
+    };
+    if is_queue_wrapper(next) {
+        return;
+    }
+    let Some(ret) = own_closure(obj, b"return") else {
+        return;
+    };
+    let Some(throw) = own_closure(obj, b"throw") else {
+        return;
+    };
+
+    let state_id = STATES.with(|states| {
+        let mut states = states.borrow_mut();
+        let id = states.len() + 1;
+        states.push(AsyncGeneratorQueueState {
+            active: false,
+            drain_scheduled: false,
+            queue: VecDeque::new(),
+        });
+        id
+    });
+
+    set_method(
+        obj,
+        b"next",
+        make_method_wrapper(state_id, next, async_generator_next_wrapper),
+    );
+    set_method(
+        obj,
+        b"return",
+        make_method_wrapper(state_id, ret, async_generator_return_wrapper),
+    );
+    set_method(
+        obj,
+        b"throw",
+        make_method_wrapper(state_id, throw, async_generator_throw_wrapper),
+    );
+}
+
+pub(crate) fn scan_async_generator_queue_roots_mut(
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            for request in state.queue.iter_mut() {
+                visitor.visit_raw_const_ptr_slot(&mut request.original);
+                visitor.visit_nanbox_f64_slot(&mut request.arg);
+                visitor.visit_raw_mut_ptr_slot(&mut request.promise);
+            }
+        }
+    });
+}
+
+fn own_closure(obj: *mut ObjectHeader, name: &[u8]) -> Option<*const ClosureHeader> {
+    let value =
+        js_object_get_own_field_or_undef(js_nanbox_pointer(obj as i64), name.as_ptr(), name.len());
+    let js_value = JSValue::from_bits(value.to_bits());
+    if js_value.is_pointer() {
+        let ptr = js_value.as_pointer::<ClosureHeader>();
+        if crate::closure::is_closure_ptr(ptr as usize) {
+            return Some(ptr);
+        }
+    }
+    None
+}
+
+fn set_method(obj: *mut ObjectHeader, name: &[u8], closure: *mut ClosureHeader) {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(obj, key, js_nanbox_pointer(closure as i64));
+}
+
+fn make_method_wrapper(
+    state_id: usize,
+    original: *const ClosureHeader,
+    func: extern "C" fn(*const ClosureHeader, f64) -> f64,
+) -> *mut ClosureHeader {
+    let wrapper = js_closure_alloc(func as *const u8, 2);
+    js_closure_set_capture_f64(wrapper, 0, state_id as f64);
+    js_closure_set_capture_ptr(wrapper, 1, original as i64);
+    wrapper
+}
+
+fn make_settle_wrapper(
+    state_id: usize,
+    out: *mut Promise,
+    is_fulfilled: bool,
+) -> *mut ClosureHeader {
+    let func = if is_fulfilled {
+        async_generator_settle_fulfill as *const u8
+    } else {
+        async_generator_settle_reject as *const u8
+    };
+    let wrapper = js_closure_alloc(func, 2);
+    js_closure_set_capture_f64(wrapper, 0, state_id as f64);
+    js_closure_set_capture_ptr(wrapper, 1, out as i64);
+    wrapper
+}
+
+fn make_drain_wrapper(state_id: usize) -> *mut ClosureHeader {
+    let wrapper = js_closure_alloc(async_generator_drain_wrapper as *const u8, 1);
+    js_closure_set_capture_f64(wrapper, 0, state_id as f64);
+    wrapper
+}
+
+fn is_queue_wrapper(closure: *const ClosureHeader) -> bool {
+    if closure.is_null() {
+        return false;
+    }
+    let func = unsafe { (*closure).func_ptr };
+    func == async_generator_next_wrapper as *const u8
+        || func == async_generator_return_wrapper as *const u8
+        || func == async_generator_throw_wrapper as *const u8
+}
+
+fn state_id_from_wrapper(closure: *const ClosureHeader) -> Option<usize> {
+    if closure.is_null() {
+        return None;
+    }
+    let id = js_closure_get_capture_f64(closure, 0) as usize;
+    if id == 0 {
+        None
+    } else {
+        Some(id)
+    }
+}
+
+fn original_from_wrapper(closure: *const ClosureHeader) -> *const ClosureHeader {
+    js_closure_get_capture_ptr(closure, 1) as *const ClosureHeader
+}
+
+extern "C" fn async_generator_next_wrapper(closure: *const ClosureHeader, arg: f64) -> f64 {
+    async_generator_request(closure, arg)
+}
+
+extern "C" fn async_generator_return_wrapper(closure: *const ClosureHeader, arg: f64) -> f64 {
+    async_generator_request(closure, arg)
+}
+
+extern "C" fn async_generator_throw_wrapper(closure: *const ClosureHeader, arg: f64) -> f64 {
+    async_generator_request(closure, arg)
+}
+
+fn async_generator_request(closure: *const ClosureHeader, arg: f64) -> f64 {
+    let Some(state_id) = state_id_from_wrapper(closure) else {
+        return call_original(original_from_wrapper(closure), arg);
+    };
+    let original = original_from_wrapper(closure);
+
+    let should_queue = STATES.with(|states| {
+        let mut states = states.borrow_mut();
+        let Some(state) = states.get_mut(state_id - 1) else {
+            return false;
+        };
+        if state.active || !state.queue.is_empty() {
+            return true;
+        }
+        state.active = true;
+        false
+    });
+
+    if should_queue {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let original_handle = scope.root_raw_const_ptr(original);
+        let arg_handle = scope.root_nanbox_f64(arg);
+        let promise = js_promise_new();
+        let original = original_handle.get_raw_const_ptr::<ClosureHeader>();
+        let arg = arg_handle.get_nanbox_f64();
+        STATES.with(|states| {
+            if let Some(state) = states.borrow_mut().get_mut(state_id - 1) {
+                crate::gc::runtime_write_barrier_root_raw_ptr(original);
+                crate::gc::runtime_write_barrier_root_nanbox(arg.to_bits());
+                crate::gc::runtime_write_barrier_root_raw_ptr(promise);
+                state.queue.push_back(AsyncGeneratorRequest {
+                    original,
+                    arg,
+                    promise,
+                });
+            } else {
+                js_promise_reject(promise, f64::from_bits(TAG_UNDEFINED));
+            }
+        });
+        return boxed_promise(promise);
+    }
+
+    let result = call_original(original, arg);
+    after_initial_result(state_id, result);
+    result
+}
+
+extern "C" fn async_generator_drain_wrapper(closure: *const ClosureHeader) -> f64 {
+    if let Some(state_id) = state_id_from_wrapper(closure) {
+        process_one_queued_request(state_id);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn async_generator_settle_fulfill(closure: *const ClosureHeader, value: f64) -> f64 {
+    if let Some(state_id) = state_id_from_wrapper(closure) {
+        let out = js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+        finish_after_pending_result(state_id, out, true, value);
+    }
+    value
+}
+
+extern "C" fn async_generator_settle_reject(closure: *const ClosureHeader, reason: f64) -> f64 {
+    if let Some(state_id) = state_id_from_wrapper(closure) {
+        let out = js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+        finish_after_pending_result(state_id, out, false, reason);
+    }
+    reason
+}
+
+fn call_original(original: *const ClosureHeader, arg: f64) -> f64 {
+    if original.is_null() {
+        return boxed_promise(crate::promise::js_promise_rejected(f64::from_bits(
+            TAG_UNDEFINED,
+        )));
+    }
+    js_closure_call1(original, arg)
+}
+
+fn after_initial_result(state_id: usize, result: f64) {
+    if let Some(promise) = promise_ptr(result) {
+        let state = unsafe { (*promise).state };
+        if state == PromiseState::Pending {
+            attach_pending_settle(state_id, promise, std::ptr::null_mut());
+            return;
+        }
+    }
+    schedule_drain(state_id);
+}
+
+fn after_queued_result(state_id: usize, out: *mut Promise, result: f64) {
+    if let Some(promise) = promise_ptr(result) {
+        match unsafe { (*promise).state } {
+            PromiseState::Pending => {
+                attach_pending_settle(state_id, promise, out);
+            }
+            PromiseState::Fulfilled => {
+                let value = unsafe { (*promise).value };
+                finish_after_immediate_queued_result(state_id, out, true, value);
+            }
+            PromiseState::Rejected => {
+                let reason = unsafe { (*promise).reason };
+                finish_after_immediate_queued_result(state_id, out, false, reason);
+            }
+        }
+    } else {
+        finish_after_immediate_queued_result(state_id, out, true, result);
+    }
+}
+
+fn attach_pending_settle(state_id: usize, promise: *mut Promise, out: *mut Promise) {
+    let fulfill = make_settle_wrapper(state_id, out, true);
+    let reject = make_settle_wrapper(state_id, out, false);
+    js_promise_attach_settle_listener(promise, fulfill, reject);
+}
+
+fn process_one_queued_request(state_id: usize) {
+    let request_and_original = STATES.with(|states| {
+        let mut states = states.borrow_mut();
+        let Some(state) = states.get_mut(state_id - 1) else {
+            return None;
+        };
+        state.drain_scheduled = false;
+        let Some(request) = state.queue.pop_front() else {
+            state.active = false;
+            return None;
+        };
+        let original = request.original;
+        Some((request, original))
+    });
+
+    let Some((request, original)) = request_and_original else {
+        return;
+    };
+    let result = call_original(original, request.arg);
+    after_queued_result(state_id, request.promise, result);
+}
+
+fn finish_after_pending_result(state_id: usize, out: *mut Promise, fulfilled: bool, value: f64) {
+    let has_queue = STATES.with(|states| {
+        states
+            .borrow()
+            .get(state_id - 1)
+            .is_some_and(|state| !state.queue.is_empty())
+    });
+    if has_queue {
+        process_one_queued_request(state_id);
+    } else {
+        mark_inactive(state_id);
+    }
+    settle_out(out, fulfilled, value);
+}
+
+fn finish_after_immediate_queued_result(
+    state_id: usize,
+    out: *mut Promise,
+    fulfilled: bool,
+    value: f64,
+) {
+    let has_queue = STATES.with(|states| {
+        states
+            .borrow()
+            .get(state_id - 1)
+            .is_some_and(|state| !state.queue.is_empty())
+    });
+    if has_queue {
+        schedule_drain(state_id);
+    } else {
+        mark_inactive(state_id);
+    }
+    settle_out(out, fulfilled, value);
+}
+
+fn mark_inactive(state_id: usize) {
+    STATES.with(|states| {
+        if let Some(state) = states.borrow_mut().get_mut(state_id - 1) {
+            state.active = false;
+            state.drain_scheduled = false;
+        }
+    });
+}
+
+fn schedule_drain(state_id: usize) {
+    let should_schedule = STATES.with(|states| {
+        let mut states = states.borrow_mut();
+        let Some(state) = states.get_mut(state_id - 1) else {
+            return false;
+        };
+        if state.drain_scheduled {
+            return false;
+        }
+        state.drain_scheduled = true;
+        true
+    });
+    if should_schedule {
+        let closure = make_drain_wrapper(state_id);
+        crate::promise::enqueue_queue_microtask(closure as i64);
+    }
+}
+
+fn settle_out(out: *mut Promise, fulfilled: bool, value: f64) {
+    if out.is_null() {
+        return;
+    }
+    if fulfilled {
+        js_promise_resolve(out, value);
+    } else {
+        js_promise_reject(out, value);
+    }
+}
+
+fn promise_ptr(value: f64) -> Option<*mut Promise> {
+    if js_value_is_promise(value) == 0 {
+        return None;
+    }
+    let ptr = js_nanbox_get_pointer(value) as *mut Promise;
+    if ptr.is_null() {
+        None
+    } else {
+        Some(ptr)
+    }
+}
+
+fn boxed_promise(promise: *mut Promise) -> f64 {
+    if promise.is_null() {
+        f64::from_bits(TAG_UNDEFINED)
+    } else {
+        js_nanbox_pointer(promise as i64)
+    }
+}

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1997,6 +1997,9 @@ pub extern "C" fn js_generator_attach_prototype(obj: f64, is_async: i32) -> f64 
     if obj_ptr == 0 {
         return obj;
     }
+    if is_async != 0 {
+        super::async_generator_queue::wrap_async_generator_instance(obj_ptr as *mut ObjectHeader);
+    }
     let gen_proto = generator_prototype_ptr(is_async != 0);
     if gen_proto.is_null() {
         return obj;

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -21,6 +21,7 @@ mod alloc;
 mod arguments;
 mod array_object_ops;
 mod assert;
+mod async_generator_queue;
 mod bigint_dispatch;
 mod buffer_dispatch;
 mod class_constructors;
@@ -1414,6 +1415,7 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
         Ordering::Acquire,
         Ordering::Release,
     );
+    async_generator_queue::scan_async_generator_queue_roots_mut(visitor);
     visitor.visit_atomic_i64_slot(&LOCAL_STORAGE_PTR, Ordering::Acquire, Ordering::Release);
     visitor.visit_atomic_i64_slot(&SESSION_STORAGE_PTR, Ordering::Acquire, Ordering::Release);
     // Shared `%IteratorPrototype%`-style singletons for Array/Map/Set/String

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -54,7 +54,7 @@ pub use native_async::{
 };
 pub use scanners::{js_promise_with_resolvers, scan_promise_roots, scan_promise_roots_mut};
 pub(crate) use scanners::{new_promise_root_scan_state, scan_promise_roots_mut_step};
-pub(crate) use then::js_promise_attach_handlers;
+pub(crate) use then::{js_promise_attach_handlers, js_promise_attach_settle_listener};
 pub use then::{
     js_promise_bound_method, js_promise_catch, js_promise_finally, js_promise_free, js_promise_new,
     js_promise_reason, js_promise_reject, js_promise_resolve, js_promise_resolve_with_promise,

--- a/crates/perry-runtime/src/promise/scanners.rs
+++ b/crates/perry-runtime/src/promise/scanners.rs
@@ -111,6 +111,7 @@ pub fn scan_promise_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     });
 
     super::combinators::scan_promise_all_states_mut(visitor);
+    super::then::scan_promise_settle_listeners_mut(visitor);
 
     MICROTASK_PREV_CONTEXTS.with(|stack| {
         for context in stack.borrow_mut().iter_mut() {
@@ -137,9 +138,10 @@ const PROMISE_SCAN_INLINE_TRAP: u8 = 5;
 const PROMISE_SCAN_ASYNC_STEP_GUARD: u8 = 6;
 const PROMISE_SCAN_CONTEXTS: u8 = 7;
 const PROMISE_SCAN_ALL_STATES: u8 = 8;
-const PROMISE_SCAN_PREV_CONTEXTS: u8 = 9;
-const PROMISE_SCAN_SCHEDULED_RESOLVES: u8 = 10;
-const PROMISE_SCAN_DONE: u8 = 11;
+const PROMISE_SCAN_SETTLE_LISTENERS: u8 = 9;
+const PROMISE_SCAN_PREV_CONTEXTS: u8 = 10;
+const PROMISE_SCAN_SCHEDULED_RESOLVES: u8 = 11;
+const PROMISE_SCAN_DONE: u8 = 12;
 
 #[derive(Default)]
 pub(crate) struct PromiseRootScanState {
@@ -197,6 +199,9 @@ pub(crate) fn scan_promise_roots_mut_step(
             PROMISE_SCAN_ASYNC_STEP_GUARD => scan_async_step_guard_step(visitor, remaining),
             PROMISE_SCAN_CONTEXTS => scan_promise_contexts_step(visitor, state, remaining),
             PROMISE_SCAN_ALL_STATES => scan_promise_all_states_step(visitor, state, remaining),
+            PROMISE_SCAN_SETTLE_LISTENERS => {
+                scan_promise_settle_listeners_step(visitor, state, remaining)
+            }
             PROMISE_SCAN_PREV_CONTEXTS => scan_prev_contexts_step(visitor, state, remaining),
             PROMISE_SCAN_SCHEDULED_RESOLVES => {
                 scan_scheduled_resolves_step(visitor, state, remaining)
@@ -563,6 +568,43 @@ fn scan_promise_all_states_step(
     })
 }
 
+fn scan_promise_settle_listeners_step(
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+    state: &mut PromiseRootScanState,
+    remaining: &mut usize,
+) -> bool {
+    super::then::PROMISE_SETTLE_LISTENERS.with(|listeners| {
+        let mut listeners = listeners.borrow_mut();
+        while state.index < listeners.len() {
+            while state.slot < 3 {
+                if !consume_root_work(remaining) {
+                    return false;
+                }
+                let (key, listener) = &mut listeners[state.index];
+                match state.slot {
+                    0 => visitor.visit_metadata_usize_slot(key),
+                    1 => visitor.visit_raw_const_ptr_slot(&mut listener.on_fulfilled),
+                    2 => visitor.visit_raw_const_ptr_slot(&mut listener.on_rejected),
+                    _ => false,
+                };
+                state.slot += 1;
+            }
+            if !crate::async_context::scan_snapshot_roots_mut_step(
+                &mut listeners[state.index].1.context,
+                visitor,
+                &mut state.context_entry,
+                &mut state.context_store,
+                remaining,
+            ) {
+                return false;
+            }
+            state.index += 1;
+            state.finish_context_item();
+        }
+        true
+    })
+}
+
 fn scan_prev_contexts_step(
     visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
     state: &mut PromiseRootScanState,
@@ -822,6 +864,7 @@ pub(crate) fn test_clear_promise_scanner_roots() {
         })
     });
     super::combinators::SCHEDULED_RESOLVES.with(|q| q.borrow_mut().clear());
+    super::then::PROMISE_SETTLE_LISTENERS.with(|listeners| listeners.borrow_mut().clear());
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -29,6 +29,105 @@ unsafe fn store_promise_next_slot(
     crate::gc::runtime_store_gc_heap_word_slot(promise as usize, slot as usize, value as u64);
 }
 
+pub(super) struct PromiseSettleListener {
+    pub(super) on_fulfilled: ClosurePtr,
+    pub(super) on_rejected: ClosurePtr,
+    pub(super) context: AsyncContextSnapshot,
+}
+
+thread_local! {
+    pub(super) static PROMISE_SETTLE_LISTENERS: RefCell<Vec<(usize, PromiseSettleListener)>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+pub(crate) fn js_promise_attach_settle_listener(
+    promise: *mut Promise,
+    on_fulfilled: ClosurePtr,
+    on_rejected: ClosurePtr,
+) {
+    if promise.is_null() {
+        return;
+    }
+
+    let context = capture_context();
+    unsafe {
+        match (*promise).state {
+            PromiseState::Pending => {
+                crate::gc::runtime_write_barrier_root_raw_ptr(promise);
+                crate::gc::runtime_write_barrier_root_raw_ptr(on_fulfilled);
+                crate::gc::runtime_write_barrier_root_raw_ptr(on_rejected);
+                PROMISE_SETTLE_LISTENERS.with(|listeners| {
+                    listeners.borrow_mut().push((
+                        promise as usize,
+                        PromiseSettleListener {
+                            on_fulfilled,
+                            on_rejected,
+                            context,
+                        },
+                    ));
+                });
+            }
+            PromiseState::Fulfilled => {
+                enqueue_settle_listener_task(on_fulfilled, (*promise).value, true, context);
+            }
+            PromiseState::Rejected => {
+                enqueue_settle_listener_task(on_rejected, (*promise).reason, false, context);
+            }
+        }
+    }
+}
+
+fn promise_take_settle_listeners(promise: *mut Promise) -> Vec<PromiseSettleListener> {
+    if promise.is_null() {
+        return Vec::new();
+    }
+    PROMISE_SETTLE_LISTENERS.with(|listeners| {
+        let mut listeners = listeners.borrow_mut();
+        let key = promise as usize;
+        let mut drained = Vec::new();
+        let mut i = 0;
+        while i < listeners.len() {
+            if listeners[i].0 == key {
+                drained.push(listeners.swap_remove(i).1);
+            } else {
+                i += 1;
+            }
+        }
+        drained
+    })
+}
+
+fn enqueue_settle_listener_task(
+    callback: ClosurePtr,
+    value: f64,
+    is_fulfilled: bool,
+    context: AsyncContextSnapshot,
+) {
+    if callback.is_null() {
+        return;
+    }
+    TASK_QUEUE.with(|q| {
+        q.borrow_mut().push_back(Task::Inline(
+            callback,
+            value,
+            ptr::null_mut(),
+            is_fulfilled,
+            context,
+        ));
+    });
+}
+
+pub(super) fn scan_promise_settle_listeners_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    PROMISE_SETTLE_LISTENERS.with(|listeners| {
+        for (key, listener) in listeners.borrow_mut().iter_mut() {
+            visitor.visit_metadata_usize_slot(key);
+            visitor.visit_raw_const_ptr_slot(&mut listener.on_fulfilled);
+            visitor.visit_raw_const_ptr_slot(&mut listener.on_rejected);
+            scan_snapshot_roots_mut(&mut listener.context, visitor);
+        }
+    });
+}
+
 /// Allocate a new Promise
 #[no_mangle]
 pub extern "C" fn js_promise_new() -> *mut Promise {
@@ -150,12 +249,25 @@ pub extern "C" fn js_promise_resolve(promise: *mut Promise, value: f64) {
         // a NULL ClosurePtr sentinel — see expr.rs:GlobalGet→PropertyGet
         // value path) skipped the queue entirely; the chained promise then
         // never settled and `await chained` busy-waited forever.
+        let settle_listeners = promise_take_settle_listeners(promise);
+        let has_settle_listeners = !settle_listeners.is_empty();
         let promise_all_states = combinators::promise_all_take_all_handlers(promise);
         let has_normal_handler = !(*promise).on_fulfilled.is_null() || !(*promise).next.is_null();
-        if !promise_all_states.is_empty() || has_normal_handler {
+        if has_settle_listeners || !promise_all_states.is_empty() || has_normal_handler {
             let task_context = context_for_promise(promise);
             TASK_QUEUE.with(|q| {
                 let mut q = q.borrow_mut();
+                for listener in settle_listeners {
+                    if !listener.on_fulfilled.is_null() {
+                        q.push_back(Task::Inline(
+                            listener.on_fulfilled,
+                            value,
+                            ptr::null_mut(),
+                            true,
+                            listener.context,
+                        ));
+                    }
+                }
                 for all_state in promise_all_states {
                     q.push_back(Task::PromiseAll(
                         all_state,
@@ -309,12 +421,25 @@ pub extern "C" fn js_promise_reject(promise: *mut Promise, reason: f64) {
         // Schedule callbacks. Same propagation rule as `js_promise_resolve`
         // (#236): push to the queue whenever there's a callback to invoke
         // OR a chained `next` promise to forward to.
+        let settle_listeners = promise_take_settle_listeners(promise);
+        let has_settle_listeners = !settle_listeners.is_empty();
         let promise_all_states = combinators::promise_all_take_all_handlers(promise);
         let has_normal_handler = !(*promise).on_rejected.is_null() || !(*promise).next.is_null();
-        if !promise_all_states.is_empty() || has_normal_handler {
+        if has_settle_listeners || !promise_all_states.is_empty() || has_normal_handler {
             let task_context = context_for_promise(promise);
             TASK_QUEUE.with(|q| {
                 let mut q = q.borrow_mut();
+                for listener in settle_listeners {
+                    if !listener.on_rejected.is_null() {
+                        q.push_back(Task::Inline(
+                            listener.on_rejected,
+                            reason,
+                            ptr::null_mut(),
+                            false,
+                            listener.context,
+                        ));
+                    }
+                }
                 for all_state in promise_all_states {
                     q.push_back(Task::PromiseAll(
                         all_state,

--- a/test-parity/node-suite/globals/async-generator-request-queue.ts
+++ b/test-parity/node-suite/globals/async-generator-request-queue.ts
@@ -1,0 +1,47 @@
+function show(label: string, result: IteratorResult<string>) {
+  console.log(label, JSON.stringify(result));
+}
+
+async function immediateTwo() {
+  async function* immediateTwoGenerator() {
+    console.log("immediate-two:body:start");
+    const sent = yield "first";
+    console.log("immediate-two:body:after-yield", sent);
+    yield "second";
+  }
+
+  const it = immediateTwoGenerator();
+  const p1 = it.next("ignored");
+  const p2 = it.next("two");
+  p1.then((result) => show("immediate-two:p1", result));
+  p2.then((result) => show("immediate-two:p2", result));
+  console.log("immediate-two:after calls");
+  await p1;
+  await p2;
+}
+
+async function immediateThree() {
+  async function* immediateThreeGenerator() {
+    console.log("immediate-three:body:start");
+    const a = yield "one";
+    console.log("immediate-three:body:a", a);
+    const b = yield "two";
+    console.log("immediate-three:body:b", b);
+    yield "three";
+  }
+
+  const it = immediateThreeGenerator();
+  const p1 = it.next();
+  const p2 = it.next("A");
+  const p3 = it.next("B");
+  p1.then((result) => show("immediate-three:p1", result));
+  p2.then((result) => show("immediate-three:p2", result));
+  p3.then((result) => show("immediate-three:p3", result));
+  console.log("immediate-three:after calls");
+  await p1;
+  await p2;
+  await p3;
+}
+
+await immediateTwo();
+await immediateThree();


### PR DESCRIPTION
## Summary
- wrap lowered async generator `next` / `return` / `throw` methods with a runtime request queue
- drain same-stack async generator requests through microtasks so ordering matches Node
- add internal Promise settle listeners and scanner roots so queue bookkeeping does not consume user-visible `.then` slots
- add a Node parity fixture for same-stack async generator request ordering

## Root Cause
Lowered async generator instance methods could be invoked reentrantly without Node-compatible request queue semantics. That let same-stack `next()` calls race the in-flight request instead of being serialized behind it.

Fixes #4438

## Validation
- `cargo check -q -p perry-runtime --lib`
- `cargo build --release -p perry-runtime -p perry` with `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target CARGO_BUILD_JOBS=1`
- `cargo fmt --all -- --check`
- `git diff --check` and `git diff --cached --check`
- `./scripts/check_file_size.sh`
- `cargo test -q -p perry-runtime test_gc_init_mutable_scanner_families_rewrite_runtime_slots` with shared `CARGO_TARGET_DIR`
- direct Node 26 vs Perry diffs for `async-generator-request-queue.ts`, generator intrinsic/prototype fixtures, `stream/readable/from-async-iterable.ts`, and Promise queue fixtures
