### PR TITLE
fix(hir): resolve same-module enum referenced before its declaration (#4510)

### DIFF
--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -359,6 +359,11 @@ pub fn lower_module_full(
     // synthesize a real concrete class extending `SomeClass`.
     pre_scan_mixin_functions(ast_module, &mut ctx);
 
+    // #4510: register module-level enums up front so a function body (or any
+    // statement) that references an enum declared later in the file resolves
+    // the member instead of silently lowering to 0.
+    pre_register_module_enums(ast_module, &mut ctx);
+
     // JSX expressions lower directly to the built-in `jsx`/`jsxs` externs in
     // `jsx.rs`. Do not synthesize a `react/jsx-runtime` import here: codegen
     // routes those extern names to Perry's runtime adapter, and making the

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -274,3 +274,41 @@ pub(crate) fn pre_scan_mixin_functions(ast_module: &ast::Module, ctx: &mut Lower
         }
     }
 }
+
+/// #4510: pre-register module-level `enum` declarations so a forward
+/// reference (an enum used in a function body or earlier statement, before its
+/// textual declaration) resolves instead of falling through to the
+/// "unknown identifier → GlobalGet(0) → 0" silent-miscompile path. Enum
+/// bindings are module-scoped in TypeScript, so a function declared above the
+/// `enum` may legally compare against `Enum.Member`. Member values are computed
+/// purely (`compute_enum_members`), so registering here produces the same id +
+/// values the real declaration site would, and `lower_enum_decl` reuses this
+/// registration rather than minting a duplicate.
+pub(crate) fn pre_register_module_enums(ast_module: &ast::Module, ctx: &mut LoweringContext) {
+    for item in &ast_module.body {
+        let enum_decl = match item {
+            ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::TsEnum(e))) => Some(e),
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(export)) => {
+                if let ast::Decl::TsEnum(e) = &export.decl {
+                    Some(e)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if let Some(e) = enum_decl {
+            // `declare enum` / `const enum` ambient declarations still carry
+            // member values usable as constants; register them too.
+            let name = e.id.sym.to_string();
+            if ctx.lookup_enum(&name).is_some() {
+                continue;
+            }
+            let members = crate::lower_decl::compute_enum_members(e);
+            let member_values: Vec<(String, EnumValue)> =
+                members.into_iter().map(|m| (m.name, m.value)).collect();
+            let id = ctx.fresh_enum();
+            ctx.define_enum(name, id, member_values);
+        }
+    }
+}

--- a/crates/perry-hir/src/lower_decl/enum_decl.rs
+++ b/crates/perry-hir/src/lower_decl/enum_decl.rs
@@ -19,8 +19,38 @@ pub fn lower_enum_decl(
     is_exported: bool,
 ) -> Result<Enum> {
     let name = enum_decl.id.sym.to_string();
-    let enum_id = ctx.fresh_enum();
+    let members = compute_enum_members(enum_decl);
 
+    // #4510: an enum referenced before its textual declaration is
+    // pre-registered (see `pre_register_module_enums`) so forward references
+    // resolve. If a registration already exists, reuse its id instead of
+    // minting a fresh one — that avoids a duplicate `ctx.enums` entry and
+    // keeps the EnumMember lookups pointing at the same id.
+    let enum_id = if let Some((existing_id, _)) = ctx.lookup_enum(&name) {
+        existing_id
+    } else {
+        let id = ctx.fresh_enum();
+        let member_values: Vec<(String, EnumValue)> = members
+            .iter()
+            .map(|m| (m.name.clone(), m.value.clone()))
+            .collect();
+        ctx.define_enum(name.clone(), id, member_values);
+        id
+    };
+
+    Ok(Enum {
+        id: enum_id,
+        name,
+        members,
+        is_exported,
+    })
+}
+
+/// Compute an enum's members (names + values) without touching the lowering
+/// context. Pure so it can run in the forward-reference pre-scan
+/// (`pre_register_module_enums`) and again at the real declaration site and
+/// produce identical results.
+pub(crate) fn compute_enum_members(enum_decl: &ast::TsEnumDecl) -> Vec<EnumMember> {
     let mut members = Vec::new();
     let mut next_value: i64 = 0;
 
@@ -75,17 +105,5 @@ pub fn lower_enum_decl(
         });
     }
 
-    // Register the enum in the context for later lookups
-    let member_values: Vec<(String, EnumValue)> = members
-        .iter()
-        .map(|m| (m.name.clone(), m.value.clone()))
-        .collect();
-    ctx.define_enum(name.clone(), enum_id, member_values);
-
-    Ok(Enum {
-        id: enum_id,
-        name,
-        members,
-        is_exported,
-    })
+    members
 }

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use class_members::{
     lower_setter_method_with_name,
 };
 pub(crate) use class_validation::validate_legacy_decorator_surface;
-pub(crate) use enum_decl::lower_enum_decl;
+pub(crate) use enum_decl::{compute_enum_members, lower_enum_decl};
 pub(crate) use fn_decl::lower_fn_decl;
 pub(crate) use helpers::{
     append_synthetic_arguments_param, body_has_use_strict, body_uses_arguments,

--- a/test-files/test_gap_4510_enum_forward_ref.ts
+++ b/test-files/test_gap_4510_enum_forward_ref.ts
@@ -1,0 +1,69 @@
+// #4510: an enum referenced before its textual declaration must resolve to the
+// real member value, not silently lower to 0. Enum bindings are module-scoped
+// in TypeScript, so a function (or earlier statement) declared above the enum
+// may legally reference it.
+
+// String enum used before declaration (the issue's minimal repro).
+function tag(): First {
+    return First.B;
+}
+enum First {
+    A = "A",
+    B = "B",
+    C = "C",
+}
+console.log("fwd:", tag()); // B
+
+// Numeric enum referenced before declaration.
+function num(): number {
+    return Second.Y;
+}
+enum Second {
+    X = 1,
+    Y = 2,
+    Z = 3,
+}
+console.log("num:", num()); // 2
+
+// Auto-incremented enum referenced before declaration.
+function auto(): number {
+    return Third.C;
+}
+enum Third {
+    A,
+    B,
+    C,
+}
+console.log("auto:", auto()); // 2
+
+// A top-level `const` initialized from an enum member declared later.
+const before = Fourth.GREEN;
+enum Fourth {
+    RED = "red",
+    GREEN = "green",
+}
+console.log("before:", before); // green
+
+// Switch dispatch against a forward-declared enum (the zod pattern).
+function kind(k: Kind): string {
+    switch (k) {
+        case Kind.A:
+            return "isA";
+        case Kind.B:
+            return "isB";
+        default:
+            return "other";
+    }
+}
+enum Kind {
+    A = "a",
+    B = "b",
+}
+console.log("dispatch:", kind(Kind.B)); // isB
+
+// Backward reference (already worked) keeps working.
+enum Fifth {
+    ON = "on",
+    OFF = "off",
+}
+console.log("back:", Fifth.OFF); // off


### PR DESCRIPTION
## Summary

Fixes #4510. An `enum` declared in a module but **referenced before its textual declaration** (valid TypeScript — enum bindings are module-scoped) was treated as an unknown global: member reads lowered to `0` and the compiler emitted a `Warning: unknown identifier '<Enum>'`. This was a silent miscompile — the binary linked but the enum value was wrong. Found in the wild in `zod` (`ZodFirstPartyTypeKind` is declared near the end of `types.ts` and referenced earlier throughout), corrupting its internal type-kind dispatch.

## Root cause

Perry registered each enum in the lowering context (`define_enum`) only when its *declaration statement* was lowered. A function body lowered earlier in the same pass therefore failed `lookup_enum`, fell through to the `unknown identifier → GlobalGet(0) → 0` path in `lower_expr`, and miscompiled. Functions are already hoisted via a pre-pass; enums were not.

## Fix

- Add `pre_register_module_enums` (in `lower/pre_scan.rs`), a pre-scan that registers every module-level enum — both `export enum` and plain `enum` — **before** any function body is lowered, mirroring the existing function-hoisting pre-pass. It runs right after `pre_scan_mixin_functions` in `lower_module_fn.rs`.
- Extract `compute_enum_members` as a pure helper (no `ctx`) so the pre-scan and the real declaration site compute identical names + values.
- `lower_enum_decl` now reuses the pre-registered enum id when one exists instead of minting a duplicate, so `ctx.enums` has exactly one entry per enum and ids stay in textual declaration order. Already-working (enum-before-use) code is byte-identical.

## Testing

New gap test `test-files/test_gap_4510_enum_forward_ref.ts` covers string / numeric / auto-increment forward enums, a top-level `const` initialized from a later enum, switch-dispatch (the zod pattern), and a backward reference (regression guard):

```
fwd: B        num: 2      auto: 2
before: green dispatch: isB back: off
```

No more `Warning: unknown identifier`. The issue's minimal repro now prints `fwd: B` (was `fwd: 0`).

- `cargo test --release -p perry-hir` — all pass.
- Existing `test_enum.ts` / `test_edge_enums_const.ts` compile and run clean (no regression).
- `cargo fmt --all -- --check` clean.

(Node's `--experimental-strip-types` rejects `enum` as non-erasable syntax, so enum behavior is validated directly rather than byte-compared.)