### PR TITLE
fix(net): stabilize socket handles and reactor paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1135 — `net.Socket` instanceof for native handles + explicit Tokio runtimes
+
+Registers the ext-net socket-handle probe so dynamic/static `instanceof
+net.Socket` (and the `net.Stream` alias) recognize native socket handles, so
+`new net.Stream() instanceof net.Socket` matches Node while preserving
+`net.Stream === net.Socket`. Socket `connect` and server `listen` futures now
+run on explicit current-thread Tokio runtimes instead of relying on an ambient
+reactor handle, stabilizing the net reactor paths. Touches
+`perry-ext-net/src/lib.rs`, `perry-runtime/src/object/instanceof.rs`, and
+`perry-codegen/src/expr/instance_misc1.rs`.
+
 ## v0.5.1134 — external `node:zlib` Transform stream handles (write/end/on/pipe/reset…)
 
 Part of #800. External `node:zlib` stream handles now expose callable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1134
+**Current Version:** 0.5.1135
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1134"
+version = "0.5.1135"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1134"
+version = "0.5.1135"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1134"
+version = "0.5.1135"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1134"
+version = "0.5.1135"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1134"
+version = "0.5.1135"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -284,6 +284,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 .get(ty)
                 .map(|source| source.strip_prefix("node:").unwrap_or(source) == "fs")
                 .unwrap_or(false);
+            let imported_from_net = ctx
+                .imported_class_sources
+                .get(ty)
+                .map(|source| source.strip_prefix("node:").unwrap_or(source) == "net")
+                .unwrap_or(false);
             let cid = match ty.as_str() {
                 "Error" => 0xFFFF0001u32,
                 "TypeError" => 0xFFFF0010u32,
@@ -387,6 +392,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "Stats" if imported_from_fs => 0xFFFF008Au32,
                 "fs.Utf8Stream" => 0xFFFF008Bu32,
                 "Utf8Stream" if imported_from_fs => 0xFFFF008Bu32,
+                // node:net `Stream` is an alias for `Socket`. Both are native
+                // small-handle values, so runtime probes the net socket map.
+                "net.Socket" | "net.Stream" => 0xFFFF00B4u32,
+                "Socket" | "Stream" if imported_from_net => 0xFFFF00B4u32,
                 "ReadStream" | "tty.ReadStream" => 0xFFFF0084u32,
                 "WriteStream" | "tty.WriteStream" => 0xFFFF0085u32,
                 "SecureContext" | "tls.SecureContext" => 0xFFFF00B5u32,

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -11,11 +11,11 @@
 //!
 //! # Differences from the perry-stdlib version
 //!
-//! - Uses `perry_ffi::spawn_blocking` + `tokio::runtime::Handle::current().block_on`
-//!   instead of `crate::common::async_bridge::spawn` (cooperative async over
-//!   the shared runtime). Each socket reader task ties up one blocking-pool
-//!   thread for the socket's lifetime — fine for v0.5.x (default blocking
-//!   pool is 512); cooperative `spawn_async` is a v0.6.0 optimization.
+//! - Uses `perry_ffi::spawn_blocking` plus an explicit current-thread Tokio
+//!   runtime instead of `crate::common::async_bridge::spawn` (cooperative async
+//!   over the shared runtime). Each socket reader task ties up one
+//!   blocking-pool thread for the socket's lifetime — fine for v0.5.x (default
+//!   blocking pool is 512); cooperative `spawn_async` is a v0.6.0 optimization.
 //! - Uses `perry_ffi::JsClosure` instead of raw `js_closure_call*` extern fns.
 //! - Uses `perry_ffi::alloc_buffer` / `BufferHeader` instead of
 //!   `perry-runtime::buffer::*` directly.
@@ -212,11 +212,22 @@ pub(crate) struct ServerState {
 
 static NET_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
 
+extern "C" {
+    fn js_register_net_socket_handle_probe(f: unsafe extern "C" fn(i64) -> bool);
+}
+
+unsafe extern "C" fn ext_net_socket_handle_probe(handle: i64) -> bool {
+    is_net_socket_handle(handle)
+}
+
 /// Register the net GC root scanner exactly once. Safe to call from any
 /// `js_net_*` entry point on the main thread.
 pub(crate) fn ensure_gc_scanner_registered() {
     NET_GC_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-net", scan_net_roots);
+        unsafe {
+            js_register_net_socket_handle_probe(ext_net_socket_handle_probe);
+        }
         // #2154 — publish the raw-consumer vtable for perry-ext-http (runs on
         // the first net FFI entry, before http could reference a socket).
         raw_bridge::register();
@@ -572,50 +583,16 @@ fn spawn_socket_runner<F>(fut_factory: F)
 where
     F: FnOnce() -> Pin<Box<dyn std::future::Future<Output = ()> + Send>> + Send + 'static,
 {
-    // Schedule the future onto a tokio runtime worker (which has
-    // the I/O reactor) instead of spawn_blocking + block_on (which
-    // creates a fresh current_thread runtime without I/O reactor).
-    // The v0.5.578 `spawn_blocking_with_reactor` shim runs the
-    // closure inside an `async` block on the multi-thread runtime,
-    // so `tokio::spawn(fut)` from inside picks up the I/O reactor
-    // properly. Detached spawn — we don't wait for the socket task
-    // to complete (that's the whole point: it loops until close).
-    perry_ffi::spawn_blocking_with_reactor(move || {
-        // We're already inside a tokio task (the
-        // spawn_blocking_with_reactor shim wraps us in
-        // `runtime().spawn(async {...})`), so `block_on` would
-        // panic with "cannot start a runtime from within a
-        // runtime". Schedule the socket future as a fresh
-        // detached task on the same multi-thread runtime
-        // instead — the future will drive itself to completion
-        // via `await` chains while we return immediately.
-        //
-        // Defeat the LTO pass that dead-strips perry-ext-net's
-        // private copy of tokio's CONTEXT statics. Without these
-        // touches, the subsequent `Handle::current()` panics with
-        // "there is no reactor running" — even though perry-stdlib's
-        // tokio runtime has the context entered. Two layers:
-        //   - eprintln of try_current() debug result keeps the
-        //     CONTEXT static referenced AT MULTIPLE call sites.
-        //   - black_box on the spawn handle prevents the
-        //     compiler from collapsing this whole closure into a
-        //     no-op when nothing later uses the result.
-        let try_h = tokio::runtime::Handle::try_current();
-        std::hint::black_box(&try_h);
-        if try_h.is_err() {
-            eprintln!(
-                "[perry-ext-net] BUG: spawn_socket_runner Handle::try_current returned Err — \
-                 LTO has likely dead-stripped tokio's CONTEXT statics. This will panic on \
-                 the subsequent `Handle::current()`."
-            );
-        }
-        let handle = tokio::runtime::Handle::current();
-        let fut = fut_factory();
-        // Detach via JoinHandle drop — tokio doesn't cancel on drop
-        // (only on explicit `abort()`), unlike `JoinSet` semantics.
-        let jh = handle.spawn(fut);
-        std::hint::black_box(&jh);
-        std::mem::forget(jh);
+    // Run each socket future on an explicit current-thread runtime. Relying on
+    // the FFI callback's ambient Handle has proven brittle under release/LTO
+    // builds, while the socket task already occupies one blocking-pool thread
+    // for its lifetime.
+    perry_ffi::spawn_blocking(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create net socket runtime");
+        rt.block_on(fut_factory());
     });
 }
 
@@ -854,23 +831,15 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, arg2: f64,
     let host_for_spawn = host.clone();
     let server_id = handle;
 
-    // Schedule the accept loop on the multi-thread tokio runtime that
-    // perry-stdlib hosts. Mirrors `js_node_http_server_listen`'s
-    // spawn_blocking_with_reactor → tokio::spawn pattern: the outer
-    // closure tickles tokio's CONTEXT statics through LTO; the inner
-    // `tokio::spawn` actually runs the async work.
-    perry_ffi::spawn_blocking_with_reactor(move || {
-        // Same LTO-defeating dance as `spawn_socket_runner` above.
-        let try_h = tokio::runtime::Handle::try_current();
-        std::hint::black_box(&try_h);
-        if try_h.is_err() {
-            eprintln!(
-                "[perry-ext-net] BUG: js_net_server_listen Handle::try_current returned Err — \
-                 LTO has likely dead-stripped tokio's CONTEXT statics."
-            );
-        }
-        let rt = tokio::runtime::Handle::current();
-        let jh = rt.spawn(async move {
+    // Run the accept loop inside a current-thread runtime on a blocking-pool
+    // thread. This avoids relying on an ambient Handle in the FFI callback,
+    // which can be absent under some release/LTO builds.
+    perry_ffi::spawn_blocking(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create net server runtime");
+        rt.block_on(async move {
             let bind_str = format!("{}:{}", host_for_spawn, port_u16);
             let listener = match TcpListener::bind(&bind_str).await {
                 Ok(l) => l,
@@ -1015,8 +984,6 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, arg2: f64,
                 }
             }
         });
-        std::hint::black_box(&jh);
-        std::mem::forget(jh);
     });
 }
 

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -9,6 +9,7 @@ use super::*;
 const CLASS_ID_EVENT_EMITTER: u32 = 0xFFFF0076;
 const CLASS_ID_EVENT_EMITTER_ASYNC_RESOURCE: u32 = 0xFFFF0077;
 const CLASS_ID_PROMISE: u32 = 0xFFFF0027;
+const CLASS_ID_NET_SOCKET: u32 = 0xFFFF00B4;
 const CLASS_ID_CRYPTO: u32 = 0xFFFF00C0;
 const CLASS_ID_SUBTLE_CRYPTO: u32 = 0xFFFF00C1;
 const CLASS_ID_CRYPTO_KEY: u32 = 0xFFFF00C2;
@@ -503,6 +504,20 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
     if class_id == CLASS_ID_EVENT_EMITTER_ASYNC_RESOURCE {
         return if is_event_emitter_async_resource_instance_value(value) {
             true_val
+        } else {
+            false_val
+        };
+    }
+    if class_id == CLASS_ID_NET_SOCKET {
+        return if let (Some(handle), Some(probe)) = (
+            small_native_handle_id(value),
+            crate::object::net_socket_handle_probe(),
+        ) {
+            if unsafe { probe(handle) } {
+                true_val
+            } else {
+                false_val
+            }
         } else {
             false_val
         };


### PR DESCRIPTION
## Summary
- register the ext-net socket handle probe so dynamic/static `instanceof net.Socket` and the `net.Stream` alias recognize native socket handles
- route ext-net socket connect and server listen futures through explicit current-thread Tokio runtimes instead of relying on an ambient reactor handle
- preserve `net.Stream === net.Socket` behavior while making `new net.Stream() instanceof net.Socket` match Node

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo check -q -p perry-ext-net -p perry-codegen -p perry-runtime`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 timeout 900 ./run_parity_tests.sh --suite node-suite --module net` -> 13 pass / 0 fail / 0 compile fail (`test-parity/reports/parity_report_20260605_061937.json`)
- focused reruns: `stream-alias`, `connection-state-limits`, `create-server-options`, `listen-port`, `socket-set-timeout` all pass
