### PR TITLE
fix(runtime): wire native error constructor prototype chains (#4533)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1708,6 +1708,26 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 return Ok(Expr::Number(value));
             }
         }
+        // #4533/#4561: `Error.isPrototypeOf(x)`, `Number.bind(...)`, etc. read an
+        // inherited Function/Object prototype method off a builtin constructor.
+        // Those builtin idents otherwise collapse to bare `GlobalGet(0)`
+        // (globalThis) in the static-member path below, so the predicate ran
+        // against globalThis instead of the real constructor. Resolve the
+        // builtin to its globalThis property so the receiver is the constructor.
+        if matches!(
+            prop_ident.sym.as_ref(),
+            "bind" | "call" | "apply" | "isPrototypeOf"
+        ) {
+            if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+                let obj_name = obj_ident.sym.as_ref();
+                if crate::analysis::is_builtin_global_value_name(obj_name) {
+                    object_expr = Expr::PropertyGet {
+                        object: Box::new(Expr::GlobalGet(0)),
+                        property: obj_name.to_string(),
+                    };
+                }
+            }
+        }
     }
     let member_object_is_global_this = matches!(
         unwrap_transparent(member.obj.as_ref()),
@@ -1927,6 +1947,24 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                                 )
                             })
                             .unwrap_or(false);
+                    // #4533/#4561: inherited Object/Function prototype methods
+                    // (`Error.isPrototypeOf`, `Number.valueOf`, `Object.bind`)
+                    // must keep the real constructor receiver, not collapse to
+                    // bare `GlobalGet(0)` — otherwise the predicate/dispatch runs
+                    // against globalThis. The reroute above already resolved the
+                    // receiver to `globalThis.<ctor>`; don't undo it here.
+                    let outer_is_inherited_object_proto_method = matches!(
+                        outer_static_member,
+                        Some(
+                            "hasOwnProperty"
+                                | "isPrototypeOf"
+                                | "propertyIsEnumerable"
+                                | "toLocaleString"
+                                | "valueOf"
+                        )
+                    );
+                    let outer_is_inherited_function_proto_method =
+                        matches!(outer_static_member, Some("bind" | "call" | "apply"));
                     if !outer_is_prototype_or_proto
                         && !receiver_is_namespace_value
                         && !outer_is_websocket_static
@@ -1935,6 +1973,8 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         && !outer_is_reified_date_static_value
                         && !outer_is_reified_string_static_value
                         && !outer_is_reified_promise_static_value
+                        && !outer_is_inherited_object_proto_method
+                        && !outer_is_inherited_function_proto_method
                         && !receiver_is_detached_console_read
                     {
                         object_expr = Expr::GlobalGet(0);

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2132,10 +2132,32 @@ unsafe fn closure_dynamic_prop_by_key(obj: usize, key: *const crate::StringHeade
     let key_len = (*key).byte_len as usize;
     let name = std::str::from_utf8(std::slice::from_raw_parts(key_ptr, key_len)).ok()?;
     let val = crate::closure::closure_get_dynamic_prop(obj, name);
-    if val.to_bits() == crate::value::TAG_UNDEFINED {
-        None
-    } else {
-        Some(val)
+    if val.to_bits() != crate::value::TAG_UNDEFINED {
+        return Some(val);
+    }
+    // #4533/#3716: reading an inherited Function/Object prototype method as a
+    // value off a closure (`Error.isPrototypeOf`, `f.bind`) must yield a real
+    // callable, not `undefined`, so `typeof Error.isPrototypeOf === "function"`.
+    if crate::closure::is_closure_ptr(obj) {
+        if let Some(method) = reified_function_method_name(name) {
+            let receiver = f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+            return Some(crate::closure::reify_function_method_value(
+                receiver, method,
+            ));
+        }
+    }
+    None
+}
+
+/// Inherited Function/Object prototype methods that reify into a BOUND_METHOD
+/// closure bound to the receiver function when read as a value.
+fn reified_function_method_name(name: &str) -> Option<&'static [u8]> {
+    match name {
+        "bind" => Some(b"bind"),
+        "call" => Some(b"call"),
+        "apply" => Some(b"apply"),
+        "isPrototypeOf" => Some(b"isPrototypeOf"),
+        _ => None,
     }
 }
 
@@ -3335,13 +3357,7 @@ pub extern "C" fn js_object_get_field_by_name(
                     // `Function.prototype.call.bind(method)` work — reading `.bind`
                     // off the reified `Function.prototype.call` previously read
                     // back `undefined`, so the bound function was never produced.
-                    let reified: Option<&'static [u8]> = match name_str {
-                        "bind" => Some(b"bind"),
-                        "call" => Some(b"call"),
-                        "apply" => Some(b"apply"),
-                        _ => None,
-                    };
-                    if let Some(method) = reified {
+                    if let Some(method) = reified_function_method_name(name_str) {
                         let receiver =
                             f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
                         return JSValue::from_bits(

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1184,6 +1184,21 @@ extern "C" fn object_prototype_is_prototype_of_thunk(
     )
 }
 
+/// #4533: native error subclass constructors whose `[[Prototype]]` is `Error`
+/// (their `.prototype.[[Prototype]]` already links to `Error.prototype`).
+fn is_native_error_subclass_constructor(name: &str) -> bool {
+    matches!(
+        name,
+        "TypeError"
+            | "RangeError"
+            | "SyntaxError"
+            | "ReferenceError"
+            | "EvalError"
+            | "URIError"
+            | "AggregateError"
+    )
+}
+
 extern "C" fn date_prototype_to_string_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
@@ -2366,6 +2381,10 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     // `%Generator(.prototype)%` chains resolve to real objects.
     ensure_generator_intrinsics();
     // Constructors: ClosureHeader-backed so typeof is "function".
+    // #4533: native error subclasses must link to `Error` / `Error.prototype`.
+    // `Error` is listed before its subclasses in GLOBAL_THIS_BUILTIN_CONSTRUCTORS,
+    // so these are populated before the subclass iterations consume them.
+    let mut error_ctor_bits: Option<u64> = None;
     for name in GLOBAL_THIS_BUILTIN_CONSTRUCTORS.iter().copied() {
         if name == "Buffer" {
             let name_bytes = name.as_bytes();
@@ -2497,6 +2516,15 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             install_error_static_methods(closure_ptr);
         }
         let ctor_value = crate::value::js_nanbox_pointer(closure_ptr as i64);
+        // #4533: `Object.getPrototypeOf(TypeError) === Error`. The constructor's
+        // `[[Prototype]]` is `Error` itself (not `Function.prototype`).
+        if name == "Error" {
+            error_ctor_bits = Some(ctor_value.to_bits());
+        } else if is_native_error_subclass_constructor(name) {
+            if let Some(proto_bits) = error_ctor_bits {
+                crate::closure::closure_set_static_prototype(closure_ptr as usize, proto_bits);
+            }
+        }
         // Stash `prototype` on the closure's dynamic-prop side table.
         // `js_object_set_field_by_name` detects the CLOSURE_MAGIC tag
         // at offset 12 and dispatches into `closure_set_dynamic_prop`

--- a/test-parity/node-suite/globals/builtin-prototype-isprototypeof.ts
+++ b/test-parity/node-suite/globals/builtin-prototype-isprototypeof.ts
@@ -1,0 +1,30 @@
+const wrapperCases: Array<[string, any, any]> = [
+  ["Number", Number.prototype, new Number(5)],
+  ["Boolean", Boolean.prototype, new Boolean(false)],
+  ["String", String.prototype, new String("x")],
+];
+
+for (const [name, proto, instance] of wrapperCases) {
+  console.log(name, "typeof", typeof proto.isPrototypeOf);
+  console.log(name, "direct", proto.isPrototypeOf(instance));
+  console.log(name, "borrowed", Object.prototype.isPrototypeOf.call(proto, instance));
+}
+
+console.log("Function typeof", typeof Function.prototype.isPrototypeOf);
+console.log("Function direct", Function.prototype.isPrototypeOf(Number));
+console.log("Function borrowed", Object.prototype.isPrototypeOf.call(Function.prototype, Number));
+
+const typedArray = new Uint8Array(2);
+console.log("Uint8Array direct", Uint8Array.prototype.isPrototypeOf(typedArray));
+console.log(
+  "Uint8Array borrowed",
+  Object.prototype.isPrototypeOf.call(Uint8Array.prototype, typedArray),
+);
+
+const arrayBuffer = new ArrayBuffer(4);
+console.log("ArrayBuffer object", Object.prototype.isPrototypeOf(arrayBuffer));
+console.log("ArrayBuffer direct", ArrayBuffer.prototype.isPrototypeOf(arrayBuffer));
+console.log(
+  "ArrayBuffer borrowed",
+  Object.prototype.isPrototypeOf.call(ArrayBuffer.prototype, arrayBuffer),
+);

--- a/test-parity/node-suite/globals/native-error-constructor-prototypes.ts
+++ b/test-parity/node-suite/globals/native-error-constructor-prototypes.ts
@@ -1,0 +1,19 @@
+const nativeErrors: Array<[string, any]> = [
+  ["EvalError", EvalError],
+  ["RangeError", RangeError],
+  ["ReferenceError", ReferenceError],
+  ["SyntaxError", SyntaxError],
+  ["TypeError", TypeError],
+  ["URIError", URIError],
+];
+
+for (const [name, Ctor] of nativeErrors) {
+  const instance = new Ctor("boom");
+  console.log(name, "ctor proto Error:", Object.getPrototypeOf(Ctor) === Error);
+  console.log(name, "proto proto Error.prototype:", Object.getPrototypeOf(Ctor.prototype) === Error.prototype);
+  console.log(name, "typeof Error.isPrototypeOf:", typeof Error.isPrototypeOf);
+  console.log(name, "Error.isPrototypeOf:", Error.isPrototypeOf(Ctor));
+  console.log(name, "Function.prototype.isPrototypeOf:", Function.prototype.isPrototypeOf(Ctor));
+  console.log(name, "Object.prototype.isPrototypeOf:", Object.prototype.isPrototypeOf(Ctor));
+  console.log(name, "instanceof:", instance instanceof Ctor, instance instanceof Error);
+}


### PR DESCRIPTION
Fixes #4533.

## Summary
Completes the `isPrototypeOf` / prototype-chain coverage tracked under #4553/#4561/#4554/#4555/#4533. The buffer/typed-array, class-prototype-materialization, and builtin-prototype-dispatch halves already landed via #4552, #4570, and #4589 — this PR is the remaining **native-error-constructor** slice (#4533), rebased onto current `main` so it does not double-apply the merged work.

Three orthogonal gaps, all now byte-identical to Node 26:

1. **`Object.getPrototypeOf(TypeError) === Error`** was `false`. Native error subclass constructors (`TypeError`, `RangeError`, `SyntaxError`, `ReferenceError`, `EvalError`, `URIError`, `AggregateError`) had `Function.prototype` as their `[[Prototype]]`. They now link to the `Error` closure (`Error` is populated first in `GLOBAL_THIS_BUILTIN_CONSTRUCTORS`, so its bits are available before the subclasses iterate). Their `.prototype.[[Prototype]]` already linked to `Error.prototype` on `main`.

2. **`Error.isPrototypeOf(TypeError)` threw "value is not a function".** The HIR collapsed the `Error` receiver of an inherited Object/Function prototype method (`isPrototypeOf`/`bind`/`call`/`apply`) to bare `GlobalGet(0)` (globalThis), so the predicate ran against globalThis. The builtin ident now resolves to `globalThis.<ctor>` and the GlobalGet-collapse is gated on the inherited-method set.

3. **`typeof Error.isPrototypeOf` read back `undefined`.** The reified function-method set (was `bind`/`call`/`apply`) is extended with `isPrototypeOf`, plus a closure-dynamic-prop fallback, so reading the method off any function yields a real callable.

## Relationship to #4562
This supersedes the still-open #4562. On current `main`, three of that PR's four targets (#4561/#4554/#4555) already pass via the merged #4552/#4570/#4589; #4562's `js_object_is_prototype_of_value` rewrite and buffer helpers are now redundant and conflicting. This PR keeps only the native-error pieces that are still needed. Co-authored with @andrewtdiz.

## Validation
- `cargo fmt --all -- --check` ✓
- `cargo clippy --release -p perry-runtime -p perry-hir` — no new warnings ✓
- `./scripts/check_file_size.sh` ✓
- `cargo test --release -p perry-runtime -p perry-hir` — 983 passed, 0 failed ✓
- node-suite globals+object sweep: 110/114 byte-match (4 failures are pre-existing and unrelated: read-only descriptor enforcement, `util/types` key ordering, `localStorage.clear`, missing wasm host lib) ✓
- Both new fixtures byte-identical to Node 26 ✓
- Repros from #4533/#4553/#4561/#4554/#4555 all match Node ✓