### PR TITLE
fix(json): format numbers with ECMAScript Number::toString (#4573)

### DIFF
--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -201,13 +201,21 @@ pub(crate) unsafe fn write_number(buf: &mut String, value: f64) {
     // `stringify_value`/`stringify_value_depth` before this numeric funnel —
     // so no Date detection is needed here anymore.
     if value.is_nan() || value.is_infinite() {
+        // JSON has no NaN/Infinity literal; the spec serializes them as null.
         buf.push_str("null");
     } else if value.fract() == 0.0 && value.abs() < (i64::MAX as f64) {
+        // Fast path for in-range integers (the overwhelming majority of JSON
+        // numbers); identical to ECMAScript NumberToString over this range.
         let mut itoa_buf = itoa::Buffer::new();
         buf.push_str(itoa_buf.format(value as i64));
     } else {
-        let mut ryu_buf = ryu::Buffer::new();
-        buf.push_str(ryu_buf.format(value));
+        // ECMAScript Number::toString (spec 6.1.6.1.20): fixed notation for an
+        // exponent in -6..=20, else exponential with an `e+`/`e-` sign. `ryu`
+        // emits shortest round-trip digits but its own notation (`1e20`,
+        // `1e-6`, `1e21`), so JSON.stringify diverged from `String(n)` and
+        // Node. Reuse the shared JS formatter so `JSON.stringify(1e20)` is
+        // `100000000000000000000` (not `1e20`) and `1e21` is `1e+21`.
+        buf.push_str(&crate::string::js_format_f64(value));
     }
 }
 

--- a/test-parity/node-suite/globals/json-stringify-number-format.ts
+++ b/test-parity/node-suite/globals/json-stringify-number-format.ts
@@ -1,0 +1,23 @@
+// JSON.stringify must format numbers with ECMAScript Number::toString
+// (spec 6.1.6.1.20) — the same notation as String(n) and Node — rather than
+// `ryu`'s shortest-digit notation. That means fixed notation for an exponent
+// in -6..=20 (so 1e20 is `100000000000000000000`, 1e-6 is `0.000001`) and
+// exponential with an `e+`/`e-` sign otherwise (1e21 is `1e+21`).
+
+function show(label: string, value: any) {
+  console.log(label + " = " + value);
+}
+
+show("1e20", JSON.stringify(1e20));
+show("1e21", JSON.stringify(1e21));
+show("1.5e21", JSON.stringify(1.5e21));
+show("1e-6", JSON.stringify(1e-6));
+show("1e-7", JSON.stringify(1e-7));
+show("1e100", JSON.stringify(1e100));
+show("1e-300", JSON.stringify(1e-300));
+show("bignum", JSON.stringify(123456789012345680000));
+show("obj", JSON.stringify({ a: 1e20, b: 1e-6, c: 3.14, d: -2.5, e: 1e21 }));
+show("arr", JSON.stringify([1e20, 1e-7, 1e100, 0.000001, 1.5e21]));
+show("pretty", JSON.stringify({ x: 1e20, y: 1e-6 }, null, 1).replace(/\s+/g, " "));
+show("ints", JSON.stringify([0, -0, 1, -1, 100, 1000000, 999999999999999, 1e15, 1e16]));
+show("fracs", JSON.stringify([0.1, 0.2, 0.30000000000000004, 3.14, -2.5]));


### PR DESCRIPTION
Fixes #4573.

## Problem

`JSON.stringify`'s `write_number` formatted non-integer / out-of-i64-range values with `ryu` (shortest digits, ryu notation), diverging from `String(n)` and Node:

```ts
JSON.stringify(1e20);   // Node: 100000000000000000000   was: 1e20
JSON.stringify(1e21);   // Node: 1e+21                   was: 1e21
JSON.stringify(1e-6);   // Node: 0.000001                was: 1e-6
```

`String(1e20)` was already correct, so JSON just needed the same formatter.

## Fix

Route `write_number`'s non-integer branch through `crate::string::js_format_f64` — the shared ECMAScript Number::toString formatter that `String(n)`/template literals already use (fixed for exponent in -6..=20, else exponential with `e+`/`e-`). The in-range-integer fast path (itoa) is unchanged.

## Verification

- Parity fixture `json-stringify-number-format.ts`.
- Identical to Node across 1e20 / 1e21 / 1.5e21 / 1e-6 / 1e-7 / 1e100 / 1e-300 / bignum / object / array / pretty / integer / fraction cases.
- 41 JSON unit tests pass; the prior JSON fixtures (#4512 / #4531 / #4541) still match.

Subnormals (`5e-324`) are a separate pre-existing dispatch edge (noted in the issue), not changed here — `String()` of them is correct and `js_format_f64` handles them; they never reach `write_number`.