### PR TITLE
fix(runtime): String.fromCharCode/fromCodePoint usable as first-class function values

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1887,12 +1887,23 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         && outer_static_member
                             .map(|member| matches!(member, "now" | "parse" | "UTC"))
                             .unwrap_or(false);
+                    // #4627: `String.fromCharCode` / `fromCodePoint` are reified
+                    // (variadic) statics — value reads need the reified String
+                    // receiver for correct `.name`/`.length`. Explicit list (NOT
+                    // the whole namespace) because `String.raw` is not reified
+                    // yet and must stay on its current intrinsic path.
+                    let outer_is_reified_string_static_value = !member_is_call_callee
+                        && property == "String"
+                        && outer_static_member
+                            .map(|member| matches!(member, "fromCharCode" | "fromCodePoint"))
+                            .unwrap_or(false);
                     if !outer_is_prototype_or_proto
                         && !receiver_is_namespace_value
                         && !outer_is_websocket_static
                         && !outer_is_reified_object_static_value
                         && !outer_is_reified_builtin_static_value
                         && !outer_is_reified_date_static_value
+                        && !outer_is_reified_string_static_value
                         && !receiver_is_detached_console_read
                     {
                         object_expr = Expr::GlobalGet(0);

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3226,6 +3226,25 @@ extern "C" fn number_is_safe_integer_thunk(
     crate::builtins::js_number_is_safe_integer(value)
 }
 
+// #4627: reified `String.fromCharCode(...units)` / `fromCodePoint(...points)`.
+// Both collect all arguments into `rest` (call-arity 0), so `rest` is already
+// the array-like the array-form runtime helpers expect.
+extern "C" fn string_from_char_code_static(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let s = crate::string::js_string_from_char_code_array(rest);
+    crate::value::js_nanbox_string(s as i64)
+}
+
+extern "C" fn string_from_code_point_static(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let s = crate::string::js_string_from_code_point_array(rest);
+    crate::value::js_nanbox_string(s as i64)
+}
+
 extern "C" fn number_parse_float_thunk(
     closure: *const crate::closure::ClosureHeader,
     value: f64,
@@ -3630,6 +3649,29 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
         "Symbol" => {
             install_constructor_static(ctor, "for", symbol_for_thunk as *const u8, 1, false);
             install_constructor_static(ctor, "keyFor", symbol_key_for_thunk as *const u8, 1, false);
+        }
+        "String" => {
+            // #4627: reify the variadic `String.fromCharCode` / `fromCodePoint`
+            // statics so they are real function values (correct `.name` /
+            // `.length`, usable via reference / spread). Call-arity 0 (all args
+            // collected into `rest`) with spec `.length` 1. `String.raw` (a tag
+            // function) is left on its intrinsic path for now.
+            install_constructor_static_with_call_arity(
+                ctor,
+                "fromCharCode",
+                string_from_char_code_static as *const u8,
+                1,
+                0,
+                true,
+            );
+            install_constructor_static_with_call_arity(
+                ctor,
+                "fromCodePoint",
+                string_from_code_point_static as *const u8,
+                1,
+                0,
+                true,
+            );
         }
         "ArrayBuffer" => {
             install_constructor_static(

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -293,6 +293,32 @@ pub extern "C" fn js_string_from_code_point(code: f64) -> *mut StringHeader {
     js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32)
 }
 
+/// `String.fromCodePoint(...codePoints)` — variadic form. Builds a string from
+/// an array-like of code points, validating each (RangeError on a non-integer /
+/// negative / > 0x10FFFF value) per ECMAScript. A lone surrogate emits U+FFFD
+/// (WTF-8 categorical gap), matching `js_string_from_code_point`. Used by the
+/// reified `String.fromCodePoint` constructor static so value reads / spread
+/// calls work. (#4627)
+pub fn js_string_from_code_point_array(value: f64) -> *mut StringHeader {
+    let arr = crate::object::js_array_like_to_array(value);
+    if arr.is_null() {
+        return js_string_from_bytes(std::ptr::null(), 0);
+    }
+    let len = crate::array::js_array_length(arr) as usize;
+    let mut out = String::with_capacity(len);
+    for i in 0..len {
+        let code = crate::array::js_array_get_f64(arr, i as u32);
+        if !code.is_finite() || code.fract() != 0.0 || code < 0.0 || code > 0x10FFFF as f64 {
+            throw_invalid_code_point(code);
+        }
+        match char::from_u32(code as u32) {
+            Some(c) => out.push(c),
+            None => out.push('\u{FFFD}'),
+        }
+    }
+    js_string_from_bytes(out.as_ptr(), out.len() as u32)
+}
+
 /// String.prototype.at(index) — supports negative indices.
 /// Returns NaN-boxed single-char string, or NaN-boxed undefined if out of bounds.
 /// Index is in UTF-16 code units (matches JS spec).

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -49,7 +49,7 @@ pub use base64_codec::{js_atob, js_btoa};
 pub use char_ops::{
     js_string_at, js_string_char_at, js_string_char_code_at, js_string_code_point_at,
     js_string_from_char_code, js_string_from_char_code_array, js_string_from_code_point,
-    js_string_index_get, js_string_to_char_array,
+    js_string_from_code_point_array, js_string_index_get, js_string_to_char_array,
 };
 pub use compare::{
     js_string_compare, js_string_ends_with, js_string_ends_with_at, js_string_equals,


### PR DESCRIPTION
Completes the static-function-values series (#4622 Date, #4626 Array, #4631 Number). Unlike those, `String.fromCharCode`/`fromCodePoint` weren't reified at all, so this reifies them **and** wires the reroute-undo exception:

- New `js_string_from_code_point_array` runtime helper (variadic `fromCodePoint` with per-element RangeError validation; lone surrogates → U+FFFD).
- Reify `fromCharCode`/`fromCodePoint` via `install_constructor_static_with_call_arity` (call-arity 0 = all args → rest; spec `.length` 1); `fromCharCode` reuses the existing `js_string_from_char_code_array`.
- **Explicit** `String` exception (fromCharCode/fromCodePoint only) in the #973/#4139 reroute-undo — `String.raw` is not reified and stays on its intrinsic path, unaffected.

Byte-identical to `node`: typeof/name/length, value-calls (incl. astral code points like 😀), direct calls, RangeError on invalid code points; `String.raw` unchanged. Fixes test262 `built-ins/String/{fromCharCode,fromCodePoint}/{name,length}`.

(`String.raw` .name/.length still tracked in #4627.)