### PR TITLE
fix(runtime): materialize class prototype objects

### DIFF
--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -676,7 +676,8 @@ fn test_class_inheritance_side_table_roots_mark_and_rewrite() {
     use crate::object::{
         scan_class_inheritance_roots_mut, test_class_parent_closure_root,
         test_class_prototype_object_root, test_clear_class_inheritance_roots,
-        test_seed_class_inheritance_roots, test_seed_class_parent_closure_root,
+        test_decl_class_prototype_root, test_seed_class_inheritance_roots,
+        test_seed_class_parent_closure_root, test_seed_decl_class_prototype_root,
     };
 
     const PROTO_CID: u32 = 0xDEAD_0001;
@@ -685,26 +686,35 @@ fn test_class_inheritance_side_table_roots_mark_and_rewrite() {
     clear_marks();
     clear_mark_seeds();
 
-    // Allocate the two "parent" objects in the nursery before snapshotting the
+    // Allocate the side-table objects in the nursery before snapshotting the
     // valid-pointer set so the mark phase recognizes them as roots.
     let proto_user = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
+    let decl_proto_user = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
     let closure_user = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
     let valid_ptrs = build_valid_pointer_set();
     let proto_old = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_OBJECT);
+    let decl_proto_old = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_OBJECT);
     let closure_old = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_OBJECT);
     let proto_hdr = unsafe { header_from_user_ptr(proto_user) as *mut GcHeader };
+    let decl_proto_hdr = unsafe { header_from_user_ptr(decl_proto_user) as *mut GcHeader };
     let closure_hdr = unsafe { header_from_user_ptr(closure_user) as *mut GcHeader };
 
     test_seed_class_inheritance_roots(PROTO_CID, proto_user as usize);
+    test_seed_decl_class_prototype_root(PROTO_CID, decl_proto_user as usize);
     test_seed_class_parent_closure_root(CLOSURE_CID, closure_user as usize);
 
-    // Mark phase: both parents become live roots.
+    // Mark phase: all side-table parents become live roots.
     scan_class_inheritance_roots_mut(&mut RuntimeRootVisitor::for_mark(&valid_ptrs));
     unsafe {
         assert_ne!(
             (*proto_hdr).gc_flags & GC_FLAG_MARKED,
             0,
             "CLASS_PROTOTYPE_OBJECTS parent must be marked as a root"
+        );
+        assert_ne!(
+            (*decl_proto_hdr).gc_flags & GC_FLAG_MARKED,
+            0,
+            "CLASS_DECL_PROTOTYPE_OBJECTS prototype must be marked as a root"
         );
         assert_ne!(
             (*closure_hdr).gc_flags & GC_FLAG_MARKED,
@@ -717,6 +727,7 @@ fn test_class_inheritance_side_table_roots_mark_and_rewrite() {
     // follow the forwarding address.
     unsafe {
         set_forwarding_address(proto_hdr, proto_old);
+        set_forwarding_address(decl_proto_hdr, decl_proto_old);
         set_forwarding_address(closure_hdr, closure_old);
     }
     scan_class_inheritance_roots_mut(&mut RuntimeRootVisitor::for_rewrite(&valid_ptrs));
@@ -725,6 +736,11 @@ fn test_class_inheritance_side_table_roots_mark_and_rewrite() {
         test_class_prototype_object_root(PROTO_CID),
         proto_old as usize,
         "CLASS_PROTOTYPE_OBJECTS parent must be rewritten to the evacuated address"
+    );
+    assert_eq!(
+        test_decl_class_prototype_root(PROTO_CID),
+        decl_proto_old as usize,
+        "CLASS_DECL_PROTOTYPE_OBJECTS prototype must be rewritten to the evacuated address"
     );
     assert_eq!(
         test_class_parent_closure_root(CLOSURE_CID),

--- a/crates/perry-runtime/src/object/class_gc_roots.rs
+++ b/crates/perry-runtime/src/object/class_gc_roots.rs
@@ -6,7 +6,9 @@
 //! holds the GC scanner (and its test seeds) that root + relocate their
 //! pointer values.
 
-use super::class_registry::{CLASS_PARENT_CLOSURES, CLASS_PROTOTYPE_OBJECTS};
+use super::class_registry::{
+    CLASS_DECL_PROTOTYPE_OBJECTS, CLASS_PARENT_CLOSURES, CLASS_PROTOTYPE_OBJECTS,
+};
 
 /// GC mutable-root scanner for the class static-inheritance side-tables
 /// (issue #1790, epic #1785 / design #1772).
@@ -47,6 +49,13 @@ pub fn scan_class_inheritance_roots_mut(visitor: &mut crate::gc::RuntimeRootVisi
             }
         }
     }
+    if let Ok(mut guard) = CLASS_DECL_PROTOTYPE_OBJECTS.write() {
+        if let Some(map) = guard.as_mut() {
+            for ptr in map.values_mut() {
+                visitor.visit_usize_slot(ptr);
+            }
+        }
+    }
     if let Ok(mut guard) = CLASS_PARENT_CLOSURES.write() {
         if let Some(map) = guard.as_mut() {
             for ptr in map.values_mut() {
@@ -63,6 +72,14 @@ pub(crate) fn test_seed_class_inheritance_roots(proto_cid: u32, proto_ptr: usize
     guard
         .get_or_insert_with(std::collections::HashMap::new)
         .insert(proto_cid, proto_ptr);
+}
+
+#[cfg(test)]
+pub(crate) fn test_seed_decl_class_prototype_root(class_id: u32, proto_ptr: usize) {
+    let mut guard = CLASS_DECL_PROTOTYPE_OBJECTS.write().unwrap();
+    guard
+        .get_or_insert_with(std::collections::HashMap::new)
+        .insert(class_id, proto_ptr);
 }
 
 #[cfg(test)]
@@ -85,6 +102,16 @@ pub(crate) fn test_class_prototype_object_root(proto_cid: u32) -> usize {
 }
 
 #[cfg(test)]
+pub(crate) fn test_decl_class_prototype_root(class_id: u32) -> usize {
+    CLASS_DECL_PROTOTYPE_OBJECTS
+        .read()
+        .unwrap()
+        .as_ref()
+        .and_then(|m| m.get(&class_id).copied())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
 pub(crate) fn test_class_parent_closure_root(closure_cid: u32) -> usize {
     CLASS_PARENT_CLOSURES
         .read()
@@ -97,6 +124,9 @@ pub(crate) fn test_class_parent_closure_root(closure_cid: u32) -> usize {
 #[cfg(test)]
 pub(crate) fn test_clear_class_inheritance_roots(proto_cid: u32, closure_cid: u32) {
     if let Some(m) = CLASS_PROTOTYPE_OBJECTS.write().unwrap().as_mut() {
+        m.remove(&proto_cid);
+    }
+    if let Some(m) = CLASS_DECL_PROTOTYPE_OBJECTS.write().unwrap().as_mut() {
         m.remove(&proto_cid);
     }
     if let Some(m) = CLASS_PARENT_CLOSURES.write().unwrap().as_mut() {

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -179,6 +179,14 @@ pub static FUNCTION_CLASS_IDS: RwLock<Option<HashMap<u64, u32>>> = RwLock::new(N
 // usage is guaranteed.
 pub static CLASS_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
 
+/// Lazily materialized `Class.prototype` objects for declared ES classes.
+/// These are separate from `CLASS_PROTOTYPE_OBJECTS`: that older table is
+/// intentionally overloaded for synthetic prototype sources and static
+/// inheritance shortcuts. Declared class prototypes need stable heap identity
+/// for `typeof C.prototype`, `Object.getPrototypeOf(new C())`, and
+/// `C.prototype.isPrototypeOf(instance)` without perturbing those paths.
+pub static CLASS_DECL_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
+
 /// #36 / #321: maps a child class_id to the raw address of a parent CLOSURE
 /// (function value) when `class Child extends <function value> {}`. effect's
 /// `class Svc extends Context.Tag("Svc")<...>() {}` extends the function
@@ -196,6 +204,18 @@ pub(crate) fn class_prototype_object_root_store(class_id: u32, proto_ptr: *mut O
         return;
     }
     let mut guard = CLASS_PROTOTYPE_OBJECTS.write().unwrap();
+    if guard.is_none() {
+        *guard = Some(HashMap::new());
+    }
+    guard.as_mut().unwrap().insert(class_id, proto_ptr as usize);
+    crate::gc::runtime_write_barrier_root_raw_ptr(proto_ptr);
+}
+
+pub(crate) fn class_decl_prototype_object_root_store(class_id: u32, proto_ptr: *mut ObjectHeader) {
+    if class_id == 0 || proto_ptr.is_null() {
+        return;
+    }
+    let mut guard = CLASS_DECL_PROTOTYPE_OBJECTS.write().unwrap();
     if guard.is_none() {
         *guard = Some(HashMap::new());
     }
@@ -221,6 +241,97 @@ pub(crate) fn class_parent_closure(class_id: u32) -> Option<usize> {
         .read()
         .ok()
         .and_then(|g| g.as_ref().and_then(|m| m.get(&class_id).copied()))
+}
+
+pub(crate) fn class_decl_prototype_object(class_id: u32) -> *mut ObjectHeader {
+    if let Ok(read) = CLASS_DECL_PROTOTYPE_OBJECTS.read() {
+        if let Some(map) = read.as_ref() {
+            return map.get(&class_id).copied().unwrap_or(0) as *mut ObjectHeader;
+        }
+    }
+    std::ptr::null_mut()
+}
+
+fn class_decl_prototype_method_names(class_id: u32) -> Vec<String> {
+    let mut names = Vec::new();
+    if let Ok(registry) = CLASS_VTABLE_REGISTRY.read() {
+        if let Some(vtable) = registry.as_ref().and_then(|reg| reg.get(&class_id)) {
+            names.extend(
+                vtable
+                    .methods
+                    .keys()
+                    .filter(|name| *name != "constructor")
+                    .cloned(),
+            );
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn install_class_decl_prototype_method_fields(proto: *mut ObjectHeader, class_id: u32) {
+    let proto_value = crate::value::js_nanbox_pointer(proto as i64);
+    for name in class_decl_prototype_method_names(class_id) {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let leaked: &'static [u8] = name.as_bytes().to_vec().leak();
+        let method = js_class_method_bind(proto_value, leaked.as_ptr(), leaked.len());
+        js_object_set_field_by_name(proto, key, method);
+        set_builtin_property_attrs(proto as usize, name, PropertyAttrs::new(true, false, true));
+    }
+}
+
+pub(crate) fn class_decl_prototype_value(class_id: u32) -> f64 {
+    if class_id == 0 || class_name_for_id(class_id).is_none() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+
+    let existing = class_decl_prototype_object(class_id);
+    if !existing.is_null() {
+        return crate::value::js_nanbox_pointer(existing as i64);
+    }
+
+    let proto = js_object_alloc(class_id, 0);
+    if proto.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    class_decl_prototype_object_root_store(class_id, proto);
+
+    let constructor_key =
+        crate::string::js_string_from_bytes(b"constructor".as_ptr(), "constructor".len() as u32);
+    js_object_set_field_by_name(
+        proto,
+        constructor_key,
+        class_constructor_ref_value(class_id),
+    );
+    set_builtin_property_attrs(
+        proto as usize,
+        "constructor".to_string(),
+        PropertyAttrs::new(true, false, true),
+    );
+    install_class_decl_prototype_method_fields(proto, class_id);
+
+    let parent_proto_bits = get_parent_class_id(class_id)
+        .filter(|parent_id| *parent_id != 0 && *parent_id != class_id)
+        .and_then(|parent_id| {
+            let parent_proto = class_decl_prototype_value(parent_id);
+            let parent_bits = parent_proto.to_bits();
+            ((parent_bits >> 48) == 0x7FFD).then_some(parent_bits)
+        })
+        .or_else(global_object_prototype_bits);
+    if let Some(bits) = parent_proto_bits {
+        super::prototype_chain::object_set_static_prototype(proto as usize, bits);
+    }
+
+    crate::value::js_nanbox_pointer(proto as i64)
+}
+
+pub(crate) fn class_decl_prototype_value_for_instance_class(class_id: u32) -> Option<f64> {
+    if class_id == 0 || class_name_for_id(class_id).is_none() {
+        return None;
+    }
+    let proto = class_decl_prototype_value(class_id);
+    ((proto.to_bits() >> 48) == 0x7FFD).then_some(proto)
 }
 
 fn global_object_prototype_bits() -> Option<u64> {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2342,7 +2342,11 @@ pub extern "C" fn js_object_get_field_by_name(
                     && is_class_id_registered(class_id)
                     && !is_prototype_ref
                 {
-                    let value = super::class_prototype_ref_value(class_id);
+                    let value = super::class_registry::class_decl_prototype_value(class_id);
+                    if value.to_bits() == crate::value::TAG_UNDEFINED {
+                        let value = super::class_prototype_ref_value(class_id);
+                        return JSValue::from_bits(value.to_bits());
+                    }
                     return JSValue::from_bits(value.to_bits());
                 }
                 if class_id != 0 && class_has_own_method(class_id, name) {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -76,8 +76,9 @@ pub use class_gc_roots::scan_class_inheritance_roots_mut;
 #[cfg(test)]
 pub(crate) use class_gc_roots::{
     test_class_parent_closure_root, test_class_prototype_object_root,
-    test_clear_class_inheritance_roots, test_seed_class_inheritance_roots,
-    test_seed_class_parent_closure_root,
+    test_clear_class_inheritance_roots, test_decl_class_prototype_root,
+    test_seed_class_inheritance_roots, test_seed_class_parent_closure_root,
+    test_seed_decl_class_prototype_root,
 };
 pub use class_registry::*;
 pub(crate) use collection_proto_thunks::{is_builtin_map_set_value, is_builtin_set_add_value};

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1864,6 +1864,13 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                     if let Some(proto) = super::iterator_prototype_for_class_id((*obj).class_id) {
                         return proto;
                     }
+                    if let Some(proto) =
+                        super::class_registry::class_decl_prototype_value_for_instance_class(
+                            (*obj).class_id,
+                        )
+                    {
+                        return proto;
+                    }
                 }
             }
             return obj_value;
@@ -1933,6 +1940,13 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                 }
                 if (*gc).obj_type == crate::gc::GC_TYPE_OBJECT {
                     if let Some(proto) = super::iterator_prototype_for_class_id((*obj).class_id) {
+                        return proto;
+                    }
+                    if let Some(proto) =
+                        super::class_registry::class_decl_prototype_value_for_instance_class(
+                            (*obj).class_id,
+                        )
+                    {
                         return proto;
                     }
                 }

--- a/test-parity/node-suite/object/class-prototype-object.ts
+++ b/test-parity/node-suite/object/class-prototype-object.ts
@@ -1,0 +1,50 @@
+function show(label: string, value: unknown) {
+  console.log(label + ":", value);
+}
+
+class Empty {}
+
+class Base {
+  value() {
+    return "base";
+  }
+}
+
+class Child extends Base {
+  child() {
+    return "child";
+  }
+}
+
+const empty = new Empty();
+const child = new Child();
+const base = new Base();
+
+const emptyProto = Empty.prototype;
+const baseProto = Base.prototype;
+const childProto = Child.prototype;
+const childRuntimeProto = Object.getPrototypeOf(child);
+
+show("empty proto typeof", typeof emptyProto);
+show("empty proto object", emptyProto !== null && typeof emptyProto === "object");
+show("empty constructor identity", emptyProto.constructor === Empty);
+show("empty proto owns constructor", Object.prototype.hasOwnProperty.call(emptyProto, "constructor"));
+show("empty proto isPrototypeOf empty", emptyProto.isPrototypeOf(empty));
+
+show("base proto typeof", typeof baseProto);
+show("base constructor identity", baseProto.constructor === Base);
+show("base own names", Object.getOwnPropertyNames(baseProto).join("|"));
+show("base value type", typeof baseProto.value);
+show("base proto parent object", Object.getPrototypeOf(baseProto) === Object.prototype);
+
+show("child proto typeof", typeof childProto);
+show("child constructor identity", childProto.constructor === Child);
+show("child own names", Object.getOwnPropertyNames(childProto).join("|"));
+show("child method type", typeof childProto.child);
+show("child runtime proto", childRuntimeProto === childProto);
+show("child proto parent", Object.getPrototypeOf(childProto) === baseProto);
+
+show("base proto isPrototypeOf child", baseProto.isPrototypeOf(child));
+show("child proto isPrototypeOf base", childProto.isPrototypeOf(base));
+show("object proto isPrototypeOf child", Object.prototype.isPrototypeOf(child));
+show("prototype identity stable", Child.prototype === childProto && Base.prototype === baseProto);


### PR DESCRIPTION
## Linked Issues
Closes #4553

## Summary
- materialize stable heap objects for declared class `.prototype` reads instead of exposing Perry's internal prototype-ref value
- return those prototype objects from `Object.getPrototypeOf` for named class instances, including subclass prototype-parent chains
- root the declared-class prototype cache in the GC mutable-root scanner and cover mark/rewrite behavior
- add a focused Node parity fixture for `typeof C.prototype`, constructor identity, own names, `isPrototypeOf`, and subclass prototype chains

## Why This Cut
This is a focused class-prototype object parity cut. I kept it separate from the older synthetic-function/Object.create prototype table because that table is also used for static inheritance shortcuts; this avoids mixing unrelated prototype models.

## Tests
- `cargo check -q -p perry-codegen -p perry-runtime`
- `cargo test -q -p perry-runtime --lib gc::tests::runtime_roots::test_class_inheritance_side_table_roots_mark_and_rewrite -- --nocapture`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter class-prototype-object`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter is-prototype-of`
- `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module object --filter constructor-prototype-chain`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./target/release/perry run test-files/test_decorators_nest_metadata_scanner.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./target/release/perry run test-files/test_gap_object_methods.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 ./target/release/perry run test-files/test_constructor_prototype_method.ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known Limitations
- Prototype method values keep Perry's existing bound-method representation; this PR changes observable prototype object identity and prototype-chain reflection, not the broader class method call model.
- This only materializes declared named class prototypes. Synthetic function prototype paths continue to use their existing table.

## Non-Goals
- Broad class representation rewrite
- Reworking static ClassRef dispatch
- Replacing synthetic function/Object.create prototype handling
- Changing builtin constructor prototype implementations
