### PR TITLE
fix(runtime): Math.pow special cases + Math.max/min -0 vs +0

### DIFF
--- a/crates/perry-runtime/src/math.rs
+++ b/crates/perry-runtime/src/math.rs
@@ -23,6 +23,18 @@ pub extern "C" fn js_math_to_number(value: f64) -> f64 {
 /// Math.pow(base, exponent) -> number
 #[no_mangle]
 pub extern "C" fn js_math_pow(base: f64, exp: f64) -> f64 {
+    // ECMAScript Math.pow deviates from IEEE-754 `pow` in two cases that Rust's
+    // `f64::powf` (libm pow) gets "wrong" for JS:
+    //  - a NaN exponent is always NaN (IEEE `pow(1, NaN)` = 1).
+    //  - |base| == 1 with a ±Infinity exponent is NaN (IEEE returns 1).
+    // A +0/-0 exponent still yields 1 (even for a NaN base), which `powf`
+    // already handles, so those fall through.
+    if exp.is_nan() {
+        return f64::NAN;
+    }
+    if exp.is_infinite() && base.abs() == 1.0 {
+        return f64::NAN;
+    }
     base.powf(exp)
 }
 
@@ -250,7 +262,9 @@ pub extern "C" fn js_math_min_array(arr_ptr: i64) -> f64 {
         if num.is_nan() {
             return f64::NAN;
         }
-        if num < result {
+        // ECMAScript Math.min treats -0 as smaller than +0; IEEE `<` treats
+        // them as equal, so add an explicit sign-of-zero tiebreaker.
+        if num < result || (num == 0.0 && result == 0.0 && num.is_sign_negative()) {
             result = num;
         }
     }
@@ -274,7 +288,9 @@ pub extern "C" fn js_math_max_array(arr_ptr: i64) -> f64 {
         if num.is_nan() {
             return f64::NAN;
         }
-        if num > result {
+        // ECMAScript Math.max treats +0 as greater than -0; IEEE `>` treats
+        // them as equal, so add an explicit sign-of-zero tiebreaker.
+        if num > result || (num == 0.0 && result == 0.0 && num.is_sign_positive()) {
             result = num;
         }
     }


### PR DESCRIPTION
## Problems (vs node)
```ts
Math.pow(1, NaN)        // 1   → NaN
Math.pow(-1, Infinity)  // 1   → NaN
Math.max(-0, 0)         // -0  → +0
Math.min(0, -0)         //  0  → -0
```

## Fix
- **Math.pow** used Rust `f64::powf` (IEEE `pow`), which differs from ECMAScript `Math.pow` in two cases: a `NaN` exponent → `NaN`, and `|base| == 1` with a `±Infinity` exponent → `NaN`. Special-cased before delegating; a `+0/-0` exponent still yields `1`.
- **Math.max/min** compared with IEEE `<`/`>`, which treat `-0`/`+0` as equal, so the sign-of-zero of the first-seen zero stuck. Added the spec tiebreaker (max prefers `+0`, min prefers `-0`).

## Verification
Byte-identical to `node --experimental-strip-types`; ordinary `pow`/`max`/`min`/spread/NaN cases unchanged. Fixes test262 `built-ins/Math/{max,min}/zeros`, `Math/pow/applying-the-exp-operator_A1/A7/A8`.