### PR TITLE
fix(hir): construct class-expression aliases statically

### DIFF
--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -111,6 +111,16 @@ fn lower_optional_args(
     .map(|args| args.unwrap_or_default())
 }
 
+fn append_class_capture_args(ctx: &LoweringContext, class_name: &str, args: &mut Vec<Expr>) {
+    let class_captures: Vec<LocalId> = ctx
+        .lookup_class_captures(class_name)
+        .map(|c| c.to_vec())
+        .unwrap_or_default();
+    for cid in class_captures {
+        args.push(Expr::LocalGet(cid));
+    }
+}
+
 fn lower_url_encoding_constructor(
     ctx: &mut LoweringContext,
     class_name: &str,
@@ -1535,6 +1545,14 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 .unwrap_or_default();
             if ctx.lookup_class(&class_name).is_none() {
                 if let Some(resolved) = ctx.resolve_class_alias(&class_name) {
+                    if ctx.lookup_class(&resolved).is_some() {
+                        append_class_capture_args(ctx, &resolved, &mut args);
+                        return Ok(Expr::New {
+                            class_name: resolved,
+                            args,
+                            type_args,
+                        });
+                    }
                     if matches!(
                         resolved.as_str(),
                         "Blob"
@@ -1615,13 +1633,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             let lookup_name = ctx
                 .resolve_class_alias(&class_name)
                 .unwrap_or_else(|| class_name.clone());
-            let class_captures: Vec<LocalId> = ctx
-                .lookup_class_captures(&lookup_name)
-                .map(|c| c.to_vec())
-                .unwrap_or_default();
-            for cid in class_captures {
-                args.push(Expr::LocalGet(cid));
-            }
+            append_class_capture_args(ctx, &lookup_name, &mut args);
             Ok(Expr::New {
                 class_name,
                 args,


### PR DESCRIPTION
## Summary
- resolve HIR class alias chains before the identifier `new` path falls back to `NewDynamic`
- emit `Expr::New` for aliases that resolve to known Perry classes, preserving captured constructor args
- keep native constructor alias handling and ES5 function-constructor locals on their existing paths

## Validation
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 timeout 600 ./run_parity_tests.sh --suite node-suite --module globals --filter class-expression-var-value` -> 1 pass / 0 fail / 0 compile fail
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 timeout 900 ./run_parity_tests.sh --suite node-suite --module globals` -> 81 pass / 1 parity fail / 1 compile fail; residual failures are WebAssembly fixtures
- `cargo check -q -p perry-hir --release`
- `cargo test -q -p perry-hir --lib` -> 134 passed
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Part of #800.