### PR TITLE
fix(json): JSON.parse coerces its argument with ToString (ECMA-262 step 1)

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -1367,14 +1367,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::JsonParse(text) => {
             let s_box = lower_expr(ctx, text)?;
             let blk = ctx.block();
-            // Materialize the operand to a real heap `*StringHeader`. A bare
-            // `unbox_to_i64` passes an SSO short-string's INLINE bytes as the
-            // pointer, and `js_json_parse` then dereferences them as a
-            // StringHeader → SIGSEGV (e.g. `JSON.parse('e' + 'n')`, or any
-            // short runtime/`.slice`-derived string). `js_get_string_pointer_
-            // unified` returns the heap pointer for heap strings and
-            // materializes SSO / number receivers to the heap. Refs #214.
-            let s_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &s_box)]);
+            // ECMA-262 JSON.parse step 1: jsonText = ? ToString(text). So
+            // `JSON.parse(null)` → "null" → null, `JSON.parse(123)` → "123" →
+            // 123, and a Symbol arg throws TypeError. `js_json_text_to_string`
+            // is ToString (throwing on symbols) and returns a real heap
+            // `*StringHeader` (identity for heap strings, materializes SSO to
+            // the heap), so it also fixes the #214 SIGSEGV that a bare
+            // `unbox_to_i64` of an SSO short-string caused.
+            let s_handle = blk.call(I64, "js_json_text_to_string", &[(DOUBLE, &s_box)]);
             let result_i64 = blk.call(I64, "js_json_parse", &[(I64, &s_handle)]);
             Ok(blk.bitcast_i64_to_double(&result_i64))
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1215,6 +1215,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // JSON.parse returns JSValue (u64) via integer register on ARM64,
     // not f64. Use I64 return + bitcast to avoid ABI mismatch crash.
     module.declare_function("js_json_parse", I64, &[I64]);
+    // #4578: ToString(text) for JSON.parse — heap *StringHeader, throws on Symbol.
+    module.declare_function("js_json_text_to_string", I64, &[DOUBLE]);
     // #2900: JSON.rawJSON(text) / JSON.isRawJSON(value). Both take and return
     // a NaN-boxed f64 (the wrapper object pointer / a boolean).
     module.declare_function("js_json_raw_json", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -381,8 +381,12 @@ pub(super) fn try_module_static_methods(
                                     Box::new(text),
                                     Box::new(reviver),
                                 )));
-                            } else if !args.is_empty() {
-                                let text = args.into_iter().next().unwrap();
+                            } else {
+                                // 0 or 1 args. `JSON.parse()` with no argument is
+                                // `JSON.parse(undefined)` → ToString(undefined) =
+                                // "undefined" → SyntaxError (NOT a TypeError from
+                                // the generic fall-through dispatch).
+                                let text = args.into_iter().next().unwrap_or(Expr::Undefined);
                                 // Issue #179 typed-parse plan: if the call site
                                 // provides a TypeScript type argument (e.g.
                                 // `JSON.parse<Item[]>(blob)`), carry it into HIR

--- a/crates/perry-runtime/src/json/parse_api.rs
+++ b/crates/perry-runtime/src/json/parse_api.rs
@@ -7,6 +7,24 @@
 use super::*;
 use crate::{js_string_from_bytes, JSValue, StringHeader};
 
+/// ECMA-262 JSON.parse step 1: `JText = ? ToString(text)`. Coerces the
+/// argument to a heap string with full ToString semantics (so `null` → "null",
+/// `123` → "123", `true` → "true", etc.), but — unlike `String(x)` — throws a
+/// TypeError for a Symbol argument, matching `ToString(symbol)`. Used by the
+/// `JSON.parse` codegen arm. (#4578)
+#[no_mangle]
+pub extern "C" fn js_json_text_to_string(value: f64) -> *mut StringHeader {
+    if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+        crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a string");
+    }
+    crate::builtins::js_string_coerce(value)
+}
+
+// Anchor so the auto-optimize bitcode rebuild doesn't dead-strip this
+// codegen-only `#[no_mangle]` (see KEEP_RAW_JSON in json/raw_json.rs).
+#[used]
+static KEEP_JSON_TEXT_TO_STRING: extern "C" fn(f64) -> *mut StringHeader = js_json_text_to_string;
+
 // ─── JSON.parse ───────────────────────────────────────────────────────────────
 
 /// JSON.parse(text) shim that returns `null` for a null input instead


### PR DESCRIPTION
## Problem
```ts
JSON.parse(null)   // threw SyntaxError   (node: null)
JSON.parse()       // threw TypeError     (node: SyntaxError)
```
`JSON.parse` only accepted real strings. ECMA-262 step 1 is `JText = ? ToString(text)`.

## Fix
- New runtime `js_json_text_to_string` = ToString returning a heap `*StringHeader`, but (unlike `String(x)`) throws `TypeError` for a `Symbol` argument, matching `ToString(symbol)`. The `JsonParse` codegen arm routes through it (also subsumes the #214 SSO-deref segfault guard).
- HIR lowers 0-arg `JSON.parse()` to `JsonParse(undefined)`.

## Verification (byte-identical to node)
```
null→null  false→false  true→true  0→0  3.14→3.14
undefined / no-arg → SyntaxError    Symbol → TypeError
```
Heap-string parsing, reviver callbacks, and round-trips unchanged. Fixes test262 `built-ins/JSON/parse/text-non-string-primitive`.