### PR TITLE
ci: allowlist expr/property_get.rs in file-size check (2004 LOC, #1435)

### DIFF
--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -235,6 +235,11 @@ crates/perry-hir/src/analysis.rs
 # Crossed the 2000-line gate after the stream/web adapter additions. Splitting
 # classic constructors from the web adapters is tracked under #1435.
 crates/perry-runtime/src/node_stream_constructors.rs
+# Codegen property-get / method-dispatch lowering tower (one arm per builtin
+# accessor + collection/string/regex method). Crossed the 2000-line gate (2004
+# LOC) on main after recent dispatch-arm additions. Splitting per receiver-type
+# family is tracked under #1435.
+crates/perry-codegen/src/expr/property_get.rs
 EOF
 )
 


### PR DESCRIPTION
`crates/perry-codegen/src/expr/property_get.rs` crossed the 2000-line gate on main (2004 LOC), failing the `lint` job on every PR branched off current main. Allowlisted pending a per-receiver-type split tracked under #1435. CI-config only.