### PR TITLE
fix(hir): ctor 'this.method = this.method.bind(this)' is a method override, not a field

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -869,6 +869,35 @@ pub fn lower_class_decl(
             }
         }
 
+        // Own instance method names. A constructor `this.method = this.method.bind(this)`
+        // (zod's `ZodType` ctor self-binds ~20 methods; React class components do the
+        // same) is a METHOD OVERRIDE, not a new data field — the assignment creates a
+        // runtime own property handled by the method-override dispatch path. Allocating
+        // an inline field slot for it makes the codegen field branch shadow the method on
+        // every read, so `this.method` reads the uninitialised slot (`undefined`) BEFORE
+        // the assignment runs — exactly what made `this.parse.bind(this)` throw "Bind must
+        // be called on a function" in zod. Mirrors the accessor exclusion (#665).
+        let mut method_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for member in &class_decl.class.body {
+            match member {
+                ast::ClassMember::Method(m) if matches!(m.kind, ast::MethodKind::Method) => {
+                    let key = match &m.key {
+                        ast::PropName::Ident(i) => i.sym.to_string(),
+                        ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
+                        _ => continue,
+                    };
+                    method_names.insert(key);
+                }
+                ast::ClassMember::PrivateMethod(m)
+                    if matches!(m.kind, ast::MethodKind::Method) =>
+                {
+                    method_names.insert(format!("#{}", m.key.name));
+                }
+                _ => {}
+            }
+        }
+
         let declared_field_names: std::collections::HashSet<String> =
             fields.iter().map(|f| f.name.clone()).collect();
         for member in &class_decl.class.body {
@@ -887,6 +916,7 @@ pub fn lower_class_decl(
                                             if !declared_field_names.contains(&fname)
                                                 && !inherited_field_names.contains(&fname)
                                                 && !accessor_names.contains(&fname)
+                                                && !method_names.contains(&fname)
                                             {
                                                 fields.push(ClassField {
                                                     name: fname,

--- a/tests/test_ctor_method_self_bind_not_field.sh
+++ b/tests/test_ctor_method_self_bind_not_field.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A constructor `this.method = this.method.bind(this)` is a METHOD OVERRIDE, not a
+# new data field. Previously the ctor-body field-inference pass added `method` as an
+# inline field (it excluded declared/inherited fields + accessors, but NOT methods),
+# so the codegen field branch shadowed the method: `this.method` read the
+# uninitialised slot (`undefined`) BEFORE the assignment ran, and `.bind(this)` on it
+# threw "Bind must be called on a function". zod's `ZodType` constructor self-binds
+# ~20 methods this way, so every `z.string()` / `z.object()` / … threw at construction.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/m.ts" <<'TS'
+// Mirrors zod's ZodType: self-bind a batch of methods in the constructor, with a
+// subclass instantiated via a static factory.
+abstract class ZodType<O = any> {
+  _def: any;
+  spa = (this as any).safeParseAsync;
+  constructor(def: any) {
+    this._def = def;
+    this.parse = this.parse.bind(this);
+    this.safeParse = this.safeParse.bind(this);
+    this.parseAsync = this.parseAsync.bind(this);
+    this.safeParseAsync = this.safeParseAsync.bind(this);
+    (this as any).spa = (this as any).spa.bind(this);
+    this.optional = this.optional.bind(this);
+    this.default = this.default.bind(this);
+    this.catch = this.catch.bind(this);
+  }
+  abstract _parse(x: any): any;
+  parse(d: unknown): O { return this._parse(d); }
+  safeParse(d: unknown) { return { success: true, data: this._parse(d) }; }
+  async parseAsync(d: unknown): Promise<O> { return this._parse(d); }
+  async safeParseAsync(d: unknown) { return { success: true, data: this._parse(d) }; }
+  optional() { return "optional"; }
+  default(v: any) { return v; }
+  catch(v: any) { return v; }
+}
+class ZodString extends ZodType<string> {
+  _parse(x: any) { return "parsed:" + x; }
+  static create = (): ZodString => new ZodString({ t: "s" });
+}
+
+const s: any = ZodString.create();
+if (typeof s.parse !== "function") throw new Error("parse not a function");
+if (s.parse("hi") !== "parsed:hi") throw new Error("parse() => " + s.parse("hi"));
+if (s.optional() !== "optional") throw new Error("optional() => " + s.optional());
+if (s.safeParse("x").data !== "parsed:x") throw new Error("safeParse data wrong");
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/m.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: ctor method self-bind is not a field"


### PR DESCRIPTION
## Problem

The ctor-body field-inference pass added any `this.x = …` assignment in a constructor as an inline data field, excluding declared/inherited fields and accessors — but **not method names**. So a self-rebind `this.parse = this.parse.bind(this)` allocated a field slot for `parse`, and the codegen field branch then shadowed the prototype method on every read: `this.parse` read the *uninitialised* slot (`undefined`) **before** the assignment ran, so `this.parse.bind(this)` threw `TypeError: Bind must be called on a function`.

zod's `ZodType` constructor self-binds ~20 methods this way, so **every** `z.string()` / `z.object()` / `z.coerce.number()` threw at construction. (React class components use the same `this.handler = this.handler.bind(this)` idiom.)

## Fix

Collect own instance-method names and exclude them from the inferred-field set — directly mirroring the existing accessor (getter/setter) exclusion (#665). A method-name assigned in the constructor is a method *override* (a runtime own property handled by the method-override dispatch path), not a new data field.

## Test

`tests/test_ctor_method_self_bind_not_field.sh` reproduces zod's `ZodType` shape (batch self-bind + subclass + static factory) and asserts the methods work. `cargo test -p perry-hir` green (136+); all prior fix regressions still pass.