### PR TITLE
fix(codegen): loose ==/!= with a string operand unboxes boxed wrappers

### DIFF
--- a/crates/perry-codegen/src/expr/compare.rs
+++ b/crates/perry-codegen/src/expr/compare.rs
@@ -182,12 +182,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     || (is_string_expr(ctx, right)
                         && !is_numeric_expr(ctx, left)
                         && !is_bool_expr(ctx, left)));
-            if one_side_string
-                && matches!(
-                    op,
-                    CompareOp::Eq | CompareOp::LooseEq | CompareOp::Ne | CompareOp::LooseNe
-                )
-            {
+            // Only STRICT eq/ne use this string-pointer fast path. Loose `==`/`!=`
+            // must fall through to `js_loose_eq` below: when one side is a boxed
+            // String/primitive *wrapper* (a POINTER_TAG object, not a STRING_TAG
+            // value), `js_get_string_pointer_unified` returns the raw ObjectHeader
+            // pointer and `js_string_equals` reads it as a bogus string → wrong
+            // result (`new String("x") == "x"` was `false`). `js_loose_eq` unboxes
+            // the wrapper first. Strict `=== "lit"` is unaffected (both sides are
+            // real strings at runtime). #boxed-loose-eq.
+            if one_side_string && matches!(op, CompareOp::Eq | CompareOp::Ne) {
                 let l = lower_expr(ctx, left)?;
                 let r = lower_expr(ctx, right)?;
                 let blk = ctx.block();


### PR DESCRIPTION
## What

Loose equality `==`/`!=` where one operand is a string and the other is statically
unknown now unboxes boxed primitive wrappers correctly. The codegen `one_side_string`
fast path called `js_get_string_pointer_unified` on both operands and compared via
`js_string_equals` — but for a boxed `String`/primitive **wrapper** (a `POINTER_TAG`
object, not a `STRING_TAG` value) that helper returns the raw `ObjectHeader` pointer,
which `js_string_equals` reads as a bogus string → wrong result.

Fix: restrict the string-pointer fast path to **strict** `===`/`!==` (where both
sides are real `STRING_TAG` strings at runtime). Loose `==`/`!=` now falls through to
the existing `js_loose_eq` arm, which unboxes wrappers and applies full cross-type
coercion.

## Why

```js
new String("abc") == "abc"   // Node: true   Perry (before): false
Object("k") == "k"           // Node: true   Perry (before): false
new String("x") != "x"       // Node: false  Perry (before): true
```

test262 `built-ins/String/S15.5.2.1_A1_*` and `built-ins/Object/S15.2.{1,2}.1_A2/A3_*`.

## Verification

- Repro above byte-identical to Node in BOTH `PERRY_NO_AUTO_OPTIMIZE=1` and default builds.
- **18/21** targeted String+Object loose-eq tests now pass (was ~0). The 3 remaining
  String stragglers (`A1_T8/T10/T11`) are a *separate* bug: `new String(fn)` doesn't
  honor a monkeypatched `Function.prototype.toString` — filed separately.
- Equality regression sanity (strict, loose, `"1"==1`, `null==undefined`, `false==0`,
  enum `===`, `NaN==NaN`) byte-identical to Node in both modes.
- `cargo test -p perry-codegen -p perry-runtime --lib` green.
- Strict `=== "literal"` (the enum/`Color.Red` case the fast path was written for) is
  unchanged — still uses the fast path.

Part of the parity roadmap #4315.
