### PR TITLE
runtime: wire Promise prototype method values

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -4406,7 +4406,24 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             }
         }
         "Promise" => {
-            install_noop_proto_methods(proto_obj, &[("catch", 1), ("finally", 1), ("then", 2)]);
+            install_proto_method(
+                proto_obj,
+                "catch",
+                crate::promise::promise_prototype_catch_thunk as *const u8,
+                1,
+            );
+            install_proto_method(
+                proto_obj,
+                "finally",
+                crate::promise::promise_prototype_finally_thunk as *const u8,
+                1,
+            );
+            install_proto_method(
+                proto_obj,
+                "then",
+                crate::promise::promise_prototype_then_thunk as *const u8,
+                2,
+            );
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "TextEncoder" => {

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -54,7 +54,10 @@ pub use native_async::{
 };
 pub use scanners::{js_promise_with_resolvers, scan_promise_roots, scan_promise_roots_mut};
 pub(crate) use scanners::{new_promise_root_scan_state, scan_promise_roots_mut_step};
-pub(crate) use then::{js_promise_attach_handlers, js_promise_attach_settle_listener};
+pub(crate) use then::{
+    js_promise_attach_handlers, js_promise_attach_settle_listener, promise_prototype_catch_thunk,
+    promise_prototype_finally_thunk, promise_prototype_then_thunk,
+};
 pub use then::{
     js_promise_bound_method, js_promise_catch, js_promise_finally, js_promise_free, js_promise_new,
     js_promise_reason, js_promise_reject, js_promise_resolve, js_promise_resolve_with_promise,

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -728,6 +728,91 @@ fn box_promise_ptr(p: *mut Promise) -> f64 {
     f64::from_bits(crate::value::JSValue::pointer(p as *const u8).bits())
 }
 
+fn throw_promise_prototype_incompatible_receiver(method: &str, receiver: f64) -> ! {
+    let jsval = crate::value::JSValue::from_bits(receiver.to_bits());
+    let label = if jsval.is_undefined() {
+        "undefined".to_string()
+    } else if jsval.is_null() {
+        "null".to_string()
+    } else if jsval.is_pointer() {
+        "#<Object>".to_string()
+    } else {
+        crate::string::string_as_str(crate::value::js_jsvalue_to_string(receiver)).to_string()
+    };
+    let msg = format!("Method Promise.prototype.{method} called on incompatible receiver {label}");
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = crate::error::js_typeerror_new(msg_str);
+    let err_value = crate::value::JSValue::pointer(err_ptr as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(err_value))
+}
+
+fn promise_prototype_receiver(method: &str) -> *mut Promise {
+    let receiver = crate::object::js_implicit_this_get();
+    if js_value_is_promise(receiver) != 0 {
+        return crate::value::js_nanbox_get_pointer(receiver) as *mut Promise;
+    }
+    throw_promise_prototype_incompatible_receiver(method, receiver)
+}
+
+fn call_receiver_then(receiver: f64, args: &[f64]) -> f64 {
+    unsafe {
+        crate::object::js_native_call_method(
+            receiver,
+            b"then".as_ptr() as *const i8,
+            b"then".len(),
+            args.as_ptr(),
+            args.len(),
+        )
+    }
+}
+
+fn throw_promise_finally_non_object() -> ! {
+    let msg = b"Promise.prototype.finally called on non-object";
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = crate::error::js_typeerror_new(msg_str);
+    let err_value = crate::value::JSValue::pointer(err_ptr as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(err_value))
+}
+
+pub(crate) extern "C" fn promise_prototype_then_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    on_fulfilled: f64,
+    on_rejected: f64,
+) -> f64 {
+    let promise = promise_prototype_receiver("then");
+    box_promise_ptr(js_promise_then(
+        promise,
+        arg_to_closure(on_fulfilled),
+        arg_to_closure(on_rejected),
+    ))
+}
+
+pub(crate) extern "C" fn promise_prototype_catch_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    on_rejected: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    let args = [f64::from_bits(crate::value::TAG_UNDEFINED), on_rejected];
+    call_receiver_then(receiver, &args)
+}
+
+pub(crate) extern "C" fn promise_prototype_finally_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    on_finally: f64,
+) -> f64 {
+    let receiver = crate::object::js_implicit_this_get();
+    if js_value_is_promise(receiver) != 0 {
+        let promise = crate::value::js_nanbox_get_pointer(receiver) as *mut Promise;
+        return box_promise_ptr(js_promise_finally(promise, arg_to_closure(on_finally)));
+    }
+    let jsval = crate::value::JSValue::from_bits(receiver.to_bits());
+    if !jsval.is_pointer() {
+        throw_promise_finally_non_object();
+    }
+    let args = [on_finally, on_finally];
+    call_receiver_then(receiver, &args)
+}
+
 extern "C" fn promise_then_bound(
     closure: *const crate::closure::ClosureHeader,
     on_fulfilled: f64,

--- a/test-parity/node-suite/globals/promise-prototype-method-values.ts
+++ b/test-parity/node-suite/globals/promise-prototype-method-values.ts
@@ -1,0 +1,80 @@
+function errShape(err: any, fragment: string): string {
+  const message = String(err?.message ?? "");
+  return `${err?.name}:${message.includes(fragment)}:${err?.code ?? ""}`;
+}
+
+function bad(label: string, fragment: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(`${label}:`, "NO_THROW");
+  } catch (err: any) {
+    console.log(`${label}:`, errShape(err, fragment));
+  }
+}
+
+async function main() {
+  const then = Promise.prototype.then;
+  const catchFn = Promise.prototype.catch;
+  const finallyFn = Promise.prototype.finally;
+
+  const viaThen = then.call(Promise.resolve("ok"), (value: string) => `then:${value}`);
+  console.log("then.return:", viaThen instanceof Promise, typeof viaThen?.then);
+  console.log("then.value:", await viaThen);
+
+  const viaApply = then.apply(Promise.resolve("apply"), [
+    (value: string) => `apply:${value}`,
+  ]);
+  console.log("then.apply:", await viaApply);
+
+  const passThrough = then.call(Promise.resolve("pass"), 7 as any);
+  console.log("then.noncallable:", await passThrough);
+
+  const viaCatch = catchFn.call(Promise.reject("boom"), (value: string) => `catch:${value}`);
+  console.log("catch.return:", viaCatch instanceof Promise, typeof viaCatch?.then);
+  console.log("catch.value:", await viaCatch);
+
+  let cleanup = "no";
+  const viaFinally = finallyFn.call(Promise.resolve("done"), () => {
+    cleanup = "yes";
+  });
+  console.log("finally.return:", viaFinally instanceof Promise, typeof viaFinally?.then);
+  console.log("finally.value:", await viaFinally, cleanup);
+
+  const genericCatchReceiver = {
+    then(onFulfilled: unknown, onRejected: unknown) {
+      console.log("generic.catch.args:", typeof onFulfilled, typeof onRejected);
+      return "generic-catch";
+    },
+  };
+  console.log("generic.catch:", catchFn.call(genericCatchReceiver, () => "unused"));
+
+  const genericFinallyReceiver = {
+    then(onFulfilled: unknown, onRejected: unknown) {
+      console.log("generic.finally.args:", typeof onFulfilled, typeof onRejected);
+      return "generic-finally";
+    },
+  };
+  console.log("generic.finally:", finallyFn.call(genericFinallyReceiver, () => "unused"));
+
+  bad("bad.then.object", "Promise.prototype.then", () => then.call({}, () => "x"));
+  bad("bad.then.null", "Promise.prototype.then", () => then.call(null as any, () => "x"));
+  bad("bad.then.undefined", "Promise.prototype.then", () =>
+    then.call(undefined as any, () => "x")
+  );
+
+  bad("bad.catch.object", "not a function", () => catchFn.call({}, () => "x"));
+  bad("bad.catch.null", "Cannot read properties", () =>
+    catchFn.call(null as any, () => "x")
+  );
+  bad("bad.catch.undefined", "Cannot read properties", () =>
+    catchFn.call(undefined as any, () => "x")
+  );
+
+  bad("bad.finally.object", "not a function", () => finallyFn.call({}, () => "x"));
+  bad("bad.finally.null", "non-object", () => finallyFn.call(null as any, () => "x"));
+  bad("bad.finally.undefined", "non-object", () =>
+    finallyFn.call(undefined as any, () => "x")
+  );
+}
+
+await main();


### PR DESCRIPTION
Refs #4521

Summary:
- install real Promise.prototype.then/catch/finally method values instead of no-op prototype thunks
- make borrowed then calls brand-check the explicit receiver and return chained Promise values
- route borrowed catch/finally through the receiver then path with Node-shaped error behavior for invalid receivers
- add focused Node parity coverage for borrowed call/apply paths, non-callable handlers, generic receivers, and invalid receivers

Validation:
- cargo fmt -p perry-runtime
- cargo check -q -p perry-runtime
- npx -y node@22 --experimental-strip-types test-parity/node-suite/globals/promise-prototype-method-values.ts
- npx -y node@26 --experimental-strip-types test-parity/node-suite/globals/promise-prototype-method-values.ts
- env RUSTC_WRAPPER= TMPDIR=/tmp CARGO_BUILD_JOBS=1 cargo build -q -p perry -p perry-runtime -p perry-stdlib
- env PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry compile --no-cache test-parity/node-suite/globals/promise-prototype-method-values.ts -o /tmp/perry-promise-prototype-method-values && /tmp/perry-promise-prototype-method-values
- git diff --check