### PR TITLE
fix(runtime): route native error and builtin isPrototypeOf chains

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -4,12 +4,27 @@
 //! Pure mechanical move — match arm bodies are verbatim copies, called from
 //! `lower_expr`'s outer dispatch.
 
-use anyhow::{anyhow, bail, Result};
+use super::property_get_names::{
+    is_headers_method_name, is_http_client_request_method_name, is_net_native_method_value,
+    is_url_pattern_data_property,
+};
 #[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
-
+use super::{
+    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
+    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
+    emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
+    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
+    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
+    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
+    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
+    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
+    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
+    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
+    try_flat_const_2d_int, try_lower_flat_const_index_get, try_lower_pod_field_get,
+    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
+    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract,
+    TypedFeedbackKind,
+};
 #[allow(unused_imports)]
 use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
 #[allow(unused_imports)]
@@ -32,28 +47,11 @@ use crate::type_analysis::{
 };
 #[allow(unused_imports)]
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
-
-use super::property_get_names::{
-    is_headers_method_name, is_http_client_request_method_name, is_net_native_method_value,
-    is_url_pattern_data_property,
-};
+use anyhow::{anyhow, bail, Result};
 #[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_lower_pod_field_get,
-    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
-    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract,
-    TypedFeedbackKind,
-};
+use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
+#[allow(unused_imports)]
+use perry_types::Type as HirType;
 
 fn class_has_computed_runtime_members(ctx: &FnCtx<'_>, class_name: &str) -> bool {
     ctx.classes
@@ -99,7 +97,6 @@ fn lower_class_method_bind(
         &[(DOUBLE, &recv_box), (I64, &bytes_i64), (I64, &len_str)],
     ))
 }
-
 fn is_primitive_builtin_proto_method(builtin_name: &str, method_name: &str) -> bool {
     match builtin_name {
         "Number" => matches!(
@@ -111,7 +108,6 @@ fn is_primitive_builtin_proto_method(builtin_name: &str, method_name: &str) -> b
         _ => false,
     }
 }
-
 fn builtin_prototype_method_read<'a>(
     object: &'a Expr,
     property: &'a str,

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1708,6 +1708,20 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 return Ok(Expr::Number(value));
             }
         }
+        if matches!(
+            prop_ident.sym.as_ref(),
+            "bind" | "call" | "apply" | "isPrototypeOf"
+        ) {
+            if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+                let obj_name = obj_ident.sym.as_ref();
+                if crate::analysis::is_builtin_global_value_name(obj_name) {
+                    object_expr = Expr::PropertyGet {
+                        object: Box::new(Expr::GlobalGet(0)),
+                        property: obj_name.to_string(),
+                    };
+                }
+            }
+        }
     }
     let member_object_is_global_this = matches!(
         unwrap_transparent(member.obj.as_ref()),
@@ -1846,6 +1860,18 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                                 crate::analysis::is_builtin_static_function_member(property, member)
                             })
                             .unwrap_or(false);
+                    let outer_is_inherited_object_proto_method = matches!(
+                        outer_static_member,
+                        Some(
+                            "hasOwnProperty"
+                                | "isPrototypeOf"
+                                | "propertyIsEnumerable"
+                                | "toLocaleString"
+                                | "valueOf"
+                        )
+                    );
+                    let outer_is_inherited_function_proto_method =
+                        matches!(outer_static_member, Some("bind" | "call" | "apply"));
                     // Non-callee `console.log` reads need the namespace
                     // receiver; the property-only GlobalGet path collides
                     // with detached `Math.log`.
@@ -1856,6 +1882,8 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         && !outer_is_websocket_static
                         && !outer_is_reified_object_static_value
                         && !outer_is_reified_builtin_static_value
+                        && !outer_is_inherited_object_proto_method
+                        && !outer_is_inherited_function_proto_method
                         && !receiver_is_detached_console_read
                     {
                         object_expr = Expr::GlobalGet(0);

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1977,10 +1977,27 @@ unsafe fn closure_dynamic_prop_by_key(obj: usize, key: *const crate::StringHeade
     let key_len = (*key).byte_len as usize;
     let name = std::str::from_utf8(std::slice::from_raw_parts(key_ptr, key_len)).ok()?;
     let val = crate::closure::closure_get_dynamic_prop(obj, name);
-    if val.to_bits() == crate::value::TAG_UNDEFINED {
-        None
-    } else {
-        Some(val)
+    if val.to_bits() != crate::value::TAG_UNDEFINED {
+        return Some(val);
+    }
+    if crate::closure::is_closure_ptr(obj) {
+        if let Some(method) = reified_function_method_name(name) {
+            let receiver = f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+            return Some(crate::closure::reify_function_method_value(
+                receiver, method,
+            ));
+        }
+    }
+    None
+}
+
+fn reified_function_method_name(name: &str) -> Option<&'static [u8]> {
+    match name {
+        "bind" => Some(b"bind"),
+        "call" => Some(b"call"),
+        "apply" => Some(b"apply"),
+        "isPrototypeOf" => Some(b"isPrototypeOf"),
+        _ => None,
     }
 }
 
@@ -2793,6 +2810,13 @@ pub extern "C" fn js_object_get_field_by_name(
                     let s = crate::string::js_string_from_bytes(fname.as_ptr(), fname.len() as u32);
                     return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
                 }
+                if let Some(method) = reified_function_method_name(name_str) {
+                    let receiver =
+                        f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                    return JSValue::from_bits(
+                        crate::closure::reify_function_method_value(receiver, method).to_bits(),
+                    );
+                }
             }
             return JSValue::undefined();
         }
@@ -3176,13 +3200,7 @@ pub extern "C" fn js_object_get_field_by_name(
                     // `Function.prototype.call.bind(method)` work — reading `.bind`
                     // off the reified `Function.prototype.call` previously read
                     // back `undefined`, so the bound function was never produced.
-                    let reified: Option<&'static [u8]> = match name_str {
-                        "bind" => Some(b"bind"),
-                        "call" => Some(b"call"),
-                        "apply" => Some(b"apply"),
-                        _ => None,
-                    };
-                    if let Some(method) = reified {
+                    if let Some(method) = reified_function_method_name(name_str) {
                         let receiver =
                             f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
                         return JSValue::from_bits(

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1121,6 +1121,19 @@ extern "C" fn object_prototype_is_prototype_of_thunk(
     )
 }
 
+fn is_native_error_subclass_constructor(name: &str) -> bool {
+    matches!(
+        name,
+        "TypeError"
+            | "RangeError"
+            | "SyntaxError"
+            | "ReferenceError"
+            | "EvalError"
+            | "URIError"
+            | "AggregateError"
+    )
+}
+
 extern "C" fn date_prototype_to_string_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
@@ -2303,6 +2316,8 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     // `%Generator(.prototype)%` chains resolve to real objects.
     ensure_generator_intrinsics();
     // Constructors: ClosureHeader-backed so typeof is "function".
+    let mut error_ctor_bits: Option<u64> = None;
+    let mut error_prototype_bits: Option<u64> = None;
     for name in GLOBAL_THIS_BUILTIN_CONSTRUCTORS.iter().copied() {
         if name == "Buffer" {
             let name_bytes = name.as_bytes();
@@ -2428,6 +2443,13 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             install_error_static_methods(closure_ptr);
         }
         let ctor_value = crate::value::js_nanbox_pointer(closure_ptr as i64);
+        if name == "Error" {
+            error_ctor_bits = Some(ctor_value.to_bits());
+        } else if is_native_error_subclass_constructor(name) {
+            if let Some(proto_bits) = error_ctor_bits {
+                crate::closure::closure_set_static_prototype(closure_ptr as usize, proto_bits);
+            }
+        }
         // Stash `prototype` on the closure's dynamic-prop side table.
         // `js_object_set_field_by_name` detects the CLOSURE_MAGIC tag
         // at offset 12 and dispatches into `closure_set_dynamic_prop`
@@ -2455,6 +2477,16 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                 "constructor".to_string(),
                 super::PropertyAttrs::new(true, false, true),
             );
+            if name == "Error" {
+                error_prototype_bits = Some(proto_value.to_bits());
+            } else if is_native_error_subclass_constructor(name) {
+                if let Some(proto_bits) = error_prototype_bits {
+                    super::prototype_chain::object_set_static_prototype(
+                        proto_obj as usize,
+                        proto_bits,
+                    );
+                }
+            }
             if is_web_fetch_constructor(name) {
                 js_object_set_field_by_name(proto_obj, ctor_key, ctor_value);
                 super::set_builtin_property_attrs(
@@ -4090,7 +4122,21 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                 function_prototype_call_thunk as *const u8,
                 1,
             );
-            install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            install_noop_proto_methods(
+                proto_obj,
+                &[
+                    ("hasOwnProperty", 1),
+                    ("propertyIsEnumerable", 1),
+                    ("toLocaleString", 0),
+                    ("valueOf", 0),
+                ],
+            );
+            install_proto_method(
+                proto_obj,
+                "isPrototypeOf",
+                object_prototype_is_prototype_of_thunk as *const u8,
+                1,
+            );
             install_function_has_instance_symbol(proto_obj);
         }
         "String" => {

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3846,22 +3846,21 @@ fn install_atomics_namespace_members(ns_obj: *mut ObjectHeader) {
     }
 }
 
-/// Install a list of `(method_name, arity)` pairs on a prototype object,
-/// each backed by `global_this_builtin_noop_thunk`. The shared no-op thunk
-/// is fine because every method shares the same backing func pointer (the
-/// arity registration on that pointer is overwritten harmlessly with each
-/// call — the last winner is whichever arity matches the dominant call
-/// site, but no current code path depends on the registered arity for the
-/// noop thunk; the real dispatch arms each register their own arity on
-/// their own thunk pointer).
+/// Install a list of `(method_name, arity)` pairs on a prototype object.
+/// Most are backed by `global_this_builtin_noop_thunk`: the shared no-op
+/// thunk is fine because every method shares the same backing func pointer
+/// (the arity registration on that pointer is overwritten harmlessly with
+/// each call). `isPrototypeOf` is the exception: direct calls on built-in
+/// prototype receivers need the real `Object.prototype` prototype-chain
+/// predicate, not the no-op's generic object string result.
 fn install_noop_proto_methods(proto_obj: *mut ObjectHeader, methods: &[(&str, u32)]) {
     for (name, arity) in methods.iter().copied() {
-        install_proto_method(
-            proto_obj,
-            name,
-            global_this_builtin_noop_thunk as *const u8,
-            arity,
-        );
+        let func_ptr = if name == "isPrototypeOf" {
+            object_prototype_is_prototype_of_thunk as *const u8
+        } else {
+            global_this_builtin_noop_thunk as *const u8
+        };
+        install_proto_method(proto_obj, name, func_ptr, arity);
     }
 }
 

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -444,6 +444,64 @@ unsafe fn prototype_identity_ptr_from_value(value: f64) -> Option<*const u8> {
     }
 }
 
+#[inline]
+fn registered_buffer_addr_from_value(value: f64) -> Option<usize> {
+    let valid_addr = |addr: usize| {
+        (addr > 0x10000 && addr <= crate::value::POINTER_MASK as usize)
+            .then_some(addr)
+            .filter(|addr| crate::buffer::is_registered_buffer(*addr))
+    };
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_pointer() {
+        return valid_addr(jsval.as_pointer::<u8>() as usize);
+    }
+    let bits = value.to_bits();
+    if (bits >> 48) == 0 {
+        return valid_addr(bits as usize);
+    }
+    if value.is_finite() && value.fract() == 0.0 && value > 0.0 {
+        return valid_addr(value as usize);
+    }
+    None
+}
+
+#[inline]
+fn builtin_prototype_or_none(name: &str) -> Option<f64> {
+    let proto = crate::object::builtin_prototype_value(name);
+    if JSValue::from_bits(proto.to_bits()).is_undefined() {
+        None
+    } else {
+        Some(proto)
+    }
+}
+
+#[inline]
+unsafe fn non_gc_object_prototype_for_is_prototype_of(value: f64) -> Option<f64> {
+    if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(value) {
+        if let Some(kind) = crate::typedarray::lookup_typed_array_kind(addr) {
+            return builtin_prototype_or_none(crate::typedarray::name_for_kind(kind));
+        }
+        if crate::buffer::is_uint8array_buffer(addr) {
+            return builtin_prototype_or_none("Uint8Array");
+        }
+    }
+
+    let addr = registered_buffer_addr_from_value(value)?;
+    if crate::buffer::is_array_buffer(addr) {
+        return builtin_prototype_or_none("ArrayBuffer");
+    }
+    if crate::buffer::is_shared_array_buffer(addr) {
+        return builtin_prototype_or_none("SharedArrayBuffer");
+    }
+    if crate::buffer::is_data_view(addr) {
+        return builtin_prototype_or_none("DataView");
+    }
+    if crate::buffer::is_uint8array_buffer(addr) {
+        return builtin_prototype_or_none("Uint8Array");
+    }
+    None
+}
+
 unsafe fn object_has_null_proto_flag(object: *const ObjectHeader) -> bool {
     let gc_header =
         (object as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
@@ -563,11 +621,6 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
         return false;
     }
 
-    let target_jsval = JSValue::from_bits(target.to_bits());
-    if !target_jsval.is_pointer() {
-        return false;
-    }
-
     if let Some(target_ptr) = object_ptr_from_value(target) {
         let has_instance_prototype =
             crate::object::prototype_chain::object_static_prototype(target_ptr as usize).is_some();
@@ -618,24 +671,22 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
             }
         }
     } else {
-        let (_, target_gc_type) = match gc_pointer_and_type_from_value(target) {
-            Some(info) => info,
-            None => return false,
-        };
-        // #4549: arrays and typed arrays are objects whose `[[Prototype]]`
-        // chain is modeled (`Array.prototype` → `Object.prototype`,
-        // `Uint8Array.prototype` → `%TypedArray%.prototype` →
-        // `Object.prototype`), so they must reach the generic walk below.
-        // Previously only closures/errors were allowed, so
-        // `Array.prototype.isPrototypeOf([1, 2])` and
-        // `Object.prototype.isPrototypeOf([])` wrongly returned `false`.
-        // (ArrayBuffer's BufferHeader representation isn't resolved by the
-        // generic pointer walk yet — tracked separately.)
-        if target_gc_type != crate::gc::GC_TYPE_CLOSURE
-            && target_gc_type != crate::gc::GC_TYPE_ERROR
-            && target_gc_type != crate::gc::GC_TYPE_ARRAY
-            && target_gc_type != crate::gc::GC_TYPE_TYPED_ARRAY
-        {
+        // #4549/#4554/#4555: arrays, typed arrays, and buffer-backed objects
+        // all have modeled prototype chains. GC-backed values can use the
+        // generic walk directly; BufferHeader-backed values need a safe first
+        // prototype hop because they do not carry a GC header.
+        let walkable_non_gc = non_gc_object_prototype_for_is_prototype_of(target).is_some();
+        let walkable_gc = matches!(
+            gc_pointer_and_type_from_value(target),
+            Some((
+                _,
+                crate::gc::GC_TYPE_CLOSURE
+                    | crate::gc::GC_TYPE_ERROR
+                    | crate::gc::GC_TYPE_ARRAY
+                    | crate::gc::GC_TYPE_TYPED_ARRAY
+            ))
+        );
+        if !walkable_non_gc && !walkable_gc {
             return false;
         }
     }
@@ -643,7 +694,10 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
     let mut current = target;
     for _ in 0..32 {
         let current_ptr = prototype_identity_ptr_from_value(current);
-        let proto = crate::object::js_object_get_prototype_of(current);
+        let proto = match non_gc_object_prototype_for_is_prototype_of(current) {
+            Some(proto) => proto,
+            None => crate::object::js_object_get_prototype_of(current),
+        };
         let proto_jsval = JSValue::from_bits(proto.to_bits());
         if proto_jsval.is_null() || proto_jsval.is_undefined() {
             break;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -74,6 +74,11 @@ unsafe fn call_primitive_builtin_prototype_method(
     call_primitive_closure_value(receiver, value, args_ptr, args_len)
 }
 
+#[inline]
+fn closure_function_proto_method_uses_builtin_dispatch(method_name: &str) -> bool {
+    matches!(method_name, "bind" | "call" | "apply" | "isPrototypeOf")
+}
+
 /// Call a method on an object with dynamic dispatch
 /// This is used for runtime method calls when the method cannot be resolved statically.
 /// object: NaN-boxed f64 containing an object pointer
@@ -426,6 +431,19 @@ unsafe fn object_ptr_from_value(value: f64) -> Option<*mut ObjectHeader> {
     }
 }
 
+#[inline]
+unsafe fn prototype_identity_ptr_from_value(value: f64) -> Option<*const u8> {
+    let (ptr, gc_type) = gc_pointer_and_type_from_value(value)?;
+    match gc_type {
+        crate::gc::GC_TYPE_OBJECT
+        | crate::gc::GC_TYPE_CLOSURE
+        | crate::gc::GC_TYPE_ERROR
+        | crate::gc::GC_TYPE_ARRAY
+        | crate::gc::GC_TYPE_TYPED_ARRAY => Some(ptr),
+        _ => None,
+    }
+}
+
 unsafe fn object_has_null_proto_flag(object: *const ObjectHeader) -> bool {
     let gc_header =
         (object as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
@@ -526,19 +544,11 @@ pub extern "C" fn js_value_to_locale_string(receiver: f64) -> f64 {
 
 /// Shared implementation for `Object.prototype.isPrototypeOf`.
 pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64) -> bool {
-    // The receiver (and every link in the target's `[[Prototype]]` chain) is
-    // compared by raw heap address. Exotic-typed prototype objects —
-    // `Array.prototype` is itself a GC_TYPE_ARRAY, `Uint8Array.prototype` a
-    // typed-array proto — are NOT `GC_TYPE_OBJECT`, so resolving them with
-    // `object_ptr_from_value` (which only accepts GC_TYPE_OBJECT) returned
-    // `None` and the walk bailed. #4549: use the raw GC pointer instead.
-    let heap_addr = |v: f64| -> Option<usize> {
-        gc_pointer_and_type_from_value(v).map(|(ptr, _)| ptr as usize)
-    };
-    let receiver_addr = match heap_addr(receiver) {
-        Some(addr) => addr,
+    let receiver_identity_ptr = match prototype_identity_ptr_from_value(receiver) {
+        Some(ptr) => ptr,
         None => return false,
     };
+    let receiver_object_ptr = object_ptr_from_value(receiver);
 
     if crate::date::is_date_value(target) {
         let ctor = crate::object::js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
@@ -547,8 +557,8 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
             return false;
         }
         let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
-        if let Some(proto_addr) = heap_addr(proto) {
-            return proto_addr == receiver_addr;
+        if let Some(proto_ptr) = prototype_identity_ptr_from_value(proto) {
+            return std::ptr::addr_eq(proto_ptr, receiver_identity_ptr);
         }
         return false;
     }
@@ -561,7 +571,7 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
     if let Some(target_ptr) = object_ptr_from_value(target) {
         let has_instance_prototype =
             crate::object::prototype_chain::object_static_prototype(target_ptr as usize).is_some();
-        if target_ptr as usize == receiver_addr {
+        if std::ptr::addr_eq(target_ptr as *const u8, receiver_identity_ptr) {
             return false;
         }
         // A `new Func()` instance snapshots the function's current
@@ -570,37 +580,40 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
         // because later `Func.prototype = other` must not rewrite older
         // instances.
         if !has_instance_prototype {
-            let mut cid = crate::object::js_object_get_class_id(target_ptr as *const ObjectHeader);
-            let mut depth = 0usize;
-            let mut visited: [u32; 32] = [0; 32];
-            while cid != 0 && depth < visited.len() {
-                if visited[..depth].contains(&cid) {
-                    break;
-                }
-                visited[depth] = cid;
-
-                let proto_obj = crate::object::class_registry::class_prototype_object(cid);
-                let mut next_cid = 0;
-                if !proto_obj.is_null() {
-                    if proto_obj as usize == receiver_addr {
-                        return true;
+            if let Some(receiver_ptr) = receiver_object_ptr {
+                let mut cid =
+                    crate::object::js_object_get_class_id(target_ptr as *const ObjectHeader);
+                let mut depth = 0usize;
+                let mut visited: [u32; 32] = [0; 32];
+                while cid != 0 && depth < visited.len() {
+                    if visited[..depth].contains(&cid) {
+                        break;
                     }
-                    next_cid =
-                        crate::object::js_object_get_class_id(proto_obj as *const ObjectHeader);
-                }
+                    visited[depth] = cid;
 
-                if next_cid != 0 && next_cid != cid {
-                    cid = next_cid;
-                    depth += 1;
-                    continue;
-                }
+                    let proto_obj = crate::object::class_registry::class_prototype_object(cid);
+                    let mut next_cid = 0;
+                    if !proto_obj.is_null() {
+                        if std::ptr::addr_eq(proto_obj, receiver_ptr) {
+                            return true;
+                        }
+                        next_cid =
+                            crate::object::js_object_get_class_id(proto_obj as *const ObjectHeader);
+                    }
 
-                match crate::object::class_registry::get_parent_class_id(cid) {
-                    Some(parent_id) if parent_id != 0 && parent_id != cid => {
-                        cid = parent_id;
+                    if next_cid != 0 && next_cid != cid {
+                        cid = next_cid;
                         depth += 1;
+                        continue;
                     }
-                    _ => break,
+
+                    match crate::object::class_registry::get_parent_class_id(cid) {
+                        Some(parent_id) if parent_id != 0 && parent_id != cid => {
+                            cid = parent_id;
+                            depth += 1;
+                        }
+                        _ => break,
+                    }
                 }
             }
         }
@@ -629,20 +642,20 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
 
     let mut current = target;
     for _ in 0..32 {
-        let current_addr = heap_addr(current);
+        let current_ptr = prototype_identity_ptr_from_value(current);
         let proto = crate::object::js_object_get_prototype_of(current);
         let proto_jsval = JSValue::from_bits(proto.to_bits());
         if proto_jsval.is_null() || proto_jsval.is_undefined() {
             break;
         }
-        let proto_addr = match heap_addr(proto) {
-            Some(addr) => addr,
+        let proto_ptr = match prototype_identity_ptr_from_value(proto) {
+            Some(ptr) => ptr,
             None => break,
         };
-        if current_addr == Some(proto_addr) {
+        if current_ptr.is_some_and(|ptr| std::ptr::addr_eq(ptr, proto_ptr)) {
             break;
         }
-        if proto_addr == receiver_addr {
+        if std::ptr::addr_eq(proto_ptr, receiver_identity_ptr) {
             return true;
         }
         current = proto;
@@ -1112,12 +1125,23 @@ pub unsafe extern "C" fn js_native_call_method(
             && crate::closure::is_closure_ptr(raw_addr)
             && !crate::closure::closure_is_key_deleted(raw_addr, method_name)
         {
-            let dyn_val = crate::closure::closure_get_dynamic_prop(raw_addr, method_name);
-            if dyn_val.to_bits() != crate::value::TAG_UNDEFINED {
-                let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
-                let result = crate::closure::js_native_call_value(dyn_val, args_ptr, args_len);
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
-                return result;
+            let own_dynamic_prop =
+                crate::closure::closure_has_own_dynamic_prop(raw_addr, method_name);
+            let skip_inherited_function_proto_method =
+                closure_function_proto_method_uses_builtin_dispatch(method_name)
+                    && !own_dynamic_prop;
+            // Inherited Function/Object prototype methods fall through to the
+            // dedicated arms below. Resolving them through the closure side
+            // table re-enters this dispatch path by name and can trip the
+            // call-depth guard before producing the primitive result.
+            if !skip_inherited_function_proto_method {
+                let dyn_val = crate::closure::closure_get_dynamic_prop(raw_addr, method_name);
+                if dyn_val.to_bits() != crate::value::TAG_UNDEFINED {
+                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+                    let result = crate::closure::js_native_call_value(dyn_val, args_ptr, args_len);
+                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    return result;
+                }
             }
         }
     }

--- a/test-parity/node-suite/globals/builtin-prototype-isprototypeof.ts
+++ b/test-parity/node-suite/globals/builtin-prototype-isprototypeof.ts
@@ -1,0 +1,15 @@
+const wrapperCases: Array<[string, any, any]> = [
+  ["Number", Number.prototype, new Number(5)],
+  ["Boolean", Boolean.prototype, new Boolean(false)],
+  ["String", String.prototype, new String("x")],
+];
+
+for (const [name, proto, instance] of wrapperCases) {
+  console.log(name, "typeof", typeof proto.isPrototypeOf);
+  console.log(name, "direct", proto.isPrototypeOf(instance));
+  console.log(name, "borrowed", Object.prototype.isPrototypeOf.call(proto, instance));
+}
+
+console.log("Function typeof", typeof Function.prototype.isPrototypeOf);
+console.log("Function direct", Function.prototype.isPrototypeOf(Number));
+console.log("Function borrowed", Object.prototype.isPrototypeOf.call(Function.prototype, Number));

--- a/test-parity/node-suite/globals/builtin-prototype-isprototypeof.ts
+++ b/test-parity/node-suite/globals/builtin-prototype-isprototypeof.ts
@@ -13,3 +13,18 @@ for (const [name, proto, instance] of wrapperCases) {
 console.log("Function typeof", typeof Function.prototype.isPrototypeOf);
 console.log("Function direct", Function.prototype.isPrototypeOf(Number));
 console.log("Function borrowed", Object.prototype.isPrototypeOf.call(Function.prototype, Number));
+
+const typedArray = new Uint8Array(2);
+console.log("Uint8Array direct", Uint8Array.prototype.isPrototypeOf(typedArray));
+console.log(
+  "Uint8Array borrowed",
+  Object.prototype.isPrototypeOf.call(Uint8Array.prototype, typedArray),
+);
+
+const arrayBuffer = new ArrayBuffer(4);
+console.log("ArrayBuffer object", Object.prototype.isPrototypeOf(arrayBuffer));
+console.log("ArrayBuffer direct", ArrayBuffer.prototype.isPrototypeOf(arrayBuffer));
+console.log(
+  "ArrayBuffer borrowed",
+  Object.prototype.isPrototypeOf.call(ArrayBuffer.prototype, arrayBuffer),
+);

--- a/test-parity/node-suite/globals/native-error-constructor-prototypes.ts
+++ b/test-parity/node-suite/globals/native-error-constructor-prototypes.ts
@@ -1,0 +1,19 @@
+const nativeErrors: Array<[string, any]> = [
+  ["EvalError", EvalError],
+  ["RangeError", RangeError],
+  ["ReferenceError", ReferenceError],
+  ["SyntaxError", SyntaxError],
+  ["TypeError", TypeError],
+  ["URIError", URIError],
+];
+
+for (const [name, Ctor] of nativeErrors) {
+  const instance = new Ctor("boom");
+  console.log(name, "ctor proto Error:", Object.getPrototypeOf(Ctor) === Error);
+  console.log(name, "proto proto Error.prototype:", Object.getPrototypeOf(Ctor.prototype) === Error.prototype);
+  console.log(name, "typeof Error.isPrototypeOf:", typeof Error.isPrototypeOf);
+  console.log(name, "Error.isPrototypeOf:", Error.isPrototypeOf(Ctor));
+  console.log(name, "Function.prototype.isPrototypeOf:", Function.prototype.isPrototypeOf(Ctor));
+  console.log(name, "Object.prototype.isPrototypeOf:", Object.prototype.isPrototypeOf(Ctor));
+  console.log(name, "instanceof:", instance instanceof Ctor, instance instanceof Error);
+}


### PR DESCRIPTION
Fixes #4533.
Fixes #4561.
Fixes #4554.
Fixes #4555.

## Summary
- Wire native error subclass constructors so their `[[Prototype]]` is `Error` and their prototype objects inherit from `Error.prototype`.
- Preserve built-in constructor receivers for inherited `isPrototypeOf` and Function prototype method dispatch/value reads.
- Extend prototype-chain identity checks across closure/error/array/typed-array-backed prototype identities while preserving current `main` behavior from #4552.
- Route built-in prototype `isPrototypeOf` methods to the real Object-prototype thunk instead of the generic no-op closure.
- Add safe first-hop prototype resolution for buffer-backed targets such as `ArrayBuffer`, `SharedArrayBuffer`, `DataView`, and Uint8Array-backed buffers before continuing the normal prototype walk.
- Add Node parity coverage for native error constructor prototype chains and built-in prototype `isPrototypeOf` dispatch on primitive wrappers, functions, typed arrays, and ArrayBuffers.
- Keep `property_get.rs` under the repository file-size limit after the expanded branch crossed it.

## Why
These fixes share the same runtime surface: closure-backed native constructors and built-in prototype receiver objects must keep the original receiver through inherited Object/Function prototype method dispatch. #4533 needs that for `Error.isPrototypeOf(TypeError)` and native error constructor/prototype chains; #4561 is the same dispatch gap on `Number.prototype`, `Boolean.prototype`, `String.prototype`, and `Function.prototype`; #4554/#4555 cover the same predicate when the target is modeled as a typed-array or buffer-backed object.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `./scripts/check_file_size.sh`
- `jq empty test-parity/known_failures.json`
- `env RUSTC_WRAPPER= TMPDIR=$PWD/target/tmp CARGO_BUILD_JOBS=1 cargo check -q -p perry-runtime -p perry-hir -p perry-codegen`
- `env RUSTC_WRAPPER= TMPDIR=$PWD/target/tmp CARGO_BUILD_JOBS=1 cargo build -q -p perry -p perry-runtime -p perry-stdlib`
- Direct Perry-vs-Node 26 output diff on the final debug binary: `test-parity/node-suite/globals/native-error-constructor-prototypes.ts` passed.
- Direct Perry-vs-Node 26 output diff on the final debug binary: `test-parity/node-suite/globals/builtin-prototype-isprototypeof.ts` passed.

## Non-goals
- Does not broaden the native error fixture beyond the currently modeled native `Error` subclasses.
- Does not change the no-op-backed behavior of unrelated built-in prototype methods that still lack dedicated thunks.