### PR TITLE
fix(hir): wire Reflect.getOwnPropertyDescriptor to ordinary [[GetOwnProperty]]

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1171,6 +1171,20 @@ pub(super) fn try_native_module_methods(
                             let target = args.into_iter().next().unwrap_or(Expr::Undefined);
                             return Ok(Ok(Expr::ReflectGetPrototypeOf(Box::new(target))));
                         }
+                        "getOwnPropertyDescriptor" => {
+                            // `Reflect.getOwnPropertyDescriptor(target, key)` is the
+                            // ordinary `[[GetOwnProperty]]` — identical to
+                            // `Object.getOwnPropertyDescriptor` for non-Proxy targets.
+                            // Without this arm it fell through to a generic call that
+                            // wasn't callable ("value is not a function").
+                            let mut it = args.into_iter();
+                            let target = it.next().unwrap_or(Expr::Undefined);
+                            let key = it.next().unwrap_or(Expr::Undefined);
+                            return Ok(Ok(Expr::ObjectGetOwnPropertyDescriptor(
+                                Box::new(target),
+                                Box::new(key),
+                            )));
+                        }
                         "defineMetadata" => {
                             let (key, value, target, property_key) = take_reflect_kvtp_args(args);
                             return Ok(Ok(Expr::ReflectDefineMetadata {


### PR DESCRIPTION
## What

`Reflect.getOwnPropertyDescriptor(target, key)` now works. It had no HIR lowering
arm (every other `Reflect.*` method does), so although `typeof
Reflect.getOwnPropertyDescriptor === "function"` (reified by #4440), *calling* it
fell through to a generic path and threw `TypeError: value is not a function`.

Lowered it to the existing `Expr::ObjectGetOwnPropertyDescriptor` machinery —
identical to `Object.getOwnPropertyDescriptor` for ordinary (non-Proxy) targets.

## Why

```js
Reflect.getOwnPropertyDescriptor({a:1}, "a")
// Node:  { value: 1, writable: true, enumerable: true, configurable: true }
// Perry (before): TypeError: value is not a function
```

test262 `built-ins/Reflect/getOwnPropertyDescriptor/*`.

## Verification

- 5/5 targeted tests pass: `return-from-accessor-descriptor`,
  `return-from-data-descriptor`, `symbol-property`, `undefined-own-property`,
  `undefined-property`.
- Byte-identical to `node --experimental-strip-types` in both
  `PERRY_NO_AUTO_OPTIMIZE=1` and the default build (HIR-only change → same path).
- `cargo test -p perry-hir -p perry-runtime --lib` green.
- Purely additive: a new match arm; `Reflect.get`/`has`/`ownKeys`/etc. unchanged.

## Out of scope (filed #4523)

The remaining `Reflect.*` gaps — non-object `target` → `TypeError`, Symbol-key
get/delete, `get` receiver-accessor, abrupt-completion propagation — are tracked
separately.

Part of the parity roadmap #4315.
