### PR TITLE
fix(promise): spec-compliant Promise.all/allSettled/race/any combinators (#4521)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1548,6 +1548,14 @@ fn match_namespace_static_member(
     if !is_known_namespace_static_function(ns, name) {
         return None;
     }
+    // #4521: the Promise combinators read the `this` constructor
+    // (`NewPromiseCapability(this)` / `GetPromiseResolve(this)`), so
+    // `Promise.all.call(C, …)` / `.apply` / `.bind` must NOT drop the
+    // thisArg — let them fall through to the generic reified-static dispatch
+    // (which preserves `this` via the implicit-this mechanism).
+    if ns == "Promise" && matches!(name, "all" | "race" | "allSettled" | "any") {
+        return None;
+    }
     Some(m.clone())
 }
 

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1959,6 +1959,30 @@ fn constructor_class_ref_id(value: f64) -> Option<u32> {
     super::class_ref_id(value)
 }
 
+/// Spec `IsConstructor(value)` — used by `NewPromiseCapability` (the Promise
+/// combinators) to validate the `this` constructor argument. Returns true for
+/// registered class constructors, the reified builtin constructors, and plain
+/// (non-arrow, non-builtin-method) function closures; false for primitives,
+/// arrow functions, and non-constructable builtin functions (e.g. `eval`).
+pub(crate) fn js_value_is_constructor(value: f64) -> bool {
+    if constructor_class_ref_id(value).is_some() {
+        return true;
+    }
+    if crate::proxy::js_proxy_is_proxy(value) == 1 {
+        return true;
+    }
+    if !is_callable_function_value(value) {
+        return false;
+    }
+    if is_arrow_function_value(value) {
+        return false;
+    }
+    if is_non_constructable_builtin_function_value(value) {
+        return false;
+    }
+    true
+}
+
 fn class_object_class_id(value: f64) -> Option<u32> {
     if !is_class_object_value(value) {
         return None;
@@ -2105,7 +2129,12 @@ fn constructor_return_overrides_this(value: f64) -> bool {
             (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         matches!(
             (*gc_header).obj_type,
-            crate::gc::GC_TYPE_OBJECT | crate::gc::GC_TYPE_ERROR
+            // Per spec, a constructor returning ANY Object overrides the
+            // implicit `this`. Promises are objects — a user constructor like
+            // `function P(exec){ return new Promise(...) }` (the
+            // `NewPromiseCapability` shape exercised by the Promise-combinator
+            // test262 cases) must yield that Promise, not the empty default.
+            crate::gc::GC_TYPE_OBJECT | crate::gc::GC_TYPE_ERROR | crate::gc::GC_TYPE_PROMISE
         )
     }
 }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3302,32 +3302,32 @@ extern "C" fn promise_all_static(
     _closure: *const crate::closure::ClosureHeader,
     iterable: f64,
 ) -> f64 {
-    let p = crate::promise::combinators::js_promise_all_iterable(iterable);
-    crate::value::js_nanbox_pointer(p as i64)
+    let this_ctor = crate::object::js_implicit_this_get();
+    crate::promise::js_promise_all_spec(this_ctor, iterable)
 }
 
 extern "C" fn promise_race_static(
     _closure: *const crate::closure::ClosureHeader,
     iterable: f64,
 ) -> f64 {
-    let p = crate::promise::combinators::js_promise_race_iterable(iterable);
-    crate::value::js_nanbox_pointer(p as i64)
+    let this_ctor = crate::object::js_implicit_this_get();
+    crate::promise::js_promise_race_spec(this_ctor, iterable)
 }
 
 extern "C" fn promise_all_settled_static(
     _closure: *const crate::closure::ClosureHeader,
     iterable: f64,
 ) -> f64 {
-    let p = crate::promise::combinators::js_promise_all_settled_iterable(iterable);
-    crate::value::js_nanbox_pointer(p as i64)
+    let this_ctor = crate::object::js_implicit_this_get();
+    crate::promise::js_promise_all_settled_spec(this_ctor, iterable)
 }
 
 extern "C" fn promise_any_static(
     _closure: *const crate::closure::ClosureHeader,
     iterable: f64,
 ) -> f64 {
-    let p = crate::promise::combinators::js_promise_any_iterable(iterable);
-    crate::value::js_nanbox_pointer(p as i64)
+    let this_ctor = crate::object::js_implicit_this_get();
+    crate::promise::js_promise_any_spec(this_ctor, iterable)
 }
 
 extern "C" fn promise_with_resolvers_static(_closure: *const crate::closure::ClosureHeader) -> f64 {

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -263,7 +263,7 @@ fn not_iterable_prefix(value: f64) -> String {
     "object".to_string()
 }
 
-fn combinator_catch_js<F: FnOnce() -> f64>(f: F) -> Result<f64, f64> {
+pub(super) fn combinator_catch_js<F: FnOnce() -> f64>(f: F) -> Result<f64, f64> {
     let env = crate::exception::js_try_push();
     let jumped = unsafe { crate::ffi::setjmp::setjmp(env as *mut c_int) };
     if jumped == 0 {
@@ -281,7 +281,7 @@ fn combinator_catch_js<F: FnOnce() -> f64>(f: F) -> Result<f64, f64> {
 /// Build the `TypeError: <prefix> is not iterable (cannot read property
 /// Symbol(Symbol.iterator))` value — Node's exact message for a non-iterable
 /// Promise-combinator argument (issue #2822).
-fn not_iterable_error_value(value: f64) -> f64 {
+pub(super) fn not_iterable_error_value(value: f64) -> f64 {
     let msg = format!(
         "{} is not iterable (cannot read property Symbol(Symbol.iterator))",
         not_iterable_prefix(value)
@@ -385,7 +385,9 @@ pub(crate) fn combinator_iterable_to_array(
     Err(not_iterable_error_value(value))
 }
 
-fn combinator_iterable_to_array_caught(value: f64) -> Result<*mut crate::array::ArrayHeader, f64> {
+pub(super) fn combinator_iterable_to_array_caught(
+    value: f64,
+) -> Result<*mut crate::array::ArrayHeader, f64> {
     let mut out = std::ptr::null_mut();
     let result = combinator_catch_js(|| match combinator_iterable_to_array(value) {
         Ok(arr) => {
@@ -400,58 +402,45 @@ fn combinator_iterable_to_array_caught(value: f64) -> Result<*mut crate::array::
     }
 }
 
-/// Iterable-accepting entry for `Promise.all` (issue #2822). Coerces any
-/// iterable to an array (rejecting non-iterables with a `TypeError`) before
-/// delegating to the array-shaped `js_promise_all`.
+/// Unwrap a spec-combinator result (NaN-boxed native Promise pointer, since the
+/// codegen direct-call path always uses the intrinsic `Promise` as `this`) back
+/// to a `*mut Promise` for the codegen ABI.
+#[inline]
+fn spec_result_to_promise(result: f64) -> *mut Promise {
+    crate::value::js_nanbox_get_pointer(result) as *mut Promise
+}
+
+/// Iterable-accepting entry for `Promise.all` (issue #2822 / #4521). Codegen's
+/// direct-call path (`Promise.all([...])`) lands here with `this` = intrinsic
+/// `Promise`; supply that constructor explicitly and delegate to the
+/// spec-compliant combinator.
 #[no_mangle]
 pub extern "C" fn js_promise_all_iterable(value: f64) -> *mut Promise {
-    match combinator_iterable_to_array_caught(value) {
-        Ok(arr) => js_promise_all(arr),
-        Err(reason) => {
-            let p = js_promise_new();
-            js_promise_reject(p, reason);
-            p
-        }
-    }
+    let c = super::spec_combinators::default_promise_ctor();
+    spec_result_to_promise(super::spec_combinators::js_promise_all_spec(c, value))
 }
 
-/// Iterable-accepting entry for `Promise.race` (issue #2822).
+/// Iterable-accepting entry for `Promise.race` (issue #2822 / #4521).
 #[no_mangle]
 pub extern "C" fn js_promise_race_iterable(value: f64) -> *mut Promise {
-    match combinator_iterable_to_array_caught(value) {
-        Ok(arr) => js_promise_race(arr),
-        Err(reason) => {
-            let p = js_promise_new();
-            js_promise_reject(p, reason);
-            p
-        }
-    }
+    let c = super::spec_combinators::default_promise_ctor();
+    spec_result_to_promise(super::spec_combinators::js_promise_race_spec(c, value))
 }
 
-/// Iterable-accepting entry for `Promise.allSettled` (issue #2822).
+/// Iterable-accepting entry for `Promise.allSettled` (issue #2822 / #4521).
 #[no_mangle]
 pub extern "C" fn js_promise_all_settled_iterable(value: f64) -> *mut Promise {
-    match combinator_iterable_to_array_caught(value) {
-        Ok(arr) => js_promise_all_settled(arr),
-        Err(reason) => {
-            let p = js_promise_new();
-            js_promise_reject(p, reason);
-            p
-        }
-    }
+    let c = super::spec_combinators::default_promise_ctor();
+    spec_result_to_promise(super::spec_combinators::js_promise_all_settled_spec(
+        c, value,
+    ))
 }
 
-/// Iterable-accepting entry for `Promise.any` (issue #2822).
+/// Iterable-accepting entry for `Promise.any` (issue #2822 / #4521).
 #[no_mangle]
 pub extern "C" fn js_promise_any_iterable(value: f64) -> *mut Promise {
-    match combinator_iterable_to_array_caught(value) {
-        Ok(arr) => js_promise_any(arr),
-        Err(reason) => {
-            let p = js_promise_new();
-            js_promise_reject(p, reason);
-            p
-        }
-    }
+    let c = super::spec_combinators::default_promise_ctor();
+    spec_result_to_promise(super::spec_combinators::js_promise_any_spec(c, value))
 }
 
 /// #2822/#3320: keepalive anchors so the whole-program LLVM (auto-optimize)
@@ -532,7 +521,10 @@ pub extern "C" fn js_promise_new_with_executor(
 
 /// Internal resolve function for Promise executor callbacks.
 /// Called when user calls resolve(value) inside the executor.
-extern "C" fn promise_resolve_fn(closure: *const crate::closure::ClosureHeader, value: f64) -> f64 {
+pub(super) extern "C" fn promise_resolve_fn(
+    closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
     use crate::closure::js_closure_get_capture_ptr;
 
     let promise_ptr = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
@@ -542,7 +534,10 @@ extern "C" fn promise_resolve_fn(closure: *const crate::closure::ClosureHeader, 
 
 /// Internal reject function for Promise executor callbacks.
 /// Called when user calls reject(reason) inside the executor.
-extern "C" fn promise_reject_fn(closure: *const crate::closure::ClosureHeader, reason: f64) -> f64 {
+pub(super) extern "C" fn promise_reject_fn(
+    closure: *const crate::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
     use crate::closure::js_closure_get_capture_ptr;
 
     let promise_ptr = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
@@ -551,7 +546,7 @@ extern "C" fn promise_reject_fn(closure: *const crate::closure::ClosureHeader, r
 }
 
 #[inline]
-fn callable_closure_value(value: f64) -> Option<*const crate::closure::ClosureHeader> {
+pub(super) fn callable_closure_value(value: f64) -> Option<*const crate::closure::ClosureHeader> {
     let bits = value.to_bits();
     let tag = bits & crate::value::TAG_MASK;
     let raw = if tag == crate::value::POINTER_TAG || tag == crate::value::STRING_TAG {

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -23,6 +23,7 @@ pub mod combinators;
 pub mod microtasks;
 pub mod native_async;
 pub mod scanners;
+pub mod spec_combinators;
 pub mod then;
 
 // ─── Explicit named re-exports ────────────────────────────────────
@@ -54,6 +55,9 @@ pub use native_async::{
 };
 pub use scanners::{js_promise_with_resolvers, scan_promise_roots, scan_promise_roots_mut};
 pub(crate) use scanners::{new_promise_root_scan_state, scan_promise_roots_mut_step};
+pub use spec_combinators::{
+    js_promise_all_settled_spec, js_promise_all_spec, js_promise_any_spec, js_promise_race_spec,
+};
 pub(crate) use then::{
     js_promise_attach_handlers, js_promise_attach_settle_listener, promise_prototype_catch_thunk,
     promise_prototype_finally_thunk, promise_prototype_then_thunk,

--- a/crates/perry-runtime/src/promise/spec_combinators.rs
+++ b/crates/perry-runtime/src/promise/spec_combinators.rs
@@ -1,0 +1,645 @@
+//! Spec-compliant `Promise.all` / `Promise.allSettled` / `Promise.race` /
+//! `Promise.any` (ECMA-262 27.2.4.1–27.2.4.x).
+//!
+//! Unlike the simplified native path in `combinators.rs`, this implementation
+//! follows the observable algorithm:
+//!
+//!   * `NewPromiseCapability(C)` — constructs `new C(executor)` with the
+//!     `GetCapabilitiesExecutor` "called twice / not callable" `TypeError`s and
+//!     the `IsConstructor(C)` guard.
+//!   * `GetPromiseResolve(C)` — reads `C.resolve` once and requires it callable.
+//!   * Per element: `nextPromise = Call(promiseResolve, C, «next»)`, then
+//!     `Invoke(nextPromise, "then", «resolveElement, reject»)` with REAL
+//!     resolve-element closures carrying the `[[AlreadyCalled]]`, `[[Index]]`,
+//!     `[[Values]]`, `[[Capability]]`, `[[RemainingElements]]` slots.
+//!
+//! These observable steps are required by test262 (`built-ins/Promise/all/*`,
+//! `allSettled/*`, `race/*`, `any/*`) — the per-element `this.resolve`
+//! invocations, the `.then` invocations, and the resolve-element call counts
+//! are all asserted.
+
+use super::combinators::{
+    combinator_catch_js, combinator_iterable_to_array_caught, promise_reject_fn, promise_resolve_fn,
+};
+use super::*;
+use crate::array::{js_array_alloc, js_array_get_f64, js_array_set_f64};
+use crate::closure::{
+    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
+    js_closure_set_capture_f64, js_closure_set_capture_ptr,
+};
+use crate::value::{js_nanbox_pointer, JSValue};
+
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+#[inline]
+fn undef() -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+#[inline]
+fn is_undef(v: f64) -> bool {
+    v.to_bits() == TAG_UNDEFINED
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum CombinatorKind {
+    All,
+    AllSettled,
+    Race,
+    Any,
+}
+
+/// A spec `PromiseCapability` record: the constructed promise plus its
+/// resolving functions, all as NaN-boxed JS values.
+struct Capability {
+    promise: f64,
+    resolve: f64,
+    reject: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Arity registration so closures invoked with fewer args than declared pad the
+// missing slots with `undefined` (rather than reading uninitialised registers).
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static ARITY_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn ensure_arity_registered() {
+    ARITY_REGISTERED.with(|done| {
+        if done.get() {
+            return;
+        }
+        done.set(true);
+        crate::closure::js_register_closure_arity(capability_executor_fn as *const u8, 2);
+        crate::closure::js_register_closure_arity(all_resolve_element_fn as *const u8, 1);
+        crate::closure::js_register_closure_arity(settled_fulfill_element_fn as *const u8, 1);
+        crate::closure::js_register_closure_arity(settled_reject_element_fn as *const u8, 1);
+        crate::closure::js_register_closure_arity(any_reject_element_fn as *const u8, 1);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// TypeError helpers
+// ---------------------------------------------------------------------------
+
+fn throw_type_error(msg: &str) -> ! {
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    let v = f64::from_bits(JSValue::pointer(err as *const u8).bits());
+    crate::exception::js_throw(v);
+}
+
+fn type_error_value(msg: &str) -> f64 {
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    f64::from_bits(JSValue::pointer(err as *const u8).bits())
+}
+
+/// Spec `IsCallable` for our purposes — a JS function value.
+fn is_callable(value: f64) -> bool {
+    // Tag-safe: the capability storage can hold ARBITRARY user values (numbers,
+    // strings, objects passed to a user `executor(resolve, reject)`), so we must
+    // not hand a bare number to `is_closure_ptr` (which dereferences the payload
+    // at `ptr+12`). Two callable encodings exist:
+    //   * NaN-boxed POINTER_TAG closures (user functions, our reified statics).
+    //   * RAW pointer-bits closures — `js_promise_new_with_executor` passes the
+    //     native resolve/reject as `f64::from_bits(closure_ptr)`, i.e. the bits
+    //     ARE a heap address, outside the NaN range.
+    // A finite JS number's bits-as-address always lands at/above 2^48 (the
+    // exponent/sign bits are set), so an upper bound on the candidate address
+    // cleanly separates real heap pointers from numbers.
+    const HEAP_ADDR_CEILING: u64 = 0x0001_0000_0000_0000; // 2^48
+    let bits = value.to_bits();
+    let tag = bits & crate::value::TAG_MASK;
+    let raw = if tag == crate::value::POINTER_TAG {
+        (bits & crate::value::POINTER_MASK) as usize
+    } else if bits < HEAP_ADDR_CEILING {
+        bits as usize
+    } else {
+        return false;
+    };
+    if raw < 0x100000 || (raw as u64) >= HEAP_ADDR_CEILING {
+        return false;
+    }
+    crate::closure::is_closure_ptr(raw) || crate::proxy::js_proxy_is_proxy(value) == 1
+}
+
+// ---------------------------------------------------------------------------
+// NewPromiseCapability(C)
+// ---------------------------------------------------------------------------
+
+/// `GetCapabilitiesExecutor` function. Captures the 2-slot capability storage
+/// array (slot0 = resolve, slot1 = reject, both init `undefined`). Throws a
+/// TypeError if either slot is already set (executor called twice).
+extern "C" fn capability_executor_fn(
+    closure: *const crate::closure::ClosureHeader,
+    resolve: f64,
+    reject: f64,
+) -> f64 {
+    let storage = js_closure_get_capture_ptr(closure, 0) as *mut crate::array::ArrayHeader;
+    if storage.is_null() {
+        return undef();
+    }
+    let cur_resolve = js_array_get_f64(storage, 0);
+    if !is_undef(cur_resolve) {
+        throw_type_error("Promise resolve or reject function is not callable");
+    }
+    let cur_reject = js_array_get_f64(storage, 1);
+    if !is_undef(cur_reject) {
+        throw_type_error("Promise resolve or reject function is not callable");
+    }
+    js_array_set_f64(storage, 0, resolve);
+    js_array_set_f64(storage, 1, reject);
+    undef()
+}
+
+/// `NewPromiseCapability(C)`. Throws (via `js_throw`) on the `IsConstructor`
+/// failure, the executor "already called" failure (propagated from the
+/// constructor), and the post-construct "resolve/reject not callable" failure.
+fn new_promise_capability(c: f64) -> Capability {
+    if !crate::object::js_value_is_constructor(c) {
+        throw_type_error("Promise.all called on non-constructor");
+    }
+
+    // Fast path: the intrinsic `Promise` constructor. Build a native capability
+    // directly (the generic construct path does not model `new Promise`).
+    if is_default_promise_constructor(c) {
+        let promise = js_promise_new();
+        let resolve = js_closure_alloc(promise_resolve_fn as *const u8, 1);
+        js_closure_set_capture_ptr(resolve, 0, promise as i64);
+        crate::object::set_builtin_closure_length(resolve as usize, 1);
+        let reject = js_closure_alloc(promise_reject_fn as *const u8, 1);
+        js_closure_set_capture_ptr(reject, 0, promise as i64);
+        crate::object::set_builtin_closure_length(reject as usize, 1);
+        return Capability {
+            promise: js_nanbox_pointer(promise as i64),
+            resolve: js_nanbox_pointer(resolve as i64),
+            reject: js_nanbox_pointer(reject as i64),
+        };
+    }
+
+    // Generic path: `new C(executor)`.
+    let storage = js_array_alloc(2);
+    unsafe {
+        (*storage).length = 2;
+    }
+    js_array_set_f64(storage, 0, undef());
+    js_array_set_f64(storage, 1, undef());
+
+    let executor = js_closure_alloc(capability_executor_fn as *const u8, 1);
+    js_closure_set_capture_ptr(executor, 0, storage as i64);
+    crate::object::set_builtin_closure_length(executor as usize, 2);
+
+    let executor_val = js_nanbox_pointer(executor as i64);
+    let args = [executor_val];
+    // Any exception thrown by the constructor (including the executor's
+    // "called twice" TypeError) propagates as a real throw — correct for the
+    // `? NewPromiseCapability(C)` step in Promise.all.
+    let promise = unsafe { crate::object::js_new_function_construct(c, args.as_ptr(), args.len()) };
+
+    let resolve = js_array_get_f64(storage, 0);
+    let reject = js_array_get_f64(storage, 1);
+    if !is_callable(resolve) || !is_callable(reject) {
+        throw_type_error("Promise resolve or reject function is not callable");
+    }
+
+    Capability {
+        promise,
+        resolve,
+        reject,
+    }
+}
+
+fn is_default_promise_constructor(c: f64) -> bool {
+    let promise_ctor =
+        crate::object::js_get_global_this_builtin_value(b"Promise".as_ptr(), b"Promise".len());
+    !is_undef(promise_ctor) && promise_ctor.to_bits() == c.to_bits()
+}
+
+// ---------------------------------------------------------------------------
+// GetPromiseResolve(C) + Call/Invoke helpers
+// ---------------------------------------------------------------------------
+
+/// `GetPromiseResolve(C)` = `? Get(C, "resolve")`, require callable. Returns the
+/// `resolve` function value on success, or `Err(thrown)` (a TypeError or the
+/// getter's own throw) to be funnelled through `IfAbruptRejectPromise`.
+fn get_promise_resolve(c: f64) -> Result<f64, f64> {
+    let resolve = combinator_catch_js(|| unsafe {
+        crate::value::js_dynamic_object_get_property(c, b"resolve".as_ptr() as *const i8, 7)
+    })?;
+    if !is_callable(resolve) {
+        return Err(type_error_value("Promise.resolve is not a function"));
+    }
+    Ok(resolve)
+}
+
+/// `Call(func, thisArg, args)` catching exceptions into `Err`.
+fn call_with_this(func: f64, this_arg: f64, args: &[f64]) -> Result<f64, f64> {
+    let (ptr, len) = if args.is_empty() {
+        (std::ptr::null(), 0)
+    } else {
+        (args.as_ptr(), args.len())
+    };
+    let prev = crate::object::js_implicit_this_set(this_arg);
+    let result =
+        combinator_catch_js(|| unsafe { crate::closure::js_native_call_value(func, ptr, len) });
+    crate::object::js_implicit_this_set(prev);
+    result
+}
+
+/// `Invoke(obj, "then", args)` catching exceptions into `Err`.
+fn invoke_then(obj: f64, args: &[f64]) -> Result<f64, f64> {
+    let (ptr, len) = if args.is_empty() {
+        (std::ptr::null(), 0)
+    } else {
+        (args.as_ptr(), args.len())
+    };
+    combinator_catch_js(|| unsafe {
+        crate::object::js_native_call_method(obj, b"then".as_ptr() as *const i8, 4, ptr, len)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Resolve-element closures
+// ---------------------------------------------------------------------------
+//
+// Shared capture layout for the per-element functions:
+//   slot 0: already_called guard array ([0] = 0/1)   (per element)
+//   slot 1: index (f64)
+//   slot 2: values/errors array (shared)
+//   slot 3: remaining-count state array ([0] = count) (shared)
+//   slot 4: capability resolve (f64) (shared)
+//   slot 5: capability reject (f64) (shared)   [allSettled/any use one of these]
+
+#[inline]
+fn take_already_called(guard: *mut crate::array::ArrayHeader) -> bool {
+    if guard.is_null() {
+        return false;
+    }
+    if js_array_get_f64(guard, 0) != 0.0 {
+        return false;
+    }
+    js_array_set_f64(guard, 0, 1.0);
+    true
+}
+
+#[inline]
+fn build_element_closure(
+    func: *const u8,
+    guard: *mut crate::array::ArrayHeader,
+    index: u32,
+    values: *mut crate::array::ArrayHeader,
+    state: *mut crate::array::ArrayHeader,
+    cap_resolve: f64,
+    cap_reject: f64,
+) -> *mut crate::closure::ClosureHeader {
+    let c = js_closure_alloc(func, 6);
+    js_closure_set_capture_ptr(c, 0, guard as i64);
+    js_closure_set_capture_f64(c, 1, index as f64);
+    js_closure_set_capture_ptr(c, 2, values as i64);
+    js_closure_set_capture_ptr(c, 3, state as i64);
+    js_closure_set_capture_f64(c, 4, cap_resolve);
+    js_closure_set_capture_f64(c, 5, cap_reject);
+    crate::object::set_builtin_closure_length(c as usize, 1);
+    // Spec: the resolve/reject element functions are anonymous built-in
+    // functions and are NOT constructors — `new resolveElement()` throws.
+    crate::object::set_builtin_closure_non_constructable(c as usize);
+    c
+}
+
+/// Decrement the shared remaining-count; return true if it just hit zero.
+#[inline]
+fn dec_remaining(state: *mut crate::array::ArrayHeader) -> bool {
+    let remaining = js_array_get_f64(state, 0) - 1.0;
+    js_array_set_f64(state, 0, remaining);
+    remaining == 0.0
+}
+
+/// Promise.all Resolve Element Function.
+extern "C" fn all_resolve_element_fn(
+    closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let guard = js_closure_get_capture_ptr(closure, 0) as *mut crate::array::ArrayHeader;
+    if !take_already_called(guard) {
+        return undef();
+    }
+    let index = js_closure_get_capture_f64(closure, 1) as u32;
+    let values = js_closure_get_capture_ptr(closure, 2) as *mut crate::array::ArrayHeader;
+    let state = js_closure_get_capture_ptr(closure, 3) as *mut crate::array::ArrayHeader;
+    let cap_resolve = js_closure_get_capture_f64(closure, 4);
+
+    js_array_set_f64(values, index, value);
+    if dec_remaining(state) {
+        let arr = js_nanbox_pointer(values as i64);
+        let _ = call_with_this(cap_resolve, undef(), &[arr]);
+    }
+    undef()
+}
+
+/// Promise.allSettled Resolve Element Function → `{status:"fulfilled", value}`.
+extern "C" fn settled_fulfill_element_fn(
+    closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let guard = js_closure_get_capture_ptr(closure, 0) as *mut crate::array::ArrayHeader;
+    if !take_already_called(guard) {
+        return undef();
+    }
+    let index = js_closure_get_capture_f64(closure, 1) as u32;
+    let values = js_closure_get_capture_ptr(closure, 2) as *mut crate::array::ArrayHeader;
+    let state = js_closure_get_capture_ptr(closure, 3) as *mut crate::array::ArrayHeader;
+    let cap_resolve = js_closure_get_capture_f64(closure, 4);
+
+    js_array_set_f64(values, index, build_settled_fulfilled(value));
+    if dec_remaining(state) {
+        let arr = js_nanbox_pointer(values as i64);
+        let _ = call_with_this(cap_resolve, undef(), &[arr]);
+    }
+    undef()
+}
+
+/// Promise.allSettled Reject Element Function → `{status:"rejected", reason}`.
+extern "C" fn settled_reject_element_fn(
+    closure: *const crate::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
+    let guard = js_closure_get_capture_ptr(closure, 0) as *mut crate::array::ArrayHeader;
+    if !take_already_called(guard) {
+        return undef();
+    }
+    let index = js_closure_get_capture_f64(closure, 1) as u32;
+    let values = js_closure_get_capture_ptr(closure, 2) as *mut crate::array::ArrayHeader;
+    let state = js_closure_get_capture_ptr(closure, 3) as *mut crate::array::ArrayHeader;
+    let cap_resolve = js_closure_get_capture_f64(closure, 4);
+
+    js_array_set_f64(values, index, build_settled_rejected(reason));
+    if dec_remaining(state) {
+        let arr = js_nanbox_pointer(values as i64);
+        let _ = call_with_this(cap_resolve, undef(), &[arr]);
+    }
+    undef()
+}
+
+/// Promise.any Reject Element Function → collect into errors array; reject with
+/// AggregateError once all reject.
+extern "C" fn any_reject_element_fn(
+    closure: *const crate::closure::ClosureHeader,
+    reason: f64,
+) -> f64 {
+    let guard = js_closure_get_capture_ptr(closure, 0) as *mut crate::array::ArrayHeader;
+    if !take_already_called(guard) {
+        return undef();
+    }
+    let index = js_closure_get_capture_f64(closure, 1) as u32;
+    let errors = js_closure_get_capture_ptr(closure, 2) as *mut crate::array::ArrayHeader;
+    let state = js_closure_get_capture_ptr(closure, 3) as *mut crate::array::ArrayHeader;
+    let cap_reject = js_closure_get_capture_f64(closure, 5);
+
+    js_array_set_f64(errors, index, reason);
+    if dec_remaining(state) {
+        let msg = crate::string::js_string_from_bytes(b"All promises were rejected".as_ptr(), 26);
+        let agg = crate::error::js_aggregateerror_new(errors, msg);
+        let agg_v = js_nanbox_pointer(agg as i64);
+        let _ = call_with_this(cap_reject, undef(), &[agg_v]);
+    }
+    undef()
+}
+
+fn build_settled_fulfilled(value: f64) -> f64 {
+    use crate::object::{js_object_alloc_with_shape, js_object_set_field};
+    let packed = b"status\0value\0";
+    let obj = js_object_alloc_with_shape(0x7FFF_FF10, 2, packed.as_ptr(), packed.len() as u32);
+    let status = crate::string::js_string_from_bytes(b"fulfilled".as_ptr(), 9);
+    js_object_set_field(
+        obj,
+        0,
+        JSValue::from_bits(crate::value::js_nanbox_string(status as i64).to_bits()),
+    );
+    js_object_set_field(obj, 1, JSValue::from_bits(value.to_bits()));
+    js_nanbox_pointer(obj as i64)
+}
+
+fn build_settled_rejected(reason: f64) -> f64 {
+    use crate::object::{js_object_alloc_with_shape, js_object_set_field};
+    let packed = b"status\0reason\0";
+    let obj = js_object_alloc_with_shape(0x7FFF_FF11, 2, packed.as_ptr(), packed.len() as u32);
+    let status = crate::string::js_string_from_bytes(b"rejected".as_ptr(), 8);
+    js_object_set_field(
+        obj,
+        0,
+        JSValue::from_bits(crate::value::js_nanbox_string(status as i64).to_bits()),
+    );
+    js_object_set_field(obj, 1, JSValue::from_bits(reason.to_bits()));
+    js_nanbox_pointer(obj as i64)
+}
+
+// ---------------------------------------------------------------------------
+// PerformPromise{All,AllSettled,Race,Any}
+// ---------------------------------------------------------------------------
+
+/// Run the per-element loop. `cap` is the result capability, `promise_resolve`
+/// the `C.resolve` function, `elements` the snapshot of iterated values.
+/// Returns `Ok(())` on success or `Err(thrown)` for `IfAbruptRejectPromise`.
+fn perform(
+    kind: CombinatorKind,
+    c: f64,
+    cap: &Capability,
+    promise_resolve: f64,
+    elements: *mut crate::array::ArrayHeader,
+) -> Result<(), f64> {
+    let count = unsafe { (*elements).length };
+
+    // Shared state: remaining-count (init 1, spec's remainingElementsCount).
+    let state = js_array_alloc(1);
+    unsafe {
+        (*state).length = 1;
+    }
+    js_array_set_f64(state, 0, 1.0);
+
+    // Shared values/errors array (not used by Race).
+    let values = if kind == CombinatorKind::Race {
+        std::ptr::null_mut()
+    } else {
+        let v = js_array_alloc(count.max(1));
+        unsafe {
+            (*v).length = count;
+        }
+        for i in 0..count {
+            js_array_set_f64(v, i, undef());
+        }
+        v
+    };
+
+    for i in 0..count {
+        let next = js_array_get_f64(elements, i);
+        // nextPromise = ? Call(promiseResolve, C, «next»)
+        let next_promise = call_with_this(promise_resolve, c, &[next])?;
+
+        match kind {
+            CombinatorKind::All => {
+                let guard = new_guard();
+                let elem = build_element_closure(
+                    all_resolve_element_fn as *const u8,
+                    guard,
+                    i,
+                    values,
+                    state,
+                    cap.resolve,
+                    cap.reject,
+                );
+                js_array_set_f64(state, 0, js_array_get_f64(state, 0) + 1.0);
+                invoke_then(next_promise, &[js_nanbox_pointer(elem as i64), cap.reject])?;
+            }
+            CombinatorKind::AllSettled => {
+                let guard = new_guard();
+                let on_ful = build_element_closure(
+                    settled_fulfill_element_fn as *const u8,
+                    guard,
+                    i,
+                    values,
+                    state,
+                    cap.resolve,
+                    cap.reject,
+                );
+                let on_rej = build_element_closure(
+                    settled_reject_element_fn as *const u8,
+                    guard,
+                    i,
+                    values,
+                    state,
+                    cap.resolve,
+                    cap.reject,
+                );
+                js_array_set_f64(state, 0, js_array_get_f64(state, 0) + 1.0);
+                invoke_then(
+                    next_promise,
+                    &[
+                        js_nanbox_pointer(on_ful as i64),
+                        js_nanbox_pointer(on_rej as i64),
+                    ],
+                )?;
+            }
+            CombinatorKind::Any => {
+                let guard = new_guard();
+                let on_rej = build_element_closure(
+                    any_reject_element_fn as *const u8,
+                    guard,
+                    i,
+                    values,
+                    state,
+                    cap.resolve,
+                    cap.reject,
+                );
+                js_array_set_f64(state, 0, js_array_get_f64(state, 0) + 1.0);
+                invoke_then(
+                    next_promise,
+                    &[cap.resolve, js_nanbox_pointer(on_rej as i64)],
+                )?;
+            }
+            CombinatorKind::Race => {
+                invoke_then(next_promise, &[cap.resolve, cap.reject])?;
+            }
+        }
+    }
+
+    // Iterator exhausted: remainingElementsCount -= 1.
+    if kind != CombinatorKind::Race {
+        let remaining = js_array_get_f64(state, 0) - 1.0;
+        js_array_set_f64(state, 0, remaining);
+        if remaining == 0.0 {
+            match kind {
+                CombinatorKind::All | CombinatorKind::AllSettled => {
+                    let arr = js_nanbox_pointer(values as i64);
+                    call_with_this(cap.resolve, undef(), &[arr])?;
+                }
+                CombinatorKind::Any => {
+                    let msg = crate::string::js_string_from_bytes(
+                        b"All promises were rejected".as_ptr(),
+                        26,
+                    );
+                    let agg = crate::error::js_aggregateerror_new(values, msg);
+                    let agg_v = js_nanbox_pointer(agg as i64);
+                    call_with_this(cap.reject, undef(), &[agg_v])?;
+                }
+                CombinatorKind::Race => unreachable!(),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn new_guard() -> *mut crate::array::ArrayHeader {
+    let g = js_array_alloc(1);
+    unsafe {
+        (*g).length = 1;
+    }
+    js_array_set_f64(g, 0, 0.0);
+    g
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry: Promise.<combinator>(iterable) with `this` = C
+// ---------------------------------------------------------------------------
+
+/// Spec entry for a Promise combinator. `c` is the `this` constructor; throws
+/// synchronously for `NewPromiseCapability` failures, otherwise returns the
+/// (possibly already-rejected) result promise.
+pub fn run_combinator(kind: CombinatorKind, c: f64, iterable: f64) -> f64 {
+    ensure_arity_registered();
+
+    // 2. Let promiseCapability be ? NewPromiseCapability(C). (may throw)
+    let cap = new_promise_capability(c);
+
+    // 3-8. The remaining steps are IfAbruptRejectPromise-guarded.
+    let result: Result<(), f64> = (|| {
+        let promise_resolve = get_promise_resolve(c)?;
+        let elements = combinator_iterable_to_array_caught(iterable)?;
+        perform(kind, c, &cap, promise_resolve, elements)
+    })();
+
+    if let Err(reason) = result {
+        let _ = call_with_this(cap.reject, undef(), &[reason]);
+    }
+    cap.promise
+}
+
+// ---------------------------------------------------------------------------
+// Public C-ABI entries (constructor-aware). Used by codegen direct-call path
+// (C = intrinsic Promise) and by the reified static thunks (C = implicit this).
+// ---------------------------------------------------------------------------
+
+/// The intrinsic `Promise` constructor value — `this` for the codegen
+/// direct-call path (`Promise.all([...])`).
+pub(super) fn default_promise_ctor() -> f64 {
+    crate::object::js_get_global_this_builtin_value(b"Promise".as_ptr(), b"Promise".len())
+}
+
+// NOTE: `this_ctor` is passed through verbatim — `undefined`/`null`/primitive
+// `this` (e.g. `Promise.all.call(undefined, [])`) must reach
+// `NewPromiseCapability` and throw a TypeError, NOT silently default to the
+// intrinsic Promise. The codegen direct-call path supplies the real Promise
+// constructor via the `*_iterable` entries in `combinators.rs`.
+
+#[no_mangle]
+pub extern "C" fn js_promise_all_spec(this_ctor: f64, iterable: f64) -> f64 {
+    run_combinator(CombinatorKind::All, this_ctor, iterable)
+}
+
+#[no_mangle]
+pub extern "C" fn js_promise_all_settled_spec(this_ctor: f64, iterable: f64) -> f64 {
+    run_combinator(CombinatorKind::AllSettled, this_ctor, iterable)
+}
+
+#[no_mangle]
+pub extern "C" fn js_promise_race_spec(this_ctor: f64, iterable: f64) -> f64 {
+    run_combinator(CombinatorKind::Race, this_ctor, iterable)
+}
+
+#[no_mangle]
+pub extern "C" fn js_promise_any_spec(this_ctor: f64, iterable: f64) -> f64 {
+    run_combinator(CombinatorKind::Any, this_ctor, iterable)
+}


### PR DESCRIPTION
## Summary

Replaces the simplified native Promise-combinator stub with the observable ECMA-262 §27.2.4.x algorithm, in a new `crates/perry-runtime/src/promise/spec_combinators.rs`.

Closes the largest remaining test262 `built-ins/Promise` parity gap (#4521).

## What changed

**`spec_combinators.rs` (new)** — `PerformPromise{All,AllSettled,Race,Any}`:
- **`NewPromiseCapability(C)`** — constructs `new C(executor)` with the `GetCapabilitiesExecutor` *"called twice"* / *"not callable"* `TypeError`s and the `IsConstructor(C)` guard. The intrinsic `Promise` takes a native-capability fast path.
- **`GetPromiseResolve(C)`** — reads `C.resolve` exactly once (honoring user getters / overrides), requires it callable.
- Per element: `nextPromise = Call(promiseResolve, C, «next»)` then `Invoke(nextPromise, "then", «resolveElement, reject»)` with **real** resolve/reject element closures carrying the `[[AlreadyCalled]]` / `[[Index]]` / `[[Values]]` / `[[Capability]]` / `[[RemainingElements]]` internal slots (`.length === 1`, non-constructable).

The combinators are now `this`-sensitive, which required two supporting fixes:
- **hir** (`expr_call/intrinsics.rs`): exclude `all`/`race`/`allSettled`/`any` from the namespace-static `.call`/`.apply`/`.bind` *thisArg-dropping* rewrite — `Promise.all.call(C, …)` must keep `C` as the constructor. The reified static thunks read implicit-`this`.
- **class_registry**: a constructor that returns a Promise (`GC_TYPE_PROMISE`) now overrides the implicit `this`, so the `function P(e){ return new Promise(...) }` NewPromiseCapability shape yields that promise. Added `js_value_is_constructor`.

## Results (test262 `built-ins/Promise`)

| dir | before | after |
|-----|-------:|------:|
| all | 67/98 | **90/98** |
| allSettled | — | **96/104** |
| race | — | **88/94** |
| any | — | **92/94** |

Verified byte-identical to `node --experimental-strip-types` on `Promise.all`/`allSettled`/`race`/`any` over resolved values, rejections, thenables, timers, and nested combinators. No regression in the 48 promise unit tests or `then`/`catch`/`finally`.

## Known remaining gaps (deeper features, follow-ups)
- `class X extends Promise` subclassing (`ctx-ctor`, `invoke-resolve-…-of-custom`) — `super()` to the native Promise base isn't wired.
- Lazy `IteratorClose` + unhandled-rejection exit-code (`iter-*-no-close`).
- Own-property `.then` override on a native Promise instance (`invoke-then`).
- A pre-existing codegen duplicate-global bug on `*/capability-executor-*` (also hits the untouched `prototype/then` cases).