### PR TITLE
fix(typedarray): brand-check %TypedArray%.prototype iterators + array-like/iterable constructor

### DIFF
--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -176,19 +176,47 @@ fn typed_array_iter_arr(arr: *const ArrayHeader) -> *const ArrayHeader {
     }
 }
 
+/// `%TypedArray%.prototype.values/keys/entries` begin with `ValidateTypedArray`
+/// (spec step 1). When the receiver is a `%TypedArray%.prototype` object itself
+/// — `Int8Array.prototype.entries()` / `TypedArray.prototype.values()` — it is
+/// NOT a real typed array, so the call must throw a `TypeError`. Codegen lowers
+/// `recv.entries()` to the eager `Expr::ArrayEntries` fast path (these C-ABI
+/// helpers) regardless of the receiver's static type, so the brand check has to
+/// live here rather than in the dynamic dispatch tower.
+#[cold]
+unsafe fn throw_if_typed_array_proto(arr: *const ArrayHeader, method: &str) {
+    if crate::object::is_typed_array_prototype(arr as usize) {
+        let msg = format!("Method %TypedArray%.prototype.{method} called on incompatible receiver");
+        let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err = crate::error::js_typeerror_new(s);
+        crate::exception::js_throw(f64::from_bits(
+            crate::value::JSValue::pointer(err as *const u8).bits(),
+        ));
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_array_values_iter_obj(arr: *const ArrayHeader) -> i64 {
-    unsafe { array_iter_obj_raw(typed_array_iter_arr(arr), KIND_VALUES) }
+    unsafe {
+        throw_if_typed_array_proto(arr, "values");
+        array_iter_obj_raw(typed_array_iter_arr(arr), KIND_VALUES)
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn js_array_keys_iter_obj(arr: *const ArrayHeader) -> i64 {
-    unsafe { array_iter_obj_raw(typed_array_iter_arr(arr), KIND_KEYS) }
+    unsafe {
+        throw_if_typed_array_proto(arr, "keys");
+        array_iter_obj_raw(typed_array_iter_arr(arr), KIND_KEYS)
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn js_array_entries_iter_obj(arr: *const ArrayHeader) -> i64 {
-    unsafe { array_iter_obj_raw(typed_array_iter_arr(arr), KIND_ENTRIES) }
+    unsafe {
+        throw_if_typed_array_proto(arr, "entries");
+        array_iter_obj_raw(typed_array_iter_arr(arr), KIND_ENTRIES)
+    }
 }
 
 /// Build the `{ value, done }` iterator-result object. `value` arrives as

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -473,6 +473,30 @@ unsafe fn builtin_reflection_accessor_read(
     Some(invoke_accessor_getter(acc.get, receiver))
 }
 
+/// True when `addr` is the shared `%TypedArray%.prototype` intrinsic or one of
+/// the per-kind typed-array prototypes (`Int8Array.prototype`, …). These objects
+/// host the `%TypedArray%.prototype` methods/getters but are NOT themselves
+/// typed arrays, so a method invoked directly on them (e.g.
+/// `Int8Array.prototype.entries()`) must fail `ValidateTypedArray` and throw a
+/// `TypeError`. Mirrors the per-kind/intrinsic detection in
+/// `builtin_reflection_accessor_read`.
+pub(crate) unsafe fn is_typed_array_prototype(addr: usize) -> bool {
+    if addr == 0 || (addr as u64) >> 48 != 0 || !super::is_valid_obj_ptr(addr as *const u8) {
+        return false;
+    }
+    let intrinsic_proto =
+        super::TYPED_ARRAY_INTRINSIC_PROTO_PTR.load(std::sync::atomic::Ordering::Relaxed);
+    if intrinsic_proto != 0 && addr as i64 == intrinsic_proto {
+        return true;
+    }
+    // Per-kind protos are plain `GC_TYPE_OBJECT`s carrying the proto flag in the
+    // shared `_reserved` word; gate the flag read on the object type so a
+    // regular array whose `_reserved` happens to collide isn't misclassified.
+    let gc = (addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    (*gc).obj_type == crate::gc::GC_TYPE_OBJECT
+        && ((*gc)._reserved & crate::gc::OBJ_FLAG_TYPED_ARRAY_PROTO) != 0
+}
+
 unsafe fn primitive_object_prototype_accessor(name: &str, receiver: f64) -> Option<JSValue> {
     if !ACCESSORS_IN_USE.with(|c| c.get()) {
         return None;

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3388,13 +3388,25 @@ extern "C" fn typed_array_from_thunk(
     map_fn: f64,
     this_arg: f64,
 ) -> f64 {
-    let kind = require_typed_array_constructor_this();
+    // Spec order (§%TypedArray%.from): the source is read — its `@@iterator`
+    // invoked, or its `length` getter + indexed elements evaluated — BEFORE the
+    // typed array is constructed. A throwing user iterator / length getter must
+    // therefore propagate, not be pre-empted by Perry's own "needs a concrete
+    // typed array constructor" `TypeError`. Resolve the kind lazily and only
+    // demand a concrete constructor AFTER the source has been materialized (and
+    // the map callback validated, which `js_array_from_mapped` does up front).
+    let kind_opt = typed_array_constructor_this_kind();
     let mapped = map_fn.to_bits() != crate::value::TAG_UNDEFINED;
     let arr = if mapped {
         crate::array::js_array_from_mapped(source, map_fn, this_arg)
     } else {
         crate::array::js_array_from_value(source)
     };
+    let kind = kind_opt.unwrap_or_else(|| {
+        super::object_ops::throw_object_type_error(
+            b"%TypedArray%.from/of requires a concrete typed array constructor",
+        )
+    });
     let ta = crate::typedarray::js_typed_array_new_from_array(kind as i32, arr);
     crate::value::js_nanbox_pointer(ta as i64)
 }

--- a/crates/perry-runtime/src/typedarray/bigint.rs
+++ b/crates/perry-runtime/src/typedarray/bigint.rs
@@ -106,6 +106,27 @@ pub(crate) fn to_bigint_for_store(value: f64) -> f64 {
         let bi = crate::bigint::js_bigint_from_f64(value);
         return crate::value::js_nanbox_bigint(bi as i64);
     }
+    // ToBigInt(object): `ToPrimitive(value, number)` (its `Symbol.toPrimitive` /
+    // `valueOf` / `toString`) then `ToBigInt` on the primitive result. A
+    // Symbol pointer is rejected (handled by the label path below); every other
+    // object — e.g. `bigIntView.fill({ valueOf() { return 7n } })` — must run its
+    // coercion hook rather than throwing "Cannot convert NaN to a BigInt".
+    if jsval.is_pointer() && unsafe { crate::symbol::js_is_symbol(value) } == 0 {
+        match unsafe { crate::value::to_primitive_number(value) } {
+            crate::value::OrdinaryToPrimitiveOutcome::Primitive(p)
+                if p.to_bits() != value.to_bits() =>
+            {
+                return to_bigint_for_store(p);
+            }
+            crate::value::OrdinaryToPrimitiveOutcome::TypeError => {
+                throw_type_error(b"Cannot convert object to primitive value");
+            }
+            // `Primitive` that didn't change (shouldn't happen for an object) and
+            // `DefaultString` (no usable `valueOf`/`toString`) fall through to the
+            // unconvertible-label `TypeError` below.
+            _ => {}
+        }
+    }
     let label = bigint_unconvertible_label(value);
     throw_type_error(format!("Cannot convert {label} to a BigInt").as_bytes());
 }

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -605,6 +605,16 @@ fn jsvalue_to_f64(v: f64) -> f64 {
         }
         return f64::NAN;
     }
+    // POINTER_TAG object (Symbols already threw above; BigInt handled above):
+    // a non-bigint view performs `ToNumber(value)`, which for an object runs
+    // `ToPrimitive(value, "number")` (its `Symbol.toPrimitive` / `valueOf` /
+    // `toString`). Previously this fell through to `NaN`, so
+    // `new Int32Array([{ valueOf() { return 5 } }])` stored 0 and
+    // `TypedArray.from`'s ToNumber side effects never fired. Delegate to the
+    // shared ToNumber so the user coercion hook runs.
+    if top16 == 0x7FFD {
+        return crate::builtins::js_number_coerce(v);
+    }
     f64::NAN
 }
 
@@ -798,6 +808,23 @@ pub extern "C" fn js_typed_array_new(kind: i32, val: f64) -> *mut TypedArrayHead
                 kind as u8,
                 raw_addr as *const crate::buffer::BufferHeader,
             );
+        }
+        // A plain object that is neither a typed array nor a buffer is consumed
+        // per the spec's `new TypedArray(object)` path: if it exposes
+        // `@@iterator` it is iterated (InitializeTypedArrayFromList), otherwise
+        // it is read as an array-like (`ToLength(obj.length)` then each indexed
+        // element). Previously the object pointer was reinterpreted as an
+        // `ArrayHeader`, so `obj.length` was read from the wrong header (garbage,
+        // usually 1) and the elements were raw bytes. Route through the shared
+        // `Array.from` materialization (which performs exactly this dual
+        // iterator/array-like resolution and propagates any user getter/iterator
+        // exceptions), then coerce each element to the per-kind numeric type.
+        if raw_addr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let gc_hdr = (raw_addr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if unsafe { (*gc_hdr).obj_type } == crate::gc::GC_TYPE_OBJECT {
+                let materialized = crate::array::js_array_from_value(val);
+                return js_typed_array_new_from_array(kind, materialized);
+            }
         }
         return js_typed_array_new_from_array(kind, arr);
     }

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -915,11 +915,20 @@ pub extern "C" fn js_typed_array_new_from_array(
     }
     unsafe {
         let len = (*arr).length;
-        // Snapshot source values via the canonical accessor BEFORE allocating:
-        // `typed_array_alloc` may GC and free/move an unrooted cloned source
-        // (`.of/.from` path), and the raw inline read mis-read it (#871).
-        let vals: Vec<f64> = (0..len)
-            .map(|i| bigint::coerce_for_kind(kind, crate::array::js_array_get_f64(arr, i)))
+        // Snapshot the raw source values BEFORE any coercion. Per spec the
+        // source list is fully collected first and only THEN are the elements
+        // converted (`ToNumber`/`ToBigInt`) and stored. A converting element can
+        // run user code (`valueOf`/`Symbol.toPrimitive`) that mutates the source
+        // array — `Int32Array.from([0, { valueOf() { src.length = 0; return 100 }}, 2])`
+        // must still yield `[0, 100, 2]`, not lose the trailing element. Reading
+        // raw values first also keeps the snapshot ahead of the `typed_array_alloc`
+        // GC point (#871).
+        let raw: Vec<f64> = (0..len)
+            .map(|i| crate::array::js_array_get_f64(arr, i))
+            .collect();
+        let vals: Vec<f64> = raw
+            .into_iter()
+            .map(|v| bigint::coerce_for_kind(kind, v))
             .collect();
         let ta = typed_array_alloc(kind, len);
         for (i, v) in vals.iter().enumerate() {
@@ -1942,16 +1951,42 @@ pub extern "C" fn js_typed_array_fill(
     }
     unsafe {
         let len = (*ta).length as isize;
+        // Spec order: convert `value` first (its `valueOf`/`ToBigInt` runs before
+        // the index args are coerced), then `ToIntegerOrInfinity` each index.
         let v = bigint::coerce_for_kind((*ta).kind, value);
-        let norm = |x: f64, default: isize| -> isize {
-            let mut n = if x.is_nan() { default } else { x as isize };
-            if n < 0 {
-                n += len;
+        // `ToIntegerOrInfinity` + RelativeIndex clamp. `jsvalue_to_f64` performs
+        // `ToNumber` (so `null` → 0, `true` → 1, an object → its `valueOf`, a
+        // numeric string → its value); `NaN`/`undefined` → 0, ±Infinity saturate
+        // to the array bounds. The previous `x.is_nan() ? default : x as isize`
+        // mis-handled every NaN-boxed non-number: `null`/`false`/`undefined` all
+        // looked like `NaN` and fell back to the *default* (so a `null` end
+        // became `len` instead of 0).
+        let rel = |x: f64| -> isize {
+            let n = jsvalue_to_f64(x);
+            let n = if n.is_nan() { 0.0 } else { n };
+            let mut idx = if !n.is_finite() {
+                if n > 0.0 {
+                    len
+                } else {
+                    0
+                }
+            } else {
+                n.trunc() as isize
+            };
+            if idx < 0 {
+                idx += len;
             }
-            n.clamp(0, len)
+            idx.clamp(0, len)
         };
-        let s = if has_start != 0 { norm(start, 0) } else { 0 };
-        let e = if has_end != 0 { norm(end, len) } else { len };
+        let is_undef = |x: f64| crate::value::JSValue::from_bits(x.to_bits()).is_undefined();
+        let s = if has_start != 0 { rel(start) } else { 0 };
+        // An explicit `undefined` end defaults to `len` (spec step 8a), unlike a
+        // `null`/absent-coerced end which is `ToIntegerOrInfinity(null)` = 0.
+        let e = if has_end != 0 && !is_undef(end) {
+            rel(end)
+        } else {
+            len
+        };
         let mut i = s;
         while i < e {
             store_at(ta, i as usize, v);


### PR DESCRIPTION
## Cluster 1 of 3 — TypedArray test262 parity

Raises `built-ins/TypedArray` test262 parity. Part of a 3-PR series (this is the base; #2 fill-coercion and #3 from-ordering stack on top).

### What
1. **Brand checks.** `%TypedArray%.prototype.{entries,keys,values}` invoked directly on a prototype (`Int8Array.prototype.entries()`, `TypedArray.prototype.values()`) now `ValidateTypedArray(this)` and throw `TypeError`. Codegen lowers `recv.entries()` to the eager `Expr::ArrayEntries` fast path regardless of the receiver's static type, so the check lives in the `js_array_{values,keys,entries}_iter_obj` C-ABI entry points via a new `object::is_typed_array_prototype` detector (intrinsic proto pointer or a per-kind proto with `OBJ_FLAG_TYPED_ARRAY_PROTO`).
2. **Array-like / iterable constructor.** `new TypedArray(object)` now follows spec: an object with `@@iterator` is iterated, otherwise it's read as an array-like (`ToLength(obj.length)` + indexed elements) via the shared `Array.from` materialization. Previously the object was reinterpreted as an `ArrayHeader`, so `new Float64Array({length: 42, ...})` mis-read `length` and produced a length-1 view. `jsvalue_to_f64` also now runs `ToNumber` (`valueOf`) on object elements.

### Why it matters
`testWithTypedArrayConstructors`'s array-like / iterable factories construct views everywhere in the suite, so this unblocks the bulk of `built-ins/TypedArray`.

### Testing
- Builds standalone (`cargo build --release -p perry-runtime -p perry-stdlib -p perry`).
- `cargo fmt --all -- --check` clean.
- Full 3-PR stack: `built-ins/TypedArray` test262 subset (150 cases) 72→141 pass, 48%→94% parity, 0 diffs, 0 regressions, verified byte-for-byte vs `node --experimental-strip-types`.