### PR TITLE
fix(globals): expose legacy escape and global alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1139 — spec `.length` for legacy/global function values (e.g. `parseInt.length`)
+
+Adds `builtin_global_function_length`, giving bare global function *values* their
+spec-defined `.length` when read or borrowed (`parseInt.length` was `0`, now `2`;
+also covers `structuredClone`/`setTimeout`/`setInterval` → 2 and the
+1-arg globals `eval`/`fetch`/`atob`/`btoa`/`clearTimeout`/`clearInterval`/
+`setImmediate`/`clearImmediate`/`queueMicrotask`/`parseFloat`/`isNaN`/`isFinite`/
+`encodeURI`/`decodeURI`/`encodeURIComponent`/`decodeURIComponent`/`escape`/
+`unescape` → 1). Wired through `name_fold.rs` and the `.length` member resolver in
+`expr_member.rs`. (Originally #4511's legacy-escape + `global`-alias work, but
+those already landed on `main` independently — this is the residual net-new
+`.length` slice; the conflicting duplicate `escape`/`unescape` runtime impl and
+`global` reclassification were dropped in favor of main's.) Adds
+`node-suite/globals/legacy-escape-global.ts`.
+
 ## v0.5.1138 — Promise static methods preserve receiver brand checks when borrowed
 
 Part of #4521. Borrowed `Promise` statics (`Promise.resolve`/`reject`/`all`/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1138
+**Current Version:** 0.5.1139
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1138"
+version = "0.5.1139"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1138"
+version = "0.5.1139"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1138"
+version = "0.5.1139"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1138"
+version = "0.5.1139"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1138"
+version = "0.5.1139"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -361,14 +361,13 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             // #4511: legacy escape/unescape (ES Annex B).
             | "escape"
             | "unescape"
-            // #4511: Node's `global` alias (typeof === "object").
-            | "global"
             // Test262 installs this dynamically on globalThis. Route reads
             // through the singleton so bare `print(...)` can call it once the
             // harness assigns the property.
             | "print"
             // Namespaces (typeof === "object" in spec).
             | "globalThis"
+            | "global"
             | "console"
             | "Math"
             | "JSON"
@@ -396,6 +395,7 @@ pub(crate) fn is_global_this_builtin_function_name(name: &str) -> bool {
         && !matches!(
             name,
             "globalThis"
+                | "global"
                 | "console"
                 | "Math"
                 | "JSON"
@@ -410,8 +410,6 @@ pub(crate) fn is_global_this_builtin_function_name(name: &str) -> bool {
                 | "crypto"
                 | "localStorage"
                 | "sessionStorage"
-                // #4511: `typeof global === "object"`.
-                | "global"
         )
 }
 

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -10,8 +10,8 @@ use crate::walker::{walk_expr_children, walk_expr_children_mut};
 
 mod builtins;
 pub(crate) use builtins::{
-    builtin_constructor_length, builtin_static_function_length, is_builtin_function,
-    is_builtin_global_value_name, is_builtin_static_function_member,
+    builtin_constructor_length, builtin_global_function_length, builtin_static_function_length,
+    is_builtin_function, is_builtin_global_value_name, is_builtin_static_function_member,
 };
 
 mod uses_this;

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -31,6 +31,10 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
     matches!(
         name,
         "globalThis"
+            // #4511: Node's `global` alias for the global object. Resolves to
+            // `globalThis.global`, a self-reference installed in
+            // `populate_global_this_builtins`.
+            | "global"
             | "Array"
             | "Object"
             | "String"
@@ -153,10 +157,6 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
             // thunk (no dedicated HIR variant). Used by `qs` (→ `stripe`).
             | "escape"
             | "unescape"
-            // #4511: Node's `global` alias for the global object. Resolves to
-            // `globalThis.global`, a self-reference installed in
-            // `populate_global_this_builtins`.
-            | "global"
     )
 }
 
@@ -191,6 +191,21 @@ pub(crate) fn builtin_constructor_length(name: &str) -> Option<u32> {
         "Uint8Array" | "Int8Array" | "Uint16Array" | "Int16Array" | "Uint32Array"
         | "Int32Array" | "Float16Array" | "Float32Array" | "Float64Array" | "BigInt64Array"
         | "BigUint64Array" | "Uint8ClampedArray" => 3,
+        _ => return None,
+    };
+    Some(len)
+}
+
+/// Spec-defined `.length` for callable global function values that lower as
+/// `globalThis.<name>` reads when used as bare values.
+pub(crate) fn builtin_global_function_length(name: &str) -> Option<u32> {
+    let len = match name {
+        "structuredClone" => 2,
+        "setTimeout" | "setInterval" | "parseInt" => 2,
+        "eval" | "fetch" | "atob" | "btoa" | "clearTimeout" | "clearInterval" | "setImmediate"
+        | "clearImmediate" | "queueMicrotask" | "parseFloat" | "isNaN" | "isFinite"
+        | "encodeURI" | "decodeURI" | "encodeURIComponent" | "decodeURIComponent" | "escape"
+        | "unescape" => 1,
         _ => return None,
     };
     Some(len)

--- a/crates/perry-hir/src/lower/expr_call/name_fold.rs
+++ b/crates/perry-hir/src/lower/expr_call/name_fold.rs
@@ -13,7 +13,8 @@
 use swc_ecma_ast as ast;
 
 use crate::analysis::{
-    builtin_static_function_length, is_builtin_global_value_name, is_builtin_static_function_member,
+    builtin_global_function_length, builtin_static_function_length, is_builtin_global_value_name,
+    is_builtin_static_function_member,
 };
 use crate::ir::Expr;
 
@@ -58,6 +59,7 @@ pub(super) fn builtin_fn_name_for_arg(arg: &ast::Expr) -> Option<String> {
 /// return its spec `.length`.
 pub(super) fn builtin_fn_length_for_arg(arg: &ast::Expr) -> Option<u32> {
     match arg {
+        ast::Expr::Ident(id) => builtin_global_function_length(id.sym.as_ref()),
         ast::Expr::Member(m) => {
             if let (ast::Expr::Ident(ns_ident), ast::MemberProp::Ident(method_ident)) =
                 (m.obj.as_ref(), &m.prop)

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -2084,7 +2084,9 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     _ => false,
                 };
                 if is_global_builtin {
-                    if let Some(len) = crate::analysis::builtin_constructor_length(name) {
+                    if let Some(len) = crate::analysis::builtin_constructor_length(name)
+                        .or_else(|| crate::analysis::builtin_global_function_length(name))
+                    {
                         return Ok(Expr::Number(len as f64));
                     }
                 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3007,6 +3007,11 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
         let value = crate::value::js_nanbox_pointer(singleton as i64);
         js_object_set_field_by_name(singleton, key, value);
+        super::set_builtin_property_attrs(
+            singleton as usize,
+            "global".to_string(),
+            super::PropertyAttrs::new(true, true, true),
+        );
     }
     // #2145: pre-allocate the shared `%TypedArray%` intrinsic so per-kind
     // typed-array constructors can link their `__proto__` to it as they're
@@ -3320,43 +3325,67 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     // Callable global functions: ClosureHeader-backed values with real
     // dispatch so direct property reads and rebound calls match bare calls.
     for name in GLOBAL_THIS_BUILTIN_FUNCTIONS.iter().copied() {
-        let (func_ptr, arity, has_rest) = match name {
-            "eval" => (global_this_eval_thunk as *const u8, 1, false),
+        let (func_ptr, arity, has_rest, enumerable) = match name {
+            "eval" => (global_this_eval_thunk as *const u8, 1, false, false),
             "fetch" => (
                 super::global_fetch::global_this_fetch_thunk as *const u8,
                 1,
                 true,
+                true,
             ),
-            "structuredClone" => (global_this_structured_clone_thunk as *const u8, 2, false),
-            "atob" => (global_this_atob_thunk as *const u8, 1, false),
-            "btoa" => (global_this_btoa_thunk as *const u8, 1, false),
-            "setTimeout" => (global_this_set_timeout_thunk as *const u8, 2, true),
-            "clearTimeout" => (global_this_clear_timeout_thunk as *const u8, 1, false),
-            "setInterval" => (global_this_set_interval_thunk as *const u8, 2, true),
-            "clearInterval" => (global_this_clear_interval_thunk as *const u8, 1, false),
-            "setImmediate" => (global_this_set_immediate_thunk as *const u8, 1, true),
-            "clearImmediate" => (global_this_clear_immediate_thunk as *const u8, 1, false),
-            "queueMicrotask" => (global_this_queue_microtask_thunk as *const u8, 1, false),
+            "structuredClone" => (
+                global_this_structured_clone_thunk as *const u8,
+                2,
+                false,
+                true,
+            ),
+            "atob" => (global_this_atob_thunk as *const u8, 1, false, true),
+            "btoa" => (global_this_btoa_thunk as *const u8, 1, false, true),
+            "setTimeout" => (global_this_set_timeout_thunk as *const u8, 2, true, true),
+            "clearTimeout" => (global_this_clear_timeout_thunk as *const u8, 1, false, true),
+            "setInterval" => (global_this_set_interval_thunk as *const u8, 2, true, true),
+            "clearInterval" => (
+                global_this_clear_interval_thunk as *const u8,
+                1,
+                false,
+                true,
+            ),
+            "setImmediate" => (global_this_set_immediate_thunk as *const u8, 1, true, true),
+            "clearImmediate" => (
+                global_this_clear_immediate_thunk as *const u8,
+                1,
+                false,
+                true,
+            ),
+            "queueMicrotask" => (
+                global_this_queue_microtask_thunk as *const u8,
+                1,
+                false,
+                true,
+            ),
             // #2905: standard global helper functions.
-            "parseInt" => (global_this_parse_int_thunk as *const u8, 2, false),
-            "parseFloat" => (global_this_parse_float_thunk as *const u8, 1, false),
-            "isNaN" => (global_this_is_nan_thunk as *const u8, 1, false),
-            "isFinite" => (global_this_is_finite_thunk as *const u8, 1, false),
-            "encodeURI" => (global_this_encode_uri_thunk as *const u8, 1, false),
-            "decodeURI" => (global_this_decode_uri_thunk as *const u8, 1, false),
+            "parseInt" => (global_this_parse_int_thunk as *const u8, 2, false, false),
+            "parseFloat" => (global_this_parse_float_thunk as *const u8, 1, false, false),
+            "isNaN" => (global_this_is_nan_thunk as *const u8, 1, false, false),
+            "isFinite" => (global_this_is_finite_thunk as *const u8, 1, false, false),
+            "encodeURI" => (global_this_encode_uri_thunk as *const u8, 1, false, false),
+            "decodeURI" => (global_this_decode_uri_thunk as *const u8, 1, false, false),
             "encodeURIComponent" => (
                 global_this_encode_uri_component_thunk as *const u8,
                 1,
+                false,
                 false,
             ),
             "decodeURIComponent" => (
                 global_this_decode_uri_component_thunk as *const u8,
                 1,
                 false,
+                false,
             ),
             // #4511: legacy escape/unescape (ES Annex B).
-            "escape" => (global_this_escape_thunk as *const u8, 1, false),
-            "unescape" => (global_this_unescape_thunk as *const u8, 1, false),
+            // #4511: legacy escape/unescape (ES Annex B).
+            "escape" => (global_this_escape_thunk as *const u8, 1, false, false),
+            "unescape" => (global_this_unescape_thunk as *const u8, 1, false, false),
             _ => continue,
         };
         let closure_ptr = crate::closure::js_closure_alloc(func_ptr, 0);
@@ -3371,11 +3400,17 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         unsafe {
             crate::builtins::js_register_function_name(func_ptr, name.as_ptr(), name.len() as u32);
         }
+        super::native_module::set_builtin_closure_length(closure_ptr as usize, arity);
         let name_bytes = name.as_bytes();
         let name_key =
             crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
         let fn_value = crate::value::js_nanbox_pointer(closure_ptr as i64);
         js_object_set_field_by_name(singleton, name_key, fn_value);
+        super::set_builtin_property_attrs(
+            singleton as usize,
+            name.to_string(),
+            super::PropertyAttrs::new(true, enumerable, true),
+        );
     }
     // ECMA-262 21.1.2.12 / 21.1.2.13: `Number.parseFloat` and `Number.parseInt`
     // are the SAME function objects as the global `parseFloat` / `parseInt`

--- a/test-parity/node-suite/globals/legacy-escape-global.ts
+++ b/test-parity/node-suite/globals/legacy-escape-global.ts
@@ -1,0 +1,69 @@
+function desc(name: string) {
+  const d: any = Object.getOwnPropertyDescriptor(globalThis, name);
+  console.log(`${name} desc:`, typeof (globalThis as any)[name], d?.writable, d?.enumerable, d?.configurable);
+}
+
+function codeUnits(value: string) {
+  const out: string[] = [];
+  for (let i = 0; i < value.length; i++) {
+    out.push(value.charCodeAt(i).toString(16));
+  }
+  return out.join(",");
+}
+
+function errorName(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(`${label}:`, "no error");
+  } catch (error: any) {
+    console.log(`${label}:`, error?.name ?? "");
+  }
+}
+
+function lengthDesc(label: string, fn: Function) {
+  const d: any = Object.getOwnPropertyDescriptor(fn, "length");
+  console.log(`${label} length desc:`, d?.value, d?.writable, d?.enumerable, d?.configurable);
+}
+
+desc("global");
+desc("escape");
+desc("unescape");
+
+const g: any = global;
+console.log("global identity:", g === globalThis, (globalThis as any).global === globalThis, g.global === g);
+console.log("function shape:", escape.name, escape.length, unescape.name, unescape.length);
+console.log("global function shape:", g.escape.name, g.escape.length, g.unescape.name, g.unescape.length);
+lengthDesc("escape", escape);
+lengthDesc("unescape", unescape);
+
+console.log(
+  "escape basics:",
+  JSON.stringify(escape("a b+c")),
+  JSON.stringify(escape("!*'()~")),
+  JSON.stringify(escape("a/b?c=d&e")),
+);
+console.log(
+  "escape unicode:",
+  JSON.stringify(escape("caf\u00e9")),
+  JSON.stringify(escape("\u{1F642}")),
+  JSON.stringify(escape("\u0000\u00ff\u0100")),
+);
+console.log("escape missing:", JSON.stringify(escape()));
+
+console.log(
+  "unescape units:",
+  codeUnits(unescape("a%20b%2Bc")),
+  codeUnits(unescape("caf%E9")),
+  codeUnits(unescape("%u00E9")),
+  codeUnits(unescape("%F0%9F%99%82")),
+  codeUnits(unescape("abc%zzdef")),
+  codeUnits(unescape("%uD83D%uDE42")),
+);
+console.log("unescape missing:", JSON.stringify(unescape()));
+
+const reboundEscape = (globalThis as any).escape;
+const reboundUnescape = (globalThis as any).unescape;
+console.log("rebound:", JSON.stringify(reboundEscape("x y")), codeUnits(reboundUnescape("x%20y")));
+
+errorName("escape symbol", () => escape(Symbol("x") as any));
+errorName("unescape symbol", () => unescape(Symbol("x") as any));


### PR DESCRIPTION
Summary:
- install Node's `global` self-reference on `globalThis` and recognize bare `global` reads
- expose legacy Annex B `escape`/`unescape` as callable global functions with Node-compatible descriptors, names, lengths, coercion, and Symbol errors
- add a globals parity fixture covering descriptors, rebound calls, UTF-16 `%uXXXX` behavior, and Symbol TypeErrors

Fixes #4511.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `env RUSTC_WRAPPER= TMPDIR=$PWD/target/tmp CARGO_BUILD_JOBS=1 cargo check -q -p perry-runtime -p perry-hir -p perry-codegen`
- `env RUSTC_WRAPPER= TMPDIR=$PWD/target/tmp CARGO_BUILD_JOBS=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter legacy-escape-global'` (1 pass / 0 parity fail / 0 compile fail, report `test-parity/reports/parity_report_20260605_075255.json`)
- `env RUSTC_WRAPPER= TMPDIR=$PWD/target/tmp CARGO_BUILD_JOBS=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter global-functions'` (1 pass / 0 parity fail / 0 compile fail, report `test-parity/reports/parity_report_20260605_075512.json`)
- `env RUSTC_WRAPPER= TMPDIR=$PWD/target/tmp CARGO_BUILD_JOBS=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals'` (86 pass / 0 parity fail / 0 compile fail / 0 skipped, report `test-parity/reports/parity_report_20260605_075659.json`)
