### PR TITLE
feat(compile): --windows-subsystem override + tier-3 Apple link dedup + pointer-width portability (v0.5.1125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1125 — feat(compile): --windows-subsystem override + tier-3 Apple link dedup + pointer-width portability
+
+Three related cross-compile / link improvements, bundled because they share the
+Windows/tvOS/watchOS build paths.
+
+**1. `--windows-subsystem` override (PE subsystem control).** `--target windows`
+previously always derived the PE subsystem from an import heuristic: a program that
+imports `perry/ui` links `/SUBSYSTEM:WINDOWS` (GUI), everything else links
+`/SUBSYSTEM:CONSOLE` so `console.log` reaches the terminal (the issue #120 regression
+guard). That left no way to ship a GUI app that renders its own window without importing
+`perry/ui` (e.g. a Bloom Engine game) — Windows would allocate a console window alongside
+it. New `--windows-subsystem auto|console|windows` flag plus a `perry.toml [windows]
+subsystem` fallback (the source that survives the `perry publish` worker round-trip, since
+the dev shell's flags don't transfer but perry.toml is uploaded with `--project`).
+Precedence: explicit CLI `console`/`windows` wins → else perry.toml → else the import
+heuristic. Unknown values are a hard error so a typo fails loudly instead of silently
+linking the wrong subsystem.
+
+- `types.rs`: new `CompileArgs.windows_subsystem` flag + `CompilationContext.windows_subsystem`.
+- `bootstrap.rs`: `validate_windows_subsystem` resolves CLI → perry.toml → `auto` in the
+  post-collect preflight chain.
+- `library_search.rs`: `windows_subsystem_needs_ui` folds the override into the
+  auto-detected `needs_ui` bool that `windows_pe_subsystem_flag` consumes.
+- `platform_cmd.rs`: link command threads the resolved override through.
+- `windows_link_tests.rs`: regression guards for auto/console/windows polarities and
+  composition with the min-windows-version suffix.
+
+**2. Tier-3 Apple (tvOS/watchOS) link dedup.** Those targets have no prebuilt std, so
+perry-runtime and perry-stdlib are each built with `-Zbuild-std` and each bundle their own
+copy of std's panic/unwind runtime (`__rust_drop_panic`, `__rust_foreign_exception`,
+`rust_begin_unwind`, `rust_eh_personality`) → `ld64.lld: duplicate symbol` at the final
+link. `strip_dedup.rs` now localizes those shims alongside the allocator shims, and
+`link/mod.rs` runs the strip over the stdlib archive and tier-3 native libs (gated to
+tvOS/watchOS; ios/macos use prebuilt std and never hit this).
+
+**3. Pointer-width portability.** Several GC/timer/typedarray plausibility checks compared
+allocation size against `1usize << 34`, which overflows on 32-bit targets (arm64_32 watchOS,
+wasm32). Switched the comparisons to `size as u64 > (1u64 << 34)` in `gc/barrier.rs`,
+`gc/copying.rs`, `timer.rs`, `typedarray/mod.rs`, and widened a `tm_gmtoff` cast to `i64`
+in `date.rs`.
+
 ## v0.5.1124 — fix(runtime): array boundary-index, sparse length, and non-integer keys
 
 Closes #4557 and #4543; supersedes #4585 and #4559 by combining both into one branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1124
+**Current Version:** 0.5.1125
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "base64",
@@ -5252,14 +5252,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "cc",
  "libc",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "base64",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,14 +5368,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "serde",
  "serde_json",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1124"
+version = "0.5.1125"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "clap",
@@ -5409,14 +5409,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5515,14 +5515,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "bytes",
  "h2",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "bson",
  "futures-util",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "image",
@@ -5709,14 +5709,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "brotli",
  "flate2",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "base64",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5939,14 +5939,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "itoa",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "block2",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "block2",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1124"
+version = "0.5.1125"
 
 [[package]]
 name = "perry-ui-test"
@@ -6035,11 +6035,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1124"
+version = "0.5.1125"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "block2",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "block2",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "block2",
  "libc",
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "libc",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1124"
+version = "0.5.1125"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1124"
+version = "0.5.1125"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -191,7 +191,7 @@ fn timestamp_to_local_components(secs: i64) -> (i32, u32, u32, u32, u32, u32, i6
         let hour = tm.tm_hour as u32;
         let minute = tm.tm_min as u32;
         let second = tm.tm_sec as u32;
-        let tz_offset = tm.tm_gmtoff;
+        let tz_offset = tm.tm_gmtoff as i64;
         (year, month, day, hour, minute, second, tz_offset)
     }
 }

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -787,7 +787,7 @@ pub(super) unsafe fn plausible_arena_user_ptr_header(
     let size = (*header).size as usize;
     if gc_type_info(obj_type).is_none()
         || size < GC_HEADER_SIZE
-        || size > (1usize << 34)
+        || size as u64 > (1u64 << 34)
         || (*header).gc_flags & GC_FLAG_ARENA == 0
         || (*header).gc_flags & GC_FLAG_FORWARDED != 0
     {
@@ -1048,7 +1048,7 @@ pub(super) fn malloc_gc_parent_addr(parent_addr: usize) -> bool {
         let size = (*header).size as usize;
         gc_type_info(obj_type).is_some()
             && size >= GC_HEADER_SIZE
-            && size <= (1usize << 34)
+            && size as u64 <= (1u64 << 34)
             && (*header).gc_flags & GC_FLAG_ARENA == 0
             && (*header).gc_flags & GC_FLAG_FORWARDED == 0
     }

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -193,7 +193,7 @@ pub(super) unsafe fn plausible_gc_header(header: *mut GcHeader, arena: bool) -> 
         return false;
     }
     let size = (*header).size as usize;
-    if size < GC_HEADER_SIZE || size > (1usize << 34) {
+    if size < GC_HEADER_SIZE || size as u64 > (1u64 << 34) {
         return false;
     }
     let is_arena = (*header).gc_flags & GC_FLAG_ARENA != 0;

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -882,7 +882,7 @@ fn raw_closure_pointer(bits: u64) -> Option<usize> {
             return None;
         }
         let size = (*header).size as usize;
-        if size < crate::gc::GC_HEADER_SIZE || size > (1usize << 34) {
+        if size < crate::gc::GC_HEADER_SIZE || size as u64 > (1u64 << 34) {
             return None;
         }
         let is_arena = (*header).gc_flags & crate::gc::GC_FLAG_ARENA != 0;

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -371,7 +371,7 @@ unsafe fn arena_payload_has_gc_type(addr: usize, expected_type: u8) -> bool {
         return false;
     }
     let size = (*header).size as usize;
-    if size < crate::gc::GC_HEADER_SIZE || size > (1usize << 34) {
+    if size < crate::gc::GC_HEADER_SIZE || size as u64 > (1u64 << 34) {
         return false;
     }
     if (*header).gc_flags & crate::gc::GC_FLAG_ARENA == 0 {

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -71,7 +71,7 @@ use library_search::{
     find_geisterhand_stdlib, find_geisterhand_ui, find_harmonyos_sdk, find_lld_link,
     find_llvm_tool, find_msvc_lib_paths, find_msvc_link_exe, find_perry_windows_sdk,
     find_runtime_library, find_stdlib_library, find_ui_library, find_wasm_host_library,
-    windows_pe_subsystem_flag,
+    windows_pe_subsystem_flag, windows_subsystem_needs_ui,
 };
 use link::{build_and_run_link, write_link_cache_manifest};
 pub use lock_scan::collect_native_archives_for_lock;
@@ -93,7 +93,10 @@ use resolve::{
     is_in_compile_package, is_in_perry_native_package, is_js_file, parse_native_library_manifest,
     parse_package_specifier, resolve_import,
 };
-use strip_dedup::{strip_duplicate_objects_from_lib, strip_duplicate_objects_from_well_known_lib};
+use strip_dedup::{
+    dedup_native_lib_for_tier3, dedup_stdlib_for_tier3, strip_duplicate_objects_from_lib,
+    strip_duplicate_objects_from_well_known_lib,
+};
 use targets::{
     apple_sdk_version, compile_for_android_widget, compile_for_ios_widget, compile_for_wasm,
     compile_for_watchos_widget, compile_for_wearos_tile, find_visionos_swift_runtime,

--- a/crates/perry/src/commands/compile/bootstrap.rs
+++ b/crates/perry/src/commands/compile/bootstrap.rs
@@ -32,6 +32,7 @@ use crate::OutputFormat;
 use super::audit_manifest::write_audit_manifest_logging_failures;
 use super::collect_modules::collect_modules;
 use super::resolve::discover_extension_entries;
+use super::resources::find_project_root_for_resources;
 use crate::commands::progress::VerboseProgress;
 
 use super::{CompilationContext, CompileArgs, ParseCache};
@@ -656,6 +657,56 @@ pub(super) fn validate_min_windows_version(
     Ok(())
 }
 
+/// Resolve the Windows PE subsystem override into `ctx.windows_subsystem`.
+///
+/// Precedence:
+///   1. `--windows-subsystem` when set to `console`/`windows` (explicit
+///      CLI intent wins).
+///   2. `perry.toml [windows] subsystem` — the source that survives the
+///      `perry publish` worker round-trip, since the dev shell's flags don't
+///      transfer but perry.toml is uploaded with `--project` (mirrors
+///      `resolve_optional_framework_dir`'s env→toml fallback).
+///   3. `auto` — defer to the `needs_ui` import heuristic at link time.
+///
+/// Unknown values from either source are a hard error so typos fail loudly
+/// instead of silently linking a console window onto a GUI game.
+pub(super) fn validate_windows_subsystem(
+    args: &CompileArgs,
+    ctx: &mut CompilationContext,
+) -> Result<()> {
+    fn check(value: &str, source: &str) -> Result<()> {
+        match value {
+            "auto" | "console" | "windows" => Ok(()),
+            other => {
+                anyhow::bail!("{source}: expected 'auto', 'console', or 'windows', got '{other}'.")
+            }
+        }
+    }
+
+    check(&args.windows_subsystem, "--windows-subsystem")?;
+
+    // 1. Explicit CLI override wins.
+    if args.windows_subsystem != "auto" {
+        ctx.windows_subsystem = args.windows_subsystem.clone();
+        return Ok(());
+    }
+
+    // 2. CLI left at default — consult perry.toml [windows] subsystem.
+    let project_root = find_project_root_for_resources(&args.input, true);
+    if let Ok(content) = std::fs::read_to_string(project_root.join("perry.toml")) {
+        if let Ok(doc) = content.parse::<toml::Table>() {
+            if let Some(sub) = super::app_metadata::toml_string(&doc, "windows", "subsystem") {
+                check(&sub, "perry.toml [windows] subsystem")?;
+                ctx.windows_subsystem = sub;
+                return Ok(());
+            }
+        }
+    }
+
+    // 3. Stays "auto" (ctx default) — import heuristic decides.
+    Ok(())
+}
+
 /// Run the full post-collect preflight chain (capability / egress /
 /// lockdown / SBOM / geisterhand / windows-version / project_root
 /// recompute / module-count print). All gates collected here so the
@@ -697,6 +748,7 @@ pub(super) fn run_post_collect_preflight(
 
     apply_geisterhand_args(args, ctx);
     validate_min_windows_version(args, ctx)?;
+    validate_windows_subsystem(args, ctx)?;
     Ok(())
 }
 

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -352,6 +352,20 @@ pub(super) fn find_perry_windows_sdk() -> Option<PathBuf> {
 /// on this version" — the binary still has to actually avoid calling APIs
 /// newer than that version. Perry's UI runtime handles the API side via
 /// `crates/perry-ui-windows/src/dpi_compat.rs` (issue #303).
+/// Fold the resolved `--windows-subsystem` / `[windows] subsystem` override
+/// (`ctx.windows_subsystem`) into the auto-detected `needs_ui` to get the
+/// effective "is this a GUI app?" bool that `windows_pe_subsystem_flag`
+/// consumes. `"windows"` forces GUI (`/SUBSYSTEM:WINDOWS`, no console window),
+/// `"console"` forces a console, `"auto"` (and any unrecognized value — the
+/// caller validates) defers to the import-driven heuristic.
+pub(super) fn windows_subsystem_needs_ui(subsystem: &str, needs_ui: bool) -> bool {
+    match subsystem {
+        "windows" => true,
+        "console" => false,
+        _ => needs_ui,
+    }
+}
+
 pub(super) fn windows_pe_subsystem_flag(needs_ui: bool, min_windows_version: &str) -> String {
     let base = if needs_ui {
         "/SUBSYSTEM:WINDOWS"

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -30,12 +30,13 @@ use std::process::Command;
 use crate::OutputFormat;
 
 use super::{
-    apple_sdk_version, build_geisterhand_libs, find_geisterhand_library, find_geisterhand_runtime,
-    find_geisterhand_stdlib, find_geisterhand_ui, find_lld_link, find_llvm_tool,
-    find_msvc_lib_paths, find_msvc_link_exe, find_perry_windows_sdk, find_stdlib_library,
-    find_ui_library, find_visionos_swift_runtime, find_watchos_swift_runtime, rust_target_triple,
-    strip_duplicate_objects_from_lib, strip_duplicate_objects_from_well_known_lib,
-    windows_pe_subsystem_flag, CompilationContext,
+    apple_sdk_version, build_geisterhand_libs, dedup_native_lib_for_tier3, dedup_stdlib_for_tier3,
+    find_geisterhand_library, find_geisterhand_runtime, find_geisterhand_stdlib,
+    find_geisterhand_ui, find_lld_link, find_llvm_tool, find_msvc_lib_paths, find_msvc_link_exe,
+    find_perry_windows_sdk, find_stdlib_library, find_ui_library, find_visionos_swift_runtime,
+    find_watchos_swift_runtime, rust_target_triple, strip_duplicate_objects_from_lib,
+    strip_duplicate_objects_from_well_known_lib, windows_pe_subsystem_flag,
+    windows_subsystem_needs_ui, CompilationContext,
 };
 
 mod link_cache;
@@ -515,7 +516,8 @@ pub(super) fn build_and_run_link(
                         cmd.arg(wk);
                     }
                 }
-                cmd.arg(stdlib);
+                // Tier-3 (tvOS/watchOS) std-duplication dedup; no-op elsewhere.
+                cmd.arg(&dedup_stdlib_for_tier3(target, stdlib));
                 // #466 Phase 4 step 2: well-known bindings normally join the
                 // link line right after perry-stdlib so they cover the exact
                 // `_js_*` symbol gap that was just opened by stripping the
@@ -1535,6 +1537,7 @@ pub(super) fn build_and_run_link(
                     );
 
                     if let Some(lib) = lib_path {
+                        let lib = dedup_native_lib_for_tier3(target, lib_name, lib);
                         // For shared libraries (.so) on Android, use -L/-l so the linker
                         // records just the soname (not the full build path) in DT_NEEDED.
                         if is_android && lib_name.ends_with(".so") {

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -602,8 +602,10 @@ pub fn select_linker_command(
         // /ENTRY:mainCRTStartup works for both subsystems: Perry emits
         // `int main()` and the MSVC CRT invokes it regardless of subsystem.
         // See windows_pe_subsystem_flag() for subsystem selection rationale.
+        // The `--windows-subsystem` / `[windows] subsystem` override (resolved
+        // into ctx.windows_subsystem) can force GUI/console past the heuristic.
         c.arg(windows_pe_subsystem_flag(
-            ctx.needs_ui,
+            windows_subsystem_needs_ui(&ctx.windows_subsystem, ctx.needs_ui),
             &ctx.min_windows_version,
         ))
         .arg("/ENTRY:mainCRTStartup")

--- a/crates/perry/src/commands/compile/strip_dedup.rs
+++ b/crates/perry/src/commands/compile/strip_dedup.rs
@@ -28,6 +28,15 @@ const RUST_ALLOCATOR_SYMBOL_PARTS: &[&str] = &[
     "__rdl_realloc",
     "__rdl_alloc_zeroed",
     "__rdl_alloc_error_handler",
+    // Panic / unwind runtime shims. On tier-3 targets (tvOS/watchOS) with no
+    // prebuilt std, perry-runtime and perry-stdlib are each built with
+    // -Zbuild-std, so both bundle std's single-definition panic runtime →
+    // `ld64.lld: duplicate symbol` for these. Localize them like the allocator
+    // shims so only one staticlib provides them.
+    "__rust_drop_panic",
+    "__rust_foreign_exception",
+    "rust_begin_unwind",
+    "rust_eh_personality",
 ];
 
 fn force_localize_symbol(symbol: &str) -> bool {
@@ -669,6 +678,50 @@ pub(super) fn strip_duplicate_objects_from_well_known_lib(lib_path: &PathBuf) ->
     );
     let _ = std::fs::remove_dir_all(&extract_dir);
     Ok(trimmed_lib)
+}
+
+/// Tier-3 (tvOS/watchOS, no prebuilt std): perry-stdlib is built with
+/// `-Zbuild-std` and bundles its own copy of std's allocator/panic runtime
+/// shims, which duplicate the ones in runtime_lib (the canonical provider) →
+/// `ld64.lld: duplicate symbol`. Localize those shims in the stdlib copy.
+/// No-op (clone) on every other target; a strip failure is non-fatal and
+/// falls back to the original archive.
+pub(super) fn dedup_stdlib_for_tier3(target: Option<&str>, stdlib: &PathBuf) -> PathBuf {
+    if matches!(target, Some("tvos") | Some("watchos")) {
+        match strip_duplicate_objects_from_well_known_lib(stdlib) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("[strip-dedup] skipped for stdlib (non-fatal): {e}");
+                stdlib.clone()
+            }
+        }
+    } else {
+        stdlib.clone()
+    }
+}
+
+/// Tier-3 Apple (tvOS/watchOS) dedup for a per-crate native binding staticlib.
+/// Same `-Zbuild-std` std-duplication as [`dedup_stdlib_for_tier3`] (alloc/
+/// panic/eh runtime: `__rust_drop_panic`, `__rdl_alloc`, …) colliding with
+/// perry-runtime's std at the final link. Skips shared libs (`.so`, Android)
+/// and every non-tier-3 target (ios/macos use prebuilt std and don't hit this).
+/// A strip failure is non-fatal and falls back to the original lib.
+pub(super) fn dedup_native_lib_for_tier3(
+    target: Option<&str>,
+    lib_name: &str,
+    lib: PathBuf,
+) -> PathBuf {
+    if matches!(target, Some("tvos") | Some("watchos")) && !lib_name.ends_with(".so") {
+        match strip_duplicate_objects_from_lib(&lib) {
+            Ok(trimmed) => trimmed,
+            Err(e) => {
+                eprintln!("[strip-dedup] skipped for native lib {lib_name} (non-fatal): {e}");
+                lib
+            }
+        }
+    } else {
+        lib
+    }
 }
 
 #[cfg(test)]

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -292,6 +292,29 @@ pub struct CompileArgs {
     #[arg(long, default_value = "10")]
     pub min_windows_version: String,
 
+    /// Windows PE subsystem for `--target windows` builds. One of `auto`
+    /// (default), `console`, `windows`. Ignored on every non-Windows target.
+    ///
+    /// `auto` keeps the import-driven heuristic: a program that imports
+    /// `perry/ui` links as `/SUBSYSTEM:WINDOWS` (GUI), everything else links
+    /// as `/SUBSYSTEM:CONSOLE` so `console.log` reaches the terminal (the
+    /// issue #120 regression guard).
+    ///
+    /// `windows` forces `/SUBSYSTEM:WINDOWS` — the right choice for a GUI
+    /// app that renders its own window (e.g. a Bloom Engine game) but does
+    /// not import `perry/ui`. Without it Windows allocates a console window
+    /// alongside the game on launch.
+    ///
+    /// `console` forces `/SUBSYSTEM:CONSOLE` even for UI programs.
+    ///
+    /// Precedence: this flag wins when set to `console`/`windows`; left at
+    /// `auto` it falls back to `perry.toml [windows] subsystem`, then to the
+    /// import heuristic. The perry.toml fallback is what survives the
+    /// `perry publish` worker round-trip (the dev shell's flags don't
+    /// transfer, but perry.toml is uploaded with `--project`).
+    #[arg(long, default_value = "auto")]
+    pub windows_subsystem: String,
+
     /// HarmonyOS HAP signing: path to the .p12 keystore file. Falls
     /// through CLI flag → `PERRY_HARMONYOS_P12` env var → saved config
     /// (`~/.perry/config.toml`, populated by `perry setup harmonyos`).
@@ -527,6 +550,13 @@ pub struct CompilationContext {
     /// #303 + `docs/src/platforms/windows-7.md`. Ignored on non-Windows
     /// targets.
     pub min_windows_version: String,
+    /// Resolved Windows PE subsystem override for `--target windows`. One of
+    /// `"auto"` (default — use the `needs_ui` import heuristic), `"console"`,
+    /// or `"windows"`. Merged from `--windows-subsystem` and perry.toml
+    /// `[windows] subsystem` by `validate_windows_subsystem`. Drives the
+    /// `/SUBSYSTEM:` linker flag via `windows_subsystem_needs_ui`. Ignored on
+    /// non-Windows targets.
+    pub windows_subsystem: String,
     /// Issue #444: canonical path of the user-supplied entry TypeScript
     /// file. `collect_modules` compares each module's canonical path
     /// against this to set `is_entry_module` on the lowering context,
@@ -743,6 +773,7 @@ impl CompilationContext {
             needs_thread: false,
             cross_module_class_field_types: HashMap::new(),
             min_windows_version: "10".to_string(),
+            windows_subsystem: "auto".to_string(),
             entry_canonical: None,
             extra_stdlib_features: BTreeSet::new(),
             refuse_dynamic_stdlib_dispatch: true,

--- a/crates/perry/src/commands/compile/windows_link_tests.rs
+++ b/crates/perry/src/commands/compile/windows_link_tests.rs
@@ -3,6 +3,7 @@
 //! `#[cfg(test)] mod windows_link_tests;` in compile.rs.
 
 use super::windows_pe_subsystem_flag;
+use super::windows_subsystem_needs_ui;
 
 // Regression guard for issue #120: without an explicit subsystem flag the
 // MSVC linker historically defaulted to WINDOWS (2), silently detaching
@@ -52,4 +53,38 @@ fn min_windows_8_appends_6_02_suffix() {
 fn unknown_min_windows_falls_through_to_default() {
     assert_eq!(windows_pe_subsystem_flag(false, "11"), "/SUBSYSTEM:CONSOLE");
     assert_eq!(windows_pe_subsystem_flag(true, ""), "/SUBSYSTEM:WINDOWS");
+}
+
+// --windows-subsystem / [windows] subsystem override (resolved into
+// ctx.windows_subsystem) folds into needs_ui before the flag is built.
+
+// "auto" defers to the import-driven heuristic — both polarities pass through.
+#[test]
+fn subsystem_auto_defers_to_needs_ui() {
+    assert!(!windows_subsystem_needs_ui("auto", false));
+    assert!(windows_subsystem_needs_ui("auto", true));
+}
+
+// "windows" forces GUI even when nothing imported perry/ui — this is the
+// Bloom-Engine-game case: no console window pops up alongside the game.
+#[test]
+fn subsystem_windows_forces_gui() {
+    assert!(windows_subsystem_needs_ui("windows", false));
+    let flag = windows_pe_subsystem_flag(windows_subsystem_needs_ui("windows", false), "10");
+    assert_eq!(flag, "/SUBSYSTEM:WINDOWS");
+}
+
+// "console" forces a console even for a UI program that would auto-detect GUI.
+#[test]
+fn subsystem_console_forces_console() {
+    assert!(!windows_subsystem_needs_ui("console", true));
+    let flag = windows_pe_subsystem_flag(windows_subsystem_needs_ui("console", true), "10");
+    assert_eq!(flag, "/SUBSYSTEM:CONSOLE");
+}
+
+// The override composes with the min-windows-version suffix.
+#[test]
+fn subsystem_override_composes_with_min_version_suffix() {
+    let flag = windows_pe_subsystem_flag(windows_subsystem_needs_ui("windows", false), "7");
+    assert_eq!(flag, "/SUBSYSTEM:WINDOWS,5.1");
 }

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -305,6 +305,7 @@ fn build_once(
         emit_sandbox: false,
         lockdown: false,
         min_windows_version: "10".to_string(),
+        windows_subsystem: "auto".to_string(),
         // Phase 2 v7: harmonyos signing flags. `perry dev` is the watch
         // mode for local iteration; unsigned HAPs are fine, fall through
         // to env / saved config.

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -226,6 +226,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         emit_sandbox: false,
         lockdown: false,
         min_windows_version: "10".to_string(),
+        windows_subsystem: "auto".to_string(),
         // Phase 2 v7: harmonyos signing flags. `perry run` is for local
         // iteration where unsigned HAPs are fine, so fall through to env
         // var / saved config without exposing CLI overrides here.


### PR DESCRIPTION
## Summary

Three related cross-compile / link improvements, bundled because they share the Windows / tvOS / watchOS build paths.

### 1. `--windows-subsystem` override (PE subsystem control)
`--target windows` previously always derived the PE subsystem from an import heuristic: a program importing `perry/ui` links `/SUBSYSTEM:WINDOWS` (GUI), everything else `/SUBSYSTEM:CONSOLE` (the #120 regression guard so `console.log` reaches the terminal). That left no way to ship a GUI app that renders its own window without importing `perry/ui` (e.g. a Bloom Engine game) — Windows would pop a console window alongside it.

New `--windows-subsystem auto|console|windows` flag + `perry.toml [windows] subsystem` fallback (survives the `perry publish` worker round-trip; dev-shell flags don't transfer but perry.toml is uploaded with `--project`). Precedence: explicit CLI `console`/`windows` wins → else perry.toml → else import heuristic. Unknown values are a hard error.

### 2. Tier-3 Apple (tvOS/watchOS) link dedup
No prebuilt std on those targets → perry-runtime and perry-stdlib are each `-Zbuild-std` and each bundle std's panic/unwind runtime (`__rust_drop_panic`, `__rust_foreign_exception`, `rust_begin_unwind`, `rust_eh_personality`) → `ld64.lld: duplicate symbol`. Localize those shims alongside the allocator shims; run the strip over the stdlib archive + tier-3 native libs (gated to tvOS/watchOS — ios/macos use prebuilt std).

### 3. Pointer-width portability
Several GC/timer/typedarray plausibility checks compared alloc size against `1usize << 34`, which overflows on 32-bit targets (arm64_32 watchOS, wasm32). Switched to `size as u64 > (1u64 << 34)` in `gc/barrier.rs`, `gc/copying.rs`, `timer.rs`, `typedarray/mod.rs`; widened a `tm_gmtoff` cast to `i64` in `date.rs`.

## Validation
- Full release build (`cargo build --release`) green.
- `cargo fmt --all -- --check` clean.
- New unit tests in `windows_link_tests.rs` cover auto/console/windows polarities + min-windows-version composition.
- Full workspace test suite deferred to CI (local disk constraint); the required `cargo-test` check is the authoritative gate.

Version bumped 0.5.1124 → 0.5.1125; CHANGELOG entry added.