### PR TITLE
fix(runtime): reify Date static function values

### DIFF
--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -315,6 +315,7 @@ pub(crate) fn is_known_namespace_static_function(obj_name: &str, prop_name: &str
         "Math" => is_known_math_static_method(prop_name),
         "JSON" => is_known_json_static_method(prop_name),
         "Atomics" => is_known_atomics_static_method(prop_name),
+        "Date" => matches!(prop_name, "now" | "parse" | "UTC"),
         "Number" => is_known_number_static_method(prop_name),
         "String" => is_known_string_static_method(prop_name),
         // #2877: `ArrayBuffer.isView` is a real static function (folded to the

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1828,9 +1828,10 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                             )
                         );
                     // #4437: value reads such as `JSON.stringify` /
-                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` need the
-                    // reified namespace/constructor receiver. Direct calls still
-                    // take the intrinsic path this reroute-undo protects.
+                    // `Reflect.apply` / `BigInt.asIntN` / `Symbol.for` /
+                    // `Date.now` need the reified namespace/constructor receiver.
+                    // Direct calls still take the intrinsic path this reroute-undo
+                    // protects.
                     let outer_static_member = match &member.prop {
                         ast::MemberProp::Ident(p) => Some(p.sym.as_ref()),
                         ast::MemberProp::Computed(c) => match c.expr.as_ref() {
@@ -1840,7 +1841,10 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         ast::MemberProp::PrivateName(_) => None,
                     };
                     let outer_is_reified_builtin_static_value = !member_is_call_callee
-                        && matches!(property.as_str(), "JSON" | "Reflect" | "BigInt" | "Symbol")
+                        && matches!(
+                            property.as_str(),
+                            "JSON" | "Reflect" | "BigInt" | "Symbol" | "Date"
+                        )
                         && outer_static_member
                             .map(|member| {
                                 crate::analysis::is_builtin_static_function_member(property, member)

--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -220,11 +220,12 @@ pub(crate) fn install_date_constructor_statics(ctor: *mut crate::closure::Closur
         1,
         false,
     );
-    super::global_this::install_constructor_static(
+    super::global_this::install_constructor_static_with_call_arity(
         ctor,
         "UTC",
         date_utc_static as *const u8,
         7,
+        0,
         true,
     );
 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3430,7 +3430,7 @@ pub(super) fn install_constructor_static(
     install_constructor_static_with_call_arity(ctor, name, func_ptr, arity, arity, has_rest);
 }
 
-fn install_constructor_static_with_call_arity(
+pub(super) fn install_constructor_static_with_call_arity(
     ctor: *mut crate::closure::ClosureHeader,
     name: &str,
     func_ptr: *const u8,

--- a/test-parity/node-suite/globals/date-static-values.ts
+++ b/test-parity/node-suite/globals/date-static-values.ts
@@ -1,0 +1,37 @@
+function show(label: string, value: unknown) {
+  console.log(label + ":", String(value));
+}
+
+function isFiniteNumber(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+const detachedNow = Date.now;
+const detachedParse = Date.parse;
+const detachedUTC = Date.UTC;
+
+show("typeof Date.now", typeof Date.now);
+show("Date.now name", Date.now.name);
+show("Date.now length", Date.now.length);
+show("typeof Date.parse", typeof Date.parse);
+show("Date.parse name", Date.parse.name);
+show("Date.parse length", Date.parse.length);
+show("typeof Date.UTC", typeof Date.UTC);
+show("Date.UTC name", Date.UTC.name);
+show("Date.UTC length", Date.UTC.length);
+
+show("direct now finite", isFiniteNumber(Date.now()));
+show("detached now type", typeof detachedNow);
+show("detached now finite", isFiniteNumber(detachedNow()));
+show("now.call object finite", isFiniteNumber(Date.now.call({})));
+show("now.bind object finite", isFiniteNumber(Date.now.bind({})()));
+
+show("direct parse epoch", Date.parse("1970-01-01T00:00:00.000Z"));
+show("detached parse day2", detachedParse("1970-01-02T00:00:00.000Z"));
+show("parse.call object day3", Date.parse.call({}, "1970-01-03T00:00:00.000Z"));
+
+show("direct UTC", Date.UTC(2020, 0, 2, 3, 4, 5, 6));
+show("detached UTC", detachedUTC(2020, 0, 2, 3, 4, 5, 6));
+show("UTC.call object", Date.UTC.call({}, 1970, 0, 1, 0, 0, 0, 1));
+show("UTC.apply object", Date.UTC.apply({}, [1970, 0, 1, 0, 0, 0, 2]));
+show("UTC.bind object", Date.UTC.bind({})(1970, 0, 1, 0, 0, 0, 3));


### PR DESCRIPTION
## Summary

Closes #4596.

- Routes non-callee `Date.now` / `Date.parse` / `Date.UTC` reads through the real Date constructor static properties instead of the property-only global fallback.
- Adds Date statics to the namespace-static recognizer so `typeof Date.now` and immediate `.call` / `.apply` / `.bind` shapes behave like callable function values while direct `Date.now()` / `Date.parse(...)` / `Date.UTC(...)` keep their existing intrinsic fast paths.
- Fixes the reified `Date.UTC` thunk registration so it preserves spec `.length === 7` but receives all detached dynamic-call arguments as a rest array.
- Adds a parity fixture for names, lengths, detached calls, `.call`, `.apply`, and `.bind`.

## Non-Goals

- No broader Date parsing correctness changes.
- No Date constructor/prototype semantic changes outside the three constructor statics.
- No unrelated constructor static surfaces.

## Tests

- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/date-static-values.ts`
- Before the fix: `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter date-static-values'` failed with `typeof Date.now: number` vs Node `function`.
- After the fix: `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter date-static-values'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter date'`
- `cargo check -q -p perry-hir -p perry-runtime -p perry-codegen`
- `cargo test -q -p perry-runtime --lib date -- --nocapture`
- `git diff --check`

Base check notes:

- `cargo fmt --all -- --check` still fails on unrelated existing indentation in `crates/perry-codegen/src/expr/property_get.rs`.
- `./scripts/check_file_size.sh` still fails on unrelated existing `crates/perry-runtime/src/regex.rs` at 2026 lines.
