### PR TITLE
fix(stream): let readable iterators coexist with data listeners

### DIFF
--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -6,6 +6,7 @@ const READABLE_ITERATOR_INDEX_KEY: &[u8] = b"__perryReadableIteratorIndex";
 const READABLE_ITERATOR_DONE_KEY: &[u8] = b"__perryReadableIteratorDone";
 const READABLE_ITERATOR_DESTROY_ON_RETURN_KEY: &[u8] = b"__perryReadableIteratorDestroyOnReturn";
 const READABLE_ITERATOR_STREAM_INDEX_KEY: &[u8] = b"__perryReadableIteratorStreamIndex";
+const READABLE_ITERATOR_CHUNKS_KEY: &[u8] = b"__perryReadableIteratorChunks";
 
 fn iterator_result(value: f64, done: bool) -> f64 {
     let obj = crate::object::js_object_alloc(0, 2);
@@ -102,6 +103,33 @@ fn set_stream_consume_index(stream: f64, index: u32) {
     );
 }
 
+fn iterator_snapshot_array(iterator: f64) -> *const crate::array::ArrayHeader {
+    let Some(chunks) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_CHUNKS_KEY)) else {
+        return std::ptr::null();
+    };
+    if !is_array_like_value(chunks) {
+        return std::ptr::null();
+    }
+    raw_ptr_from_value(chunks) as *const crate::array::ArrayHeader
+}
+
+fn readable_data_listener_snapshot(stream: f64) -> Option<f64> {
+    if stream_listener_count_for_event(stream, string_value(b"data")) == 0 {
+        return None;
+    }
+    let chunks = readable_hidden_chunks(stream)?;
+    let mut values = Vec::new();
+    push_chunk_values(chunks, &mut values, 0);
+    if values.is_empty() {
+        return None;
+    }
+    let mut arr = crate::array::js_array_alloc(0);
+    for value in values {
+        arr = crate::array::js_array_push_f64(arr, value);
+    }
+    Some(box_pointer(arr as *const u8))
+}
+
 fn settle_iterator_return_value(value: f64) {
     if crate::promise::js_value_is_promise(value) == 0 {
         return;
@@ -148,6 +176,27 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
         return readable_iterator_done();
     };
     prepare_readable_for_iteration(stream);
+
+    let snapshot = iterator_snapshot_array(iterator);
+    if !snapshot.is_null() {
+        let index = iterator_local_index(iterator);
+        if index < crate::array::js_array_length(snapshot) {
+            let value = crate::array::js_array_get_f64(snapshot, index);
+            set_hidden_value(
+                iterator,
+                hidden_key(READABLE_ITERATOR_INDEX_KEY),
+                (index + 1) as f64,
+            );
+            mark_disturbed(stream);
+            return readable_iterator_chunk_result(value);
+        }
+        set_hidden_value(
+            iterator,
+            hidden_key(READABLE_ITERATOR_DONE_KEY),
+            f64::from_bits(TAG_TRUE),
+        );
+        return readable_iterator_done();
+    }
 
     if !readable_object_mode(stream) {
         let value = read_stream_available_default(stream);
@@ -270,6 +319,9 @@ fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
             TAG_FALSE
         }),
     );
+    if let Some(chunks) = readable_data_listener_snapshot(stream) {
+        set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_CHUNKS_KEY), chunks);
+    }
     install_async_iterator_symbol(iterator, ns_readable_iterator_self);
     iterator
 }


### PR DESCRIPTION
## Summary
- preserve an iterator-local snapshot of buffered readable chunks when a `data` listener is already attached before async iteration starts
- serve that snapshot through `Readable` async iterator `next()` so `for await...of` still yields chunks even as the flowing `data` path drains the stream
- keep the live read path unchanged for streams without an existing `data` listener

Refs #2521.

## Tests
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/stream-iter-data-check CARGO_BUILD_JOBS=2 cargo check -p perry-runtime`
- `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/stream-iter-data-check/debug /root/perry-worktrees/.build-targets/probe-node-20260605/release/perry compile --no-cache test-parity/node-suite/stream/readable/iter-and-data-listener.ts -o /tmp/perry_iter_data_listener_probe && /tmp/perry_iter_data_listener_probe`
- `PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/stream-iter-data-check/debug /root/perry-worktrees/.build-targets/probe-node-20260605/release/perry compile --no-cache test-parity/node-suite/stream/readable/async-iterator-symbol.ts -o /tmp/perry_async_iterator_symbol_probe && /tmp/perry_async_iterator_symbol_probe`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
