### PR TITLE
fix(runtime): preserve array non-integer property keys

### DIFF
--- a/crates/perry-codegen/src/expr/index.rs
+++ b/crates/perry-codegen/src/expr/index.rs
@@ -114,6 +114,8 @@ pub(crate) fn lower_index_set_fast(
     // semantics and writes the returned receiver back to the local slot.
     let guard_ok = {
         let blk = ctx.block();
+        let idx_roundtrip = blk.sitofp(I32, &idx_i32, DOUBLE);
+        let idx_is_integer = blk.fcmp("oeq", idx_double, &idx_roundtrip);
         let guard_fn = if require_numeric_layout {
             "js_typed_feedback_numeric_array_index_set_guard"
         } else {
@@ -125,12 +127,14 @@ pub(crate) fn lower_index_set_fast(
             &[
                 (I64, feedback_site_id),
                 (DOUBLE, arr_box),
+                (DOUBLE, idx_double),
                 (I32, &idx_i32),
                 (DOUBLE, val_double),
                 (I32, "0"),
             ],
         );
-        blk.icmp_ne(I32, &guard_i32, "0")
+        let guard_passed = blk.icmp_ne(I32, &guard_i32, "0");
+        blk.and(I1, &guard_passed, &idx_is_integer)
     };
     ctx.block()
         .cond_br(&guard_ok, &guarded_label, &guard_fallback_label);
@@ -143,7 +147,7 @@ pub(crate) fn lower_index_set_fast(
             &[
                 (I64, feedback_site_id),
                 (DOUBLE, arr_box),
-                (I32, &idx_i32),
+                (DOUBLE, idx_double),
                 (DOUBLE, val_double),
             ],
         );

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -660,6 +660,50 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(DOUBLE, &obj_box), (DOUBLE, &key_box)],
                     ));
                 }
+                if let Expr::String(literal) = index.as_ref() {
+                    let arr_box = lower_expr(ctx, object)?;
+                    let key_idx = ctx.strings.intern(literal);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let blk = ctx.block();
+                    let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                    let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_bits = blk.bitcast_double_to_i64(&key_box);
+                    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    let site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::PropertyGet,
+                        "array[string_index]",
+                        TypedFeedbackContract::object_get_by_name(),
+                    );
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_typed_feedback_object_get_field_by_name_f64",
+                        &[(I64, &site_id), (I64, &arr_handle), (I64, &key_raw)],
+                    ));
+                }
+                if is_string_expr(ctx, index) {
+                    let arr_box = lower_expr(ctx, object)?;
+                    let key_box = lower_expr(ctx, index)?;
+                    let (arr_handle, key_handle) = {
+                        let blk = ctx.block();
+                        let arr_handle = unbox_to_i64(blk, &arr_box);
+                        let key_handle = unbox_str_handle(blk, &key_box);
+                        (arr_handle, key_handle)
+                    };
+                    let site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::PropertyGet,
+                        "array[string_index]",
+                        TypedFeedbackContract::object_get_by_name(),
+                    );
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_typed_feedback_object_get_field_by_name_f64",
+                        &[(I64, &site_id), (I64, &arr_handle), (I64, &key_handle)],
+                    ));
+                }
                 let require_numeric_layout =
                     expr_has_numeric_pointer_free_array_layout(ctx, object);
                 // Bounded-index fast path (mirrors the IndexSet

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -289,11 +289,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let val_double = lower_expr(ctx, value)?;
                         // Grab i32 slot name before mutably borrowing ctx for block().
                         let i32_slot_opt = ctx.i32_counter_slots.get(idx_id).cloned();
-                        let idx_i32 = if let Some(ref i32_slot) = i32_slot_opt {
-                            ctx.block().load(I32, i32_slot)
+                        let (idx_i32, idx_double) = if let Some(ref i32_slot) = i32_slot_opt {
+                            let idx_i32 = ctx.block().load(I32, i32_slot);
+                            let idx_double = ctx.block().sitofp(I32, &idx_i32, DOUBLE);
+                            (idx_i32, idx_double)
                         } else {
                             let idx_double = lower_expr(ctx, index)?;
-                            ctx.block().fptosi(DOUBLE, &idx_double, I32)
+                            let idx_i32 = ctx.block().fptosi(DOUBLE, &idx_double, I32);
+                            (idx_i32, idx_double)
                         };
                         if require_numeric_layout {
                             let feedback_site_id = emit_typed_feedback_register_site(
@@ -317,6 +320,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     &[
                                         (I64, &feedback_site_id),
                                         (DOUBLE, &arr_box),
+                                        (DOUBLE, &idx_double),
                                         (I32, &idx_i32),
                                         (DOUBLE, &val_double),
                                         (I32, "1"),
@@ -334,7 +338,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     &[
                                         (I64, &feedback_site_id),
                                         (DOUBLE, &arr_box),
-                                        (I32, &idx_i32),
+                                        (DOUBLE, &idx_double),
                                         (DOUBLE, &val_double),
                                     ],
                                 );
@@ -482,9 +486,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // receiver is a local that's actually in ctx.locals
                 // (stack slot). Module-level arrays accessed from inside
                 // a function are in ctx.module_globals instead — for
-                // those we use js_array_set_f64_extend (the realloc-
-                // capable variant) and write the new pointer back to
-                // the global slot. Issue #221: the previous code
+                // those we use the raw-key array set helper and write
+                // the new pointer back to the global slot. Issue #221:
+                // the previous code
                 // funneled module globals through js_array_set_f64
                 // which returns silently when `index >= length` — so
                 // every `arr[i] = v` against a `const A: T[] = []`
@@ -508,14 +512,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let blk = ctx.block();
                         let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                        let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
                         let new_handle = blk.call(
                             I64,
-                            "js_typed_feedback_array_set_f64_extend",
+                            "js_typed_feedback_array_set_index_or_string",
                             &[
                                 (I64, &feedback_site_id),
                                 (I64, &arr_handle),
-                                (I32, &idx_i32),
+                                (DOUBLE, &idx_double),
                                 (DOUBLE, &val_double),
                             ],
                         );
@@ -538,23 +541,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         // captured array (common pattern: closure body
                         // does `arr[++i] = X` to populate from outer
                         // scope), this dropped every write. Switch to
-                        // `js_array_set_f64_extend` — the forwarding-
-                        // pointer mechanism (issue #233) handles realloc
-                        // visibility for the caller, so we don't need a
-                        // writeback target here. Discard the returned
-                        // pointer; downstream reads via clean_arr_ptr
-                        // follow the forwarding chain to the new head.
+                        // the raw-key array set helper. Its canonical
+                        // integer path still extends storage, and the
+                        // forwarding-pointer mechanism (issue #233) handles
+                        // realloc visibility for the caller, so we don't
+                        // need a writeback target here. Discard the returned
+                        // pointer; downstream reads via clean_arr_ptr follow
+                        // the forwarding chain to the new head.
                         let blk = ctx.block();
                         let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                        let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
                         blk.call(
                             I64,
-                            "js_typed_feedback_array_set_f64_extend",
+                            "js_typed_feedback_array_set_index_or_string",
                             &[
                                 (I64, &feedback_site_id),
                                 (I64, &arr_handle),
-                                (I32, &idx_i32),
+                                (DOUBLE, &idx_double),
                                 (DOUBLE, &val_double),
                             ],
                         );
@@ -568,12 +571,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let blk = ctx.block();
                     let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                     let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                    let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
-                    // Issue #637 followup / hono r2: use the extend variant
-                    // so `arr[i] = X` for i >= length grows the array per
-                    // JS spec, instead of silently no-op'ing (which the
-                    // non-extend `js_array_set_f64` did via `if index >=
-                    // length { return; }`). The hono Trie's
+                    // Issue #637 followup / hono r2: use the raw-key helper
+                    // so canonical integer keys extend the array per JS spec
+                    // and non-integer keys stay ordinary properties, instead
+                    // of silently no-op'ing (which the non-extend
+                    // `js_array_set_f64` did via `if index >= length {
+                    // return; }`). The hono Trie's
                     // `indexReplacementMap[++captureIndex] = N` pattern
                     // (sparse-extend from a closure capturing the array)
                     // was the load-bearing site — pre-fix the array stayed
@@ -582,11 +585,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     // zero times and `handlerMap` ended up empty.
                     blk.call(
                         I64,
-                        "js_typed_feedback_array_set_f64_extend",
+                        "js_typed_feedback_array_set_index_or_string",
                         &[
                             (I64, &feedback_site_id),
                             (I64, &arr_handle),
-                            (I32, &idx_i32),
+                            (DOUBLE, &idx_double),
                             (DOUBLE, &val_double),
                         ],
                     );

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -199,12 +199,12 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function(
         "js_typed_feedback_plain_array_index_set_guard",
         I32,
-        &[I64, DOUBLE, I32, DOUBLE, I32],
+        &[I64, DOUBLE, DOUBLE, I32, DOUBLE, I32],
     );
     module.declare_function(
         "js_typed_feedback_numeric_array_index_set_guard",
         I32,
-        &[I64, DOUBLE, I32, DOUBLE, I32],
+        &[I64, DOUBLE, DOUBLE, I32, DOUBLE, I32],
     );
     module.declare_function(
         "js_typed_feedback_numeric_array_push_guard",
@@ -214,7 +214,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function(
         "js_typed_feedback_array_index_set_fallback_boxed",
         DOUBLE,
-        &[I64, DOUBLE, I32, DOUBLE],
+        &[I64, DOUBLE, DOUBLE, DOUBLE],
     );
     module.declare_function(
         "js_typed_feedback_observe_array_element",

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -554,14 +554,9 @@ pub extern "C" fn js_array_set_index_or_string(
         if n.is_finite() && n.trunc() == n && n >= 0.0 && n < u32::MAX as f64 {
             return js_array_set_f64_extend(arr, n as u32, value);
         }
-        if n.is_finite() && n.trunc() == n {
-            let s = if n == 0.0 {
-                "0".to_string()
-            } else {
-                format!("{:.0}", n)
-            };
-            let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-            return js_array_set_string_key(arr, key, value);
+        let key = crate::value::js_jsvalue_to_string(idx);
+        if !key.is_null() {
+            return js_array_set_string_key(arr, key as *const crate::StringHeader, value);
         }
     }
     // Fallback for a NON-numeric key: a primitive (`a[null]`, `a[undefined]`,
@@ -569,10 +564,10 @@ pub extern "C" fn js_array_set_index_or_string(
     // ToPropertyKey these become string property keys (or, for `10n`, the
     // canonical index "10"); `js_array_set_string_key` routes accordingly.
     // Arrays previously DROPPED these writes (plain objects handled them).
-    // Restricted to `numeric.is_none()`: a non-integer FLOAT key (`a[1.5]`) is
-    // left untouched here because `js_array_set_string_key("1.5")` currently
-    // mis-parses it as index 1 (corrupting `a[1]`) — that's a separate bug,
-    // tracked. Symbols stay symbol-keyed (handled elsewhere).
+    // Restricted to `numeric.is_none()`: numeric keys were handled above,
+    // including non-integer finite numbers such as `a[1.5]`, which become the
+    // ordinary string property `"1.5"`. Symbols stay symbol-keyed (handled
+    // elsewhere).
     if numeric.is_none() && unsafe { crate::symbol::js_is_symbol(idx) } == 0 {
         let key = crate::value::js_jsvalue_to_string(idx);
         if !key.is_null() {

--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -190,10 +190,11 @@ pub extern "C" fn js_object_set_index_polymorphic(obj_handle: i64, idx: f64, val
 
     if gc_type == crate::gc::GC_TYPE_ARRAY {
         if idx_i32 < 0 || idx != (idx_i32 as f64) {
-            let key = unsafe { property_key_string_ptr(idx) };
-            if !key.is_null() {
-                js_object_set_field_by_name(raw as *mut ObjectHeader, key, value);
-            }
+            crate::array::js_array_set_index_or_string(
+                raw as *mut crate::array::ArrayHeader,
+                idx,
+                value,
+            );
             return;
         }
         // Includes lazy/forwarded — js_array_set_f64_extend's clean_arr_ptr_mut

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1168,7 +1168,9 @@ pub extern "C" fn js_typed_feedback_plain_array_index_get_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
-    let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
+    let index_valid =
+        is_plain_number_bits(index_value.to_bits()) && index_value == index as f64 && index >= 0;
+    let observed_index = if index_valid { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
         source: ObservationSource::Array,
@@ -1180,8 +1182,7 @@ pub extern "C" fn js_typed_feedback_plain_array_index_get_guard(
         aux,
         value_tag: element_kind,
     };
-    let contract_valid = is_plain_number_bits(index_value.to_bits())
-        && index >= 0
+    let contract_valid = index_valid
         && plain_array_index_guard(
             raw_addr as *const ArrayHeader,
             index as u32,
@@ -1209,7 +1210,9 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_get_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
-    let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
+    let index_valid =
+        is_plain_number_bits(index_value.to_bits()) && index_value == index as f64 && index >= 0;
+    let observed_index = if index_valid { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
         source: ObservationSource::Array,
@@ -1221,8 +1224,7 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_get_guard(
         aux,
         value_tag: element_kind,
     };
-    let contract_valid = is_plain_number_bits(index_value.to_bits())
-        && index >= 0
+    let contract_valid = index_valid
         && numeric_array_index_guard(
             raw_addr as *const ArrayHeader,
             index as u32,
@@ -1279,10 +1281,15 @@ pub extern "C" fn js_typed_feedback_array_index_get_fallback_boxed(
             (raw_addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         match (*gc_header).obj_type {
             crate::gc::GC_TYPE_ARRAY | crate::gc::GC_TYPE_LAZY_ARRAY => {
-                if !index.is_finite() || index < 0.0 {
-                    f64::from_bits(TAG_UNDEFINED)
-                } else {
+                let int_index = index as i32;
+                if index.is_finite() && index >= 0.0 && index == int_index as f64 {
                     crate::array::js_array_get_f64(raw_addr as *const ArrayHeader, index as u32)
+                } else {
+                    let key_ptr = index_value_to_property_key(index);
+                    crate::object::js_object_get_field_by_name_f64(
+                        raw_addr as *const ObjectHeader,
+                        key_ptr,
+                    )
                 }
             }
             crate::gc::GC_TYPE_OBJECT | crate::gc::GC_TYPE_CLOSURE => {
@@ -1389,12 +1396,15 @@ pub extern "C" fn js_typed_feedback_array_set_f64_extend(
 pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
     site_id: u64,
     receiver: f64,
+    index_value: f64,
     index: i32,
     value: f64,
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
-    let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
+    let index_valid =
+        is_plain_number_bits(index_value.to_bits()) && index_value == index as f64 && index >= 0;
+    let observed_index = if index_valid { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
         source: ObservationSource::Array,
@@ -1406,7 +1416,7 @@ pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
         aux,
         value_tag: stable_value_kind(value.to_bits()),
     };
-    let contract_valid = index >= 0
+    let contract_valid = index_valid
         && plain_array_index_guard(
             raw_addr as *const ArrayHeader,
             index as u32,
@@ -1429,12 +1439,15 @@ pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
 pub extern "C" fn js_typed_feedback_numeric_array_index_set_guard(
     site_id: u64,
     receiver: f64,
+    index_value: f64,
     index: i32,
     value: f64,
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
-    let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
+    let index_valid =
+        is_plain_number_bits(index_value.to_bits()) && index_value == index as f64 && index >= 0;
+    let observed_index = if index_valid { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
         source: ObservationSource::Array,
@@ -1446,7 +1459,7 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_set_guard(
         aux,
         value_tag: stable_value_kind(value.to_bits()),
     };
-    let contract_valid = index >= 0
+    let contract_valid = index_valid
         && is_numeric_value_bits(value.to_bits())
         && numeric_array_index_guard(
             raw_addr as *const ArrayHeader,
@@ -1507,7 +1520,7 @@ pub extern "C" fn js_typed_feedback_numeric_array_push_guard(
 pub extern "C" fn js_typed_feedback_array_index_set_fallback_boxed(
     site_id: u64,
     receiver: f64,
-    index: i32,
+    index: f64,
     value: f64,
 ) -> f64 {
     record_fallback_call(site_id);
@@ -1517,15 +1530,10 @@ pub extern "C" fn js_typed_feedback_array_index_set_fallback_boxed(
         return receiver;
     }
 
-    let index_value = index as f64;
     if crate::buffer::is_registered_buffer(raw_addr)
         || crate::typedarray::lookup_typed_array_kind(raw_addr).is_some()
     {
-        crate::array::js_array_set_index_or_string(
-            raw_addr as *mut ArrayHeader,
-            index_value,
-            value,
-        );
+        crate::array::js_array_set_index_or_string(raw_addr as *mut ArrayHeader, index, value);
         return receiver;
     }
 
@@ -1540,14 +1548,13 @@ pub extern "C" fn js_typed_feedback_array_index_set_fallback_boxed(
             crate::gc::GC_TYPE_ARRAY | crate::gc::GC_TYPE_LAZY_ARRAY => {
                 let new_arr = crate::array::js_array_set_index_or_string(
                     raw_addr as *mut ArrayHeader,
-                    index_value,
+                    index,
                     value,
                 );
                 crate::value::js_nanbox_pointer(new_arr as i64)
             }
             crate::gc::GC_TYPE_OBJECT | crate::gc::GC_TYPE_CLOSURE => {
-                let key = index.to_string();
-                let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+                let key_ptr = index_value_to_property_key(index);
                 crate::object::js_object_set_field_by_name(
                     raw_addr as *mut ObjectHeader,
                     key_ptr,
@@ -1589,7 +1596,7 @@ pub extern "C" fn js_typed_feedback_array_set_index_or_string(
     idx: f64,
     value: f64,
 ) -> *mut ArrayHeader {
-    let index = if idx.is_finite() && idx >= 0.0 && idx <= u32::MAX as f64 {
+    let index = if idx.is_finite() && idx.trunc() == idx && idx >= 0.0 && idx <= u32::MAX as f64 {
         idx as u32
     } else {
         u32::MAX
@@ -1611,7 +1618,7 @@ pub extern "C" fn js_typed_feedback_object_set_index_polymorphic(
     idx: f64,
     value: f64,
 ) {
-    let index = if idx.is_finite() && idx >= 0.0 && idx <= u32::MAX as f64 {
+    let index = if idx.is_finite() && idx.trunc() == idx && idx >= 0.0 && idx <= u32::MAX as f64 {
         idx as u32
     } else {
         u32::MAX

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -462,10 +462,10 @@ fn typed_feedback_non_bounded_array_set_guard_failure_uses_jsvalue_object_fallba
     // Models an array-typed compiled local slot that receives an object
     // from a dynamic boundary: the non-bounded set guard must fail before
     // codegen can read ArrayHeader fields or raw-store an element.
-    let guard = js_typed_feedback_plain_array_index_set_guard(24, obj_box, 0, 99.0, 0);
+    let guard = js_typed_feedback_plain_array_index_set_guard(24, obj_box, 0.0, 0, 99.0, 0);
     assert_eq!(guard, 0);
 
-    let returned = js_typed_feedback_array_index_set_fallback_boxed(24, obj_box, 0, 99.0);
+    let returned = js_typed_feedback_array_index_set_fallback_boxed(24, obj_box, 0.0, 99.0);
     assert_eq!(returned.to_bits(), obj_box.to_bits());
 
     let key = crate::string::js_string_from_bytes(b"0".as_ptr(), 1);
@@ -515,23 +515,77 @@ fn typed_feedback_numeric_array_set_guard_requires_numeric_value_and_layout() {
     let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
     let arr_box = crate::value::js_nanbox_pointer(arr as i64);
 
-    let first = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, 3.0, 1);
+    let first = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1.0, 1, 3.0, 1);
     assert_eq!(first, 1);
 
     let payload = crate::string::js_string_from_bytes(b"not-number".as_ptr(), 10);
     let payload_value = crate::value::js_nanbox_string(payload as i64);
     let nonnumeric =
-        js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, payload_value, 1);
+        js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1.0, 1, payload_value, 1);
     assert_eq!(nonnumeric, 0);
 
     crate::array::js_array_set_f64(arr, 0, payload_value);
-    let downgraded = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, 4.0, 1);
+    let downgraded = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1.0, 1, 4.0, 1);
     assert_eq!(downgraded, 0);
 
     let site = &typed_feedback_snapshot().sites[0];
     assert_eq!(site.guard_passes, 1);
     assert_eq!(site.guard_failures, 2);
     assert_eq!(site.fallback_calls, 0);
+}
+
+#[test]
+fn typed_feedback_array_set_guards_reject_noninteger_index_values() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(280, TypedFeedbackSiteKind::ArrayElement, "plain_arr[i]=");
+    register(281, TypedFeedbackSiteKind::ArrayElement, "numeric_arr[i]=");
+
+    let values = [1.0, 2.0];
+    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    assert_eq!(
+        js_typed_feedback_plain_array_index_set_guard(280, arr_box, 1.5, 1, 3.0, 1),
+        0
+    );
+    assert_eq!(
+        js_typed_feedback_numeric_array_index_set_guard(281, arr_box, 1.5, 1, 3.0, 1),
+        0
+    );
+
+    let snapshot = typed_feedback_snapshot();
+    assert_eq!(snapshot.sites[0].guard_passes, 0);
+    assert_eq!(snapshot.sites[0].guard_failures, 1);
+    assert_eq!(snapshot.sites[1].guard_passes, 0);
+    assert_eq!(snapshot.sites[1].guard_failures, 1);
+}
+
+#[test]
+fn typed_feedback_array_get_guards_reject_noninteger_index_values() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(282, TypedFeedbackSiteKind::ArrayElement, "plain_arr[i]");
+    register(283, TypedFeedbackSiteKind::ArrayElement, "numeric_arr[i]");
+
+    let values = [1.0, 2.0];
+    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    assert_eq!(
+        js_typed_feedback_plain_array_index_get_guard(282, arr_box, 1.5, 1, 1),
+        0
+    );
+    assert_eq!(
+        js_typed_feedback_numeric_array_index_get_guard(283, arr_box, 1.5, 1, 1),
+        0
+    );
+
+    let snapshot = typed_feedback_snapshot();
+    assert_eq!(snapshot.sites[0].guard_passes, 0);
+    assert_eq!(snapshot.sites[0].guard_failures, 1);
+    assert_eq!(snapshot.sites[1].guard_passes, 0);
+    assert_eq!(snapshot.sites[1].guard_failures, 1);
 }
 
 #[test]
@@ -1051,14 +1105,14 @@ fn typed_feedback_trace_json_includes_observed_kinds() {
     let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
     let arr_box = crate::value::js_nanbox_pointer(arr as i64);
     assert_eq!(
-        js_typed_feedback_numeric_array_index_set_guard(67, arr_box, 1, 3.0, 1),
+        js_typed_feedback_numeric_array_index_set_guard(67, arr_box, 1.0, 1, 3.0, 1),
         1
     );
 
     let payload = crate::string::js_string_from_bytes(b"not-number".as_ptr(), 10);
     let payload_value = crate::value::js_nanbox_string(payload as i64);
     assert_eq!(
-        js_typed_feedback_numeric_array_index_set_guard(67, arr_box, 1, payload_value, 1),
+        js_typed_feedback_numeric_array_index_set_guard(67, arr_box, 1.0, 1, payload_value, 1),
         0
     );
 

--- a/crates/perry-runtime/src/typed_feedback/trace.rs
+++ b/crates/perry-runtime/src/typed_feedback/trace.rs
@@ -365,8 +365,8 @@ mod keep_typed_feedback {
     #[used] static K12: extern "C" fn(u64, f64, f64) -> f64 = js_typed_feedback_array_index_get_fallback_boxed;
     #[used] static K13: extern "C" fn(u64, *mut ArrayHeader, u32, f64) = js_typed_feedback_array_set_f64;
     #[used] static K14: extern "C" fn(u64, *mut ArrayHeader, u32, f64) -> *mut ArrayHeader = js_typed_feedback_array_set_f64_extend;
-    #[used] static K15: extern "C" fn(u64, f64, i32, f64, i32) -> i32 = js_typed_feedback_plain_array_index_set_guard;
-    #[used] static K16: extern "C" fn(u64, f64, i32, f64) -> f64 = js_typed_feedback_array_index_set_fallback_boxed;
+    #[used] static K15: extern "C" fn(u64, f64, f64, i32, f64, i32) -> i32 = js_typed_feedback_plain_array_index_set_guard;
+    #[used] static K16: extern "C" fn(u64, f64, f64, f64) -> f64 = js_typed_feedback_array_index_set_fallback_boxed;
     #[used] static K17: extern "C" fn(u64, *const ArrayHeader, u32) = js_typed_feedback_observe_array_element;
     #[used] static K18: extern "C" fn(u64, *mut ArrayHeader, *const crate::StringHeader, f64) -> *mut ArrayHeader = js_typed_feedback_array_set_string_key;
     #[used] static K19: extern "C" fn(u64, *mut ArrayHeader, f64, f64) -> *mut ArrayHeader = js_typed_feedback_array_set_index_or_string;

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -153,13 +153,21 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         // `undefined`. The narrow gate (GC_TYPE_ARRAY) keeps object
         // numeric-key fast path unchanged.
         if obj_type == crate::gc::GC_TYPE_ARRAY {
-            if idx_i32 < 0 {
-                return f64::from_bits(TAG_UNDEFINED);
-            }
             let arr = raw_ptr as *const crate::array::ArrayHeader;
-            let length = unsafe { (*arr).length };
-            if (idx_i32 as u32) >= length {
-                return f64::from_bits(TAG_UNDEFINED);
+            if index.is_finite() && idx_i32 >= 0 && index == idx_i32 as f64 {
+                let length = unsafe { (*arr).length };
+                if (idx_i32 as u32) >= length {
+                    return f64::from_bits(TAG_UNDEFINED);
+                }
+            } else {
+                let key = crate::value::js_jsvalue_to_string(index);
+                if key.is_null() {
+                    return f64::from_bits(TAG_UNDEFINED);
+                }
+                return crate::object::js_object_get_field_by_name_f64(
+                    raw_ptr as *const crate::object::ObjectHeader,
+                    key,
+                );
             }
         }
         if obj_type == crate::gc::GC_TYPE_OBJECT || obj_type == crate::gc::GC_TYPE_CLOSURE {

--- a/test-parity/node-suite/globals/array-property-keys.ts
+++ b/test-parity/node-suite/globals/array-property-keys.ts
@@ -1,0 +1,33 @@
+function show(label: string, value: unknown) {
+  console.log(label + ":", JSON.stringify(value));
+}
+
+const nonInteger: any = [0, 1, 2];
+nonInteger[1.5] = "half";
+show("noninteger numeric read", nonInteger[1.5]);
+show("noninteger string read", nonInteger["1.5"]);
+show("index one unchanged", nonInteger[1]);
+show("noninteger own", Object.prototype.hasOwnProperty.call(nonInteger, "1.5"));
+show("noninteger length", nonInteger.length);
+show("delete noninteger", delete nonInteger[1.5]);
+show("noninteger after delete", Object.prototype.hasOwnProperty.call(nonInteger, "1.5"));
+show("index one after delete", nonInteger[1]);
+
+const numericString: any = [];
+numericString["1.5"] = "string half";
+show("string noninteger string read", numericString["1.5"]);
+show("string noninteger numeric read", numericString[1.5]);
+show("string noninteger index one", numericString[1]);
+show("string noninteger length", numericString.length);
+
+const bigintKey: any = [];
+bigintKey[10n as any] = "ten";
+show("bigint key string read", bigintKey["10"]);
+show("bigint key numeric read", bigintKey[10]);
+show("bigint key own", Object.prototype.hasOwnProperty.call(bigintKey, "10"));
+show("bigint key in", "10" in bigintKey);
+show("bigint key length", bigintKey.length);
+show("delete bigint key", delete bigintKey["10"]);
+show("bigint key after delete", bigintKey["10"]);
+show("bigint key own after delete", Object.prototype.hasOwnProperty.call(bigintKey, "10"));
+show("bigint key length after delete", bigintKey.length);


### PR DESCRIPTION
Fixes #4543

## Summary
- route non-integer numeric array writes like `a[1.5]` through property-key storage instead of truncating to element index `1`
- preserve canonical string/BigInt array-key reads and writes through the array-aware named-property and boxed fallback paths
- tighten typed-feedback array index guards so non-integer numeric keys fail before learning truncated element feedback
- add Node parity coverage for non-integer numeric keys, canonical string keys, BigInt keys, own/in checks, and deletion

## Verification
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH node --experimental-strip-types test-parity/node-suite/globals/array-property-keys.ts`
- `cargo check -q -p perry-runtime -p perry-codegen`
- `cargo test -q -p perry-runtime --lib typed_feedback`
- `cargo test -q -p perry-codegen --lib typed_feedback` (0 matching tests; 86 filtered out)
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter array-property-keys`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter array`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Note
- `cargo test -q -p perry-runtime --lib array` was also tried; it passed 108/109 but failed `array::tests::test_array_exotic_descriptors_and_global_prototype_identity` under the broad filter. The same test passes when run isolated, so this appears to be existing order-sensitive global state rather than this patch.
