### PR TITLE
fix(hir): export { x } of a const aliasing a class static field is cross-module readable

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -1478,6 +1478,17 @@ pub(crate) fn lower_module_decl(
                                             | Expr::FuncRef(_)
                                             | Expr::ExternFuncRef { .. }
                                             | Expr::PropertyGet { .. }
+                                            // A const aliasing a class STATIC field value
+                                            // (`const stringType = ZodString.create;
+                                            // export { stringType as string }`) lowers its
+                                            // init to `StaticFieldGet`. Like `PropertyGet`
+                                            // above it must flow through `exported_objects`
+                                            // so the importer reads the const's value via the
+                                            // module getter instead of link-failing to a
+                                            // nonexistent `perry_fn_<src>__<name>` symbol
+                                            // (which made the call return `undefined`). zod's
+                                            // `z.string`/`z.number`/… are all this shape.
+                                            | Expr::StaticFieldGet { .. }
                                             // #421 fix (v0.5.574): primitive literals must
                                             // also flow through `exported_objects` so the
                                             // importing module's `imported_vars` set picks

--- a/tests/test_export_const_static_field_alias.sh
+++ b/tests/test_export_const_static_field_alias.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A module-level const that aliases a class STATIC field value, re-exported via a
+# separate `export { x }` clause, must be readable + callable cross-module.
+# Before the fix its init lowered to `Expr::StaticFieldGet`, which was missing
+# from the separate-clause export's `is_exportable` set — so the const never got
+# a backing module global and the importer link-resolved a nonexistent
+# `perry_fn_<src>__<name>` symbol, making the call return `undefined`.
+# zod's `z.string`/`z.number`/… are exactly this shape:
+#   const stringType = ZodString.create; export { stringType as string }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/types.ts" <<'TS'
+export class ZS {
+  v = 5;
+  static create = (): ZS => { return new ZS(); };
+}
+const stringType = ZS.create;          // const aliasing a static arrow field
+export { stringType as string };        // separate-clause re-export with alias
+TS
+cat >"$TMPDIR/barrel.ts" <<'TS'
+import * as z from "./types.js";
+export { z };
+TS
+cat >"$TMPDIR/main.ts" <<'TS'
+import { z } from "./barrel.js";
+import { string as direct } from "./types.js";
+const a = (z as any).string();
+if (!a || (a as any).v !== 5) throw new Error("via namespace: " + JSON.stringify(a));
+const b = (direct as any)();
+if (!b || (b as any).v !== 5) throw new Error("direct import: " + JSON.stringify(b));
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/main.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: export const static-field alias"


### PR DESCRIPTION
## Problem

```ts
const stringType = ZodString.create;   // const aliasing a class STATIC field
export { stringType as string };        // separate-clause re-export
```
Imported and called from another module, `string()` returned `undefined`. The init lowered to `Expr::StaticFieldGet`, which was missing from the `is_exportable` set in the separate-clause local-export path. Without that promotion to `exported_objects`, no backing module global/getter is emitted, so the importer link-resolves a nonexistent `perry_fn_<src>__<name>` symbol and the call yields `undefined`.

The inline form (`export const x = ...`) already worked — it promotes unconditionally. `PropertyGet` was already in the list; `StaticFieldGet` (the static-field shape) was not.

## Impact

zod's `z.string` / `z.number` / `z.coerce` / … are all `const xType = ZodX.create; export { xType as x }`, so this unblocks **constructing zod schemas** (previously every `z.string()` etc. returned `undefined`).

## Test

`tests/test_export_const_static_field_alias.sh` (static-field alias via both namespace re-export and direct import). `cargo test -p perry-hir` green.