### PR TITLE
fix(json): empty class instance serializes as {} not null/[0] (#4541)

### DIFF
--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -137,8 +137,9 @@ unsafe fn dispatch_pointer_with_replacer(
         crate::gc::GC_TYPE_OBJECT => {
             if is_object_pointer(ptr) {
                 stringify_object_with_replacer_pretty(ptr, replacer, buf, indent, depth);
-            } else if (*(ptr as *const crate::ObjectHeader)).keys_array.is_null() {
-                // Genuinely-empty object (#1704): emit "{}" not "null".
+            } else if super::stringify::object_has_no_own_keys(ptr) {
+                // Empty object (#1704) incl. a class instance with no own fields
+                // (only prototype methods/getters): emit "{}" not "null".
                 buf.push_str("{}");
             } else {
                 buf.push_str("null");
@@ -535,6 +536,25 @@ pub(crate) unsafe fn stringify_value_pretty(
             gc_obj_type(ptr),
             crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET | crate::gc::GC_TYPE_ERROR
         ) {
+            buf.push_str("{}");
+            return;
+        }
+        // An empty object (incl. a class instance with no own fields — only
+        // prototype methods/getters) fails `is_object_pointer` and would be
+        // misdetected as an array by the `else` fallback below. Emit "{}" after
+        // a `toJSON` probe (a `class { toJSON() {…} }` instance carries no own
+        // field but must still honour the prototype method).
+        if gc_obj_type(ptr) == crate::gc::GC_TYPE_OBJECT
+            && super::stringify::object_has_no_own_keys(ptr)
+        {
+            if (*(ptr as *const crate::ObjectHeader)).class_id != 0 {
+                if let Some(to_json_val) = object_get_to_json(ptr) {
+                    arm_to_json_result_guard(to_json_val);
+                    stringify_value_pretty(to_json_val, TYPE_UNKNOWN, buf, indent, depth);
+                    SUPPRESS_NEXT_TO_JSON.with(|c| c.set(false));
+                    return;
+                }
+            }
             buf.push_str("{}");
             return;
         }

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -177,6 +177,24 @@ pub(crate) unsafe fn is_object_pointer(ptr: *const u8) -> bool {
     }
 }
 
+/// True when `ptr` is a valid object with NO own (enumerable) keys: either a
+/// null `keys_array` (`{}`, `Object.fromEntries([])`) or a valid-but-empty one
+/// — the shape of a `class C {}` instance or a class whose only members are
+/// prototype methods/getters (those are not own properties). Such objects
+/// serialize as `{}`, never `null` or an array. Used by the value dispatchers
+/// to disambiguate an empty object from a corrupted pointer after the
+/// `keys_len > 0` `is_object_pointer` probe fails.
+pub(crate) unsafe fn object_has_no_own_keys(ptr: *const u8) -> bool {
+    let keys = (*(ptr as *const crate::ObjectHeader)).keys_array;
+    if keys.is_null() {
+        return true;
+    }
+    let kp = keys as u64;
+    let top_16 = kp >> 48;
+    let looks_valid = (top_16 == 0 || top_16 == 1) && kp > 0x10000 && (kp & 0x7) == 0;
+    looks_valid && (*keys).length == 0
+}
+
 #[inline]
 pub(crate) unsafe fn write_number(buf: &mut String, value: f64) {
     // #2089: a Date is now a NaN-boxed `DateCell` pointer, handled in
@@ -580,12 +598,13 @@ pub(crate) unsafe fn stringify_value(value: f64, type_hint: u32, buf: &mut Strin
                             return;
                         }
                     }
-                    if (*(ptr as *const crate::ObjectHeader)).keys_array.is_null() {
-                        // #1704: a genuinely empty object (null keys_array, e.g.
-                        // `Object.fromEntries([])` / a never-mutated `{}`) fails
-                        // `is_object_pointer`'s `keys_len > 0` guard but is valid —
-                        // emit "{}" not "null". A non-empty object that fails the
-                        // check is treated as corrupted and still emits "null".
+                    if object_has_no_own_keys(ptr) {
+                        // A valid object with no own keys (null keys_array like
+                        // `Object.fromEntries([])` / `{}`, OR a valid-but-empty
+                        // keys_array like a `class C {}` instance or a class with
+                        // only prototype methods/getters) fails `is_object_pointer`'s
+                        // `keys_len > 0` guard but is still `{}`, not `null`. A
+                        // non-empty object that fails the check is corrupted → "null".
                         buf.push_str("{}");
                     } else {
                         buf.push_str("null");

--- a/test-parity/node-suite/globals/json-stringify-empty-class.ts
+++ b/test-parity/node-suite/globals/json-stringify-empty-class.ts
@@ -1,0 +1,42 @@
+// JSON.stringify of a class instance with no own enumerable data fields
+// (an empty class, or a class whose only members are prototype methods /
+// getters) must serialize as `{}` — methods and getters live on the
+// prototype, not as own properties. Such instances fail the `keys_len > 0`
+// object probe, and previously fell through to `null` (compact / replacer)
+// or were misdetected as an array (`[ 0 ]`, pretty). A prototype `toJSON`
+// is still honoured.
+
+function show(label: string, value: any) {
+  console.log(label + " = " + value);
+}
+
+class Empty {}
+class OnlyMethod { m() { return 1; } }
+class OnlyGetter { get g() { return 9; } }
+class WithField { x = 1; get g() { return 2; } }
+class WithToJSON { toJSON() { return { ok: 1 }; } }
+
+// Top level.
+show("empty", JSON.stringify(new Empty()));
+show("only-method", JSON.stringify(new OnlyMethod()));
+show("only-getter", JSON.stringify(new OnlyGetter()));
+show("with-field", JSON.stringify(new WithField()));
+
+// Nested (compact / pretty / function-replacer).
+show("nested", JSON.stringify({ svc: new OnlyMethod(), x: 1 }));
+show("nested-pretty", JSON.stringify({ svc: new OnlyMethod() }, null, 1).replace(/\s+/g, " "));
+show("nested-replacer", JSON.stringify({ svc: new OnlyMethod() }, (_k, v) => v));
+
+// Array of empty instances.
+show("array", JSON.stringify([new Empty(), new OnlyMethod()]));
+
+// Top-level pretty.
+show("pretty-top", JSON.stringify(new Empty(), null, 2).replace(/\s+/g, " "));
+
+// A prototype toJSON is still honoured (compact + pretty).
+show("toJSON", JSON.stringify(new WithToJSON()));
+show("toJSON-pretty", JSON.stringify(new WithToJSON(), null, 1).replace(/\s+/g, " "));
+
+// Regression: plain objects and arrays are unaffected.
+show("plain", JSON.stringify({}));
+show("obj", JSON.stringify({ a: 1, b: { c: 2 } }));


### PR DESCRIPTION
Fixes #4541. Completes the JSON/property-descriptor series (#4513 enumerability, #4532 getters).

## Problem

`JSON.stringify` of a class instance with no own enumerable data fields (empty class, or only prototype methods/getters) didn't return `{}`, and the wrong result differed by path:

```ts
class D { m(){return 1;} }
JSON.stringify(new D());                 // Node: {}            was: null
JSON.stringify({svc:new D()}, null, 1);  // Node: {"svc":{}}    was: {"svc":[ 0 ]}
JSON.stringify({svc:new D()}, (k,v)=>v); // Node: {"svc":{}}    was: {"svc":null}
```

Such instances fail `is_object_pointer`'s `keys_len > 0` check; the compact/replacer paths then emitted `null` (only a *null* keys_array counted as empty) and the pretty path misdetected the object as an array (reading a preallocated field slot → `[ 0 ]`).

## Fix

Add `object_has_no_own_keys(ptr)` (null OR valid-but-empty keys_array) and emit `{}` for empty-but-valid objects across the compact (`stringify_value_depth`), pretty (`stringify_value_pretty`), and function-replacer dispatchers. A prototype `toJSON` is still probed first for class instances; genuinely corrupted pointers still emit `null`.

## Verification

- Parity fixture `json-stringify-empty-class.ts`.
- Identical to Node for empty / only-method / only-getter / with-field / nested / pretty / replacer / array / toJSON cases.
- 41 JSON unit tests pass; prior JSON fixtures (#4512, #4531) still match.