### PR TITLE
fix(proxy): construct class targets through proxies

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -122,7 +122,6 @@ impl LoweringContext {
             wasm_instance_locals: HashSet::new(),
             plain_object_locals: HashSet::new(),
             proxy_revoke_locals: HashMap::new(),
-            proxy_target_classes: HashMap::new(),
             class_expr_aliases: HashMap::new(),
             in_constructor_class: None,
             current_class_super_ident: None,

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -1199,28 +1199,6 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     })
                     .transpose()?
                     .unwrap_or_default();
-                // If the proxy's construction wrapped a known class,
-                // call the construct trap (for side effects) then
-                // instantiate the real class. This matches the
-                // test's expected behaviour.
-                if let Some(target_class) = ctx.proxy_target_classes.get(&class_name).cloned() {
-                    if ctx.lookup_class(&target_class).is_some() {
-                        if let Some(id) = ctx.lookup_local(&class_name) {
-                            let trap_call = Expr::ProxyConstruct {
-                                proxy: Box::new(Expr::LocalGet(id)),
-                                args: args.clone(),
-                            };
-                            return Ok(Expr::Sequence(vec![
-                                trap_call,
-                                Expr::New {
-                                    class_name: target_class,
-                                    args,
-                                    type_args: vec![],
-                                },
-                            ]));
-                        }
-                    }
-                }
                 if let Some(id) = ctx.lookup_local(&class_name) {
                     return Ok(Expr::ProxyConstruct {
                         proxy: Box::new(Expr::LocalGet(id)),

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -354,10 +354,6 @@ pub struct LoweringContext {
     /// timestamp and print `1970-01-01T00:00:00.000Z`).
     pub(crate) plain_object_locals: HashSet<String>,
     pub(crate) proxy_revoke_locals: HashMap<String, String>,
-    /// For `const p = new Proxy(ClassName, handler)`, record the class name
-    /// so `new p(args)` can fold to `new ClassName(args)` (pragmatic — lets
-    /// the test's construct trap see the expected value).
-    pub(crate) proxy_target_classes: HashMap<String, String>,
     /// Alias map for class expressions: `const MyClass = class { ... }`
     /// binds the local `MyClass` to the synthetic class name created
     /// by `lower_class_from_ast`. The `new MyClass(...)` lowering looks

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -65,16 +65,7 @@ pub(crate) fn pre_scan_weakref_locals(ast_module: &ast::Module, ctx: &mut Loweri
                         ctx.weakset_locals.insert(name);
                     }
                     Some("Proxy") => {
-                        ctx.proxy_locals.insert(name.clone());
-                        // Track proxy target class for `new p(args)` fold.
-                        if let Some(args) = new_expr.args.as_ref() {
-                            if let Some(first) = args.first() {
-                                if let ast::Expr::Ident(cls_ident) = first.expr.as_ref() {
-                                    let cls_name = cls_ident.sym.to_string();
-                                    ctx.proxy_target_classes.insert(name, cls_name);
-                                }
-                            }
-                        }
+                        ctx.proxy_locals.insert(name);
                     }
                     _ => {}
                 }

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -7,6 +7,32 @@
 
 use super::*;
 
+static CLASS_KEYS_BY_ID: std::sync::RwLock<Option<std::collections::HashMap<u32, (usize, u32)>>> =
+    std::sync::RwLock::new(None);
+
+fn remember_class_keys_array(class_id: u32, field_count: u32, keys_array: *mut ArrayHeader) {
+    if class_id == 0 || keys_array.is_null() {
+        return;
+    }
+    let mut guard = CLASS_KEYS_BY_ID.write().unwrap();
+    if guard.is_none() {
+        *guard = Some(std::collections::HashMap::new());
+    }
+    guard
+        .as_mut()
+        .unwrap()
+        .insert(class_id, (keys_array as usize, field_count));
+}
+
+pub(crate) fn registered_class_keys_array(class_id: u32) -> Option<(*mut ArrayHeader, u32)> {
+    let guard = CLASS_KEYS_BY_ID.read().ok()?;
+    let (addr, field_count) = guard.as_ref()?.get(&class_id).copied()?;
+    if addr == 0 {
+        return None;
+    }
+    Some((addr as *mut ArrayHeader, field_count))
+}
+
 /// Allocate a new object with the given class ID and field count
 /// Returns a pointer to the object header
 #[no_mangle]
@@ -237,11 +263,13 @@ pub extern "C" fn js_build_class_keys_array(
         .wrapping_add(1000000);
     let cached = shape_cache_get(shape_id);
     if !cached.is_null() {
+        remember_class_keys_array(class_id, field_count, cached);
         return cached;
     }
     if field_count == 0 || packed_keys_len == 0 || packed_keys.is_null() {
         let arr = crate::array::js_array_alloc_with_length_longlived(0);
         shape_cache_insert(shape_id, arr);
+        remember_class_keys_array(class_id, field_count, arr);
         return arr;
     }
     let keys_bytes = unsafe { std::slice::from_raw_parts(packed_keys, packed_keys_len as usize) };
@@ -273,6 +301,7 @@ pub extern "C" fn js_build_class_keys_array(
         }
     }
     shape_cache_insert(shape_id, arr);
+    remember_class_keys_array(class_id, field_count, arr);
     arr
 }
 
@@ -357,6 +386,7 @@ pub extern "C" fn js_object_alloc_class_with_keys(
     unsafe {
         set_object_keys_array(ptr, keys_arr);
     }
+    remember_class_keys_array(class_id, field_count, keys_arr);
     ptr
 }
 

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -130,3 +130,37 @@ pub(crate) unsafe fn replay_class_object_constructor(
         false,
     );
 }
+
+/// Replay a registered class declaration constructor for an INT32-tagged
+/// ClassRef callee. Unlike class-expression values, class declarations do not
+/// carry per-evaluation capture slots on a heap class object, so only the
+/// user-provided `new` arguments are forwarded.
+pub(crate) unsafe fn replay_registered_class_constructor(
+    class_cid: u32,
+    inst: *mut ObjectHeader,
+    args_ptr: *const f64,
+    args_len: usize,
+) {
+    let Some((ctor_ptr, total_params)) = lookup_class_constructor(class_cid) else {
+        return;
+    };
+
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let mut final_args: Vec<f64> = Vec::with_capacity(total_params as usize);
+    for i in 0..total_params as usize {
+        if !args_ptr.is_null() && i < args_len {
+            final_args.push(*args_ptr.add(i));
+        } else {
+            final_args.push(undef);
+        }
+    }
+    let _ = call_vtable_method(
+        ctor_ptr,
+        inst as i64,
+        final_args.as_ptr(),
+        final_args.len(),
+        total_params,
+        false,
+        false,
+    );
+}

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1218,7 +1218,7 @@ pub unsafe extern "C" fn js_new_function_construct(
         if jv.is_undefined()
             || jv.is_null()
             || jv.is_bool()
-            || jv.is_int32()
+            || (jv.is_int32() && constructor_class_ref_id(func_value).is_none())
             || jv.is_any_string()
             || jv.is_bigint()
         {
@@ -1757,34 +1757,12 @@ pub unsafe extern "C" fn js_new_function_construct(
         }
     }
 
-    // #321 (effect Layer/Scope): `new C(args)` where `C` is a *class
-    // reference held as a first-class value* — the INT32-tagged form a bare
-    // `class` identifier lowers to (`Expr::ClassRef` → `INT32_TAG |
-    // class_id`). This reaches the dynamic-new helper via the
-    // `Expr::LocalGet` callee route in `new_dynamic.rs` whenever a class is
-    // aliased through a variable / field / cross-module argument
-    // (`const C = Svc; new C()`, or effect's `flatMap(self, …)` storing a
-    // `Context.Tag` subclass into `effect_instruction_i0`). Pre-fix this
-    // value was neither a heap class-object (the `is_class_object_value`
-    // arm above) nor a pointer-shaped closure (so
-    // `synthetic_class_id_for_function` returned 0 — it requires
-    // `is_pointer()`), leaving the instance stamped with class_id 0: every
-    // inherited prototype method then threw `<m> is not a function`.
-    // Stamp the registered class id so method dispatch walks the parent
-    // chain. Mirrors the #1789 heap-class-object arm above: the constructor
-    // body / field initializers are emitted on the static `new ClassName()`
-    // codegen path (there is no constructor-by-class_id runtime entry), so a
-    // dynamically-constructed instance starts with no own props — fields
-    // written afterward and prototype methods work.
-    {
-        let bits = func_value.to_bits();
-        if (bits >> 48) == 0x7FFE {
-            let class_cid = (bits & 0xFFFF_FFFF) as u32;
-            if class_cid != 0 && is_class_id_registered(class_cid) {
-                let inst = js_object_alloc(class_cid, 0);
-                return crate::value::js_nanbox_pointer(inst as i64);
-            }
-        }
+    // #321/#4530: `new C(args)` where `C` is a first-class ClassRef, including
+    // proxy-forwarded construction. Allocate an instance stamped with the
+    // registered class id and replay the standalone constructor so field
+    // initializers and `this.foo = ...` writes match static `new ClassName()`.
+    if let Some(class_cid) = constructor_class_ref_id(func_value) {
+        return construct_registered_class_ref(class_cid, class_cid, args_ptr, args_len);
     }
     if is_arrow_function_value(func_value) {
         crate::fs::validate::throw_type_error_with_code(
@@ -1836,6 +1814,47 @@ pub unsafe extern "C" fn js_new_function_construct(
     nan_boxed
 }
 
+fn constructor_class_ref_id(value: f64) -> Option<u32> {
+    if super::class_prototype_ref_id(value).is_some() {
+        return None;
+    }
+    super::class_ref_id(value)
+}
+
+fn class_object_class_id(value: f64) -> Option<u32> {
+    if !is_class_object_value(value) {
+        return None;
+    }
+    let obj = crate::value::JSValue::from_bits(value.to_bits()).as_pointer::<ObjectHeader>();
+    let class_id = js_object_get_class_id(obj);
+    if class_id != 0 && is_class_id_registered(class_id) {
+        Some(class_id)
+    } else {
+        None
+    }
+}
+
+fn new_target_class_id(new_target: f64) -> Option<u32> {
+    constructor_class_ref_id(new_target).or_else(|| class_object_class_id(new_target))
+}
+
+unsafe fn construct_registered_class_ref(
+    target_cid: u32,
+    instance_cid: u32,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let inst = if let Some((keys_array, field_count)) = registered_class_keys_array(instance_cid) {
+        js_object_alloc_class_inline_keys(instance_cid, 0, field_count, keys_array)
+    } else {
+        js_object_alloc(instance_cid, 0)
+    };
+    super::class_constructors::replay_registered_class_constructor(
+        target_cid, inst, args_ptr, args_len,
+    );
+    crate::value::js_nanbox_pointer(inst as i64)
+}
+
 fn constructor_prototype_bits(new_target: f64) -> Option<u64> {
     let bits = new_target.to_bits();
     if (bits >> 48) != 0x7FFD {
@@ -1879,6 +1898,10 @@ pub unsafe extern "C" fn js_new_function_construct_with_new_target(
         }
         let arr_box = f64::from_bits(0x7FFD_0000_0000_0000 | (a as u64 & 0x0000_FFFF_FFFF_FFFF));
         return crate::proxy::js_proxy_construct(func_value, arr_box, nt);
+    }
+    if let Some(target_cid) = constructor_class_ref_id(func_value) {
+        let instance_cid = new_target_class_id(nt).unwrap_or(target_cid);
+        return construct_registered_class_ref(target_cid, instance_cid, args_ptr, args_len);
     }
     if !is_callable_function_value(func_value) {
         return js_new_function_construct(func_value, args_ptr, args_len);

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -524,7 +524,7 @@ fn target_set(target: f64, key: f64, value: f64) {
         }
         return;
     }
-    let key_ptr = extract_pointer(property_key.to_bits()) as *const crate::StringHeader;
+    let key_ptr = crate::builtins::js_string_coerce(property_key) as *const crate::StringHeader;
     if crate::object::class_ref_id(target).is_some() {
         // Preserve the INT32-tagged class-ref bits so class dynamic props
         // land in CLASS_DYNAMIC_PROPS instead of being pointer-extracted to 0.

--- a/test-parity/node-suite/object/reflect-proxy-construct.ts
+++ b/test-parity/node-suite/object/reflect-proxy-construct.ts
@@ -84,3 +84,45 @@ show("proxy chain honors newTarget prototype", () => {
     Object.getPrototypeOf(bar) === (Bar as any).prototype,
   ];
 });
+
+class Thing {
+  value: string;
+  constructor(value: string) {
+    this.value = value;
+  }
+  method() {
+    return `m:${this.value}`;
+  }
+}
+
+show("proxy class empty handler", () => {
+  const Wrapped: any = new Proxy(Thing, {});
+  const instance: any = new Wrapped("x");
+  return [instance instanceof Thing, instance.method()];
+});
+
+const classConstructHandler = {
+  construct(target: any, args: any[], newTarget: any) {
+    const instance: any = Reflect.construct(target, args, newTarget);
+    instance.value = `${instance.value}:proxy`;
+    return instance;
+  },
+};
+const WrappedThingWithTrap: any = new Proxy(Thing, classConstructHandler);
+
+show("proxy class construct trap delegates", () => {
+  const instance: any = new WrappedThingWithTrap("x");
+  return [instance instanceof Thing, instance.value, instance.method()];
+});
+
+class Child extends Thing {
+  child() {
+    return `child:${this.value}`;
+  }
+}
+
+show("proxy class empty handler newTarget", () => {
+  const Wrapped: any = new Proxy(Thing, {});
+  const instance: any = Reflect.construct(Wrapped, ["y"], Child);
+  return [instance instanceof Child, instance instanceof Thing, instance.child()];
+});


### PR DESCRIPTION
## Linked Issues

Fixes #4530.

## Summary

- Route `new proxyToClass(...)` through the proxy construct path instead of running the trap for side effects and then directly constructing the target class.
- Add runtime construction for registered ClassRef callees that replays the registered constructor, preserving field initializers and constructor writes.
- Preserve inline class key metadata for ClassRef allocation so proxy and `Reflect.construct` paths get correctly shaped instances.
- Coerce proxy `set` property keys before class field writes so short-string keys update inline slots correctly.

## Why This Cut

The failing Node behavior crosses HIR lowering, proxy construct dispatch, `Reflect.construct(..., newTarget)`, and registered class allocation. Keeping these together avoids leaving any class-target proxy path half-fixed.

## Tests Added

- Extended `test-parity/node-suite/object/reflect-proxy-construct.ts` with class target coverage for:
  - empty proxy handlers
  - construct traps that delegate via `Reflect.construct`
  - `Reflect.construct` with a proxied class target and subclass `newTarget`

## Validation

- `cargo check -p perry-hir -p perry-runtime`
- `cargo check -p perry-hir`
- `cargo build --release -p perry`
- `npm exec --yes --package=node@26 -- bash -lc 'node --version; PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter reflect-proxy-construct'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo test -p perry-runtime proxy` (no matching unit tests; 984 filtered out)

## Known Limitations / Non-goals

- This does not attempt a broader rewrite of Proxy internal method semantics.
- This does not expand unrelated `Reflect.*` validation behavior outside construct/newTarget paths covered here.
