### PR TITLE
fix(zlib): throw on external decode errors

### DIFF
--- a/crates/perry-ext-zlib/src/lib.rs
+++ b/crates/perry-ext-zlib/src/lib.rs
@@ -6,10 +6,10 @@
 //! aren't valid UTF-8, so the wrapper can't go through the standard
 //! `read_string` / `alloc_string` path.
 
-use flate2::read::{GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder};
+use flate2::read::{GzEncoder, MultiGzDecoder, ZlibDecoder, ZlibEncoder};
 use flate2::Compression;
-use perry_ffi::{alloc_buffer, BufferHeader};
-use std::io::Read;
+use perry_ffi::{alloc_buffer, BufferHeader, ErrorKind};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read};
 
 // #1843 — Transform-stream objects (`createGzip`/`createDeflate`/… with
 // `.write`/`.end`/`.on`/`.pipe`) and Brotli one-shots. Split into its own
@@ -31,10 +31,17 @@ fn gzip_bytes_with(data: &[u8], level: Compression) -> std::io::Result<Vec<u8>> 
 }
 
 fn gunzip_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
-    let mut decoder = GzDecoder::new(data);
+    let mut decoder = MultiGzDecoder::new(data);
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed)?;
     Ok(decompressed)
+}
+
+fn throw_deflate_decode_error(err: IoError) -> ! {
+    if err.kind() == IoErrorKind::UnexpectedEof {
+        perry_ffi::throw_with_code("unexpected end of file", "Z_BUF_ERROR", ErrorKind::Error);
+    }
+    perry_ffi::throw_with_code("incorrect header check", "Z_DATA_ERROR", ErrorKind::Error)
 }
 
 // Node's `zlib.deflateSync`/`inflateSync` use the zlib format (RFC 1950 —
@@ -93,6 +100,7 @@ pub unsafe extern "C" fn js_zlib_gunzip_sync(data_bits: i64) -> *mut BufferHeade
     stream::js_zlib_validate_buffer_arg(data_bits); // #3662
     match stream::read_input_from_bits(data_bits).map(|d| gunzip_bytes(&d)) {
         Some(Ok(out)) => alloc_buffer(&out),
+        Some(Err(err)) => throw_deflate_decode_error(err),
         _ => std::ptr::null_mut(),
     }
 }
@@ -125,6 +133,7 @@ pub unsafe extern "C" fn js_zlib_inflate_sync(data_bits: i64) -> *mut BufferHead
     stream::js_zlib_validate_buffer_arg(data_bits); // #3662
     match stream::read_input_from_bits(data_bits).map(|d| inflate_bytes(&d)) {
         Some(Ok(out)) => alloc_buffer(&out),
+        Some(Err(err)) => throw_deflate_decode_error(err),
         _ => std::ptr::null_mut(),
     }
 }
@@ -186,11 +195,39 @@ mod tests {
     }
 
     #[test]
+    fn gunzip_reads_all_gzip_members() {
+        let a = gzip_bytes(b"first ").unwrap();
+        let b = gzip_bytes(b"second ").unwrap();
+        let c = gzip_bytes(b"third").unwrap();
+        let mut concatenated = Vec::new();
+        concatenated.extend_from_slice(&a);
+        concatenated.extend_from_slice(&b);
+        concatenated.extend_from_slice(&c);
+        assert_eq!(gunzip_bytes(&concatenated).unwrap(), b"first second third");
+    }
+
+    #[test]
+    fn gunzip_rejects_invalid_data() {
+        assert!(gunzip_bytes(b"not a gzip stream").is_err());
+    }
+
+    #[test]
     fn deflate_then_inflate_round_trips() {
         let input = b"deflate test deflate test deflate test deflate test";
         let compressed = deflate_bytes(input).unwrap();
         let decompressed = inflate_bytes(&compressed).unwrap();
         assert_eq!(decompressed, input);
+    }
+
+    #[test]
+    fn inflate_rejects_raw_deflate_payload() {
+        use flate2::read::DeflateEncoder;
+
+        let mut raw = Vec::new();
+        DeflateEncoder::new(&b"hello"[..], Compression::default())
+            .read_to_end(&mut raw)
+            .unwrap();
+        assert!(inflate_bytes(&raw).is_err());
     }
 
     // End-to-end TS smoke tests cover the FFI Buffer allocation path.

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -19,14 +19,14 @@
 
 use perry_ffi::{
     alloc_buffer, alloc_string, gc_register_mutable_root_scanner_named, notify_main_thread,
-    BufferHeader, GcRootVisitor, JsClosure, JsValue, RawClosureHeader, StringHeader,
+    BufferHeader, ErrorKind, GcRootVisitor, JsClosure, JsValue, RawClosureHeader, StringHeader,
 };
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::Mutex;
 
 use flate2::read::{
-    DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder,
+    DeflateDecoder, DeflateEncoder, GzEncoder, MultiGzDecoder, ZlibDecoder, ZlibEncoder,
 };
 use flate2::Compression;
 
@@ -96,6 +96,14 @@ fn brotli_decompress_bytes(data: &[u8]) -> std::io::Result<Vec<u8>> {
     let mut out = Vec::new();
     brotli::Decompressor::new(data, 4096).read_to_end(&mut out)?;
     Ok(out)
+}
+
+fn throw_brotli_decode_error() -> ! {
+    perry_ffi::throw_with_code(
+        "Decompression failed",
+        "ERR__ERROR_FORMAT_PADDING_2",
+        ErrorKind::Error,
+    )
 }
 
 /// Read the bytes of a one-shot input argument. Node's `gzipSync` / `gunzipSync`
@@ -169,6 +177,7 @@ pub unsafe extern "C" fn js_zlib_brotli_decompress_sync(data_bits: i64) -> *mut 
     js_zlib_validate_buffer_arg(data_bits);
     match read_input_from_bits(data_bits).map(|d| brotli_decompress_bytes(&d)) {
         Some(Ok(out)) => alloc_buffer(&out),
+        Some(Err(_)) => throw_brotli_decode_error(),
         _ => std::ptr::null_mut(),
     }
 }
@@ -217,7 +226,7 @@ fn run_codec(codec: Codec, input: &[u8]) -> std::io::Result<Vec<u8>> {
             GzEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
         }
         Codec::Gunzip => {
-            GzDecoder::new(input).read_to_end(&mut out)?;
+            MultiGzDecoder::new(input).read_to_end(&mut out)?;
         }
         Codec::Deflate => {
             ZlibEncoder::new(input, Compression::default()).read_to_end(&mut out)?;
@@ -234,7 +243,7 @@ fn run_codec(codec: Codec, input: &[u8]) -> std::io::Result<Vec<u8>> {
         Codec::Unzip => {
             // Node's `createUnzip` auto-detects gzip vs zlib by header.
             if input.len() >= 2 && input[0] == 0x1f && input[1] == 0x8b {
-                GzDecoder::new(input).read_to_end(&mut out)?;
+                MultiGzDecoder::new(input).read_to_end(&mut out)?;
             } else {
                 ZlibDecoder::new(input).read_to_end(&mut out)?;
             }
@@ -1002,6 +1011,21 @@ mod stream_tests {
     }
 
     #[test]
+    fn gunzip_run_codec_reads_all_members() {
+        let a = stream_compress(Codec::Gzip, &[b"first "]);
+        let b = stream_compress(Codec::Gzip, &[b"second "]);
+        let c = stream_compress(Codec::Gzip, &[b"third"]);
+        let mut concatenated = Vec::new();
+        concatenated.extend_from_slice(&a);
+        concatenated.extend_from_slice(&b);
+        concatenated.extend_from_slice(&c);
+        assert_eq!(
+            run_codec(Codec::Gunzip, &concatenated).unwrap(),
+            b"first second third"
+        );
+    }
+
+    #[test]
     fn deflate_stream_is_zlib_format_and_roundtrips() {
         let c = stream_compress(Codec::Deflate, &[b"AAAA", b"BBBB"]);
         assert_eq!(c[0], 0x78); // zlib header (NOT raw deflate)
@@ -1021,5 +1045,10 @@ mod stream_tests {
             run_codec(Codec::BrotliDecompress, &c).unwrap(),
             b"brotli stream test"
         );
+    }
+
+    #[test]
+    fn brotli_decompress_rejects_invalid_data() {
+        assert!(brotli_decompress_bytes(b"not a brotli stream").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- make external `gunzipSync()` decode every concatenated gzip member, matching Node's multi-member gzip behavior
- throw Node-shaped zlib errors from external `gunzipSync()`, `inflateSync()`, and `brotliDecompressSync()` sync decode failures instead of returning without throwing
- use multi-member gzip decoding in the external zlib one-shot/stream helper path and add focused Rust coverage

Refs #800

## Validation
- `cargo test -q -p perry-ext-zlib --lib` (12 pass / 0 fail; existing runtime warnings)
- `cargo build -q -p perry-ext-zlib --release` (passes; existing `make_codec_state` dead-code warning)
- `cargo check -q -p perry-ext-zlib --release` (passes; existing `make_codec_state` dead-code warning)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 timeout 600 ./run_parity_tests.sh --suite node-suite --module zlib --filter multi-member` (1 pass / 0 fail, `test-parity/reports/parity_report_20260605_024112.json`)
- focused zlib decode-error fixtures passed with `PERRY_NO_AUTO_OPTIMIZE=1`: `brotli-invalid`, `gunzip-bad-magic`, `gunzip-truncated`, `inflate-raw-format`
- full `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module zlib`: 53 pass / 5 fail / 0 compile fail, `test-parity/reports/parity_report_20260605_024844.json`

Remaining full-zlib failures are outside this cut: zlib Transform stream method/lifecycle fixtures and `validation/callback-required` callback validation/output details.
