### PR TITLE
fix(runtime): preserve BigInt typed-array coercion

### DIFF
--- a/crates/perry-runtime/src/buffer/access.rs
+++ b/crates/perry-runtime/src/buffer/access.rs
@@ -142,6 +142,11 @@ unsafe fn collect_buffer_set_bytes(source: BufferSetSource, source_len: usize) -
             }
         }
         BufferSetSource::TypedArray(ptr) => {
+            if let Some(kind) = crate::typedarray::lookup_typed_array_kind(ptr as usize) {
+                if crate::typedarray::bigint::is_bigint_kind(kind) {
+                    crate::typedarray::bigint::throw_bigint_number_mix();
+                }
+            }
             for i in 0..source_len {
                 bytes.push(to_uint8(crate::typedarray::js_typed_array_get(
                     ptr, i as i32,

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -546,6 +546,24 @@ pub extern "C" fn js_uint8array_new(val: f64) -> *mut BufferHeader {
                 return dst;
             }
         }
+        if let Some(src_kind) = crate::typedarray::lookup_typed_array_kind(raw) {
+            if crate::typedarray::bigint::is_bigint_kind(src_kind) {
+                crate::typedarray::bigint::throw_bigint_number_mix();
+            }
+            let src = raw as *const crate::typedarray::TypedArrayHeader;
+            unsafe {
+                let len = crate::typedarray::js_typed_array_length(src).max(0) as u32;
+                let dst = buffer_alloc(len);
+                (*dst).length = len;
+                let dst_data = buffer_data_mut(dst);
+                for i in 0..len as usize {
+                    let value = crate::typedarray::js_typed_array_get(src, i as i32);
+                    *dst_data.add(i) = buffer_byte_from_js_value(value);
+                }
+                mark_as_uint8array(dst as usize);
+                return dst;
+            }
+        }
         // Otherwise treat as a numeric source array.
         return js_uint8array_from_array(raw as *const ArrayHeader);
     }

--- a/crates/perry-runtime/src/typedarray/bigint.rs
+++ b/crates/perry-runtime/src/typedarray/bigint.rs
@@ -10,7 +10,47 @@
 //!   - `coerce_for_kind` — pick `ToBigInt` vs `ToNumber` by destination kind
 //!     for the construction / `set()` paths.
 
-use super::{jsvalue_to_f64, throw_type_error, KIND_BIGINT64, KIND_BIGUINT64};
+use super::{
+    jsvalue_to_f64, store_at, throw_type_error, typed_array_alloc, TypedArrayHeader, KIND_BIGINT64,
+    KIND_BIGUINT64,
+};
+
+pub(crate) fn is_bigint_kind(kind: u8) -> bool {
+    matches!(kind, KIND_BIGINT64 | KIND_BIGUINT64)
+}
+
+#[cold]
+pub(crate) fn throw_bigint_number_mix() -> ! {
+    throw_type_error(b"Cannot mix BigInt and other types, use explicit conversions")
+}
+
+#[inline]
+pub(super) fn validate_copy_kinds(dst_kind: u8, src_kind: u8) {
+    if is_bigint_kind(dst_kind) != is_bigint_kind(src_kind) {
+        throw_bigint_number_mix();
+    }
+}
+
+pub(super) fn copy_from_uint8_buffer(
+    dst_kind: u8,
+    src: *const crate::buffer::BufferHeader,
+) -> *mut TypedArrayHeader {
+    if is_bigint_kind(dst_kind) {
+        throw_bigint_number_mix();
+    }
+    if src.is_null() {
+        return typed_array_alloc(dst_kind, 0);
+    }
+    unsafe {
+        let len = (*src).length;
+        let out = typed_array_alloc(dst_kind, len);
+        for i in 0..len as usize {
+            let v = crate::buffer::js_buffer_get(src, i as i32) as f64;
+            store_at(out, i, v);
+        }
+        out
+    }
+}
 
 /// Extract the low 64 bits to write into a `BigInt64`/`BigUint64` slot. The
 /// element-set path hands us an already-`ToBigInt`-coerced, NaN-boxed BigInt

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -604,7 +604,7 @@ fn jsvalue_to_f64(v: f64) -> f64 {
 }
 
 /// Store a number into the typed array slot, performing the per-kind cast.
-unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64) {
+pub(super) unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64) {
     let kind = (*ta).kind;
     let elem_size = (*ta).elem_size as usize;
     let base = data_ptr_mut(ta);
@@ -782,11 +782,17 @@ pub extern "C" fn js_typed_array_new(kind: i32, val: f64) -> *mut TypedArrayHead
                 raw_addr as *const TypedArrayHeader,
             );
         }
-        if crate::buffer::is_registered_buffer(raw_addr)
-            && crate::buffer::is_any_array_buffer(raw_addr)
-        {
-            let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
-            return crate::typedarray_view::js_typed_array_view(kind, val, undefined, undefined);
+        if crate::buffer::is_registered_buffer(raw_addr) {
+            if crate::buffer::is_any_array_buffer(raw_addr) {
+                let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+                return crate::typedarray_view::js_typed_array_view(
+                    kind, val, undefined, undefined,
+                );
+            }
+            return bigint::copy_from_uint8_buffer(
+                kind as u8,
+                raw_addr as *const crate::buffer::BufferHeader,
+            );
         }
         return js_typed_array_new_from_array(kind, arr);
     }
@@ -837,6 +843,7 @@ fn typed_array_copy_from_typed_array(
         return typed_array_alloc(dst_kind, 0);
     }
     unsafe {
+        bigint::validate_copy_kinds(dst_kind, (*src).kind);
         let len = (*src).length;
         let out = typed_array_alloc(dst_kind, len);
         for i in 0..len as usize {
@@ -1034,10 +1041,30 @@ unsafe fn collect_typed_array_set_source(source_value: f64, dst_kind: u8) -> Opt
     // Source is another typed array.
     if lookup_typed_array_kind(addr).is_some() {
         let src = addr as *const TypedArrayHeader;
+        bigint::validate_copy_kinds(dst_kind, (*src).kind);
         let len = (*src).length as usize;
         let mut out = Vec::with_capacity(len);
         for i in 0..len {
             out.push(load_at(src, i));
+        }
+        return Some(out);
+    }
+
+    // Perry's Uint8Array is Buffer-backed; treat it as a numeric typed-array
+    // source for inter-kind copy/coercion instead of reading its bytes as f64
+    // array slots.
+    if crate::buffer::is_registered_buffer(addr) {
+        if crate::buffer::is_any_array_buffer(addr) {
+            return Some(Vec::new());
+        }
+        if bigint::is_bigint_kind(dst_kind) {
+            bigint::throw_bigint_number_mix();
+        }
+        let src = addr as *const crate::buffer::BufferHeader;
+        let len = (*src).length as usize;
+        let mut out = Vec::with_capacity(len);
+        for i in 0..len {
+            out.push(crate::buffer::js_buffer_get(src, i as i32) as f64);
         }
         return Some(out);
     }
@@ -1413,10 +1440,11 @@ pub extern "C" fn js_typed_array_with(
             throw_range_error(b"Invalid typed array index");
         }
         let idx = resolved as i64;
+        let replacement = bigint::coerce_for_kind(kind, value);
         let out = typed_array_alloc(kind, len as u32);
         for i in 0..len {
             if i as i64 == idx {
-                store_at(out, i, jsvalue_to_f64(value));
+                store_at(out, i, replacement);
             } else {
                 store_at(out, i, load_at(ta, i));
             }
@@ -1510,7 +1538,7 @@ pub extern "C" fn js_typed_array_map(
         for i in 0..len {
             let v = load_at(ta, i);
             let r = crate::closure::js_closure_call3(callback, v, i as f64, recv);
-            store_at(out, i, jsvalue_to_f64(r));
+            store_at(out, i, bigint::coerce_for_kind(kind, r));
         }
         out
     }
@@ -1882,7 +1910,7 @@ pub extern "C" fn js_typed_array_fill(
     }
     unsafe {
         let len = (*ta).length as isize;
-        let v = jsvalue_to_f64(value);
+        let v = bigint::coerce_for_kind((*ta).kind, value);
         let norm = |x: f64, default: isize| -> isize {
             let mut n = if x.is_nan() { default } else { x as isize };
             if n < 0 {

--- a/test-parity/node-suite/bigint/typed-array/harness-coercion.ts
+++ b/test-parity/node-suite/bigint/typed-array/harness-coercion.ts
@@ -1,0 +1,90 @@
+// @ts-nocheck
+
+const constructors: any[] = [
+  Int8Array,
+  Uint8Array,
+  Uint8ClampedArray,
+  Int16Array,
+  Uint16Array,
+  Int32Array,
+  Uint32Array,
+  Float16Array,
+  Float32Array,
+  Float64Array,
+  BigInt64Array,
+  BigUint64Array,
+];
+
+function isBigIntCtor(ctor: any): boolean {
+  return ctor === BigInt64Array || ctor === BigUint64Array;
+}
+
+function sampleValues(ctor: any): any[] {
+  return isBigIntCtor(ctor) ? [1n, 2n, 3n] : [1, 2, 3];
+}
+
+function replacementValue(ctor: any): any {
+  return isBigIntCtor(ctor) ? 9n : 9;
+}
+
+function viewValues(view: any): string {
+  const parts: string[] = [];
+  for (let i = 0; i < view.length; i++) {
+    parts.push(String(view[i]) + ":" + typeof view[i]);
+  }
+  return parts.join("|");
+}
+
+function showView(label: string, view: any): void {
+  console.log(label + ":" + view.length + ":" + viewValues(view));
+}
+
+function showThrow(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(label + ":NO_THROW");
+  } catch (error) {
+    console.log(label + ":" + error.constructor.name + " - " + error.message);
+  }
+}
+
+for (const Ctor of constructors) {
+  const name = Ctor.name;
+  const lengthView = new Ctor(3);
+  console.log(
+    "isView:" +
+      name +
+      ":" +
+      ArrayBuffer.isView(lengthView) +
+      ":" +
+      lengthView.length +
+      ":" +
+      typeof lengthView[0],
+  );
+
+  const fromArray = new Ctor(sampleValues(Ctor));
+  showView("fromArray:" + name, fromArray);
+  showView("copyWithin:" + name, fromArray.copyWithin(1, 0, 2));
+  showView("map:" + name, fromArray.map((value: any) => value));
+  showView("with:" + name, fromArray.with(0, replacementValue(Ctor)));
+  const filled = new Ctor(sampleValues(Ctor));
+  showView("fill:" + name, filled.fill(replacementValue(Ctor), 1));
+}
+
+showThrow("BigInt64Array number array", () => {
+  new BigInt64Array([1, 2] as any);
+});
+showThrow("BigInt64Array numeric TA source", () => {
+  new BigInt64Array(new Uint8Array([1, 2]) as any);
+});
+showThrow("BigInt64Array set numeric TA", () => {
+  const target = new BigInt64Array(2);
+  target.set(new Uint8Array([1, 2]) as any);
+});
+showThrow("Uint8Array bigint TA source", () => {
+  new Uint8Array(new BigInt64Array([1n, 2n]) as any);
+});
+showThrow("Uint8Array set bigint TA", () => {
+  const target = new Uint8Array(2);
+  target.set(new BigInt64Array([1n, 2n]) as any);
+});


### PR DESCRIPTION
Fixes #4518

Behavior cluster:
- Routes `BigInt64Array` / `BigUint64Array` `map`, `with`, and `fill` writes through the destination-kind `ToBigInt` path instead of `ToNumber`.
- Rejects mixed numeric typed-array and BigInt typed-array source copies with Node-shaped `TypeError: Cannot mix BigInt and other types, use explicit conversions`.
- Treats Perry Buffer-backed `Uint8Array` sources as numeric typed-array inputs for constructor and `set()` coercion, avoiding byte storage being read as f64 array slots.

Why batched:
- These are all the same value-domain boundary: constructing, copying, or transforming values into typed-array element storage.
- Splitting the `map` / `with` / `fill` and source-copy pieces would leave the shared TypedArray/ArrayBuffer harness blocked by the next adjacent BigInt coercion path.

Tests added:
- `test-parity/node-suite/bigint/typed-array/harness-coercion.ts` covers all typed-array constructors plus the BigInt-only success and throw cases for constructor sources, `set()`, `map`, `with`, and `fill`.

Validation:
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/bigint/typed-array/harness-coercion.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module bigint --filter harness-coercion'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module bigint --filter typed-array'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter typedarray'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-runtime` (passes with existing warning stream)

Known limitations / non-goals:
- No detached-buffer semantics changes.
- No unrelated TypedArray view offset/length validation changes.
- No broad Test262 import or async/Promise work.
