### PR TITLE
fix(ext-mysql2): handle method dispatch so generic pool.query/execute routes natively

### DIFF
--- a/crates/perry-ext-mysql2/src/lib.rs
+++ b/crates/perry-ext-mysql2/src/lib.rs
@@ -308,6 +308,18 @@ fn raw_row_to_js_object(row: &RawRowData) -> *mut ObjectHeader {
     obj
 }
 
+/// Build a row as a positional ARRAY `[v0, v1, …]` in column order. mysql2's
+/// `{ rowsAsArray: true }` option (which Drizzle sets for its relational-query
+/// and `select()` paths) returns rows this way; Drizzle's `mapResultRow` then
+/// maps positions to columns via the selected-fields list.
+fn raw_row_to_js_array(row: &RawRowData) -> *mut ArrayHeader {
+    let mut arr = unsafe { js_array_alloc(row.values.len() as u32) };
+    for (_, val) in &row.values {
+        arr = unsafe { js_array_push(arr, raw_value_to_jsvalue(val)) };
+    }
+    arr
+}
+
 fn raw_column_to_field_packet(col: &RawColumnInfo) -> *mut ObjectHeader {
     let (packed, shape_id) = build_object_shape(&["name", "type", "length"]);
     let obj =
@@ -322,13 +334,19 @@ fn raw_column_to_field_packet(col: &RawColumnInfo) -> *mut ObjectHeader {
     obj
 }
 
-/// Build the mysql2 result tuple `[rows, fields]`.
-fn raws_to_result_tuple(raw: &RawQueryResult) -> JsValue {
+/// Build the mysql2 result tuple `[rows, fields]`. When `rows_as_array` each row
+/// is a positional array (mysql2 `{ rowsAsArray: true }`), else a column→value
+/// object.
+fn raws_to_result_tuple(raw: &RawQueryResult, rows_as_array: bool) -> JsValue {
     let mut result = unsafe { js_array_alloc(2) };
     let mut rows_arr = unsafe { js_array_alloc(raw.rows.len() as u32) };
     for r in &raw.rows {
-        let obj = raw_row_to_js_object(r);
-        rows_arr = unsafe { js_array_push(rows_arr, JsValue::from_object_ptr(obj)) };
+        let row_val = if rows_as_array {
+            JsValue::from_object_ptr(raw_row_to_js_array(r))
+        } else {
+            JsValue::from_object_ptr(raw_row_to_js_object(r))
+        };
+        rows_arr = unsafe { js_array_push(rows_arr, row_val) };
     }
     result = unsafe { js_array_push(result, JsValue::from_object_ptr(rows_arr)) };
 
@@ -358,9 +376,9 @@ fn affected_rows_result(affected: u64, last_insert_id: u64) -> JsValue {
     JsValue::from_object_ptr(result)
 }
 
-fn outcome_to_jsvalue(outcome: &QueryOutcome) -> JsValue {
+fn outcome_to_jsvalue(outcome: &QueryOutcome, rows_as_array: bool) -> JsValue {
     match outcome {
-        QueryOutcome::Rows(raw) => raws_to_result_tuple(raw),
+        QueryOutcome::Rows(raw) => raws_to_result_tuple(raw, rows_as_array),
         QueryOutcome::Executed {
             affected_rows,
             last_insert_id,
@@ -504,6 +522,7 @@ unsafe fn run_connection_query(
     conn_handle: Handle,
     sql_ptr: *const u8,
     params_f: f64,
+    rows_as_array: bool,
 ) -> *mut Promise {
     let sql = read_sql(sql_ptr);
     let params = JsValue::from_bits(params_f.to_bits());
@@ -560,7 +579,7 @@ unsafe fn run_connection_query(
             // allocates arrays/objects/strings, which is UB on this blocking-pool
             // thread (worker thread-local arena → dangling on the main thread once
             // the pooled thread idles out). `out` is plain Send Rust data.
-            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out)),
+            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out, rows_as_array)),
             Err(e) => promise.reject_string(&e),
         }
     });
@@ -577,7 +596,7 @@ pub unsafe extern "C" fn js_mysql2_connection_query(
     sql_ptr: *const u8,
     params_f: f64,
 ) -> *mut Promise {
-    run_connection_query(conn_handle, sql_ptr, params_f)
+    run_connection_query(conn_handle, sql_ptr, params_f, false)
 }
 
 /// `connection.execute(sql, params) -> Promise<[rows, fields]>`.
@@ -591,7 +610,7 @@ pub unsafe extern "C" fn js_mysql2_connection_execute(
     sql_ptr: *const u8,
     params_f: f64,
 ) -> *mut Promise {
-    run_connection_query(conn_handle, sql_ptr, params_f)
+    run_connection_query(conn_handle, sql_ptr, params_f, false)
 }
 
 fn run_simple_command(conn_handle: Handle, sql: &'static str) -> *mut Promise {
@@ -666,6 +685,10 @@ impl MysqlPoolConnectionHandle {
 /// `config_f` is a NaN-boxed JsValue.
 #[no_mangle]
 pub unsafe extern "C" fn js_mysql2_create_pool(config_f: f64) -> Handle {
+    // Register the handle method dispatch so generic `pool.query(...)` calls work
+    // (Drizzle threads the pool through interface-typed values, losing the static
+    // "Pool" type the codegen needs to route `.query`/`.execute` natively).
+    ensure_dispatch_registered();
     let config = JsValue::from_bits(config_f.to_bits());
     let mysql_config = parse_mysql_config(config);
     let url = mysql_config.to_url();
@@ -699,6 +722,154 @@ pub unsafe extern "C" fn js_mysql2_create_pool(config_f: f64) -> Handle {
     }
 }
 
+// ── Generic handle method dispatch ────────────────────────────────
+//
+// The codegen routes `pool.query(sql, params)` to the native query fns ONLY
+// when the receiver is statically typed as a mysql2 `Pool`. Drizzle stores the
+// pool behind interface-typed fields (`this.client: Pool | Connection`), so by
+// the time it calls `client.query(query, params)` the static type is lost and
+// the call falls back to a generic dynamic dispatch that returned garbage. The
+// runtime consults HANDLE_METHOD_DISPATCH for a generic call on a small handle;
+// register an extension here so a mysql2 pool/connection handle answers
+// `query`/`execute` (and `end`/`getConnection`) regardless of static type.
+
+const DISPATCH_POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const DISPATCH_POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+const DISPATCH_TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+extern "C" {
+    fn js_register_handle_method_dispatch_extension(
+        f: unsafe extern "C" fn(i64, *const u8, usize, *const f64, usize, *mut f64) -> i32,
+    );
+    // Runtime generic field read; returns the runtime `JSValue` (repr-transparent
+    // u64), ABI-compatible with `u64` here.
+    fn js_object_get_field_by_name(obj: *const ObjectHeader, key: *const StringHeader) -> u64;
+}
+
+fn dispatch_nanbox_ptr<T>(ptr: *mut T) -> f64 {
+    f64::from_bits(DISPATCH_POINTER_TAG | (ptr as u64 & DISPATCH_POINTER_MASK))
+}
+
+fn ensure_dispatch_registered() {
+    static REGISTER: std::sync::Once = std::sync::Once::new();
+    REGISTER.call_once(|| unsafe {
+        js_register_handle_method_dispatch_extension(js_mysql2_handle_method_dispatch);
+    });
+}
+
+/// Read a named field off a JS object value. Returns `JsValue::UNDEFINED` for a
+/// non-object receiver or a missing key.
+unsafe fn object_field_by_name(obj: JsValue, name: &str) -> JsValue {
+    let obj_ptr = obj.as_pointer::<ObjectHeader>();
+    if obj_ptr.is_null() {
+        return JsValue::UNDEFINED;
+    }
+    let key = alloc_string(name);
+    let bits = js_object_get_field_by_name(obj_ptr, key.as_raw());
+    JsValue::from_bits(bits)
+}
+
+/// Resolve the SQL `StringHeader` pointer and `rowsAsArray` flag from a `query`
+/// argument that is either a SQL string or a mysql2 options object
+/// (`{ sql, rowsAsArray? }` — Drizzle's shape).
+unsafe fn query_sql_ptr_and_rows_as_array(arg: JsValue) -> Option<(*const u8, bool)> {
+    if arg.is_string() {
+        let p = arg.as_string_ptr();
+        if p.is_null() {
+            return None;
+        }
+        return Some((p as *const u8, false));
+    }
+    if arg.is_pointer() {
+        let sql_val = object_field_by_name(arg, "sql");
+        if sql_val.is_string() {
+            let p = sql_val.as_string_ptr();
+            if !p.is_null() {
+                let rows_as_array = object_field_by_name(arg, "rowsAsArray").to_bool();
+                return Some((p as *const u8, rows_as_array));
+            }
+        }
+    }
+    None
+}
+
+/// Handle-method dispatch extension for mysql2 pool / connection handles.
+#[no_mangle]
+unsafe extern "C" fn js_mysql2_handle_method_dispatch(
+    handle: i64,
+    method_name_ptr: *const u8,
+    method_name_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+    out: *mut f64,
+) -> i32 {
+    if method_name_ptr.is_null() || method_name_len == 0 {
+        return 0;
+    }
+    let method = match std::str::from_utf8(std::slice::from_raw_parts(
+        method_name_ptr,
+        method_name_len,
+    )) {
+        Ok(m) => m,
+        Err(_) => return 0,
+    };
+    let args: &[f64] = if args_ptr.is_null() || args_len == 0 {
+        &[]
+    } else {
+        std::slice::from_raw_parts(args_ptr, args_len)
+    };
+    let arg = |i: usize| -> JsValue {
+        args.get(i)
+            .copied()
+            .map(|f| JsValue::from_bits(f.to_bits()))
+            .unwrap_or(JsValue::UNDEFINED)
+    };
+
+    // Only claim methods for handles we actually own.
+    let is_pool = perry_ffi::get_handle::<MysqlPoolHandle>(handle).is_some();
+    let is_pool_conn = perry_ffi::get_handle::<MysqlPoolConnectionHandle>(handle).is_some();
+    let is_conn = perry_ffi::get_handle::<MysqlConnectionHandle>(handle).is_some();
+    if !is_pool && !is_pool_conn && !is_conn {
+        return 0;
+    }
+
+    let result: f64 = match method {
+        "query" | "execute" => {
+            let Some((sql_ptr, rows_as_array)) =
+                query_sql_ptr_and_rows_as_array(arg(0))
+            else {
+                return 0;
+            };
+            let params_f = args.get(1).copied().unwrap_or(f64::from_bits(DISPATCH_TAG_UNDEFINED));
+            let promise = if is_pool {
+                run_pool_query(handle, sql_ptr, params_f, rows_as_array)
+            } else if is_pool_conn {
+                run_pool_conn_query(handle, sql_ptr, params_f, rows_as_array)
+            } else {
+                run_connection_query(handle, sql_ptr, params_f, rows_as_array)
+            };
+            dispatch_nanbox_ptr(promise)
+        }
+        "getConnection" if is_pool => dispatch_nanbox_ptr(js_mysql2_pool_get_connection(handle)),
+        "end" if is_pool => dispatch_nanbox_ptr(js_mysql2_pool_end(handle)),
+        "release" if is_pool_conn => {
+            js_mysql2_pool_connection_release(handle);
+            f64::from_bits(DISPATCH_TAG_UNDEFINED)
+        }
+        "end" if is_conn => dispatch_nanbox_ptr(js_mysql2_connection_end(handle)),
+        // `mysql2/promise` pools are already promise-based: `pool.promise()`
+        // returns the pool itself. Drizzle's `isCallbackClient` only reaches this
+        // when it mis-detects; return the same handle to be safe.
+        "promise" => dispatch_nanbox_ptr(handle as *mut u8),
+        _ => return 0,
+    };
+
+    if !out.is_null() {
+        *out = result;
+    }
+    1
+}
+
 #[no_mangle]
 pub extern "C" fn js_mysql2_pool_end(pool_handle: Handle) -> *mut Promise {
     let promise = JsPromise::new();
@@ -714,7 +885,12 @@ pub extern "C" fn js_mysql2_pool_end(pool_handle: Handle) -> *mut Promise {
     raw
 }
 
-unsafe fn run_pool_query(pool_handle: Handle, sql_ptr: *const u8, params_f: f64) -> *mut Promise {
+unsafe fn run_pool_query(
+    pool_handle: Handle,
+    sql_ptr: *const u8,
+    params_f: f64,
+    rows_as_array: bool,
+) -> *mut Promise {
     let sql = read_sql(sql_ptr);
     let params = JsValue::from_bits(params_f.to_bits());
     let param_values = extract_params_from_jsvalue(params);
@@ -766,7 +942,7 @@ unsafe fn run_pool_query(pool_handle: Handle, sql_ptr: *const u8, params_f: f64)
             // allocates arrays/objects/strings, which is UB on this blocking-pool
             // thread (worker thread-local arena → dangling on the main thread once
             // the pooled thread idles out). `out` is plain Send Rust data.
-            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out)),
+            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out, rows_as_array)),
             Err(e) => promise.reject_string(&e),
         }
     });
@@ -781,7 +957,7 @@ pub unsafe extern "C" fn js_mysql2_pool_query(
     sql_ptr: *const u8,
     params_f: f64,
 ) -> *mut Promise {
-    run_pool_query(pool_handle, sql_ptr, params_f)
+    run_pool_query(pool_handle, sql_ptr, params_f, false)
 }
 
 /// # Safety
@@ -792,7 +968,7 @@ pub unsafe extern "C" fn js_mysql2_pool_execute(
     sql_ptr: *const u8,
     params_f: f64,
 ) -> *mut Promise {
-    run_pool_query(pool_handle, sql_ptr, params_f)
+    run_pool_query(pool_handle, sql_ptr, params_f, false)
 }
 
 #[no_mangle]
@@ -833,6 +1009,7 @@ unsafe fn run_pool_conn_query(
     conn_handle: Handle,
     sql_ptr: *const u8,
     params_f: f64,
+    rows_as_array: bool,
 ) -> *mut Promise {
     let sql = read_sql(sql_ptr);
     let params = JsValue::from_bits(params_f.to_bits());
@@ -888,7 +1065,7 @@ unsafe fn run_pool_conn_query(
             // allocates arrays/objects/strings, which is UB on this blocking-pool
             // thread (worker thread-local arena → dangling on the main thread once
             // the pooled thread idles out). `out` is plain Send Rust data.
-            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out)),
+            Ok(out) => promise.resolve_with(move || outcome_to_jsvalue(&out, rows_as_array)),
             Err(e) => promise.reject_string(&e),
         }
     });
@@ -903,7 +1080,7 @@ pub unsafe extern "C" fn js_mysql2_pool_connection_query(
     sql_ptr: *const u8,
     params_f: f64,
 ) -> *mut Promise {
-    run_pool_conn_query(conn_handle, sql_ptr, params_f)
+    run_pool_conn_query(conn_handle, sql_ptr, params_f, false)
 }
 
 /// # Safety
@@ -914,7 +1091,7 @@ pub unsafe extern "C" fn js_mysql2_pool_connection_execute(
     sql_ptr: *const u8,
     params_f: f64,
 ) -> *mut Promise {
-    run_pool_conn_query(conn_handle, sql_ptr, params_f)
+    run_pool_conn_query(conn_handle, sql_ptr, params_f, false)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The codegen routes `pool.query(sql, params)` to the native query fns only when the receiver is statically typed as a mysql2 `Pool`. Drizzle stores the pool behind interface-typed fields (`this.client: Pool | Connection`), so by the time it calls `client.query(query, params)` the static type is gone and the call fell back to a generic dynamic dispatch that returned garbage — every `db.select()` crashed with "Cannot read properties of undefined (reading 'map')".

## Fix
Register a HANDLE_METHOD_DISPATCH extension (mirroring `perry-ext-net`) so a mysql2 pool/connection handle answers `query`/`execute`/`getConnection`/`end`/`release` regardless of static type. The dispatch:
- extracts the SQL from arg0 (a string OR a mysql2 options object `{ sql, rowsAsArray? }` — Drizzle's shape), reading `.sql`/`.rowsAsArray` by name;
- honours `rowsAsArray` (positional-array rows for Drizzle's `mapResultRow`, else column→value objects);
- only claims handles it owns.

## Validation
End-to-end against a real MySQL: `db.select().from(t)`, `db.update(t).set(...).where(...)`, and generic `pool.query(...)` through an any-typed binding all return real rows / the `[rows, fields]` tuple. `cargo test -p perry-ext-mysql2` green.