### PR TITLE
feat(ui-windows): modern DWM chrome (rounded corners + theme-aware title bar) by default

### DIFF
--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -227,6 +227,11 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
             // Attach any pending menu bar now that the window exists
             crate::menu::attach_pending_menubar(hwnd);
 
+            // Apply modern Win11 chrome by default (rounded corners +
+            // theme-aware title bar) before the window is shown — issue #4681.
+            // No-op / ignored on Windows 10 and earlier.
+            crate::dwm::apply_default_window_chrome(hwnd);
+
             APPS.with(|apps| {
                 let mut apps = apps.borrow_mut();
                 apps.push(AppEntry {
@@ -718,23 +723,8 @@ pub fn app_set_frameless(app_handle: i64, value: f64) {
                         SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER,
                     );
 
-                    // Request rounded corners on Windows 11+ via DWM
-                    // DWMWA_WINDOW_CORNER_PREFERENCE = 33, DWMWCP_ROUND = 2
-                    extern "system" {
-                        fn DwmSetWindowAttribute(
-                            hwnd: isize,
-                            attr: u32,
-                            value: *const i32,
-                            size: u32,
-                        ) -> i32;
-                    }
-                    let corner_pref: i32 = 2; // DWMWCP_ROUND
-                    let _ = DwmSetWindowAttribute(
-                        hwnd.0 as isize,
-                        33, // DWMWA_WINDOW_CORNER_PREFERENCE
-                        &corner_pref,
-                        std::mem::size_of::<i32>() as u32,
-                    );
+                    // Request rounded corners on Windows 11+ via DWM.
+                    crate::dwm::apply_rounded_corners(hwnd);
                 }
             }
         });
@@ -830,30 +820,10 @@ pub fn app_set_vibrancy(app_handle: i64, value_ptr: *const u8) {
                         _ => 3, // Acrylic default
                     };
 
-                    // DwmSetWindowAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdrop, sizeof)
-                    extern "system" {
-                        fn DwmSetWindowAttribute(
-                            hwnd: isize,
-                            attr: u32,
-                            value: *const i32,
-                            size: u32,
-                        ) -> i32;
-                    }
-                    let _ = DwmSetWindowAttribute(
-                        hwnd.0 as isize,
-                        38, // DWMWA_SYSTEMBACKDROP_TYPE
-                        &backdrop_type,
-                        std::mem::size_of::<i32>() as u32,
-                    );
+                    crate::dwm::set_backdrop(hwnd, backdrop_type);
 
                     // Also enable dark mode title bar for better blending
-                    let use_dark: i32 = 1;
-                    let _ = DwmSetWindowAttribute(
-                        hwnd.0 as isize,
-                        20, // DWMWA_USE_IMMERSIVE_DARK_MODE
-                        &use_dark,
-                        std::mem::size_of::<i32>() as u32,
-                    );
+                    crate::dwm::set_attr_i32(hwnd, 20 /* DWMWA_USE_IMMERSIVE_DARK_MODE */, 1);
 
                     // Extend client area into frame for borderless mica/acrylic
                     extern "system" {

--- a/crates/perry-ui-windows/src/dwm.rs
+++ b/crates/perry-ui-windows/src/dwm.rs
@@ -1,0 +1,81 @@
+//! Modern window chrome via the Desktop Window Manager (DWM).
+//!
+//! Win32's default frame looks dated (issue #4681 / discussion #3486). DWM lets
+//! us request Windows 11 Fluent chrome — rounded corners and a theme-aware
+//! (light/dark) title bar — without switching off the Win32 backend. This is
+//! applied by default at window creation in `app::app_create` and
+//! `window::create`. On Windows 10 and earlier the unsupported attributes
+//! return `E_INVALIDARG` and are silently ignored, so the same call is safe on
+//! every supported Windows version.
+//!
+//! `dwmapi.lib` is already on the final link line (see
+//! `crates/perry/src/commands/compile/link/mod.rs`), and `dwmapi.dll` has
+//! shipped since Vista, so we bind `DwmSetWindowAttribute` directly — unlike
+//! the Win10-only DPI APIs in `dpi_compat`, this import resolves at load time
+//! on every supported Windows version.
+//!
+//! This whole module is `#[cfg(target_os = "windows")]`-gated at the `mod`
+//! declaration in `lib.rs`.
+
+use windows::Win32::Foundation::HWND;
+
+// DWM window-attribute identifiers (dwmapi.h). Several of these aren't exposed
+// by the `windows` crate at our pinned `0.58`, so we use the raw numeric
+// values (matching the previously-inline `extern` blocks in `app.rs`).
+const DWMWA_USE_IMMERSIVE_DARK_MODE: u32 = 20;
+const DWMWA_WINDOW_CORNER_PREFERENCE: u32 = 33;
+const DWMWA_SYSTEMBACKDROP_TYPE: u32 = 38;
+
+/// `DWM_WINDOW_CORNER_PREFERENCE::DWMWCP_ROUND` — round the window corners
+/// (full radius) on Windows 11.
+const DWMWCP_ROUND: i32 = 2;
+
+extern "system" {
+    fn DwmSetWindowAttribute(hwnd: isize, attr: u32, value: *const i32, size: u32) -> i32;
+}
+
+/// Set a single `BOOL`/`DWORD`-valued DWM attribute. Failures are ignored —
+/// versions of Windows that don't recognize `attr` return `E_INVALIDARG`, and
+/// the request being unsupported is not an error worth surfacing for cosmetic
+/// chrome.
+pub fn set_attr_i32(hwnd: HWND, attr: u32, value: i32) {
+    unsafe {
+        let _ = DwmSetWindowAttribute(
+            hwnd.0 as isize,
+            attr,
+            &value,
+            std::mem::size_of::<i32>() as u32,
+        );
+    }
+}
+
+/// Match the title bar to the current system *app* theme (light/dark). Reuses
+/// the same `Personalize\AppsUseLightTheme` probe as `system::is_dark_mode`.
+pub fn apply_titlebar_theme(hwnd: HWND) {
+    let dark = crate::system::is_dark_mode() != 0;
+    set_attr_i32(
+        hwnd,
+        DWMWA_USE_IMMERSIVE_DARK_MODE,
+        if dark { 1 } else { 0 },
+    );
+}
+
+/// Request rounded corners (Windows 11). No-op on Windows 10 and earlier.
+pub fn apply_rounded_corners(hwnd: HWND) {
+    set_attr_i32(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND);
+}
+
+/// The default Fluent-leaning chrome Perry applies to every top-level window:
+/// rounded corners + a theme-aware title bar. Called once at window creation,
+/// before the window is shown.
+pub fn apply_default_window_chrome(hwnd: HWND) {
+    apply_rounded_corners(hwnd);
+    apply_titlebar_theme(hwnd);
+}
+
+/// Set the system backdrop material via `DWMWA_SYSTEMBACKDROP_TYPE`
+/// (`0`=Auto, `1`=None, `2`=Mica, `3`=Acrylic, `4`=MicaAlt). Windows 11 22H2+;
+/// ignored on older systems. Used by the `app.setVibrancy` opt-in path.
+pub fn set_backdrop(hwnd: HWND, backdrop: i32) {
+    set_attr_i32(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, backdrop);
+}

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -4,6 +4,8 @@ pub mod audio_playback;
 pub mod deeplinks_stub;
 #[cfg(target_os = "windows")]
 pub mod dpi_compat;
+#[cfg(target_os = "windows")]
+pub mod dwm;
 pub mod issue_552_stub;
 #[cfg(target_os = "windows")]
 pub mod keyboard;

--- a/crates/perry-ui-windows/src/window.rs
+++ b/crates/perry-ui-windows/src/window.rs
@@ -148,6 +148,11 @@ pub fn create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
             )
             .unwrap();
 
+            // Modern Win11 chrome by default (rounded corners + theme-aware
+            // title bar) to match the main app window — issue #4681. Ignored
+            // on Windows 10 and earlier.
+            crate::dwm::apply_default_window_chrome(hwnd);
+
             HWND_TO_WINDOW.with(|m| m.borrow_mut().insert(hwnd.0 as isize, id));
             WINDOWS.with(|w| w.borrow_mut().insert(id, hwnd));
         }


### PR DESCRIPTION
## What

First slice of #4681 (Win32 Fluent polish). Win32 top-level windows shipped with square corners and a title bar that ignored the system light/dark theme — the dated look called out in discussion #3486. This applies Windows 11 Fluent chrome **by default** at window creation, without leaving the Win32 backend.

## Changes

- **New `crate::dwm` module** wrapping `DwmSetWindowAttribute`. `dwmapi.lib` is already on the final link line and `dwmapi.dll` ships since Vista, so the import resolves on every supported Windows version (unlike the Win10-only DPI APIs in `dpi_compat`). Helpers: `apply_rounded_corners`, `apply_titlebar_theme`, `apply_default_window_chrome`, `set_backdrop`, `set_attr_i32`.
- **`app::app_create` and `window::create`** now call `apply_default_window_chrome` (rounded corners + theme-aware title bar) before the window is shown. Unsupported attributes return `E_INVALIDARG` on Windows 10 and earlier and are ignored, so the call is safe everywhere.
- **Refactor**: the duplicated inline `DwmSetWindowAttribute` `extern` blocks in `app_set_frameless` / `app_set_vibrancy` now route through the shared helper.

Title-bar theme reuses the existing `Personalize\AppsUseLightTheme` probe from `system::is_dark_mode`.

## Scope / what's deferred (still tracked by #4681)

This PR is the contained, low-risk piece — frame chrome only. The rest of #4681 is intentionally left for follow-ups that need a Windows host to verify:

- **comctl32 v6 visual-styles manifest** — the biggest win for the "40-year-old controls" complaint (themed buttons/lists). Requires embedding an `RT_MANIFEST` resource in the link pipeline (native `rc.exe`/`link /MANIFEST` + the cross-from-mac `lld-link` path), which can't be verified on a non-Windows host.
- Mica/Acrylic backdrop **by default** (currently opt-in via `app.setVibrancy`) — needs care so it doesn't break existing GDI-painted backgrounds.
- Finishing the stubbed border/opacity/shadow apply paths (#210/#230) and DPI crispness.

## Testing

`perry-ui-windows` is Windows-only; all changes are `#[cfg(target_os = "windows")]`-gated. Could not compile-check the MSVC target on this macOS host (a transitive C dep — `mimalloc-sys` — needs the Windows CRT headers). Code mirrors the existing `DwmSetWindowAttribute` extern signature and `HWND.0 as isize` usage already in `app.rs`. **Needs a Windows-runner CI pass / manual smoke before merge** to confirm rounded corners + dark title bar render on the ToDo sample.

Refs #4681, discussion #3486.