### PR TITLE
fix(string): generic-`this` for all String.prototype methods + slice/substring index coercion (built-ins/String 60.2%→79.3%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1128 — fix(string): generic-`this` for all String.prototype methods + slice/substring index coercion (built-ins/String 60.2%→79.3%)
+
+Extends the generic-`this` work started in #4713 (which only covered the
+char-access methods `at`/`charAt`/`charCodeAt`/`codePointAt` +
+`[Symbol.iterator]`) to **every** coercing `String.prototype` method, and fixes
+a class of argument-coercion bugs on the slice/substring index path. Lifts the
+full `built-ins/String` test262 subset from **60.2% → 79.3%** parity
+(`pass 561→739`, `runtime-fail 343→171`), **zero regressions** (the four
+`prototype/trim/*` items flagged in the contended full sweep pass cleanly in
+isolation — transient auto-optimize/cargo contention, not real failures).
+
+Per ECMA-262 §22.1.3 each method begins with `RequireObjectCoercible(this)` then
+`ToString(this)`, so a boxed `new String("x")` / `new Boolean(false)` /
+`new Number(5)` / `{ toString }` receiver coerces, and a `null`/`undefined`/
+`Symbol` receiver throws a `TypeError`.
+
+Generic-`this` reflective methods (`crates/perry-runtime/src/object/string_proto_thunks.rs`):
+- One shared `string_proto_generic_thunk` now backs `concat`, `endsWith`,
+  `includes`, `indexOf`, `isWellFormed`, `lastIndexOf`, `localeCompare`,
+  `match`, `matchAll`, `normalize`, `padEnd`, `padStart`, `repeat`, `replace`,
+  `replaceAll`, `search`, `slice`, `split`, `startsWith`, `substr`, `substring`,
+  `toLocaleLowerCase`, `toLocaleUpperCase`, `toLowerCase`, `toUpperCase`,
+  `toWellFormed`, `trim`, `trimEnd`, `trimStart` (replacing the no-op thunks).
+  It reads its own method name off the closure, applies RequireObjectCoercible +
+  ToString to `this`, and re-dispatches to the typed string-method tower
+  (`js_native_call_method`) with the coerced string as receiver. `toString` /
+  `valueOf` stay no-op-backed — they are brand-checked, not ToString-coercing.
+- These methods are excluded from the HIR `.call`/`.apply` fold
+  (`is_string_prototype_generic_method`) so `String.prototype.slice.call(x, …)`
+  reaches the coercing thunk instead of being rewritten to `x.slice(…)` (which
+  dispatched on `x`'s own type and threw).
+
+Native dispatch arms (`crates/perry-runtime/src/object/native_call_method.rs`):
+- Added `padStart`/`padEnd`/`normalize`/`localeCompare`/`isWellFormed`/
+  `toWellFormed` arms (previously only a codegen fast path existed), so the
+  generic-`this` re-dispatch and `(s: any).<m>(…)` dynamic dispatch resolve to
+  the runtime helper instead of the TypeError catch-all.
+- `indexOf`/`lastIndexOf` now `ToString` the search argument
+  (`s.indexOf(undefined)` searches for `"undefined"`; `{toString}` objects
+  coerce) instead of returning `-1`.
+- Index/position args (`slice`/`substring`/`substr`/positions) route through
+  `js_string_index_to_i32` (full `ToIntegerOrInfinity`) instead of a raw
+  `v as i32`, so a boolean (`slice(false, true)` → `0,1`), numeric string, or
+  `{ valueOf }` index coerces per spec.
+- `split` passes a RegExp separator through as its raw pointer (so
+  `js_string_split_n` detects + delegates to the regex splitter),
+  ToString-coerces a primitive separator, and treats an `undefined`/omitted
+  separator as "whole string" (not a per-character split).
+- Receiver re-fetched (rooted) after any argument coercion that can run user
+  code, and the coerced needle is rooted, to stay GC-safe.
+
+Codegen + spec end-index fix (`crates/perry-codegen/src/lower_string_method.rs`,
+new `js_string_end_index_to_i32`):
+- `slice`/`substring` now coerce `start`/`end` via `js_string_index_to_i32`
+  rather than a raw `fptosi(DOUBLE → i32)` — `fptosi` is UB on `±Infinity`/`NaN`
+  and on x86 yields the integer-indefinite `i32::MIN`, so
+  `"abc".substring(Infinity, NaN)` wrongly clamped to `""`.
+- An `undefined` `end` (omitted **or** explicit) now means `len`, not
+  `ToInteger(undefined) === 0`, in both codegen and the runtime arm —
+  `s.substring(0, undefined) === s`.
+
 ## v0.5.1127 — fix(array): Array.prototype callback `thisArg`, array-like `ToLength`, spec op-order + 0-arg validation
 
 Closes a batch of `built-ins/Array/prototype/*` test262 gaps in the callback /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1127
+**Current Version:** 0.5.1128
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "base64",
@@ -5252,14 +5252,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "cc",
  "libc",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "base64",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,14 +5368,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "serde",
  "serde_json",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1127"
+version = "0.5.1128"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "clap",
@@ -5409,14 +5409,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5515,14 +5515,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "bytes",
  "h2",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "bson",
  "futures-util",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "image",
@@ -5709,14 +5709,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "brotli",
  "flate2",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "base64",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5939,14 +5939,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "itoa",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "block2",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "block2",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1127"
+version = "0.5.1128"
 
 [[package]]
 name = "perry-ui-test"
@@ -6035,11 +6035,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1127"
+version = "0.5.1128"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "block2",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "block2",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "block2",
  "libc",
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "libc",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1127"
+version = "0.5.1128"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1127"
+version = "0.5.1128"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -145,25 +145,36 @@ pub(crate) fn lower_string_method(
             } else {
                 lower_expr(ctx, &args[0])?
             };
-            // 2-arg form: explicit end. 0/1-arg form: end defaults to the
-            // string's length, computed inline (load i32 at offset 0).
+            // 2-arg form: explicit end (may be `undefined` → treated as `len`).
             let end_d = if args.len() == 2 {
-                lower_expr(ctx, &args[1])?
+                Some(lower_expr(ctx, &args[1])?)
             } else {
-                // Issue #214: route through SSO-safe unbox so the
-                // length read works for SHORT_STRING_TAG receivers.
-                // The inline `bits & POINTER_MASK_I64` would treat
-                // the SSO payload as a heap pointer.
-                let blk = ctx.block();
-                let recv_handle = unbox_str_handle(blk, &recv_box);
-                let len_ptr = blk.inttoptr(I64, &recv_handle);
-                let len_i32 = blk.load(I32, &len_ptr);
-                blk.sitofp(I32, &len_i32, DOUBLE)
+                None
             };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let start_i32 = blk.fptosi(DOUBLE, &start_d, I32);
-            let end_i32 = blk.fptosi(DOUBLE, &end_d, I32);
+            // String length (i32 at header offset 0). Used as the default end
+            // (0/1-arg form, issue #316/#214) and the `undefined`-end fallback.
+            // Routed through SSO-safe unbox so SHORT_STRING_TAG receivers work.
+            let len_ptr = blk.inttoptr(I64, &recv_handle);
+            let len_i32 = blk.load(I32, &len_ptr);
+            // `ToIntegerOrInfinity` via the runtime helper, NOT a raw `fptosi`:
+            // `fptosi(±Infinity/NaN → i32)` is UB and on x86 yields the integer-
+            // indefinite `i32::MIN`, so `"abc".slice(Infinity)` / `.substring(
+            // Infinity, NaN)` clamped to the wrong end. The helper truncates and
+            // clamps ±Infinity to the i32 bounds (and runs ToNumber on a boxed
+            // arg), matching the char-access methods and the runtime dispatch arm.
+            let start_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &start_d)]);
+            // An explicit `undefined` end means `len` (not `ToInteger(undefined)
+            // === 0`), per spec — `s.substring(0, undefined) === s`.
+            let end_i32 = match &end_d {
+                Some(end_d) => blk.call(
+                    I32,
+                    "js_string_end_index_to_i32",
+                    &[(DOUBLE, end_d), (I32, &len_i32)],
+                ),
+                None => len_i32.clone(),
+            };
             let runtime_fn = if property == "slice" {
                 "js_string_slice"
             } else {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -522,6 +522,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // #2787: NaN-safe JS index coercion (undefined/NaN -> 0, trunc, clamp) for
     // the char-access methods, replacing a raw `fptosi` that is UB on a NaN.
     module.declare_function("js_string_index_to_i32", I32, &[DOUBLE]);
+    // `end`-arg coercion for slice/substring: `undefined` -> `len` (not 0), else
+    // ToIntegerOrInfinity. `(value, len) -> i32`.
+    module.declare_function("js_string_end_index_to_i32", I32, &[DOUBLE, I32]);
     // Issue #514: tag-aware dynamic index dispatch — routes `obj[idx]` to
     // `js_string_char_at` / `js_array_get_f64` / `js_object_get_field_by_name_f64`
     // based on the receiver's NaN-box tag at runtime. Used by IndexGet's

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1139,7 +1139,45 @@ fn is_string_prototype_generic_method(recv: &ast::Expr, method: &str) -> bool {
         return false;
     };
     base.sym.as_ref() == "String"
-        && matches!(method, "at" | "charAt" | "charCodeAt" | "codePointAt")
+        && matches!(
+            method,
+            // Char-access (dedicated thunks) + every coercing method installed
+            // as the generic `string_proto_generic_thunk`. Keep in lock-step with
+            // `string_proto_thunks::GENERIC_STRING_PROTO_METHODS`. Excluded:
+            // `toString`/`valueOf` (brand-checked, not ToString-coercing).
+            "at" | "charAt"
+                | "charCodeAt"
+                | "codePointAt"
+                | "concat"
+                | "endsWith"
+                | "includes"
+                | "indexOf"
+                | "isWellFormed"
+                | "lastIndexOf"
+                | "localeCompare"
+                | "match"
+                | "matchAll"
+                | "normalize"
+                | "padEnd"
+                | "padStart"
+                | "repeat"
+                | "replace"
+                | "replaceAll"
+                | "search"
+                | "slice"
+                | "split"
+                | "startsWith"
+                | "substr"
+                | "substring"
+                | "toLocaleLowerCase"
+                | "toLocaleUpperCase"
+                | "toLowerCase"
+                | "toUpperCase"
+                | "toWellFormed"
+                | "trim"
+                | "trimEnd"
+                | "trimStart"
+        )
 }
 
 pub(super) fn try_builtin_prototype_method_apply_call(

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -4431,48 +4431,17 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             install_function_has_instance_symbol(proto_obj);
         }
         "String" => {
-            // #4576-style: generic-`this` char-access methods + `Symbol.iterator`
-            // get real reflective thunks (RequireObjectCoercible + ToString) so
-            // `String.prototype.charAt.call(receiver, i)` works on a boxed/object
-            // receiver. The remaining methods stay no-op-backed (value-introspect
-            // only); their direct/dispatch paths are handled elsewhere.
+            // #4713: generic-`this` char-access methods + `Symbol.iterator`, and
+            // (this change) every other coercing method (slice/indexOf/split/
+            // replace/…) get real reflective thunks (RequireObjectCoercible +
+            // ToString) installed by `install_string_proto_methods` so
+            // `String.prototype.slice.call(receiver, …)` works on a boxed/object
+            // receiver. Only `toString` (and `valueOf`, via OBJECT_PROTO_METHODS)
+            // stay no-op-backed: they are brand-checked (must throw on a
+            // non-String `this`), not ToString-coercing, so a generic coercing
+            // thunk would be wrong.
             string_proto_thunks::install_string_proto_methods("String", proto_obj);
-            install_noop_proto_methods(
-                proto_obj,
-                &[
-                    ("concat", 1),
-                    ("endsWith", 1),
-                    ("includes", 1),
-                    ("indexOf", 1),
-                    ("isWellFormed", 0),
-                    ("lastIndexOf", 1),
-                    ("localeCompare", 1),
-                    ("match", 1),
-                    ("matchAll", 1),
-                    ("normalize", 0),
-                    ("padEnd", 1),
-                    ("padStart", 1),
-                    ("repeat", 1),
-                    ("replace", 2),
-                    ("replaceAll", 2),
-                    ("search", 1),
-                    ("slice", 2),
-                    ("split", 2),
-                    ("startsWith", 1),
-                    ("substr", 2),
-                    ("substring", 2),
-                    ("toLocaleLowerCase", 0),
-                    ("toLocaleUpperCase", 0),
-                    ("toLowerCase", 0),
-                    ("toString", 0),
-                    ("toUpperCase", 0),
-                    ("toWellFormed", 0),
-                    ("trim", 0),
-                    ("trimEnd", 0),
-                    ("trimStart", 0),
-                    ("valueOf", 0),
-                ],
-            );
+            install_noop_proto_methods(proto_obj, &[("toString", 0)]);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "Number" => {

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1678,15 +1678,16 @@ pub unsafe extern "C" fn js_native_call_method(
                     None
                 }
             };
+            // Index/position args follow `ToIntegerOrInfinity` (ToNumber, then
+            // truncate, clamping ±Infinity to i32 bounds) so a boolean
+            // (`slice(false, true)` → 0,1), numeric string (`"2"`), or `{ valueOf
+            // }` object coerces like Node instead of being read as NaN→0. Plain
+            // numbers/int32 take the fast path inside the helper. A missing arg
+            // is 0 (the per-method default end/length is applied by the arm).
             let arg_i32 = |i: usize| -> i32 {
-                if let Some(v) = arg_at(i) {
-                    if v.is_nan() || v.is_infinite() {
-                        0
-                    } else {
-                        v as i32
-                    }
-                } else {
-                    0
+                match arg_at(i) {
+                    Some(v) => crate::string::js_string_index_to_i32(v),
+                    None => 0,
                 }
             };
             match method_name {
@@ -1757,10 +1758,20 @@ pub unsafe extern "C" fn js_native_call_method(
                     return crate::string::js_string_char_code_at(s_ptr, arg_i32(0));
                 }
                 "slice" => {
+                    // Coerce args first (`arg_i32` may run user `valueOf` and move
+                    // the receiver under GC), then re-fetch the rooted receiver.
+                    // An `undefined` end means `len` (spec), not `ToInteger(0)`.
                     let start = if args_len >= 1 { arg_i32(0) } else { 0 };
-                    let len_i32 = unsafe { (*s_ptr).byte_len } as i32;
-                    let end = if args_len >= 2 { arg_i32(1) } else { len_i32 };
-                    let result = crate::string::js_string_slice(s_ptr, start, end);
+                    let end_arg = match arg_at(1) {
+                        Some(v) if !JSValue::from_bits(v.to_bits()).is_undefined() => {
+                            Some(arg_i32(1))
+                        }
+                        _ => None,
+                    };
+                    let s = receiver_string();
+                    let len_i32 = unsafe { (*s).byte_len } as i32;
+                    let end = end_arg.unwrap_or(len_i32);
+                    let result = crate::string::js_string_slice(s, start, end);
                     if result.is_null() {
                         return f64::from_bits(JSValue::undefined().bits());
                     }
@@ -1844,27 +1855,38 @@ pub unsafe extern "C" fn js_native_call_method(
                     return f64::from_bits(JSValue::string_ptr(result).bits());
                 }
                 "indexOf" | "includes" | "lastIndexOf" | "startsWith" | "endsWith" => {
-                    let arg_str = |i: usize| -> *const crate::StringHeader {
-                        if i < args_len && !args_ptr.is_null() {
-                            let v = unsafe { *args_ptr.add(i) };
-                            crate::value::js_get_string_pointer_unified(v)
-                                as *const crate::StringHeader
-                        } else {
-                            std::ptr::null()
-                        }
-                    };
                     let search_arg_to_string = |method_id: i32| -> *const crate::StringHeader {
                         let value = arg_at(0)
                             .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
                         crate::string::js_string_search_value_to_string(value, method_id)
                             as *const crate::StringHeader
                     };
-                    let needle = match method_name {
+                    let needle_raw = match method_name {
                         "includes" => search_arg_to_string(0),
                         "startsWith" => search_arg_to_string(1),
                         "endsWith" => search_arg_to_string(2),
-                        _ => arg_str(0),
+                        // indexOf / lastIndexOf apply `ToString(searchString)` with
+                        // no RegExp TypeError: `s.indexOf(undefined)` searches for
+                        // "undefined", `s.indexOf({toString(){…}})` uses the result.
+                        _ => {
+                            let value = arg_at(0)
+                                .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+                            crate::value::js_jsvalue_to_string(value) as *const crate::StringHeader
+                        }
                     };
+                    // ToString above may run user code (object `toString`/`valueOf`)
+                    // and move either string under GC — root the needle and re-read
+                    // the receiver before the byte-level helpers below.
+                    let needle_h = if needle_raw.is_null() {
+                        None
+                    } else {
+                        Some(root_scope.root_string_ptr(needle_raw))
+                    };
+                    let needle = needle_h
+                        .as_ref()
+                        .map(|h| h.get_raw_const_ptr::<crate::StringHeader>())
+                        .unwrap_or(std::ptr::null());
+                    let s_ptr = receiver_string();
                     // Integer-returning methods MUST return raw `i as f64` (not
                     // NaN-boxed INT32_TAG) — otherwise downstream comparisons
                     // like `idx < url.length` fail because NaN-boxed values
@@ -1940,10 +1962,18 @@ pub unsafe extern "C" fn js_native_call_method(
                     return f64::from_bits(JSValue::string_ptr(r).bits());
                 }
                 "substring" => {
-                    let len_i32 = unsafe { (*s_ptr).byte_len } as i32;
+                    // An `undefined` end means `len` (spec), not `ToInteger(0)`.
                     let start = if args_len >= 1 { arg_i32(0) } else { 0 };
-                    let end = if args_len >= 2 { arg_i32(1) } else { len_i32 };
-                    let r = crate::string::js_string_substring(s_ptr, start, end);
+                    let end_arg = match arg_at(1) {
+                        Some(v) if !JSValue::from_bits(v.to_bits()).is_undefined() => {
+                            Some(arg_i32(1))
+                        }
+                        _ => None,
+                    };
+                    let s = receiver_string();
+                    let len_i32 = unsafe { (*s).byte_len } as i32;
+                    let end = end_arg.unwrap_or(len_i32);
+                    let r = crate::string::js_string_substring(s, start, end);
                     return f64::from_bits(JSValue::string_ptr(r).bits());
                 }
                 "substr" => {
@@ -1951,7 +1981,8 @@ pub unsafe extern "C" fn js_native_call_method(
                     // 2nd arg is a length. i32::MIN = "length omitted" (#2897).
                     let start = if args_len >= 1 { arg_i32(0) } else { 0 };
                     let length = if args_len >= 2 { arg_i32(1) } else { i32::MIN };
-                    let r = crate::string::js_string_substr(s_ptr, start, length);
+                    let s = receiver_string();
+                    let r = crate::string::js_string_substr(s, start, length);
                     return f64::from_bits(JSValue::string_ptr(r).bits());
                 }
                 "toLocaleLowerCase" => {
@@ -1975,7 +2006,6 @@ pub unsafe extern "C" fn js_native_call_method(
                     return f64::from_bits(JSValue::string_ptr(r).bits());
                 }
                 "split" => {
-                    let sep_handle = root_string_arg_handle(&root_scope, &arg_handles, 0);
                     // Issue #567: optional 2nd arg `limit`.
                     let limit = if let Some(v) = arg_at(1) {
                         let jsv = JSValue::from_bits(v.to_bits());
@@ -1999,11 +2029,46 @@ pub unsafe extern "C" fn js_native_call_method(
                     } else {
                         -1
                     };
-                    let sep = sep_handle
-                        .as_ref()
-                        .map(|handle| handle.get_raw_const_ptr::<crate::StringHeader>())
-                        .unwrap_or(std::ptr::null());
-                    let arr = crate::string::js_string_split_n(receiver_string(), sep, limit);
+                    // `split(undefined)` (or no separator) yields the whole string
+                    // as a single element — NOT a per-character split (which is what
+                    // an empty-string separator does), and NOT [] (`limit === 0`).
+                    let sep_undefined = match arg_at(0) {
+                        None => true,
+                        Some(v) => JSValue::from_bits(v.to_bits()).is_undefined(),
+                    };
+                    if sep_undefined {
+                        let s = receiver_string();
+                        let arr = if limit == 0 {
+                            crate::array::js_array_alloc(0)
+                        } else {
+                            let a = crate::array::js_array_alloc(0);
+                            crate::array::js_array_push_f64(
+                                a,
+                                f64::from_bits(
+                                    JSValue::string_ptr(s as *mut crate::StringHeader).bits(),
+                                ),
+                            )
+                        };
+                        return f64::from_bits(JSValue::pointer(arr as *mut u8).bits());
+                    }
+                    // A RegExp separator must be passed through as its raw pointer so
+                    // `js_string_split_n` detects it (by GC header) and delegates to
+                    // the regex splitter. Any other value is ToString-coerced.
+                    let v0 = arg_at(0).unwrap();
+                    let jv0 = JSValue::from_bits(v0.to_bits());
+                    let sep_is_regex =
+                        jv0.is_pointer() && crate::regex::is_regex_pointer(jv0.as_pointer::<u8>());
+                    let (sep, _sep_h) = if sep_is_regex {
+                        (jv0.as_pointer::<crate::StringHeader>(), None)
+                    } else {
+                        let coerced =
+                            crate::builtins::js_string_coerce(v0) as *const crate::StringHeader;
+                        let h = root_scope.root_string_ptr(coerced);
+                        let p = h.get_raw_const_ptr::<crate::StringHeader>();
+                        (p, Some(h))
+                    };
+                    let s = receiver_string();
+                    let arr = crate::string::js_string_split_n(s, sep, limit);
                     return f64::from_bits(JSValue::pointer(arr as *mut u8).bits());
                 }
                 "replace" | "replaceAll" => {
@@ -2109,6 +2174,66 @@ pub unsafe extern "C" fn js_native_call_method(
                             repl_str(),
                         )
                     };
+                    return f64::from_bits(JSValue::string_ptr(r).bits());
+                }
+                // Methods with only a codegen fast path (no native arm) — needed
+                // so generic-`this` reflective calls (`String.prototype.padStart.
+                // call(boxed, …)`, routed through `string_proto_thunks` after
+                // coercing `this` to a string) and `(s: any).padStart(…)` dynamic
+                // dispatch resolve to the runtime helper instead of the TypeError
+                // catch-all. Argument coercion mirrors `lower_string_method.rs`.
+                "padStart" | "padEnd" => {
+                    let target_len = arg_at(0).unwrap_or(0.0);
+                    // ToString(fillString) when present and not undefined; absent /
+                    // undefined leaves a null ptr so the helper defaults to " ".
+                    let pad = match arg_at(1) {
+                        Some(v) if !JSValue::from_bits(v.to_bits()).is_undefined() => {
+                            crate::builtins::js_string_coerce(v) as *const crate::StringHeader
+                        }
+                        _ => std::ptr::null(),
+                    };
+                    let s = receiver_string();
+                    let r = if method_name == "padStart" {
+                        crate::string::js_string_pad_start(s, target_len, pad)
+                    } else {
+                        crate::string::js_string_pad_end(s, target_len, pad)
+                    };
+                    return f64::from_bits(JSValue::string_ptr(r).bits());
+                }
+                "normalize" => {
+                    let form =
+                        arg_at(0).unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+                    let r = crate::string::js_string_normalize(receiver_string(), form);
+                    return f64::from_bits(JSValue::string_ptr(r).bits());
+                }
+                "localeCompare" => {
+                    // ToString(that) is required even for undefined ("undefined").
+                    // Root it — `js_string_validate_locales` below may allocate.
+                    let other_raw = crate::builtins::js_string_coerce(
+                        arg_at(0).unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits())),
+                    );
+                    let other_h = root_scope.root_string_ptr(other_raw);
+                    // `locales` (2nd arg) validated for its RangeError side effect.
+                    if let Some(loc) = arg_at(1) {
+                        let jv = JSValue::from_bits(loc.to_bits());
+                        if !jv.is_undefined() {
+                            crate::string::js_string_validate_locales(loc);
+                        }
+                    }
+                    let s = receiver_string();
+                    let other = other_h.get_raw_const_ptr::<crate::StringHeader>();
+                    // Returns a plain f64 (-1/0/1) — NOT NaN-tagged.
+                    return if let Some(opts) = arg_at(2) {
+                        crate::string::js_string_locale_compare_opts(s, other, opts)
+                    } else {
+                        crate::string::js_string_locale_compare(s, other)
+                    };
+                }
+                "isWellFormed" => {
+                    return crate::string::js_string_is_well_formed(receiver_string());
+                }
+                "toWellFormed" => {
+                    let r = crate::string::js_string_to_well_formed(receiver_string());
                     return f64::from_bits(JSValue::string_ptr(r).bits());
                 }
                 _ => {} // not a handled string method — fall through to TypeError catch-all

--- a/crates/perry-runtime/src/object/string_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/string_proto_thunks.rs
@@ -50,7 +50,101 @@ pub(super) fn install_string_proto_methods(
         1,
     );
     install_string_iterator_symbol(proto_obj);
+    install_generic_string_proto_methods(proto_obj);
     true
+}
+
+/// Every other `String.prototype` method that is RequireObjectCoercible +
+/// ToString on `this` (i.e. all of them except the brand-checked `toString`/
+/// `valueOf`). Each is installed as the single `string_proto_generic_thunk`,
+/// which reads its own method name off the closure and re-dispatches to the
+/// typed string-method tower after coercing `this`. The `(name, spec_length)`
+/// pairs mirror the per-method `.length` (read back by `.length` /
+/// `getOwnPropertyDescriptor`). Kept in lock-step with the HIR
+/// `.call`/`.apply` fold exclusion (`is_string_prototype_generic_method`) so
+/// the reflective path reaches the thunk instead of being folded to
+/// `receiver.<m>()` (which would dispatch on the receiver's own type).
+const GENERIC_STRING_PROTO_METHODS: &[(&str, u32)] = &[
+    ("concat", 1),
+    ("endsWith", 1),
+    ("includes", 1),
+    ("indexOf", 1),
+    ("isWellFormed", 0),
+    ("lastIndexOf", 1),
+    ("localeCompare", 1),
+    ("match", 1),
+    ("matchAll", 1),
+    ("normalize", 0),
+    ("padEnd", 1),
+    ("padStart", 1),
+    ("repeat", 1),
+    ("replace", 2),
+    ("replaceAll", 2),
+    ("search", 1),
+    ("slice", 2),
+    ("split", 2),
+    ("startsWith", 1),
+    ("substr", 2),
+    ("substring", 2),
+    ("toLocaleLowerCase", 0),
+    ("toLocaleUpperCase", 0),
+    ("toLowerCase", 0),
+    ("toUpperCase", 0),
+    ("toWellFormed", 0),
+    ("trim", 0),
+    ("trimEnd", 0),
+    ("trimStart", 0),
+];
+
+fn install_generic_string_proto_methods(proto_obj: *mut ObjectHeader) {
+    for (name, spec_length) in GENERIC_STRING_PROTO_METHODS.iter().copied() {
+        // `call_fixed_arity = 0` → the thunk receives all args as a rest array.
+        super::global_this::install_proto_method_rest_with_length(
+            proto_obj,
+            name,
+            string_proto_generic_thunk as *const u8,
+            spec_length,
+            0,
+        );
+    }
+}
+
+/// Generic `String.prototype` method thunk. Performs `RequireObjectCoercible(
+/// this)` + `ToString(this)` then re-dispatches to the typed string-method
+/// tower (`js_native_call_method`) with the coerced string as the receiver, so
+/// a boxed `new String("x")` / `new Boolean(false)` / `{ toString }` receiver
+/// works and a `null`/`undefined`/`Symbol` receiver throws a `TypeError`. One
+/// thunk backs every method in `GENERIC_STRING_PROTO_METHODS`; it reads its
+/// own method name off the closure. Args arrive as a rest array.
+pub(super) extern "C" fn string_proto_generic_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    // Copy the method name to an owned String — `string_this_or_throw` may run
+    // user `toString`/`valueOf` (allocates, can move the closure's name string
+    // under GC), so a borrow into the header would dangle.
+    let name_val = crate::closure::closure_get_dynamic_prop(closure as usize, "name");
+    let name_hdr = crate::builtins::js_string_coerce(name_val);
+    let name: String = unsafe { super::has_own_helpers::str_from_string_header(name_hdr) }
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+    let s = string_this_or_throw(&name);
+    let s_val = f64::from_bits(crate::value::JSValue::string_ptr(s).bits());
+    let args = super::global_this::global_this_rest_array_values(rest);
+    let (args_ptr, args_len) = if args.is_empty() {
+        (std::ptr::null::<f64>(), 0)
+    } else {
+        (args.as_ptr(), args.len())
+    };
+    unsafe {
+        super::native_call_method::js_native_call_method(
+            s_val,
+            name.as_ptr() as *const i8,
+            name.len(),
+            args_ptr,
+            args_len,
+        )
+    }
 }
 
 /// Install `String.prototype[Symbol.iterator]` as a real, reflectable function

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -40,6 +40,19 @@ pub extern "C" fn js_string_index_to_i32(index: f64) -> i32 {
     }
 }
 
+/// `end`-argument coercion for `slice`/`substring`. Per ECMA-262 §22.1.3.20 /
+/// §22.1.3.24, an `undefined` `end` (whether the arg is omitted or explicitly
+/// `undefined`) means "to the end of the string" — `len`, NOT `ToInteger(
+/// undefined) === 0`. So `"abc".substring(0, undefined)` is `"abc"`, not `""`.
+/// Any other value goes through the ordinary `ToIntegerOrInfinity`.
+#[no_mangle]
+pub extern "C" fn js_string_end_index_to_i32(value: f64, len: i32) -> i32 {
+    if crate::value::JSValue::from_bits(value.to_bits()).is_undefined() {
+        return len;
+    }
+    js_string_index_to_i32(value)
+}
+
 /// Get character code at index (returns UTF-16 code unit, or NaN if out of bounds).
 /// Index is in UTF-16 code units (matches JS spec). For ASCII strings this is
 /// equivalent to byte indexing; for multi-byte UTF-8 we walk codepoints without

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -48,15 +48,15 @@ pub use append::js_string_append;
 pub use base64_codec::{js_atob, js_btoa};
 pub use char_ops::{
     js_string_at, js_string_char_at, js_string_char_code_at, js_string_code_point_at,
-    js_string_from_char_code, js_string_from_char_code_array, js_string_from_code_point,
-    js_string_from_code_point_array, js_string_index_get, js_string_index_to_i32,
-    js_string_to_char_array,
+    js_string_end_index_to_i32, js_string_from_char_code, js_string_from_char_code_array,
+    js_string_from_code_point, js_string_from_code_point_array, js_string_index_get,
+    js_string_index_to_i32, js_string_to_char_array,
 };
 pub use compare::{
     js_string_compare, js_string_ends_with, js_string_ends_with_at, js_string_equals,
-    js_string_is_well_formed, js_string_locale_compare, js_string_normalize,
-    js_string_search_value_to_string, js_string_starts_with, js_string_starts_with_at,
-    js_string_to_well_formed,
+    js_string_is_well_formed, js_string_locale_compare, js_string_locale_compare_opts,
+    js_string_normalize, js_string_search_value_to_string, js_string_starts_with,
+    js_string_starts_with_at, js_string_to_well_formed,
 };
 // #1781: SSO-aware key lookup helpers, used to retire the
 // `is_string() && js_string_equals(key, key_val.as_string_ptr())` shape


### PR DESCRIPTION
## Summary

Extends the generic-`this` work from #4713 (which only covered the char-access methods `at`/`charAt`/`charCodeAt`/`codePointAt` + `[Symbol.iterator]`) to **every** coercing `String.prototype` method, and fixes a class of argument-coercion bugs on the slice/substring index path.

Lifts the full `built-ins/String` test262 subset from **60.2% → 79.3%** parity (`pass 561→739`, `runtime-fail 343→171`), **zero regressions**.

Per ECMA-262 §22.1.3 each method does `RequireObjectCoercible(this)` then `ToString(this)`, so a boxed `new String("x")` / `new Boolean(false)` / `{ toString }` receiver coerces, and a `null`/`undefined`/`Symbol` receiver throws a `TypeError`.

## What changed

- **`string_proto_thunks.rs`** — one shared `string_proto_generic_thunk` backs `concat`, `slice`, `split`, `replace`, `indexOf`, `toUpperCase`, … (29 methods). It reads its own method name off the closure, coerces `this`, and re-dispatches to the typed string-method tower. `toString`/`valueOf` stay no-op (brand-checked). Methods are excluded from the `.call`/`.apply` HIR fold so the reflective path reaches the coercing thunk.
- **`native_call_method.rs`** — added `padStart`/`padEnd`/`normalize`/`localeCompare`/`isWellFormed`/`toWellFormed` arms (previously codegen-only); `indexOf`/`lastIndexOf` now `ToString` the search arg; index/position args route through `js_string_index_to_i32` (`ToIntegerOrInfinity`); `split` handles regex/primitive/`undefined` separators; receiver/needle re-rooted for GC safety after user-code coercion.
- **`lower_string_method.rs` + new `js_string_end_index_to_i32`** — `slice`/`substring` coerce `start`/`end` via `js_string_index_to_i32` instead of a raw `fptosi` (UB on `±Infinity`/`NaN`; on x86 → `i32::MIN`), and an `undefined` `end` (omitted or explicit) now means `len`, not `0`.

## Testing

`scripts/test262_subset.py --dir built-ins/String --jobs 6`: 60.2% → 79.3%. Per-method spot checks confirm zero regressions (the 4 `prototype/trim/*` items flagged in a contended full sweep pass cleanly in isolation — transient auto-optimize/cargo contention). Remaining failures are predominantly the direct-path object-`valueOf` argument crashes and lookbehind/normalize/locale edge cases.