### PR TITLE
ci(feature-matrix): make advisory-only, drop pull_request trigger

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -1,20 +1,17 @@
 name: TypeScript Feature Matrix
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/feature-matrix.yml"
-      - "scripts/gen_feature_matrix.py"
-      - "test-features/**"
-      - "crates/perry/**"
-      - "crates/perry-codegen/**"
-      - "crates/perry-hir/**"
-      - "crates/perry-runtime/**"
-      - "crates/perry-stdlib/**"
+  # Advisory language-feature drift signal — NOT a required gate. Runs on a
+  # nightly schedule and on demand only; intentionally NOT on pull_request.
+  #
+  # The check regenerates the matrix and diffs it against the committed
+  # snapshot (test-features/feature_matrix.md), so any single regressed row
+  # (a probe that flips PASS/DIFF/RUNTIME-FAIL) fails it on *every* PR that
+  # touches the compiler, regardless of that PR's content. Surfacing drift as
+  # a red, required-looking check on unrelated PRs is noise; the nightly run
+  # plus the uploaded artifact/summary is the actual signal.
   workflow_dispatch:
   schedule:
-    # Advisory language-feature drift signal. It is not a required gate.
     - cron: "43 4 * * *"
 
 permissions:


### PR DESCRIPTION
## What

Removes the `pull_request` trigger from the **TypeScript Feature Matrix** workflow, leaving `schedule` (nightly) + `workflow_dispatch`.

## Why

The feature matrix is an **advisory drift radar**, not a required gate — its own header comment says *"It is not a required gate."* It rebuilds `perry`, runs the `test-features/probes/**` fixtures through Node and Perry, regenerates `test-features/feature_matrix.md`, and **diffs the result against the committed snapshot**. Any single row that changes classification (`PASS`/`DIFF`/`RUNTIME-FAIL`) fails the whole check — on **every** PR that touches the compiler, regardless of what that PR changed.

Right now ~every open PR is red on `feature-matrix` because **one** row regressed on `main`:

```
- | proxy-reflect | construct-trap | DIFF         | Node proxy:x:proxy vs Perry proxy:x |
+ | proxy-reflect | construct-trap | RUNTIME-FAIL | Perry exit 1: TypeError: is not a constructor |
```

### Root cause (tracked separately, not fixed here)

#4480 (`new` on a primitive callee throws `TypeError: is not a constructor`) added a guard in `js_new_function_construct`. It surfaced a **latent codegen bug**: `Expr::ClassRef("Thing")` lowers to an int32-tagged class id (`arrays_finds.rs`, `INT32_TAG | cid`). `js_proxy_new` stores that int as the proxy's *target*; when the proxy forwards construction (`forward_construct` -> `js_new_function_construct_with_new_target`) the runtime gets back int32 `1` and cannot distinguish it from a genuine integer (the `js_new_dynamic` decode TODO). Pre-#4480 this was silently wrong; now it's a hard throw. Re-snapshotting the matrix would **bless** this regression, so that's deliberately not done here — a real fix to proxy-target construction will follow.

## Effect

The drift signal still runs nightly and on demand, with the JSON/markdown artifact + step summary intact. It just stops appearing as a red, required-looking check on unrelated PRs.