### PR TITLE
fix(events): validate max-listener targets

### DIFF
--- a/crates/perry-ext-events/src/lib.rs
+++ b/crates/perry-ext-events/src/lib.rs
@@ -24,12 +24,20 @@ use perry_ffi::{
     throw_with_code, ArrayHeader, ErrorKind, Handle, JsPromise, JsString, JsValue, ObjectHeader,
     Promise, RawClosureHeader, StringHeader,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::sync::{Mutex, MutexGuard, Once, OnceLock};
 
+mod max_listeners;
+mod target_helpers;
+
 #[cfg(test)]
 mod test_async_shims;
+
+use max_listeners::{emit_max_listeners_warning, validate_max_listeners};
+use target_helpers::{
+    event_helper_target, event_target_array_len, stream_array_len, EventHelperTarget,
+};
 
 const MIN_HEAP_POINTER: u64 = 0x1000;
 const EVENT_TARGET_MIN_HEAP_POINTER: u64 = 0x10000;
@@ -76,10 +84,13 @@ extern "C" {
     // #1557: AbortSignal listener attachment for events.addAbortListener.
     fn js_string_from_bytes(data: *const u8, len: u32) -> *mut StringHeader;
     fn js_object_alloc(class_id: u32, field_count: u32) -> *mut ObjectHeader;
+    fn js_error_new_with_message(message: *mut StringHeader) -> *mut ObjectHeader;
     fn js_object_get_field_by_name_f64(obj: *const ObjectHeader, key: *const StringHeader) -> f64;
     fn js_object_set_field_by_name(obj: *mut ObjectHeader, key: *const StringHeader, value: f64);
     fn js_symbol_for(key_f64: f64) -> f64;
     fn js_object_set_symbol_property(obj_f64: f64, sym_f64: f64, value_f64: f64) -> f64;
+    fn js_get_global_this() -> f64;
+    fn js_array_is_array(value: f64) -> f64;
     fn js_abort_signal_add_listener(signal: *mut u8, event: f64, listener: f64);
     fn js_event_target_is_event_target(target: *const u8) -> i32;
     fn js_event_target_get_event_listeners(
@@ -89,6 +100,8 @@ extern "C" {
     fn js_event_target_get_max_listeners(target: *mut u8) -> f64;
     fn js_event_target_set_max_listeners(target: *mut u8, n: f64) -> i32;
     fn js_node_stream_method_listeners(stream_handle: i64, event: f64) -> i64;
+    fn js_node_stream_method_get_max_listeners(stream_handle: i64) -> f64;
+    fn js_node_stream_method_set_max_listeners(stream_handle: i64, value: f64) -> f64;
     fn js_node_stream_method_once(stream_handle: i64, event: f64, cb: f64) -> f64;
     fn js_node_stream_method_remove_listener(stream_handle: i64, event: f64, cb: f64) -> f64;
     fn js_node_stream_is_readable(stream: f64) -> f64;
@@ -125,7 +138,10 @@ unsafe fn validate_event_listener(listener_bits: i64) -> i64 {
 
 const TAG_UNDEFINED_F64_BITS: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL_F64_BITS: u64 = 0x7FFC_0000_0000_0002;
+const TAG_TRUE_F64_BITS: u64 = 0x7FFC_0000_0000_0004;
+const BIGINT_TAG: u64 = 0x7FFA_0000_0000_0000;
 const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
 const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
 const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
 const TAG_MASK: u64 = 0xFFFF_0000_0000_0000;
@@ -194,7 +210,8 @@ pub struct EventEmitterHandle {
     events: HashMap<String, Vec<Listener>>,
     event_order: Vec<String>,
     pending_once_promises: HashMap<String, Vec<PendingOnce>>,
-    max_listeners: i32,
+    warned_events: HashSet<String>,
+    max_listeners: f64,
     capture_rejections: bool,
     domain_handle: Option<Handle>,
 }
@@ -217,9 +234,10 @@ impl EventEmitterHandle {
             events: HashMap::new(),
             event_order: Vec::new(),
             pending_once_promises: HashMap::new(),
+            warned_events: HashSet::new(),
             // Node's default — `getMaxListeners()` on a fresh emitter
             // returns 10.
-            max_listeners: 10,
+            max_listeners: 10.0,
             capture_rejections: false,
             domain_handle: None,
         }
@@ -238,6 +256,7 @@ impl EventEmitterHandle {
         };
         if drop_it {
             self.events.remove(name);
+            self.warned_events.remove(name);
             if let Some(pos) = self.event_order.iter().position(|s| s == name) {
                 self.event_order.remove(pos);
             }
@@ -279,21 +298,30 @@ impl EventEmitterHandle {
     ) {
         self.emit_meta_event(handle, "newListener", name, callback);
         self.note_event(name);
-        let vec = self.events.entry(name.to_string()).or_default();
         let raw_wrapper = if once {
             unsafe { create_once_raw_wrapper(handle, name, callback) }
         } else {
             0
         };
-        let listener = Listener {
-            callback,
-            raw_wrapper,
-            once,
+        let count = {
+            let vec = self.events.entry(name.to_string()).or_default();
+            let listener = Listener {
+                callback,
+                raw_wrapper,
+                once,
+            };
+            if prepend {
+                vec.insert(0, listener);
+            } else {
+                vec.push(listener);
+            }
+            vec.len()
         };
-        if prepend {
-            vec.insert(0, listener);
-        } else {
-            vec.push(listener);
+        if self.max_listeners > 0.0
+            && (count as f64) > self.max_listeners
+            && self.warned_events.insert(name.to_string())
+        {
+            unsafe { emit_max_listeners_warning(handle, name, count, self.max_listeners) };
         }
     }
 }
@@ -501,19 +529,6 @@ unsafe fn stream_value_from_handle(handle: Handle) -> Option<f64> {
     }
 }
 
-fn handle_from_js_value_bits(bits: u64) -> Handle {
-    if (bits & 0xFFFF_0000_0000_0000) == POINTER_TAG {
-        (bits & POINTER_MASK) as Handle
-    } else {
-        let value = f64::from_bits(bits);
-        if value.is_finite() && value > 0.0 && value.fract() == 0.0 {
-            value as Handle
-        } else {
-            bits as Handle
-        }
-    }
-}
-
 fn handle_from_value(value: f64) -> Handle {
     let bits = value.to_bits();
     if (bits & 0xFFFF_0000_0000_0000) == POINTER_TAG {
@@ -586,11 +601,14 @@ fn describe_received(value: f64) -> String {
     if jsval.is_string() {
         let text = unsafe { read_string(JsString::from_raw(jsval.as_string_ptr())) };
         return match text {
-            Some(text) => format!("type string ({text:?})"),
+            Some(text) => format!("type string ('{text}')"),
             None => "type string".to_string(),
         };
     }
     if jsval.is_pointer() {
+        if unsafe { js_array_is_array(value).to_bits() == TAG_TRUE_F64_BITS } {
+            return "an instance of Array".to_string();
+        }
         return "an instance of Object".to_string();
     }
     "unknown".to_string()
@@ -1301,6 +1319,7 @@ pub unsafe extern "C" fn js_event_emitter_remove_all_listeners(
                 .collect();
             emitter.events.clear();
             emitter.event_order.clear();
+            emitter.warned_events.clear();
             for (name, callback) in removed {
                 emitter.emit_meta_event(handle, "removeListener", &name, callback);
             }
@@ -1313,6 +1332,7 @@ pub unsafe extern "C" fn js_event_emitter_remove_all_listeners(
                 .map(|listeners| listeners.iter().map(|listener| listener.callback).collect())
                 .unwrap_or_default();
             emitter.events.remove(&event_name);
+            emitter.warned_events.remove(&event_name);
             if let Some(pos) = emitter.event_order.iter().position(|s| s == &event_name) {
                 emitter.event_order.remove(pos);
             }
@@ -1372,8 +1392,9 @@ pub unsafe extern "C" fn js_event_emitter_listener_count(
 /// `emitter.setMaxListeners(n)`.
 #[no_mangle]
 pub unsafe extern "C" fn js_event_emitter_set_max_listeners(handle: Handle, n: f64) -> Handle {
+    let n = validate_max_listeners(n);
     if let Some(emitter) = get_event_emitter_mut(handle) {
-        emitter.max_listeners = n as i32;
+        emitter.max_listeners = n;
     }
     handle
 }
@@ -1382,7 +1403,7 @@ pub unsafe extern "C" fn js_event_emitter_set_max_listeners(handle: Handle, n: f
 #[no_mangle]
 pub unsafe extern "C" fn js_event_emitter_get_max_listeners(handle: Handle) -> f64 {
     if let Some(emitter) = get_event_emitter_mut(handle) {
-        return emitter.max_listeners as f64;
+        return emitter.max_listeners;
     }
     10.0
 }
@@ -1857,17 +1878,24 @@ pub unsafe extern "C" fn js_events_get_event_listeners(
     target_value: f64,
     event_name_ptr: *const StringHeader,
 ) -> *mut ArrayHeader {
-    let handle = handle_from_value(target_value);
-    if get_event_emitter_mut(handle).is_some() {
-        return js_event_emitter_listeners(handle, event_name_ptr as i64);
+    match event_helper_target(target_value).unwrap_or_else(|| {
+        throw_invalid_arg_type(&invalid_instance_arg_message(
+            "emitter",
+            "EventEmitter or EventTarget",
+            target_value,
+        ))
+    }) {
+        EventHelperTarget::EventEmitter(handle) => {
+            js_event_emitter_listeners(handle, event_name_ptr as i64)
+        }
+        EventHelperTarget::EventTarget(target) => {
+            js_event_target_get_event_listeners(target, event_name_ptr)
+        }
+        EventHelperTarget::Stream(handle) => {
+            stream_listeners_for_heap_object(handle, event_name_ptr)
+                .unwrap_or_else(|| js_array_alloc(0))
+        }
     }
-    if let Some(target) = event_target_ptr(handle) {
-        return js_event_target_get_event_listeners(target, event_name_ptr);
-    }
-    if let Some(listeners) = stream_listeners_for_heap_object(handle, event_name_ptr) {
-        return listeners;
-    }
-    js_array_alloc(0)
 }
 
 /// `events.listenerCount(emitter, eventName)` — alias.
@@ -1880,21 +1908,39 @@ pub unsafe extern "C" fn js_events_listener_count(
     target_value: f64,
     event_name_ptr: *const StringHeader,
 ) -> f64 {
-    let handle = handle_from_value(target_value);
-    js_event_emitter_listener_count(handle, event_name_ptr as i64, TAG_UNDEFINED_F64_BITS as i64)
+    match event_helper_target(target_value).unwrap_or_else(|| {
+        throw_invalid_arg_type(&invalid_instance_arg_message(
+            "emitter",
+            "EventEmitter or EventTarget",
+            target_value,
+        ))
+    }) {
+        EventHelperTarget::EventEmitter(handle) => js_event_emitter_listener_count(
+            handle,
+            event_name_ptr as i64,
+            TAG_UNDEFINED_F64_BITS as i64,
+        ),
+        EventHelperTarget::EventTarget(target) => event_target_array_len(target, event_name_ptr),
+        EventHelperTarget::Stream(handle) => {
+            stream_array_len(handle, event_name_ptr).unwrap_or(0.0)
+        }
+    }
 }
 
 /// `events.getMaxListeners(emitter)` — alias.
 #[no_mangle]
 pub unsafe extern "C" fn js_events_get_max_listeners(target_value: f64) -> f64 {
-    let handle = handle_from_value(target_value);
-    if let Some(emitter) = get_event_emitter_mut(handle) {
-        return emitter.max_listeners as f64;
+    match event_helper_target(target_value).unwrap_or_else(|| {
+        throw_invalid_arg_type(&invalid_instance_arg_message(
+            "emitter",
+            "EventEmitter or EventTarget",
+            target_value,
+        ))
+    }) {
+        EventHelperTarget::EventEmitter(handle) => js_event_emitter_get_max_listeners(handle),
+        EventHelperTarget::EventTarget(target) => js_event_target_get_max_listeners(target),
+        EventHelperTarget::Stream(handle) => js_node_stream_method_get_max_listeners(handle),
     }
-    if let Some(target) = event_target_ptr(handle) {
-        return js_event_target_get_max_listeners(target);
-    }
-    10.0
 }
 
 /// `events.setMaxListeners(n, ...emitters)` — Perry FFI takes a single
@@ -1904,14 +1950,29 @@ pub unsafe extern "C" fn js_events_set_max_listeners(
     n: f64,
     handles_ptr: *const ArrayHeader,
 ) -> f64 {
+    let n = validate_max_listeners(n);
     if !handles_ptr.is_null() {
         let len = (*handles_ptr).length;
         for i in 0..len {
-            let handle = handle_from_js_value_bits(js_array_get(handles_ptr, i).bits());
-            if let Some(emitter) = get_event_emitter_mut(handle) {
-                emitter.max_listeners = n as i32;
-            } else if let Some(target) = event_target_ptr(handle) {
-                let _ = js_event_target_set_max_listeners(target, n);
+            let value = f64::from_bits(js_array_get(handles_ptr, i).bits());
+            match event_helper_target(value).unwrap_or_else(|| {
+                throw_invalid_arg_type(&invalid_instance_arg_message(
+                    "eventTargets",
+                    "EventEmitter or EventTarget",
+                    value,
+                ))
+            }) {
+                EventHelperTarget::EventEmitter(handle) => {
+                    if let Some(emitter) = get_event_emitter_mut(handle) {
+                        emitter.max_listeners = n;
+                    }
+                }
+                EventHelperTarget::EventTarget(target) => {
+                    let _ = js_event_target_set_max_listeners(target, n);
+                }
+                EventHelperTarget::Stream(handle) => {
+                    let _ = js_node_stream_method_set_max_listeners(handle, n);
+                }
             }
         }
     }

--- a/crates/perry-ext-events/src/max_listeners.rs
+++ b/crates/perry-ext-events/src/max_listeners.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+fn format_max_listeners_received(n: f64) -> String {
+    if n.is_nan() {
+        return "NaN".to_string();
+    }
+    if n.is_infinite() {
+        return if n.is_sign_negative() {
+            "-Infinity"
+        } else {
+            "Infinity"
+        }
+        .to_string();
+    }
+    if n.fract() == 0.0 && n.abs() < 1e21 {
+        format!("{}", n as i64)
+    } else {
+        format!("{}", n)
+    }
+}
+
+fn max_listeners_is_number(value: f64) -> bool {
+    let bits = value.to_bits();
+    let high = bits & TAG_MASK;
+    if high == INT32_TAG {
+        return true;
+    }
+    !matches!(
+        bits,
+        TAG_UNDEFINED_F64_BITS | TAG_NULL_F64_BITS | 0x7FFC_0000_0000_0003 | TAG_TRUE_F64_BITS
+    ) && !matches!(high, BIGINT_TAG | POINTER_TAG | STRING_TAG | INT32_TAG)
+}
+
+fn max_listeners_number(value: f64) -> f64 {
+    let bits = value.to_bits();
+    if (bits & TAG_MASK) == INT32_TAG {
+        (bits as u32 as i32) as f64
+    } else {
+        value
+    }
+}
+
+fn throw_max_listeners_invalid_type(value: f64) -> ! {
+    let message = format!(
+        "The \"setMaxListeners\" argument must be of type number. Received {}",
+        describe_received(value)
+    );
+    throw_with_code(&message, "ERR_INVALID_ARG_TYPE", ErrorKind::TypeError)
+}
+
+fn throw_max_listeners_out_of_range(n: f64) -> ! {
+    let message = format!(
+        "The value of \"setMaxListeners\" is out of range. It must be >= 0. Received {}",
+        format_max_listeners_received(n)
+    );
+    throw_with_code(&message, "ERR_OUT_OF_RANGE", ErrorKind::RangeError)
+}
+
+pub(super) fn validate_max_listeners(value: f64) -> f64 {
+    if !max_listeners_is_number(value) {
+        throw_max_listeners_invalid_type(value);
+    }
+    let n = max_listeners_number(value);
+    if n.is_nan() || n < 0.0 {
+        throw_max_listeners_out_of_range(n);
+    }
+    n
+}
+
+unsafe fn string_value(text: &str) -> f64 {
+    let ptr = js_string_from_bytes(text.as_ptr(), text.len() as u32);
+    f64::from_bits(nanbox_string_bits(ptr))
+}
+
+unsafe fn set_object_string_prop(obj: *mut ObjectHeader, name: &str, value: &str) {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(obj, key, string_value(value));
+}
+
+unsafe fn set_object_number_prop(obj: *mut ObjectHeader, name: &str, value: f64) {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(obj, key, value);
+}
+
+unsafe fn set_object_value_prop(obj: *mut ObjectHeader, name: &str, value: f64) {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(obj, key, value);
+}
+
+unsafe fn get_object_field_by_str(obj: *const ObjectHeader, name: &str) -> f64 {
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_get_field_by_name_f64(obj, key)
+}
+
+unsafe fn current_process_value() -> Option<f64> {
+    let global = JsValue::from_bits(js_get_global_this().to_bits());
+    if !global.is_pointer() {
+        return None;
+    }
+    let process = get_object_field_by_str(global.as_pointer::<ObjectHeader>(), "process");
+    if JsValue::from_bits(process.to_bits()).is_pointer() {
+        Some(process)
+    } else {
+        None
+    }
+}
+
+unsafe fn call_process_emit_warning(warning: f64) {
+    let Some(process) = current_process_value() else {
+        return;
+    };
+    let process_value = JsValue::from_bits(process.to_bits());
+    let process_obj = process_value.as_pointer::<ObjectHeader>();
+    let emit_warning = get_object_field_by_str(process_obj, "emitWarning");
+    let previous_this = js_implicit_this_set(process);
+    let args = [warning];
+    js_native_call_value(emit_warning, args.as_ptr(), args.len());
+    js_implicit_this_set(previous_this);
+}
+
+pub(super) unsafe fn emit_max_listeners_warning(
+    handle: Handle,
+    event_name: &str,
+    count: usize,
+    max: f64,
+) {
+    let message = format!(
+        "Possible EventEmitter memory leak detected. {count} {event_name} listeners added to [EventEmitter]. MaxListeners is {}. Use emitter.setMaxListeners() to increase limit",
+        format_max_listeners_received(max)
+    );
+    let message_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let warning = js_error_new_with_message(message_ptr);
+    set_object_string_prop(warning, "name", "MaxListenersExceededWarning");
+    set_object_string_prop(warning, "type", event_name);
+    set_object_number_prop(warning, "count", count as f64);
+    set_object_value_prop(warning, "emitter", nanbox_pointer_bits(handle));
+    call_process_emit_warning(nanbox_pointer_bits(warning as i64));
+}

--- a/crates/perry-ext-events/src/target_helpers.rs
+++ b/crates/perry-ext-events/src/target_helpers.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+pub(super) enum EventHelperTarget {
+    EventEmitter(Handle),
+    EventTarget(*mut u8),
+    Stream(Handle),
+}
+
+pub(super) unsafe fn event_helper_target(value: f64) -> Option<EventHelperTarget> {
+    let handle = handle_from_value(value);
+    if is_local_event_emitter_handle(handle) {
+        return Some(EventHelperTarget::EventEmitter(handle));
+    }
+    if let Some(target) = event_target_ptr(handle) {
+        return Some(EventHelperTarget::EventTarget(target));
+    }
+    if stream_value_from_handle(handle).is_some() {
+        return Some(EventHelperTarget::Stream(handle));
+    }
+    None
+}
+
+pub(super) unsafe fn event_target_array_len(
+    target: *mut u8,
+    event_name_ptr: *const StringHeader,
+) -> f64 {
+    let listeners = js_event_target_get_event_listeners(target, event_name_ptr);
+    if listeners.is_null() {
+        0.0
+    } else {
+        (*listeners).length as f64
+    }
+}
+
+pub(super) unsafe fn stream_array_len(
+    handle: Handle,
+    event_name_ptr: *const StringHeader,
+) -> Option<f64> {
+    stream_listeners_for_heap_object(handle, event_name_ptr).map(|arr| {
+        if arr.is_null() {
+            0.0
+        } else {
+            (*arr).length as f64
+        }
+    })
+}

--- a/crates/perry-ext-events/src/tests.rs
+++ b/crates/perry-ext-events/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use perry_ffi::alloc_string;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, MutexGuard};
 
 static GC_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -177,7 +177,8 @@ fn gc_mutable_scanner_rewrites_listener_and_pending_promise_roots() {
         events,
         event_order: vec!["ready".to_string()],
         pending_once_promises,
-        max_listeners: 10,
+        warned_events: HashSet::new(),
+        max_listeners: 10.0,
         capture_rejections: false,
         domain_handle: None,
     });


### PR DESCRIPTION
Refs #4633

Summary:
- Validate `EventEmitter#setMaxListeners(n)` with Node-compatible number, NaN, and range handling while preserving `Infinity`.
- Track per-event max-listener warnings and emit `MaxListenersExceededWarning` through the current `process.emitWarning` hook.
- Validate module helper targets for `events.getEventListeners`, `events.listenerCount`, `events.getMaxListeners`, and `events.setMaxListeners`, including EventEmitter, EventTarget-like values, and stream targets.
- Split the new helper logic into `max_listeners.rs` and `target_helpers.rs` so `lib.rs` stays below the repository file-size limit.

Why batched:
- These paths share the same `node:events` target classification and max-listener count validation behavior.
- Keeping the count validation, module target validation, and warning emission together avoids inconsistent helper behavior between instance and static APIs.

Tests added or updated:
- Updated the `perry-ext-events` unit-test fixture setup for the new warning-state and floating max-listener storage.
- Existing `node-suite/events/max-listeners/*` parity fixtures now cover the fixed behavior.

Validation:
- `cargo check -p perry-ext-events -j 2`
- `cargo build --release -p perry-ext-events -j 2`
- `CARGO_BUILD_JOBS=2 PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc ./run_parity_tests.sh --suite node-suite --module events --filter max-listeners/` -> 7 pass, 0 fail (`parity_report_20260605_201314.json`)
- `CARGO_BUILD_JOBS=2 PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc ./run_parity_tests.sh --suite node-suite --module events` -> 65 pass, 4 existing output mismatches, 0 compile failures (`parity_report_20260605_200057.json`)
- `cargo test -p perry-ext-events -j 2`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

Known limitations:
- The full events sweep still has residual mismatches in `events/async-resource/basic`, `events/errors/error-monitor`, `events/on/validation`, and `events/once/validation`.

Non-goals:
- EventEmitterAsyncResource behavior.
- errorMonitor dispatch.
- events.on/events.once validation behavior.
- Async resource lifecycle behavior.