### PR TITLE
fix(runtime): Array/TypedArray.prototype.isPrototypeOf compares by raw heap address

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -526,8 +526,17 @@ pub extern "C" fn js_value_to_locale_string(receiver: f64) -> f64 {
 
 /// Shared implementation for `Object.prototype.isPrototypeOf`.
 pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64) -> bool {
-    let receiver_ptr = match object_ptr_from_value(receiver) {
-        Some(ptr) => ptr,
+    // The receiver (and every link in the target's `[[Prototype]]` chain) is
+    // compared by raw heap address. Exotic-typed prototype objects —
+    // `Array.prototype` is itself a GC_TYPE_ARRAY, `Uint8Array.prototype` a
+    // typed-array proto — are NOT `GC_TYPE_OBJECT`, so resolving them with
+    // `object_ptr_from_value` (which only accepts GC_TYPE_OBJECT) returned
+    // `None` and the walk bailed. #4549: use the raw GC pointer instead.
+    let heap_addr = |v: f64| -> Option<usize> {
+        gc_pointer_and_type_from_value(v).map(|(ptr, _)| ptr as usize)
+    };
+    let receiver_addr = match heap_addr(receiver) {
+        Some(addr) => addr,
         None => return false,
     };
 
@@ -538,8 +547,8 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
             return false;
         }
         let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
-        if let Some(proto_ptr) = object_ptr_from_value(proto) {
-            return std::ptr::addr_eq(proto_ptr, receiver_ptr);
+        if let Some(proto_addr) = heap_addr(proto) {
+            return proto_addr == receiver_addr;
         }
         return false;
     }
@@ -552,7 +561,7 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
     if let Some(target_ptr) = object_ptr_from_value(target) {
         let has_instance_prototype =
             crate::object::prototype_chain::object_static_prototype(target_ptr as usize).is_some();
-        if std::ptr::addr_eq(target_ptr, receiver_ptr) {
+        if target_ptr as usize == receiver_addr {
             return false;
         }
         // A `new Func()` instance snapshots the function's current
@@ -573,7 +582,7 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
                 let proto_obj = crate::object::class_registry::class_prototype_object(cid);
                 let mut next_cid = 0;
                 if !proto_obj.is_null() {
-                    if std::ptr::addr_eq(proto_obj, receiver_ptr) {
+                    if proto_obj as usize == receiver_addr {
                         return true;
                     }
                     next_cid =
@@ -600,8 +609,19 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
             Some(info) => info,
             None => return false,
         };
+        // #4549: arrays and typed arrays are objects whose `[[Prototype]]`
+        // chain is modeled (`Array.prototype` → `Object.prototype`,
+        // `Uint8Array.prototype` → `%TypedArray%.prototype` →
+        // `Object.prototype`), so they must reach the generic walk below.
+        // Previously only closures/errors were allowed, so
+        // `Array.prototype.isPrototypeOf([1, 2])` and
+        // `Object.prototype.isPrototypeOf([])` wrongly returned `false`.
+        // (ArrayBuffer's BufferHeader representation isn't resolved by the
+        // generic pointer walk yet — tracked separately.)
         if target_gc_type != crate::gc::GC_TYPE_CLOSURE
             && target_gc_type != crate::gc::GC_TYPE_ERROR
+            && target_gc_type != crate::gc::GC_TYPE_ARRAY
+            && target_gc_type != crate::gc::GC_TYPE_TYPED_ARRAY
         {
             return false;
         }
@@ -609,20 +629,20 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
 
     let mut current = target;
     for _ in 0..32 {
-        let current_ptr = object_ptr_from_value(current);
+        let current_addr = heap_addr(current);
         let proto = crate::object::js_object_get_prototype_of(current);
         let proto_jsval = JSValue::from_bits(proto.to_bits());
         if proto_jsval.is_null() || proto_jsval.is_undefined() {
             break;
         }
-        let proto_ptr = match object_ptr_from_value(proto) {
-            Some(ptr) => ptr,
+        let proto_addr = match heap_addr(proto) {
+            Some(addr) => addr,
             None => break,
         };
-        if current_ptr.is_some_and(|ptr| std::ptr::addr_eq(ptr, proto_ptr)) {
+        if current_addr == Some(proto_addr) {
             break;
         }
-        if std::ptr::addr_eq(proto_ptr, receiver_ptr) {
+        if proto_addr == receiver_addr {
             return true;
         }
         current = proto;


### PR DESCRIPTION
## Problem
`Array.prototype.isPrototypeOf([1,2])` and `Object.prototype.isPrototypeOf([])` returned **false** (node: true).

`Array.prototype` is itself an exotic `GC_TYPE_ARRAY` object, and `Uint8Array.prototype` a typed-array proto — neither is `GC_TYPE_OBJECT`. `js_object_is_prototype_of_value` resolved the receiver and every `[[Prototype]]`-chain link with `object_ptr_from_value` (which only accepts `GC_TYPE_OBJECT`), so it returned `None` for these and the walk bailed before any comparison.

## Fix
Compare by **raw GC heap address** (`gc_pointer_and_type_from_value`) for the receiver and each chain link, and let array / typed-array targets reach the generic `[[Prototype]]` walk — their chains are already modeled by `js_object_get_prototype_of`.

```
Array.prototype.isPrototypeOf([1,2])         // false → true
Object.prototype.isPrototypeOf([])           // false → true
Object.prototype.isPrototypeOf(new Uint8Array(2))  // true (unchanged-correct)
Array.prototype.isPrototypeOf({})            // false (unchanged-correct)
```

Object-pointer and function/error receivers resolve to the identical address as before — no behavior change there. Verified the two originally-failing **test262** tests now pass: `built-ins/Array/S15.4.1_A1.1_T3`, `S15.4.2.1_A1.1_T3`.

## Deferred (separate root causes, noted in code)
- **ArrayBuffer targets** — `BufferHeader` representation isn't resolved by the generic pointer walk.
- **class `.prototype` receivers** — `C.prototype` is a synthetic class-ref value (`typeof === "number"`), not a heap object, so all class-instance isPrototypeOf is blocked on that representation.