### PR TITLE
fix(console): format symbol numeric placeholders as nan

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -1801,6 +1801,15 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
         let bs = std::slice::from_raw_parts(data, len);
         std::str::from_utf8(bs).unwrap_or("").to_string()
     }
+    fn util_number_placeholder_coerce(val: f64, jv: &JSValue) -> f64 {
+        if jv.is_int32() {
+            jv.as_int32() as f64
+        } else if unsafe { crate::symbol::js_is_symbol(val) } != 0 {
+            f64::NAN
+        } else {
+            js_number_coerce(val)
+        }
+    }
     if arr_ptr.is_null() {
         return boxed_string("");
     }
@@ -1887,11 +1896,7 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
                     if jv.is_bigint() {
                         out.push_str(&format_bigint_literal(val));
                     } else {
-                        let f = if jv.is_int32() {
-                            jv.as_int32() as f64
-                        } else {
-                            js_number_coerce(val)
-                        };
+                        let f = util_number_placeholder_coerce(val, &jv);
                         out.push_str(&format_util_number(f));
                     }
                 }
@@ -1910,7 +1915,7 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
                         {
                             f64::NAN
                         } else {
-                            js_number_coerce(val)
+                            util_number_placeholder_coerce(val, &jv)
                         };
                         if f.is_nan() {
                             out.push_str("NaN");
@@ -1950,7 +1955,7 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
                         {
                             f64::NAN
                         } else {
-                            js_number_coerce(val)
+                            util_number_placeholder_coerce(val, &jv)
                         };
                         if f.is_nan() {
                             out.push_str("NaN");


### PR DESCRIPTION
## Summary
- format `Symbol` values passed to `%d`, `%i`, and `%f` placeholders as `NaN`
- keep the existing BigInt handling and int fast path intact
- preserve generic `ToNumber(Symbol)` TypeError behavior outside util/console numeric placeholders

Refs #800

## Validation
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" timeout 1200 ./run_parity_tests.sh --suite node-suite --module console --filter symbol-in-number-format` (1 pass / 0 fail, `test-parity/reports/parity_report_20260605_020615.json`)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" timeout 1500 ./run_parity_tests.sh --suite node-suite --module console` (119 pass / 0 fail, `test-parity/reports/parity_report_20260605_020844.json`)
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" timeout 600 ./run_parity_tests.sh --suite node-suite --module globals --filter math-tonumber-coercion` (1 pass / 0 fail, `test-parity/reports/parity_report_20260605_021211.json`)
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" timeout 900 ./run_parity_tests.sh --suite node-suite --module util --filter format` (12 pass / 0 fail, `test-parity/reports/parity_report_20260605_021259.json`)
- `cargo check -p perry-runtime` (passes; existing warnings)
