### PR TITLE
fix(uri): reject lone surrogates during encoding

### DIFF
--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -45,9 +45,9 @@ const URI_RESERVED: &[u8] = b";/?:@&=+$,#";
 const URI_COMPONENT_UNESCAPED: &[u8] =
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()";
 
-fn percent_encode(input: &str, safe_chars: &[u8]) -> String {
+fn percent_encode(input: &[u8], safe_chars: &[u8]) -> String {
     let mut result = String::with_capacity(input.len() * 3);
-    for byte in input.as_bytes() {
+    for byte in input {
         if safe_chars.contains(byte) {
             result.push(*byte as char);
         } else {
@@ -117,14 +117,44 @@ fn extract_str_from_nanbox(value: f64) -> String {
     }
 }
 
+struct ExtractedStringBytes {
+    bytes: Vec<u8>,
+    flags: u32,
+}
+
+fn extract_string_bytes_from_nanbox(value: f64) -> ExtractedStringBytes {
+    let str_ptr = crate::value::js_get_string_pointer_unified(value);
+    if (str_ptr as usize) < 0x1000 {
+        return ExtractedStringBytes {
+            bytes: Vec::new(),
+            flags: 0,
+        };
+    }
+    unsafe {
+        let header = str_ptr as *const StringHeader;
+        let len = (*header).byte_len as usize;
+        let flags = (*header).flags;
+        let data = (header as *const u8).add(std::mem::size_of::<StringHeader>());
+        let bytes = std::slice::from_raw_parts(data, len).to_vec();
+        ExtractedStringBytes { bytes, flags }
+    }
+}
+
+fn throw_if_lone_surrogate(input: &ExtractedStringBytes) {
+    if input.flags & crate::string::STRING_FLAG_HAS_LONE_SURROGATES != 0 {
+        throw_uri_malformed();
+    }
+}
+
 /// encodeURI(string) -> string
 #[no_mangle]
 pub extern "C" fn js_encode_uri(value: f64) -> i64 {
-    let input = extract_str_from_nanbox(value);
+    let input = extract_string_bytes_from_nanbox(value);
+    throw_if_lone_surrogate(&input);
     let mut safe = Vec::with_capacity(URI_UNESCAPED.len() + URI_RESERVED.len());
     safe.extend_from_slice(URI_UNESCAPED);
     safe.extend_from_slice(URI_RESERVED);
-    let encoded = percent_encode(&input, &safe);
+    let encoded = percent_encode(&input.bytes, &safe);
     let ptr = js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32);
     ptr as i64
 }
@@ -141,8 +171,9 @@ pub extern "C" fn js_decode_uri(value: f64) -> i64 {
 /// encodeURIComponent(string) -> string
 #[no_mangle]
 pub extern "C" fn js_encode_uri_component(value: f64) -> i64 {
-    let input = extract_str_from_nanbox(value);
-    let encoded = percent_encode(&input, URI_COMPONENT_UNESCAPED);
+    let input = extract_string_bytes_from_nanbox(value);
+    throw_if_lone_surrogate(&input);
+    let encoded = percent_encode(&input.bytes, URI_COMPONENT_UNESCAPED);
     let ptr = js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32);
     ptr as i64
 }

--- a/test-parity/expected/uri-encode-surrogates.txt
+++ b/test-parity/expected/uri-encode-surrogates.txt
@@ -1,0 +1,17 @@
+high-start encodeURI throw URIError URI malformed true
+high-start encodeURIComponent throw URIError URI malformed true
+high-end encodeURI throw URIError URI malformed true
+high-end encodeURIComponent throw URIError URI malformed true
+low-start encodeURI throw URIError URI malformed true
+low-start encodeURIComponent throw URIError URI malformed true
+low-end encodeURI throw URIError URI malformed true
+low-end encodeURIComponent throw URIError URI malformed true
+mixed-high encodeURI throw URIError URI malformed true
+mixed-high encodeURIComponent throw URIError URI malformed true
+mixed-low encodeURI throw URIError URI malformed true
+mixed-low encodeURIComponent throw URIError URI malformed true
+pair uri %F0%9F%98%80
+pair component %F0%9F%98%80
+reserved uri ;/?:@&=+$,#%20alpha
+reserved component %3B%2F%3F%3A%40%26%3D%2B%24%2C%23%20alpha
+bmp caf%C3%A9 caf%C3%A9

--- a/test-parity/node-suite/globals/uri-encode-surrogates.ts
+++ b/test-parity/node-suite/globals/uri-encode-surrogates.ts
@@ -1,0 +1,31 @@
+function runEncode(name, input) {
+  if (name === "encodeURI") return encodeURI(input);
+  return encodeURIComponent(input);
+}
+
+function showEncode(label, name, input) {
+  try {
+    console.log(label, name, "ok", runEncode(name, input));
+  } catch (err) {
+    const e = err;
+    console.log(label, name, "throw", e.name, e.message, err instanceof URIError);
+  }
+}
+
+for (const [label, input] of [
+  ["high-start", "\uD800"],
+  ["high-end", "\uDBFF"],
+  ["low-start", "\uDC00"],
+  ["low-end", "\uDFFF"],
+  ["mixed-high", "a\uD800b"],
+  ["mixed-low", "a\uDC00b"],
+]) {
+  showEncode(label, "encodeURI", input);
+  showEncode(label, "encodeURIComponent", input);
+}
+
+console.log("pair uri", encodeURI("\uD83D\uDE00"));
+console.log("pair component", encodeURIComponent("\uD83D\uDE00"));
+console.log("reserved uri", encodeURI(";/?:@&=+$,# alpha"));
+console.log("reserved component", encodeURIComponent(";/?:@&=+$,# alpha"));
+console.log("bmp", encodeURI("caf\u00e9"), encodeURIComponent("caf\u00e9"));


### PR DESCRIPTION
## Linked Issues

- Fixes #4519

## Behavior Cluster

This PR aligns the global URI encoders with Node/ECMAScript behavior for malformed UTF-16 input:

- `encodeURI` throws `URIError: URI malformed` when the input contains a lone high or low surrogate.
- `encodeURIComponent` does the same.
- Valid surrogate pairs still percent-encode as UTF-8 bytes.
- The existing `encodeURI` vs `encodeURIComponent` reserved-character split is preserved.

## Why This Cut

This is a single focused runtime cut because the failing cases share one implementation path: Perry already marks WTF-8 string literals that contain lone surrogates, but the URI encoder previously converted those bytes through a UTF-8-only string path and silently encoded an empty string instead of throwing.

## Tests Added

- `test-parity/node-suite/globals/uri-encode-surrogates.ts`
- `test-parity/expected/uri-encode-surrogates.txt`

The expected-output file is included because this environment's system `node` is not compiled with TypeScript stripping support and the parity runner falls back to expected output for `.ts` fixtures. The Node 26 oracle was run separately.

## Validation

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/uri-encode-surrogates.ts`
- pre-fix repro: `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter uri-encode-surrogates` failed with `Perry: high-start encodeURI ok`
- `cargo check -p perry-runtime`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter uri-encode-surrogates`
- `npm exec --yes --package=node@26 -- bash -lc 'node --version; PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter uri-decode-errors'`
- `npm exec --yes --package=node@26 -- bash -lc 'node --version; PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter uri'`
- `cargo test -p perry-runtime uri`
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `./scripts/check_file_size.sh`

## Known Limitations / Non-goals

- Does not change the broader WTF-8/string representation model.
- Does not alter `decodeURI` / `decodeURIComponent` semantics beyond preserving existing passing coverage.
- Does not implement legacy `escape` / `unescape` globals or unrelated global descriptor work.
