### PR TITLE
fix(string): generic-this String.prototype methods + exotic/coercion parity

### DIFF
--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -78,6 +78,21 @@ pub(crate) fn lower_string_method(
     args: &[Expr],
 ) -> Result<String> {
     let recv_box = lower_expr(ctx, object)?;
+    // Optimistic any-typed path: `property_get` routes `(x: any).charAt(i)` /
+    // `.split(…)` here even when `x` is not statically a string, because most
+    // such receivers ARE strings (e.g. `readFileSync(p).split('\n')`). But a
+    // boxed/object receiver — `new Boolean().charAt = String.prototype.charAt;
+    // …charAt(i)`, a `{ toString }` object — must have `ToString(this)` applied
+    // (ECMA-262 §22.1.3) before the inline string helpers run, or they would
+    // bit-cast the object pointer as a string and read garbage. A statically
+    // string-typed receiver skips this (fast path, no coercion).
+    let recv_box = if is_string_expr(ctx, object) {
+        recv_box
+    } else {
+        let blk = ctx.block();
+        let coerced = blk.call(I64, "js_string_coerce", &[(DOUBLE, &recv_box)]);
+        nanbox_string_inline(blk, &coerced)
+    };
 
     match property {
         "indexOf" => {

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1116,6 +1116,32 @@ fn is_primitive_wrapper_brand_method(recv: &ast::Expr, method: &str) -> bool {
     }
 }
 
+/// True when `recv.<method>` is a `String.prototype` generic-`this` method backed
+/// by a real reflective runtime thunk (RequireObjectCoercible + ToString(this)).
+/// Folding `String.prototype.charAt.call(x)` into `x.charAt()` would re-dispatch
+/// `charAt` *by name on `x`'s own type* — a boolean/number/object has no
+/// `charAt`, so it throws `(boolean).charAt is not a function`. Keeping it
+/// reflective lets the installed thunk coerce `this` to a string. Only the
+/// `String.prototype.<m>` receiver shape is guarded (string-literal receivers
+/// like `"".charAt.call(x)` are vanishingly rare); kept in lock-step with
+/// `string_proto_thunks::install_string_proto_methods`.
+fn is_string_prototype_generic_method(recv: &ast::Expr, method: &str) -> bool {
+    let ast::Expr::Member(member) = recv else {
+        return false;
+    };
+    let ast::MemberProp::Ident(prop) = &member.prop else {
+        return false;
+    };
+    if prop.sym.as_ref() != "prototype" {
+        return false;
+    }
+    let ast::Expr::Ident(base) = member.obj.as_ref() else {
+        return false;
+    };
+    base.sym.as_ref() == "String"
+        && matches!(method, "at" | "charAt" | "charCodeAt" | "codePointAt")
+}
+
 pub(super) fn try_builtin_prototype_method_apply_call(
     ctx: &mut LoweringContext,
     call: &ast::CallExpr,
@@ -1173,6 +1199,13 @@ pub(super) fn try_builtin_prototype_method_apply_call(
             // `this`). Folding to `x.<method>()` routes through the lenient
             // `Object.prototype` fallback (`"[object Object]"`, no throw).
             if is_primitive_wrapper_brand_method(inner.obj.as_ref(), method_ident.sym.as_ref()) {
+                return Ok(None);
+            }
+            // Generic-`this` String.prototype char-access methods must stay
+            // reflective so the runtime thunk coerces `this` to a string (see
+            // `is_string_prototype_generic_method`). Folding to `x.<m>()` would
+            // dispatch on `x`'s own type and throw.
+            if is_string_prototype_generic_method(inner.obj.as_ref(), method_ident.sym.as_ref()) {
                 return Ok(None);
             }
             method_ident.clone()
@@ -1390,6 +1423,11 @@ pub(crate) fn as_builtin_proto_method_ref(
     // (see `is_primitive_wrapper_brand_method`). Untracked, the value read goes
     // through the reflective dispatch, which throws correctly.
     if is_primitive_wrapper_brand_method(&member.obj, method.sym.as_ref()) {
+        return None;
+    }
+    // Keep `const m = String.prototype.charAt; m.call(x)` reflective too — the
+    // thunk must coerce `this` (see `is_string_prototype_generic_method`).
+    if is_string_prototype_generic_method(&member.obj, method.sym.as_ref()) {
         return None;
     }
     // For a `<Ctor>.prototype` receiver, any method ident is accepted (mirrors

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -121,6 +121,38 @@ fn install_string_wrapper_length(
     );
 }
 
+/// String exotic objects (ECMA-262 §10.4.3) expose each UTF-16 code unit as an
+/// integer-indexed own property `"0".."len-1"` with the descriptor
+/// `{ value: <char>, writable: false, enumerable: true, configurable: false }`.
+/// `new String("abc")` therefore reports `getOwnPropertyDescriptor(s, "0")`,
+/// `s.hasOwnProperty("0")`, and `Object.keys(s)`/enumeration over the indices.
+/// Installed eagerly at construction (typical `new String` receivers are
+/// short); the wrapper's `length` is installed separately and stays last.
+fn install_string_wrapper_indices(
+    obj: *mut crate::object::ObjectHeader,
+    string_ptr: *const crate::string::StringHeader,
+) {
+    if obj.is_null() || string_ptr.is_null() {
+        return;
+    }
+    let len = crate::string::js_string_length(string_ptr);
+    for i in 0..len {
+        let ch = crate::string::js_string_char_at(string_ptr, i as i32);
+        if ch.is_null() {
+            continue;
+        }
+        let name = i.to_string();
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let ch_value = f64::from_bits(crate::value::JSValue::string_ptr(ch).bits());
+        crate::object::js_object_set_field_by_name(obj, key, ch_value);
+        crate::object::set_builtin_property_attrs(
+            obj as usize,
+            name,
+            crate::object::PropertyAttrs::new(false, true, false),
+        );
+    }
+}
+
 pub fn scan_boxed_primitive_payload_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     let mut moved = Vec::new();
     BOXED_PRIMITIVE_PAYLOADS.with(|m| {
@@ -221,6 +253,7 @@ pub extern "C" fn js_boxed_string_new(value: f64) -> f64 {
     };
     let boxed = f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits());
     register_boxed_primitive_payload(obj, boxed);
+    install_string_wrapper_indices(obj, ptr);
     install_string_wrapper_length(obj, ptr);
     attach_boxed_primitive_prototype(obj, CLASS_ID_BOXED_STRING);
     crate::value::js_nanbox_pointer(obj as i64)

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1343,6 +1343,13 @@ pub unsafe extern "C" fn js_new_function_construct(
             super::object_ops::throw_object_type_error(b"is not a constructor");
         }
     }
+    // `new (new String(""))` / `new (new Number(1))` — a boxed primitive WRAPPER
+    // object is an ordinary object, never a constructor, so `new` on it throws
+    // `TypeError` (Test262 `S15.5.5_A2`). Without this it fell through to the
+    // empty-object construction fallback and silently produced `{}`.
+    if crate::builtins::boxed_primitive_payload(func_value).is_some() {
+        super::object_ops::throw_object_type_error(b"is not a constructor");
+    }
     // #3656: `new p()` where `p` is a Proxy dispatches through its `construct`
     // trap (or forwards to the target). Reached when the compiler can't prove
     // the callee is a proxy statically (e.g. `new record.proxy()`). newTarget
@@ -2190,6 +2197,14 @@ fn is_arrow_function_value(value: f64) -> bool {
 
 pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Option<f64> {
     if !is_callable_function_value(func_value) || is_arrow_function_value(func_value) {
+        return None;
+    }
+    // Built-in methods (`String.prototype.charAt`, `Array.prototype.map`, …) are
+    // not constructors and have NO `prototype` own property — `String.prototype.
+    // charAt.prototype === undefined` (ECMA-262: built-in non-constructor
+    // functions don't get the auto-created `.prototype`). Don't lazily synthesize
+    // one for them.
+    if super::native_module::builtin_closure_is_non_constructable_value(func_value) {
         return None;
     }
     let cid = synthetic_class_id_for_function(func_value);

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -4393,13 +4393,15 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             install_function_has_instance_symbol(proto_obj);
         }
         "String" => {
+            // #4576-style: generic-`this` char-access methods + `Symbol.iterator`
+            // get real reflective thunks (RequireObjectCoercible + ToString) so
+            // `String.prototype.charAt.call(receiver, i)` works on a boxed/object
+            // receiver. The remaining methods stay no-op-backed (value-introspect
+            // only); their direct/dispatch paths are handled elsewhere.
+            string_proto_thunks::install_string_proto_methods("String", proto_obj);
             install_noop_proto_methods(
                 proto_obj,
                 &[
-                    ("at", 1),
-                    ("charAt", 1),
-                    ("charCodeAt", 1),
-                    ("codePointAt", 1),
                     ("concat", 1),
                     ("endsWith", 1),
                     ("includes", 1),

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -60,6 +60,7 @@ mod property_key;
 pub(crate) mod prototype_chain;
 mod prototype_helpers;
 mod reflect_support;
+mod string_proto_thunks;
 mod typed_array_define;
 mod typed_array_proto_thunks;
 mod util_types;

--- a/crates/perry-runtime/src/object/string_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/string_proto_thunks.rs
@@ -1,0 +1,174 @@
+//! `String.prototype` generic-`this` method thunks.
+//!
+//! These methods are observable as function *values*
+//! (`String.prototype.charAt.call(receiver, i)`, `__obj.charAt = String.
+//! prototype.charAt; __obj.charAt(i)`) and per ECMA-262 §22.1.3 each begins
+//! with `RequireObjectCoercible(this)` followed by `ToString(this)` — so a
+//! boxed `new Boolean(false)` receiver coerces to `"false"`, a `{ toString }`
+//! object coerces via its method, and a `null`/`undefined` receiver throws a
+//! `TypeError`.
+//!
+//! Without a real thunk these were installed as the shared
+//! `global_this_builtin_noop_thunk`; a reflective `.call(receiver)` then
+//! re-dispatched *by name on the receiver's own type* (a boolean has no
+//! `charAt`), throwing `(boolean).charAt is not a function`. The direct, typed
+//! `"abc".charAt(1)` fast path (codegen `lower_string_method.rs`) and the
+//! any-typed-string dispatch arm in `native_call_method.rs` are unaffected —
+//! they never read `String.prototype`.
+
+use super::*;
+
+/// Methods routed through real thunks. Kept in lock-step with the HIR
+/// `.call`/`.apply` fold exclusion (`is_string_prototype_generic_method`) so the
+/// reflective path actually reaches these thunks instead of being rewritten to
+/// `receiver.<method>()`.
+pub(super) fn install_string_proto_methods(
+    builtin_name: &str,
+    proto_obj: *mut ObjectHeader,
+) -> bool {
+    if builtin_name != "String" {
+        return false;
+    }
+    use super::global_this::install_proto_method as ipm;
+    ipm(proto_obj, "at", string_proto_at_thunk as *const u8, 1);
+    ipm(
+        proto_obj,
+        "charAt",
+        string_proto_char_at_thunk as *const u8,
+        1,
+    );
+    ipm(
+        proto_obj,
+        "charCodeAt",
+        string_proto_char_code_at_thunk as *const u8,
+        1,
+    );
+    ipm(
+        proto_obj,
+        "codePointAt",
+        string_proto_code_point_at_thunk as *const u8,
+        1,
+    );
+    install_string_iterator_symbol(proto_obj);
+    true
+}
+
+/// Install `String.prototype[Symbol.iterator]` as a real, reflectable function
+/// value (`{ writable: true, enumerable: false, configurable: true }`, `name`
+/// `"[Symbol.iterator]"`, `length` 0). The thunk applies RequireObjectCoercible
+/// + ToString to `this` and returns a codepoint-aware String iterator. Mirrors
+/// the Map/Set iterator exposure (#4576).
+fn install_string_iterator_symbol(proto_obj: *mut ObjectHeader) {
+    if proto_obj.is_null() {
+        return;
+    }
+    let iter = crate::symbol::well_known_symbol("iterator");
+    if iter.is_null() {
+        return;
+    }
+    let func_ptr = string_proto_symbol_iterator_thunk as *const u8;
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return;
+    }
+    crate::closure::js_register_closure_arity(func_ptr, 0);
+    super::native_module::set_bound_native_closure_name(closure, "[Symbol.iterator]");
+    super::native_module::set_builtin_closure_length(closure as usize, 0);
+    super::native_module::set_builtin_closure_non_constructable(closure as usize);
+    super::set_builtin_property_attrs(
+        closure as usize,
+        "name".to_string(),
+        super::PropertyAttrs::new(false, false, true),
+    );
+    super::set_builtin_property_attrs(
+        closure as usize,
+        "length".to_string(),
+        super::PropertyAttrs::new(false, false, true),
+    );
+    let method_value = crate::value::js_nanbox_pointer(closure as i64);
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            crate::value::js_nanbox_pointer(proto_obj as i64),
+            f64::from_bits(crate::value::JSValue::pointer(iter as *const u8).bits()),
+            method_value,
+        );
+    }
+    crate::symbol::set_symbol_property_attrs(
+        proto_obj as usize,
+        iter as usize,
+        super::PropertyAttrs::new(true, false, true),
+    );
+}
+
+fn throw_string_proto_nullish(method: &str) -> ! {
+    let msg = format!("String.prototype.{method} called on null or undefined");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// `RequireObjectCoercible(this)` + `ToString(this)` for the generic-`this`
+/// String.prototype methods. `this` is the IMPLICIT_THIS receiver bound by
+/// `.call`/`.apply`/property dispatch. `null`/`undefined` throw `TypeError`;
+/// everything else (a primitive string, a boxed `String`/`Boolean`/`Number`
+/// object, a `{ toString }` object) coerces via the shared `js_string_coerce`,
+/// which runs user `toString`/`valueOf`.
+fn string_this_or_throw(method: &str) -> *mut crate::string::StringHeader {
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let jv = crate::value::JSValue::from_bits(this.to_bits());
+    if jv.is_undefined() || jv.is_null() {
+        throw_string_proto_nullish(method);
+    }
+    // ToString(Symbol) is a TypeError (abstract `ToString`, ECMA-262 §7.1.17) —
+    // `String.prototype.codePointAt.call(Symbol(), 1)` must throw, not stringify
+    // to `"Symbol(...)"`. Symbols are NaN-boxed pointers, so guard before the
+    // generic `js_string_coerce` (which would render the description).
+    if unsafe { crate::symbol::js_is_symbol(this) } != 0 {
+        crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a string");
+    }
+    crate::builtins::js_string_coerce(this)
+}
+
+pub(super) extern "C" fn string_proto_char_at_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    pos: f64,
+) -> f64 {
+    let s = string_this_or_throw("charAt");
+    let idx = crate::string::js_string_index_to_i32(pos);
+    let r = crate::string::js_string_char_at(s, idx);
+    f64::from_bits(crate::value::JSValue::string_ptr(r).bits())
+}
+
+pub(super) extern "C" fn string_proto_char_code_at_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    pos: f64,
+) -> f64 {
+    let s = string_this_or_throw("charCodeAt");
+    let idx = crate::string::js_string_index_to_i32(pos);
+    crate::string::js_string_char_code_at(s, idx)
+}
+
+pub(super) extern "C" fn string_proto_code_point_at_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    pos: f64,
+) -> f64 {
+    let s = string_this_or_throw("codePointAt");
+    let idx = crate::string::js_string_index_to_i32(pos);
+    crate::string::js_string_code_point_at(s, idx)
+}
+
+pub(super) extern "C" fn string_proto_at_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    index: f64,
+) -> f64 {
+    let s = string_this_or_throw("at");
+    let idx = crate::string::js_string_index_to_i32(index);
+    crate::string::js_string_at(s, idx)
+}
+
+pub(super) extern "C" fn string_proto_symbol_iterator_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let s = string_this_or_throw("[Symbol.iterator]");
+    crate::string::string_values_iter(s)
+}

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -4,18 +4,33 @@
 use super::*;
 
 /// JS index coercion for the String character-access methods (#2787).
-/// Applies `ToIntegerOrInfinity`: `undefined`, `null`, and `NaN` are all NaN /
-/// non-numeric bit patterns that map to `0`; finite values truncate toward
-/// zero; the result is clamped into `i32` so the integer-index helpers below
-/// see a safe value (a far-out-of-range magnitude clamps to a still-OOB index,
-/// which the helpers already handle). Codegen routes the raw NaN-boxed index
-/// through here instead of `fptosi`, which is undefined behavior on a NaN.
+/// Applies `ToIntegerOrInfinity`: a non-numeric argument is first run through
+/// the full `ToNumber` (`js_number_coerce`) so an object index with a custom
+/// `valueOf`/`toString` (`"lego".charAt({toString:()=>1})` → `"e"`), a numeric
+/// string (`"1"`), a boolean, `null`, etc. coerce per spec — and a `Symbol`
+/// index throws `TypeError` (ToNumber(Symbol)). `undefined`/`NaN` map to `0`;
+/// finite values truncate toward zero; the result is clamped into `i32` so the
+/// integer-index helpers below see a safe value (a far-out-of-range magnitude
+/// clamps to a still-OOB index, which the helpers already handle). Codegen
+/// routes the raw NaN-boxed index through here instead of `fptosi`, which is
+/// undefined behavior on a NaN.
 #[no_mangle]
 pub extern "C" fn js_string_index_to_i32(index: f64) -> i32 {
-    if index.is_nan() {
+    let jsval = crate::value::JSValue::from_bits(index.to_bits());
+    // Fast path: a real number / int32 needs no ToNumber. Anything else
+    // (object, string, bool, null, undefined, bigint, symbol) goes through
+    // `ToNumber` first (may throw on Symbol, may run user `valueOf`/`toString`).
+    let n = if jsval.is_int32() {
+        jsval.as_int32() as f64
+    } else if jsval.is_number() {
+        index
+    } else {
+        crate::builtins::js_number_coerce(index)
+    };
+    if n.is_nan() {
         return 0;
     }
-    let truncated = index.trunc();
+    let truncated = n.trunc();
     if truncated <= i32::MIN as f64 {
         i32::MIN
     } else if truncated >= i32::MAX as f64 {
@@ -210,13 +225,34 @@ fn to_uint16(code: f64) -> u16 {
     code.trunc().rem_euclid(65536.0) as u16
 }
 
+/// `String.fromCharCode` per-argument coercion (ECMA-262 §22.1.2.1):
+/// `nextCU = ToUint16(next)`, where `ToUint16` first applies the abstract
+/// `ToNumber`. A bare numeric value short-circuits; everything else is run
+/// through the full `ToNumber` so a boxed `new Boolean(true)` / a `{ valueOf }`
+/// object coerce (→ 1 / their numeric value) instead of mapping to `0`. A
+/// `BigInt` throws `TypeError` (abstract `ToNumber(BigInt)`, unlike the lenient
+/// `Number(bigint)`); a `Symbol` throws via `js_number_coerce`.
+fn fromcharcode_arg_to_uint16(code: f64) -> u16 {
+    let jv = crate::value::JSValue::from_bits(code.to_bits());
+    let n = if jv.is_int32() {
+        jv.as_int32() as f64
+    } else if jv.is_number() {
+        code
+    } else if jv.is_bigint() {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
+    } else {
+        crate::builtins::js_number_coerce(code)
+    };
+    to_uint16(n)
+}
+
 /// Create a string from a character code (String.fromCharCode).
 /// The argument is coerced with `ToUint16` (#2788), so out-of-range and
 /// negative values wrap modulo 65536 rather than returning `""`. Codegen
 /// passes the raw NaN-boxed `f64` (not `fptosi`, which is UB on a NaN).
 #[no_mangle]
 pub extern "C" fn js_string_from_char_code(code: f64) -> *mut StringHeader {
-    let unit = to_uint16(code);
+    let unit = fromcharcode_arg_to_uint16(code);
 
     // For ASCII characters, create a simple 1-byte string.
     if unit < 128 {
@@ -249,7 +285,7 @@ pub extern "C" fn js_string_from_char_code_array(value: f64) -> *mut StringHeade
 
     let mut out = String::with_capacity(len);
     for i in 0..len {
-        let unit = to_uint16(crate::array::js_array_get_f64(arr, i as u32));
+        let unit = fromcharcode_arg_to_uint16(crate::array::js_array_get_f64(arr, i as u32));
         match char::from_u32(unit as u32) {
             Some(ch) => out.push(ch),
             None => out.push('\u{FFFD}'),

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -49,7 +49,8 @@ pub use base64_codec::{js_atob, js_btoa};
 pub use char_ops::{
     js_string_at, js_string_char_at, js_string_char_code_at, js_string_code_point_at,
     js_string_from_char_code, js_string_from_char_code_array, js_string_from_code_point,
-    js_string_from_code_point_array, js_string_index_get, js_string_to_char_array,
+    js_string_from_code_point_array, js_string_index_get, js_string_index_to_i32,
+    js_string_to_char_array,
 };
 pub use compare::{
     js_string_compare, js_string_ends_with, js_string_ends_with_at, js_string_equals,

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -73,11 +73,23 @@ unsafe fn ordinary_to_primitive_string_inner(value: f64) -> Option<f64> {
 
     match call_method_for_primitive(&scope, &value_handle, b"valueOf") {
         MethodOutcome::Primitive(p) => Some(p),
-        // Both toString and valueOf failed to produce a primitive — Node
-        // throws `TypeError: Cannot convert object to primitive value`. We
-        // approximate by falling back to the default `"[object Object]"`.
-        MethodOutcome::NonPrimitive | MethodOutcome::Absent => None,
+        // We only reach here when a *custom* `toString` ran and returned a
+        // non-primitive (the `Absent` toString case already returned
+        // `"[object Object]"` above). Per spec `OrdinaryToPrimitive` then tries
+        // `valueOf`; if that also fails to yield a primitive, ToPrimitive throws
+        // `TypeError: Cannot convert object to primitive value` (Node agrees:
+        // `String({ toString: () => ({}) })` throws). A plain object with no
+        // custom `toString` never reaches this throw.
+        MethodOutcome::NonPrimitive | MethodOutcome::Absent => throw_cannot_convert_to_primitive(),
     }
+}
+
+#[cold]
+fn throw_cannot_convert_to_primitive() -> ! {
+    let msg = b"Cannot convert object to primitive value";
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
 /// Function objects are closure headers, not `ObjectHeader`s, so the ordinary


### PR DESCRIPTION
Lifts `built-ins/String` test262 parity from **71.7% → 91.1%** (first-180 sorted window; +35 cases passing, 0 regressions). Targets the generic-`this` / coercion / String-exotic clusters tracked under the Node + TypeScript compatibility roadmap (#793).

## Generic-`this` reflective methods
New `object/string_proto_thunks.rs` installs real thunks for `charAt`/`charCodeAt`/`codePointAt`/`at`/`[Symbol.iterator]` that do `RequireObjectCoercible(this)` + `ToString(this)` (§22.1.3). Previously these were shared no-op thunks, so a reflective `.call` re-dispatched *by the receiver's own type* and threw `(boolean).charAt is not a function`.

- `String.prototype.charAt.call(new Boolean(false), 0)` → `"f"`; `obj.charAt = String.prototype.charAt; obj.charAt(i)` works on boxed/object receivers.
- `ToString(Symbol)` receiver throws `TypeError`.
- These methods are excluded from the HIR `.call`/`.apply` fold (`is_string_prototype_generic_method`) so the reflective path actually reaches the thunk instead of being rewritten to `receiver.<m>()`.
- `String.prototype[Symbol.iterator]` is now a reflectable function value (`name` `"[Symbol.iterator]"`, `length` 0, `{writable, !enumerable, configurable}`).

## Index / argument coercion
- `js_string_index_to_i32` now applies full `ToIntegerOrInfinity` via `js_number_coerce` (`"lego".charAt({toString:()=>1})` → `"e"`; Symbol index throws).
- `lower_string_method` coerces non-string optimistic-path receivers via `js_string_coerce` before the inline helpers (fixes the boxed/object receiver on the codegen fast path).
- `String.fromCharCode` applies `ToUint16` per arg through `ToNumber` (boxed `Boolean` → 1, `{valueOf}` object; `BigInt` throws `TypeError`).

## Constructor / exotic-object parity
- `new String("abc")` exposes integer-indexed own properties `"0".."n-1"` (`{value, !writable, enumerable, !configurable}`).
- `new (new String())` (boxed-primitive-wrapper receiver) throws `TypeError`.
- Built-in non-constructor methods report `.prototype === undefined`.
- `OrdinaryToPrimitive` throws `Cannot convert object to primitive value` when a custom `toString` returns a non-primitive and `valueOf` also fails.

## Validation
- `test262_subset.py --dir built-ins/String --max 180`: 129→164 pass.
- Coercion regression sanity (arrays, plain objects, Date, Error, class instances, template literals) byte-identical to Node.
- `cargo fmt --all --check` clean.

Remaining failures are out-of-cluster: `eval`-based index tests, the general prototype chain for `function F(){}` instances, non-strict read-only writes, `delete` of built-in prototype methods, and monkey-patched `Array.prototype.toString`.