### PR TITLE
[codex] Fix HTTPS Agent method value reads

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -34,8 +34,8 @@ use crate::type_analysis::{
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
 use super::property_get_names::{
-    is_headers_method_name, is_http_client_request_method_name, is_net_native_method_value,
-    is_url_pattern_data_property,
+    is_headers_method_name, is_http_agent_method_name, is_http_client_request_method_name,
+    is_net_native_method_value, is_url_pattern_data_property,
 };
 #[allow(unused_imports)]
 use super::{
@@ -1318,6 +1318,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     ));
                 }
                 if is_net_native_method_value(&class_name, property) {
+                    return lower_class_method_bind(ctx, object, property);
+                }
+                if class_name == "Agent" && is_http_agent_method_name(property) {
                     return lower_class_method_bind(ctx, object, property);
                 }
                 if class_has_computed_runtime_members(ctx, &class_name) {

--- a/crates/perry-codegen/src/expr/property_get_names.rs
+++ b/crates/perry-codegen/src/expr/property_get_names.rs
@@ -38,6 +38,13 @@ pub(super) fn is_http_client_request_method_name(name: &str) -> bool {
     )
 }
 
+pub(super) fn is_http_agent_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "keepSocketAlive" | "reuseSocket" | "getName" | "destroy" | "close"
+    )
+}
+
 fn is_net_socket_method_name(name: &str) -> bool {
     matches!(
         name,

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1043,6 +1043,20 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             ) {
                                 return Ok(Expr::String("function".to_string()));
                             }
+                            // `http.Agent` and `https.Agent` share the same
+                            // native class tag in Perry. These are prototype
+                            // methods; `typeof agent.getName` should observe a
+                            // function value instead of falling through to a
+                            // missing generic field lookup.
+                            if matches!(
+                                ctx.lookup_native_instance(obj_name),
+                                Some(("http", "Agent")) | Some(("https", "Agent"))
+                            ) && matches!(
+                                prop_name,
+                                "keepSocketAlive" | "reuseSocket" | "getName" | "destroy" | "close"
+                            ) {
+                                return Ok(Expr::String("function".to_string()));
+                            }
                             // #1320: `typeof obs.observe` on a PerformanceObserver
                             // instance. A bare member read on a native-class
                             // instance lowers to a 0-arg NativeMethodCall (getter

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -14,12 +14,6 @@
     "category": "module-inventory",
     "reason": "Node.js module inventory \u2014 `node:http` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
-  "test_parity_https": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Node.js module inventory \u2014 `node:https` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
-  },
   "test_parity_stream": {
     "issue": "793",
     "added": "2026-05-15",

--- a/test-parity/node-suite/https/surface/mirror-surface.ts
+++ b/test-parity/node-suite/https/surface/mirror-surface.ts
@@ -80,6 +80,17 @@ console.log(
   typeof agent.getName,
   typeof agent.destroy,
 );
+const keepSocketAliveValue = agent.keepSocketAlive;
+const reuseSocketValue = agent.reuseSocket;
+const getNameValue = agent.getName;
+const destroyValue = agent.destroy;
+console.log(
+  "https agent method values:",
+  typeof keepSocketAliveValue,
+  typeof reuseSocketValue,
+  typeof getNameValue,
+  typeof destroyValue,
+);
 const replacement = () => undefined;
 agent.createConnection = replacement;
 console.log("https agent override:", agent.createConnection === replacement);


### PR DESCRIPTION
## Summary
- Bind `http`/`https` `Agent` prototype method value reads so `keepSocketAlive`, `reuseSocket`, `getName`, `destroy`, and `close` surface as callable method values.
- Fold `typeof agent.method` for Agent native instances to Node's public `"function"` result without invoking native methods.
- Extend the HTTPS node-suite mirror fixture to cover captured Agent method values and remove the stale `test_parity_https` known failure.

## Reference
- Node v26 `node:https` docs describe `https.Agent` as similar to `http.Agent`: https://nodejs.org/api/https.html
- Node v26 `node:http` docs expose `Agent` instance methods including `keepSocketAlive`, `reuseSocket`, `getName`, and `destroy`: https://nodejs.org/api/http.html

## Validation
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/stream-web-knownfail-scan cargo build --release -p perry`
- Direct Node 26 vs Perry diff for `test-files/test_parity_https.ts` (no diff)
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/stream-web-knownfail-scan PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --filter test_parity_https'`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/stream-web-knownfail-scan PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module https --filter mirror-surface'`
- `cargo fmt --all -- --check`
- `jq empty test-parity/known_failures.json`
- `git diff --check`
- `./scripts/check_file_size.sh`

Non-goals: TLS/socket reuse semantics and HTTP response framing.
