### PR TITLE
fix(codegen): push with >1 arg/spread inside a method or getter body (#4508)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -931,15 +931,10 @@ pub(super) fn try_array_only_methods(
                         };
                         if !is_user_class_receiver {
                             let array_expr = lower_expr(ctx, &member.obj)?;
-                            if call.args.first().is_some_and(|arg| arg.spread.is_some()) {
-                                return Ok(Ok(Expr::NativeMethodCall {
-                                    module: "array".to_string(),
-                                    method: "push_spread".to_string(),
-                                    class_name: None,
-                                    object: Some(Box::new(array_expr)),
-                                    args,
-                                }));
-                            } else {
+                            let any_spread = call.args.iter().any(|a| a.spread.is_some());
+                            if !any_spread {
+                                // No spreads — `push_single` loops over every
+                                // arg, so a single native call handles N values.
                                 return Ok(Ok(Expr::NativeMethodCall {
                                     module: "array".to_string(),
                                     method: "push_single".to_string(),
@@ -948,6 +943,47 @@ pub(super) fn try_array_only_methods(
                                     args,
                                 }));
                             }
+                            if args.len() == 1 {
+                                // Exactly one spread arg — the `push_spread`
+                                // native arm packs the source as `args[0]`.
+                                return Ok(Ok(Expr::NativeMethodCall {
+                                    module: "array".to_string(),
+                                    method: "push_spread".to_string(),
+                                    class_name: None,
+                                    object: Some(Box::new(array_expr)),
+                                    args,
+                                }));
+                            }
+                            // Mixed/multiple args with at least one spread
+                            // (e.g. `arr.push(...a, ...b)` or `arr.push(...a, x)`
+                            // inside a method/getter body). The single-arg
+                            // `push_spread`/`push_single` native arms each
+                            // expect exactly one arg; the previous code passed
+                            // all of them to one `push_spread`, which bailed at
+                            // codegen ("expects exactly 1 arg"). Decompose into a
+                            // `Sequence` of single-arg native calls, choosing the
+                            // helper per-arg from the original AST spread flag.
+                            // Each native arm re-reads the receiver and writes
+                            // back the (possibly realloc'd) handle, so chaining
+                            // threads the array correctly; JS `push` returns the
+                            // final length, which is exactly what the last
+                            // element of the `Sequence` yields. (#4508)
+                            let mut stmts: Vec<Expr> = Vec::with_capacity(args.len());
+                            for (ast_arg, arg) in call.args.iter().zip(args.into_iter()) {
+                                let method = if ast_arg.spread.is_some() {
+                                    "push_spread"
+                                } else {
+                                    "push_single"
+                                };
+                                stmts.push(Expr::NativeMethodCall {
+                                    module: "array".to_string(),
+                                    method: method.to_string(),
+                                    class_name: None,
+                                    object: Some(Box::new(array_expr.clone())),
+                                    args: vec![arg],
+                                });
+                            }
+                            return Ok(Ok(Expr::Sequence(stmts)));
                         }
                     }
                     _ => {} // Fall through - ambiguous methods on non-array expressions use generic dispatch

--- a/test-files/test_issue_4508_push_spread_multi_arg_in_method.ts
+++ b/test-files/test_issue_4508_push_spread_multi_arg_in_method.ts
@@ -1,0 +1,56 @@
+// Refs #4508: `Array.prototype.push` with more than one argument (two
+// spreads, or a spread combined with another element) failed native
+// codegen when the call was inside a class method or getter body. The
+// HIR lowered the whole arg list into a single `push_spread`
+// NativeMethodCall, and the codegen arm bailed with
+// "array.push_spread expects exactly 1 arg, got 2", rejecting the whole
+// module. The same statement at module top level (local-array receiver)
+// already worked because that path decomposed multi-arg push into a
+// Sequence of single-arg pushes. Found in the wild in zod's
+// `ParseInputLazyPath.get path()`.
+//
+// Fix: decompose the multi-arg/property-receiver case the same way —
+// into per-arg single native pushes, choosing spread vs single from the
+// original AST spread flag. Output is byte-for-byte against Node.
+
+class Path {
+    _path = [1, 2];
+    _key: number | number[];
+    _cached: number[] = [];
+    constructor(k: number | number[]) {
+        this._key = k;
+    }
+    get path(): number[] {
+        if (Array.isArray(this._key)) {
+            this._cached.push(...this._path, ...this._key); // two spreads
+        } else {
+            this._cached.push(...this._path, this._key); // spread + element
+        }
+        return this._cached;
+    }
+}
+console.log(new Path([3, 4]).path.join(",")); // 1,2,3,4
+console.log(new Path(9).path.join(",")); // 1,2,9
+
+// element-first then spread then element, inside a method body.
+// (Pre-fix this also mis-routed: only the FIRST arg was checked for a
+// spread, so a leading non-spread arg sent the call to `push_single`,
+// which would have treated the trailing `...a` as a single element.)
+class M {
+    out: number[] = [];
+    run(a: number[]) {
+        this.out.push(0, ...a, 7);
+        return this.out;
+    }
+}
+console.log(new M().run([5, 6]).join(",")); // 0,5,6,7
+
+// no-spread multi-arg push on a property receiver still works
+class N {
+    out: number[] = [];
+    fill() {
+        this.out.push(1, 2, 3);
+        return this.out;
+    }
+}
+console.log(new N().fill().join(",")); // 1,2,3


### PR DESCRIPTION
## Summary

`Array.prototype.push` with **more than one argument** — two spreads, or a spread combined with another element — failed native codegen when the call sat inside a **class method or getter body**:

```
array.push_spread expects exactly 1 arg, got 2
✗ ENTRY MODULE FAILED TO COMPILE — REFUSING TO LINK
```

The whole module was rejected, so a single such call in a dependency aborted the build. Found in the wild in **zod** (`ParseInputLazyPath.get path()`) — the only module-level codegen failure when compiling a zod-using app.

## Root cause

The same statement at module top level compiled fine because the local-array lowering path (`local_array_methods.rs`) already decomposes multi-arg push into a `Sequence` of single-arg pushes. The **property-receiver** path (`array_only_methods.rs`) instead packed the entire arg list into one `push_spread` `NativeMethodCall`, and the codegen arm bails on >1 arg.

## Fix

In the `array_only_methods` push arm, decompose the *multiple-args-with-a-spread* case into a `Sequence` of single-arg native calls, choosing `push_spread` vs `push_single` per-arg from the original AST spread flag. Each native arm re-reads the receiver and writes back the (possibly realloc'd) handle, so chaining threads the array correctly; `push` returns the final length, which the last `Sequence` element yields.

Also fixes a **latent mis-route**: the old code only checked the *first* arg for a spread, so `arr.push(0, ...a)` went to `push_single` and treated `...a` as a single element. The new any-spread check handles it.

## Verification

Output is byte-for-byte against `node --experimental-strip-types` for:
- two spreads in a getter: `this._cached.push(...this._path, ...this._key)` → `1,2,3,4`
- spread + element in a method: `push(...this._path, this._key)` → `1,2,9`
- element + spread + element: `push(0, ...a, 7)` → `0,5,6,7`
- plain multi-arg on a property receiver: `push(1, 2, 3)` → `1,2,3`

Added `test-files/test_issue_4508_push_spread_multi_arg_in_method.ts`. `perry-hir` tests pass; `cargo fmt --check` clean.

Closes #4508.