### PR TITLE
fix(runtime): Number.MIN_VALUE denormal, Number('INFINITY')→NaN, Symbol/BigInt radix→TypeError

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -772,7 +772,8 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     "MAX_SAFE_INTEGER" => Some(9007199254740991.0),
                     "MIN_SAFE_INTEGER" => Some(-9007199254740991.0),
                     "MAX_VALUE" => Some(f64::MAX),
-                    "MIN_VALUE" => Some(f64::MIN_POSITIVE),
+                    // smallest denormal (5e-324), not smallest normal
+                    "MIN_VALUE" => Some(f64::from_bits(1)),
                     "EPSILON" => Some(f64::EPSILON),
                     "POSITIVE_INFINITY" => Some(f64::INFINITY),
                     "NEGATIVE_INFINITY" => Some(f64::NEG_INFINITY),

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -367,6 +367,17 @@ pub extern "C" fn js_number_coerce(value: f64) -> f64 {
                             Err(_) => f64::NAN,
                         };
                     }
+                    // Rust's f64::from_str accepts `inf`/`infinity`/`INFINITY`
+                    // case-insensitively, but ECMAScript StrNumericLiteral only
+                    // accepts exactly `Infinity` (optionally signed). Reject any
+                    // alphabetic body that isn't exactly `Infinity`.
+                    let body = trimmed.strip_prefix(['+', '-']).unwrap_or(trimmed);
+                    if body.eq_ignore_ascii_case("inf")
+                        || (body.eq_ignore_ascii_case("infinity") && body != "Infinity")
+                        || body.eq_ignore_ascii_case("nan")
+                    {
+                        return f64::NAN;
+                    }
                     trimmed.parse::<f64>().unwrap_or(f64::NAN)
                 } else {
                     f64::NAN

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3400,7 +3400,9 @@ fn install_number_static_data_properties(ctor: *mut crate::closure::ClosureHeade
         ("POSITIVE_INFINITY", f64::INFINITY),
         ("NEGATIVE_INFINITY", f64::NEG_INFINITY),
         ("MAX_VALUE", f64::MAX),
-        ("MIN_VALUE", f64::MIN_POSITIVE),
+        // ECMAScript Number.MIN_VALUE is the smallest *denormal* (5e-324 =
+        // 2^-1074 = bit pattern 1), NOT f64::MIN_POSITIVE (smallest *normal*).
+        ("MIN_VALUE", f64::from_bits(1)),
         ("EPSILON", f64::EPSILON),
         ("MAX_SAFE_INTEGER", 9007199254740991.0),
         ("MIN_SAFE_INTEGER", -9007199254740991.0),

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -498,6 +498,15 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
 /// Returns NaN for anything that does not coerce to a finite number.
 unsafe fn radix_arg_to_number(radix_value: f64) -> f64 {
     let jsval = JSValue::from_bits(radix_value.to_bits());
+    // ToInteger(radix) → ToNumber(radix): a Symbol or BigInt radix throws a
+    // TypeError (must precede the NaN→RangeError path). e.g.
+    // `(0n).toString(Symbol())` / `(123).toString(2n)` → TypeError, not RangeError.
+    if jsval.is_bigint() {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
+    }
+    if crate::symbol::js_is_symbol(radix_value) != 0 {
+        crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a number");
+    }
     if jsval.is_int32() {
         jsval.as_int32() as f64
     } else if jsval.is_bool() {


### PR DESCRIPTION
## What

Three independent numeric/bigint coercion fixes:

1. **`Number.MIN_VALUE`** is now the smallest *denormal* `5e-324` (`f64::from_bits(1)`,
   2^-1074), not the smallest *normal* `f64::MIN_POSITIVE` (2^-1022). Fixed at both
   sites (runtime `global_this.rs` + the HIR constant fold in `expr_member.rs`).
2. **`Number("INFINITY")` / `Number("infinity")` → `NaN`.** Rust's `f64::from_str`
   accepts `inf`/`infinity`/`nan` case-insensitively, but ECMAScript
   StrNumericLiteral only accepts exactly `Infinity` (optionally signed). Reject any
   alphabetic body that isn't exactly `Infinity`.
3. **Symbol/BigInt radix → `TypeError`.** `(0n).toString(Symbol())` /
   `(123).toString(2n)` must throw `TypeError` (ToNumber on the radix), not the
   `RangeError` Perry produced from the NaN→invalid-radix path.

## Why

test262 `built-ins/Number/MIN_VALUE/value.js`, `Number/S15.7.1.1_A1.js`,
`BigInt/prototype/toString/radix-tointegerorinfinity-throws-*`,
`Number/prototype/toString/...` radix cases.

## Verification

Byte-identical to `node --experimental-strip-types` in BOTH `PERRY_NO_AUTO_OPTIMIZE=1`
and default builds:
```
Number.MIN_VALUE => 5e-324 ; Number.MIN_VALUE/2 => 0
Number("INFINITY")/("infinity") => NaN ; Number("Infinity")/("-Infinity") => ±Infinity
(0n).toString(Symbol()) / (123).toString(2n) => TypeError
(255).toString(16) => "ff" ; (10).toString(2) => "1010"  (normal radix unaffected)
```
`cargo test -p perry-runtime -p perry-hir --lib` green.

Part of the parity roadmap #4315.
