### PR TITLE
fix(zlib): validate async callback argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1133 — zlib async one-shot helpers validate their callback synchronously
+
+Node throws synchronously (`ERR_INVALID_ARG_TYPE`) when an async one-shot zlib
+helper (`gzip`/`gunzip`/`brotliCompress`/`brotliDecompress`/… `(data, cb)`) is
+called without a callable callback, *before* any codec work is queued. Perry's
+ext-zlib path previously coerced a missing/invalid callback to a null pointer
+and silently dropped the result. It now calls a new
+`js_zlib_validate_callback` runtime shim (delegating to the shared
+`fs::validate::validate_required_callback`) at the top of
+`queue_one_shot_callback`, so the throw happens up front and matches Node. The
+old ad-hoc `callback_ptr` helper is removed in favor of the validated handle.
+
 ## v0.5.1132 — WebCrypto `algorithm.length` for KMAC128/KMAC256, not ChaCha20-Poly1305
 
 Aligns the `CryptoKey.algorithm.length` surface with WebCrypto/Node:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1132
+**Current Version:** 0.5.1133
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1132"
+version = "0.5.1133"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1132"
+version = "0.5.1133"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1132"
+version = "0.5.1133"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1132"
+version = "0.5.1133"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1132"
+version = "0.5.1133"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -63,6 +63,9 @@ extern "C" {
     // any bytes. The in-tree codecs validate inline; this shared helper gives
     // the ext crate the same rejection without the runtime's value typing.
     pub(crate) fn js_zlib_validate_buffer_arg(data_bits: i64);
+    // Async one-shot zlib helpers require a callable callback and throw
+    // synchronously before queuing codec work.
+    pub(crate) fn js_zlib_validate_callback(callback: f64) -> i64;
     fn js_native_call_method_str_key(
         object: f64,
         name_handle: i64,
@@ -531,15 +534,6 @@ unsafe fn make_buffer_f64(bytes: &[u8]) -> Option<f64> {
     Some(f64::from_bits(POINTER_TAG | (buf as u64 & POINTER_MASK)))
 }
 
-fn callback_ptr(value: f64) -> i64 {
-    let bits = value.to_bits();
-    if JsValue::from_bits(bits).is_pointer() {
-        (bits & POINTER_MASK) as i64
-    } else {
-        0
-    }
-}
-
 unsafe fn call_one_shot_callback(callback: i64, result: Result<Vec<u8>, String>) {
     if callback == 0 {
         return;
@@ -567,6 +561,7 @@ pub(crate) unsafe fn queue_one_shot_callback<F>(
 ) where
     F: FnOnce(&[u8]) -> std::io::Result<Vec<u8>>,
 {
+    let callback = js_zlib_validate_callback(callback_value);
     let data_bits = data_value.to_bits() as i64;
     js_zlib_validate_buffer_arg(data_bits);
     let result = match read_input_from_bits(data_bits) {
@@ -579,10 +574,7 @@ pub(crate) unsafe fn queue_one_shot_callback<F>(
         .lock()
         .unwrap()
         .pending
-        .push(ZlibEvent::OneShotCallback(
-            callback_ptr(callback_value),
-            result,
-        ));
+        .push(ZlibEvent::OneShotCallback(callback, result));
     notify_main_thread();
 }
 

--- a/crates/perry-runtime/src/node_submodules/zlib.rs
+++ b/crates/perry-runtime/src/node_submodules/zlib.rs
@@ -264,6 +264,15 @@ pub extern "C" fn js_zlib_validate_buffer_arg(data_bits: i64) {
     crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE");
 }
 
+/// Validate the required callback for async one-shot zlib helpers
+/// (`gzip(data, cb)`, `gunzip(data, cb)`, `brotliDecompress(data, cb)`, ...).
+/// Node throws synchronously before queuing codec work when the callback is
+/// missing or not callable.
+#[no_mangle]
+pub extern "C" fn js_zlib_validate_callback(callback: f64) -> i64 {
+    crate::fs::validate::validate_required_callback("callback", callback) as i64
+}
+
 /// Keep the codegen-emitted symbol alive through the whole-program LLVM
 /// bitcode rebuild performed by auto-optimize (see
 /// `project_auto_optimize_keepalive_3320`). Called only from generated `.o` /
@@ -276,3 +285,5 @@ static KEEP_JS_ZLIB_VALIDATE_PARAMS: extern "C" fn(f64, f64) -> i32 = js_zlib_va
 static KEEP_JS_ZLIB_VALIDATE_OPTIONS: extern "C" fn(f64, i32) = js_zlib_validate_options;
 #[used]
 static KEEP_JS_ZLIB_VALIDATE_BUFFER_ARG: extern "C" fn(i64) = js_zlib_validate_buffer_arg;
+#[used]
+static KEEP_JS_ZLIB_VALIDATE_CALLBACK: extern "C" fn(f64) -> i64 = js_zlib_validate_callback;


### PR DESCRIPTION
Refs #2013. Refs #800.

## Summary
- add a runtime `js_zlib_validate_callback` helper that reuses the shared Node-shaped required-callback validator
- validate async one-shot zlib callbacks before reading input or queuing codec work in the external zlib path
- store the validated closure pointer in queued one-shot callback events instead of accepting arbitrary pointer-shaped values

## Why this cut
The current zlib validation tail is one coherent fixture: `node-suite/zlib/validation/callback-required`. Recent zlib decode work left this callback-required fixture out of scope, and the failing cases all share the same missing/non-callable callback validation path.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/zlib/validation/callback-required.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib --filter callback-required'` - 1 pass / 0 fail / 0 compile fail
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib --filter validation'` - 4 pass / 0 fail / 0 compile fail
- `cargo check -p perry-runtime -p perry-ext-zlib` - passes with existing warnings
- `cargo test -p perry-ext-zlib --lib` - 12 pass / 0 fail, with existing warnings
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Non-goals
- zlib Transform stream methods/lifecycle
- callback scheduling/order beyond synchronous validation
- invalid compressed payload behavior
- broader full-module zlib parity cleanup