### PR TITLE
fix(runtime): BigInt(object) applies ToPrimitive before the integer check

### DIFF
--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -267,6 +267,42 @@ pub extern "C" fn js_bigint_from_f64(value: f64) -> *mut BigIntHeader {
         throw_bigint_type_error("Cannot convert null to a BigInt");
     }
 
+    // Object / Symbol pointer. ECMAScript ToBigInt step 1 is
+    // `ToPrimitive(value, number)`, so `valueOf` / `toString` /
+    // `@@toPrimitive` must run (and propagate their exceptions) *before* the
+    // integer check — `BigInt({valueOf(){throw}})` rethrows, and
+    // `BigInt({valueOf(){return 2n}})` is 2n. Previously a non-string,
+    // non-bigint pointer fell through to the Number branch below, where its
+    // NaN-boxed bits read as NaN and threw a (premature) RangeError. A Symbol
+    // has no primitive conversion → TypeError. Mirrors `js_number_coerce`.
+    if jsval.is_pointer() {
+        let ptr = (value.to_bits() & crate::value::POINTER_MASK) as usize;
+        if crate::symbol::is_registered_symbol(ptr) {
+            throw_bigint_type_error("Cannot convert a Symbol value to a BigInt");
+        }
+        // `@@toPrimitive("number")` first.
+        let primitive = unsafe { crate::symbol::js_to_primitive(value, 1) };
+        if primitive.to_bits() != value.to_bits() {
+            return js_bigint_from_f64(primitive);
+        }
+        // OrdinaryToPrimitive(O, "number"): valueOf then toString.
+        match unsafe { crate::value::ordinary_to_primitive_number_for_add(value) } {
+            crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => {
+                if p.to_bits() != value.to_bits() {
+                    return js_bigint_from_f64(p);
+                }
+            }
+            crate::value::OrdinaryToPrimitiveOutcome::TypeError
+            | crate::value::OrdinaryToPrimitiveOutcome::DefaultString => {}
+        }
+        // Fall back to string coercion (e.g. an array → join → parse:
+        // `BigInt([5])` === 5n, `BigInt([])` === 0n).
+        let str_ptr = crate::value::js_jsvalue_to_string(value);
+        if !str_ptr.is_null() {
+            return js_bigint_from_f64(crate::value::js_nanbox_string(str_ptr as i64));
+        }
+    }
+
     // Remaining case: a real Number. Node only converts finite integers;
     // NaN, ±Infinity, and any value with a fractional part throw RangeError.
     if !value.is_finite() || value.fract() != 0.0 {


### PR DESCRIPTION
## Problem
```ts
BigInt({ valueOf() { return 2n } })       // threw RangeError  → 2n
BigInt({ valueOf() { throw e } })          // threw RangeError  → rethrows e
BigInt(Symbol())                           // threw RangeError  → TypeError
BigInt([5])                                // threw RangeError  → 5n
```
ECMAScript ToBigInt step 1 is `ToPrimitive(value, number)`, but a non-string/non-bigint object fell through to the Number branch, where its NaN-boxed pointer bits read as `NaN` → premature RangeError, so `valueOf`/`toString`/`@@toPrimitive` never ran.

## Fix
An object pointer now runs `@@toPrimitive("number")`, then OrdinaryToPrimitive (`valueOf` then `toString`), re-coerces the primitive, with array string-fallback. A Symbol throws TypeError. Mirrors the ToPrimitive path in `js_number_coerce`.

## Verification
Byte-identical to `node --experimental-strip-types`, including the "fails after fetching the primitive" ordering. Regressions intact (`BigInt(123)`/`"456"`/`true`/`10n`/`1.5`→RangeError/`undefined`→TypeError). Fixes test262 `built-ins/BigInt/{tostring-throws,valueof-throws,nan-throws-rangeerror,infinity-throws-rangeerror,constructor-coercion}` (5 tests).