### PR TITLE
fix(array): exotic length [[DefineOwnProperty]] (ArraySetLength) + OOB prototype reads

### DIFF
--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -11,6 +11,13 @@ fn throw_invalid_array_length() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+/// Throw the `RangeError: Invalid array length` raised by `ArraySetLength`
+/// when `ToUint32(value) !== ToNumber(value)` (a fractional / out-of-range
+/// length). Does not return.
+pub(crate) fn array_length_range_error() -> ! {
+    throw_invalid_array_length()
+}
+
 pub(crate) fn array_length_from_number_or_throw(number: f64) -> u32 {
     if number.is_finite() && number >= 0.0 && number <= u32::MAX as f64 && number.trunc() == number
     {

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -1,8 +1,73 @@
 //! Indexing — length / element get / element set / hybrid string-or-index dispatch.
 use super::*;
 use std::ptr;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 const MAX_DENSE_ARRAY_GROW_LENGTH: u32 = 1_000_000;
+
+/// Lazily-memoized address of the `Array.prototype` array, and a sticky flag
+/// recording whether anyone has installed an indexed property on it. An
+/// out-of-bounds element read on an ordinary array must fall through to
+/// `Array.prototype[index]` (ECMA-262 OrdinaryGet → prototype chain), but in
+/// real code nobody adds numeric indices to `Array.prototype`, so the hot OOB
+/// path stays a single relaxed atomic load until the (rare) write flips the
+/// flag. `usize::MAX` marks the address as not-yet-computed.
+static ARRAY_PROTO_ADDR: AtomicUsize = AtomicUsize::new(usize::MAX);
+static ARRAY_PROTO_HAS_INDEX: AtomicBool = AtomicBool::new(false);
+
+fn array_prototype_addr() -> usize {
+    let cached = ARRAY_PROTO_ADDR.load(Ordering::Relaxed);
+    if cached != usize::MAX {
+        return cached;
+    }
+    let ctor = crate::object::js_get_global_this_builtin_value(b"Array".as_ptr(), 5);
+    let ctor_value = crate::value::JSValue::from_bits(ctor.to_bits());
+    let addr = if ctor_value.is_pointer() {
+        let ctor_ptr = ctor_value.as_pointer::<u8>() as usize;
+        let proto = crate::closure::closure_get_dynamic_prop(ctor_ptr, "prototype");
+        let proto_value = crate::value::JSValue::from_bits(proto.to_bits());
+        if proto_value.is_pointer() {
+            proto_value.as_pointer::<u8>() as usize
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+    ARRAY_PROTO_ADDR.store(addr, Ordering::Relaxed);
+    addr
+}
+
+/// Record (if `arr` is `Array.prototype`) that the prototype now carries an
+/// indexed property, so subsequent out-of-bounds reads consult it. Called from
+/// the array element-write paths; cheap (two relaxed atomic loads + compare).
+#[inline]
+pub(crate) fn note_array_index_write(arr: usize) {
+    if !ARRAY_PROTO_HAS_INDEX.load(Ordering::Relaxed) && arr != 0 && arr == array_prototype_addr() {
+        ARRAY_PROTO_HAS_INDEX.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Out-of-bounds element read fallback: `Array.prototype[index]` when the
+/// prototype has indexed properties (see `ARRAY_PROTO_HAS_INDEX`). Returns the
+/// inherited value, or `undefined` if absent. Skipped entirely when the
+/// receiver IS `Array.prototype` (avoids self-recursion) or the flag is unset.
+#[inline]
+unsafe fn array_oob_prototype_get(receiver: usize, index: u32) -> f64 {
+    const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
+    if !ARRAY_PROTO_HAS_INDEX.load(Ordering::Relaxed) {
+        return TAG_UNDEFINED_F64;
+    }
+    let proto = array_prototype_addr();
+    if proto == 0 || proto == receiver {
+        return TAG_UNDEFINED_F64;
+    }
+    let proto_arr = proto as *const ArrayHeader;
+    if index >= (*proto_arr).length {
+        return TAG_UNDEFINED_F64;
+    }
+    js_array_get_f64(proto_arr, index)
+}
 
 unsafe fn array_sparse_index_property_get(arr: *const ArrayHeader, index: u32) -> Option<f64> {
     let arr = clean_arr_ptr(arr);
@@ -123,13 +188,13 @@ pub extern "C" fn js_array_get_f64_unchecked(arr: *const ArrayHeader, index: u32
     unsafe {
         let length = (*arr).length;
         if index >= length {
-            return TAG_UNDEFINED_F64;
+            return array_oob_prototype_get(arr as usize, index);
         }
         if let Some(value) = array_sparse_index_property_get(arr, index) {
             return value;
         }
         if index >= (*arr).capacity {
-            return TAG_UNDEFINED_F64;
+            return array_oob_prototype_get(arr as usize, index);
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
         let raw = *elements_ptr.add(index as usize);
@@ -241,13 +306,15 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
     unsafe {
         let length = (*arr).length;
         if index >= length {
-            return TAG_UNDEFINED_F64;
+            // Out of bounds: fall through to `Array.prototype[index]` (gated;
+            // see `array_oob_prototype_get`). Common case is one atomic load.
+            return array_oob_prototype_get(arr as usize, index);
         }
         if let Some(value) = array_sparse_index_property_get(arr, index) {
             return value;
         }
         if index >= (*arr).capacity {
-            return TAG_UNDEFINED_F64;
+            return array_oob_prototype_get(arr as usize, index);
         }
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
         let raw = *elements_ptr.add(index as usize);
@@ -367,6 +434,10 @@ pub extern "C" fn js_array_set_f64_extend(
     if arr.is_null() {
         return js_array_alloc(0);
     }
+    // If this write targets `Array.prototype`, mark the prototype as carrying an
+    // indexed property so out-of-bounds element reads on ordinary arrays consult
+    // it (ECMA-262 OrdinaryGet → prototype chain). Cheap no-op otherwise.
+    note_array_index_write(arr as usize);
     // Check if this is actually a buffer (Uint8Array) — write individual bytes
     if crate::buffer::is_registered_buffer(arr as usize) {
         crate::buffer::js_buffer_set(

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -21,6 +21,7 @@ mod splice_slice;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use self::alloc::array_length_range_error;
 pub use self::alloc::{
     js_array_alloc, js_array_alloc_literal, js_array_alloc_with_length,
     js_array_alloc_with_length_longlived, js_array_constructor_single, js_array_create,

--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -44,22 +44,167 @@ pub(crate) unsafe fn array_property_is_enumerable(
     }))
 }
 
+/// ToUint32 (ECMA-262 §7.1.6) of an already-`ToNumber`-coerced value.
+fn to_uint32(number: f64) -> u32 {
+    if !number.is_finite() || number == 0.0 {
+        return 0;
+    }
+    number.trunc().rem_euclid(4_294_967_296.0) as u32
+}
+
+/// `ArraySetLength(A, Desc)` (ECMA-262 §10.4.2.4): the array exotic
+/// `[[DefineOwnProperty]]` for the `"length"` property. The `length` property
+/// is a non-configurable, non-enumerable data property; its writability is
+/// tracked in the property-attrs side table (absent ⇒ writable). Returns `true`
+/// if the definition succeeds, `false` if it must be rejected (the caller turns
+/// that into a thrown `TypeError` for `Object.defineProperty` or a `false`
+/// return for `Reflect.defineProperty`). A non-integer / out-of-range length
+/// throws a `RangeError`, which propagates through both callers.
+pub(crate) unsafe fn array_set_length_from_descriptor(
+    obj: *mut ObjectHeader,
+    descriptor_value: f64,
+) -> bool {
+    let desc_ptr = extract_obj_ptr(descriptor_value);
+    if desc_ptr.is_null() {
+        return true;
+    }
+    let arr = obj as *mut crate::array::ArrayHeader;
+
+    let read_present = |name: &[u8]| -> bool {
+        let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        own_key_present(desc_ptr, k)
+    };
+    let read_bool = |name: &[u8]| -> bool {
+        let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
+        crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0
+    };
+
+    let has_get = read_present(b"get");
+    let has_set = read_present(b"set");
+    let has_accessor = has_get || has_set;
+    let has_value = read_present(b"value");
+    let has_writable = read_present(b"writable");
+    let new_writable = has_writable && read_bool(b"writable");
+    let has_enumerable = read_present(b"enumerable");
+    let new_enumerable = has_enumerable && read_bool(b"enumerable");
+    let has_configurable = read_present(b"configurable");
+    let new_configurable = has_configurable && read_bool(b"configurable");
+
+    // Steps 3-5 (only when a value is supplied): ToUint32 then ToNumber, in that
+    // order — each runs `ToNumber` on the descriptor's `value`, so a `valueOf`
+    // observer is invoked exactly twice and may mutate the array between calls.
+    // Read the current `length` descriptor AFTER both coercions so such a
+    // mutation (e.g. flipping `writable` to false) is honored.
+    let new_len: Option<u32> = if has_value {
+        let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+        let value_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
+        let value = f64::from_bits(value_field.bits());
+        let uint = to_uint32(crate::builtins::js_number_coerce(value));
+        let number = crate::builtins::js_number_coerce(value);
+        // SameValueZero(newLen, numberLen): a fractional / out-of-range length
+        // is a RangeError.
+        if (uint as f64) != number {
+            crate::array::array_length_range_error();
+        }
+        Some(uint)
+    } else {
+        None
+    };
+
+    let old_len = (*arr).length;
+    // `length` is non-configurable, non-enumerable; writable defaults to true
+    // until explicitly set otherwise via the side table.
+    let cur_writable = super::get_property_attrs(obj as usize, "length")
+        .map(|a| a.writable())
+        .unwrap_or(true);
+
+    // ValidateAndApplyPropertyDescriptor against the current (non-configurable
+    // data) `length` descriptor.
+    if has_configurable && new_configurable {
+        return false; // can't make a non-configurable property configurable
+    }
+    if has_enumerable && new_enumerable {
+        return false; // can't make a non-enumerable property enumerable
+    }
+    if has_accessor {
+        return false; // can't turn a non-configurable data prop into an accessor
+    }
+    if !cur_writable {
+        if has_writable && new_writable {
+            return false; // can't re-enable writability on a non-configurable prop
+        }
+        if let Some(n) = new_len {
+            if n != old_len {
+                return false; // can't change the value of a non-writable length
+            }
+        }
+    }
+
+    // Apply. Shrinking deletes the now-out-of-range indices (handled by
+    // `js_array_set_length`, which holes the truncated slots); growing pads with
+    // holes. `js_array_set_length` doesn't consult the writable side table, and
+    // we've already validated the write above.
+    if let Some(n) = new_len {
+        crate::array::js_array_set_length(arr, n as f64);
+    }
+    if has_writable {
+        // Persist the new writability (enumerable/configurable stay false).
+        super::set_property_attrs(
+            obj as usize,
+            "length".to_string(),
+            PropertyAttrs::new(new_writable, false, false),
+        );
+    }
+    true
+}
+
+/// `Reflect.defineProperty` hook for the array `length` property. Returns
+/// `Some(ok)` only when `obj_value` is an array and `key_value` is `"length"`,
+/// so non-length array defines keep flowing through the ordinary path.
+pub(crate) unsafe fn array_length_reflect_define(
+    obj_value: f64,
+    key_value: f64,
+    descriptor_value: f64,
+) -> Option<bool> {
+    let obj = extract_obj_ptr(obj_value);
+    if obj.is_null() || !is_array_object(obj) {
+        return None;
+    }
+    let key_str = crate::builtins::js_string_coerce(key_value);
+    if key_str.is_null() {
+        return None;
+    }
+    let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let name_len = (*key_str).byte_len as usize;
+    let key_name = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)).ok()?;
+    if key_name != "length" {
+        return None;
+    }
+    Some(array_set_length_from_descriptor(obj, descriptor_value))
+}
+
 pub(crate) unsafe fn define_array_property(
     obj: *mut ObjectHeader,
     obj_value: f64,
     key_str: *const crate::StringHeader,
     key_name: Option<&str>,
     descriptor_value: f64,
-) -> Option<f64> {
+) -> Option<bool> {
     if !is_array_object(obj) {
         return None;
     }
     let Some(key_name) = key_name else {
-        return Some(obj_value);
+        return Some(true);
     };
+
+    if key_name == "length" {
+        return Some(array_set_length_from_descriptor(obj, descriptor_value));
+    }
+
     let desc_ptr = extract_obj_ptr(descriptor_value);
     if desc_ptr.is_null() {
-        return Some(obj_value);
+        return Some(true);
     }
     let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
     let has_value = own_key_present(desc_ptr, value_key);
@@ -70,12 +215,6 @@ pub(crate) unsafe fn define_array_property(
         f64::from_bits(crate::value::TAG_UNDEFINED)
     };
 
-    if key_name == "length" {
-        if has_value {
-            crate::array::js_array_set_length(obj as *mut crate::array::ArrayHeader, value);
-        }
-        return Some(obj_value);
-    }
     if let Some(index) = super::canonical_array_index(key_name) {
         if has_value {
             crate::array::js_array_set_f64_extend(
@@ -84,7 +223,7 @@ pub(crate) unsafe fn define_array_property(
                 value,
             );
         }
-        return Some(obj_value);
+        return Some(true);
     }
 
     crate::array::array_named_property_set(obj as *mut crate::array::ArrayHeader, key_str, value);
@@ -105,7 +244,8 @@ pub(crate) unsafe fn define_array_property(
         key_name.to_string(),
         PropertyAttrs::new(writable, enumerable, configurable),
     );
-    Some(obj_value)
+    let _ = obj_value;
+    Some(true)
 }
 
 fn builtin_constructor_prototype_value(name: &[u8]) -> Option<f64> {

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -80,6 +80,11 @@ pub(super) unsafe fn array_own_key_present(
     arr: *const crate::array::ArrayHeader,
     key: *const crate::StringHeader,
 ) -> bool {
+    // Issue #233: resolve a grow forwarding pointer so `arr.hasOwnProperty(i)` /
+    // `getOwnPropertyDescriptor` stay correct after `arr.length = N` reallocated
+    // the buffer (the `in` path already does this; the named-method paths reach
+    // here with the stale pre-grow pointer otherwise).
+    let arr = crate::array::clean_arr_ptr(arr);
     let Some(key_name) = string_header_as_str(key) else {
         return false;
     };

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1212,14 +1212,20 @@ pub extern "C" fn js_object_define_property(
             }
             return obj_value;
         }
-        if let Some(result) = super::define_array_property(
+        if let Some(ok) = super::define_array_property(
             obj,
             obj_value,
             key_str,
             key_rust.as_deref(),
             descriptor_value,
         ) {
-            return result;
+            if ok {
+                return obj_value;
+            }
+            // A rejected array `[[DefineOwnProperty]]` (e.g. redefining the
+            // non-configurable / non-writable `length`) throws under
+            // `Object.defineProperty`.
+            throw_object_type_error(b"Cannot redefine property: length");
         }
         // #2843: enforce frozen / sealed / non-extensible invariants BEFORE any
         // mutation, so a rejected definition leaves the object untouched and the

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -119,6 +119,13 @@ pub(crate) fn reflect_define_property(obj: f64, key: f64, descriptor: f64) -> f6
         super::TypedArrayDefineOutcome::Rejected => return reflect_bool(false),
         super::TypedArrayDefineOutcome::NotTypedArray => {}
     }
+    // The array exotic `[[DefineOwnProperty]]` for `length` (ArraySetLength)
+    // reports success/failure as a boolean here rather than throwing — bypass
+    // the generic non-configurable pre-check below, which would mishandle the
+    // (non-configurable but writable) `length` property.
+    if let Some(ok) = unsafe { super::array_length_reflect_define(obj, key, descriptor) } {
+        return reflect_bool(ok);
+    }
     let has_own = obj_value_has_own_key(obj, key);
     // Redefining a non-configurable existing property fails.
     if has_own {


### PR DESCRIPTION
## Summary

Implements **ArraySetLength** (ECMA-262 §10.4.2.4) — the array exotic `[[DefineOwnProperty]]` for the `length` property — plus two related correctness fixes the target tests exercise.

### ArraySetLength (`array_set_length_from_descriptor`)
- `ToUint32` then `ToNumber` **in spec order** (a `valueOf` observer fires exactly twice, and a mutation between the two calls — e.g. flipping `writable` to false — is honored because the current descriptor is read *after* both coercions). `RangeError` when `ToUint32(v) !== ToNumber(v)` (non-integer / out-of-range length).
- ValidateAndApplyPropertyDescriptor against the current (non-configurable, writable-by-default) `length` data descriptor: rejects making it configurable/enumerable, turning it into an accessor, or re-enabling writability / changing the value once non-writable.
- `Object.defineProperty` throws `TypeError` on reject; `Reflect.defineProperty` returns `false` — it intercepts the `length` key *before* its generic non-configurable pre-check (which mishandled the writable-but-non-configurable `length`).

### hasOwnProperty / getOwnPropertyDescriptor / propertyIsEnumerable hole fix
`array_own_key_present` now follows the grow forwarding pointer (`clean_arr_ptr`), matching the `in` operator. After `arr.length = N` reallocates the buffer, the named-method paths reached the stale pre-grow pointer and reported truncated indices as own.

### Out-of-bounds prototype reads
An OOB element read now falls through to `Array.prototype[index]` (OrdinaryGet → prototype chain), **gated** by a sticky flag set only when an index is written to `Array.prototype`. The hot OOB path (e.g. destructuring defaults) stays a single relaxed atomic load until the rare write flips the flag — no behavior change for normal programs.

## Tests
Fixes `built-ins/Array/length`: `define-own-prop-length-coercion-order.js`, `define-own-prop-length-no-value-order.js`, `S15.4.5.1_A1.2_T3.js`.

Spot-checked vs Node: `Object.defineProperty([1,2,3],"length",{value:1})` then `hasOwnProperty("2")===false`; `Object.defineProperty([],"length",{configurable:true})` throws TypeError; `Reflect.defineProperty([],"length",{enumerable:true})===false`; RangeError on `{value:4294967296}` / `{value:1.5}`; `Array.prototype[2]=2; x=[0,1]; x.length=3 → hasOwn(2)===false; x.length=2 → x[2]===2`. Common array ops (map/filter/push/sort/destructuring/length-shrink) unchanged.