### PR TITLE
fix(runtime): support generic array reverse receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1137 — generic `Array.prototype.reverse` over array-like receivers
+
+`Array.prototype.reverse.call(arrayLike)` (and bound/`.apply` forms) now
+reverses a generic array-like receiver in place and returns the *same*
+receiver, instead of falling through to the array-only member-call path. A
+dedicated `Expr::ArrayReverseValue` HIR variant lowers to a new
+`js_array_reverse_value` runtime helper (wired through the codegen collectors,
+JS emitter, stable-hash, and HIR walkers). Routed beside the `fill` /
+`copyWithin` generic mutators in `try_arraylike_receiver_method`. Verified:
+`{length:3,0:'a',1:'b',2:'c'}` → `c b a` (same receiver identity);
+`[1,2,3,4].reverse()` → `[4,3,2,1]`. Adds
+`node-suite/globals/array-generic-reverse.ts`.
+
 ## v0.5.1136 — generic `Array.prototype.fill` over array-like receivers
 
 `Array.prototype.fill.call(arrayLike, …)` (and bound/`.apply` forms) now mutates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1136
+**Current Version:** 0.5.1137
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1136"
+version = "0.5.1137"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1136"
+version = "0.5.1137"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1136"
+version = "0.5.1137"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1136"
+version = "0.5.1137"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1136"
+version = "0.5.1137"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -820,6 +820,7 @@ pub fn check_escapes_in_expr(
             }
         }
         Expr::ArrayToReversed { array }
+        | Expr::ArrayReverseValue { receiver: array }
         | Expr::ArrayFlat { array }
         | Expr::ArrayEntries(array)
         | Expr::ArrayKeys(array)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -601,6 +601,7 @@ fn collect_used_new_fields_in_expr(
             }
         }
         Expr::ArrayToReversed { array }
+        | Expr::ArrayReverseValue { receiver: array }
         | Expr::ArrayFlat { array }
         | Expr::ArrayEntries(array)
         | Expr::ArrayKeys(array)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -795,7 +795,8 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::ArrayKeys(array)
         | Expr::ArrayValues(array)
         | Expr::ArrayFlat { array }
-        | Expr::ArrayToReversed { array } => {
+        | Expr::ArrayToReversed { array }
+        | Expr::ArrayReverseValue { receiver: array } => {
             walk(array, out);
         }
         Expr::ArrayUnshift { array_id, value } => {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1780,6 +1780,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::DateToLocaleDateString(..)
         | Expr::DateToLocaleTimeString(..)
         | Expr::DateToJSON(..)
+        | Expr::ArrayReverseValue { .. }
         | Expr::ArrayWith { .. }
         | Expr::ArrayCopyWithin { .. }
         | Expr::ArrayCopyWithinValue { .. }

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -271,6 +271,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             );
             Ok(nanbox_pointer_inline(blk, &result))
         }
+        Expr::ArrayReverseValue { receiver } => {
+            let receiver_d = lower_expr(ctx, receiver)?;
+            let blk = ctx.block();
+            let result = blk.call(DOUBLE, "js_array_reverse_value", &[(DOUBLE, &receiver_d)]);
+            Ok(result)
+        }
         Expr::ArrayCopyWithin {
             array_id,
             target,

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -962,6 +962,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_array_reduce_right", DOUBLE, &[I64, I64, I32, DOUBLE]);
     module.declare_function("js_array_sort_default", I64, &[I64]);
     module.declare_function("js_array_reverse", I64, &[I64]);
+    module.declare_function("js_array_reverse_value", DOUBLE, &[DOUBLE]);
     module.declare_function("js_array_flat", I64, &[I64]);
     module.declare_function("js_array_flat_depth", I64, &[I64, DOUBLE]);
     module.declare_function("js_array_flatMap", I64, &[I64, I64]);

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -611,6 +611,12 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
             collect_assigned_locals_expr(index, assigned);
             collect_assigned_locals_expr(value, assigned);
         }
+        Expr::ArrayReverseValue { receiver } => {
+            if let Expr::LocalGet(id) = receiver.as_ref() {
+                assigned.push(*id);
+            }
+            collect_assigned_locals_expr(receiver, assigned);
+        }
         Expr::ArrayCopyWithin {
             array_id,
             target,

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1492,6 +1492,9 @@ pub enum Expr {
         index: Box<Expr>,
         value: Box<Expr>,
     }, // arr.with(index, value) -> new array
+    ArrayReverseValue {
+        receiver: Box<Expr>,
+    }, // Array.prototype.reverse.call(receiver) -> same receiver
     ArrayCopyWithin {
         array_id: LocalId,
         target: Box<Expr>,

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -1089,7 +1089,9 @@ pub fn transform_expr(
                 transform_expr(sep, js_imports, extern_func_to_js, local_name_to_js, tracker);
             }
         }
-        Expr::ArrayFlat { array } | Expr::ArrayToReversed { array } => {
+        Expr::ArrayFlat { array }
+        | Expr::ArrayToReversed { array }
+        | Expr::ArrayReverseValue { receiver: array } => {
             transform_expr(array, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
         Expr::ArrayEntries(array) | Expr::ArrayKeys(array) | Expr::ArrayValues(array) => {

--- a/crates/perry-hir/src/lower/closure_analysis.rs
+++ b/crates/perry-hir/src/lower/closure_analysis.rs
@@ -299,7 +299,7 @@ fn widen_mutable_captures_expr(
                 widen_mutable_captures_expr(init, scope_mutable);
             }
         }
-        Expr::ArrayToReversed { array } => {
+        Expr::ArrayToReversed { array } | Expr::ArrayReverseValue { receiver: array } => {
             widen_mutable_captures_expr(array, scope_mutable);
         }
         Expr::ArrayToSorted { array, comparator } => {
@@ -607,7 +607,7 @@ fn collect_closure_assigned_expr(expr: &Expr, out: &mut std::collections::HashSe
                 collect_closure_assigned_expr(init, out);
             }
         }
-        Expr::ArrayToReversed { array } => {
+        Expr::ArrayToReversed { array } | Expr::ArrayReverseValue { receiver: array } => {
             collect_closure_assigned_expr(array, out);
         }
         Expr::ArrayToSorted { array, comparator } => {
@@ -889,7 +889,7 @@ fn collect_closure_captures_expr(expr: &Expr, out: &mut std::collections::HashSe
                 collect_closure_captures_expr(init, out);
             }
         }
-        Expr::ArrayToReversed { array } => {
+        Expr::ArrayToReversed { array } | Expr::ArrayReverseValue { receiver: array } => {
             collect_closure_captures_expr(array, out);
         }
         Expr::ArrayToSorted { array, comparator } => {
@@ -1332,7 +1332,7 @@ fn collect_closure_assigned_in_body_expr(
                 collect_closure_assigned_in_body_expr(init, out);
             }
         }
-        Expr::ArrayToReversed { array } => {
+        Expr::ArrayToReversed { array } | Expr::ArrayReverseValue { receiver: array } => {
             collect_closure_assigned_in_body_expr(array, out);
         }
         Expr::ArrayToSorted { array, comparator } => {

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1297,8 +1297,8 @@ pub(super) fn try_builtin_prototype_method_apply_call(
         call.args.iter().skip(1).cloned().collect()
     };
 
-    // `Array.prototype.<m>.call(arrayLike, ...)` — when `<m>` is a known
-    // read-only Array method, this is an explicit, unambiguous request to run
+    // `Array.prototype.<m>.call(arrayLike, ...)` — when `<m>` is a supported
+    // generic Array method, this is an explicit, unambiguous request to run
     // the Array algorithm on a *generic array-like* receiver (a plain object
     // with `length` + indexed keys; ECMA-262 §23.1.3). The default synthesized
     // `(thisArg).<m>(...)` member call below only routes to the Array runtime
@@ -1308,10 +1308,10 @@ pub(super) fn try_builtin_prototype_method_apply_call(
     // `Expr::Array*` variant directly so the receiver flows to `js_array_*`
     // regardless of its static type — the runtime materializes the array-like
     // (see `normalize_array_receiver`). Most handled methods are
-    // read-only/returning; `fill` has a dedicated generic mutator helper because
-    // it must write back to the original receiver rather than a materialized
-    // clone. Unsupported mutators fall through to the member call below
-    // (unchanged behavior).
+    // read-only/returning; the mutators `fill` / `copyWithin` / `reverse` use
+    // dedicated generic helpers because they must write back to the original
+    // receiver rather than a materialized clone. Unsupported mutators fall
+    // through to the member call below (unchanged behavior).
     if let Some(folded) =
         try_arraylike_receiver_method(ctx, method_prop.sym.as_ref(), &this_arg.expr, &rest_args)?
     {
@@ -1339,10 +1339,10 @@ pub(super) fn try_builtin_prototype_method_apply_call(
 /// expanded from the `.apply` array if applicable).
 ///
 /// Returns `Some(expr)` for a supported read-only/returning method, plus
-/// dedicated generic `fill` / `copyWithin` mutator paths, or `None` for other
-/// mutators / unsupported methods (caller falls back to the synthesized member
-/// call). The read-only set mirrors the runtime methods that route through
-/// `normalize_array_receiver`.
+/// dedicated generic `fill` / `copyWithin` / `reverse` mutator paths, or `None`
+/// for other mutators / unsupported methods (caller falls back to the
+/// synthesized member call). The read-only set mirrors the runtime methods that
+/// route through `normalize_array_receiver`.
 fn try_arraylike_receiver_method(
     ctx: &mut LoweringContext,
     method: &str,
@@ -1394,6 +1394,16 @@ fn try_arraylike_receiver_method(
             target,
             start,
             end,
+        }));
+    }
+    // `reverse` mutates in place and returns the same receiver; route to the
+    // dedicated `js_array_reverse_value` helper (no positional args allowed).
+    if method == "reverse" {
+        if !rest_args.is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(Expr::ArrayReverseValue {
+            receiver: Box::new(lower_expr(ctx, receiver)?),
         }));
     }
     // The read-only/returning methods the runtime generic engine implements

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -643,6 +643,9 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
             index: Box::new(substitute_expr(index, substitutions)),
             value: Box::new(substitute_expr(value, substitutions)),
         },
+        Expr::ArrayReverseValue { receiver } => Expr::ArrayReverseValue {
+            receiver: Box::new(substitute_expr(receiver, substitutions)),
+        },
         Expr::ArrayCopyWithin {
             array_id,
             target,

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -391,6 +391,7 @@ impl SH for Expr {
             Expr::ArrayToSorted { array, comparator } => { tag(h, 275); array.as_ref().hash(h); comparator.hash(h); }
             Expr::ArrayToSpliced { array, start, delete_count, items, } => { tag(h, 276); array.as_ref().hash(h); start.as_ref().hash(h); delete_count.as_ref().hash(h); items.hash(h); }
             Expr::ArrayWith { array, index, value, } => { tag(h, 277); array.as_ref().hash(h); index.as_ref().hash(h); value.as_ref().hash(h); }
+            Expr::ArrayReverseValue { receiver } => { tag(h, 12092); receiver.as_ref().hash(h); }
             Expr::ArrayCopyWithin { array_id, target, start, end, } => { tag(h, 278); array_id.hash(h); target.as_ref().hash(h); start.as_ref().hash(h); end.hash(h); }
             Expr::ArrayCopyWithinValue { receiver, target, start, end, } => { tag(h, 12091); receiver.as_ref().hash(h); target.as_ref().hash(h); start.as_ref().hash(h); end.hash(h); }
             Expr::ArrayEntries(e) => { tag(h, 279); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1608,6 +1608,9 @@ where
             f(index);
             f(value);
         }
+        Expr::ArrayReverseValue { receiver } => {
+            f(receiver);
+        }
         Expr::ArrayCopyWithin {
             array_id: _,
             target,

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1583,6 +1583,9 @@ where
             f(index);
             f(value);
         }
+        Expr::ArrayReverseValue { receiver } => {
+            f(receiver);
+        }
         Expr::ArrayCopyWithin {
             array_id: _,
             target,

--- a/crates/perry-runtime/src/array/concat_reverse.rs
+++ b/crates/perry-runtime/src/array/concat_reverse.rs
@@ -225,6 +225,108 @@ pub extern "C" fn js_array_reverse(arr: *mut ArrayHeader) -> *mut ArrayHeader {
     }
 }
 
+/// `Array.prototype.reverse.call(value)` for generic array-like receivers.
+#[no_mangle]
+pub extern "C" fn js_array_reverse_value(receiver: f64) -> f64 {
+    let receiver_js = crate::value::JSValue::from_bits(receiver.to_bits());
+    if receiver_js.is_null() || receiver_js.is_undefined() {
+        reverse_throw_type_error(b"Cannot convert undefined or null to object");
+    }
+
+    let object = crate::object::js_object_coerce(receiver);
+    let len = reverse_length_of_array_like(object);
+    if reverse_is_boxed_string(object) && len > 1 {
+        reverse_throw_type_error(b"Cannot assign to read only property");
+    }
+    if len <= 1 {
+        return object;
+    }
+
+    let handle = object.to_bits() as i64;
+    let object_ptr =
+        crate::value::js_nanbox_get_pointer(object) as *mut crate::object::ObjectHeader;
+    let mut lower = 0u64;
+    let mut upper = len - 1;
+    while lower < upper {
+        let lower_exists = reverse_has_own_index(object, lower);
+        let upper_exists = reverse_has_own_index(object, upper);
+        let lower_value = if lower_exists {
+            crate::object::js_object_get_index_polymorphic(handle, lower as f64)
+        } else {
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        };
+        let upper_value = if upper_exists {
+            crate::object::js_object_get_index_polymorphic(handle, upper as f64)
+        } else {
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        };
+
+        match (lower_exists, upper_exists) {
+            (true, true) => {
+                crate::object::js_object_set_index_polymorphic(handle, lower as f64, upper_value);
+                crate::object::js_object_set_index_polymorphic(handle, upper as f64, lower_value);
+            }
+            (false, true) => {
+                crate::object::js_object_set_index_polymorphic(handle, lower as f64, upper_value);
+                reverse_delete_index(object_ptr, upper);
+            }
+            (true, false) => {
+                reverse_delete_index(object_ptr, lower);
+                crate::object::js_object_set_index_polymorphic(handle, upper as f64, lower_value);
+            }
+            (false, false) => {}
+        }
+
+        lower += 1;
+        upper -= 1;
+    }
+    object
+}
+
+fn reverse_length_of_array_like(object: f64) -> u64 {
+    let key = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+    let object_ptr =
+        crate::value::js_nanbox_get_pointer(object) as *const crate::object::ObjectHeader;
+    if object_ptr.is_null() {
+        return 0;
+    }
+    reverse_to_length(crate::object::js_object_get_field_by_name_f64(
+        object_ptr, key,
+    ))
+}
+
+fn reverse_to_length(value: f64) -> u64 {
+    let n = crate::builtins::js_number_coerce(value);
+    if n.is_nan() || n <= 0.0 {
+        0
+    } else if n.is_infinite() || n >= (1u64 << 53) as f64 {
+        (1u64 << 53) - 1
+    } else {
+        n.trunc() as u64
+    }
+}
+
+fn reverse_is_boxed_string(object: f64) -> bool {
+    crate::builtins::boxed_primitive_to_string_tag(object) == Some("String")
+}
+
+fn reverse_has_own_index(object: f64, index: u64) -> bool {
+    let present = crate::object::js_object_has_own(object, index as f64);
+    crate::value::js_is_truthy(present) != 0
+}
+
+fn reverse_delete_index(obj: *mut crate::object::ObjectHeader, index: u64) {
+    if crate::object::js_object_delete_dynamic(obj, index as f64) == 0 {
+        reverse_throw_type_error(b"Cannot delete property");
+    }
+}
+
+fn reverse_throw_type_error(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 /// `Array.prototype.fill(value)` — fills every element (0..length) with
 /// `value`. Returns the same array pointer.
 #[no_mangle]

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -29,7 +29,7 @@ pub use self::alloc::{
 };
 pub use self::concat_reverse::{
     js_array_concat, js_array_concat_new, js_array_fill, js_array_fill_generic,
-    js_array_fill_range, js_array_reverse,
+    js_array_fill_range, js_array_reverse, js_array_reverse_value,
 };
 pub use self::flat_clone::{
     js_array_clone, js_array_entries, js_array_flat, js_array_flat_depth, js_array_keys,

--- a/test-parity/expected/array-generic-reverse.txt
+++ b/test-parity/expected/array-generic-reverse.txt
@@ -1,0 +1,13 @@
+sparse return same: true
+sparse: e,<hole>,c,<hole>,a keys=0|2|4|length
+one-sided: <hole>,<hole>,b,<hole> keys=2|length
+coerced length: d,c,b,a keys=0|1|2|3|length
+apply return same: true
+apply: z,y,x,w keys=0|1|2|3|length
+delete missing source: <hole>,<hole>,a keys=2|length
+delete has: false true
+null receiver: TypeError
+undefined receiver: TypeError
+string abc receiver: TypeError
+string one: object 1 "a"
+string empty: object 0 ""

--- a/test-parity/node-suite/globals/array-generic-reverse.ts
+++ b/test-parity/node-suite/globals/array-generic-reverse.ts
@@ -1,0 +1,58 @@
+function displayLength(value: any): number {
+  const n = Number(value.length);
+  if (!Number.isFinite(n) || n <= 0) {
+    return 0;
+  }
+  return Math.trunc(n);
+}
+
+function show(label: string, value: any): void {
+  const parts: string[] = [];
+  for (let i = 0; i < displayLength(value); i++) {
+    parts.push(Object.hasOwn(value, i) ? String(value[i]) : "<hole>");
+  }
+  const keys = Object.getOwnPropertyNames(value).sort().join("|");
+  console.log(label + ": " + parts.join(",") + " keys=" + keys);
+}
+
+function showError(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(label + ": no throw");
+  } catch (e: any) {
+    console.log(label + ": " + e.constructor.name);
+  }
+}
+
+const sparse: any = { 0: "a", 2: "c", 4: "e", length: 5 };
+const sparseRet = Array.prototype.reverse.call(sparse);
+console.log("sparse return same: " + (sparseRet === sparse));
+show("sparse", sparse);
+
+const oneSided: any = { 1: "b", length: 4 };
+Array.prototype.reverse.call(oneSided);
+show("one-sided", oneSided);
+
+const coercedLength: any = { 0: "a", 1: "b", 2: "c", 3: "d", length: "4.9" };
+Array.prototype.reverse.call(coercedLength);
+show("coerced length", coercedLength);
+
+const applyTarget: any = { 0: "w", 1: "x", 2: "y", 3: "z", length: 4 };
+const applyRet = Array.prototype.reverse.apply(applyTarget, []);
+console.log("apply return same: " + (applyRet === applyTarget));
+show("apply", applyTarget);
+
+const deleted: any = { 0: "a", length: 3 };
+Array.prototype.reverse.call(deleted);
+show("delete missing source", deleted);
+console.log("delete has: " + Object.hasOwn(deleted, 0) + " " + Object.hasOwn(deleted, 2));
+
+showError("null receiver", () => Array.prototype.reverse.call(null));
+showError("undefined receiver", () => Array.prototype.reverse.call(undefined));
+showError("string abc receiver", () => Array.prototype.reverse.call("abc"));
+
+const one = Array.prototype.reverse.call("a") as any;
+console.log("string one: " + typeof one + " " + one.length + " \"" + one.valueOf() + "\"");
+
+const empty = Array.prototype.reverse.call("") as any;
+console.log("string empty: " + typeof empty + " " + empty.length + " \"" + empty.valueOf() + "\"");


### PR DESCRIPTION
## Summary
- lower zero-argument borrowed `Array.prototype.reverse.call/apply` on array-like receivers to a value-level runtime helper
- mutate and return the original receiver with `ToLength`, sparse own-index swap/delete behavior, nullish receiver throws, and string receiver edge cases
- add a Node parity fixture for generic `reverse` over sparse/coerced/apply/string/nullish receivers

## Validation
- current-main repro: compiled fixture fails at runtime with `TypeError: value is not a function`
- `diff -u test-parity/expected/array-generic-reverse.txt <(npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/globals/array-generic-reverse.ts)`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter array-generic-reverse'`
  - report: `test-parity/reports/parity_report_20260605_190454.json`
- `PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module globals --filter array-'`
  - report: `test-parity/reports/parity_report_20260605_190504.json`
- `cargo fmt --all -- --check`
- `cargo check -q -p perry-hir -p perry-codegen -p perry-runtime`
- `git diff --check`
- `./scripts/check_file_size.sh`

Refs #4597
