### PR TITLE
fix(hir): keep class-expression aliases constructable

### DIFF
--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -1570,7 +1570,9 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             // allocation that matches the pre-fix baseline. Real
             // classes still win — the `lookup_class` check above
             // returns `Expr::New { class_name }` before reaching here.
-            if ctx.lookup_class(&class_name).is_none() {
+            if ctx.lookup_class(&class_name).is_none()
+                && ctx.resolve_class_alias(&class_name).is_none()
+            {
                 if let Some(local_id) = ctx.lookup_local(&class_name) {
                     return Ok(Expr::NewDynamic {
                         callee: Box::new(Expr::LocalGet(local_id)),

--- a/test-parity/node-suite/globals/class-expression-var-value.ts
+++ b/test-parity/node-suite/globals/class-expression-var-value.ts
@@ -20,6 +20,7 @@ const C = class {
 };
 
 const D = B;
+const E = D;
 
 console.log("typeof B:", typeof B);
 console.log("B.parse:", B.parse(1));
@@ -31,3 +32,6 @@ console.log("new C:", new C().parse(4));
 console.log("typeof D:", typeof D);
 console.log("D.parse:", D.parse(5));
 console.log("new D:", new D().parse(6));
+console.log("typeof E:", typeof E);
+console.log("E.parse:", E.parse(7));
+console.log("new E:", new E().parse(8));


### PR DESCRIPTION
## Summary
- Keep known class aliases out of the local dynamic `new` fallback so `const D = B; new D()` lowers through normal class construction.
- Expand the node-suite globals fixture to cover an alias chain (`const E = D`) for `typeof`, static method calls, and construction.

## Why This Cluster
This closes the class-expression value/alias constructor gap from the current node-core parity scan. It stays scoped to aliases; arbitrary `new C()` for class objects passed through function parameters remains a separate dynamic-constructor issue.

Refs #800

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/class-expression-var-value.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry test-parity/node-suite/globals/class-expression-var-value.ts -o /tmp/perry_class_expression_var_value_fixed && /tmp/perry_class_expression_var_value_fixed`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry test-files/test_gap_class_expr_inherited_static_method.ts -o /tmp/perry_class_expr_static_fixed && /tmp/perry_class_expr_static_fixed`
- `cargo check -p perry-hir -p perry-codegen`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `npm exec --yes --package=node@26 -- bash -lc 'PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter class-expression-var-value'`