### PR TITLE
fix(runtime): brand-check Promise prototype methods

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -4406,7 +4406,7 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             }
         }
         "Promise" => {
-            install_noop_proto_methods(proto_obj, &[("catch", 1), ("finally", 1), ("then", 2)]);
+            super::promise_proto_thunks::install_promise_proto_methods(proto_obj);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "TextEncoder" => {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -56,6 +56,7 @@ mod object_ops;
 mod object_ops_frozen;
 mod polymorphic_index;
 mod primitive_proto_thunks;
+mod promise_proto_thunks;
 mod property_key;
 pub(crate) mod prototype_chain;
 mod prototype_helpers;

--- a/crates/perry-runtime/src/object/promise_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/promise_proto_thunks.rs
@@ -1,0 +1,96 @@
+//! `Promise.prototype` method thunks with receiver brand checks.
+//!
+//! Instance value-reads (`const f = promise.then`) intentionally return
+//! bound methods elsewhere so common deferred use keeps the original promise.
+//! The prototype methods themselves are different: `Promise.prototype.then`
+//! is a built-in function that must reject an incompatible `this` value.
+//! These thunks cover reflective calls (`.call`/`.apply`) and bare detached
+//! prototype calls by reading `IMPLICIT_THIS`, validating that it is a Promise,
+//! and then delegating to the existing Promise chaining helpers.
+
+use super::*;
+
+pub(super) fn install_promise_proto_methods(proto_obj: *mut ObjectHeader) {
+    use super::global_this::install_proto_method as ipm;
+
+    ipm(
+        proto_obj,
+        "catch",
+        promise_proto_catch_thunk as *const u8,
+        1,
+    );
+    ipm(
+        proto_obj,
+        "finally",
+        promise_proto_finally_thunk as *const u8,
+        1,
+    );
+    ipm(proto_obj, "then", promise_proto_then_thunk as *const u8, 2);
+}
+
+fn throw_incompatible_receiver(method: &str) -> ! {
+    let msg = format!("Method Promise.prototype.{method} called on incompatible receiver");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+#[inline]
+fn promise_receiver_or_throw(method: &str) -> *mut crate::promise::Promise {
+    let receiver = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    if crate::promise::js_value_is_promise(receiver) == 0 {
+        throw_incompatible_receiver(method);
+    }
+    crate::value::js_nanbox_get_pointer(receiver) as *mut crate::promise::Promise
+}
+
+#[inline]
+fn handler_arg_to_closure(value: f64) -> crate::promise::ClosurePtr {
+    let bits = value.to_bits();
+    let tag = bits & crate::value::TAG_MASK;
+    let candidate = if tag == crate::value::POINTER_TAG {
+        bits & crate::value::POINTER_MASK
+    } else if tag == 0 {
+        bits
+    } else {
+        0
+    } as usize;
+
+    if crate::closure::is_closure_ptr(candidate) {
+        candidate as crate::promise::ClosurePtr
+    } else {
+        std::ptr::null()
+    }
+}
+
+extern "C" fn promise_proto_then_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    on_fulfilled: f64,
+    on_rejected: f64,
+) -> f64 {
+    let promise = promise_receiver_or_throw("then");
+    let next = crate::promise::js_promise_then(
+        promise,
+        handler_arg_to_closure(on_fulfilled),
+        handler_arg_to_closure(on_rejected),
+    );
+    crate::value::js_nanbox_pointer(next as i64)
+}
+
+extern "C" fn promise_proto_catch_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    on_rejected: f64,
+) -> f64 {
+    let promise = promise_receiver_or_throw("catch");
+    let next = crate::promise::js_promise_catch(promise, handler_arg_to_closure(on_rejected));
+    crate::value::js_nanbox_pointer(next as i64)
+}
+
+extern "C" fn promise_proto_finally_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    on_finally: f64,
+) -> f64 {
+    let promise = promise_receiver_or_throw("finally");
+    let next = crate::promise::js_promise_finally(promise, handler_arg_to_closure(on_finally));
+    crate::value::js_nanbox_pointer(next as i64)
+}

--- a/test-parity/expected/promise-prototype-brand-checks.txt
+++ b/test-parity/expected/promise-prototype-brand-checks.txt
@@ -1,0 +1,20 @@
+types: function function function
+names: then catch finally
+lengths: 2 1 1
+then object:throw:TypeError
+then undefined:throw:TypeError
+then null:throw:TypeError
+then number:throw:TypeError
+then apply object:throw:TypeError
+then detached bare:throw:TypeError
+catch object:throw:TypeError
+catch undefined:throw:TypeError
+catch detached bare:throw:TypeError
+finally object:throw:TypeError
+finally undefined:throw:TypeError
+finally detached bare:throw:TypeError
+then valid:ok
+then apply valid:apply
+catch valid:TypeError
+finally callback
+finally valid:done

--- a/test-parity/node-suite/globals/promise-prototype-brand-checks.ts
+++ b/test-parity/node-suite/globals/promise-prototype-brand-checks.ts
@@ -1,0 +1,40 @@
+function showError(label: string, fn: () => unknown) {
+  try {
+    const value = fn();
+    console.log(label + ":ok:" + String(value));
+  } catch (error: any) {
+    console.log(label + ":throw:" + error.name);
+  }
+}
+
+const then = Promise.prototype.then;
+const catchMethod = Promise.prototype.catch;
+const finallyMethod = Promise.prototype.finally;
+
+console.log("types:", typeof then, typeof catchMethod, typeof finallyMethod);
+console.log("names:", then.name, catchMethod.name, finallyMethod.name);
+console.log("lengths:", then.length, catchMethod.length, finallyMethod.length);
+
+showError("then object", () => then.call({}));
+showError("then undefined", () => then.call(undefined));
+showError("then null", () => then.call(null));
+showError("then number", () => then.call(1));
+showError("then apply object", () => then.apply({}, []));
+showError("then detached bare", () => then(() => "x"));
+showError("catch object", () => catchMethod.call({}));
+showError("catch undefined", () => catchMethod.call(undefined));
+showError("catch detached bare", () => catchMethod(() => "x"));
+showError("finally object", () => finallyMethod.call({}));
+showError("finally undefined", () => finallyMethod.call(undefined));
+showError("finally detached bare", () => finallyMethod(() => "x"));
+
+then.call(Promise.resolve("ok"), (value) => console.log("then valid:" + value));
+then.apply(Promise.resolve("apply"), [(value) => console.log("then apply valid:" + value)]);
+catchMethod.call(Promise.reject(new TypeError("caught")), (error) =>
+  console.log("catch valid:" + error.name)
+);
+finallyMethod.call(Promise.resolve("done"), () => console.log("finally callback"))
+  .then((value) => console.log("finally valid:" + value));
+
+await Promise.resolve();
+await Promise.resolve();


### PR DESCRIPTION
## Summary
- Replace the no-op `Promise.prototype.then` / `catch` / `finally` method bodies with receiver-brand-checking thunks.
- Delegate valid borrowed prototype calls to the existing Promise chaining helpers, preserving `.name` / `.length` installation behavior.
- Add globals parity coverage for invalid receivers, bare detached prototype calls, and valid `.call` / `.apply` Promise receivers.

Closes part of #4521.

## Tests
- `node --input-type=module - <<'JS' ...` (Node oracle for the stored expected output)
- `cargo check -p perry-runtime` (passes; existing warnings only)
- `./run_parity_tests.sh --suite node-suite --module globals --filter promise-prototype-brand-checks` (passes; local Node reports `ERR_NO_TYPESCRIPT` for `.ts`, so the fixture uses stored expected output)
- `git diff --cached --check`
- `rustfmt --check crates/perry-runtime/src/object/promise_proto_thunks.rs`

Base-state hygiene notes:
- `cargo fmt --all -- --check` still fails on pre-existing indentation in `crates/perry-codegen/src/expr/property_get.rs`.
- `./scripts/check_file_size.sh` still fails on pre-existing `crates/perry-runtime/src/regex.rs` at 2026 lines.
