### PR TITLE
hir: preserve Date static function values

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1827,10 +1827,11 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                                     | "values"
                             )
                         );
-                    // #4437: value reads such as `JSON.stringify` /
-                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` need the
-                    // reified namespace/constructor receiver. Direct calls still
-                    // take the intrinsic path this reroute-undo protects.
+                    // #4437/#4596: value reads such as `JSON.stringify` /
+                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` /
+                    // `Date.now` need the reified namespace/constructor receiver.
+                    // Direct calls still take the intrinsic path this
+                    // reroute-undo protects.
                     let outer_static_member = match &member.prop {
                         ast::MemberProp::Ident(p) => Some(p.sym.as_ref()),
                         ast::MemberProp::Computed(c) => match c.expr.as_ref() {
@@ -1840,7 +1841,10 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         ast::MemberProp::PrivateName(_) => None,
                     };
                     let outer_is_reified_builtin_static_value = !member_is_call_callee
-                        && matches!(property.as_str(), "JSON" | "Reflect" | "BigInt" | "Symbol")
+                        && matches!(
+                            property.as_str(),
+                            "JSON" | "Reflect" | "BigInt" | "Symbol" | "Date"
+                        )
                         && outer_static_member
                             .map(|member| {
                                 crate::analysis::is_builtin_static_function_member(property, member)

--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -220,11 +220,14 @@ pub(crate) fn install_date_constructor_statics(ctor: *mut crate::closure::Closur
         1,
         false,
     );
-    super::global_this::install_constructor_static(
+    // `Date.UTC.length` is 7, but the runtime helper also needs the actual
+    // argument count so omitted month/day keep their spec defaults.
+    super::global_this::install_constructor_static_with_call_arity(
         ctor,
         "UTC",
         date_utc_static as *const u8,
         7,
+        0,
         true,
     );
 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3430,7 +3430,7 @@ pub(super) fn install_constructor_static(
     install_constructor_static_with_call_arity(ctor, name, func_ptr, arity, arity, has_rest);
 }
 
-fn install_constructor_static_with_call_arity(
+pub(super) fn install_constructor_static_with_call_arity(
     ctor: *mut crate::closure::ClosureHeader,
     name: &str,
     func_ptr: *const u8,

--- a/test-parity/node-suite/globals/date-static-function-values.ts
+++ b/test-parity/node-suite/globals/date-static-function-values.ts
@@ -1,0 +1,52 @@
+function errorName(fn: () => unknown): string {
+  try {
+    fn();
+    return "none";
+  } catch (err) {
+    return (err as Error).name;
+  }
+}
+
+const nowFn = Date.now;
+const parseFn = Date.parse;
+const utcFn = Date.UTC;
+
+console.log("typeof:", typeof Date.now, typeof Date.parse, typeof Date.UTC);
+console.log("names:", Date.now.name, Date.parse.name, Date.UTC.name);
+console.log("lengths:", Date.now.length, Date.parse.length, Date.UTC.length);
+
+const before = Date.now();
+const nowValue = nowFn();
+const after = Date.now();
+console.log("now detached:", typeof nowValue, nowValue >= before && nowValue <= after);
+
+console.log(
+  "parse detached:",
+  parseFn("1970-01-01T00:00:00.000Z"),
+  Number.isNaN(parseFn("not a date")),
+);
+console.log("utc detached:", utcFn(1970, 0, 1), utcFn(2000, 1, 29, 12, 34, 56, 789));
+console.log(
+  "utc arity defaults:",
+  utcFn(1970),
+  Number.isNaN(utcFn()),
+  Number.isNaN(utcFn(1970, undefined)),
+);
+
+const funcs = [Date.now, Date.parse, Date.UTC];
+console.log(
+  "array calls:",
+  typeof funcs[0](),
+  funcs[1]("1970-01-01T00:00:00.000Z"),
+  funcs[2](1970, 0, 1),
+);
+
+const holder = { utc: Date.UTC };
+console.log("object value:", typeof holder.utc, holder.utc(1970, 0, 2));
+
+console.log(
+  "direct calls:",
+  typeof Date.now(),
+  Date.parse("1970-01-01T00:00:00.000Z"),
+  Date.UTC(1970, 0, 1),
+);


### PR DESCRIPTION
Summary:
- Preserve the reified Date constructor receiver for non-callee static function value reads so Date.now / Date.parse / Date.UTC are callable as first-class values.
- Register Date.UTC with a rest-only call ABI while keeping its spec .length of 7, preserving actual argument-count semantics for omitted UTC components.
- Add a Node parity fixture covering typeof/name/length, detached calls, array/object value calls, and direct-call fast paths.

Validation:
- cargo check -q -p perry-hir -p perry-runtime
- env RUSTC_WRAPPER= TMPDIR=/tmp CARGO_BUILD_JOBS=1 cargo build -q -p perry -p perry-runtime -p perry-stdlib
- npx -y node@22 --experimental-strip-types test-parity/node-suite/globals/date-static-function-values.ts
- npx -y node@26 --experimental-strip-types test-parity/node-suite/globals/date-static-function-values.ts
- env PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry test-parity/node-suite/globals/date-static-function-values.ts -o /tmp/perry-date-static-function-values && /tmp/perry-date-static-function-values
- git diff --check HEAD~1..HEAD

Addresses #4596