### PR TITLE
fix(hir): namespace 'export const' members are accessible cross-module

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -1880,6 +1880,14 @@ pub(crate) fn lower_namespace_as_class(
 
     let mut static_methods = Vec::new();
     let mut static_method_names = Vec::new();
+    // Namespace `export const` members surfaced as static fields so `Ns.member`
+    // resolves CROSS-MODULE (the per-module `namespace_vars` local is invisible
+    // to importers; only namespace FUNCTIONS — lowered as static methods —
+    // crossed the boundary). The field's VALUE is copied from the const's local
+    // by a `StaticFieldSet` appended to `module.init` right after the const's
+    // own `Let`, so it is evaluated exactly once and in the right order. zod's
+    // `util` namespace (`util.objectKeys`, …) is imported this way.
+    let mut ns_static_fields: Vec<crate::ir::ClassField> = Vec::new();
 
     // First pass: collect exported function names, pre-register all functions and variables
     // (so namespace members can reference each other regardless of declaration order)
@@ -2046,9 +2054,32 @@ pub(crate) fn lower_namespace_as_class(
                                     mutable,
                                     init: Some(expr),
                                 });
-                                // Track as namespace variable for Ns.member access resolution
+                                // Track as namespace variable for `Ns.member`
+                                // access AND intra-namespace bare references.
                                 ctx.namespace_vars
                                     .push((ns_name.to_string(), name.clone(), id));
+                                // Surface as a static field of the namespace class
+                                // and copy the const's value into it (after the Let
+                                // above), so `Ns.member` resolves cross-module via
+                                // the static-field global. The field carries no
+                                // initializer of its own — the value is set once,
+                                // here, from the already-evaluated local.
+                                if is_exported {
+                                    ns_static_fields.push(crate::ir::ClassField {
+                                        name: name.clone(),
+                                        key_expr: None,
+                                        ty: Type::Any,
+                                        init: None,
+                                        is_private: false,
+                                        is_readonly: !mutable,
+                                        decorators: Vec::new(),
+                                    });
+                                    module.init.push(Stmt::Expr(Expr::StaticFieldSet {
+                                        class_name: ns_name.to_string(),
+                                        field_name: name.clone(),
+                                        value: Box::new(Expr::LocalGet(id)),
+                                    }));
+                                }
                                 // Export the variable for cross-module access
                                 if is_exported {
                                     module.exported_objects.push(name.clone());
@@ -2087,7 +2118,7 @@ pub(crate) fn lower_namespace_as_class(
         methods: Vec::new(),
         getters: Vec::new(),
         setters: Vec::new(),
-        static_fields: Vec::new(),
+        static_fields: ns_static_fields,
         static_methods,
         computed_members: Vec::new(),
         decorators: Vec::new(),

--- a/tests/test_namespace_const_cross_module.sh
+++ b/tests/test_namespace_const_cross_module.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A TS `namespace`'s `export const` members must be accessible when the namespace
+# is imported into ANOTHER module. Namespace FUNCTIONS lowered as static methods
+# already crossed the module boundary, but `export const` members lived only in
+# the defining module's per-module `namespace_vars`, so an importer read them back
+# as undefined/garbage. zod's `util` namespace (`util.objectKeys`, …) is imported
+# this way, so `_getCached` got null keys and every `z.object({...}).parse()`
+# silently dropped all fields.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/util_mod.ts" <<'TS'
+export namespace util {
+  export function fn() { return "FN"; }
+  export const objectKeys = (obj: any) => Object.keys(obj);
+  export const arrow = () => "ARROW";
+  export const num = 42;
+}
+TS
+cat >"$TMPDIR/main.ts" <<'TS'
+import { util } from "./util_mod.js";
+if (util.fn() !== "FN") throw new Error("fn: " + util.fn());
+if (util.arrow() !== "ARROW") throw new Error("arrow: " + util.arrow());
+if (util.num !== 42) throw new Error("num: " + util.num);
+if (JSON.stringify(util.objectKeys({ a: 1, b: 2 })) !== '["a","b"]') {
+  throw new Error("objectKeys: " + JSON.stringify(util.objectKeys({ a: 1, b: 2 })));
+}
+// assigning the member to a local and calling it must also work
+const ok = util.objectKeys;
+if (JSON.stringify(ok({ x: 1 })) !== '["x"]') throw new Error("via local: " + JSON.stringify(ok({ x: 1 })));
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/main.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: namespace const cross-module access"


### PR DESCRIPTION
## Problem

A TS `namespace`'s exported **functions** were lowered as static methods of the namespace class and crossed the module boundary, but its `export const` members lived only in the defining module's per-module `namespace_vars`. An importing module read `ns.member` back as **undefined/garbage** for value members.

```ts
// a.ts
export namespace util { export const objectKeys = (o:any) => Object.keys(o); }
// b.ts
import { util } from "./a.js";
util.objectKeys({a:1})   // was null/garbage; now ["a"]
```

## Fix

Surface each `export const` as a **static field** of the namespace class and copy the const's value into it via a `StaticFieldSet` appended to `module.init` right after the const's own `Let` (evaluated once, correct order). `ns.member` then resolves cross-module through the static-field global; same-module access and intra-namespace bare references keep using the local.

## Impact

Fixes zod's imported `util` namespace — `util.objectKeys(shape)` returned null, so `ZodObject._getCached` produced null keys and **every `z.object({...}).parse()` silently dropped all fields**. With this, object parsing, coercion, and defaults all work.

## Test

`tests/test_namespace_const_cross_module.sh`. perry-hir 136/0; all prior-fix regressions pass.