### PR TITLE
fix(runtime): brand-check Promise static receivers

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1512,12 +1512,17 @@ fn is_builtin_prototype_receiver(ctx: &LoweringContext, recv: &ast::Expr) -> boo
 /// "value is not a function" at the outer call.
 ///
 /// Rewrite at the AST level for the shapes whose intent is unambiguous and
-/// where the `thisArg` is irrelevant (namespace statics don't read `this`):
+/// where the `thisArg` is irrelevant (most namespace statics don't read `this`):
 ///
 ///   `<NS>.<static>.call(thisArg, a, b, …)`     → `<NS>.<static>(a, b, …)`
 ///   `<NS>.<static>.apply(thisArg)`             → `<NS>.<static>()`
 ///   `<NS>.<static>.apply(thisArg, [a, b, …])`  → `<NS>.<static>(a, b, …)`
 ///   `<NS>.<static>.bind(thisArg, …pre)(…rest)` → `<NS>.<static>(…pre, …rest)`
+///
+/// Promise statics are receiver-sensitive: ECMA-262 uses their `this` value as
+/// the constructor receiver. Only keep the rewrite when the borrowed-call
+/// receiver is the real global `Promise`; otherwise leave the call reflective
+/// so runtime validation can throw.
 ///
 /// The deferred-bind shape (`const f = Promise.resolve.bind(Promise);
 /// f(x);`) cannot be rewritten purely at the AST level — that needs a
@@ -1543,6 +1548,14 @@ pub(super) fn try_namespace_static_method_apply_call_bind(
                 _ => None,
             };
             if let Some(is_apply) = mode {
+                if let Some(inner) = match_promise_static_member(ctx, outer.obj.as_ref()) {
+                    if call.args.first().is_some_and(|arg| {
+                        expr_is_global_promise_constructor(ctx, arg.expr.as_ref())
+                    }) {
+                        return rewrite_dropping_this(ctx, call, &inner, is_apply);
+                    }
+                    return Ok(None);
+                }
                 if let Some(inner) = match_namespace_static_member(ctx, outer.obj.as_ref()) {
                     return rewrite_dropping_this(ctx, call, &inner, is_apply);
                 }
@@ -1561,6 +1574,26 @@ pub(super) fn try_namespace_static_method_apply_call_bind(
                         // understand; require at least `thisArg`.
                         let bind_spread = bind_call.args.iter().any(|a| a.spread.is_some());
                         if !bind_spread && !bind_call.args.is_empty() {
+                            if let Some(inner_member) =
+                                match_promise_static_member(ctx, bind_member.obj.as_ref())
+                            {
+                                if expr_is_global_promise_constructor(
+                                    ctx,
+                                    bind_call.args[0].expr.as_ref(),
+                                ) {
+                                    let pre_bound: Vec<ast::ExprOrSpread> =
+                                        bind_call.args.iter().skip(1).cloned().collect();
+                                    let mut synth = call.clone();
+                                    synth.callee = ast::Callee::Expr(Box::new(ast::Expr::Member(
+                                        inner_member,
+                                    )));
+                                    let mut combined = pre_bound;
+                                    combined.extend(call.args.iter().cloned());
+                                    synth.args = combined;
+                                    return Ok(Some(super::lower_call(ctx, &synth)?));
+                                }
+                                return Ok(None);
+                            }
                             if let Some(inner_member) =
                                 match_namespace_static_member(ctx, bind_member.obj.as_ref())
                             {
@@ -1585,8 +1618,51 @@ pub(super) fn try_namespace_static_method_apply_call_bind(
     Ok(None)
 }
 
+fn match_promise_static_member(ctx: &LoweringContext, expr: &ast::Expr) -> Option<ast::MemberExpr> {
+    let ast::Expr::Member(m) = expr else {
+        return None;
+    };
+    let ast::MemberProp::Ident(prop) = &m.prop else {
+        return None;
+    };
+    let ast::Expr::Ident(base) = m.obj.as_ref() else {
+        return None;
+    };
+    let ns = base.sym.as_ref();
+    let name = prop.sym.as_ref();
+    if ns != "Promise" {
+        return None;
+    }
+    if ctx.lookup_local(ns).is_some()
+        || ctx.lookup_func(ns).is_some()
+        || ctx.lookup_imported_func(ns).is_some()
+    {
+        return None;
+    }
+    crate::analysis::is_builtin_static_function_member(ns, name).then_some(m.clone())
+}
+
+fn expr_is_global_promise_constructor(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let mut expr = expr;
+    loop {
+        expr = match expr {
+            ast::Expr::TsAs(x) => x.expr.as_ref(),
+            ast::Expr::TsNonNull(x) => x.expr.as_ref(),
+            ast::Expr::TsSatisfies(x) => x.expr.as_ref(),
+            ast::Expr::TsTypeAssertion(x) => x.expr.as_ref(),
+            ast::Expr::TsConstAssertion(x) => x.expr.as_ref(),
+            ast::Expr::Paren(x) => x.expr.as_ref(),
+            _ => break,
+        };
+    }
+    matches!(expr, ast::Expr::Ident(ident) if ident.sym.as_ref() == "Promise")
+        && ctx.lookup_local("Promise").is_none()
+        && ctx.lookup_func("Promise").is_none()
+        && ctx.lookup_imported_func("Promise").is_none()
+}
+
 /// If `expr` is `<NS>.<static>` where `<NS>` is a known namespace-static
-/// holder (Promise/Math/JSON/Number/String/Object/Array) not shadowed by a
+/// holder (Math/JSON/Number/String/Object/Array) not shadowed by a
 /// local, and `<static>` is a known method on it, return a clone of that
 /// MemberExpr so it can be reused as the rewritten callee.
 fn match_namespace_static_member(
@@ -1604,6 +1680,9 @@ fn match_namespace_static_member(
     };
     let ns = base.sym.as_ref();
     let name = prop.sym.as_ref();
+    if ns == "Promise" {
+        return None;
+    }
     if ctx.lookup_local(ns).is_some() || ctx.lookup_func(ns).is_some() {
         return None;
     }

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -217,6 +217,41 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         }
     }
 
+    // Promise statics are receiver-sensitive. Value reads such as
+    // `Promise.resolve.call(...)` must preserve the `Promise` constructor
+    // receiver instead of collapsing to the legacy property-only
+    // `GlobalGet(0).resolve` intrinsic shape.
+    if !member_is_call_callee {
+        if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+            if obj_ident.sym.as_ref() == "Promise"
+                && ctx.lookup_local("Promise").is_none()
+                && ctx.lookup_func("Promise").is_none()
+                && ctx.lookup_imported_func("Promise").is_none()
+            {
+                let static_member = match &member.prop {
+                    ast::MemberProp::Ident(prop_ident) => Some(prop_ident.sym.as_ref()),
+                    ast::MemberProp::Computed(computed) => match computed.expr.as_ref() {
+                        ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str(),
+                        _ => None,
+                    },
+                    ast::MemberProp::PrivateName(_) => None,
+                };
+                if let Some(static_member) = static_member {
+                    if crate::analysis::is_builtin_static_function_member("Promise", static_member)
+                    {
+                        return Ok(Expr::PropertyGet {
+                            object: Box::new(Expr::PropertyGet {
+                                object: Box::new(Expr::GlobalGet(0)),
+                                property: "Promise".to_string(),
+                            }),
+                            property: static_member.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
     // process.std{in,out,err}.{isTTY,columns,rows} — direct extern-call
     // shapes recognized BEFORE the regular process.X arm below, since the
     // double-Member shape (Member(Member(process, stream), prop)) doesn't
@@ -1828,9 +1863,10 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                             )
                         );
                     // #4437: value reads such as `JSON.stringify` /
-                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` need the
-                    // reified namespace/constructor receiver. Direct calls still
-                    // take the intrinsic path this reroute-undo protects.
+                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` /
+                    // `Promise.resolve` need the reified namespace/constructor
+                    // receiver. Direct calls still take the intrinsic path this
+                    // reroute-undo protects.
                     let outer_static_member = match &member.prop {
                         ast::MemberProp::Ident(p) => Some(p.sym.as_ref()),
                         ast::MemberProp::Computed(c) => match c.expr.as_ref() {
@@ -1840,7 +1876,10 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         ast::MemberProp::PrivateName(_) => None,
                     };
                     let outer_is_reified_builtin_static_value = !member_is_call_callee
-                        && matches!(property.as_str(), "JSON" | "Reflect" | "BigInt" | "Symbol")
+                        && matches!(
+                            property.as_str(),
+                            "JSON" | "Reflect" | "BigInt" | "Symbol" | "Promise"
+                        )
                         && outer_static_member
                             .map(|member| {
                                 crate::analysis::is_builtin_static_function_member(property, member)

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3276,6 +3276,92 @@ extern "C" fn typed_array_of_thunk(
     crate::value::js_nanbox_pointer(ta as i64)
 }
 
+fn require_promise_constructor_this() {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let promise_ctor = js_get_global_this_builtin_value(b"Promise".as_ptr(), 7);
+    if this_value.to_bits() != promise_ctor.to_bits() {
+        super::object_ops::throw_object_type_error(
+            b"Promise static method requires a Promise constructor receiver",
+        );
+    }
+}
+
+extern "C" fn promise_resolve_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    crate::value::js_nanbox_pointer(crate::promise::js_promise_resolved(value) as i64)
+}
+
+extern "C" fn promise_reject_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    crate::value::js_nanbox_pointer(crate::promise::js_promise_rejected(reason) as i64)
+}
+
+extern "C" fn promise_all_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    iterable: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    crate::value::js_nanbox_pointer(
+        crate::promise::combinators::js_promise_all_iterable(iterable) as i64,
+    )
+}
+
+extern "C" fn promise_race_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    iterable: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    crate::value::js_nanbox_pointer(
+        crate::promise::combinators::js_promise_race_iterable(iterable) as i64,
+    )
+}
+
+extern "C" fn promise_all_settled_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    iterable: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    crate::value::js_nanbox_pointer(
+        crate::promise::combinators::js_promise_all_settled_iterable(iterable) as i64,
+    )
+}
+
+extern "C" fn promise_any_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    iterable: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    crate::value::js_nanbox_pointer(
+        crate::promise::combinators::js_promise_any_iterable(iterable) as i64,
+    )
+}
+
+extern "C" fn promise_with_resolvers_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    require_promise_constructor_this();
+    crate::value::js_nanbox_pointer(crate::promise::js_promise_with_resolvers() as i64)
+}
+
+extern "C" fn promise_try_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    require_promise_constructor_this();
+    let rest_value = crate::value::JSValue::from_bits(rest.to_bits());
+    let rest_ptr = if rest_value.is_pointer() {
+        rest_value.as_pointer::<crate::array::ArrayHeader>()
+    } else {
+        std::ptr::null()
+    };
+    crate::value::js_nanbox_pointer(crate::promise::js_promise_try(callback, rest_ptr) as i64)
+}
+
 extern "C" fn url_can_parse_thunk(
     _closure: *const crate::closure::ClosureHeader,
     input: f64,
@@ -3565,6 +3651,34 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
             );
             install_constructor_static(ctor, "from", array_from_thunk as *const u8, 1, false);
             install_constructor_static(ctor, "of", array_of_thunk as *const u8, 0, true);
+        }
+        "Promise" => {
+            install_constructor_static(
+                ctor,
+                "resolve",
+                promise_resolve_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(ctor, "reject", promise_reject_thunk as *const u8, 1, false);
+            install_constructor_static(ctor, "all", promise_all_thunk as *const u8, 1, false);
+            install_constructor_static(ctor, "race", promise_race_thunk as *const u8, 1, false);
+            install_constructor_static(
+                ctor,
+                "allSettled",
+                promise_all_settled_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(ctor, "any", promise_any_thunk as *const u8, 1, false);
+            install_constructor_static(
+                ctor,
+                "withResolvers",
+                promise_with_resolvers_thunk as *const u8,
+                0,
+                false,
+            );
+            install_constructor_static(ctor, "try", promise_try_thunk as *const u8, 1, true);
         }
         "Date" => {
             // `Date.now` / `Date.parse` / `Date.UTC` as real own data props

--- a/test-parity/node-suite/globals/promise-static-receiver.ts
+++ b/test-parity/node-suite/globals/promise-static-receiver.ts
@@ -1,0 +1,65 @@
+function formatValue(value: any): string {
+  if (Array.isArray(value)) {
+    return JSON.stringify(value);
+  }
+  if (value && typeof value === "object" && "promise" in value) {
+    return [
+      typeof value.promise?.then,
+      typeof value.resolve,
+      typeof value.reject,
+    ].join("/");
+  }
+  return String(value);
+}
+
+async function showPromise(label: string, promise: Promise<any>) {
+  try {
+    console.log(label + ":fulfilled:" + formatValue(await promise));
+  } catch (error: any) {
+    console.log(label + ":rejected:" + error.name + ":" + formatValue(error));
+  }
+}
+
+function showThrow(label: string, fn: () => any) {
+  try {
+    const result = fn();
+    console.log(label + ":ok:" + formatValue(result));
+  } catch (error: any) {
+    console.log(label + ":throw:" + error.name);
+  }
+}
+
+console.log("typeof resolve:", typeof Promise.resolve);
+console.log("resolve length:", Promise.resolve.length);
+console.log("allSettled length:", Promise.allSettled.length);
+console.log("withResolvers length:", Promise.withResolvers.length);
+
+const detachedResolve = Promise.resolve;
+console.log("detached resolve typeof:", typeof detachedResolve);
+console.log("detached resolve length:", detachedResolve.length);
+
+await showPromise("resolve.call.Promise", Promise.resolve.call(Promise, 7));
+await showPromise("reject.call.Promise", Promise.reject.call(Promise, "bad"));
+await showPromise("all.call.Promise", Promise.all.call(Promise, [Promise.resolve(1), 2]));
+await showPromise("race.call.Promise", Promise.race.call(Promise, [Promise.resolve("race")]));
+await showPromise(
+  "allSettled.call.Promise",
+  Promise.allSettled.call(Promise, [Promise.resolve(1), Promise.reject("err")]),
+);
+await showPromise("any.call.Promise", Promise.any.call(Promise, [Promise.reject("x"), "ok"]));
+console.log("withResolvers.call.Promise:", formatValue(Promise.withResolvers.call(Promise)));
+await showPromise("try.call.Promise", Promise.try.call(Promise, () => 11));
+await showPromise("resolve.bind.Promise", Promise.resolve.bind(Promise)(9));
+
+showThrow("resolve.detached", () => detachedResolve(1));
+showThrow("resolve.call.object", () => Promise.resolve.call({} as any, 1));
+showThrow("reject.call.object", () => Promise.reject.call({} as any, "x"));
+showThrow("all.call.object", () => Promise.all.call({} as any, []));
+showThrow("race.call.object", () => Promise.race.call({} as any, []));
+showThrow("allSettled.call.object", () => Promise.allSettled.call({} as any, []));
+showThrow("any.call.object", () => Promise.any.call({} as any, []));
+showThrow("withResolvers.call.object", () => Promise.withResolvers.call({} as any));
+showThrow("try.call.object", () => Promise.try.call({} as any, () => 1));
+showThrow("resolve.apply.object", () => Promise.resolve.apply({} as any, [1]));
+showThrow("all.apply.object", () => Promise.all.apply({} as any, [[]]));
+showThrow("resolve.bind.object", () => Promise.resolve.bind({} as any)(1));


### PR DESCRIPTION
## Summary

Refs #4521.

This is a focused Promise static receiver slice:

- Reifies `Promise.resolve` / `reject` / `all` / `race` / `allSettled` / `any` / `withResolvers` / `try` as actual constructor data properties for reflective value reads such as `.length`, `const f = Promise.resolve`, `.call`, `.apply`, and `.bind`.
- Stops the generic namespace-static `.call` / `.apply` / `.bind` rewrite from dropping Promise's constructor receiver unless the borrowed-call receiver is the real global `Promise`.
- Adds runtime receiver validation for the reified Promise static thunks so non-Promise receivers throw `TypeError` instead of manufacturing promise results from arbitrary objects.
- Adds a Node parity fixture covering detached static values, valid `Promise` receivers, and invalid object receivers.

## Why This Is One Cut

All changed behavior is part of the same receiver-sensitive Promise static value path: lowering must preserve the constructor receiver, and runtime must validate it when the call is reflective.

## Non-Goals

- No Promise aggregation ordering/bookkeeping changes.
- No `Promise.prototype.then` brand-check or microtask behavior overhaul.
- No subclass/species constructor support.

## Tests

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/promise-static-receiver.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter promise-static-receiver'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter promise'`
- `cargo check -q -p perry-hir -p perry-runtime -p perry-codegen`
- `cargo test -q -p perry-runtime --lib object::tests -- --nocapture`
- `cargo test -q -p perry-runtime --lib promise::combinators -- --nocapture`
- `cargo test -q -p perry-runtime --lib gc::tests::alloc::test_async_hooks_promise_alloc_remains_malloc_tracked -- --nocapture`
- `git diff --check origin/main...HEAD`

Base check notes:

- `cargo fmt --all -- --check` still fails on unrelated existing indentation in `crates/perry-codegen/src/expr/property_get.rs`.
- `./scripts/check_file_size.sh` still fails on unrelated existing `crates/perry-runtime/src/regex.rs` at 2026 lines.
