### PR TITLE
runtime: add async-from-sync iterator adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1131 — async-from-sync iterator adapter (`for await` over sync iterables)
+
+Closes #4520. `for await...of` over a *synchronous* iterable that yields
+promises now unwraps each yielded promise instead of materializing the sync
+iterable up front and awaiting the raw values.
+
+A runtime async-from-sync iterator wrapper (`crates/perry-runtime/src/array/iterator.rs`)
+implements `next`/`return`/`throw`/`[Symbol.asyncIterator]` with full argument
+forwarding, missing-`return`/missing-`throw` handling, sync-call rejection, and
+close-on-rejected-value semantics. Dynamic `for await...of` lowering now routes
+through `js_get_async_iterator` rather than eagerly draining sync iterables, and
+`Array.fromAsync` wraps sync iterables so promise-valued sync yields are
+unwrapped while async-generator inputs stay on the async path. Parity coverage
+added under `node-suite/globals/async-from-sync-iterator.ts` (for-await, early
+close, destructuring, `Array.fromAsync`, rejected promise values, malformed
+iterator results). Async-generator `yield*` delegation keeps its separate
+transform path and is out of scope here.
+
 ## v0.5.1130 — subclassing native `Request`/`Response` exposes working body methods
 
 Subclassing the native global `Request` (or `Response`) produced instances that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1130
+**Current Version:** 0.5.1131
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1130"
+version = "0.5.1131"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1130"
+version = "0.5.1131"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1130"
+version = "0.5.1131"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1130"
+version = "0.5.1131"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1130"
+version = "0.5.1131"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -1048,6 +1048,13 @@ impl JsEmitter {
                 self.emit_expr(val);
                 self.output.push(')');
             }
+            Expr::GetAsyncIterator(val) => {
+                self.output.push_str("(");
+                self.emit_expr(val);
+                self.output.push_str(")[Symbol.asyncIterator]?.() ?? (");
+                self.emit_expr(val);
+                self.output.push_str(")[Symbol.iterator]()");
+            }
             Expr::ArrayFromMapped {
                 iterable,
                 map_fn,

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -396,6 +396,7 @@ pub fn check_escapes_in_expr(
         | Expr::JsonIsRawJson(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
+        | Expr::GetAsyncIterator(operand)
         | Expr::ForOfToArray(operand)
         | Expr::ForAwaitToArray(operand)
         | Expr::WeakRefNew(operand)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -255,6 +255,7 @@ fn collect_used_new_fields_in_expr(
         | Expr::JsonIsRawJson(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
+        | Expr::GetAsyncIterator(operand)
         | Expr::ForOfToArray(operand)
         | Expr::ForAwaitToArray(operand)
         | Expr::WeakRefNew(operand)

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1114,6 +1114,7 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
+        | Expr::GetAsyncIterator(operand)
         | Expr::ForOfToArray(operand)
         | Expr::ForAwaitToArray(operand)
         | Expr::WeakRefNew(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -237,6 +237,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)
         | Expr::GetIterator(operand)
+        | Expr::GetAsyncIterator(operand)
         | Expr::ForOfToArray(operand)
         | Expr::ForAwaitToArray(operand)
         | Expr::WeakRefNew(operand)

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -563,6 +563,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let v = lower_expr(ctx, o)?;
             Ok(ctx.block().call(DOUBLE, "js_get_iterator", &[(DOUBLE, &v)]))
         }
+        Expr::GetAsyncIterator(o) => {
+            let v = lower_expr(ctx, o)?;
+            Ok(ctx
+                .block()
+                .call(DOUBLE, "js_get_async_iterator", &[(DOUBLE, &v)]))
+        }
         Expr::ForOfToArray(o) => {
             // #321: materialize an untyped `for...of` receiver into a plain
             // Array. Runtime inspects the value's GC kind (Map → [k,v]

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1581,6 +1581,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::FsMkdirSync(..)
         | Expr::IteratorToArray(..)
         | Expr::GetIterator(..)
+        | Expr::GetAsyncIterator(..)
         | Expr::ForOfToArray(..)
         | Expr::ForAwaitToArray(..)
         | Expr::WeakRefDeref(..)

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -195,6 +195,7 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // #1831: `yield*` iterator resolution — `operand[Symbol.iterator]()` or the
     // operand itself when already an iterator. Returns a NaN-boxed JSValue.
     module.declare_function("js_get_iterator", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_get_async_iterator", DOUBLE, &[DOUBLE]);
     // #321: materialize an untyped `for...of` receiver into a plain Array by
     // inspecting its runtime GC kind (Map/Set/Array/string/iterable).
     // Returns a NaN-boxed array JSValue.

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2103,6 +2103,11 @@ pub enum Expr {
     /// `operand[Symbol.iterator]()` when iterable, else the operand itself (a
     /// generator object already *is* its iterator). Lowers to `js_get_iterator`.
     GetIterator(Box<Expr>),
+    /// Resolve the iterator for generic `for await...of`: use
+    /// `operand[Symbol.asyncIterator]()` when present, otherwise wrap the
+    /// synchronous iterator from `operand[Symbol.iterator]()` in Perry's
+    /// AsyncFromSyncIterator adapter.
+    GetAsyncIterator(Box<Expr>),
     /// #321: materialize an UNTYPED `for...of` receiver into a plain Array
     /// by inspecting its runtime kind. The `for...of` desugar uses an
     /// index loop (`for (i=0; i<arr.length; i++) item = arr[i]`); when the

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -307,6 +307,100 @@ fn insert_iterator_return_before_abrupts(
     *stmts = rewritten;
 }
 
+fn lower_runtime_for_await_iterator(
+    ctx: &mut LoweringContext,
+    module: &mut Module,
+    for_of_stmt: &ast::ForOfStmt,
+    source_expr: Expr,
+) -> Result<()> {
+    let for_scope_mark = ctx.push_block_scope();
+    let iter_id = ctx.fresh_local();
+    ctx.locals
+        .push((format!("__iter_{}", iter_id), iter_id, Type::Any));
+    module.init.push(Stmt::Let {
+        id: iter_id,
+        name: format!("__iter_{}", iter_id),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(Expr::GetAsyncIterator(Box::new(source_expr))),
+    });
+
+    let result_id = ctx.fresh_local();
+    ctx.locals
+        .push((format!("__result_{}", result_id), result_id, Type::Any));
+    let raw_next_call = Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(iter_id)),
+            property: "next".to_string(),
+        }),
+        args: vec![],
+        type_args: vec![],
+    };
+    let next_call = Expr::Await(Box::new(raw_next_call));
+    module.init.push(Stmt::Let {
+        id: result_id,
+        name: format!("__result_{}", result_id),
+        ty: Type::Any,
+        mutable: true,
+        init: Some(next_call.clone()),
+    });
+
+    let binding_pat = match &for_of_stmt.left {
+        ast::ForHead::VarDecl(var_decl) => var_decl
+            .decls
+            .first()
+            .map(|decl| &decl.name)
+            .ok_or_else(|| anyhow!("for-await-of requires a variable declaration"))?,
+        ast::ForHead::Pat(pat) => pat,
+        _ => return Err(anyhow!("Unsupported for-await-of left-hand side")),
+    };
+    let mut var_ids = Vec::new();
+    collect_for_of_pattern_leaves(ctx, binding_pat, &mut var_ids);
+    if var_ids.is_empty() {
+        return Err(anyhow!("Unsupported for-await-of binding pattern"));
+    }
+
+    let mut body_stmts = Vec::new();
+    let mut var_idx = 0;
+    emit_for_of_pattern_binding(
+        ctx,
+        binding_pat,
+        Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(result_id)),
+            property: "value".to_string(),
+        },
+        &var_ids,
+        &mut var_idx,
+        &mut body_stmts,
+    )?;
+    let init_before = module.init.len();
+    if let ast::Stmt::Block(block) = &*for_of_stmt.body {
+        for s in &block.stmts {
+            lower_stmt(ctx, module, s)?;
+        }
+    } else {
+        lower_stmt(ctx, module, &for_of_stmt.body)?;
+    }
+    let mut user_body: Vec<Stmt> = module.init.drain(init_before..).collect();
+    insert_iterator_return_before_abrupts(&mut user_body, iter_id, true);
+    body_stmts.append(&mut user_body);
+    body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));
+
+    module.init.push(Stmt::While {
+        condition: Expr::Unary {
+            op: UnaryOp::Not,
+            operand: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(result_id)),
+                property: "done".to_string(),
+            }),
+        },
+        body: body_stmts,
+    });
+
+    ctx.pop_block_scope(for_scope_mark);
+    Ok(())
+}
+
 pub(crate) fn lower_stmt_for_of(
     ctx: &mut LoweringContext,
     module: &mut Module,
@@ -961,6 +1055,9 @@ pub(crate) fn lower_stmt_for_of(
         && !is_iterable_set
         && !is_iterable_typed_array
         && !proven_array;
+    if for_of_stmt.is_await && needs_runtime_iterator {
+        return lower_runtime_for_await_iterator(ctx, module, for_of_stmt, arr_expr);
+    }
     let arr_expr = if is_iterable_map {
         if let Some(args) = map_type_args.as_ref() {
             if args.len() >= 2 {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -17,7 +17,10 @@ use super::class_computed::{
 use super::helpers::{async_iterator_method_call, is_filehandle_readlines_for_await_target};
 use super::*;
 
+mod for_await;
 mod nested_fn_decl;
+
+use for_await::lower_runtime_for_await_iterator_body;
 
 fn unwrap_stream_expr(mut expr: &ast::Expr) -> &ast::Expr {
     loop {
@@ -1313,6 +1316,9 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 && !is_iterable_set
                 && !is_iterable_typed_array
                 && !proven_array;
+            if for_of_stmt.is_await && needs_runtime_iterator {
+                return lower_runtime_for_await_iterator_body(ctx, for_of_stmt, arr_expr);
+            }
             let arr_expr = if is_iterable_map {
                 if map_kv_fastpath {
                     arr_expr

--- a/crates/perry-hir/src/lower_decl/body_stmt/for_await.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/for_await.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+pub(super) fn lower_runtime_for_await_iterator_body(
+    ctx: &mut LoweringContext,
+    for_of_stmt: &ast::ForOfStmt,
+    source_expr: Expr,
+) -> Result<Vec<Stmt>> {
+    let mut result = Vec::new();
+    let scope_mark = ctx.push_block_scope();
+
+    let iter_id = ctx.fresh_local();
+    ctx.locals
+        .push((format!("__iter_{}", iter_id), iter_id, Type::Any));
+    result.push(Stmt::Let {
+        id: iter_id,
+        name: format!("__iter_{}", iter_id),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(Expr::GetAsyncIterator(Box::new(source_expr))),
+    });
+
+    let result_id = ctx.fresh_local();
+    ctx.locals
+        .push((format!("__result_{}", result_id), result_id, Type::Any));
+    let raw_next_call = Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(iter_id)),
+            property: "next".to_string(),
+        }),
+        args: vec![],
+        type_args: vec![],
+    };
+    let next_call = Expr::Await(Box::new(raw_next_call));
+    result.push(Stmt::Let {
+        id: result_id,
+        name: format!("__result_{}", result_id),
+        ty: Type::Any,
+        mutable: true,
+        init: Some(next_call.clone()),
+    });
+
+    let binding_pat = match &for_of_stmt.left {
+        ast::ForHead::VarDecl(var_decl) => var_decl
+            .decls
+            .first()
+            .map(|decl| &decl.name)
+            .ok_or_else(|| anyhow!("for-await-of requires a variable declaration"))?,
+        ast::ForHead::Pat(pat) => pat,
+        _ => return Err(anyhow!("Unsupported for-await-of left-hand side")),
+    };
+    let mut var_ids = Vec::new();
+    collect_for_of_pattern_leaves(ctx, binding_pat, &mut var_ids);
+    if var_ids.is_empty() {
+        return Err(anyhow!("Unsupported for-await-of binding pattern"));
+    }
+
+    let mut body_stmts = Vec::new();
+    let mut var_idx = 0;
+    emit_for_of_pattern_binding(
+        ctx,
+        binding_pat,
+        Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(result_id)),
+            property: "value".to_string(),
+        },
+        &var_ids,
+        &mut var_idx,
+        &mut body_stmts,
+    )?;
+    let mut user_body = lower_body_stmt(ctx, &for_of_stmt.body)?;
+    insert_iterator_return_before_abrupts(&mut user_body, iter_id, true);
+    body_stmts.extend(user_body);
+    body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));
+
+    result.push(Stmt::While {
+        condition: Expr::Unary {
+            op: UnaryOp::Not,
+            operand: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(result_id)),
+                property: "done".to_string(),
+            }),
+        },
+        body: body_stmts,
+    });
+
+    ctx.pop_block_scope(scope_mark);
+    Ok(result)
+}

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -553,6 +553,7 @@ impl SH for Expr {
             Expr::IteratorFrom(e) => { tag(h, 12270); e.as_ref().hash(h); }
             Expr::IteratorToArray(e) => { tag(h, 398); e.as_ref().hash(h); }
             Expr::GetIterator(e) => { tag(h, 11238); e.as_ref().hash(h); }
+            Expr::GetAsyncIterator(e) => { tag(h, 12502); e.as_ref().hash(h); }
             Expr::ForOfToArray(e) => { tag(h, 11243); e.as_ref().hash(h); }
             Expr::ForAwaitToArray(e) => { tag(h, 12501); e.as_ref().hash(h); }
             Expr::ArrayFromMapped { iterable, map_fn, this_arg } => { tag(h, 399); iterable.as_ref().hash(h); map_fn.as_ref().hash(h); this_arg.is_some().hash(h); if let Some(t) = this_arg { t.as_ref().hash(h); } }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -244,6 +244,7 @@ where
         | Expr::IteratorFrom(v)
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)
+        | Expr::GetAsyncIterator(v)
         | Expr::ForOfToArray(v)
         | Expr::ForAwaitToArray(v)
         | Expr::ObjectRest { object: v, .. }

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -245,6 +245,7 @@ where
         | Expr::IteratorFrom(v)
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)
+        | Expr::GetAsyncIterator(v)
         | Expr::ForOfToArray(v)
         | Expr::ForAwaitToArray(v)
         | Expr::ObjectRest { object: v, .. }

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -175,6 +175,300 @@ fn has_named_next(value: f64) -> bool {
     is_callable_value(named_field(value, b"next"))
 }
 
+fn boxed_promise_value(promise: *mut crate::promise::Promise) -> f64 {
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+fn async_from_sync_type_error(message: &[u8]) -> f64 {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+fn async_from_sync_rejected(message: &[u8]) -> f64 {
+    boxed_promise_value(crate::promise::js_promise_rejected(
+        async_from_sync_type_error(message),
+    ))
+}
+
+fn undefined_value() -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+fn async_from_sync_iter_result(value: f64, done: bool) -> f64 {
+    let obj = crate::object::js_object_alloc(0, 2);
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
+    crate::object::js_object_set_field_by_name(obj, value_key, value);
+    crate::object::js_object_set_field_by_name(
+        obj,
+        done_key,
+        if done {
+            f64::from_bits(crate::value::TAG_TRUE)
+        } else {
+            f64::from_bits(crate::value::TAG_FALSE)
+        },
+    );
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+extern "C" fn async_from_sync_fulfilled(
+    closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let promise =
+        crate::closure::js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
+    let done = crate::closure::js_closure_get_capture_f64(closure, 1) != 0.0;
+    if !promise.is_null() {
+        crate::promise::js_promise_resolve(promise, async_from_sync_iter_result(value, done));
+    }
+    0.0
+}
+
+extern "C" fn async_from_sync_rejected_value(
+    closure: *const crate::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
+    let promise =
+        crate::closure::js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
+    let iter = crate::closure::js_closure_get_capture_f64(closure, 1);
+    let close_on_rejection = crate::closure::js_closure_get_capture_f64(closure, 2) != 0.0;
+    if close_on_rejection {
+        async_from_sync_close(iter);
+    }
+    if !promise.is_null() {
+        crate::promise::js_promise_reject(promise, reason);
+    }
+    0.0
+}
+
+fn async_from_sync_continue(iter: f64, step_result: f64, close_on_rejection: bool) -> f64 {
+    let ptr = crate::value::js_nanbox_get_pointer(step_result);
+    if ptr == 0 {
+        return async_from_sync_rejected(b"Iterator result is not an object");
+    }
+
+    let result_obj = ptr as *const crate::object::ObjectHeader;
+    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
+    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    let done = {
+        let done_val = crate::object::js_object_get_field_by_name(result_obj, done_key);
+        let done_f64 = f64::from_bits(done_val.bits());
+        crate::value::js_is_truthy(done_f64) != 0
+    };
+    let value = {
+        let value_val = crate::object::js_object_get_field_by_name(result_obj, value_key);
+        f64::from_bits(value_val.bits())
+    };
+
+    let outer = crate::promise::js_promise_new();
+    let on_fulfilled = crate::closure::js_closure_alloc(async_from_sync_fulfilled as *const u8, 2);
+    let on_rejected =
+        crate::closure::js_closure_alloc(async_from_sync_rejected_value as *const u8, 3);
+    crate::closure::js_closure_set_capture_ptr(on_fulfilled, 0, outer as i64);
+    crate::closure::js_closure_set_capture_f64(on_fulfilled, 1, if done { 1.0 } else { 0.0 });
+    crate::closure::js_closure_set_capture_ptr(on_rejected, 0, outer as i64);
+    crate::closure::js_closure_set_capture_f64(on_rejected, 1, iter);
+    crate::closure::js_closure_set_capture_f64(
+        on_rejected,
+        2,
+        if close_on_rejection { 1.0 } else { 0.0 },
+    );
+
+    let value_promise = crate::promise::js_promise_resolved(value);
+    crate::promise::js_promise_then(value_promise, on_fulfilled, on_rejected);
+    boxed_promise_value(outer)
+}
+
+fn async_from_sync_rest_args(rest: f64) -> (usize, f64) {
+    let ptr = crate::value::js_nanbox_get_pointer(rest) as *const crate::array::ArrayHeader;
+    if ptr.is_null() {
+        return (0, undefined_value());
+    }
+    let len = crate::array::js_array_length(ptr) as usize;
+    let first = if len == 0 {
+        undefined_value()
+    } else {
+        crate::array::js_array_get_f64(ptr, 0)
+    };
+    (len, first)
+}
+
+fn async_from_sync_call_raw(iter: f64, method: &[u8], args: &[f64]) -> Result<Option<f64>, f64> {
+    let method_value = named_field(iter, method);
+    if method_value.to_bits() == crate::value::TAG_UNDEFINED {
+        let raw = crate::value::js_nanbox_get_pointer(iter) as usize;
+        if method != b"next" || !is_builtin_iterator_class_id(raw) {
+            return Ok(None);
+        }
+    } else if !is_callable_value(method_value) {
+        return Err(async_from_sync_type_error(
+            b"Async-from-sync iterator method is not callable",
+        ));
+    }
+
+    let trap_buf = crate::exception::js_try_push();
+    let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut std::os::raw::c_int) };
+    let result = if jumped == 0 {
+        let args_ptr = if args.is_empty() {
+            std::ptr::null()
+        } else {
+            args.as_ptr()
+        };
+        let value = unsafe {
+            crate::object::js_native_call_method(
+                iter,
+                method.as_ptr() as *const i8,
+                method.len(),
+                args_ptr,
+                args.len(),
+            )
+        };
+        Ok(Some(value))
+    } else {
+        let exc = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        Err(exc)
+    };
+    crate::exception::js_try_end();
+    result
+}
+
+fn async_from_sync_close(iter: f64) {
+    let _ = async_from_sync_call_raw(iter, b"return", &[]);
+}
+
+fn async_from_sync_call(iter: f64, method: &[u8], args: &[f64], close_on_rejection: bool) -> f64 {
+    match async_from_sync_call_raw(iter, method, args) {
+        Ok(Some(step)) => async_from_sync_continue(iter, step, close_on_rejection),
+        Ok(None) => async_from_sync_rejected(b"Async-from-sync iterator method is not callable"),
+        Err(reason) => boxed_promise_value(crate::promise::js_promise_rejected(reason)),
+    }
+}
+
+extern "C" fn async_from_sync_next(
+    closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let iter = crate::closure::js_closure_get_capture_f64(closure, 0);
+    let (argc, first) = async_from_sync_rest_args(rest);
+    let single = [first];
+    let args: &[f64] = if argc == 0 { &[] } else { &single };
+    async_from_sync_call(iter, b"next", args, true)
+}
+
+extern "C" fn async_from_sync_return(
+    closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let iter = crate::closure::js_closure_get_capture_f64(closure, 0);
+    let (argc, first) = async_from_sync_rest_args(rest);
+    let single = [first];
+    let args: &[f64] = if argc == 0 { &[] } else { &single };
+    match async_from_sync_call_raw(iter, b"return", args) {
+        Ok(Some(step)) => async_from_sync_continue(iter, step, false),
+        Ok(None) => {
+            let value = if argc == 0 { undefined_value() } else { first };
+            let done = async_from_sync_iter_result(value, true);
+            boxed_promise_value(crate::promise::js_promise_resolved(done))
+        }
+        Err(reason) => boxed_promise_value(crate::promise::js_promise_rejected(reason)),
+    }
+}
+
+extern "C" fn async_from_sync_throw(
+    closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let iter = crate::closure::js_closure_get_capture_f64(closure, 0);
+    let (argc, first) = async_from_sync_rest_args(rest);
+    let single = [first];
+    let args: &[f64] = if argc == 0 { &[] } else { &single };
+    match async_from_sync_call_raw(iter, b"throw", args) {
+        Ok(Some(step)) => async_from_sync_continue(iter, step, true),
+        Ok(None) => {
+            async_from_sync_close(iter);
+            async_from_sync_rejected(b"The iterator does not provide a 'throw' method.")
+        }
+        Err(reason) => boxed_promise_value(crate::promise::js_promise_rejected(reason)),
+    }
+}
+
+extern "C" fn async_from_sync_async_iterator(closure: *const crate::closure::ClosureHeader) -> f64 {
+    crate::closure::js_closure_get_capture_f64(closure, 0)
+}
+
+fn register_async_from_sync_thunks_once() {
+    thread_local! {
+        static REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+    REGISTERED.with(|flag| {
+        if flag.get() {
+            return;
+        }
+        crate::closure::js_register_closure_rest(async_from_sync_next as *const u8, 0);
+        crate::closure::js_register_closure_rest(async_from_sync_return as *const u8, 0);
+        crate::closure::js_register_closure_rest(async_from_sync_throw as *const u8, 0);
+        crate::closure::js_register_closure_arity(async_from_sync_async_iterator as *const u8, 0);
+        flag.set(true);
+    });
+}
+
+fn install_async_from_sync_method(
+    obj: *mut crate::object::ObjectHeader,
+    name: &[u8],
+    func: extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64,
+    iter: f64,
+) -> f64 {
+    let closure = crate::closure::js_closure_alloc(func as *const u8, 1);
+    crate::closure::js_closure_set_capture_f64(closure, 0, iter);
+    let value = crate::value::js_nanbox_pointer(closure as i64);
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::object::js_object_set_field_by_name(obj, key, value);
+    value
+}
+
+pub(crate) fn async_from_sync_wrap_iterator(iter: f64) -> f64 {
+    register_async_from_sync_thunks_once();
+    let obj = crate::object::js_object_alloc(0, 0);
+    let wrapper = crate::value::js_nanbox_pointer(obj as i64);
+    install_async_from_sync_method(obj, b"next", async_from_sync_next, iter);
+    install_async_from_sync_method(obj, b"return", async_from_sync_return, iter);
+    install_async_from_sync_method(obj, b"throw", async_from_sync_throw, iter);
+    let async_iter =
+        crate::closure::js_closure_alloc(async_from_sync_async_iterator as *const u8, 1);
+    crate::closure::js_closure_set_capture_f64(async_iter, 0, wrapper);
+    let sym = crate::symbol::well_known_symbol("asyncIterator");
+    if !sym.is_null() {
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(
+                wrapper,
+                f64::from_bits(crate::value::JSValue::pointer(sym as *const u8).bits()),
+                crate::value::js_nanbox_pointer(async_iter as i64),
+            );
+        }
+    }
+    wrapper
+}
+
+#[no_mangle]
+pub extern "C" fn js_get_async_iterator(value: f64) -> f64 {
+    if let Some(iter) = call_symbol_async_iterator(value) {
+        return iter;
+    }
+
+    let iter = crate::symbol::js_get_iterator(value);
+    let raw = crate::value::js_nanbox_get_pointer(iter) as usize;
+    if iter.to_bits() == value.to_bits()
+        && !is_builtin_iterator_class_id(raw)
+        && !has_named_next(iter)
+    {
+        throw_not_iterable(value);
+    }
+
+    async_from_sync_wrap_iterator(iter)
+}
+
 #[cold]
 fn throw_not_iterable(value: f64) -> ! {
     let label = if value.to_bits() == crate::value::TAG_NULL {

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -79,13 +79,16 @@ pub use self::iter_object::{
     ARRAY_ITERATOR_CLASS_ID,
 };
 pub(crate) use self::iterator::is_builtin_iterator_class_id;
-pub use self::iterator::{js_array_spread_append, js_for_of_to_array, js_iterator_to_array};
+pub use self::iterator::{
+    js_array_spread_append, js_for_of_to_array, js_get_async_iterator, js_iterator_to_array,
+};
 // Issue #1572 — flatten helpers reused by `node_stream::ns_iter_flat_map`
 // so an `async function*` mapper return is driven through the iterator
 // protocol instead of being appended as a single chunk.
 pub(crate) use self::iterator::{
-    async_iterator_to_array_for_flat_map, call_symbol_async_iterator_for_flat_map,
-    entries_array_for_small_handle_id, has_iterator_next, sync_iterator_to_array_if_not_async,
+    async_from_sync_wrap_iterator, async_iterator_to_array_for_flat_map,
+    call_symbol_async_iterator_for_flat_map, entries_array_for_small_handle_id, has_iterator_next,
+    sync_iterator_to_array_if_not_async,
 };
 pub use self::jsvalue_api::{
     js_array_from_jsvalue, js_array_get, js_array_get_jsvalue, js_array_push,

--- a/crates/perry-runtime/src/object/async_generator_queue.rs
+++ b/crates/perry-runtime/src/object/async_generator_queue.rs
@@ -203,6 +203,21 @@ fn is_queue_wrapper(closure: *const ClosureHeader) -> bool {
         || func == async_generator_throw_wrapper as *const u8
 }
 
+pub(crate) fn is_async_generator_instance_value(value: f64) -> bool {
+    let ptr = crate::value::js_nanbox_get_pointer(value) as usize;
+    if ptr < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return false;
+    }
+    let is_object = unsafe {
+        let gc = (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*gc).obj_type == crate::gc::GC_TYPE_OBJECT
+    };
+    if !is_object {
+        return false;
+    }
+    own_closure(ptr as *mut ObjectHeader, b"next").is_some_and(is_queue_wrapper)
+}
+
 fn state_id_from_wrapper(closure: *const ClosureHeader) -> Option<usize> {
     if closure.is_null() {
         return None;

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -70,6 +70,7 @@ pub use alloc::*;
 pub use arguments::*;
 pub(crate) use array_object_ops::*;
 pub use assert::*;
+pub(crate) use async_generator_queue::is_async_generator_instance_value;
 pub(crate) use bigint_dispatch::*;
 pub use buffer_dispatch::*;
 pub use class_constructors::*;

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -587,7 +587,18 @@ fn iterator_value_for_from_async(input: f64) -> Option<f64> {
     if let Some(iter) = crate::array::call_symbol_async_iterator_for_flat_map(input) {
         return Some(iter);
     }
-    crate::array::has_iterator_next(input).then_some(input)
+    if crate::object::is_async_generator_instance_value(input) {
+        return Some(input);
+    }
+    let iter = crate::symbol::js_get_iterator(input);
+    let raw = crate::value::js_nanbox_get_pointer(iter) as usize;
+    if iter.to_bits() != input.to_bits()
+        || crate::array::is_builtin_iterator_class_id(raw)
+        || crate::array::has_iterator_next(iter)
+    {
+        return Some(crate::array::async_from_sync_wrap_iterator(iter));
+    }
+    None
 }
 
 /// `Array.fromAsync(input, mapFn?, thisArg?)` — Node 22+ static method.

--- a/test-parity/node-suite/globals/async-from-sync-iterator.ts
+++ b/test-parity/node-suite/globals/async-from-sync-iterator.ts
@@ -1,0 +1,155 @@
+async function runFullIteration(): Promise<void> {
+  const log: string[] = [];
+  let idx = 0;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          log.push("next:" + idx);
+          if (idx === 0) {
+            idx++;
+            return { value: Promise.resolve(10), done: false };
+          }
+          if (idx === 1) {
+            idx++;
+            return { value: 20, done: false };
+          }
+          return { value: 0, done: true };
+        },
+      };
+    },
+  };
+
+  let sum = 0;
+  for await (const value of iterable) {
+    log.push("body:" + value);
+    sum += value;
+  }
+  console.log("full:", log.join("|"), "sum=" + sum);
+}
+
+async function runEarlyBreak(): Promise<void> {
+  const log: string[] = [];
+  let idx = 0;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          log.push("next:" + idx);
+          if (idx === 0) {
+            idx++;
+            return { value: Promise.resolve("first"), done: false };
+          }
+          if (idx === 1) {
+            idx++;
+            return { value: Promise.resolve("second"), done: false };
+          }
+          return { value: undefined, done: true };
+        },
+        return(value?: unknown) {
+          log.push("return:" + String(value));
+          return { value: "closed", done: true };
+        },
+      };
+    },
+  };
+
+  for await (const value of iterable) {
+    log.push("body:" + value);
+    break;
+  }
+  console.log("break:", log.join("|"));
+}
+
+async function runArrayFromAsync(): Promise<void> {
+  const log: string[] = [];
+  let idx = 0;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          log.push("next:" + idx);
+          if (idx === 0) {
+            idx++;
+            return { value: Promise.resolve("a"), done: false };
+          }
+          if (idx === 1) {
+            idx++;
+            return { value: "b", done: false };
+          }
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+
+  const out = await Array.fromAsync(iterable);
+  console.log("array:", out.join(","), log.join("|"));
+}
+
+async function runDestructuring(): Promise<void> {
+  let idx = 0;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          if (idx === 0) {
+            idx++;
+            return { value: Promise.resolve(["pair", 7]), done: false };
+          }
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+
+  for await (const [label, value] of iterable) {
+    console.log("destructure:", label + ":" + value);
+  }
+}
+
+async function runRejectedValue(): Promise<void> {
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: Promise.reject("boom"), done: false };
+        },
+      };
+    },
+  };
+
+  try {
+    for await (const value of iterable) {
+      console.log("rejected-value: body:" + value);
+    }
+  } catch (error) {
+    console.log("rejected-value:", String(error));
+  }
+}
+
+async function runBadIteratorResult(): Promise<void> {
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return 1;
+        },
+      };
+    },
+  };
+
+  try {
+    await Array.fromAsync(iterable);
+    console.log("bad-result: resolved");
+  } catch (error) {
+    console.log("bad-result:", (error as Error).constructor.name);
+  }
+}
+
+await runFullIteration();
+await runEarlyBreak();
+await runArrayFromAsync();
+await runDestructuring();
+await runRejectedValue();
+await runBadIteratorResult();


### PR DESCRIPTION
Fixes #4520.

## Summary
- add a runtime async-from-sync iterator wrapper with `next`, `return`, `throw`, and `[Symbol.asyncIterator]` methods
- route dynamic `for await...of` lowering through `js_get_async_iterator` instead of materializing sync iterables before awaiting values
- make `Array.fromAsync` wrap sync iterables so promise-valued sync yields are unwrapped while keeping async-generator inputs on the async path
- add parity coverage for `for await`, early close, destructuring, `Array.fromAsync`, rejected promise values, and malformed iterator results

## Notes
- the runtime wrapper includes argument forwarding, missing-`return` / missing-`throw` handling, sync-call rejection, and close-on-rejected-value handling
- async-generator `yield*` delegation still has a separate transform path and is not claimed as completed in this PR

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
- `cargo check -p perry-runtime -p perry-hir -p perry-codegen`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter async-from-sync-iterator'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter array-from-async-mapfn'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter async-generator-request-queue'`