### PR TITLE
fix(json): JSON.stringify honors non-enumerable own properties (#4512)

### DIFF
--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -208,9 +208,19 @@ pub(crate) unsafe fn stringify_object_with_replacer_pretty(
     let actual_fields = std::cmp::min(num_fields, keys_len);
     let use_pretty = !indent.is_empty();
     let inner_depth = depth + 1;
+    // A function replacer only sees own ENUMERABLE keys (EnumerableOwnProperty
+    // Names); gated for the common no-descriptor case.
+    let filter_non_enum = crate::object::descriptors_in_use();
     buf.push('{');
     let mut first = true;
     for f in 0..actual_fields {
+        // Skip non-enumerable own keys before invoking the replacer.
+        if filter_non_enum
+            && f < keys_len
+            && super::stringify::json_key_non_enumerable(obj, *keys_elements.add(f as usize))
+        {
+            continue;
+        }
         // Get the key as a string
         let (key_str_ptr, key_str_opt) = if f < keys_len {
             let key_f64 = *keys_elements.add(f as usize);
@@ -588,6 +598,8 @@ pub(crate) unsafe fn stringify_object_pretty(
     let fields_ptr =
         (ptr as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *const f64;
     let actual_fields = std::cmp::min(num_fields, keys_len);
+    // Only own ENUMERABLE keys are serialized (gated for the common case).
+    let filter_non_enum = crate::object::descriptors_in_use();
 
     // Collect non-undefined, non-closure fields
     let mut entries: Vec<(String, f64)> = Vec::new();
@@ -595,6 +607,14 @@ pub(crate) unsafe fn stringify_object_pretty(
         let field_val = *fields_ptr.add(f as usize);
         let field_bits = field_val.to_bits();
         if field_bits == TAG_UNDEFINED || is_closure_value(field_bits) {
+            continue;
+        }
+        // Skip non-enumerable own keys (`Object.defineProperty(o, k,
+        // { enumerable: false })`).
+        if filter_non_enum
+            && f < keys_len
+            && super::stringify::json_key_non_enumerable(obj, *keys_elements.add(f as usize))
+        {
             continue;
         }
         let key_name = if f < keys_len {

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -810,6 +810,30 @@ pub(crate) unsafe fn stringify_value_depth(
     write_number(buf, value);
 }
 
+/// JSON.stringify serializes only own ENUMERABLE string-keyed properties.
+/// Returns `true` when the own key `key_f64` on `obj` carries an explicit
+/// `enumerable: false` descriptor (`Object.defineProperty`, `freeze`/`seal`,
+/// or a builtin descriptor such as `Uint8Array.prototype.BYTES_PER_ELEMENT`),
+/// so the caller must skip it. Callers gate this behind
+/// `crate::object::descriptors_in_use()` so the common no-descriptor object
+/// pays only a single relaxed atomic load and never touches the descriptor map.
+pub(crate) unsafe fn json_key_non_enumerable(
+    obj: *const crate::ObjectHeader,
+    key_f64: f64,
+) -> bool {
+    let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    if let Some(kb) =
+        crate::string::js_string_key_bytes(crate::JSValue::from_bits(key_f64.to_bits()), &mut sso)
+    {
+        if let Ok(ks) = std::str::from_utf8(kb) {
+            if let Some(attrs) = crate::object::get_property_attrs(obj as usize, ks) {
+                return !attrs.enumerable();
+            }
+        }
+    }
+    false
+}
+
 #[inline]
 pub(crate) unsafe fn stringify_object(ptr: *const u8, buf: &mut String) {
     stringify_object_inner(ptr, buf, 0)
@@ -887,7 +911,10 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
         let keys_arr = (*obj).keys_array;
         !keys_arr.is_null() && (*keys_arr).length > num_fields
     };
-    if num_fields >= 5 && !has_overflow_fields {
+    // The shape-template fast path emits every key in the shape; it can't
+    // honor per-key `enumerable: false`, so fall through to the slow path
+    // (which filters) whenever any descriptor exists on this thread.
+    if num_fields >= 5 && !has_overflow_fields && !crate::object::descriptors_in_use() {
         if let Some(tmpl_ptr) = shape_template_for(ptr) {
             if try_emit_shape_element(make_pointer_bits(ptr), &*tmpl_ptr, buf, depth) {
                 if depth > MAX_FAST_DEPTH {
@@ -993,6 +1020,9 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
 
     buf.push('{');
     let mut first = true;
+    // Only own ENUMERABLE keys are serialized; gated so descriptor-free
+    // objects (the common case) pay a single relaxed atomic load.
+    let filter_non_enum = crate::object::descriptors_in_use();
     // `pos(j)` maps the j-th enumerated slot to its key/field index: spec
     // order when array-index keys are present, else slot `j` (no allocation).
     let pos = |j: u32| -> u32 {
@@ -1013,6 +1043,11 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
         // Guarded by has_closure_field: if no field is a closure, the in-loop
         // check is skipped entirely for every field.
         if has_closure_field && is_closure_value(field_bits) {
+            continue;
+        }
+        // Skip non-enumerable own keys (e.g. `Object.defineProperty(o, k,
+        // { enumerable: false })`).
+        if filter_non_enum && json_key_non_enumerable(obj, *keys_elements.add(f as usize)) {
             continue;
         }
 

--- a/test-parity/node-suite/globals/json-stringify-non-enumerable.ts
+++ b/test-parity/node-suite/globals/json-stringify-non-enumerable.ts
@@ -1,0 +1,44 @@
+// JSON.stringify serializes only own ENUMERABLE string-keyed properties.
+// Non-enumerable own properties (Object.defineProperty with enumerable:false,
+// and builtin descriptors like Math's constants or a TypedArray prototype's
+// BYTES_PER_ELEMENT) must be skipped — matching Object.keys, across the
+// compact, pretty, and function-replacer paths. The array (property-list)
+// replacer is the exception: it emits listed keys regardless of enumerability.
+
+function show(label: string, value: any) {
+  console.log(label + " = " + value);
+}
+
+// User-defined non-enumerable own property.
+const a: any = { x: 1, y: 2 };
+Object.defineProperty(a, "hidden", { value: 9, enumerable: false });
+show("compact", JSON.stringify(a));
+show("pretty", JSON.stringify(a, null, 2).replace(/\s+/g, " "));
+show("fn-replacer", JSON.stringify(a, (_k, v) => v));
+show("array-replacer", JSON.stringify(a, ["x", "hidden"])); // array replacer keeps it
+
+// Native objects with non-enumerable own properties.
+show("Math", JSON.stringify(Math as any));
+show("U8-proto", JSON.stringify(Uint8Array.prototype as any));
+
+// Nested object with a non-enumerable property.
+const n: any = { o: {} };
+Object.defineProperty(n.o, "hid", { value: 1, enumerable: false });
+n.o.vis = 2;
+show("nested", JSON.stringify(n));
+
+// Shape-template fast path (>=5 enumerable fields) must still skip a
+// non-enumerable sibling.
+const big: any = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+Object.defineProperty(big, "sec", { value: 6, enumerable: false });
+show("big5", JSON.stringify(big));
+
+// A non-enumerable accessor is skipped; freeze leaves enumerability intact.
+const g: any = { x: 1 };
+Object.defineProperty(g, "ge", { get: () => 7, enumerable: false });
+show("getter-nonenum", JSON.stringify(g));
+show("frozen", JSON.stringify(Object.freeze({ k: 1 })));
+
+// Regression: descriptor-free objects are unaffected.
+show("normal", JSON.stringify({ a: 1, b: [2, 3], c: { d: 4 }, e: "s", f: true, g: null }));
+show("array", JSON.stringify([1, { a: 1 }, ["x"]]));


### PR DESCRIPTION
Fixes #4512. Surfaced while verifying #4140 (a TypedArray prototype's `BYTES_PER_ELEMENT` descriptor leaked into `JSON.stringify`).

## Problem

`JSON.stringify` serialized non-enumerable own string-keyed properties — user-defined (`Object.defineProperty(o, k, {enumerable:false})`) and builtin (all of `Math`'s constants, a TypedArray prototype's `BYTES_PER_ELEMENT`) — while `Object.keys` correctly excluded them. The JSON object walk iterated `keys_array` without consulting the property-descriptor side-table.

```ts
const o:any={x:1}; Object.defineProperty(o,'hidden',{value:2,enumerable:false});
JSON.stringify(o);     // Node: {"x":1}   was: {"x":1,"hidden":2}
JSON.stringify(Math);  // Node: {}        was: {"E":...,"PI":...}
```

## Fix

Mirror `Object.keys`' enumerability filter (`get_property_attrs(...).enumerable()`), gated on the existing `descriptors_in_use()` atomic so descriptor-free objects (the common case) pay only one relaxed load:
- Skip non-enumerable own keys in the compact, pretty, and function-replacer paths.
- Fall through from the shape-template fast path whenever any descriptor exists (it can't honor per-key enumerability).
- The array (property-list) replacer is unchanged — it emits listed keys regardless of enumerability, matching Node.

## Verification

- Parity fixture `test-parity/node-suite/globals/json-stringify-non-enumerable.ts`.
- Verified identical-to-Node across compact / pretty / function-replacer / array-replacer / native (`Math`, TA proto) / nested / shape-template (≥5 fields) / frozen / non-enumerable-getter cases.
- 41 JSON unit tests still pass; broad JSON regression sweep unchanged.