### PR TITLE
fix(webcrypto): align modern key metadata

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -122,7 +122,7 @@ fn crypto_key_algorithm_has_hash(algo: u8) -> bool {
 }
 
 fn crypto_key_algorithm_has_length(algo: u8) -> bool {
-    matches!(algo, 1 | 2 | 3 | 4 | 5 | 21 | 22 | 25)
+    matches!(algo, 1 | 2 | 3 | 4 | 5 | 21 | 23 | 24 | 25)
 }
 
 fn crypto_key_named_curve(algo: u8) -> Option<&'static str> {


### PR DESCRIPTION
## Summary
- stop exposing `CryptoKey.algorithm.length` for `ChaCha20-Poly1305` keys
- expose `CryptoKey.algorithm.length` for `KMAC128` and `KMAC256` keys using the stored key byte length in bits
- closes the current-main WebCrypto metadata tail in the crypto Node-suite parity scan

## Validation
- `CARGO_BUILD_JOBS=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter chacha20-poly1305'` -> 1 pass / 0 fail / 0 compile fail
- `CARGO_BUILD_JOBS=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto --filter kmac'` -> 1 pass / 0 fail / 0 compile fail
- `CARGO_BUILD_JOBS=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module crypto'` -> 241 pass / 0 fail / 0 compile fail
- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo check -q -p perry-runtime`
- `CARGO_BUILD_JOBS=1 cargo check -q -p perry-stdlib`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
