### PR TITLE
fix(promise): thread `this` through Promise.{resolve,reject}.call(C,…) + fix var-redeclare codegen

### DIFF
--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1401,6 +1401,15 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 module_global_types.insert(*id, ty.clone());
             }
             if referenced_from_fn.contains(id) || exported_var_names.contains(name) {
+                // A `var` redeclared at module scope (`var x = …; … var x = …;`)
+                // lowers to multiple `Stmt::Let` sharing the SAME id. The backing
+                // global (and any exported getter) is keyed by that id, so emit it
+                // exactly once — a second `add_global` for the same symbol is an
+                // LLVM "redefinition of global" hard error. Captured + redeclared
+                // module vars are the trigger (e.g. test262 capability tests).
+                if module_globals.contains_key(id) {
+                    continue;
+                }
                 // Use external linkage for exported vars so other
                 // modules can reference them. Internal for the rest.
                 let is_exported = exported_var_names.contains(name);

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1553,7 +1553,16 @@ fn match_namespace_static_member(
     // `Promise.all.call(C, …)` / `.apply` / `.bind` must NOT drop the
     // thisArg — let them fall through to the generic reified-static dispatch
     // (which preserves `this` via the implicit-this mechanism).
-    if ns == "Promise" && matches!(name, "all" | "race" | "allSettled" | "any") {
+    // `resolve` / `reject` are likewise `this`-sensitive: `Promise.{resolve,
+    // reject}.call(C, x)` go through `NewPromiseCapability(C)` (a non-ctor /
+    // non-object `this` throws; a custom constructor's executor runs), so they
+    // must keep their receiver too.
+    if ns == "Promise"
+        && matches!(
+            name,
+            "all" | "race" | "allSettled" | "any" | "resolve" | "reject"
+        )
+    {
         return None;
     }
     // `Array.from` is `this`-sensitive: per ECMA-262 §23.1.2.1 it constructs


### PR DESCRIPTION
Follow-up to #4705. That PR added constructor-aware `js_promise_{resolve,reject}_spec` runtime entries, but the literal `Promise.resolve.call(C, x)` / `Promise.reject.call(C, r)` syntax never reached them — the HIR folded the `.call` away. This wires the codegen so the receiver actually flows through, and fixes a latent codegen bug that the wiring exposed.

## 1. HIR: keep `resolve`/`reject` receiver-sensitive (`intrinsics.rs`)

The namespace-static `.call`/`.apply`/`.bind` fold rewrote `Promise.reject.call(C, r)` → `Promise.reject(r)`, discarding `thisArg`. #4521 already exempted the combinators (`all`/`race`/`allSettled`/`any`) for the same reason; extend that exemption to `resolve`/`reject` so they fall through to the reified-static dispatch that preserves `this` via implicit-this → `js_promise_{resolve,reject}_spec`. Direct `Promise.resolve(x)` / `Promise.reject(x)` keep their codegen fast path (`js_promise_resolved` / `js_promise_rejected`).

## 2. Codegen: dedup module-var globals (`codegen/mod.rs`)

A module-scope `var` redeclared (`var x = …; … var x = …;`) lowers to multiple `Stmt::Let` sharing one HIR id. When such a var is **also captured by a closure**, its backing `@perry_global_<mod>__<id>` was emitted twice → LLVM `redefinition of global` **compile error**. Emit each id's global (and exported getter) exactly once.

This was a latent bug: the `this`-dropping fold used to discard the executor function entirely, so it was never compiled and never captured the redeclared var. Change 1 compiles it, and test262's capability tests redeclare `var checkPoint` and capture it in the executor — surfacing the crash. Minimal repro:
```js
var cp = ''; foo(function (e) { cp += 'a'; });
var cp = ''; foo(function (e) { cp += 'a'; });   // 'redefinition of global' before this fix
```

## Results (test262, byte-identical to `node --experimental-strip-types`)

| dir | before | after |
|-----|--------|-------|
| built-ins/Promise/reject  | 42.9% (6 pass) | **92.9% (13 pass)** — 7 fixed, 0 compile-fail |
| built-ins/Promise/resolve | 44.8% (13 pass) | **69.0% (20 pass)** — 4 fixed, 0 compile-fail |

Fixed: ctx-non-ctor, ctx-non-object, ctx-ctor-throws, capability-executor-called-twice, capability-executor-not-callable, capability-invocation, context-non-object-with-promise, S25.4.4.4_A3.1_T1. No regressions (direct `Promise.resolve/reject`, combinators, thenable assimilation, and normal var/closure capture all verified unchanged).