### PR TITLE
fix(hir): keep namespace identity when re-exporting import-* via export { ns }

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -114,6 +114,7 @@ impl LoweringContext {
             weakmap_locals: HashSet::new(),
             weakset_locals: HashSet::new(),
             namespace_import_locals: HashSet::new(),
+            namespace_import_sources: std::collections::HashMap::new(),
             generator_func_names: HashSet::new(),
             async_generator_func_names: HashSet::new(),
             iterator_func_for_class: std::collections::HashMap::new(),

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -321,6 +321,13 @@ pub struct LoweringContext {
     /// default imports of actual classes (`import { MongoClient }`) are NOT in
     /// this set and keep the static-method path.
     pub(crate) namespace_import_locals: HashSet<String>,
+    /// Maps a namespace-import local (`import * as z from "src"`) to its source
+    /// module. Used so a later bare `export { z }` re-export of that local routes
+    /// to `Export::NamespaceReExport` (equivalent to `export * as z from "src"`)
+    /// rather than `Export::Named`, which would resolve `z` to a bare function
+    /// symbol in the importer and drop every namespace member. Closes the zod
+    /// `import { z }` breakage (zod's index does `import * as z; export { z }`).
+    pub(crate) namespace_import_sources: std::collections::HashMap<String, String>,
     /// Names of functions declared with `function*` — used to detect generator
     /// calls in `for...of` so the iterator protocol loop is emitted instead of
     /// the array-index loop.

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -415,6 +415,11 @@ pub(crate) fn lower_module_decl(
                             // not lower to StaticMethodCall — see the heuristic
                             // in expr_call::static_and_instance.
                             ctx.namespace_import_locals.insert(local.clone());
+                            // Remember the source so a later bare `export { local }`
+                            // re-exports the namespace itself rather than a bare
+                            // function symbol (see the local-export branch below).
+                            ctx.namespace_import_sources
+                                .insert(local.clone(), source.clone());
                         }
                         specifiers.push(ImportSpecifier::Namespace { local });
                     }
@@ -1374,6 +1379,26 @@ pub(crate) fn lower_module_decl(
                                 }
                             })
                             .unwrap_or_else(|| local.clone());
+
+                        // When the re-exported local is a namespace import
+                        // (`import * as z from "src"; export { z }`), it is NOT a
+                        // plain binding — it is the module namespace of `src`.
+                        // Emit it as a NamespaceReExport (the same lowering as
+                        // `export * as z from "src"`, #310) so the importer
+                        // receives the namespace object with all its members,
+                        // not a bare `perry_fn_<mod>__z` function symbol. This is
+                        // exactly how zod re-exports `z`, so without this every
+                        // `z.object` / `z.coerce` in consumer code is undefined.
+                        if let Some(ns_source) =
+                            ctx.namespace_import_sources.get(&local).cloned()
+                        {
+                            module.exports.push(Export::NamespaceReExport {
+                                source: ns_source,
+                                name: exported.clone(),
+                            });
+                            continue;
+                        }
+
                         module.exports.push(Export::Named {
                             local: local.clone(),
                             exported: exported.clone(),

--- a/tests/test_namespace_reexport_binding.sh
+++ b/tests/test_namespace_reexport_binding.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Re-exporting an `import * as ns` namespace binding via a bare `export { ns }`
+# must hand the importer the namespace OBJECT (with all its members), not a bare
+# function symbol. Before the fix, `export { z }` of a namespace local lowered to
+# `Export::Named`, so a consumer's `import { z }` resolved `z` to a function and
+# every `z.<member>` was `undefined`. This is exactly how zod re-exports `z`
+# (`import * as z from "./external"; export { z }`), so it broke all of zod.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Mirrors zod's shape: a target module using `export *` + a direct export, a
+# barrel that does `import * as z` then `export { z }` (and `export default z`).
+cat >"$TMPDIR/sub.ts" <<'TS'
+export function object() { return "obj"; }
+TS
+cat >"$TMPDIR/external.ts" <<'TS'
+export * from "./sub.js";
+export const coerce = { number: () => 42 };
+TS
+cat >"$TMPDIR/barrel.ts" <<'TS'
+import * as z from "./external.js";
+export * from "./external.js";
+export { z };
+export default z;
+TS
+cat >"$TMPDIR/main.ts" <<'TS'
+import { z } from "./barrel.js";
+if (typeof z !== "object") throw new Error(`typeof z: ${typeof z}`);
+if (typeof (z as any).object !== "function") throw new Error("z.object missing");
+if (typeof (z as any).coerce !== "object") throw new Error("z.coerce missing");
+if ((z as any).coerce.number() !== 42) throw new Error("z.coerce.number() wrong");
+if ((z as any).object() !== "obj") throw new Error("z.object() wrong");
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/main.ts" 2>&1)" || {
+    echo "FAIL: perry run errored"
+    echo "$OUT"
+    exit 1
+}
+
+if ! grep -q "^OK$" <<<"$OUT"; then
+    echo "FAIL: expected OK, got:"
+    echo "$OUT"
+    exit 1
+fi
+
+echo "PASS: namespace re-export binding"


### PR DESCRIPTION
## Problem

A bare `export { z }` whose local came from `import * as z from "src"` lowered to `Export::Named`. A consumer's `import { z }` then resolved `z` to a bare function symbol, so `typeof z === "function"` and every `z.<member>` was `undefined`.

This is exactly how zod's entry re-exports `z`:
```js
import * as z from "./v3/external.js";
export { z };
export default z;
```
so the bug broke **all** of zod (`z.object`, `z.coerce`, `z.string`, … all undefined) — and therefore every app using zod.

## Fix

Record each namespace-import local's source module, and when a bare `export { local }` re-exports such a local, emit `Export::NamespaceReExport` (the same lowering as `export * as local from "src"`, #310) instead of `Export::Named`. The importer then receives the namespace object with all members.

## Test

`tests/test_namespace_reexport_binding.sh` reproduces zod's shape (export-* target + `import * as z; export { z }; export default z`) and asserts the consumer sees the namespace with working members. `cargo test -p perry-hir` passes.