### PR TITLE
Support generic Array.prototype.fill on array-like receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1136 — generic `Array.prototype.fill` over array-like receivers
+
+`Array.prototype.fill.call(arrayLike, …)` (and bound/`.apply` forms) now mutates
+a generic array-like receiver in place instead of falling through to the
+member-call path that only handled real arrays. A dedicated
+`js_array_fill_generic` runtime helper writes back to the *original* receiver
+(rather than a materialized clone), wired through a new `array`/`fill_generic`
+`NativeMethodCall` lowering in `try_arraylike_receiver_method` — sitting beside
+the existing generic `copyWithin` mutator and the #4597 read-only generic
+engine. Plain objects with a `length` + indexed keys, and real arrays, both fill
+correctly (`{length:3,0:'a',1:'b',2:'c'}` → `a x x`; `[1,2,3,4].fill(9,1,3)` →
+`[1,9,9,4]`). Adds `node-suite/globals/array-generic-fill.ts`.
+
 ## v0.5.1135 — `net.Socket` instanceof for native handles + explicit Tokio runtimes
 
 Registers the ext-net socket-handle probe so dynamic/static `instanceof

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1135
+**Current Version:** 0.5.1136
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1135"
+version = "0.5.1136"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1135"
+version = "0.5.1136"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1135"
+version = "0.5.1136"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1135"
+version = "0.5.1136"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1135"
+version = "0.5.1136"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -2117,6 +2117,41 @@ pub(crate) fn lower_native_method_call(
         );
     }
 
+    if module == "array" && method == "fill_generic" {
+        let recv_box = lower_expr(ctx, recv)?;
+        let mut lowered: Vec<String> = Vec::with_capacity(args.len());
+        for arg in args {
+            lowered.push(lower_expr(ctx, arg)?);
+        }
+        let undefined = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+        let value = lowered
+            .first()
+            .cloned()
+            .unwrap_or_else(|| undefined.clone());
+        let (has_start, start) = if let Some(start) = lowered.get(1) {
+            ("1".to_string(), start.clone())
+        } else {
+            ("0".to_string(), undefined.clone())
+        };
+        let (has_end, end) = if let Some(end) = lowered.get(2) {
+            ("1".to_string(), end.clone())
+        } else {
+            ("0".to_string(), undefined)
+        };
+        return Ok(ctx.block().call(
+            DOUBLE,
+            "js_array_fill_generic",
+            &[
+                (DOUBLE, &recv_box),
+                (DOUBLE, &value),
+                (I32, &has_start),
+                (DOUBLE, &start),
+                (I32, &has_end),
+                (DOUBLE, &end),
+            ],
+        ));
+    }
+
     if module == "array" && method == "push_spread" {
         // Refs #488 drizzle-sqlite: `arr.push(...src)` shape. Pre-fix
         // this had no codegen arm — the catch-all at the end of this

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -116,6 +116,11 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     module.declare_function("js_array_forEach", VOID, &[I64, I64]);
     module.declare_function("js_array_fill", I64, &[I64, DOUBLE]);
     module.declare_function("js_array_fill_range", I64, &[I64, DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_array_fill_generic",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, I32, DOUBLE, I32, DOUBLE],
+    );
     module.declare_function("js_array_delete", I32, &[I64, I32]);
     // Closes #304: `arr.length = N` truncate / extend.
     module.declare_function("js_array_set_length", VOID, &[I64, DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1307,9 +1307,11 @@ pub(super) fn try_builtin_prototype_method_apply_call(
     // field and throws "value is not a function". Build the dedicated
     // `Expr::Array*` variant directly so the receiver flows to `js_array_*`
     // regardless of its static type — the runtime materializes the array-like
-    // (see `normalize_array_receiver`). Only the read-only/returning methods are
-    // handled here; mutators and unsupported shapes fall through to the member
-    // call below (unchanged behavior).
+    // (see `normalize_array_receiver`). Most handled methods are
+    // read-only/returning; `fill` has a dedicated generic mutator helper because
+    // it must write back to the original receiver rather than a materialized
+    // clone. Unsupported mutators fall through to the member call below
+    // (unchanged behavior).
     if let Some(folded) =
         try_arraylike_receiver_method(ctx, method_prop.sym.as_ref(), &this_arg.expr, &rest_args)?
     {
@@ -1336,9 +1338,10 @@ pub(super) fn try_builtin_prototype_method_apply_call(
 /// `thisArg`; `rest_args` are the post-`thisArg` positional arguments (already
 /// expanded from the `.apply` array if applicable).
 ///
-/// Returns `Some(expr)` for a supported read-only/returning method, or `None`
-/// for mutators / unsupported methods (caller falls back to the synthesized
-/// member call). The chosen set mirrors the runtime methods that route through
+/// Returns `Some(expr)` for a supported read-only/returning method, plus
+/// dedicated generic `fill` / `copyWithin` mutator paths, or `None` for other
+/// mutators / unsupported methods (caller falls back to the synthesized member
+/// call). The read-only set mirrors the runtime methods that route through
 /// `normalize_array_receiver`.
 fn try_arraylike_receiver_method(
     ctx: &mut LoweringContext,
@@ -1349,6 +1352,23 @@ fn try_arraylike_receiver_method(
     // Any spread in the positional args defeats static argument expansion.
     if rest_args.iter().any(|a| a.spread.is_some()) {
         return Ok(None);
+    }
+    // `fill` mutates in place but is generic over an array-like receiver; route
+    // to the dedicated generic mutator helper (`js_array_fill_generic`), which
+    // writes back to the original receiver rather than a materialized clone.
+    if method == "fill" {
+        let object = Box::new(lower_expr(ctx, receiver)?);
+        let mut args = Vec::with_capacity(rest_args.len());
+        for a in rest_args {
+            args.push(lower_expr(ctx, &a.expr)?);
+        }
+        return Ok(Some(Expr::NativeMethodCall {
+            module: "array".to_string(),
+            class_name: None,
+            object: Some(object),
+            method: "fill_generic".to_string(),
+            args,
+        }));
     }
     // `copyWithin` mutates in place but is generic over an array-like receiver;
     // keep the dedicated value-receiver lowering.

--- a/crates/perry-runtime/src/array/concat_reverse.rs
+++ b/crates/perry-runtime/src/array/concat_reverse.rs
@@ -1,6 +1,71 @@
 //! concat / reverse / fill.
 use super::*;
+use crate::JSValue;
 use std::ptr;
+
+fn fill_to_number(value: f64) -> f64 {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_any_string() {
+        let ptr = crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader;
+        if ptr.is_null() || (ptr as usize) < 0x1000 {
+            return f64::NAN;
+        }
+        let s = crate::string::string_as_str(ptr).trim();
+        if s.is_empty() {
+            0.0
+        } else {
+            s.parse::<f64>().unwrap_or(f64::NAN)
+        }
+    } else {
+        jsval.to_number()
+    }
+}
+
+fn fill_to_length(value: f64) -> u32 {
+    let number = fill_to_number(value);
+    if number.is_nan() || number <= 0.0 {
+        0
+    } else if !number.is_finite() || number > u32::MAX as f64 {
+        u32::MAX
+    } else {
+        number as u32
+    }
+}
+
+fn fill_relative_index(value: f64, len: i64, default_value: i64) -> i64 {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_undefined() {
+        return default_value;
+    }
+    let number = fill_to_number(value);
+    if number.is_nan() {
+        return 0;
+    }
+    let mut index = if number.is_infinite() {
+        if number > 0.0 {
+            len
+        } else {
+            -len
+        }
+    } else {
+        number as i64
+    };
+    if index < 0 {
+        index += len;
+        if index < 0 {
+            return 0;
+        }
+    }
+    if index > len {
+        len
+    } else {
+        index
+    }
+}
+
+fn throw_fill_nullish_receiver() -> ! {
+    crate::collection_iter::throw_type_error("Cannot convert undefined or null to object")
+}
 
 /// Append all elements from source array to destination array
 /// Returns the (possibly reallocated) destination array pointer
@@ -263,4 +328,75 @@ pub extern "C" fn js_array_fill_range(
         rebuild_array_layout(arr);
         arr
     }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_fill_generic(
+    receiver: f64,
+    value: f64,
+    has_start: i32,
+    start: f64,
+    has_end: i32,
+    end: f64,
+) -> f64 {
+    let receiver_value = JSValue::from_bits(receiver.to_bits());
+    if receiver_value.is_null() || receiver_value.is_undefined() {
+        throw_fill_nullish_receiver();
+    }
+
+    if receiver_value.is_pointer() {
+        let raw = (receiver.to_bits() & crate::value::POINTER_MASK) as usize;
+        if raw >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let obj_type = unsafe {
+                let hdr =
+                    (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                (*hdr).obj_type
+            };
+            if obj_type == crate::gc::GC_TYPE_ARRAY || obj_type == crate::gc::GC_TYPE_LAZY_ARRAY {
+                let arr = raw as *mut ArrayHeader;
+                let result = if has_start != 0 || has_end != 0 {
+                    let start_value = if has_start != 0 { start } else { 0.0 };
+                    let end_value =
+                        if has_end != 0 && !JSValue::from_bits(end.to_bits()).is_undefined() {
+                            end
+                        } else {
+                            f64::INFINITY
+                        };
+                    js_array_fill_range(arr, value, start_value, end_value)
+                } else {
+                    js_array_fill(arr, value)
+                };
+                return f64::from_bits(JSValue::pointer(result as *mut u8).bits());
+            }
+            if obj_type == crate::gc::GC_TYPE_OBJECT || obj_type == crate::gc::GC_TYPE_CLOSURE {
+                let obj = raw as *mut crate::object::ObjectHeader;
+                let length_key = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+                let len_value = crate::object::js_object_get_field_by_name_f64(obj, length_key);
+                let len = fill_to_length(len_value) as i64;
+                if len == 0 {
+                    return receiver;
+                }
+                let start_index = if has_start != 0 {
+                    fill_relative_index(start, len, 0)
+                } else {
+                    0
+                };
+                let end_index = if has_end != 0 {
+                    fill_relative_index(end, len, len)
+                } else {
+                    len
+                };
+                if start_index >= end_index {
+                    return receiver;
+                }
+                for index in start_index..end_index {
+                    crate::object::js_object_set_index_polymorphic(raw as i64, index as f64, value);
+                }
+                return receiver;
+            }
+        }
+    }
+
+    let object = crate::object::js_object_coerce(receiver);
+    js_array_fill_generic(object, value, has_start, start, has_end, end)
 }

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -28,7 +28,8 @@ pub use self::alloc::{
     js_array_from_arraylike_holey_value, js_array_from_f64,
 };
 pub use self::concat_reverse::{
-    js_array_concat, js_array_concat_new, js_array_fill, js_array_fill_range, js_array_reverse,
+    js_array_concat, js_array_concat_new, js_array_fill, js_array_fill_generic,
+    js_array_fill_range, js_array_reverse,
 };
 pub use self::flat_clone::{
     js_array_clone, js_array_entries, js_array_flat, js_array_flat_depth, js_array_keys,

--- a/test-parity/node-suite/globals/array-generic-fill.ts
+++ b/test-parity/node-suite/globals/array-generic-fill.ts
@@ -1,0 +1,39 @@
+const hasOwn = Object.prototype.hasOwnProperty;
+
+function slot(value: any): string {
+  return value === undefined ? "undefined" : String(value);
+}
+
+function dump(label: string, value: any): void {
+  console.log(
+    `${label}.values:${slot(value[0])}|${slot(value[1])}|${slot(value[2])}|${slot(value[3])}|${slot(value[4])}`,
+  );
+  console.log(
+    `${label}.has:${hasOwn.call(value, "0")}|${hasOwn.call(value, "1")}|${hasOwn.call(value, "2")}|${hasOwn.call(value, "3")}|${hasOwn.call(value, "4")}`,
+  );
+  console.log(`${label}.length:${value.length}`);
+}
+
+const rangeReceiver: any = { 0: "a", 2: "c", 4: "e", length: 5 };
+const rangeReturned = Array.prototype.fill.call(rangeReceiver, "x", 1, -1);
+console.log(`range.same:${rangeReturned === rangeReceiver}`);
+dump("range", rangeReceiver);
+
+const negativeReceiver: any = { 0: "a", 1: "b", 2: "c", length: 3 };
+Array.prototype.fill.call(negativeReceiver, "z", -2);
+dump("negative", negativeReceiver);
+
+const infiniteReceiver: any = { length: 4 };
+Array.prototype.fill.call(infiniteReceiver, "q", -Infinity, Infinity);
+dump("infinite", infiniteReceiver);
+
+const stringCoercedReceiver: any = { 0: "a", 3: "d", length: "4" };
+Array.prototype.fill.call(stringCoercedReceiver, "s", "1", "3");
+dump("string", stringCoercedReceiver);
+
+try {
+  Array.prototype.fill.call(null, "n");
+  console.log("nullish:no-throw");
+} catch (err: any) {
+  console.log(`nullish:${err.name}`);
+}


### PR DESCRIPTION
Addresses a focused slice of #4597.

What changed:
- Lower borrowed `Array.prototype.fill.call/apply(arrayLike, ...)` to a dedicated generic array helper instead of the normal member-dispatch fallback.
- Add a runtime helper that rejects nullish receivers, reads array-like `length`, normalizes `start`/`end` including numeric strings and infinities, writes indexed properties on object/function receivers, and returns the original receiver.
- Keep real arrays on the existing `fill`/`fill_range` runtime path.

Validation:
- `npx -y node@22 --experimental-strip-types test-parity/node-suite/globals/array-generic-fill.ts`
- `npx -y node@26 --experimental-strip-types test-parity/node-suite/globals/array-generic-fill.ts`
- `env RUSTC_WRAPPER= TMPDIR=/tmp CARGO_BUILD_JOBS=1 cargo check -q -p perry-hir -p perry-codegen -p perry-runtime`
- `env RUSTC_WRAPPER= TMPDIR=/tmp CARGO_BUILD_JOBS=1 cargo build -q -p perry -p perry-runtime -p perry-stdlib`
- `env PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry compile --no-cache test-parity/node-suite/globals/array-generic-fill.ts -o /tmp/perry-array-generic-fill && /tmp/perry-array-generic-fill`
- `git diff --check`
