### PR TITLE
fix(runtime): require new for collection constructors

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -753,6 +753,10 @@ pub(super) fn identify_global_builtin_constructor(func_value: f64) -> Option<&'s
             || func_ptr == global_this_string_thunk as *const u8 as usize
             || func_ptr == global_this_number_thunk as *const u8 as usize
             || func_ptr == global_this_boolean_thunk as *const u8 as usize
+            || func_ptr == map_constructor_call_thunk as *const u8 as usize
+            || func_ptr == set_constructor_call_thunk as *const u8 as usize
+            || func_ptr == weakmap_constructor_call_thunk as *const u8 as usize
+            || func_ptr == weakset_constructor_call_thunk as *const u8 as usize
             || func_ptr == error_constructor_call_thunk as *const u8 as usize
             || func_ptr == type_error_constructor_call_thunk as *const u8 as usize
             || func_ptr == range_error_constructor_call_thunk as *const u8 as usize
@@ -1523,6 +1527,38 @@ pub unsafe extern "C" fn js_new_function_construct(
                     .copied()
                     .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED));
                 return crate::object::global_this_response_thunk(std::ptr::null(), body, init);
+            }
+            "Map" => {
+                let map = if let Some(iterable) = args.first().copied() {
+                    crate::map::js_map_from_iterable(iterable)
+                } else {
+                    crate::map::js_map_alloc(4)
+                };
+                return crate::value::js_nanbox_pointer(map as i64);
+            }
+            "Set" => {
+                let set = if let Some(iterable) = args.first().copied() {
+                    crate::set::js_set_from_iterable(iterable)
+                } else {
+                    crate::set::js_set_alloc(4)
+                };
+                return crate::value::js_nanbox_pointer(set as i64);
+            }
+            "WeakMap" => {
+                let map = crate::weakref::js_weakmap_new();
+                let map_value = crate::value::js_nanbox_pointer(map as i64);
+                if let Some(iterable) = args.first().copied() {
+                    return crate::weakref::js_weakmap_init_iterable(map_value, iterable);
+                }
+                return map_value;
+            }
+            "WeakSet" => {
+                let set = crate::weakref::js_weakset_new();
+                let set_value = crate::value::js_nanbox_pointer(set as i64);
+                if let Some(iterable) = args.first().copied() {
+                    return crate::weakref::js_weakset_init_iterable(set_value, iterable);
+                }
+                return set_value;
             }
             "Event" => {
                 let event_type = args

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -339,6 +339,38 @@ pub(crate) extern "C" fn typed_array_constructor_call_thunk(
     super::object_ops::throw_object_type_error(b"Constructor %TypedArray% requires 'new'")
 }
 
+fn throw_collection_constructor_requires_new(name: &[u8]) -> f64 {
+    let mut message = Vec::with_capacity("Constructor  requires 'new'".len() + name.len());
+    message.extend_from_slice(b"Constructor ");
+    message.extend_from_slice(name);
+    message.extend_from_slice(b" requires 'new'");
+    super::object_ops::throw_object_type_error(&message)
+}
+
+pub(crate) extern "C" fn map_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    throw_collection_constructor_requires_new(b"Map")
+}
+
+pub(crate) extern "C" fn set_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    throw_collection_constructor_requires_new(b"Set")
+}
+
+pub(crate) extern "C" fn weakmap_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    throw_collection_constructor_requires_new(b"WeakMap")
+}
+
+pub(crate) extern "C" fn weakset_constructor_call_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    throw_collection_constructor_requires_new(b"WeakSet")
+}
+
 extern "C" fn global_this_url_pattern_call_thunk(
     _closure: *const crate::closure::ClosureHeader,
     input: f64,
@@ -2325,6 +2357,10 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             // global value coerce like the bare-call lowering does.
             "Number" => global_this_number_thunk as *const u8,
             "Boolean" => global_this_boolean_thunk as *const u8,
+            "Map" => map_constructor_call_thunk as *const u8,
+            "Set" => set_constructor_call_thunk as *const u8,
+            "WeakMap" => weakmap_constructor_call_thunk as *const u8,
+            "WeakSet" => weakset_constructor_call_thunk as *const u8,
             "Error" => error_constructor_call_thunk as *const u8,
             "TypeError" => type_error_constructor_call_thunk as *const u8,
             "RangeError" => range_error_constructor_call_thunk as *const u8,

--- a/test-parity/node-suite/globals/collection-constructor-newtarget.ts
+++ b/test-parity/node-suite/globals/collection-constructor-newtarget.ts
@@ -1,0 +1,25 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label + ":", String(fn()));
+  } catch (e: any) {
+    console.log(label + ":", e?.name + ":" + e?.message);
+  }
+}
+
+const constructors = [
+  ["Map", Map],
+  ["Set", Set],
+  ["WeakMap", WeakMap],
+  ["WeakSet", WeakSet],
+] as const;
+
+for (const [name, Ctor] of constructors) {
+  show(name + " direct call", () => (Ctor as any)());
+  show(name + " rebound call", () => {
+    const C = Ctor as any;
+    return C();
+  });
+  show(name + " call method", () => (Ctor as any).call(undefined));
+  show(name + " reflect apply", () => Reflect.apply(Ctor as any, {}, []));
+  show(name + " rebound new tag", () => Object.prototype.toString.call(new (Ctor as any)()));
+}


### PR DESCRIPTION
## Summary
- Fix global Map/Set/WeakMap/WeakSet call-form constructors to throw Node-compatible TypeErrors when invoked without `new`.
- Keep rebound `new Ctor()` construction working by routing recognized collection constructor closures through the existing collection allocation and iterable initialization paths.
- Add a focused Node parity fixture covering direct calls, rebound calls, `.call`, `Reflect.apply`, and rebound `new` tags.

Closes #4569.

## Why this batch
All four ECMAScript collection constructors share the same global constructor closure/newTarget behavior in this runtime. Updating them together keeps the call-form TypeError handling and the recognized built-in construction path consistent.

## Tests
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH node --experimental-strip-types test-parity/node-suite/globals/collection-constructor-newtarget.ts`
- `cargo check -q -p perry-runtime`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter collection-constructor-newtarget`
- `cargo test -q -p perry-runtime --lib set::tests`
- `cargo test -q -p perry-runtime --lib weakref::tests`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter reflective-builtins`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known limitations / non-goals
- Does not change static `new Map/Set/WeakMap/WeakSet` lowering beyond preserving the existing allocation and iterable paths for rebound construction.
- Does not change collection prototype method semantics.
- Does not address unrelated sparse-array or broader constructor/newTarget issues.
