### PR TITLE
fix(runtime): Array.isArray/from/of usable as first-class function values

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1839,8 +1839,22 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         },
                         ast::MemberProp::PrivateName(_) => None,
                     };
+                    // #4596 follow-up: `Array.isArray` / `Array.from` /
+                    // `Array.of` read as VALUES need the reified Array
+                    // constructor receiver so they resolve to the real native
+                    // function objects (correct `.name` / `.length`). They are
+                    // installed with metadata via `install_constructor_static`
+                    // (global_this.rs), but the reroute-undo otherwise collapses
+                    // them to `GlobalGet(0).<name>`, whose intrinsic path drops
+                    // the metadata (`typeof` is "function" but `.name` was
+                    // undefined). `Array.fromAsync` is unreified and stays
+                    // undefined either way. Direct calls keep the intrinsic
+                    // fast path via the `!member_is_call_callee` gate.
                     let outer_is_reified_builtin_static_value = !member_is_call_callee
-                        && matches!(property.as_str(), "JSON" | "Reflect" | "BigInt" | "Symbol")
+                        && matches!(
+                            property.as_str(),
+                            "JSON" | "Reflect" | "BigInt" | "Symbol" | "Array"
+                        )
                         && outer_static_member
                             .map(|member| {
                                 crate::analysis::is_builtin_static_function_member(property, member)


### PR DESCRIPTION
Follow-up to #4622 (Date statics), same root cause. Value reads of `Array.isArray` / `Array.from` / `Array.of` were collapsed by the #973/#4139 reroute-undo to `GlobalGet(0).<name>`, whose intrinsic path drops the function metadata — `typeof` was "function" but `.name` and `.length` were `undefined`.

These are installed with metadata via `install_constructor_static` (global_this.rs:3558-3567), so add `Array` to the reified-static reroute-undo exception. `Array.fromAsync` is unreified and unchanged; direct calls keep the intrinsic fast path via the `!member_is_call_callee` gate.

Byte-identical to `node --experimental-strip-types`:
```
Array.isArray.name 'isArray' / .length 1
Array.from.name    'from'    / .length 1
Array.of.name      'of'      / .length 0
```
Value-calls (`const f = Array.from; f([1,2,3])`) and direct calls work. Fixes test262 `built-ins/Array/{isArray,from,of}/{name,length}` (6 tests).

(Number/String have the same gap but only *partial* static reification, so they need explicit per-member handling — deferred to a follow-up.)