### PR TITLE
fix: lower node:stream/web constructor aliases

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -188,12 +188,24 @@ fn call_local_constructor_symbol(
 ///   enclosing function, not the constructor body)
 /// - No method dispatch or vtables — those land in Phase C.2/C.3
 pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) -> Result<String> {
+    let builtin_resolved_owned: String;
+    let builtin_class_name: &str = if !ctx.classes.contains_key(class_name) {
+        if let Some(resolved) = ctx.local_class_aliases.get(class_name).cloned() {
+            builtin_resolved_owned = resolved;
+            &builtin_resolved_owned
+        } else {
+            class_name
+        }
+    } else {
+        class_name
+    };
+
     // Built-in Web classes that the runtime provides constructors for.
     // These are checked BEFORE the ctx.classes lookup because the user
     // code may shadow the name — if they do, the class lookup below
     // wins.
-    if !ctx.classes.contains_key(class_name) {
-        if matches!(class_name, "Crypto" | "CryptoKey" | "SubtleCrypto") {
+    if !ctx.classes.contains_key(builtin_class_name) {
+        if matches!(builtin_class_name, "Crypto" | "CryptoKey" | "SubtleCrypto") {
             for a in args {
                 let _ = lower_expr(ctx, a)?;
             }
@@ -201,8 +213,10 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                 .block()
                 .call(DOUBLE, "js_webcrypto_illegal_constructor", &[]));
         }
-        if let Some((submod_key, exported_name)) =
-            ctx.import_function_node_submodule.get(class_name).cloned()
+        if let Some((submod_key, exported_name)) = ctx
+            .import_function_node_submodule
+            .get(builtin_class_name)
+            .cloned()
         {
             if submod_key == "readline_promises" && exported_name == "Readline" {
                 let output = if let Some(first) = args.first() {
@@ -230,7 +244,7 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                 ));
             }
         }
-        if let Some(val) = lower_builtin_new(ctx, class_name, args)? {
+        if let Some(val) = lower_builtin_new(ctx, builtin_class_name, args)? {
             return Ok(val);
         }
     }

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -20,6 +20,29 @@ fn is_global_this_value(expr: &perry_hir::Expr) -> bool {
         )
 }
 
+const STREAM_WEB_CTOR_NAMES: [&str; 9] = [
+    "ReadableStream",
+    "WritableStream",
+    "TransformStream",
+    "ByteLengthQueuingStrategy",
+    "CountQueuingStrategy",
+    "TextEncoderStream",
+    "TextDecoderStream",
+    "CompressionStream",
+    "DecompressionStream",
+];
+
+fn stream_web_constructor_name(name: &str) -> Option<&'static str> {
+    STREAM_WEB_CTOR_NAMES
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == name)
+}
+
+fn is_stream_web_module_name(module: &str) -> bool {
+    matches!(module, "stream/web" | "node:stream/web")
+}
+
 pub(crate) fn lower_let(
     ctx: &mut FnCtx<'_>,
     id: u32,
@@ -124,6 +147,14 @@ pub(crate) fn lower_let(
                         | "File"
                         | "WebSocket"
                 )
+            {
+                ctx.local_class_aliases
+                    .insert(name.to_string(), property.clone());
+            }
+            if matches!(
+                object.as_ref(),
+                perry_hir::Expr::NativeModuleRef(module) if is_stream_web_module_name(module)
+            ) && stream_web_constructor_name(property).is_some()
             {
                 ctx.local_class_aliases
                     .insert(name.to_string(), property.clone());

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -16,6 +16,84 @@ fn is_global_this_value(ctx: &LoweringContext, expr: &Expr) -> bool {
 /// #3663: classic-stream constructor export names from `node:stream`.
 const STREAM_CTOR_NAMES: [&str; 5] = ["Readable", "Writable", "Duplex", "Transform", "PassThrough"];
 
+/// #1545: implemented constructor exports from `node:stream/web`.
+const STREAM_WEB_CTOR_NAMES: [&str; 9] = [
+    "ReadableStream",
+    "WritableStream",
+    "TransformStream",
+    "ByteLengthQueuingStrategy",
+    "CountQueuingStrategy",
+    "TextEncoderStream",
+    "TextDecoderStream",
+    "CompressionStream",
+    "DecompressionStream",
+];
+
+fn stream_web_constructor_name(name: &str) -> Option<&'static str> {
+    STREAM_WEB_CTOR_NAMES
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == name)
+}
+
+fn is_stream_web_module_name(module: &str) -> bool {
+    matches!(module, "stream/web" | "node:stream/web")
+}
+
+fn stream_web_native_instance_module(class_name: &str) -> Option<&'static str> {
+    match class_name {
+        "ReadableStream" => Some("readable_stream"),
+        "WritableStream" => Some("writable_stream"),
+        "TransformStream" => Some("transform_stream"),
+        _ => None,
+    }
+}
+
+fn is_stream_web_namespace_expr(ctx: &LoweringContext, expr: &Expr) -> bool {
+    match expr {
+        Expr::NativeModuleRef(module) => is_stream_web_module_name(module),
+        Expr::ExternFuncRef { name, .. } => ctx
+            .lookup_builtin_module_alias(name)
+            .is_some_and(is_stream_web_module_name),
+        _ => false,
+    }
+}
+
+fn unwrap_ast_ts_wrappers(e: &ast::Expr) -> &ast::Expr {
+    let mut cur = e;
+    loop {
+        match cur {
+            ast::Expr::TsAs(x) => cur = &x.expr,
+            ast::Expr::TsNonNull(x) => cur = &x.expr,
+            ast::Expr::TsSatisfies(x) => cur = &x.expr,
+            ast::Expr::TsTypeAssertion(x) => cur = &x.expr,
+            ast::Expr::TsConstAssertion(x) => cur = &x.expr,
+            ast::Expr::Paren(x) => cur = &x.expr,
+            _ => return cur,
+        }
+    }
+}
+
+fn is_readable_stream_from_receiver_ast(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    match unwrap_ast_ts_wrappers(expr) {
+        ast::Expr::Ident(ident) => ident.sym.as_ref() == "ReadableStream",
+        ast::Expr::Member(member) => {
+            if !matches!(
+                &member.prop,
+                ast::MemberProp::Ident(prop) if prop.sym.as_ref() == "ReadableStream"
+            ) {
+                return false;
+            }
+            let ast::Expr::Ident(ns_ident) = unwrap_ast_ts_wrappers(member.obj.as_ref()) else {
+                return false;
+            };
+            ctx.lookup_builtin_module_alias(ns_ident.sym.as_ref())
+                .is_some_and(is_stream_web_module_name)
+        }
+        _ => false,
+    }
+}
+
 /// #3663: the string argument of a `require("<literal>")` call, if any. Unlike
 /// `is_require_builtin_module` (whose allowlist is just fs/path/crypto), this
 /// returns the specifier verbatim so the caller can match the module it cares
@@ -189,6 +267,11 @@ pub(crate) fn lower_var_decl_with_destructuring(
                     if let ast::Expr::New(new_expr) = init_expr.as_ref() {
                         if let ast::Expr::Ident(class_ident) = new_expr.callee.as_ref() {
                             let class_name = class_ident.sym.as_ref();
+                            let resolved_stream_web_class = ctx
+                                .resolve_class_alias(class_name)
+                                .and_then(|resolved| stream_web_constructor_name(&resolved));
+                            let class_name_for_inference =
+                                resolved_stream_web_class.unwrap_or(class_name);
                             if class_name == "Set" || class_name == "Map" {
                                 // Extract type arguments from new Set<T>() or new Map<K, V>()
                                 let type_args: Vec<Type> = new_expr
@@ -218,6 +301,10 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                 "Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough"
                             ) {
                                 ty = Type::Named(class_name.to_string());
+                            } else if stream_web_constructor_name(class_name_for_inference)
+                                .is_some()
+                            {
+                                ty = Type::Named(class_name_for_inference.to_string());
                             } else if class_name == "Uint8Array" || class_name == "Buffer" {
                                 ty = Type::Named("Uint8Array".to_string());
                             } else if matches!(
@@ -282,8 +369,12 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                             _ => break,
                                         };
                                     }
-                                    if let ast::Expr::Ident(obj_id) = obj_inner {
-                                        let method = prop.sym.as_ref();
+                                    let method = prop.sym.as_ref();
+                                    if method == "from"
+                                        && is_readable_stream_from_receiver_ast(ctx, obj_inner)
+                                    {
+                                        ty = Type::Named("ReadableStream".to_string());
+                                    } else if let ast::Expr::Ident(obj_id) = obj_inner {
                                         let recv_class = ctx
                                             .lookup_native_instance(obj_id.sym.as_ref())
                                             .map(|(_, c)| c.to_string());
@@ -299,10 +390,6 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                             ty = Type::Named(
                                                 "WritableStreamDefaultWriter".to_string(),
                                             );
-                                        } else if method == "from"
-                                            && obj_id.sym.as_ref() == "ReadableStream"
-                                        {
-                                            ty = Type::Named("ReadableStream".to_string());
                                         } else if method == "from"
                                             && obj_id.sym.as_ref() == "Readable"
                                         {
@@ -321,6 +408,21 @@ pub(crate) fn lower_var_decl_with_destructuring(
                 if let ast::Expr::New(new_expr) = init_expr.as_ref() {
                     if let ast::Expr::Ident(class_ident) = new_expr.callee.as_ref() {
                         let class_name = class_ident.sym.as_ref();
+                        if let Some(resolved_stream_class) = ctx
+                            .resolve_class_alias(class_name)
+                            .and_then(|resolved| stream_web_constructor_name(&resolved))
+                        {
+                            if let Some(module) =
+                                stream_web_native_instance_module(resolved_stream_class)
+                            {
+                                ctx.register_native_instance(
+                                    name.clone(),
+                                    module.to_string(),
+                                    resolved_stream_class.to_string(),
+                                );
+                                ctx.uses_fetch = true;
+                            }
+                        }
                         // A user `class Big {...}` in scope shadows the
                         // hardcoded library-name fallback below. Without
                         // this gate `class Big { f0=0; ... } const b = new
@@ -460,10 +562,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                                             _ => break,
                                         };
                                     }
-                                    if matches!(
-                                        obj_inner,
-                                        ast::Expr::Ident(i) if i.sym.as_ref() == "ReadableStream"
-                                    ) {
+                                    if is_readable_stream_from_receiver_ast(ctx, obj_inner) {
                                         ctx.register_native_instance(
                                             name.clone(),
                                             "readable_stream".to_string(),
@@ -1844,6 +1943,12 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         ) {
                             ctx.uses_fetch = true;
                         }
+                    }
+                    Expr::PropertyGet { object, property }
+                        if is_stream_web_namespace_expr(ctx, object.as_ref())
+                            && stream_web_constructor_name(property).is_some() =>
+                    {
+                        ctx.register_let_class_alias(name.clone(), property.clone());
                     }
                     Expr::PropertyGet { object, property }
                         if matches!(object.as_ref(), Expr::NativeModuleRef(module)

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -45,6 +45,27 @@ fn unwrap_ts_wrappers(e: &ast::Expr) -> &ast::Expr {
     }
 }
 
+fn is_stream_web_module_name(module: &str) -> bool {
+    matches!(module, "stream/web" | "node:stream/web")
+}
+
+fn is_stream_web_readable_stream_member(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let ast::Expr::Member(class_member) = unwrap_ts_wrappers(expr) else {
+        return false;
+    };
+    if !matches!(
+        &class_member.prop,
+        ast::MemberProp::Ident(prop) if prop.sym.as_ref() == "ReadableStream"
+    ) {
+        return false;
+    }
+    let ast::Expr::Ident(ns_ident) = unwrap_ts_wrappers(class_member.obj.as_ref()) else {
+        return false;
+    };
+    ctx.lookup_builtin_module_alias(ns_ident.sym.as_ref())
+        .is_some_and(is_stream_web_module_name)
+}
+
 fn is_node_stream_class_name(name: &str) -> bool {
     matches!(
         name,
@@ -60,6 +81,20 @@ pub(super) fn try_native_module_methods(
 ) -> Result<Result<Expr, Vec<Expr>>> {
     // Check for native module method calls (e.g., mysql.createConnection())
     if let ast::Expr::Member(member) = expr {
+        if matches!(
+            &member.prop,
+            ast::MemberProp::Ident(method_ident) if method_ident.sym.as_ref() == "from"
+        ) && is_stream_web_readable_stream_member(ctx, member.obj.as_ref())
+        {
+            return Ok(Ok(Expr::NativeMethodCall {
+                module: "readable_stream".to_string(),
+                class_name: Some("ReadableStream".to_string()),
+                object: None,
+                method: "from".to_string(),
+                args,
+            }));
+        }
+
         // #1534/#1540/#1541: the stream acceptance tests deliberately cast
         // the class / namespace before a static call —
         // `(Readable as any).isErrored(r)`, `(Readable as any).toWeb(r)`,

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -165,16 +165,31 @@ fn module_constructor_name(module_name: &str, method_name: Option<&str>) -> Opti
         ("url", Some("URLPattern")) => Some("URLPattern"),
         ("util", Some("TextEncoder")) => Some("TextEncoder"),
         ("util", Some("TextDecoder")) => Some("TextDecoder"),
-        ("stream/web", Some("TextEncoderStream"))
-        | ("node:stream/web", Some("TextEncoderStream")) => Some("TextEncoderStream"),
-        ("stream/web", Some("TextDecoderStream"))
-        | ("node:stream/web", Some("TextDecoderStream")) => Some("TextDecoderStream"),
-        ("stream/web", Some("CompressionStream"))
-        | ("node:stream/web", Some("CompressionStream")) => Some("CompressionStream"),
-        ("stream/web", Some("DecompressionStream"))
-        | ("node:stream/web", Some("DecompressionStream")) => Some("DecompressionStream"),
+        ("stream/web" | "node:stream/web", Some(name)) => stream_web_constructor_name(name),
         _ => None,
     }
+}
+
+fn stream_web_constructor_name(name: &str) -> Option<&'static str> {
+    match name {
+        "ReadableStream" => Some("ReadableStream"),
+        "WritableStream" => Some("WritableStream"),
+        "TransformStream" => Some("TransformStream"),
+        "ByteLengthQueuingStrategy" => Some("ByteLengthQueuingStrategy"),
+        "CountQueuingStrategy" => Some("CountQueuingStrategy"),
+        "TextEncoderStream" => Some("TextEncoderStream"),
+        "TextDecoderStream" => Some("TextDecoderStream"),
+        "CompressionStream" => Some("CompressionStream"),
+        "DecompressionStream" => Some("DecompressionStream"),
+        _ => None,
+    }
+}
+
+fn is_stream_web_handle_constructor(name: &str) -> bool {
+    matches!(
+        name,
+        "ReadableStream" | "WritableStream" | "TransformStream"
+    )
 }
 
 fn global_member_constructor_name(
@@ -330,6 +345,16 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     lower_url_encoding_constructor(ctx, class_name, new_expr.args.as_deref())?
                 {
                     return Ok(expr);
+                }
+                if stream_web_constructor_name(class_name).is_some() {
+                    if is_stream_web_handle_constructor(class_name) {
+                        ctx.uses_fetch = true;
+                    }
+                    return Ok(Expr::New {
+                        class_name: class_name.to_string(),
+                        args: lower_optional_args(ctx, new_expr.args.as_deref())?,
+                        type_args: Vec::new(),
+                    });
                 }
             }
             if obj_name == "globalThis"
@@ -668,8 +693,10 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
     // calls on it silently no-op. Each field maps to (param_index,
     // module, class_name) — TransformStream's `transform(chunk,
     // controller)` controller is param 1, the rest are param 0.
-    if let ast::Expr::Ident(ident) = new_expr.callee.as_ref() {
-        let cls = ident.sym.as_ref();
+    if let ast::Expr::Ident(ident) = callee_expr {
+        let raw_cls = ident.sym.as_ref();
+        let resolved_cls = ctx.resolve_class_alias(raw_cls);
+        let cls = resolved_cls.as_deref().unwrap_or(raw_cls);
         let field_specs: &[(&'static str, usize, &'static str, &'static str)] = match cls {
             "ReadableStream" => &[
                 ("start", 0, "readable_stream", "ReadableStream"),
@@ -1535,7 +1562,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 .unwrap_or_default();
             if ctx.lookup_class(&class_name).is_none() {
                 if let Some(resolved) = ctx.resolve_class_alias(&class_name) {
-                    if matches!(
+                    let resolved_is_fetch_like = matches!(
                         resolved.as_str(),
                         "Blob"
                             | "File"
@@ -1544,8 +1571,12 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                             | "Request"
                             | "Response"
                             | "WebSocket"
-                    ) {
-                        if is_fetch_constructor_name(&resolved) {
+                    );
+                    let resolved_is_stream_web = stream_web_constructor_name(&resolved).is_some();
+                    if resolved_is_fetch_like || resolved_is_stream_web {
+                        if is_fetch_constructor_name(&resolved)
+                            || is_stream_web_handle_constructor(&resolved)
+                        {
                             ctx.uses_fetch = true;
                         }
                         return Ok(Expr::New {

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -78,6 +78,21 @@ fn node_submodule_default_export_key(module_name: &str) -> Option<&'static str> 
     }
 }
 
+fn stream_web_constructor_name(name: &str) -> Option<&'static str> {
+    match name {
+        "ReadableStream" => Some("ReadableStream"),
+        "WritableStream" => Some("WritableStream"),
+        "TransformStream" => Some("TransformStream"),
+        "ByteLengthQueuingStrategy" => Some("ByteLengthQueuingStrategy"),
+        "CountQueuingStrategy" => Some("CountQueuingStrategy"),
+        "TextEncoderStream" => Some("TextEncoderStream"),
+        "TextDecoderStream" => Some("TextDecoderStream"),
+        "CompressionStream" => Some("CompressionStream"),
+        "DecompressionStream" => Some("DecompressionStream"),
+        _ => None,
+    }
+}
+
 pub(crate) fn lower_module_decl(
     ctx: &mut LoweringContext,
     module: &mut Module,
@@ -307,6 +322,14 @@ pub(crate) fn lower_module_decl(
                             // `local == imported` (the common no-alias case)
                             // this is identical to the previous behavior.
                             ctx.register_imported_func(local.clone(), local.clone());
+                            if source == "stream/web" {
+                                if let Some(class_name) = stream_web_constructor_name(&imported) {
+                                    ctx.register_let_class_alias(
+                                        local.clone(),
+                                        class_name.to_string(),
+                                    );
+                                }
+                            }
                         }
                         specifiers.push(ImportSpecifier::Named { imported, local });
                     }
@@ -407,7 +430,7 @@ pub(crate) fn lower_module_decl(
                         } else {
                             // Namespace import from JS module - register so calls resolve to ExternFuncRef
                             ctx.register_imported_func(local.clone(), local.clone());
-                            if source == "fs/promises" {
+                            if source == "fs/promises" || source == "stream/web" {
                                 ctx.register_builtin_module_alias(local.clone(), source.clone());
                             }
                             // Record that `local` is a module namespace (not a

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -26,12 +26,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_stream_web": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:stream/web` (WHATWG streams) surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_sock_write_map": {
     "issue": "1634",
     "added": "2026-05-15",

--- a/test-parity/node-suite/stream/web/constructor-value-refs.ts
+++ b/test-parity/node-suite/stream/web/constructor-value-refs.ts
@@ -1,0 +1,89 @@
+import * as web from "node:stream/web";
+
+async function collect(readable: any): Promise<string> {
+  const reader = readable.getReader();
+  const values: string[] = [];
+  while (true) {
+    const item = await reader.read();
+    if (item.done) break;
+    values.push(String(item.value));
+  }
+  return values.join("|");
+}
+
+const ReadableAlias = (web as any).ReadableStream;
+const WritableAlias = (web as any).WritableStream;
+const TransformAlias = (web as any).TransformStream;
+const ByteLengthAlias = (web as any).ByteLengthQueuingStrategy;
+const CountAlias = (web as any).CountQueuingStrategy;
+const TextEncoderAlias = (web as any).TextEncoderStream;
+const TextDecoderAlias = (web as any).TextDecoderStream;
+const CompressionAlias = (web as any).CompressionStream;
+const DecompressionAlias = (web as any).DecompressionStream;
+
+const aliasReadable = new ReadableAlias({
+  start(controller: any) {
+    controller.enqueue("alias");
+    controller.close();
+  },
+});
+console.log("alias readable:", await collect(aliasReadable));
+
+const memberReadable = new (web as any).ReadableStream({
+  start(controller: any) {
+    controller.enqueue("member");
+    controller.close();
+  },
+});
+console.log("member readable:", await collect(memberReadable));
+
+const fromReadable = (web as any).ReadableStream.from(["from", "namespace"]);
+console.log("namespace from:", await collect(fromReadable));
+
+const writes: string[] = [];
+const writable = new WritableAlias({
+  write(chunk: any) {
+    writes.push(String(chunk));
+  },
+});
+const writer = writable.getWriter();
+await writer.write("write");
+await writer.close();
+console.log("writable writes:", writes.join("|"));
+
+const transform = new TransformAlias({
+  transform(chunk: any, controller: any) {
+    controller.enqueue(String(chunk).toUpperCase());
+  },
+});
+const transformWriter = transform.writable.getWriter();
+const transformReader = transform.readable.getReader();
+const transformWrite = transformWriter.write("tx");
+console.log("transform value:", (await transformReader.read()).value);
+await transformWrite;
+await transformWriter.close();
+
+const byteStrategy = new ByteLengthAlias({ highWaterMark: 16 });
+console.log("byte strategy:", byteStrategy.highWaterMark, byteStrategy.size({ byteLength: 3 }));
+
+const countStrategy = new CountAlias({ highWaterMark: 4 });
+console.log("count strategy:", countStrategy.highWaterMark, countStrategy.size("x"));
+
+const encoder = new TextEncoderAlias();
+console.log("encoder metadata:", encoder.encoding, typeof encoder.readable, typeof encoder.writable);
+
+const decoder = new TextDecoderAlias("utf-8", { fatal: true, ignoreBOM: true });
+console.log(
+  "decoder metadata:",
+  decoder.encoding,
+  decoder.fatal,
+  decoder.ignoreBOM,
+  typeof decoder.readable,
+  typeof decoder.writable,
+);
+
+const compression = new CompressionAlias("gzip");
+console.log("compression sides:", typeof compression.readable, typeof compression.writable);
+
+const decompression = new DecompressionAlias("gzip");
+console.log("decompression sides:", typeof decompression.readable, typeof decompression.writable);


### PR DESCRIPTION
## Summary
- Recognize `node:stream/web` constructor exports from namespace/member aliases and named imports so captured constructor values lower to built-in `new` calls.
- Route namespace `ReadableStream.from(...)` to the native readable-stream factory and preserve ReadableStream binding metadata.
- Add focused stream/web parity coverage and remove `test_parity_stream_web` from known failures now that it passes.

Fixes #1545.

## Tests
- `cargo check -p perry-hir -p perry-codegen`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream --filter constructor-value-refs'`\n- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --filter test_parity_stream_web'`\n- `jq empty test-parity/known_failures.json`\n