### PR TITLE
fix(runtime): Number.isInteger/isSafeInteger usable as first-class function values

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1850,10 +1850,17 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // undefined). `Array.fromAsync` is unreified and stays
                     // undefined either way. Direct calls keep the intrinsic
                     // fast path via the `!member_is_call_callee` gate.
+                    // #4627: all six Number statics (isFinite / isInteger /
+                    // isNaN / isSafeInteger / parseFloat / parseInt) are reified
+                    // with metadata via install_constructor_static, so routing
+                    // value reads to the reified Number receiver is safe and
+                    // fixes the missing `.name`/`.length` on isInteger /
+                    // isSafeInteger. (String's fromCharCode/etc. are NOT reified
+                    // yet — left to #4627.)
                     let outer_is_reified_builtin_static_value = !member_is_call_callee
                         && matches!(
                             property.as_str(),
-                            "JSON" | "Reflect" | "BigInt" | "Symbol" | "Array"
+                            "JSON" | "Reflect" | "BigInt" | "Symbol" | "Array" | "Number"
                         )
                         && outer_static_member
                             .map(|member| {


### PR DESCRIPTION
Third in the series (#4622 Date, #4626 Array), same root cause. All six Number statics are reified with metadata via `install_constructor_static`, but the #973/#4139 reroute-undo collapsed value reads to `GlobalGet(0).<name>`, whose intrinsic path dropped the metadata for `isInteger`/`isSafeInteger` (`.name`/`.length` were `undefined`).

Add `Number` to the reified-static reroute-undo exception. The already-named siblings (isFinite/isNaN/parseFloat/parseInt) are also reified, so routing them to the reified receiver preserves their names; direct calls keep the intrinsic fast path via the `!member_is_call_callee` gate.

Byte-identical to `node`: `Number.isInteger.name === 'isInteger'` / `.length === 1`, `isSafeInteger` likewise; value-calls and direct calls work. Fixes test262 `built-ins/Number/{isInteger,isSafeInteger}/{name,length}`.

`String.fromCharCode`/`fromCodePoint`/`raw` have the same gap but are **not reified** yet (need install_constructor_static first) — tracked in #4627.