### PR TITLE
fix(array): Array.prototype callback thisArg, array-like ToLength, op-order + 0-arg validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1127 — fix(array): Array.prototype callback `thisArg`, array-like `ToLength`, spec op-order + 0-arg validation
+
+Closes a batch of `built-ins/Array/prototype/*` test262 gaps in the callback /
+array-like / validation clusters. Focused `built-ins/Array` test262 parity
+(test262_subset radar) moved **61.5% → 72.5%** (~290 fewer runtime/compile
+failures); zero regressions in the forEach before/after diff.
+
+**1. `thisArg` on the dense-array callback methods.** `arr.forEach(cb, thisArg)`
+(and `map`/`filter`/`some`/`every`/`find`/`findIndex`/`findLast`/`findLastIndex`/
+`flatMap`) silently dropped the second `thisArg` argument — the callback's `this`
+was whatever ambient `this` happened to be active, so the entire
+`15.4.4.N-5-*` ("thisArg is X") test series failed. The hot `js_array_<m>(arr,
+cb)` runtime entry points take no `this`, and the HIR fast-path variants
+(`Expr::ArrayForEach { array, callback }` …) carry no `thisArg` field.
+
+- Runtime: added `js_array_<m>_this(arr, cb, this_arg)` wrappers
+  (`array/iter_methods.rs`) that install `this_arg` via the implicit-`this`
+  thread-local (a `Drop` guard restores the prior binding) and delegate to the
+  existing loop, so hole/length semantics stay in one place. `#[used]` anchors
+  pin them against dead-strip on the default bitcode-relink path (#3320).
+- Codegen: `lower_array_method` now lowers the optional 2nd arg and calls the
+  `_this` variant when present; the no-`thisArg` path is byte-identical.
+- HIR: the array-method folds (`array_only_methods`, `local_array_methods`,
+  `inline_array_methods`, `imported_array_methods`, `array_fold`) only fold to
+  the fast-path variant for the 1-arg form now; a 2-arg call falls through to
+  the generic member call → `lower_array_method` (which binds `this`).
+  `reduce`/`reduceRight` (whose 2nd arg is the initial value) are unchanged.
+
+**2. Array-like `LengthOfArrayLike` = `ToLength(ToNumber(...))`.** The generic
+`Array.prototype.<m>.call(arrayLike, …)` engine (`array/generic.rs`) read the
+`length` property and fed the raw NaN-boxed value straight to `ToLength`. String
+/ boolean / null `length` values are themselves NaN bit-patterns, so
+`length: "2"` / `"0x0002"` collapsed to 0 and iteration was skipped. Now runs
+`js_number_coerce` (ToNumber) first; an un-coercible object `length`
+(`{valueOf,toString}` returning objects) correctly throws a `TypeError`.
+
+**3. Spec operation order.** All generic array-like callback methods computed the
+`IsCallable(callbackfn)` check before `LengthOfArrayLike`. Per ECMA-262 §23.1.3,
+`LengthOfArrayLike` (step 2) runs first, so a `length` getter's side effects /
+throw are observed even when the callback is non-callable. Swapped the order.
+
+**4. 0-arg validation (compile-fail → runtime semantics).**
+`[].reduce()` / `[].reduceRight()` compile-failed instead of throwing a
+`TypeError` at runtime; `[undefined].indexOf()` / `.lastIndexOf()` compile-failed
+instead of searching for `undefined` (returns `0`). These `lower_array_method`
+arms now pad the missing argument and defer to the runtime (validator throws for
+the callback methods; the search proceeds for indexOf/lastIndexOf), matching
+Node.
+
+Known remaining `built-ins/Array/prototype` clusters (follow-ups): boxed-
+primitive / exotic-object receivers (`-1-*`: `forEach.call(false, cb)`,
+Date/RegExp/Error expandos), and live-mutation / index-getter / inherited-
+`HasProperty` during iteration (`-7-*`).
+
 ## v0.5.1126 — fix(class): hide private members from reflection + unblock exotic-private-name compilation
 
 Two fixes for class **private members** (`#x` fields, `#m()` methods, `get/set #a`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1126
+**Current Version:** 0.5.1127
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,7 +5197,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "base64",
@@ -5252,14 +5252,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "cc",
  "libc",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "base64",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,14 +5368,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "serde",
  "serde_json",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1126"
+version = "0.5.1127"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "clap",
@@ -5409,14 +5409,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5515,14 +5515,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "bytes",
  "h2",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "bson",
  "futures-util",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "image",
@@ -5709,14 +5709,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "brotli",
  "flate2",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "base64",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -5939,14 +5939,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "itoa",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "block2",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "block2",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1126"
+version = "0.5.1127"
 
 [[package]]
 name = "perry-ui-test"
@@ -6035,11 +6035,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1126"
+version = "0.5.1127"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "block2",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "block2",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "block2",
  "libc",
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "libc",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1126"
+version = "0.5.1127"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1126"
+version = "0.5.1127"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -16,6 +16,17 @@ use crate::expr::{
 use crate::nanbox::{double_literal, TAG_UNDEFINED};
 use crate::types::{DOUBLE, I32, I64, PTR};
 
+/// Lower the optional `thisArg` (2nd positional argument) of a dense Array
+/// callback method. Must be called *after* the callback is lowered (source
+/// evaluation order: receiver, callback, thisArg) and *before* `ctx.block()`
+/// is borrowed. Returns the boxed value name, or `None` when absent.
+fn lower_opt_this_arg(ctx: &mut FnCtx<'_>, args: &[Expr]) -> Result<Option<String>> {
+    Ok(match args.get(1) {
+        Some(e) => Some(lower_expr(ctx, e)?),
+        None => None,
+    })
+}
+
 /// Lower `arr.method(args…)` for an array-typed receiver. Currently
 /// supported: `pop`, `join`. `push` is handled separately by the HIR
 /// `Expr::ArrayPush` variant (Phase B.7).
@@ -56,27 +67,30 @@ pub(crate) fn lower_array_method(
             // `arr.some()` / `arr.every()` with no callback must throw a
             // runtime TypeError ("undefined is not a function"), not fail to
             // compile — pad a missing callback with `undefined` and let
-            // `js_validate_array_callback` raise it. (A trailing `thisArg`
-            // is accepted but not yet applied.)
+            // `js_validate_array_callback` raise it.
             let cb_box = if let Some(arg) = args.first() {
                 lower_expr(ctx, arg)?
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            let runtime_fn = if property == "some" {
-                "js_array_some"
+            let (base_fn, this_fn) = if property == "some" {
+                ("js_array_some", "js_array_some_this")
             } else {
-                "js_array_every"
+                ("js_array_every", "js_array_every_this")
             };
-            Ok(blk.call(
-                DOUBLE,
-                runtime_fn,
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            ))
+            Ok(match &this_box {
+                Some(tb) => blk.call(
+                    DOUBLE,
+                    this_fn,
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call(DOUBLE, base_fn, &[(I64, &recv_handle), (I64, &cb_handle)]),
+            })
         }
         "toString" => {
             // arr.toString() == arr.join(",")
@@ -236,15 +250,23 @@ pub(crate) fn lower_array_method(
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            let result = blk.call(
-                I64,
-                "js_array_flatMap",
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            );
+            let result = match &this_box {
+                Some(tb) => blk.call(
+                    I64,
+                    "js_array_flatMap_this",
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call(
+                    I64,
+                    "js_array_flatMap",
+                    &[(I64, &recv_handle), (I64, &cb_handle)],
+                ),
+            };
             Ok(nanbox_pointer_inline(blk, &result))
         }
         // -------- Safety-net handlers for methods that normally arrive --------
@@ -257,15 +279,23 @@ pub(crate) fn lower_array_method(
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            Ok(blk.call(
-                DOUBLE,
-                "js_array_find",
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            ))
+            Ok(match &this_box {
+                Some(tb) => blk.call(
+                    DOUBLE,
+                    "js_array_find_this",
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call(
+                    DOUBLE,
+                    "js_array_find",
+                    &[(I64, &recv_handle), (I64, &cb_handle)],
+                ),
+            })
         }
         "findIndex" => {
             // 0-arg → runtime TypeError (pad undefined), not compile-fail.
@@ -274,15 +304,23 @@ pub(crate) fn lower_array_method(
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            let i32_v = blk.call(
-                I32,
-                "js_array_findIndex",
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            );
+            let i32_v = match &this_box {
+                Some(tb) => blk.call(
+                    I32,
+                    "js_array_findIndex_this",
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call(
+                    I32,
+                    "js_array_findIndex",
+                    &[(I64, &recv_handle), (I64, &cb_handle)],
+                ),
+            };
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
         "findLast" => {
@@ -292,15 +330,23 @@ pub(crate) fn lower_array_method(
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            Ok(blk.call(
-                DOUBLE,
-                "js_array_find_last",
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            ))
+            Ok(match &this_box {
+                Some(tb) => blk.call(
+                    DOUBLE,
+                    "js_array_find_last_this",
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call(
+                    DOUBLE,
+                    "js_array_find_last",
+                    &[(I64, &recv_handle), (I64, &cb_handle)],
+                ),
+            })
         }
         "findLastIndex" => {
             // 0-arg → runtime TypeError (pad undefined), not compile-fail.
@@ -309,25 +355,40 @@ pub(crate) fn lower_array_method(
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            let i32_v = blk.call(
-                I32,
-                "js_array_find_last_index",
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            );
+            let i32_v = match &this_box {
+                Some(tb) => blk.call(
+                    I32,
+                    "js_array_find_last_index_this",
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call(
+                    I32,
+                    "js_array_find_last_index",
+                    &[(I64, &recv_handle), (I64, &cb_handle)],
+                ),
+            };
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
         "reduce" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.reduce expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let cb_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → runtime TypeError ("undefined is not a function") via the
+            // callback validator below, not a compile error: Node rejects
+            // `[].reduce()` at runtime, so pad a missing callback with undefined.
+            let cb_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             let (has_initial, initial_box) = if args.len() == 2 {
                 let init = lower_expr(ctx, &args[1])?;
                 (1i32, init)
@@ -351,13 +412,19 @@ pub(crate) fn lower_array_method(
             ))
         }
         "reduceRight" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.reduceRight expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let cb_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → runtime TypeError via the validator (Node rejects
+            // `[].reduceRight()` at runtime), not a compile error.
+            let cb_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             let (has_initial, initial_box) = if args.len() == 2 {
                 let init = lower_expr(ctx, &args[1])?;
                 (1i32, init)
@@ -387,6 +454,7 @@ pub(crate) fn lower_array_method(
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
@@ -397,11 +465,18 @@ pub(crate) fn lower_array_method(
                 "js_validate_array_map_callback",
                 &[(I64, &recv_handle), (DOUBLE, &cb_box)],
             );
-            let result = blk.call(
-                I64,
-                "js_array_map",
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            );
+            let result = match &this_box {
+                Some(tb) => blk.call(
+                    I64,
+                    "js_array_map_this",
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call(
+                    I64,
+                    "js_array_map",
+                    &[(I64, &recv_handle), (I64, &cb_handle)],
+                ),
+            };
             Ok(nanbox_pointer_inline(blk, &result))
         }
         "filter" => {
@@ -411,15 +486,23 @@ pub(crate) fn lower_array_method(
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            let result = blk.call(
-                I64,
-                "js_array_filter",
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            );
+            let result = match &this_box {
+                Some(tb) => blk.call(
+                    I64,
+                    "js_array_filter_this",
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call(
+                    I64,
+                    "js_array_filter",
+                    &[(I64, &recv_handle), (I64, &cb_handle)],
+                ),
+            };
             Ok(nanbox_pointer_inline(blk, &result))
         }
         "forEach" => {
@@ -429,14 +512,21 @@ pub(crate) fn lower_array_method(
             } else {
                 crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
             };
+            let this_box = lower_opt_this_arg(ctx, args)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             // #4091: throw TypeError for a non-callable callback before iterating.
             let cb_handle = blk.call(I64, "js_validate_array_callback", &[(DOUBLE, &cb_box)]);
-            blk.call_void(
-                "js_array_forEach",
-                &[(I64, &recv_handle), (I64, &cb_handle)],
-            );
+            match &this_box {
+                Some(tb) => blk.call_void(
+                    "js_array_forEach_this",
+                    &[(I64, &recv_handle), (I64, &cb_handle), (DOUBLE, tb)],
+                ),
+                None => blk.call_void(
+                    "js_array_forEach",
+                    &[(I64, &recv_handle), (I64, &cb_handle)],
+                ),
+            }
             // forEach returns undefined
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
@@ -484,13 +574,19 @@ pub(crate) fn lower_array_method(
             Ok(blk.bitcast_i64_to_double(&tagged))
         }
         "indexOf" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.indexOf expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let val_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → `indexOf(undefined)` (Node: `[undefined].indexOf() === 0`),
+            // not a compile error. Pad a missing searchElement with undefined.
+            let val_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             // #2804: optional fromIndex (2nd arg). has_from=1 + lowered index
             // when present; otherwise has_from=0 with a placeholder DOUBLE.
             let (from_box, has_from) = if args.len() == 2 {
@@ -519,13 +615,19 @@ pub(crate) fn lower_array_method(
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
         "lastIndexOf" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.lastIndexOf expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let val_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → `lastIndexOf(undefined)` (Node: `[undefined].lastIndexOf()
+            // === 0`), not a compile error.
+            let val_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             // Optional fromIndex: with has_from=1 pass the lowered index;
             // when absent pass has_from=0 (runtime defaults to length-1) and
             // reuse `val_box` as an ignored placeholder DOUBLE operand.

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -114,6 +114,19 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     module.declare_function("js_array_join", I64, &[I64, I64]);
     module.declare_function("js_array_join_value", I64, &[I64, DOUBLE]);
     module.declare_function("js_array_forEach", VOID, &[I64, I64]);
+    // `thisArg`-aware wrappers for the dense callback methods: same as the base
+    // `js_array_<m>` but the trailing DOUBLE is the callback `this` binding,
+    // installed for the iteration. Emitted only when source passes a 2nd arg.
+    module.declare_function("js_array_forEach_this", VOID, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_map_this", I64, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_filter_this", I64, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_some_this", DOUBLE, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_every_this", DOUBLE, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_find_this", DOUBLE, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_findIndex_this", I32, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_find_last_this", DOUBLE, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_find_last_index_this", I32, &[I64, I64, DOUBLE]);
+    module.declare_function("js_array_flatMap_this", I64, &[I64, I64, DOUBLE]);
     module.declare_function("js_array_fill", I64, &[I64, DOUBLE]);
     module.declare_function("js_array_fill_range", I64, &[I64, DOUBLE, DOUBLE, DOUBLE]);
     module.declare_function("js_array_delete", I32, &[I64, I32]);

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -45,63 +45,63 @@ pub(crate) fn try_fold_array_method_call(call: Expr) -> Expr {
         type_args: Vec::new(),
     };
     match property.as_str() {
-        "map" if !args.is_empty() => {
+        "map" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArrayMap {
                 array: object,
                 callback: Box::new(cb),
             }
         }
-        "filter" if !args.is_empty() => {
+        "filter" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArrayFilter {
                 array: object,
                 callback: Box::new(cb),
             }
         }
-        "forEach" if !args.is_empty() => {
+        "forEach" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArrayForEach {
                 array: object,
                 callback: Box::new(cb),
             }
         }
-        "find" if !args.is_empty() => {
+        "find" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArrayFind {
                 array: object,
                 callback: Box::new(cb),
             }
         }
-        "findIndex" if !args.is_empty() => {
+        "findIndex" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArrayFindIndex {
                 array: object,
                 callback: Box::new(cb),
             }
         }
-        "findLast" if !args.is_empty() => {
+        "findLast" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArrayFindLast {
                 array: object,
                 callback: Box::new(cb),
             }
         }
-        "findLastIndex" if !args.is_empty() => {
+        "findLastIndex" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArrayFindLastIndex {
                 array: object,
                 callback: Box::new(cb),
             }
         }
-        "some" if !args.is_empty() => {
+        "some" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArraySome {
                 array: object,
                 callback: Box::new(cb),
             }
         }
-        "every" if !args.is_empty() => {
+        "every" if args.len() == 1 => {
             let cb = args.into_iter().next().unwrap();
             Expr::ArrayEvery {
                 array: object,

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -518,7 +518,7 @@ pub(super) fn try_array_only_methods(
                             initial,
                         }));
                     }
-                    "map" if !args.is_empty() && !recv_is_class => {
+                    "map" if args.len() == 1 && !recv_is_class => {
                         let cb = args.into_iter().next().unwrap();
                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                         let array_expr = lower_expr(ctx, &member.obj)?;
@@ -527,7 +527,7 @@ pub(super) fn try_array_only_methods(
                             callback: Box::new(cb),
                         }));
                     }
-                    "filter" if !args.is_empty() && !recv_is_class => {
+                    "filter" if args.len() == 1 && !recv_is_class => {
                         let cb = args.into_iter().next().unwrap();
                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                         let array_expr = lower_expr(ctx, &member.obj)?;
@@ -536,7 +536,7 @@ pub(super) fn try_array_only_methods(
                             callback: Box::new(cb),
                         }));
                     }
-                    "forEach" if !args.is_empty() && !recv_is_class => {
+                    "forEach" if args.len() == 1 && !recv_is_class => {
                         // Check if the receiver is a Map or Set - if so, don't use ArrayForEach
                         let is_map_or_set = if let ast::Expr::Ident(ident) = member.obj.as_ref() {
                             ctx.lookup_local_type(ident.sym.as_ref())
@@ -555,7 +555,7 @@ pub(super) fn try_array_only_methods(
                             }));
                         }
                     }
-                    "find" if !args.is_empty() && !recv_is_class => {
+                    "find" if args.len() == 1 && !recv_is_class => {
                         let cb = args.into_iter().next().unwrap();
                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                         let array_expr = lower_expr(ctx, &member.obj)?;
@@ -564,7 +564,7 @@ pub(super) fn try_array_only_methods(
                             callback: Box::new(cb),
                         }));
                     }
-                    "findIndex" if !args.is_empty() && !recv_is_class => {
+                    "findIndex" if args.len() == 1 && !recv_is_class => {
                         let cb = args.into_iter().next().unwrap();
                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                         let array_expr = lower_expr(ctx, &member.obj)?;
@@ -573,7 +573,7 @@ pub(super) fn try_array_only_methods(
                             callback: Box::new(cb),
                         }));
                     }
-                    "some" if !args.is_empty() && !recv_is_class => {
+                    "some" if args.len() == 1 && !recv_is_class => {
                         let cb = args.into_iter().next().unwrap();
                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                         let array_expr = lower_expr(ctx, &member.obj)?;
@@ -582,7 +582,7 @@ pub(super) fn try_array_only_methods(
                             callback: Box::new(cb),
                         }));
                     }
-                    "every" if !args.is_empty() && !recv_is_class => {
+                    "every" if args.len() == 1 && !recv_is_class => {
                         let cb = args.into_iter().next().unwrap();
                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                         let array_expr = lower_expr(ctx, &member.obj)?;

--- a/crates/perry-hir/src/lower/expr_call/imported_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/imported_array_methods.rs
@@ -79,7 +79,7 @@ pub(super) fn try_imported_array_methods(
                                     // Fall through.
                                 }
                                 "map" => {
-                                    if !args.is_empty() {
+                                    if args.len() == 1 {
                                         let cb = args.into_iter().next().unwrap();
                                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                         return Ok(Ok(Expr::ArrayMap {
@@ -89,7 +89,7 @@ pub(super) fn try_imported_array_methods(
                                     }
                                 }
                                 "filter" => {
-                                    if !args.is_empty() {
+                                    if args.len() == 1 {
                                         let cb = args.into_iter().next().unwrap();
                                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                         return Ok(Ok(Expr::ArrayFilter {
@@ -99,7 +99,7 @@ pub(super) fn try_imported_array_methods(
                                     }
                                 }
                                 "forEach" => {
-                                    if !args.is_empty() {
+                                    if args.len() == 1 {
                                         let cb = args.into_iter().next().unwrap();
                                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                         return Ok(Ok(Expr::ArrayForEach {
@@ -109,7 +109,7 @@ pub(super) fn try_imported_array_methods(
                                     }
                                 }
                                 "find" => {
-                                    if !args.is_empty() {
+                                    if args.len() == 1 {
                                         let cb = args.into_iter().next().unwrap();
                                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                         return Ok(Ok(Expr::ArrayFind {

--- a/crates/perry-hir/src/lower/expr_call/inline_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/inline_array_methods.rs
@@ -37,7 +37,9 @@ pub(super) fn try_inline_array_methods(
                             }));
                         }
                         "map" => {
-                            if !args.is_empty() {
+                            // 1-arg only; a 2nd `thisArg` falls through to the
+                            // generic call → `lower_array_method` (binds `this`).
+                            if args.len() == 1 {
                                 let cb = args.into_iter().next().unwrap();
                                 let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                 return Ok(Ok(Expr::ArrayMap {
@@ -47,7 +49,9 @@ pub(super) fn try_inline_array_methods(
                             }
                         }
                         "filter" => {
-                            if !args.is_empty() {
+                            // 1-arg only; a 2nd `thisArg` falls through to the
+                            // generic call → `lower_array_method` (binds `this`).
+                            if args.len() == 1 {
                                 let cb = args.into_iter().next().unwrap();
                                 let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                 return Ok(Ok(Expr::ArrayFilter {
@@ -57,7 +61,9 @@ pub(super) fn try_inline_array_methods(
                             }
                         }
                         "forEach" => {
-                            if !args.is_empty() {
+                            // 1-arg only; a 2nd `thisArg` falls through to the
+                            // generic call → `lower_array_method` (binds `this`).
+                            if args.len() == 1 {
                                 let cb = args.into_iter().next().unwrap();
                                 let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                 return Ok(Ok(Expr::ArrayForEach {
@@ -67,7 +73,9 @@ pub(super) fn try_inline_array_methods(
                             }
                         }
                         "find" => {
-                            if !args.is_empty() {
+                            // 1-arg only; a 2nd `thisArg` falls through to the
+                            // generic call → `lower_array_method` (binds `this`).
+                            if args.len() == 1 {
                                 let cb = args.into_iter().next().unwrap();
                                 let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                 return Ok(Ok(Expr::ArrayFind {

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -339,7 +339,12 @@ pub(super) fn try_local_array_methods(
                                     }
                                     _ => false,
                                 };
-                                if !is_map_or_set && !args.is_empty() {
+                                // Only fold the fast path for the 1-arg form. With
+                                // an explicit `thisArg` (2nd arg), fall through to
+                                // the generic call → `lower_array_method`, which
+                                // binds the callback `this` (the fast-path
+                                // `Expr::ArrayForEach` carries no `thisArg`).
+                                if !is_map_or_set && args.len() == 1 {
                                     let cb = args.into_iter().next().unwrap();
                                     let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                     return Ok(Ok(Expr::ArrayForEach {
@@ -406,7 +411,10 @@ pub(super) fn try_local_array_methods(
                                                 index: Box::new(args.into_iter().next().unwrap()),
                                             }));
                                         }
-                                    } else if method_name != "at" && !args.is_empty() {
+                                    } else if method_name != "at" && args.len() == 1 {
+                                        // 1-arg only: a 2nd `thisArg` falls through
+                                        // to the generic call → `lower_array_method`
+                                        // (binds the callback `this`).
                                         let cb = args.into_iter().next().unwrap();
                                         let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                         let array = Box::new(Expr::LocalGet(array_id));
@@ -428,7 +436,9 @@ pub(super) fn try_local_array_methods(
                                 }
                             }
                             "flatMap" => {
-                                if !args.is_empty() {
+                                // 1-arg only; a 2nd `thisArg` falls through to the
+                                // generic call → `lower_array_method`.
+                                if args.len() == 1 {
                                     let cb = args.into_iter().next().unwrap();
                                     let cb = ctx.maybe_wrap_builtin_callback(cb, &call.args[0]);
                                     return Ok(Ok(Expr::ArrayFlatMap {

--- a/crates/perry-runtime/src/array/generic.rs
+++ b/crates/perry-runtime/src/array/generic.rs
@@ -215,7 +215,13 @@ fn al_length(recv: f64) -> i64 {
                 (b & 0x0000_FFFF_FFFF_FFFF) as *const crate::object::ObjectHeader,
                 key,
             );
-            to_length(len_val)
+            // `LengthOfArrayLike` is `ToLength(Get(O, "length"))`, and `ToLength`
+            // begins with `ToNumber`. The raw property value may be a string
+            // (`length: "2"`), boolean, `null`, etc.; without coercion those
+            // NaN-boxed bit patterns are themselves NaN floats and `to_length`
+            // would collapse them to 0. Run `ToNumber` first so e.g.
+            // `length: "0x0002"` → 2.
+            to_length(crate::builtins::js_number_coerce(len_val))
         }
         // Typed arrays / buffers expose a real length via the safe dispatcher.
         Some(PtrKind::IndexedNative) => to_length(crate::value::js_value_length_f64(recv)),
@@ -302,8 +308,11 @@ impl Drop for ThisGuard {
 #[no_mangle]
 pub extern "C" fn js_arraylike_forEach(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let _g = ThisGuard::new(this_arg);
     for k in 0..len {
         if !al_has(recv, k) {
@@ -318,8 +327,11 @@ pub extern "C" fn js_arraylike_forEach(recv: f64, cb: f64, this_arg: f64) -> f64
 #[no_mangle]
 pub extern "C" fn js_arraylike_map(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let result = js_array_alloc_with_length(len.max(0) as u32);
     let elems = unsafe { (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64 };
     let _g = ThisGuard::new(this_arg);
@@ -340,8 +352,11 @@ pub extern "C" fn js_arraylike_map(recv: f64, cb: f64, this_arg: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_arraylike_filter(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let mut result = js_array_alloc(0);
     let _g = ThisGuard::new(this_arg);
     for k in 0..len {
@@ -360,8 +375,11 @@ pub extern "C" fn js_arraylike_filter(recv: f64, cb: f64, this_arg: f64) -> f64 
 #[no_mangle]
 pub extern "C" fn js_arraylike_some(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let _g = ThisGuard::new(this_arg);
     for k in 0..len {
         if !al_has(recv, k) {
@@ -378,8 +396,11 @@ pub extern "C" fn js_arraylike_some(recv: f64, cb: f64, this_arg: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_arraylike_every(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let _g = ThisGuard::new(this_arg);
     for k in 0..len {
         if !al_has(recv, k) {
@@ -399,8 +420,11 @@ pub extern "C" fn js_arraylike_every(recv: f64, cb: f64, this_arg: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_arraylike_find(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let _g = ThisGuard::new(this_arg);
     for k in 0..len {
         let v = al_get(recv, k);
@@ -414,8 +438,11 @@ pub extern "C" fn js_arraylike_find(recv: f64, cb: f64, this_arg: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_arraylike_findIndex(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let _g = ThisGuard::new(this_arg);
     for k in 0..len {
         let v = al_get(recv, k);
@@ -429,8 +456,11 @@ pub extern "C" fn js_arraylike_findIndex(recv: f64, cb: f64, this_arg: f64) -> f
 #[no_mangle]
 pub extern "C" fn js_arraylike_findLast(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let _g = ThisGuard::new(this_arg);
     let mut k = len - 1;
     while k >= 0 {
@@ -446,8 +476,11 @@ pub extern "C" fn js_arraylike_findLast(recv: f64, cb: f64, this_arg: f64) -> f6
 #[no_mangle]
 pub extern "C" fn js_arraylike_findLastIndex(recv: f64, cb: f64, this_arg: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let _g = ThisGuard::new(this_arg);
     let mut k = len - 1;
     while k >= 0 {
@@ -474,8 +507,11 @@ fn throw_reduce_empty() -> ! {
 #[no_mangle]
 pub extern "C" fn js_arraylike_reduce(recv: f64, cb: f64, has_init: i32, init: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let mut acc = init;
     let mut k = 0i64;
     if has_init == 0 {
@@ -505,8 +541,11 @@ pub extern "C" fn js_arraylike_reduce(recv: f64, cb: f64, has_init: i32, init: f
 #[no_mangle]
 pub extern "C" fn js_arraylike_reduceRight(recv: f64, cb: f64, has_init: i32, init: f64) -> f64 {
     let recv = to_object(recv);
-    let cb = callable(cb);
+    // Spec order: `LengthOfArrayLike` (step 2) runs *before* the `IsCallable`
+    // check (step 3) — a `length` getter's side effects / throw must be
+    // observed even when the callback is non-callable.
     let len = al_length(recv);
+    let cb = callable(cb);
     let mut acc = init;
     let mut k = len - 1;
     if has_init == 0 {

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -992,3 +992,163 @@ pub extern "C" fn js_validate_array_map_callback(arr: i64, cb_boxed: f64) -> i64
 #[used]
 static KEEP_VALIDATE_ARRAY_MAP_CALLBACK: extern "C" fn(i64, f64) -> i64 =
     js_validate_array_map_callback;
+
+// ---------------------------------------------------------------------------
+// `thisArg`-aware wrappers for the dense-array callback methods.
+//
+// The hot `js_array_<m>` paths above bind no callback `this` — they are reached
+// from `arr.<m>(cb)` with no second argument. When source passes an explicit
+// `thisArg` (`arr.forEach(cb, obj)`, ECMA-262 §23.1.3), codegen routes here:
+// each wrapper installs `thisArg` as the ambient `this` (read by the callback
+// via `js_implicit_this_get`) for the duration of the iteration, then restores
+// the prior binding. The base function does the actual work, so hole/length
+// semantics stay in one place. No `thisArg` ⇒ codegen keeps calling the
+// 2-argument base directly (unchanged behavior, incl. sloppy-mode global
+// `this`). reduce/reduceRight take no `thisArg` and are intentionally absent.
+struct CallbackThisGuard(f64);
+impl CallbackThisGuard {
+    #[inline]
+    fn new(this_arg: f64) -> Self {
+        CallbackThisGuard(crate::object::js_implicit_this_set(this_arg))
+    }
+}
+impl Drop for CallbackThisGuard {
+    #[inline]
+    fn drop(&mut self) {
+        crate::object::js_implicit_this_set(self.0);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_forEach_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_forEach(arr, callback);
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_map_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> *mut ArrayHeader {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_map(arr, callback)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_filter_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> *mut ArrayHeader {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_filter(arr, callback)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_some_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> f64 {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_some(arr, callback)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_every_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> f64 {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_every(arr, callback)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_find_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> f64 {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_find(arr, callback)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_findIndex_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> i32 {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_findIndex(arr, callback)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_find_last_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> f64 {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_find_last(arr, callback)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_find_last_index_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> i32 {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_find_last_index(arr, callback)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_flatMap_this(
+    arr: *const ArrayHeader,
+    callback: *const ClosureHeader,
+    this_arg: f64,
+) -> *mut ArrayHeader {
+    let _g = CallbackThisGuard::new(this_arg);
+    js_array_flatMap(arr, callback)
+}
+
+// Pin the `thisArg` wrappers against dead-strip in the default (codegen-only
+// reference) compile path — `#[no_mangle]` alone is not enough once the
+// whole-program bitcode is re-linked (see #3320).
+#[used]
+static KEEP_ARRAY_CB_THIS_VOID: extern "C" fn(*const ArrayHeader, *const ClosureHeader, f64) =
+    js_array_forEach_this;
+#[used]
+static KEEP_ARRAY_CB_THIS_PTR: [extern "C" fn(
+    *const ArrayHeader,
+    *const ClosureHeader,
+    f64,
+) -> *mut ArrayHeader; 3] = [
+    js_array_map_this,
+    js_array_filter_this,
+    js_array_flatMap_this,
+];
+#[used]
+static KEEP_ARRAY_CB_THIS_F64: [extern "C" fn(
+    *const ArrayHeader,
+    *const ClosureHeader,
+    f64,
+) -> f64; 4] = [
+    js_array_some_this,
+    js_array_every_this,
+    js_array_find_this,
+    js_array_find_last_this,
+];
+#[used]
+static KEEP_ARRAY_CB_THIS_I32: [extern "C" fn(
+    *const ArrayHeader,
+    *const ClosureHeader,
+    f64,
+) -> i32; 2] = [js_array_findIndex_this, js_array_find_last_index_this];


### PR DESCRIPTION
## Summary

Closes a batch of `built-ins/Array/prototype/*` test262 gaps in the **callback / array-like / validation** clusters. Focused `built-ins/Array` test262 parity (test262_subset radar) moved **61.5% → 72.5%** (~290 fewer runtime/compile failures); zero regressions in the forEach before/after diff.

## What's fixed

**1. `thisArg` on the dense-array callback methods.** `arr.forEach(cb, thisArg)` (and `map`/`filter`/`some`/`every`/`find`/`findIndex`/`findLast`/`findLastIndex`/`flatMap`) silently dropped the second `thisArg` argument, so the entire `15.4.4.N-5-*` ("thisArg is X") series failed across every method.
- Runtime: new `js_array_<m>_this(arr, cb, this_arg)` wrappers (`array/iter_methods.rs`) install `this_arg` via the implicit-`this` thread-local (a `Drop` guard restores the prior binding) and delegate to the existing loop, so hole/length semantics stay in one place. `#[used]` anchors pin them against dead-strip on the bitcode-relink path (#3320).
- Codegen: `lower_array_method` lowers the optional 2nd arg and calls the `_this` variant when present; the no-`thisArg` path is byte-identical.
- HIR: the array-method folds only fast-path the 1-arg form now; a 2-arg call falls through to the generic member call → `lower_array_method` (which binds `this`). `reduce`/`reduceRight` (2nd arg = initial value) are unchanged.

**2. Array-like `LengthOfArrayLike` = `ToLength(ToNumber(length))`.** The generic `Array.prototype.<m>.call(arrayLike, …)` engine (`array/generic.rs`) fed the raw NaN-boxed `length` straight to `ToLength`; string/bool/null values are themselves NaN bit-patterns and collapsed to 0 (`length: "2"` skipped iteration). Now runs `js_number_coerce` first; an un-coercible object `length` throws `TypeError`.

**3. Spec operation order.** All generic array-like callback methods checked `IsCallable` before `LengthOfArrayLike`. Per ECMA-262 §23.1.3, `LengthOfArrayLike` (step 2) runs first, so a `length` getter's side effects/throw are observed even when the callback is non-callable.

**4. 0-arg validation (compile-fail → runtime semantics).** `[].reduce()`/`reduceRight()` now throw a runtime `TypeError`, and `[undefined].indexOf()`/`lastIndexOf()` search for `undefined` (return `0`), instead of compile-failing.

## Verification

- Focused `built-ins/Array` test262 sweep: **72.5%** parity (1831 pass / 2527 judged).
- forEach probe: 75 → ~39 non-pass, **0 regressions**.
- `thisArg` fix generalises across forEach/map/filter/some/every/find/findIndex (the `-5-*` series dropped from ~21 to ~1 per method).
- All 4 previously-compile-failing 0-arg tests now pass.

## Known follow-ups (not in this PR)

- Boxed-primitive / exotic-object receivers (`-1-*`: `forEach.call(false, cb)`, Date/RegExp/Error/function expandos).
- Live-mutation / index-getter / inherited-`HasProperty` during iteration (`-7-*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)