### PR TITLE
Fix stream Readable helper chains in for-await lowering

### DIFF
--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -63,13 +63,7 @@ fn destructure_builtin_module_source(ctx: &LoweringContext, init: &ast::Expr) ->
     None
 }
 
-/// #3663: register destructured `node:stream` constructor bindings as
-/// native-module member aliases, mirroring `import { Readable } from 'stream'`.
-/// Without this, `const { Readable } = require('stream')` leaves `Readable` as a
-/// plain local, so the later `const r = new Readable(...)` binding is never
-/// tagged as a stream instance — and `r.on()/.write()/.pipe()` then fall through
-/// to no-op stub closures instead of routing to the real stream pump (the
-/// `NativeMethodCall` path the named-import form already takes).
+/// #3663: register destructured stream constructors as native-module aliases.
 fn register_destructured_stream_ctors(ctx: &mut LoweringContext, decl: &ast::VarDeclarator) {
     let ast::Pat::Object(obj_pat) = &decl.name else {
         return;
@@ -994,6 +988,12 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         }
                     }
                     None
+                }
+
+                if crate::lower_types::is_node_readable_static_factory_call(ctx, init_expr) {
+                    let readable = "Readable".to_string();
+                    ty = Type::Named(readable.clone());
+                    ctx.register_native_instance(name.clone(), "stream".to_string(), readable);
                 }
 
                 // Check for: const response = fetch(url) / fetchWithAuth(url, auth) / fetchPostWithAuth(url, auth, body)

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -40,6 +40,31 @@ fn is_stream_class_ref(expr: &ast::Expr) -> bool {
     matches!(name, "Readable" | "Duplex" | "Transform" | "PassThrough")
 }
 
+fn is_node_readable_receiver(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let ast::Expr::Ident(ident) = unwrap_transparent_expr(expr) else {
+        return false;
+    };
+    let name = ident.sym.as_ref();
+    ctx.lookup_native_instance(name)
+        .is_some_and(|(module, class_name)| {
+            matches!(module, "stream" | "node:stream")
+                && matches!(
+                    class_name,
+                    "Readable" | "Duplex" | "Transform" | "PassThrough"
+                )
+        })
+        || ctx.lookup_local_type(name).is_some_and(|ty| {
+            matches!(
+                ty,
+                Type::Named(class_name)
+                    if matches!(
+                        class_name.as_str(),
+                        "Readable" | "Duplex" | "Transform" | "PassThrough"
+                    )
+            )
+        })
+}
+
 fn is_module_builtin_modules_expr(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
     let ast::Expr::Member(member) = unwrap_transparent_expr(expr) else {
         return false;
@@ -139,21 +164,23 @@ fn is_fs_dir_receiver(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
 }
 
 /// Does this expression's method chain originate from a node:stream
-/// source — `Readable.from(...)` / `Readable.of(...)`, `new Transform()`,
-/// or a chain of lazy iterator helpers (`map`/`filter`/`flatMap`/`take`/
-/// `drop`) on top of one? (#1558)
+/// source — `Readable.from(...)` / `Readable.of(...)`, a local already tagged
+/// as a readable stream, `new Transform()`, or a chain of lazy iterator helpers
+/// (`map`/`filter`/`flatMap`/`take`/`drop`) on top of one? (#1558)
 ///
 /// The lazy stream helpers return another Readable, not an array, so a
 /// chain like `Readable.from(x).map(f).filter(g)` must NOT be folded
 /// into `Expr::Array<Method>` ops — `js_array_map` would read garbage
 /// out of the stream object's header. Detecting the stream root here
 /// keeps such chains on dynamic dispatch so the runtime's stream
-/// iterator-helper stubs run. AST-only (no type info) so it catches the
-/// common inline-chain form without depending on receiver inference.
-fn chain_roots_at_stream(expr: &ast::Expr) -> bool {
+/// iterator-helper stubs run.
+fn chain_roots_at_stream(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
     let expr = unwrap_transparent_expr(expr);
+    if is_node_readable_receiver(ctx, expr) {
+        return true;
+    }
     match expr {
-        ast::Expr::Await(a) => chain_roots_at_stream(&a.arg),
+        ast::Expr::Await(a) => chain_roots_at_stream(ctx, &a.arg),
         ast::Expr::New(new) => is_stream_class_ref(&new.callee),
         ast::Expr::Call(call) => {
             let ast::Callee::Expr(callee) = &call.callee else {
@@ -169,7 +196,9 @@ fn chain_roots_at_stream(expr: &ast::Expr) -> bool {
                 // Static factories that produce a Readable.
                 "from" | "of" => is_stream_class_ref(&m.obj),
                 // Lazy helpers preserve the stream — recurse into the receiver.
-                "map" | "filter" | "flatMap" | "take" | "drop" => chain_roots_at_stream(&m.obj),
+                "map" | "filter" | "flatMap" | "take" | "drop" => {
+                    chain_roots_at_stream(ctx, &m.obj)
+                }
                 _ => false,
             }
         }
@@ -474,7 +503,7 @@ pub(super) fn try_array_only_methods(
                 // would read garbage out of the stream object's header. Bail to
                 // dynamic dispatch so the runtime's iterator-helper stubs run.
                 let recv_is_class = recv_is_class
-                    || chain_roots_at_stream(member_obj)
+                    || chain_roots_at_stream(ctx, member_obj)
                     || chain_roots_at_iterator_from(member_obj)
                     || is_util_mime_params_receiver(ctx, member_obj);
                 match method_name {

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -117,6 +117,14 @@ pub(super) fn try_local_array_methods(
                     Some(Type::Named(n))
                         if n == "Uint8Array" || n == "Buffer" || n == "Uint8ClampedArray"
                 );
+                let is_node_stream_readable_type = matches!(
+                    type_info,
+                    Some(Type::Named(n))
+                        if matches!(
+                            n.as_str(),
+                            "Readable" | "Duplex" | "Transform" | "PassThrough"
+                        )
+                );
                 let is_ambiguous_method = matches!(
                     method_name,
                     "indexOf" | "includes" | "slice" | "lastIndexOf"
@@ -129,6 +137,8 @@ pub(super) fn try_local_array_methods(
                     false // object type literal — dispatch via method call, not array ops
                 } else if is_buffer_type {
                     false // Buffer/Uint8Array — runtime dispatch handles byte-level methods
+                } else if is_node_stream_readable_type {
+                    false // Node streams expose iterator helpers with Array-like names
                 } else if is_known_not_string {
                     true // definitely not a string, enter array block
                 } else if is_ambiguous_method {

--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -31,6 +31,33 @@ fn unwrap_ts_wrappers(e: &ast::Expr) -> &ast::Expr {
     }
 }
 
+fn is_node_stream_iterator_helper_instance_method(
+    module_name: &str,
+    class_name: &str,
+    method_name: &str,
+) -> bool {
+    matches!(module_name, "stream" | "node:stream")
+        && matches!(
+            class_name,
+            "Readable" | "Duplex" | "Transform" | "PassThrough"
+        )
+        && matches!(
+            method_name,
+            "toArray"
+                | "map"
+                | "filter"
+                | "reduce"
+                | "forEach"
+                | "find"
+                | "some"
+                | "every"
+                | "flatMap"
+                | "take"
+                | "drop"
+                | "iterator"
+        )
+}
+
 pub(super) fn try_static_method_and_instance(
     ctx: &mut LoweringContext,
     // #854: kept for the uniform `try_*` dispatch-helper signature; this arm
@@ -184,11 +211,21 @@ pub(super) fn try_static_method_and_instance(
                                 | "addEventListener"
                                 | "removeEventListener"
                         );
-                    if is_util_mime_instance || is_worker_messaging_instance {
+                    let is_node_stream_iterator_helper =
+                        is_node_stream_iterator_helper_instance_method(
+                            &module_name,
+                            &class_name,
+                            &method_name,
+                        );
+                    if is_util_mime_instance
+                        || is_worker_messaging_instance
+                        || is_node_stream_iterator_helper
+                    {
                         // MIMEType/MIMEParams methods are ordinary object
                         // prototype methods registered in the runtime class
-                        // vtable; let the generic property-call path bind
-                        // `this` dynamically.
+                        // vtable; node:stream iterator helpers are also only
+                        // installed on the runtime object method table. Let the
+                        // generic property-call path bind `this` dynamically.
                     } else if is_stream_module && !is_stream_api_method(&module_name, &method_name)
                     {
                         // Fall through — let the regular method-call

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1147,7 +1147,9 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         object: Box::new(object_expr),
                         property: property_name,
                     });
-                } else if module_name == "stream" && is_classic_stream_method_name(&property_name) {
+                } else if matches!(module_name.as_str(), "stream" | "node:stream")
+                    && is_classic_stream_method_name(&property_name)
+                {
                     // Classic Node streams materialize core stream and
                     // EventEmitter methods as closure-valued fields on the
                     // stream object. A bare method read (`r.read`, `r.on`)
@@ -2534,6 +2536,18 @@ fn is_classic_stream_method_name(prop: &str) -> bool {
             | "uncork"
             | "setDefaultEncoding"
             | "compose"
+            | "iterator"
+            | "toArray"
+            | "map"
+            | "filter"
+            | "reduce"
+            | "forEach"
+            | "find"
+            | "some"
+            | "every"
+            | "flatMap"
+            | "take"
+            | "drop"
             | "on"
             | "addListener"
             | "once"

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -105,14 +105,39 @@ fn is_node_readable_static_factory(expr: &ast::Expr) -> bool {
     matches!(prop.sym.as_ref(), "from" | "of") && is_node_readable_class_ref(&member.obj)
 }
 
-fn is_node_readable_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
-    if is_node_readable_static_factory(expr) {
-        return true;
+fn is_node_readable_expr(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    is_node_readable_static_factory(expr)
+        || is_node_readable_helper_chain(ctx, expr)
+        || matches!(
+            crate::lower_types::infer_type_from_expr(strip_for_of_expr_wrappers(expr), ctx),
+            Type::Named(name) if name == "Readable"
+        )
+}
+
+fn is_node_readable_helper_chain(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let ast::Expr::Call(call) = strip_for_of_expr_wrappers(expr) else {
+        return false;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(member) = strip_for_of_expr_wrappers(callee.as_ref()) else {
+        return false;
+    };
+    let ast::MemberProp::Ident(prop) = &member.prop else {
+        return false;
+    };
+    match prop.sym.as_ref() {
+        "from" | "of" => is_node_readable_class_ref(&member.obj),
+        "map" | "filter" | "flatMap" | "take" | "drop" | "compose" => {
+            is_node_readable_expr(ctx, &member.obj)
+        }
+        _ => false,
     }
-    matches!(
-        crate::lower_types::infer_type_from_expr(strip_for_of_expr_wrappers(expr), ctx),
-        Type::Named(name) if name == "Readable"
-    )
+}
+
+fn is_node_readable_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    is_node_readable_expr(ctx, expr)
 }
 
 fn is_filehandle_readlines_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -136,14 +136,35 @@ fn is_node_readable_static_factory(expr: &ast::Expr) -> bool {
     matches!(prop.sym.as_ref(), "from" | "of") && is_node_readable_class_ref(&member.obj)
 }
 
-fn is_node_readable_for_await_target(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
-    if is_node_readable_static_factory(expr) {
-        return true;
+fn is_node_readable_expr(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    is_node_readable_static_factory(expr)
+        || is_node_readable_helper_chain(ctx, expr)
+        || matches!(
+            crate::lower_types::infer_type_from_expr(strip_for_of_expr_wrappers(expr), ctx),
+            Type::Named(name) if name == "Readable"
+        )
+}
+
+fn is_node_readable_helper_chain(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let ast::Expr::Call(call) = strip_for_of_expr_wrappers(expr) else {
+        return false;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(member) = strip_for_of_expr_wrappers(callee.as_ref()) else {
+        return false;
+    };
+    let ast::MemberProp::Ident(prop) = &member.prop else {
+        return false;
+    };
+    match prop.sym.as_ref() {
+        "from" | "of" => is_node_readable_class_ref(&member.obj),
+        "map" | "filter" | "flatMap" | "take" | "drop" | "compose" => {
+            is_node_readable_expr(ctx, &member.obj)
+        }
+        _ => false,
     }
-    matches!(
-        crate::lower_types::infer_type_from_expr(strip_for_of_expr_wrappers(expr), ctx),
-        Type::Named(name) if name == "Readable"
-    )
 }
 
 /// `for await (const line of rl)` where `rl = readline.createInterface(...)`.
@@ -1030,7 +1051,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 };
 
             let is_node_readable_for_await =
-                for_of_stmt.is_await && is_node_readable_for_await_target(ctx, &for_of_stmt.right);
+                for_of_stmt.is_await && is_node_readable_expr(ctx, &for_of_stmt.right);
             let is_filehandle_readlines_for_await = for_of_stmt.is_await
                 && is_filehandle_readlines_for_await_target(ctx, &for_of_stmt.right);
             let is_fs_dir_for_await =

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -841,6 +841,64 @@ fn ident_has_known_static_method_return(
     false
 }
 
+fn is_node_stream_module_alias(ctx: &LoweringContext, name: &str) -> bool {
+    matches!(
+        ctx.lookup_builtin_module_alias(name),
+        Some("stream" | "node:stream")
+    ) || matches!(
+        ctx.lookup_native_module(name),
+        Some(("stream" | "node:stream", None))
+    )
+}
+
+pub(crate) fn is_node_readable_constructor_ref(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    match expr {
+        ast::Expr::Ident(ident) => {
+            let name = ident.sym.as_ref();
+            name == "Readable"
+                || matches!(
+                    ctx.lookup_native_module(name),
+                    Some(("stream" | "node:stream", Some("Readable")))
+                )
+        }
+        ast::Expr::Member(member) => {
+            let (ast::Expr::Ident(obj), ast::MemberProp::Ident(prop)) =
+                (member.obj.as_ref(), &member.prop)
+            else {
+                return false;
+            };
+            prop.sym.as_ref() == "Readable" && is_node_stream_module_alias(ctx, obj.sym.as_ref())
+        }
+        ast::Expr::Paren(paren) => is_node_readable_constructor_ref(ctx, &paren.expr),
+        ast::Expr::TsAs(ts_as) => is_node_readable_constructor_ref(ctx, &ts_as.expr),
+        ast::Expr::TsTypeAssertion(ts_assert) => {
+            is_node_readable_constructor_ref(ctx, &ts_assert.expr)
+        }
+        ast::Expr::TsNonNull(non_null) => is_node_readable_constructor_ref(ctx, &non_null.expr),
+        ast::Expr::TsConstAssertion(const_assert) => {
+            is_node_readable_constructor_ref(ctx, &const_assert.expr)
+        }
+        _ => false,
+    }
+}
+
+pub(crate) fn is_node_readable_static_factory_call(
+    ctx: &LoweringContext,
+    expr: &ast::Expr,
+) -> bool {
+    let ast::Expr::Call(call) = expr else {
+        return false;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(member) = callee.as_ref() else {
+        return false;
+    };
+    matches!(&member.prop, ast::MemberProp::Ident(prop) if matches!(prop.sym.as_ref(), "from" | "of"))
+        && is_node_readable_constructor_ref(ctx, member.obj.as_ref())
+}
+
 fn expr_may_have_typed_receiver(expr: &ast::Expr, ctx: &LoweringContext) -> bool {
     match expr {
         ast::Expr::Lit(ast::Lit::Str(_)) => true,
@@ -939,6 +997,11 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
         ast::Expr::Member(member) => {
             if let ast::MemberProp::Ident(method) = &member.prop {
                 let method_name = method.sym.as_ref();
+                if matches!(method_name, "from" | "of")
+                    && is_node_readable_constructor_ref(ctx, &member.obj)
+                {
+                    return Type::Named("Readable".to_string());
+                }
                 if method_name == "open" {
                     if let ast::Expr::Ident(obj) = member.obj.as_ref() {
                         let namespace_is_fs_promises = matches!(

--- a/test-parity/node-suite/stream/iter-helpers/for-await-local-tail.ts
+++ b/test-parity/node-suite/stream/iter-helpers/for-await-local-tail.ts
@@ -1,0 +1,22 @@
+import * as stream from "node:stream";
+
+const flatMapSource = stream.Readable.from([1, 2]);
+const flatMapOut: number[] = [];
+for await (const value of flatMapSource.flatMap((n: number) => [n, n * 10])) {
+  flatMapOut.push(value as number);
+}
+console.log("flatMap local:", flatMapOut.join(","));
+
+const dropSource = stream.Readable.from([1, 2, 3, 4]);
+const dropOut: number[] = [];
+for await (const value of dropSource.drop(2)) {
+  dropOut.push(value as number);
+}
+console.log("drop local:", dropOut.join(","));
+
+const takeSource = stream.Readable.from([1, 2, 3, 4]);
+const takeOut: number[] = [];
+for await (const value of takeSource.take(2)) {
+  takeOut.push(value as number);
+}
+console.log("take local:", takeOut.join(","));

--- a/test-parity/node-suite/stream/iter-helpers/for-await-tail.ts
+++ b/test-parity/node-suite/stream/iter-helpers/for-await-tail.ts
@@ -1,0 +1,31 @@
+import * as stream from "node:stream";
+
+const forEachOut: string[] = [];
+await stream.Readable.from(["a", "b"]).forEach((value: string) => {
+  forEachOut.push(value);
+});
+console.log("forEach:", forEachOut.join(","));
+
+const flatMapOut: number[] = [];
+for await (const value of stream.Readable.from([1, 2]).flatMap((n: number) => [n, n * 10])) {
+  flatMapOut.push(value as number);
+}
+console.log("flatMap:", flatMapOut.join(","));
+
+const dropOut: number[] = [];
+for await (const value of stream.Readable.from([1, 2, 3, 4]).drop(2)) {
+  dropOut.push(value as number);
+}
+console.log("drop:", dropOut.join(","));
+
+const takeOut: number[] = [];
+for await (const value of stream.Readable.from([1, 2, 3, 4]).take(2)) {
+  takeOut.push(value as number);
+}
+console.log("take:", takeOut.join(","));
+
+const reduced = await stream.Readable.from([1, 2, 3, 4]).reduce(
+  (acc: number, value: number) => acc + value,
+  0,
+);
+console.log("reduce:", reduced);


### PR DESCRIPTION
## Summary
- Recognize `stream.Readable.from/of` values and helper chains as Node Readable async-iteration targets in both HIR lowering paths.
- Preserve stream helper method calls on local `Readable` variables as dynamic stream calls instead of folding them through array/native method lowering.
- Cover namespace-shaped and local-variable `Readable.from(...).flatMap/drop/take` consumption by `for await`, plus adjacent `forEach` and `reduce` helper behavior.

## Linked Issues
- Closes #2521

## Why These Were Batched
- These cases share the same lowering gap: `Readable.from(...)` helper chains were not reliably classified as Node Readable async-iteration targets, so `for await` could use the generic iterable path or array/native helper lowering.
- This stays separate from stream lifecycle/backpressure and web stream constructor work because those exercise different runtime surfaces.

## Tests Added
- `test-parity/node-suite/stream/iter-helpers/for-await-tail.ts`
- `test-parity/node-suite/stream/iter-helpers/for-await-local-tail.ts`

## Commands Run
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/stream/iter-helpers/for-await-tail.ts`
- `npm exec --yes --package=node@26 -- node --experimental-strip-types test-parity/node-suite/stream/iter-helpers/for-await-local-tail.ts`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry test-parity/node-suite/stream/iter-helpers/for-await-tail.ts -o /tmp/perry_stream_for_await_tail && timeout 10s /tmp/perry_stream_for_await_tail`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry test-parity/node-suite/stream/iter-helpers/for-await-local-tail.ts -o /tmp/perry_stream_for_await_local_tail && timeout 10s /tmp/perry_stream_for_await_local_tail`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry compile --print-hir --no-link --no-cache test-parity/node-suite/stream/iter-helpers/for-await-local-tail.ts -o /tmp/perry_hir_probe`
- `PERRY_NO_AUTO_OPTIMIZE=1 target/debug/perry test-files/test_parity_stream.ts -o /tmp/perry_test_parity_stream && timeout 25s /tmp/perry_test_parity_stream`
- `CARGO_BUILD_JOBS=1 PERRY_NO_AUTO_OPTIMIZE=1 npm exec --yes --package=node@26 -- bash -lc './run_parity_tests.sh --suite node-suite --module stream --filter for-await'` (4 pass, 0 parity failures, 0 compile failures)
- `CARGO_BUILD_JOBS=1 cargo check -p perry-hir`
- `CARGO_BUILD_JOBS=1 cargo build -p perry`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`

## Known Limitations
- The broad legacy `test-files/test_parity_stream.ts` fixture now reaches the helper-tail probes and prints `flatMap`, `drop`, `take`, and `reduce` results, then exits later with Perry's existing unsettled top-level-await status after `pipeline(cb)`. This PR keeps that separate lifecycle/top-level-await behavior out of scope.

## Non-Goals
- `Readable.wrap` behavior.
- Data-listener async iteration on existing Readables.
- `stream/web` constructors.
- Chunk-boundary, lifecycle, and backpressure semantics.