### PR TITLE
fix(hir): materialize TypeScript enum objects

### DIFF
--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -573,6 +573,26 @@ pub fn lower_module_full(
         }
     }
 
+    // Pre-register enum declarations so function bodies declared before the
+    // enum can still fold `Enum.Member` and capture the runtime enum object
+    // used by dynamic reverse-map reads.
+    for item in &ast_module.body {
+        let enum_decl = match item {
+            ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::TsEnum(enum_decl))) => Some(enum_decl),
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(export_decl)) => {
+                if let ast::Decl::TsEnum(enum_decl) = &export_decl.decl {
+                    Some(enum_decl)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if let Some(enum_decl) = enum_decl {
+            pre_register_enum_decl(&mut ctx, enum_decl)?;
+        }
+    }
+
     // Main pass: lower everything
     for item in &ast_module.body {
         match item {

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -1239,6 +1239,16 @@ pub(crate) fn lower_module_decl(
                 ast::Decl::TsEnum(enum_decl) => {
                     let en = lower_enum_decl(ctx, enum_decl, true)?;
                     let enum_name = en.name.clone();
+                    let enum_local = ctx
+                        .lookup_local(&enum_name)
+                        .unwrap_or_else(|| ctx.define_local(enum_name.clone(), Type::Any));
+                    module.init.push(Stmt::Let {
+                        id: enum_local,
+                        name: enum_name.clone(),
+                        ty: Type::Any,
+                        mutable: false,
+                        init: Some(enum_runtime_object_expr(&en)),
+                    });
                     module.enums.push(en);
                     module.exported_objects.push(enum_name.clone());
                     module.exports.push(Export::Named {

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1003,6 +1003,16 @@ pub(crate) fn lower_stmt(
                 }
                 ast::Decl::TsEnum(enum_decl) => {
                     let en = lower_enum_decl(ctx, enum_decl, false)?;
+                    let enum_local = ctx
+                        .lookup_local(&en.name)
+                        .unwrap_or_else(|| ctx.define_local(en.name.clone(), Type::Any));
+                    module.init.push(Stmt::Let {
+                        id: enum_local,
+                        name: en.name.clone(),
+                        ty: Type::Any,
+                        mutable: false,
+                        init: Some(enum_runtime_object_expr(&en)),
+                    });
                     module.enums.push(en);
                 }
                 ast::Decl::TsInterface(iface_decl) => {

--- a/crates/perry-hir/src/lower_decl/enum_decl.rs
+++ b/crates/perry-hir/src/lower_decl/enum_decl.rs
@@ -13,14 +13,8 @@ use crate::lower_types::*;
 
 use super::*;
 
-pub fn lower_enum_decl(
-    ctx: &mut LoweringContext,
-    enum_decl: &ast::TsEnumDecl,
-    is_exported: bool,
-) -> Result<Enum> {
+fn collect_enum_members(enum_decl: &ast::TsEnumDecl) -> (String, Vec<EnumMember>) {
     let name = enum_decl.id.sym.to_string();
-    let enum_id = ctx.fresh_enum();
-
     let mut members = Vec::new();
     let mut next_value: i64 = 0;
 
@@ -75,12 +69,74 @@ pub fn lower_enum_decl(
         });
     }
 
-    // Register the enum in the context for later lookups
+    (name, members)
+}
+
+pub(crate) fn pre_register_enum_decl(
+    ctx: &mut LoweringContext,
+    enum_decl: &ast::TsEnumDecl,
+) -> Result<()> {
+    let (name, members) = collect_enum_members(enum_decl);
+    if ctx.lookup_enum(&name).is_some() {
+        return Ok(());
+    }
+
+    let enum_id = ctx.fresh_enum();
     let member_values: Vec<(String, EnumValue)> = members
         .iter()
         .map(|m| (m.name.clone(), m.value.clone()))
         .collect();
     ctx.define_enum(name.clone(), enum_id, member_values);
+    if ctx.lookup_local(&name).is_none() {
+        ctx.define_local(name, Type::Any);
+    }
+    Ok(())
+}
+
+fn push_or_replace_prop(props: &mut Vec<(String, Expr)>, key: String, value: Expr) {
+    if let Some((_, existing)) = props
+        .iter_mut()
+        .find(|(existing_key, _)| existing_key == &key)
+    {
+        *existing = value;
+    } else {
+        props.push((key, value));
+    }
+}
+
+pub(crate) fn enum_runtime_object_expr(en: &Enum) -> Expr {
+    let mut props = Vec::new();
+    for member in &en.members {
+        match &member.value {
+            EnumValue::Number(n) => {
+                push_or_replace_prop(&mut props, member.name.clone(), Expr::Number(*n as f64));
+                push_or_replace_prop(&mut props, n.to_string(), Expr::String(member.name.clone()));
+            }
+            EnumValue::String(s) => {
+                push_or_replace_prop(&mut props, member.name.clone(), Expr::String(s.clone()));
+            }
+        }
+    }
+    Expr::Object(props)
+}
+
+pub fn lower_enum_decl(
+    ctx: &mut LoweringContext,
+    enum_decl: &ast::TsEnumDecl,
+    is_exported: bool,
+) -> Result<Enum> {
+    pre_register_enum_decl(ctx, enum_decl)?;
+    let name = enum_decl.id.sym.to_string();
+    let (enum_id, member_values) = ctx
+        .lookup_enum(&name)
+        .ok_or_else(|| anyhow!("enum '{}' was not registered", name))?;
+    let members = member_values
+        .iter()
+        .map(|(name, value)| EnumMember {
+            name: name.clone(),
+            value: value.clone(),
+        })
+        .collect();
 
     Ok(Enum {
         id: enum_id,

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use class_members::{
     lower_setter_method_with_name,
 };
 pub(crate) use class_validation::validate_legacy_decorator_surface;
-pub(crate) use enum_decl::lower_enum_decl;
+pub(crate) use enum_decl::{enum_runtime_object_expr, lower_enum_decl, pre_register_enum_decl};
 pub(crate) use fn_decl::lower_fn_decl;
 pub(crate) use helpers::{
     append_synthetic_arguments_param, body_has_use_strict, body_uses_arguments,

--- a/test-parity/expected/forward-enum-reference.txt
+++ b/test-parity/expected/forward-enum-reference.txt
@@ -1,0 +1,3 @@
+string fwd: B
+numeric fwd: C
+direct: C 1

--- a/test-parity/expected/numeric-reverse-mapping.txt
+++ b/test-parity/expected/numeric-reverse-mapping.txt
@@ -1,0 +1,5 @@
+forward: 5 reverse: Blue
+red reverse: Red green reverse: Green missing: undefined
+string key: 5
+mixed number: 0 No
+mixed string: YES undefined

--- a/test-parity/node-suite/codegen/enums/forward-enum-reference.ts
+++ b/test-parity/node-suite/codegen/enums/forward-enum-reference.ts
@@ -1,0 +1,23 @@
+function stringTag(): First {
+  return First.B;
+}
+
+function numericTag(): string {
+  return Numbered[Numbered.C];
+}
+
+enum First {
+  A = "A",
+  B = "B",
+  C = "C",
+}
+
+enum Numbered {
+  A,
+  B,
+  C,
+}
+
+console.log("string fwd:", stringTag());
+console.log("numeric fwd:", numericTag());
+console.log("direct:", First.C, Numbered.B);

--- a/test-parity/node-suite/codegen/enums/numeric-reverse-mapping.ts
+++ b/test-parity/node-suite/codegen/enums/numeric-reverse-mapping.ts
@@ -1,0 +1,18 @@
+enum Color {
+  Red,
+  Green = 4,
+  Blue,
+}
+
+const c: Color = Color.Blue;
+console.log("forward:", Color.Blue, "reverse:", Color[c]);
+console.log("red reverse:", Color[0], "green reverse:", Color[4], "missing:", Color[99]);
+console.log("string key:", Color["Blue" as any]);
+
+enum Mixed {
+  No = 0,
+  Yes = "YES",
+}
+
+console.log("mixed number:", Mixed.No, Mixed[0]);
+console.log("mixed string:", Mixed.Yes, (Mixed as any)["YES"]);


### PR DESCRIPTION
## Linked issues
- Fixes #4509
- Fixes #4510

## Behavior cluster
- Pre-registers TypeScript enum declarations before lowering function bodies, so same-module functions declared before an enum can still resolve later `Enum.Member` references.
- Materializes a runtime enum object at the enum declaration site, preserving numeric enum reverse mappings such as `E[value] === "Name"`.
- Keeps string enum members one-way only, matching TypeScript/Node output: `E.Name === "VALUE"`, but `E["VALUE"]` is `undefined`.

## Why batched
Both issues are the same enum lowering failure surface: static member folding needs enum metadata available before source-order lowering, while dynamic indexed reads need the runtime enum object that TypeScript emits. Fixing either one alone would still leave zod-style enum usage silently wrong.

## Tests added
- `test-parity/node-suite/codegen/enums/forward-enum-reference.ts`
- `test-parity/node-suite/codegen/enums/numeric-reverse-mapping.ts`
- Expected-output files for both fixtures, since the parity runner's Node mode uses type stripping and cannot transform TypeScript enum syntax directly.

## Commands run
- `cargo check -p perry-hir`
- `cargo test -p perry-hir enum`
- `cargo check -p perry-codegen`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module codegen/enums` (2 pass, 0 fail)
- `./run_parity_tests.sh --suite node-suite --module codegen/enums` (2 pass, 0 fail)
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `./scripts/check_file_size.sh`

## Limitations / non-goals
- Does not address unrelated class field ordering, async lowering, or Array.push spread lowering issues.
- Does not expand enum constant-expression evaluation beyond the existing numeric/string member handling.
- Does not change broader global/declaration-instantiation semantics outside TypeScript enum declarations.
