### PR TITLE
fix(runtime): Map/Set keys — a Symbol never equals the empty-string key

### DIFF
--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -554,6 +554,15 @@ fn jsvalue_eq(a: f64, b: f64) -> bool {
         return true;
     }
 
+    // Symbols are compared by identity only — two distinct symbols are never
+    // equal (and a same-symbol match was already caught by the bit-equality
+    // fast path). A description-less `Symbol()` exposes a zero-length string
+    // view, so without this guard it would content-compare equal to the ""
+    // key and collide inside Map/Set. (#4570)
+    if unsafe { crate::symbol::js_is_symbol(a) != 0 || crate::symbol::js_is_symbol(b) != 0 } {
+        return false;
+    }
+
     if is_string_like(a_bits) && is_string_like(b_bits) {
         let mut a_scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         let mut b_scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -469,6 +469,14 @@ fn jsvalue_eq(a: f64, b: f64) -> bool {
         return true;
     }
 
+    // Symbols compare by identity only (same-symbol caught by the fast path
+    // above). A description-less `Symbol()` exposes a zero-length string view,
+    // so without this guard it would content-compare equal to the "" key and
+    // collide inside Set/Map. (#4570)
+    if unsafe { crate::symbol::js_is_symbol(a) != 0 || crate::symbol::js_is_symbol(b) != 0 } {
+        return false;
+    }
+
     if is_string_like(a_bits) && is_string_like(b_bits) {
         let mut a_scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         let mut b_scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];


### PR DESCRIPTION
## Problem
```ts
const m = new Map(); m.set('', 'empty'); m.set(Symbol(), 'sym');
m.size      // 1  (node: 2)
m.get('')   // 'sym'  (node: 'empty')
```
A description-less `Symbol()` exposes a **zero-length string view**, and the Map/Set key comparator (`jsvalue_eq`) content-compared any two string-like values. So `jsvalue_eq("", Symbol())` saw two zero-length strings and returned `true` — the `""` and `Symbol()` keys collided.

## Fix
Symbols compare by **identity only** (two distinct symbols are never equal; same-symbol is already caught by the bit-equality fast path). Guard `jsvalue_eq` in both `map.rs` and `set.rs` to return false when either operand is a symbol, before the string-content path.

## Verification
Byte-identical to `node --experimental-strip-types`:
- `'' ` vs `Symbol()` → distinct (size 2)
- distinct symbols stay distinct; same-symbol identity merges
- string content-equality (`'hi'` === `'h'+'i'`) unchanged

Fixes test262 `built-ins/Map/prototype/size/returns-count-of-present-values-by-{insertion,iterable}`.