### PR TITLE
fix(runtime): Date.now/parse/UTC usable as first-class function values

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1851,11 +1851,27 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // with detached `Math.log`.
                     let receiver_is_detached_console_read =
                         property == "console" && !member_is_call_callee;
+                    // #4596: `Date.now` / `Date.parse` / `Date.UTC` read as a
+                    // VALUE needs the reified Date constructor receiver so it
+                    // resolves to the real native function object (typeof
+                    // "function", correct `.name`/`.length`, callable). Undoing
+                    // the reroute collapses it to `GlobalGet(0).now`, for which
+                    // codegen has no intrinsic handler (unlike `Object.keys` /
+                    // `Math.max`) — so the read mis-folds to a number. Direct
+                    // CALLS (`Date.now()`) are intercepted earlier as
+                    // `Expr::DateNow` / `DateParse` / `DateUtc`, so gate on a
+                    // non-callee read.
+                    let outer_is_reified_date_static_value = !member_is_call_callee
+                        && property == "Date"
+                        && outer_static_member
+                            .map(|member| matches!(member, "now" | "parse" | "UTC"))
+                            .unwrap_or(false);
                     if !outer_is_prototype_or_proto
                         && !receiver_is_namespace_value
                         && !outer_is_websocket_static
                         && !outer_is_reified_object_static_value
                         && !outer_is_reified_builtin_static_value
+                        && !outer_is_reified_date_static_value
                         && !receiver_is_detached_console_read
                     {
                         object_expr = Expr::GlobalGet(0);

--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -220,11 +220,17 @@ pub(crate) fn install_date_constructor_statics(ctor: *mut crate::closure::Closur
         1,
         false,
     );
-    super::global_this::install_constructor_static(
+    // `date_utc_static` collects *all* arguments into its `rest` param, so the
+    // call-arity (fixed params before the rest) must be 0 — otherwise the rest
+    // registration reserves 7 fixed slots and `Date.UTC(2020, 0)` (fewer than 7
+    // args) puts nothing in the rest array → js_date_utc([]) → NaN. The spec
+    // `.length` stays 7. (#4596)
+    super::global_this::install_constructor_static_with_call_arity(
         ctor,
         "UTC",
         date_utc_static as *const u8,
         7,
+        0,
         true,
     );
 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3430,7 +3430,7 @@ pub(super) fn install_constructor_static(
     install_constructor_static_with_call_arity(ctor, name, func_ptr, arity, arity, has_rest);
 }
 
-fn install_constructor_static_with_call_arity(
+pub(super) fn install_constructor_static_with_call_arity(
     ctor: *mut crate::closure::ClosureHeader,
     name: &str,
     func_ptr: *const u8,


### PR DESCRIPTION
## Problem
```ts
typeof Date.now      // "number"     → "function"
Date.now.name        // undefined     → "now"
Date.UTC.length      // undefined     → 7
const u = Date.UTC; u(2020, 0)  // NaN → 1577836800000
```

## Root causes (two)
1. The #973/#4139 reroute-undo collapsed value reads of `Date.now`/`.parse`/`.UTC` to `GlobalGet(0).<name>`, for which codegen has **no** intrinsic handler (unlike `Object.keys` / `Math.max`), so they mis-folded to a number. Added a Date now/parse/UTC exception to the reroute-undo so the read hits the **reified Date constructor object** (the aliased `const D=Date; D.now` and computed `Date['now']` forms already worked). Direct calls `Date.now()` stay on the `Expr::DateNow` fast path — unaffected.
2. `date_utc_static` collects all args into its `rest` param, but `Date.UTC` was registered with **call-arity 7** (7 fixed params before the rest), so `Date.UTC(2020,0)` (fewer than 7 args) put nothing in the rest array → `js_date_utc([])` → NaN. Registered call-arity **0** (all args → rest) while keeping spec `.length = 7`.

## Verification
Byte-identical to `node --experimental-strip-types`: typeof/name/length, value-calls (`const u=Date.UTC; u(2020,0)`), and direct calls. Fixes test262 `Date/{now,parse,UTC}/{name,length}`, `Date/now/15.9.4.4-0-1`, `15.9.4.4-0-3` (8 tests). Date general usage (construction, getters, instanceof) unchanged.