### PR TITLE
fix(zlib): expose transform stream handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1134 — external `node:zlib` Transform stream handles (write/end/on/pipe/reset…)
+
+Part of #800. External `node:zlib` stream handles now expose callable
+Transform-style method properties (`write`, `end`, `on`, `pipe`, `close`,
+`destroy`, `params`, `reset`), add `reset()` support, and report Node-like
+`bytesWritten` timing for queued stream writes. The external zlib stream pump is
+drained whenever `external-zlib-pump` is enabled (including no-auto node-suite
+builds that keep the full stdlib), and `run_parity_tests.sh` now builds
+`perry-ext-zlib` + the stdlib zlib pump bridge for no-auto zlib parity runs so
+stream fixtures exercise the same external archive path. Complementary to #4506
+(async one-shot callback validation); no overlap.
+
 ## v0.5.1133 — zlib async one-shot helpers validate their callback synchronously
 
 Node throws synchronously (`ERR_INVALID_ARG_TYPE`) when an async one-shot zlib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1133
+**Current Version:** 0.5.1134
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1133"
+version = "0.5.1134"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1133"
+version = "0.5.1134"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1133"
+version = "0.5.1134"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1133"
+version = "0.5.1134"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1133"
+version = "0.5.1134"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -367,6 +367,7 @@ fn make_codec_state_with_level(codec: Codec, level: Compression) -> Option<Codec
 
 struct ZlibStreamState {
     codec: Codec,
+    level: Compression,
     /// Streaming codec, fed incrementally. `None` for `createUnzip` (uses
     /// `input` + `run_codec` on `.end()`) or once finalized.
     codec_state: Option<CodecState>,
@@ -377,6 +378,8 @@ struct ZlibStreamState {
     /// encoder at a new level (flate2 has no mid-stream `deflateParams`) before
     /// this flips; after data is written it validates + flushes only (#3285).
     wrote_data: bool,
+    bytes_written: usize,
+    pending_bytes_written: usize,
     /// `.pipe(dest)` destinations as NaN-boxed bits; 'data'/'end' forward here.
     pipes: Vec<u64>,
 }
@@ -453,10 +456,13 @@ fn create_stream(codec: Codec, level: Compression) -> i64 {
         id,
         ZlibStreamState {
             codec,
+            level,
             codec_state: make_codec_state_with_level(codec, level),
             input: Vec::new(),
             ended: false,
             wrote_data: false,
+            bytes_written: 0,
+            pending_bytes_written: 0,
             pipes: Vec::new(),
         },
     );
@@ -600,6 +606,7 @@ fn stream_write(handle: i64, bytes: &[u8]) {
     let event = match g.streams.get_mut(&handle) {
         Some(s) if !s.ended => {
             s.wrote_data = true;
+            s.pending_bytes_written = s.pending_bytes_written.saturating_add(bytes.len());
             match s.codec_state.as_mut() {
                 Some(cs) => match cs.write_chunk(bytes) {
                     Ok(()) => {
@@ -665,7 +672,9 @@ unsafe fn stream_params(handle: i64, level: f64, strategy: f64, cb: i64) {
     let mut g = statics().lock().unwrap();
     if let Some(s) = g.streams.get_mut(&handle) {
         if !s.ended && !s.wrote_data {
-            s.codec_state = make_codec_state_with_level(s.codec, Compression::new(clamped as u32));
+            let level = Compression::new(clamped as u32);
+            s.level = level;
+            s.codec_state = make_codec_state_with_level(s.codec, level);
         } else if !s.ended {
             if let Some(cs) = s.codec_state.as_mut() {
                 let _ = cs.flush_codec();
@@ -681,6 +690,34 @@ unsafe fn stream_params(handle: i64, level: f64, strategy: f64, cb: i64) {
     }
     drop(g);
     notify_main_thread();
+}
+
+fn stream_reset(handle: i64) {
+    let mut g = statics().lock().unwrap();
+    if let Some(s) = g.streams.get_mut(&handle) {
+        s.codec_state = make_codec_state_with_level(s.codec, s.level);
+        s.input.clear();
+        s.ended = false;
+        s.wrote_data = false;
+        s.bytes_written = 0;
+        s.pending_bytes_written = 0;
+    }
+}
+
+fn stream_bytes_written(handle: i64) -> f64 {
+    statics()
+        .lock()
+        .unwrap()
+        .streams
+        .get(&handle)
+        .map(|s| s.bytes_written as f64)
+        .unwrap_or(0.0)
+}
+
+fn publish_bytes_written(handle: i64) {
+    if let Some(s) = statics().lock().unwrap().streams.get_mut(&handle) {
+        s.bytes_written = s.pending_bytes_written;
+    }
 }
 
 /// Finalize the stream and queue the remaining output + 'end' (or 'error').
@@ -828,8 +865,17 @@ pub unsafe extern "C" fn js_ext_zlib_dispatch_method(
             stream_params(handle, level, strategy, cb);
             self_ref
         }
+        "reset" => {
+            stream_reset(handle);
+            f64::from_bits(UNDEFINED)
+        }
         _ => f64::from_bits(UNDEFINED),
     }
+}
+
+#[no_mangle]
+pub extern "C" fn js_ext_zlib_stream_bytes_written(handle: i64) -> f64 {
+    stream_bytes_written(handle)
 }
 
 // ── pump (drained on the main thread from perry-stdlib) ─────────────────────────
@@ -899,6 +945,7 @@ pub unsafe extern "C" fn js_ext_zlib_process_pending() -> i32 {
     for ev in events {
         match ev {
             ZlibEvent::Data(id, bytes) => {
+                publish_bytes_written(id);
                 let cbs = listeners_for(id, "data");
                 if !cbs.is_empty() {
                     if let Some(buf_f64) = make_buffer_f64(&bytes) {
@@ -915,6 +962,7 @@ pub unsafe extern "C" fn js_ext_zlib_process_pending() -> i32 {
                 }
             }
             ZlibEvent::End(id) => {
+                publish_bytes_written(id);
                 for cb in listeners_for(id, "end") {
                     if cb != 0 {
                         let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call0();

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -522,7 +522,7 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
     }
     // External path: the well-known flip routed `node:zlib` to perry-ext-zlib
     // and stripped `compression`. Drain perry-ext-zlib's queue via its extern.
-    #[cfg(all(feature = "external-zlib-pump", not(feature = "compression")))]
+    #[cfg(feature = "external-zlib-pump")]
     {
         extern "C" {
             fn js_ext_zlib_process_pending() -> i32;
@@ -746,7 +746,7 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
         }
     }
     // External (perry-ext-zlib) path:
-    #[cfg(all(feature = "external-zlib-pump", not(feature = "compression")))]
+    #[cfg(feature = "external-zlib-pump")]
     {
         extern "C" {
             fn js_ext_zlib_has_active_handles() -> i32;

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -651,10 +651,11 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     }
 
     // External zlib path (#1843): when the well-known flip routes `node:zlib`
-    // to perry-ext-zlib and strips `compression`, the stream handle + dispatch
-    // live in perry-ext-zlib. Same registry-gated contract; the per-method
-    // match runs inside `js_ext_zlib_dispatch_method`.
-    #[cfg(all(feature = "external-zlib-pump", not(feature = "compression")))]
+    // to perry-ext-zlib, the stream handle + dispatch live in perry-ext-zlib.
+    // Same registry-gated contract; the per-method match runs inside
+    // `js_ext_zlib_dispatch_method`. This may coexist with `compression` in
+    // no-auto test builds that use the full stdlib plus external archives.
+    #[cfg(feature = "external-zlib-pump")]
     if matches!(
         method_name,
         "write"
@@ -1721,7 +1722,51 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
                     method_name_len: usize,
                 ) -> f64;
             }
-            return js_class_method_bind(handle as f64, name_bytes.as_ptr(), name_bytes.len());
+            return js_class_method_bind(
+                f64::from_bits(handle as u64),
+                name_bytes.as_ptr(),
+                name_bytes.len(),
+            );
+        }
+    }
+
+    #[cfg(feature = "external-zlib-pump")]
+    {
+        extern "C" {
+            fn js_ext_zlib_is_stream_handle(handle: i64) -> i32;
+            fn js_ext_zlib_stream_bytes_written(handle: i64) -> f64;
+            fn js_class_method_bind(
+                instance: f64,
+                method_name_ptr: *const u8,
+                method_name_len: usize,
+            ) -> f64;
+        }
+
+        if js_ext_zlib_is_stream_handle(handle) != 0 {
+            if property_name == "bytesWritten" {
+                return js_ext_zlib_stream_bytes_written(handle);
+            }
+            let method: Option<&'static [u8]> = match property_name {
+                "write" => Some(b"write"),
+                "end" => Some(b"end"),
+                "on" => Some(b"on"),
+                "once" => Some(b"once"),
+                "addListener" => Some(b"addListener"),
+                "pipe" => Some(b"pipe"),
+                "flush" => Some(b"flush"),
+                "close" => Some(b"close"),
+                "destroy" => Some(b"destroy"),
+                "params" => Some(b"params"),
+                "reset" => Some(b"reset"),
+                _ => None,
+            };
+            if let Some(name_bytes) = method {
+                return js_class_method_bind(
+                    f64::from_bits(handle as u64),
+                    name_bytes.as_ptr(),
+                    name_bytes.len(),
+                );
+            }
         }
     }
 

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -364,6 +364,15 @@ if [[ -n "${PERRY_NO_AUTO_OPTIMIZE:-}" && "$TEST_SUITE" == "node-suite" ]]; then
             BUILD_FEATURES+=(perry-stdlib/external-http-server-pump perry-stdlib/external-http-client-pump)
             ;;
     esac
+    case "$MODULE_FILTER" in
+        ""|zlib|zlib/*)
+            # zlib no-auto node-suite runs still route `node:zlib` through the
+            # well-known external archive, so build that archive and the stdlib
+            # bridge that drains its stream queue and dispatches stream handles.
+            BUILD_PACKAGES+=(-p perry-ext-zlib)
+            BUILD_FEATURES+=(perry-stdlib/external-zlib-pump)
+            ;;
+    esac
 fi
 needs_wasm_host=0
 if [[ "$TEST_SUITE" == "node-suite" ]]; then


### PR DESCRIPTION
## Linked issues
- Part of #800

## Summary
- Exposes callable Transform-style method properties for external `node:zlib` stream handles (`write`, `end`, `on`, `pipe`, `close`, `destroy`, `params`, `reset`).
- Adds external zlib stream `reset()` support plus Node-like `bytesWritten` timing for queued stream writes.
- Drains the external zlib stream pump whenever `external-zlib-pump` is enabled, including no-auto node-suite builds that keep the full stdlib enabled.
- Builds `perry-ext-zlib` and the stdlib zlib pump bridge for no-auto zlib parity runs so stream fixtures exercise the same external archive path.

## Why batched
These failures share the same external zlib stream handle surface: property lookup, method dispatch, lifecycle event pumping, and `bytesWritten` visibility all route through the same small-handle bridge. Keeping them together avoids landing a partially callable stream object that still cannot complete roundtrip stream tests.

## Tests
- `cargo fmt --all`
- `cargo check -p perry-ext-zlib`
- `cargo check -p perry-stdlib --no-default-features --features external-zlib-pump`
- `cargo check -p perry-stdlib --features external-zlib-pump`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module zlib --filter streams'` (4 pass, 0 fail)

## Limitations / non-goals
- Does not change async one-shot zlib callback validation; that is covered separately by #4506.
- Does not cover zlib decode-error or multi-member gzip behavior, generic stream/web constructors, or one-shot codec paths.
- #800 is a broad Node compatibility tracker, so this PR narrows only the zlib Transform stream handle/lifecycle slice.
