### PR TITLE
Expose https Agent method values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1140 — `http`/`https` Agent drops the bogus `close` method (matches Node)
+
+Node's `http.Agent`/`https.Agent` has no `close()` method — only `destroy()`.
+Perry previously bound `agent.close` as a chainable no-op, so `typeof
+agent.close` was `"function"` instead of Node's `"undefined"`. `close` is now
+removed from the Agent method/property surface (`expr_member.rs`,
+`common/dispatch.rs`, `http/agent_dispatch.rs`, `agent.rs`, the http-client
+native table, and `http.rs`), so a bare read of `agent.close` is `undefined`
+while `destroy`/`getName`/`keepSocketAlive`/`reuseSocket` keep working. The PR's
+`js_ext_http_agent_dispatch_method` had already landed on `main` via another
+change; the duplicate was reconciled (kept the `close`-free version). Adds
+`node-suite/https/surface/agent-method-values.ts`.
+
 ## v0.5.1139 — spec `.length` for legacy/global function values (e.g. `parseInt.length`)
 
 Adds `builtin_global_function_length`, giving bare global function *values* their

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1139
+**Current Version:** 0.5.1140
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1139"
+version = "0.5.1140"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1139"
+version = "0.5.1140"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1139"
+version = "0.5.1140"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1139"
+version = "0.5.1140"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1139"
+version = "0.5.1140"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -34,8 +34,8 @@ use crate::type_analysis::{
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
 use super::property_get_names::{
-    is_headers_method_name, is_http_client_request_method_name, is_net_native_method_value,
-    is_url_pattern_data_property,
+    is_headers_method_name, is_http_agent_method_name, is_http_client_request_method_name,
+    is_net_native_method_value, is_url_pattern_data_property,
 };
 #[allow(unused_imports)]
 use super::{
@@ -1418,6 +1418,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         "js_class_method_bind",
                         &[(DOUBLE, &recv_box), (I64, &bytes_i64), (I64, &len_str)],
                     ));
+                }
+                if class_name == "Agent" && is_http_agent_method_name(property) {
+                    return lower_class_method_bind(ctx, object, property);
                 }
                 if is_net_native_method_value(&class_name, property) {
                     return lower_class_method_bind(ctx, object, property);

--- a/crates/perry-codegen/src/expr/property_get_names.rs
+++ b/crates/perry-codegen/src/expr/property_get_names.rs
@@ -38,6 +38,13 @@ pub(super) fn is_http_client_request_method_name(name: &str) -> bool {
     )
 }
 
+pub(super) fn is_http_agent_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "keepSocketAlive" | "reuseSocket" | "getName" | "destroy"
+    )
+}
+
 fn is_net_socket_method_name(name: &str) -> bool {
     matches!(
         name,

--- a/crates/perry-codegen/src/lower_call/native_table/http_client.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http_client.rs
@@ -390,15 +390,6 @@ pub(super) const HTTP_CLIENT_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "http",
         has_receiver: true,
-        method: "close",
-        class_filter: Some("Agent"),
-        runtime: "js_http_agent_noop_self",
-        args: &[],
-        ret: NR_PTR,
-    },
-    NativeModSig {
-        module: "http",
-        has_receiver: true,
         method: "keepSocketAlive",
         class_filter: Some("Agent"),
         runtime: "js_http_agent_noop_self",

--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -69,8 +69,12 @@ fn bind_agent_method(handle: Handle, name: &'static [u8]) -> i64 {
     (bind_agent_method_value(handle, name).to_bits() & PTR_MASK) as i64
 }
 
+fn handle_value(handle: Handle) -> f64 {
+    f64::from_bits(POINTER_TAG | (handle as u64 & PTR_MASK))
+}
+
 fn bind_agent_method_value(handle: Handle, name: &'static [u8]) -> f64 {
-    let instance = f64::from_bits(POINTER_TAG | (handle as u64 & PTR_MASK));
+    let instance = handle_value(handle);
     unsafe { js_class_method_bind(instance, name.as_ptr(), name.len()) }
 }
 
@@ -455,7 +459,34 @@ pub unsafe extern "C" fn js_ext_http_agent_dispatch_property(
         "reuseSocket" => bind_agent_method_value(handle, b"reuseSocket"),
         "getName" => bind_agent_method_value(handle, b"getName"),
         "destroy" => bind_agent_method_value(handle, b"destroy"),
-        "close" => bind_agent_method_value(handle, b"close"),
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_ext_http_agent_dispatch_method(
+    handle: Handle,
+    method_ptr: *const u8,
+    method_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    if method_ptr.is_null() || method_len == 0 || get_handle_mut::<AgentHandle>(handle).is_none() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let method = String::from_utf8_lossy(std::slice::from_raw_parts(method_ptr, method_len));
+    match method.as_ref() {
+        "getName" => {
+            let options = if !args_ptr.is_null() && args_len > 0 {
+                *args_ptr
+            } else {
+                f64::from_bits(TAG_UNDEFINED)
+            };
+            let ptr = js_http_agent_get_name(handle, options);
+            f64::from_bits(JsValue::from_string_ptr(ptr).bits())
+        }
+        "destroy" => handle_value(js_http_agent_destroy(handle)),
+        "keepSocketAlive" | "reuseSocket" => handle_value(js_http_agent_noop_self(handle)),
         _ => f64::from_bits(TAG_UNDEFINED),
     }
 }
@@ -780,7 +811,7 @@ fn json_value_to_string(v: &serde_json::Value) -> String {
 }
 
 // ------------------------------------------------------------------
-// destroy / close / keepSocketAlive / reuseSocket — chainable no-ops
+// destroy / keepSocketAlive / reuseSocket — chainable no-ops
 // ------------------------------------------------------------------
 
 #[no_mangle]

--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -491,36 +491,6 @@ pub unsafe extern "C" fn js_ext_http_agent_dispatch_method(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn js_ext_http_agent_dispatch_method(
-    handle: Handle,
-    method_ptr: *const u8,
-    method_len: usize,
-    args_ptr: *const f64,
-    args_len: usize,
-) -> f64 {
-    if method_ptr.is_null() || method_len == 0 || get_handle_mut::<AgentHandle>(handle).is_none() {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
-    let method = String::from_utf8_lossy(std::slice::from_raw_parts(method_ptr, method_len));
-    match method.as_ref() {
-        "getName" => {
-            let options = if args_len > 0 && !args_ptr.is_null() {
-                *args_ptr
-            } else {
-                f64::from_bits(TAG_UNDEFINED)
-            };
-            let ptr = js_http_agent_get_name(handle, options);
-            f64::from_bits(JsValue::from_string_ptr(ptr).bits())
-        }
-        "destroy" => pointer_value(js_http_agent_destroy(handle)),
-        "close" | "keepSocketAlive" | "reuseSocket" => {
-            pointer_value(js_http_agent_noop_self(handle))
-        }
-        _ => f64::from_bits(TAG_UNDEFINED),
-    }
-}
-
 // ------------------------------------------------------------------
 // Constructor (with validation)
 // ------------------------------------------------------------------

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1247,9 +1247,14 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     });
                 } else if matches!(module_name.as_str(), "http" | "https")
                     && class_name == "Agent"
+                    && property_name == "close"
+                {
+                    return Ok(Expr::Undefined);
+                } else if matches!(module_name.as_str(), "http" | "https")
+                    && class_name == "Agent"
                     && matches!(
                         property_name.as_str(),
-                        "keepSocketAlive" | "reuseSocket" | "getName" | "destroy" | "close"
+                        "keepSocketAlive" | "reuseSocket" | "getName" | "destroy"
                     )
                 {
                     // A bare read of an Agent method (`typeof a.getName`)

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
 
         if matches!(
             method_name,
-            "getName" | "destroy" | "close" | "keepSocketAlive" | "reuseSocket"
+            "getName" | "destroy" | "keepSocketAlive" | "reuseSocket"
         ) && js_ext_http_agent_is_handle(handle) != 0
         {
             let args_ptr = if args.is_empty() {
@@ -1789,7 +1789,6 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
                 | "reuseSocket"
                 | "getName"
                 | "destroy"
-                | "close"
         ) && unsafe { js_ext_http_agent_is_handle(handle) } != 0
         {
             return unsafe {

--- a/crates/perry-stdlib/src/http.rs
+++ b/crates/perry-stdlib/src/http.rs
@@ -1768,8 +1768,8 @@ unsafe fn append_https_agent_name_fields(name: &mut String, options_f64: f64) {
     push_truthy_string(name, "privateKeyEngine");
 }
 
-/// `agent.destroy()` / `.close()` — release pooled sockets. Perry doesn't
-/// pool today, so it's a no-op that returns the receiver for chainability.
+/// `agent.destroy()` — release pooled sockets. Perry doesn't pool today, so
+/// it's a no-op that returns the receiver for chainability.
 #[no_mangle]
 pub extern "C" fn js_http_agent_noop_self(handle: Handle) -> Handle {
     handle

--- a/crates/perry-stdlib/src/http/agent_dispatch.rs
+++ b/crates/perry-stdlib/src/http/agent_dispatch.rs
@@ -31,7 +31,6 @@ pub(crate) fn dispatch_agent_property(handle: Handle, property: &str) -> Option<
         "createSocket" => pointer_value(js_http_agent_create_socket(handle)),
         "getName" => bind_agent_method_value(handle, b"getName"),
         "destroy" => bind_agent_method_value(handle, b"destroy"),
-        "close" => bind_agent_method_value(handle, b"close"),
         "keepSocketAlive" => bind_agent_method_value(handle, b"keepSocketAlive"),
         "reuseSocket" => bind_agent_method_value(handle, b"reuseSocket"),
         _ => return None,
@@ -54,9 +53,7 @@ pub(crate) unsafe fn dispatch_agent_method(
             f64::from_bits(JSValue::string_ptr(ptr).bits())
         }
         "destroy" => pointer_value(js_http_agent_destroy(handle)),
-        "close" | "keepSocketAlive" | "reuseSocket" => {
-            pointer_value(js_http_agent_noop_self(handle))
-        }
+        "keepSocketAlive" | "reuseSocket" => pointer_value(js_http_agent_noop_self(handle)),
         _ => return None,
     })
 }

--- a/test-parity/node-suite/https/surface/agent-method-values.ts
+++ b/test-parity/node-suite/https/surface/agent-method-values.ts
@@ -1,0 +1,21 @@
+import * as https from "node:https";
+
+const agent = new https.Agent({ keepAlive: true, maxSockets: 5 });
+
+const createConnection = agent.createConnection;
+const keepSocketAlive = agent.keepSocketAlive;
+const reuseSocket = agent.reuseSocket;
+const getName = agent.getName;
+const destroy = agent.destroy;
+const close = agent.close;
+
+console.log("createConnection value:", typeof createConnection);
+console.log("keepSocketAlive value:", typeof keepSocketAlive);
+console.log("reuseSocket value:", typeof reuseSocket);
+console.log("getName value:", typeof getName);
+console.log("destroy value:", typeof destroy);
+console.log("close value:", typeof close);
+console.log("getName detached:", getName({ host: "127.0.0.1", port: 443 }));
+
+agent.destroy();
+console.log("agent destroyed:", true);


### PR DESCRIPTION
Refs #2132

Summary:
- Expose callable method values for HTTP/HTTPS Agent `keepSocketAlive`, `reuseSocket`, `getName`, and `destroy`.
- Keep `Agent#close` absent as in Node and remove the stale close dispatch paths.
- Route external HTTP Agent detached method calls through handle method dispatch.
- Add a focused `node-suite/https/surface/agent-method-values` parity fixture.
- Include a rustfmt-only cleanup for the current-main mysql2 dispatch formatting drift so `cargo fmt --check` remains green after rebase.

Validation:
- `NODE22_BIN=$(npx -y node@22 -e 'console.log(process.execPath)') && PATH="$(dirname "$NODE22_BIN"):$PATH" ./run_parity_tests.sh --suite node-suite --module https/surface --filter agent-method-values`\n- Direct Node 22/26 fixture output matched Perry output.\n- `PERRY_ALLOW_UNIMPLEMENTED=1 ./target/release/perry test-files/test_parity_https.ts -o /tmp/perry_test_parity_https_rebased` plus Node 22 output diff matched on the rebased branch.\n- `cargo fmt --all -- --check`\n- `cargo check -p perry-codegen -p perry-hir -p perry-stdlib -p perry-ext-http --features perry-stdlib/external-http-client-pump`\n- `./scripts/check_file_size.sh`\n- `git diff origin/main..HEAD --check`\n\nNon-goals:\n- No TLS/socket pooling changes.\n- No request/get/createServer response framing changes.