### PR TITLE
fix(runtime): dispatch Reflect proxy descriptors

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1900,6 +1900,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ReflectApply { .. }
         | Expr::ReflectConstruct { .. }
         | Expr::ReflectDefineProperty { .. }
+        | Expr::ReflectGetOwnPropertyDescriptor { .. }
         | Expr::ReflectGetPrototypeOf(..)
         | Expr::ReflectSetPrototypeOf { .. }
         | Expr::ReflectIsExtensible(..)

--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -534,6 +534,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 &[(DOUBLE, &t), (DOUBLE, &k), (DOUBLE, &d)],
             ))
         }
+        Expr::ReflectGetOwnPropertyDescriptor { target, key } => {
+            let t = lower_expr(ctx, target)?;
+            let k = lower_expr(ctx, key)?;
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_reflect_get_own_property_descriptor",
+                &[(DOUBLE, &t), (DOUBLE, &k)],
+            ))
+        }
         Expr::ReflectSetPrototypeOf { target, proto } => {
             // #2761: Reflect-specific boolean result (false on rejected change)
             // + TypeError on bad args, distinct from Object.setPrototypeOf.

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -272,6 +272,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE],
     );
+    module.declare_function(
+        "js_reflect_get_own_property_descriptor",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     module.declare_function("js_reflect_get_prototype_of", DOUBLE, &[DOUBLE]);
     module.declare_function("js_reflect_set_prototype_of", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_reflect_is_extensible", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2344,6 +2344,10 @@ pub enum Expr {
         key: Box<Expr>,
         descriptor: Box<Expr>,
     },
+    ReflectGetOwnPropertyDescriptor {
+        target: Box<Expr>,
+        key: Box<Expr>,
+    },
     ReflectGetPrototypeOf(Box<Expr>),
     /// #2761: `Reflect.setPrototypeOf(target, proto)` — returns a boolean
     /// (false when rejected), unlike `Object.setPrototypeOf` which returns the

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1172,18 +1172,13 @@ pub(super) fn try_native_module_methods(
                             return Ok(Ok(Expr::ReflectGetPrototypeOf(Box::new(target))));
                         }
                         "getOwnPropertyDescriptor" => {
-                            // `Reflect.getOwnPropertyDescriptor(target, key)` is the
-                            // ordinary `[[GetOwnProperty]]` — identical to
-                            // `Object.getOwnPropertyDescriptor` for non-Proxy targets.
-                            // Without this arm it fell through to a generic call that
-                            // wasn't callable ("value is not a function").
                             let mut it = args.into_iter();
                             let target = it.next().unwrap_or(Expr::Undefined);
                             let key = it.next().unwrap_or(Expr::Undefined);
-                            return Ok(Ok(Expr::ObjectGetOwnPropertyDescriptor(
-                                Box::new(target),
-                                Box::new(key),
-                            )));
+                            return Ok(Ok(Expr::ReflectGetOwnPropertyDescriptor {
+                                target: Box::new(target),
+                                key: Box::new(key),
+                            }));
                         }
                         "defineMetadata" => {
                             let (key, value, target, property_key) = take_reflect_kvtp_args(args);

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -600,6 +600,7 @@ impl SH for Expr {
             Expr::ReflectApply { func, this_arg, args, } => { tag(h, 438); func.as_ref().hash(h); this_arg.as_ref().hash(h); args.as_ref().hash(h); }
             Expr::ReflectConstruct { target, args, new_target } => { tag(h, 439); target.as_ref().hash(h); args.as_ref().hash(h); new_target.as_ref().hash(h); }
             Expr::ReflectDefineProperty { target, key, descriptor, } => { tag(h, 440); target.as_ref().hash(h); key.as_ref().hash(h); descriptor.as_ref().hash(h); }
+            Expr::ReflectGetOwnPropertyDescriptor { target, key } => { tag(h, 12505); target.as_ref().hash(h); key.as_ref().hash(h); }
             Expr::ReflectGetPrototypeOf(e) => { tag(h, 441); e.as_ref().hash(h); }
             Expr::ReflectSetPrototypeOf { target, proto } => { tag(h, 12230); target.as_ref().hash(h); proto.as_ref().hash(h); }
             Expr::ReflectIsExtensible(e) => { tag(h, 12048); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1681,6 +1681,10 @@ where
             f(target);
             f(key);
         }
+        Expr::ReflectGetOwnPropertyDescriptor { target, key } => {
+            f(target);
+            f(key);
+        }
         Expr::ReflectSet { target, key, value } => {
             f(target);
             f(key);

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1652,6 +1652,10 @@ where
             f(target);
             f(key);
         }
+        Expr::ReflectGetOwnPropertyDescriptor { target, key } => {
+            f(target);
+            f(key);
+        }
         Expr::ReflectSet { target, key, value } => {
             f(target);
             f(key);

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -16,17 +16,21 @@
 //! HIR lowering time, which route through the entry points here.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::closure::{js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3};
 
 mod json;
+mod metadata;
 mod reflect;
 
 pub(crate) use json::{
     js_proxy_checked_target, js_proxy_checked_target_for_is_array, js_proxy_own_keys_for_json,
 };
-pub use reflect::{js_reflect_delete, js_reflect_get, js_reflect_has, js_reflect_set};
+pub use reflect::{
+    js_reflect_delete, js_reflect_get, js_reflect_get_own_property_descriptor, js_reflect_has,
+    js_reflect_set,
+};
 
 /// A single Proxy registry entry.
 #[repr(C)]
@@ -304,17 +308,35 @@ fn throw_type_error(msg: &str) -> f64 {
     crate::exception::js_throw(boxed)
 }
 
+fn reflect_value_is_symbol(value: f64) -> bool {
+    let bits = value.to_bits();
+    (bits >> 48) == (POINTER_TAG >> 48)
+        && (bits & POINTER_MASK) >= 0x1_0000_0000
+        && unsafe { crate::symbol::js_is_symbol(value) != 0 }
+}
+
 /// Is `value` a Reflect-acceptable object? Heap objects, class refs (callable
 /// constructors), and proxies all count. Primitives / null / undefined do not.
 fn reflect_value_is_object(value: f64) -> bool {
     if lookup(value).is_some() {
         return true;
     }
+    let bits = value.to_bits();
+    let top16 = bits >> 48;
+    if top16 == (POINTER_TAG >> 48) {
+        let lower48 = bits & POINTER_MASK;
+        if lower48 < 0x1_0000_0000 {
+            return false;
+        }
+        if reflect_value_is_symbol(value) {
+            return false;
+        }
+    }
     if crate::object::js_value_is_heap_object(value) {
         return true;
     }
     // Class refs (INT32-tagged constructors) are callable objects.
-    (value.to_bits() >> 48) == 0x7FFE
+    top16 == 0x7FFE
 }
 
 /// `CreateListFromArrayLike(value)` — collect indexed `0..length` properties of
@@ -808,6 +830,10 @@ fn prototype_of_for_set(value: f64) -> Option<f64> {
     } else {
         Some(proto)
     }
+}
+
+fn reflect_target_get_prototype_of(value: f64) -> f64 {
+    prototype_of_for_set(value).unwrap_or_else(|| crate::object::js_object_get_prototype_of(value))
 }
 
 fn call_setter_with_receiver(setter_bits: u64, receiver: f64, value: f64) -> bool {
@@ -1337,9 +1363,7 @@ pub extern "C" fn js_proxy_construct(proxy_boxed: f64, args_array: f64, new_targ
     let result = js_closure_call3(closure, target, args_array, nt);
     crate::object::js_implicit_this_set(prev);
     // [[Construct]] must return an Object (spec step 9 of the construct trap).
-    // Symbols are primitives despite being pointer-backed, so exclude them.
-    let is_symbol = unsafe { crate::symbol::js_is_symbol(result) != 0 };
-    if is_symbol || !reflect_value_is_object(result) {
+    if !reflect_value_is_object(result) {
         return throw_type_error("proxy [[Construct]] trap returned a non-object value");
     }
     result
@@ -1528,7 +1552,50 @@ pub extern "C" fn js_reflect_get_prototype_of(obj: f64) -> f64 {
     // step 1). Note `Object.getPrototypeOf` is more lenient (ToObject-coerces
     // primitives), so guard here before delegating. Proxies have a registered
     // entry and are objects, so they pass this check and dispatch below.
-    if lookup(obj).is_none() && !reflect_value_is_object(obj) {
+    if let Some(id) = lookup(obj) {
+        let (target, handler, revoked) = PROXIES.with(|p| {
+            p.borrow()
+                .get(id as usize)
+                .and_then(|o| o.as_ref())
+                .map(|e| (e.target, e.handler, e.revoked))
+                .unwrap_or((
+                    f64::from_bits(TAG_UNDEFINED),
+                    f64::from_bits(TAG_UNDEFINED),
+                    false,
+                ))
+        });
+        if revoked {
+            return revoked_return();
+        }
+        let trap = handler_trap(handler, "getPrototypeOf");
+        let trap_bits = trap.to_bits();
+        if trap_bits == TAG_UNDEFINED || trap_bits == TAG_NULL {
+            return reflect_target_get_prototype_of(target);
+        }
+        if !is_callable_function(trap) {
+            return throw_type_error("proxy getPrototypeOf trap is not a function");
+        }
+        let rebound = crate::closure::clone_closure_rebind_this(trap_bits, handler);
+        let closure = closure_from(f64::from_bits(rebound));
+        if closure.is_null() {
+            return throw_type_error("proxy getPrototypeOf trap is not a function");
+        }
+        let prev = crate::object::js_implicit_this_set(handler);
+        let result = js_closure_call1(closure, target);
+        crate::object::js_implicit_this_set(prev);
+        let result_bits = result.to_bits();
+        if result_bits != TAG_NULL && !reflect_value_is_object(result) {
+            return throw_type_error("proxy getPrototypeOf trap returned non-object");
+        }
+        if crate::object::obj_value_no_extend(target) {
+            let actual = reflect_target_get_prototype_of(target);
+            if actual.to_bits() != result_bits {
+                return throw_type_error("proxy getPrototypeOf trap violates target invariant");
+            }
+        }
+        return result;
+    }
+    if !reflect_value_is_object(obj) {
         return reflect_non_object_typeerror("getPrototypeOf");
     }
     if lookup(obj).is_some() {
@@ -1657,243 +1724,6 @@ pub extern "C" fn js_reflect_set_prototype_of(target: f64, proto: f64) -> f64 {
     nanbox_bool(true)
 }
 
-#[no_mangle]
-pub extern "C" fn js_reflect_define_metadata(
-    key: f64,
-    value: f64,
-    target: f64,
-    property_key: f64,
-) -> f64 {
-    if let Some(metadata_key) = make_metadata_key(key, target, property_key) {
-        REFLECT_METADATA.with(|store| {
-            store.borrow_mut().insert(metadata_key, value);
-        });
-    }
-    f64::from_bits(TAG_UNDEFINED)
-}
-
-#[no_mangle]
-pub extern "C" fn js_reflect_get_metadata(key: f64, target: f64, property_key: f64) -> f64 {
-    let Some(key_part) = metadata_key_part(key) else {
-        return f64::from_bits(TAG_UNDEFINED);
-    };
-    let Some(property_key_part) = metadata_property_key_part(property_key) else {
-        return f64::from_bits(TAG_UNDEFINED);
-    };
-    get_metadata_in_prototype_chain(&key_part, target, property_key_part.as_ref())
-}
-
-fn get_own_metadata(key: f64, target: f64, property_key: f64) -> f64 {
-    let Some(metadata_key) = make_metadata_key(key, target, property_key) else {
-        return f64::from_bits(TAG_UNDEFINED);
-    };
-    REFLECT_METADATA.with(|store| {
-        store
-            .borrow()
-            .get(&metadata_key)
-            .copied()
-            .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED))
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn js_reflect_get_own_metadata(key: f64, target: f64, property_key: f64) -> f64 {
-    get_own_metadata(key, target, property_key)
-}
-
-#[no_mangle]
-pub extern "C" fn js_reflect_has_metadata(key: f64, target: f64, property_key: f64) -> f64 {
-    let Some(key_part) = metadata_key_part(key) else {
-        return f64::from_bits(TAG_FALSE);
-    };
-    let Some(property_key_part) = metadata_property_key_part(property_key) else {
-        return f64::from_bits(TAG_FALSE);
-    };
-    let found = get_metadata_in_prototype_chain(&key_part, target, property_key_part.as_ref())
-        .to_bits()
-        != TAG_UNDEFINED;
-    f64::from_bits(if found { TAG_TRUE } else { TAG_FALSE })
-}
-
-#[no_mangle]
-pub extern "C" fn js_reflect_has_own_metadata(key: f64, target: f64, property_key: f64) -> f64 {
-    let Some(metadata_key) = make_metadata_key(key, target, property_key) else {
-        return f64::from_bits(TAG_FALSE);
-    };
-    let found = REFLECT_METADATA.with(|store| store.borrow().contains_key(&metadata_key));
-    f64::from_bits(if found { TAG_TRUE } else { TAG_FALSE })
-}
-
-#[no_mangle]
-pub extern "C" fn js_reflect_get_metadata_keys(target: f64, property_key: f64) -> f64 {
-    metadata_keys_for(target, property_key, true)
-}
-
-#[no_mangle]
-pub extern "C" fn js_reflect_get_own_metadata_keys(target: f64, property_key: f64) -> f64 {
-    metadata_keys_for(target, property_key, false)
-}
-
-#[no_mangle]
-pub extern "C" fn js_reflect_delete_metadata(key: f64, target: f64, property_key: f64) -> f64 {
-    let Some(metadata_key) = make_metadata_key(key, target, property_key) else {
-        return f64::from_bits(TAG_FALSE);
-    };
-    let deleted = REFLECT_METADATA.with(|store| store.borrow_mut().remove(&metadata_key).is_some());
-    f64::from_bits(if deleted { TAG_TRUE } else { TAG_FALSE })
-}
-
-fn make_metadata_key(key: f64, target: f64, property_key: f64) -> Option<MetadataKey> {
-    Some(MetadataKey {
-        target_bits: target.to_bits(),
-        key: metadata_key_part(key)?,
-        property_key: metadata_property_key_part(property_key)?,
-    })
-}
-
-/// Resolve the `propertyKey` argument of a `Reflect.*Metadata(…)` call.
-///
-/// Returns:
-/// - `Some(None)` when the argument is `undefined` — class-level metadata.
-/// - `Some(Some(s))` for any value that coerces to a string.
-/// - `None` for values we explicitly refuse to key on (e.g. Symbols). The
-///   caller treats this as "skip the operation" so we never silently store
-///   metadata under an unstable bit-pattern key (#754 review).
-fn metadata_property_key_part(property_key: f64) -> Option<Option<String>> {
-    if property_key.to_bits() == TAG_UNDEFINED {
-        return Some(None);
-    }
-    metadata_key_part(property_key).map(Some)
-}
-
-/// Coerce a metadata key to a stable owned String, or return None if the
-/// value cannot be represented as a string key. Returning None makes the
-/// caller treat the op as a no-op rather than fabricating a fake key.
-///
-/// Symbol-keyed metadata is explicitly unsupported (see
-/// docs/src/language/decorators.md) — Symbols flow through here and return
-/// None rather than colliding on `toString()`'s `"Symbol()"` rendering.
-fn metadata_key_part(value: f64) -> Option<String> {
-    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
-    if let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(value, &mut scratch) {
-        if ptr.is_null() {
-            return None;
-        }
-        if len == 0 {
-            return Some(String::new());
-        }
-        let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
-        return Some(String::from_utf8_lossy(bytes).into_owned());
-    }
-    if crate::value::is_js_handle(value) {
-        let str_ptr = crate::value::js_jsvalue_to_string(value);
-        if !str_ptr.is_null() {
-            let nb =
-                f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & 0x0000_FFFF_FFFF_FFFF));
-            if let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(nb, &mut scratch) {
-                if !ptr.is_null() {
-                    if len == 0 {
-                        return Some(String::new());
-                    }
-                    let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
-                    return Some(String::from_utf8_lossy(bytes).into_owned());
-                }
-            }
-        }
-    }
-    // Numbers, booleans, null — coerce through the standard JS path so
-    // e.g. `0`, `true`, etc. produce deterministic string keys.
-    let coerced = crate::builtins::js_string_coerce(value);
-    if !coerced.is_null() {
-        let name_ptr =
-            unsafe { (coerced as *const u8).add(std::mem::size_of::<crate::StringHeader>()) };
-        let name_len = unsafe { (*coerced).byte_len as usize };
-        if let Ok(s) =
-            std::str::from_utf8(unsafe { std::slice::from_raw_parts(name_ptr, name_len) })
-        {
-            return Some(s.to_string());
-        }
-    }
-    None
-}
-
-fn get_metadata_in_prototype_chain(key: &str, target: f64, property_key: Option<&String>) -> f64 {
-    let mut current = target;
-    loop {
-        let current_bits = current.to_bits();
-        let found = REFLECT_METADATA.with(|store| {
-            store
-                .borrow()
-                .get(&MetadataKey {
-                    target_bits: current_bits,
-                    key: key.to_string(),
-                    property_key: property_key.cloned(),
-                })
-                .copied()
-        });
-        if let Some(value) = found {
-            return value;
-        }
-
-        let next = crate::object::js_object_get_prototype_of(current);
-        let next_bits = next.to_bits();
-        if next_bits == TAG_NULL || next_bits == TAG_UNDEFINED || next_bits == current_bits {
-            return f64::from_bits(TAG_UNDEFINED);
-        }
-        current = next;
-    }
-}
-
-fn metadata_keys_for(target: f64, property_key: f64, include_prototypes: bool) -> f64 {
-    let Some(wanted_property_key) = metadata_property_key_part(property_key) else {
-        let empty = crate::array::js_array_alloc(0);
-        return f64::from_bits(POINTER_TAG | ((empty as u64) & POINTER_MASK));
-    };
-
-    let keys = REFLECT_METADATA.with(|store| {
-        let mut seen = HashSet::new();
-        let mut keys = Vec::new();
-        let store = store.borrow();
-        let mut current = target;
-
-        loop {
-            let current_bits = current.to_bits();
-            for metadata_key in store.keys() {
-                if metadata_key.target_bits == current_bits
-                    && metadata_key.property_key == wanted_property_key
-                    && seen.insert(metadata_key.key.clone())
-                {
-                    keys.push(metadata_key.key.clone());
-                }
-            }
-
-            if !include_prototypes {
-                break;
-            }
-
-            let next = crate::object::js_object_get_prototype_of(current);
-            let next_bits = next.to_bits();
-            if next_bits == TAG_NULL || next_bits == TAG_UNDEFINED || next_bits == current_bits {
-                break;
-            }
-            current = next;
-        }
-
-        keys
-    });
-
-    let mut values = Vec::with_capacity(keys.len());
-    for key in keys {
-        values.push(crate::string::js_string_new_sso(
-            key.as_ptr(),
-            key.len() as u32,
-        ));
-    }
-
-    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
-    f64::from_bits(POINTER_TAG | ((arr as u64) & POINTER_MASK))
-}
-
 /// Native trampoline backing the `revoke` function returned by
 /// `Proxy.revocable`. The closure captures the proxy value in capture slot 0;
 /// invoking it revokes that specific proxy. Idempotent — revoking an
@@ -1967,6 +1797,9 @@ static KEEP_REFLECT_SET_PROTOTYPE_OF: extern "C" fn(f64, f64) -> f64 = js_reflec
 // `receiver` arg (#2766) and must keep its new signature retained.
 #[used]
 static KEEP_REFLECT_GET: extern "C" fn(f64, f64, f64) -> f64 = js_reflect_get;
+#[used]
+static KEEP_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR: extern "C" fn(f64, f64) -> f64 =
+    js_reflect_get_own_property_descriptor;
 #[used]
 static KEEP_REFLECT_HAS: extern "C" fn(f64, f64) -> f64 = js_reflect_has;
 #[used]

--- a/crates/perry-runtime/src/proxy/metadata.rs
+++ b/crates/perry-runtime/src/proxy/metadata.rs
@@ -1,0 +1,248 @@
+//! `Reflect.{define,get,has,delete}Metadata` and related metadata-keys
+//! helpers, backed by the `REFLECT_METADATA` thread-local in the parent
+//! module. Extracted from `proxy.rs` to keep that file under the 2000-line
+//! cap; behavior is unchanged.
+
+use std::collections::HashSet;
+
+use super::{
+    MetadataKey, POINTER_MASK, POINTER_TAG, REFLECT_METADATA, TAG_FALSE, TAG_NULL, TAG_TRUE,
+    TAG_UNDEFINED,
+};
+
+#[no_mangle]
+pub extern "C" fn js_reflect_define_metadata(
+    key: f64,
+    value: f64,
+    target: f64,
+    property_key: f64,
+) -> f64 {
+    if let Some(metadata_key) = make_metadata_key(key, target, property_key) {
+        REFLECT_METADATA.with(|store| {
+            store.borrow_mut().insert(metadata_key, value);
+        });
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+#[no_mangle]
+pub extern "C" fn js_reflect_get_metadata(key: f64, target: f64, property_key: f64) -> f64 {
+    let Some(key_part) = metadata_key_part(key) else {
+        return f64::from_bits(TAG_UNDEFINED);
+    };
+    let Some(property_key_part) = metadata_property_key_part(property_key) else {
+        return f64::from_bits(TAG_UNDEFINED);
+    };
+    get_metadata_in_prototype_chain(&key_part, target, property_key_part.as_ref())
+}
+
+fn get_own_metadata(key: f64, target: f64, property_key: f64) -> f64 {
+    let Some(metadata_key) = make_metadata_key(key, target, property_key) else {
+        return f64::from_bits(TAG_UNDEFINED);
+    };
+    REFLECT_METADATA.with(|store| {
+        store
+            .borrow()
+            .get(&metadata_key)
+            .copied()
+            .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED))
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn js_reflect_get_own_metadata(key: f64, target: f64, property_key: f64) -> f64 {
+    get_own_metadata(key, target, property_key)
+}
+
+#[no_mangle]
+pub extern "C" fn js_reflect_has_metadata(key: f64, target: f64, property_key: f64) -> f64 {
+    let Some(key_part) = metadata_key_part(key) else {
+        return f64::from_bits(TAG_FALSE);
+    };
+    let Some(property_key_part) = metadata_property_key_part(property_key) else {
+        return f64::from_bits(TAG_FALSE);
+    };
+    let found = get_metadata_in_prototype_chain(&key_part, target, property_key_part.as_ref())
+        .to_bits()
+        != TAG_UNDEFINED;
+    f64::from_bits(if found { TAG_TRUE } else { TAG_FALSE })
+}
+
+#[no_mangle]
+pub extern "C" fn js_reflect_has_own_metadata(key: f64, target: f64, property_key: f64) -> f64 {
+    let Some(metadata_key) = make_metadata_key(key, target, property_key) else {
+        return f64::from_bits(TAG_FALSE);
+    };
+    let found = REFLECT_METADATA.with(|store| store.borrow().contains_key(&metadata_key));
+    f64::from_bits(if found { TAG_TRUE } else { TAG_FALSE })
+}
+
+#[no_mangle]
+pub extern "C" fn js_reflect_get_metadata_keys(target: f64, property_key: f64) -> f64 {
+    metadata_keys_for(target, property_key, true)
+}
+
+#[no_mangle]
+pub extern "C" fn js_reflect_get_own_metadata_keys(target: f64, property_key: f64) -> f64 {
+    metadata_keys_for(target, property_key, false)
+}
+
+#[no_mangle]
+pub extern "C" fn js_reflect_delete_metadata(key: f64, target: f64, property_key: f64) -> f64 {
+    let Some(metadata_key) = make_metadata_key(key, target, property_key) else {
+        return f64::from_bits(TAG_FALSE);
+    };
+    let deleted = REFLECT_METADATA.with(|store| store.borrow_mut().remove(&metadata_key).is_some());
+    f64::from_bits(if deleted { TAG_TRUE } else { TAG_FALSE })
+}
+
+fn make_metadata_key(key: f64, target: f64, property_key: f64) -> Option<MetadataKey> {
+    Some(MetadataKey {
+        target_bits: target.to_bits(),
+        key: metadata_key_part(key)?,
+        property_key: metadata_property_key_part(property_key)?,
+    })
+}
+
+/// Resolve the `propertyKey` argument of a `Reflect.*Metadata(…)` call.
+///
+/// Returns:
+/// - `Some(None)` when the argument is `undefined` — class-level metadata.
+/// - `Some(Some(s))` for any value that coerces to a string.
+/// - `None` for values we explicitly refuse to key on (e.g. Symbols). The
+///   caller treats this as "skip the operation" so we never silently store
+///   metadata under an unstable bit-pattern key (#754 review).
+fn metadata_property_key_part(property_key: f64) -> Option<Option<String>> {
+    if property_key.to_bits() == TAG_UNDEFINED {
+        return Some(None);
+    }
+    metadata_key_part(property_key).map(Some)
+}
+
+/// Coerce a metadata key to a stable owned String, or return None if the
+/// value cannot be represented as a string key. Returning None makes the
+/// caller treat the op as a no-op rather than fabricating a fake key.
+///
+/// Symbol-keyed metadata is explicitly unsupported (see
+/// docs/src/language/decorators.md) — Symbols flow through here and return
+/// None rather than colliding on `toString()`'s `"Symbol()"` rendering.
+fn metadata_key_part(value: f64) -> Option<String> {
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    if let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(value, &mut scratch) {
+        if ptr.is_null() {
+            return None;
+        }
+        if len == 0 {
+            return Some(String::new());
+        }
+        let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+        return Some(String::from_utf8_lossy(bytes).into_owned());
+    }
+    if crate::value::is_js_handle(value) {
+        let str_ptr = crate::value::js_jsvalue_to_string(value);
+        if !str_ptr.is_null() {
+            let nb =
+                f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & 0x0000_FFFF_FFFF_FFFF));
+            if let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(nb, &mut scratch) {
+                if !ptr.is_null() {
+                    if len == 0 {
+                        return Some(String::new());
+                    }
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+                    return Some(String::from_utf8_lossy(bytes).into_owned());
+                }
+            }
+        }
+    }
+    // Numbers, booleans, null — coerce through the standard JS path so
+    // e.g. `0`, `true`, etc. produce deterministic string keys.
+    let coerced = crate::builtins::js_string_coerce(value);
+    if !coerced.is_null() {
+        let name_ptr =
+            unsafe { (coerced as *const u8).add(std::mem::size_of::<crate::StringHeader>()) };
+        let name_len = unsafe { (*coerced).byte_len as usize };
+        if let Ok(s) =
+            std::str::from_utf8(unsafe { std::slice::from_raw_parts(name_ptr, name_len) })
+        {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+fn get_metadata_in_prototype_chain(key: &str, target: f64, property_key: Option<&String>) -> f64 {
+    let mut current = target;
+    loop {
+        let current_bits = current.to_bits();
+        let found = REFLECT_METADATA.with(|store| {
+            store
+                .borrow()
+                .get(&MetadataKey {
+                    target_bits: current_bits,
+                    key: key.to_string(),
+                    property_key: property_key.cloned(),
+                })
+                .copied()
+        });
+        if let Some(value) = found {
+            return value;
+        }
+
+        let next = crate::object::js_object_get_prototype_of(current);
+        let next_bits = next.to_bits();
+        if next_bits == TAG_NULL || next_bits == TAG_UNDEFINED || next_bits == current_bits {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        current = next;
+    }
+}
+
+fn metadata_keys_for(target: f64, property_key: f64, include_prototypes: bool) -> f64 {
+    let Some(wanted_property_key) = metadata_property_key_part(property_key) else {
+        let empty = crate::array::js_array_alloc(0);
+        return f64::from_bits(POINTER_TAG | ((empty as u64) & POINTER_MASK));
+    };
+
+    let keys = REFLECT_METADATA.with(|store| {
+        let mut seen = HashSet::new();
+        let mut keys = Vec::new();
+        let store = store.borrow();
+        let mut current = target;
+
+        loop {
+            let current_bits = current.to_bits();
+            for metadata_key in store.keys() {
+                if metadata_key.target_bits == current_bits
+                    && metadata_key.property_key == wanted_property_key
+                    && seen.insert(metadata_key.key.clone())
+                {
+                    keys.push(metadata_key.key.clone());
+                }
+            }
+
+            if !include_prototypes {
+                break;
+            }
+
+            let next = crate::object::js_object_get_prototype_of(current);
+            let next_bits = next.to_bits();
+            if next_bits == TAG_NULL || next_bits == TAG_UNDEFINED || next_bits == current_bits {
+                break;
+            }
+            current = next;
+        }
+
+        keys
+    });
+
+    let mut values = Vec::with_capacity(keys.len());
+    for key in keys {
+        values.push(crate::string::js_string_new_sso(
+            key.as_ptr(),
+            key.len() as u32,
+        ));
+    }
+
+    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
+    f64::from_bits(POINTER_TAG | ((arr as u64) & POINTER_MASK))
+}

--- a/crates/perry-runtime/src/proxy/reflect.rs
+++ b/crates/perry-runtime/src/proxy/reflect.rs
@@ -1,8 +1,9 @@
 use super::{
-    closure_from, coerce_trap_bool, js_closure_call0, js_proxy_delete, js_proxy_get, js_proxy_has,
-    js_proxy_set, lookup, nanbox_bool, reflect_non_object_typeerror,
-    reflect_ordinary_delete_property_key, reflect_ordinary_set_property_key,
-    reflect_value_is_object, target_get_property_key, TAG_TRUE, TAG_UNDEFINED,
+    closure_from, coerce_trap_bool, extract_pointer, handler_trap, is_callable_function,
+    js_closure_call0, js_closure_call2, js_proxy_delete, js_proxy_get, js_proxy_has, js_proxy_set,
+    lookup, nanbox_bool, reflect_non_object_typeerror, reflect_ordinary_delete_property_key,
+    reflect_ordinary_set_property_key, reflect_value_is_object, revoked_return,
+    target_get_property_key, throw_type_error, PROXIES, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
 };
 
 /// `Reflect.get(target, key, receiver)` (#2766).
@@ -167,4 +168,204 @@ pub extern "C" fn js_reflect_delete(target: f64, key: f64) -> f64 {
         return js_proxy_delete(target, property_key);
     }
     reflect_ordinary_delete_property_key(target, property_key)
+}
+
+fn proxy_entry(proxy_boxed: f64) -> Option<(f64, f64, bool)> {
+    let id = lookup(proxy_boxed)?;
+    PROXIES.with(|p| {
+        p.borrow()
+            .get(id as usize)
+            .and_then(|o| o.as_ref())
+            .map(|e| (e.target, e.handler, e.revoked))
+    })
+}
+
+fn descriptor_key(name: &[u8]) -> (*const crate::StringHeader, f64) {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let key_value = crate::value::js_nanbox_string(key as i64);
+    (key, key_value)
+}
+
+unsafe fn descriptor_field_present(desc: f64, name: &[u8]) -> bool {
+    let (key, key_value) = descriptor_key(name);
+    if lookup(desc).is_some() {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let desc_handle = scope.root_nanbox_f64(desc);
+        let key_handle = scope.root_nanbox_f64(key_value);
+        return crate::value::js_is_truthy(js_proxy_has(
+            desc_handle.get_nanbox_f64(),
+            key_handle.get_nanbox_f64(),
+        )) != 0;
+    }
+    let ptr = extract_pointer(desc.to_bits()) as *mut crate::object::ObjectHeader;
+    crate::object::own_key_present(ptr, key)
+}
+
+unsafe fn descriptor_field(desc: f64, name: &[u8]) -> f64 {
+    let (key, key_value) = descriptor_key(name);
+    if lookup(desc).is_some() {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let desc_handle = scope.root_nanbox_f64(desc);
+        let key_handle = scope.root_nanbox_f64(key_value);
+        return js_proxy_get(desc_handle.get_nanbox_f64(), key_handle.get_nanbox_f64());
+    }
+    let ptr = extract_pointer(desc.to_bits()) as *const crate::object::ObjectHeader;
+    if ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    f64::from_bits(crate::object::js_object_get_field_by_name(ptr, key).bits())
+}
+
+unsafe fn descriptor_bool_field(desc: f64, name: &[u8]) -> Option<bool> {
+    if !descriptor_field_present(desc, name) {
+        return None;
+    }
+    Some(crate::value::js_is_truthy(descriptor_field(desc, name)) != 0)
+}
+
+unsafe fn complete_proxy_descriptor_result(desc: f64) -> f64 {
+    if !reflect_value_is_object(desc) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let desc_handle = scope.root_nanbox_f64(desc);
+    let desc = desc_handle.get_nanbox_f64();
+
+    let has_enumerable = descriptor_field_present(desc, b"enumerable");
+    let has_configurable = descriptor_field_present(desc, b"configurable");
+    let has_value = descriptor_field_present(desc, b"value");
+    let has_writable = descriptor_field_present(desc, b"writable");
+    let has_get = descriptor_field_present(desc, b"get");
+    let has_set = descriptor_field_present(desc, b"set");
+
+    let enumerable =
+        has_enumerable && crate::value::js_is_truthy(descriptor_field(desc, b"enumerable")) != 0;
+    let configurable = has_configurable
+        && crate::value::js_is_truthy(descriptor_field(desc, b"configurable")) != 0;
+    let value = if has_value {
+        descriptor_field(desc, b"value")
+    } else {
+        f64::from_bits(TAG_UNDEFINED)
+    };
+    let value_handle = scope.root_nanbox_f64(value);
+    let writable =
+        has_writable && crate::value::js_is_truthy(descriptor_field(desc, b"writable")) != 0;
+
+    let getter = if has_get {
+        descriptor_field(desc, b"get")
+    } else {
+        f64::from_bits(TAG_UNDEFINED)
+    };
+    let getter_handle = scope.root_nanbox_f64(getter);
+    let setter = if has_set {
+        descriptor_field(desc, b"set")
+    } else {
+        f64::from_bits(TAG_UNDEFINED)
+    };
+    let setter_handle = scope.root_nanbox_f64(setter);
+
+    let getter = getter_handle.get_nanbox_f64();
+    if getter.to_bits() != TAG_UNDEFINED && !is_callable_function(getter) {
+        throw_type_error("Getter must be a function");
+    }
+    let setter = setter_handle.get_nanbox_f64();
+    if setter.to_bits() != TAG_UNDEFINED && !is_callable_function(setter) {
+        throw_type_error("Setter must be a function");
+    }
+    if (has_get || has_set) && (has_value || has_writable) {
+        throw_type_error("Invalid property descriptor");
+    }
+
+    if has_get || has_set {
+        crate::object::build_accessor_descriptor(getter, setter, enumerable, configurable)
+    } else {
+        crate::object::build_data_descriptor(
+            value_handle.get_nanbox_f64(),
+            writable,
+            enumerable,
+            configurable,
+        )
+    }
+}
+
+/// `Reflect.getOwnPropertyDescriptor(target, key)` — Reflect-specific
+/// `[[GetOwnProperty]]` entry point: non-object targets throw, property keys
+/// are normalized before dispatch, and proxy traps are observed.
+#[no_mangle]
+pub extern "C" fn js_reflect_get_own_property_descriptor(target: f64, key: f64) -> f64 {
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("getOwnPropertyDescriptor");
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    let target = target_handle.get_nanbox_f64();
+    let property_key = property_key_handle.get_nanbox_f64();
+
+    let Some((inner, handler, revoked)) = proxy_entry(target) else {
+        return crate::object::js_object_get_own_property_descriptor(target, property_key);
+    };
+    if revoked {
+        return revoked_return();
+    }
+
+    let trap = handler_trap(handler, "getOwnPropertyDescriptor");
+    let trap_bits = trap.to_bits();
+    if trap_bits == TAG_UNDEFINED || trap_bits == TAG_NULL {
+        return crate::object::js_object_get_own_property_descriptor(inner, property_key);
+    }
+    if !is_callable_function(trap) {
+        return throw_type_error("proxy getOwnPropertyDescriptor trap is not a function");
+    }
+
+    let rebound = crate::closure::clone_closure_rebind_this(trap_bits, handler);
+    let closure = closure_from(f64::from_bits(rebound));
+    if closure.is_null() {
+        return throw_type_error("proxy getOwnPropertyDescriptor trap is not a function");
+    }
+    let prev = crate::object::js_implicit_this_set(handler);
+    let result = js_closure_call2(closure, inner, property_key);
+    crate::object::js_implicit_this_set(prev);
+    let result_handle = scope.root_nanbox_f64(result);
+
+    let target_desc = crate::object::js_object_get_own_property_descriptor(inner, property_key);
+    let target_desc_handle = scope.root_nanbox_f64(target_desc);
+    let result = result_handle.get_nanbox_f64();
+    let target_desc = target_desc_handle.get_nanbox_f64();
+    if result.to_bits() == TAG_UNDEFINED {
+        if target_desc.to_bits() != TAG_UNDEFINED
+            && (crate::object::obj_value_no_extend(inner)
+                || unsafe { descriptor_bool_field(target_desc, b"configurable") } == Some(false))
+        {
+            return throw_type_error(
+                "proxy getOwnPropertyDescriptor trap cannot hide target property",
+            );
+        }
+        return result;
+    }
+
+    if !reflect_value_is_object(result) {
+        return throw_type_error("proxy getOwnPropertyDescriptor trap returned non-object");
+    }
+    let result = unsafe { complete_proxy_descriptor_result(result) };
+    let result_handle = scope.root_nanbox_f64(result);
+    let result = result_handle.get_nanbox_f64();
+
+    if target_desc.to_bits() == TAG_UNDEFINED {
+        if crate::object::obj_value_no_extend(inner) {
+            return throw_type_error(
+                "proxy getOwnPropertyDescriptor trap reports new property on non-extensible target",
+            );
+        }
+    } else if unsafe { descriptor_bool_field(target_desc, b"configurable") } == Some(false)
+        && unsafe { descriptor_bool_field(result, b"configurable") } == Some(true)
+    {
+        return throw_type_error(
+            "proxy getOwnPropertyDescriptor trap reports incompatible descriptor",
+        );
+    }
+
+    result
 }

--- a/test-parity/node-suite/object/reflect-proxy-abrupt.ts
+++ b/test-parity/node-suite/object/reflect-proxy-abrupt.ts
@@ -1,0 +1,160 @@
+function format(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  return JSON.stringify(value);
+}
+
+function descSummary(desc: PropertyDescriptor | undefined) {
+  if (desc === undefined) {
+    return "undefined";
+  }
+  return {
+    value: desc.value,
+    writable: desc.writable,
+    enumerable: desc.enumerable,
+    configurable: desc.configurable,
+    hasValue: Object.prototype.hasOwnProperty.call(desc, "value"),
+  };
+}
+
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label + ":", "ok", format(fn()));
+  } catch (err: any) {
+    console.log(label + ":", "throw", err.name);
+  }
+}
+
+show("gopd primitive target", () => Reflect.getOwnPropertyDescriptor(1 as any, "x"));
+show("gopd symbol target", () => Reflect.getOwnPropertyDescriptor(Symbol("target") as any, "x"));
+show("gopd key abrupt", () =>
+  Reflect.getOwnPropertyDescriptor({}, {
+    toString() {
+      throw new RangeError("key");
+    },
+  } as any),
+);
+
+const fallbackTarget: any = {};
+Object.defineProperty(fallbackTarget, "x", {
+  value: 7,
+  writable: false,
+  enumerable: true,
+  configurable: true,
+});
+show("gopd proxy no trap", () =>
+  descSummary(Reflect.getOwnPropertyDescriptor(new Proxy(fallbackTarget, {}), "x")),
+);
+
+show("gopd proxy descriptor", () =>
+  descSummary(Reflect.getOwnPropertyDescriptor(new Proxy({}, {
+    getOwnPropertyDescriptor() {
+      return { value: 9, writable: true, enumerable: false, configurable: true };
+    },
+  }), "x")),
+);
+
+show("gopd proxy descriptor proxy object", () =>
+  descSummary(Reflect.getOwnPropertyDescriptor(new Proxy({}, {
+    getOwnPropertyDescriptor() {
+      return new Proxy({ value: 11, writable: true, enumerable: true, configurable: true }, {});
+    },
+  }), "x")),
+);
+
+show("gopd proxy undefined", () =>
+  descSummary(Reflect.getOwnPropertyDescriptor(new Proxy({}, {
+    getOwnPropertyDescriptor() {
+      return undefined;
+    },
+  }), "x")),
+);
+
+show("gopd proxy primitive result", () =>
+  Reflect.getOwnPropertyDescriptor(new Proxy({}, {
+    getOwnPropertyDescriptor() {
+      return 1 as any;
+    },
+  }), "x"),
+);
+
+show("gopd proxy result abrupt", () =>
+  Reflect.getOwnPropertyDescriptor(new Proxy({}, {
+    getOwnPropertyDescriptor() {
+      return {
+        value: 1,
+        configurable: true,
+        get enumerable() {
+          throw new RangeError("descriptor");
+        },
+      };
+    },
+  }), "x"),
+);
+
+show("gopd proxy descriptor proxy abrupt", () =>
+  Reflect.getOwnPropertyDescriptor(new Proxy({}, {
+    getOwnPropertyDescriptor() {
+      return new Proxy({ value: 1, configurable: true }, {
+        has(_target, prop) {
+          if (prop === "enumerable") {
+            throw new RangeError("descriptor proxy");
+          }
+          return prop in _target;
+        },
+      });
+    },
+  }), "x"),
+);
+
+show("gopd proxy noncallable trap", () =>
+  Reflect.getOwnPropertyDescriptor(new Proxy({}, {
+    getOwnPropertyDescriptor: {} as any,
+  }), "x"),
+);
+
+const revokedDesc = Proxy.revocable({}, {});
+revokedDesc.revoke();
+show("gopd revoked proxy", () => Reflect.getOwnPropertyDescriptor(revokedDesc.proxy, "x"));
+
+const proto = { marker: "proto" };
+const protoTarget = Object.create(proto);
+show("getProto proxy no trap", () => Reflect.getPrototypeOf(new Proxy(protoTarget, {})) === proto);
+show("getProto proxy object result", () =>
+  Reflect.getPrototypeOf(new Proxy({}, {
+    getPrototypeOf() {
+      return proto;
+    },
+  })) === proto,
+);
+show("getProto proxy null result", () =>
+  Reflect.getPrototypeOf(new Proxy({}, {
+    getPrototypeOf() {
+      return null;
+    },
+  })) === null,
+);
+show("getProto proxy primitive result", () =>
+  Reflect.getPrototypeOf(new Proxy({}, {
+    getPrototypeOf() {
+      return 1 as any;
+    },
+  })),
+);
+show("getProto proxy abrupt", () =>
+  Reflect.getPrototypeOf(new Proxy({}, {
+    getPrototypeOf() {
+      throw new RangeError("prototype");
+    },
+  })),
+);
+show("getProto proxy noncallable trap", () =>
+  Reflect.getPrototypeOf(new Proxy({}, {
+    getPrototypeOf: {} as any,
+  })),
+);
+
+const revokedProto = Proxy.revocable({}, {});
+revokedProto.revoke();
+show("getProto revoked proxy", () => Reflect.getPrototypeOf(revokedProto.proxy));


### PR DESCRIPTION
Part of #4523.

## Summary
- Route `Reflect.getOwnPropertyDescriptor` through a Reflect-specific HIR/runtime entry point instead of the `Object.*` path.
- Dispatch proxy `getOwnPropertyDescriptor` traps, including revoked proxies, missing traps, non-callable traps, non-object trap results, descriptor field abrupt completions, proxy descriptor-result objects, and descriptor completion before returning.
- Dispatch proxy `getPrototypeOf` traps and fallback to the target's recorded prototype, including `Object.create(proto)` targets.
- Treat symbol targets as Reflect non-objects without dereferencing low proxy handles as heap pointers.

## Non-goals
- `Reflect.construct` newTarget semantics (#2768).
- A broad Proxy invariant rewrite beyond the descriptor/prototype result validation covered here.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/object/reflect-proxy-abrupt.ts`
- Pre-fix Perry repro: `Reflect.getOwnPropertyDescriptor(1, "x")` returned `undefined`, then the proxy descriptor path segfaulted.
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module object --filter reflect-proxy-abrupt'` (pass 1/1)
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module object --filter reflect'` (pass 3/3)
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module object --filter proxy'` (pass 2/2)
- `cargo check -q -p perry-hir -p perry-runtime -p perry-codegen`
- `cargo test -q -p perry-runtime --lib object -- --nocapture --test-threads=1` (pass 99/99; expected panic assertions print panic text)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
