### PR TITLE
[codex] align Buffer iterators and indexed enumerability

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -107,6 +107,8 @@ pub extern "C" fn js_for_of_to_array(val_f64: f64) -> f64 {
             let iter = crate::symbol::js_get_iterator(val_f64);
             let arr = if iter.to_bits() != val_f64.to_bits() {
                 js_iterator_to_array(iter)
+            } else if is_builtin_iterator_class_id(raw_ptr as usize) {
+                js_iterator_to_array(iter)
             } else if has_named_next(iter) {
                 js_iterator_to_array(iter)
             } else {

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -702,6 +702,10 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
             return f64::from_bits(if is_length { TAG_FALSE } else { TAG_TRUE });
         }
 
+        if let Some(present) = registered_buffer_index_own_property_present(obj_value, key_str) {
+            return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+        }
+
         if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
             let enumerable = crate::typedarray_props::typed_array_property_is_enumerable(
                 addr as *const crate::typedarray::TypedArrayHeader,

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1589,6 +1589,31 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
     if let Some(v) = resolve_explicit_object_prototype_symbol(obj_f64, sym_f64) {
         return v;
     }
+    if sym_key != 0 {
+        let iter_wk = well_known_symbol("iterator");
+        if !iter_wk.is_null() {
+            let iter_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
+            if sym_key == sym_key_from_f64(iter_f64) {
+                let raw_iter_ptr = crate::value::js_nanbox_get_pointer(obj_f64) as usize;
+                if raw_iter_ptr >= 0x10000
+                    && crate::array::is_builtin_iterator_class_id(raw_iter_ptr)
+                {
+                    let receiver = if (bits >> 48) == 0x7FFD {
+                        obj_f64
+                    } else {
+                        crate::value::js_nanbox_pointer(raw_iter_ptr as i64)
+                    };
+                    let method = b"Symbol.iterator";
+                    return crate::object::js_class_method_bind(
+                        receiver,
+                        method.as_ptr(),
+                        method.len(),
+                    );
+                }
+            }
+        }
+    }
     // Buffer extends Uint8Array in Node, so Buffer values must expose
     // @@iterator as values(). Perry's direct Buffer.from() paths often
     // materialize through array-clone fast paths, but runtime-produced

--- a/test-parity/node-suite/buffer/iterator-spread.ts
+++ b/test-parity/node-suite/buffer/iterator-spread.ts
@@ -7,10 +7,25 @@ console.log("spread entries", JSON.stringify([...buf.entries()]));
 console.log("from keys", JSON.stringify(Array.from(buf.keys())));
 console.log("from values", JSON.stringify(Array.from(buf.values())));
 console.log("from entries len", Array.from(buf.entries()).length);
-// .next() / for-of already worked — keep them covered so a regression in
-// either direction is caught.
+// Keep direct .next(), self-iterability, and for-of covered so iterator
+// protocol consumers take the same path as Node.
 const it = buf.values();
 console.log("next", JSON.stringify(it.next()), JSON.stringify(it.next()));
+const valuesIt = buf.values();
+const keysIt = buf.keys();
+const entriesIt = buf.entries();
+valuesIt.next();
+keysIt.next();
+entriesIt.next();
+console.log("values self next", JSON.stringify(valuesIt[Symbol.iterator]().next()));
+console.log("keys self next", JSON.stringify(keysIt[Symbol.iterator]().next()));
+console.log("entries self next", JSON.stringify(entriesIt[Symbol.iterator]().next()));
 let sum = 0;
 for (const v of buf.values()) sum += v;
 console.log("for-of sum", sum);
+let keySum = 0;
+for (const k of buf.keys()) keySum += k;
+console.log("for-of keys sum", keySum);
+let entrySum = 0;
+for (const [k, v] of buf.entries()) entrySum += k + v;
+console.log("for-of entries sum", entrySum);

--- a/test-parity/node-suite/buffer/properties/enumerable-indices.ts
+++ b/test-parity/node-suite/buffer/properties/enumerable-indices.ts
@@ -11,3 +11,10 @@ console.log("object has 2:", Object.hasOwn(b, "2"));
 console.log("proto has 1:", Object.prototype.hasOwnProperty.call(b, "1"));
 console.log("proto has 2:", Object.prototype.hasOwnProperty.call(b, "2"));
 console.log("proto enum 0:", Object.prototype.propertyIsEnumerable.call(b, "0"));
+console.log("proto enum 2:", Object.prototype.propertyIsEnumerable.call(b, "2"));
+console.log("proto enum leading:", Object.prototype.propertyIsEnumerable.call(b, "01"));
+console.log("proto enum length:", Object.prototype.propertyIsEnumerable.call(b, "length"));
+console.log(
+  "empty proto enum 0:",
+  Object.prototype.propertyIsEnumerable.call(Buffer.alloc(0), "0"),
+);


### PR DESCRIPTION
## Linked issues

- Closes part of #800

## Behavior cluster

This PR closes the two current-main Buffer parity failures that shared Buffer indexed/iterator runtime paths:

- `node-suite/buffer/iterator-spread`: Buffer iterator objects now expose `Symbol.iterator` as a self-returning iterator method, and `for...of` over built-in iterator objects without an own `.next` field drives the iterator protocol instead of throwing.
- `node-suite/buffer/properties/enumerable-indices`: `Object.prototype.propertyIsEnumerable.call(buffer, index)` now sees registered Buffer indexed own properties before the TypedArray property fallback.

## Why batched

Both failures are Buffer-facing parity gaps in existing Buffer fixtures, and both sit at the boundary between Buffer runtime objects and shared object/iterator dispatch. Keeping them together makes the Buffer module move from 132 pass / 2 fail to 134 pass / 0 fail without mixing unrelated modules.

## Tests added/updated

- Expanded `test-parity/node-suite/buffer/iterator-spread.ts` to cover Buffer iterator self-iteration by cursor continuation and `for...of` over `keys()`, `values()`, and `entries()`.
- Expanded `test-parity/node-suite/buffer/properties/enumerable-indices.ts` with out-of-range, non-canonical, `length`, and empty-Buffer prototype-call enumerability cases.

## Commands run

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/buffer/iterator-spread.ts`
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/buffer/properties/enumerable-indices.ts`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module buffer --filter iterator-spread'`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module buffer --filter enumerable-indices'`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module buffer'` (134 pass / 0 fail, after rebase)
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter typedarray-own-properties'`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter string-matchall-iterator'`
- `CARGO_TARGET_DIR=/root/perry-worktrees/perry-node-probe-20260604/target cargo test -p perry-runtime buffer::` (18 passed; existing warnings only)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`

## Known limitations

- This does not attempt broader JS object identity lowering changes; the self-iterator coverage checks protocol continuation semantics.

## Non-goals

- Console formatting, zlib one-shot codecs, async generators, streams, and broader TypedArray semantics.
- Node-core CI wiring or known-failure manifest changes.