### PR TITLE
fix(array): Array.prototype read-only methods generic over array-like receivers (#4597)

### DIFF
--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -186,6 +186,140 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_string_inline(blk, &result))
         }
 
+        // -------- Array.prototype.<m>.call/apply(arrayLike, ...) (#4597) --------
+        // Generic over an array-like receiver: the runtime `js_arraylike_*`
+        // entry points take the *original* receiver value (NaN-boxed `f64`) so
+        // they apply ToObject + LengthOfArrayLike + indexed Get/HasProperty and
+        // pass the original receiver as the callback's 3rd argument. The result
+        // is already a NaN-boxed JS value (number / boolean / pointer / string),
+        // so it is returned directly with no re-boxing.
+        Expr::ArrayLikeMethod {
+            method,
+            receiver,
+            args,
+        } => {
+            let recv_box = lower_expr(ctx, receiver)?;
+            let mut arg_boxes: Vec<String> = Vec::with_capacity(args.len());
+            for a in args {
+                arg_boxes.push(lower_expr(ctx, a)?);
+            }
+            let undef = || double_literal(f64::from_bits(TAG_UNDEFINED));
+            let nth = |i: usize| arg_boxes.get(i).cloned();
+            let blk = ctx.block();
+            let result = match method.as_str() {
+                // Callback iterators: (recv, callback, thisArg).
+                "forEach" | "map" | "filter" | "some" | "every" | "find" | "findIndex"
+                | "findLast" | "findLastIndex" => {
+                    let cb = nth(0).unwrap_or_else(undef);
+                    let this_arg = nth(1).unwrap_or_else(undef);
+                    let fname = match method.as_str() {
+                        "forEach" => "js_arraylike_forEach",
+                        "map" => "js_arraylike_map",
+                        "filter" => "js_arraylike_filter",
+                        "some" => "js_arraylike_some",
+                        "every" => "js_arraylike_every",
+                        "find" => "js_arraylike_find",
+                        "findIndex" => "js_arraylike_findIndex",
+                        "findLast" => "js_arraylike_findLast",
+                        _ => "js_arraylike_findLastIndex",
+                    };
+                    blk.call(
+                        DOUBLE,
+                        fname,
+                        &[(DOUBLE, &recv_box), (DOUBLE, &cb), (DOUBLE, &this_arg)],
+                    )
+                }
+                // Reducers: (recv, callback, has_init, init).
+                "reduce" | "reduceRight" => {
+                    let cb = nth(0).unwrap_or_else(undef);
+                    let (has_init, init) = match nth(1) {
+                        Some(i) => ("1".to_string(), i),
+                        None => ("0".to_string(), undef()),
+                    };
+                    let fname = if method == "reduce" {
+                        "js_arraylike_reduce"
+                    } else {
+                        "js_arraylike_reduceRight"
+                    };
+                    blk.call(
+                        DOUBLE,
+                        fname,
+                        &[
+                            (DOUBLE, &recv_box),
+                            (DOUBLE, &cb),
+                            (I32, &has_init),
+                            (DOUBLE, &init),
+                        ],
+                    )
+                }
+                // Search: (recv, value, fromIndex, has_from).
+                "indexOf" | "lastIndexOf" | "includes" => {
+                    let value = nth(0).unwrap_or_else(undef);
+                    let (has_from, from) = match nth(1) {
+                        Some(f) => ("1".to_string(), f),
+                        None => ("0".to_string(), undef()),
+                    };
+                    let fname = match method.as_str() {
+                        "indexOf" => "js_arraylike_indexOf",
+                        "lastIndexOf" => "js_arraylike_lastIndexOf",
+                        _ => "js_arraylike_includes",
+                    };
+                    blk.call(
+                        DOUBLE,
+                        fname,
+                        &[
+                            (DOUBLE, &recv_box),
+                            (DOUBLE, &value),
+                            (DOUBLE, &from),
+                            (I32, &has_from),
+                        ],
+                    )
+                }
+                // at(index): ToIntegerOrInfinity(undefined) === 0 when omitted.
+                "at" => {
+                    let idx = nth(0).unwrap_or_else(undef);
+                    blk.call(
+                        DOUBLE,
+                        "js_arraylike_at",
+                        &[(DOUBLE, &recv_box), (DOUBLE, &idx)],
+                    )
+                }
+                // join(separator?): undefined separator → comma.
+                "join" => {
+                    let sep = nth(0).unwrap_or_else(undef);
+                    blk.call(
+                        DOUBLE,
+                        "js_arraylike_join",
+                        &[(DOUBLE, &recv_box), (DOUBLE, &sep)],
+                    )
+                }
+                // slice(start?, end?): has-flags distinguish omitted from undefined.
+                "slice" => {
+                    let (has_start, start) = match nth(0) {
+                        Some(s) => ("1".to_string(), s),
+                        None => ("0".to_string(), undef()),
+                    };
+                    let (has_end, end) = match nth(1) {
+                        Some(e) => ("1".to_string(), e),
+                        None => ("0".to_string(), undef()),
+                    };
+                    blk.call(
+                        DOUBLE,
+                        "js_arraylike_slice",
+                        &[
+                            (DOUBLE, &recv_box),
+                            (DOUBLE, &start),
+                            (I32, &has_start),
+                            (DOUBLE, &end),
+                            (I32, &has_end),
+                        ],
+                    )
+                }
+                other => bail!("unsupported generic array-like method '{other}'"),
+            };
+            Ok(result)
+        }
+
         // -------- map.delete(key) -> boolean --------
         Expr::MapDelete { map, key } => {
             let m_box = lower_expr(ctx, map)?;

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1482,6 +1482,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::BooleanCoerce(..)
         | Expr::ArraySlice { .. }
         | Expr::ArrayShift(..)
+        | Expr::ArrayLikeMethod { .. }
         | Expr::SetNew
         | Expr::In { .. }
         | Expr::PrivateBrandCheck { .. }

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -137,6 +137,54 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // #2805: Array.prototype.concat(...args) — non-mutating, variadic, with
     // Symbol.isConcatSpreadable handling. (recv_handle, args_ptr, count).
     module.declare_function("js_array_concat_variadic", I64, &[I64, PTR, I32]);
+    // #4597: generic `Array.prototype.<m>.call/apply(arrayLike, …)` — operate on
+    // the original receiver value (ToObject + LengthOfArrayLike + indexed
+    // Get/HasProperty). All take/return NaN-boxed DOUBLE values.
+    for f in [
+        "js_arraylike_forEach",
+        "js_arraylike_map",
+        "js_arraylike_filter",
+        "js_arraylike_some",
+        "js_arraylike_every",
+        "js_arraylike_find",
+        "js_arraylike_findIndex",
+        "js_arraylike_findLast",
+        "js_arraylike_findLastIndex",
+    ] {
+        module.declare_function(f, DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
+    }
+    module.declare_function(
+        "js_arraylike_reduce",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, I32, DOUBLE],
+    );
+    module.declare_function(
+        "js_arraylike_reduceRight",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, I32, DOUBLE],
+    );
+    module.declare_function(
+        "js_arraylike_indexOf",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE, I32],
+    );
+    module.declare_function(
+        "js_arraylike_lastIndexOf",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE, I32],
+    );
+    module.declare_function(
+        "js_arraylike_includes",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE, I32],
+    );
+    module.declare_function("js_arraylike_at", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_arraylike_join", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function(
+        "js_arraylike_slice",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, I32, DOUBLE, I32],
+    );
     // Spread `[...x]` — strict GetIterator/materialization.
     module.declare_function("js_array_clone_for_spread", I64, &[DOUBLE]);
     module.declare_function("js_array_spread_append", I64, &[I64, DOUBLE]);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1508,6 +1508,21 @@ pub enum Expr {
     ArrayKeys(Box<Expr>),    // arr.keys() -> Array<index>
     ArrayValues(Box<Expr>),  // arr.values() -> Array<value> (essentially clone)
 
+    /// `Array.prototype.<method>.call/apply(receiver, ...args)` (and the
+    /// bound-local form `const m = [].map; m.call(receiver, ...)`) dispatched
+    /// generically over an *array-like* receiver per ECMA-262 §23.1.3 (#4597).
+    /// Unlike the specialised `Array*` variants above — which require a genuine
+    /// array receiver — this carries the receiver as a raw value so the runtime
+    /// applies `ToObject` + `LengthOfArrayLike` + indexed `Get`/`HasProperty`,
+    /// preserving receiver identity for the callback's 3rd argument.
+    /// `method` is the resolved Array method name; `args` are the post-receiver
+    /// positional arguments (already expanded from `.apply`).
+    ArrayLikeMethod {
+        method: String,
+        receiver: Box<Expr>,
+        args: Vec<Expr>,
+    },
+
     // String methods
     StringSplit(Box<Expr>, Box<Expr>), // string.split(delimiter) -> string[]
     StringFromCharCode(Box<Expr>),     // String.fromCharCode(code) -> single-char string

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1279,6 +1279,8 @@ fn try_arraylike_receiver_method(
     if rest_args.iter().any(|a| a.spread.is_some()) {
         return Ok(None);
     }
+    // `copyWithin` mutates in place but is generic over an array-like receiver;
+    // keep the dedicated value-receiver lowering.
     if method == "copyWithin" {
         let receiver = Box::new(lower_expr(ctx, receiver)?);
         let arg = |ctx: &mut LoweringContext, i: usize| -> Result<Option<Box<Expr>>> {
@@ -1303,10 +1305,16 @@ fn try_arraylike_receiver_method(
             end,
         }));
     }
-    // Only fold the read-only/returning methods. Bail early for everything else
-    // (mutators, flat, etc.) BEFORE lowering the receiver, so unrelated shapes
-    // keep the existing member-call behavior with no side effects.
-    let supported = matches!(
+    // The read-only/returning methods the runtime generic engine implements
+    // directly over an array-like receiver (`js_arraylike_*`, #4597). Unlike
+    // the old materialize-then-call fold, these preserve the original receiver
+    // identity (passed as the callback's 3rd argument) and read live via
+    // `Get(O, k)` / `HasProperty(O, k)` — so they also work on plain objects,
+    // functions (`obj.length`/expando indices), strings, and bare primitives,
+    // and pass the receiver-identity test262 cases that a materialised clone
+    // fails. The hot `arr.<m>(…)` member-call paths are untouched — only the
+    // explicit `.call`/`.apply`/bound-local forms route here.
+    let generic = matches!(
         method,
         "map"
             | "filter"
@@ -1317,7 +1325,6 @@ fn try_arraylike_receiver_method(
             | "findLastIndex"
             | "some"
             | "every"
-            | "flatMap"
             | "reduce"
             | "reduceRight"
             | "indexOf"
@@ -1327,124 +1334,37 @@ fn try_arraylike_receiver_method(
             | "at"
             | "join"
     );
-    if !supported {
+    if generic {
+        // Receiver lowers before the positional args, matching source order.
+        let receiver = Box::new(lower_expr(ctx, receiver)?);
+        let mut args = Vec::with_capacity(rest_args.len());
+        for a in rest_args {
+            args.push(lower_expr(ctx, &a.expr)?);
+        }
+        return Ok(Some(Expr::ArrayLikeMethod {
+            method: method.to_string(),
+            receiver,
+            args,
+        }));
+    }
+
+    // `flatMap` has no generic runtime entry yet; keep the holey
+    // materialize-then-call behavior. `Expr::ArrayFromArrayLikeHoley` keeps
+    // absent indexed keys as holes (vs `Array.from({ length })` creating
+    // present undefined slots), so the flatMap callback doesn't visit holes.
+    // Everything else (mutators, flat, etc.) bails BEFORE lowering the receiver
+    // so unrelated shapes keep the existing member-call behavior.
+    if method != "flatMap" {
         return Ok(None);
     }
-    // Materialize the array-like receiver into a REAL array up front, but keep
-    // absent indexed keys as holes. These Array.prototype algorithms use
-    // HasProperty/Get on the receiver; `Array.from({ length: 2 })` would create
-    // present undefined slots, making `indexOf(undefined)` and callback methods
-    // visit holes incorrectly.
-    let array_src = lower_expr(ctx, receiver)?;
-    let array = Box::new(Expr::ArrayFromArrayLikeHoley(Box::new(array_src)));
-    // Lower a positional argument by index, if present.
-    let mut arg = |ctx: &mut LoweringContext, i: usize| -> Result<Option<Box<Expr>>> {
-        match rest_args.get(i) {
-            Some(a) => Ok(Some(Box::new(lower_expr(ctx, &a.expr)?))),
-            None => Ok(None),
-        }
+    let Some(cb) = rest_args.first() else {
+        return Ok(None);
     };
-    // Callback-taking methods require the callback argument to be present.
-    macro_rules! cb_method {
-        ($variant:ident) => {{
-            let Some(cb) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            Ok(Some(Expr::$variant {
-                array,
-                callback: cb,
-            }))
-        }};
-    }
-    match method {
-        "map" => cb_method!(ArrayMap),
-        "filter" => cb_method!(ArrayFilter),
-        "forEach" => cb_method!(ArrayForEach),
-        "find" => cb_method!(ArrayFind),
-        "findIndex" => cb_method!(ArrayFindIndex),
-        "findLast" => cb_method!(ArrayFindLast),
-        "findLastIndex" => cb_method!(ArrayFindLastIndex),
-        "some" => cb_method!(ArraySome),
-        "every" => cb_method!(ArrayEvery),
-        "flatMap" => cb_method!(ArrayFlatMap),
-        "reduce" => {
-            let Some(cb) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let initial = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayReduce {
-                array,
-                callback: cb,
-                initial,
-            }))
-        }
-        "reduceRight" => {
-            let Some(cb) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let initial = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayReduceRight {
-                array,
-                callback: cb,
-                initial,
-            }))
-        }
-        "indexOf" => {
-            let Some(value) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let from_index = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayIndexOf {
-                array,
-                value,
-                from_index,
-            }))
-        }
-        "lastIndexOf" => {
-            let Some(value) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let from_index = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayLastIndexOf {
-                array,
-                value,
-                from_index,
-            }))
-        }
-        "includes" => {
-            let Some(value) = arg(ctx, 0)? else {
-                return Ok(None);
-            };
-            let from_index = arg(ctx, 1)?;
-            Ok(Some(Expr::ArrayIncludes {
-                array,
-                value,
-                from_index,
-            }))
-        }
-        "slice" => {
-            // `slice()` with no args copies from index 0.
-            let start = match arg(ctx, 0)? {
-                Some(s) => s,
-                None => Box::new(Expr::Integer(0)),
-            };
-            let end = arg(ctx, 1)?;
-            Ok(Some(Expr::ArraySlice { array, start, end }))
-        }
-        "at" => {
-            let index = match arg(ctx, 0)? {
-                Some(i) => i,
-                None => Box::new(Expr::Integer(0)),
-            };
-            Ok(Some(Expr::ArrayAt { array, index }))
-        }
-        "join" => {
-            let separator = arg(ctx, 0)?;
-            Ok(Some(Expr::ArrayJoin { array, separator }))
-        }
-        // Unreachable: `supported` gate above filters to exactly these arms.
-        _ => Ok(None),
-    }
+    let array = Box::new(Expr::ArrayFromArrayLikeHoley(Box::new(lower_expr(
+        ctx, receiver,
+    )?)));
+    let callback = Box::new(lower_expr(ctx, &cb.expr)?);
+    Ok(Some(Expr::ArrayFlatMap { array, callback }))
 }
 
 /// #3144: if `init` is a value-read of a builtin prototype method whose

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -596,6 +596,18 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
                 .as_ref()
                 .map(|s| Box::new(substitute_expr(s, substitutions))),
         },
+        Expr::ArrayLikeMethod {
+            method,
+            receiver,
+            args,
+        } => Expr::ArrayLikeMethod {
+            method: method.clone(),
+            receiver: Box::new(substitute_expr(receiver, substitutions)),
+            args: args
+                .iter()
+                .map(|a| substitute_expr(a, substitutions))
+                .collect(),
+        },
         Expr::ArrayFlat { array } => Expr::ArrayFlat {
             array: Box::new(substitute_expr(array, substitutions)),
         },

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -396,6 +396,7 @@ impl SH for Expr {
             Expr::ArrayEntries(e) => { tag(h, 279); e.as_ref().hash(h); }
             Expr::ArrayKeys(e) => { tag(h, 280); e.as_ref().hash(h); }
             Expr::ArrayValues(e) => { tag(h, 281); e.as_ref().hash(h); }
+            Expr::ArrayLikeMethod { method, receiver, args } => { tag(h, 12500); method.hash(h); receiver.as_ref().hash(h); args.hash(h); }
             Expr::StringSplit(a, b) => { tag(h, 282); a.as_ref().hash(h); b.as_ref().hash(h); }
             Expr::StringFromCharCode(e) => { tag(h, 283); e.as_ref().hash(h); }
             Expr::StringFromCharCodeSpread(e) => { tag(h, 12045); e.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1567,6 +1567,16 @@ where
                 f(s);
             }
         }
+        Expr::ArrayLikeMethod {
+            method: _,
+            receiver,
+            args,
+        } => {
+            f(receiver);
+            for a in args {
+                f(a);
+            }
+        }
         Expr::ArrayToSorted { array, comparator } => {
             f(array);
             if let Some(c) = comparator {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1542,6 +1542,16 @@ where
                 f(s);
             }
         }
+        Expr::ArrayLikeMethod {
+            method: _,
+            receiver,
+            args,
+        } => {
+            f(receiver);
+            for a in args {
+                f(a);
+            }
+        }
         Expr::ArrayToSorted { array, comparator } => {
             f(array);
             if let Some(c) = comparator {

--- a/crates/perry-runtime/src/array/generic.rs
+++ b/crates/perry-runtime/src/array/generic.rs
@@ -1,0 +1,763 @@
+//! Generic `Array.prototype` methods over *array-like* receivers (#4597).
+//!
+//! ECMA-262 §23.1.3 specifies each `Array.prototype` method as operating on
+//! `O = ToObject(this)` with `len = LengthOfArrayLike(O)` and indexed
+//! `Get(O, k)` / `HasProperty(O, k)` — i.e. the algorithms are *generic* over
+//! any object that exposes a `length` and indexed properties (plain objects,
+//! `arguments`, functions, strings, typed arrays …), not just genuine
+//! `Array` exotic objects.
+//!
+//! Perry's primary (hot) array methods in the sibling modules are specialised
+//! to a real `ArrayHeader` receiver for speed. Those paths are untouched. The
+//! functions here are reached *only* from the explicit
+//! `Array.prototype.<m>.call(receiver, …)` / `.apply(…)` (and bound-local)
+//! forms — lowered to `Expr::ArrayLikeMethod` in the HIR — where `receiver`
+//! may be any value. They operate on the **original** receiver value so that:
+//!   * the callback observes the original object as its 3rd argument
+//!     (`(value, index, O)`), per spec, rather than a materialised clone, and
+//!   * element reads are live `Get(O, k)` (data props, getters, function
+//!     expandos), and holes are honoured via `HasProperty(O, k)`.
+//!
+//! Receiver coercion mirrors `ToObject`:
+//!   * `undefined` / `null` → `TypeError`,
+//!   * a real array → fast direct element access,
+//!   * a string → length is the code-unit count, indices are 1-char strings,
+//!   * any other heap object/closure → `Get`/`HasProperty` via the polymorphic
+//!     object helpers,
+//!   * a bare number/boolean → boxed into its `Number`/`Boolean` wrapper object
+//!     (so inherited prototype `length`/indices are read and the callback's
+//!     3rd argument is `instanceof Number`/`Boolean`),
+//!   * a symbol/bigint → no indexed properties → an empty array-like (length 0).
+
+use super::*;
+use crate::closure::{js_closure_call3, ClosureHeader};
+use crate::value::{JSValue, TAG_HOLE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED};
+use std::ptr;
+
+#[inline(always)]
+fn undef() -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+#[inline(always)]
+fn boxed_bool(b: bool) -> f64 {
+    f64::from_bits(if b { TAG_TRUE } else { crate::value::TAG_FALSE })
+}
+
+#[inline(always)]
+fn nanbox_arr(arr: *mut ArrayHeader) -> f64 {
+    f64::from_bits(JSValue::pointer(arr as *const u8).bits())
+}
+
+#[inline(always)]
+fn top16(bits: u64) -> u64 {
+    bits >> 48
+}
+
+/// `ToObject(recv)` (ECMA-262 §7.1.18). `undefined` / `null` throw a
+/// `TypeError`; a bare number / boolean primitive is boxed into its wrapper
+/// object so the generic algorithms below (and the callback's 3rd argument)
+/// observe an object with the right prototype chain — e.g.
+/// `Array.prototype.map.call(false, fn)` must read length/indices inherited
+/// from `Boolean.prototype` and pass a `Boolean` wrapper to `fn`. Strings keep
+/// their dedicated code-unit path; symbols / bigints (no indexed properties)
+/// are returned as-is and read as an empty array-like.
+fn to_object(recv: f64) -> f64 {
+    let b = recv.to_bits();
+    if b == TAG_UNDEFINED || b == TAG_NULL {
+        let msg = b"Cannot convert undefined or null to object";
+        let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err = crate::error::js_typeerror_new(s);
+        crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+    }
+    // Already a heap object / array / closure, or a string (handled specially).
+    if top16(b) == 0x7FFD || is_string_value(b) {
+        return recv;
+    }
+    if b == TAG_TRUE || b == crate::value::TAG_FALSE {
+        return crate::builtins::js_boxed_boolean_new(recv);
+    }
+    // Numbers: real f64 values (`is_number`) and INT32-tagged small integers
+    // (0x7FFE), which `is_number` excludes because the tag sits in the
+    // string/special band.
+    if top16(b) == 0x7FFE || JSValue::from_bits(b).is_number() {
+        return crate::builtins::js_boxed_number_new(recv);
+    }
+    // Symbol / BigInt — no indexed properties; treated as an empty array-like.
+    recv
+}
+
+/// Validate `cb` is callable, returning its `ClosureHeader*` (throws a
+/// `TypeError` otherwise, reusing the array-method renderer for parity with the
+/// specialised paths).
+#[inline]
+fn callable(cb: f64) -> *const ClosureHeader {
+    crate::array::js_validate_array_map_callback(0, cb) as *const ClosureHeader
+}
+
+/// `ToIntegerOrInfinity` clamped to a non-negative `i64` length
+/// (`LengthOfArrayLike`'s `ToLength`).
+#[inline]
+fn to_length(v: f64) -> i64 {
+    if v.is_nan() {
+        return 0;
+    }
+    let n = v.trunc();
+    if n <= 0.0 {
+        0
+    } else if n > 9_007_199_254_740_991.0 {
+        9_007_199_254_740_991
+    } else {
+        n as i64
+    }
+}
+
+/// Genuine `ArrayHeader*` if `recv` is a real (or lazy) array, else null.
+///
+/// Objects and arrays share `POINTER_TAG`, so the GC-header `obj_type` byte —
+/// not `clean_arr_ptr` alone — must gate the array fast path: `clean_arr_ptr`
+/// accepts an object pointer whose leading `ObjectHeader` words happen to pass
+/// its `length <= capacity` bound, then `(*arr).length` / the element buffer
+/// read `field_count` / inline slots as garbage (see `normalize_array_receiver`).
+#[inline]
+fn as_real_array(recv: f64) -> *mut ArrayHeader {
+    let b = recv.to_bits();
+    if top16(b) != 0x7FFD {
+        return ptr::null_mut();
+    }
+    let raw = (b & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return ptr::null_mut();
+    }
+    let obj_type = unsafe {
+        let hdr = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*hdr).obj_type
+    };
+    if obj_type == crate::gc::GC_TYPE_ARRAY || obj_type == crate::gc::GC_TYPE_LAZY_ARRAY {
+        return clean_arr_ptr_mut(raw as *mut ArrayHeader);
+    }
+    ptr::null_mut()
+}
+
+#[inline]
+fn is_string_value(bits: u64) -> bool {
+    let t = top16(bits);
+    // Heap string (0x7FFF) or small-string-optimised inline string (0x7FF9).
+    t == 0x7FFF || t == 0x7FF9
+}
+
+/// `LengthOfArrayLike(ToObject(recv))`.
+/// Classification of a (non-array, non-string) `POINTER_TAG` receiver, used to
+/// pick a *safe* property-access path. Exotic GC cells (Date, Map, Set, BigInt,
+/// Error, …) must NOT be dereferenced as an `ObjectHeader` (that SIGBUSes) nor
+/// passed to `js_object_get_index_polymorphic` (whose final fallback reads them
+/// as an `ArrayHeader`). Typed arrays / buffers carry NO GC header, so they are
+/// detected via their registries *before* the GC-header byte is read.
+enum PtrKind {
+    /// Plain object or function/closure — `length`/index reads via the object
+    /// helpers (prototype-chain aware) are safe.
+    Object,
+    /// Typed array or buffer — `js_value_length_f64` /
+    /// `js_object_get_index_polymorphic` handle these by registry.
+    IndexedNative,
+    /// Date / Map / Set / Symbol / BigInt / … — no safe array-like access;
+    /// treated as an empty array-like.
+    Exotic,
+}
+
+fn classify_pointer(recv: f64) -> Option<PtrKind> {
+    let b = recv.to_bits();
+    if top16(b) != 0x7FFD {
+        return None;
+    }
+    let raw = (b & 0x0000_FFFF_FFFF_FFFF) as usize;
+    // Typed arrays / buffers are `std::alloc`-backed (no GC header) — probe
+    // their registries before any GC-header read.
+    if crate::buffer::is_registered_buffer(raw)
+        || crate::typedarray::lookup_typed_array_kind(raw).is_some()
+    {
+        return Some(PtrKind::IndexedNative);
+    }
+    if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return Some(PtrKind::Exotic);
+    }
+    let obj_type = unsafe {
+        let hdr = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*hdr).obj_type
+    };
+    if obj_type == crate::gc::GC_TYPE_OBJECT || obj_type == crate::gc::GC_TYPE_CLOSURE {
+        Some(PtrKind::Object)
+    } else {
+        Some(PtrKind::Exotic)
+    }
+}
+
+/// `LengthOfArrayLike(ToObject(recv))`.
+fn al_length(recv: f64) -> i64 {
+    let arr = as_real_array(recv);
+    if !arr.is_null() {
+        return unsafe { (*arr).length as i64 };
+    }
+    let b = recv.to_bits();
+    if is_string_value(b) {
+        let sh = crate::value::js_jsvalue_to_string(recv);
+        if sh.is_null() {
+            return 0;
+        }
+        return crate::string::js_string_length(sh) as i64;
+    }
+    match classify_pointer(recv) {
+        Some(PtrKind::Object) => {
+            // Plain object / function: read the `length` property (its absence
+            // ToLength-coerces to 0). Safe — guaranteed `GC_TYPE_OBJECT/CLOSURE`.
+            let key = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+            let len_val = crate::object::js_object_get_field_by_name_f64(
+                (b & 0x0000_FFFF_FFFF_FFFF) as *const crate::object::ObjectHeader,
+                key,
+            );
+            to_length(len_val)
+        }
+        // Typed arrays / buffers expose a real length via the safe dispatcher.
+        Some(PtrKind::IndexedNative) => to_length(crate::value::js_value_length_f64(recv)),
+        // Exotic cells / bare primitives → empty array-like.
+        Some(PtrKind::Exotic) | None => 0,
+    }
+}
+
+/// `Get(ToObject(recv), k)` (returns `undefined` for absent/out-of-range).
+fn al_get(recv: f64, k: i64) -> f64 {
+    let arr = as_real_array(recv);
+    if !arr.is_null() {
+        if k < 0 {
+            return undef();
+        }
+        return js_array_get_f64(arr, k as u32);
+    }
+    let b = recv.to_bits();
+    if is_string_value(b) {
+        return crate::object::js_object_get_index_polymorphic(b as i64, k as f64);
+    }
+    match classify_pointer(recv) {
+        // `js_object_get_index_polymorphic` is safe for objects/closures and
+        // for typed arrays / buffers (handled at its top).
+        Some(PtrKind::Object) | Some(PtrKind::IndexedNative) => {
+            crate::object::js_object_get_index_polymorphic(b as i64, k as f64)
+        }
+        Some(PtrKind::Exotic) | None => undef(),
+    }
+}
+
+/// `HasProperty(ToObject(recv), k)`.
+fn al_has(recv: f64, k: i64) -> bool {
+    if k < 0 {
+        return false;
+    }
+    let arr = as_real_array(recv);
+    if !arr.is_null() {
+        unsafe {
+            if k >= (*arr).length as i64 {
+                return false;
+            }
+            let el = *((arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64)
+                .add(k as usize);
+            return el.to_bits() != TAG_HOLE;
+        }
+    }
+    let b = recv.to_bits();
+    if is_string_value(b) {
+        return k < al_length(recv);
+    }
+    match classify_pointer(recv) {
+        Some(PtrKind::Object) => {
+            let s = k.to_string();
+            let key = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+            let key_val = f64::from_bits(JSValue::string_ptr(key).bits());
+            crate::object::js_object_has_property(recv, key_val).to_bits() == TAG_TRUE
+        }
+        // Typed arrays / buffers are dense over their length.
+        Some(PtrKind::IndexedNative) => k < al_length(recv),
+        Some(PtrKind::Exotic) | None => false,
+    }
+}
+
+/// RAII-ish guard binding the callback `this` (the optional `thisArg`) for the
+/// duration of a generic iteration, restoring the previous binding on drop.
+struct ThisGuard(f64);
+impl ThisGuard {
+    fn new(this_arg: f64) -> Self {
+        ThisGuard(crate::object::js_implicit_this_set(this_arg))
+    }
+}
+impl Drop for ThisGuard {
+    fn drop(&mut self) {
+        crate::object::js_implicit_this_set(self.0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Callback iteration methods. The callback receives `(value, index, O)` with
+// `O` the *original* receiver value; `this_arg` binds the callback's `this`.
+// ---------------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_forEach(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let _g = ThisGuard::new(this_arg);
+    for k in 0..len {
+        if !al_has(recv, k) {
+            continue;
+        }
+        let v = al_get(recv, k);
+        js_closure_call3(cb, v, k as f64, recv);
+    }
+    undef()
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_map(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let result = js_array_alloc_with_length(len.max(0) as u32);
+    let elems = unsafe { (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64 };
+    let _g = ThisGuard::new(this_arg);
+    for k in 0..len {
+        if !al_has(recv, k) {
+            continue; // preserve holes
+        }
+        let v = al_get(recv, k);
+        let mapped = js_closure_call3(cb, v, k as f64, recv);
+        unsafe {
+            ptr::write(elems.add(k as usize), mapped);
+            note_array_slot(result, k as usize, mapped.to_bits());
+        }
+    }
+    nanbox_arr(result)
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_filter(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let mut result = js_array_alloc(0);
+    let _g = ThisGuard::new(this_arg);
+    for k in 0..len {
+        if !al_has(recv, k) {
+            continue;
+        }
+        let v = al_get(recv, k);
+        let keep = js_closure_call3(cb, v, k as f64, recv);
+        if crate::value::js_is_truthy(keep) != 0 {
+            result = js_array_push_f64(result, v);
+        }
+    }
+    nanbox_arr(result)
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_some(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let _g = ThisGuard::new(this_arg);
+    for k in 0..len {
+        if !al_has(recv, k) {
+            continue;
+        }
+        let v = al_get(recv, k);
+        if crate::value::js_is_truthy(js_closure_call3(cb, v, k as f64, recv)) != 0 {
+            return boxed_bool(true);
+        }
+    }
+    boxed_bool(false)
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_every(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let _g = ThisGuard::new(this_arg);
+    for k in 0..len {
+        if !al_has(recv, k) {
+            continue;
+        }
+        let v = al_get(recv, k);
+        if crate::value::js_is_truthy(js_closure_call3(cb, v, k as f64, recv)) == 0 {
+            return boxed_bool(false);
+        }
+    }
+    boxed_bool(true)
+}
+
+// find / findIndex / findLast / findLastIndex do NOT skip holes (spec uses
+// Get, treating absent as undefined).
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_find(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let _g = ThisGuard::new(this_arg);
+    for k in 0..len {
+        let v = al_get(recv, k);
+        if crate::value::js_is_truthy(js_closure_call3(cb, v, k as f64, recv)) != 0 {
+            return v;
+        }
+    }
+    undef()
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_findIndex(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let _g = ThisGuard::new(this_arg);
+    for k in 0..len {
+        let v = al_get(recv, k);
+        if crate::value::js_is_truthy(js_closure_call3(cb, v, k as f64, recv)) != 0 {
+            return k as f64;
+        }
+    }
+    -1.0
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_findLast(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let _g = ThisGuard::new(this_arg);
+    let mut k = len - 1;
+    while k >= 0 {
+        let v = al_get(recv, k);
+        if crate::value::js_is_truthy(js_closure_call3(cb, v, k as f64, recv)) != 0 {
+            return v;
+        }
+        k -= 1;
+    }
+    undef()
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_findLastIndex(recv: f64, cb: f64, this_arg: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let _g = ThisGuard::new(this_arg);
+    let mut k = len - 1;
+    while k >= 0 {
+        let v = al_get(recv, k);
+        if crate::value::js_is_truthy(js_closure_call3(cb, v, k as f64, recv)) != 0 {
+            return k as f64;
+        }
+        k -= 1;
+    }
+    -1.0
+}
+
+// ---------------------------------------------------------------------------
+// reduce / reduceRight — accumulator, optional initial value.
+// ---------------------------------------------------------------------------
+
+fn throw_reduce_empty() -> ! {
+    let msg = b"Reduce of empty array with no initial value";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_reduce(recv: f64, cb: f64, has_init: i32, init: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let mut acc = init;
+    let mut k = 0i64;
+    if has_init == 0 {
+        // Seed from the first present element.
+        loop {
+            if k >= len {
+                throw_reduce_empty();
+            }
+            if al_has(recv, k) {
+                acc = al_get(recv, k);
+                k += 1;
+                break;
+            }
+            k += 1;
+        }
+    }
+    while k < len {
+        if al_has(recv, k) {
+            let v = al_get(recv, k);
+            acc = crate::closure::js_closure_call4(cb, acc, v, k as f64, recv);
+        }
+        k += 1;
+    }
+    acc
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_reduceRight(recv: f64, cb: f64, has_init: i32, init: f64) -> f64 {
+    let recv = to_object(recv);
+    let cb = callable(cb);
+    let len = al_length(recv);
+    let mut acc = init;
+    let mut k = len - 1;
+    if has_init == 0 {
+        loop {
+            if k < 0 {
+                throw_reduce_empty();
+            }
+            if al_has(recv, k) {
+                acc = al_get(recv, k);
+                k -= 1;
+                break;
+            }
+            k -= 1;
+        }
+    }
+    while k >= 0 {
+        if al_has(recv, k) {
+            let v = al_get(recv, k);
+            acc = crate::closure::js_closure_call4(cb, acc, v, k as f64, recv);
+        }
+        k -= 1;
+    }
+    acc
+}
+
+// ---------------------------------------------------------------------------
+// Search methods.
+// ---------------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_indexOf(recv: f64, value: f64, from: f64, has_from: i32) -> f64 {
+    let recv = to_object(recv);
+    let len = al_length(recv);
+    if len == 0 {
+        return -1.0;
+    }
+    // ToIntegerOrInfinity(fromIndex), clamped.
+    let mut start = if has_from == 0 {
+        0
+    } else {
+        let n = if from.is_nan() { 0.0 } else { from.trunc() };
+        if n >= len as f64 {
+            return -1.0;
+        } else if n >= 0.0 {
+            n as i64
+        } else if n >= -(len as f64) {
+            len + n as i64
+        } else {
+            0
+        }
+    };
+    if start < 0 {
+        start = 0;
+    }
+    for k in start..len {
+        if !al_has(recv, k) {
+            continue;
+        }
+        let v = al_get(recv, k);
+        if crate::value::js_jsvalue_equals(v, value) == 1 {
+            return k as f64;
+        }
+    }
+    -1.0
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_lastIndexOf(recv: f64, value: f64, from: f64, has_from: i32) -> f64 {
+    let recv = to_object(recv);
+    let len = al_length(recv);
+    if len == 0 {
+        return -1.0;
+    }
+    let mut start = if has_from == 0 {
+        len - 1
+    } else {
+        let n = if from.is_nan() { 0.0 } else { from.trunc() };
+        if n >= 0.0 {
+            (n as i64).min(len - 1)
+        } else if n >= -(len as f64) {
+            len + n as i64
+        } else {
+            return -1.0;
+        }
+    };
+    while start >= 0 {
+        if al_has(recv, start) {
+            let v = al_get(recv, start);
+            if crate::value::js_jsvalue_equals(v, value) == 1 {
+                return start as f64;
+            }
+        }
+        start -= 1;
+    }
+    -1.0
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_includes(recv: f64, value: f64, from: f64, has_from: i32) -> f64 {
+    let recv = to_object(recv);
+    let len = al_length(recv);
+    if len == 0 {
+        return boxed_bool(false);
+    }
+    let mut start = if has_from == 0 {
+        0
+    } else {
+        let n = if from.is_nan() { 0.0 } else { from.trunc() };
+        if n >= len as f64 {
+            return boxed_bool(false);
+        } else if n >= 0.0 {
+            n as i64
+        } else if n >= -(len as f64) {
+            len + n as i64
+        } else {
+            0
+        }
+    };
+    if start < 0 {
+        start = 0;
+    }
+    // includes does NOT skip holes — absent indices read as undefined.
+    for k in start..len {
+        let v = al_get(recv, k);
+        if crate::value::js_jsvalue_same_value_zero(v, value) == 1 {
+            return boxed_bool(true);
+        }
+    }
+    boxed_bool(false)
+}
+
+// ---------------------------------------------------------------------------
+// at / join / slice — no callback identity concerns; materialise where it
+// keeps the implementation simple (slice/join build fresh results anyway).
+// ---------------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_at(recv: f64, index: f64) -> f64 {
+    let recv = to_object(recv);
+    let len = al_length(recv);
+    let n = if index.is_nan() { 0.0 } else { index.trunc() };
+    let mut k = n as i64;
+    if k < 0 {
+        k += len;
+    }
+    if k < 0 || k >= len {
+        return undef();
+    }
+    al_get(recv, k)
+}
+
+/// Materialise `recv` into a fresh real array (holes preserved as `TAG_HOLE`),
+/// for the delegating `join` / `slice` paths.
+fn materialize(recv: f64) -> *mut ArrayHeader {
+    let len = al_length(recv);
+    let arr = js_array_alloc_with_length(len.max(0) as u32);
+    let elems = unsafe { (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64 };
+    for k in 0..len {
+        if !al_has(recv, k) {
+            continue; // leave the hole
+        }
+        let v = al_get(recv, k);
+        unsafe {
+            ptr::write(elems.add(k as usize), v);
+            note_array_slot(arr, k as usize, v.to_bits());
+        }
+    }
+    arr
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_join(recv: f64, sep: f64) -> f64 {
+    let recv = to_object(recv);
+    let arr = materialize(recv);
+    let sep_ptr = if sep.to_bits() == TAG_UNDEFINED {
+        ptr::null()
+    } else {
+        crate::value::js_jsvalue_to_string(sep) as *const crate::string::StringHeader
+    };
+    let s = crate::array::js_array_join(arr, sep_ptr);
+    f64::from_bits(JSValue::string_ptr(s).bits())
+}
+
+#[no_mangle]
+pub extern "C" fn js_arraylike_slice(
+    recv: f64,
+    start: f64,
+    has_start: i32,
+    end: f64,
+    has_end: i32,
+) -> f64 {
+    let recv = to_object(recv);
+    let arr = materialize(recv);
+    let len = unsafe { (*arr).length as i64 };
+    let s = if has_start == 0 {
+        0
+    } else {
+        clamp_index(start, len)
+    };
+    let e = if has_end == 0 {
+        len
+    } else {
+        clamp_index(end, len)
+    };
+    let result = js_array_slice(arr, s as i32, e as i32);
+    nanbox_arr(result)
+}
+
+/// ECMA-262 relative-index clamp used by `slice` (negative counts from the end,
+/// `NaN`/`-Infinity` → 0, `+Infinity` → len).
+fn clamp_index(v: f64, len: i64) -> i64 {
+    let n = if v.is_nan() { 0.0 } else { v.trunc() };
+    if n < 0.0 {
+        let r = len + n as i64;
+        r.max(0)
+    } else if n > len as f64 {
+        len
+    } else {
+        n as i64
+    }
+}
+
+// Keep the generic entry points anchored against dead-strip in the default
+// (codegen-only reference) compile path.
+// Keep the generic entry points anchored against dead-strip in the default
+// (codegen-only reference) compile path (see #3320 — `#[no_mangle]` alone is
+// not enough once the bitcode is re-linked).
+#[used]
+static KEEP_ARRAYLIKE_CB: [extern "C" fn(f64, f64, f64) -> f64; 9] = [
+    js_arraylike_forEach,
+    js_arraylike_map,
+    js_arraylike_filter,
+    js_arraylike_some,
+    js_arraylike_every,
+    js_arraylike_find,
+    js_arraylike_findIndex,
+    js_arraylike_findLast,
+    js_arraylike_findLastIndex,
+];
+#[used]
+static KEEP_ARRAYLIKE_REDUCE: [extern "C" fn(f64, f64, i32, f64) -> f64; 2] =
+    [js_arraylike_reduce, js_arraylike_reduceRight];
+#[used]
+static KEEP_ARRAYLIKE_SEARCH: [extern "C" fn(f64, f64, f64, i32) -> f64; 3] = [
+    js_arraylike_indexOf,
+    js_arraylike_lastIndexOf,
+    js_arraylike_includes,
+];
+#[used]
+static KEEP_ARRAYLIKE_AT: extern "C" fn(f64, f64) -> f64 = js_arraylike_at;
+#[used]
+static KEEP_ARRAYLIKE_JOIN: extern "C" fn(f64, f64) -> f64 = js_arraylike_join;
+#[used]
+static KEEP_ARRAYLIKE_SLICE: extern "C" fn(f64, f64, i32, f64, i32) -> f64 = js_arraylike_slice;

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -3,6 +3,7 @@ mod alloc;
 mod concat_reverse;
 mod flat_clone;
 mod from_concat;
+mod generic;
 mod header;
 mod immutable;
 mod indexing;
@@ -33,6 +34,13 @@ pub use self::flat_clone::{
     js_array_values,
 };
 pub use self::from_concat::{js_array_concat_variadic, js_array_from_mapped, js_array_from_value};
+pub use self::generic::{
+    js_arraylike_at, js_arraylike_every, js_arraylike_filter, js_arraylike_find,
+    js_arraylike_findIndex, js_arraylike_findLast, js_arraylike_findLastIndex,
+    js_arraylike_forEach, js_arraylike_includes, js_arraylike_indexOf, js_arraylike_join,
+    js_arraylike_lastIndexOf, js_arraylike_map, js_arraylike_reduce, js_arraylike_reduceRight,
+    js_arraylike_slice, js_arraylike_some,
+};
 pub(crate) use self::header::{array_has_arguments_object_flag, mark_array_as_arguments_object};
 pub use self::header::{
     js_array_clear_numeric_layout, js_array_is_numeric_f64_layout, js_array_mark_arguments_object,

--- a/test-files/test_gap_4597_arraylike_generic_methods.ts
+++ b/test-files/test_gap_4597_arraylike_generic_methods.ts
@@ -1,0 +1,68 @@
+// #4597: Array.prototype methods generic over array-like receivers.
+// Each Array.prototype method begins with O = ToObject(this); len =
+// LengthOfArrayLike(O); then indexed Get/HasProperty on O. The explicit
+// `Array.prototype.<m>.call(receiver, ...)` form must run the Array algorithm
+// on a generic array-like receiver — a plain object, a function (length =
+// arity, expando indices), a string (code-unit indices), or a primitive
+// (boxed via ToObject) — preserving receiver identity for the callback's 3rd
+// argument and honouring holes via HasProperty.
+
+// --- plain array-like object ---
+console.log(Array.prototype.map.call({ length: 3, 0: "a", 1: "b", 2: "c" }, (x: any, i: number) => x + i).join("|")); // a0|b1|c2
+console.log(Array.prototype.filter.call({ length: 3, 0: 1, 2: 3 }, () => true).join(",")); // 1,3 (hole at 1 skipped)
+console.log(Array.prototype.reduce.call({ length: 3, 0: 1, 1: 2, 2: 3 }, (s: any, x: any) => s + x, 10)); // 16
+console.log(Array.prototype.indexOf.call({ length: 2, 0: "a", 1: "b" }, "b")); // 1
+console.log(Array.prototype.join.call({ length: 2, 0: "a", 1: "b" }, "-")); // a-b
+
+// --- callback observes the ORIGINAL receiver as its 3rd argument ---
+(globalThis as any).Math.length = 1;
+(globalThis as any).Math[0] = 1;
+console.log(Array.prototype.map.call(Math, (_v: any, _i: any, obj: any) => Object.prototype.toString.call(obj))[0]); // [object Math]
+
+// --- function receiver: length = arity, expando indices ---
+function fn(a: any, b: any) {
+  return a + b;
+}
+(fn as any)[1] = true;
+console.log(Array.prototype.indexOf.call(fn, true)); // 1
+
+// --- string receiver ---
+console.log(Array.prototype.map.call("abc", (c: string) => c.toUpperCase()).join("")); // ABC
+console.log(Array.prototype.indexOf.call("abc", "c")); // 2
+
+// --- holes are skipped by iterators, preserved by map ---
+console.log(Array.prototype.map.call({ length: 3, 0: "a", 2: "c" }, (x: any) => x + "!").join(",")); // a!,,c!
+
+// --- thisArg binds the callback's `this` ---
+console.log(
+  Array.prototype.map
+    .call([1, 2, 3], function (this: any, x: number) {
+      return x * this.mul;
+    }, { mul: 10 })
+    .join(","),
+); // 10,20,30
+
+// --- primitive number receiver -> empty array-like ---
+console.log(Array.prototype.map.call(5, (x: any) => x).length); // 0
+
+// --- search / find family ---
+console.log(Array.prototype.findLastIndex.call({ length: 3, 0: 1, 1: 2, 2: 3 }, (x: any) => x < 3)); // 1
+console.log(Array.prototype.at.call({ length: 3, 0: "a", 1: "b", 2: "c" }, -1)); // c
+console.log(Array.prototype.lastIndexOf.call([1, 2, 1, 2], 2)); // 3
+console.log(Array.prototype.slice.call({ length: 4, 0: "a", 1: "b", 2: "c", 3: "d" }, -2).join(",")); // c,d
+
+// --- nullish receiver throws TypeError ---
+try {
+  Array.prototype.forEach.call(null, () => {});
+  console.log("no throw");
+} catch (e: any) {
+  console.log(e instanceof TypeError); // true
+}
+
+// --- non-callable callback throws TypeError ---
+try {
+  Array.prototype.map.call({ length: 1, 0: 1 }, undefined as any);
+  console.log("no throw");
+} catch (e: any) {
+  console.log(e instanceof TypeError); // true
+}


### PR DESCRIPTION
## Summary

Per ECMA-262 §23.1.3 each `Array.prototype` method begins with `O = ToObject(this)`, `len = LengthOfArrayLike(O)`, then indexed `Get`/`HasProperty` on `O` — the algorithms are **generic over any array-like** (plain objects, functions, strings, typed arrays, primitives), not just real `Array` exotics.

The explicit `Array.prototype.<m>.call/apply(receiver, …)` (and bound-local `const m = [].map; m.call(…)`) forms previously **materialized** the receiver into a fresh array. That lost receiver identity (the callback's spec-mandated 3rd argument) and didn't handle function/string/primitive receivers — failing ~127 test262 `built-ins/Array/prototype` cases (`call-with-*` / array-like).

### Approach
A shared runtime engine (`perry-runtime/src/array/generic.rs`) operates on the **original receiver value**: `ToObject` (incl. Number/Boolean boxing) + `LengthOfArrayLike` + indexed `Get`/`HasProperty`, with a **real-array fast path** and an object/function/string slow path via the existing polymorphic helpers. It covers the read-only/returning methods — `forEach, map, filter, some, every, find, findIndex, findLast, findLastIndex, reduce, reduceRight, indexOf, lastIndexOf, includes, at, join, slice` — passing the original receiver as the callback's 3rd argument, binding `thisArg`, and honouring holes via `HasProperty`.

A new `Expr::ArrayLikeMethod` HIR variant carries the raw receiver value to the `js_arraylike_*` entry points; `try_arraylike_receiver_method` routes the `.call`/`.apply`/bound-local forms there instead of materializing. **The hot member path (`arr.map(fn)` → `js_array_map`) is physically untouched** — zero fast-path regression risk.

`classify_pointer` gates property access strictly by GC type so exotic cells (Date/Map/Set/RegExp) are never dereferenced as objects (would SIGBUS); typed-arrays/buffers (no GC header) are detected by registry first.

### Repro (now matches Node)
```js
Array.prototype.map.call(Math, (_v,_i,o) => Object.prototype.toString.call(o))[0] // "[object Math]"
Array.prototype.indexOf.call(function f(a,b){}, true)  // function receiver: length=arity, expandos
Array.prototype.join.call({length:2,0:'a',1:'b'})      // "a,b"
Array.prototype.map.call("abc", c => c.toUpperCase())  // ["A","B","C"]
```

### Out of scope (follow-up under #4597)
Mutators (`copyWithin/fill/reverse/sort/splice/push/pop/shift/unshift/with`) and `concat` receiver-spreadability need write-back to the receiver object and are left for a follow-up.

### Validation
Byte-identical to `node --experimental-strip-types` across:
- new `test-files/test_gap_4597_arraylike_generic_methods.ts`
- hot-path + generic **sanity** (no regression)
- 20 edge cases (object/function/string/primitive/**exotic** receivers, holes, callback identity, `thisArg`, find family, slice/at/lastIndexOf, empty, TypeErrors)
- `.apply` + bound-local forms

Re-running the **804 baseline-failing** `built-ins/Array/prototype` test262 cases: **127 now pass, 0 regressions** in the validated forms — concentrated in `every (20), reduceRight (20), filter (19), map (17), reduce (17), forEach (16), lastIndexOf (10), indexOf (8)`.

> Maintainer note: version bump + CHANGELOG intentionally omitted per the worktree/contributor convention — please fold those in at merge.