### PR TITLE
fix(hir): logical property assignment must short-circuit the store (#4586)

### DIFF
--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -222,6 +222,43 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
             .flatten(),
     )?;
 
+    // #4586: logical assignments (`&&=`, `||=`, `??=`) to a PROPERTY target
+    // must not store unconditionally. Desugaring to `a.b = (a.b OP rhs)` (the
+    // generic compound-assign shape below) always runs PutValue, which fires
+    // setters spuriously and throws `TypeError: Cannot assign to read only
+    // property` on non-writable `Object.defineProperty` data props — e.g.
+    // Zod v4's `inst._zod ??= {}` where `_zod` is already non-nullish and
+    // read-only, breaking every check/refinement-based schema under
+    // `perry.compilePackages`.
+    //
+    // Per ECMAScript LogicalAssignment, the store (PutValue) must be skipped
+    // entirely when the short-circuit holds. We desugar to
+    // `read(a.b) OP (a.b = rhs)` so the assignment lives on the RHS of the
+    // logical operator and is therefore only evaluated on the branch that
+    // actually needs to write. `rhs` is consumed exactly once.
+    //
+    // Scoped to `Member` targets: plain `Ident` locals/globals have no
+    // setters and no read-only data descriptors, so an unconditional
+    // `LocalSet` there is observationally identical to the spec — leaving
+    // that path untouched keeps the blast radius minimal.
+    if let ast::AssignTarget::Simple(ast::SimpleAssignTarget::Member(member)) = &assign.left {
+        if let Some(logical_op) = match assign.op {
+            ast::AssignOp::AndAssign => Some(LogicalOp::And),
+            ast::AssignOp::OrAssign => Some(LogicalOp::Or),
+            ast::AssignOp::NullishAssign => Some(LogicalOp::Coalesce),
+            _ => None,
+        } {
+            let read_left = lower_assign_target_to_expr(ctx, &assign.left)?;
+            let target_expr = ast::Expr::Member(member.clone());
+            let store = lower_expr_assignment(ctx, &target_expr, Box::new(rhs))?;
+            return Ok(Expr::Logical {
+                op: logical_op,
+                left: Box::new(read_left),
+                right: Box::new(store),
+            });
+        }
+    }
+
     // Handle compound assignment operators (+=, -=, *=, /=, etc.)
     let value = match assign.op {
         ast::AssignOp::Assign => Box::new(rhs),

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -1,5 +1,5 @@
 use perry_diagnostics::SourceCache;
-use perry_hir::{lower_module, ArrayElement, BinaryOp, Expr, Function, Stmt};
+use perry_hir::{lower_module, ArrayElement, BinaryOp, Expr, Function, LogicalOp, Stmt};
 use perry_parser::parse_typescript_with_cache;
 
 fn lower_src(src: &str) -> perry_hir::Module {
@@ -483,4 +483,49 @@ fn sloppy_js_yield_identifier_arrow_parameters_lower() {
     assert!(matches!(top_level_init(&module, "f"), Expr::Closure { .. }));
     assert!(matches!(top_level_init(&module, "g"), Expr::Closure { .. }));
     assert!(matches!(top_level_init(&module, "h"), Expr::Closure { .. }));
+}
+
+#[test]
+fn logical_property_assignment_short_circuits_the_store_4586() {
+    // #4586: `obj.prop ??= v` / `||=` / `&&=` must not store unconditionally.
+    // The pre-fix desugaring `obj.prop = (obj.prop OP v)` always ran PutValue,
+    // which fired setters spuriously and threw `TypeError: Cannot assign to
+    // read only property` on non-writable `Object.defineProperty` data props
+    // (e.g. Zod v4's `inst._zod ??= {}`). The fix desugars to
+    // `read(obj.prop) OP (obj.prop = v)` so the store lives on the
+    // short-circuit RHS and only runs on the branch that actually writes.
+    for (src, expected_op) in [
+        ("const o = { x: 1 }; o.x ??= 2;", LogicalOp::Coalesce),
+        ("const o = { x: 1 }; o.x ||= 2;", LogicalOp::Or),
+        ("const o = { x: 1 }; o.x &&= 2;", LogicalOp::And),
+    ] {
+        let module = lower_src(src);
+        let logical = module
+            .init
+            .iter()
+            .rev()
+            .find_map(|stmt| match stmt {
+                Stmt::Expr(expr @ Expr::Logical { .. }) => Some(expr),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                panic!("expected a short-circuiting Logical for `{src}`, got {:?}", module.init)
+            });
+
+        let Expr::Logical { op, left, right } = logical else {
+            unreachable!();
+        };
+        assert_eq!(*op, expected_op, "operator mismatch for `{src}`");
+        // LHS is the property READ (GetValue), not a store.
+        assert!(
+            matches!(left.as_ref(), Expr::PropertyGet { property, .. } if property == "x"),
+            "expected a property read on the LHS for `{src}`, got {left:?}"
+        );
+        // The single store lives on the RHS, so it is only evaluated when the
+        // short-circuit does NOT hold.
+        assert!(
+            matches!(right.as_ref(), Expr::PutValueSet { .. }),
+            "expected the store to live on the short-circuit RHS for `{src}`, got {right:?}"
+        );
+    }
 }

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -509,7 +509,10 @@ fn logical_property_assignment_short_circuits_the_store_4586() {
                 _ => None,
             })
             .unwrap_or_else(|| {
-                panic!("expected a short-circuiting Logical for `{src}`, got {:?}", module.init)
+                panic!(
+                    "expected a short-circuiting Logical for `{src}`, got {:?}",
+                    module.init
+                )
             });
 
         let Expr::Logical { op, left, right } = logical else {


### PR DESCRIPTION
## Summary

Fixes #4586. Logical compound assignments to a **property target** (`a.b ??= c`, `a.b ||= c`, `a.b &&= c`) were lowered to `a.b = (a.b OP c)` — an unconditional store. Per ECMAScript, a logical assignment must skip `PutValue` entirely when the short-circuit holds.

The redundant store is observationally silent on normal writable data properties, but it surfaces as:
- a spurious **setter** call when the accessor already holds a non-nullish/truthy value, and
- a `TypeError: Cannot assign to read only property` on **non-writable** `Object.defineProperty` data props.

This broke **Zod v4** under `perry.compilePackages`: `$ZodCheck` runs `inst._zod ??= {}` where `_zod` is an already-defined non-writable property, so the spurious store threw and blocked every check/refinement-based schema (`.email()`, `.uuid()`, `.min()`, `.refine()`, `.transform()`, coercion, …).

## Fix

In `lower/expr_assign.rs`, `Member` targets with a logical op now desugar to `read(a.b) OP (a.b = c)`. The store lives on the logical operator's RHS, so it is only evaluated on the non-short-circuit branch, reusing the existing member-store path. Scoped to `Member` targets — plain `Ident` locals have no setters or read-only descriptors, so their unconditional `LocalSet` already matches spec.

## Testing

- New HIR regression test `logical_property_assignment_short_circuits_the_store_4586` in `crates/perry-hir/tests/c262_parity.rs` asserts the desugared shape for `??=`/`||=`/`&&=`.
- Full `perry-hir` suite green.
- Manual parity vs Node:
  - accessor `a.x ??= v` → setter fires 0 times (was 1),
  - non-writable `o._zod ??= {}` → no throw,
  - short-circuit-not-held cases still assign and return the correct value (incl. computed members).

## Notes

This unblocks Zod's check-construction path; a **separate, independent** blocker remains for full Zod v4 end-to-end (a lazy builder method reads `this.def` as `undefined` in compiled packages — distinct from this issue, will be filed separately).
