### PR TITLE
fix(runtime): Map/Set.forEach validate callback; Map.clear() returns undefined

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -335,7 +335,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let blk = ctx.block();
             let m_handle = unbox_to_i64(blk, &m_box);
             blk.call_void("js_map_clear", &[(I64, &m_handle)]);
-            Ok(double_literal(0.0))
+            // Map.prototype.clear() returns undefined, not 0.
+            Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
 
         // -------- Map.entries / Map.keys / Map.values --------

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -1400,6 +1400,11 @@ static KEEP_JS_MAP_FROM_ITERABLE: extern "C" fn(f64) -> *mut MapHeader = js_map_
 /// when omitted at the call site.
 #[no_mangle]
 pub extern "C" fn js_map_foreach(map: *const MapHeader, callback: f64, this_arg: f64) {
+    // ECMA-262 Map.prototype.forEach step 4: a non-callable callback throws a
+    // TypeError *before* iterating (and before any null-map early return).
+    // Without this, a non-function callback either silently no-ops or — for a
+    // numeric value — is dereferenced as a function pointer and segfaults.
+    crate::array::js_validate_array_callback(callback);
     let map = clean_map_ptr(map);
     if map.is_null() {
         return;

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -901,6 +901,9 @@ pub extern "C" fn js_set_from_iterable(value: f64) -> *mut SetHeader {
 /// omitted at the call site.
 #[no_mangle]
 pub extern "C" fn js_set_foreach(set: *const SetHeader, callback: f64, this_arg: f64) {
+    // ECMA-262 Set.prototype.forEach step 4: a non-callable callback throws a
+    // TypeError before iterating (and before any null-set early return).
+    crate::array::js_validate_array_callback(callback);
     let set = clean_set_ptr(set);
     if set.is_null() {
         return;


### PR DESCRIPTION
## Problems
1. **`Map.prototype.forEach` / `Set.prototype.forEach` with a non-callable callback** silently no-op'd instead of throwing `TypeError` — and with a *numeric* argument dereferenced it as a function pointer and **segfaulted** (`m.forEach(123)`).
2. **`Map.prototype.clear()` returned `0`** instead of `undefined` (the inline `Expr::MapClear` codegen path; Set.clear and the generic property-get clear paths were already correct).

## Fix
- Validate the callback via `js_validate_array_callback` at the top of `js_map_foreach`/`js_set_foreach` (ECMA-262: callable check precedes iteration).
- Return `undefined` from the `Expr::MapClear` arm.

## Verification
Byte-identical to `node --experimental-strip-types`:
```
m.forEach(undefined) // TypeError    m.forEach(123) // TypeError (was segfault)
m.clear()            // undefined    s.clear()      // undefined
```
Normal `forEach`/`clear` usage unchanged. Fixes test262 `built-ins/{Map,Set}/prototype/forEach/*` non-callable cases and `Map/prototype/clear/returns-undefined`.