### PR TITLE
fix(runtime): align json number formatting

### DIFF
--- a/crates/perry-runtime/src/json/stringify_api.rs
+++ b/crates/perry-runtime/src/json/stringify_api.rs
@@ -205,8 +205,7 @@ pub unsafe extern "C" fn js_json_stringify_number(value: f64) -> *mut StringHead
         let s = itoa_buf.format(value as i64);
         return js_string_from_bytes(s.as_ptr(), s.len() as u32);
     }
-    let mut ryu_buf = ryu::Buffer::new();
-    let s = ryu_buf.format(value);
+    let s = crate::string::js_format_f64(value);
     js_string_from_bytes(s.as_ptr(), s.len() as u32)
 }
 


### PR DESCRIPTION
Fixes #4573.

Summary:
- Route JSON.stringify finite non-i64 number formatting through the shared ECMAScript Number::toString formatter instead of ryu.
- Apply the same formatter to the specialized scalar JSON number helper.
- Add a globals parity fixture covering direct numbers, arrays, objects, boundary exponent forms, signed zero, and non-finite values.

Validation:
- cargo fmt --all -- --check
- git diff --check
- ./scripts/check_file_size.sh
- cargo check -p perry-runtime
- npm exec --yes --package=node@26 -- bash -lc 'node --version; PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter json-stringify-number-format'