### PR TITLE
fix(runtime): array boundary-index, sparse length, and non-integer keys (#4557, #4543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,14 @@ classify them, so `2**32-1` and non-integer keys never reached
 
 **Fix.**
 - **Codegen** (`expr/index_get.rs`, `expr/index_set.rs`): `numeric_index_needs_runtime_key`
-  now routes any literal that is not a clean array index in `0..=i32::MAX` — negatives,
+  now routes any **literal** that is not a clean array index in `0..=i32::MAX` — negatives,
   out-of-range integers (`a[2**32-1]`), non-integer floats (`a[1.5]`), and non-finite
   values (`a[NaN]`/`a[Infinity]`) — through `js_array_get/set_index_or_string` instead
-  of the truncating i32 path.
+  of the truncating i32 path. Computed/dynamic numeric indices (`a[i % n]`) are
+  deliberately left on the typed-feedback numeric-array guard path (which has its own
+  out-of-range fallback); rerouting them would drop the index guard and regress the
+  native-region proof. Boundary-valued *variables* (`const k = 2**32-1; a[k]`) remain a
+  known follow-up.
 - **Runtime sparse storage** (`array/indexing.rs`, `array/header.rs`): far writes beyond
   `MAX_DENSE_ARRAY_GROW_LENGTH` (1M) and writes at/above the dense capacity store into
   the array's `ARRAY_NAMED_PROPS` side table while `length` is tracked separately, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1124 — fix(runtime): array boundary-index, sparse length, and non-integer keys
+
+Closes #4557 and #4543; supersedes #4585 and #4559 by combining both into one branch.
+
+**Symptom.** `const a=[0,1,2]; a[4294967295]='x'` produced a deterministically-bogus
+`length` of 193 and an unreadable element. `b[4294967294]='y'` (the max valid index)
+could not be represented at all by the dense model. `a[1.5]='z'` truncated to `a[1]`,
+clobbering an existing element instead of creating the `"1.5"` string property.
+
+**Root cause.** Two orthogonal gaps sharing the boundary: (1) the computed-member
+fast path narrowed numeric/computed keys through `i32` before the runtime could
+classify them, so `2**32-1` and non-integer keys never reached
+`js_array_set_index_or_string`; (2) the dense array model assumed
+`length <= capacity`, so a far-but-valid index (`2**32-2`) had no representation.
+
+**Fix.**
+- **Codegen** (`expr/index_get.rs`, `expr/index_set.rs`): `numeric_index_needs_runtime_key`
+  now routes any literal that is not a clean array index in `0..=i32::MAX` — negatives,
+  out-of-range integers (`a[2**32-1]`), non-integer floats (`a[1.5]`), and non-finite
+  values (`a[NaN]`/`a[Infinity]`) — through `js_array_get/set_index_or_string` instead
+  of the truncating i32 path.
+- **Runtime sparse storage** (`array/indexing.rs`, `array/header.rs`): far writes beyond
+  `MAX_DENSE_ARRAY_GROW_LENGTH` (1M) and writes at/above the dense capacity store into
+  the array's `ARRAY_NAMED_PROPS` side table while `length` is tracked separately, so
+  `b[2**32-2]='y'` yields `length === 4294967295` with one stored element instead of a
+  ~32 GB allocation. `clean_arr_ptr` admits the `length > capacity` sparse shape (gated
+  on `GC_TYPE_ARRAY` + `capacity <= 1M`). New `js_array_get_index_or_string` mirrors the
+  set helper for reads.
+- **Non-integer keys** (`array/indexing.rs`): `js_array_set_index_or_string` now
+  stringifies any non-canonical number (`2**32-1`+, negatives, `1.5`) via
+  `js_jsvalue_to_string` and stores it as an ordinary `"…"` property, instead of the old
+  `format!("{:.0}")` integer path that dropped/mis-parsed non-integer floats.
+
+**Verification.** Byte-identical to `node --experimental-strip-types` for `a[2**32-1]`,
+`a[2**32-2]`, `a[1.5]`, `a[-1]`, string-key reads, `a[10n]` canonical index, and
+delete/hasOwnProperty/in. test262-equivalent of `built-ins/Array/15.4.5.1-5-1.js` /
+`-5-2.js`: 10/10. node-suite fixtures `array-index-boundary.ts` and
+`array-property-keys.ts` identical to node in both auto-optimize and
+`PERRY_NO_AUTO_OPTIMIZE=1` paths. Dense-array regression sweep
+(map/filter/reduce/for-of/forEach/JSON/push/pop/slice/spread/Object.keys/1000-element
+grow) unaffected. `cargo test -p perry-runtime --lib array::` 57/0.
+
 ## v0.5.1123 — fix(json): internalize JSON.parse reviver via the spec InternalizeJSONProperty walk (#4588)
 
 `JSON.parse(text, reviver)` previously walked the parsed value's raw object/array storage slots in place — it never went through `[[Get]]`/`[[Delete]]`/`CreateDataProperty`, so spec-mandated behaviours were invisible: deleting the property when the reviver returns `undefined`, re-reading a value the reviver mutated, holder `this` binding, the root `{ "": rootValue }` wrapper, and `Object.keys`/array-length snapshots taken before iteration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1123
+**Current Version:** 0.5.1124
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "base64",
@@ -5252,14 +5252,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "cc",
  "libc",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "base64",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,14 +5368,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "serde",
  "serde_json",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1123"
+version = "0.5.1124"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "clap",
@@ -5409,14 +5409,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5515,14 +5515,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "bytes",
  "h2",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "bson",
  "futures-util",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "image",
@@ -5709,14 +5709,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "brotli",
  "flate2",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "base64",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5939,14 +5939,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "itoa",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "block2",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "block2",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1123"
+version = "0.5.1124"
 
 [[package]]
 name = "perry-ui-test"
@@ -6035,11 +6035,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1123"
+version = "0.5.1124"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "block2",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "block2",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "block2",
  "libc",
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "libc",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1123"
+version = "0.5.1124"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1123"
+version = "0.5.1124"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -35,7 +35,7 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 use super::arrays_finds::lower_buffer_index_get_i32;
 #[allow(unused_imports)]
 use super::{
-    buffer_access_materialization_reason, buffer_alias_metadata_suffix, can_lower_expr_as_i32,
+    buffer_access_materialization_reason, buffer_alias_metadata_suffix,
     emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
     emit_string_literal_global, emit_typed_feedback_register_site, emit_v8_export_call,
     emit_v8_member_method_call, emit_write_barrier, emit_write_barrier_slot_on_block,
@@ -76,32 +76,24 @@ fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     )
 }
 
-fn numeric_index_needs_runtime_key(ctx: &FnCtx<'_>, index: &Expr) -> bool {
+fn numeric_index_needs_runtime_key(index: &Expr) -> bool {
+    // Only a LITERAL numeric key that is not a clean array index in
+    // `0..=i32::MAX` needs the runtime key helper: out-of-range/negative
+    // integers (`a[2**32-1]`, `a[-1]`), non-integer floats (`a[1.5]`), and
+    // non-finite values (`a[NaN]`/`a[Infinity]`). These become string-keyed
+    // properties and must reach `js_array_*_index_or_string`.
+    //
+    // Computed/dynamic numeric indices are deliberately NOT rerouted here:
+    // they keep flowing through the typed-feedback numeric-array guard path,
+    // which already carries its own out-of-range/non-integer fallback. Sending
+    // them to the runtime key helper would defeat the native numeric-array hot
+    // path and drop the index guard (regressing the native-region proof and
+    // the typed-feedback hot-path tests). (#4557/#4543)
     match index {
         Expr::Integer(i) => *i < 0 || *i > i32::MAX as i64,
-        // Route through the runtime key helper unless the literal is a clean
-        // array index the i32 fast path carries without loss: a finite,
-        // non-negative integer in `0..=i32::MAX`. Everything else — negatives,
-        // out-of-range integers (`a[2**32-1]`), non-integer floats (`a[1.5]`),
-        // and non-finite values (`a[NaN]`/`a[Infinity]`) — is a string-keyed
-        // property, so it must reach `js_array_*_index_or_string`. (#4557/#4543)
         Expr::Number(n) => {
             !(n.is_finite() && n.fract() == 0.0 && *n >= 0.0 && *n <= i32::MAX as f64)
         }
-        Expr::LocalGet(id) if is_numeric_expr(ctx, index) => {
-            !ctx.i32_counter_slots.contains_key(id)
-        }
-        _ if is_numeric_expr(ctx, index) => !can_lower_expr_as_i32(
-            index,
-            &ctx.i32_counter_slots,
-            ctx.flat_const_arrays,
-            &ctx.array_row_aliases,
-            ctx.integer_locals,
-            ctx.clamp3_functions,
-            ctx.clamp_u8_functions,
-            ctx.integer_returning_functions,
-            ctx.i32_identity_functions,
-        ),
         _ => false,
     }
 }
@@ -703,7 +695,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &arr_handle), (DOUBLE, &idx_double)],
                     ));
                 }
-                if numeric_index_needs_runtime_key(ctx, index) {
+                if numeric_index_needs_runtime_key(index) {
                     let arr_box = lower_expr(ctx, object)?;
                     let idx_double = lower_expr(ctx, index)?;
                     let arr_handle = {

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -76,6 +76,36 @@ fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     )
 }
 
+fn numeric_index_needs_runtime_key(ctx: &FnCtx<'_>, index: &Expr) -> bool {
+    match index {
+        Expr::Integer(i) => *i < 0 || *i > i32::MAX as i64,
+        // Route through the runtime key helper unless the literal is a clean
+        // array index the i32 fast path carries without loss: a finite,
+        // non-negative integer in `0..=i32::MAX`. Everything else — negatives,
+        // out-of-range integers (`a[2**32-1]`), non-integer floats (`a[1.5]`),
+        // and non-finite values (`a[NaN]`/`a[Infinity]`) — is a string-keyed
+        // property, so it must reach `js_array_*_index_or_string`. (#4557/#4543)
+        Expr::Number(n) => {
+            !(n.is_finite() && n.fract() == 0.0 && *n >= 0.0 && *n <= i32::MAX as f64)
+        }
+        Expr::LocalGet(id) if is_numeric_expr(ctx, index) => {
+            !ctx.i32_counter_slots.contains_key(id)
+        }
+        _ if is_numeric_expr(ctx, index) => !can_lower_expr_as_i32(
+            index,
+            &ctx.i32_counter_slots,
+            ctx.flat_const_arrays,
+            &ctx.array_row_aliases,
+            ctx.integer_locals,
+            ctx.clamp3_functions,
+            ctx.clamp_u8_functions,
+            ctx.integer_returning_functions,
+            ctx.i32_identity_functions,
+        ),
+        _ => false,
+    }
+}
+
 fn is_async_dispose_symbol_index(index: &Expr) -> bool {
     let Expr::SymbolFor(symbol_name) = index else {
         return false;
@@ -658,6 +688,32 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         DOUBLE,
                         "js_object_get_symbol_property",
                         &[(DOUBLE, &obj_box), (DOUBLE, &key_box)],
+                    ));
+                }
+                if !is_numeric_expr(ctx, index) {
+                    let arr_box = lower_expr(ctx, object)?;
+                    let idx_double = lower_expr(ctx, index)?;
+                    let arr_handle = {
+                        let blk = ctx.block();
+                        unbox_to_i64(blk, &arr_box)
+                    };
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_array_get_index_or_string",
+                        &[(I64, &arr_handle), (DOUBLE, &idx_double)],
+                    ));
+                }
+                if numeric_index_needs_runtime_key(ctx, index) {
+                    let arr_box = lower_expr(ctx, object)?;
+                    let idx_double = lower_expr(ctx, index)?;
+                    let arr_handle = {
+                        let blk = ctx.block();
+                        unbox_to_i64(blk, &arr_box)
+                    };
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_array_get_index_or_string",
+                        &[(I64, &arr_handle), (DOUBLE, &idx_double)],
                     ));
                 }
                 let require_numeric_layout =

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -78,6 +78,36 @@ fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     )
 }
 
+fn numeric_index_needs_runtime_key(ctx: &FnCtx<'_>, index: &Expr) -> bool {
+    match index {
+        Expr::Integer(i) => *i < 0 || *i > i32::MAX as i64,
+        // Route through the runtime key helper unless the literal is a clean
+        // array index the i32 fast path carries without loss: a finite,
+        // non-negative integer in `0..=i32::MAX`. Everything else — negatives,
+        // out-of-range integers (`a[2**32-1]`), non-integer floats (`a[1.5]`),
+        // and non-finite values (`a[NaN]`/`a[Infinity]`) — is a string-keyed
+        // property, so it must reach `js_array_*_index_or_string`. (#4557/#4543)
+        Expr::Number(n) => {
+            !(n.is_finite() && n.fract() == 0.0 && *n >= 0.0 && *n <= i32::MAX as f64)
+        }
+        Expr::LocalGet(id) if is_numeric_expr(ctx, index) => {
+            !ctx.i32_counter_slots.contains_key(id)
+        }
+        _ if is_numeric_expr(ctx, index) => !can_lower_expr_as_i32(
+            index,
+            &ctx.i32_counter_slots,
+            ctx.flat_const_arrays,
+            &ctx.array_row_aliases,
+            ctx.integer_locals,
+            ctx.clamp3_functions,
+            ctx.clamp_u8_functions,
+            ctx.integer_returning_functions,
+            ctx.i32_identity_functions,
+        ),
+        _ => false,
+    }
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::IndexSet {
@@ -242,6 +272,38 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     ctx,
                     TypedFeedbackKind::ArrayElement,
                     "array[dynamic_index]",
+                    TypedFeedbackContract::array_set_index(),
+                );
+                ctx.block().call(
+                    I64,
+                    "js_typed_feedback_array_set_index_or_string",
+                    &[
+                        (I64, &site_id),
+                        (I64, &arr_handle),
+                        (DOUBLE, &idx_double),
+                        (DOUBLE, &val_double),
+                    ],
+                );
+                if value_needs_barrier {
+                    let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
+                    let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
+                    emit_write_barrier(ctx, &arr_bits, &val_bits);
+                }
+                return Ok(val_double);
+            }
+            if is_array_expr(ctx, object) && numeric_index_needs_runtime_key(ctx, index) {
+                let arr_box = lower_expr(ctx, object)?;
+                let idx_double = lower_expr(ctx, index)?;
+                let value_needs_barrier = array_store_needs_write_barrier(ctx, value);
+                let val_double = lower_expr(ctx, value)?;
+                let arr_handle = {
+                    let blk = ctx.block();
+                    unbox_to_i64(blk, &arr_box)
+                };
+                let site_id = emit_typed_feedback_register_site(
+                    ctx,
+                    TypedFeedbackKind::ArrayElement,
+                    "array[boundary_index]",
                     TypedFeedbackContract::array_set_index(),
                 );
                 ctx.block().call(

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -35,7 +35,7 @@ use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 #[allow(unused_imports)]
 use super::{
     array_store_needs_layout_note, array_store_needs_write_barrier,
-    buffer_access_materialization_reason, buffer_alias_metadata_suffix, can_lower_expr_as_i32,
+    buffer_access_materialization_reason, buffer_alias_metadata_suffix,
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
     emit_layout_note_slot_on_block, emit_root_nanbox_store_on_block, emit_shadow_slot_clear,
     emit_shadow_slot_update_for_expr, emit_string_literal_global,
@@ -78,32 +78,24 @@ fn is_uint8array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     )
 }
 
-fn numeric_index_needs_runtime_key(ctx: &FnCtx<'_>, index: &Expr) -> bool {
+fn numeric_index_needs_runtime_key(index: &Expr) -> bool {
+    // Only a LITERAL numeric key that is not a clean array index in
+    // `0..=i32::MAX` needs the runtime key helper: out-of-range/negative
+    // integers (`a[2**32-1]`, `a[-1]`), non-integer floats (`a[1.5]`), and
+    // non-finite values (`a[NaN]`/`a[Infinity]`). These become string-keyed
+    // properties and must reach `js_array_*_index_or_string`.
+    //
+    // Computed/dynamic numeric indices are deliberately NOT rerouted here:
+    // they keep flowing through the typed-feedback numeric-array guard path,
+    // which already carries its own out-of-range/non-integer fallback. Sending
+    // them to the runtime key helper would defeat the native numeric-array hot
+    // path and drop the index guard (regressing the native-region proof and
+    // the typed-feedback hot-path tests). (#4557/#4543)
     match index {
         Expr::Integer(i) => *i < 0 || *i > i32::MAX as i64,
-        // Route through the runtime key helper unless the literal is a clean
-        // array index the i32 fast path carries without loss: a finite,
-        // non-negative integer in `0..=i32::MAX`. Everything else — negatives,
-        // out-of-range integers (`a[2**32-1]`), non-integer floats (`a[1.5]`),
-        // and non-finite values (`a[NaN]`/`a[Infinity]`) — is a string-keyed
-        // property, so it must reach `js_array_*_index_or_string`. (#4557/#4543)
         Expr::Number(n) => {
             !(n.is_finite() && n.fract() == 0.0 && *n >= 0.0 && *n <= i32::MAX as f64)
         }
-        Expr::LocalGet(id) if is_numeric_expr(ctx, index) => {
-            !ctx.i32_counter_slots.contains_key(id)
-        }
-        _ if is_numeric_expr(ctx, index) => !can_lower_expr_as_i32(
-            index,
-            &ctx.i32_counter_slots,
-            ctx.flat_const_arrays,
-            &ctx.array_row_aliases,
-            ctx.integer_locals,
-            ctx.clamp3_functions,
-            ctx.clamp_u8_functions,
-            ctx.integer_returning_functions,
-            ctx.i32_identity_functions,
-        ),
         _ => false,
     }
 }
@@ -291,7 +283,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 }
                 return Ok(val_double);
             }
-            if is_array_expr(ctx, object) && numeric_index_needs_runtime_key(ctx, index) {
+            if is_array_expr(ctx, object) && numeric_index_needs_runtime_key(index) {
                 let arr_box = lower_expr(ctx, object)?;
                 let idx_double = lower_expr(ctx, index)?;
                 let value_needs_barrier = array_store_needs_write_barrier(ctx, value);

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -169,7 +169,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let recv_bits = blk.bitcast_double_to_i64(&recv_box);
             let recv_handle = blk.and(I64, &recv_bits, POINTER_MASK_I64);
             let len_i32 = blk.safe_load_i32_from_ptr(&recv_handle);
-            Ok(blk.sitofp(I32, &len_i32, DOUBLE))
+            Ok(blk.uitofp(I32, &len_i32, DOUBLE))
         }
 
         // Phase H err: `agg.errors` — AggregateError.errors field.
@@ -256,7 +256,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // `arr.length` / `str.length` — INLINE. Both ArrayHeader and
         // StringHeader start with `length: u32` (`crates/perry-runtime/src
         // /array.rs` and `string.rs`). Same pattern: unbox pointer, load
-        // u32 from offset 0, sitofp to double.
+        // u32 from offset 0, uitofp to double.
         // `.length` — INLINE for array, string, and interface-typed
         // receivers. Named types (interfaces, class instances) often
         // wrap strings or arrays at runtime, where length is at offset 0.
@@ -381,7 +381,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
             ctx.current_block = fast_idx;
             let fast_len_i32 = ctx.block().safe_load_i32_from_ptr(&recv_handle);
-            let fast_len = ctx.block().sitofp(I32, &fast_len_i32, DOUBLE);
+            let fast_len = ctx.block().uitofp(I32, &fast_len_i32, DOUBLE);
             let fast_pred_label = ctx.block().label.clone();
             ctx.block().br(&merge_label);
 

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -40,6 +40,7 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // Refs #488: bulk push for `arr.push(...src)` spread call.
     module.declare_function("js_array_push_spread_f64", I64, &[I64, I64]);
     module.declare_function("js_array_get_f64", DOUBLE, &[I64, I32]);
+    module.declare_function("js_array_get_index_or_string", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_array_numeric_get_f64_unboxed", DOUBLE, &[I64, I32]);
     module.declare_function("js_array_set_f64", VOID, &[I64, I32, DOUBLE]);
     module.declare_function("js_array_numeric_set_f64_unboxed", I32, &[I64, I32, DOUBLE]);

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -556,14 +556,13 @@ pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
             }
         }
     }
-    // Length/capacity sanity: a real ArrayHeader has length <= capacity,
-    // and length below 100M (800 MB of element payload — well above
-    // legitimate large result sets, far below the 775M / 926M patterns
-    // we observed when a reused arena slot landed ASCII text at offsets
-    // 0/4). Buffers can be much larger than arrays, so only gate the
-    // polymorphic entry on the tighter array-sized bound and let
-    // buffer-specific runtime paths dispatch themselves when they
-    // recognize a registered buffer pointer.
+    // Length/capacity sanity: dense arrays have length <= capacity and
+    // length below 100M (800 MB of element payload — well above legitimate
+    // large result sets, far below the 775M / 926M patterns we observed
+    // when a reused arena slot landed ASCII text at offsets 0/4). Sparse
+    // arrays created by far-index writes are the one legal exception:
+    // logical length can be huge while dense capacity stays small and the
+    // far slots live in ARRAY_NAMED_PROPS.
     unsafe {
         let hdr = &*cleaned;
         if hdr.length > hdr.capacity || hdr.length > 100_000_000 {
@@ -573,11 +572,24 @@ pub(crate) fn clean_arr_ptr(arr: *const ArrayHeader) -> *const ArrayHeader {
             // wave them through; everything else at this size is
             // almost certainly corrupted.
             let addr = cleaned as usize;
-            if !crate::buffer::is_registered_buffer(addr)
-                && crate::typedarray::lookup_typed_array_kind(addr).is_none()
-            {
-                return std::ptr::null();
+            let sparse_array_shape = if addr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+                let gc_header = (cleaned as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                    as *const crate::gc::GcHeader;
+                (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY
+                    && hdr.length > hdr.capacity
+                    && hdr.capacity <= 1_000_000
+            } else {
+                false
+            };
+            if sparse_array_shape {
+                return cleaned;
             }
+            if crate::buffer::is_registered_buffer(addr)
+                || crate::typedarray::lookup_typed_array_kind(addr).is_some()
+            {
+                return cleaned;
+            }
+            return std::ptr::null();
         }
     }
     cleaned

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -2,6 +2,33 @@
 use super::*;
 use std::ptr;
 
+const MAX_DENSE_ARRAY_GROW_LENGTH: u32 = 1_000_000;
+
+unsafe fn array_sparse_index_property_get(arr: *const ArrayHeader, index: u32) -> Option<f64> {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() || index < (*arr).capacity {
+        return None;
+    }
+    let key = index.to_string();
+    array_named_property_get_by_name(arr, &key)
+}
+
+unsafe fn array_sparse_index_property_set(arr: *mut ArrayHeader, index: u32, value: f64) {
+    let key = index.to_string();
+    let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    array_named_property_set(arr, key_ptr, value);
+    let new_length = index + 1;
+    if (*arr).length < new_length {
+        (*arr).length = new_length;
+    }
+}
+
+fn array_get_property_by_key(arr: *const ArrayHeader, key: *const crate::StringHeader) -> f64 {
+    let value =
+        crate::object::js_object_get_field_by_name(arr as *const crate::object::ObjectHeader, key);
+    f64::from_bits(value.bits())
+}
+
 #[no_mangle]
 pub extern "C" fn js_array_length(arr: *const ArrayHeader) -> u32 {
     let arr = {
@@ -98,7 +125,10 @@ pub extern "C" fn js_array_get_f64_unchecked(arr: *const ArrayHeader, index: u32
         if index >= length {
             return TAG_UNDEFINED_F64;
         }
-        if length > 100_000_000 {
+        if let Some(value) = array_sparse_index_property_get(arr, index) {
+            return value;
+        }
+        if index >= (*arr).capacity {
             return TAG_UNDEFINED_F64;
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -213,8 +243,10 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
         if index >= length {
             return TAG_UNDEFINED_F64;
         }
-        // Guard: corrupted arrays with unreasonably large length
-        if length > 100_000_000 {
+        if let Some(value) = array_sparse_index_property_get(arr, index) {
+            return value;
+        }
+        if index >= (*arr).capacity {
             return TAG_UNDEFINED_F64;
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
@@ -243,6 +275,10 @@ pub extern "C" fn js_array_set_f64_unchecked(arr: *mut ArrayHeader, index: u32, 
     unsafe {
         let length = (*arr).length;
         if index >= length {
+            return;
+        }
+        if index >= (*arr).capacity {
+            array_sparse_index_property_set(arr, index, value);
             return;
         }
         let value = canonicalize_array_numeric_store_value(arr, value);
@@ -305,6 +341,10 @@ pub extern "C" fn js_array_set_f64(arr: *mut ArrayHeader, index: u32, value: f64
         if index >= length {
             return;
         }
+        if index >= (*arr).capacity {
+            array_sparse_index_property_set(arr, index, value);
+            return;
+        }
         let value = canonicalize_array_numeric_store_value(arr, value);
         let value_bits = value.to_bits();
         let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
@@ -364,6 +404,11 @@ pub extern "C" fn js_array_set_f64_extend(
             if is_frozen {
                 return arr;
             }
+            if index >= (*arr).capacity {
+                let value = value_handle.get_nanbox_f64();
+                array_sparse_index_property_set(arr, index, value);
+                return arr;
+            }
             let value = canonicalize_array_numeric_store_value(arr, value);
             let value_bits = value.to_bits();
             let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
@@ -379,6 +424,11 @@ pub extern "C" fn js_array_set_f64_extend(
 
         // Need to extend the array
         let new_length = index + 1;
+        if new_length > (*arr).capacity && new_length > MAX_DENSE_ARRAY_GROW_LENGTH {
+            let value = value_handle.get_nanbox_f64();
+            array_sparse_index_property_set(arr, index, value);
+            return arr;
+        }
         let arr = if new_length > (*arr).capacity {
             js_array_grow(arr, new_length)
         } else {
@@ -504,6 +554,57 @@ pub extern "C" fn js_array_set_string_key(
     arr
 }
 
+/// `arr[idx]` where `idx` may be a number or property-key value. This mirrors
+/// `js_array_set_index_or_string` for read paths that cannot safely narrow the
+/// key through i32 codegen.
+#[no_mangle]
+pub extern "C" fn js_array_get_index_or_string(arr: *const ArrayHeader, idx: f64) -> f64 {
+    if arr.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let bits = idx.to_bits();
+    let top16 = bits >> 48;
+    if top16 == 0x7FFF {
+        let key = (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::StringHeader;
+        return array_get_property_by_key(arr, key);
+    }
+    if top16 == 0x7FF9 {
+        let key = crate::value::js_get_string_pointer_unified(idx) as *const crate::StringHeader;
+        return array_get_property_by_key(arr, key);
+    }
+
+    let numeric = if (bits & crate::value::TAG_MASK) == crate::value::INT32_TAG {
+        Some(crate::value::JSValue::from_bits(bits).as_int32() as f64)
+    } else if top16 < 0x7FF8 || top16 > 0x7FFF {
+        Some(idx)
+    } else {
+        None
+    };
+    if let Some(n) = numeric {
+        if n.is_finite() && n.trunc() == n && n >= 0.0 && n < u32::MAX as f64 {
+            return js_array_get_f64(arr, n as u32);
+        }
+        if n.is_finite() && n.trunc() == n {
+            let key = if n == 0.0 {
+                "0".to_string()
+            } else {
+                format!("{:.0}", n)
+            };
+            let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+            return array_get_property_by_key(arr, key_ptr);
+        }
+    }
+
+    if unsafe { crate::symbol::js_is_symbol(idx) } != 0 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let key = crate::value::js_jsvalue_to_string(idx);
+    if key.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    array_get_property_by_key(arr, key as *const crate::StringHeader)
+}
+
 /// `arr[idx] = value` where idx may be a NaN-boxed string (numeric-string
 /// key) OR a number. Dispatches at runtime: string tags → parse and route
 /// to `js_array_set_string_key`; otherwise treat as numeric and route to
@@ -554,14 +655,16 @@ pub extern "C" fn js_array_set_index_or_string(
         if n.is_finite() && n.trunc() == n && n >= 0.0 && n < u32::MAX as f64 {
             return js_array_set_f64_extend(arr, n as u32, value);
         }
-        if n.is_finite() && n.trunc() == n {
-            let s = if n == 0.0 {
-                "0".to_string()
-            } else {
-                format!("{:.0}", n)
-            };
-            let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-            return js_array_set_string_key(arr, key, value);
+        // Any other finite/non-finite number that is NOT a canonical array
+        // index (2^32-1 and above, negatives, and non-integer floats such as
+        // `a[1.5]`) becomes an ordinary string property. Route through
+        // `js_jsvalue_to_string` so the key is the spec ToString of the
+        // number ("4294967295", "-1", "1.5", "NaN") rather than a truncated
+        // integer — `js_array_set_string_key` then stores it on the expando
+        // map without touching `length` or any element slot. (Issue #4543.)
+        let key = crate::value::js_jsvalue_to_string(idx);
+        if !key.is_null() {
+            return js_array_set_string_key(arr, key as *const crate::StringHeader, value);
         }
     }
     // Fallback for a NON-numeric key: a primitive (`a[null]`, `a[undefined]`,
@@ -569,10 +672,8 @@ pub extern "C" fn js_array_set_index_or_string(
     // ToPropertyKey these become string property keys (or, for `10n`, the
     // canonical index "10"); `js_array_set_string_key` routes accordingly.
     // Arrays previously DROPPED these writes (plain objects handled them).
-    // Restricted to `numeric.is_none()`: a non-integer FLOAT key (`a[1.5]`) is
-    // left untouched here because `js_array_set_string_key("1.5")` currently
-    // mis-parses it as index 1 (corrupting `a[1]`) — that's a separate bug,
-    // tracked. Symbols stay symbol-keyed (handled elsewhere).
+    // Restricted to `numeric.is_none()`: numeric keys (including non-integer
+    // finite floats) are handled above. Symbols stay symbol-keyed.
     if numeric.is_none() && unsafe { crate::symbol::js_is_symbol(idx) } == 0 {
         let key = crate::value::js_jsvalue_to_string(idx);
         if !key.is_null() {

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -47,9 +47,10 @@ pub use self::immutable::{
 };
 pub use self::indexing::{
     js_array_get_element, js_array_get_element_f64, js_array_get_f64, js_array_get_f64_unchecked,
-    js_array_get_length, js_array_length, js_array_numeric_get_f64_unboxed,
-    js_array_numeric_set_f64_unboxed, js_array_set_f64, js_array_set_f64_extend,
-    js_array_set_f64_unchecked, js_array_set_index_or_string, js_array_set_string_key,
+    js_array_get_index_or_string, js_array_get_length, js_array_length,
+    js_array_numeric_get_f64_unboxed, js_array_numeric_set_f64_unboxed, js_array_set_f64,
+    js_array_set_f64_extend, js_array_set_f64_unchecked, js_array_set_index_or_string,
+    js_array_set_string_key,
 };
 pub use self::is_array::js_array_is_array;
 pub(crate) use self::iter_methods::throw_reduce_of_empty;

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -162,6 +162,31 @@ fn test_array_exotic_named_indices_and_boundary_props() {
 }
 
 #[test]
+fn test_array_sparse_max_valid_index_boundary() {
+    let mut arr = js_array_alloc(3);
+    arr = js_array_push_f64(arr, 0.0);
+    arr = js_array_push_f64(arr, 1.0);
+    arr = js_array_push_f64(arr, 2.0);
+
+    let max_index = u32::MAX - 1;
+    arr = js_array_set_f64_extend(arr, max_index, 77.0);
+
+    assert_eq!(js_array_length(arr), u32::MAX);
+    assert_eq!(js_array_get_f64(arr, max_index), 77.0);
+    assert_eq!(
+        js_array_get_index_or_string(arr, max_index as f64).to_bits(),
+        77.0f64.to_bits()
+    );
+
+    let key = string_key(b"4294967294");
+    assert_eq!(
+        crate::object::js_object_has_own(boxed_pointer(arr as *mut u8), string_value(key))
+            .to_bits(),
+        crate::value::TAG_TRUE
+    );
+}
+
+#[test]
 fn test_array_exotic_descriptors_and_global_prototype_identity() {
     let arr = js_array_alloc(0);
     let arr_box = boxed_pointer(arr as *mut u8);

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1411,7 +1411,35 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                 let arr = crate::array::clean_arr_ptr(stripped as *const crate::array::ArrayHeader);
                 let length = (*arr).length;
                 if length > 100_000 {
-                    return crate::array::js_array_alloc(0);
+                    let names = crate::array::array_named_property_names(arr, true);
+                    let dense_limit = if length > (*arr).capacity && (*arr).capacity <= 1_000_000 {
+                        (*arr).capacity
+                    } else {
+                        0
+                    };
+                    let result = crate::array::js_array_alloc(
+                        dense_limit.saturating_add(names.len() as u32),
+                    );
+                    if dense_limit > 0 {
+                        let elements = (arr as *const u8)
+                            .add(std::mem::size_of::<crate::array::ArrayHeader>())
+                            as *const u64;
+                        for i in 0..dense_limit {
+                            if std::ptr::read(elements.add(i as usize)) == crate::value::TAG_HOLE {
+                                continue;
+                            }
+                            let s = i.to_string();
+                            let key_box =
+                                crate::string::js_string_new_sso(s.as_ptr(), s.len() as u32);
+                            crate::array::js_array_push_f64(result, key_box);
+                        }
+                    }
+                    for name in names {
+                        let key =
+                            crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                        crate::array::js_array_push(result, JSValue::string_ptr(key));
+                    }
+                    return result;
                 }
                 let elements = (arr as *const u8)
                     .add(std::mem::size_of::<crate::array::ArrayHeader>())
@@ -1970,9 +1998,6 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                 // / `arr.hasOwnProperty(i)` stay correct after `arr.length = N`.
                 let arr = crate::array::clean_arr_ptr(obj_ptr as *const crate::array::ArrayHeader);
                 let length = (*arr).length;
-                if length > 100_000 {
-                    return nanbox_false;
-                }
                 // Numeric key: extract the index. Accept both NaN-boxed i32
                 // and plain f64 (e.g. literal `1`) provided it's a
                 // non-negative integer in range.
@@ -1997,6 +2022,13 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                     if idx >= length {
                         return nanbox_false;
                     }
+                    let sparse_key = idx.to_string();
+                    if crate::array::array_named_property_get_by_name(arr, &sparse_key).is_some() {
+                        return nanbox_true;
+                    }
+                    if idx >= (*arr).capacity {
+                        return nanbox_false;
+                    }
                     let elements = (arr as *const u8)
                         .add(std::mem::size_of::<crate::array::ArrayHeader>())
                         as *const u64;
@@ -2012,24 +2044,11 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                         if let Some(key_name) =
                             super::has_own_helpers::str_from_string_header(key_str)
                         {
-                            if key_name == "length" {
+                            if super::has_own_helpers::array_own_key_present(arr, key_str) {
                                 return nanbox_true;
                             }
-                            if let Some(index) = super::canonical_array_index(key_name) {
-                                if index < length {
-                                    let elements = (arr as *const u8)
-                                        .add(std::mem::size_of::<crate::array::ArrayHeader>())
-                                        as *const u64;
-                                    if std::ptr::read(elements.add(index as usize))
-                                        != crate::value::TAG_HOLE
-                                    {
-                                        return nanbox_true;
-                                    }
-                                }
+                            if super::canonical_array_index(key_name).is_some() {
                                 return nanbox_false;
-                            }
-                            if crate::array::array_named_property_has(arr, key_str) {
-                                return nanbox_true;
                             }
                             if array_prototype_property_value(key_name, obj_ptr as usize).is_some()
                             {

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -96,6 +96,9 @@ pub(super) unsafe fn array_own_key_present(
     if index >= length {
         return false;
     }
+    if index >= (*arr).capacity {
+        return false;
+    }
     let elements =
         (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const u64;
     std::ptr::read(elements.add(index as usize)) != crate::value::TAG_HOLE

--- a/test-parity/node-suite/globals/array-index-boundary.ts
+++ b/test-parity/node-suite/globals/array-index-boundary.ts
@@ -1,0 +1,35 @@
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label + ":", String(fn()));
+  } catch (e: any) {
+    console.log(label + ":", e?.name + ":" + e?.message);
+  }
+}
+
+const highNonIndex = 4294967295;
+const maxIndex = 4294967294;
+const overIndex = 4294967296;
+
+const a = [0, 1, 2];
+a[highNonIndex] = "x";
+show("2^32-1 length", () => a.length);
+show("2^32-1 value", () => a[highNonIndex]);
+show("2^32-1 own", () => Object.prototype.hasOwnProperty.call(a, String(highNonIndex)));
+
+const b = [0, 1, 2];
+b[maxIndex] = "y";
+show("2^32-2 length", () => b.length);
+show("2^32-2 value", () => b[maxIndex]);
+show("2^32-2 own", () => Object.prototype.hasOwnProperty.call(b, String(maxIndex)));
+show("2^32-2 keys", () => Object.keys(b).join("|"));
+
+const c = [0, 1, 2];
+c[overIndex] = "z";
+show("2^32 length", () => c.length);
+show("2^32 value", () => c[overIndex]);
+show("2^32 own", () => Object.prototype.hasOwnProperty.call(c, String(overIndex)));
+
+const d = [0, 1, 2];
+d[String(highNonIndex)] = "s";
+show("string 2^32-1 length", () => d.length);
+show("string 2^32-1 value", () => d[String(highNonIndex)]);

--- a/test-parity/node-suite/globals/array-index-boundary.ts
+++ b/test-parity/node-suite/globals/array-index-boundary.ts
@@ -6,30 +6,46 @@ function show(label: string, fn: () => unknown) {
   }
 }
 
-const highNonIndex = 4294967295;
-const maxIndex = 4294967294;
-const overIndex = 4294967296;
-
-const a = [0, 1, 2];
-a[highNonIndex] = "x";
+// 2^32-1 (4294967295) is NOT a valid array index: it stays an ordinary
+// string-keyed property and does not change `length`.
+const a: any = [0, 1, 2];
+a[4294967295] = "x";
 show("2^32-1 length", () => a.length);
-show("2^32-1 value", () => a[highNonIndex]);
-show("2^32-1 own", () => Object.prototype.hasOwnProperty.call(a, String(highNonIndex)));
+show("2^32-1 value", () => a[4294967295]);
+show("2^32-1 own", () => Object.prototype.hasOwnProperty.call(a, "4294967295"));
 
-const b = [0, 1, 2];
-b[maxIndex] = "y";
+// 2^32-2 (4294967294) is the maximum valid array index: writing it sets
+// `length` to 2^32-1 with the element stored sparsely.
+const b: any = [0, 1, 2];
+b[4294967294] = "y";
 show("2^32-2 length", () => b.length);
-show("2^32-2 value", () => b[maxIndex]);
-show("2^32-2 own", () => Object.prototype.hasOwnProperty.call(b, String(maxIndex)));
+show("2^32-2 value", () => b[4294967294]);
+show("2^32-2 own", () => Object.prototype.hasOwnProperty.call(b, "4294967294"));
 show("2^32-2 keys", () => Object.keys(b).join("|"));
 
-const c = [0, 1, 2];
-c[overIndex] = "z";
+// 2^32 (4294967296) is past the index range: ordinary string property.
+const c: any = [0, 1, 2];
+c[4294967296] = "z";
 show("2^32 length", () => c.length);
-show("2^32 value", () => c[overIndex]);
-show("2^32 own", () => Object.prototype.hasOwnProperty.call(c, String(overIndex)));
+show("2^32 value", () => c[4294967296]);
+show("2^32 own", () => Object.prototype.hasOwnProperty.call(c, "4294967296"));
 
-const d = [0, 1, 2];
-d[String(highNonIndex)] = "s";
+// An explicit numeric-string key behaves like the string property above.
+const d: any = [0, 1, 2];
+d["4294967295"] = "s";
 show("string 2^32-1 length", () => d.length);
-show("string 2^32-1 value", () => d[String(highNonIndex)]);
+show("string 2^32-1 value", () => d["4294967295"]);
+
+// A non-integer numeric key is the string property "1.5"; it must not be
+// truncated onto element 1.
+const e: any = [0, 1, 2];
+e[1.5] = "half";
+show("1.5 length", () => e.length);
+show("1.5 value", () => e[1.5]);
+show("1.5 element-one", () => e[1]);
+
+// A negative numeric key is the string property "-1".
+const f: any = [0, 1, 2];
+f[-1] = "neg";
+show("-1 length", () => f.length);
+show("-1 value", () => f[-1]);

--- a/test-parity/node-suite/globals/array-property-keys.ts
+++ b/test-parity/node-suite/globals/array-property-keys.ts
@@ -1,0 +1,33 @@
+function show(label: string, value: unknown) {
+  console.log(label + ":", JSON.stringify(value));
+}
+
+const nonInteger: any = [0, 1, 2];
+nonInteger[1.5] = "half";
+show("noninteger numeric read", nonInteger[1.5]);
+show("noninteger string read", nonInteger["1.5"]);
+show("index one unchanged", nonInteger[1]);
+show("noninteger own", Object.prototype.hasOwnProperty.call(nonInteger, "1.5"));
+show("noninteger length", nonInteger.length);
+show("delete noninteger", delete nonInteger[1.5]);
+show("noninteger after delete", Object.prototype.hasOwnProperty.call(nonInteger, "1.5"));
+show("index one after delete", nonInteger[1]);
+
+const numericString: any = [];
+numericString["1.5"] = "string half";
+show("string noninteger string read", numericString["1.5"]);
+show("string noninteger numeric read", numericString[1.5]);
+show("string noninteger index one", numericString[1]);
+show("string noninteger length", numericString.length);
+
+const bigintKey: any = [];
+bigintKey[10n as any] = "ten";
+show("bigint key string read", bigintKey["10"]);
+show("bigint key numeric read", bigintKey[10]);
+show("bigint key own", Object.prototype.hasOwnProperty.call(bigintKey, "10"));
+show("bigint key in", "10" in bigintKey);
+show("bigint key length", bigintKey.length);
+show("delete bigint key", delete bigintKey["10"]);
+show("bigint key after delete", bigintKey["10"]);
+show("bigint key own after delete", Object.prototype.hasOwnProperty.call(bigintKey, "10"));
+show("bigint key length after delete", bigintKey.length);


### PR DESCRIPTION
Closes #4557. Closes #4543. Supersedes #4585 and #4559 (combines and extends both).

## Problem
\`a[2**32-1] = v\` produced a deterministically-bogus length of 193 (the computed-member-assignment fast path truncated the index through i32), and Perry's dense array model could not represent \`a[2**32-2] = v\` (max valid index → length 4294967295 with one element). Separately, \`a[1.5] = v\` truncated to \`a[1]\`, corrupting an existing element instead of creating the \`"1.5"\` string property.

## What this does
- **Boundary keys (#4557):** \`2**32-1\` and larger numeric keys are ordinary string properties — length is unchanged and the value is readable.
- **Sparse length (#4557):** \`2**32-2\` (the max valid index) sets length to \`2**32-1\` and stores the element in the array's named-property side table (\`ARRAY_NAMED_PROPS\`) rather than attempting a ~32 GB dense allocation. \`clean_arr_ptr\` now admits the \`length > capacity\` sparse shape. Far writes beyond \`MAX_DENSE_ARRAY_GROW_LENGTH\` (1M) go sparse; the dense prefix stays dense.
- **Non-integer / non-canonical keys (#4543):** \`a[1.5]\`, \`a[-1]\`, \`a[NaN]\`, \`a[Infinity]\` become ordinary string properties (\`"1.5"\`, \`"-1"\`, \`"NaN"\`, \`"Infinity"\`) via \`js_jsvalue_to_string\`, never truncated to an element slot. String/bigint keys (\`a["1.5"]\`, \`a[10n]\`) round-trip through the array-aware named-property path.

### Codegen
\`numeric_index_needs_runtime_key\` (index_get/index_set) routes any literal that is **not** a clean array index in \`0..=i32::MAX\` — negatives, out-of-range integers, non-integer floats, non-finite — through \`js_array_get/set_index_or_string\` instead of the i32 fast path.

### Runtime
\`js_array_set_index_or_string\` stringifies non-canonical numbers via \`js_jsvalue_to_string\`; new \`js_array_get_index_or_string\` mirrors it for reads; sparse get/set helpers use the named-property table while tracking \`length\` separately.

## Verification (byte-identical to \`node --experimental-strip-types\`)
- \`a[2**32-1]\` → length 3, value \`'x'\` readable
- \`a[2**32-2]\` → length 4294967295, value readable, dense prefix intact
- \`a[1.5]\` → length 3, \`"1.5"\` property, \`a[1]\` untouched
- \`a[-1]\`, string-key reads, \`a[10n]\` canonical-index, delete/hasOwnProperty/in
- test262-equivalent of \`built-ins/Array/15.4.5.1-5-1.js\` / \`-5-2.js\`: 10/10 pass
- node-suite fixtures \`array-index-boundary.ts\` and \`array-property-keys.ts\`: IDENTICAL to node (both auto-optimize and \`PERRY_NO_AUTO_OPTIMIZE=1\` paths)
- \`cargo test -p perry-runtime --lib array::\`: 57 passed, 0 failed (incl. new sparse-boundary tests)
- Dense-array regression sweep (map/filter/reduce/for-of/forEach/JSON/push/pop/slice/spread/Object.keys/1000-element grow): IDENTICAL to node
- \`cargo fmt --all -- --check\` ✓ · \`./scripts/check_file_size.sh\` ✓

## Non-goals
Does not rewrite Perry into a general sparse-array engine; very large dense enumeration stays bounded. Preserves dense prefixes and sparse side-table keys for sparse high-index arrays.

Co-authored-by: Andrew DiZenzo <andrewdizenzojhu@gmail.com>