### PR TITLE
style: rustfmt class_decl.rs (unblock CI lint on main)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -877,8 +877,7 @@ pub fn lower_class_decl(
         // every read, so `this.method` reads the uninitialised slot (`undefined`) BEFORE
         // the assignment runs — exactly what made `this.parse.bind(this)` throw "Bind must
         // be called on a function" in zod. Mirrors the accessor exclusion (#665).
-        let mut method_names: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut method_names: std::collections::HashSet<String> = std::collections::HashSet::new();
         for member in &class_decl.class.body {
             match member {
                 ast::ClassMember::Method(m) if matches!(m.kind, ast::MethodKind::Method) => {
@@ -889,9 +888,7 @@ pub fn lower_class_decl(
                     };
                     method_names.insert(key);
                 }
-                ast::ClassMember::PrivateMethod(m)
-                    if matches!(m.kind, ast::MethodKind::Method) =>
-                {
+                ast::ClassMember::PrivateMethod(m) if matches!(m.kind, ast::MethodKind::Method) => {
                     method_names.insert(format!("#{}", m.key.name));
                 }
                 _ => {}


### PR DESCRIPTION
Main's `crates/perry-hir/src/lower_decl/class_decl.rs` has an unformatted region (lines 877/889) that fails the `lint` (`cargo fmt --all -- --check`) job on every PR branched off current main. Pure `rustfmt` reformat, no logic change.