### PR TITLE
fix: HTTP request handling for Hono apps (object-literal getter `this`, http2 instanceof, handle symbol read)

### DIFF
--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -418,7 +418,6 @@ fn lower_accessor_prop(
     captures.dedup();
     captures = ctx.filter_module_level_captures(captures);
 
-    let uses_this = closure_uses_this(&body);
     let mut all_assigned = Vec::new();
     for stmt in &body {
         collect_assigned_locals_stmt(stmt, &mut all_assigned);
@@ -429,12 +428,17 @@ fn lower_accessor_prop(
         .filter(|id| assigned_set.contains(id) || ctx.var_hoisted_ids.contains(id))
         .copied()
         .collect();
-    let enclosing_class = if uses_this {
-        ctx.current_class.clone()
-    } else {
-        None
-    };
-
+    // An object-literal accessor (`get k() {}`) is a REGULAR (non-arrow)
+    // function: `this` binds dynamically to the receiver at call time, NOT to
+    // the object the accessor is defined on. Emitting `captures_this: true`
+    // (mirroring `uses_this`) captured `this` at object-construction time, so an
+    // inherited read (`Object.create(proto).k`, where the getter lives on
+    // `proto`) saw `this === proto` instead of the instance — @hono/node-server's
+    // request prototype `get method() { return this[incomingKey].method }`
+    // crashed because `this[incomingKey]` was undefined on the prototype. The
+    // runtime accessor-invocation path binds `this` via IMPLICIT_THIS (the same
+    // way `Object.defineProperty(obj, k, { get(){…} })` already worked), so the
+    // closure must NOT capture it.
     let closure = Expr::Closure {
         func_id,
         params,
@@ -442,9 +446,9 @@ fn lower_accessor_prop(
         body,
         captures,
         mutable_captures,
-        captures_this: uses_this,
+        captures_this: false,
         captures_new_target: false,
-        enclosing_class,
+        enclosing_class: None,
         is_arrow: false,
         is_async: false,
         is_generator: false,

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -474,7 +474,14 @@ unsafe fn resolve_proto_chain_field_inner(
             }
             let field_val = if let Some(receiver) = receiver {
                 let previous_this = js_implicit_this_set(receiver);
+                // The recursive `get_field(proto_obj, key)` re-derives a class
+                // getter's `this` from `proto_obj`; stash the real instance so an
+                // inherited getter (object-literal `get x()` on an
+                // `Object.create(proto)` prototype) binds `this` to the instance.
+                let prev_override =
+                    super::field_get_set::accessor_receiver_override_begin(receiver);
                 let value = js_object_get_field_by_name(proto_obj as *const _, key);
+                super::field_get_set::accessor_receiver_override_end(prev_override);
                 js_implicit_this_set(previous_this);
                 value
             } else {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -338,12 +338,56 @@ unsafe fn ordinary_object_prototype_method_value(
     }
 }
 
+thread_local! {
+    /// Receiver to bind when an accessor getter is reached by walking a
+    /// prototype chain. `js_object_get_field_by_name(proto, key)` re-derives the
+    /// accessor receiver from its `obj` argument — which is the PROTOTYPE during
+    /// an inherited read, not the original instance. `resolve_inherited_field`
+    /// stashes the real receiver here for the duration of the walk; the getter
+    /// invocation consumes it so `this` is the instance, matching the spec's
+    /// `[[Get]](P, Receiver)`. (object-literal getters on a `Object.create`
+    /// prototype — e.g. @hono/node-server's request prototype reading
+    /// `this[incomingKey].method`.)
+    static ACCESSOR_RECEIVER_OVERRIDE: std::cell::Cell<Option<f64>>
+        = const { std::cell::Cell::new(None) };
+}
+
+pub(crate) fn accessor_receiver_override_begin(receiver: f64) -> Option<f64> {
+    ACCESSOR_RECEIVER_OVERRIDE.with(|c| {
+        // Keep the OUTERMOST receiver across multi-hop prototype walks.
+        let to_set = c.get().or(Some(receiver));
+        c.replace(to_set)
+    })
+}
+
+pub(crate) fn accessor_receiver_override_end(prev: Option<f64>) {
+    ACCESSOR_RECEIVER_OVERRIDE.with(|c| c.set(prev));
+}
+
+/// `this` to pass to a class getter (vtable `getters`) found while resolving a
+/// property. When the getter was reached by walking a prototype chain, `obj` is
+/// the PROTOTYPE the getter lives on — bind the original instance stashed by
+/// `resolve_inherited_field` instead. Take() consumes it so the getter body
+/// runs with a clean override.
+unsafe fn class_getter_this(obj: *const ObjectHeader) -> f64 {
+    ACCESSOR_RECEIVER_OVERRIDE
+        .with(|c| c.take())
+        .unwrap_or_else(|| f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits()))
+}
+
 unsafe fn invoke_accessor_getter(get_bits: u64, receiver: f64) -> JSValue {
     let closure = (get_bits & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
     if closure.is_null() {
         return JSValue::undefined();
     }
-    let prev = super::js_implicit_this_set(receiver);
+    // Consume any inherited-receiver override: the getter's `this` must be the
+    // original instance, not the prototype the accessor lives on. Take() clears
+    // it so the getter BODY runs with a fresh override (a nested inherited read
+    // inside the getter gets its own).
+    let eff_receiver = ACCESSOR_RECEIVER_OVERRIDE
+        .with(|c| c.take())
+        .unwrap_or(receiver);
+    let prev = super::js_implicit_this_set(eff_receiver);
     let result_f64 = crate::closure::js_closure_call0(closure);
     super::js_implicit_this_set(prev);
     JSValue::from_bits(result_f64.to_bits())
@@ -3920,9 +3964,7 @@ pub extern "C" fn js_object_get_field_by_name(
                             while depth < 32 {
                                 if let Some(vtable) = reg.get(&cid) {
                                     if let Some(&getter_ptr) = vtable.getters.get(name) {
-                                        let this_f64 = f64::from_bits(
-                                            crate::value::js_nanbox_pointer(obj as i64).to_bits(),
-                                        );
+                                        let this_f64 = class_getter_this(obj);
                                         let f: extern "C" fn(f64) -> f64 =
                                             std::mem::transmute(getter_ptr);
                                         return JSValue::from_bits(f(this_f64).to_bits());
@@ -4186,9 +4228,7 @@ pub extern "C" fn js_object_get_field_by_name(
                                     // Getters take `this` as f64 (NaN-boxed
                                     // POINTER_TAG), matching the codegen
                                     // calling convention for class methods.
-                                    let this_f64: f64 = f64::from_bits(
-                                        crate::value::js_nanbox_pointer(obj as i64).to_bits(),
-                                    );
+                                                                    let this_f64: f64 = class_getter_this(obj);
                                     let f: extern "C" fn(f64) -> f64 =
                                         std::mem::transmute(getter_ptr);
                                     return JSValue::from_bits(f(this_f64).to_bits());

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -7362,6 +7362,21 @@ pub(crate) unsafe fn get_native_module_constant(
         "http2" => match property {
             "constants" => Some(create_sub_namespace("http2.constants")),
             "sensitiveHeaders" => Some(crate::node_http2_constants::sensitive_headers_symbol()),
+            // `Http2ServerRequest` / `Http2ServerResponse` imported as VALUES are
+            // used by libraries purely for `req instanceof Http2ServerRequest`
+            // brand checks (e.g. @hono/node-server distinguishing HTTP/2 from
+            // HTTP/1 requests). Resolve them to callable class values so the
+            // `instanceof` RHS is a function (returns `false` for Perry's HTTP/1
+            // handles) instead of `undefined` — which threw "Right-hand side of
+            // 'instanceof' is not an object" and 400'd every request.
+            "Http2ServerRequest" => Some(bound_native_callable_export_value(
+                "http2",
+                "Http2ServerRequest",
+            )),
+            "Http2ServerResponse" => Some(bound_native_callable_export_value(
+                "http2",
+                "Http2ServerResponse",
+            )),
             // #3905: `import http2 from "node:http2"` — default is the module
             // namespace object.
             "default" => Some(native_namespace_or_create("http2", namespace_obj)),

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -171,7 +171,12 @@ pub(crate) fn resolve_inherited_field(
     // object instead of the instance.
     let receiver = f64::from_bits(crate::value::js_nanbox_pointer(obj_ptr as i64).to_bits());
     let previous_this = super::js_implicit_this_set(receiver);
+    // The recursive `get_field(proto, key)` re-derives the accessor receiver
+    // from `proto`; stash the real instance so an inherited getter binds `this`
+    // to it, not to the prototype.
+    let prev_override = super::field_get_set::accessor_receiver_override_begin(receiver);
     let v = super::js_object_get_field_by_name(proto, key);
+    super::field_get_set::accessor_receiver_override_end(prev_override);
     super::js_implicit_this_set(previous_this);
     if v.bits() == 0x7FFC_0000_0000_0001 {
         // undefined — treat as "not present" so callers fall back cleanly.

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1626,6 +1626,31 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
+    // Small native handles (HTTP IncomingMessage/socket, fetch bodies, etc.)
+    // NaN-boxed as POINTER are NOT heap objects: the well-known-symbol dispatch
+    // above already handled the symbols they expose. Any OTHER symbol read must
+    // return undefined rather than falling through to the pointer-deref paths
+    // below (`symbol_accessor_property` / `own_symbol_property` /
+    // `resolve_explicit_object_prototype_symbol`), which reinterpret the tiny
+    // handle id as an ObjectHeader and read `id + offset` → EXC_BAD_ACCESS.
+    // @hono/node-server reads symbols off the IncomingMessage handle while
+    // adapting it to a web Request. Proxies share the small-id band
+    // (0xF0000..0x100000) but have real symbol semantics, so exclude them.
+    if (bits >> 48) == 0x7FFD {
+        let id = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+        // Only short-circuit values that are NOT real heap objects. A genuine
+        // ObjectHeader can live at a low address in a small program, so gate on
+        // `is_valid_obj_ptr` (validates the GcHeader) rather than the address
+        // band alone — otherwise a symbol read on a low-address object returned
+        // undefined. Proxies (registered small ids) keep their own semantics.
+        if id > 0
+            && id < 0x100000
+            && !crate::object::is_valid_obj_ptr(id as *const u8)
+            && crate::proxy::js_proxy_is_proxy(obj_f64) == 0
+        {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+    }
     if let Some(acc) = accessors::symbol_accessor_property(obj_f64, sym_f64) {
         return accessors::invoke_symbol_accessor_getter(acc.get, obj_f64);
     }

--- a/tests/test_http2_server_request_value.sh
+++ b/tests/test_http2_server_request_value.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `Http2ServerRequest` / `Http2ServerResponse` imported as VALUES from
+# `node:http2` are used by libraries purely for `x instanceof Http2ServerRequest`
+# brand checks (e.g. @hono/node-server distinguishing HTTP/2 from HTTP/1
+# requests). They resolved to `undefined`, so the `instanceof` RHS was not an
+# object and threw "Right-hand side of 'instanceof' is not an object", 400'ing
+# every request. They must be callable class values (so `instanceof` returns
+# `false` for non-HTTP/2 values without throwing).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+import { Http2ServerRequest, Http2ServerResponse } from "node:http2";
+
+if (typeof Http2ServerRequest !== "function") {
+  throw new Error("Http2ServerRequest typeof: " + typeof Http2ServerRequest);
+}
+if (typeof Http2ServerResponse !== "function") {
+  throw new Error("Http2ServerResponse typeof: " + typeof Http2ServerResponse);
+}
+// instanceof must not throw and must be false for ordinary values.
+const someObj: any = { url: "/x" };
+if (someObj instanceof Http2ServerRequest) throw new Error("plain obj matched Http2ServerRequest");
+if ((42 as any) instanceof Http2ServerResponse) throw new Error("number matched Http2ServerResponse");
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: node:http2 Http2ServerRequest/Response are callable for instanceof"

--- a/tests/test_object_literal_getter_this_binding.sh
+++ b/tests/test_object_literal_getter_this_binding.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# An object-literal accessor (`{ get k() {...} }`) is a REGULAR (non-arrow)
+# function: `this` binds dynamically to the receiver at call time, NOT to the
+# object the accessor is defined on. The HIR lowered it with `captures_this:
+# true`, capturing `this` at object-construction time — so an INHERITED read
+# (`Object.create(proto).k`, where the getter lives on `proto`) saw
+# `this === proto` instead of the instance, and `this[k]` / `this.field` came
+# back undefined. @hono/node-server's request prototype
+# (`get method() { return this[incomingKey].method }`) crashed on every request.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+const k = Symbol("k");
+const proto: any = {
+  get method() { return (this as any)[k] ? (this as any)[k].m : "GET"; },
+  get plusOne() { return (this as any).x + 1; },
+};
+// Inherited read: `this` must be the instance, not `proto`.
+const inst: any = Object.create(proto);
+inst[k] = { m: "POST" };
+inst.x = 41;
+if (inst.method !== "POST") throw new Error("inherited symbol this: " + inst.method);
+if (inst.plusOne !== 42) throw new Error("inherited field this: " + inst.plusOne);
+
+// A second instance off the same prototype sees its OWN state (no static capture).
+const inst2: any = Object.create(proto);
+inst2[k] = { m: "PUT" };
+inst2.x = 9;
+if (inst2.method !== "PUT") throw new Error("instance2 method: " + inst2.method);
+if (inst2.plusOne !== 10) throw new Error("instance2 plusOne: " + inst2.plusOne);
+
+// Own (non-inherited) accessor still binds `this` to the object.
+const own: any = { _v: 5, get v() { return (this as any)._v; } };
+if (own.v !== 5) throw new Error("own accessor this: " + own.v);
+
+// Setter `this` also binds to the receiver (inherited).
+const sproto: any = { set val(v: number) { (this as any)._v = v * 2; }, get val() { return (this as any)._v; } };
+const sinst: any = Object.create(sproto);
+sinst.val = 21;
+if (sinst.val !== 42) throw new Error("inherited setter this: " + sinst.val);
+
+// A CLASS getter inherited through `Object.create(instance)` must also bind
+// `this` to the leaf object (the runtime walks the prototype chain and the
+// vtable getter would otherwise observe the prototype instance).
+class A { v = 0; get x() { return (this as any).v + 100; } }
+const aInst: any = new A();
+const leaf: any = Object.create(aInst);
+leaf.v = 5;
+if (leaf.x !== 105) throw new Error("inherited class getter this: " + leaf.x);
+
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: object-literal getter binds this dynamically (inherited + own)"


### PR DESCRIPTION
Four fixes that together let a real **Hono + @hono/node-server** app serve requests natively. The app previously booted and listened, but every request crashed / 400'd / 500'd.

## Fixes
1. **HIR / object accessors** — an object-literal getter/setter (`{ get k(){…} }`) is a REGULAR (non-arrow) function: `this` binds dynamically to the receiver at call time. Lowering emitted `captures_this: true` (mirroring `uses_this`), capturing `this` at object-construction time — so an INHERITED read (`Object.create(proto).k`) saw `this === proto` instead of the instance. @hono/node-server's request prototype (`get method(){ return this[incomingKey].method }`) crashed because `this[incomingKey]` was undefined on the prototype. Bind dynamically like `Object.defineProperty` getters already did.

2. **runtime / prototype walk** — when an inherited read resolves a class (vtable) getter, the recursive `get_field(proto, key)` re-derived the getter's `this` from the prototype. Thread the original receiver through an override consumed at getter invocation, so inherited class getters also bind `this` to the instance.

3. **runtime / node:http2** — `Http2ServerRequest`/`Http2ServerResponse` imported as values resolved to `undefined`; libraries use them only for `x instanceof Http2ServerRequest` brand checks, so the `instanceof` RHS threw "Right-hand side of 'instanceof' is not an object" and 400'd every request. Resolve them to callable class values (instanceof → false for HTTP/1 handles).

4. **runtime / symbol** — a symbol read on a small native handle (HTTP IncomingMessage, etc.) dereferenced the handle id as an ObjectHeader (EXC_BAD_ACCESS). Return undefined for handle/non-object pointers (gated on `is_valid_obj_ptr` so real low-address objects are unaffected); proxies keep their own semantics.

## Result
A real Hono+Drizzle+mysql2+Stripe+zod app now compiles to native, boots, and serves: `GET /healthz` → `{"ok":true}` 200, `/` → 302, `/admin` → 401.

## Tests
- `tests/test_object_literal_getter_this_binding.sh` — inherited+own getters, setters, inherited class getter.
- `tests/test_http2_server_request_value.sh` — http2 class values for instanceof.

Existing accessor/object/cross-module/namespace tests remain green.