### PR TITLE
fix(codegen): run a no-own-ctor subclass's own field initializers after super()

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -769,6 +769,27 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                     ctx.class_stack.push(class_name.to_string());
 
                     restore_inline_constructor_scope(ctx, saved_scope);
+
+                    // Apply the field initializers of every class BELOW the
+                    // inherited-ctor class — the leaf and any intermediates —
+                    // now that the parent ctor body has run (the post-super()
+                    // step, mirroring the own-ctor path's SelfOnly-after). The
+                    // up-front pass above used `UpToInclusive(inherited)`, which
+                    // keeps `chain[0..=idx(inherited)]` and therefore EXCLUDES
+                    // the leaf, so without this a no-own-ctor subclass's own
+                    // field initializers never ran — e.g. zod's
+                    // `class ZodObject extends ZodType { private _cached = null }`
+                    // left `_cached` at the raw-0 slot, so `_getCached()`'s
+                    // `this._cached !== null` was true (0 !== null) and returned
+                    // 0; `_parse` then destructured `{ keys }` off 0, iterated
+                    // nothing, and every `z.object({...}).parse()` dropped all
+                    // fields.
+                    apply_field_initializers_recursive(
+                        ctx,
+                        class_name,
+                        FieldInitMode::BetweenExclusiveTo(pname.to_string()),
+                    )?;
+
                     found_inherited_ctor = true;
                     break; // Found and inlined the parent ctor.
                 }

--- a/tests/test_subclass_own_field_init_after_super.sh
+++ b/tests/test_subclass_own_field_init_after_super.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A subclass with NO own constructor, extending a parent that HAS one, must still
+# run its OWN field initializers (the implicit default ctor is
+# `constructor(...args){ super(...args); <own field inits> }`). The inline
+# construction path applied `UpToInclusive(inherited_ctor_class)` up front — which
+# keeps `chain[0..=idx(inherited)]` and EXCLUDES the leaf — and never applied the
+# leaf's fields after super(). So a subclass's own `field = <init>` never ran; the
+# field read the raw-0 slot.
+#
+# zod hit this exactly: `class ZodObject extends ZodType { private _cached = null }`
+# left `_cached` at 0, so `_getCached()`'s `this._cached !== null` was true
+# (0 !== null) and returned 0; `_parse` destructured `{ keys }` off 0 and every
+# `z.object({...}).parse()` silently dropped all fields.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+abstract class Base {
+  _def: any;
+  constructor(def: any) { this._def = def; }
+  abstract _p(): any;
+}
+class Leaf extends Base {                 // no own ctor; own field initializers
+  _cached: any = null;
+  _count = 7;
+  _list: number[] = [1, 2];
+  _p() { return 1; }
+  static create = (): Leaf => new Leaf({ k: 1 });
+}
+
+const o: any = Leaf.create();
+if (o._cached !== null) throw new Error("_cached: " + o._cached);     // not raw-0
+if (o._cached === 0) throw new Error("_cached is 0");
+if (o._count !== 7) throw new Error("_count: " + o._count);
+if (JSON.stringify(o._list) !== "[1,2]") throw new Error("_list: " + JSON.stringify(o._list));
+if (JSON.stringify(o._def) !== '{"k":1}') throw new Error("_def (super): " + JSON.stringify(o._def));
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: subclass own field init after super"


### PR DESCRIPTION
## Problem

`class Leaf extends Base {}`'s implicit default ctor is `constructor(...args){ super(...args); <own field inits> }`. The inline construction path applied `UpToInclusive(inherited_ctor_class)` up front — which keeps `chain[0..=idx(inherited)]` and **excludes the leaf** — then inlined the inherited ctor body, but **never applied the leaf's own field initializers afterward**. So a no-own-ctor subclass's `field = <init>` never ran; the field read the raw-0 slot.

## Fix

Apply `BetweenExclusiveTo(inherited_ctor_class)` (the leaf + any intermediates) after the inherited ctor body — the post-super() step, mirroring the own-ctor path's `SelfOnly`-after.

## Impact

Fixes zod `class ZodObject extends ZodType { private _cached = null }`: `_cached` was 0, so `_getCached()`'s `this._cached !== null` was true (0 !== null) and returned 0; `_parse` then destructured `{ keys }` off 0, iterated nothing, and **every `z.object({...}).parse()` silently dropped all fields**. With this, `_cached` is `null` and object parsing proceeds.

## Test

`tests/test_subclass_own_field_init_after_super.sh`. perry-codegen 86/0; prior-fix regressions pass.