### PR TITLE
fix(runtime): obj.toLocaleString runtime dispatch + async-gen 0-arg return/throw arity

### DIFF
--- a/crates/perry-codegen/src/expr/env_clones.rs
+++ b/crates/perry-codegen/src/expr/env_clones.rs
@@ -90,15 +90,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let v = lower_expr(ctx, d)?;
             let inferred = crate::type_analysis::refine_type_from_init(ctx, d)
                 .or_else(|| crate::type_analysis::static_type_of(ctx, d));
-            let rt_fn = match inferred {
+            match inferred {
                 Some(perry_types::Type::Number) | Some(perry_types::Type::Int32) => {
-                    "js_number_to_locale_string"
+                    let blk = ctx.block();
+                    let handle = blk.call(I64, "js_number_to_locale_string", &[(DOUBLE, &v)]);
+                    Ok(nanbox_string_inline(blk, &handle))
                 }
-                _ => "js_date_to_locale_string",
-            };
-            let blk = ctx.block();
-            let handle = blk.call(I64, rt_fn, &[(DOUBLE, &v)]);
-            Ok(nanbox_string_inline(blk, &handle))
+                // #4546: a plain object / string / boolean receiver was
+                // mis-routed to `js_date_to_locale_string`, printing a
+                // 1970-epoch "Invalid Date" instead of `[object Object]`
+                // (or a custom `toLocaleString`). Dispatch on the value's
+                // runtime tag instead; the helper returns an already
+                // NaN-boxed value, so do NOT re-box it.
+                _ => {
+                    let blk = ctx.block();
+                    Ok(blk.call(DOUBLE, "js_value_to_locale_string", &[(DOUBLE, &v)]))
+                }
+            }
         }
         // #600: `fetchWithAuth(url, "Bearer ...")` — perry's recognized
         // built-in for authenticated GET. Dispatches to perry-stdlib's

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1522,6 +1522,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // `Expr::DateToLocaleString` LLVM arm when the receiver's static
     // type narrows to `HirType::Number` / `HirType::Int32`.
     module.declare_function("js_number_to_locale_string", I64, &[DOUBLE]);
+    // Runtime-dispatched `value.toLocaleString()` for receivers whose
+    // static type is unknown at codegen time (plain objects, strings,
+    // booleans). Returns an already-NaN-boxed value, so the LLVM arm
+    // must NOT re-box it.
+    module.declare_function("js_value_to_locale_string", DOUBLE, &[DOUBLE]);
 
     // ========== String ==========
     module.declare_function("js_string_split_regex", I64, &[I64, I64]);

--- a/crates/perry-runtime/src/object/async_generator_queue.rs
+++ b/crates/perry-runtime/src/object/async_generator_queue.rs
@@ -39,6 +39,7 @@ pub(crate) fn wrap_async_generator_instance(obj: *mut ObjectHeader) {
     if obj.is_null() {
         return;
     }
+    register_wrapper_arities();
 
     let Some(next) = own_closure(obj, b"next") else {
         return;
@@ -111,6 +112,26 @@ fn own_closure(obj: *mut ObjectHeader, name: &[u8]) -> Option<*const ClosureHead
 fn set_method(obj: *mut ObjectHeader, name: &[u8], closure: *mut ClosureHeader) {
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
     js_object_set_field_by_name(obj, key, js_nanbox_pointer(closure as i64));
+}
+
+/// #4547: the queue wrappers each take a single `arg` (the value passed to
+/// `next`/`return`/`throw`). Without a registered arity, dispatch padding has
+/// no declared count, so a 0-arg `gen.return()` / `gen.throw()` read an
+/// uninitialized stack slot for `arg` instead of `undefined`. Record arity 1
+/// for all three func pointers so the call path pads the missing argument.
+fn register_wrapper_arities() {
+    thread_local! {
+        static REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+    REGISTERED.with(|done| {
+        if done.get() {
+            return;
+        }
+        done.set(true);
+        crate::closure::js_register_closure_arity(async_generator_next_wrapper as *const u8, 1);
+        crate::closure::js_register_closure_arity(async_generator_return_wrapper as *const u8, 1);
+        crate::closure::js_register_closure_arity(async_generator_throw_wrapper as *const u8, 1);
+    });
 }
 
 fn make_method_wrapper(

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -512,6 +512,18 @@ pub(crate) unsafe fn js_object_default_to_locale_string(receiver: f64) -> f64 {
     crate::object::js_object_to_string(receiver)
 }
 
+/// #4546: codegen entry point for `value.toLocaleString()` when the
+/// receiver's static type is unknown (plain object, string, boolean) — the
+/// `Expr::DateToLocaleString` LLVM arm used to mis-route every non-number
+/// receiver to `js_date_to_locale_string`, yielding a 1970-epoch
+/// "Invalid Date" string. Dispatches on the runtime tag (number → grouping,
+/// Date → date string, object → custom/`[object Object]`). Returns an
+/// already-NaN-boxed value.
+#[no_mangle]
+pub extern "C" fn js_value_to_locale_string(receiver: f64) -> f64 {
+    unsafe { js_object_default_to_locale_string(receiver) }
+}
+
 /// Shared implementation for `Object.prototype.isPrototypeOf`.
 pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64) -> bool {
     let receiver_ptr = match object_ptr_from_value(receiver) {


### PR DESCRIPTION
## Two test262/parity fixes

### 1. `value.toLocaleString()` on non-number receivers (#4546)
The `Expr::DateToLocaleString` codegen arm routed **every** non-number receiver to `js_date_to_locale_string`, so a plain object / string / boolean printed a 1970-epoch "Invalid Date" instead of `[object Object]` (or a custom `toLocaleString`).

Fix: new `js_value_to_locale_string` runtime helper that dispatches on the value tag (number → grouping, Date → date string, object → custom/`[object Object]`). The unknown-static-type arm now calls it; Number/Int32 keep their fast path; dates flow through the runtime tag check.

```
({}).toLocaleString()        // before: "Invalid Date"  → now: "[object Object]"
"hi".toLocaleString()        // before: "Invalid Date"  → now: "hi"
true.toLocaleString()        // before: "Invalid Date"  → now: "true"
[1,2,3].toLocaleString()     // "1,2,3"  (unchanged)
(12345.6).toLocaleString()   // "12,345.6"  (unchanged, #600/#3917)
```

### 2. async-generator 0-arg `.return()` / `.throw()` (#4547)
The queue wrappers (`next`/`return`/`throw`) each take one `arg` but had no registered arity, so a 0-arg `gen.return()` / `gen.throw()` read an uninitialized stack slot instead of `undefined`. Register arity 1 for the three wrapper func pointers.

All cases above verified **byte-identical** against `node --experimental-strip-types`.