### PR TITLE
fix(array): Array.isArray unwraps Proxy targets (revoked → TypeError)

### DIFF
--- a/crates/perry-runtime/src/array/is_array.rs
+++ b/crates/perry-runtime/src/array/is_array.rs
@@ -12,6 +12,16 @@ pub extern "C" fn js_array_is_array(value: f64) -> f64 {
     let false_val = f64::from_bits(TAG_FALSE);
     let true_val = f64::from_bits(TAG_TRUE);
 
+    // IsArray (ECMA-262 §7.2.2) recurses through a Proxy to its target — a
+    // `Proxy([], {})` is an Array, a `Proxy(Proxy([], {}), {})` is too — and
+    // throws a TypeError if the Proxy has been revoked. Unwrap before the
+    // ordinary heap-pointer inspection below (proxy ids are small encoded
+    // values that the pointer checks would otherwise reject as non-arrays).
+    let mut value = value;
+    while let Some(target) = crate::proxy::is_array_proxy_step(value) {
+        value = target;
+    }
+
     let bits = value.to_bits();
     let jsvalue = JSValue::from_bits(bits);
 

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -214,6 +214,25 @@ pub extern "C" fn js_proxy_is_proxy(value: f64) -> i32 {
     }
 }
 
+/// `IsArray`'s Proxy branch (ECMA-262 §7.2.2). If `value` is a live Proxy,
+/// returns `Some(target)` so the caller can recurse on the target; if the Proxy
+/// has been revoked, throws a `TypeError` (does not return). Returns `None` for
+/// any non-Proxy value, so the caller falls back to its ordinary array check.
+pub(crate) fn is_array_proxy_step(value: f64) -> Option<f64> {
+    let id = lookup(value)?;
+    let (target, revoked) = PROXIES.with(|p| {
+        p.borrow()
+            .get(id as usize)
+            .and_then(|o| o.as_ref())
+            .map(|e| (e.target, e.revoked))
+            .unwrap_or((f64::from_bits(TAG_UNDEFINED), false))
+    });
+    if revoked {
+        revoked_return_with_message("Cannot perform 'IsArray' on a proxy that has been revoked");
+    }
+    Some(target)
+}
+
 /// Return the proxy's target (for Proxy.revocable.proxy revocation checks).
 #[no_mangle]
 pub extern "C" fn js_proxy_target(proxy_boxed: f64) -> f64 {


### PR DESCRIPTION
## Summary

`Array.isArray` (IsArray, ECMA-262 §7.2.2) must recurse through a `Proxy` to its target, and throw a `TypeError` if the proxy has been revoked. Perry previously returned `false` for any proxy (proxy ids are small encoded pointers the heap-type inspection rejects as non-arrays).

- `js_array_is_array` now unwraps the proxy chain before its ordinary GC-type check.
- New `proxy::is_array_proxy_step` helper: returns the target for a live proxy (so the loop recurses — a `Proxy(Proxy([],{}),{})` is still an Array), throws a `TypeError` for a revoked proxy, and returns `None` for non-proxies (fast path — `lookup` fails immediately, so ordinary arrays are unaffected).

## Tests
Fixes `built-ins/Array/isArray/proxy.js` and `built-ins/Array/isArray/proxy-revoked.js`.

Spot-checked vs Node:
```
Array.isArray(new Proxy([], {}))            // true
Array.isArray(new Proxy({}, {}))            // false
Array.isArray(new Proxy(new Proxy([],{}),{})) // true
const h = Proxy.revocable([], {}); h.revoke();
Array.isArray(h.proxy)                       // throws TypeError
```
No regression to plain array usage (the proxy step is a no-op for non-proxy values).