### PR TITLE
fix(fs): preserve dir async iteration values

### DIFF
--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -16,6 +16,10 @@ fn is_fs_promises_module(module: &str) -> bool {
     module.strip_prefix("node:").unwrap_or(module) == "fs/promises"
 }
 
+fn is_fs_module(module: &str) -> bool {
+    module.strip_prefix("node:").unwrap_or(module) == "fs"
+}
+
 fn filehandle_type() -> Type {
     Type::Named("FileHandle".to_string())
 }
@@ -910,6 +914,12 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                 return Type::Promise(Box::new(dir_type()));
             }
             if matches!(
+                ctx.lookup_native_module(name),
+                Some((module, Some("opendirSync"))) if is_fs_module(module)
+            ) {
+                return dir_type();
+            }
+            if matches!(
                 ctx.lookup_builtin_named_import(name),
                 Some((module, "open")) if is_fs_promises_module(module)
             ) {
@@ -920,6 +930,12 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                 Some((module, "opendir")) if is_fs_promises_module(module)
             ) {
                 return Type::Promise(Box::new(dir_type()));
+            }
+            if matches!(
+                ctx.lookup_builtin_named_import(name),
+                Some((module, "opendirSync")) if is_fs_module(module)
+            ) {
+                return dir_type();
             }
             // Check user-defined function return types
             if let Some(ty) = ctx.lookup_func_return_type(name) {
@@ -962,6 +978,19 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                             .is_some_and(is_fs_promises_module);
                         if namespace_is_fs_promises {
                             return Type::Promise(Box::new(dir_type()));
+                        }
+                    }
+                }
+                if method_name == "opendirSync" {
+                    if let ast::Expr::Ident(obj) = member.obj.as_ref() {
+                        let namespace_is_fs = matches!(
+                            ctx.lookup_native_module(obj.sym.as_ref()),
+                            Some((module, None)) if is_fs_module(module)
+                        ) || ctx
+                            .lookup_builtin_module_alias(obj.sym.as_ref())
+                            .is_some_and(is_fs_module);
+                        if namespace_is_fs {
+                            return dir_type();
                         }
                     }
                 }

--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -1021,14 +1021,21 @@ fn dir_iterator_self_value(closure: *const ClosureHeader) -> f64 {
 }
 
 fn dir_iterator_result(value: f64, done: bool) -> f64 {
+    use crate::value::JSValue;
+
     let obj = crate::object::js_object_alloc(0, 2);
     let value_key = js_string_from_bytes(b"value".as_ptr(), b"value".len() as u32);
     let done_key = js_string_from_bytes(b"done".as_ptr(), b"done".len() as u32);
-    crate::object::js_object_set_field_by_name(obj, value_key, value);
-    crate::object::js_object_set_field_by_name(
+    let keys = crate::array::js_array_alloc(2);
+    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
+    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
+    crate::object::js_object_set_keys(obj, keys);
+
+    crate::object::js_object_set_field(obj, 0, JSValue::from_bits(value.to_bits()));
+    crate::object::js_object_set_field(
         obj,
-        done_key,
-        f64::from_bits(crate::value::JSValue::bool(done).bits()),
+        1,
+        JSValue::from_bits(crate::value::JSValue::bool(done).bits()),
     );
     f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits())
 }


### PR DESCRIPTION
## Summary
- type `fs.opendirSync()` results as `Dir` so top-level `for await` over `Dir` and `Dir.entries()` uses the async-iterator lowering instead of array entries
- shape `fs.Dir` async iterator result objects with keyed `{ value, done }` slots so generated property reads preserve `Dirent` values

Fixes #4668

## Tests
- `cargo check -p perry-hir`
- `cargo check -p perry-runtime`
- `cargo build --release -p perry -p perry-runtime -p perry-stdlib`
- `./run_parity_tests.sh --suite node-suite --module fs --filter opendir-iteration-disposal`
- `./run_parity_tests.sh --suite node-suite --module fs --filter opendir`
- `./run_parity_tests.sh --suite node-suite --module fs` (171 pass / 2 pre-existing `fs.promises.watch` output mismatches)
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`