### PR TITLE
fix(array): read array elements through string keys (a["1"], a[k])

### DIFF
--- a/crates/perry-codegen/src/expr/i32_fast_path.rs
+++ b/crates/perry-codegen/src/expr/i32_fast_path.rs
@@ -93,6 +93,21 @@ pub(crate) fn try_lower_flat_const_index_get(
         _ => return Ok(None),
     };
 
+    // A string-keyed access (`m["1"]["0"]`) must NOT take the integer flat
+    // path: `fptosi` on a NaN-boxed string collapses to index 0, so every
+    // string-keyed read returned the matrix's element 0. Bail to the caller's
+    // tag-aware dispatch, which resolves a canonical numeric-string index to
+    // the real element (`m` itself materializes as a heap array; only the
+    // separately-tracked `const row = m[i]` alias does not). Proven-numeric /
+    // loop-counter indices keep the flat path.
+    let row_is_string = matches!(row_expr.as_ref(), Expr::String(_))
+        || crate::type_analysis::is_string_expr(ctx, &row_expr);
+    let col_is_string = matches!(col_expr.as_ref(), Expr::String(_))
+        || crate::type_analysis::is_string_expr(ctx, &col_expr);
+    if row_is_string || col_is_string {
+        return Ok(None);
+    }
+
     // Compute `row_i32` and `col_i32` as i32 SSA values. Use the existing
     // integer lowering when possible (both operands are likely small
     // loop-derived values); otherwise fall back to the double path and

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1279,11 +1279,31 @@ pub extern "C" fn js_typed_feedback_array_index_get_fallback_boxed(
             (raw_addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         match (*gc_header).obj_type {
             crate::gc::GC_TYPE_ARRAY | crate::gc::GC_TYPE_LAZY_ARRAY => {
-                if !index.is_finite() || index < 0.0 {
-                    f64::from_bits(TAG_UNDEFINED)
-                } else {
-                    crate::array::js_array_get_f64(raw_addr as *const ArrayHeader, index as u32)
+                // Fast path: a plain non-negative integer double indexes
+                // element storage directly.
+                if is_plain_number_bits(index.to_bits())
+                    && index >= 0.0
+                    && index.fract() == 0.0
+                    && index < u32::MAX as f64
+                {
+                    return crate::array::js_array_get_f64(
+                        raw_addr as *const ArrayHeader,
+                        index as u32,
+                    );
                 }
+                // Everything else — a string key ("1" canonical index, or a
+                // "foo" / "-1" expando), or a negative / fractional / non-finite
+                // number — coerces to a property key and dispatches through the
+                // full array getter, which routes canonical indices to element
+                // storage and otherwise consults named props, `length`, and the
+                // Array prototype. Previously every such key returned
+                // `undefined`, so `a["1"]` / `a[k]` (k a numeric string) and the
+                // `a[-1]` expando read silently missed.
+                let key_ptr = index_value_to_property_key(index);
+                crate::object::js_object_get_field_by_name_f64(
+                    raw_addr as *const ObjectHeader,
+                    key_ptr,
+                )
             }
             crate::gc::GC_TYPE_OBJECT | crate::gc::GC_TYPE_CLOSURE => {
                 let key_ptr = index_value_to_property_key(index);

--- a/test-parity/node-suite/globals/array-string-index-get.ts
+++ b/test-parity/node-suite/globals/array-string-index-get.ts
@@ -1,0 +1,61 @@
+// Reading an array element through a *string* key — `a["1"]`, `a[k]` where k
+// is a numeric string, `a[String(i)]` — must resolve the same element as the
+// numeric `a[1]`, per ToPropertyKey / OrdinaryGet (a canonical numeric-string
+// index addresses the element store). Previously the codegen array fast path
+// and the typed-feedback boxed fallback `fptosi`'d the key, collapsing a
+// NaN-boxed string to index 0, so every string-keyed read returned element 0
+// (or undefined). Negative / non-index string keys are ordinary expando
+// properties; `length` and Array.prototype methods resolve through the key
+// as well.
+
+function show(label: string, value: any) {
+  console.log(label + " = " + value);
+}
+
+// number[] — string-literal and string-variable index.
+const a = [10, 20, 30];
+show('a["0"]', a["0"]);
+show('a["1"]', a["1"]);
+show('a["2"]', a["2"]);
+show('a["3"] oob', a["3"]);
+const k = "1";
+show("a[k]", a[k]);
+show("a[String(2)]", a[String(2)]);
+
+// Dynamic numeric-string keys from a forEach (issue #637 sibling).
+["0", "1", "2"].forEach((key) => show("byKey " + key, a[key as any]));
+
+// string[] — element type isn't a pointer-free number, exercises the
+// non-numeric-layout codegen path.
+const s = ["x", "y", "z"];
+show('s["1"]', s["1"]);
+show("s[k]", s[k]);
+
+// object[] — string index then property read.
+const o = [{ v: 10 }, { v: 20 }];
+show('o["1"].v', o["1"].v);
+
+// 2D int matrix (#50 flat-const) — string-keyed double index.
+const m = [[1, 2], [3, 4]];
+show('m["1"]["0"]', m["1"]["0"]);
+show('m[1]["0"]', m[1]["0"]);
+show('m["1"][0]', m["1"][0]);
+
+// Negative / non-index string keys are ordinary own (expando) properties.
+const b: any = [1, 2, 3];
+b[-1] = 99;
+b["meta"] = "hi";
+show("b[-1]", b[-1]);
+show("b.meta", b["meta"]);
+show("b[-1] missing", ([1, 2] as any)[-1]);
+
+// `length` and prototype methods resolve through a string key too.
+show('a["length"]', a["length"]);
+show('typeof a["push"]', typeof a["push"]);
+
+// Regression: plain numeric indexing and loops are unchanged.
+show("a[0] num", a[0]);
+show("a[2] num", a[2]);
+let total = 0;
+for (let i = 0; i < a.length; i++) total += a[i];
+show("loop sum", total);


### PR DESCRIPTION
Fixes #4638.

## Problem

Reading an array element through a **string** key resolved the wrong element (or `undefined`) instead of the canonical numeric-index element:

```ts
const a = [10, 20, 30];
a["1"];          // was: undefined        now: 20
const k = "1"; a[k];   // was: undefined  now: 20
["x","y","z"]["1"];    // was: "x" (el 0) now: "y"
[{v:10},{v:20}]["1"].v;// was: 10          now: 20
[[1,2],[3,4]]["1"]["0"];// was: 1          now: 3
const b:any=[1,2,3]; b[-1]=99; b[-1]; // was: undefined  now: 99
```

## Root cause

Two fast paths convert the index with `fptosi` before reading element storage. A NaN-boxed string key has a NaN bit pattern, so `fptosi` collapses it to `0` (or the read bails out-of-range). The full array getter `js_object_get_field_by_name` already resolves canonical-index strings, named expandos, `length`, and Array.prototype methods — these fast paths just never reached it for string keys.

## Fix

- **`perry-codegen/src/expr/index_get.rs`** — string-keyed array reads route through the tag-aware `js_dyn_index_get` dispatcher instead of the `fptosi` element fast path (mirrors the existing typed-array and symbol-key guards in the same function).
- **`perry-codegen/src/expr/i32_fast_path.rs`** (#50 flat-const 2D int matrix) — bail on string indices so `m["1"]["0"]` falls through to the dispatcher (`m` itself materializes as a real heap array).
- **`perry-runtime/src/typed_feedback.rs`** — `js_typed_feedback_array_index_get_fallback_boxed`'s array branch coerces a string / negative / non-integer key to a property key and dispatches through the full array getter, instead of returning `undefined`.

Proven-numeric / loop-counter indexing is unchanged (string guards are `false` for them).

## Verification

- New parity fixture `test-parity/node-suite/globals/array-string-index-get.ts` — **identical to `node --experimental-strip-types`**.
- Broad Array differential sweeps (numeric/string indexing, forEach-dynamic-key #637 sibling, nested) — identical, no regressions.
- `cargo test -p perry-runtime --lib` (981 pass; the 2 failures are the known shared-global flaky tests `test_array_exotic_descriptors_and_global_prototype_identity` / `stream_constructors_expose_static_method_values`, both pass `--test-threads=1` in isolation) and `cargo test -p perry-codegen --lib` (86 pass).
- `cargo fmt` clean; file-size gate OK.

## Out of scope

`const row = matrix[i]` on a module-const 2D int-literal matrix returns `undefined` for both numeric and string `i` — a separate pre-existing flat-const row-alias materialization limitation (verified on `main`), noted in #4638.