### PR TITLE
fix(runtime): Proxy forwards [[GetPrototypeOf]] and instanceof to its target

### DIFF
--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -66,6 +66,20 @@ fn is_native_module_namespace_value(value: f64, expected: &str) -> bool {
 #[no_mangle]
 pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    // `proxy instanceof C` uses the proxy's `[[GetPrototypeOf]]`, which (absent a
+    // trap) forwards to the target — so it is equivalent to `target instanceof
+    // C`. The proxy itself is a small registered id with no class chain, so
+    // without this it always returned false. Unwrap nested proxies (drizzle
+    // aliases columns as `new Proxy(column, …)` and its `is(value, type)` brand
+    // check relies on `value instanceof type`). Bounded to guard a cycle.
+    let mut value = value;
+    {
+        let mut depth = 0;
+        while depth < 16 && crate::proxy::js_proxy_is_proxy(value) != 0 {
+            value = crate::proxy::js_proxy_target(value);
+            depth += 1;
+        }
+    }
     let bits = type_ref.to_bits();
     let top16 = bits >> 48;
     if top16 == 0x7FFE {
@@ -449,6 +463,18 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
 
     if class_id == 0 {
         return false_val;
+    }
+    // `proxy instanceof C` follows the proxy's prototype chain, which forwards
+    // to the target (absent a `getPrototypeOf` trap) — so unwrap to the target
+    // before walking the class chain. The proxy is a small id with no chain of
+    // its own. (drizzle's aliased-column proxies + `is(value, type)`.)
+    let mut value = value;
+    {
+        let mut depth = 0;
+        while depth < 16 && crate::proxy::js_proxy_is_proxy(value) != 0 {
+            value = crate::proxy::js_proxy_target(value);
+            depth += 1;
+        }
     }
     // Keep in sync with perry-codegen/src/expr/instance_misc1.rs.
     let classic_stream_name = match class_id {

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1707,6 +1707,15 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
             throw_object_type_error(b"Cannot convert undefined or null to object");
         }
     }
+    // A Proxy is a small registered id, NOT a heap object — the handle path
+    // below would mis-read it and return `null`. Route it to the proxy
+    // `[[GetPrototypeOf]]` (handler trap, else the target's prototype) so
+    // `Object.getPrototypeOf(proxy)` matches the target. drizzle aliases columns
+    // as `new Proxy(column, …)` and `is(value, type)` reads
+    // `getPrototypeOf(value).constructor`, which crashed on `null.constructor`.
+    if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        return crate::proxy::js_proxy_get_prototype_of(obj_value);
+    }
     let bits = obj_value.to_bits();
     let top16 = bits >> 48;
     if top16 == 0x7FFD {

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1478,6 +1478,40 @@ pub extern "C" fn js_reflect_define_property(obj: f64, key: f64, descriptor: f64
     crate::object::reflect_define_property(obj, key, descriptor)
 }
 
+/// `[[GetPrototypeOf]]` for a Proxy: invoke the handler's `getPrototypeOf`
+/// trap when present, otherwise forward to the TARGET's `[[Prototype]]`. A
+/// Proxy itself is a small registered id (not a heap object), so the generic
+/// `js_object_get_prototype_of` would mis-read it and return `null` — which
+/// broke `Object.getPrototypeOf(proxy).constructor` (drizzle aliases columns as
+/// `new Proxy(column, …)` and its `is(value, type)` reads
+/// `getPrototypeOf(value).constructor`, crashing on `null.constructor`).
+/// Callers must have already confirmed `obj` is a registered proxy.
+pub(crate) fn js_proxy_get_prototype_of(obj: f64) -> f64 {
+    let Some(id) = lookup(obj) else {
+        return crate::object::js_object_get_prototype_of(obj);
+    };
+    let (target, handler, revoked) = PROXIES.with(|p| {
+        p.borrow()
+            .get(id as usize)
+            .and_then(|o| o.as_ref())
+            .map(|e| (e.target, e.handler, e.revoked))
+            .unwrap_or((
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+                false,
+            ))
+    });
+    if revoked {
+        return revoked_return();
+    }
+    let trap = handler_trap(handler, "getPrototypeOf");
+    if is_callable(trap) {
+        return js_closure_call1(closure_from(trap), target);
+    }
+    // No trap — the prototype is the target's prototype.
+    crate::object::js_object_get_prototype_of(target)
+}
+
 /// `Reflect.getPrototypeOf(obj)` — shares the actual prototype lookup with
 /// `Object.getPrototypeOf` (#2757): returns the object's `[[Prototype]]`,
 /// including `null` for null-prototype objects, not the object itself.
@@ -1489,6 +1523,9 @@ pub extern "C" fn js_reflect_get_prototype_of(obj: f64) -> f64 {
     // entry and are objects, so they pass this check and dispatch below.
     if lookup(obj).is_none() && !reflect_value_is_object(obj) {
         return reflect_non_object_typeerror("getPrototypeOf");
+    }
+    if lookup(obj).is_some() {
+        return js_proxy_get_prototype_of(obj);
     }
     crate::object::js_object_get_prototype_of(obj)
 }

--- a/tests/test_proxy_getprototypeof_instanceof.sh
+++ b/tests/test_proxy_getprototypeof_instanceof.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A Proxy without a `getPrototypeOf` trap must forward `[[GetPrototypeOf]]` to its
+# target, and `proxy instanceof C` must follow that forwarded chain. Perry
+# represents a Proxy as a small registered id (not a heap object), so
+# `Object.getPrototypeOf(proxy)` returned `null` and `proxy instanceof C` was
+# always `false`. Drizzle aliases columns as `new Proxy(column, …)` and its
+# brand check `is(value, type)` reads `getPrototypeOf(value).constructor` / does
+# `value instanceof type` — the null prototype crashed on `null.constructor`.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+class Base { static tag = "B"; }
+class Mid extends Base {}
+class Leaf extends Mid { constructor(public n: string) { super(); } }
+
+const leaf = new Leaf("x");
+const handler = { get(t: any, k: any) { return t[k]; } };
+const proxy: any = new Proxy(leaf, handler);
+
+// getPrototypeOf forwards to the target's prototype (constructor = the class).
+const proto = Object.getPrototypeOf(proxy);
+if (proto === null || proto === undefined) throw new Error("getPrototypeOf(proxy) was nullish");
+if (proto.constructor?.name !== "Leaf") throw new Error("proto.constructor: " + proto.constructor?.name);
+
+// instanceof follows the forwarded chain (target's class hierarchy).
+if (!(proxy instanceof Leaf)) throw new Error("proxy not instanceof Leaf");
+if (!(proxy instanceof Mid)) throw new Error("proxy not instanceof Mid");
+if (!(proxy instanceof Base)) throw new Error("proxy not instanceof Base");
+if (!(proxy instanceof Object)) throw new Error("proxy not instanceof Object");
+
+// member access still forwards through the get trap.
+if (proxy.n !== "x") throw new Error("proxy.n: " + proxy.n);
+
+// nested proxy (proxy of a proxy) still resolves to the real target.
+const proxy2: any = new Proxy(proxy, handler);
+if (!(proxy2 instanceof Leaf)) throw new Error("nested proxy not instanceof Leaf");
+if (Object.getPrototypeOf(proxy2)?.constructor?.name !== "Leaf") throw new Error("nested getPrototypeOf");
+
+// the `is()`-style brand check no longer crashes on null.constructor.
+function is(value: any, type: any): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (value instanceof type) return true;
+  let cls = Object.getPrototypeOf(value)?.constructor;
+  while (cls) cls = Object.getPrototypeOf(cls);
+  return false;
+}
+if (!is(proxy, Base)) throw new Error("is(proxy, Base) was false");
+
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: proxy getPrototypeOf forwards to target + instanceof follows it"


### PR DESCRIPTION
A Proxy is a small registered id, not a heap object. `Object.getPrototypeOf(proxy)` mis-read it and returned `null`, and `proxy instanceof C` walked the proxy's (non-existent) class chain and returned `false`. Per spec, with no `getPrototypeOf` trap both forward to the target.

- `js_object_get_prototype_of` / `Reflect.getPrototypeOf`: route a registered proxy to a new `js_proxy_get_prototype_of` (invoke the `getPrototypeOf` trap if present, else return the **target's** prototype).
- `js_instanceof` / `js_instanceof_dynamic`: unwrap nested proxies to the target before walking the class chain.

Drizzle aliases columns as `new Proxy(column, …)` and its brand check `is(value, type)` does `value instanceof type` and reads `Object.getPrototypeOf(value).constructor` — the null prototype crashed every relational query on `null.constructor`. This unblocks that brand check (the relational-query builder has further gaps tracked separately).

Test: `tests/test_proxy_getprototypeof_instanceof.sh` (forwarding, multi-level chain, nested proxies, member-access forwarding, the is()-style walk). Existing object/class/getter/namespace tests stay green.