### PR TITLE
fix(runtime): expose collection prototype iterators

### DIFF
--- a/crates/perry-runtime/src/object/collection_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/collection_proto_thunks.rs
@@ -114,7 +114,7 @@ pub(super) fn install_collection_proto_methods(
             );
             ipm(proto_obj, "clear", map_proto_clear_thunk as *const u8, 0);
             ipm(proto_obj, "delete", map_proto_delete_thunk as *const u8, 1);
-            ipm(
+            let entries_value = ipm(
                 proto_obj,
                 "entries",
                 map_proto_entries_thunk as *const u8,
@@ -131,6 +131,7 @@ pub(super) fn install_collection_proto_methods(
             ipm(proto_obj, "keys", map_proto_keys_thunk as *const u8, 0);
             let set_value = ipm(proto_obj, "set", map_proto_set_thunk as *const u8, 2);
             ipm(proto_obj, "values", map_proto_values_thunk as *const u8, 0);
+            install_collection_iterator_symbol(proto_obj, entries_value);
             remember_builtin_collection_method(
                 proto_obj,
                 "set",
@@ -162,7 +163,8 @@ pub(super) fn install_collection_proto_methods(
             );
             ipm(proto_obj, "has", set_proto_has_thunk as *const u8, 1);
             ipm(proto_obj, "keys", set_proto_keys_thunk as *const u8, 0);
-            ipm(proto_obj, "values", set_proto_values_thunk as *const u8, 0);
+            let values_value = ipm(proto_obj, "values", set_proto_values_thunk as *const u8, 0);
+            install_collection_iterator_symbol(proto_obj, values_value);
             remember_builtin_collection_method(
                 proto_obj,
                 "add",
@@ -194,6 +196,28 @@ pub(super) fn install_collection_proto_methods(
         _ => return false,
     }
     true
+}
+
+fn install_collection_iterator_symbol(proto_obj: *mut ObjectHeader, method_value: f64) {
+    if proto_obj.is_null() || method_value.to_bits() == crate::value::TAG_UNDEFINED {
+        return;
+    }
+    let iter = crate::symbol::well_known_symbol("iterator");
+    if iter.is_null() {
+        return;
+    }
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            crate::value::js_nanbox_pointer(proto_obj as i64),
+            f64::from_bits(crate::value::JSValue::pointer(iter as *const u8).bits()),
+            method_value,
+        );
+    }
+    crate::symbol::set_symbol_property_attrs(
+        proto_obj as usize,
+        iter as usize,
+        super::PropertyAttrs::new(true, false, true),
+    );
 }
 
 fn install_collection_size_getter(proto_obj: *mut ObjectHeader, name: &str, func_ptr: *const u8) {

--- a/test-parity/node-suite/globals/collection-prototype-symbol-iterator.ts
+++ b/test-parity/node-suite/globals/collection-prototype-symbol-iterator.ts
@@ -1,0 +1,47 @@
+function showDescriptor(label: string, descriptor: PropertyDescriptor | undefined) {
+  console.log(
+    label,
+    typeof descriptor?.value,
+    descriptor?.value?.name,
+    descriptor?.value?.length,
+    descriptor?.writable,
+    descriptor?.enumerable,
+    descriptor?.configurable,
+  );
+}
+
+console.log("map iterator typeof:", typeof Map.prototype[Symbol.iterator]);
+console.log(
+  "map iterator equals entries:",
+  Map.prototype[Symbol.iterator] === Map.prototype.entries,
+);
+showDescriptor(
+  "map iterator descriptor:",
+  Object.getOwnPropertyDescriptor(Map.prototype, Symbol.iterator),
+);
+console.log(
+  "map iterator next:",
+  JSON.stringify(Map.prototype[Symbol.iterator].call(new Map([[1, 2]])).next()),
+);
+console.log(
+  "map symbols include iterator:",
+  Object.getOwnPropertySymbols(Map.prototype).some((sym) => sym === Symbol.iterator),
+);
+
+console.log("set iterator typeof:", typeof Set.prototype[Symbol.iterator]);
+console.log(
+  "set iterator equals values:",
+  Set.prototype[Symbol.iterator] === Set.prototype.values,
+);
+showDescriptor(
+  "set iterator descriptor:",
+  Object.getOwnPropertyDescriptor(Set.prototype, Symbol.iterator),
+);
+console.log(
+  "set iterator next:",
+  JSON.stringify(Set.prototype[Symbol.iterator].call(new Set([3])).next()),
+);
+console.log(
+  "set symbols include iterator:",
+  Object.getOwnPropertySymbols(Set.prototype).some((sym) => sym === Symbol.iterator),
+);


### PR DESCRIPTION
Fixes #4566.

Summary:
- Install Map.prototype[Symbol.iterator] as the same callable closure as Map.prototype.entries.
- Install Set.prototype[Symbol.iterator] as the same callable closure as Set.prototype.values.
- Record symbol-property descriptor attrs so reflective descriptor checks see writable true, enumerable false, configurable true.
- Add a globals parity fixture covering typeof, identity, descriptors, symbol enumeration, and direct iterator calls.

Validation:
- cargo fmt --all -- --check
- git diff --check origin/main..HEAD
- ./scripts/check_file_size.sh
- cargo check -p perry-runtime
- npm exec --yes --package=node@26 -- bash -lc 'node --version; PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter collection-prototype-symbol-iterator'