### PR TITLE
fix(runtime): String.raw usable as a first-class function value

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1887,15 +1887,17 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         && outer_static_member
                             .map(|member| matches!(member, "now" | "parse" | "UTC"))
                             .unwrap_or(false);
-                    // #4627: `String.fromCharCode` / `fromCodePoint` are reified
-                    // (variadic) statics — value reads need the reified String
-                    // receiver for correct `.name`/`.length`. Explicit list (NOT
-                    // the whole namespace) because `String.raw` is not reified
-                    // yet and must stay on its current intrinsic path.
+                    // #4627: `String.fromCharCode` / `fromCodePoint` / `raw` are
+                    // reified statics — value reads need the reified String
+                    // receiver for correct `.name`/`.length`. Explicit member
+                    // list (NOT the whole namespace) so only the reified statics
+                    // are rerouted.
                     let outer_is_reified_string_static_value = !member_is_call_callee
                         && property == "String"
                         && outer_static_member
-                            .map(|member| matches!(member, "fromCharCode" | "fromCodePoint"))
+                            .map(|member| {
+                                matches!(member, "fromCharCode" | "fromCodePoint" | "raw")
+                            })
                             .unwrap_or(false);
                     if !outer_is_prototype_or_proto
                         && !receiver_is_namespace_value

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3245,6 +3245,19 @@ extern "C" fn string_from_code_point_static(
     crate::value::js_nanbox_string(s as i64)
 }
 
+// #4627: reified `String.raw(callSite, ...substitutions)` tag function. One
+// fixed param (the template/cooked object) then a rest of substitutions, which
+// `js_string_raw` reads by numeric index — so `rest` (the collected array) is
+// passed straight through as the substitutions array-like.
+extern "C" fn string_raw_static(
+    _closure: *const crate::closure::ClosureHeader,
+    call_site: f64,
+    rest: f64,
+) -> f64 {
+    let s = crate::string::js_string_raw(call_site, rest);
+    crate::value::js_nanbox_string(s as i64)
+}
+
 extern "C" fn number_parse_float_thunk(
     closure: *const crate::closure::ClosureHeader,
     value: f64,
@@ -3670,6 +3683,16 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 string_from_code_point_static as *const u8,
                 1,
                 0,
+                true,
+            );
+            // #4627: `String.raw` (tag function) — 1 fixed param (template
+            // object) + rest substitutions; spec `.length` 1.
+            install_constructor_static_with_call_arity(
+                ctor,
+                "raw",
+                string_raw_static as *const u8,
+                1,
+                1,
                 true,
             );
         }


### PR DESCRIPTION
Completes the static-function-values series (Date #4622, Array #4626, Number #4631, String.fromCharCode/fromCodePoint #4634).

Reify `String.raw` as a real function value: a thunk taking the template/cooked object as a fixed param plus a rest of substitutions (call-arity 1, spec `.length` 1), forwarding to `js_string_raw`. Add `raw` to the String reroute-undo exception so value reads hit the reified receiver.

Byte-identical to `node`: `String.raw.name === 'raw'` / `.length === 1`, value-calls (`const r = String.raw; r({raw:[…]}, …)`) and tagged-template calls (`String.raw\`x${10}y\``) work. Fixes test262 `built-ins/String/raw/{name,length}`; closes the String portion of #4627.