### PR TITLE
feat(compile): embed comctl32 v6 manifest so Windows UI apps get themed controls

### DIFF
--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -46,6 +46,13 @@ use link_cache::prepare_link_cache_status;
 pub(super) use link_cache::{write_link_cache_manifest, LinkCacheStatus};
 pub use platform_cmd::select_linker_command;
 
+/// Win32 application manifest embedded into UI executables. Declares the
+/// comctl32 v6 (`Microsoft.Windows.Common-Controls`) side-by-side dependency
+/// so common controls render with visual styles instead of the unthemed
+/// classic style, plus an `asInvoker` execution level. See issue #4681 /
+/// discussion #3486, and the embed site in the `is_windows` link branch.
+pub(super) const WINDOWS_APP_MANIFEST: &str = include_str!("windows_app.manifest");
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NativeBackendLinkMetadata {
     backend: super::NativeBackend,
@@ -919,6 +926,40 @@ pub(super) fn build_and_run_link(
             // through perry-ui-windows's `staticlib` crate-type to perry's final
             // link line. Closes #732.
             .arg("winhttp.lib");
+
+        // Embed a comctl32 v6 application manifest into UI executables so
+        // common controls render with visual styles (Fluent look) instead of
+        // the unthemed Win95/classic style. Without the side-by-side
+        // `Microsoft.Windows.Common-Controls` v6 dependency the process binds
+        // comctl32 v5 and every button/list/edit box looks decades old —
+        // issue #4681 / discussion #3486. Gated on `needs_ui` so console-only
+        // binaries stay manifest-free.
+        //
+        // Both link.exe and lld-link embed `/MANIFESTINPUT:` content via
+        // `/MANIFEST:EMBED` with no external `mt.exe`/`rc.exe`. `/MANIFESTUAC:NO`
+        // suppresses the linker's auto-generated UAC fragment so it can't
+        // produce a second `trustInfo` element alongside the one in our input
+        // manifest (which already declares `asInvoker`).
+        if ctx.needs_ui {
+            let manifest_path = std::env::temp_dir().join(format!(
+                "perry_app_manifest_{}.manifest",
+                std::process::id()
+            ));
+            match std::fs::write(&manifest_path, WINDOWS_APP_MANIFEST) {
+                Ok(()) => {
+                    cmd.arg("/MANIFEST:EMBED")
+                        .arg("/MANIFESTUAC:NO")
+                        .arg(format!("/MANIFESTINPUT:{}", manifest_path.display()));
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not write Windows application manifest to {} ({e}); \
+                         common controls will render in the unthemed classic style.",
+                        manifest_path.display()
+                    );
+                }
+            }
+        }
     } else {
         // macOS frameworks for runtime (sysinfo, etc.) and V8.
         // Gate on `!is_harmonyos` so the macOS host doesn't leak its

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -41,17 +41,12 @@ use super::{
 
 mod link_cache;
 mod platform_cmd;
+mod windows_link;
 
 use link_cache::prepare_link_cache_status;
 pub(super) use link_cache::{write_link_cache_manifest, LinkCacheStatus};
 pub use platform_cmd::select_linker_command;
-
-/// Win32 application manifest embedded into UI executables. Declares the
-/// comctl32 v6 (`Microsoft.Windows.Common-Controls`) side-by-side dependency
-/// so common controls render with visual styles instead of the unthemed
-/// classic style, plus an `asInvoker` execution level. See issue #4681 /
-/// discussion #3486, and the embed site in the `is_windows` link branch.
-pub(super) const WINDOWS_APP_MANIFEST: &str = include_str!("windows_app.manifest");
+pub(super) use windows_link::WINDOWS_APP_MANIFEST; // guarded by windows_link_tests
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NativeBackendLinkMetadata {
@@ -888,78 +883,8 @@ pub(super) fn build_and_run_link(
             cmd.arg("-lssl").arg("-lcrypto");
         }
     } else if is_windows {
-        // Windows system libraries
-        cmd.arg("user32.lib")
-            .arg("gdi32.lib")
-            .arg("gdiplus.lib")
-            .arg("msimg32.lib")
-            .arg("kernel32.lib")
-            .arg("shell32.lib")
-            .arg("ole32.lib")
-            .arg("comctl32.lib")
-            .arg("advapi32.lib")
-            .arg("comdlg32.lib")
-            .arg("ws2_32.lib")
-            .arg("dwmapi.lib");
-        // MSVC CRT (dynamic) and additional Windows API libraries needed by the Rust runtime
-        cmd.arg("msvcrt.lib")
-            .arg("vcruntime.lib")
-            .arg("ucrt.lib")
-            .arg("bcrypt.lib")
-            .arg("ntdll.lib")
-            .arg("userenv.lib")
-            // secur32.lib exports `GetUserNameExW`, called by the `whoami`
-            // crate (transitively pulled in via `sqlx-mysql`/`sqlx-postgres`
-            // through `perry-stdlib`). Without it, every doc-test that
-            // touches stdlib fails on the Windows runner with
-            // `LNK2019: unresolved external symbol __imp_GetUserNameExW`.
-            // Closes #220.
-            .arg("secur32.lib")
-            .arg("oleaut32.lib")
-            .arg("propsys.lib")
-            .arg("runtimeobject.lib")
-            .arg("iphlpapi.lib")
-            // winhttp.lib — perry-ui-windows::widgets::image::fetch_url_blocking
-            // uses WinHttpOpen/Connect/OpenRequest/SendRequest/ReceiveResponse
-            // to fetch Image(url) bytes. The `windows` crate's `Win32_Networking_WinHttp`
-            // feature emits #[link] attrs in the rlib, but those don't propagate
-            // through perry-ui-windows's `staticlib` crate-type to perry's final
-            // link line. Closes #732.
-            .arg("winhttp.lib");
-
-        // Embed a comctl32 v6 application manifest into UI executables so
-        // common controls render with visual styles (Fluent look) instead of
-        // the unthemed Win95/classic style. Without the side-by-side
-        // `Microsoft.Windows.Common-Controls` v6 dependency the process binds
-        // comctl32 v5 and every button/list/edit box looks decades old —
-        // issue #4681 / discussion #3486. Gated on `needs_ui` so console-only
-        // binaries stay manifest-free.
-        //
-        // Both link.exe and lld-link embed `/MANIFESTINPUT:` content via
-        // `/MANIFEST:EMBED` with no external `mt.exe`/`rc.exe`. `/MANIFESTUAC:NO`
-        // suppresses the linker's auto-generated UAC fragment so it can't
-        // produce a second `trustInfo` element alongside the one in our input
-        // manifest (which already declares `asInvoker`).
-        if ctx.needs_ui {
-            let manifest_path = std::env::temp_dir().join(format!(
-                "perry_app_manifest_{}.manifest",
-                std::process::id()
-            ));
-            match std::fs::write(&manifest_path, WINDOWS_APP_MANIFEST) {
-                Ok(()) => {
-                    cmd.arg("/MANIFEST:EMBED")
-                        .arg("/MANIFESTUAC:NO")
-                        .arg(format!("/MANIFESTINPUT:{}", manifest_path.display()));
-                }
-                Err(e) => {
-                    eprintln!(
-                        "Warning: could not write Windows application manifest to {} ({e}); \
-                         common controls will render in the unthemed classic style.",
-                        manifest_path.display()
-                    );
-                }
-            }
-        }
+        windows_link::add_system_libs(&mut cmd);
+        windows_link::embed_app_manifest(&mut cmd, ctx.needs_ui);
     } else {
         // macOS frameworks for runtime (sysinfo, etc.) and V8.
         // Gate on `!is_harmonyos` so the macOS host doesn't leak its

--- a/crates/perry/src/commands/compile/link/windows_app.manifest
+++ b/crates/perry/src/commands/compile/link/windows_app.manifest
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type="win32" name="Perry.App" version="1.0.0.0" processorArchitecture="*"/>
+  <!--
+    comctl32 v6 dependency. Without this side-by-side assembly reference the
+    process loads comctl32 v5 and every common control (buttons, list views,
+    edit boxes, etc.) renders in the unthemed Win95/classic style regardless
+    of the OS theme. Activating v6 is what gives the Fluent/visual-styles look
+    on Windows 10/11. See issue #4681 / discussion #3486.
+  -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"/>
+    </dependentAssembly>
+  </dependency>
+  <!--
+    Run with the invoking user's token. Declaring asInvoker explicitly opts the
+    binary out of the installer-detection heuristic that would otherwise show a
+    UAC prompt for executables whose name contains "setup"/"install"/"update".
+  -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/crates/perry/src/commands/compile/link/windows_link.rs
+++ b/crates/perry/src/commands/compile/link/windows_link.rs
@@ -1,0 +1,103 @@
+//! Windows-specific link helpers for the Win32 link step (`is_windows`
+//! branch of `build_and_run_link`). Holds the system-library link line and the
+//! comctl32 v6 application-manifest embed. Extracted from `link/mod.rs` to keep
+//! that file under the 2000-line CI gate (`scripts/check_file_size.sh`).
+//!
+//! Compiled Windows UI apps bound comctl32 v5 because Perry embedded no
+//! application manifest into the linked `.exe`, so every common control
+//! (buttons, list views, edit boxes…) rendered in the unthemed Win95/classic
+//! style regardless of the OS theme. Embedding a manifest that declares the
+//! `Microsoft.Windows.Common-Controls` v6 side-by-side dependency activates
+//! visual styles (the Fluent look) on Windows 10/11. See issue #4681 /
+//! discussion #3486.
+
+use std::process::Command;
+
+/// Win32 application manifest embedded into UI executables. Declares the
+/// comctl32 v6 (`Microsoft.Windows.Common-Controls`) side-by-side dependency
+/// so common controls render with visual styles instead of the unthemed
+/// classic style, plus an `asInvoker` execution level.
+pub(crate) const WINDOWS_APP_MANIFEST: &str = include_str!("windows_app.manifest");
+
+/// Append the Windows system import libraries the runtime/UI/stdlib link
+/// against: the Win32 GUI + shell stack, the MSVC dynamic CRT, and the extra
+/// API libs the Rust runtime pulls in. Always emitted on Windows targets (the
+/// `whoami`/`winhttp`/etc. symbols are needed even by console binaries through
+/// `perry-stdlib`).
+pub(super) fn add_system_libs(cmd: &mut Command) {
+    // Win32 GUI + shell system libraries.
+    cmd.arg("user32.lib")
+        .arg("gdi32.lib")
+        .arg("gdiplus.lib")
+        .arg("msimg32.lib")
+        .arg("kernel32.lib")
+        .arg("shell32.lib")
+        .arg("ole32.lib")
+        .arg("comctl32.lib")
+        .arg("advapi32.lib")
+        .arg("comdlg32.lib")
+        .arg("ws2_32.lib")
+        .arg("dwmapi.lib");
+    // MSVC CRT (dynamic) and additional Windows API libraries needed by the Rust runtime.
+    cmd.arg("msvcrt.lib")
+        .arg("vcruntime.lib")
+        .arg("ucrt.lib")
+        .arg("bcrypt.lib")
+        .arg("ntdll.lib")
+        .arg("userenv.lib")
+        // secur32.lib exports `GetUserNameExW`, called by the `whoami`
+        // crate (transitively pulled in via `sqlx-mysql`/`sqlx-postgres`
+        // through `perry-stdlib`). Without it, every doc-test that
+        // touches stdlib fails on the Windows runner with
+        // `LNK2019: unresolved external symbol __imp_GetUserNameExW`.
+        // Closes #220.
+        .arg("secur32.lib")
+        .arg("oleaut32.lib")
+        .arg("propsys.lib")
+        .arg("runtimeobject.lib")
+        .arg("iphlpapi.lib")
+        // winhttp.lib — perry-ui-windows::widgets::image::fetch_url_blocking
+        // uses WinHttpOpen/Connect/OpenRequest/SendRequest/ReceiveResponse
+        // to fetch Image(url) bytes. The `windows` crate's `Win32_Networking_WinHttp`
+        // feature emits #[link] attrs in the rlib, but those don't propagate
+        // through perry-ui-windows's `staticlib` crate-type to perry's final
+        // link line. Closes #732.
+        .arg("winhttp.lib");
+}
+
+/// Embed the comctl32 v6 application manifest into a UI executable so common
+/// controls render with visual styles (Fluent look) instead of the unthemed
+/// Win95/classic style. Without the side-by-side
+/// `Microsoft.Windows.Common-Controls` v6 dependency the process binds comctl32
+/// v5 and every button/list/edit box looks decades old — issue #4681 /
+/// discussion #3486. No-op unless `needs_ui` so console-only binaries stay
+/// manifest-free.
+///
+/// Both `link.exe` and `lld-link` embed `/MANIFESTINPUT:` content via
+/// `/MANIFEST:EMBED` with no external `mt.exe`/`rc.exe`. `/MANIFESTUAC:NO`
+/// suppresses the linker's auto-generated UAC fragment so it can't produce a
+/// second `trustInfo` element alongside the one in our input manifest (which
+/// already declares `asInvoker`).
+pub(super) fn embed_app_manifest(cmd: &mut Command, needs_ui: bool) {
+    if !needs_ui {
+        return;
+    }
+    let manifest_path = std::env::temp_dir().join(format!(
+        "perry_app_manifest_{}.manifest",
+        std::process::id()
+    ));
+    match std::fs::write(&manifest_path, WINDOWS_APP_MANIFEST) {
+        Ok(()) => {
+            cmd.arg("/MANIFEST:EMBED")
+                .arg("/MANIFESTUAC:NO")
+                .arg(format!("/MANIFESTINPUT:{}", manifest_path.display()));
+        }
+        Err(e) => {
+            eprintln!(
+                "Warning: could not write Windows application manifest to {} ({e}); \
+                 common controls will render in the unthemed classic style.",
+                manifest_path.display()
+            );
+        }
+    }
+}

--- a/crates/perry/src/commands/compile/windows_link_tests.rs
+++ b/crates/perry/src/commands/compile/windows_link_tests.rs
@@ -2,6 +2,7 @@
 //! in v0.5.1019 (file-size CI gate). Brought back in via
 //! `#[cfg(test)] mod windows_link_tests;` in compile.rs.
 
+use super::link::WINDOWS_APP_MANIFEST;
 use super::windows_pe_subsystem_flag;
 use super::windows_subsystem_needs_ui;
 
@@ -87,4 +88,37 @@ fn subsystem_console_forces_console() {
 fn subsystem_override_composes_with_min_version_suffix() {
     let flag = windows_pe_subsystem_flag(windows_subsystem_needs_ui("windows", false), "7");
     assert_eq!(flag, "/SUBSYSTEM:WINDOWS,5.1");
+}
+
+// Issue #4681 / discussion #3486: the embedded app manifest must declare the
+// comctl32 v6 side-by-side dependency, otherwise common controls bind v5 and
+// render unthemed. Guards against accidental edits to windows_app.manifest.
+#[test]
+fn app_manifest_requests_comctl32_v6() {
+    assert!(
+        WINDOWS_APP_MANIFEST.starts_with("<?xml"),
+        "manifest should be a well-formed XML document"
+    );
+    assert!(
+        WINDOWS_APP_MANIFEST.contains("Microsoft.Windows.Common-Controls"),
+        "manifest must reference the Common-Controls assembly"
+    );
+    assert!(
+        WINDOWS_APP_MANIFEST.contains("version=\"6.0.0.0\""),
+        "manifest must request Common-Controls v6 for visual styles"
+    );
+    assert!(
+        WINDOWS_APP_MANIFEST.contains("6595b64144ccf1df"),
+        "manifest must carry the Common-Controls public key token"
+    );
+}
+
+// asInvoker keeps UI binaries out of the UAC installer-detection heuristic and
+// avoids a second linker-generated trustInfo block (we pass /MANIFESTUAC:NO).
+#[test]
+fn app_manifest_runs_as_invoker() {
+    assert!(
+        WINDOWS_APP_MANIFEST.contains("level=\"asInvoker\""),
+        "manifest must declare the asInvoker execution level"
+    );
 }


### PR DESCRIPTION
## What

The biggest fix for the "controls look 40 years old" complaint in discussion #3486. Compiled Windows UI apps bound **comctl32 v5** because Perry embedded no application manifest into the linked `.exe`, so every common control (buttons, list views, edit boxes…) rendered in the unthemed Win95/classic style regardless of the OS theme. This embeds a Win32 manifest declaring the **`Microsoft.Windows.Common-Controls` v6** side-by-side dependency, which activates visual styles (the Fluent look) on Windows 10/11.

DWM (#4682) modernizes the *frame*; this modernizes the *controls*. Together they close most of the visual gap on the existing Win32 backend.

## Changes

- **New `windows_app.manifest`** — comctl32 v6 dependency + an `asInvoker` execution level (declaring it explicitly keeps UI binaries out of the UAC installer-detection heuristic).
- **Link step** writes the manifest to a temp file and passes `/MANIFEST:EMBED /MANIFESTUAC:NO /MANIFESTINPUT:<path>`. Both `link.exe` and `lld-link` embed `/MANIFESTINPUT:` content via `/MANIFEST:EMBED` with **no external `mt.exe`/`rc.exe`**, so this works on the MSVC path and the cross-from-mac `lld-link` path alike. `/MANIFESTUAC:NO` suppresses the linker's auto-generated UAC fragment so it can't emit a second `trustInfo` block alongside ours.
- **Gated on `ctx.needs_ui`** so console-only binaries stay manifest-free.
- Hoisted the manifest to a `pub(super) const WINDOWS_APP_MANIFEST` and added regression tests guarding the v6 dependency, public key token, and `asInvoker` level.

## Why not DPI in the manifest

This manifest deliberately does **not** declare `dpiAware`/`dpiAwareness`. Perry sets DPI awareness at runtime via `dpi_compat` (issue #303, to keep Win7 startup working and choose per-monitor-v2); a manifest declaration would conflict with that path. DPI stays out of scope here.

## Testing

- `cargo test -p perry --bin perry windows_link_tests` — **7 passed** (5 existing subsystem guards + 2 new manifest guards).
- `cargo check -p perry` clean; `cargo fmt` clean.
- The runtime-`if is_windows` link branch compiles on the macOS host (not `cfg`-gated), so the embed code is type-checked here. **The actual embedding + control theming needs a Windows runner / manual smoke before merge** — confirm `dumpbin /manifest` (or Resource Hacker) shows the Common-Controls v6 dependency in a built UI `.exe` and that the ToDo sample renders themed controls.

Part of #4681, discussion #3486.