### PR TITLE
fix(runtime): support generic array copyWithin receivers

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -853,6 +853,19 @@ pub fn check_escapes_in_expr(
                 check_escapes_in_expr(e, candidates, classes, escaped);
             }
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            check_escapes_in_expr(receiver, candidates, classes, escaped);
+            check_escapes_in_expr(target, candidates, classes, escaped);
+            check_escapes_in_expr(start, candidates, classes, escaped);
+            if let Some(e) = end {
+                check_escapes_in_expr(e, candidates, classes, escaped);
+            }
+        }
         Expr::ArrayAt { array, index } => {
             check_escapes_in_expr(array, candidates, classes, escaped);
             check_escapes_in_expr(index, candidates, classes, escaped);

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -634,6 +634,19 @@ fn collect_used_new_fields_in_expr(
                 collect_used_new_fields_in_expr(end, non_escaping_news, used);
             }
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            collect_used_new_fields_in_expr(receiver, non_escaping_news, used);
+            collect_used_new_fields_in_expr(target, non_escaping_news, used);
+            collect_used_new_fields_in_expr(start, non_escaping_news, used);
+            if let Some(end) = end {
+                collect_used_new_fields_in_expr(end, non_escaping_news, used);
+            }
+        }
         Expr::ArrayAt { array, index } => {
             collect_used_new_fields_in_expr(array, non_escaping_news, used);
             collect_used_new_fields_in_expr(index, non_escaping_news, used);

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -863,6 +863,19 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
                 walk(e, out);
             }
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            walk(receiver, out);
+            walk(target, out);
+            walk(start, out);
+            if let Some(e) = end {
+                walk(e, out);
+            }
+        }
         // Issue #894: prepended to the Sequence wrapping `Expr::ClassRef`
         // for class expressions returned from factory functions. The
         // key/value reference module-level (or function-local) lets;

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1773,6 +1773,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::DateToJSON(..)
         | Expr::ArrayWith { .. }
         | Expr::ArrayCopyWithin { .. }
+        | Expr::ArrayCopyWithinValue { .. }
         | Expr::ArrayToReversed { .. }
         | Expr::ArrayToSorted { .. }
         | Expr::ArrayToSpliced { .. }

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -301,6 +301,33 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             );
             Ok(nanbox_pointer_inline(blk, &result))
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            let receiver_box = lower_expr(ctx, receiver)?;
+            let target_d = lower_expr(ctx, target)?;
+            let start_d = lower_expr(ctx, start)?;
+            let (has_end_str, end_d) = if let Some(e) = end {
+                let v = lower_expr(ctx, e)?;
+                ("1".to_string(), v)
+            } else {
+                ("0".to_string(), "0.0".to_string())
+            };
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_array_copy_within_value",
+                &[
+                    (DOUBLE, &receiver_box),
+                    (DOUBLE, &target_d),
+                    (DOUBLE, &start_d),
+                    (I32, &has_end_str),
+                    (DOUBLE, &end_d),
+                ],
+            ))
+        }
         Expr::ArrayToReversed { array } => {
             let arr_box = lower_expr(ctx, array)?;
             let blk = ctx.block();

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -971,6 +971,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         I64,
         &[I64, DOUBLE, DOUBLE, I32, DOUBLE],
     );
+    module.declare_function(
+        "js_array_copy_within_value",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE, I32, DOUBLE],
+    );
     module.declare_function("js_regexp_new", I64, &[I64, I64]);
     module.declare_function("js_regexp_test", I32, &[I64, I64]);
     // RegExp.escape(str) — #2899. Takes/returns NaN-boxed f64 (string).

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -624,6 +624,19 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
                 collect_assigned_locals_expr(e, assigned);
             }
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            collect_assigned_locals_expr(receiver, assigned);
+            collect_assigned_locals_expr(target, assigned);
+            collect_assigned_locals_expr(start, assigned);
+            if let Some(e) = end {
+                collect_assigned_locals_expr(e, assigned);
+            }
+        }
         Expr::ArrayEntries(array) | Expr::ArrayKeys(array) | Expr::ArrayValues(array) => {
             collect_assigned_locals_expr(array, assigned);
         }

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1498,6 +1498,12 @@ pub enum Expr {
         start: Box<Expr>,
         end: Option<Box<Expr>>,
     }, // arr.copyWithin(target, start, end?) -> same array
+    ArrayCopyWithinValue {
+        receiver: Box<Expr>,
+        target: Box<Expr>,
+        start: Box<Expr>,
+        end: Option<Box<Expr>>,
+    }, // Array.prototype.copyWithin.call(arrayLike, target, start, end?) -> same receiver
     ArrayEntries(Box<Expr>), // arr.entries() -> Array<[index, value]> (eager materialization)
     ArrayKeys(Box<Expr>),    // arr.keys() -> Array<index>
     ArrayValues(Box<Expr>),  // arr.values() -> Array<value> (essentially clone)

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -1115,6 +1115,12 @@ pub fn transform_expr(
             transform_expr(start, js_imports, extern_func_to_js, local_name_to_js, tracker);
             if let Some(e) = end { transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker); }
         }
+        Expr::ArrayCopyWithinValue { receiver, target, start, end } => {
+            transform_expr(receiver, js_imports, extern_func_to_js, local_name_to_js, tracker);
+            transform_expr(target, js_imports, extern_func_to_js, local_name_to_js, tracker);
+            transform_expr(start, js_imports, extern_func_to_js, local_name_to_js, tracker);
+            if let Some(e) = end { transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker); }
+        }
         Expr::StringSplit(a, b) => {
             transform_expr(a, js_imports, extern_func_to_js, local_name_to_js, tracker);
             transform_expr(b, js_imports, extern_func_to_js, local_name_to_js, tracker);

--- a/crates/perry-hir/src/lower/closure_analysis.rs
+++ b/crates/perry-hir/src/lower/closure_analysis.rs
@@ -339,6 +339,19 @@ fn widen_mutable_captures_expr(
                 widen_mutable_captures_expr(e, scope_mutable);
             }
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            widen_mutable_captures_expr(receiver, scope_mutable);
+            widen_mutable_captures_expr(target, scope_mutable);
+            widen_mutable_captures_expr(start, scope_mutable);
+            if let Some(e) = end {
+                widen_mutable_captures_expr(e, scope_mutable);
+            }
+        }
         Expr::ArrayEntries(array) | Expr::ArrayKeys(array) | Expr::ArrayValues(array) => {
             widen_mutable_captures_expr(array, scope_mutable);
         }
@@ -634,6 +647,19 @@ fn collect_closure_assigned_expr(expr: &Expr, out: &mut std::collections::HashSe
                 collect_closure_assigned_expr(e, out);
             }
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            collect_closure_assigned_expr(receiver, out);
+            collect_closure_assigned_expr(target, out);
+            collect_closure_assigned_expr(start, out);
+            if let Some(e) = end {
+                collect_closure_assigned_expr(e, out);
+            }
+        }
         Expr::ArrayEntries(array) | Expr::ArrayKeys(array) | Expr::ArrayValues(array) => {
             collect_closure_assigned_expr(array, out);
         }
@@ -897,6 +923,19 @@ fn collect_closure_captures_expr(expr: &Expr, out: &mut std::collections::HashSe
         Expr::ArrayCopyWithin {
             target, start, end, ..
         } => {
+            collect_closure_captures_expr(target, out);
+            collect_closure_captures_expr(start, out);
+            if let Some(e) = end {
+                collect_closure_captures_expr(e, out);
+            }
+        }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            collect_closure_captures_expr(receiver, out);
             collect_closure_captures_expr(target, out);
             collect_closure_captures_expr(start, out);
             if let Some(e) = end {
@@ -1327,6 +1366,19 @@ fn collect_closure_assigned_in_body_expr(
         Expr::ArrayCopyWithin {
             target, start, end, ..
         } => {
+            collect_closure_assigned_in_body_expr(target, out);
+            collect_closure_assigned_in_body_expr(start, out);
+            if let Some(e) = end {
+                collect_closure_assigned_in_body_expr(e, out);
+            }
+        }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            collect_closure_assigned_in_body_expr(receiver, out);
             collect_closure_assigned_in_body_expr(target, out);
             collect_closure_assigned_in_body_expr(start, out);
             if let Some(e) = end {

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1279,6 +1279,30 @@ fn try_arraylike_receiver_method(
     if rest_args.iter().any(|a| a.spread.is_some()) {
         return Ok(None);
     }
+    if method == "copyWithin" {
+        let receiver = Box::new(lower_expr(ctx, receiver)?);
+        let arg = |ctx: &mut LoweringContext, i: usize| -> Result<Option<Box<Expr>>> {
+            match rest_args.get(i) {
+                Some(a) => Ok(Some(Box::new(lower_expr(ctx, &a.expr)?))),
+                None => Ok(None),
+            }
+        };
+        let target = match arg(ctx, 0)? {
+            Some(t) => t,
+            None => Box::new(Expr::Undefined),
+        };
+        let start = match arg(ctx, 1)? {
+            Some(s) => s,
+            None => Box::new(Expr::Undefined),
+        };
+        let end = arg(ctx, 2)?;
+        return Ok(Some(Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        }));
+    }
     // Only fold the read-only/returning methods. Bail early for everything else
     // (mutators, flat, etc.) BEFORE lowering the receiver, so unrelated shapes
     // keep the existing member-call behavior with no side effects.

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -644,6 +644,19 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
                 .as_ref()
                 .map(|e| Box::new(substitute_expr(e, substitutions))),
         },
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => Expr::ArrayCopyWithinValue {
+            receiver: Box::new(substitute_expr(receiver, substitutions)),
+            target: Box::new(substitute_expr(target, substitutions)),
+            start: Box::new(substitute_expr(start, substitutions)),
+            end: end
+                .as_ref()
+                .map(|e| Box::new(substitute_expr(e, substitutions))),
+        },
         Expr::ArrayEntries(array) => {
             Expr::ArrayEntries(Box::new(substitute_expr(array, substitutions)))
         }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -392,6 +392,7 @@ impl SH for Expr {
             Expr::ArrayToSpliced { array, start, delete_count, items, } => { tag(h, 276); array.as_ref().hash(h); start.as_ref().hash(h); delete_count.as_ref().hash(h); items.hash(h); }
             Expr::ArrayWith { array, index, value, } => { tag(h, 277); array.as_ref().hash(h); index.as_ref().hash(h); value.as_ref().hash(h); }
             Expr::ArrayCopyWithin { array_id, target, start, end, } => { tag(h, 278); array_id.hash(h); target.as_ref().hash(h); start.as_ref().hash(h); end.hash(h); }
+            Expr::ArrayCopyWithinValue { receiver, target, start, end, } => { tag(h, 12091); receiver.as_ref().hash(h); target.as_ref().hash(h); start.as_ref().hash(h); end.hash(h); }
             Expr::ArrayEntries(e) => { tag(h, 279); e.as_ref().hash(h); }
             Expr::ArrayKeys(e) => { tag(h, 280); e.as_ref().hash(h); }
             Expr::ArrayValues(e) => { tag(h, 281); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1606,6 +1606,19 @@ where
                 f(e);
             }
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            f(receiver);
+            f(target);
+            f(start);
+            if let Some(e) = end {
+                f(e);
+            }
+        }
 
         // ─── Map / Set methods (non-leaf) ────────────────────────────────
         Expr::MapSet { map, key, value } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1581,6 +1581,19 @@ where
                 f(e);
             }
         }
+        Expr::ArrayCopyWithinValue {
+            receiver,
+            target,
+            start,
+            end,
+        } => {
+            f(receiver);
+            f(target);
+            f(start);
+            if let Some(e) = end {
+                f(e);
+            }
+        }
         Expr::MapSet { map, key, value } => {
             f(map);
             f(key);

--- a/crates/perry-runtime/src/array/immutable.rs
+++ b/crates/perry-runtime/src/array/immutable.rs
@@ -333,3 +333,123 @@ pub extern "C" fn js_array_copy_within(
         arr
     }
 }
+
+#[cold]
+fn throw_copy_within_type_error(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+fn copy_within_to_integer_or_infinity(value: f64) -> f64 {
+    let number = crate::builtins::js_number_coerce(value);
+    if number.is_nan() || number == 0.0 {
+        0.0
+    } else if number.is_infinite() {
+        number
+    } else {
+        number.trunc()
+    }
+}
+
+fn copy_within_to_length(value: f64) -> u32 {
+    let number = crate::builtins::js_number_coerce(value);
+    if number.is_nan() || number <= 0.0 {
+        0
+    } else if number.is_infinite() {
+        if number.is_sign_positive() {
+            u32::MAX
+        } else {
+            0
+        }
+    } else {
+        number.trunc().min(u32::MAX as f64) as u32
+    }
+}
+
+fn copy_within_relative_index(value: f64, len: i64) -> i64 {
+    let integer = copy_within_to_integer_or_infinity(value);
+    if integer == f64::NEG_INFINITY {
+        0
+    } else if integer < 0.0 {
+        (len as f64 + integer).max(0.0) as i64
+    } else {
+        integer.min(len as f64) as i64
+    }
+}
+
+fn copy_within_length_of_array_like(receiver: f64) -> u32 {
+    let length = unsafe {
+        crate::value::js_dynamic_object_get_property(receiver, b"length".as_ptr() as *const i8, 6)
+    };
+    copy_within_to_length(length)
+}
+
+fn copy_within_has_property(receiver: f64, index: i64) -> bool {
+    crate::value::js_is_truthy(crate::object::js_object_has_own(receiver, index as f64)) != 0
+}
+
+/// Generic `Array.prototype.copyWithin.call(arrayLike, target, start?, end?)`.
+///
+/// This keeps the original `this` value rather than materializing an Array:
+/// the spec mutates the receiver's indexed properties and returns that same
+/// receiver after ToObject coercion.
+#[no_mangle]
+pub extern "C" fn js_array_copy_within_value(
+    receiver: f64,
+    target: f64,
+    start: f64,
+    has_end: i32,
+    end: f64,
+) -> f64 {
+    let receiver_value = crate::value::JSValue::from_bits(receiver.to_bits());
+    if receiver_value.is_null() || receiver_value.is_undefined() {
+        throw_copy_within_type_error(b"Cannot convert undefined or null to object");
+    }
+
+    let receiver = crate::object::js_object_coerce(receiver);
+    let len = copy_within_length_of_array_like(receiver) as i64;
+    let to = copy_within_relative_index(target, len);
+    let from = copy_within_relative_index(start, len);
+    let final_index = if has_end != 0 {
+        copy_within_relative_index(end, len)
+    } else {
+        len
+    };
+    let count = (final_index - from).min(len - to).max(0);
+    if count <= 0 {
+        return receiver;
+    }
+
+    if crate::builtins::boxed_primitive_to_string_tag(receiver) == Some("String") {
+        throw_copy_within_type_error(b"Cannot assign to read only property");
+    }
+
+    let mut from_idx = from;
+    let mut to_idx = to;
+    let direction = if from < to && to < from + count {
+        from_idx += count - 1;
+        to_idx += count - 1;
+        -1
+    } else {
+        1
+    };
+
+    let receiver_bits = receiver.to_bits() as i64;
+    for _ in 0..count {
+        if copy_within_has_property(receiver, from_idx) {
+            let value =
+                crate::object::js_object_get_index_polymorphic(receiver_bits, from_idx as f64);
+            crate::object::js_object_set_index_polymorphic(receiver_bits, to_idx as f64, value);
+        } else {
+            let obj = unsafe { crate::object::extract_obj_ptr(receiver) };
+            if !obj.is_null() && crate::object::js_object_delete_dynamic(obj, to_idx as f64) == 0 {
+                throw_copy_within_type_error(b"Cannot delete property");
+            }
+        }
+        from_idx += direction;
+        to_idx += direction;
+    }
+
+    receiver
+}

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -41,8 +41,9 @@ pub use self::header::{
     scan_template_raw_roots_mut, ArrayHeader,
 };
 pub use self::immutable::{
-    js_array_copy_within, js_array_to_reversed, js_array_to_sorted_default,
-    js_array_to_sorted_with_comparator, js_array_to_spliced, js_array_with,
+    js_array_copy_within, js_array_copy_within_value, js_array_to_reversed,
+    js_array_to_sorted_default, js_array_to_sorted_with_comparator, js_array_to_spliced,
+    js_array_with,
 };
 pub use self::indexing::{
     js_array_get_element, js_array_get_element_f64, js_array_get_f64, js_array_get_f64_unchecked,

--- a/test-parity/expected/array-generic-copywithin.txt
+++ b/test-parity/expected/array-generic-copywithin.txt
@@ -1,0 +1,14 @@
+sparse return same: true
+sparse: a,a,b,<hole>,d keys=0|1|2|4|length
+overlap backward: a,a,b,c,d keys=0|1|2|3|4|length
+negative offsets: a,b,c,b,c keys=0|1|2|3|4|length
+apply return same: true
+apply: y,z,y,z keys=0|1|2|3|length
+delete missing source: a,<hole>,<hole>,c keys=0|3|length
+delete has: false true
+coerced bounds: a,a,b,c,d keys=0|1|2|3|4|length
+no args return same: true
+no args: a,b keys=0|1|length
+null receiver: TypeError
+undefined receiver: TypeError
+string receiver: TypeError

--- a/test-parity/node-suite/globals/array-generic-copywithin.ts
+++ b/test-parity/node-suite/globals/array-generic-copywithin.ts
@@ -1,0 +1,55 @@
+function dump(label: string, value: any) {
+  const parts: string[] = [];
+  const len = Number(value.length);
+  for (let i = 0; i < len; i++) {
+    parts.push(Object.hasOwn(value, i) ? String(value[i]) : "<hole>");
+  }
+  console.log(label + ": " + parts.join(",") + " keys=" + Object.keys(value).join("|"));
+}
+
+function showError(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(label + ": no throw");
+  } catch (err: any) {
+    console.log(label + ": " + err.name);
+  }
+}
+
+const sparse: any = { length: 5, 0: "a", 1: "b", 3: "d" };
+const sparseReturned = Array.prototype.copyWithin.call(sparse, 1, 0, 4);
+console.log("sparse return same:", sparseReturned === sparse);
+dump("sparse", sparse);
+
+const overlap: any = { length: 5, 0: "a", 1: "b", 2: "c", 3: "d", 4: "e" };
+Array.prototype.copyWithin.call(overlap, 1, 0, 4);
+dump("overlap backward", overlap);
+
+const negative: any = { length: 5, 0: "a", 1: "b", 2: "c", 3: "d", 4: "e" };
+Array.prototype.copyWithin.call(negative, -2, -4, -1);
+dump("negative offsets", negative);
+
+const applied: any = { length: 4, 0: "w", 1: "x", 2: "y", 3: "z" };
+const appliedReturned = Array.prototype.copyWithin.apply(applied, [0, 2]);
+console.log("apply return same:", appliedReturned === applied);
+dump("apply", applied);
+
+const deleted: any = { length: 4, 0: "a", 2: "c", 3: "d" };
+Array.prototype.copyWithin.call(deleted, 2, 1, 3);
+dump("delete missing source", deleted);
+console.log("delete has:", Object.hasOwn(deleted, 2), Object.hasOwn(deleted, 3));
+
+const coerced: any = { length: "5", 0: "a", 1: "b", 2: "c", 3: "d", 4: "e" };
+Array.prototype.copyWithin.call(coerced, "1", "-Infinity", Infinity);
+dump("coerced bounds", coerced);
+
+const noArgs: any = { length: 2, 0: "a", 1: "b" };
+const noArgsReturned = Array.prototype.copyWithin.call(noArgs);
+console.log("no args return same:", noArgsReturned === noArgs);
+dump("no args", noArgs);
+
+showError("null receiver", () => Array.prototype.copyWithin.call(null as any, 0, 1));
+showError("undefined receiver", () =>
+  Array.prototype.copyWithin.call(undefined as any, 0, 1)
+);
+showError("string receiver", () => Array.prototype.copyWithin.call("abc" as any, 0, 1));


### PR DESCRIPTION
## Summary
- lower borrowed `Array.prototype.copyWithin.call/apply(...)` on array-like receivers without materializing an intermediate Array
- add a runtime helper that mutates the original receiver, preserves return identity, handles sparse delete semantics, offset coercion, overlap direction, and nullish/string receiver errors
- add a Node parity fixture for sparse ordinary objects, `.apply`, negative/coerced bounds, omitted args, and error cases

## Repro
- On `origin/main` (`3791cd801`), the new fixture compiles but diverges at runtime: the receiver remains unchanged and execution exits with `TypeError: value is not a function` before the nullish/string receiver checks.

## Validation
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/array-generic-copywithin.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter array-generic-copywithin'`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter array-'`
- `cargo fmt --all -- --check`
- `cargo check -q -p perry-hir -p perry-codegen -p perry-runtime`
- `git diff --check`
- `./scripts/check_file_size.sh`

Fixes #4597.
