### PR TITLE
fix(runtime): normalize Reflect property keys

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -20,6 +20,10 @@ use std::collections::{HashMap, HashSet};
 
 use crate::closure::{js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3};
 
+mod reflect;
+
+pub use reflect::{js_reflect_delete, js_reflect_get, js_reflect_has, js_reflect_set};
+
 /// A single Proxy registry entry.
 #[repr(C)]
 pub struct ProxyEntry {
@@ -463,13 +467,29 @@ fn set_handle_property(target: f64, key: f64, value: f64) -> Option<bool> {
     Some(true)
 }
 
-fn target_get(target: f64, key: f64) -> f64 {
+fn target_get_property_key(target: f64, property_key: f64) -> f64 {
+    if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
+        return unsafe { crate::symbol::js_object_get_symbol_property(target, property_key) };
+    }
     let obj_ptr = extract_pointer(target.to_bits()) as *const crate::ObjectHeader;
-    let key_ptr = extract_pointer(key.to_bits()) as *const crate::StringHeader;
+    let key_ptr =
+        crate::value::js_get_string_pointer_unified(property_key) as *const crate::StringHeader;
     if obj_ptr.is_null() || key_ptr.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
     crate::object::js_object_get_field_by_name_f64(obj_ptr, key_ptr)
+}
+
+fn target_get(target: f64, key: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    target_get_property_key(
+        target_handle.get_nanbox_f64(),
+        property_key_handle.get_nanbox_f64(),
+    )
 }
 
 /// `proxy[key] = value` — if handler.set exists, call it with
@@ -512,8 +532,27 @@ pub extern "C" fn js_proxy_set(proxy_boxed: f64, key: f64, value: f64) -> f64 {
 /// boolean, without throwing on a non-writable / non-extensible target the way
 /// strict-mode assignment does (#2756 / #615). Returns `false` when the write
 /// cannot be applied.
+fn reflect_ordinary_set_property_key(target: f64, property_key: f64, value: f64) -> f64 {
+    nanbox_bool(ordinary_set_with_receiver(
+        target,
+        property_key,
+        value,
+        target,
+    ))
+}
+
 fn reflect_ordinary_set(target: f64, key: f64, value: f64) -> f64 {
-    nanbox_bool(ordinary_set_with_receiver(target, key, value, target))
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let value_handle = scope.root_nanbox_f64(value);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    reflect_ordinary_set_property_key(
+        target_handle.get_nanbox_f64(),
+        property_key_handle.get_nanbox_f64(),
+        value_handle.get_nanbox_f64(),
+    )
 }
 
 fn target_set(target: f64, key: f64, value: f64) {
@@ -1065,19 +1104,37 @@ pub extern "C" fn js_proxy_delete(proxy_boxed: f64, key: f64) -> f64 {
 /// NaN-boxed boolean. Returns `false` for a non-configurable property (#2760),
 /// matching `Reflect.deleteProperty` rather than the silent-success behavior of
 /// the `delete` operator.
-fn reflect_ordinary_delete(target: f64, key: f64) -> f64 {
-    if let Some((_writable, configurable)) = crate::object::obj_value_attrs(target, key) {
+fn reflect_ordinary_delete_property_key(target: f64, property_key: f64) -> f64 {
+    if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
+        let deleted =
+            unsafe { crate::symbol::js_object_delete_symbol_property(target, property_key) };
+        return nanbox_bool(deleted != 0);
+    }
+    if let Some((_writable, configurable)) = crate::object::obj_value_attrs(target, property_key) {
         if !configurable {
             return nanbox_bool(false);
         }
     }
     let obj_ptr = extract_pointer(target.to_bits()) as *mut crate::ObjectHeader;
-    let key_ptr = extract_pointer(key.to_bits()) as *const crate::StringHeader;
+    let key_ptr =
+        crate::value::js_get_string_pointer_unified(property_key) as *const crate::StringHeader;
     if !obj_ptr.is_null() && !key_ptr.is_null() {
         let deleted = crate::object::js_object_delete_field(obj_ptr, key_ptr);
         return nanbox_bool(deleted != 0);
     }
     nanbox_bool(true)
+}
+
+fn reflect_ordinary_delete(target: f64, key: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    reflect_ordinary_delete_property_key(
+        target_handle.get_nanbox_f64(),
+        property_key_handle.get_nanbox_f64(),
+    )
 }
 
 /// Is `value` a callable function value: a closure, a class-ref constructor, or
@@ -1314,130 +1371,6 @@ pub extern "C" fn js_reflect_construct(target: f64, args_like: f64, new_target: 
         (args.as_ptr(), args.len())
     };
     unsafe { crate::object::js_new_function_construct_with_new_target(target, ptr, n, nt) }
-}
-
-// ---- Reflect.* helpers (direct wrappers, not proxy-specific) -----
-
-/// `Reflect.get(target, key, receiver)` (#2766).
-///
-/// - throws `TypeError` for a non-object target,
-/// - uses `receiver` as the `this` binding for accessor getters,
-/// - dispatches proxy `get` traps (forwarding `(target, key)` to the existing
-///   proxy path; the three-argument trap receiver is out of scope — Perry's
-///   proxy traps are two-argument).
-///
-/// `receiver` is the optional third argument; codegen passes `target` when the
-/// call site omits it (matching the spec default), and `undefined` is treated
-/// as "use target".
-#[no_mangle]
-pub extern "C" fn js_reflect_get(target: f64, key: f64, receiver: f64) -> f64 {
-    if lookup(target).is_some() {
-        return js_proxy_get(target, key);
-    }
-    if !reflect_value_is_object(target) {
-        return reflect_non_object_typeerror("get");
-    }
-    // Default receiver to target when undefined.
-    let recv = if receiver.to_bits() == TAG_UNDEFINED {
-        target
-    } else {
-        receiver
-    };
-    // #2766: if `key` resolves to an accessor *getter* on `target`, rebind its
-    // `this` to the receiver and invoke it — object-literal getters capture
-    // `this` in a reserved closure slot (not `IMPLICIT_THIS`), so plain
-    // forwarding would read the target's fields, not the receiver's. When the
-    // receiver equals the target we can skip the clone and use the ordinary
-    // read.
-    if recv.to_bits() != target.to_bits() {
-        if let Some(getter_bits) = crate::object::reflect_getter_closure_bits(target, key) {
-            if getter_bits == 0 {
-                // Accessor with no getter → undefined.
-                return f64::from_bits(TAG_UNDEFINED);
-            }
-            let rebound = crate::closure::clone_closure_rebind_this(getter_bits, recv);
-            let closure = closure_from(f64::from_bits(rebound));
-            if !closure.is_null() {
-                // Also set IMPLICIT_THIS for free-function getters that read
-                // `this` from the implicit-this fallback rather than a slot.
-                let prev = crate::object::js_implicit_this_set(recv);
-                let result = js_closure_call0(closure);
-                crate::object::js_implicit_this_set(prev);
-                return result;
-            }
-        }
-    }
-    let prev = crate::object::js_implicit_this_set(recv);
-    let result = target_get(target, key);
-    crate::object::js_implicit_this_set(prev);
-    result
-}
-
-/// `Reflect.set(target, key, value)` — returns the boolean result of the
-/// `[[Set]]` operation (#2756): `false` for a non-writable property or a new
-/// key on a non-extensible object, and the coerced trap result for a proxy.
-#[no_mangle]
-pub extern "C" fn js_reflect_set(target: f64, key: f64, value: f64) -> f64 {
-    if lookup(target).is_some() {
-        return js_proxy_set(target, key, value);
-    }
-    // Reflect.set on a non-object target must throw TypeError (spec step 1),
-    // matching Reflect.has/get/etc. Pre-fix it silently returned false.
-    if !reflect_value_is_object(target) {
-        return reflect_non_object_typeerror("set");
-    }
-    reflect_ordinary_set(target, key, value)
-}
-
-/// `Reflect.has(target, key)` (#2764) — `[[HasProperty]]` semantics:
-///
-/// - throws `TypeError` for a non-object target,
-/// - walks the recorded ordinary prototype chain (e.g. `Object.create(proto)`),
-/// - dispatches to a proxy `has` trap (with `ToBoolean` coercion).
-#[no_mangle]
-pub extern "C" fn js_reflect_has(target: f64, key: f64) -> f64 {
-    if lookup(target).is_some() {
-        let trap_result = js_proxy_has(target, key);
-        // #2764: normalize the trap result with ToBoolean.
-        return coerce_trap_bool(trap_result);
-    }
-    if !reflect_value_is_object(target) {
-        return reflect_non_object_typeerror("has");
-    }
-    // Own + (for class refs / closures) internal lookup.
-    let own = crate::object::js_object_has_property(target, key);
-    if own.to_bits() == TAG_TRUE {
-        return own;
-    }
-    // #2764: `[[HasProperty]]` must also see inherited properties. Perry's
-    // `js_object_has_property` only checks own keys, but the ordinary field
-    // getter DOES walk the (Object.create / setPrototypeOf-recorded) prototype
-    // chain. So probe via a field read: a non-`undefined` result means the
-    // property resolves somewhere on the chain. (A genuinely
-    // present-but-`undefined` inherited value is indistinguishable here, which
-    // matches the own-undefined behavior of `js_object_has_property` and is
-    // acceptable for the inherited case.)
-    let inherited = target_get(target, key);
-    if inherited.to_bits() != TAG_UNDEFINED {
-        return nanbox_bool(true);
-    }
-    nanbox_bool(false)
-}
-
-/// `Reflect.deleteProperty(target, key)` — returns the boolean delete result
-/// (#2760): `false` for a non-configurable property, and the coerced trap
-/// result for a proxy.
-#[no_mangle]
-pub extern "C" fn js_reflect_delete(target: f64, key: f64) -> f64 {
-    if lookup(target).is_some() {
-        return js_proxy_delete(target, key);
-    }
-    // Reflect.deleteProperty on a non-object target must throw TypeError (spec
-    // step 1). Pre-fix it silently returned true.
-    if !reflect_value_is_object(target) {
-        return reflect_non_object_typeerror("deleteProperty");
-    }
-    reflect_ordinary_delete(target, key)
 }
 
 /// `Reflect.ownKeys(target)` (#2763) — returns string own-property names

--- a/crates/perry-runtime/src/proxy/reflect.rs
+++ b/crates/perry-runtime/src/proxy/reflect.rs
@@ -1,0 +1,170 @@
+use super::{
+    closure_from, coerce_trap_bool, js_closure_call0, js_proxy_delete, js_proxy_get, js_proxy_has,
+    js_proxy_set, lookup, nanbox_bool, reflect_non_object_typeerror,
+    reflect_ordinary_delete_property_key, reflect_ordinary_set_property_key,
+    reflect_value_is_object, target_get_property_key, TAG_TRUE, TAG_UNDEFINED,
+};
+
+/// `Reflect.get(target, key, receiver)` (#2766).
+///
+/// - throws `TypeError` for a non-object target,
+/// - uses `receiver` as the `this` binding for accessor getters,
+/// - dispatches proxy `get` traps (forwarding `(target, key)` to the existing
+///   proxy path; the three-argument trap receiver is out of scope - Perry's
+///   proxy traps are two-argument).
+///
+/// `receiver` is the optional third argument; codegen passes `target` when the
+/// call site omits it (matching the spec default), and `undefined` is treated
+/// as "use target".
+#[no_mangle]
+pub extern "C" fn js_reflect_get(target: f64, key: f64, receiver: f64) -> f64 {
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("get");
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let receiver_handle = scope.root_nanbox_f64(receiver);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    let target = target_handle.get_nanbox_f64();
+    let property_key = property_key_handle.get_nanbox_f64();
+    if lookup(target).is_some() {
+        return js_proxy_get(target, property_key);
+    }
+    // Default receiver to target when undefined.
+    let receiver = receiver_handle.get_nanbox_f64();
+    let recv = if receiver.to_bits() == TAG_UNDEFINED {
+        target
+    } else {
+        receiver
+    };
+    // #2766: if `key` resolves to an accessor *getter* on `target`, rebind its
+    // `this` to the receiver and invoke it - object-literal getters capture
+    // `this` in a reserved closure slot (not `IMPLICIT_THIS`), so plain
+    // forwarding would read the target's fields, not the receiver's. When the
+    // receiver equals the target we can skip the clone and use the ordinary
+    // read.
+    if recv.to_bits() != target.to_bits() {
+        let getter_bits = if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
+            unsafe { crate::symbol::reflect_symbol_getter_closure_bits(target, property_key) }
+        } else {
+            crate::object::reflect_getter_closure_bits(target, property_key)
+        };
+        if let Some(getter_bits) = getter_bits {
+            if getter_bits == 0 {
+                // Accessor with no getter -> undefined.
+                return f64::from_bits(TAG_UNDEFINED);
+            }
+            let rebound = crate::closure::clone_closure_rebind_this(getter_bits, recv);
+            let closure = closure_from(f64::from_bits(rebound));
+            if !closure.is_null() {
+                // Also set IMPLICIT_THIS for free-function getters that read
+                // `this` from the implicit-this fallback rather than a slot.
+                let prev = crate::object::js_implicit_this_set(recv);
+                let result = js_closure_call0(closure);
+                crate::object::js_implicit_this_set(prev);
+                return result;
+            }
+        }
+    }
+    let prev = crate::object::js_implicit_this_set(recv);
+    let result = target_get_property_key(target, property_key);
+    crate::object::js_implicit_this_set(prev);
+    result
+}
+
+/// `Reflect.set(target, key, value)` - returns the boolean result of the
+/// `[[Set]]` operation (#2756): `false` for a non-writable property or a new
+/// key on a non-extensible object, and the coerced trap result for a proxy.
+#[no_mangle]
+pub extern "C" fn js_reflect_set(target: f64, key: f64, value: f64) -> f64 {
+    // Reflect.set on a non-object target must throw TypeError (spec step 1),
+    // matching Reflect.has/get/etc. Pre-fix it silently returned false.
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("set");
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let value_handle = scope.root_nanbox_f64(value);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    let target = target_handle.get_nanbox_f64();
+    let property_key = property_key_handle.get_nanbox_f64();
+    let value = value_handle.get_nanbox_f64();
+    if lookup(target).is_some() {
+        return js_proxy_set(target, property_key, value);
+    }
+    reflect_ordinary_set_property_key(target, property_key, value)
+}
+
+/// `Reflect.has(target, key)` (#2764) - `[[HasProperty]]` semantics:
+///
+/// - throws `TypeError` for a non-object target,
+/// - walks the recorded ordinary prototype chain (e.g. `Object.create(proto)`),
+/// - dispatches to a proxy `has` trap (with `ToBoolean` coercion).
+#[no_mangle]
+pub extern "C" fn js_reflect_has(target: f64, key: f64) -> f64 {
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("has");
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    let target = target_handle.get_nanbox_f64();
+    let property_key = property_key_handle.get_nanbox_f64();
+    if lookup(target).is_some() {
+        let trap_result = js_proxy_has(target, property_key);
+        // #2764: normalize the trap result with ToBoolean.
+        return coerce_trap_bool(trap_result);
+    }
+    if unsafe { crate::symbol::js_is_symbol(property_key) } != 0
+        && unsafe { crate::symbol::js_object_has_own_symbol_property(target, property_key) }
+    {
+        return nanbox_bool(true);
+    }
+    // Own + (for class refs / closures) internal lookup.
+    let own = crate::object::js_object_has_property(target, property_key);
+    if own.to_bits() == TAG_TRUE {
+        return own;
+    }
+    // #2764: `[[HasProperty]]` must also see inherited properties. Perry's
+    // `js_object_has_property` only checks own keys, but the ordinary field
+    // getter DOES walk the (Object.create / setPrototypeOf-recorded) prototype
+    // chain. So probe via a field read: a non-`undefined` result means the
+    // property resolves somewhere on the chain. (A genuinely
+    // present-but-`undefined` inherited value is indistinguishable here, which
+    // matches the own-undefined behavior of `js_object_has_property` and is
+    // acceptable for the inherited case.)
+    let inherited = target_get_property_key(target, property_key);
+    if inherited.to_bits() != TAG_UNDEFINED {
+        return nanbox_bool(true);
+    }
+    nanbox_bool(false)
+}
+
+/// `Reflect.deleteProperty(target, key)` - returns the boolean delete result
+/// (#2760): `false` for a non-configurable property, and the coerced trap
+/// result for a proxy.
+#[no_mangle]
+pub extern "C" fn js_reflect_delete(target: f64, key: f64) -> f64 {
+    // Reflect.deleteProperty on a non-object target must throw TypeError (spec
+    // step 1). Pre-fix it silently returned true.
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("deleteProperty");
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    let target = target_handle.get_nanbox_f64();
+    let property_key = property_key_handle.get_nanbox_f64();
+    if lookup(target).is_some() {
+        return js_proxy_delete(target, property_key);
+    }
+    reflect_ordinary_delete_property_key(target, property_key)
+}

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -523,6 +523,40 @@ pub(crate) fn set_symbol_property_attrs(
     guard.as_mut().unwrap().insert((owner, sym_key), attrs);
 }
 
+pub(crate) unsafe fn js_object_delete_symbol_property(obj_f64: f64, sym_f64: f64) -> i32 {
+    let obj_key = obj_key_from_f64(obj_f64);
+    let sym_key = sym_key_from_f64(sym_f64);
+    if obj_key == 0 || sym_key == 0 {
+        return 1;
+    }
+    if get_symbol_property_attrs(obj_key, sym_key).is_some_and(|attrs| !attrs.configurable()) {
+        return 0;
+    }
+
+    accessors::clear_symbol_accessor_property(obj_key, sym_key);
+    {
+        let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
+        if let Some(map) = guard.as_mut() {
+            let should_remove_owner = if let Some(entries) = map.get_mut(&obj_key) {
+                entries.retain(|(key, _)| *key != sym_key);
+                entries.is_empty()
+            } else {
+                false
+            };
+            if should_remove_owner {
+                map.remove(&obj_key);
+            }
+        }
+    }
+    {
+        let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTY_ATTRS);
+        if let Some(map) = guard.as_mut() {
+            map.remove(&(obj_key, sym_key));
+        }
+    }
+    1
+}
+
 pub(crate) fn symbol_property_is_enumerable(owner: usize, sym_key: usize) -> bool {
     get_symbol_property_attrs(owner, sym_key)
         .map(|attrs| attrs.enumerable())
@@ -531,6 +565,35 @@ pub(crate) fn symbol_property_is_enumerable(owner: usize, sym_key: usize) -> boo
 
 pub(crate) fn symbol_accessor_descriptor_bits(owner: usize, sym_key: usize) -> Option<(u64, u64)> {
     accessors::symbol_accessor_property_by_key(owner, sym_key).map(|acc| (acc.get, acc.set))
+}
+
+pub(crate) unsafe fn reflect_symbol_getter_closure_bits(obj_f64: f64, sym_f64: f64) -> Option<u64> {
+    let obj_key = obj_key_from_f64(obj_f64);
+    let sym_key = sym_key_from_f64(sym_f64);
+    if obj_key == 0 || sym_key == 0 {
+        return None;
+    }
+    let acc = accessors::symbol_accessor_property_by_key(obj_key, sym_key)?;
+    if acc.get != 0 {
+        Some(acc.get)
+    } else {
+        Some(0)
+    }
+}
+
+pub(crate) unsafe fn js_object_has_own_symbol_property(obj_f64: f64, sym_f64: f64) -> bool {
+    let bits = obj_f64.to_bits();
+    if (bits >> 48) == 0x7FFE {
+        let class_id = (bits & 0xFFFF_FFFF) as u32;
+        return class_static_symbol_lookup(class_id, sym_f64).is_some();
+    }
+    let obj_key = obj_key_from_f64(obj_f64);
+    let sym_key = sym_key_from_f64(sym_f64);
+    if obj_key == 0 || sym_key == 0 {
+        return false;
+    }
+    accessors::has_own_symbol_accessor(obj_key, sym_key)
+        || object_symbol_data_property_exists(obj_key, sym_key)
 }
 
 /// Extract the raw object pointer from a NaN-boxed JSValue. Returns 0 if the

--- a/test-parity/node-suite/object/reflect-property-ops.ts
+++ b/test-parity/node-suite/object/reflect-property-ops.ts
@@ -1,0 +1,73 @@
+function show(label: string, value: unknown) {
+  console.log(label + ":", JSON.stringify(value));
+}
+
+function throwsName(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(label + ":", "no throw");
+  } catch (err) {
+    console.log(label + ":", (err as Error).name);
+  }
+}
+
+const numericKey: any = { 1: "one" };
+show("get numeric key", Reflect.get(numericKey, 1));
+show("has numeric key", Reflect.has(numericKey, 1));
+show("delete numeric key", Reflect.deleteProperty(numericKey, 1));
+show("numeric key after delete", Object.prototype.hasOwnProperty.call(numericKey, "1"));
+
+const objectKeyTarget: any = { dyn: "dynamic" };
+const objectKey = {
+  toString() {
+    return "dyn";
+  },
+};
+show("get object key", Reflect.get(objectKeyTarget, objectKey));
+show("has object key", Reflect.has(objectKeyTarget, objectKey));
+
+const numericSetTarget: any = {};
+show("set numeric key", Reflect.set(numericSetTarget, 2, "two"));
+show("set numeric read", numericSetTarget["2"]);
+
+const objectSetTarget: any = {};
+show("set object key", Reflect.set(objectSetTarget, objectKey, "written"));
+show("set object read", objectSetTarget.dyn);
+
+const sym = Symbol("k");
+const symbolTarget: any = {};
+symbolTarget[sym] = 42;
+show("get symbol key", Reflect.get(symbolTarget, sym));
+show("has symbol key", Reflect.has(symbolTarget, sym));
+show("delete symbol key", Reflect.deleteProperty(symbolTarget, sym));
+show("symbol key after delete", Reflect.get(symbolTarget, sym));
+
+const symbolSetTarget: any = {};
+show("set symbol key", Reflect.set(symbolSetTarget, sym, 9));
+show("set symbol read", symbolSetTarget[sym]);
+
+const symbolUndefinedTarget: any = {};
+symbolUndefinedTarget[sym] = undefined;
+show("has symbol undefined", Reflect.has(symbolUndefinedTarget, sym));
+
+const base = {
+  get value() {
+    return (this as any).marker;
+  },
+};
+show("accessor receiver", Reflect.get(base, "value", { marker: "receiver" }));
+
+const symAccessor = Symbol("accessor");
+const symbolBase = {
+  get [symAccessor]() {
+    return (this as any).marker;
+  },
+};
+show(
+  "symbol accessor receiver",
+  Reflect.get(symbolBase, symAccessor, { marker: "symbol receiver" }),
+);
+
+throwsName("define primitive target", () =>
+  Reflect.defineProperty(1 as any, "x", { value: 1 }),
+);


### PR DESCRIPTION
Refs #4523

## Summary
- normalize `Reflect.get`, `Reflect.set`, `Reflect.has`, and `Reflect.deleteProperty` keys through `ToPropertyKey` after target validation and before proxy or ordinary dispatch
- preserve Symbol property keys for Reflect reads, writes, presence checks, deletes, and explicit receiver accessor dispatch
- remove symbol side-table entries on `Reflect.deleteProperty` and recognize own symbol properties whose value is `undefined`
- split the Reflect property-operation entry points into `proxy/reflect.rs` so `proxy.rs` stays under the file-size gate

## Why batched
These Reflect operations share the same key-normalization and symbol side-table paths. Fixing only one operation would leave the same observable coercion and Symbol gaps in adjacent Reflect property APIs.

## Tests
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH node --experimental-strip-types test-parity/node-suite/object/reflect-property-ops.ts`
- `cargo check -q -p perry-runtime`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter reflect-property-ops`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter reflect`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations / non-goals
- Does not attempt a broad Proxy trap abrupt-completion audit.
- Does not change `Reflect.construct` behavior.