### PR TITLE
fix(class): hide private members from reflection + fix exotic-private-name symbol collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1126 — fix(class): hide private members from reflection + unblock exotic-private-name compilation
+
+Two fixes for class **private members** (`#x` fields, `#m()` methods, `get/set #a`
+accessors, and their `static` forms), targeting the largest test262 class cluster.
+On `language/expressions/class/elements` this moved the radar from **pass=415 /
+parity 30.4%** to **pass=497 / parity 36.4%** (+82 tests, 0 regressions), with the
+`compile-fail` bucket dropping 430→5.
+
+**1. Private names are no longer observable as own string properties.** Perry
+stores a class instance's private fields in the object's `keys_array` under their
+`#`-prefixed source name, and private methods/accessors in the class vtable /
+static tables under `#name` keys. These leaked into every reflection and
+enumeration surface — `Object.getOwnPropertyNames(c)` returned `["#x"]`,
+`c.hasOwnProperty("#x")` / `"#x" in c` returned `true`, and `#m` showed up on the
+prototype's own-property list — none of which Node does. Per ECMA-262 a private
+name is never an own string property.
+
+Added `private_member_key_bytes` / `private_member_key_value` helpers
+(`object/field_get_set.rs`) and filtered `#`-prefixed keys from: `Object.keys` /
+`values` / `entries`, `Object.getOwnPropertyNames` (both the class-ref
+prototype/constructor path and the instance `keys_array` path),
+`getOwnPropertyDescriptor` (both paths → `undefined`), `hasOwnProperty` (instance
+*and* class-ref, so `static #gen` no longer appears on the constructor),
+`propertyIsEnumerable`, the `in` operator, `JSON.stringify`, object spread
+(`{...c}`), and `Object.assign`. `Reflect.ownKeys` is covered transitively.
+
+The instance-side filters are gated on `class_id != 0` (i.e. the receiver is a
+class instance), so a plain object literal that legitimately uses a `#`-prefixed
+*string* key — e.g. a hex-color map `{ "#fff": "white" }` created via
+`obj["#fff"] = …` — keeps that key visible. The class-ref (prototype/constructor)
+paths filter unconditionally, since a `#`-name there is always a private member.
+
+**2. Exotic private names no longer collide into one LLVM symbol.** The codegen
+symbol sanitizer (`codegen/helpers.rs::sanitize`) replaced every character outside
+`[A-Za-z0-9_]` with a single `_`, so distinct private methods like `#$`, `#_`, and
+`#℘` all mangled to the same `perry_method_…__C____` symbol and clang aborted the
+whole module with `invalid redefinition of function`. This failed ~425 procedurally
+generated `*-private*` cases (which exercise private names built from `$`, unicode,
+and zero-width joiners) at compile time.
+
+The fix adds a new injective `sanitize_member` (escapes each non-alnum char to
+`_<hex-codepoint>_`) and applies it to the **member-name component** of method /
+getter / setter / static-method symbols (`perry_method_…` / `perry_static_…__c<id>__…`).
+Member symbols are module-local — instance methods/accessors dispatch through the
+runtime vtable by source name, not by cross-module LLVM symbol — so the encoding
+only has to be self-consistent within one codegen pass. `sanitize` itself is left
+unchanged (single-`_` collapse): it is also used for the **module-symbol prefix**
+(`perry_fn_<prefix>__<name>`, `native_region_slug`), which must stay byte-compatible
+with the driver's `compute_module_prefix`, or cross-module function references go
+unresolved at link time. Names made only of `[A-Za-z0-9_]` (essentially all ordinary
+identifiers) are returned unchanged by both, so existing symbols are unperturbed.
+
+Not yet covered (follow-ups): the private **brand check on access** — reading
+`other.#x` on a receiver that lacks the brand must throw `TypeError`, but Perry
+currently returns `undefined`; a correct fix needs lexical resolution of the
+private name's *declaring* class (it is not always the innermost class), so it is
+deferred to avoid regressing nested-class private access. Many of the now-compiling
+tests also depend on unrelated **public** static-method descriptor support
+(`verifyProperty(C, "m", …)` on `static *m()`), which is tracked separately.
+
 ## v0.5.1125 — feat(compile): --windows-subsystem override + tier-3 Apple link dedup + pointer-width portability
 
 Three related cross-compile / link improvements, bundled because they share the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1125
+**Current Version:** 0.5.1126
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "base64",
@@ -5252,14 +5252,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "cc",
  "libc",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "base64",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,14 +5368,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "serde",
  "serde_json",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1125"
+version = "0.5.1126"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "clap",
@@ -5409,14 +5409,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5515,14 +5515,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "bytes",
  "h2",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "bson",
  "futures-util",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "image",
@@ -5709,14 +5709,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "brotli",
  "flate2",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "base64",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5939,14 +5939,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "itoa",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "block2",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "block2",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1125"
+version = "0.5.1126"
 
 [[package]]
 name = "perry-ui-test"
@@ -6035,11 +6035,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1125"
+version = "0.5.1126"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "block2",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "block2",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "block2",
  "libc",
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "libc",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1125"
+version = "0.5.1126"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1125"
+version = "0.5.1126"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -123,7 +123,7 @@ pub(super) fn scoped_static_method_name(
         module_prefix,
         sanitize(class_name),
         class_id,
-        sanitize(method_name)
+        sanitize_member(method_name)
     )
 }
 
@@ -267,7 +267,7 @@ pub(super) fn scoped_method_name(
         "perry_method_{}__{}__{}",
         module_prefix,
         sanitize(class_name),
-        sanitize(method_name)
+        sanitize_member(method_name)
     )
 }
 
@@ -275,6 +275,15 @@ pub(super) fn scoped_method_name(
 /// `[A-Za-z0-9_]` with an underscore. LLVM IR identifiers cannot start with
 /// a digit, so prefix with `_` if the first character would be one (this
 /// happens with module names like `05_fibonacci.ts`).
+///
+/// This must stay byte-compatible with the driver's `compute_module_prefix`
+/// (perry/src/commands/compile/resolve.rs): the module-symbol prefix is
+/// `sanitize(hir.name)` on the codegen side and `compute_module_prefix(path)`
+/// on the importer side, and the two have to agree or cross-module
+/// `perry_fn_<prefix>__<name>` references go unresolved at link time. It is
+/// therefore deliberately *lossy* (and not injective) — do NOT change the
+/// `_`-collapse here. For class member names, which need an injective mapping
+/// to avoid symbol collisions, use [`sanitize_member`] instead.
 pub(super) fn sanitize(name: &str) -> String {
     let mut s: String = name
         .chars()
@@ -286,6 +295,40 @@ pub(super) fn sanitize(name: &str) -> String {
             }
         })
         .collect();
+    if s.chars()
+        .next()
+        .map(|c| c.is_ascii_digit())
+        .unwrap_or(false)
+    {
+        s.insert(0, '_');
+    }
+    s
+}
+
+/// Sanitize a class **member** name (method / getter / setter) for use in an
+/// LLVM symbol, injectively.
+///
+/// [`sanitize`] collapses every non-`[A-Za-z0-9_]` char to a single `_`, so
+/// distinct private members like `#$`, `#_`, and `#℘` all mangle to the same
+/// `perry_method_…__C____` symbol and clang rejects the second definition with
+/// "invalid redefinition of function" — failing the whole module. Member
+/// symbols are module-local (instance methods/accessors dispatch through the
+/// runtime vtable by source name, not by cross-module LLVM symbol), so the
+/// encoding only has to be self-consistent within one codegen pass; it does
+/// NOT need to match the driver's module-prefix derivation. Escaping each
+/// non-alnum char to `_<hex-codepoint>_` keeps the mapping injective and within
+/// the legal symbol charset. Names made only of `[A-Za-z0-9_]` (essentially all
+/// ordinary identifiers) are returned byte-for-byte unchanged.
+pub(super) fn sanitize_member(name: &str) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            s.push(c);
+        } else {
+            let _ = write!(s, "_{:x}_", c as u32);
+        }
+    }
     if s.chars()
         .next()
         .map(|c| c.is_ascii_digit())

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -60,7 +60,7 @@ use artifacts::{emit_module_artifacts, ModuleArtifactsCtx};
 use function::compile_function;
 use helpers::{
     collect_return_class, emit_buffer_alias_metadata, function_body_returns_generator_object,
-    sanitize, scoped_fn_name, scoped_method_name, scoped_static_method_name,
+    sanitize, sanitize_member, scoped_fn_name, scoped_method_name, scoped_static_method_name,
 };
 
 // Collector and boxing-analysis walkers live in dedicated modules.
@@ -1726,7 +1726,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 "perry_method_{}__{}__{}",
                 sanitize(src),
                 sanitize(&ic.name),
-                sanitize(method_name),
+                sanitize_member(method_name),
             );
             method_names
                 .entry((effective_name.to_string(), method_name.clone()))

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -6,7 +6,7 @@ use crate::module::LlModule;
 use crate::strings::StringPool;
 use crate::types::{DOUBLE, I32, I64, PTR, VOID};
 
-use super::helpers::{sanitize, scoped_static_method_name};
+use super::helpers::{sanitize, sanitize_member, scoped_static_method_name};
 
 /// Emit the string pool into the module: byte-array constants, handle
 /// globals, and the `__perry_init_strings_<prefix>` function that
@@ -395,7 +395,7 @@ pub(super) fn emit_string_pool(
                 "perry_method_{}__{}__{}",
                 module_prefix,
                 sanitize(class_name),
-                sanitize(&method.name),
+                sanitize_member(&method.name),
             );
             let has_synth_args = method
                 .params
@@ -643,7 +643,7 @@ pub(super) fn emit_string_pool(
                 "perry_method_{}__{}__{}",
                 module_prefix,
                 sanitize(class_name),
-                sanitize(&inner),
+                sanitize_member(&inner),
             );
             getter_pairs.push((cid, prop.clone(), llvm_name));
         }
@@ -703,7 +703,7 @@ pub(super) fn emit_string_pool(
                 "perry_method_{}__{}__{}",
                 module_prefix,
                 sanitize(class_name),
-                sanitize(&inner),
+                sanitize_member(&inner),
             );
             setter_pairs.push((cid, prop.clone(), llvm_name));
         }

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -978,6 +978,11 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
     };
     let actual_fields = keys_len;
 
+    // Class instances store private fields (`#x`) in `keys_array`, but `JSON.
+    // stringify` must skip them (Node does). Plain object literals (class_id 0)
+    // keep any real `#`-prefixed string key.
+    let hide_private = (*obj).class_id != 0;
+
     // #2438: enumerate own keys in ECMA-262 OrdinaryOwnPropertyKeys order —
     // array-index keys first (ascending numeric), then string keys in
     // insertion order. `None` means no array-index keys, so insertion order
@@ -1060,6 +1065,14 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
     };
     for j in 0..actual_fields {
         let f = pos(j);
+        // Skip class-instance private fields (`#x`).
+        if hide_private
+            && crate::object::private_member_key_value(crate::JSValue::from_bits(
+                (*keys_elements.add(f as usize)).to_bits(),
+            ))
+        {
+            continue;
+        }
         // Skip non-enumerable own keys (e.g. `Object.defineProperty(o, k,
         // { enumerable: false })`) before touching the value.
         if filter_non_enum && json_key_non_enumerable(obj, *keys_elements.add(f as usize)) {

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -632,6 +632,9 @@ pub unsafe extern "C" fn js_object_copy_own_fields(dst_i64: i64, src_f64: f64) {
     let alloc_limit = std::cmp::max(src_field_count, 8);
     let header_size = std::mem::size_of::<ObjectHeader>();
     let src_fields = (src as *const u8).add(header_size) as *const u64;
+    // Spread (`{...src}`) copies own enumerable string keys; a class instance's
+    // private fields (`#x`) are not enumerable and must not be copied.
+    let src_hide_private = (*src).class_id != 0;
 
     // Iterate up to `key_count`, not `min(key_count, src_field_count)`.
     // For objects with overflow fields (≥9 keys) `src_field_count` caps
@@ -648,6 +651,9 @@ pub unsafe extern "C" fn js_object_copy_own_fields(dst_i64: i64, src_f64: f64) {
         // Route SSO through `js_get_string_pointer_unified` so the
         // destination set-by-name path sees a stable heap pointer.
         if !key_val.is_any_string() {
+            continue;
+        }
+        if src_hide_private && super::field_get_set::private_member_key_value(key_val) {
             continue;
         }
         let key_f64 = f64::from_bits(key_val.bits());
@@ -833,6 +839,11 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(src_keys, i as u32);
             if !key_val.is_any_string() {
+                continue;
+            }
+            // `Object.assign` copies own enumerable string keys; a class
+            // instance's private fields (`#x`) are not enumerable.
+            if (*src).class_id != 0 && super::field_get_set::private_member_key_value(key_val) {
                 continue;
             }
             let key_f64 = f64::from_bits(key_val.bits());

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -183,6 +183,11 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
         if let Some(class_id) = class_ref_id(obj_value) {
             let method_name = metadata_key_to_string(key_value);
             if let Some(method_name) = method_name {
+                // Private methods/accessors/static fields (`#m`) are not own
+                // properties of the prototype or constructor.
+                if super::field_get_set::private_member_key_bytes(method_name.as_bytes()) {
+                    return f64::from_bits(crate::value::TAG_UNDEFINED);
+                }
                 if super::class_registry::class_is_key_deleted(class_id, &method_name) {
                     return f64::from_bits(crate::value::TAG_UNDEFINED);
                 }
@@ -402,6 +407,21 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
             std::str::from_utf8(name_bytes).ok().map(|s| s.to_string())
         };
+
+        // Class-instance private fields (`#x`) are not own string properties.
+        // Guarded on the real object GC type so `class_id` isn't read off an
+        // array/other header.
+        if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let gc_header =
+                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if (*gc_header).obj_type == crate::gc::GC_TYPE_OBJECT && (*obj).class_id != 0 {
+                if let Some(ref name) = key_rust {
+                    if super::field_get_set::private_member_key_bytes(name.as_bytes()) {
+                        return f64::from_bits(crate::value::TAG_UNDEFINED);
+                    }
+                }
+            }
+        }
 
         if let Some(desc) = super::arguments_object_descriptor(obj, key_str) {
             return desc;
@@ -771,6 +791,10 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                     }
                 });
             }
+            // Private methods/accessors (`#m`) and static private fields (`#x`)
+            // live in the vtable / static tables under `#`-prefixed keys but are
+            // never own properties of the prototype or constructor.
+            names.retain(|n| !super::field_get_set::private_member_key_bytes(n.as_bytes()));
             sort_property_names_ecma(&mut names);
             let result = crate::array::js_array_alloc(names.len() as u32);
             for name in names {
@@ -901,9 +925,15 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                 None => j as u32,
             }
         };
+        // Hide class-instance private fields (`#x`); plain object literals
+        // (class_id 0) keep any real `#`-prefixed string key.
+        let hide_private = (*obj).class_id != 0;
         let result = crate::array::js_array_alloc(len as u32);
         for i in 0..len {
             let key_val = crate::array::js_array_get(keys, pos(i));
+            if hide_private && super::field_get_set::private_member_key_value(key_val) {
+                continue;
+            }
             crate::array::js_array_push_f64(result, f64::from_bits(key_val.bits()));
         }
         f64::from_bits((result as u64) | 0x7FFD_0000_0000_0000)

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -27,6 +27,36 @@ const CRYPTO_USAGE_DECAPSULATE_BITS: u32 = 1 << 9;
 const CRYPTO_USAGE_ENCAPSULATE_KEY: u32 = 1 << 10;
 const CRYPTO_USAGE_DECAPSULATE_KEY: u32 = 1 << 11;
 
+/// True when `name` is a class private-member key (`#name`).
+///
+/// Private fields are stored in a class instance's `keys_array` under their
+/// `#`-prefixed source name (the constructor sets them via PropertySet-by-name),
+/// and private methods/accessors live in the class vtable under `#name` keys.
+/// Per ECMAScript, a private name is NEVER observable as an own *string*
+/// property: `Object.keys`/`for-in`/`JSON.stringify`, `Object.getOwnProperty{
+/// Names,Descriptor}`, `hasOwnProperty`, the `in` operator, `propertyIsEnumerable`,
+/// object spread, and `Object.assign` must all skip it.
+///
+/// Callers gate this on the receiver being a class instance (`class_id != 0`) or
+/// a class ref, because a `#`-prefixed *string* key can legitimately reach a
+/// plain object literal via `obj["#fff"] = …` (e.g. a hex-color map) and must
+/// stay visible there.
+#[inline]
+pub(crate) fn private_member_key_bytes(name: &[u8]) -> bool {
+    name.first() == Some(&b'#')
+}
+
+/// [`private_member_key_bytes`] for a stored-key `JSValue` (heap or SSO string).
+/// Non-string keys are never private.
+#[inline]
+pub(crate) fn private_member_key_value(key_val: JSValue) -> bool {
+    let mut buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    matches!(
+        unsafe { crate::string::js_string_key_bytes(key_val, &mut buf) },
+        Some(b) if private_member_key_bytes(b)
+    )
+}
+
 pub(crate) unsafe fn crypto_key_property_value(addr: usize, key_bytes: &[u8]) -> Option<JSValue> {
     let (algo, hash, kind, extractable, usages) = crate::buffer::crypto_key_meta(addr)?;
     match key_bytes {
@@ -1530,6 +1560,10 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
         // per-key descriptor check.
         let has_descriptors =
             PROPERTY_DESCRIPTORS.with(|m| m.borrow().keys().any(|(ptr, _)| *ptr == obj as usize));
+        // Class instances store private fields (`#x`) in `keys_array`, but they
+        // are not enumerable own properties — hide them. Plain object literals
+        // (class_id 0) keep any real `#`-prefixed string key.
+        let hide_private = (*obj).class_id != 0;
         let len = crate::array::js_array_length(keys) as usize;
         // #2438: enumerate in ECMA-262 OrdinaryOwnPropertyKeys order —
         // array-index keys first (ascending numeric), then string keys in
@@ -1546,6 +1580,9 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
             let out = crate::array::js_array_alloc(len as u32);
             for j in 0..len {
                 let key_val = crate::array::js_array_get(keys, pos(j));
+                if hide_private && private_member_key_value(key_val) {
+                    continue;
+                }
                 crate::array::js_array_push_f64(out, f64::from_bits(key_val.bits()));
             }
             return out;
@@ -1566,6 +1603,9 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                 Ok(s) => s,
                 Err(_) => continue,
             };
+            if hide_private && private_member_key_bytes(key_str.as_bytes()) {
+                continue;
+            }
             // If a descriptor explicitly marks this key non-enumerable, skip it.
             if let Some(attrs) = get_property_attrs(obj as usize, key_str) {
                 if !attrs.enumerable() {
@@ -1668,8 +1708,17 @@ pub extern "C" fn js_object_values(obj: *const ObjectHeader) -> *mut ArrayHeader
                 None => j as u32,
             }
         };
+        // Hide class-instance private fields (`#x`), matching `js_object_keys`.
+        let hide_private = (*obj).class_id != 0 && !keys.is_null();
         for j in 0..count {
-            let value = js_object_get_field(obj as *mut ObjectHeader, pos(j));
+            let slot = pos(j);
+            if hide_private {
+                let key_val = crate::array::js_array_get(keys, slot);
+                if private_member_key_value(key_val) {
+                    continue;
+                }
+            }
+            let value = js_object_get_field(obj as *mut ObjectHeader, slot);
             crate::array::js_array_push_f64(result, f64::from_bits(value.bits()));
         }
 
@@ -1799,8 +1848,16 @@ pub extern "C" fn js_object_entries(obj: *const ObjectHeader) -> *mut ArrayHeade
                 None => j as u32,
             }
         };
+        // Hide class-instance private fields (`#x`), matching `js_object_keys`.
+        let hide_private = (*obj).class_id != 0 && !keys.is_null();
         for j in 0..count {
             let i = pos(j);
+            if hide_private && i < crate::array::js_array_length(keys) {
+                let key_val = crate::array::js_array_get(keys, i);
+                if private_member_key_value(key_val) {
+                    continue;
+                }
+            }
             // Create a pair array [key, value]
             let pair = crate::array::js_array_alloc(2);
 
@@ -2122,6 +2179,18 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     let key_str = crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
 
     unsafe {
+        // A class instance's private members (`#x` field, `#m` method) are never
+        // reachable via `in` with a string key. `"#x" in instance` must be
+        // false even though `#x` lives in the instance keys_array. Plain object
+        // literals (class_id 0) keep real `#`-prefixed string keys visible.
+        if (*obj_ptr).class_id != 0 {
+            if let Some(qk) = super::has_own_helpers::str_from_string_header(key_str) {
+                if private_member_key_bytes(qk.as_bytes()) {
+                    return nanbox_false;
+                }
+            }
+        }
+
         let keys = (*obj_ptr).keys_array;
         if keys.is_null() {
             return nanbox_false;

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -549,7 +549,13 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
         if let Some(class_id) = super::class_ref_id(obj_value) {
             let present = super::has_own_helpers::str_from_string_header(key_str)
                 .map(|key| {
-                    if super::class_registry::class_is_key_deleted(class_id, key) {
+                    if super::field_get_set::private_member_key_bytes(key.as_bytes()) {
+                        // Static private members (`#gen`) and private
+                        // methods/accessors (`#m` on the prototype ref) are
+                        // never own string properties of the constructor or
+                        // prototype.
+                        false
+                    } else if super::class_registry::class_is_key_deleted(class_id, key) {
                         false
                     } else if matches!(key, "length" | "prototype") {
                         true
@@ -662,6 +668,19 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
             return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
         }
 
+        // Class instances store private fields (`#x`) in `keys_array`, but they
+        // are never observable as own string properties. Plain object literals
+        // (class_id 0) keep any real `#`-prefixed string key. Checked here —
+        // after the array/native-module guards — so `(*obj).class_id` is read
+        // off a real `ObjectHeader`.
+        if (*obj).class_id != 0 {
+            if let Some(k) = super::has_own_helpers::str_from_string_header(key_str) {
+                if super::field_get_set::private_member_key_bytes(k.as_bytes()) {
+                    return f64::from_bits(TAG_FALSE);
+                }
+            }
+        }
+
         if own_key_present(obj, key_str) {
             f64::from_bits(TAG_TRUE)
         } else {
@@ -756,6 +775,12 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
             return result;
         }
         if !is_valid_obj_ptr(obj as *const u8) {
+            return f64::from_bits(TAG_FALSE);
+        }
+        // Class-instance private members (`#x`) are not enumerable own props.
+        if (*obj).class_id != 0
+            && super::field_get_set::private_member_key_bytes(key_name.as_bytes())
+        {
             return f64::from_bits(TAG_FALSE);
         }
         if (*obj).class_id == NATIVE_MODULE_CLASS_ID {


### PR DESCRIPTION
## Summary

Two fixes for class **private members** (`#x` fields, `#m()` methods, `get/set #a` accessors, and their `static` forms) — the largest test262 class cluster.

On `language/expressions/class/elements`: **pass 415 → 497 (+82), parity 30.4% → 36.4%, compile-fail 430 → 5, 0 regressions** (full 3-shard re-run vs clean baseline).

### 1. Private names are no longer observable as own string properties
Perry stores private fields in a class instance's `keys_array` under their `#`-prefixed source name, and private methods/accessors in the class vtable/static tables under `#name` keys. These leaked into **every** reflection/enumeration surface — `Object.getOwnPropertyNames(c)` returned `["#x"]`, `c.hasOwnProperty("#x")` / `"#x" in c` returned `true`, `#m` appeared on the prototype's own-property list. Per ECMA-262 a private name is never an own string property.

Added `private_member_key_{bytes,value}` helpers and filtered `#`-prefixed keys from: `Object.keys`/`values`/`entries`, `getOwnPropertyNames` (class-ref + instance paths), `getOwnPropertyDescriptor` (both → `undefined`), `hasOwnProperty` (instance **and** class-ref, so `static #gen` no longer shows on the constructor), `propertyIsEnumerable`, the `in` operator, `JSON.stringify`, object spread, and `Object.assign`. `Reflect.ownKeys` is covered transitively.

Instance-side filters are gated on `class_id != 0` so a plain object literal that legitimately uses a `#`-prefixed **string** key (e.g. a hex-color map `{ "#fff": "white" }`) keeps it visible; class-ref paths filter unconditionally.

### 2. Exotic private names no longer collide into one LLVM symbol
`codegen::sanitize` replaced every non-`[A-Za-z0-9_]` char with a single `_`, so distinct private methods like `#$`, `#_`, `#℘` all mangled to the same `perry_method_…__C____` symbol and clang aborted the module with `invalid redefinition of function` — failing ~425 generated `*-private*` cases at compile time. `sanitize` now hex-escapes each non-alnum char (`_<hex>_`), which is injective; ordinary identifiers are returned byte-for-byte unchanged.

## Not covered (follow-ups)
- Private **brand check on access** (`other.#x` on a wrong receiver must throw `TypeError`; currently returns `undefined`). A correct fix needs lexical resolution of the private name's *declaring* class (not always the innermost class), deferred to avoid regressing nested-class private access.
- Many now-compiling tests depend on unrelated **public** static-method descriptor support (`verifyProperty(C, "m")` on `static *m()`) and async-generator semantics, tracked separately.

## Testing
- test262 `language/expressions/class/elements`: +82 / 0 regressions (full 3-shard sweep).
- Repros vs Node confirm instance/static private members hidden from all reflection surfaces and exotic-private-name modules compile.
- `cargo build --release` of all crates passes.
