### PR TITLE
fix(array): spec-complete Array.of (constructor-this + abrupt propagation)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1556,13 +1556,13 @@ fn match_namespace_static_member(
     if ns == "Promise" && matches!(name, "all" | "race" | "allSettled" | "any") {
         return None;
     }
-    // `Array.from` is `this`-sensitive: per ECMA-262 §23.1.2.1 it constructs
-    // the result via its `this` value when that is a constructor
-    // (`Array.from.call(C, items)` builds an instance of `C`). The
-    // `this`-dropping fold below would discard the receiver, so route these
-    // through the dynamic dispatch path (the runtime `Array.from` thunk reads
-    // the implicit `this` and runs the full algorithm).
-    if ns == "Array" && name == "from" {
+    // `Array.from` / `Array.of` are `this`-sensitive: per ECMA-262 §23.1.2.1 /
+    // §23.1.2.3 each constructs the result via its `this` value when that is a
+    // constructor (`Array.from.call(C, items)` / `Array.of.call(C, …)` build an
+    // instance of `C`). The `this`-dropping fold below would discard the
+    // receiver, so route these through the dynamic dispatch path (the runtime
+    // thunks read the implicit `this` and run the full algorithm).
+    if ns == "Array" && matches!(name, "from" | "of") {
         return None;
     }
     Some(m.clone())

--- a/crates/perry-runtime/src/array/from_concat.rs
+++ b/crates/perry-runtime/src/array/from_concat.rs
@@ -606,6 +606,36 @@ pub fn array_from_full(c: f64, items: f64, mapfn: f64, this_arg: f64) -> f64 {
     }
 }
 
+/// Spec-complete `Array.of ( ...items )` (ECMA-262 §23.1.2.3), returning a
+/// NaN-boxed result value. `c` is the `this` value: when it `IsConstructor`,
+/// the result is `Construct(C, «len»)`; otherwise a plain Array is created.
+/// Each element is installed via `CreateDataPropertyOrThrow` and the final
+/// `Set(A, "length", len, true)` runs — every abrupt completion (a throwing
+/// constructor, a failed define, a poisoned length setter) propagates.
+pub fn array_of_full(c: f64, vals: &[f64]) -> f64 {
+    let len = vals.len();
+    let is_ctor = is_constructor_value(c);
+    let result = if is_ctor {
+        let len_arg = [len as f64];
+        unsafe { crate::object::js_new_function_construct(c, len_arg.as_ptr(), 1) }
+    } else {
+        let arr = js_array_alloc(len as u32);
+        unsafe {
+            (*arr).length = 0;
+        }
+        f64::from_bits(JSValue::pointer(arr as *const u8).bits())
+    };
+    for (k, &v) in vals.iter().enumerate() {
+        if !unsafe { create_index_data_property(result, k, v) } {
+            throw_cannot_define_property(k);
+        }
+    }
+    unsafe {
+        set_result_length(result, len);
+    }
+    result
+}
+
 /// Append every element of the (already-materializable) source array `src`
 /// into `result`, returning the (possibly reallocated) result. `src` is
 /// materialized via `js_array_clone` so sets/maps/typed-arrays/buffers spread

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -34,7 +34,8 @@ pub use self::flat_clone::{
     js_array_values,
 };
 pub use self::from_concat::{
-    array_from_full, js_array_concat_variadic, js_array_from_mapped, js_array_from_value,
+    array_from_full, array_of_full, js_array_concat_variadic, js_array_from_mapped,
+    js_array_from_value,
 };
 pub use self::generic::{
     js_arraylike_at, js_arraylike_every, js_arraylike_filter, js_arraylike_find,

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3052,16 +3052,13 @@ extern "C" fn array_from_thunk(_closure: *const crate::closure::ClosureHeader, v
 }
 
 extern "C" fn array_of_thunk(_closure: *const crate::closure::ClosureHeader, rest: f64) -> f64 {
+    // Reflective `Array.of.call(C, ...items)` binds `C` as the implicit `this`.
+    // Read it FIRST (before any nested call can overwrite it); when `C
+    // IsConstructor` the result is built via `Construct(C, «len»)`, otherwise the
+    // default `%Array%` path is taken. See `array_of_full` (ECMA-262 §23.1.2.3).
+    let c = crate::object::js_implicit_this_get();
     let vals = global_this_rest_array_values(rest);
-    let len = vals.len() as u32;
-    let arr = crate::array::js_array_alloc(len);
-    unsafe {
-        (*arr).length = len;
-        for (i, &v) in vals.iter().enumerate() {
-            crate::array::js_array_set_f64(arr, i as u32, v);
-        }
-    }
-    crate::value::js_nanbox_pointer(arr as i64)
+    crate::array::array_of_full(c, &vals)
 }
 
 extern "C" fn number_is_nan_thunk(


### PR DESCRIPTION
## Summary

`Array.of` (ECMA-262 §23.1.2.3) is `this`-sensitive, the same way `Array.from` was made spec-complete in #4700. When `this` IsConstructor (`Array.of.call(C, …)`), the result is `Construct(C, «len»)`; each item is installed via `CreateDataPropertyOrThrow`, then `Set(A, "length", len)` runs. Every abrupt completion propagates. Perry previously ignored `this` entirely and swallowed errors — it always built a plain `%Array%`.

Two parts (mirroring #4700):
- **runtime:** new `array::array_of_full` reuses the Array.from machinery (`is_constructor_value` / `create_index_data_property` / `set_result_length`). `array_of_thunk` reads the implicit `this` and delegates.
- **hir:** `Array.of` joins `Array.from` in the `this`-sensitive exclusion of the namespace-static `.call`/`.apply`/`.bind` fold (`try_namespace_static_method_apply_call_bind`), which otherwise dropped the receiver. `.call`/`.apply` now route through the dynamic dispatch path that preserves `this`.

## Tests
Fixes `built-ins/Array/of`: `construct-this-with-the-number-of-arguments.js`, `return-abrupt-from-constructor.js`, `return-abrupt-from-data-property-using-define.js`, `sets-length.js` — **built-ins/Array/of 7 → 12 passing**, no `Array.from` regression (from dir stays 43 passing).

Spot-checked vs Node: `Array.of(1,2,3)`, `Array.of.call(class extends Array{}, 1)`, a plain-function constructor receiving `len`/args, and a throwing constructor rethrowing.

Remaining out-of-scope `of` failures: `return-a-new-array-object.js` (`result instanceof Array` — separate instanceof gap) and `return-abrupt-from-data-property-using-proxy.js` (needs Proxy-trap constructor — #4654 territory).