### PR TITLE
fix(hir): await generic async iterables

### DIFF
--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -193,6 +193,20 @@ fn async_iterator_method_call(iterable: Expr) -> Expr {
     }
 }
 
+fn array_from_async_expr(iterable: Expr) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::GlobalGet(0)),
+                property: "Array".to_string(),
+            }),
+            property: "fromAsync".to_string(),
+        }),
+        args: vec![iterable],
+        type_args: vec![],
+    }
+}
+
 fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
     let call = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
@@ -925,7 +939,11 @@ pub(crate) fn lower_stmt_for_of(
     } else if is_iterable_typed_array {
         Expr::ArrayFrom(Box::new(arr_expr))
     } else if needs_runtime_iterator {
-        Expr::ForOfToArray(Box::new(arr_expr))
+        if for_of_stmt.is_await {
+            Expr::Await(Box::new(array_from_async_expr(arr_expr)))
+        } else {
+            Expr::ForOfToArray(Box::new(arr_expr))
+        }
     } else {
         arr_expr
     };

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -11,7 +11,9 @@ use crate::lower::{
 use crate::lower_patterns::*;
 use crate::lower_types::*;
 
-use super::helpers::{async_iterator_method_call, is_filehandle_readlines_for_await_target};
+use super::helpers::{
+    array_from_async_expr, async_iterator_method_call, is_filehandle_readlines_for_await_target,
+};
 use super::*;
 
 fn class_computed_member_registration_expr(class_name: &str, member: &ClassComputedMember) -> Expr {
@@ -1299,7 +1301,11 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             } else if is_iterable_typed_array {
                 Expr::ArrayFrom(Box::new(arr_expr))
             } else if needs_runtime_iterator {
-                Expr::ForOfToArray(Box::new(arr_expr))
+                if for_of_stmt.is_await {
+                    Expr::Await(Box::new(array_from_async_expr(arr_expr)))
+                } else {
+                    Expr::ForOfToArray(Box::new(arr_expr))
+                }
             } else {
                 arr_expr
             };

--- a/crates/perry-hir/src/lower_decl/helpers.rs
+++ b/crates/perry-hir/src/lower_decl/helpers.rs
@@ -54,6 +54,20 @@ pub(super) fn async_iterator_method_call(iterable: Expr) -> Expr {
     }
 }
 
+pub(super) fn array_from_async_expr(iterable: Expr) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::GlobalGet(0)),
+                property: "Array".to_string(),
+            }),
+            property: "fromAsync".to_string(),
+        }),
+        args: vec![iterable],
+        type_args: vec![],
+    }
+}
+
 /// Build `if (param === undefined) { param = default; }` stmts for every
 /// param with a default value. Prepended to function/constructor bodies so
 /// cross-module callers that pad missing args with `undefined` still observe


### PR DESCRIPTION
## Summary
- Route untyped `for await...of` fallback materialization through `await Array.fromAsync(source)` instead of the sync `ForOfToArray(source)` path.
- Apply the same fallback in module-level and function-body loop lowering.
- Fixes `node:test/reporters` reporter streams returned through an `any` callback parameter, where Perry previously threw `TypeError: value is not iterable`.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -q -p perry-hir` (passes with existing warning noise)
- `git diff --check`
- `./scripts/check_file_size.sh`
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module test --filter reporters/basic` -> 1 pass / 0 fail / 0 compile fail
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module test` -> 11 pass / 0 fail / 0 compile fail
- `PATH="/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH" PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter array-from-async-mapfn` -> 1 pass / 0 fail / 0 compile fail

Part of #800.
