### PR TITLE
fix(fs): root fs promises iterator state

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -65,6 +65,7 @@ impl LoweringContext {
             interface_source_keys: std::collections::HashMap::new(),
             interface_object_types: std::collections::HashMap::new(),
             imported_functions: Vec::new(),
+            builtin_named_imports: Vec::new(),
             native_modules: Vec::new(),
             builtin_module_aliases: Vec::new(),
             subns_path_aliases: HashMap::new(),
@@ -938,6 +939,23 @@ impl LoweringContext {
         self.imported_functions_index
             .insert(local_name.clone(), idx);
         self.imported_functions.push((local_name, original_name));
+    }
+
+    pub(crate) fn register_builtin_named_import(
+        &mut self,
+        local_name: String,
+        module_name: String,
+        exported_name: String,
+    ) {
+        self.builtin_named_imports
+            .push((local_name, module_name, exported_name));
+    }
+
+    pub(crate) fn lookup_builtin_named_import(&self, name: &str) -> Option<(&str, &str)> {
+        self.builtin_named_imports
+            .iter()
+            .find(|(local, _, _)| local == name)
+            .map(|(_, module, exported)| (module.as_str(), exported.as_str()))
     }
 
     pub(crate) fn register_extern_func_types(

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -125,6 +125,19 @@ fn is_util_mime_params_receiver(ctx: &LoweringContext, expr: &ast::Expr) -> bool
     }
 }
 
+fn is_fs_dir_receiver(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let ast::Expr::Ident(ident) = unwrap_transparent_expr(expr) else {
+        return false;
+    };
+    ctx.lookup_local_type(ident.sym.as_ref())
+        .is_some_and(|ty| matches!(ty, Type::Named(name) if name == "Dir" || name == "fs.Dir"))
+        || ctx
+            .lookup_native_instance(ident.sym.as_ref())
+            .is_some_and(|(module, class_name)| {
+                module.strip_prefix("node:").unwrap_or(module) == "fs" && class_name == "Dir"
+            })
+}
+
 /// Does this expression's method chain originate from a node:stream
 /// source — `Readable.from(...)` / `Readable.of(...)`, `new Transform()`,
 /// or a chain of lazy iterator helpers (`map`/`filter`/`flatMap`/`take`/
@@ -570,7 +583,11 @@ pub(super) fn try_array_only_methods(
                     // `for (const [valueIndex, value] of values.entries())`
                     // where `values` arrives via destructuring of an
                     // any-typed function param.
-                    "entries" if args.is_empty() && !recv_is_class => {
+                    "entries"
+                        if args.is_empty()
+                            && !recv_is_class
+                            && !is_fs_dir_receiver(ctx, &member.obj) =>
+                    {
                         let array_expr = lower_expr(ctx, &member.obj)?;
                         return Ok(Ok(Expr::ArrayEntries(Box::new(array_expr))));
                     }

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -127,6 +127,10 @@ pub struct LoweringContext {
     pub(crate) interface_object_types: std::collections::HashMap<String, perry_types::ObjectType>,
     /// Imported functions: local_name -> original_name (the exported name in the source module)
     pub(crate) imported_functions: Vec<(String, String)>,
+    /// Built-in named imports: local_name -> (module_name, exported_name).
+    /// Kept separate from `imported_functions`, whose identity mapping is part
+    /// of cross-module codegen symbol disambiguation.
+    pub(crate) builtin_named_imports: Vec<(String, String, String)>,
     /// Native module imports: local_name -> (module_name, method_name)
     /// For namespace imports (import * as x), method_name is None
     /// For named imports (import { v4 as uuid }), method_name is Some("v4")

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -276,6 +276,13 @@ pub(crate) fn lower_module_decl(
                                 }
                             }
                         } else {
+                            if is_node_builtin_module(&source) {
+                                ctx.register_builtin_named_import(
+                                    local.clone(),
+                                    source.clone(),
+                                    imported.clone(),
+                                );
+                            }
                             // Register as imported function. Issue #35 (#321):
                             // use the LOCAL name as the original-name marker
                             // (identity registration) — mirroring the Default

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -122,6 +122,34 @@ fn is_filehandle_readlines_for_await_target(ctx: &LoweringContext, expr: &ast::E
     )
 }
 
+fn is_fs_dir_type(ty: Type) -> bool {
+    matches!(ty, Type::Named(name) if name == "Dir" || name == "fs.Dir")
+}
+
+fn is_fs_dir_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let expr = strip_for_of_expr_wrappers(expr);
+    if is_fs_dir_type(crate::lower_types::infer_type_from_expr(expr, ctx)) {
+        return true;
+    }
+
+    let ast::Expr::Call(call) = expr else {
+        return false;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(member) = strip_for_of_expr_wrappers(callee.as_ref()) else {
+        return false;
+    };
+    if !matches!(&member.prop, ast::MemberProp::Ident(prop) if prop.sym.as_ref() == "entries") {
+        return false;
+    }
+    is_fs_dir_type(crate::lower_types::infer_type_from_expr(
+        strip_for_of_expr_wrappers(&member.obj),
+        ctx,
+    ))
+}
+
 fn is_fs_promises_glob_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
     let ast::Expr::Call(call) = strip_for_of_expr_wrappers(expr) else {
         return false;
@@ -350,6 +378,8 @@ pub(crate) fn lower_stmt_for_of(
         for_of_stmt.is_await && is_node_readable_for_await_target(ctx, &for_of_stmt.right);
     let is_filehandle_readlines_for_await =
         for_of_stmt.is_await && is_filehandle_readlines_for_await_target(ctx, &for_of_stmt.right);
+    let is_fs_dir_for_await =
+        for_of_stmt.is_await && is_fs_dir_for_await_target(ctx, &for_of_stmt.right);
     let is_fs_promises_glob_for_await =
         for_of_stmt.is_await && is_fs_promises_glob_for_await_target(ctx, &for_of_stmt.right);
     let is_readline_interface_for_await =
@@ -360,6 +390,7 @@ pub(crate) fn lower_stmt_for_of(
         || is_timer_promises_interval_call
         || is_node_readable_for_await
         || is_filehandle_readlines_for_await
+        || is_fs_dir_for_await
         || is_fs_promises_glob_for_await
         || is_readline_interface_for_await
     {
@@ -380,7 +411,7 @@ pub(crate) fn lower_stmt_for_of(
                 args: vec![iter_expr],
                 type_args: vec![],
             }
-        } else if is_filehandle_readlines_for_await {
+        } else if is_filehandle_readlines_for_await || is_fs_dir_for_await {
             async_iterator_method_call(iter_expr)
         } else if is_node_readable_for_await {
             Expr::Call {
@@ -489,6 +520,7 @@ pub(crate) fn lower_stmt_for_of(
         let mut user_body: Vec<Stmt> = module.init.drain(init_before..).collect();
         if is_node_readable_for_await
             || is_filehandle_readlines_for_await
+            || is_fs_dir_for_await
             || is_readline_interface_for_await
         {
             insert_iterator_return_before_abrupts(&mut user_body, iter_id, needs_await);

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -159,6 +159,34 @@ fn is_readline_interface_for_await_target(ctx: &LoweringContext, expr: &ast::Exp
     )
 }
 
+fn is_fs_dir_type(ty: Type) -> bool {
+    matches!(ty, Type::Named(name) if name == "Dir" || name == "fs.Dir")
+}
+
+fn is_fs_dir_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let expr = strip_for_of_expr_wrappers(expr);
+    if is_fs_dir_type(crate::lower_types::infer_type_from_expr(expr, ctx)) {
+        return true;
+    }
+
+    let ast::Expr::Call(call) = expr else {
+        return false;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(member) = strip_for_of_expr_wrappers(callee.as_ref()) else {
+        return false;
+    };
+    if !matches!(&member.prop, ast::MemberProp::Ident(prop) if prop.sym.as_ref() == "entries") {
+        return false;
+    }
+    is_fs_dir_type(crate::lower_types::infer_type_from_expr(
+        strip_for_of_expr_wrappers(&member.obj),
+        ctx,
+    ))
+}
+
 fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
     let call = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
@@ -1005,6 +1033,8 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 for_of_stmt.is_await && is_node_readable_for_await_target(ctx, &for_of_stmt.right);
             let is_filehandle_readlines_for_await = for_of_stmt.is_await
                 && is_filehandle_readlines_for_await_target(ctx, &for_of_stmt.right);
+            let is_fs_dir_for_await =
+                for_of_stmt.is_await && is_fs_dir_for_await_target(ctx, &for_of_stmt.right);
             let is_readline_interface_for_await = for_of_stmt.is_await
                 && is_readline_interface_for_await_target(ctx, &for_of_stmt.right);
 
@@ -1013,6 +1043,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 || is_timer_promises_interval_call
                 || is_node_readable_for_await
                 || is_filehandle_readlines_for_await
+                || is_fs_dir_for_await
                 || is_readline_interface_for_await
             {
                 let scope_mark = ctx.push_block_scope();
@@ -1023,7 +1054,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         args: vec![iter_expr_raw],
                         type_args: vec![],
                     }
-                } else if is_filehandle_readlines_for_await {
+                } else if is_filehandle_readlines_for_await || is_fs_dir_for_await {
                     async_iterator_method_call(iter_expr_raw)
                 } else if is_node_readable_for_await {
                     Expr::Call {
@@ -1109,6 +1140,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 let mut user_body = lower_body_stmt(ctx, &for_of_stmt.body)?;
                 if is_node_readable_for_await
                     || is_filehandle_readlines_for_await
+                    || is_fs_dir_for_await
                     || is_readline_interface_for_await
                 {
                     insert_iterator_return_before_abrupts(&mut user_body, iter_id, needs_await);

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -20,6 +20,10 @@ fn filehandle_type() -> Type {
     Type::Named("FileHandle".to_string())
 }
 
+fn dir_type() -> Type {
+    Type::Named("Dir".to_string())
+}
+
 fn typed_array_name_for_name(name: &str) -> Option<&'static str> {
     match name {
         "Int8Array" => Some("Int8Array"),
@@ -899,6 +903,24 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
             ) {
                 return Type::Promise(Box::new(filehandle_type()));
             }
+            if matches!(
+                ctx.lookup_native_module(name),
+                Some((module, Some("opendir"))) if is_fs_promises_module(module)
+            ) {
+                return Type::Promise(Box::new(dir_type()));
+            }
+            if matches!(
+                ctx.lookup_builtin_named_import(name),
+                Some((module, "open")) if is_fs_promises_module(module)
+            ) {
+                return Type::Promise(Box::new(filehandle_type()));
+            }
+            if matches!(
+                ctx.lookup_builtin_named_import(name),
+                Some((module, "opendir")) if is_fs_promises_module(module)
+            ) {
+                return Type::Promise(Box::new(dir_type()));
+            }
             // Check user-defined function return types
             if let Some(ty) = ctx.lookup_func_return_type(name) {
                 return ty.clone();
@@ -927,6 +949,19 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                             .is_some_and(is_fs_promises_module);
                         if namespace_is_fs_promises {
                             return Type::Promise(Box::new(filehandle_type()));
+                        }
+                    }
+                }
+                if method_name == "opendir" {
+                    if let ast::Expr::Ident(obj) = member.obj.as_ref() {
+                        let namespace_is_fs_promises = matches!(
+                            ctx.lookup_native_module(obj.sym.as_ref()),
+                            Some((module, None)) if is_fs_promises_module(module)
+                        ) || ctx
+                            .lookup_builtin_module_alias(obj.sym.as_ref())
+                            .is_some_and(is_fs_promises_module);
+                        if namespace_is_fs_promises {
+                            return Type::Promise(Box::new(dir_type()));
                         }
                     }
                 }

--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -707,6 +707,16 @@ pub(crate) fn alloc_dir_state(entries: Vec<f64>) -> usize {
     id
 }
 
+pub(crate) fn scan_fs_dir_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    DIR_REGISTRY.with(|r| {
+        for state in r.borrow_mut().values_mut() {
+            for entry in &mut state.entries {
+                visitor.visit_nanbox_f64_slot(entry);
+            }
+        }
+    });
+}
+
 pub(crate) fn dir_id_of(closure: *const ClosureHeader) -> usize {
     crate::closure::js_closure_get_capture_ptr(closure, 0) as usize
 }
@@ -733,6 +743,7 @@ pub(crate) fn dir_mark_closed(id: usize) {
         if let Some(state) = r.borrow_mut().get_mut(&id) {
             state.closed = true;
             state.operation_pending = false;
+            state.entries.clear();
         }
     });
 }
@@ -747,6 +758,7 @@ pub(crate) fn dir_close_result(id: usize) -> Result<(), f64> {
             return Err(dir_closed_error_value());
         }
         state.closed = true;
+        state.entries.clear();
         Ok(())
     })
 }
@@ -764,6 +776,7 @@ fn dir_close_sync_result(id: usize) -> Result<(), f64> {
             return Err(dir_concurrent_operation_error_value());
         }
         state.closed = true;
+        state.entries.clear();
         Ok(())
     })
 }

--- a/crates/perry-runtime/src/fs/filehandle.rs
+++ b/crates/perry-runtime/src/fs/filehandle.rs
@@ -62,6 +62,24 @@ struct FileHandleWriterState {
     closed: bool,
 }
 
+pub(crate) fn scan_filehandle_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    READ_LINES_REGISTRY.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.handle);
+        }
+    });
+    STREAM_ITER_REGISTRY.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.handle);
+        }
+    });
+    WRITER_REGISTRY.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.handle);
+        }
+    });
+}
+
 pub(crate) unsafe fn build_file_io_result(
     count_name: &str,
     count: f64,

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -59,6 +59,30 @@ thread_local! {
 
 static NEXT_FD: AtomicI32 = AtomicI32::new(100);
 
+pub(crate) fn scan_fs_handle_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    scan_filehandle_object_fd_metadata_roots_mut(visitor);
+    scan_filehandle_roots_mut(visitor);
+    scan_fs_dir_roots_mut(visitor);
+}
+
+fn scan_filehandle_object_fd_metadata_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    FILEHANDLE_OBJECT_FDS.with(|fds| {
+        let mut fds = fds.borrow_mut();
+        let mut moved = Vec::new();
+        for (&owner, _) in fds.iter() {
+            let mut new_owner = owner;
+            if visitor.visit_metadata_usize_slot(&mut new_owner) {
+                moved.push((owner, new_owner));
+            }
+        }
+        for (old_owner, new_owner) in moved {
+            if let Some(fd) = fds.remove(&old_owner) {
+                fds.insert(new_owner, fd);
+            }
+        }
+    });
+}
+
 pub(crate) fn allocate_synthetic_fd() -> i32 {
     NEXT_FD.fetch_add(1, Ordering::Relaxed)
 }

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -348,6 +348,7 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::process::scan_process_module_loader_roots_mut);
     gc_register_mutable_root_scanner(crate::os::scan_process_event_listener_roots_mut);
     gc_register_mutable_root_scanner(crate::os::scan_process_stream_singleton_roots_mut);
+    gc_register_mutable_root_scanner(crate::fs::scan_fs_handle_roots_mut);
     gc_register_mutable_root_scanner(crate::fs::scan_fs_stream_roots_mut);
     gc_register_mutable_root_scanner(crate::fs::scan_fs_watcher_roots_mut);
     #[cfg(feature = "full")]


### PR DESCRIPTION
Closes #800.

## Summary
- root fs/promises FileHandle iterator state and Dir dirent entries during GC
- preserve built-in named import metadata so aliased fs/promises `open` and `opendir` infer FileHandle/Dir results
- route `for await` over `fs.Dir` and `dir.entries()` through the async iterator loop instead of sync materialization

## Tests
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 timeout 900 ./run_parity_tests.sh --suite node-suite --module fs-promises --filter filehandle-readlines`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 timeout 900 ./run_parity_tests.sh --suite node-suite --module fs-promises --filter opendir-iteration-disposal`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 timeout 900 ./run_parity_tests.sh --suite node-suite --module fs-promises` (81 pass / 0 fail)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo check -q -p perry-hir -p perry-runtime`