### PR TITLE
fix(json): internalize JSON.parse reviver properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1123 — fix(json): internalize JSON.parse reviver via the spec InternalizeJSONProperty walk (#4588)
+
+`JSON.parse(text, reviver)` previously walked the parsed value's raw object/array storage slots in place — it never went through `[[Get]]`/`[[Delete]]`/`CreateDataProperty`, so spec-mandated behaviours were invisible: deleting the property when the reviver returns `undefined`, re-reading a value the reviver mutated, holder `this` binding, the root `{ "": rootValue }` wrapper, and `Object.keys`/array-length snapshots taken before iteration.
+
+This reworks `crates/perry-runtime/src/json/reviver.rs` to implement ECMA-262 25.5.1.1 `InternalizeJSONProperty(holder, name, reviver)` post-order:
+
+- The root value is wrapped in `{ "": rootValue }` and the walk starts from that holder. `apply_reviver` builds the wrapper with a raw own-field set (`js_object_set_field_by_name`), not `[[Set]]`, so a setter installed on `Object.prototype` for the empty key is never invoked (matches `reviver-wrapper`).
+- For each key (objects: an `Object.keys` snapshot; arrays: a `length` snapshot via the header), the walk does a real `[[Get]]` re-read off the holder, recurses, then applies the reviver result: `undefined` → `[[Delete]]` (`delete-or-keep`), else `CreateDataProperty` (`create-or-keep`). Both follow ordinary-object semantics — a non-configurable property silently survives an attempted delete/redefine with no throw, per `OrdinaryDelete` / `CreateDataProperty` returning `false` rather than throwing.
+- The reviver is invoked with the holder bound as `this` (`js_implicit_this_set`); abrupt completions from a throwing reviver or holder getter propagate via the existing setjmp/longjmp unwind. GC-moved handles are refreshed across the callback and descriptor writes.
+
+Verified against test262 `built-ins/JSON/parse/reviver-*`: the applicable (non-`Proxy`, non-`json-parse-with-source`) cases go from 1/24 to 5/24 exit-code parity with Node — newly passing: `reviver-call-order`, `reviver-object-non-configurable-prop-create`, `reviver-object-non-configurable-prop-delete`, `reviver-wrapper`. Zero regressions; common value-transform usage (`JSON.parse(x, (k,v)=>…)`, including delete-via-`undefined`, nested objects/arrays, and the `""` root key) stays byte-identical to Node. The orthogonal arg-`ToString` fix (#4587) is untouched.
+
+Out of scope (separate pre-existing gaps, tracked as follow-ups): `Proxy`-holder traps (`reviver-*-{define-prop,delete,own-keys,length-*}-err`, `revived-proxy*`), the ES2025 `{ source }` third-argument feature (`reviver-context-source-*`, `reviver-forward-modifies-object`, `reviver-call-args-after-forward-modification`), `Object.prototype`-inherited re-reads (`reviver-*-get-prop-from-prototype` — a general object-model limitation), and array index `[[DefineOwnProperty]]`/accessor descriptors (`reviver-array-non-configurable-prop-*`, `reviver-get-name-err`).
+
+Authored by @andrewtdiz.
+
 ## v0.5.1122 — fix(release): decouple aspirational platform/framework smokes from the publish gate
 
 v0.5.1121's publish was blocked at `await-tests` because the tag-gated **Tests** workflow concluded failure — but the only *core*-job failures were `cargo-test` (the `secret_key_buffer_metadata_survives_ic_miss_for_aes_sizes` regression from #4363 typed-array own-properties, since fixed on `main` by #4399) and `lint` (a transient rustup/curl network flake during toolchain setup). The v0.5.1121 tag predated #4399, so its `cargo-test` could never pass; this release re-tags from a `main` that includes the fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1122
+**Current Version:** 0.5.1123
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "base64",
@@ -5252,14 +5252,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "cc",
  "libc",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "base64",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,14 +5368,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "serde",
  "serde_json",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1122"
+version = "0.5.1123"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "clap",
@@ -5409,14 +5409,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5515,14 +5515,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "bytes",
  "h2",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "bson",
  "futures-util",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "image",
@@ -5709,14 +5709,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "brotli",
  "flate2",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "base64",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5939,14 +5939,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "itoa",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "block2",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "block2",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1122"
+version = "0.5.1123"
 
 [[package]]
 name = "perry-ui-test"
@@ -6035,11 +6035,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1122"
+version = "0.5.1123"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "block2",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "block2",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "block2",
  "libc",
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "libc",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1122"
+version = "0.5.1123"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1122"
+version = "0.5.1123"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/json/reviver.rs
+++ b/crates/perry-runtime/src/json/reviver.rs
@@ -37,99 +37,258 @@ unsafe fn force_materialize_if_lazy(value: JSValue) -> JSValue {
     JSValue::object_ptr(materialized as *mut u8)
 }
 
-/// Apply reviver to a parsed JSON value. The reviver is called as reviver(key, value).
-/// For objects, it's called for each property; for the root, key is "".
+unsafe fn key_name_from_string_ptr(key: *const StringHeader) -> Option<String> {
+    if key.is_null() {
+        return None;
+    }
+    let data = (key as *const u8).add(std::mem::size_of::<StringHeader>());
+    let len = (*key).byte_len as usize;
+    std::str::from_utf8(std::slice::from_raw_parts(data, len))
+        .ok()
+        .map(|s| s.to_string())
+}
+
+unsafe fn pointer_value(bits: u64) -> f64 {
+    f64::from_bits(POINTER_TAG | (bits & POINTER_MASK))
+}
+
+unsafe fn data_descriptor_value(value_handle: &crate::gc::RuntimeHandle<'_>) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let desc = crate::object::js_object_alloc(0, 4);
+    let desc_handle = scope.root_raw_mut_ptr(desc);
+
+    let value_key = js_string_from_bytes(b"value".as_ptr(), 5);
+    let value_key_handle = scope.root_string_ptr(value_key);
+    crate::object::js_object_set_field_by_name(
+        desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>(),
+        value_key_handle.get_raw_const_ptr::<StringHeader>(),
+        value_handle.get_nanbox_f64(),
+    );
+
+    for (name, field_value) in [
+        (b"writable".as_slice(), f64::from_bits(TAG_TRUE)),
+        (b"enumerable".as_slice(), f64::from_bits(TAG_TRUE)),
+        (b"configurable".as_slice(), f64::from_bits(TAG_TRUE)),
+    ] {
+        let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let key_handle = scope.root_string_ptr(key);
+        crate::object::js_object_set_field_by_name(
+            desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>(),
+            key_handle.get_raw_const_ptr::<StringHeader>(),
+            field_value,
+        );
+    }
+    pointer_value(desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>() as u64)
+}
+
+unsafe fn holder_ptr_from_bits(bits: u64) -> *mut crate::ObjectHeader {
+    (bits & POINTER_MASK) as *mut crate::ObjectHeader
+}
+
+unsafe fn delete_property_or_keep(
+    holder_handle: &crate::gc::RuntimeHandle<'_>,
+    key_handle: &crate::gc::RuntimeHandle<'_>,
+) {
+    let holder = holder_ptr_from_bits(holder_handle.get_nanbox_u64());
+    if holder.is_null() {
+        return;
+    }
+    let _ = crate::object::js_object_delete_field(
+        holder,
+        key_handle.get_raw_const_ptr::<StringHeader>(),
+    );
+}
+
+unsafe fn create_data_property_or_keep(
+    holder_handle: &crate::gc::RuntimeHandle<'_>,
+    key_handle: &crate::gc::RuntimeHandle<'_>,
+    value_handle: &crate::gc::RuntimeHandle<'_>,
+) {
+    let holder_addr = (holder_handle.get_nanbox_u64() & POINTER_MASK) as usize;
+    if let Some(name) = key_name_from_string_ptr(key_handle.get_raw_const_ptr::<StringHeader>()) {
+        if crate::object::get_property_attrs(holder_addr, &name)
+            .is_some_and(|attrs| !attrs.configurable())
+        {
+            return;
+        }
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let descriptor = data_descriptor_value(value_handle);
+    let descriptor_handle = scope.root_nanbox_f64(descriptor);
+    let key_value = nanbox_string_f64(key_handle.get_raw_const_ptr::<StringHeader>());
+    crate::object::js_object_define_property(
+        holder_handle.get_nanbox_f64(),
+        key_value,
+        descriptor_handle.get_nanbox_f64(),
+    );
+}
+
+unsafe fn apply_internalized_child(
+    holder_handle: &crate::gc::RuntimeHandle<'_>,
+    key_handle: &crate::gc::RuntimeHandle<'_>,
+    child: JSValue,
+) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let child_handle = scope.root_nanbox_u64(child.bits());
+    if child_handle.get_nanbox_u64() == TAG_UNDEFINED {
+        delete_property_or_keep(holder_handle, key_handle);
+    } else {
+        create_data_property_or_keep(holder_handle, key_handle, &child_handle);
+    }
+}
+
+unsafe fn internalize_array(
+    value_handle: &crate::gc::RuntimeHandle<'_>,
+    reviver: *const crate::closure::ClosureHeader,
+) {
+    let reviver_scope = crate::gc::RuntimeHandleScope::new();
+    let reviver_handle = reviver_scope.root_raw_const_ptr(reviver);
+    let arr = (value_handle.get_nanbox_u64() & POINTER_MASK) as *const crate::ArrayHeader;
+    if arr.is_null() {
+        return;
+    }
+    let len = (*arr).length;
+    for i in 0..len {
+        let iteration_scope = crate::gc::RuntimeHandleScope::new();
+        let idx = i.to_string();
+        let key = js_string_from_bytes(idx.as_ptr(), idx.len() as u32);
+        let key_handle = iteration_scope.root_string_ptr(key);
+        let key_value = nanbox_string_f64(key_handle.get_raw_const_ptr::<StringHeader>());
+        let child = internalize_json_property(
+            JSValue::from_bits(value_handle.get_nanbox_u64()),
+            key_value,
+            reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
+        );
+        apply_internalized_child(value_handle, &key_handle, child);
+    }
+}
+
+unsafe fn internalize_object(
+    value_handle: &crate::gc::RuntimeHandle<'_>,
+    reviver: *const crate::closure::ClosureHeader,
+) {
+    let reviver_scope = crate::gc::RuntimeHandleScope::new();
+    let reviver_handle = reviver_scope.root_raw_const_ptr(reviver);
+    let keys = crate::object::js_object_keys_value(value_handle.get_nanbox_f64());
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let keys_handle = scope.root_raw_mut_ptr(keys);
+    let len = crate::array::js_array_length(keys_handle.get_raw_mut_ptr::<crate::ArrayHeader>());
+    for i in 0..len {
+        let iteration_scope = crate::gc::RuntimeHandleScope::new();
+        let keys = keys_handle.get_raw_mut_ptr::<crate::ArrayHeader>();
+        let key_value = crate::array::js_array_get(keys, i);
+        let key_value_handle = iteration_scope.root_nanbox_u64(key_value.bits());
+        let key_ptr = crate::value::js_get_string_pointer_unified(key_value_handle.get_nanbox_f64())
+            as *const StringHeader;
+        let key_handle = iteration_scope.root_string_ptr(key_ptr);
+        let key_value = nanbox_string_f64(key_handle.get_raw_const_ptr::<StringHeader>());
+        let child = internalize_json_property(
+            JSValue::from_bits(value_handle.get_nanbox_u64()),
+            key_value,
+            reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
+        );
+        apply_internalized_child(value_handle, &key_handle, child);
+    }
+}
+
+unsafe fn call_reviver(
+    holder_handle: &crate::gc::RuntimeHandle<'_>,
+    key_handle: &crate::gc::RuntimeHandle<'_>,
+    value_handle: &crate::gc::RuntimeHandle<'_>,
+    reviver: *const crate::closure::ClosureHeader,
+) -> JSValue {
+    let holder_arg = holder_handle.get_nanbox_f64();
+    let key_arg = key_handle.get_nanbox_f64();
+    let value_arg = value_handle.get_nanbox_f64();
+    let prev_this = crate::object::js_implicit_this_set(holder_arg);
+    let result = crate::js_closure_call2(reviver, key_arg, value_arg);
+    crate::object::js_implicit_this_set(prev_this);
+    let result_bits = result.to_bits();
+    let revived_bits = if result_bits == value_arg.to_bits() {
+        value_handle.get_nanbox_u64()
+    } else if result_bits == key_arg.to_bits() {
+        key_handle.get_nanbox_u64()
+    } else if result_bits == holder_arg.to_bits() {
+        holder_handle.get_nanbox_u64()
+    } else {
+        result_bits
+    };
+    JSValue::from_bits(revived_bits)
+}
+
+unsafe fn internalize_json_property(
+    holder: JSValue,
+    key_f64: f64,
+    reviver: *const crate::closure::ClosureHeader,
+) -> JSValue {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let holder_handle = scope.root_nanbox_u64(holder.bits());
+    let reviver_handle = scope.root_raw_const_ptr(reviver);
+    let key_handle = scope.root_nanbox_f64(key_f64);
+    let key_ptr = crate::value::js_get_string_pointer_unified(key_handle.get_nanbox_f64())
+        as *const StringHeader;
+    let key_ptr_handle = scope.root_string_ptr(key_ptr);
+    let holder_ptr = holder_ptr_from_bits(holder_handle.get_nanbox_u64());
+    let value = crate::object::js_object_get_field_by_name(
+        holder_ptr as *const crate::ObjectHeader,
+        key_ptr_handle.get_raw_const_ptr::<StringHeader>(),
+    );
+    let value = force_materialize_if_lazy(value);
+    let value_handle = scope.root_nanbox_u64(value.bits());
+
+    if let Some(ptr) = extract_pointer(value_handle.get_nanbox_u64()) {
+        match gc_obj_type(ptr) {
+            crate::gc::GC_TYPE_ARRAY => {
+                internalize_array(
+                    &value_handle,
+                    reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
+                );
+            }
+            crate::gc::GC_TYPE_OBJECT => {
+                internalize_object(
+                    &value_handle,
+                    reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    call_reviver(
+        &holder_handle,
+        &key_handle,
+        &value_handle,
+        reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
+    )
+}
+
+/// Apply reviver to a parsed JSON value through the same root-holder wrapper
+/// used by `JSON.parse(text, reviver)`.
 pub(crate) unsafe fn apply_reviver(
     value: JSValue,
     key_f64: f64,
     reviver: *const crate::closure::ClosureHeader,
 ) -> JSValue {
-    // A lazy-tape array must be materialized before the in-place element walk
-    // (its header layout differs from ArrayHeader). #1424.
-    let value = force_materialize_if_lazy(value);
     let scope = crate::gc::RuntimeHandleScope::new();
-    let value_handle = scope.root_nanbox_u64(value.bits());
-    let key_handle = scope.root_nanbox_f64(key_f64);
+    let wrapper = crate::object::js_object_alloc(0, 1);
+    let wrapper_handle = scope.root_raw_mut_ptr(wrapper);
     let reviver_handle = scope.root_raw_const_ptr(reviver);
-    let bits = value_handle.get_nanbox_u64();
-
-    // If value is an object, recurse into its properties first
-    if let Some(ptr) = extract_pointer(bits) {
-        let obj_type = gc_obj_type(ptr);
-        if obj_type == crate::gc::GC_TYPE_OBJECT {
-            let obj = (value_handle.get_nanbox_u64() & POINTER_MASK) as *const crate::ObjectHeader;
-            let num_fields = (*obj).field_count;
-            let keys_arr = (*obj).keys_array;
-            let keys_len = (*keys_arr).length;
-            let actual_fields = std::cmp::min(num_fields, keys_len);
-
-            for f in 0..actual_fields {
-                let obj =
-                    (value_handle.get_nanbox_u64() & POINTER_MASK) as *const crate::ObjectHeader;
-                let keys_arr = (*obj).keys_array;
-                let keys_elements = (keys_arr as *const u8)
-                    .add(std::mem::size_of::<crate::ArrayHeader>())
-                    as *const f64;
-                let fields_ptr =
-                    (obj as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *mut f64;
-                let field_key_f64 = *keys_elements.add(f as usize);
-                let field_val_f64 = *fields_ptr.add(f as usize);
-                let child_val = JSValue::from_bits(field_val_f64.to_bits());
-                let revived_child = apply_reviver(
-                    child_val,
-                    field_key_f64,
-                    reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
-                );
-                // Write back the revived value
-                let obj =
-                    (value_handle.get_nanbox_u64() & POINTER_MASK) as *mut crate::ObjectHeader;
-                crate::object::store_object_field_slot(obj, f as usize, revived_child.bits());
-            }
-        } else if obj_type == crate::gc::GC_TYPE_ARRAY {
-            let arr = (value_handle.get_nanbox_u64() & POINTER_MASK) as *const crate::ArrayHeader;
-            if !arr.is_null() {
-                let len = (*arr).length;
-                let cap = (*arr).capacity;
-                if len <= cap && cap > 0 && cap < 10000 {
-                    for i in 0..len {
-                        let idx_str = i.to_string();
-                        let idx_ptr = js_string_from_bytes(idx_str.as_ptr(), idx_str.len() as u32);
-                        let idx_key_f64 = nanbox_string_f64(idx_ptr);
-                        let arr = (value_handle.get_nanbox_u64() & POINTER_MASK)
-                            as *const crate::ArrayHeader;
-                        let elements = (arr as *const u8)
-                            .add(std::mem::size_of::<crate::ArrayHeader>())
-                            as *mut f64;
-                        let elem_f64 = *elements.add(i as usize);
-                        let child_val = JSValue::from_bits(elem_f64.to_bits());
-                        let revived_child = apply_reviver(
-                            child_val,
-                            idx_key_f64,
-                            reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
-                        );
-                        let arr = (value_handle.get_nanbox_u64() & POINTER_MASK)
-                            as *mut crate::ArrayHeader;
-                        crate::array::note_array_slot(arr, i as usize, revived_child.bits());
-                    }
-                }
-            }
-        }
-    }
-
-    // Now call reviver on this value
-    let value_f64 = value_handle.get_nanbox_f64();
-    let key_f64 = key_handle.get_nanbox_f64();
-    let reviver = reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
-    let result = crate::js_closure_call2(reviver, key_f64, value_f64);
-    let result_bits = result.to_bits();
-    let revived_bits = if result_bits == value_f64.to_bits() {
-        value_handle.get_nanbox_u64()
-    } else if result_bits == key_f64.to_bits() {
-        key_handle.get_nanbox_f64().to_bits()
-    } else {
-        result_bits
-    };
-    JSValue::from_bits(revived_bits)
+    let key_handle = scope.root_nanbox_f64(key_f64);
+    let key_ptr = crate::value::js_get_string_pointer_unified(key_handle.get_nanbox_f64())
+        as *const StringHeader;
+    let key_ptr_handle = scope.root_string_ptr(key_ptr);
+    let value = force_materialize_if_lazy(value);
+    let value_handle = scope.root_nanbox_u64(value.bits());
+    crate::object::js_object_set_field_by_name(
+        wrapper_handle.get_raw_mut_ptr::<crate::ObjectHeader>(),
+        key_ptr_handle.get_raw_const_ptr::<StringHeader>(),
+        value_handle.get_nanbox_f64(),
+    );
+    internalize_json_property(
+        JSValue::object_ptr(wrapper_handle.get_raw_mut_ptr::<crate::ObjectHeader>() as *mut u8),
+        key_handle.get_nanbox_f64(),
+        reviver_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
+    )
 }
 
 #[cfg(test)]

--- a/test-parity/node-suite/globals/json-parse-reviver-internalize.ts
+++ b/test-parity/node-suite/globals/json-parse-reviver-internalize.ts
@@ -1,0 +1,131 @@
+function own(obj: unknown, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function errorLine(label: string, fn: () => unknown): void {
+  try {
+    fn();
+    console.log(label + ": no throw");
+  } catch (err) {
+    const e = err as Error;
+    console.log(label + ":", e.name + ":" + String(e.message).split("\n")[0]);
+  }
+}
+
+const order: string[] = [];
+const nested = JSON.parse('{"a":1,"b":{"c":2},"d":3}', function (key, value) {
+  order.push(key + ":" + (value === null ? "null" : typeof value));
+  if (key === "c") {
+    return 4;
+  }
+  return value;
+});
+console.log("post order:", order.join("|"));
+console.log("nested value:", nested.b.c);
+
+const objectDelete = JSON.parse('{"a":1,"b":2,"c":3}', function (key, value) {
+  return key === "b" ? undefined : value;
+});
+console.log(
+  "object delete:",
+  own(objectDelete, "b"),
+  Object.keys(objectDelete).join("|"),
+  JSON.stringify(objectDelete),
+);
+
+const arrayDelete = JSON.parse("[1,2,3]", function (key, value) {
+  return key === "1" ? undefined : value;
+});
+console.log(
+  "array delete:",
+  arrayDelete.length,
+  own(arrayDelete, "1"),
+  1 in arrayDelete,
+  Object.keys(arrayDelete).join("|"),
+  JSON.stringify(arrayDelete),
+);
+
+const protoSeen: unknown[] = [];
+const reread = JSON.parse('{"a":1,"b":2}', function (key, value) {
+  if (key === "a") {
+    delete this.b;
+    Object.setPrototypeOf(this, { b: 3 });
+  }
+  if (key === "b") {
+    protoSeen.push(value);
+  }
+  return value;
+});
+console.log(
+  "holder reread:",
+  protoSeen.join("|"),
+  reread.b,
+  own(reread, "b"),
+  Object.getPrototypeOf(reread).b,
+);
+
+let rootOwn = false;
+const rootResult = JSON.parse('{"x":1}', function (key, value) {
+  if (key === "") {
+    rootOwn = own(this, "");
+    return undefined;
+  }
+  return value;
+});
+console.log("root holder:", rootOwn, rootResult === undefined);
+
+errorLine("getter abrupt", () =>
+  JSON.parse('{"a":1,"b":2}', function (key, value) {
+    if (key === "a") {
+      Object.defineProperty(this, "b", {
+        get() {
+          throw new Error("boom-get");
+        },
+        enumerable: true,
+        configurable: true,
+      });
+    }
+    return value;
+  }),
+);
+
+const nonConfigDelete = JSON.parse('{"locked":1}', function (key, value) {
+  if (key === "locked") {
+    Object.defineProperty(this, "locked", {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: false,
+    });
+    return undefined;
+  }
+  return value;
+});
+const nonConfigDeleteDesc = Object.getOwnPropertyDescriptor(nonConfigDelete, "locked");
+console.log(
+  "nonconfig delete:",
+  own(nonConfigDelete, "locked"),
+  nonConfigDelete.locked,
+  Object.keys(nonConfigDelete).join("|"),
+  nonConfigDeleteDesc?.configurable,
+);
+
+const nonConfigDefine = JSON.parse('{"locked":1}', function (key, value) {
+  if (key === "locked") {
+    Object.defineProperty(this, "locked", {
+      value,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+    return 2;
+  }
+  return value;
+});
+const nonConfigDefineDesc = Object.getOwnPropertyDescriptor(nonConfigDefine, "locked");
+console.log(
+  "nonconfig define:",
+  nonConfigDefine.locked,
+  nonConfigDefineDesc?.writable,
+  nonConfigDefineDesc?.configurable,
+);


### PR DESCRIPTION
## Linked Issues
Closes #4588

## Summary
- Rework `JSON.parse(text, reviver)` to walk via holder/key internalization instead of raw object/array slots.
- Use post-order traversal with `[[Get]]` re-reads, `Object.keys` snapshots for objects, array-length snapshots for arrays, holder `this` binding, and root wrapper semantics.
- Apply reviver results through delete-or-define behavior while preserving non-configurable properties and keeping moved-GC handles refreshed across callbacks and descriptor writes.
- Add a globals parity fixture for deletion, holes, inherited re-reads, root handling, getter abrupt completion, and non-configurable descriptor cases.

## Why This Cut
This is scoped to JSON.parse reviver internalization semantics. It intentionally stays separate from JSON.parse argument coercion and broader object/array descriptor model work.

## Tests
- PASS: `cargo test -q -p perry-runtime --lib json_reviver -- --nocapture`
- PASS: `cargo test -q -p perry-runtime --lib json:: -- --nocapture`
- PASS: `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH PERRY_NO_AUTO_OPTIMIZE=1 ./run_parity_tests.sh --suite node-suite --module globals --filter json-parse-reviver-internalize`
- PASS: `PERRY_JSON_TAPE=1 PERRY_NO_AUTO_OPTIMIZE=1 ./target/release/perry run test-files/test_json_lazy_reviver.ts`
- PASS: `PATH=/root/.npm/_npx/bac97da9607b7ef2/node_modules/.bin:$PATH node --experimental-strip-types test-parity/node-suite/globals/json-parse-reviver-internalize.ts`
- PASS: `cargo check -q -p perry-codegen -p perry-runtime` (existing warnings)
- PASS: `git diff --check`

## Current Base Check Notes
- `cargo fmt --all -- --check` currently fails on `crates/perry-codegen/src/expr/property_get.rs`, which is outside this PR's diff and present on the rebased base.
- `./scripts/check_file_size.sh` currently fails because `crates/perry-runtime/src/regex.rs` is 2080 lines on the rebased base; this PR does not touch that file.

## Known Limitations
- Proxy-specific internal methods are not covered here; this uses Perry's existing object, array, prototype, accessor, and descriptor paths.
- Array numeric accessor descriptor support remains separate; the parity fixture avoids depending on that unrelated gap.

## Non-Goals
- JSON parser/stringifier rewrite
- JSON.parse argument ToString behavior
- Proxy internal method parity
- Array descriptor model rewrite