### PR TITLE
fix(json): JSON.stringify invokes own getters (#4531)

### DIFF
--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -245,8 +245,16 @@ pub(crate) unsafe fn stringify_object_with_replacer_pretty(
             nanbox_string_f64(fallback_ptr)
         };
 
-        // Get the field value, resolve toJSON, then apply the replacer.
-        let field_val = *fields_ptr.add(f as usize);
+        // Get the field value (invoking an own getter, as spec [[Get]] does),
+        // resolve toJSON, then apply the replacer.
+        let mut field_val = *fields_ptr.add(f as usize);
+        if filter_non_enum && f < keys_len {
+            if let Some(gv) =
+                crate::object::json_object_getter_value(obj, *keys_elements.add(f as usize))
+            {
+                field_val = gv;
+            }
+        }
         let field_after_to_json = apply_to_json_keyed(field_val, key_f64_for_replacer);
         let replaced = call_replacer(replacer, key_f64_for_replacer, field_after_to_json);
         let replaced_bits = replaced.to_bits();
@@ -604,17 +612,25 @@ pub(crate) unsafe fn stringify_object_pretty(
     // Collect non-undefined, non-closure fields
     let mut entries: Vec<(String, f64)> = Vec::new();
     for f in 0..actual_fields {
-        let field_val = *fields_ptr.add(f as usize);
-        let field_bits = field_val.to_bits();
-        if field_bits == TAG_UNDEFINED || is_closure_value(field_bits) {
-            continue;
-        }
         // Skip non-enumerable own keys (`Object.defineProperty(o, k,
-        // { enumerable: false })`).
+        // { enumerable: false })`) before touching the value.
         if filter_non_enum
             && f < keys_len
             && super::stringify::json_key_non_enumerable(obj, *keys_elements.add(f as usize))
         {
+            continue;
+        }
+        let mut field_val = *fields_ptr.add(f as usize);
+        // Own accessor properties: serialize the getter's return value.
+        if filter_non_enum && f < keys_len {
+            if let Some(gv) =
+                crate::object::json_object_getter_value(obj, *keys_elements.add(f as usize))
+            {
+                field_val = gv;
+            }
+        }
+        let field_bits = field_val.to_bits();
+        if field_bits == TAG_UNDEFINED || is_closure_value(field_bits) {
             continue;
         }
         let key_name = if f < keys_len {

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -1033,9 +1033,25 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
     };
     for j in 0..actual_fields {
         let f = pos(j);
-        let field_bits = read_field_bits(f);
+        // Skip non-enumerable own keys (e.g. `Object.defineProperty(o, k,
+        // { enumerable: false })`) before touching the value.
+        if filter_non_enum && json_key_non_enumerable(obj, *keys_elements.add(f as usize)) {
+            continue;
+        }
+        let mut field_bits = read_field_bits(f);
+        // Own accessor properties: serialize the getter's return value (Node
+        // invokes the getter), not the raw slot — which holds the getter
+        // closure (object-literal `get x() {}`) or an empty placeholder
+        // (`Object.defineProperty(o, k, { get })`). Gated on the descriptor flag.
+        if filter_non_enum {
+            if let Some(gv) =
+                crate::object::json_object_getter_value(obj, *keys_elements.add(f as usize))
+            {
+                field_bits = gv.to_bits();
+            }
+        }
         let field_val = f64::from_bits(field_bits);
-        // Skip undefined per JSON spec
+        // Skip undefined per JSON spec (incl. a getter that returned undefined).
         if field_bits == TAG_UNDEFINED {
             continue;
         }
@@ -1043,11 +1059,6 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
         // Guarded by has_closure_field: if no field is a closure, the in-loop
         // check is skipped entirely for every field.
         if has_closure_field && is_closure_value(field_bits) {
-            continue;
-        }
-        // Skip non-enumerable own keys (e.g. `Object.defineProperty(o, k,
-        // { enumerable: false })`).
-        if filter_non_enum && json_key_non_enumerable(obj, *keys_elements.add(f as usize)) {
             continue;
         }
 

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -655,6 +655,39 @@ pub(crate) fn reflect_getter_closure_bits(value: f64, key: f64) -> Option<u64> {
     }
 }
 
+/// `JSON.stringify` helper: if the own key `key_f64` on `obj` is an accessor
+/// property, invoke its getter (with `obj` as the `this` receiver) and return
+/// the result bits; `None` when there is no own accessor (caller falls back to
+/// the data-field slot). An accessor with no getter reads as `undefined`, which
+/// `JSON.stringify` then omits. Node serializes a getter's *return value*, not
+/// the stored slot (which holds the getter closure or an empty placeholder).
+/// Callers gate this on `descriptors_in_use()`.
+pub(crate) unsafe fn json_object_getter_value(
+    obj: *const ObjectHeader,
+    key_f64: f64,
+) -> Option<f64> {
+    let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let kb = crate::string::js_string_key_bytes(
+        crate::value::JSValue::from_bits(key_f64.to_bits()),
+        &mut sso,
+    )?;
+    let name = std::str::from_utf8(kb).ok()?;
+    let acc = get_accessor_descriptor(obj as usize, name)?;
+    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    if acc.get == 0 {
+        return Some(f64::from_bits(TAG_UNDEFINED));
+    }
+    let closure = (acc.get & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
+    if closure.is_null() {
+        return Some(f64::from_bits(TAG_UNDEFINED));
+    }
+    let receiver = crate::value::js_nanbox_pointer(obj as i64);
+    let prev = js_implicit_this_set(receiver);
+    let result = crate::closure::js_closure_call0(closure);
+    js_implicit_this_set(prev);
+    Some(result)
+}
+
 /// Store an accessor descriptor for (obj, key).
 pub(crate) fn set_accessor_descriptor(obj: usize, key: String, acc: AccessorDescriptor) {
     ACCESSORS_IN_USE.with(|c| c.set(true));

--- a/test-parity/node-suite/globals/json-stringify-getters.ts
+++ b/test-parity/node-suite/globals/json-stringify-getters.ts
@@ -1,0 +1,43 @@
+// JSON.stringify serializes an own accessor property's getter *return value*
+// (spec SerializeJSONProperty does an ordinary [[Get]]), not the raw field
+// slot — which holds the getter closure (object-literal `get x() {}`) or an
+// empty placeholder (`Object.defineProperty(o, k, { get })`). Covers the
+// compact, pretty, and function-replacer paths. Non-enumerable accessors are
+// skipped; a getter returning undefined omits the key.
+
+function show(label: string, value: any) {
+  console.log(label + " = " + value);
+}
+
+// Object.defineProperty enumerable getter.
+const o: any = { x: 1 };
+Object.defineProperty(o, "g", { get: () => 7, enumerable: true });
+show("defineProperty", JSON.stringify(o));
+
+// Object-literal getter (slot holds the getter closure).
+const lit: any = { a: 1, get b() { return 5; }, c: 3 };
+show("literal", JSON.stringify(lit));
+show("literal-pretty", JSON.stringify(lit, null, 1).replace(/\s+/g, " "));
+show("literal-replacer", JSON.stringify(lit, (_k, v) => v));
+
+// Getter returning a nested object/array recurses correctly.
+const nest: any = {};
+Object.defineProperty(nest, "n", { get: () => ({ z: [1, 2] }), enumerable: true });
+show("nested", JSON.stringify(nest));
+
+// Getter returning undefined omits the key.
+const u: any = { x: 1 };
+Object.defineProperty(u, "u", { get: () => undefined, enumerable: true });
+show("undefined", JSON.stringify(u));
+
+// Non-enumerable getter is skipped entirely.
+const ne: any = { x: 1 };
+Object.defineProperty(ne, "h", { get: () => 9, enumerable: false });
+show("nonenum", JSON.stringify(ne));
+
+// The getter runs with the object as `this`.
+const t: any = { base: 10, get derived() { return this.base * 2; } };
+show("this-binding", JSON.stringify(t));
+
+// Regression: descriptor-free objects are unaffected.
+show("normal", JSON.stringify({ a: 1, b: { c: [2, 3] }, d: "x" }));


### PR DESCRIPTION
Fixes #4531. Follow-up to #4513 (JSON enumerability); together these make `JSON.stringify` of objects with property descriptors match Node.

## Problem

`JSON.stringify` serialized the raw field slot of an own accessor property instead of the getter's return value:

```ts
const o:any={x:1}; Object.defineProperty(o,'g',{get(){return 7;},enumerable:true});
JSON.stringify(o);   // Node: {"x":1,"g":7}   was: {"x":1,"g":0}
const lit:any={a:1, get b(){return 5;}};
JSON.stringify(lit); // Node: {"a":1,"b":5}   was: {"a":1}  (b omitted as a closure)
```

## Fix

Add `json_object_getter_value(obj, key)` (looks up the own accessor descriptor, invokes the getter with `obj` as `this`) and override the serialized value with it in the compact, pretty, and function-replacer paths. Gated on the existing `descriptors_in_use()` atomic, so descriptor-free objects pay nothing. A getter returning undefined omits the key; non-enumerable accessors stay filtered; the shape-template fast path already bails when descriptors exist.

## Verification

- Parity fixture `json-stringify-getters.ts`.
- Identical to Node across defineProperty / object-literal / pretty / function-replacer / nested-getter-value / undefined / non-enumerable / this-binding cases.
- 41 JSON unit tests pass; the #4512 non-enumerable fixture still matches.