### PR TITLE
fix(fs): lazy-start promises watch iteration

### DIFF
--- a/crates/perry-runtime/src/fs/dir_glob_watch.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch.rs
@@ -800,6 +800,8 @@ struct PromiseWatchState {
     encoding: String,
     object_value: f64,
     timer_id: i64,
+    persistent: bool,
+    active: bool,
     snapshot: WatchSnapshot,
     queue: VecDeque<WatchEvent>,
     pending: VecDeque<*mut crate::promise::Promise>,
@@ -1342,7 +1344,9 @@ fn close_promise_watcher_return(id: usize) -> Vec<*mut crate::promise::Promise> 
     let Some(state) = removed else {
         return Vec::new();
     };
-    crate::timer::clearInterval(state.timer_id);
+    if state.timer_id != 0 {
+        crate::timer::clearInterval(state.timer_id);
+    }
     remove_abort_listener(state.signal, state.abort_listener);
     state.pending.into_iter().collect()
 }
@@ -1353,9 +1357,12 @@ fn abort_promise_watcher(id: usize, reason: f64) -> Vec<*mut crate::promise::Pro
         let Some(state) = watchers.get_mut(&id) else {
             return Vec::new();
         };
-        crate::timer::clearInterval(state.timer_id);
+        if state.timer_id != 0 {
+            crate::timer::clearInterval(state.timer_id);
+        }
         remove_abort_listener(state.signal, state.abort_listener);
         state.timer_id = 0;
+        state.active = false;
         state.signal = undefined_value();
         state.abort_listener = undefined_value();
         state.object_value = undefined_value();
@@ -1509,6 +1516,20 @@ extern "C" fn promise_watcher_poll_impl(closure: *const ClosureHeader) -> f64 {
         resolve_promise_with_event(promise, event, encoding);
     }
     undefined_value()
+}
+
+fn start_promise_watcher(id: usize, state: &mut PromiseWatchState) {
+    if state.active || state.closed {
+        return;
+    }
+    state.snapshot = snapshot_watch_target(&state.path, state.recursive).unwrap_or_default();
+    let timer_callback = poll_closure_value(promise_watcher_poll_impl as *const u8, id);
+    let timer_id = crate::timer::setInterval(timer_callback as i64, FS_WATCH_POLL_INTERVAL_MS);
+    if !state.persistent {
+        crate::timer::js_timer_unref(timer_id);
+    }
+    state.timer_id = timer_id;
+    state.active = true;
 }
 
 extern "C" fn watch_file_poll_impl(closure: *const ClosureHeader) -> f64 {
@@ -1776,6 +1797,7 @@ extern "C" fn promise_watcher_next_impl(closure: *const ClosureHeader) -> f64 {
         if state.closed {
             return PromiseNextAction::Done;
         }
+        start_promise_watcher(id, state);
         if let Some(event) = state.queue.pop_front() {
             return PromiseNextAction::Event(event, state.encoding.clone());
         }
@@ -2185,19 +2207,13 @@ pub extern "C" fn js_fs_promises_watch(path_value: f64, options_value: f64) -> f
         Ok(signal) => signal,
         Err(err) => crate::exception::js_throw(err),
     };
-    let snapshot = match snapshot_watch_target(&path, recursive) {
-        Ok(snapshot) => snapshot,
-        Err(err) => unsafe {
+    if let Err(err) = snapshot_watch_target(&path, recursive) {
+        unsafe {
             crate::exception::js_throw(build_fs_error_value(&err, "watch", &path));
-        },
-    };
+        }
+    }
     let id = next_watch_id();
     let object_value = build_promise_watcher_object(id);
-    let timer_callback = poll_closure_value(promise_watcher_poll_impl as *const u8, id);
-    let timer_id = crate::timer::setInterval(timer_callback as i64, FS_WATCH_POLL_INTERVAL_MS);
-    if !persistent {
-        crate::timer::js_timer_unref(timer_id);
-    }
     let abort_listener = signal
         .filter(|signal| !signal_is_aborted(*signal))
         .map(|signal| add_abort_listener(signal, id, promise_watcher_abort_impl))
@@ -2216,8 +2232,10 @@ pub extern "C" fn js_fs_promises_watch(path_value: f64, options_value: f64) -> f
                 recursive,
                 encoding,
                 object_value,
-                timer_id,
-                snapshot,
+                timer_id: 0,
+                persistent,
+                active: false,
+                snapshot: WatchSnapshot::new(),
                 queue: VecDeque::new(),
                 pending: VecDeque::new(),
                 signal: signal_value,
@@ -2227,9 +2245,6 @@ pub extern "C" fn js_fs_promises_watch(path_value: f64, options_value: f64) -> f
             },
         );
     });
-    if abort_reason.is_some() {
-        crate::timer::clearInterval(timer_id);
-    }
     object_value
 }
 

--- a/test-parity/node-suite/fs/watch/promises-lazy-start.ts
+++ b/test-parity/node-suite/fs/watch/promises-lazy-start.ts
@@ -1,0 +1,32 @@
+import * as fs from "node:fs";
+import { watch } from "node:fs/promises";
+
+const ROOT = "/tmp/perry_node_suite_fs_promises_watch_lazy";
+try { fs.rmSync(ROOT, { recursive: true, force: true }); } catch (_e) {}
+fs.mkdirSync(ROOT, { recursive: true });
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const filenameOf = (result) => result.done ? "done" : String(result.value?.filename);
+
+const iterator = watch(ROOT);
+
+await sleep(80);
+fs.writeFileSync(ROOT + "/early.txt", "early");
+
+const pending = iterator.next().then(filenameOf);
+const prePullOutcome = await Promise.race([
+  pending,
+  sleep(200).then(() => "timeout"),
+]);
+
+await sleep(80);
+fs.writeFileSync(ROOT + "/late.txt", "late");
+const postPullOutcome = await Promise.race([
+  pending,
+  sleep(1000).then(() => "timeout"),
+]);
+
+await iterator.return();
+
+console.log("promises watch pre-pull ignored:", prePullOutcome === "timeout");
+console.log("promises watch post-pull delivered:", postPullOutcome === "late.txt");

--- a/test-parity/node-suite/fs/watch/promises-recursive-abort.ts
+++ b/test-parity/node-suite/fs/watch/promises-recursive-abort.ts
@@ -17,12 +17,13 @@ const nextMatching = async (iterator, predicate) => {
 };
 
 const recursive = watch(ROOT, { recursive: true });
-await new Promise((resolve) => setTimeout(resolve, 80));
-fs.writeFileSync(ROOT + "/sub/nested.txt", "x");
-const recursiveResult = await nextMatching(
+const recursivePending = nextMatching(
   recursive,
   (event) => normalize(event.filename) === "sub/nested.txt",
 );
+await new Promise((resolve) => setTimeout(resolve, 80));
+fs.writeFileSync(ROOT + "/sub/nested.txt", "x");
+const recursiveResult = await recursivePending;
 await recursive.return();
 
 const abortRoot = ROOT + "/abort";

--- a/test-parity/node-suite/fs/watch/promises-watch.ts
+++ b/test-parity/node-suite/fs/watch/promises-watch.ts
@@ -16,13 +16,15 @@ const nextMatching = async (iterator, predicate) => {
 
 const iterator = watch(ROOT);
 
+const firstPending = nextMatching(iterator, (event) => event.filename === "promise.txt");
 await new Promise((resolve) => setTimeout(resolve, 80));
 fs.writeFileSync(ROOT + "/promise.txt", "a");
-const firstResult = await nextMatching(iterator, (event) => event.filename === "promise.txt");
+const firstResult = await firstPending;
 
+const secondPending = nextMatching(iterator, (event) => event.filename === "promise.txt");
 await new Promise((resolve) => setTimeout(resolve, 80));
 fs.appendFileSync(ROOT + "/promise.txt", "b");
-const secondResult = await nextMatching(iterator, (event) => event.filename === "promise.txt");
+const secondResult = await secondPending;
 
 const returned = await iterator.return();
 const afterReturn = await iterator.next();


### PR DESCRIPTION
Closes #4673

Summary:
- start `fs.promises.watch()` polling on the first async iterator pull so pre-pull filesystem changes are ignored
- keep construction-time path validation while avoiding pre-pull timers and event queues
- update promise watch parity fixtures to pull before writes and add lazy-start regression coverage

Validation:
- direct Node 26 oracle runs for `promises-watch`, `promises-recursive-abort`, and `promises-lazy-start`
- `./run_parity_tests.sh --suite node-suite --module fs/watch --filter promises-lazy-start`
- `./run_parity_tests.sh --suite node-suite --module fs/watch` (11 pass, 0 fail)
- `cargo check -p perry-runtime -j 2`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_file_size.sh`