### PR TITLE
fix(runtime): array non-int key writes, builtin getter .name, ArrayBuffer ctor ToIndex

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -564,5 +564,20 @@ pub extern "C" fn js_array_set_index_or_string(
             return js_array_set_string_key(arr, key, value);
         }
     }
+    // Fallback for a NON-numeric key: a primitive (`a[null]`, `a[undefined]`,
+    // `a[true]`, `a[10n]`) or a boxed object (`a[new Number(1)]`). Per
+    // ToPropertyKey these become string property keys (or, for `10n`, the
+    // canonical index "10"); `js_array_set_string_key` routes accordingly.
+    // Arrays previously DROPPED these writes (plain objects handled them).
+    // Restricted to `numeric.is_none()`: a non-integer FLOAT key (`a[1.5]`) is
+    // left untouched here because `js_array_set_string_key("1.5")` currently
+    // mis-parses it as index 1 (corrupting `a[1]`) — that's a separate bug,
+    // tracked. Symbols stay symbol-keyed (handled elsewhere).
+    if numeric.is_none() && unsafe { crate::symbol::js_is_symbol(idx) } == 0 {
+        let key = crate::value::js_jsvalue_to_string(idx);
+        if !key.is_null() {
+            return js_array_set_string_key(arr, key as *const crate::StringHeader, value);
+        }
+    }
     arr
 }

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -634,7 +634,15 @@ fn array_buffer_to_index(value: f64) -> i32 {
     if jv.is_undefined() {
         return 0;
     }
-    let n = jv.to_number();
+    // ToIndex(length) → ToNumber: a BigInt throws TypeError; `js_number_coerce`
+    // is the full ToNumber — it runs an object's `valueOf`/`toString` (so a
+    // throwing one propagates) and throws TypeError on a Symbol. The bare
+    // `JSValue::to_number()` previously produced NaN→0 for objects/symbols, so
+    // `new ArrayBuffer({valueOf(){return 42}})` silently became length 0.
+    if jv.is_bigint() {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
+    }
+    let n = crate::builtins::js_number_coerce(value);
     if n.is_nan() {
         return 0;
     }

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1440,6 +1440,15 @@ pub(crate) unsafe fn install_builtin_getter(proto: *mut ObjectHeader, key: &str,
     }
     // Make the key discoverable by `own_key_present` / `getOwnPropertyNames`.
     ensure_key_in_keys_array(proto, key_str);
+    // Spec: an accessor getter's `.name` is `"get " + key` (e.g.
+    // `Object.getOwnPropertyDescriptor(ArrayBuffer.prototype,"byteLength").get.name
+    // === "get byteLength"`). Register it against the getter closure's func_ptr;
+    // without this the `.name` read returned `""`.
+    let getter_ptr = (getter_bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if getter_ptr >= 0x1000 && crate::closure::is_closure_ptr(getter_ptr) {
+        let func_ptr = (*(getter_ptr as *const crate::closure::ClosureHeader)).func_ptr as usize;
+        crate::builtins::register_function_name_if_absent(func_ptr, &format!("get {key}"));
+    }
     set_builtin_accessor_descriptor(
         proto as usize,
         key.to_string(),


### PR DESCRIPTION
## What

Three Array/ArrayBuffer fixes:

1. **Array writes with non-numeric keys.** `a[null]=…`, `a[undefined]=…`, `a[true]=…`,
   `a[10n]=…`, `a[new Number(1)]=…` were silently DROPPED on arrays (plain objects
   handled them). Added a ToPropertyKey→string fallback in
   `js_array_set_index_or_string` (restricted to non-numeric keys; symbols stay
   symbol-keyed). A non-integer-float key like `a[1.5]` is intentionally left as-is
   here — `js_array_set_string_key("1.5")` currently mis-parses it as index 1; that's
   a separate bug, filed.
2. **Builtin accessor getter `.name`** is now `"get <prop>"`. `ArrayBuffer.prototype`
   / `%TypedArray%.prototype` getters (`byteLength`, `buffer`, `byteOffset`, …)
   reported `.name === ""`; registered `"get <key>"` against the getter closure.
3. **`new ArrayBuffer(length)` ToIndex coercion.** `length` now goes through full
   ToNumber: an object's `valueOf`/`toString` runs (throwing ones propagate), a
   Symbol throws TypeError, a BigInt throws TypeError. Was the bare
   `JSValue::to_number()` → NaN→0 (`new ArrayBuffer({valueOf:()=>42})` silently 0).

## Verification

Byte-identical to `node --experimental-strip-types`, both build modes:
```
a[null]/[undefined]/[true]/[new Number(1)] writes → readable (was dropped)
a[10n]=5 → a[10]===5   (canonical index, no corruption)
Object.getOwnPropertyDescriptor(ArrayBuffer.prototype,"byteLength").get.name === "get byteLength"
new ArrayBuffer({valueOf:()=>42}).byteLength === 42 ; new ArrayBuffer("8") === 8
new ArrayBuffer(Symbol()) → TypeError
```
`cargo test -p perry-runtime --lib` green.

## Out of scope (filed)
`js_array_set_string_key` mis-parses non-integer numeric strings (`"1.5"`→index 1);
the array string-key READ path (`a["10"]` after `a[10n]=`) — separate array-storage
bugs, filed for follow-up.

Part of the parity roadmap #4315.
