### PR TITLE
fix(hir): new Number/String/Boolean coerce a present argument (explicit undefined ≠ no-arg)

### DIFF
--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -1182,7 +1182,22 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     "Boolean" => crate::BoxedPrimitiveKind::Boolean,
                     _ => unreachable!(),
                 };
-                let arg = args.drain(..).next().unwrap_or(Expr::Undefined);
+                // A *present* argument is coerced per spec: `new Number(x)` →
+                // ToNumber(x), `new String(x)` → ToString(x). This matters for
+                // an explicit `undefined`: `new Number(undefined)` is NaN and
+                // `new String(undefined)` is "undefined" — distinct from the
+                // *no-arg* forms `new Number()`/`new String()` which box +0/""
+                // (handled by the undefined sentinel in `js_boxed_*_new`).
+                // Without this, both collapse to `Expr::Undefined` and the
+                // runtime can't tell them apart.
+                let arg = match args.drain(..).next() {
+                    Some(inner) => match kind {
+                        crate::BoxedPrimitiveKind::Number => Expr::NumberCoerce(Box::new(inner)),
+                        crate::BoxedPrimitiveKind::String => Expr::StringCoerce(Box::new(inner)),
+                        crate::BoxedPrimitiveKind::Boolean => Expr::BooleanCoerce(Box::new(inner)),
+                    },
+                    None => Expr::Undefined,
+                };
                 return Ok(Expr::BoxedPrimitiveNew {
                     kind,
                     arg: Box::new(arg),


### PR DESCRIPTION
## Problem
```ts
new Number(undefined).valueOf()  // 0   (node: NaN)
new String(undefined).valueOf()  // ""  (node: "undefined")
```
Both an explicit `undefined` argument and the no-arg form lowered to `Expr::Undefined`, so `js_boxed_*_new`'s missing-arg sentinel couldn't tell them apart and mapped both to the no-arg default (+0 / "").

## Fix
Per spec a **present** argument is coerced: `new Number(x)` → ToNumber(x), `new String(x)` → ToString(x). Wrap a present arg in `NumberCoerce`/`StringCoerce`/`BooleanCoerce` during lowering; emit the undefined sentinel only for the genuinely no-arg form.

```
new Number(undefined)  // NaN          new Number()  // 0
new String(undefined)  // "undefined"   new String()  // ""
new Number("42")       // 42  (unchanged)
```

Fixes test262 `built-ins/Number/S9.3_A5_T1`. Verified byte-identical to `node --experimental-strip-types` across no-arg, explicit-undefined, and value args for all three wrappers.