### PR TITLE
runtime: assimilate thenables in Promise aggregation

### DIFF
--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -951,7 +951,6 @@ fn promise_all_reject_direct(
 pub extern "C" fn js_promise_race(promises_arr: *const crate::array::ArrayHeader) -> *mut Promise {
     use crate::array::{js_array_get_f64, js_array_length};
     use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
-    use crate::value::js_nanbox_get_pointer;
 
     let result_promise = js_promise_new();
 
@@ -973,28 +972,14 @@ pub extern "C" fn js_promise_race(promises_arr: *const crate::array::ArrayHeader
     let shared_reject = js_closure_alloc(promise_race_reject_handler as *const u8, 1);
     js_closure_set_capture_ptr(shared_reject, 0, result_promise as i64);
 
-    // For each promise, attach resolve/reject handlers that settle the result promise.
-    // Per the spec, even when an input promise is already settled we MUST route the
-    // resolution through the microtask queue (by registering `.then` handlers) rather
-    // than calling js_promise_resolve synchronously.  The synchronous short-circuit was
-    // causing race / any results to appear too early in the output when compared against
-    // Node's microtask-ordered output.
+    // Normalize each input with PromiseResolve semantics before attaching handlers.
+    // This keeps plain values asynchronous and gives thenables a chance to settle
+    // through the same guarded job path used by Promise.all/allSettled.
     for i in 0..count {
-        let promise_f64 = adapt_foreign_promise_value(js_array_get_f64(promises_arr, i));
-        // Discriminate via GC-header obj_type — string/bigint NaN-boxed
-        // values would otherwise pass through pointer extraction and crash
-        // js_promise_then.
-        if js_value_is_promise(promise_f64) == 0 {
-            // Non-promise value — wrap as an already-resolved promise so the
-            // resolution goes through the normal microtask path.
-            let wrapped = js_promise_resolved(promise_f64);
-            js_promise_then(wrapped, shared_resolve, shared_reject);
-            continue;
-        }
-        let promise_ptr = js_nanbox_get_pointer(promise_f64) as *mut Promise;
-
-        // Attach handlers via then — if the input is already settled this will
-        // push a microtask rather than resolving result_promise synchronously.
+        let promise_ptr = match promise_resolve_for_combinator(js_array_get_f64(promises_arr, i)) {
+            Ok(promise) => promise,
+            Err(reason) => js_promise_rejected(reason),
+        };
         js_promise_attach_handlers(promise_ptr, shared_resolve, shared_reject);
     }
 
@@ -1352,7 +1337,6 @@ pub extern "C" fn js_promise_any(promises_arr: *const crate::array::ArrayHeader)
     use crate::closure::{
         js_closure_alloc, js_closure_set_capture_f64, js_closure_set_capture_ptr,
     };
-    use crate::value::js_nanbox_get_pointer;
 
     let result_promise = js_promise_new();
 
@@ -1405,20 +1389,10 @@ pub extern "C" fn js_promise_any(promises_arr: *const crate::array::ArrayHeader)
     js_closure_set_capture_ptr(shared_fulfill, 1, state_arr as i64);
 
     for i in 0..count {
-        let promise_f64 = adapt_foreign_promise_value(js_array_get_f64(promises_arr, i));
-        // Discriminate via GC-header obj_type — string/bigint NaN-boxed
-        // values would otherwise pass through pointer extraction and crash
-        // js_promise_then.
-        if js_value_is_promise(promise_f64) == 0 {
-            // Non-promise value — treat as fulfilled, settle immediately if not yet settled
-            let already_settled = js_array_get_f64(state_arr, 1);
-            if already_settled == 0.0 {
-                js_array_set_f64(state_arr, 1, 1.0);
-                js_promise_resolve(result_promise, promise_f64);
-            }
-            return result_promise;
-        }
-        let promise_ptr = js_nanbox_get_pointer(promise_f64) as *mut Promise;
+        let promise_ptr = match promise_resolve_for_combinator(js_array_get_f64(promises_arr, i)) {
+            Ok(promise) => promise,
+            Err(reason) => js_promise_rejected(reason),
+        };
 
         let reject_closure = js_closure_alloc(promise_any_reject_handler as *const u8, 4);
         js_closure_set_capture_ptr(reject_closure, 0, result_promise as i64);

--- a/test-parity/node-suite/globals/promise-aggregation-thenables.ts
+++ b/test-parity/node-suite/globals/promise-aggregation-thenables.ts
@@ -1,0 +1,83 @@
+const events: string[] = [];
+
+function show(value: unknown): string {
+  if (typeof value === "object" && value && "marker" in value) {
+    return `object:${(value as { marker: string }).marker}`;
+  }
+  return String(value);
+}
+
+let raceCalls = 0;
+const raceThenable = {
+  marker: "race-thenable",
+  then(resolve: (value: string) => void) {
+    raceCalls++;
+    events.push(`race.then:${raceCalls}`);
+    resolve("race-value");
+    resolve("race-ignored");
+  },
+};
+
+async function observeRace() {
+  try {
+    const value = await Promise.race([raceThenable]);
+    events.push(`race.value:${show(value)}`);
+  } catch (reason) {
+    events.push(`race.reason:${show(reason)}`);
+  }
+}
+
+const raceDone = observeRace();
+events.push(`race.calls.after:${raceCalls}`);
+
+let anyRejectCalls = 0;
+const anyRejectThenable = {
+  marker: "any-reject-thenable",
+  then(resolve: (value: string) => void, reject: (reason: string) => void) {
+    anyRejectCalls++;
+    events.push(`any.reject.then:${anyRejectCalls}`);
+    reject("thenable-reject");
+    resolve("thenable-ignored");
+  },
+};
+
+async function observeAnyReject() {
+  try {
+    const value = await Promise.any([Promise.reject("native-reject"), anyRejectThenable]);
+    events.push(`any.reject.value:${show(value)}`);
+  } catch (reason: any) {
+    events.push(`any.reject.reason:${reason.name}:${reason.errors.join("|")}`);
+  }
+}
+
+const anyRejectDone = observeAnyReject();
+events.push(`any.reject.calls.after:${anyRejectCalls}`);
+
+let anyFulfillCalls = 0;
+const anyFulfillThenable = {
+  marker: "any-fulfill-thenable",
+  then(resolve: (value: string) => void, reject: (reason: string) => void) {
+    anyFulfillCalls++;
+    events.push(`any.fulfill.then:${anyFulfillCalls}`);
+    resolve("thenable-fulfill");
+    reject("thenable-ignored");
+  },
+};
+
+async function observeAnyFulfill() {
+  try {
+    const value = await Promise.any([Promise.reject("native-reject-2"), anyFulfillThenable]);
+    events.push(`any.fulfill.value:${show(value)}`);
+  } catch (reason: any) {
+    events.push(`any.fulfill.reason:${reason.name}`);
+  }
+}
+
+const anyFulfillDone = observeAnyFulfill();
+events.push(`any.fulfill.calls.after:${anyFulfillCalls}`);
+
+await raceDone;
+await anyRejectDone;
+await anyFulfillDone;
+
+console.log(events.join("\n"));


### PR DESCRIPTION
Refs #4521

Summary:
- Route Promise.race and Promise.any inputs through the existing PromiseResolve combinator helper before attaching aggregation handlers.
- Preserve asynchronous handling for plain values while allowing thenables to settle through the guarded thenable job path already used by Promise.all/allSettled.
- Add a Node parity fixture covering Promise.race and Promise.any thenables, double resolve/reject guards, AggregateError ordering, and non-synchronous then calls.

Validation:
- cargo fmt -p perry-runtime
- cargo check -q -p perry-runtime
- npx -y node@22 --experimental-strip-types test-parity/node-suite/globals/promise-aggregation-thenables.ts
- npx -y node@26 --experimental-strip-types test-parity/node-suite/globals/promise-aggregation-thenables.ts
- env RUSTC_WRAPPER= TMPDIR=/tmp CARGO_BUILD_JOBS=1 cargo build -q -p perry -p perry-runtime -p perry-stdlib
- env PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry compile --no-cache test-parity/node-suite/globals/promise-aggregation-thenables.ts -o /tmp/perry-promise-aggregation-thenables && /tmp/perry-promise-aggregation-thenables
- git diff --check