### PR TITLE
fix(runtime): preserve array index boundary keys

### DIFF
--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -76,6 +76,28 @@ fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     )
 }
 
+fn numeric_index_needs_runtime_key(ctx: &FnCtx<'_>, index: &Expr) -> bool {
+    match index {
+        Expr::Integer(i) => *i < 0 || *i > i32::MAX as i64,
+        Expr::Number(n) => n.is_finite() && n.fract() == 0.0 && (*n < 0.0 || *n > i32::MAX as f64),
+        Expr::LocalGet(id) if is_numeric_expr(ctx, index) => {
+            !ctx.i32_counter_slots.contains_key(id)
+        }
+        _ if is_numeric_expr(ctx, index) => !can_lower_expr_as_i32(
+            index,
+            &ctx.i32_counter_slots,
+            ctx.flat_const_arrays,
+            &ctx.array_row_aliases,
+            ctx.integer_locals,
+            ctx.clamp3_functions,
+            ctx.clamp_u8_functions,
+            ctx.integer_returning_functions,
+            ctx.i32_identity_functions,
+        ),
+        _ => false,
+    }
+}
+
 fn is_async_dispose_symbol_index(index: &Expr) -> bool {
     let Expr::SymbolFor(symbol_name) = index else {
         return false;
@@ -658,6 +680,32 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         DOUBLE,
                         "js_object_get_symbol_property",
                         &[(DOUBLE, &obj_box), (DOUBLE, &key_box)],
+                    ));
+                }
+                if !is_numeric_expr(ctx, index) {
+                    let arr_box = lower_expr(ctx, object)?;
+                    let idx_double = lower_expr(ctx, index)?;
+                    let arr_handle = {
+                        let blk = ctx.block();
+                        unbox_to_i64(blk, &arr_box)
+                    };
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_array_get_index_or_string",
+                        &[(I64, &arr_handle), (DOUBLE, &idx_double)],
+                    ));
+                }
+                if numeric_index_needs_runtime_key(ctx, index) {
+                    let arr_box = lower_expr(ctx, object)?;
+                    let idx_double = lower_expr(ctx, index)?;
+                    let arr_handle = {
+                        let blk = ctx.block();
+                        unbox_to_i64(blk, &arr_box)
+                    };
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_array_get_index_or_string",
+                        &[(I64, &arr_handle), (DOUBLE, &idx_double)],
                     ));
                 }
                 let require_numeric_layout =

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -78,6 +78,28 @@ fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     )
 }
 
+fn numeric_index_needs_runtime_key(ctx: &FnCtx<'_>, index: &Expr) -> bool {
+    match index {
+        Expr::Integer(i) => *i < 0 || *i > i32::MAX as i64,
+        Expr::Number(n) => n.is_finite() && n.fract() == 0.0 && (*n < 0.0 || *n > i32::MAX as f64),
+        Expr::LocalGet(id) if is_numeric_expr(ctx, index) => {
+            !ctx.i32_counter_slots.contains_key(id)
+        }
+        _ if is_numeric_expr(ctx, index) => !can_lower_expr_as_i32(
+            index,
+            &ctx.i32_counter_slots,
+            ctx.flat_const_arrays,
+            &ctx.array_row_aliases,
+            ctx.integer_locals,
+            ctx.clamp3_functions,
+            ctx.clamp_u8_functions,
+            ctx.integer_returning_functions,
+            ctx.i32_identity_functions,
+        ),
+        _ => false,
+    }
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::IndexSet {
@@ -242,6 +264,38 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     ctx,
                     TypedFeedbackKind::ArrayElement,
                     "array[dynamic_index]",
+                    TypedFeedbackContract::array_set_index(),
+                );
+                ctx.block().call(
+                    I64,
+                    "js_typed_feedback_array_set_index_or_string",
+                    &[
+                        (I64, &site_id),
+                        (I64, &arr_handle),
+                        (DOUBLE, &idx_double),
+                        (DOUBLE, &val_double),
+                    ],
+                );
+                if value_needs_barrier {
+                    let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
+                    let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
+                    emit_write_barrier(ctx, &arr_bits, &val_bits);
+                }
+                return Ok(val_double);
+            }
+            if is_array_expr(ctx, object) && numeric_index_needs_runtime_key(ctx, index) {
+                let arr_box = lower_expr(ctx, object)?;
+                let idx_double = lower_expr(ctx, index)?;
+                let value_needs_barrier = array_store_needs_write_barrier(ctx, value);
+                let val_double = lower_expr(ctx, value)?;
+                let arr_handle = {
+                    let blk = ctx.block();
+                    unbox_to_i64(blk, &arr_box)
+                };
+                let site_id = emit_typed_feedback_register_site(
+                    ctx,
+                    TypedFeedbackKind::ArrayElement,
+                    "array[boundary_index]",
                     TypedFeedbackContract::array_set_index(),
                 );
                 ctx.block().call(

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -169,7 +169,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let recv_bits = blk.bitcast_double_to_i64(&recv_box);
             let recv_handle = blk.and(I64, &recv_bits, POINTER_MASK_I64);
             let len_i32 = blk.safe_load_i32_from_ptr(&recv_handle);
-            Ok(blk.sitofp(I32, &len_i32, DOUBLE))
+            Ok(blk.uitofp(I32, &len_i32, DOUBLE))
         }
 
         // Phase H err: `agg.errors` — AggregateError.errors field.
@@ -256,7 +256,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // `arr.length` / `str.length` — INLINE. Both ArrayHeader and
         // StringHeader start with `length: u32` (`crates/perry-runtime/src
         // /array.rs` and `string.rs`). Same pattern: unbox pointer, load
-        // u32 from offset 0, sitofp to double.
+        // u32 from offset 0, uitofp to double.
         // `.length` — INLINE for array, string, and interface-typed
         // receivers. Named types (interfaces, class instances) often
         // wrap strings or arrays at runtime, where length is at offset 0.
@@ -381,7 +381,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
             ctx.current_block = fast_idx;
             let fast_len_i32 = ctx.block().safe_load_i32_from_ptr(&recv_handle);
-            let fast_len = ctx.block().sitofp(I32, &fast_len_i32, DOUBLE);
+            let fast_len = ctx.block().uitofp(I32, &fast_len_i32, DOUBLE);
             let fast_pred_label = ctx.block().label.clone();
             ctx.block().br(&merge_label);
 

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -40,6 +40,7 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // Refs #488: bulk push for `arr.push(...src)` spread call.
     module.declare_function("js_array_push_spread_f64", I64, &[I64, I64]);
     module.declare_function("js_array_get_f64", DOUBLE, &[I64, I32]);
+    module.declare_function("js_array_get_index_or_string", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_array_numeric_get_f64_unboxed", DOUBLE, &[I64, I32]);
     module.declare_function("js_array_set_f64", VOID, &[I64, I32, DOUBLE]);
     module.declare_function("js_array_numeric_set_f64_unboxed", I32, &[I64, I32, DOUBLE]);

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -556,14 +556,13 @@ pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
             }
         }
     }
-    // Length/capacity sanity: a real ArrayHeader has length <= capacity,
-    // and length below 100M (800 MB of element payload — well above
-    // legitimate large result sets, far below the 775M / 926M patterns
-    // we observed when a reused arena slot landed ASCII text at offsets
-    // 0/4). Buffers can be much larger than arrays, so only gate the
-    // polymorphic entry on the tighter array-sized bound and let
-    // buffer-specific runtime paths dispatch themselves when they
-    // recognize a registered buffer pointer.
+    // Length/capacity sanity: dense arrays have length <= capacity and
+    // length below 100M (800 MB of element payload — well above legitimate
+    // large result sets, far below the 775M / 926M patterns we observed
+    // when a reused arena slot landed ASCII text at offsets 0/4). Sparse
+    // arrays created by far-index writes are the one legal exception:
+    // logical length can be huge while dense capacity stays small and the
+    // far slots live in ARRAY_NAMED_PROPS.
     unsafe {
         let hdr = &*cleaned;
         if hdr.length > hdr.capacity || hdr.length > 100_000_000 {
@@ -573,11 +572,24 @@ pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
             // wave them through; everything else at this size is
             // almost certainly corrupted.
             let addr = cleaned as usize;
-            if !crate::buffer::is_registered_buffer(addr)
-                && crate::typedarray::lookup_typed_array_kind(addr).is_none()
-            {
-                return std::ptr::null();
+            let sparse_array_shape = if addr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+                let gc_header = (cleaned as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                    as *const crate::gc::GcHeader;
+                (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY
+                    && hdr.length > hdr.capacity
+                    && hdr.capacity <= 1_000_000
+            } else {
+                false
+            };
+            if sparse_array_shape {
+                return cleaned;
             }
+            if crate::buffer::is_registered_buffer(addr)
+                || crate::typedarray::lookup_typed_array_kind(addr).is_some()
+            {
+                return cleaned;
+            }
+            return std::ptr::null();
         }
     }
     cleaned

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -2,6 +2,33 @@
 use super::*;
 use std::ptr;
 
+const MAX_DENSE_ARRAY_GROW_LENGTH: u32 = 1_000_000;
+
+unsafe fn array_sparse_index_property_get(arr: *const ArrayHeader, index: u32) -> Option<f64> {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() || index < (*arr).capacity {
+        return None;
+    }
+    let key = index.to_string();
+    array_named_property_get_by_name(arr, &key)
+}
+
+unsafe fn array_sparse_index_property_set(arr: *mut ArrayHeader, index: u32, value: f64) {
+    let key = index.to_string();
+    let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    array_named_property_set(arr, key_ptr, value);
+    let new_length = index + 1;
+    if (*arr).length < new_length {
+        (*arr).length = new_length;
+    }
+}
+
+fn array_get_property_by_key(arr: *const ArrayHeader, key: *const crate::StringHeader) -> f64 {
+    let value =
+        crate::object::js_object_get_field_by_name(arr as *const crate::object::ObjectHeader, key);
+    f64::from_bits(value.bits())
+}
+
 #[no_mangle]
 pub extern "C" fn js_array_length(arr: *const ArrayHeader) -> u32 {
     let arr = {
@@ -98,7 +125,10 @@ pub extern "C" fn js_array_get_f64_unchecked(arr: *const ArrayHeader, index: u32
         if index >= length {
             return TAG_UNDEFINED_F64;
         }
-        if length > 100_000_000 {
+        if let Some(value) = array_sparse_index_property_get(arr, index) {
+            return value;
+        }
+        if index >= (*arr).capacity {
             return TAG_UNDEFINED_F64;
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -213,8 +243,10 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
         if index >= length {
             return TAG_UNDEFINED_F64;
         }
-        // Guard: corrupted arrays with unreasonably large length
-        if length > 100_000_000 {
+        if let Some(value) = array_sparse_index_property_get(arr, index) {
+            return value;
+        }
+        if index >= (*arr).capacity {
             return TAG_UNDEFINED_F64;
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -243,6 +275,10 @@ pub extern "C" fn js_array_set_f64_unchecked(arr: *mut ArrayHeader, index: u32, 
     unsafe {
         let length = (*arr).length;
         if index >= length {
+            return;
+        }
+        if index >= (*arr).capacity {
+            array_sparse_index_property_set(arr, index, value);
             return;
         }
         let value = canonicalize_array_numeric_store_value(arr, value);
@@ -305,6 +341,10 @@ pub extern "C" fn js_array_set_f64(arr: *mut ArrayHeader, index: u32, value: f64
         if index >= length {
             return;
         }
+        if index >= (*arr).capacity {
+            array_sparse_index_property_set(arr, index, value);
+            return;
+        }
         let value = canonicalize_array_numeric_store_value(arr, value);
         let value_bits = value.to_bits();
         let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
@@ -364,6 +404,11 @@ pub extern "C" fn js_array_set_f64_extend(
             if is_frozen {
                 return arr;
             }
+            if index >= (*arr).capacity {
+                let value = value_handle.get_nanbox_f64();
+                array_sparse_index_property_set(arr, index, value);
+                return arr;
+            }
             let value = canonicalize_array_numeric_store_value(arr, value);
             let value_bits = value.to_bits();
             let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
@@ -379,6 +424,11 @@ pub extern "C" fn js_array_set_f64_extend(
 
         // Need to extend the array
         let new_length = index + 1;
+        if new_length > (*arr).capacity && new_length > MAX_DENSE_ARRAY_GROW_LENGTH {
+            let value = value_handle.get_nanbox_f64();
+            array_sparse_index_property_set(arr, index, value);
+            return arr;
+        }
         let arr = if new_length > (*arr).capacity {
             js_array_grow(arr, new_length)
         } else {
@@ -502,6 +552,57 @@ pub extern "C" fn js_array_set_string_key(
         array_named_property_set(arr, key, value);
     }
     arr
+}
+
+/// `arr[idx]` where `idx` may be a number or property-key value. This mirrors
+/// `js_array_set_index_or_string` for read paths that cannot safely narrow the
+/// key through i32 codegen.
+#[no_mangle]
+pub extern "C" fn js_array_get_index_or_string(arr: *const ArrayHeader, idx: f64) -> f64 {
+    if arr.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let bits = idx.to_bits();
+    let top16 = bits >> 48;
+    if top16 == 0x7FFF {
+        let key = (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::StringHeader;
+        return array_get_property_by_key(arr, key);
+    }
+    if top16 == 0x7FF9 {
+        let key = crate::value::js_get_string_pointer_unified(idx) as *const crate::StringHeader;
+        return array_get_property_by_key(arr, key);
+    }
+
+    let numeric = if (bits & crate::value::TAG_MASK) == crate::value::INT32_TAG {
+        Some(crate::value::JSValue::from_bits(bits).as_int32() as f64)
+    } else if top16 < 0x7FF8 || top16 > 0x7FFF {
+        Some(idx)
+    } else {
+        None
+    };
+    if let Some(n) = numeric {
+        if n.is_finite() && n.trunc() == n && n >= 0.0 && n < u32::MAX as f64 {
+            return js_array_get_f64(arr, n as u32);
+        }
+        if n.is_finite() && n.trunc() == n {
+            let key = if n == 0.0 {
+                "0".to_string()
+            } else {
+                format!("{:.0}", n)
+            };
+            let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+            return array_get_property_by_key(arr, key_ptr);
+        }
+    }
+
+    if unsafe { crate::symbol::js_is_symbol(idx) } != 0 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let key = crate::value::js_jsvalue_to_string(idx);
+    if key.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    array_get_property_by_key(arr, key as *const crate::StringHeader)
 }
 
 /// `arr[idx] = value` where idx may be a NaN-boxed string (numeric-string

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -46,9 +46,10 @@ pub use self::immutable::{
 };
 pub use self::indexing::{
     js_array_get_element, js_array_get_element_f64, js_array_get_f64, js_array_get_f64_unchecked,
-    js_array_get_length, js_array_length, js_array_numeric_get_f64_unboxed,
-    js_array_numeric_set_f64_unboxed, js_array_set_f64, js_array_set_f64_extend,
-    js_array_set_f64_unchecked, js_array_set_index_or_string, js_array_set_string_key,
+    js_array_get_index_or_string, js_array_get_length, js_array_length,
+    js_array_numeric_get_f64_unboxed, js_array_numeric_set_f64_unboxed, js_array_set_f64,
+    js_array_set_f64_extend, js_array_set_f64_unchecked, js_array_set_index_or_string,
+    js_array_set_string_key,
 };
 pub use self::is_array::js_array_is_array;
 pub(crate) use self::iter_methods::throw_reduce_of_empty;

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -162,6 +162,31 @@ fn test_array_exotic_named_indices_and_boundary_props() {
 }
 
 #[test]
+fn test_array_sparse_max_valid_index_boundary() {
+    let mut arr = js_array_alloc(3);
+    arr = js_array_push_f64(arr, 0.0);
+    arr = js_array_push_f64(arr, 1.0);
+    arr = js_array_push_f64(arr, 2.0);
+
+    let max_index = u32::MAX - 1;
+    arr = js_array_set_f64_extend(arr, max_index, 77.0);
+
+    assert_eq!(js_array_length(arr), u32::MAX);
+    assert_eq!(js_array_get_f64(arr, max_index), 77.0);
+    assert_eq!(
+        js_array_get_index_or_string(arr, max_index as f64).to_bits(),
+        77.0f64.to_bits()
+    );
+
+    let key = string_key(b"4294967294");
+    assert_eq!(
+        crate::object::js_object_has_own(boxed_pointer(arr as *mut u8), string_value(key))
+            .to_bits(),
+        crate::value::TAG_TRUE
+    );
+}
+
+#[test]
 fn test_array_exotic_descriptors_and_global_prototype_identity() {
     let arr = js_array_alloc(0);
     let arr_box = boxed_pointer(arr as *mut u8);

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1362,7 +1362,35 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                 let arr = stripped as *const crate::array::ArrayHeader;
                 let length = (*arr).length;
                 if length > 100_000 {
-                    return crate::array::js_array_alloc(0);
+                    let names = crate::array::array_named_property_names(arr, true);
+                    let dense_limit = if length > (*arr).capacity && (*arr).capacity <= 1_000_000 {
+                        (*arr).capacity
+                    } else {
+                        0
+                    };
+                    let result = crate::array::js_array_alloc(
+                        dense_limit.saturating_add(names.len() as u32),
+                    );
+                    if dense_limit > 0 {
+                        let elements = (arr as *const u8)
+                            .add(std::mem::size_of::<crate::array::ArrayHeader>())
+                            as *const u64;
+                        for i in 0..dense_limit {
+                            if std::ptr::read(elements.add(i as usize)) == crate::value::TAG_HOLE {
+                                continue;
+                            }
+                            let s = i.to_string();
+                            let key_box =
+                                crate::string::js_string_new_sso(s.as_ptr(), s.len() as u32);
+                            crate::array::js_array_push_f64(result, key_box);
+                        }
+                    }
+                    for name in names {
+                        let key =
+                            crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                        crate::array::js_array_push(result, JSValue::string_ptr(key));
+                    }
+                    return result;
                 }
                 let elements = (arr as *const u8)
                     .add(std::mem::size_of::<crate::array::ArrayHeader>())
@@ -1834,9 +1862,6 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
             if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
                 let arr = obj_ptr as *const crate::array::ArrayHeader;
                 let length = (*arr).length;
-                if length > 100_000 {
-                    return nanbox_false;
-                }
                 // Numeric key: extract the index. Accept both NaN-boxed i32
                 // and plain f64 (e.g. literal `1`) provided it's a
                 // non-negative integer in range.
@@ -1861,6 +1886,13 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                     if idx >= length {
                         return nanbox_false;
                     }
+                    let sparse_key = idx.to_string();
+                    if crate::array::array_named_property_get_by_name(arr, &sparse_key).is_some() {
+                        return nanbox_true;
+                    }
+                    if idx >= (*arr).capacity {
+                        return nanbox_false;
+                    }
                     let elements = (arr as *const u8)
                         .add(std::mem::size_of::<crate::array::ArrayHeader>())
                         as *const u64;
@@ -1876,24 +1908,11 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                         if let Some(key_name) =
                             super::has_own_helpers::str_from_string_header(key_str)
                         {
-                            if key_name == "length" {
+                            if super::has_own_helpers::array_own_key_present(arr, key_str) {
                                 return nanbox_true;
                             }
-                            if let Some(index) = super::canonical_array_index(key_name) {
-                                if index < length {
-                                    let elements = (arr as *const u8)
-                                        .add(std::mem::size_of::<crate::array::ArrayHeader>())
-                                        as *const u64;
-                                    if std::ptr::read(elements.add(index as usize))
-                                        != crate::value::TAG_HOLE
-                                    {
-                                        return nanbox_true;
-                                    }
-                                }
+                            if super::canonical_array_index(key_name).is_some() {
                                 return nanbox_false;
-                            }
-                            if crate::array::array_named_property_has(arr, key_str) {
-                                return nanbox_true;
                             }
                             if array_prototype_property_value(key_name, obj_ptr as usize).is_some()
                             {

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -96,6 +96,9 @@ pub(super) unsafe fn array_own_key_present(
     if index >= length {
         return false;
     }
+    if index >= (*arr).capacity {
+        return false;
+    }
     let elements =
         (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const u64;
     std::ptr::read(elements.add(index as usize)) != crate::value::TAG_HOLE

--- a/test-parity/node-suite/globals/array-index-boundary.ts
+++ b/test-parity/node-suite/globals/array-index-boundary.ts
@@ -1,0 +1,35 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label + ":", String(fn()));
+  } catch (e: any) {
+    console.log(label + ":", e?.name + ":" + e?.message);
+  }
+}
+
+const highNonIndex = 4294967295;
+const maxIndex = 4294967294;
+const overIndex = 4294967296;
+
+const a = [0, 1, 2];
+a[highNonIndex] = "x";
+show("2^32-1 length", () => a.length);
+show("2^32-1 value", () => a[highNonIndex]);
+show("2^32-1 own", () => Object.prototype.hasOwnProperty.call(a, String(highNonIndex)));
+
+const b = [0, 1, 2];
+b[maxIndex] = "y";
+show("2^32-2 length", () => b.length);
+show("2^32-2 value", () => b[maxIndex]);
+show("2^32-2 own", () => Object.prototype.hasOwnProperty.call(b, String(maxIndex)));
+show("2^32-2 keys", () => Object.keys(b).join("|"));
+
+const c = [0, 1, 2];
+c[overIndex] = "z";
+show("2^32 length", () => c.length);
+show("2^32 value", () => c[overIndex]);
+show("2^32 own", () => Object.prototype.hasOwnProperty.call(c, String(overIndex)));
+
+const d = [0, 1, 2];
+d[String(highNonIndex)] = "s";
+show("string 2^32-1 length", () => d.length);
+show("string 2^32-1 value", () => d[String(highNonIndex)]);


### PR DESCRIPTION
Closes #4557.

## Summary
- routes unsafe numeric and computed array keys through runtime key handling instead of truncating through `i32`
- stores far sparse array indices in the array property side table while preserving `length` up to `2^32 - 1`
- treats `2^32 - 1` and larger numeric keys as ordinary string properties that do not change array length
- materializes array `.length` with unsigned semantics so `4294967295` prints correctly
- keeps sparse large-array own/key lookups bounded while preserving dense prefix keys before sparse side-table keys

## Why This Cut
The reported boundary behavior shares one root cause: high numeric/computed keys were narrowed too early, and the runtime assumed dense `length <= capacity`. Fixing the codegen dispatch without the sparse runtime storage still leaves the valid `2^32 - 2` index unreadable; fixing storage without the codegen dispatch still truncates computed locals before runtime can classify them.

## Tests
- `cargo check -q -p perry-codegen -p perry-runtime`
- `cargo test -q -p perry-runtime --lib array::tests::test_array_sparse_max_valid_index_boundary -- --nocapture`
- `cargo test -q -p perry-runtime --lib array::tests::test_array_exotic_named_indices_and_boundary_props -- --nocapture`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter array-index-boundary`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter array-length-invalid`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Non-Goals
- This does not rewrite Perry's full array storage model into a general sparse-array engine.
- Very large dense array enumeration remains bounded; this cut preserves sparse side-table keys and dense prefixes for sparse high-index arrays.
- This does not change unrelated non-integer array key semantics covered in a separate cut.
