### PR TITLE
runtime: preserve Promise static receiver checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1138 — Promise static methods preserve receiver brand checks when borrowed
+
+Part of #4521. Borrowed `Promise` statics (`Promise.resolve`/`reject`/`all`/
+`race`/`allSettled`/`any` via `.call`/`.apply`/`.bind` or detached value reads)
+now keep their receiver-sensitive behavior: invoked on a non-`Promise` `this`
+(or detached) they throw a `TypeError`, while `Promise.resolve.call(Promise, x)`
+still works. `Promise` joins the reified-builtin-static-value set in
+`expr_member.rs` (alongside main's `Array`/`Number`) so the value read resolves
+to the real native function object, and new `js_promise_static_function_value`
+runtime thunks brand-check `this` against the Promise constructor. Verified
+against the parity fixture: detached/object receivers `throw:TypeError`,
+proper-receiver calls fulfil/reject as expected. Adds
+`node-suite/globals/promise-static-brand-checks.ts`.
+
 ## v0.5.1137 — generic `Array.prototype.reverse` over array-like receivers
 
 `Array.prototype.reverse.call(arrayLike)` (and bound/`.apply` forms) now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1137
+**Current Version:** 0.5.1138
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1137"
+version = "0.5.1138"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1137"
+version = "0.5.1138"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1137"
+version = "0.5.1138"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1137"
+version = "0.5.1138"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1137"
+version = "0.5.1138"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -140,6 +140,64 @@ fn builtin_prototype_method_read<'a>(
         .then_some((builtin_name.as_str(), property))
 }
 
+fn is_global_builtin_value_expr(expr: &Expr, name: &str) -> bool {
+    matches!(
+        expr,
+        Expr::PropertyGet { object, property }
+            if property == name && matches!(object.as_ref(), Expr::GlobalGet(_))
+    )
+}
+
+fn promise_static_function_length_expr(expr: &Expr) -> Option<u32> {
+    let Expr::PropertyGet { object, property } = expr else {
+        return None;
+    };
+    let is_promise_receiver = matches!(object.as_ref(), Expr::GlobalGet(_))
+        || is_global_builtin_value_expr(object, "Promise");
+    if !is_promise_receiver {
+        return None;
+    }
+    match property.as_str() {
+        "withResolvers" => Some(0),
+        "resolve" | "reject" | "all" | "race" | "allSettled" | "any" | "try" => Some(1),
+        _ => None,
+    }
+}
+
+fn lower_global_builtin_static_value(ctx: &mut FnCtx<'_>, builtin: &str, property: &str) -> String {
+    if builtin == "Promise" {
+        let key_idx = ctx.strings.intern(property);
+        let key_bytes_global = format!("@{}", ctx.strings.entry(key_idx).bytes_global);
+        let key_len = property.len().to_string();
+        return ctx.block().call(
+            DOUBLE,
+            "js_promise_static_function_value",
+            &[(PTR, &key_bytes_global), (I64, &key_len)],
+        );
+    }
+
+    let builtin_idx = ctx.strings.intern(builtin);
+    let builtin_bytes_global = format!("@{}", ctx.strings.entry(builtin_idx).bytes_global);
+    let builtin_len = builtin.len().to_string();
+    let builtin_value = ctx.block().call(
+        DOUBLE,
+        "js_get_global_this_builtin_value",
+        &[(PTR, &builtin_bytes_global), (I64, &builtin_len)],
+    );
+    let key_idx = ctx.strings.intern(property);
+    let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+    let blk = ctx.block();
+    let builtin_handle = unbox_to_i64(blk, &builtin_value);
+    let key_box = blk.load(DOUBLE, &key_handle_global);
+    let key_bits = blk.bitcast_double_to_i64(&key_box);
+    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+    blk.call(
+        DOUBLE,
+        "js_object_get_field_by_name_f64",
+        &[(I64, &builtin_handle), (I64, &key_raw)],
+    )
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::PropertyGet { object, property }
@@ -183,6 +241,30 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let recv_handle = unbox_to_i64(blk, &recv_box);
             let arr_handle = blk.call(I64, "js_error_get_errors", &[(I64, &recv_handle)]);
             Ok(nanbox_pointer_inline(blk, &arr_handle))
+        }
+
+        Expr::PropertyGet { object, property }
+            if is_global_builtin_value_expr(object, "Promise")
+                && matches!(
+                    property.as_str(),
+                    "resolve"
+                        | "reject"
+                        | "all"
+                        | "race"
+                        | "allSettled"
+                        | "any"
+                        | "withResolvers"
+                        | "try"
+                ) =>
+        {
+            Ok(lower_global_builtin_static_value(ctx, "Promise", property))
+        }
+
+        Expr::PropertyGet { object, property }
+            if property == "length" && promise_static_function_length_expr(object).is_some() =>
+        {
+            let len = promise_static_function_length_expr(object).unwrap();
+            Ok(double_literal(len as f64))
         }
 
         // TypedArray `.length` can be shadowed by an own property, so use
@@ -709,6 +791,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // property string alone is safe here.
                 if property == "env" {
                     return Ok(ctx.block().call(DOUBLE, "js_process_env", &[]));
+                }
+                if matches!(
+                    property.as_str(),
+                    "resolve"
+                        | "reject"
+                        | "all"
+                        | "race"
+                        | "allSettled"
+                        | "any"
+                        | "withResolvers"
+                        | "try"
+                ) {
+                    return Ok(lower_global_builtin_static_value(ctx, "Promise", property));
                 }
                 // #2904: V8/Node static Error members read as values
                 // (`typeof Error.isError`, `Error.stackTraceLimit`, …). The

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1062,6 +1062,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // so `inst.constructor === Date` (date-fns / drizzle / lodash duck
     // checks) holds.
     module.declare_function("js_get_global_this_builtin_value", DOUBLE, &[PTR, I64]);
+    module.declare_function("js_promise_static_function_value", DOUBLE, &[PTR, I64]);
     module.declare_function(
         "js_builtin_prototype_method_value",
         DOUBLE,

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1556,12 +1556,17 @@ fn is_builtin_prototype_receiver(ctx: &LoweringContext, recv: &ast::Expr) -> boo
 /// "value is not a function" at the outer call.
 ///
 /// Rewrite at the AST level for the shapes whose intent is unambiguous and
-/// where the `thisArg` is irrelevant (namespace statics don't read `this`):
+/// where the `thisArg` is irrelevant (most namespace statics don't read `this`):
 ///
 ///   `<NS>.<static>.call(thisArg, a, b, …)`     → `<NS>.<static>(a, b, …)`
 ///   `<NS>.<static>.apply(thisArg)`             → `<NS>.<static>()`
 ///   `<NS>.<static>.apply(thisArg, [a, b, …])`  → `<NS>.<static>(a, b, …)`
 ///   `<NS>.<static>.bind(thisArg, …pre)(…rest)` → `<NS>.<static>(…pre, …rest)`
+///
+/// Promise statics are handled only when the borrowed-call receiver is the real
+/// global `Promise` constructor. ECMA-262 reads their `this` value as the
+/// constructor receiver, so `Promise.resolve.call({}, x)` must not become
+/// `Promise.resolve(x)`.
 ///
 /// The deferred-bind shape (`const f = Promise.resolve.bind(Promise);
 /// f(x);`) cannot be rewritten purely at the AST level — that needs a
@@ -1587,6 +1592,13 @@ pub(super) fn try_namespace_static_method_apply_call_bind(
                 _ => None,
             };
             if let Some(is_apply) = mode {
+                if let Some(inner) = match_promise_static_member(ctx, outer.obj.as_ref()) {
+                    if call.args.first().is_some_and(|arg| {
+                        expr_is_global_promise_constructor(ctx, arg.expr.as_ref())
+                    }) {
+                        return rewrite_dropping_this(ctx, call, &inner, is_apply);
+                    }
+                }
                 if let Some(inner) = match_namespace_static_member(ctx, outer.obj.as_ref()) {
                     return rewrite_dropping_this(ctx, call, &inner, is_apply);
                 }
@@ -1605,6 +1617,26 @@ pub(super) fn try_namespace_static_method_apply_call_bind(
                         // understand; require at least `thisArg`.
                         let bind_spread = bind_call.args.iter().any(|a| a.spread.is_some());
                         if !bind_spread && !bind_call.args.is_empty() {
+                            if let Some(inner_member) =
+                                match_promise_static_member(ctx, bind_member.obj.as_ref())
+                            {
+                                if expr_is_global_promise_constructor(
+                                    ctx,
+                                    bind_call.args[0].expr.as_ref(),
+                                ) {
+                                    // Build: <inner_member>(…preBound, …rest)
+                                    let pre_bound: Vec<ast::ExprOrSpread> =
+                                        bind_call.args.iter().skip(1).cloned().collect();
+                                    let mut synth = call.clone();
+                                    synth.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(
+                                        inner_member,
+                                    )));
+                                    let mut combined = pre_bound;
+                                    combined.extend(call.args.iter().cloned());
+                                    synth.args = combined;
+                                    return Ok(Some(super::lower_call(ctx, &synth)?));
+                                }
+                            }
                             if let Some(inner_member) =
                                 match_namespace_static_member(ctx, bind_member.obj.as_ref())
                             {
@@ -1629,8 +1661,54 @@ pub(super) fn try_namespace_static_method_apply_call_bind(
     Ok(None)
 }
 
+fn match_promise_static_member(ctx: &LoweringContext, expr: &ast::Expr) -> Option<ast::MemberExpr> {
+    let ast::Expr::Member(m) = expr else {
+        return None;
+    };
+    let ast::MemberProp::Ident(prop) = &m.prop else {
+        return None;
+    };
+    let ast::Expr::Ident(base) = m.obj.as_ref() else {
+        return None;
+    };
+    let ns = base.sym.as_ref();
+    let name = prop.sym.as_ref();
+    if ns != "Promise" {
+        return None;
+    }
+    if ctx.lookup_local(ns).is_some()
+        || ctx.lookup_func(ns).is_some()
+        || ctx.lookup_imported_func(ns).is_some()
+    {
+        return None;
+    }
+    if !is_known_namespace_static_function(ns, name) {
+        return None;
+    }
+    Some(m.clone())
+}
+
+fn expr_is_global_promise_constructor(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let mut expr = expr;
+    loop {
+        expr = match expr {
+            ast::Expr::TsAs(x) => x.expr.as_ref(),
+            ast::Expr::TsNonNull(x) => x.expr.as_ref(),
+            ast::Expr::TsSatisfies(x) => x.expr.as_ref(),
+            ast::Expr::TsTypeAssertion(x) => x.expr.as_ref(),
+            ast::Expr::TsConstAssertion(x) => x.expr.as_ref(),
+            ast::Expr::Paren(x) => x.expr.as_ref(),
+            _ => break,
+        };
+    }
+    matches!(expr, ast::Expr::Ident(ident) if ident.sym.as_ref() == "Promise")
+        && ctx.lookup_local("Promise").is_none()
+        && ctx.lookup_func("Promise").is_none()
+        && ctx.lookup_imported_func("Promise").is_none()
+}
+
 /// If `expr` is `<NS>.<static>` where `<NS>` is a known namespace-static
-/// holder (Promise/Math/JSON/Number/String/Object/Array) not shadowed by a
+/// holder (Math/JSON/Number/String/Object/Array) not shadowed by a
 /// local, and `<static>` is a known method on it, return a clone of that
 /// MemberExpr so it can be reused as the rewritten callee.
 fn match_namespace_static_member(
@@ -1648,6 +1726,9 @@ fn match_namespace_static_member(
     };
     let ns = base.sym.as_ref();
     let name = prop.sym.as_ref();
+    if ns == "Promise" {
+        return None;
+    }
     if ctx.lookup_local(ns).is_some() || ctx.lookup_func(ns).is_some() {
         return None;
     }

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1919,7 +1919,12 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     let outer_is_reified_builtin_static_value = !member_is_call_callee
                         && matches!(
                             property.as_str(),
-                            "JSON" | "Reflect" | "BigInt" | "Symbol" | "Array" | "Number"
+                            "JSON"
+                                | "Reflect"
+                                | "BigInt"
+                                | "Symbol"
+                                | "Array"
+                                | "Number"
                                 | "Promise"
                         )
                         && outer_static_member

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -217,6 +217,37 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         }
     }
 
+    // Promise statics are receiver-sensitive: ECMA-262 uses their `this`
+    // value as the constructor, so value reads like `Promise.resolve.call(...)`
+    // must keep the `Promise` receiver instead of collapsing to the legacy
+    // property-only `GlobalGet(0).resolve` intrinsic shape.
+    if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+        let promise_is_source_bound = ctx.lookup_local("Promise").is_some()
+            || ctx.lookup_func("Promise").is_some()
+            || ctx.lookup_imported_func("Promise").is_some();
+        if obj_ident.sym.as_ref() == "Promise" && !promise_is_source_bound {
+            let static_member = match &member.prop {
+                ast::MemberProp::Ident(prop_ident) => Some(prop_ident.sym.as_ref()),
+                ast::MemberProp::Computed(computed) => match computed.expr.as_ref() {
+                    ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str(),
+                    _ => None,
+                },
+                ast::MemberProp::PrivateName(_) => None,
+            };
+            if let Some(static_member) = static_member {
+                if crate::analysis::is_builtin_static_function_member("Promise", static_member) {
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(Expr::PropertyGet {
+                            object: Box::new(Expr::GlobalGet(0)),
+                            property: "Promise".to_string(),
+                        }),
+                        property: static_member.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
     // process.std{in,out,err}.{isTTY,columns,rows} — direct extern-call
     // shapes recognized BEFORE the regular process.X arm below, since the
     // double-Member shape (Member(Member(process, stream), prop)) doesn't
@@ -1855,9 +1886,10 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                             )
                         );
                     // #4437: value reads such as `JSON.stringify` /
-                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` need the
-                    // reified namespace/constructor receiver. Direct calls still
-                    // take the intrinsic path this reroute-undo protects.
+                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` /
+                    // `Promise.resolve` need the reified namespace/constructor
+                    // receiver. Direct calls still take the intrinsic path this
+                    // reroute-undo protects.
                     let outer_static_member = match &member.prop {
                         ast::MemberProp::Ident(p) => Some(p.sym.as_ref()),
                         ast::MemberProp::Computed(c) => match c.expr.as_ref() {
@@ -1888,6 +1920,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         && matches!(
                             property.as_str(),
                             "JSON" | "Reflect" | "BigInt" | "Symbol" | "Array" | "Number"
+                                | "Promise"
                         )
                         && outer_static_member
                             .map(|member| {

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -4105,6 +4105,155 @@ extern "C" fn typed_array_of_thunk(
     crate::value::js_nanbox_pointer(ta as i64)
 }
 
+fn require_promise_constructor_this() {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let promise_ctor = js_get_global_this_builtin_value(b"Promise".as_ptr(), 7);
+    if this_value.to_bits() != promise_ctor.to_bits() {
+        super::object_ops::throw_object_type_error(
+            b"Promise static method requires a Promise constructor receiver",
+        );
+    }
+}
+
+extern "C" fn promise_resolve_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    let promise = crate::promise::js_promise_resolved(value);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+extern "C" fn promise_reject_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    let promise = crate::promise::js_promise_rejected(reason);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+extern "C" fn promise_all_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    iterable: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    let promise = crate::promise::combinators::js_promise_all_iterable(iterable);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+extern "C" fn promise_race_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    iterable: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    let promise = crate::promise::combinators::js_promise_race_iterable(iterable);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+extern "C" fn promise_all_settled_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    iterable: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    let promise = crate::promise::combinators::js_promise_all_settled_iterable(iterable);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+extern "C" fn promise_any_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    iterable: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    let promise = crate::promise::combinators::js_promise_any_iterable(iterable);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+extern "C" fn promise_with_resolvers_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    require_promise_constructor_this();
+    let result = crate::promise::js_promise_with_resolvers();
+    crate::value::js_nanbox_pointer(result as i64)
+}
+
+extern "C" fn promise_try_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    let rest_value = JSValue::from_bits(rest.to_bits());
+    let rest_ptr = if rest_value.is_pointer() {
+        rest_value.as_pointer::<crate::array::ArrayHeader>()
+    } else {
+        std::ptr::null()
+    };
+    let promise = crate::promise::js_promise_try(callback, rest_ptr);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+fn promise_static_function_spec(name: &str) -> Option<(*const u8, u32, u32, bool)> {
+    match name {
+        "resolve" => Some((promise_resolve_thunk as *const u8, 1, 1, false)),
+        "reject" => Some((promise_reject_thunk as *const u8, 1, 1, false)),
+        "all" => Some((promise_all_thunk as *const u8, 1, 1, false)),
+        "race" => Some((promise_race_thunk as *const u8, 1, 1, false)),
+        "allSettled" => Some((promise_all_settled_thunk as *const u8, 1, 1, false)),
+        "any" => Some((promise_any_thunk as *const u8, 1, 1, false)),
+        "withResolvers" => Some((promise_with_resolvers_thunk as *const u8, 0, 0, false)),
+        "try" => Some((promise_try_thunk as *const u8, 1, 1, true)),
+        _ => None,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_promise_static_function_value(name_ptr: *const u8, name_len: usize) -> f64 {
+    if name_ptr.is_null() || name_len == 0 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let name_bytes = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
+    let Ok(name) = std::str::from_utf8(name_bytes) else {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    };
+    let Some((func_ptr, spec_length, call_arity, has_rest)) = promise_static_function_spec(name)
+    else {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    };
+
+    let ctor_value = js_get_global_this_builtin_value(b"Promise".as_ptr(), 7);
+    let ctor_ptr =
+        crate::value::js_nanbox_get_pointer(ctor_value) as *mut crate::closure::ClosureHeader;
+    if !ctor_ptr.is_null() {
+        let existing = crate::closure::closure_get_dynamic_prop(ctor_ptr as usize, name);
+        if existing.to_bits() != crate::value::TAG_UNDEFINED {
+            return existing;
+        }
+    }
+
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    if has_rest {
+        crate::closure::js_register_closure_rest(func_ptr, call_arity);
+    } else {
+        crate::closure::js_register_closure_arity(func_ptr, call_arity);
+    }
+    super::native_module::set_bound_native_closure_name(closure, name);
+    super::native_module::set_builtin_closure_length(closure as usize, spec_length);
+    super::native_module::set_builtin_closure_non_constructable(closure as usize);
+
+    let value = crate::value::js_nanbox_pointer(closure as i64);
+    if !ctor_ptr.is_null() {
+        crate::closure::closure_set_dynamic_prop(ctor_ptr as usize, name, value);
+        super::set_builtin_property_attrs(
+            ctor_ptr as usize,
+            name.to_string(),
+            super::PropertyAttrs::new(true, false, true),
+        );
+    }
+    value
+}
+
 extern "C" fn url_can_parse_thunk(
     _closure: *const crate::closure::ClosureHeader,
     input: f64,
@@ -4394,6 +4543,31 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
             );
             install_constructor_static(ctor, "from", array_from_thunk as *const u8, 1, false);
             install_constructor_static(ctor, "of", array_of_thunk as *const u8, 0, true);
+        }
+        "Promise" => {
+            for static_name in [
+                "resolve",
+                "reject",
+                "all",
+                "race",
+                "allSettled",
+                "any",
+                "withResolvers",
+                "try",
+            ] {
+                if let Some((func_ptr, spec_length, call_arity, has_rest)) =
+                    promise_static_function_spec(static_name)
+                {
+                    install_constructor_static_with_call_arity(
+                        ctor,
+                        static_name,
+                        func_ptr,
+                        spec_length,
+                        call_arity,
+                        has_rest,
+                    );
+                }
+            }
         }
         "Date" => {
             // `Date.now` / `Date.parse` / `Date.UTC` as real own data props

--- a/test-parity/node-suite/globals/promise-static-brand-checks.ts
+++ b/test-parity/node-suite/globals/promise-static-brand-checks.ts
@@ -1,0 +1,54 @@
+function formatValue(value: any): string {
+  if (Array.isArray(value)) {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+async function showPromise(label: string, promise: Promise<any>) {
+  try {
+    console.log(label + ":fulfilled:" + formatValue(await promise));
+  } catch (error: any) {
+    console.log(label + ":rejected:" + formatValue(error));
+  }
+}
+
+function showThrow(label: string, fn: () => any) {
+  try {
+    const result = fn();
+    console.log(label + ":ok:" + formatValue(result));
+  } catch (error: any) {
+    console.log(label + ":throw:" + error.name);
+  }
+}
+
+console.log("typeof resolve:", typeof Promise.resolve);
+console.log("resolve length:", Promise.resolve.length);
+console.log("all length:", Promise.all.length);
+
+const detachedResolve = Promise.resolve;
+console.log("detached resolve typeof:", typeof detachedResolve);
+console.log("detached resolve length:", detachedResolve.length);
+
+await showPromise("resolve.call.Promise", Promise.resolve.call(Promise, 7));
+await showPromise("reject.call.Promise", Promise.reject.call(Promise, "bad"));
+await showPromise("all.call.Promise", Promise.all.call(Promise, [Promise.resolve(1), 2]));
+await showPromise("race.call.Promise", Promise.race.call(Promise, [Promise.resolve("race")]));
+await showPromise(
+  "allSettled.call.Promise",
+  Promise.allSettled.call(Promise, [Promise.resolve(1), Promise.reject("err")]),
+);
+await showPromise("any.call.Promise", Promise.any.call(Promise, [Promise.reject("x"), "ok"]));
+
+showThrow("resolve.detached", () => {
+  return detachedResolve(1);
+});
+showThrow("resolve.call.object", () => Promise.resolve.call({} as any, 1));
+showThrow("reject.call.object", () => Promise.reject.call({} as any, "x"));
+showThrow("all.call.object", () => Promise.all.call({} as any, []));
+showThrow("race.call.object", () => Promise.race.call({} as any, []));
+showThrow("allSettled.call.object", () => Promise.allSettled.call({} as any, []));
+showThrow("any.call.object", () => Promise.any.call({} as any, []));
+showThrow("resolve.apply.object", () => Promise.resolve.apply({} as any, [1]));
+showThrow("all.apply.object", () => Promise.all.apply({} as any, [[]]));
+showThrow("resolve.bind.object", () => Promise.resolve.bind({} as any)(1));


### PR DESCRIPTION
Part of #4521.

## Summary
- preserve Promise static member values so borrowed `.call/.apply/.bind` keeps receiver-sensitive behavior
- add runtime Promise static function values that brand-check `this` against the Promise constructor
- add Node parity coverage for detached statics and object receivers

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/promise-static-brand-checks.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 ./run_parity_tests.sh --suite node-suite --module globals --filter promise-static-brand-checks` with Node 26 first in `PATH` for the TS oracle
- `cargo check -q -p perry-hir -p perry-codegen -p perry-runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`