### PR TITLE
fix(runtime): route fused proxy method calls through the proxy, not the handle dispatcher

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1156,6 +1156,42 @@ pub unsafe extern "C" fn js_native_call_method(
         return f64::from_bits(0x7FF8_0000_0000_0001); // undefined
     }
 
+    // #4661 follow-up: a *fused* method call `proxy.method(args)` on a Proxy
+    // receiver. The decomposed form `const f = proxy.method; f(args)` already
+    // works because the property read routes through `js_proxy_get`. The fused
+    // form, however, reaches this generic dispatcher with the proxy id intact.
+    // Proxy ids encode to small pointer-tagged values (band 0xF0000..0x100000),
+    // so without this guard the receiver is misclassified as a native-module
+    // *integer handle* by the `raw_ptr < 0x100000` small-handle dispatch below
+    // (when an app links a native handle dispatcher, e.g. mysql2 / Fastify),
+    // which returns null for an unknown id — silently dropping the call.
+    //
+    // Mirror the spec: `Get(proxy, "method")` (honors the get trap / forwards
+    // through the target's prototype chain) then `Call(method, proxy, args)`
+    // with `this` bound to the proxy itself.
+    if crate::proxy::js_proxy_is_proxy(object) == 1 {
+        let key = crate::string::js_string_from_bytes(
+            method_name_ptr as *const u8,
+            method_name_len as u32,
+        );
+        let key_box = f64::from_bits(JSValue::string_ptr(key).bits());
+        let key_handle = root_scope.root_nanbox_f64(key_box);
+        let method_value =
+            crate::proxy::js_proxy_get(object_handle.get_nanbox_f64(), key_handle.get_nanbox_f64());
+        let method_handle = root_scope.root_nanbox_f64(method_value);
+        let args = refreshed_args();
+        // Bind `this` to the proxy for the duration of the call, matching the
+        // receiver semantics of a normal `obj.method(args)` invocation.
+        let prev_this = IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits()));
+        let result = crate::closure::js_native_call_value(
+            method_handle.get_nanbox_f64(),
+            args.as_ptr(),
+            args.len(),
+        );
+        IMPLICIT_THIS.with(|c| c.set(prev_this));
+        return result;
+    }
+
     if (object.to_bits() >> 48) == 0x7FFE {
         let class_id = (object.to_bits() & 0xFFFF_FFFF) as u32;
         if crate::object::class_prototype_ref_id(object).is_some() {

--- a/tests/test_proxy_fused_method_call.sh
+++ b/tests/test_proxy_fused_method_call.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A *fused* method call `proxy.method(arg)` on a Proxy receiver must route the
+# call through the proxy (Get(proxy, method) + Call(method, proxy, args)),
+# not misclassify the proxy's small registered id as a native-module integer
+# handle. Proxy ids encode to small pointer-tagged values in the runtime's
+# `< 0x100000` "small handle" band; the generic dynamic dispatcher
+# (`js_native_call_method`) used to fall straight into that handle path for a
+# fused call, dropping the argument and returning null/undefined.
+#
+# The decomposed form `const f = proxy.method; f(arg)` always worked (the read
+# goes through `js_proxy_get`); only the fused form was broken. drizzle's
+# relational-query mapper does `decoder.mapFromDriverValue(value)` where
+# `decoder` is an aliased-column proxy, so every `findMany` column came back
+# null. Regression for fix/proxy-fused-method-call (follow-up to #4661).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+// The receiver must be opaque (`any`) and the method reached via the dynamic
+// dispatcher for the bug to fire. An own *function-valued property* on the
+// target (rather than a statically-resolvable class method) keeps the static
+// analyzer from binding the call to a known vtable, so codegen emits the
+// generic `js_native_call_method` dispatch — exactly the drizzle shape.
+function makeForwardingProxy(): any {
+  const target: any = { kind: "col" };
+  target.run = function (v: any) { return v; };
+  return new Proxy(target, { get(t: any, k: any) { return t[k]; } });
+}
+
+// 1) Forwarding get-trap proxy: fused call must not drop the argument.
+const p: any = makeForwardingProxy();
+const fused = p.run("hi");
+if (fused !== "hi") throw new Error("fused get-trap proxy call dropped arg: " + JSON.stringify(fused));
+
+// The decomposed form must keep working too.
+const f = p.run; const decomp = f("hi");
+if (decomp !== "hi") throw new Error("decomposed proxy call wrong: " + JSON.stringify(decomp));
+
+// 2) No get trap -> forward to target; fused call still returns the arg.
+function makePassthroughProxy(): any {
+  const target: any = { kind: "col2" };
+  target.echo = function (v: any) { return v; };
+  return new Proxy(target, {});
+}
+const p2: any = makePassthroughProxy();
+if (p2.echo("yo") !== "yo") throw new Error("fused no-trap proxy call dropped arg: " + JSON.stringify(p2.echo("yo")));
+
+// 3) `this` is bound to the proxy inside the fused call.
+function makeThisProxy(): any {
+  const target: any = { tag: "T" };
+  target.readTag = function (this: any) { return this.tag; };
+  return new Proxy(target, { get(t: any, k: any) { return t[k]; } });
+}
+const p3: any = makeThisProxy();
+if (p3.readTag() !== "T") throw new Error("`this` not bound to proxy in fused call: " + JSON.stringify(p3.readTag()));
+
+// 4) Inherited method through the target's prototype chain (the real drizzle
+//    case: `mapFromDriverValue` is inherited from a base class).
+class Base { mapFromDriverValue(v: any) { return v; } }
+class Mid extends Base { x = 1; }
+class Leaf extends Mid { y = 2; }
+function makeInheritedProxy(): any {
+  const inst: any = new Leaf();
+  return new Proxy(inst, { get(t: any, k: any) { return t[k]; } });
+}
+const p4: any = makeInheritedProxy();
+if (p4.mapFromDriverValue("hi") !== "hi") {
+  throw new Error("fused call to inherited method dropped arg: " + JSON.stringify(p4.mapFromDriverValue("hi")));
+}
+
+// 5) Multiple args are all forwarded.
+function makeSumProxy(): any {
+  const target: any = {};
+  target.add3 = function (a: number, b: number, c: number) { return a + b + c; };
+  return new Proxy(target, { get(t: any, k: any) { return t[k]; } });
+}
+const p5: any = makeSumProxy();
+if (p5.add3(1, 2, 3) !== 6) throw new Error("fused multi-arg call wrong: " + JSON.stringify(p5.add3(1, 2, 3)));
+
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: fused method call on a Proxy receiver forwards arg + this (not dropped)"


### PR DESCRIPTION
## Problem

A **fused** method call `proxy.method(args)` on a `Proxy` receiver reached the generic dynamic dispatcher `js_native_call_method` with the proxy id intact. Proxy ids NaN-box to small pointer-tagged values in the runtime's `< 0x100000` **small-handle band** (the band used for native-module integer handles, e.g. mysql2/Fastify/ioredis). With no proxy guard, the dispatcher misclassified the proxy as a native handle and routed it to `handle_method_dispatch`, which returns null for an unknown id — **silently dropping the argument**.

The decomposed form `const f = proxy.method; f(args)` already worked (the property read routes through `js_proxy_get`); only the fused form was broken.

Impact: drizzle-orm's relational-query mapper (`mapRelationalRow`) calls `decoder.mapFromDriverValue(value)` on aliased-column proxies, so **every `db.query.*.findMany()` returned `null` for every column** (after the #4661 crash fix unblocked it).

## Fix

In `js_native_call_method`, before any small-handle / pointer-deref path: when the receiver is a proxy, mirror the spec — `Get(proxy, method)` via `js_proxy_get` (honors the get trap / forwards through the target's prototype chain), then `Call(method, proxy, args)` with `this` bound to the proxy. The guard is a cheap tag-check; non-proxy dynamic dispatch is unaffected.

## Tests

- New `tests/test_proxy_fused_method_call.sh` (5 cases: forwarding get-trap, no-trap passthrough, `this`-binding, inherited method, multi-arg) — PASS. Fails on clean main, passes with the fix.
- Existing `tests/test_proxy_symbol_property.sh` + `tests/test_proxy_getprototypeof_instanceof.sh` — PASS.
- End-to-end: a real `db.query.customer.findMany()` against MySQL via drizzle now returns the correct `displayName`/`email`/`locale` (was all-null).

Follow-up to #4661.