### PR TITLE
fix(runtime): walk built-in prototypes for isPrototypeOf

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -877,8 +877,7 @@ pub fn lower_class_decl(
         // every read, so `this.method` reads the uninitialised slot (`undefined`) BEFORE
         // the assignment runs — exactly what made `this.parse.bind(this)` throw "Bind must
         // be called on a function" in zod. Mirrors the accessor exclusion (#665).
-        let mut method_names: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut method_names: std::collections::HashSet<String> = std::collections::HashSet::new();
         for member in &class_decl.class.body {
             match member {
                 ast::ClassMember::Method(m) if matches!(m.kind, ast::MethodKind::Method) => {
@@ -889,9 +888,7 @@ pub fn lower_class_decl(
                     };
                     method_names.insert(key);
                 }
-                ast::ClassMember::PrivateMethod(m)
-                    if matches!(m.kind, ast::MethodKind::Method) =>
-                {
+                ast::ClassMember::PrivateMethod(m) if matches!(m.kind, ast::MethodKind::Method) => {
                     method_names.insert(format!("#{}", m.key.name));
                 }
                 _ => {}

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3814,22 +3814,17 @@ fn install_atomics_namespace_members(ns_obj: *mut ObjectHeader) {
     }
 }
 
-/// Install a list of `(method_name, arity)` pairs on a prototype object,
-/// each backed by `global_this_builtin_noop_thunk`. The shared no-op thunk
-/// is fine because every method shares the same backing func pointer (the
-/// arity registration on that pointer is overwritten harmlessly with each
-/// call — the last winner is whichever arity matches the dominant call
-/// site, but no current code path depends on the registered arity for the
-/// noop thunk; the real dispatch arms each register their own arity on
-/// their own thunk pointer).
+/// Install a list of `(method_name, arity)` pairs on a prototype object.
+/// Most entries are reflection-only methods backed by
+/// `global_this_builtin_noop_thunk`, but inherited Object methods with
+/// observable receiver-sensitive behavior use their real thunk.
 fn install_noop_proto_methods(proto_obj: *mut ObjectHeader, methods: &[(&str, u32)]) {
     for (name, arity) in methods.iter().copied() {
-        install_proto_method(
-            proto_obj,
-            name,
-            global_this_builtin_noop_thunk as *const u8,
-            arity,
-        );
+        let func_ptr = match name {
+            "isPrototypeOf" => object_prototype_is_prototype_of_thunk as *const u8,
+            _ => global_this_builtin_noop_thunk as *const u8,
+        };
+        install_proto_method(proto_obj, name, func_ptr, arity);
     }
 }
 

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -394,17 +394,32 @@ fn throw_object_to_string_not_function() -> ! {
 #[inline]
 unsafe fn gc_pointer_and_type_from_value(value: f64) -> Option<(*const u8, u8)> {
     let jsval = JSValue::from_bits(value.to_bits());
-    if !jsval.is_pointer() {
-        return None;
-    }
-    let ptr = jsval.as_pointer::<u8>();
-    if ptr.is_null()
-        || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000
-        || !is_valid_obj_ptr(ptr as *const u8)
-    {
+    let ptr = if jsval.is_pointer() {
+        jsval.as_pointer::<u8>()
+    } else {
+        let bits = value.to_bits();
+        if (bits >> 48) == 0 && bits >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+            bits as *const u8
+        } else {
+            return None;
+        }
+    };
+    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
         return None;
     }
     let addr = ptr as usize;
+    if crate::buffer::is_any_array_buffer(addr) {
+        return Some((ptr, crate::gc::GC_TYPE_BUFFER));
+    }
+    if crate::buffer::is_uint8array_buffer(addr) {
+        return Some((ptr, crate::gc::GC_TYPE_BUFFER));
+    }
+    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+        return Some((ptr, crate::gc::GC_TYPE_TYPED_ARRAY));
+    }
+    if !is_valid_obj_ptr(ptr as *const u8) {
+        return None;
+    }
     if crate::set::is_registered_set(addr)
         || crate::map::is_registered_map(addr)
         || crate::regex::is_regex_pointer(ptr as *const u8)
@@ -554,7 +569,7 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
     }
 
     let target_jsval = JSValue::from_bits(target.to_bits());
-    if !target_jsval.is_pointer() {
+    if !target_jsval.is_pointer() && gc_pointer_and_type_from_value(target).is_none() {
         return false;
     }
 
@@ -616,12 +631,14 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
         // Previously only closures/errors were allowed, so
         // `Array.prototype.isPrototypeOf([1, 2])` and
         // `Object.prototype.isPrototypeOf([])` wrongly returned `false`.
-        // (ArrayBuffer's BufferHeader representation isn't resolved by the
-        // generic pointer walk yet — tracked separately.)
+        // #4554: ArrayBuffer / SharedArrayBuffer use BufferHeader storage
+        // without a GcHeader for small buffers, but they still have a modeled
+        // prototype chain via `js_object_get_prototype_of`.
         if target_gc_type != crate::gc::GC_TYPE_CLOSURE
             && target_gc_type != crate::gc::GC_TYPE_ERROR
             && target_gc_type != crate::gc::GC_TYPE_ARRAY
             && target_gc_type != crate::gc::GC_TYPE_TYPED_ARRAY
+            && target_gc_type != crate::gc::GC_TYPE_BUFFER
         {
             return false;
         }
@@ -3992,11 +4009,18 @@ pub unsafe extern "C" fn js_native_call_method(
                     // pointer, so non-callable field values (numbers,
                     // strings, booleans) safely return undefined.
                     let field_val = js_object_get_field(obj as *mut _, i as u32);
-                    return crate::closure::js_native_call_value(
-                        f64::from_bits(field_val.bits()),
+                    let bound = crate::closure::clone_closure_rebind_this(
+                        field_val.bits(),
+                        f64::from_bits(jsval.bits()),
+                    );
+                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
+                    let result = crate::closure::js_native_call_value(
+                        f64::from_bits(bound),
                         args_ptr,
                         args_len,
                     );
+                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    return result;
                 }
             }
         }

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1736,6 +1736,41 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
         }
         None
     };
+    let buffer_backed_prototype = |addr: usize| -> Option<f64> {
+        let name = if crate::buffer::is_array_buffer(addr) {
+            "ArrayBuffer"
+        } else if crate::buffer::is_shared_array_buffer(addr) {
+            "SharedArrayBuffer"
+        } else {
+            return None;
+        };
+        let proto = crate::object::builtin_prototype_value(name);
+        if proto.to_bits() != crate::value::TAG_UNDEFINED {
+            Some(proto)
+        } else {
+            None
+        }
+    };
+    let buffer_backed_uint8array_prototype = |addr: usize| -> Option<f64> {
+        if !crate::buffer::is_uint8array_buffer(addr) {
+            return None;
+        }
+        let proto = crate::object::builtin_prototype_value("Uint8Array");
+        if proto.to_bits() != crate::value::TAG_UNDEFINED {
+            Some(proto)
+        } else {
+            None
+        }
+    };
+    let typed_array_instance_prototype = |addr: usize| -> Option<f64> {
+        let kind = crate::typedarray::lookup_typed_array_kind(addr)?;
+        let proto = crate::object::builtin_prototype_value(crate::typedarray::name_for_kind(kind));
+        if proto.to_bits() != crate::value::TAG_UNDEFINED {
+            Some(proto)
+        } else {
+            None
+        }
+    };
     let function_prototype_or_null = || {
         let proto = crate::object::builtin_prototype_value("Function");
         if proto.to_bits() != crate::value::TAG_UNDEFINED {
@@ -1774,6 +1809,15 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     if top16 == 0x7FFD {
         let raw_addr = bits & 0x0000_FFFF_FFFF_FFFF;
         if raw_addr != 0 && raw_addr >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+            if let Some(proto) = typed_array_instance_prototype(raw_addr as usize) {
+                return proto;
+            }
+            if let Some(proto) = buffer_backed_prototype(raw_addr as usize) {
+                return proto;
+            }
+            if let Some(proto) = buffer_backed_uint8array_prototype(raw_addr as usize) {
+                return proto;
+            }
             if let Some(proto) = collection_prototype(raw_addr as usize) {
                 return proto;
             }
@@ -1871,6 +1915,15 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     }
     if top16 == 0 {
         if bits >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+            if let Some(proto) = typed_array_instance_prototype(bits as usize) {
+                return proto;
+            }
+            if let Some(proto) = buffer_backed_prototype(bits as usize) {
+                return proto;
+            }
+            if let Some(proto) = buffer_backed_uint8array_prototype(bits as usize) {
+                return proto;
+            }
             if let Some(proto) = collection_prototype(bits as usize) {
                 return proto;
             }

--- a/test-parity/node-suite/object/prototype-dispatch-builtins.ts
+++ b/test-parity/node-suite/object/prototype-dispatch-builtins.ts
@@ -1,0 +1,28 @@
+function show(label: string, value: unknown) {
+  console.log(label + ":", String(value));
+}
+
+function showCall(label: string, fn: () => unknown) {
+  try {
+    show(label, fn());
+  } catch (e: any) {
+    show(label, e?.name + ":" + e?.message);
+  }
+}
+
+const buffer = new ArrayBuffer(4);
+showCall("object proto arraybuffer", () => Object.prototype.isPrototypeOf(buffer));
+showCall("arraybuffer proto via call", () => Object.prototype.isPrototypeOf.call(ArrayBuffer.prototype, buffer));
+showCall("arraybuffer proto target", () => ArrayBuffer.prototype.isPrototypeOf(buffer));
+showCall("arraybuffer get proto is ctor proto", () => Object.getPrototypeOf(buffer) === ArrayBuffer.prototype);
+showCall("arraybuffer proto parent object", () => Object.getPrototypeOf(ArrayBuffer.prototype) === Object.prototype);
+
+const typed = new Uint8Array(2);
+showCall("typedarray get proto is ctor proto", () => Object.getPrototypeOf(typed) === Uint8Array.prototype);
+showCall("typedarray proto isPrototypeOf", () => Uint8Array.prototype.isPrototypeOf(typed));
+showCall("typedarray proto via call", () => Object.prototype.isPrototypeOf.call(Uint8Array.prototype, typed));
+showCall(
+  "typedarray proto shared parent",
+  () => Object.getPrototypeOf(Uint8Array.prototype) === Object.getPrototypeOf(Int8Array.prototype),
+);
+showCall("typedarray proto method type", () => typeof Uint8Array.prototype.isPrototypeOf);


### PR DESCRIPTION
## Summary
- Let `Object.prototype.isPrototypeOf` walk ArrayBuffer / SharedArrayBuffer BufferHeader targets through `Object.getPrototypeOf` instead of rejecting them before the generic chain walk.
- Map BufferHeader-backed `Uint8Array` values to `Uint8Array.prototype` for prototype resolution, including raw pointer call sites.
- Install the real `isPrototypeOf` thunk on built-in prototype objects and bind `this` for direct object-field method dispatch.
- Add focused Node parity coverage for ArrayBuffer and Uint8Array prototype dispatch.

Closes #4554.
Closes #4555.

## Verification
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH node --experimental-strip-types test-parity/node-suite/object/prototype-dispatch-builtins.ts`
- `cargo check -q -p perry-runtime`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter prototype-dispatch-builtins`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter is-prototype-of`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter prototype`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
