### PR TITLE
style: rustfmt module_decl.rs (unblock CI lint)

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -1389,9 +1389,7 @@ pub(crate) fn lower_module_decl(
                         // not a bare `perry_fn_<mod>__z` function symbol. This is
                         // exactly how zod re-exports `z`, so without this every
                         // `z.object` / `z.coerce` in consumer code is undefined.
-                        if let Some(ns_source) =
-                            ctx.namespace_import_sources.get(&local).cloned()
-                        {
+                        if let Some(ns_source) = ctx.namespace_import_sources.get(&local).cloned() {
                             module.exports.push(Export::NamespaceReExport {
                                 source: ns_source,
                                 name: exported.clone(),


### PR DESCRIPTION
Pure whitespace: `module_decl.rs:1389` was committed unformatted (collapses to one line under stable rustfmt), failing the `lint` gate on **every** open PR. Whitespace-only, no logic change. Unblocks the fleet.