### PR TITLE
Fix Drizzle SQLite class constructor property semantics

### DIFF
--- a/crates/perry-runtime/src/object/prototype_helpers.rs
+++ b/crates/perry-runtime/src/object/prototype_helpers.rs
@@ -23,10 +23,18 @@ pub(crate) fn constructor_dynamic_prototype(obj: *const ObjectHeader) -> Option<
     let proto = crate::closure::closure_get_dynamic_prop(raw_addr, "prototype");
     let proto_jsv = crate::value::JSValue::from_bits(proto.to_bits());
     if proto_jsv.is_undefined() {
-        None
-    } else {
-        Some(proto)
+        return None;
     }
+    if proto_jsv.is_pointer() {
+        let proto_addr = proto_jsv.as_pointer::<u8>() as usize;
+        // Prototype objects commonly have `constructor` pointing back to the
+        // constructor whose `.prototype` is this same object. That is not their
+        // [[Prototype]]; let the caller fall back to Object.prototype/null.
+        if proto_addr == obj as usize {
+            return None;
+        }
+    }
+    Some(proto)
 }
 
 pub(crate) fn error_kind_prototype_value(kind: u32) -> Option<f64> {

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -524,6 +524,19 @@ fn target_set(target: f64, key: f64, value: f64) {
         }
         return;
     }
+    let key_ptr = extract_pointer(property_key.to_bits()) as *const crate::StringHeader;
+    if crate::object::class_ref_id(target).is_some() {
+        // Preserve the INT32-tagged class-ref bits so class dynamic props
+        // land in CLASS_DYNAMIC_PROPS instead of being pointer-extracted to 0.
+        if !key_ptr.is_null() {
+            crate::object::js_object_set_field_by_name(
+                target.to_bits() as *mut crate::ObjectHeader,
+                key_ptr,
+                value,
+            );
+        }
+        return;
+    }
     let obj_addr = extract_pointer(target.to_bits()) as usize;
     if crate::closure::is_closure_ptr(obj_addr) {
         if let Some(name) = key_to_rust_string(property_key) {
@@ -532,7 +545,6 @@ fn target_set(target: f64, key: f64, value: f64) {
         return;
     }
     let obj_ptr = obj_addr as *mut crate::ObjectHeader;
-    let key_ptr = extract_pointer(property_key.to_bits()) as *const crate::StringHeader;
     if obj_ptr.is_null() || key_ptr.is_null() {
         return;
     }

--- a/test-parity/node-suite/object/globals/constructor-prototype-chain.ts
+++ b/test-parity/node-suite/object/globals/constructor-prototype-chain.ts
@@ -1,0 +1,68 @@
+const entityKind = Symbol.for("fixture:entityKind");
+
+class Table {
+  static [entityKind] = "Table";
+}
+
+function entityWalk(value: any, type: any): string {
+  if (!value || typeof value !== "object") {
+    return "non-object";
+  }
+  if (value instanceof type) {
+    return "instance";
+  }
+  if (!Object.prototype.hasOwnProperty.call(type, entityKind)) {
+    return "bad-type";
+  }
+
+  let cls = Object.getPrototypeOf(value).constructor;
+  let steps = 0;
+  while (cls) {
+    steps++;
+    if (entityKind in cls && cls[entityKind] === type[entityKind]) {
+      return `match:${steps}`;
+    }
+    cls = Object.getPrototypeOf(cls);
+    if (steps > 10) {
+      return `loop:${typeof cls}`;
+    }
+  }
+  return `done:${steps}`;
+}
+
+console.log("Array ctor parent:", Object.getPrototypeOf(Array) === Function.prototype);
+console.log(
+  "Function prototype parent:",
+  Object.getPrototypeOf(Function.prototype) === Object.prototype,
+);
+console.log("Object prototype parent:", Object.getPrototypeOf(Object.prototype) === null);
+console.log("array entity walk:", entityWalk([], Table));
+console.log("object entity walk:", entityWalk({}, Table));
+
+class NamespaceTarget {}
+class DirectStatic {}
+function RegularFunction() {}
+
+(NamespaceTarget as any).DirectStatic = DirectStatic;
+function assignViaAlias(target: any) {
+  class ViaAlias {}
+  target.ViaAlias = ViaAlias;
+}
+assignViaAlias(NamespaceTarget);
+
+const selected: any = NamespaceTarget || {};
+((target: any) => {
+  class ViaIife {}
+  target.ViaIife = ViaIife;
+})(selected);
+
+(RegularFunction as any).extra = 1;
+
+console.log("class direct static:", typeof (NamespaceTarget as any).DirectStatic);
+console.log("class alias static:", typeof (NamespaceTarget as any).ViaAlias);
+console.log("class iife static:", typeof (NamespaceTarget as any).ViaIife);
+console.log("function dynamic prop:", (RegularFunction as any).extra);
+console.log(
+  "class iife instanceof:",
+  {} instanceof (NamespaceTarget as any).ViaIife,
+);


### PR DESCRIPTION
Summary:
- avoid treating constructor .prototype backrefs as the object's [[Prototype]], which lets Object.getPrototypeOf(Function.prototype) fall back correctly
- preserve INT32-tagged class constructor refs when PutValueSet writes dynamic/static properties, so class namespace patterns like SQL.Aliased stay readable and valid for instanceof
- add focused parity coverage for the constructor walk and class static property assignment paths

Closes #1024
Closes #1069

Validation:
- cargo check -p perry-runtime
- cargo build --release -p perry -p perry-runtime -p perry-stdlib
- PERRY_BIN=/root/perry-worktrees/perry-drizzle-sqlite-hang-20260605/target/release/perry PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module object --filter constructor-prototype-chain'
- PERRY_BIN=/root/perry-worktrees/perry-drizzle-sqlite-hang-20260605/target/release/perry tests/release/packages/_harness.sh --filter drizzle-sqlite
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh

Non-goal:
- dynamic new through a class constructor stored on another class remains outside this package fix; the covered contract is property read plus instanceof RHS behavior used by the Drizzle path.