### PR TITLE
fix: cross-module fn statics, Object.assign fn source, bind-as-value, regex replace lookahead

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -1212,8 +1212,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // Without this, the codegen uses the address of the
             // ClosureHeader global (wrong memory) instead of the
             // object stored in the module's export global.
+            //
+            // Gate strictly on `imported_vars`: only exported const/let
+            // bindings have a `perry_fn_<src>__<name>` *getter* whose call
+            // returns the value. For an imported *function*, that same symbol
+            // IS the function body — calling it here invoked the function with
+            // zero args (reading garbage params) and read the property off its
+            // return value. Stripe hit this on `StripeResource.method` /
+            // `.extend` (an `export { StripeResource }` function with static
+            // props); every static read invoked the constructor instead. The
+            // function/class case falls through to the generic path below,
+            // which materializes the closure value and reads its dynamic prop.
             if let Expr::ExternFuncRef { name, .. } = object.as_ref() {
-                if let Some(source_prefix) = ctx.import_function_prefixes.get(name).cloned() {
+                if ctx.imported_vars.contains(name) {
+                    if let Some(source_prefix) = ctx.import_function_prefixes.get(name).cloned() {
                     // Issue #678: re-export renames mean the suffix in the
                     // origin module differs from the consumer-visible name.
                     let origin_suffix =
@@ -1236,6 +1248,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         "js_object_get_field_by_name_f64",
                         &[(I64, &obj_handle), (I64, &key_handle)],
                     ));
+                    }
                 }
             }
             // Getter dispatch: if the receiver is a known class and

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -794,6 +794,33 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
         return target_f64;
     }
 
+    // A function/closure source is NOT an `ObjectHeader`: reading `keys_array`
+    // off it dereferences a bogus field, yielding a garbage `key_count` and a
+    // runaway copy loop. Enumerate the closure's own *enumerable* dynamic props
+    // instead — the built-in `length`/`name`/`prototype` slots are
+    // non-enumerable and excluded, matching `Object.keys`/`getOwnPropertyNames`.
+    // (Stripe's `protoExtend` does `Object.assign(Constructor, Super)` to copy a
+    // resource class's enumerable statics like `.extend`/`.method`; without this
+    // the call hung at `import 'stripe'`.)
+    if crate::closure::is_closure_ptr(src_raw) {
+        for (name, value) in crate::closure::closure_dynamic_props_snapshot(src_raw) {
+            if matches!(name.as_str(), "length" | "name" | "prototype") {
+                continue;
+            }
+            if crate::closure::closure_is_key_deleted(src_raw, &name) {
+                continue;
+            }
+            if let Some(attrs) = get_property_attrs(src_raw, &name) {
+                if !attrs.enumerable() {
+                    continue;
+                }
+            }
+            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            object_assign_set_string_key(target, target_is_array, key_ptr, value);
+        }
+        return target_f64;
+    }
+
     let src = src_raw as *const ObjectHeader;
 
     // 1) Copy own string-keyed enumerable properties from source to target,

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1022,6 +1022,29 @@ extern "C" fn function_prototype_call_thunk(
     result
 }
 
+/// `Function.prototype.bind` as a real callable thunk. Reads the target
+/// function from `IMPLICIT_THIS` (set by `.call`/`.apply`/`Reflect.apply`),
+/// flattens `(thisArg, ...boundArgs)` into one argument list, and delegates to
+/// `js_function_bind` (which builds the BOUND_FUNCTION closure).
+///
+/// Previously `bind` was installed as a *no-op* proto method, so calling it as
+/// a value — `Reflect.apply(Function.prototype.bind, fn, [thisArg])` or
+/// `Function.prototype.bind.apply(fn, …)` — returned `undefined` instead of a
+/// bound function. The `Function.prototype.call.bind(method)` uncurry idiom in
+/// `call-bind-apply-helpers` (used by call-bound → side-channel → qs → Stripe)
+/// hit exactly this: `Reflect.apply(bind, call, [fn])` yielded `undefined`.
+extern "C" fn function_prototype_bind_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    this_arg: f64,
+    rest: f64,
+) -> f64 {
+    let target = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let mut args: Vec<f64> = Vec::with_capacity(1);
+    args.push(this_arg);
+    args.extend(global_this_rest_array_values(rest));
+    unsafe { crate::closure::js_function_bind(target, args.as_ptr(), args.len()) }
+}
+
 extern "C" fn global_this_set_timeout_thunk(
     _closure: *const crate::closure::ClosureHeader,
     callback: f64,
@@ -4121,7 +4144,12 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                 function_prototype_apply_thunk as *const u8,
                 2,
             );
-            install_noop_proto_methods(proto_obj, &[("bind", 1)]);
+            install_proto_method_rest(
+                proto_obj,
+                "bind",
+                function_prototype_bind_thunk as *const u8,
+                1,
+            );
             // #4101: dedicated toString thunk (source reconstruction + brand
             // check) instead of the shared no-op.
             install_proto_method(

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -1426,6 +1426,96 @@ pub extern "C" fn js_regexp_set_last_index(re: *mut RegExpHeader, value: f64) {
     }
 }
 
+/// Fancy-regex fallback for `js_string_replace_regex_fn`: used when the pattern
+/// needs lookahead/backreferences that the `regex` crate can't compile. Mirrors
+/// the standard-engine loop below (full ECMAScript callback argument list,
+/// char-based offset, named-group `groups` object) but drives the match loop
+/// with `fancy_regex`.
+unsafe fn replace_regex_fn_fancy(
+    str_data: &str,
+    fre: &fancy_regex::Regex,
+    global: bool,
+    closure_ptr: *const crate::closure::ClosureHeader,
+) -> *mut StringHeader {
+    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+    let has_named_groups = fre.capture_names().any(|n| n.is_some());
+
+    // Collect captures up front so a GC during callback dispatch can't disturb
+    // the iterator's borrow of `str_data`.
+    let mut captures_list: Vec<fancy_regex::Captures> = Vec::new();
+    let mut iter = fre.captures_iter(str_data);
+    while let Some(Ok(caps)) = iter.next() {
+        captures_list.push(caps);
+        if !global {
+            break;
+        }
+    }
+
+    let mut result = String::new();
+    let mut last_end = 0usize;
+
+    for caps in &captures_list {
+        let full_match = caps.get(0).unwrap();
+        result.push_str(&str_data[last_end..full_match.start()]);
+
+        let char_offset = str_data[..full_match.start()].chars().count();
+
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let mut arg_handles: Vec<crate::gc::RuntimeHandle<'_>> = Vec::new();
+
+        let match_nanboxed = js_nanbox_string(js_string_from_str(full_match.as_str()) as i64);
+        arg_handles.push(scope.root_nanbox_f64(match_nanboxed));
+
+        let num_groups = caps.len() - 1; // exclude full match
+        for gi in 1..=num_groups {
+            let group_val = if let Some(m) = caps.get(gi) {
+                js_nanbox_string(js_string_from_str(m.as_str()) as i64)
+            } else {
+                f64::from_bits(TAG_UNDEFINED)
+            };
+            arg_handles.push(scope.root_nanbox_f64(group_val));
+        }
+
+        arg_handles.push(scope.root_nanbox_f64(char_offset as f64));
+        let string_nanboxed = js_nanbox_string(js_string_from_str(str_data) as i64);
+        arg_handles.push(scope.root_nanbox_f64(string_nanboxed));
+
+        if has_named_groups {
+            let groups_obj = crate::object::js_object_alloc(0, 0);
+            let groups_handle = scope.root_raw_mut_ptr(groups_obj);
+            let group_names: Vec<(&str, Option<fancy_regex::Match>)> = fre
+                .capture_names()
+                .enumerate()
+                .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
+                .collect();
+            for (name, m) in &group_names {
+                let val = if let Some(m) = m {
+                    js_nanbox_string(js_string_from_str(m.as_str()) as i64)
+                } else {
+                    f64::from_bits(TAG_UNDEFINED)
+                };
+                let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+                crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
+            }
+            let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+            let groups_value = crate::value::js_nanbox_pointer(groups_ptr as i64);
+            arg_handles.push(scope.root_nanbox_f64(groups_value));
+        }
+
+        let call_args: Vec<f64> = arg_handles.iter().map(|h| h.get_nanbox_f64()).collect();
+        let callback_value =
+            f64::from_bits(crate::value::JSValue::pointer(closure_ptr as *mut u8).bits());
+        result.push_str(&call_replace_callback(callback_value, &call_args));
+
+        last_end = full_match.end();
+    }
+
+    result.push_str(&str_data[last_end..]);
+    js_string_from_str(&result)
+}
+
 /// string.replace(regex, replacerFn) — replace with a callback function.
 ///
 /// The callback receives the full ECMAScript argument list (#2867):
@@ -1461,6 +1551,17 @@ pub extern "C" fn js_string_replace_regex_fn(
             crate::value::js_nanbox_get_pointer(callback) as *const crate::closure::ClosureHeader;
         if closure_ptr.is_null() {
             return js_string_from_str(str_data);
+        }
+
+        // If the `regex` crate couldn't compile this pattern (lookahead,
+        // backreferences, …), `get_or_compile_regex` stashed a never-match
+        // placeholder in `(*re).regex_ptr` and the real pattern in
+        // `FANCY_CACHE`. Route the callback-replace through fancy-regex so the
+        // callback actually fires — otherwise `captures_iter` below would
+        // silently match nothing and return the input unchanged. (get-intrinsic's
+        // `stringToPath` relies on `String.prototype.replace(/…(?=…)…/g, fn)`.)
+        if let Some(fre) = lookup_fancy_regex(re) {
+            return replace_regex_fn_fancy(str_data, &fre, global, closure_ptr);
         }
 
         let mut result = String::new();

--- a/tests/test_function_bind_value_reflect_apply.sh
+++ b/tests/test_function_bind_value_reflect_apply.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `Function.prototype.bind` invoked as a *value* (not a `fn.bind(...)` method
+# call) must create a bound function. It was installed as a no-op proto method,
+# so `Reflect.apply(Function.prototype.bind, fn, [thisArg])` and
+# `Function.prototype.bind.apply(fn, …)` returned `undefined`. The
+# `Function.prototype.call.bind(method)` uncurry-this idiom in
+# `call-bind-apply-helpers` (call-bound → side-channel → qs → Stripe) relies on
+# `Reflect.apply(bind, call, [fn])` returning a real bound function.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+const bind = Function.prototype.bind;
+const call = Function.prototype.call;
+
+// uncurry-this: `Function.prototype.call.bind(String.prototype.indexOf)`
+// built via Reflect.apply(bind, call, [indexOf]).
+const indexOf = String.prototype.indexOf;
+const boundCall: any = (Reflect as any).apply(bind, call, [indexOf]);
+if (typeof boundCall !== "function") throw new Error("not a function: " + typeof boundCall);
+// boundCall("hello", "l") === "hello".indexOf("l") === 2
+if (boundCall("hello", "l") !== 2) throw new Error("uncurry: " + boundCall("hello", "l"));
+
+// Also via Function.prototype.bind.apply
+function add(a: number, b: number) { return a + b; }
+const g: any = (bind as any).apply(add, [null, 10]);   // add.bind(null, 10)
+if (typeof g !== "function") throw new Error("bind.apply not fn: " + typeof g);
+if (g(5) !== 15) throw new Error("bind.apply partial: " + g(5));
+
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: Function.prototype.bind as a value (Reflect.apply / .apply)"

--- a/tests/test_imported_function_static_property.sh
+++ b/tests/test_imported_function_static_property.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reading a static property off a cross-module *imported function* must read the
+# property — not invoke the function. PropertyGet on an `Expr::ExternFuncRef`
+# unconditionally called the `perry_fn_<src>__<name>()` getter (correct only for
+# an exported const/let, whose symbol IS a value getter). For an imported
+# *function*, that symbol is the function body, so every `Fn.staticProp` read
+# invoked the function with zero args and read the property off its return value
+# (undefined). Stripe hit this on `StripeResource.method` / `.extend` — an
+# `export { StripeResource }` function carrying static props — so each static
+# read constructed a StripeResource instead.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/res.ts" <<'TS'
+function StripeResource(this: any, stripe: any, deprecated: any) {
+  if (deprecated) throw new Error("invoked with a 2nd arg: " + typeof deprecated);
+  this._stripe = stripe;
+}
+(StripeResource as any).method = function () { return "M"; };
+(StripeResource as any).extend = function () { return "E"; };
+(StripeResource as any).MAX = 42;
+(StripeResource as any).prototype = { _stripe: null, path: "", initialize() {} };
+export { StripeResource };
+TS
+cat >"$TMPDIR/main.ts" <<'TS'
+import { StripeResource } from "./res.js";
+// Reads must NOT invoke the constructor.
+if (typeof (StripeResource as any).method !== "function") throw new Error("method: " + typeof (StripeResource as any).method);
+if (typeof (StripeResource as any).extend !== "function") throw new Error("extend: " + typeof (StripeResource as any).extend);
+if ((StripeResource as any).MAX !== 42) throw new Error("MAX: " + (StripeResource as any).MAX);
+// Built-in function props read off the imported function too.
+if ((StripeResource as any).name !== "StripeResource") throw new Error("name: " + (StripeResource as any).name);
+// Reading the static into a local then calling it (the Stripe pattern:
+// `const stripeMethod = StripeResource.method;`) dispatches correctly.
+const m: any = (StripeResource as any).method;
+if (m() !== "M") throw new Error("method via local: " + m());
+const e: any = (StripeResource as any).extend;
+if (e() !== "E") throw new Error("extend via local: " + e());
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/main.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: imported function static property read (no spurious invocation)"

--- a/tests/test_object_assign_function_source.sh
+++ b/tests/test_object_assign_function_source.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `Object.assign(target, fn)` where the source is a function/closure must copy
+# the function's own *enumerable* statics (and skip the non-enumerable
+# `length`/`name`/`prototype` slots) without hanging. A function is a
+# ClosureHeader, not an ObjectHeader; reading `keys_array` off it yielded a
+# garbage key_count and a runaway copy loop. Stripe's `protoExtend` does
+# `Object.assign(Constructor, Super)` to copy a resource class's enumerable
+# statics — this hung at `import 'stripe'`.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+function Super(this: any, a: any) { this._a = a; }
+(Super as any).extend = "EXT";
+(Super as any).method = "METH";
+(Super as any).MAX = 100;
+// Reassigning `.prototype` to a plain object is what Stripe's protoExtend does.
+(Super as any).prototype = { _a: null, path: "", initialize() {}, foo() { return 1; } };
+
+const t: any = {};
+Object.assign(t, Super);
+// Enumerable statics copied:
+if (t.extend !== "EXT") throw new Error("extend: " + t.extend);
+if (t.method !== "METH") throw new Error("method: " + t.method);
+if (t.MAX !== 100) throw new Error("MAX: " + t.MAX);
+// Non-enumerable `prototype`/`name`/`length` must NOT be copied.
+const keys = Object.keys(t).sort();
+if (JSON.stringify(keys) !== '["MAX","extend","method"]') throw new Error("keys: " + JSON.stringify(keys));
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: Object.assign with a function source copies enumerable statics"

--- a/tests/test_regex_replace_fn_lookahead.sh
+++ b/tests/test_regex_replace_fn_lookahead.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `String.prototype.replace(re, fn)` must fire the callback even when the regex
+# needs lookahead/backreferences (which the `regex` crate can't compile, so the
+# pattern is stashed in the fancy-regex FANCY_CACHE behind a never-match
+# placeholder). The callback-replace path had no fancy-regex fallback, so the
+# callback never fired and the input came back unchanged — get-intrinsic's
+# `stringToPath` (`'%String.prototype.indexOf%'.replace(/…(?=…)…/g, fn)`)
+# returned an empty parts list, breaking the whole call-bound→qs→Stripe chain.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+// Lookahead alternative — needs fancy-regex.
+function run(re: RegExp, s: string): string[] {
+  const out: string[] = [];
+  s.replace(re, (m: string) => { out.push(m); return m; });
+  return out;
+}
+// `[a-z]+ | (?=\.)`: first match "ab", a zero-width lookahead at '.', "cd".
+const a = run(/[a-z]+|(?=\.)/g, "ab.cd");
+if (JSON.stringify(a) !== '["ab","cd"]') throw new Error("A: " + JSON.stringify(a));
+// Pure zero-width lookahead repeated — must not infinite-loop.
+const d = run(/(?=\.)/g, "a.b.c");
+if (JSON.stringify(d) !== '["",""]') throw new Error("D: " + JSON.stringify(d));
+// get-intrinsic's stringToPath regex.
+const rePropName = /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g;
+const result: any[] = [];
+"%String.prototype.indexOf%".replace(rePropName, function (m: any, num: any, q: any, sub: any) {
+  result[result.length] = q ? sub : (num || m);
+  return m;
+} as any);
+if (JSON.stringify(result) !== '["String","prototype","indexOf"]') {
+  throw new Error("rePropName: " + JSON.stringify(result));
+}
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: regex replace callback with lookahead (fancy-regex fallback)"


### PR DESCRIPTION
Four independent compiler/runtime fixes surfaced while compiling a real-world Hono + Drizzle + mysql2 + Stripe + zod application to native.

## Fixes

1. **codegen/property_get** — Reading a static off a cross-module imported function (ExternFuncRef as a PropertyGet base) unconditionally called the perry_fn_<src>__<name>() getter. That symbol is a value-getter only for an exported const/let; for an imported function it IS the body, so every Fn.staticProp read invoked the function with zero args. Now gated on imported_vars; functions/classes fall through to the generic closure-value + dynamic-prop path. (Stripe StripeResource.method/.extend.)

2. **runtime/Object.assign** — A function/closure source was misread as an ObjectHeader; reading keys_array off it produced a garbage key_count and a runaway loop. Now enumerates the closure's own enumerable dynamic props (skipping non-enumerable length/name/prototype). (Stripe protoExtend hung at import.)

3. **runtime/Function.prototype.bind** — Was a no-op proto method, so bind invoked as a value (Reflect.apply(bind, call, [fn]), bind.apply(fn, ...)) returned undefined. Added a real bind thunk reading the target from IMPLICIT_THIS. (call-bind-apply-helpers uncurry-this.)

4. **runtime/regex** — String.prototype.replace(re, fn) had no fancy-regex fallback, so a lookahead pattern fired the callback zero times. Routes through fancy-regex now. (get-intrinsic stringToPath.)

Four regression tests added under tests/. All pass.