### PR TITLE
fix(runtime): preserve holes for borrowed array methods

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -386,6 +386,7 @@ pub fn check_escapes_in_expr(
         | Expr::MathMinSpread(operand)
         | Expr::MathMaxSpread(operand)
         | Expr::ArrayFrom(operand)
+        | Expr::ArrayFromArrayLikeHoley(operand)
         | Expr::IteratorFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::JsonParse(operand)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -245,6 +245,7 @@ fn collect_used_new_fields_in_expr(
         | Expr::MathMinSpread(operand)
         | Expr::MathMaxSpread(operand)
         | Expr::ArrayFrom(operand)
+        | Expr::ArrayFromArrayLikeHoley(operand)
         | Expr::IteratorFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::JsonParse(operand)

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1108,6 +1108,7 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::SetSize(operand)
         | Expr::SetClear(operand)
         | Expr::ArrayFrom(operand)
+        | Expr::ArrayFromArrayLikeHoley(operand)
         | Expr::IteratorFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -231,6 +231,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::SetSize(operand)
         | Expr::SetClear(operand)
         | Expr::ArrayFrom(operand)
+        | Expr::ArrayFromArrayLikeHoley(operand)
         | Expr::IteratorFrom(operand)
         | Expr::Uint8ArrayFrom(operand)
         | Expr::IteratorToArray(operand)

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -637,6 +637,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &result))
         }
 
+        Expr::ArrayFromArrayLikeHoley(iter) => {
+            let iter_box = lower_expr(ctx, iter)?;
+            let blk = ctx.block();
+            let result = blk.call(
+                I64,
+                "js_array_from_arraylike_holey_value",
+                &[(DOUBLE, &iter_box)],
+            );
+            Ok(nanbox_pointer_inline(blk, &result))
+        }
+
         // `Iterator.from(x)` (#2874) — wrap any iterable/iterator in a TC39
         // iterator-helper object so the lazy helper methods (map/filter/take/
         // drop/flatMap/reduce/toArray/...) dispatch at runtime against

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1506,6 +1506,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::Delete(..)
         | Expr::Sequence(..)
         | Expr::ArrayFrom(..)
+        | Expr::ArrayFromArrayLikeHoley(..)
         | Expr::IteratorFrom(..)
         | Expr::TaggedTemplateStrings { .. }
         | Expr::TemplateRaw(..)

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -124,6 +124,9 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // number/boolean/symbol -> [], otherwise materializes via js_array_clone.
     // Takes the raw NaN-boxed value so the tag bits survive.
     module.declare_function("js_array_from_value", I64, &[DOUBLE]);
+    // Array.prototype generic receiver materialization — like LengthOfArrayLike,
+    // but absent indexed keys remain holes rather than present undefined slots.
+    module.declare_function("js_array_from_arraylike_holey_value", I64, &[DOUBLE]);
     // #2874: Iterator.from(x) — wrap any iterable in a lazy iterator-helper
     // object. Returns an already NaN-boxed pointer (DOUBLE).
     module.declare_function("js_iterator_from", DOUBLE, &[DOUBLE]);

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -85,6 +85,7 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         | Expr::ArrayFlat { .. }
         | Expr::ArrayFlatMap { .. }
         | Expr::ArrayFrom(_)
+        | Expr::ArrayFromArrayLikeHoley(_)
         | Expr::ArrayFromMapped { .. }
         | Expr::ArraySort { .. }
         | Expr::ArrayToReversed { .. }
@@ -1887,6 +1888,7 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
         | Expr::ArrayFlatMap { .. }
         | Expr::ArrayFromMapped { .. }
         | Expr::ArrayFrom(_)
+        | Expr::ArrayFromArrayLikeHoley(_)
         | Expr::ArrayEntries(_)
         | Expr::ArrayKeys(_)
         | Expr::ArrayValues(_)

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -1121,7 +1121,9 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
             collect_assigned_locals_expr(items, assigned);
             collect_assigned_locals_expr(key_fn, assigned);
         }
-        Expr::ArrayIsArray(value) | Expr::ArrayFrom(value) => {
+        Expr::ArrayIsArray(value)
+        | Expr::ArrayFrom(value)
+        | Expr::ArrayFromArrayLikeHoley(value) => {
             collect_assigned_locals_expr(value, assigned);
         }
         Expr::ArrayFromMapped {

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2045,6 +2045,8 @@ pub enum Expr {
     /// Array.from(iterable) -> Array
     /// Creates a new array from an iterable (e.g., Map.entries(), Map.keys(), another array)
     ArrayFrom(Box<Expr>),
+    /// Array.prototype generic receiver materialization preserving absent keys as holes.
+    ArrayFromArrayLikeHoley(Box<Expr>),
 
     /// `Iterator.from(iterable)` (#2874) — wrap any iterable/iterator in a lazy
     /// iterator-helper object exposing `.map`/`.filter`/`.take`/`.drop`/

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -661,7 +661,8 @@ pub(super) fn try_array_only_methods(
                             &array_expr,
                             Expr::ArrayMap { .. } | Expr::ArrayFilter { .. } | Expr::ArraySort { .. } |
                                     Expr::ArraySlice { .. } | Expr::Array(_) | Expr::ArraySpread(_) |
-                                    Expr::ArrayFrom(_) | Expr::ArrayFromMapped { .. } |
+                                    Expr::ArrayFrom(_) | Expr::ArrayFromArrayLikeHoley(_) |
+                                    Expr::ArrayFromMapped { .. } |
                                     Expr::ArrayFlat { .. } | Expr::StringSplit(_, _) |
                                     Expr::ArrayToReversed { .. } | Expr::ArrayToSorted { .. } |
                                     Expr::ArrayToSpliced { .. } | Expr::ArrayWith { .. } |
@@ -708,6 +709,7 @@ pub(super) fn try_array_only_methods(
                                 | Expr::ArraySlice { .. }
                                 | Expr::ArraySpread(_)
                                 | Expr::ArrayFrom(_)
+                                | Expr::ArrayFromArrayLikeHoley(_)
                                 | Expr::ArrayFromMapped { .. }
                                 | Expr::ArrayFlat { .. }
                                 | Expr::StringSplit(_, _)
@@ -768,6 +770,7 @@ pub(super) fn try_array_only_methods(
                                         | Expr::ArraySlice { .. }
                                         | Expr::Array(_)
                                         | Expr::ArrayFrom(_)
+                                        | Expr::ArrayFromArrayLikeHoley(_)
                                         | Expr::StringSplit(_, _)
                                         | Expr::ObjectKeys(_)
                                         | Expr::ObjectValues(_)
@@ -807,6 +810,7 @@ pub(super) fn try_array_only_methods(
                                         | Expr::ArraySlice { .. }
                                         | Expr::Array(_)
                                         | Expr::ArrayFrom(_)
+                                        | Expr::ArrayFromArrayLikeHoley(_)
                                         | Expr::StringSplit(_, _)
                                         | Expr::ObjectKeys(_)
                                         | Expr::ObjectValues(_)

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1306,19 +1306,13 @@ fn try_arraylike_receiver_method(
     if !supported {
         return Ok(None);
     }
-    // Materialize the array-like receiver into a REAL array up front via
-    // `Expr::ArrayFrom` (→ `js_array_from_value` → `js_array_clone`, which has
-    // the array-like `{length, 0:…}` detection). This makes EVERY downstream
-    // method see a genuine `ArrayHeader` — crucial for the methods whose codegen
-    // is INLINED (e.g. `forEach` reads `(*arr).length` + `arr[i]` directly
-    // rather than calling `js_array_forEach`), which the runtime-side
-    // `normalize_array_receiver` can't reach. For a real-array receiver this
-    // clones (correct; the read-only methods don't mutate the receiver), and
-    // for null/undefined `js_array_from_value` throws a TypeError to match Node.
-    // The receiver (`thisArg`) lowers before the positional args, matching
-    // source order.
+    // Materialize the array-like receiver into a REAL array up front, but keep
+    // absent indexed keys as holes. These Array.prototype algorithms use
+    // HasProperty/Get on the receiver; `Array.from({ length: 2 })` would create
+    // present undefined slots, making `indexOf(undefined)` and callback methods
+    // visit holes incorrectly.
     let array_src = lower_expr(ctx, receiver)?;
-    let array = Box::new(Expr::ArrayFrom(Box::new(array_src)));
+    let array = Box::new(Expr::ArrayFromArrayLikeHoley(Box::new(array_src)));
     // Lower a positional argument by index, if present.
     let mut arg = |ctx: &mut LoweringContext, i: usize| -> Result<Option<Box<Expr>>> {
         match rest_args.get(i) {

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -890,6 +890,9 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             Expr::ArrayIsArray(Box::new(substitute_expr(value, substitutions)))
         }
         Expr::ArrayFrom(value) => Expr::ArrayFrom(Box::new(substitute_expr(value, substitutions))),
+        Expr::ArrayFromArrayLikeHoley(value) => {
+            Expr::ArrayFromArrayLikeHoley(Box::new(substitute_expr(value, substitutions)))
+        }
         Expr::ArrayFromMapped {
             iterable,
             map_fn,

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -546,6 +546,7 @@ impl SH for Expr {
             Expr::ObjectRest { object, exclude_keys, } => { tag(h, 395); object.as_ref().hash(h); exclude_keys.hash(h); }
             Expr::ArrayIsArray(e) => { tag(h, 396); e.as_ref().hash(h); }
             Expr::ArrayFrom(e) => { tag(h, 397); e.as_ref().hash(h); }
+            Expr::ArrayFromArrayLikeHoley(e) => { tag(h, 12320); e.as_ref().hash(h); }
             Expr::IteratorFrom(e) => { tag(h, 12270); e.as_ref().hash(h); }
             Expr::IteratorToArray(e) => { tag(h, 398); e.as_ref().hash(h); }
             Expr::GetIterator(e) => { tag(h, 11238); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -239,6 +239,7 @@ where
         | Expr::StaticPluginResolve(v)
         | Expr::ArrayIsArray(v)
         | Expr::ArrayFrom(v)
+        | Expr::ArrayFromArrayLikeHoley(v)
         | Expr::IteratorFrom(v)
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -240,6 +240,7 @@ where
         | Expr::StaticPluginResolve(v)
         | Expr::ArrayIsArray(v)
         | Expr::ArrayFrom(v)
+        | Expr::ArrayFromArrayLikeHoley(v)
         | Expr::IteratorFrom(v)
         | Expr::IteratorToArray(v)
         | Expr::GetIterator(v)

--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -163,6 +163,19 @@ pub extern "C" fn js_array_from_f64(elements: *const f64, count: u32) -> *mut Ar
 pub(crate) unsafe fn js_array_from_arraylike(
     obj: *const crate::object::ObjectHeader,
 ) -> *mut ArrayHeader {
+    js_array_from_arraylike_with_missing(obj, f64::from_bits(crate::value::TAG_UNDEFINED))
+}
+
+pub(crate) unsafe fn js_array_from_arraylike_holey(
+    obj: *const crate::object::ObjectHeader,
+) -> *mut ArrayHeader {
+    js_array_from_arraylike_with_missing(obj, f64::from_bits(crate::value::TAG_HOLE))
+}
+
+unsafe fn js_array_from_arraylike_with_missing(
+    obj: *const crate::object::ObjectHeader,
+    missing_value: f64,
+) -> *mut ArrayHeader {
     if obj.is_null() {
         return js_array_alloc(0);
     }
@@ -183,22 +196,58 @@ pub(crate) unsafe fn js_array_from_arraylike(
     (*arr).length = len;
     clear_array_numeric_layout(arr);
     let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
-    let undefined = f64::from_bits(TAG_UNDEFINED);
     for i in 0..len {
-        // Pre-init to undefined in case the key lookup returns the
-        // wrong type / produces a sentinel we want to coerce.
-        // GC_STORE_AUDIT(POINTER_FREE): undefined prefill is a non-pointer sentinel.
-        *elements.add(i as usize) = undefined;
         let key_str = i.to_string();
         let key = crate::string::js_string_from_bytes(key_str.as_ptr(), key_str.len() as u32);
-        let v = crate::object::js_object_get_field_by_name_f64(obj, key);
+        let key_value = f64::from_bits(crate::value::JSValue::string_ptr(key).bits());
+        let obj_value = f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits());
+        let has_property =
+            crate::value::js_is_truthy(crate::object::js_object_has_property(obj_value, key_value))
+                != 0;
+        let v = if has_property {
+            crate::object::js_object_get_field_by_name_f64(obj, key)
+        } else {
+            missing_value
+        };
         // GC_STORE_AUDIT(BARRIERED): arraylike element write is immediately recorded via note_array_slot.
         *elements.add(i as usize) = v;
         note_array_slot(arr, i as usize, v.to_bits());
     }
     refresh_array_numeric_layout(arr);
     arr
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_from_arraylike_holey_value(boxed: f64) -> *mut ArrayHeader {
+    let bits = boxed.to_bits();
+    let jv = crate::value::JSValue::from_bits(bits);
+    if jv.is_undefined() || jv.is_null() {
+        crate::object::has_own_helpers::throw_to_object_nullish_type_error();
+    }
+    if !jv.is_pointer() {
+        return crate::array::js_array_from_value(boxed);
+    }
+    let raw_addr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+    unsafe {
+        if let Some(arr) =
+            crate::object::arguments_object_to_array(raw_addr as *const crate::object::ObjectHeader)
+        {
+            return arr;
+        }
+        if raw_addr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let hdr = (raw_addr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                as *const crate::gc::GcHeader;
+            if (*hdr).obj_type == crate::gc::GC_TYPE_OBJECT
+                && crate::typedarray::lookup_typed_array_kind(raw_addr).is_none()
+                && !crate::buffer::is_registered_buffer(raw_addr)
+            {
+                return js_array_from_arraylike_holey(
+                    raw_addr as *const crate::object::ObjectHeader,
+                );
+            }
+        }
+    }
+    crate::array::js_array_from_value(boxed)
 }
 
 /// `Array.from(string)` — split the source string into Unicode codepoints

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -23,7 +23,7 @@ mod tests;
 pub use self::alloc::{
     js_array_alloc, js_array_alloc_literal, js_array_alloc_with_length,
     js_array_alloc_with_length_longlived, js_array_constructor_single, js_array_create,
-    js_array_from_f64,
+    js_array_from_arraylike_holey_value, js_array_from_f64,
 };
 pub use self::concat_reverse::{
     js_array_concat, js_array_concat_new, js_array_fill, js_array_fill_range, js_array_reverse,

--- a/test-parity/node-suite/globals/array-generic-readonly-methods.ts
+++ b/test-parity/node-suite/globals/array-generic-readonly-methods.ts
@@ -1,0 +1,53 @@
+function show(label: string, value: any) {
+  console.log(label + ":", String(value));
+}
+
+function showArray(label: string, value: any[]) {
+  console.log(
+    label + ":",
+    JSON.stringify(value),
+    "length=" + value.length,
+    "keys=" + Object.keys(value).join("|"),
+    "has0=" + String(0 in value),
+    "has1=" + String(1 in value),
+    "has2=" + String(2 in value),
+  );
+}
+
+const sparseLike: any = { 0: "a", 2: "c", length: 3 };
+const holeOnly: any = { length: 2 };
+
+show("join sparse object", Array.prototype.join.call(sparseLike, "|"));
+show("includes missing undefined", Array.prototype.includes.call(holeOnly, undefined));
+show("indexOf missing undefined", Array.prototype.indexOf.call(holeOnly, undefined));
+show("indexOf object c", Array.prototype.indexOf.call(sparseLike, "c"));
+show("lastIndexOf object a", Array.prototype.lastIndexOf.call(sparseLike, "a"));
+
+showArray("slice sparse object", Array.prototype.slice.call(sparseLike, 0, 3));
+showArray("map missing object", Array.prototype.map.call(holeOnly, (value: any, index: number) => {
+  return String(index) + ":" + String(value);
+}));
+
+const forEachCalls: string[] = [];
+Array.prototype.forEach.call(holeOnly, (value: any, index: number) => {
+  forEachCalls.push(index + ":" + String(value));
+});
+show("forEach missing calls", forEachCalls.join("|"));
+
+const someCalls: string[] = [];
+show("some missing result", Array.prototype.some.call(holeOnly, (value: any, index: number) => {
+  someCalls.push(index + ":" + String(value));
+  return true;
+}));
+show("some missing calls", someCalls.join("|"));
+
+show("join primitive string", Array.prototype.join.call("ab", "-"));
+showArray("slice primitive string", Array.prototype.slice.call("abc", 1));
+show("indexOf null throws", (() => {
+  try {
+    Array.prototype.indexOf.call(null as any, "x");
+    return "no throw";
+  } catch (err: any) {
+    return err.name;
+  }
+})());


### PR DESCRIPTION
Part of #4597.

## Summary
- add hole-preserving array-like materialization for borrowed `Array.prototype` read/callback methods
- route supported `Array.prototype.<method>.call/apply(arrayLike, ...)` through a new HIR node instead of `Array.from`
- keep normal `Array.from` semantics unchanged, including present `undefined` slots for missing indexes
- add a Node parity fixture covering sparse array-like receivers, primitive strings, and null receiver errors

## Scope
This covers the read-only/callback slice: `join`, `includes`, `indexOf`, `lastIndexOf`, `every`, `some`, `forEach`, `map`, `filter`, `find`, `findIndex`, `reduce`, `reduceRight`, and `slice` when borrowed through `.call`/`.apply`.

Non-goals for this PR: `concat`/species behavior and mutating generic methods such as `copyWithin`, `fill`, `reverse`, `sort`, `splice`, `push`, `pop`, `shift`, and `unshift`.

## Validation
- Node oracle: `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/array-generic-readonly-methods.ts`
- Pre-fix repro: focused parity fixture failed because Perry materialized missing indexes as present `undefined` slots
- Focused parity: `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter array-generic-readonly-methods'` passes 1/1
- Adjacent parity: `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter array-'` passes 14/14
- Rust: `cargo check -q -p perry-hir -p perry-runtime -p perry-codegen`
- Rust unit filter: `cargo test -q -p perry-runtime --lib array -- --nocapture --test-threads=1` passes 108/108
- Hygiene: `git diff --check`

Known unrelated repo hygiene failures still present on this base:
- `cargo fmt --all -- --check` fails on `crates/perry-codegen/src/expr/property_get.rs`
- `./scripts/check_file_size.sh` fails on `crates/perry-runtime/src/regex.rs` at 2026 lines
