### PR TITLE
Fix array large-index boundary writes

### DIFF
--- a/crates/perry-codegen/src/expr/index.rs
+++ b/crates/perry-codegen/src/expr/index.rs
@@ -125,6 +125,7 @@ pub(crate) fn lower_index_set_fast(
             &[
                 (I64, feedback_site_id),
                 (DOUBLE, arr_box),
+                (DOUBLE, idx_double),
                 (I32, &idx_i32),
                 (DOUBLE, val_double),
                 (I32, "0"),
@@ -143,7 +144,7 @@ pub(crate) fn lower_index_set_fast(
             &[
                 (I64, feedback_site_id),
                 (DOUBLE, arr_box),
-                (I32, &idx_i32),
+                (DOUBLE, idx_double),
                 (DOUBLE, val_double),
             ],
         );
@@ -326,8 +327,12 @@ pub(crate) fn lower_index_set_fast(
         );
         let new_handle = blk.call(
             I64,
-            "js_array_set_f64_extend",
-            &[(I64, &arr_handle), (I32, &idx_i32), (DOUBLE, val_double)],
+            "js_array_set_index_or_string",
+            &[
+                (I64, &arr_handle),
+                (DOUBLE, idx_double),
+                (DOUBLE, val_double),
+            ],
         );
         let new_box = nanbox_pointer_inline(blk, &new_handle);
         blk.store(DOUBLE, &new_box, &slot);

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -87,6 +87,20 @@ fn is_async_dispose_symbol_index(index: &Expr) -> bool {
     }
 }
 
+fn static_numeric_index_value(index: &Expr) -> Option<f64> {
+    match index {
+        Expr::Integer(value) => Some(*value as f64),
+        Expr::Number(value) => Some(*value),
+        _ => None,
+    }
+}
+
+fn static_numeric_index_needs_raw_key(index: &Expr) -> bool {
+    static_numeric_index_value(index).is_some_and(|value| {
+        value.is_finite() && value.trunc() == value && (value < 0.0 || value > i32::MAX as f64)
+    })
+}
+
 fn lower_class_method_bind(
     ctx: &mut FnCtx<'_>,
     object: &Expr,
@@ -660,6 +674,25 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(DOUBLE, &obj_box), (DOUBLE, &key_box)],
                     ));
                 }
+                if matches!(index.as_ref(), Expr::String(_)) || is_string_expr(ctx, index) {
+                    let arr_box = lower_expr(ctx, object)?;
+                    let key_box = lower_expr(ctx, index)?;
+                    let (arr_handle, key_handle) = {
+                        let blk = ctx.block();
+                        (unbox_to_i64(blk, &arr_box), unbox_str_handle(blk, &key_box))
+                    };
+                    let site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::PropertyGet,
+                        "array[string_index]",
+                        TypedFeedbackContract::object_get_by_name(),
+                    );
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_typed_feedback_object_get_field_by_name_f64",
+                        &[(I64, &site_id), (I64, &arr_handle), (I64, &key_handle)],
+                    ));
+                }
                 let require_numeric_layout =
                     expr_has_numeric_pointer_free_array_layout(ctx, object);
                 // Bounded-index fast path (mirrors the IndexSet
@@ -701,6 +734,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
                 let arr_box = lower_expr(ctx, object)?;
                 let idx_double = lower_expr(ctx, index)?;
+                if static_numeric_index_needs_raw_key(index) {
+                    let feedback_site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::ArrayElement,
+                        "array[index]",
+                        TypedFeedbackContract::array_get_index(),
+                    );
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_typed_feedback_array_index_get_fallback_boxed",
+                        &[
+                            (I64, &feedback_site_id),
+                            (DOUBLE, &arr_box),
+                            (DOUBLE, &idx_double),
+                        ],
+                    ));
+                }
                 let idx_i32 = ctx.block().fptosi(DOUBLE, &idx_double, I32);
                 if !require_numeric_layout
                     && !matches!(index.as_ref(), Expr::Integer(_) | Expr::Number(_))

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -78,6 +78,20 @@ fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     )
 }
 
+fn static_numeric_index_value(index: &Expr) -> Option<f64> {
+    match index {
+        Expr::Integer(value) => Some(*value as f64),
+        Expr::Number(value) => Some(*value),
+        _ => None,
+    }
+}
+
+fn static_numeric_index_needs_raw_key(index: &Expr) -> bool {
+    static_numeric_index_value(index).is_some_and(|value| {
+        value.is_finite() && value.trunc() == value && (value < 0.0 || value > i32::MAX as f64)
+    })
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::IndexSet {
@@ -265,6 +279,51 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // string key on dynamic receiver → object field set, otherwise
             // bail with a clear error.
             if is_array_expr(ctx, object) {
+                if static_numeric_index_needs_raw_key(index) {
+                    let layout_note_needed = array_store_needs_layout_note(ctx, object, value);
+                    let write_barrier_needed = array_store_needs_write_barrier(ctx, value);
+                    let arr_box = lower_expr(ctx, object)?;
+                    let idx_double = lower_expr(ctx, index)?;
+                    let val_double = lower_expr(ctx, value)?;
+                    let feedback_site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::ArrayElement,
+                        "array[index]=",
+                        TypedFeedbackContract::array_set_index(),
+                    );
+                    let blk = ctx.block();
+                    let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                    let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                    let new_handle = blk.call(
+                        I64,
+                        "js_typed_feedback_array_set_index_or_string",
+                        &[
+                            (I64, &feedback_site_id),
+                            (I64, &arr_handle),
+                            (DOUBLE, &idx_double),
+                            (DOUBLE, &val_double),
+                        ],
+                    );
+                    let new_box = nanbox_pointer_inline(blk, &new_handle);
+                    if let Expr::LocalGet(id) = object.as_ref() {
+                        if let Some(slot) = ctx.locals.get(id).cloned() {
+                            ctx.block().store(DOUBLE, &new_box, &slot);
+                        } else if let Some(global_name) = ctx.module_globals.get(id).cloned() {
+                            let g_ref = format!("@{}", global_name);
+                            emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
+                        }
+                    }
+                    if write_barrier_needed {
+                        let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
+                        let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
+                        emit_write_barrier(ctx, &arr_bits, &val_bits);
+                    }
+                    if layout_note_needed {
+                        let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
+                        emit_array_numeric_write_note_on_block(ctx.block(), &arr_handle, &val_bits);
+                    }
+                    return Ok(val_double);
+                }
                 // Bounded-index fast-fast path: when the surrounding
                 // for-loop has registered `(counter_id, arr_id)` as a
                 // bounded pair (via `lower_for`'s
@@ -289,12 +348,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let val_double = lower_expr(ctx, value)?;
                         // Grab i32 slot name before mutably borrowing ctx for block().
                         let i32_slot_opt = ctx.i32_counter_slots.get(idx_id).cloned();
-                        let idx_i32 = if let Some(ref i32_slot) = i32_slot_opt {
-                            ctx.block().load(I32, i32_slot)
-                        } else {
-                            let idx_double = lower_expr(ctx, index)?;
-                            ctx.block().fptosi(DOUBLE, &idx_double, I32)
-                        };
+                        let (idx_i32, idx_double_for_runtime) =
+                            if let Some(ref i32_slot) = i32_slot_opt {
+                                let idx_i32 = ctx.block().load(I32, i32_slot);
+                                let idx_double = ctx.block().sitofp(I32, &idx_i32, DOUBLE);
+                                (idx_i32, idx_double)
+                            } else {
+                                let idx_double = lower_expr(ctx, index)?;
+                                let idx_i32 = ctx.block().fptosi(DOUBLE, &idx_double, I32);
+                                (idx_i32, idx_double)
+                            };
                         if require_numeric_layout {
                             let feedback_site_id = emit_typed_feedback_register_site(
                                 ctx,
@@ -317,6 +380,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     &[
                                         (I64, &feedback_site_id),
                                         (DOUBLE, &arr_box),
+                                        (DOUBLE, &idx_double_for_runtime),
                                         (I32, &idx_i32),
                                         (DOUBLE, &val_double),
                                         (I32, "1"),
@@ -334,7 +398,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     &[
                                         (I64, &feedback_site_id),
                                         (DOUBLE, &arr_box),
-                                        (I32, &idx_i32),
+                                        (DOUBLE, &idx_double_for_runtime),
                                         (DOUBLE, &val_double),
                                     ],
                                 );
@@ -508,14 +572,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let blk = ctx.block();
                         let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                        let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
                         let new_handle = blk.call(
                             I64,
-                            "js_typed_feedback_array_set_f64_extend",
+                            "js_typed_feedback_array_set_index_or_string",
                             &[
                                 (I64, &feedback_site_id),
                                 (I64, &arr_handle),
-                                (I32, &idx_i32),
+                                (DOUBLE, &idx_double),
                                 (DOUBLE, &val_double),
                             ],
                         );
@@ -547,14 +610,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let blk = ctx.block();
                         let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                        let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
                         blk.call(
                             I64,
-                            "js_typed_feedback_array_set_f64_extend",
+                            "js_typed_feedback_array_set_index_or_string",
                             &[
                                 (I64, &feedback_site_id),
                                 (I64, &arr_handle),
-                                (I32, &idx_i32),
+                                (DOUBLE, &idx_double),
                                 (DOUBLE, &val_double),
                             ],
                         );
@@ -568,12 +630,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let blk = ctx.block();
                     let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                     let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                    let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
-                    // Issue #637 followup / hono r2: use the extend variant
+                    // Issue #637 followup / hono r2: use the raw-key helper
                     // so `arr[i] = X` for i >= length grows the array per
                     // JS spec, instead of silently no-op'ing (which the
                     // non-extend `js_array_set_f64` did via `if index >=
-                    // length { return; }`). The hono Trie's
+                    // length { return; }`) and so large numeric literals do
+                    // not truncate through i32. The hono Trie's
                     // `indexReplacementMap[++captureIndex] = N` pattern
                     // (sparse-extend from a closure capturing the array)
                     // was the load-bearing site — pre-fix the array stayed
@@ -582,11 +644,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     // zero times and `handlerMap` ended up empty.
                     blk.call(
                         I64,
-                        "js_typed_feedback_array_set_f64_extend",
+                        "js_typed_feedback_array_set_index_or_string",
                         &[
                             (I64, &feedback_site_id),
                             (I64, &arr_handle),
-                            (I32, &idx_i32),
+                            (DOUBLE, &idx_double),
                             (DOUBLE, &val_double),
                         ],
                     );

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -169,7 +169,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let recv_bits = blk.bitcast_double_to_i64(&recv_box);
             let recv_handle = blk.and(I64, &recv_bits, POINTER_MASK_I64);
             let len_i32 = blk.safe_load_i32_from_ptr(&recv_handle);
-            Ok(blk.sitofp(I32, &len_i32, DOUBLE))
+            Ok(blk.uitofp(I32, &len_i32, DOUBLE))
         }
 
         // Phase H err: `agg.errors` — AggregateError.errors field.
@@ -256,7 +256,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // `arr.length` / `str.length` — INLINE. Both ArrayHeader and
         // StringHeader start with `length: u32` (`crates/perry-runtime/src
         // /array.rs` and `string.rs`). Same pattern: unbox pointer, load
-        // u32 from offset 0, sitofp to double.
+        // u32 from offset 0, uitofp to double.
         // `.length` — INLINE for array, string, and interface-typed
         // receivers. Named types (interfaces, class instances) often
         // wrap strings or arrays at runtime, where length is at offset 0.
@@ -381,7 +381,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
             ctx.current_block = fast_idx;
             let fast_len_i32 = ctx.block().safe_load_i32_from_ptr(&recv_handle);
-            let fast_len = ctx.block().sitofp(I32, &fast_len_i32, DOUBLE);
+            let fast_len = ctx.block().uitofp(I32, &fast_len_i32, DOUBLE);
             let fast_pred_label = ctx.block().label.clone();
             ctx.block().br(&merge_label);
 

--- a/crates/perry-codegen/src/expr/typed_feedback.rs
+++ b/crates/perry-codegen/src/expr/typed_feedback.rs
@@ -83,7 +83,10 @@ impl TypedFeedbackContract {
     }
 
     pub(crate) const fn array_set_index() -> Self {
-        Self::new("plain_array_index_set_guard", "js_array_set_f64_extend")
+        Self::new(
+            "plain_array_index_set_guard",
+            "js_array_set_index_or_string",
+        )
     }
 
     // #854: near-future typed-feedback contract seam, not yet emitted.
@@ -96,7 +99,10 @@ impl TypedFeedbackContract {
     }
 
     pub(crate) const fn numeric_array_set_index() -> Self {
-        Self::new("numeric_array_index_set_guard", "js_array_set_f64_extend")
+        Self::new(
+            "numeric_array_index_set_guard",
+            "js_array_set_index_or_string",
+        )
     }
 
     // #854: near-future typed-feedback contract seam, not yet emitted.

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -199,12 +199,12 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function(
         "js_typed_feedback_plain_array_index_set_guard",
         I32,
-        &[I64, DOUBLE, I32, DOUBLE, I32],
+        &[I64, DOUBLE, DOUBLE, I32, DOUBLE, I32],
     );
     module.declare_function(
         "js_typed_feedback_numeric_array_index_set_guard",
         I32,
-        &[I64, DOUBLE, I32, DOUBLE, I32],
+        &[I64, DOUBLE, DOUBLE, I32, DOUBLE, I32],
     );
     module.declare_function(
         "js_typed_feedback_numeric_array_push_guard",
@@ -214,7 +214,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function(
         "js_typed_feedback_array_index_set_fallback_boxed",
         DOUBLE,
-        &[I64, DOUBLE, I32, DOUBLE],
+        &[I64, DOUBLE, DOUBLE, DOUBLE],
     );
     module.declare_function(
         "js_typed_feedback_observe_array_element",

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -3,7 +3,7 @@
 //! pulls these basics in via `use super::*;`.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 thread_local! {
     /// Tagged-template `.raw` side-table — maps a cooked-strings array
@@ -31,6 +31,13 @@ thread_local! {
     /// `"4294967295"` are stored here per ECMA-262.
     static ARRAY_NAMED_PROPS: RefCell<HashMap<usize, Vec<ArrayNamedProperty>>> =
         RefCell::new(HashMap::new());
+
+    /// Arrays whose logical length is intentionally larger than their dense
+    /// inline capacity because a very high index is stored in the named-property
+    /// side table. This preserves the ArrayHeader corruption guard for ordinary
+    /// arrays while allowing `a[4294967294] = v` to set `length` to 2^32-1
+    /// without allocating a dense 4B-slot buffer.
+    static ARRAY_SPARSE_LENGTHS: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
 }
 
 #[derive(Clone)]
@@ -269,6 +276,21 @@ pub(crate) fn scan_array_named_property_roots_mut(visitor: &mut crate::gc::Runti
             }
         }
     });
+    ARRAY_SPARSE_LENGTHS.with(|m| {
+        let mut sparse = m.borrow_mut();
+        let owners: Vec<usize> = sparse.iter().copied().collect();
+        let mut moved = Vec::new();
+        for owner in owners {
+            let mut new_owner = owner;
+            if visitor.visit_metadata_usize_slot(&mut new_owner) {
+                moved.push((owner, new_owner));
+            }
+        }
+        for (old_owner, new_owner) in moved {
+            sparse.remove(&old_owner);
+            sparse.insert(new_owner);
+        }
+    });
 }
 
 unsafe fn string_header_as_str<'a>(key: *const crate::StringHeader) -> Option<&'a str> {
@@ -404,6 +426,29 @@ pub(crate) unsafe fn array_named_property_delete(
         props.remove(index);
         true
     })
+}
+
+pub(crate) unsafe fn array_mark_sparse_length(arr: *mut ArrayHeader) {
+    if arr.is_null() {
+        return;
+    }
+    ARRAY_SPARSE_LENGTHS.with(|m| {
+        m.borrow_mut().insert(arr as usize);
+    });
+}
+
+pub(crate) unsafe fn array_clear_sparse_length(arr: *mut ArrayHeader) {
+    if arr.is_null() {
+        return;
+    }
+    ARRAY_SPARSE_LENGTHS.with(|m| {
+        m.borrow_mut().remove(&(arr as usize));
+    });
+}
+
+#[inline]
+pub(crate) fn array_has_sparse_length_owner(owner: usize) -> bool {
+    ARRAY_SPARSE_LENGTHS.with(|m| m.borrow().contains(&owner))
 }
 
 #[cfg(test)]
@@ -575,6 +620,7 @@ pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
             let addr = cleaned as usize;
             if !crate::buffer::is_registered_buffer(addr)
                 && crate::typedarray::lookup_typed_array_kind(addr).is_none()
+                && !array_has_sparse_length_owner(addr)
             {
                 return std::ptr::null();
             }

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -2,6 +2,8 @@
 use super::*;
 use std::ptr;
 
+const MAX_DENSE_ARRAY_WRITE_LENGTH: u32 = 100_000_000;
+
 #[no_mangle]
 pub extern "C" fn js_array_length(arr: *const ArrayHeader) -> u32 {
     let arr = {
@@ -95,10 +97,17 @@ pub extern "C" fn js_array_get_f64_unchecked(arr: *const ArrayHeader, index: u32
     const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
     unsafe {
         let length = (*arr).length;
+        let capacity = (*arr).capacity;
+        if index == u32::MAX || index >= capacity {
+            let name = index.to_string();
+            if let Some(value) = array_named_property_get_by_name(arr, &name) {
+                return value;
+            }
+        }
         if index >= length {
             return TAG_UNDEFINED_F64;
         }
-        if length > 100_000_000 {
+        if index >= capacity || capacity > MAX_DENSE_ARRAY_WRITE_LENGTH {
             return TAG_UNDEFINED_F64;
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -210,11 +219,18 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
     const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
     unsafe {
         let length = (*arr).length;
+        let capacity = (*arr).capacity;
+        if index == u32::MAX || index >= capacity {
+            let name = index.to_string();
+            if let Some(value) = array_named_property_get_by_name(arr, &name) {
+                return value;
+            }
+        }
         if index >= length {
             return TAG_UNDEFINED_F64;
         }
-        // Guard: corrupted arrays with unreasonably large length
-        if length > 100_000_000 {
+        // Guard: dense storage is only safe up to the actual inline capacity.
+        if index >= capacity || capacity > MAX_DENSE_ARRAY_WRITE_LENGTH {
             return TAG_UNDEFINED_F64;
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -243,6 +259,9 @@ pub extern "C" fn js_array_set_f64_unchecked(arr: *mut ArrayHeader, index: u32, 
     unsafe {
         let length = (*arr).length;
         if index >= length {
+            return;
+        }
+        if index >= (*arr).capacity {
             return;
         }
         let value = canonicalize_array_numeric_store_value(arr, value);
@@ -305,6 +324,9 @@ pub extern "C" fn js_array_set_f64(arr: *mut ArrayHeader, index: u32, value: f64
         if index >= length {
             return;
         }
+        if index >= (*arr).capacity {
+            return;
+        }
         let value = canonicalize_array_numeric_store_value(arr, value);
         let value_bits = value.to_bits();
         let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
@@ -312,6 +334,47 @@ pub extern "C" fn js_array_set_f64(arr: *mut ArrayHeader, index: u32, value: f64
         ptr::write(elements_ptr.add(index as usize), value);
         note_array_slot(arr, index as usize, value_bits);
     }
+}
+
+unsafe fn js_array_set_sparse_index_property(
+    arr: *mut ArrayHeader,
+    index: u32,
+    value: f64,
+) -> *mut ArrayHeader {
+    if arr.is_null() || index == u32::MAX {
+        return arr;
+    }
+    if array_is_frozen(arr) {
+        return arr;
+    }
+
+    let name = index.to_string();
+    let existing = array_named_property_get_by_name(arr, &name).is_some();
+    if !existing && array_is_sealed_or_no_extend(arr) {
+        return arr;
+    }
+    if let Some(attrs) = crate::object::get_property_attrs(arr as usize, &name) {
+        if !attrs.writable() {
+            return arr;
+        }
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+    let value_handle = scope.root_nanbox_f64(value);
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
+    if arr.is_null() {
+        return arr;
+    }
+
+    array_mark_sparse_length(arr);
+    array_named_property_set(arr, key, value_handle.get_nanbox_f64());
+    let new_length = index + 1;
+    if new_length > (*arr).length {
+        (*arr).length = new_length;
+    }
+    arr
 }
 
 /// Set an element in an array by index, extending the array if needed
@@ -364,6 +427,13 @@ pub extern "C" fn js_array_set_f64_extend(
             if is_frozen {
                 return arr;
             }
+            if index >= (*arr).capacity {
+                return js_array_set_sparse_index_property(
+                    arr,
+                    index,
+                    value_handle.get_nanbox_f64(),
+                );
+            }
             let value = canonicalize_array_numeric_store_value(arr, value);
             let value_bits = value.to_bits();
             let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
@@ -379,6 +449,9 @@ pub extern "C" fn js_array_set_f64_extend(
 
         // Need to extend the array
         let new_length = index + 1;
+        if new_length > MAX_DENSE_ARRAY_WRITE_LENGTH {
+            return js_array_set_sparse_index_property(arr, index, value_handle.get_nanbox_f64());
+        }
         let arr = if new_length > (*arr).capacity {
             js_array_grow(arr, new_length)
         } else {

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -97,13 +97,13 @@ pub use self::splice_slice::{
 pub(crate) use self::alloc::array_length_from_property_value_or_throw;
 pub(crate) use self::alloc::{js_array_from_arraylike, js_array_from_string_codepoints};
 pub(crate) use self::header::{
-    array_byte_size, array_is_frozen, array_is_sealed_or_no_extend, array_named_property_delete,
-    array_named_property_get, array_named_property_get_by_name, array_named_property_has,
-    array_named_property_names, array_named_property_set, array_numeric_raw_f64_get,
-    array_numeric_raw_f64_push_inbounds, array_numeric_raw_f64_set_inbounds, array_object_flags,
-    canonicalize_array_numeric_store_value, clean_arr_ptr, clean_arr_ptr_mut,
-    clear_array_numeric_layout, clear_array_numeric_layout_ptr, gc_element_slot_range,
-    mark_array_layout_unknown, normalize_array_receiver, note_array_slot,
+    array_byte_size, array_clear_sparse_length, array_is_frozen, array_is_sealed_or_no_extend,
+    array_mark_sparse_length, array_named_property_delete, array_named_property_get,
+    array_named_property_get_by_name, array_named_property_has, array_named_property_names,
+    array_named_property_set, array_numeric_raw_f64_get, array_numeric_raw_f64_push_inbounds,
+    array_numeric_raw_f64_set_inbounds, array_object_flags, canonicalize_array_numeric_store_value,
+    clean_arr_ptr, clean_arr_ptr_mut, clear_array_numeric_layout, clear_array_numeric_layout_ptr,
+    gc_element_slot_range, mark_array_layout_unknown, normalize_array_receiver, note_array_slot,
     note_array_slot_layout_only, rebuild_array_layout, rebuild_array_layout_exact,
     refresh_array_numeric_layout, replay_array_growth_write_barriers, set_array_numeric_layout,
     store_array_slot, transfer_array_numeric_layout, value_bits_to_number, NumericArrayLayout,

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -285,10 +285,14 @@ pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
             // not stale data. The capacity stays unchanged — JS doesn't
             // require Perry to release the underlying buffer here, and growing
             // back via `push` would just re-overwrite these slots anyway.
-            for i in n..cur {
+            let dense_end = cur.min((*arr).capacity);
+            for i in n..dense_end {
                 note_array_slot(arr, i as usize, crate::value::TAG_HOLE);
             }
             (*arr).length = n;
+            if n <= (*arr).capacity {
+                array_clear_sparse_length(arr);
+            }
             refresh_array_numeric_layout(arr);
         } else if n > cur {
             // Extend: pad with TAG_HOLE. Past-capacity extensions go
@@ -296,6 +300,12 @@ pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
             // the OLD location (issue #233 mechanism), so the caller's stale
             // pointer transparently follows the chain to the resized buffer
             // on the next access — no callsite-side writeback needed.
+            if n > 100_000_000 {
+                array_mark_sparse_length(arr);
+                (*arr).length = n;
+                refresh_array_numeric_layout(arr);
+                return;
+            }
             let target = if n > (*arr).capacity {
                 js_array_grow(arr, n)
             } else {

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -146,6 +146,50 @@ fn test_array_exotic_named_indices_and_boundary_props() {
         crate::object::js_object_get_field_by_name(arr_obj, max_key).bits(),
         99.0f64.to_bits()
     );
+    assert_eq!(js_array_get_f64(arr, u32::MAX), 99.0);
+    assert_eq!(
+        crate::object::js_object_has_property(boxed_pointer(arr as *mut u8), string_value(max_key))
+            .to_bits(),
+        crate::value::TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_object_has_property(boxed_pointer(arr as *mut u8), u32::MAX as f64)
+            .to_bits(),
+        crate::value::TAG_TRUE
+    );
+
+    arr = js_array_set_f64_extend(arr, u32::MAX - 1, 123.0);
+    assert_eq!(
+        js_array_length(arr),
+        u32::MAX,
+        "2^32-2 is the maximum array index"
+    );
+    assert_eq!(js_array_get_f64(arr, u32::MAX - 1), 123.0);
+    assert_eq!(
+        crate::object::js_object_get_field_by_name(arr_obj, string_key(b"4294967294")).bits(),
+        123.0f64.to_bits()
+    );
+    assert_eq!(
+        crate::object::js_object_has_own(
+            boxed_pointer(arr as *mut u8),
+            string_value(string_key(b"4294967294"))
+        )
+        .to_bits(),
+        crate::value::TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_object_has_property(
+            boxed_pointer(arr as *mut u8),
+            string_value(string_key(b"4294967294"))
+        )
+        .to_bits(),
+        crate::value::TAG_TRUE
+    );
+    assert_eq!(
+        crate::object::js_object_has_property(boxed_pointer(arr as *mut u8), (u32::MAX - 1) as f64)
+            .to_bits(),
+        crate::value::TAG_TRUE
+    );
 
     let foo = string_key(b"foo");
     crate::object::js_object_set_field_by_name(arr_obj, foo, 7.0);
@@ -157,6 +201,7 @@ fn test_array_exotic_named_indices_and_boundary_props() {
     let keys = crate::object::js_object_keys(arr_obj);
     assert!(array_keys_contain(keys, b"2"));
     assert!(array_keys_contain(keys, b"foo"));
+    assert!(array_keys_contain(keys, b"4294967294"));
     assert!(array_keys_contain(keys, b"4294967295"));
     assert!(!array_keys_contain(keys, b"0"));
 }

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -801,10 +801,12 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                 None
             };
             if let Some(n) = n {
-                let result = crate::array::js_array_alloc(n + 1);
                 if crate::array::js_array_is_array(obj_value).to_bits() == TAG_TRUE_BITS {
                     let ap = extract_obj_ptr(obj_value) as *const crate::array::ArrayHeader;
-                    for i in 0..n {
+                    let named = crate::array::array_named_property_names(ap, false);
+                    let dense_len = n.min((*ap).capacity).min(100_000);
+                    let result = crate::array::js_array_alloc(dense_len + 1 + named.len() as u32);
+                    for i in 0..dense_len {
                         if super::has_own_helpers::array_own_key_present(ap, {
                             let s = i.to_string();
                             crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32)
@@ -816,12 +818,14 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                     }
                     let lk = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
                     crate::array::js_array_push(result, JSValue::string_ptr(lk));
-                    for name in crate::array::array_named_property_names(ap, false) {
+                    for name in named {
                         let k =
                             crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
                         crate::array::js_array_push(result, JSValue::string_ptr(k));
                     }
+                    return f64::from_bits((result as u64) | 0x7FFD_0000_0000_0000);
                 } else {
+                    let result = crate::array::js_array_alloc(n + 1);
                     for i in 0..n {
                         let s = i.to_string();
                         let k = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
@@ -829,8 +833,8 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                     }
                     let lk = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
                     crate::array::js_array_push(result, JSValue::string_ptr(lk));
+                    return f64::from_bits((result as u64) | 0x7FFD_0000_0000_0000);
                 }
-                return f64::from_bits((result as u64) | 0x7FFD_0000_0000_0000);
             }
         }
 

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1361,14 +1361,16 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
             if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
                 let arr = stripped as *const crate::array::ArrayHeader;
                 let length = (*arr).length;
-                if length > 100_000 {
+                let named = crate::array::array_named_property_names(arr, true);
+                if length > 100_000 && named.is_empty() {
                     return crate::array::js_array_alloc(0);
                 }
                 let elements = (arr as *const u8)
                     .add(std::mem::size_of::<crate::array::ArrayHeader>())
                     as *const u64;
-                let result = crate::array::js_array_alloc(length);
-                for i in 0..length {
+                let dense_len = length.min((*arr).capacity).min(100_000);
+                let result = crate::array::js_array_alloc(dense_len + named.len() as u32);
+                for i in 0..dense_len {
                     if std::ptr::read(elements.add(i as usize)) == crate::value::TAG_HOLE {
                         continue;
                     }
@@ -1379,7 +1381,7 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                     let key_box = crate::string::js_string_new_sso(s.as_ptr(), s.len() as u32);
                     crate::array::js_array_push_f64(result, key_box);
                 }
-                for name in crate::array::array_named_property_names(arr, true) {
+                for name in named {
                     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
                     crate::array::js_array_push(result, JSValue::string_ptr(key));
                 }
@@ -1834,12 +1836,10 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
             if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
                 let arr = obj_ptr as *const crate::array::ArrayHeader;
                 let length = (*arr).length;
-                if length > 100_000 {
-                    return nanbox_false;
-                }
                 // Numeric key: extract the index. Accept both NaN-boxed i32
                 // and plain f64 (e.g. literal `1`) provided it's a
                 // non-negative integer in range.
+                let mut numeric_property_name: Option<String> = None;
                 let idx: Option<u32> = if key_val.is_int32() {
                     let i = key_val.as_int32();
                     if i >= 0 {
@@ -1852,6 +1852,9 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                     if f >= 0.0 && f.fract() == 0.0 && f < u32::MAX as f64 {
                         Some(f as u32)
                     } else {
+                        if f.is_finite() && f.fract() == 0.0 {
+                            numeric_property_name = Some(format!("{}", f));
+                        }
                         None
                     }
                 } else {
@@ -1861,6 +1864,16 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                     if idx >= length {
                         return nanbox_false;
                     }
+                    if idx >= (*arr).capacity {
+                        let name = idx.to_string();
+                        return if crate::array::array_named_property_get_by_name(arr, &name)
+                            .is_some()
+                        {
+                            nanbox_true
+                        } else {
+                            nanbox_false
+                        };
+                    }
                     let elements = (arr as *const u8)
                         .add(std::mem::size_of::<crate::array::ArrayHeader>())
                         as *const u64;
@@ -1868,6 +1881,11 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                         return nanbox_false;
                     }
                     return nanbox_true;
+                }
+                if let Some(name) = numeric_property_name {
+                    if crate::array::array_named_property_get_by_name(arr, &name).is_some() {
+                        return nanbox_true;
+                    }
                 }
                 if key_val.is_any_string() {
                     let key_str = crate::value::js_get_string_pointer_unified(key)
@@ -1881,6 +1899,17 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                             }
                             if let Some(index) = super::canonical_array_index(key_name) {
                                 if index < length {
+                                    if index >= (*arr).capacity {
+                                        return if crate::array::array_named_property_get_by_name(
+                                            arr, key_name,
+                                        )
+                                        .is_some()
+                                        {
+                                            nanbox_true
+                                        } else {
+                                            nanbox_false
+                                        };
+                                    }
                                     let elements = (arr as *const u8)
                                         .add(std::mem::size_of::<crate::array::ArrayHeader>())
                                         as *const u64;

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -96,6 +96,9 @@ pub(super) unsafe fn array_own_key_present(
     if index >= length {
         return false;
     }
+    if index >= (*arr).capacity {
+        return false;
+    }
     let elements =
         (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const u64;
     std::ptr::read(elements.add(index as usize)) != crate::value::TAG_HOLE

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -491,6 +491,13 @@ fn array_layout_kind(addr: usize, len: u64) -> u8 {
     }
 }
 
+fn valid_i32_array_index_value(index_value: f64, index: i32) -> bool {
+    index >= 0
+        && index_value.is_finite()
+        && index_value.trunc() == index_value
+        && index_value == index as f64
+}
+
 fn array_element_kind(addr: usize, index: Option<u32>, len: u64, layout_kind: u8) -> u16 {
     let Some(index) = index else {
         return layout_kind as u16;
@@ -602,14 +609,24 @@ fn classify_array(addr: usize, index: Option<u32>) -> (u32, u16, u64, u16) {
             );
         }
 
-        let len = (*(addr as *const ArrayHeader)).length as u64;
+        let arr = addr as *const ArrayHeader;
+        let len = (*arr).length as u64;
+        let capacity = (*arr).capacity as u64;
         let access_kind = match index {
             Some(i) if i != u32::MAX && i as u64 >= len => ARRAY_ACCESS_INDEXED_OUT_OF_BOUNDS,
             _ => access_kind,
         };
-        let layout_kind = array_layout_kind(addr, len);
-        let element_kind =
-            array_element_kind(addr, index.filter(|i| *i != u32::MAX), len, layout_kind);
+        let dense_layout_safe = len <= capacity && len <= 16_000_000;
+        let layout_kind = if dense_layout_safe {
+            array_layout_kind(addr, len)
+        } else {
+            ARRAY_LAYOUT_UNKNOWN
+        };
+        let element_kind = if dense_layout_safe {
+            array_element_kind(addr, index.filter(|i| *i != u32::MAX), len, layout_kind)
+        } else {
+            STABLE_VALUE_UNDEFINED
+        };
         (
             0,
             gc_type as u16,
@@ -1181,7 +1198,7 @@ pub extern "C" fn js_typed_feedback_plain_array_index_get_guard(
         value_tag: element_kind,
     };
     let contract_valid = is_plain_number_bits(index_value.to_bits())
-        && index >= 0
+        && valid_i32_array_index_value(index_value, index)
         && plain_array_index_guard(
             raw_addr as *const ArrayHeader,
             index as u32,
@@ -1222,7 +1239,7 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_get_guard(
         value_tag: element_kind,
     };
     let contract_valid = is_plain_number_bits(index_value.to_bits())
-        && index >= 0
+        && valid_i32_array_index_value(index_value, index)
         && numeric_array_index_guard(
             raw_addr as *const ArrayHeader,
             index as u32,
@@ -1389,6 +1406,7 @@ pub extern "C" fn js_typed_feedback_array_set_f64_extend(
 pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
     site_id: u64,
     receiver: f64,
+    index_value: f64,
     index: i32,
     value: f64,
     require_in_bounds: i32,
@@ -1406,7 +1424,7 @@ pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
         aux,
         value_tag: stable_value_kind(value.to_bits()),
     };
-    let contract_valid = index >= 0
+    let contract_valid = valid_i32_array_index_value(index_value, index)
         && plain_array_index_guard(
             raw_addr as *const ArrayHeader,
             index as u32,
@@ -1429,6 +1447,7 @@ pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
 pub extern "C" fn js_typed_feedback_numeric_array_index_set_guard(
     site_id: u64,
     receiver: f64,
+    index_value: f64,
     index: i32,
     value: f64,
     require_in_bounds: i32,
@@ -1446,7 +1465,7 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_set_guard(
         aux,
         value_tag: stable_value_kind(value.to_bits()),
     };
-    let contract_valid = index >= 0
+    let contract_valid = valid_i32_array_index_value(index_value, index)
         && is_numeric_value_bits(value.to_bits())
         && numeric_array_index_guard(
             raw_addr as *const ArrayHeader,
@@ -1507,7 +1526,7 @@ pub extern "C" fn js_typed_feedback_numeric_array_push_guard(
 pub extern "C" fn js_typed_feedback_array_index_set_fallback_boxed(
     site_id: u64,
     receiver: f64,
-    index: i32,
+    index: f64,
     value: f64,
 ) -> f64 {
     record_fallback_call(site_id);
@@ -1517,15 +1536,10 @@ pub extern "C" fn js_typed_feedback_array_index_set_fallback_boxed(
         return receiver;
     }
 
-    let index_value = index as f64;
     if crate::buffer::is_registered_buffer(raw_addr)
         || crate::typedarray::lookup_typed_array_kind(raw_addr).is_some()
     {
-        crate::array::js_array_set_index_or_string(
-            raw_addr as *mut ArrayHeader,
-            index_value,
-            value,
-        );
+        crate::array::js_array_set_index_or_string(raw_addr as *mut ArrayHeader, index, value);
         return receiver;
     }
 
@@ -1540,14 +1554,13 @@ pub extern "C" fn js_typed_feedback_array_index_set_fallback_boxed(
             crate::gc::GC_TYPE_ARRAY | crate::gc::GC_TYPE_LAZY_ARRAY => {
                 let new_arr = crate::array::js_array_set_index_or_string(
                     raw_addr as *mut ArrayHeader,
-                    index_value,
+                    index,
                     value,
                 );
                 crate::value::js_nanbox_pointer(new_arr as i64)
             }
             crate::gc::GC_TYPE_OBJECT | crate::gc::GC_TYPE_CLOSURE => {
-                let key = index.to_string();
-                let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+                let key_ptr = index_value_to_property_key(index);
                 crate::object::js_object_set_field_by_name(
                     raw_addr as *mut ObjectHeader,
                     key_ptr,
@@ -1589,7 +1602,7 @@ pub extern "C" fn js_typed_feedback_array_set_index_or_string(
     idx: f64,
     value: f64,
 ) -> *mut ArrayHeader {
-    let index = if idx.is_finite() && idx >= 0.0 && idx <= u32::MAX as f64 {
+    let index = if idx.is_finite() && idx >= 0.0 && idx < u32::MAX as f64 {
         idx as u32
     } else {
         u32::MAX

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -462,10 +462,10 @@ fn typed_feedback_non_bounded_array_set_guard_failure_uses_jsvalue_object_fallba
     // Models an array-typed compiled local slot that receives an object
     // from a dynamic boundary: the non-bounded set guard must fail before
     // codegen can read ArrayHeader fields or raw-store an element.
-    let guard = js_typed_feedback_plain_array_index_set_guard(24, obj_box, 0, 99.0, 0);
+    let guard = js_typed_feedback_plain_array_index_set_guard(24, obj_box, 0.0, 0, 99.0, 0);
     assert_eq!(guard, 0);
 
-    let returned = js_typed_feedback_array_index_set_fallback_boxed(24, obj_box, 0, 99.0);
+    let returned = js_typed_feedback_array_index_set_fallback_boxed(24, obj_box, 0.0, 99.0);
     assert_eq!(returned.to_bits(), obj_box.to_bits());
 
     let key = crate::string::js_string_from_bytes(b"0".as_ptr(), 1);
@@ -515,17 +515,17 @@ fn typed_feedback_numeric_array_set_guard_requires_numeric_value_and_layout() {
     let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
     let arr_box = crate::value::js_nanbox_pointer(arr as i64);
 
-    let first = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, 3.0, 1);
+    let first = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1.0, 1, 3.0, 1);
     assert_eq!(first, 1);
 
     let payload = crate::string::js_string_from_bytes(b"not-number".as_ptr(), 10);
     let payload_value = crate::value::js_nanbox_string(payload as i64);
     let nonnumeric =
-        js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, payload_value, 1);
+        js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1.0, 1, payload_value, 1);
     assert_eq!(nonnumeric, 0);
 
     crate::array::js_array_set_f64(arr, 0, payload_value);
-    let downgraded = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1, 4.0, 1);
+    let downgraded = js_typed_feedback_numeric_array_index_set_guard(27, arr_box, 1.0, 1, 4.0, 1);
     assert_eq!(downgraded, 0);
 
     let site = &typed_feedback_snapshot().sites[0];
@@ -1051,14 +1051,14 @@ fn typed_feedback_trace_json_includes_observed_kinds() {
     let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
     let arr_box = crate::value::js_nanbox_pointer(arr as i64);
     assert_eq!(
-        js_typed_feedback_numeric_array_index_set_guard(67, arr_box, 1, 3.0, 1),
+        js_typed_feedback_numeric_array_index_set_guard(67, arr_box, 1.0, 1, 3.0, 1),
         1
     );
 
     let payload = crate::string::js_string_from_bytes(b"not-number".as_ptr(), 10);
     let payload_value = crate::value::js_nanbox_string(payload as i64);
     assert_eq!(
-        js_typed_feedback_numeric_array_index_set_guard(67, arr_box, 1, payload_value, 1),
+        js_typed_feedback_numeric_array_index_set_guard(67, arr_box, 1.0, 1, payload_value, 1),
         0
     );
 

--- a/crates/perry-runtime/src/typed_feedback/trace.rs
+++ b/crates/perry-runtime/src/typed_feedback/trace.rs
@@ -365,8 +365,8 @@ mod keep_typed_feedback {
     #[used] static K12: extern "C" fn(u64, f64, f64) -> f64 = js_typed_feedback_array_index_get_fallback_boxed;
     #[used] static K13: extern "C" fn(u64, *mut ArrayHeader, u32, f64) = js_typed_feedback_array_set_f64;
     #[used] static K14: extern "C" fn(u64, *mut ArrayHeader, u32, f64) -> *mut ArrayHeader = js_typed_feedback_array_set_f64_extend;
-    #[used] static K15: extern "C" fn(u64, f64, i32, f64, i32) -> i32 = js_typed_feedback_plain_array_index_set_guard;
-    #[used] static K16: extern "C" fn(u64, f64, i32, f64) -> f64 = js_typed_feedback_array_index_set_fallback_boxed;
+    #[used] static K15: extern "C" fn(u64, f64, f64, i32, f64, i32) -> i32 = js_typed_feedback_plain_array_index_set_guard;
+    #[used] static K16: extern "C" fn(u64, f64, f64, f64) -> f64 = js_typed_feedback_array_index_set_fallback_boxed;
     #[used] static K17: extern "C" fn(u64, *const ArrayHeader, u32) = js_typed_feedback_observe_array_element;
     #[used] static K18: extern "C" fn(u64, *mut ArrayHeader, *const crate::StringHeader, f64) -> *mut ArrayHeader = js_typed_feedback_array_set_string_key;
     #[used] static K19: extern "C" fn(u64, *mut ArrayHeader, f64, f64) -> *mut ArrayHeader = js_typed_feedback_array_set_index_or_string;

--- a/test-parity/node-suite/globals/array-large-index-boundary.ts
+++ b/test-parity/node-suite/globals/array-large-index-boundary.ts
@@ -1,0 +1,25 @@
+function show(label: string, value: any) {
+  try {
+    console.log(label + ':', String(value));
+  } catch (err: any) {
+    console.log(label + ': throw', err && err.name, err && err.message);
+  }
+}
+
+const a: any = [0, 1, 2];
+a[4294967295] = 'x';
+show('a length', a.length);
+show('a max-u32', a[4294967295]);
+show('a string max-u32', a['4294967295']);
+show('a has max-u32', 4294967295 in a);
+show('a own max-u32', Object.prototype.hasOwnProperty.call(a, '4294967295'));
+show('a keys', Object.keys(a).join(','));
+
+const b: any = [0, 1, 2];
+b[4294967294] = 'y';
+show('b length', b.length);
+show('b max-index', b[4294967294]);
+show('b string max-index', b['4294967294']);
+show('b has max-index', 4294967294 in b);
+show('b own max-index', Object.prototype.hasOwnProperty.call(b, '4294967294'));
+show('b keys tail', Object.keys(b).slice(-3).join(','));


### PR DESCRIPTION
Fixes #4557

Summary:
- Preserve raw numeric keys for large array index get/set and typed-feedback fallback paths.
- Store the maximum valid array index (4294967294) sparsely without allocating a huge dense buffer, while treating 4294967295 as a named property.
- Bound array own-key enumeration by dense capacity and append sparse/named properties.

Tests:
- cargo check -q -p perry-codegen -p perry-runtime
- cargo test -q -p perry-runtime test_array_exotic_named_indices_and_boundary_props
- cargo test -q -p perry-runtime typed_feedback_numeric_array_set_guard_requires_numeric_value_and_layout
- cargo test -q -p perry-runtime typed_feedback_non_bounded_array_set_guard_failure_uses_jsvalue_object_fallback
- Direct Node 26 vs Perry diff for test-parity/node-suite/globals/array-large-index-boundary.ts