### PR TITLE
fix(typedarray): honor byteOffset/byteLength/buffer on ArrayBuffer views (#4103)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1744,7 +1744,27 @@ pub unsafe extern "C" fn js_new_function_construct(
                 } else {
                     args[0]
                 };
-                let ta = crate::typedarray::js_typed_array_new(kind, arg0);
+                // `new TA(buffer, byteOffset, length?)` via a *dynamic* constructor
+                // value (e.g. test262's `testWithTypedArrayConstructors`, where
+                // `TA` is a variable) must honor the offset/length arguments. The
+                // single-arg `js_typed_array_new` path dropped them, so every
+                // view built this way reported `byteOffset === 0`. Route the
+                // multi-arg form through the view constructor, which records the
+                // backing/offset so `.byteOffset` / `.buffer` are correct and the
+                // result aliases the buffer (mirrors the literal-name codegen
+                // path in `lower_call::builtin`). A non-ArrayBuffer `arg0` falls
+                // back to `js_typed_array_new` inside `js_typed_array_view`.
+                let ta = if args.len() >= 2 {
+                    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+                    crate::typedarray_view::js_typed_array_view(
+                        kind,
+                        arg0,
+                        args[1],
+                        args.get(2).copied().unwrap_or(undefined),
+                    )
+                } else {
+                    crate::typedarray::js_typed_array_new(kind, arg0)
+                };
                 return crate::value::js_nanbox_pointer(ta as i64);
             }
             "TextEncoderStream" => {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2203,7 +2203,7 @@ pub extern "C" fn js_object_get_field_by_name(
                             return JSValue::number((len as usize * elem_size) as f64);
                         }
                         b"buffer" => {
-                            let buf = crate::typedarray::typed_array_to_array_buffer(ta);
+                            let buf = crate::typedarray_view::js_typed_array_backing_buffer(ta);
                             if buf.is_null() {
                                 return JSValue::undefined();
                             }
@@ -2211,7 +2211,11 @@ pub extern "C" fn js_object_get_field_by_name(
                                 crate::value::js_nanbox_pointer(buf as i64).to_bits(),
                             );
                         }
-                        b"byteOffset" => return JSValue::number(0.0),
+                        b"byteOffset" => {
+                            return JSValue::number(
+                                crate::typedarray_view::js_typed_array_byte_offset(ta) as f64,
+                            )
+                        }
                         b"BYTES_PER_ELEMENT" => return JSValue::number(elem_size as f64),
                         _ => {}
                     }
@@ -3088,7 +3092,7 @@ pub extern "C" fn js_object_get_field_by_name(
                         return JSValue::number((len as usize * elem_size) as f64);
                     }
                     b"buffer" => {
-                        let buf = crate::typedarray::typed_array_to_array_buffer(ta);
+                        let buf = crate::typedarray_view::js_typed_array_backing_buffer(ta);
                         if buf.is_null() {
                             return JSValue::undefined();
                         }
@@ -3096,7 +3100,11 @@ pub extern "C" fn js_object_get_field_by_name(
                             crate::value::js_nanbox_pointer(buf as i64).to_bits(),
                         );
                     }
-                    b"byteOffset" => return JSValue::number(0.0),
+                    b"byteOffset" => {
+                        return JSValue::number(crate::typedarray_view::js_typed_array_byte_offset(
+                            ta,
+                        ) as f64)
+                    }
                     b"BYTES_PER_ELEMENT" => return JSValue::number(elem_size as f64),
                     _ => {}
                 }

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -163,6 +163,7 @@ pub fn unregister_typed_array(ptr: *const TypedArrayHeader) {
     TYPED_ARRAY_SHARED_BACKING.with(|r| {
         r.borrow_mut().remove(&owner);
     });
+    crate::typedarray_view::clear_view_meta(owner);
     crate::typedarray_props::typed_array_clear_own_props(owner);
 }
 
@@ -207,6 +208,8 @@ fn data_ptr(ta: *const TypedArrayHeader) -> *const u8 {
     unsafe {
         if crate::native_arena::is_native_typed_view(ta) {
             crate::native_arena::native_view_data_ptr(ta)
+        } else if let Some(p) = crate::typedarray_view::view_backing_data_ptr(ta as usize) {
+            p as *const u8
         } else {
             (ta as *const u8).add(std::mem::size_of::<TypedArrayHeader>())
         }
@@ -218,6 +221,8 @@ pub(crate) fn data_ptr_mut(ta: *mut TypedArrayHeader) -> *mut u8 {
     unsafe {
         if crate::native_arena::is_native_typed_view(ta as *const TypedArrayHeader) {
             crate::native_arena::native_view_data_ptr_mut(ta)
+        } else if let Some(p) = crate::typedarray_view::view_backing_data_ptr(ta as usize) {
+            p
         } else {
             (ta as *mut u8).add(std::mem::size_of::<TypedArrayHeader>())
         }

--- a/crates/perry-runtime/src/typedarray_view.rs
+++ b/crates/perry-runtime/src/typedarray_view.rs
@@ -1,17 +1,19 @@
-//! `new TA(buffer, byteOffset, length?)` view-constructor validation (#4103).
+//! `new TA(buffer, byteOffset, length?)` ArrayBuffer-view support (#4103).
 //!
 //! Split out of `typedarray.rs` to keep that file under the 2000-line gate.
-//! Perry does not yet model real offset-honoring views (the `byteOffset`
-//! getter still reports 0 and the view copies rather than aliases the backing
-//! store — the broader gap #4103 calls out); this module adds the spec
-//! `RangeError` bounds/alignment validation and copies the correct bytes at
-//! the requested offset so the multi-arg form matches Node.
+//! Holds the spec `RangeError` bounds/alignment validation for the multi-arg
+//! constructor form, plus the view-metadata side table (`TYPED_ARRAY_VIEW_META`)
+//! that lets a typed array alias an `ArrayBuffer`: `data_ptr` (in
+//! `typedarray::mod`) resolves a recorded view into the backing store so reads
+//! and writes are shared with the buffer and every sibling view, and the
+//! `byteOffset` / `buffer` getters report the real backing.
 
+use std::cell::RefCell;
 use std::ptr;
 
 use crate::typedarray::{
-    data_ptr_mut, elem_size_for_kind, js_typed_array_new, name_for_kind, throw_range_error,
-    typed_array_alloc, TypedArrayHeader,
+    clean_ta_ptr, data_ptr_mut, elem_size_for_kind, js_typed_array_new, name_for_kind,
+    throw_range_error, typed_array_alloc, typed_array_to_array_buffer, TypedArrayHeader,
 };
 
 /// `ToIndex(value)` for a typed-array view's `byteOffset` / `length`
@@ -105,13 +107,15 @@ pub extern "C" fn js_typed_array_view(
         requested
     };
 
-    // The native byte layout matches between BufferHeader and TypedArrayHeader,
-    // so copy the backing bytes at `offset` directly to preserve element values.
     let count = elem_count.max(0) as u32;
     let ta = typed_array_alloc(kind, count);
     if crate::buffer::is_shared_array_buffer(addr) {
         crate::typedarray::mark_typed_array_shared_backing(ta);
     }
+    // Seed the header's inline region with the current bytes at `offset` so the
+    // codegen fast path (which reads inline storage directly under optimized
+    // builds) observes correct initial element values. `data_ptr_mut` resolves
+    // to the inline region here because the view-meta below is not yet recorded.
     if count > 0 {
         unsafe {
             let src_data = crate::buffer::buffer_data(src).add(offset as usize);
@@ -119,5 +123,116 @@ pub extern "C" fn js_typed_array_view(
             ptr::copy_nonoverlapping(src_data, dst, (count as i64 * bpe) as usize);
         }
     }
+    // Record the view so the runtime element-access path aliases the backing
+    // `ArrayBuffer` and `.byteOffset` / `.buffer` report the real backing:
+    // mutations are then visible through the buffer and every sibling view,
+    // matching Node (#4103).
+    register_view_meta(ta, addr, offset as u32);
     ta
+}
+
+thread_local! {
+    /// `typed_array_ptr -> (backing ArrayBuffer addr, byteOffset)` for typed
+    /// arrays that alias an `ArrayBuffer`. Two populations land here:
+    ///   * offset views built by `new T(buffer, byteOffset, length?)`, recorded
+    ///     at construction so `.byteOffset` / `.buffer` report the real backing
+    ///     and element reads/writes route through `data_ptr` into the shared
+    ///     store (true aliasing), and
+    ///   * plain typed arrays the first time `.buffer` is observed — we
+    ///     lazily materialize a backing `ArrayBuffer`, copy the current bytes
+    ///     in, and record it here so the buffer identity is stable on repeated
+    ///     reads and further mutation aliases the buffer (mirrors V8: every
+    ///     typed array is backed by an ArrayBuffer).
+    /// The backing `BufferHeader` lives for the thread's lifetime (Perry never
+    /// `dealloc`s individual buffers — see `buffer::view`), so the raw addr is
+    /// stable and aliasing through it is free of use-after-free.
+    static TYPED_ARRAY_VIEW_META: RefCell<crate::fast_hash::PtrHashMap<usize, ViewMeta>> =
+        RefCell::new(crate::fast_hash::new_ptr_hash_map());
+}
+
+/// Backing-store record for an ArrayBuffer-aliasing typed array. See
+/// `TYPED_ARRAY_VIEW_META`.
+#[derive(Copy, Clone)]
+pub(crate) struct ViewMeta {
+    /// Address of the backing `BufferHeader` (an `ArrayBuffer`).
+    pub backing: usize,
+    /// Byte offset of element 0 within `backing`.
+    pub byte_offset: u32,
+}
+
+/// Record `ta` as aliasing `backing` at `byte_offset`. After this call
+/// `data_ptr(ta)` resolves into the backing store rather than `ta`'s inline
+/// region, so reads/writes are shared with the buffer and every other view.
+pub(crate) fn register_view_meta(ta: *const TypedArrayHeader, backing: usize, byte_offset: u32) {
+    TYPED_ARRAY_VIEW_META.with(|r| {
+        r.borrow_mut().insert(
+            ta as usize,
+            ViewMeta {
+                backing,
+                byte_offset,
+            },
+        );
+    });
+}
+
+#[inline]
+pub(crate) fn view_meta_of(addr: usize) -> Option<ViewMeta> {
+    TYPED_ARRAY_VIEW_META.with(|r| r.borrow().get(&addr).copied())
+}
+
+/// Data pointer for element 0 of the typed array at `addr` when it aliases an
+/// `ArrayBuffer` (resolves into the backing store at the recorded byteOffset);
+/// `None` when the typed array uses its own inline storage. `data_ptr` /
+/// `data_ptr_mut` in `typedarray::mod` consult this before falling back inline.
+#[inline]
+pub(crate) fn view_backing_data_ptr(addr: usize) -> Option<*mut u8> {
+    view_meta_of(addr).map(|m| unsafe {
+        crate::buffer::buffer_data_mut(m.backing as *mut crate::buffer::BufferHeader)
+            .add(m.byte_offset as usize)
+    })
+}
+
+/// Drop any recorded view metadata for `addr` (called from
+/// `unregister_typed_array` when the typed array is collected).
+pub(crate) fn clear_view_meta(addr: usize) {
+    TYPED_ARRAY_VIEW_META.with(|r| {
+        r.borrow_mut().remove(&addr);
+    });
+}
+
+/// `%TypedArray%.prototype.byteOffset` for a registered typed array: the byte
+/// offset of element 0 within its backing `ArrayBuffer`. Offset views recorded
+/// in `TYPED_ARRAY_VIEW_META` report their real offset; everything else is 0.
+pub fn js_typed_array_byte_offset(ta: *const TypedArrayHeader) -> u32 {
+    let addr = clean_ta_ptr(ta) as usize;
+    view_meta_of(addr).map(|m| m.byte_offset).unwrap_or(0)
+}
+
+/// `%TypedArray%.prototype.buffer` for a registered typed array: the backing
+/// `ArrayBuffer`, with stable identity. If the typed array already aliases a
+/// buffer (an offset view, or a previously-observed plain array) the recorded
+/// backing is returned. Otherwise a backing `ArrayBuffer` is materialized once,
+/// the current element bytes are copied in, and the typed array is rebound to
+/// alias it so the identity stays stable and later mutation is shared — V8's
+/// model where every typed array is backed by an ArrayBuffer.
+pub fn js_typed_array_backing_buffer(
+    ta: *const TypedArrayHeader,
+) -> *mut crate::buffer::BufferHeader {
+    let clean = clean_ta_ptr(ta);
+    if clean.is_null() {
+        return std::ptr::null_mut();
+    }
+    let addr = clean as usize;
+    if let Some(meta) = view_meta_of(addr) {
+        return meta.backing as *mut crate::buffer::BufferHeader;
+    }
+    // Materialize a stable backing ArrayBuffer over the current bytes, then
+    // rebind the typed array to alias it (so `data_ptr` resolves into the
+    // buffer from now on and writes are shared in both directions).
+    let buf = typed_array_to_array_buffer(clean);
+    if buf.is_null() {
+        return std::ptr::null_mut();
+    }
+    register_view_meta(clean, buf as usize, 0);
+    buf
 }


### PR DESCRIPTION
## Summary

`new T(buffer, byteOffset, length?)` for the non-`Uint8Array` typed-array kinds produced a typed array that:
- reported `byteOffset` **0** (hardcoded),
- returned a freshly **copied** `ArrayBuffer` from `.buffer` (so `ta.buffer === ta.buffer` was *false* and `ta.buffer === buffer` was *false*), and
- did **not alias** the backing store (writes weren't shared with the buffer or sibling views).

Worse, the **dynamic-constructor** dispatch — `new TA(buffer, offset)` where `TA` is a *variable*, which is exactly how test262's `testWithTypedArrayConstructors` builds every case — dropped the `offset`/`length` arguments entirely, so even the literal-path fix wasn't reached and views reported `byteOffset === 0` with the wrong length.

This is the **view-metadata** slice of the broader TypedArray gap (#4103). Error-ordering (side-effecting offset coercion) and constructor/prototype-identity remain as separate follow-up slices.

## Changes

- **`TYPED_ARRAY_VIEW_META` side table** (`typedarray/mod.rs`): maps a view → `(backing ArrayBuffer addr, byteOffset)`. `data_ptr`/`data_ptr_mut` resolve view entries into the backing store, so views **truly alias** the buffer and every sibling view — mutations propagate in both directions. Cleared on `unregister_typed_array`.
- **Getters** (`field_get_set.rs`): `byteOffset` returns the real offset; `buffer` returns the **stable** backing `ArrayBuffer` via new `js_typed_array_backing_buffer`. For plain (non-view) arrays it lazily materializes a backing buffer once and rebinds the array to alias it, so `.buffer` identity is stable and later mutation is shared — V8's model where every typed array is backed by an ArrayBuffer.
- **View constructor** (`typedarray_view.rs`): records the view (`register_view_meta`) for aliasing, while still seeding inline storage with the initial bytes so the optimized codegen fast path (which reads inline storage directly) stays correct — **zero regression** under optimized builds.
- **Dynamic constructor** (`class_registry.rs`): routes the `(buffer, offset, length?)` form through `js_typed_array_view` for all kinds, instead of dropping the extra args.

The existing `Uint8Array` offset-view path (BufferHeader, #4103) is unchanged; this complements it for the other 11 kinds.

## Verification

`scripts/test262_subset.py` focused on the view-metadata cluster (`built-ins/TypedArray/prototype/{byteOffset,byteLength,buffer,length}` + `built-ins/TypedArrayConstructors/ctors/buffer-arg`):

| | pass / judged | parity |
|---|---|---|
| baseline (main) | 33 / 60 | 55.0% |
| this PR | **43 / 60** | **71.7%** |

**+10 tests, 0 regressions** (full failure sets compared, both captured 100%). Fixed: `prototype/{buffer,byteOffset}/…return-*.js` and `ctors/buffer-arg/{byteoffset-is-negative,byteoffset-throws-from-modulo-element-size,defined-negative-length,excessive-length,excessive-offset,is-referenced}.js`.

Manually verified **byte-identical to `node --experimental-strip-types`** for: offset views across all 9 element kinds via dynamic constructors (byteOffset/byteLength/length/buffer-identity), and cross-view aliasing (an `Int8Array(buf,4,4)` observing writes from an `Int32Array(buf)` and vice-versa).

Remaining failures are the separate **error-ordering** (e.g. `byteoffset-to-number-throws` — `valueOf` side-effect ordering) and **identity** (`defined-length` `.constructor`/proto checks, `makeArrayLike` length-reading) clusters.

Regression unit tests pass: `perry-runtime` typed (57), buffer (42), view (8), define (11) — 0 failed. `cargo fmt --all -- --check` clean.