### PR TITLE
fix(fs): type opendirSync results for Dir iteration

### DIFF
--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -16,6 +16,10 @@ fn is_fs_promises_module(module: &str) -> bool {
     module.strip_prefix("node:").unwrap_or(module) == "fs/promises"
 }
 
+fn is_fs_module(module: &str) -> bool {
+    module.strip_prefix("node:").unwrap_or(module) == "fs"
+}
+
 fn filehandle_type() -> Type {
     Type::Named("FileHandle".to_string())
 }
@@ -921,6 +925,12 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
             ) {
                 return Type::Promise(Box::new(dir_type()));
             }
+            if matches!(
+                ctx.lookup_builtin_named_import(name),
+                Some((module, "opendirSync")) if is_fs_module(module)
+            ) {
+                return dir_type();
+            }
             // Check user-defined function return types
             if let Some(ty) = ctx.lookup_func_return_type(name) {
                 return ty.clone();
@@ -962,6 +972,19 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                             .is_some_and(is_fs_promises_module);
                         if namespace_is_fs_promises {
                             return Type::Promise(Box::new(dir_type()));
+                        }
+                    }
+                }
+                if method_name == "opendirSync" {
+                    if let ast::Expr::Ident(obj) = member.obj.as_ref() {
+                        let namespace_is_fs = matches!(
+                            ctx.lookup_native_module(obj.sym.as_ref()),
+                            Some((module, None)) if is_fs_module(module)
+                        ) || ctx
+                            .lookup_builtin_module_alias(obj.sym.as_ref())
+                            .is_some_and(is_fs_module);
+                        if namespace_is_fs {
+                            return dir_type();
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- infer `node:fs` / `fs` `opendirSync()` return values as `Dir` for namespace calls and named imports
- let the existing `for await` Dir lowering path handle `Dir.entries()` and direct Dir async iteration
- preserve the runtime Dir iterator and disposal behavior while fixing the sync open typing path

Refs #4668

## Tests
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/fs-dir-iter-check CARGO_BUILD_JOBS=2 cargo check -p perry-hir`
- `CARGO_TARGET_DIR=/root/perry-worktrees/.build-targets/fs-dir-iter-check CARGO_BUILD_JOBS=2 cargo build -p perry`
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/fs/readdir/opendir-iteration-disposal.ts`
- `PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/probe-node-20260605/release /root/perry-worktrees/.build-targets/fs-dir-iter-check/debug/perry compile --no-cache test-parity/node-suite/fs/readdir/opendir-iteration-disposal.ts -o /tmp/perry_fs_dir_iter_probe && /tmp/perry_fs_dir_iter_probe`
- `PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/probe-node-20260605/release /root/perry-worktrees/.build-targets/fs-dir-iter-check/debug/perry compile --no-cache test-parity/node-suite/fs/readdir/opendir-promises-methods.ts -o /tmp/perry_opendir_promises_methods_probe && /tmp/perry_opendir_promises_methods_probe`
- `PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=/root/perry-worktrees/.build-targets/probe-node-20260605/release /root/perry-worktrees/.build-targets/fs-dir-iter-check/debug/perry compile --no-cache test-parity/node-suite/fs/readdir/opendir-prototype-close.ts -o /tmp/perry_opendir_prototype_close_probe && /tmp/perry_opendir_prototype_close_probe`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`
