### PR TITLE
fix(array): flat skips holes and doesn't flatten/crash on non-array elements (#4613)

### DIFF
--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -60,6 +60,11 @@ unsafe fn js_array_flat_into(
     for i in 0..len {
         let element = *elements.add(i);
         let bits = element.to_bits();
+        // Per ECMAScript FlattenIntoArray, holes are absent (HasProperty is
+        // false) and are skipped, not copied as `null`/`undefined`.
+        if bits == crate::value::TAG_HOLE {
+            continue;
+        }
         let top16 = (bits >> 48) as u16;
         let maybe_arr_ptr = if top16 >= 0x7FF8 {
             if top16 == 0x7FFD {
@@ -124,6 +129,10 @@ pub extern "C" fn js_array_flat(arr: *const ArrayHeader) -> *mut ArrayHeader {
         for i in 0..len {
             let element = *elements.add(i);
             let bits = element.to_bits();
+            // Per ECMAScript FlattenIntoArray, holes are absent and skipped.
+            if bits == crate::value::TAG_HOLE {
+                continue;
+            }
             let top16 = (bits >> 48) as u16;
 
             // Check if the element is an array pointer (NaN-boxed or raw)
@@ -148,30 +157,40 @@ pub extern "C" fn js_array_flat(arr: *const ArrayHeader) -> *mut ArrayHeader {
                 None
             };
 
-            if let Some(sub_arr) = maybe_arr_ptr {
-                // Check if it's a registered set — if so, it's not an array
-                if crate::set::is_registered_set(sub_arr as usize)
-                    || crate::map::is_registered_map(sub_arr as usize)
-                {
-                    // Not an array — push as-is
-                    result = js_array_push_f64(result, element);
-                } else {
-                    // Try to read as array
-                    let sub_len = (*sub_arr).length as usize;
-                    // Sanity check: if length is unreasonably large, treat as non-array
-                    if sub_len <= 1_000_000 {
-                        let sub_elements = (sub_arr as *const u8)
-                            .add(std::mem::size_of::<ArrayHeader>())
-                            as *const f64;
-                        for j in 0..sub_len {
-                            result = js_array_push_f64(result, *sub_elements.add(j));
+            // Only flatten when the pointer is genuinely an array. A plain
+            // object / Set / Map / string etc. is a non-array element and must
+            // be pushed as-is — `flat` only spreads arrays. Pre-fix this read
+            // an arbitrary heap object's bytes as an `ArrayHeader.length` and
+            // iterated garbage (segfault on `[{…}].flat()`). Mirrors the
+            // `GC_TYPE_ARRAY` gate in the recursive `js_array_flat_into`.
+            let is_array = match maybe_arr_ptr {
+                Some(sub_arr) if (sub_arr as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 => {
+                    let hdr = (sub_arr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                        as *const crate::gc::GcHeader;
+                    (*hdr).obj_type == crate::gc::GC_TYPE_ARRAY
+                }
+                _ => false,
+            };
+            if let (true, Some(sub_arr)) = (is_array, maybe_arr_ptr) {
+                let sub_len = (*sub_arr).length as usize;
+                // Sanity check: if length is unreasonably large, treat as non-array.
+                if sub_len <= 1_000_000 {
+                    let sub_elements = (sub_arr as *const u8)
+                        .add(std::mem::size_of::<ArrayHeader>())
+                        as *const f64;
+                    for j in 0..sub_len {
+                        let sub = *sub_elements.add(j);
+                        // Skip holes in the flattened sub-array too.
+                        if sub.to_bits() == crate::value::TAG_HOLE {
+                            continue;
                         }
-                    } else {
-                        result = js_array_push_f64(result, element);
+                        result = js_array_push_f64(result, sub);
                     }
+                } else {
+                    result = js_array_push_f64(result, element);
                 }
             } else {
-                // Not a pointer - push element directly
+                // Not an array (non-pointer, or a non-array object) — push as-is.
                 result = js_array_push_f64(result, element);
             }
         }

--- a/test-parity/node-suite/globals/array-flat-holes.ts
+++ b/test-parity/node-suite/globals/array-flat-holes.ts
@@ -1,0 +1,36 @@
+// Array.prototype.flat per ECMAScript FlattenIntoArray: holes are absent
+// (HasProperty is false) and are skipped — not copied as null — at every
+// depth, including flat(0). `undefined` / `null` elements are real and kept.
+// Non-array elements (plain objects, etc.) are pushed as-is, never flattened
+// (previously a plain-object element segfaulted: its bytes were read as an
+// ArrayHeader length).
+
+function show(label: string, value: any) {
+  console.log(label + " = " + value);
+}
+
+// Holes skipped at depth 1.
+show("hole d1", JSON.stringify([1, , 3].flat()));
+show("nested hole", JSON.stringify([1, , [3, , 4]].flat()));
+show("only holes", JSON.stringify([, , ,].flat()));
+show("trailing hole", JSON.stringify([[1, ,], [, 2]].flat()));
+
+// Deeper depths and Infinity also skip holes.
+show("d2", JSON.stringify([1, [2, , [3, , 4]]].flat(2)));
+show("inf", JSON.stringify([1, , [2, , [3, , 4]]].flat(Infinity)));
+show("d0", JSON.stringify([1, , 3].flat(0)));
+
+// undefined / null are kept; only holes are removed.
+show("undefined kept", JSON.stringify([1, undefined, 3].flat()));
+show("null kept", JSON.stringify([1, null, [null]].flat()));
+show("mixed", JSON.stringify([1, "x", , [true, , null], , undefined].flat()));
+
+// Non-array elements (plain objects) are pushed as-is, not flattened.
+show("object elem", JSON.stringify([{ a: 1 }].flat()));
+show("object + array", JSON.stringify([{ a: 1 }, , [{ b: 2 }]].flat()));
+
+// Regression: arrays with no holes flatten normally.
+show("no holes d1", JSON.stringify([1, [2, 3], [4, [5]]].flat()));
+show("no holes d2", JSON.stringify([1, [2, [3]]].flat(2)));
+show("deep no hole", JSON.stringify([1, [2, [3, [4]]]].flat(Infinity)));
+show("empty", JSON.stringify([].flat()));


### PR DESCRIPTION
Fixes #4613.

## Problem

`Array.prototype.flat`:
1. Copied **holes** as `null` instead of skipping them (FlattenIntoArray omits absent indices at every depth, incl. `flat(0)`).
2. **Segfaulted on a plain-object element** — the depth-1 fast path treated any non-Set/Map pointer as an array and read its bytes as an `ArrayHeader.length`.

```ts
[1, , 3].flat();     // Node: [1,3]      was: [1,null,3]
[{ a: 1 }].flat();   // Node: [{"a":1}]  was: CRASH
```

## Fix

- Skip `TAG_HOLE` elements in `js_array_flat` (outer + flattened sub-array) and the recursive `js_array_flat_into`.
- Gate the depth-1 path on `GC_TYPE_ARRAY` (mirrors `js_array_flat_into`); push non-array elements as-is.

## Verification

- Parity fixture `array-flat-holes.ts`.
- Identical to Node for holes at depth 0/1/2/Infinity, undefined/null kept, object elements (no crash), and no-hole regressions.
- Array unit tests pass.

(The unrelated `regex.rs` file-size lint failure is a pre-existing repo-wide gate breakage — `regex.rs` is 2026 lines on main — not touched by this PR.)