### PR TITLE
fix(codegen): materialize `import * as ns` as an enumerable runtime-export object

### DIFF
--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -474,6 +474,59 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // dedicated arms above; this catch-all only fires for
             // names with no resolution at all.
             if ctx.namespace_imports.contains(name) {
+                // A namespace import used as a whole VALUE (passed to a
+                // function, iterated by `Object.keys`/`for…in`/`Object.entries`,
+                // spread, …) must be a real object whose OWN ENUMERABLE
+                // properties are the source module's exports — not the empty
+                // `js_unresolved_namespace_stub`. Drizzle's
+                // `drizzle(pool, { schema })` (with `import * as schema`) and
+                // Stripe's `_prepResources` (`for (const name in resources)`
+                // over `import * as resources`) both enumerate the namespace and
+                // silently saw zero members otherwise. Materialize the object by
+                // resolving each exported member through the SAME per-member
+                // `ns.member` PropertyGet lowering (functions → closure
+                // singletons, consts → getters, classes → class refs).
+                let mut members: Vec<String> = ctx
+                    .namespace_member_prefixes
+                    .keys()
+                    .filter(|(ns, _)| ns == name)
+                    .map(|(_, m)| m.clone())
+                    .collect();
+                if !members.is_empty() {
+                    members.sort();
+                    members.dedup();
+                    let n_str = (members.len() as u32).to_string();
+                    let zero_str = "0".to_string();
+                    let handle = ctx.block().call(
+                        I64,
+                        "js_object_alloc",
+                        &[(I32, &zero_str), (I32, &n_str)],
+                    );
+                    for member in &members {
+                        let member_get = Expr::PropertyGet {
+                            object: Box::new(Expr::ExternFuncRef {
+                                name: name.clone(),
+                                param_types: Vec::new(),
+                                return_type: HirType::Any,
+                            }),
+                            property: member.clone(),
+                        };
+                        let v_box = lower_expr(ctx, &member_get)?;
+                        let key_idx = ctx.strings.intern(member);
+                        let key_handle_global =
+                            format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                        let blk = ctx.block();
+                        let key_box = blk.load(DOUBLE, &key_handle_global);
+                        let key_bits = blk.bitcast_double_to_i64(&key_box);
+                        let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                        blk.call_void(
+                            "js_object_set_field_by_name",
+                            &[(I64, &handle), (I64, &key_raw), (DOUBLE, &v_box)],
+                        );
+                    }
+                    let blk = ctx.block();
+                    return Ok(nanbox_pointer_inline(blk, &handle));
+                }
                 return Ok(ctx
                     .block()
                     .call(DOUBLE, "js_unresolved_namespace_stub", &[]));

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -911,9 +911,50 @@ pub fn run_with_parse_cache(
                 exports.insert(en.name.clone(), path_str.clone());
             }
         }
+        // `export type X` / `export interface X` still lower to an
+        // `Export::Named` (so type re-export chains resolve), but they are
+        // TYPE-ONLY — erased at runtime, with no `perry_fn_*` symbol. They must
+        // not enter the runtime export set: that set drives `import * as ns`
+        // materialization (Object.keys/for-in), and a phantom type name there
+        // resolves to a bogus closure value that breaks consumers enumerating
+        // the namespace (drizzle's `drizzle(pool, { schema })`, where the schema
+        // module also `export type Customer = …` alongside the real tables).
+        // A name that is ALSO a value export (declaration merging, a class)
+        // stays — only names that are exclusively types are dropped.
+        let value_export_names: std::collections::HashSet<&str> = hir_module
+            .functions
+            .iter()
+            .filter(|f| f.is_exported)
+            .map(|f| f.name.as_str())
+            .chain(hir_module.exported_objects.iter().map(|s| s.as_str()))
+            .chain(
+                hir_module
+                    .classes
+                    .iter()
+                    .filter(|c| c.is_exported)
+                    .map(|c| c.name.as_str()),
+            )
+            .chain(
+                hir_module
+                    .enums
+                    .iter()
+                    .filter(|e| e.is_exported)
+                    .map(|e| e.name.as_str()),
+            )
+            .collect();
+        let type_only_export_names: std::collections::HashSet<String> = hir_module
+            .type_aliases
+            .iter()
+            .map(|t| t.name.clone())
+            .chain(hir_module.interfaces.iter().map(|i| i.name.clone()))
+            .filter(|n| !value_export_names.contains(n.as_str()))
+            .collect();
         // Named exports (export { foo, bar as baz })
         for export in &hir_module.exports {
             if let perry_hir::Export::Named { local, exported } = export {
+                if type_only_export_names.contains(exported) {
+                    continue;
+                }
                 exports.insert(exported.clone(), path_str.clone());
                 // #1758: a LOCAL renamed export of a CLASS
                 // (`export { Number$ as Number }`, no `from`) must record the

--- a/tests/test_namespace_import_enumerable.sh
+++ b/tests/test_namespace_import_enumerable.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A namespace import (`import * as ns from "./m.js"`) used as a whole VALUE must
+# be a real object whose OWN ENUMERABLE properties are the source module's
+# RUNTIME exports — so `Object.keys(ns)`, `for…in ns`, `Object.entries(ns)`,
+# `hasOwnProperty`, and passing `ns` to a library all see the members. Pre-fix
+# the namespace value lowered to an empty `js_unresolved_namespace_stub`, so
+# `Object.keys` was `[]` (drizzle's `drizzle(pool, { schema })` where
+# `import * as schema` saw zero tables; Stripe's `_prepResources`
+# `for (const n in resources)` attached nothing).
+#
+# Type-only exports (`export type` / `export interface`) are erased at runtime
+# and must NOT appear among the enumerable members (they have no runtime value).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/schema.ts" <<'TS'
+export const alpha = { id: 1 };
+export const beta = { id: 2 };
+export const gammaEnum = ["x", "y"] as const;
+export function helper() { return "H"; }
+// Type-only exports — erased at runtime, must not be enumerable members.
+export type Alpha = typeof alpha;
+export type Beta = typeof beta;
+export interface Thing { id: number }
+TS
+cat >"$TMPDIR/main.ts" <<'TS'
+import * as schema from "./schema.js";
+
+const keys = Object.keys(schema).sort();
+if (JSON.stringify(keys) !== '["alpha","beta","gammaEnum","helper"]') {
+  throw new Error("keys: " + JSON.stringify(keys));
+}
+// for…in matches.
+const forIn: string[] = [];
+for (const k in schema) forIn.push(k);
+if (JSON.stringify(forIn.sort()) !== '["alpha","beta","gammaEnum","helper"]') {
+  throw new Error("for-in: " + JSON.stringify(forIn));
+}
+// hasOwnProperty + Object.entries.
+if (!Object.prototype.hasOwnProperty.call(schema, "alpha")) throw new Error("hasOwn alpha");
+if (Object.prototype.hasOwnProperty.call(schema, "Alpha")) throw new Error("type leaked: Alpha");
+const entries = Object.entries(schema).map(([k]) => k).sort();
+if (entries.length !== 4) throw new Error("entries: " + JSON.stringify(entries));
+// Members still resolve to their real values + the direct `ns.member` read works.
+if ((schema as any).alpha.id !== 1) throw new Error("alpha.id: " + (schema as any).alpha.id);
+if ((schema as any).helper() !== "H") throw new Error("helper(): " + (schema as any).helper());
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/main.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: namespace import is an enumerable runtime-export object"


### PR DESCRIPTION
A namespace import used as a whole VALUE (`Object.keys`/`for…in`/`Object.entries`, or passed to a library) lowered to an empty `js_unresolved_namespace_stub`, so enumeration saw zero members even though `ns.member` reads worked.

## Fix
Materialize the namespace value by resolving each exported member through the SAME per-member `ns.member` PropertyGet lowering (functions → closure singletons, consts → getters, classes → class refs), building a real object with the members as own enumerable properties.

Surfaced compiling a real Hono+Drizzle+Stripe app:
- drizzle `drizzle(pool, { schema })` (with `import * as schema`) saw an empty schema and crashed building relational config.
- Stripe `_prepResources` (`for (const n in resources)` over `import * as resources`) attached zero resources.

Also exclude **type-only exports** from the runtime export set: `export type X` / `export interface X` lower to an `Export::Named` (so type re-export chains resolve) but are erased at runtime with no `perry_fn_*` symbol. Including them produced phantom members resolving to bogus closure values (drizzle's schema also has `export type Customer = …` alongside the real tables). A name that is ALSO a value export is kept.

## Test
`tests/test_namespace_import_enumerable.sh` — covers Object.keys/for-in/entries/hasOwnProperty, type-export exclusion, and that members still resolve to their real values. Existing namespace/cross-module tests remain green.