### PR TITLE
Support generic Array.prototype methods over array-like receivers

### DIFF
--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -28,6 +28,26 @@ use super::{
     perry_updater_table_lookup, try_rewrite_perry_tui_jsx_intrinsic,
 };
 
+fn force_boxed_js_value_abi(name: &str) -> bool {
+    matches!(
+        name,
+        "js_array_like_join_value"
+            | "js_array_like_map_value"
+            | "js_array_like_filter_value"
+            | "js_array_like_for_each_value"
+            | "js_array_like_some"
+            | "js_array_like_every"
+            | "js_array_like_find"
+            | "js_array_like_find_index_value"
+            | "js_array_like_index_of_value"
+            | "js_array_like_last_index_of_value"
+            | "js_array_like_includes_value"
+            | "js_array_like_reduce_value"
+            | "js_array_like_reduce_right_value"
+            | "js_array_like_slice_value"
+    )
+}
+
 fn record_native_abi_param(
     ctx: &mut FnCtx<'_>,
     descriptor: &NativeAbiType,
@@ -1426,6 +1446,13 @@ pub fn try_lower_extern_func_call(
         }
         let arg_slices: Vec<(crate::types::LlvmType, &str)> =
             lowered.iter().map(|s| (DOUBLE, s.as_str())).collect();
+        if force_boxed_js_value_abi(name) {
+            ctx.pending_declares.push((
+                name.clone(),
+                DOUBLE,
+                std::iter::repeat_n(DOUBLE, args.len()).collect(),
+            ));
+        }
         return Ok(Some(ctx.block().call(DOUBLE, name, &arg_slices)));
     }
     // Issue #692: default-import call against an unresolved module.
@@ -1496,6 +1523,7 @@ pub fn try_lower_extern_func_call(
         // garbage value out of x0/x1 since Perry put the handle in
         // d-registers.
         let manifest_sig = ctx.ffi_signatures.get(name).cloned();
+        let force_boxed_js_value_abi = force_boxed_js_value_abi(name);
         let mut lowered: Vec<String> = Vec::with_capacity(args.len());
         let mut arg_types: Vec<crate::types::LlvmType> = Vec::with_capacity(args.len());
         let mut abi_slot_index = 0usize;
@@ -1542,14 +1570,14 @@ pub fn try_lower_extern_func_call(
                     &mut arg_types,
                 );
                 abi_slot_index += descriptor.abi_slot_count();
-            } else if is_string_expr(ctx, a) {
+            } else if !force_boxed_js_value_abi && is_string_expr(ctx, a) {
                 let blk = ctx.block();
                 let raw_ptr = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &val)]);
                 let ptr_val = blk.inttoptr(I64, &raw_ptr);
                 lowered.push(ptr_val);
                 arg_types.push(PTR);
                 abi_slot_index += 1;
-            } else if is_array_expr(ctx, a) {
+            } else if !force_boxed_js_value_abi && is_array_expr(ctx, a) {
                 let blk = ctx.block();
                 let bits = blk.bitcast_double_to_i64(&val);
                 let header_handle = blk.and(I64, &bits, POINTER_MASK_I64);

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -121,6 +121,7 @@ impl LoweringContext {
             iterator_func_for_class: std::collections::HashMap::new(),
             proxy_locals: HashSet::new(),
             builtin_proto_method_locals: HashMap::new(),
+            array_proto_method_locals: HashSet::new(),
             wasm_instance_locals: HashSet::new(),
             plain_object_locals: HashSet::new(),
             proxy_revoke_locals: HashMap::new(),

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1147,51 +1147,59 @@ pub(super) fn try_builtin_prototype_method_apply_call(
     //     ref, e.g. `const m = [].map` (#3144).
     // `method_prop` is the `IdentName` for the resolved method; we reuse it as
     // the synthesized member's `.prop`.
-    let method_prop: ast::IdentName = match outer.obj.as_ref() {
-        ast::Expr::Member(inner) => {
-            let ast::MemberProp::Ident(method_ident) = &inner.prop else {
-                return Ok(None);
-            };
-            if !is_builtin_prototype_receiver(ctx, inner.obj.as_ref()) {
-                return Ok(None);
+    let (method_prop, method_from_array_prototype): (ast::IdentName, bool) =
+        match outer.obj.as_ref() {
+            ast::Expr::Member(inner) => {
+                let ast::MemberProp::Ident(method_ident) = &inner.prop else {
+                    return Ok(None);
+                };
+                if !is_builtin_prototype_receiver(ctx, inner.obj.as_ref()) {
+                    return Ok(None);
+                }
+                // #4101: keep `Function.prototype.toString.call(x)` reflective so
+                // the runtime thunk runs its brand check (throw a TypeError on a
+                // non-function `this`) and reconstructs source. Folding it to
+                // `x.toString()` would erase the Function brand and route through
+                // the lenient universal `toString` (returns "[object Object]", no
+                // throw). `Object.prototype.toString.call(x)` is unaffected — it
+                // keeps folding (ramda relies on it).
+                if method_ident.sym.as_ref() == "toString"
+                    && is_function_prototype_member(inner.obj.as_ref())
+                {
+                    return Ok(None);
+                }
+                // #4100: keep `Number.prototype.valueOf.call(x)` /
+                // `Boolean.prototype.toString.call(x)` reflective so the installed
+                // brand-check thunk runs (throws a `TypeError` on an incompatible
+                // `this`). Folding to `x.<method>()` routes through the lenient
+                // `Object.prototype` fallback (`"[object Object]"`, no throw).
+                if is_primitive_wrapper_brand_method(inner.obj.as_ref(), method_ident.sym.as_ref())
+                {
+                    return Ok(None);
+                }
+                (
+                    method_ident.clone(),
+                    is_array_prototype_receiver(ctx, inner.obj.as_ref()),
+                )
             }
-            // #4101: keep `Function.prototype.toString.call(x)` reflective so
-            // the runtime thunk runs its brand check (throw a TypeError on a
-            // non-function `this`) and reconstructs source. Folding it to
-            // `x.toString()` would erase the Function brand and route through
-            // the lenient universal `toString` (returns "[object Object]", no
-            // throw). `Object.prototype.toString.call(x)` is unaffected — it
-            // keeps folding (ramda relies on it).
-            if method_ident.sym.as_ref() == "toString"
-                && is_function_prototype_member(inner.obj.as_ref())
-            {
-                return Ok(None);
-            }
-            // #4100: keep `Number.prototype.valueOf.call(x)` /
-            // `Boolean.prototype.toString.call(x)` reflective so the installed
-            // brand-check thunk runs (throws a `TypeError` on an incompatible
-            // `this`). Folding to `x.<method>()` routes through the lenient
-            // `Object.prototype` fallback (`"[object Object]"`, no throw).
-            if is_primitive_wrapper_brand_method(inner.obj.as_ref(), method_ident.sym.as_ref()) {
-                return Ok(None);
-            }
-            method_ident.clone()
-        }
-        ast::Expr::Ident(id) => match ctx.builtin_proto_method_locals.get(id.sym.as_ref()) {
-            Some(name) => {
-                // Build the method `.prop` IdentName by cloning the outer
-                // `.call`/`.apply` IdentName and overwriting its `sym`
-                // (avoids needing a synthetic span).
-                let mut prop = outer_prop.clone();
-                prop.sym = name.as_str().into();
-                prop
-            }
-            // Not a tracked builtin-method local: leave unrelated
-            // `someFn.call(...)` untouched.
-            None => return Ok(None),
-        },
-        _ => return Ok(None),
-    };
+            ast::Expr::Ident(id) => match ctx.builtin_proto_method_locals.get(id.sym.as_ref()) {
+                Some(name) => {
+                    // Build the method `.prop` IdentName by cloning the outer
+                    // `.call`/`.apply` IdentName and overwriting its `sym`
+                    // (avoids needing a synthetic span).
+                    let mut prop = outer_prop.clone();
+                    prop.sym = name.as_str().into();
+                    (
+                        prop,
+                        ctx.array_proto_method_locals.contains(id.sym.as_ref()),
+                    )
+                }
+                // Not a tracked builtin-method local: leave unrelated
+                // `someFn.call(...)` untouched.
+                None => return Ok(None),
+            },
+            _ => return Ok(None),
+        };
 
     // `.call`/`.apply` need at least the `thisArg` (the new receiver). A
     // spread in the `thisArg` slot can't be statically resolved to a receiver.
@@ -1239,10 +1247,15 @@ pub(super) fn try_builtin_prototype_method_apply_call(
     // (see `normalize_array_receiver`). Only the read-only/returning methods are
     // handled here; mutators and unsupported shapes fall through to the member
     // call below (unchanged behavior).
-    if let Some(folded) =
-        try_arraylike_receiver_method(ctx, method_prop.sym.as_ref(), &this_arg.expr, &rest_args)?
-    {
-        return Ok(Some(folded));
+    if method_from_array_prototype {
+        if let Some(folded) = try_arraylike_receiver_method(
+            ctx,
+            method_prop.sym.as_ref(),
+            &this_arg.expr,
+            &rest_args,
+        )? {
+            return Ok(Some(folded));
+        }
     }
 
     // Synthesize `(thisArg).<method>(rest_args)`: use the resolved method
@@ -1259,16 +1272,63 @@ pub(super) fn try_builtin_prototype_method_apply_call(
     Ok(Some(super::lower_call(ctx, &synth_call)?))
 }
 
-/// Build a dedicated `Expr::Array*` HIR variant for `Array.prototype.<m>.call`
-/// / `.apply` on a *generic array-like* receiver, bypassing the receiver-type
-/// gate that the normal member-call fast path applies. `receiver` is the
+fn array_like_extern_call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::ExternFuncRef {
+            name: name.to_string(),
+            param_types: Vec::new(),
+            return_type: Type::Any,
+        }),
+        args,
+        type_args: Vec::new(),
+    }
+}
+
+fn lower_rest_arg_or(
+    ctx: &mut LoweringContext,
+    rest_args: &[ast::ExprOrSpread],
+    index: usize,
+    default: Expr,
+) -> Result<Expr> {
+    match rest_args.get(index) {
+        Some(arg) => Ok(lower_expr(ctx, &arg.expr)?),
+        None => Ok(default),
+    }
+}
+
+fn lower_rest_arg_or_undefined(
+    ctx: &mut LoweringContext,
+    rest_args: &[ast::ExprOrSpread],
+    index: usize,
+) -> Result<Expr> {
+    lower_rest_arg_or(ctx, rest_args, index, Expr::Undefined)
+}
+
+fn array_like_callback_extern_call(
+    ctx: &mut LoweringContext,
+    symbol: &str,
+    receiver: &ast::Expr,
+    rest_args: &[ast::ExprOrSpread],
+) -> Result<Expr> {
+    let receiver = lower_expr(ctx, receiver)?;
+    let callback = lower_rest_arg_or_undefined(ctx, rest_args, 0)?;
+    let this_arg = lower_rest_arg_or_undefined(ctx, rest_args, 1)?;
+    Ok(array_like_extern_call(
+        symbol,
+        vec![receiver, callback, this_arg],
+    ))
+}
+
+/// Build a direct runtime helper call for `Array.prototype.<m>.call` /
+/// `.apply` on a generic array-like receiver. The receiver is the `.call`
 /// `thisArg`; `rest_args` are the post-`thisArg` positional arguments (already
 /// expanded from the `.apply` array if applicable).
 ///
-/// Returns `Some(expr)` for a supported read-only/returning method, or `None`
-/// for mutators / unsupported methods (caller falls back to the synthesized
-/// member call). The chosen set mirrors the runtime methods that route through
-/// `normalize_array_receiver`.
+/// The helper-backed methods preserve ECMAScript array-like semantics that
+/// `Expr::ArrayFrom` cannot: sparse holes, per-index HasProperty checks,
+/// callback `thisArg`, and the `find`/`includes` hole-visiting distinction.
+/// A small legacy `ArrayFrom` fallback remains for Array methods that do not
+/// yet have dedicated generic helpers.
 fn try_arraylike_receiver_method(
     ctx: &mut LoweringContext,
     method: &str,
@@ -1279,48 +1339,155 @@ fn try_arraylike_receiver_method(
     if rest_args.iter().any(|a| a.spread.is_some()) {
         return Ok(None);
     }
-    // Only fold the read-only/returning methods. Bail early for everything else
-    // (mutators, flat, etc.) BEFORE lowering the receiver, so unrelated shapes
-    // keep the existing member-call behavior with no side effects.
-    let supported = matches!(
-        method,
-        "map"
-            | "filter"
-            | "forEach"
-            | "find"
-            | "findIndex"
-            | "findLast"
-            | "findLastIndex"
-            | "some"
-            | "every"
-            | "flatMap"
-            | "reduce"
-            | "reduceRight"
-            | "indexOf"
-            | "lastIndexOf"
-            | "includes"
-            | "slice"
-            | "at"
-            | "join"
-    );
-    if !supported {
+
+    let direct = match method {
+        "join" => {
+            let receiver = lower_expr(ctx, receiver)?;
+            let separator = lower_rest_arg_or_undefined(ctx, rest_args, 0)?;
+            Some(array_like_extern_call(
+                "js_array_like_join_value",
+                vec![receiver, separator],
+            ))
+        }
+        "map" => Some(array_like_callback_extern_call(
+            ctx,
+            "js_array_like_map_value",
+            receiver,
+            rest_args,
+        )?),
+        "filter" => Some(array_like_callback_extern_call(
+            ctx,
+            "js_array_like_filter_value",
+            receiver,
+            rest_args,
+        )?),
+        "forEach" => Some(array_like_callback_extern_call(
+            ctx,
+            "js_array_like_for_each_value",
+            receiver,
+            rest_args,
+        )?),
+        "some" => Some(array_like_callback_extern_call(
+            ctx,
+            "js_array_like_some",
+            receiver,
+            rest_args,
+        )?),
+        "every" => Some(array_like_callback_extern_call(
+            ctx,
+            "js_array_like_every",
+            receiver,
+            rest_args,
+        )?),
+        "find" => Some(array_like_callback_extern_call(
+            ctx,
+            "js_array_like_find",
+            receiver,
+            rest_args,
+        )?),
+        "findIndex" => Some(array_like_callback_extern_call(
+            ctx,
+            "js_array_like_find_index_value",
+            receiver,
+            rest_args,
+        )?),
+        "indexOf" => {
+            let receiver = lower_expr(ctx, receiver)?;
+            let search = lower_rest_arg_or_undefined(ctx, rest_args, 0)?;
+            let has_from = rest_args.get(1).is_some();
+            let from_index = lower_rest_arg_or_undefined(ctx, rest_args, 1)?;
+            Some(array_like_extern_call(
+                "js_array_like_index_of_value",
+                vec![
+                    receiver,
+                    search,
+                    from_index,
+                    Expr::Integer(if has_from { 1 } else { 0 }),
+                ],
+            ))
+        }
+        "lastIndexOf" => {
+            let receiver = lower_expr(ctx, receiver)?;
+            let search = lower_rest_arg_or_undefined(ctx, rest_args, 0)?;
+            let has_from = rest_args.get(1).is_some();
+            let from_index = lower_rest_arg_or_undefined(ctx, rest_args, 1)?;
+            Some(array_like_extern_call(
+                "js_array_like_last_index_of_value",
+                vec![
+                    receiver,
+                    search,
+                    from_index,
+                    Expr::Integer(if has_from { 1 } else { 0 }),
+                ],
+            ))
+        }
+        "includes" => {
+            let receiver = lower_expr(ctx, receiver)?;
+            let search = lower_rest_arg_or_undefined(ctx, rest_args, 0)?;
+            let has_from = rest_args.get(1).is_some();
+            let from_index = lower_rest_arg_or_undefined(ctx, rest_args, 1)?;
+            Some(array_like_extern_call(
+                "js_array_like_includes_value",
+                vec![
+                    receiver,
+                    search,
+                    from_index,
+                    Expr::Integer(if has_from { 1 } else { 0 }),
+                ],
+            ))
+        }
+        "reduce" => {
+            let receiver = lower_expr(ctx, receiver)?;
+            let callback = lower_rest_arg_or_undefined(ctx, rest_args, 0)?;
+            let has_initial = rest_args.get(1).is_some();
+            let initial = lower_rest_arg_or_undefined(ctx, rest_args, 1)?;
+            Some(array_like_extern_call(
+                "js_array_like_reduce_value",
+                vec![
+                    receiver,
+                    callback,
+                    Expr::Integer(if has_initial { 1 } else { 0 }),
+                    initial,
+                ],
+            ))
+        }
+        "reduceRight" => {
+            let receiver = lower_expr(ctx, receiver)?;
+            let callback = lower_rest_arg_or_undefined(ctx, rest_args, 0)?;
+            let has_initial = rest_args.get(1).is_some();
+            let initial = lower_rest_arg_or_undefined(ctx, rest_args, 1)?;
+            Some(array_like_extern_call(
+                "js_array_like_reduce_right_value",
+                vec![
+                    receiver,
+                    callback,
+                    Expr::Integer(if has_initial { 1 } else { 0 }),
+                    initial,
+                ],
+            ))
+        }
+        "slice" => {
+            let receiver = lower_expr(ctx, receiver)?;
+            let start = lower_rest_arg_or(ctx, rest_args, 0, Expr::Integer(0))?;
+            let end = lower_rest_arg_or_undefined(ctx, rest_args, 1)?;
+            Some(array_like_extern_call(
+                "js_array_like_slice_value",
+                vec![receiver, start, end],
+            ))
+        }
+        _ => None,
+    };
+    if direct.is_some() {
+        return Ok(direct);
+    }
+
+    let legacy_supported = matches!(method, "findLast" | "findLastIndex" | "flatMap" | "at");
+    if !legacy_supported {
         return Ok(None);
     }
-    // Materialize the array-like receiver into a REAL array up front via
-    // `Expr::ArrayFrom` (→ `js_array_from_value` → `js_array_clone`, which has
-    // the array-like `{length, 0:…}` detection). This makes EVERY downstream
-    // method see a genuine `ArrayHeader` — crucial for the methods whose codegen
-    // is INLINED (e.g. `forEach` reads `(*arr).length` + `arr[i]` directly
-    // rather than calling `js_array_forEach`), which the runtime-side
-    // `normalize_array_receiver` can't reach. For a real-array receiver this
-    // clones (correct; the read-only methods don't mutate the receiver), and
-    // for null/undefined `js_array_from_value` throws a TypeError to match Node.
-    // The receiver (`thisArg`) lowers before the positional args, matching
-    // source order.
     let array_src = lower_expr(ctx, receiver)?;
     let array = Box::new(Expr::ArrayFrom(Box::new(array_src)));
-    // Lower a positional argument by index, if present.
-    let mut arg = |ctx: &mut LoweringContext, i: usize| -> Result<Option<Box<Expr>>> {
+    let arg = |ctx: &mut LoweringContext, i: usize| -> Result<Option<Box<Expr>>> {
         match rest_args.get(i) {
             Some(a) => Ok(Some(Box::new(lower_expr(ctx, &a.expr)?))),
             None => Ok(None),
@@ -1339,80 +1506,9 @@ fn try_arraylike_receiver_method(
         }};
     }
     match method {
-        "map" => cb_method!(ArrayMap),
-        "filter" => cb_method!(ArrayFilter),
-        "forEach" => cb_method!(ArrayForEach),
-        "find" => cb_method!(ArrayFind),
-        "findIndex" => cb_method!(ArrayFindIndex),
         "findLast" => cb_method!(ArrayFindLast),
         "findLastIndex" => cb_method!(ArrayFindLastIndex),
-        "some" => cb_method!(ArraySome),
-        "every" => cb_method!(ArrayEvery),
         "flatMap" => cb_method!(ArrayFlatMap),
-        "reduce" => {
-            let Some(cb) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let initial = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayReduce {
-                array,
-                callback: cb,
-                initial,
-            }))
-        }
-        "reduceRight" => {
-            let Some(cb) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let initial = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayReduceRight {
-                array,
-                callback: cb,
-                initial,
-            }))
-        }
-        "indexOf" => {
-            let Some(value) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let from_index = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayIndexOf {
-                array,
-                value,
-                from_index,
-            }))
-        }
-        "lastIndexOf" => {
-            let Some(value) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let from_index = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayLastIndexOf {
-                array,
-                value,
-                from_index,
-            }))
-        }
-        "includes" => {
-            let Some(value) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let from_index = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayIncludes {
-                array,
-                value,
-                from_index,
-            }))
-        }
-        "slice" => {
-            // `slice()` with no args copies from index 0.
-            let start = match arg(ctx, 0)? {
-                Some(s) => s,
-                None => Box::new(Expr::Integer(0)),
-            };
-            let end = arg(ctx, 1)?;
-            Ok(Some(Expr::ArraySlice { array, start, end }))
-        }
         "at" => {
             let index = match arg(ctx, 0)? {
                 Some(i) => i,
@@ -1420,11 +1516,6 @@ fn try_arraylike_receiver_method(
             };
             Ok(Some(Expr::ArrayAt { array, index }))
         }
-        "join" => {
-            let separator = arg(ctx, 0)?;
-            Ok(Some(Expr::ArrayJoin { array, separator }))
-        }
-        // Unreachable: `supported` gate above filters to exactly these arms.
         _ => Ok(None),
     }
 }
@@ -1469,6 +1560,13 @@ pub(crate) fn as_builtin_proto_method_ref(
     }
 }
 
+pub(crate) fn is_array_proto_method_ref(ctx: &LoweringContext, init: &ast::Expr) -> bool {
+    let ast::Expr::Member(member) = init else {
+        return false;
+    };
+    is_array_prototype_receiver(ctx, &member.obj)
+}
+
 /// True when `recv` is a builtin constructor's `.prototype` (and that
 /// constructor name is not shadowed by a local/function binding) or an
 /// array/string literal — the receiver shapes whose prototype-method *values*
@@ -1498,6 +1596,27 @@ fn is_builtin_prototype_receiver(ctx: &LoweringContext, recv: &ast::Expr) -> boo
         ast::Expr::Array(_) => true,
         // `"".charAt.call(…)`.
         ast::Expr::Lit(ast::Lit::Str(_)) => true,
+        _ => false,
+    }
+}
+
+fn is_array_prototype_receiver(ctx: &LoweringContext, recv: &ast::Expr) -> bool {
+    match recv {
+        ast::Expr::Member(m) => {
+            let ast::MemberProp::Ident(p) = &m.prop else {
+                return false;
+            };
+            if p.sym.as_ref() != "prototype" {
+                return false;
+            }
+            let ast::Expr::Ident(base) = m.obj.as_ref() else {
+                return false;
+            };
+            base.sym.as_ref() == "Array"
+                && ctx.lookup_local("Array").is_none()
+                && ctx.lookup_func("Array").is_none()
+        }
+        ast::Expr::Array(_) => true,
         _ => false,
     }
 }

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -351,6 +351,10 @@ pub struct LoweringContext {
     /// rewrite recognize `m.call(arr, ...)` (the receiver of `.call` is a plain
     /// identifier, not a member/literal) and synthesize `arr.map(...)`.
     pub(crate) builtin_proto_method_locals: HashMap<String, String>,
+    /// Subset of `builtin_proto_method_locals` whose initializer came from
+    /// `Array.prototype` or an array literal. Same-named String methods must not
+    /// be folded to Array's generic helpers.
+    pub(crate) array_proto_method_locals: HashSet<String>,
     /// Issue #76 — locals known to hold a WebAssembly instance handle (i.e.
     /// `const x = WebAssembly.instantiate(...)`). Used to route
     /// `x.exports.<method>(...)` to `Expr::WebAssemblyCallExport` only when

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -99,6 +99,13 @@ pub(crate) fn pre_scan_weakref_locals(ast_module: &ast::Module, ctx: &mut Loweri
                 {
                     ctx.builtin_proto_method_locals
                         .insert(ident.id.sym.to_string(), method);
+                    if crate::lower::expr_call::intrinsics::is_array_proto_method_ref(
+                        ctx,
+                        init_unwrapped,
+                    ) {
+                        ctx.array_proto_method_locals
+                            .insert(ident.id.sym.to_string());
+                    }
                 }
             }
         }

--- a/crates/perry-runtime/src/array/array_like_methods.rs
+++ b/crates/perry-runtime/src/array/array_like_methods.rs
@@ -1,0 +1,983 @@
+//! Generic `Array.prototype` methods for array-like receivers.
+use super::*;
+use crate::closure::{js_closure_call3, js_closure_call4, ClosureHeader};
+use crate::value::{JSValue, TAG_FALSE, TAG_TRUE, TAG_UNDEFINED};
+use std::ptr;
+
+#[inline(always)]
+fn undefined_value() -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+#[inline(always)]
+fn bool_value(value: bool) -> f64 {
+    f64::from_bits(if value { TAG_TRUE } else { TAG_FALSE })
+}
+
+#[inline(always)]
+fn string_result_value(value: *mut crate::string::StringHeader) -> f64 {
+    f64::from_bits(JSValue::string_ptr(value).bits())
+}
+
+#[inline(always)]
+fn array_result_value(value: *mut ArrayHeader) -> f64 {
+    f64::from_bits(JSValue::pointer(value as *const u8).bits())
+}
+
+#[cold]
+fn throw_nullish_receiver() -> ! {
+    crate::object::throw_object_type_error(b"Array.prototype method called on null or undefined")
+}
+
+#[inline]
+fn raw_pointer_addr(value: f64) -> Option<usize> {
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_pointer() {
+        return Some(jv.as_pointer::<u8>() as usize);
+    }
+    let bits = value.to_bits();
+    if bits >> 48 == 0 && bits > 0x10000 {
+        Some(bits as usize)
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn is_nullish(value: f64) -> bool {
+    let jv = JSValue::from_bits(value.to_bits());
+    jv.is_null() || jv.is_undefined()
+}
+
+#[inline]
+unsafe fn is_array_or_lazy_addr(addr: usize) -> bool {
+    if addr < crate::gc::GC_HEADER_SIZE + 0x1000
+        || crate::buffer::is_registered_buffer(addr)
+        || crate::symbol::is_registered_symbol(addr)
+    {
+        return false;
+    }
+    let gc_header =
+        (addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY
+        || (*gc_header).obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
+}
+
+#[inline]
+fn receiver_array_ptr(value: f64) -> Option<*const ArrayHeader> {
+    let addr = raw_pointer_addr(value)?;
+    unsafe {
+        if is_array_or_lazy_addr(addr) || crate::typedarray::lookup_typed_array_kind(addr).is_some()
+        {
+            Some(addr as *const ArrayHeader)
+        } else {
+            None
+        }
+    }
+}
+
+#[inline]
+fn receiver_string_array(value: f64) -> Option<*mut ArrayHeader> {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_any_string() {
+        return None;
+    }
+    let ptr =
+        crate::value::js_get_string_pointer_unified(value) as *const crate::string::StringHeader;
+    if ptr.is_null() {
+        return Some(js_array_alloc(0));
+    }
+    Some(unsafe { js_array_from_string_codepoints(ptr) })
+}
+
+#[inline]
+fn receiver_object_ptr(value: f64) -> Option<*const crate::object::ObjectHeader> {
+    let addr = raw_pointer_addr(value)?;
+    unsafe {
+        if is_array_or_lazy_addr(addr)
+            || crate::typedarray::lookup_typed_array_kind(addr).is_some()
+            || crate::buffer::is_registered_buffer(addr)
+            || crate::symbol::is_registered_symbol(addr)
+        {
+            None
+        } else {
+            Some(addr as *const crate::object::ObjectHeader)
+        }
+    }
+}
+
+fn array_like_length(receiver: *const crate::object::ObjectHeader) -> u32 {
+    if receiver.is_null() {
+        return 0;
+    }
+    let key = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+    let value = crate::object::js_object_get_field_by_name_f64(receiver, key);
+    let number = crate::builtins::js_number_coerce(value);
+    if !number.is_finite() || number <= 0.0 {
+        0
+    } else if number >= u32::MAX as f64 {
+        u32::MAX
+    } else {
+        number.trunc() as u32
+    }
+}
+
+fn index_key(index: u32) -> *mut crate::string::StringHeader {
+    let key = index.to_string();
+    crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32)
+}
+
+#[inline]
+fn object_has_index(
+    receiver_value: f64,
+    receiver: *const crate::object::ObjectHeader,
+    index: u32,
+) -> bool {
+    let key = index_key(index);
+    let key_value = f64::from_bits(JSValue::string_ptr(key).bits());
+    if crate::object::js_object_has_property(receiver_value, key_value).to_bits() == TAG_TRUE {
+        return true;
+    }
+    let value = crate::object::js_object_get_field_by_name_f64(receiver, key);
+    !JSValue::from_bits(value.to_bits()).is_undefined()
+}
+
+#[inline]
+fn object_get_index(receiver: *const crate::object::ObjectHeader, index: u32) -> f64 {
+    let key = index_key(index);
+    crate::object::js_object_get_field_by_name_f64(receiver, key)
+}
+
+#[inline]
+fn validate_callback(callback: f64, map_form_receiver: i64) -> *const ClosureHeader {
+    if map_form_receiver != 0 {
+        crate::array::js_validate_array_map_callback(map_form_receiver, callback)
+            as *const ClosureHeader
+    } else {
+        crate::array::js_validate_array_callback(callback) as *const ClosureHeader
+    }
+}
+
+#[inline]
+fn with_callback_this<F, R>(this_arg: f64, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let previous = crate::object::js_implicit_this_set(this_arg);
+    let result = f();
+    crate::object::js_implicit_this_set(previous);
+    result
+}
+
+#[inline]
+fn from_index_forward(length: i64, from_index: f64, has_from: bool) -> Option<i64> {
+    if !has_from {
+        return Some(0);
+    }
+    let number = crate::builtins::js_number_coerce(from_index);
+    let n = if number.is_nan() { 0.0 } else { number.trunc() };
+    if n >= length as f64 {
+        None
+    } else if n >= 0.0 {
+        Some(n as i64)
+    } else if n >= -(length as f64) {
+        Some(length + n as i64)
+    } else {
+        Some(0)
+    }
+}
+
+#[inline]
+fn from_index_backward(length: i64, from_index: f64, has_from: bool) -> Option<i64> {
+    if length == 0 {
+        return None;
+    }
+    if !has_from {
+        return Some(length - 1);
+    }
+    let number = crate::builtins::js_number_coerce(from_index);
+    let n = if number.is_nan() { 0.0 } else { number.trunc() };
+    if n >= length as f64 {
+        Some(length - 1)
+    } else if n >= 0.0 {
+        Some(n as i64)
+    } else if n >= -(length as f64) {
+        Some(length + n as i64)
+    } else {
+        None
+    }
+}
+
+fn slice_index(value: f64, default_end: bool) -> i32 {
+    if default_end && JSValue::from_bits(value.to_bits()).is_undefined() {
+        return i32::MAX;
+    }
+    let number = crate::builtins::js_number_coerce(value);
+    if number.is_nan() {
+        0
+    } else if number >= i32::MAX as f64 {
+        i32::MAX
+    } else if number <= i32::MIN as f64 {
+        i32::MIN
+    } else {
+        number.trunc() as i32
+    }
+}
+
+#[inline]
+fn normalize_slice_index(len: u32, index: i32, is_end: bool) -> u32 {
+    let len_i32 = len.min(i32::MAX as u32) as i32;
+    if is_end && index == i32::MAX {
+        len
+    } else if index < 0 {
+        (len_i32 + index).max(0) as u32
+    } else {
+        (index as u32).min(len)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_join(
+    receiver_value: f64,
+    separator_value: f64,
+) -> *mut crate::string::StringHeader {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        return crate::array::js_array_join_value(arr, separator_value);
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        return crate::array::js_array_join_value(arr, separator_value);
+    }
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return crate::string::js_string_from_bytes(ptr::null(), 0);
+    };
+    let len = array_like_length(receiver);
+    if len == 0 {
+        return crate::string::js_string_from_bytes(ptr::null(), 0);
+    }
+    let separator = if JSValue::from_bits(separator_value.to_bits()).is_undefined() {
+        ",".to_string()
+    } else {
+        let sp = crate::value::js_jsvalue_to_string(separator_value);
+        if sp.is_null() {
+            String::new()
+        } else {
+            unsafe {
+                let header = &*sp;
+                let data =
+                    (sp as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+                String::from_utf8_lossy(std::slice::from_raw_parts(data, header.byte_len as usize))
+                    .into_owned()
+            }
+        }
+    };
+    let mut output = String::new();
+    for i in 0..len {
+        if i > 0 {
+            output.push_str(&separator);
+        }
+        let value = object_get_index(receiver, i);
+        let jv = JSValue::from_bits(value.to_bits());
+        if jv.is_null() || jv.is_undefined() {
+            continue;
+        }
+        let sp = crate::value::js_jsvalue_to_string(value);
+        if sp.is_null() {
+            continue;
+        }
+        unsafe {
+            let header = &*sp;
+            let data = (sp as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+            output.push_str(std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                data,
+                header.byte_len as usize,
+            )));
+        }
+    }
+    crate::string::js_string_from_bytes(output.as_ptr(), output.len() as u32)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_map(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> *mut ArrayHeader {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, arr as i64);
+        return with_callback_this(this_arg, || crate::array::js_array_map(arr, callback));
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, arr as i64);
+        return with_callback_this(this_arg, || crate::array::js_array_map(arr, callback));
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return js_array_alloc(0);
+    };
+    let len = array_like_length(receiver);
+    let result = js_array_alloc_with_length(len);
+    let result_elements =
+        unsafe { (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64 };
+    with_callback_this(this_arg, || {
+        for i in 0..len {
+            if !object_has_index(receiver_value, receiver, i) {
+                continue;
+            }
+            let element = object_get_index(receiver, i);
+            let mapped = js_closure_call3(callback, element, i as f64, receiver_value);
+            unsafe {
+                ptr::write(result_elements.add(i as usize), mapped);
+            }
+            let bits = mapped.to_bits();
+            unsafe {
+                if len <= 64 {
+                    note_array_slot_layout_only(result, i as usize, bits);
+                } else {
+                    note_array_slot(result, i as usize, bits);
+                }
+            }
+        }
+    });
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_filter(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> *mut ArrayHeader {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_filter(arr, callback));
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_filter(arr, callback));
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return js_array_alloc(0);
+    };
+    let len = array_like_length(receiver);
+    let mut result = js_array_alloc(0);
+    with_callback_this(this_arg, || {
+        for i in 0..len {
+            if !object_has_index(receiver_value, receiver, i) {
+                continue;
+            }
+            let element = object_get_index(receiver, i);
+            let keep = js_closure_call3(callback, element, i as f64, receiver_value);
+            if crate::value::js_is_truthy(keep) != 0 {
+                result = js_array_push_f64(result, element);
+            }
+        }
+    });
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_for_each(receiver_value: f64, callback_value: f64, this_arg: f64) {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        with_callback_this(this_arg, || crate::array::js_array_forEach(arr, callback));
+        return;
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        with_callback_this(this_arg, || crate::array::js_array_forEach(arr, callback));
+        return;
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return;
+    };
+    let len = array_like_length(receiver);
+    with_callback_this(this_arg, || {
+        for i in 0..len {
+            if !object_has_index(receiver_value, receiver, i) {
+                continue;
+            }
+            let element = object_get_index(receiver, i);
+            js_closure_call3(callback, element, i as f64, receiver_value);
+        }
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_some(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> f64 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_some(arr, callback));
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_some(arr, callback));
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return bool_value(false);
+    };
+    let len = array_like_length(receiver);
+    with_callback_this(this_arg, || {
+        for i in 0..len {
+            if !object_has_index(receiver_value, receiver, i) {
+                continue;
+            }
+            let element = object_get_index(receiver, i);
+            let result = js_closure_call3(callback, element, i as f64, receiver_value);
+            if crate::value::js_is_truthy(result) != 0 {
+                return bool_value(true);
+            }
+        }
+        bool_value(false)
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_every(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> f64 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_every(arr, callback));
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_every(arr, callback));
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return bool_value(true);
+    };
+    let len = array_like_length(receiver);
+    with_callback_this(this_arg, || {
+        for i in 0..len {
+            if !object_has_index(receiver_value, receiver, i) {
+                continue;
+            }
+            let element = object_get_index(receiver, i);
+            let result = js_closure_call3(callback, element, i as f64, receiver_value);
+            if crate::value::js_is_truthy(result) == 0 {
+                return bool_value(false);
+            }
+        }
+        bool_value(true)
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_find(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> f64 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_find(arr, callback));
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_find(arr, callback));
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return undefined_value();
+    };
+    let len = array_like_length(receiver);
+    with_callback_this(this_arg, || {
+        for i in 0..len {
+            let element = object_get_index(receiver, i);
+            let result = js_closure_call3(callback, element, i as f64, receiver_value);
+            if crate::value::js_is_truthy(result) != 0 {
+                return element;
+            }
+        }
+        undefined_value()
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_find_index(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> i32 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_findIndex(arr, callback));
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return with_callback_this(this_arg, || crate::array::js_array_findIndex(arr, callback));
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return -1;
+    };
+    let len = array_like_length(receiver);
+    with_callback_this(this_arg, || {
+        for i in 0..len {
+            let element = object_get_index(receiver, i);
+            let result = js_closure_call3(callback, element, i as f64, receiver_value);
+            if crate::value::js_is_truthy(result) != 0 {
+                return i as i32;
+            }
+        }
+        -1
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_index_of(
+    receiver_value: f64,
+    search: f64,
+    from_index: f64,
+    has_from: i32,
+) -> i32 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        return crate::array::js_array_indexOf_jsvalue(arr, search, from_index, has_from);
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        return crate::array::js_array_indexOf_jsvalue(arr, search, from_index, has_from);
+    }
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return -1;
+    };
+    let len = array_like_length(receiver) as i64;
+    let Some(start) = from_index_forward(len, from_index, has_from != 0) else {
+        return -1;
+    };
+    for i in start..len {
+        if !object_has_index(receiver_value, receiver, i as u32) {
+            continue;
+        }
+        let element = object_get_index(receiver, i as u32);
+        if crate::value::js_jsvalue_equals(element, search) == 1 {
+            return i as i32;
+        }
+    }
+    -1
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_last_index_of(
+    receiver_value: f64,
+    search: f64,
+    from_index: f64,
+    has_from: i32,
+) -> i32 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        return crate::array::js_array_last_index_of_jsvalue(arr, search, from_index, has_from);
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        return crate::array::js_array_last_index_of_jsvalue(arr, search, from_index, has_from);
+    }
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return -1;
+    };
+    let len = array_like_length(receiver) as i64;
+    let Some(mut i) = from_index_backward(len, from_index, has_from != 0) else {
+        return -1;
+    };
+    while i >= 0 {
+        if object_has_index(receiver_value, receiver, i as u32) {
+            let element = object_get_index(receiver, i as u32);
+            if crate::value::js_jsvalue_equals(element, search) == 1 {
+                return i as i32;
+            }
+        }
+        i -= 1;
+    }
+    -1
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_includes(
+    receiver_value: f64,
+    search: f64,
+    from_index: f64,
+    has_from: i32,
+) -> f64 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        return bool_value(
+            crate::array::js_array_includes_jsvalue(arr, search, from_index, has_from) != 0,
+        );
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        return bool_value(
+            crate::array::js_array_includes_jsvalue(arr, search, from_index, has_from) != 0,
+        );
+    }
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return bool_value(false);
+    };
+    let len = array_like_length(receiver) as i64;
+    let Some(start) = from_index_forward(len, from_index, has_from != 0) else {
+        return bool_value(false);
+    };
+    for i in start..len {
+        let element = object_get_index(receiver, i as u32);
+        if crate::value::js_jsvalue_same_value_zero(element, search) == 1 {
+            return bool_value(true);
+        }
+    }
+    bool_value(false)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_reduce(
+    receiver_value: f64,
+    callback_value: f64,
+    has_initial: i32,
+    initial: f64,
+) -> f64 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return crate::array::js_array_reduce(arr, callback, has_initial, initial);
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return crate::array::js_array_reduce(arr, callback, has_initial, initial);
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        if has_initial != 0 {
+            return initial;
+        }
+        throw_reduce_of_empty();
+    };
+    let len = array_like_length(receiver);
+    let (mut accumulator, start) = if has_initial != 0 {
+        (initial, 0)
+    } else {
+        let mut seed = None;
+        for i in 0..len {
+            if object_has_index(receiver_value, receiver, i) {
+                seed = Some((object_get_index(receiver, i), i + 1));
+                break;
+            }
+        }
+        match seed {
+            Some(seed) => seed,
+            None => throw_reduce_of_empty(),
+        }
+    };
+    for i in start..len {
+        if !object_has_index(receiver_value, receiver, i) {
+            continue;
+        }
+        let element = object_get_index(receiver, i);
+        accumulator = js_closure_call4(callback, accumulator, element, i as f64, receiver_value);
+    }
+    accumulator
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_reduce_right(
+    receiver_value: f64,
+    callback_value: f64,
+    has_initial: i32,
+    initial: f64,
+) -> f64 {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return crate::array::js_array_reduce_right(arr, callback, has_initial, initial);
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        let callback = validate_callback(callback_value, 0);
+        return crate::array::js_array_reduce_right(arr, callback, has_initial, initial);
+    }
+    let callback = validate_callback(callback_value, 0);
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        if has_initial != 0 {
+            return initial;
+        }
+        throw_reduce_of_empty();
+    };
+    let len = array_like_length(receiver);
+    let (mut accumulator, start_exclusive) = if has_initial != 0 {
+        (initial, len)
+    } else {
+        let mut seed = None;
+        for i in (0..len).rev() {
+            if object_has_index(receiver_value, receiver, i) {
+                seed = Some((object_get_index(receiver, i), i));
+                break;
+            }
+        }
+        match seed {
+            Some(seed) => seed,
+            None => throw_reduce_of_empty(),
+        }
+    };
+    if start_exclusive > 0 {
+        for i in (0..start_exclusive).rev() {
+            if !object_has_index(receiver_value, receiver, i) {
+                continue;
+            }
+            let element = object_get_index(receiver, i);
+            accumulator =
+                js_closure_call4(callback, accumulator, element, i as f64, receiver_value);
+        }
+    }
+    accumulator
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_slice(
+    receiver_value: f64,
+    start_value: f64,
+    end_value: f64,
+) -> *mut ArrayHeader {
+    if is_nullish(receiver_value) {
+        throw_nullish_receiver();
+    }
+    if let Some(arr) = receiver_array_ptr(receiver_value) {
+        return crate::array::js_array_slice_values(arr, start_value, end_value);
+    }
+    if let Some(arr) = receiver_string_array(receiver_value) {
+        return crate::array::js_array_slice_values(arr, start_value, end_value);
+    }
+    let Some(receiver) = receiver_object_ptr(receiver_value) else {
+        return js_array_alloc(0);
+    };
+    let len = array_like_length(receiver);
+    let start_idx = normalize_slice_index(len, slice_index(start_value, false), false);
+    let end_idx = normalize_slice_index(len, slice_index(end_value, true), true);
+    let slice_len = end_idx.saturating_sub(start_idx);
+    let result = js_array_alloc_with_length(slice_len);
+    let result_elements =
+        unsafe { (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64 };
+    for offset in 0..slice_len {
+        let source_index = start_idx + offset;
+        if !object_has_index(receiver_value, receiver, source_index) {
+            continue;
+        }
+        let value = object_get_index(receiver, source_index);
+        unsafe {
+            ptr::write(result_elements.add(offset as usize), value);
+        }
+        let bits = value.to_bits();
+        unsafe {
+            if slice_len <= 64 {
+                note_array_slot_layout_only(result, offset as usize, bits);
+            } else {
+                note_array_slot(result, offset as usize, bits);
+            }
+        }
+    }
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_join_value(receiver_value: f64, separator_value: f64) -> f64 {
+    string_result_value(js_array_like_join(receiver_value, separator_value))
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_map_value(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> f64 {
+    array_result_value(js_array_like_map(receiver_value, callback_value, this_arg))
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_filter_value(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> f64 {
+    array_result_value(js_array_like_filter(
+        receiver_value,
+        callback_value,
+        this_arg,
+    ))
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_for_each_value(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> f64 {
+    js_array_like_for_each(receiver_value, callback_value, this_arg);
+    undefined_value()
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_find_index_value(
+    receiver_value: f64,
+    callback_value: f64,
+    this_arg: f64,
+) -> f64 {
+    js_array_like_find_index(receiver_value, callback_value, this_arg) as f64
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_index_of_value(
+    receiver_value: f64,
+    search: f64,
+    from_index: f64,
+    has_from: f64,
+) -> f64 {
+    js_array_like_index_of(
+        receiver_value,
+        search,
+        from_index,
+        if has_from != 0.0 { 1 } else { 0 },
+    ) as f64
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_last_index_of_value(
+    receiver_value: f64,
+    search: f64,
+    from_index: f64,
+    has_from: f64,
+) -> f64 {
+    js_array_like_last_index_of(
+        receiver_value,
+        search,
+        from_index,
+        if has_from != 0.0 { 1 } else { 0 },
+    ) as f64
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_includes_value(
+    receiver_value: f64,
+    search: f64,
+    from_index: f64,
+    has_from: f64,
+) -> f64 {
+    js_array_like_includes(
+        receiver_value,
+        search,
+        from_index,
+        if has_from != 0.0 { 1 } else { 0 },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_reduce_value(
+    receiver_value: f64,
+    callback_value: f64,
+    has_initial: f64,
+    initial: f64,
+) -> f64 {
+    js_array_like_reduce(
+        receiver_value,
+        callback_value,
+        if has_initial != 0.0 { 1 } else { 0 },
+        initial,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_reduce_right_value(
+    receiver_value: f64,
+    callback_value: f64,
+    has_initial: f64,
+    initial: f64,
+) -> f64 {
+    js_array_like_reduce_right(
+        receiver_value,
+        callback_value,
+        if has_initial != 0.0 { 1 } else { 0 },
+        initial,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_like_slice_value(
+    receiver_value: f64,
+    start_value: f64,
+    end_value: f64,
+) -> f64 {
+    array_result_value(js_array_like_slice(receiver_value, start_value, end_value))
+}
+
+#[used]
+static KEEP_ARRAY_LIKE_JOIN_VALUE: extern "C" fn(f64, f64) -> f64 = js_array_like_join_value;
+#[used]
+static KEEP_ARRAY_LIKE_MAP_VALUE: extern "C" fn(f64, f64, f64) -> f64 = js_array_like_map_value;
+#[used]
+static KEEP_ARRAY_LIKE_FILTER_VALUE: extern "C" fn(f64, f64, f64) -> f64 =
+    js_array_like_filter_value;
+#[used]
+static KEEP_ARRAY_LIKE_FOR_EACH_VALUE: extern "C" fn(f64, f64, f64) -> f64 =
+    js_array_like_for_each_value;
+#[used]
+static KEEP_ARRAY_LIKE_SOME: extern "C" fn(f64, f64, f64) -> f64 = js_array_like_some;
+#[used]
+static KEEP_ARRAY_LIKE_EVERY: extern "C" fn(f64, f64, f64) -> f64 = js_array_like_every;
+#[used]
+static KEEP_ARRAY_LIKE_FIND: extern "C" fn(f64, f64, f64) -> f64 = js_array_like_find;
+#[used]
+static KEEP_ARRAY_LIKE_FIND_INDEX_VALUE: extern "C" fn(f64, f64, f64) -> f64 =
+    js_array_like_find_index_value;
+#[used]
+static KEEP_ARRAY_LIKE_INDEX_OF_VALUE: extern "C" fn(f64, f64, f64, f64) -> f64 =
+    js_array_like_index_of_value;
+#[used]
+static KEEP_ARRAY_LIKE_LAST_INDEX_OF_VALUE: extern "C" fn(f64, f64, f64, f64) -> f64 =
+    js_array_like_last_index_of_value;
+#[used]
+static KEEP_ARRAY_LIKE_INCLUDES_VALUE: extern "C" fn(f64, f64, f64, f64) -> f64 =
+    js_array_like_includes_value;
+#[used]
+static KEEP_ARRAY_LIKE_REDUCE_VALUE: extern "C" fn(f64, f64, f64, f64) -> f64 =
+    js_array_like_reduce_value;
+#[used]
+static KEEP_ARRAY_LIKE_REDUCE_RIGHT_VALUE: extern "C" fn(f64, f64, f64, f64) -> f64 =
+    js_array_like_reduce_right_value;
+#[used]
+static KEEP_ARRAY_LIKE_SLICE_VALUE: extern "C" fn(f64, f64, f64) -> f64 = js_array_like_slice_value;

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -1,5 +1,6 @@
 //! Array representation for Perry — split into topical sub-modules.
 mod alloc;
+mod array_like_methods;
 mod concat_reverse;
 mod flat_clone;
 mod from_concat;
@@ -24,6 +25,12 @@ pub use self::alloc::{
     js_array_alloc, js_array_alloc_literal, js_array_alloc_with_length,
     js_array_alloc_with_length_longlived, js_array_constructor_single, js_array_create,
     js_array_from_f64,
+};
+pub use self::array_like_methods::{
+    js_array_like_every, js_array_like_filter, js_array_like_find, js_array_like_find_index,
+    js_array_like_for_each, js_array_like_includes, js_array_like_index_of, js_array_like_join,
+    js_array_like_last_index_of, js_array_like_map, js_array_like_reduce,
+    js_array_like_reduce_right, js_array_like_slice, js_array_like_some,
 };
 pub use self::concat_reverse::{
     js_array_concat, js_array_concat_new, js_array_fill, js_array_fill_range, js_array_reverse,

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1367,36 +1367,145 @@ extern "C" fn array_prototype_slice_thunk(
     start_val: f64,
     end_val: f64,
 ) -> f64 {
-    use crate::value::JSValue;
-    let this_bits = IMPLICIT_THIS.with(|c| c.get());
-    let this_jsv = JSValue::from_bits(this_bits);
-    let arr_ptr = if this_jsv.is_pointer() {
-        this_jsv.as_pointer::<crate::array::ArrayHeader>()
-    } else {
-        // Tolerate raw-i64-encoded array receivers (some module-init
-        // call sites stash array pointers in IMPLICIT_THIS without
-        // NaN-boxing). The clean_arr_ptr check inside js_array_slice
-        // re-validates.
-        let raw = this_bits as *const crate::array::ArrayHeader;
-        if (raw as usize) > 0x10000 {
-            raw
-        } else {
-            std::ptr::null()
-        }
-    };
-    if arr_ptr.is_null() {
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
-    }
-    let result = unsafe {
-        if let Some(arr) =
-            crate::object::arguments_object_to_array(arr_ptr as *const crate::object::ObjectHeader)
-        {
-            crate::array::js_array_slice_values(arr, start_val, end_val)
-        } else {
-            crate::array::js_array_slice_values(arr_ptr, start_val, end_val)
-        }
-    };
+    let receiver = crate::object::js_implicit_this_get();
+    let result = crate::array::js_array_like_slice(receiver, start_val, end_val);
     f64::from_bits(crate::value::js_nanbox_pointer(result as i64).to_bits())
+}
+
+extern "C" fn array_prototype_join_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    separator: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    let result = crate::array::js_array_like_join(receiver, separator);
+    f64::from_bits(crate::value::JSValue::string_ptr(result).bits())
+}
+
+extern "C" fn array_prototype_map_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    let result = crate::array::js_array_like_map(receiver, callback, rest_arg(rest, 0));
+    f64::from_bits(crate::value::JSValue::pointer(result as *mut u8).bits())
+}
+
+extern "C" fn array_prototype_filter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    let result = crate::array::js_array_like_filter(receiver, callback, rest_arg(rest, 0));
+    f64::from_bits(crate::value::JSValue::pointer(result as *mut u8).bits())
+}
+
+extern "C" fn array_prototype_for_each_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_for_each(receiver, callback, rest_arg(rest, 0));
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn array_prototype_some_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_some(receiver, callback, rest_arg(rest, 0))
+}
+
+extern "C" fn array_prototype_every_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_every(receiver, callback, rest_arg(rest, 0))
+}
+
+extern "C" fn array_prototype_find_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_find(receiver, callback, rest_arg(rest, 0))
+}
+
+extern "C" fn array_prototype_find_index_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_find_index(receiver, callback, rest_arg(rest, 0)) as f64
+}
+
+extern "C" fn array_prototype_index_of_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    search: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_index_of(receiver, search, rest_arg(rest, 0), rest_len(rest) as i32)
+        as f64
+}
+
+extern "C" fn array_prototype_last_index_of_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    search: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_last_index_of(
+        receiver,
+        search,
+        rest_arg(rest, 0),
+        rest_len(rest) as i32,
+    ) as f64
+}
+
+extern "C" fn array_prototype_includes_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    search: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_includes(receiver, search, rest_arg(rest, 0), rest_len(rest) as i32)
+}
+
+extern "C" fn array_prototype_reduce_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_reduce(
+        receiver,
+        callback,
+        if rest_len(rest) > 0 { 1 } else { 0 },
+        rest_arg(rest, 0),
+    )
+}
+
+extern "C" fn array_prototype_reduce_right_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    callback: f64,
+    rest: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    crate::array::js_array_like_reduce_right(
+        receiver,
+        callback,
+        if rest_len(rest) > 0 { 1 } else { 0 },
+        rest_arg(rest, 0),
+    )
 }
 
 fn array_buffer_receiver_addr() -> Option<usize> {
@@ -3924,16 +4033,33 @@ extern "C" fn url_pattern_exec_thunk(
     crate::url::js_url_pattern_exec(pattern, input, base)
 }
 
-fn rest_first_arg(rest: f64) -> f64 {
+fn rest_len(rest: f64) -> u32 {
+    let value = crate::value::JSValue::from_bits(rest.to_bits());
+    if !value.is_pointer() {
+        return 0;
+    }
+    let arr = value.as_pointer::<crate::array::ArrayHeader>();
+    if arr.is_null() {
+        0
+    } else {
+        crate::array::js_array_length(arr)
+    }
+}
+
+fn rest_arg(rest: f64, index: u32) -> f64 {
     let value = crate::value::JSValue::from_bits(rest.to_bits());
     if !value.is_pointer() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
     let arr = value.as_pointer::<crate::array::ArrayHeader>();
-    if arr.is_null() || crate::array::js_array_length(arr) == 0 {
+    if arr.is_null() || crate::array::js_array_length(arr) <= index {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
-    crate::array::js_array_get_f64(arr, 0)
+    crate::array::js_array_get_f64(arr, index)
+}
+
+fn rest_first_arg(rest: f64) -> f64 {
+    rest_arg(rest, 0)
 }
 
 /// Universal `Object.prototype` methods inherited by every receiver in
@@ -4003,6 +4129,96 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                 array_prototype_slice_thunk as *const u8,
                 2,
             );
+            install_proto_method(
+                proto_obj,
+                "join",
+                array_prototype_join_thunk as *const u8,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "map",
+                array_prototype_map_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "filter",
+                array_prototype_filter_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "forEach",
+                array_prototype_for_each_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "some",
+                array_prototype_some_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "every",
+                array_prototype_every_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "find",
+                array_prototype_find_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "findIndex",
+                array_prototype_find_index_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "indexOf",
+                array_prototype_index_of_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "lastIndexOf",
+                array_prototype_last_index_of_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "includes",
+                array_prototype_includes_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "reduce",
+                array_prototype_reduce_thunk as *const u8,
+                1,
+                1,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "reduceRight",
+                array_prototype_reduce_right_thunk as *const u8,
+                1,
+                1,
+            );
             install_noop_proto_methods(
                 proto_obj,
                 &[
@@ -4010,29 +4226,16 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
                     ("concat", 1),
                     ("copyWithin", 2),
                     ("entries", 0),
-                    ("every", 1),
                     ("fill", 1),
-                    ("filter", 1),
-                    ("find", 1),
-                    ("findIndex", 1),
                     ("findLast", 1),
                     ("findLastIndex", 1),
                     ("flat", 0),
                     ("flatMap", 1),
-                    ("forEach", 1),
-                    ("includes", 1),
-                    ("indexOf", 1),
-                    ("join", 1),
                     ("keys", 0),
-                    ("lastIndexOf", 1),
-                    ("map", 1),
                     ("pop", 0),
                     ("push", 1),
-                    ("reduce", 1),
-                    ("reduceRight", 1),
                     ("reverse", 0),
                     ("shift", 0),
-                    ("some", 1),
                     ("sort", 1),
                     ("splice", 2),
                     ("toLocaleString", 0),

--- a/test-parity/node-suite/globals/array-prototype-generic-arraylike.ts
+++ b/test-parity/node-suite/globals/array-prototype-generic-arraylike.ts
@@ -1,0 +1,108 @@
+function hasOwn(obj: any, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function summarizeArray(value: any): string {
+  const parts: string[] = [];
+  for (let i = 0; i < value.length; i++) {
+    parts.push(hasOwn(value, String(i)) ? String(value[i]) : "<hole>");
+  }
+  return `len=${value.length};keys=${Object.keys(value).join(",")};values=${parts.join("|")}`;
+}
+
+function show(label: string, value: any): void {
+  if (Array.isArray(value)) {
+    console.log(`${label}:${summarizeArray(value)}`);
+  } else {
+    console.log(`${label}:${String(value)}`);
+  }
+}
+
+function showThrow(label: string, fn: () => any): void {
+  try {
+    show(label, fn());
+  } catch (error: any) {
+    console.log(`${label}:throw:${error.name}`);
+  }
+}
+
+const sparseLike = { length: 3, 0: "a", 2: "c" };
+
+show("join.sparseLike", Array.prototype.join.call(sparseLike, "|"));
+show(
+  "map.sparseLike",
+  Array.prototype.map.call(sparseLike, (value: any, index: number) => `${index}:${String(value)}`),
+);
+show(
+  "filter.sparseLike",
+  Array.prototype.filter.call(sparseLike, (_value: any, index: number) => index >= 1),
+);
+show(
+  "slice.sparseLike",
+  Array.prototype.slice.call(sparseLike, 0, 3),
+);
+show(
+  "indexOf.missingUndefined",
+  Array.prototype.indexOf.call({ length: 1 }, undefined),
+);
+show(
+  "includes.missingUndefined",
+  Array.prototype.includes.call({ length: 1 }, undefined),
+);
+show(
+  "reduce.sparseLike",
+  Array.prototype.reduce.call(
+    sparseLike,
+    (acc: string, value: any, index: number) => acc + `:${index}:${String(value)}`,
+    "seed",
+  ),
+);
+
+const liveLike: any = { length: 3, 0: "a", 2: "c" };
+const visits: string[] = [];
+Array.prototype.forEach.call(liveLike, (value: any, index: number) => {
+  visits.push(`${index}:${String(value)}`);
+  if (index === 0) {
+    liveLike[1] = "b";
+  }
+});
+show("forEach.liveMutation", visits.join("|"));
+
+const thisArgResult = Array.prototype.map.call(
+  { length: 1, 0: 2 },
+  function (this: any, value: number) {
+    return this.scale * value;
+  },
+  { scale: 3 },
+);
+show("map.thisArg", thisArgResult);
+
+show(
+  "some.thisArg",
+  Array.prototype.some.call(
+    { length: 1, 0: 4 },
+    function (this: any, value: number) {
+      return value === this.target;
+    },
+    { target: 4 },
+  ),
+);
+
+show(
+  "find.holeVisited",
+  Array.prototype.find.call({ length: 2, 1: "x" }, (value: any) => value === undefined),
+);
+show("join.string", Array.prototype.join.call("abc", "-"));
+show(
+  "map.string",
+  Array.prototype.map.call("ab", (value: any, index: number) => `${value}${index}`),
+);
+
+const borrowedJoin = Array.prototype.join;
+show("join.borrowedCall", borrowedJoin.call(sparseLike, "/"));
+
+const borrowedSlice = Array.prototype.slice;
+show("slice.borrowedApply", borrowedSlice.apply(sparseLike, [1, 3]));
+
+showThrow("join.null", () => Array.prototype.join.call(null));
+showThrow("map.badCallback", () => Array.prototype.map.call({ length: 1, 0: 1 }, 5 as any));


### PR DESCRIPTION
Closes #4597.

## Summary
- routes Array prototype `.call`/`.apply` borrows through generic array-like runtime helpers for the covered read-only/returning methods
- implements sparse-aware array-like semantics for `join`, `map`, `filter`, `forEach`, `some`, `every`, `find`, `findIndex`, `indexOf`, `lastIndexOf`, `includes`, `reduce`, `reduceRight`, and `slice`
- installs real Array prototype thunks for reflective method calls and adds parity coverage for direct and borrowed calls

## Verification
- `cargo check -p perry-runtime -p perry-hir -p perry-codegen`
- `cargo build --release -p perry-runtime`
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/array-prototype-generic-arraylike.ts > /tmp/perry-array-generic-node.out`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_ALLOW_UNIMPLEMENTED=1 cargo run -q -p perry -- run test-parity/node-suite/globals/array-prototype-generic-arraylike.ts 2>/tmp/perry-array-generic-perry.stderr | rg "^(join|map|filter|slice|indexOf|includes|reduce|forEach|some|find)\." > /tmp/perry-array-generic-perry.out`
- `diff -u /tmp/perry-array-generic-node.out /tmp/perry-array-generic-perry.out`