### PR TITLE
fix(runtime): reject collection constructors without new

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -760,6 +760,10 @@ pub(super) fn identify_global_builtin_constructor(func_value: f64) -> Option<&'s
             || func_ptr == syntax_error_constructor_call_thunk as *const u8 as usize
             || func_ptr == eval_error_constructor_call_thunk as *const u8 as usize
             || func_ptr == uri_error_constructor_call_thunk as *const u8 as usize
+            || func_ptr == map_constructor_call_thunk as *const u8 as usize
+            || func_ptr == set_constructor_call_thunk as *const u8 as usize
+            || func_ptr == weak_map_constructor_call_thunk as *const u8 as usize
+            || func_ptr == weak_set_constructor_call_thunk as *const u8 as usize
             || func_ptr == webcrypto_illegal_constructor_thunk as *const u8 as usize
             || func_ptr
                 == crate::messaging::js_message_channel_constructor_call_error as *const u8

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -339,6 +339,30 @@ pub(crate) extern "C" fn typed_array_constructor_call_thunk(
     super::object_ops::throw_object_type_error(b"Constructor %TypedArray% requires 'new'")
 }
 
+pub(crate) extern "C" fn map_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    super::object_ops::throw_object_type_error(b"Constructor Map requires 'new'")
+}
+
+pub(crate) extern "C" fn set_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    super::object_ops::throw_object_type_error(b"Constructor Set requires 'new'")
+}
+
+pub(crate) extern "C" fn weak_map_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    super::object_ops::throw_object_type_error(b"Constructor WeakMap requires 'new'")
+}
+
+pub(crate) extern "C" fn weak_set_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    super::object_ops::throw_object_type_error(b"Constructor WeakSet requires 'new'")
+}
+
 extern "C" fn global_this_url_pattern_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     input: f64,
@@ -2332,6 +2356,10 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             "SyntaxError" => syntax_error_constructor_call_thunk as *const u8,
             "EvalError" => eval_error_constructor_call_thunk as *const u8,
             "URIError" => uri_error_constructor_call_thunk as *const u8,
+            "Map" => map_constructor_call_thunk as *const u8,
+            "Set" => set_constructor_call_thunk as *const u8,
+            "WeakMap" => weak_map_constructor_call_thunk as *const u8,
+            "WeakSet" => weak_set_constructor_call_thunk as *const u8,
             "MessageChannel" => {
                 crate::messaging::js_message_channel_constructor_call_error as *const u8
             }
@@ -2383,6 +2411,9 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                 crate::closure::js_register_closure_arity(func_ptr, 1);
             }
             "MessageChannel" | "MessagePort" | "Storage" => {
+                crate::closure::js_register_closure_arity(func_ptr, 0);
+            }
+            "Map" | "Set" | "WeakMap" | "WeakSet" => {
                 crate::closure::js_register_closure_arity(func_ptr, 0);
             }
             "URLPattern" => {

--- a/test-parity/node-suite/globals/collection-constructor-call-newtarget.ts
+++ b/test-parity/node-suite/globals/collection-constructor-call-newtarget.ts
@@ -1,0 +1,28 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label, "ok", fn());
+  } catch (err: any) {
+    console.log(label, err?.name, err?.message);
+  }
+}
+
+const MapAlias: any = Map;
+const SetAlias: any = Set;
+const WeakMapAlias: any = WeakMap;
+const WeakSetAlias: any = WeakSet;
+
+show("Map direct", () => (Map as any)());
+show("Map alias", () => MapAlias());
+show("Map global", () => (globalThis.Map as any)());
+
+show("Set direct", () => (Set as any)());
+show("Set alias", () => SetAlias());
+show("Set global", () => (globalThis.Set as any)());
+
+show("WeakMap direct", () => (WeakMap as any)());
+show("WeakMap alias", () => WeakMapAlias());
+show("WeakMap global", () => (globalThis.WeakMap as any)());
+
+show("WeakSet direct", () => (WeakSet as any)());
+show("WeakSet alias", () => WeakSetAlias());
+show("WeakSet global", () => (globalThis.WeakSet as any)());


### PR DESCRIPTION
Fixes #4569.

Summary:
- Route Map, Set, WeakMap, and WeakSet global constructor call forms to zero-argument TypeError thunks instead of the shared no-op thunk.
- Keep built-in constructor identity recovery aware of the new collection thunk pointers.
- Add a globals parity fixture covering direct, aliased, and globalThis call forms for all four collection constructors.

Validation:
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh
- cargo check -p perry-runtime
- npm exec --yes --package=node@26 -- bash -lc 'node --version; PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter collection-constructor-call-newtarget'