### PR TITLE
fix(runtime): route symbol-keyed reads on a Proxy through the get trap

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1489,6 +1489,15 @@ unsafe fn web_stream_symbol_property(obj_f64: f64, sym_f64: f64) -> Option<f64> 
 
 #[no_mangle]
 pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f64) -> f64 {
+    // A Proxy is a small registered id (its band overlaps the small-handle
+    // band); dereferencing it as a heap object to read a symbol-keyed property
+    // is an EXC_BAD_ACCESS. Route a SYMBOL-keyed read through the proxy `get`
+    // trap (which forwards to the target). drizzle's aliased-column proxies are
+    // read with symbol keys (`col[entityKind]`, `col[Table.Symbol.*]`) while
+    // building a relational query.
+    if crate::proxy::js_proxy_is_proxy(obj_f64) != 0 {
+        return crate::proxy::js_proxy_get(obj_f64, sym_f64);
+    }
     // Check CLASS_STATIC_SYMBOLS first when receiver is a class ref
     // (top16 == 0x7FFE, INT32_TAG).
     let bits = obj_f64.to_bits();

--- a/tests/test_proxy_symbol_property.sh
+++ b/tests/test_proxy_symbol_property.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reading a SYMBOL-keyed property off a Proxy must forward through the proxy
+# `get` trap (or to the target), not dereference the proxy's small registered id
+# as a heap object — which was an EXC_BAD_ACCESS. drizzle's relational-query
+# builder reads symbol keys (`col[entityKind]`, `col[Table.Symbol.*]`) off
+# aliased-column proxies (`new Proxy(column, …)`), so every `findMany` crashed.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+const tag = Symbol("tag");
+const other = Symbol.for("shared");
+
+// forwarding get trap
+const target: any = { [tag]: "T", [other]: 42, plain: "p" };
+const proxy: any = new Proxy(target, { get(t: any, k: any) { return t[k]; } });
+if (proxy[tag] !== "T") throw new Error("symbol via get trap: " + String(proxy[tag]));
+if (proxy[other] !== 42) throw new Error("Symbol.for via get trap: " + String(proxy[other]));
+if (proxy.plain !== "p") throw new Error("string via get trap: " + proxy.plain);
+
+// no get trap -> forward to target
+const p2: any = new Proxy(target, {});
+if (p2[tag] !== "T") throw new Error("symbol forward to target: " + String(p2[tag]));
+
+// a class instance behind the proxy, read its static-ish symbol off the instance
+class C { [tag] = "instTag"; }
+const inst: any = new C();
+const p3: any = new Proxy(inst, { get(t: any, k: any) { return t[k]; } });
+if (p3[tag] !== "instTag") throw new Error("instance symbol via proxy: " + String(p3[tag]));
+
+// missing symbol returns undefined, not a crash
+if (proxy[Symbol("absent")] !== undefined) throw new Error("absent symbol should be undefined");
+
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: symbol-keyed read on a Proxy forwards (no EXC_BAD_ACCESS)"


### PR DESCRIPTION
## Problem

Reading a **symbol-keyed** property off a `Proxy` dereferenced the proxy's small registered id as a heap object → `EXC_BAD_ACCESS`. A Proxy id lives in a band that overlaps the small-handle band, so `js_object_get_symbol_property` walked it as an `ObjectHeader*`.

drizzle-orm's relational-query builder reads symbol keys (`col[entityKind]`, `col[Table.Symbol.*]`) off aliased-column proxies (`new Proxy(column, …)`) while building a query, so **every `db.query.*.findMany()` hard-crashed** here.

## Fix

At the top of `js_object_get_symbol_property`, if the receiver is a proxy, forward the symbol-keyed read through `js_proxy_get` (the `get` trap, which forwards to the target).

## Test

`tests/test_proxy_symbol_property.sh` — symbol via get trap, `Symbol.for` via get trap, no-trap forward-to-target, instance symbol via proxy, and absent-symbol → `undefined` (no crash). Passes.