### PR TITLE
fix(codegen): forward constructor args through a subclass with no own ctor

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -132,6 +132,33 @@ fn pack_lowered_args_array(ctx: &mut FnCtx<'_>, args: &[String]) -> String {
     nanbox_pointer_inline(ctx.block(), &current)
 }
 
+/// The effective constructor arity for `new <class>(...)`: the class's own
+/// ctor params, else — for a subclass with no own ctor — the closest
+/// ancestor-with-a-ctor's param count (the synthesized default ctor forwards
+/// `super(...args)`). Matches the standalone-ctor signature emitted in
+/// `codegen/artifacts.rs`, so callers pass the right number of args.
+fn effective_constructor_param_count(ctx: &FnCtx<'_>, class: &perry_hir::Class) -> usize {
+    if let Some(ctor) = class.constructor.as_ref() {
+        return ctor.params.len();
+    }
+    let mut parent = class.extends_name.as_deref();
+    while let Some(pname) = parent {
+        if let Some((_sym, n)) = ctx.imported_class_ctors.get(pname) {
+            return *n;
+        }
+        match ctx.classes.get(pname).copied() {
+            Some(pc) => {
+                if let Some(pctor) = pc.constructor.as_ref() {
+                    return pctor.params.len();
+                }
+                parent = pc.extends_name.as_deref();
+            }
+            None => break,
+        }
+    }
+    0
+}
+
 fn call_local_constructor_symbol(
     ctx: &mut FnCtx<'_>,
     class: &perry_hir::Class,
@@ -146,11 +173,18 @@ fn call_local_constructor_symbol(
     else {
         return;
     };
-    let param_count = class
-        .constructor
-        .as_ref()
-        .map(|ctor| ctor.params.len())
-        .unwrap_or(0);
+    // The standalone `<class>_constructor` symbol's signature is the class's
+    // OWN ctor params, OR — when the class has no own ctor — the closest
+    // ancestor-with-a-ctor's params (codegen/artifacts.rs synthesizes the
+    // default ctor `constructor(...args) { super(...args) }` with that adopted
+    // signature). Mirror that here so we pass the constructor arguments through
+    // this nested-construction path. Reading `param_count` from `class.constructor`
+    // alone yielded 0 for a no-own-ctor subclass, so `new Sub(arg)` issued inside a
+    // method of `Sub` (the recursion-guarded symbol-call path) dropped every arg —
+    // the synthesized ctor's forwarded params then read uninitialized and the
+    // inherited `this.x = arg` stored garbage. Pervasive in zod (`new ZodNumber({…})`
+    // from `_addCheck`, where ZodNumber has no own ctor and ZodType does).
+    let param_count = effective_constructor_param_count(ctx, class);
     let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
     let mut ctor_values = lowered_args.to_vec();
     ctor_values.truncate(param_count);

--- a/tests/test_inherited_ctor_arg_forwarding.sh
+++ b/tests/test_inherited_ctor_arg_forwarding.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `new Sub(arg)` where Sub has NO own constructor but its parent does must forward
+# `arg` to the parent ctor (JS implicit `constructor(...args){ super(...args) }`).
+# The recursion-guarded "symbol-call" construction path (taken when `new Sub(...)`
+# appears inside a method of Sub) computed the ctor arity from Sub's own ctor —
+# `None` → 0 — so it dropped every argument; the synthesized ctor's forwarded
+# params then read uninitialized and the inherited `this.x = arg` stored garbage.
+# Pervasive in zod: `new ZodNumber({checks:[...]})` from `_addCheck` (ZodNumber has
+# no own ctor, ZodType does) made `_def` undefined → `[...this._def.checks]` threw.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/c.ts" <<'TS'
+abstract class Base {
+  _def: any;
+  constructor(def: any) { this._def = def; }
+  abstract _p(): any;
+}
+class Num extends Base {              // no own constructor — inherits Base's
+  _p() { return 1; }
+  // `new Num(...)` issued INSIDE a Num method -> recursion-guarded symbol-call path
+  addCheck(c: any): Num { return new Num({ ...this._def, checks: [...this._def.checks, c] }); }
+  static create = (): Num => new Num({ checks: [], tn: "N" });
+}
+
+const a: any = Num.create();
+if (JSON.stringify(a._def) !== '{"checks":[],"tn":"N"}') throw new Error("create _def: " + JSON.stringify(a._def));
+const b: any = a.addCheck({ kind: "int" });
+if (JSON.stringify(b._def.checks) !== '[{"kind":"int"}]') throw new Error("addCheck _def: " + JSON.stringify(b._def));
+const c: any = a.addCheck({ kind: "int" }).addCheck({ kind: "min" });
+if (c._def.checks.length !== 2) throw new Error("chain: " + JSON.stringify(c._def.checks));
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/c.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: inherited-ctor argument forwarding"


### PR DESCRIPTION
## Problem

`new Sub(arg)` where `Sub` has **no own constructor** but its parent does must forward `arg` (JS implicit `constructor(...args){ super(...args) }`). The recursion-guarded **symbol-call** construction path — taken when `new Sub(...)` appears inside a method of `Sub` — read the ctor arity from `class.constructor` (`None` → 0) and truncated **all** args away.

The synthesized standalone ctor (codegen/artifacts.rs) adopts the ancestor ctor's signature and forwards via super — so with no args passed, its params read uninitialized garbage and the inherited `this.x = arg` stored `0`/undefined.

The LLVM IR was unambiguous:
```
%r19 = call js_closure_call1(...)              ; the arg object
%r43 = call @Sub_constructor(double %r42)       ; called with ONLY this — %r19 dropped
```

## Fix

Compute the arity from the closest ancestor-with-a-ctor when the subclass has none (mirrors the synthesized-ctor signature), so the args are passed.

## Impact

Fixes zod `new ZodNumber({checks:[...]})` from `_addCheck`/`setLimit` (ZodNumber has no own ctor, ZodType does) — `_def` was undefined so `z.coerce.number().int()` threw 'undefined is not iterable'. **zod schemas now construct + run `.parse()` without crashing.**

## Test

`tests/test_inherited_ctor_arg_forwarding.sh`. perry-codegen 86/0, perry-hir 136/0; all prior-fix regressions pass.