### PR TITLE
fix(string): replace/replaceAll string pattern processes $ replacement patterns (#4581)

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -24,7 +24,10 @@ pub use match_all::{
     REGEXP_STRING_ITERATOR_CLASS_ID,
 };
 use replace_fn::call_replace_callback;
-pub use replace_fn::{js_string_replace_all_string_fn, js_string_replace_string_fn};
+pub use replace_fn::{
+    js_string_replace_all_string, js_string_replace_all_string_fn, js_string_replace_string,
+    js_string_replace_string_fn,
+};
 
 thread_local! {
     /// Last exec result metadata: (index, groups_object_ptr)
@@ -886,63 +889,6 @@ pub extern "C" fn js_string_replace_all_regex(
 
     ensure_replace_all_regex_global(re);
     js_string_replace_regex(s, re, replacement)
-}
-
-/// Replace with a simple string pattern (not regex)
-/// string.replace(pattern, replacement) -> string
-#[no_mangle]
-pub extern "C" fn js_string_replace_string(
-    s: *const StringHeader,
-    pattern: *const StringHeader,
-    replacement: *const StringHeader,
-) -> *mut StringHeader {
-    if !is_valid_ptr(s) {
-        return js_string_from_str("");
-    }
-
-    let str_data = string_as_str(s);
-    let pattern_str = if is_valid_ptr(pattern) {
-        string_as_str(pattern)
-    } else {
-        ""
-    };
-    let repl_str = if is_valid_ptr(replacement) {
-        string_as_str(replacement)
-    } else {
-        "undefined"
-    };
-
-    // String.replace with a string pattern only replaces the first occurrence
-    let result = str_data.replacen(pattern_str, repl_str, 1);
-    js_string_from_str(&result)
-}
-
-/// Replace ALL occurrences with a simple string pattern (not regex)
-/// string.replaceAll(pattern, replacement) -> string
-#[no_mangle]
-pub extern "C" fn js_string_replace_all_string(
-    s: *const StringHeader,
-    pattern: *const StringHeader,
-    replacement: *const StringHeader,
-) -> *mut StringHeader {
-    if !is_valid_ptr(s) {
-        return js_string_from_str("");
-    }
-
-    let str_data = string_as_str(s);
-    let pattern_str = if is_valid_ptr(pattern) {
-        string_as_str(pattern)
-    } else {
-        ""
-    };
-    let repl_str = if is_valid_ptr(replacement) {
-        string_as_str(replacement)
-    } else {
-        "undefined"
-    };
-
-    let result = str_data.replace(pattern_str, repl_str);
-    js_string_from_str(&result)
 }
 
 /// Split a string by a regex delimiter

--- a/crates/perry-runtime/src/regex/replace_fn.rs
+++ b/crates/perry-runtime/src/regex/replace_fn.rs
@@ -126,3 +126,135 @@ pub extern "C" fn js_string_replace_all_string_fn(
         js_string_from_str(&result)
     }
 }
+
+/// Expand a replacement template against a single string-pattern match, per
+/// ECMAScript `GetSubstitution` (22.1.3.19.1) for a *string* `searchValue`:
+/// `$$` → `$`, `$&` → matched, `` $` `` → text before the match, `$'` → text
+/// after it. There are no capture groups for a string pattern, so `$n` /
+/// `$<name>` are left verbatim. A `$` not starting a recognised escape is also
+/// left verbatim.
+fn expand_string_pattern_replacement(
+    repl: &str,
+    full: &str,
+    match_start: usize,
+    matched: &str,
+) -> String {
+    let mut out = String::with_capacity(repl.len());
+    let mut chars = repl.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '$' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            Some('$') => {
+                out.push('$');
+                chars.next();
+            }
+            Some('&') => {
+                out.push_str(matched);
+                chars.next();
+            }
+            Some('`') => {
+                out.push_str(&full[..match_start]);
+                chars.next();
+            }
+            Some('\'') => {
+                out.push_str(&full[match_start + matched.len()..]);
+                chars.next();
+            }
+            // `$` followed by anything else (incl. a digit, since a string
+            // pattern has no captures) stays literal.
+            _ => out.push('$'),
+        }
+    }
+    out
+}
+
+/// Replace with a simple string pattern (not regex)
+/// string.replace(pattern, replacement) -> string
+#[no_mangle]
+pub extern "C" fn js_string_replace_string(
+    s: *const StringHeader,
+    pattern: *const StringHeader,
+    replacement: *const StringHeader,
+) -> *mut StringHeader {
+    if !is_valid_ptr(s) {
+        return js_string_from_str("");
+    }
+
+    let str_data = string_as_str(s);
+    let pattern_str = if is_valid_ptr(pattern) {
+        string_as_str(pattern)
+    } else {
+        ""
+    };
+    let repl_str = if is_valid_ptr(replacement) {
+        string_as_str(replacement)
+    } else {
+        "undefined"
+    };
+
+    // String.replace with a string pattern only replaces the first occurrence.
+    // Fast path: a replacement with no `$` needs no substitution.
+    if !repl_str.contains('$') || pattern_str.is_empty() {
+        let result = str_data.replacen(pattern_str, repl_str, 1);
+        return js_string_from_str(&result);
+    }
+    let result = match str_data.find(pattern_str) {
+        Some(pos) => {
+            let expanded = expand_string_pattern_replacement(repl_str, str_data, pos, pattern_str);
+            let mut out = String::with_capacity(str_data.len() + expanded.len());
+            out.push_str(&str_data[..pos]);
+            out.push_str(&expanded);
+            out.push_str(&str_data[pos + pattern_str.len()..]);
+            out
+        }
+        None => str_data.to_string(),
+    };
+    js_string_from_str(&result)
+}
+
+/// Replace ALL occurrences with a simple string pattern (not regex)
+/// string.replaceAll(pattern, replacement) -> string
+#[no_mangle]
+pub extern "C" fn js_string_replace_all_string(
+    s: *const StringHeader,
+    pattern: *const StringHeader,
+    replacement: *const StringHeader,
+) -> *mut StringHeader {
+    if !is_valid_ptr(s) {
+        return js_string_from_str("");
+    }
+
+    let str_data = string_as_str(s);
+    let pattern_str = if is_valid_ptr(pattern) {
+        string_as_str(pattern)
+    } else {
+        ""
+    };
+    let repl_str = if is_valid_ptr(replacement) {
+        string_as_str(replacement)
+    } else {
+        "undefined"
+    };
+
+    // Fast path: a replacement with no `$` (or an empty pattern, whose
+    // between-every-char match positions are left to Rust's `replace`) needs
+    // no `$$`/`$&`/`` $` ``/`$'` substitution.
+    if !repl_str.contains('$') || pattern_str.is_empty() {
+        let result = str_data.replace(pattern_str, repl_str);
+        return js_string_from_str(&result);
+    }
+    let mut result = String::with_capacity(str_data.len());
+    let mut last = 0;
+    for (pos, m) in str_data.match_indices(pattern_str) {
+        result.push_str(&str_data[last..pos]);
+        result.push_str(&expand_string_pattern_replacement(
+            repl_str, str_data, pos, m,
+        ));
+        last = pos + m.len();
+    }
+    result.push_str(&str_data[last..]);
+    js_string_from_str(&result)
+}

--- a/test-parity/node-suite/globals/string-replace-string-dollar.ts
+++ b/test-parity/node-suite/globals/string-replace-string-dollar.ts
@@ -1,0 +1,37 @@
+// String.prototype.replace / replaceAll with a *string* pattern must process
+// the special replacement patterns from ECMAScript GetSubstitution:
+//   $$ -> $    $& -> matched    $` -> text before match    $' -> text after
+// A string pattern has no capture groups, so $1 / $<name> stay literal.
+
+function show(label: string, value: any) {
+  console.log(label + " = " + value);
+}
+
+// replace (first occurrence).
+show("$$", "abc".replace("b", "$$"));
+show("$&", "abc".replace("b", "[$&]"));
+show("$`", "abc".replace("b", "$`"));
+show("$'", "abc".replace("b", "$'"));
+show("$1-literal", "abc".replace("b", "$1"));
+show("mixed", "xby".replace("b", "$$$&$`$'"));
+show("price", "cost 100".replace("100", "$$100"));
+show("trailing-$", "ab".replace("a", "x$"));
+
+// replaceAll.
+show("all-$$", "a.b.c".replaceAll(".", "$$"));
+show("all-$&", "a.b.c".replaceAll(".", "[$&]"));
+show("all-mixed", "1x2x3".replaceAll("x", "-$&-"));
+
+// Regression: no `$`, no match, empty pattern.
+show("plain", "a.b.c".replaceAll(".", "-"));
+show("plain-first", "abc".replace("b", "X"));
+show("no-match", "abc".replace("z", "$$"));
+show("empty-pat", "abc".replace("", "$"));
+
+// UTF-8 safety around and inside the match.
+show("utf8-repl", "héllo".replace("l", "$&$&"));
+show("utf8-around", "aXé".replace("X", "[$`|$']"));
+
+// The regex path is unchanged (still supports $1 captures).
+show("regex-$$", "abc".replace(/b/, "$$"));
+show("regex-$1", "2024-03".replace(/(\d+)-(\d+)/, "$2/$1"));


### PR DESCRIPTION
Fixes #4581.

## Problem

`String.prototype.replace` / `replaceAll` with a *string* searchValue passed the replacement template to Rust's `replacen`/`replace` verbatim, ignoring the ECMAScript GetSubstitution escapes:

```ts
"x".replace("x", "$$");      // Node: $       was: $$
"abc".replace("b", "[$&]");   // Node: a[b]c   was: a[$&]c
"cost 100".replace("100","$$100"); // Node: cost $100  was: cost $$100
```

The regex path already handled them (`expand_js_replacement`).

## Fix

Add `expand_string_pattern_replacement` (GetSubstitution for a string pattern: `$$`->`$`, `$&`->matched, `$\``->prefix, `$'`->suffix; `$n`/`$<name>` stay literal) and use it in both `js_string_replace_string` and `js_string_replace_all_string`. A no-`$` replacement (or empty pattern) keeps the existing fast Rust path. UTF-8 safe.

## Verification

- Parity fixture `string-replace-string-dollar.ts`.
- Identical to Node across $$ / $& / $` / $' / mixed / replaceAll / no-$ / no-match / empty-pattern / UTF-8 cases; regex replace unchanged.
- regex (10) + replace (7) unit tests pass.