### PR TITLE
fix(hir): object shorthand resolves a cross-module imported binding

### DIFF
--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -551,6 +551,25 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                         (Expr::LocalGet(local_id), ty)
                     } else if let Some(func_id) = ctx.lookup_func(&name) {
                         (Expr::FuncRef(func_id), Type::Any)
+                    } else if let Some(orig_name) = ctx.lookup_imported_func(&name) {
+                        // An imported binding (`import { db } from "./client.js"`)
+                        // used as a shorthand property (`{ db }`). Resolve it to
+                        // the same `ExternFuncRef` the explicit form `{ db: db }`
+                        // produces — otherwise the property was silently dropped
+                        // (`{ db }` lowered to an EMPTY object), so e.g.
+                        // `getContext()` returned a context with `db === undefined`.
+                        let (param_types, return_type) = ctx
+                            .lookup_extern_func_types(orig_name)
+                            .map(|(p, r)| (p.clone(), r.clone()))
+                            .unwrap_or_else(|| (Vec::new(), Type::Any));
+                        (
+                            Expr::ExternFuncRef {
+                                name: orig_name.to_string(),
+                                param_types,
+                                return_type,
+                            },
+                            Type::Any,
+                        )
                     } else if ctx.lookup_class(&name).is_some() {
                         (Expr::ClassRef(name.clone()), Type::Any)
                     } else if let Some(value) = builtin_global_value_expr(ctx, &name) {
@@ -731,6 +750,20 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                             Expr::LocalGet(local_id)
                         } else if let Some(func_id) = ctx.lookup_func(&name) {
                             Expr::FuncRef(func_id)
+                        } else if let Some(orig_name) = ctx.lookup_imported_func(&name) {
+                            // Imported binding used as shorthand in a spread/method
+                            // object literal (`{ db, ...rest }` — getContext's exact
+                            // shape). Resolve to the `ExternFuncRef` value rather
+                            // than dropping the property (which left `db` undefined).
+                            let (param_types, return_type) = ctx
+                                .lookup_extern_func_types(orig_name)
+                                .map(|(p, r)| (p.clone(), r.clone()))
+                                .unwrap_or_else(|| (Vec::new(), Type::Any));
+                            Expr::ExternFuncRef {
+                                name: orig_name.to_string(),
+                                param_types,
+                                return_type,
+                            }
                         } else if ctx.lookup_class(&name).is_some() {
                             Expr::ClassRef(name.clone())
                         } else if let Some(value) = builtin_global_value_expr(ctx, &name) {
@@ -1007,6 +1040,18 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                         Expr::FuncRef(func_id)
                     } else if let Some(local_id) = ctx.lookup_local(&name) {
                         Expr::LocalGet(local_id)
+                    } else if let Some(orig_name) = ctx.lookup_imported_func(&name) {
+                        // Imported binding used as a shorthand property — resolve
+                        // to its `ExternFuncRef` value instead of dropping it.
+                        let (param_types, return_type) = ctx
+                            .lookup_extern_func_types(orig_name)
+                            .map(|(p, r)| (p.clone(), r.clone()))
+                            .unwrap_or_else(|| (Vec::new(), Type::Any));
+                        Expr::ExternFuncRef {
+                            name: orig_name.to_string(),
+                            param_types,
+                            return_type,
+                        }
                     } else if ctx.lookup_class(&name).is_some() {
                         Expr::ClassRef(name.clone())
                     } else if let Some(value) = builtin_global_value_expr(ctx, &name) {

--- a/tests/test_object_shorthand_imported_binding.sh
+++ b/tests/test_object_shorthand_imported_binding.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# An object-literal SHORTHAND property whose name is a cross-module imported
+# binding (`import { db } from "./client.js"; const ctx = { db, ...rest }`) must
+# resolve to the imported value. The HIR shorthand-folding only checked
+# local/func/class/builtin bindings, so an imported name fell through and the
+# property was silently DROPPED — `{ db }` lowered to an empty object, so
+# `getContext().db` was `undefined` and every `db.query.*` read crashed
+# ("Cannot read properties of undefined"). Covers all three object-literal
+# lowering paths: closed-shape, spread/method IIFE, and the computed-key path.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/client.ts" <<'TS'
+export const db = { tag: "DBINST", q: () => 7 };
+export const helper = () => "H";
+TS
+cat >"$TMPDIR/main.ts" <<'TS'
+import { db, helper } from "./client.js";
+
+// 1) closed-shape shorthand
+const a: any = { db };
+if (a.db?.tag !== "DBINST") throw new Error("closed-shape: " + JSON.stringify(a.db));
+
+// 2) shorthand + sibling (still closed-shape)
+const b: any = { db, n: 1 };
+if (b.db?.tag !== "DBINST" || b.n !== 1) throw new Error("sibling: " + JSON.stringify(b));
+
+// 3) shorthand + spread (the getContext shape — IIFE path)
+const rest = { x: 9 };
+const c: any = { db, helper, ...rest };
+if (c.db?.tag !== "DBINST") throw new Error("spread db: " + JSON.stringify(c.db));
+if (typeof c.helper !== "function" || c.helper() !== "H") throw new Error("spread helper");
+if (c.x !== 9) throw new Error("spread x: " + c.x);
+
+// 4) shorthand + computed key (computed-key path)
+const key = "dyn";
+const d: any = { db, [key]: 5 };
+if (d.db?.tag !== "DBINST" || d.dyn !== 5) throw new Error("computed: " + JSON.stringify(d));
+
+// the imported value is fully usable
+if (a.db.q() !== 7) throw new Error("method call: " + a.db.q());
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/main.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: object shorthand resolves a cross-module imported binding"


### PR DESCRIPTION
An object-literal shorthand property whose name is a cross-module imported binding (`import { db } from "./client.js"; const ctx = { db, ...rest }`) was silently **dropped** — the shorthand-folding only resolved local / func / class / builtin names, so an imported name fell through and the property never made it into the object (`{ db }` lowered to an empty object).

A common DI pattern broke: `getContext() = { db, ...integrations }` returned a context whose `db` was `undefined`, so every `db.query.*` / `db.select()` read crashed with "Cannot read properties of undefined". The explicit form `{ db: db }` already worked (its value lowers via `lower_expr`, which resolves imports to `ExternFuncRef`).

Resolve an imported shorthand name to the same `ExternFuncRef` in all three object-literal lowering paths (closed-shape fold, spread/method IIFE, computed-key). Test: `tests/test_object_shorthand_imported_binding.sh`.