### PR TITLE
fix(hir): numeric enum reverse mapping (E[value] -> name) (#4509)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -834,6 +834,58 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         }
     }
 
+    // Computed access on an enum identifier: `Color[expr]` (#4509).
+    // TypeScript numeric enums carry a reverse mapping in addition to the
+    // forward one — `Color.Blue === 2` *and* `Color[2] === "Blue"`. The
+    // `.Member` form above folds to a compile-time constant, but the
+    // computed form can index with a runtime value, so materialize the
+    // enum's runtime object — the forward members plus a reverse entry for
+    // every numeric member — and index into it. String-valued members get
+    // no reverse entry, matching tsc (string enums are one-directional).
+    // Unwrap TS-only casts/parens so `(Color as any)[c]` is recognised too.
+    {
+        fn unwrap_enum_receiver(mut e: &ast::Expr) -> &ast::Expr {
+            loop {
+                match e {
+                    ast::Expr::TsAs(x) => e = &x.expr,
+                    ast::Expr::TsNonNull(x) => e = &x.expr,
+                    ast::Expr::TsConstAssertion(x) => e = &x.expr,
+                    ast::Expr::TsTypeAssertion(x) => e = &x.expr,
+                    ast::Expr::TsSatisfies(x) => e = &x.expr,
+                    ast::Expr::Paren(x) => e = &x.expr,
+                    _ => break,
+                }
+            }
+            e
+        }
+        if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Computed(computed)) =
+            (unwrap_enum_receiver(member.obj.as_ref()), &member.prop)
+        {
+            let members: Option<Vec<(String, crate::ir::EnumValue)>> = ctx
+                .lookup_enum(obj_ident.sym.as_ref())
+                .map(|(_, m)| m.to_vec());
+            if let Some(members) = members {
+                let index = lower_expr(ctx, &computed.expr)?;
+                let mut fields: Vec<(String, Expr)> = Vec::new();
+                for (name, value) in &members {
+                    match value {
+                        crate::ir::EnumValue::Number(n) => {
+                            fields.push((name.clone(), Expr::Number(*n as f64)));
+                            fields.push((n.to_string(), Expr::String(name.clone())));
+                        }
+                        crate::ir::EnumValue::String(s) => {
+                            fields.push((name.clone(), Expr::String(s.clone())));
+                        }
+                    }
+                }
+                return Ok(Expr::IndexGet {
+                    object: Box::new(Expr::Object(fields)),
+                    index: Box::new(index),
+                });
+            }
+        }
+    }
+
     // Check if this is a static field access (e.g., Counter.count)
     if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
         let obj_name = obj_ident.sym.to_string();

--- a/test-files/test_enum.ts
+++ b/test-files/test_enum.ts
@@ -28,3 +28,11 @@ let myColor = Color.Green;
 if (myColor === Color.Green) {
     console.log(100); // Should print 100 (means test passed)
 }
+
+// Reverse mapping (#4509): numeric enums map value -> name.
+const cIdx: Color = Color.Blue;
+console.log(Color[cIdx]); // Should print Blue (dynamic index)
+console.log(Color[0]);    // Should print Red
+console.log(Color[1]);    // Should print Green
+console.log(Color[2]);    // Should print Blue
+console.log(Status[5]);   // Should print Active

--- a/tests/test_issue_4509_numeric_enum_reverse_mapping.sh
+++ b/tests/test_issue_4509_numeric_enum_reverse_mapping.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Issue #4509: TypeScript numeric enums generate a reverse mapping
+# (`E[value] === "Name"`). Perry emitted the forward members but the
+# reverse lookup returned `undefined` — a silent miscompile. This test
+# pins both directions: numeric enums reverse-map (dynamic + literal
+# index), the forward computed form still works, and string enums stay
+# one-directional (no reverse entry), matching tsc.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/enum_reverse.ts" <<'TS'
+enum Color { Red, Green, Blue }
+enum Dir { Up = 1, Down }
+enum S { A = "aaa", B = "bbb" }
+
+const c: Color = Color.Blue;
+
+// Reverse mapping (numeric): dynamic index and literal indices.
+if (Color[c] !== "Blue") throw new Error(`reverse dyn: ${Color[c]}`);
+if (Color[0] !== "Red" || Color[1] !== "Green" || Color[2] !== "Blue") {
+  throw new Error(`reverse lit: ${Color[0]},${Color[1]},${Color[2]}`);
+}
+if (Dir[1] !== "Up" || Dir[2] !== "Down") {
+  throw new Error(`reverse explicit-base: ${Dir[1]},${Dir[2]}`);
+}
+
+// Forward mapping still works through the computed form.
+if ((Color["Blue"] as number) !== 2 || (Dir["Down"] as number) !== 2) {
+  throw new Error(`forward computed: ${Color["Blue"]},${Dir["Down"]}`);
+}
+
+// Forward `.Member` constant fold is unaffected.
+if (Color.Blue !== 2 || Dir.Down !== 2) {
+  throw new Error(`forward member: ${Color.Blue},${Dir.Down}`);
+}
+
+// String enums are one-directional — no reverse entry.
+if (S.A !== "aaa" || S["B"] !== "bbb") {
+  throw new Error(`string forward: ${S.A},${S["B"]}`);
+}
+if ((S as any)["aaa"] !== undefined) {
+  throw new Error(`string reverse should be undefined: ${(S as any)["aaa"]}`);
+}
+
+// Out-of-range numeric reverse lookup is undefined.
+if ((Color as any)[99] !== undefined) {
+  throw new Error(`oob reverse should be undefined: ${(Color as any)[99]}`);
+}
+
+console.log("numeric enum reverse mapping ok");
+TS
+
+"$PERRY" compile --no-cache --no-auto-optimize "$TMPDIR/enum_reverse.ts" \
+    -o "$TMPDIR/enum_reverse" >"$TMPDIR/compile.log" 2>&1 || {
+    echo "FAIL: compile failed"
+    sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+    exit 1
+}
+
+"$TMPDIR/enum_reverse" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q "numeric enum reverse mapping ok" "$TMPDIR/run.log"; then
+    echo "FAIL: expected success marker"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+echo "PASS: numeric enum reverse mapping"


### PR DESCRIPTION
## Summary

Fixes #4509. TypeScript **numeric enums** generate a reverse mapping (`E[value] === "Name"`) in addition to the forward one. Perry folded the forward `.Member` form (`Color.Blue === 2`) to a constant but left **computed access on an enum identifier** unhandled, so `Color[c]` and `Color[2]` returned `undefined` — a silent miscompile.

## Fix

In member lowering (`crates/perry-hir/src/lower/expr_member.rs`), `EnumIdent[expr]` (with TS casts/parens unwrapped, so `(Color as any)[c]` is recognised too) now lowers to an `IndexGet` over a materialized enum object:

- forward members (`name -> value`), plus
- a **reverse** entry for every **numeric** member (`value -> name`).

String-valued members get no reverse entry, matching `tsc` (string enums are one-directional). Dynamic and literal indices both resolve correctly. The forward computed form (`Color["Blue"]`) and the `.Member` constant fold are untouched.

## Before / After

```ts
enum Color { Red, Green, Blue }
const c: Color = Color.Blue;
console.log("forward:", Color.Blue, "reverse:", Color[c]);
```

- Before: `forward: 2 reverse: undefined`
- After:  `forward: 2 reverse: Blue`  ✅ (matches Node/tsc)

## Verification

Byte-identical to the `tsc`-transpiled reference (Node strip-types mode rejects enums) across: reverse (dynamic + literal index), explicit-base numeric, forward computed, `.Member` fold, string-enum forward, string-enum reverse (`undefined`), and out-of-range (`undefined`).

- New regression: `tests/test_issue_4509_numeric_enum_reverse_mapping.sh` (PASS).
- Extended `test-files/test_enum.ts` with reverse-mapping cases (compile-smoke coverage).
- `cargo test -p perry-hir`: all green; `cargo fmt --check`: clean.

## Out of scope

Cross-module **imported** enum reverse access (`ImportedEnum[c]`) remains a pre-existing gap — the lowering pass only knows locally-defined enums. Can be a follow-up.