### PR TITLE
fix: eliminate test262 segfaults in Proxy / String / Object.create / Array (v0.5.1126–1129)

### DIFF
--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -25,10 +25,13 @@ pub extern "C" fn js_object_delete_field(
             const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
             let boxed = f64::from_bits(POINTER_TAG | (addr & 0x0000_FFFF_FFFF_FFFF));
             if crate::proxy::js_proxy_is_proxy(boxed) != 0 {
-                let key_f64 =
-                    f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
+                let key_f64 = f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
                 let r = crate::proxy::js_proxy_delete(boxed, key_f64);
-                return if crate::value::js_is_truthy(r) != 0 { 1 } else { 0 };
+                return if crate::value::js_is_truthy(r) != 0 {
+                    1
+                } else {
+                    0
+                };
             }
         }
     }
@@ -240,7 +243,11 @@ pub extern "C" fn js_object_delete_dynamic(obj: *mut ObjectHeader, key: f64) -> 
             let boxed = f64::from_bits(POINTER_TAG | (addr & 0x0000_FFFF_FFFF_FFFF));
             if crate::proxy::js_proxy_is_proxy(boxed) != 0 {
                 let r = crate::proxy::js_proxy_delete(boxed, key);
-                return if crate::value::js_is_truthy(r) != 0 { 1 } else { 0 };
+                return if crate::value::js_is_truthy(r) != 0 {
+                    1
+                } else {
+                    0
+                };
             }
         }
     }

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -15,6 +15,23 @@ pub extern "C" fn js_object_delete_field(
     if obj.is_null() || key.is_null() {
         return 1;
     }
+    // A Proxy is a small registered id in [0xF0000, 0x100000), not a heap
+    // ObjectHeader. Dereferencing it below (GC header / keys_array reads) would
+    // segfault. Route `delete proxy.k` / `delete proxy[k]` through the proxy
+    // `deleteProperty` trap. (#2846-family Proxy crash cluster.)
+    {
+        let addr = obj as u64;
+        if (0xF0000..0x100000).contains(&addr) {
+            const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+            let boxed = f64::from_bits(POINTER_TAG | (addr & 0x0000_FFFF_FFFF_FFFF));
+            if crate::proxy::js_proxy_is_proxy(boxed) != 0 {
+                let key_f64 =
+                    f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
+                let r = crate::proxy::js_proxy_delete(boxed, key_f64);
+                return if crate::value::js_is_truthy(r) != 0 { 1 } else { 0 };
+            }
+        }
+    }
     if (obj as usize) < 0x10000 {
         unsafe {
             if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
@@ -212,6 +229,21 @@ pub extern "C" fn js_object_delete_field(
 /// Returns 1 if successful, 0 otherwise
 #[no_mangle]
 pub extern "C" fn js_object_delete_dynamic(obj: *mut ObjectHeader, key: f64) -> i32 {
+    // Proxy receiver (small registered id) — route through the proxy
+    // `deleteProperty` trap before any key coercion that would deref the fake
+    // pointer. Handles symbol keys too (the string path also funnels into
+    // `js_object_delete_field`, which has its own guard).
+    {
+        let addr = obj as u64;
+        if (0xF0000..0x100000).contains(&addr) {
+            const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+            let boxed = f64::from_bits(POINTER_TAG | (addr & 0x0000_FFFF_FFFF_FFFF));
+            if crate::proxy::js_proxy_is_proxy(boxed) != 0 {
+                let r = crate::proxy::js_proxy_delete(boxed, key);
+                return if crate::value::js_is_truthy(r) != 0 { 1 } else { 0 };
+            }
+        }
+    }
     let key_val = JSValue::from_bits(key.to_bits());
 
     // If the key is a string, use js_object_delete_field. #1781: accept

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -113,6 +113,15 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             super::has_own_helpers::throw_to_object_nullish_type_error();
         }
 
+        // A Proxy is a small registered id, not a heap object — the ordinary
+        // resolution below would deref the fake pointer and segfault. The
+        // Reflect entry point shares `[[GetOwnProperty]]` semantics (trap +
+        // invariant checks + FromPropertyDescriptor) and forwards non-proxies
+        // straight back here, so there's no recursion. (Proxy crash cluster.)
+        if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+            return crate::proxy::js_reflect_get_own_property_descriptor(obj_value, key_value);
+        }
+
         // #2818: string primitives box to String objects whose own
         // properties are the index keys "0".."len-1" (writable:false,
         // enumerable:true, configurable:false) plus "length"

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1896,6 +1896,20 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     let obj_val = JSValue::from_bits(obj.to_bits());
     let key_val = JSValue::from_bits(key.to_bits());
 
+    // A Proxy is a small registered id (POINTER_TAG with a tiny pointer), not a
+    // heap object. Falling through to the symbol/class/pointer paths below would
+    // deref the fake pointer (or call symbol helpers that do) and segfault. Route
+    // `key in proxy` through the proxy `has` trap and ToBoolean-coerce, matching
+    // `Reflect.has`.
+    if crate::proxy::js_proxy_is_proxy(obj) != 0 {
+        let r = crate::proxy::js_proxy_has(obj, key);
+        return if crate::value::js_is_truthy(r) != 0 {
+            nanbox_true
+        } else {
+            nanbox_false
+        };
+    }
+
     // #1758: a SYMBOL key. The class-ref path below + the keys_array scan
     // (string keys only) can't see a class-object's static `[Sym]` props nor
     // ones inherited from a class-expression parent. Delegate to the symbol

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -517,6 +517,19 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
             super::has_own_helpers::throw_to_object_nullish_type_error();
         }
 
+        // A Proxy is a small registered id, not a heap object — route
+        // `hasOwnProperty` through `[[GetOwnProperty]]` (a present own property
+        // is one whose descriptor is not undefined) rather than dereferencing
+        // the fake pointer. (Proxy crash cluster.)
+        if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+            let desc = crate::proxy::js_reflect_get_own_property_descriptor(obj_value, key_value);
+            return f64::from_bits(if desc.to_bits() != crate::value::TAG_UNDEFINED {
+                TAG_TRUE
+            } else {
+                TAG_FALSE
+            });
+        }
+
         // Symbol-keyed lookup: route through SYMBOL_PROPERTIES side table.
         if crate::symbol::js_is_symbol(key_value) != 0 {
             // ClassRef receivers carry class_id in the low 32 bits.
@@ -698,6 +711,29 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
         let obj_jv = crate::JSValue::from_bits(obj_value.to_bits());
         if obj_jv.is_null() || obj_jv.is_undefined() {
             super::has_own_helpers::throw_to_object_nullish_type_error();
+        }
+
+        // Proxy receiver: resolve the descriptor via `[[GetOwnProperty]]` and
+        // report its `enumerable` attribute (absent property → false) rather
+        // than dereferencing the fake pointer. (Proxy crash cluster.)
+        if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+            let desc = crate::proxy::js_reflect_get_own_property_descriptor(obj_value, key_value);
+            if desc.to_bits() == crate::value::TAG_UNDEFINED {
+                return f64::from_bits(TAG_FALSE);
+            }
+            let desc_ptr = extract_obj_ptr(desc);
+            if desc_ptr.is_null() {
+                return f64::from_bits(TAG_FALSE);
+            }
+            let enum_key = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
+            let enum_v =
+                js_object_get_field_by_name(desc_ptr as *const ObjectHeader, enum_key);
+            return f64::from_bits(if crate::value::js_is_truthy(f64::from_bits(enum_v.bits())) != 0
+            {
+                TAG_TRUE
+            } else {
+                TAG_FALSE
+            });
         }
 
         let key_str = crate::builtins::js_string_coerce(key_value);
@@ -939,6 +975,31 @@ pub extern "C" fn js_object_define_property(
     descriptor_value: f64,
 ) -> f64 {
     unsafe {
+        // A Proxy receiver is a small registered id, not a heap object — it
+        // fails the `value_is_object_like` test below (so it would wrongly throw
+        // "called on non-object") and the ordinary paths would deref the fake
+        // pointer and segfault. Per spec, Object.defineProperty(proxy, …):
+        // validate the descriptor (ToPropertyDescriptor), invoke the
+        // `[[DefineOwnProperty]]` trap, and throw a TypeError if it reports
+        // failure. (Proxy crash cluster.)
+        if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+            if !value_is_object_like(descriptor_value) {
+                let desc = describe_value_for_type_error(descriptor_value);
+                throw_object_type_error_with_suffix(
+                    "Property description must be an object: ",
+                    &desc,
+                );
+            }
+            validate_property_descriptor(descriptor_value);
+            let ok = crate::proxy::js_reflect_define_property(obj_value, key_value, descriptor_value);
+            if crate::value::js_is_truthy(ok) == 0 {
+                throw_object_type_error(
+                    b"'defineProperty' on proxy: trap returned falsish",
+                );
+            }
+            return obj_value;
+        }
+
         // #2817: ES Object.defineProperty validation.
         //   1. Target must be an object (or class-ref / function — all objects
         //      in Node). Primitives / null / undefined throw.
@@ -2194,6 +2255,16 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
     const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
     let obj_bits = obj_value.to_bits();
     let proto_bits = proto.to_bits();
+
+    // A Proxy receiver is a small registered id, not a heap object — the
+    // recording path below would deref the fake pointer and segfault. Route
+    // through the Reflect entry (which resolves the proxy to its target) and
+    // return the proxy per Object.setPrototypeOf's contract. (Proxy crash
+    // cluster.)
+    if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        crate::proxy::js_reflect_set_prototype_of(obj_value, proto);
+        return obj_value;
+    }
 
     // #2820: `Object.setPrototypeOf(null | undefined, proto)` throws
     // `TypeError: Object.setPrototypeOf called on null or undefined`.

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -726,14 +726,14 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
                 return f64::from_bits(TAG_FALSE);
             }
             let enum_key = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
-            let enum_v =
-                js_object_get_field_by_name(desc_ptr as *const ObjectHeader, enum_key);
-            return f64::from_bits(if crate::value::js_is_truthy(f64::from_bits(enum_v.bits())) != 0
-            {
-                TAG_TRUE
-            } else {
-                TAG_FALSE
-            });
+            let enum_v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, enum_key);
+            return f64::from_bits(
+                if crate::value::js_is_truthy(f64::from_bits(enum_v.bits())) != 0 {
+                    TAG_TRUE
+                } else {
+                    TAG_FALSE
+                },
+            );
         }
 
         let key_str = crate::builtins::js_string_coerce(key_value);
@@ -991,11 +991,10 @@ pub extern "C" fn js_object_define_property(
                 );
             }
             validate_property_descriptor(descriptor_value);
-            let ok = crate::proxy::js_reflect_define_property(obj_value, key_value, descriptor_value);
+            let ok =
+                crate::proxy::js_reflect_define_property(obj_value, key_value, descriptor_value);
             if crate::value::js_is_truthy(ok) == 0 {
-                throw_object_type_error(
-                    b"'defineProperty' on proxy: trap returned falsish",
-                );
+                throw_object_type_error(b"'defineProperty' on proxy: trap returned falsish");
             }
             return obj_value;
         }

--- a/crates/perry-runtime/src/object/object_ops_frozen.rs
+++ b/crates/perry-runtime/src/object/object_ops_frozen.rs
@@ -44,6 +44,17 @@ pub extern "C" fn js_object_seal(obj_value: f64) -> f64 {
 /// Object.preventExtensions(obj) — sets the no-extend flag. Returns the object.
 #[no_mangle]
 pub extern "C" fn js_object_prevent_extensions(obj_value: f64) -> f64 {
+    // A Proxy is a small registered id, not a heap object — `extract_obj_ptr`
+    // yields the fake pointer and `gc_header_for` would deref unmapped memory.
+    // Route through the `[[PreventExtensions]]` trap; per spec throw a TypeError
+    // if it reports failure, then return the proxy. (Proxy crash cluster.)
+    if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        let ok = crate::proxy::js_reflect_prevent_extensions(obj_value);
+        if crate::value::js_is_truthy(ok) == 0 {
+            throw_object_type_error(b"'preventExtensions' on proxy: trap returned falsish");
+        }
+        return obj_value;
+    }
     unsafe {
         let obj = extract_obj_ptr(obj_value);
         if !obj.is_null() && (obj as usize) > 0x10000 {
@@ -97,6 +108,16 @@ pub extern "C" fn js_object_is_sealed(obj_value: f64) -> f64 {
 pub extern "C" fn js_object_is_extensible(obj_value: f64) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    // Proxy receiver: route through the `[[IsExtensible]]` trap rather than
+    // dereferencing the fake pointer. (Proxy crash cluster.)
+    if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        let r = crate::proxy::js_reflect_is_extensible(obj_value);
+        return if crate::value::js_is_truthy(r) != 0 {
+            f64::from_bits(TAG_TRUE)
+        } else {
+            f64::from_bits(TAG_FALSE)
+        };
+    }
     unsafe {
         let obj = extract_obj_ptr(obj_value);
         if obj.is_null() || (obj as usize) <= 0x10000 {

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -572,7 +572,12 @@ pub extern "C" fn js_proxy_set(proxy_boxed: f64, key: f64, value: f64) -> f64 {
         let trap_result = js_closure_call3(closure_from(trap), target, key, value);
         return coerce_trap_bool(trap_result);
     }
-    // No set trap — write to target and report the ordinary [[Set]] result.
+    // No set trap — forward to the target's `[[Set]]`. When the target is
+    // itself a Proxy, recurse through the proxy dispatch (its own trap or
+    // target) rather than `ordinary_set`, which would deref the fake pointer.
+    if lookup(target).is_some() {
+        return js_proxy_set(target, key, value);
+    }
     reflect_ordinary_set(target, key, value)
 }
 
@@ -1522,7 +1527,12 @@ pub extern "C" fn js_reflect_define_property(obj: f64, key: f64, descriptor: f64
             let trap_result = js_closure_call3(closure_from(trap), target, key, descriptor);
             return coerce_trap_bool(trap_result);
         }
-        // No trap — define on the underlying target with ordinary semantics.
+        // No trap — define on the underlying target. When the target is itself
+        // a Proxy, recurse through the proxy dispatch rather than the ordinary
+        // path, which would deref the fake pointer.
+        if lookup(target).is_some() {
+            return js_reflect_define_property(target, key, descriptor);
+        }
         return crate::object::reflect_define_property(target, key, descriptor);
     }
     crate::object::reflect_define_property(obj, key, descriptor)
@@ -1703,18 +1713,26 @@ pub extern "C" fn js_reflect_prevent_extensions(target: f64) -> f64 {
 /// target reports `true` after recording the change on its underlying target.
 #[no_mangle]
 pub extern "C" fn js_reflect_set_prototype_of(target: f64, proto: f64) -> f64 {
-    // Resolve a proxy to its underlying target.
-    let real = if let Some(id) = lookup(target) {
-        PROXIES.with(|p| {
-            p.borrow()
-                .get(id as usize)
-                .and_then(|o| o.as_ref())
-                .map(|e| e.target)
-                .unwrap_or(f64::from_bits(TAG_UNDEFINED))
-        })
-    } else {
-        target
-    };
+    // Resolve a proxy to its underlying target. A proxy's target can itself be
+    // a proxy, so unwrap to the innermost non-proxy object — operating on a
+    // proxy via the ordinary `obj_value_no_extend` / set-prototype helpers below
+    // would deref the fake pointer and segfault. (setPrototypeOf trap dispatch
+    // is out of scope; this just avoids the crash.)
+    let mut real = target;
+    for _ in 0..64 {
+        match lookup(real) {
+            Some(id) => {
+                real = PROXIES.with(|p| {
+                    p.borrow()
+                        .get(id as usize)
+                        .and_then(|o| o.as_ref())
+                        .map(|e| e.target)
+                        .unwrap_or(f64::from_bits(TAG_UNDEFINED))
+                });
+            }
+            None => break,
+        }
+    }
 
     // Target must be an object.
     if !reflect_value_is_object(real) {

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -504,6 +504,19 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
         // objects fall back to "[object Object]".
         let ptr: *const u8 = jsval.as_pointer();
         if !ptr.is_null() && (ptr as usize) >= 0x10000 {
+            // A Proxy is a small registered id, not a heap object — the GC-header
+            // probes / ToPrimitive dispatch below would deref the fake pointer
+            // and segfault (e.g. `String(proxy)`). Default `ToString` has no
+            // toString/valueOf trap of its own, so resolve to the target and
+            // stringify that ("[object Object]" for an ordinary object target),
+            // which matches Node for the trap-less case. (Proxy crash cluster.)
+            if crate::proxy::js_proxy_is_proxy(value) != 0 {
+                let target = crate::proxy::js_proxy_target(value);
+                if target.to_bits() != value.to_bits() {
+                    return js_jsvalue_to_string(target);
+                }
+                return crate::string::js_string_from_bytes(b"[object Object]".as_ptr(), 15);
+            }
             // Symbols: detect via the side-table before any GC header read.
             if crate::symbol::is_registered_symbol(ptr as usize) {
                 return unsafe {


### PR DESCRIPTION
Finds & fixes memory-safety crashes (SIGSEGV/SIGBUS) surfaced by the test262 sweep. Common root cause across all four: a non-\`ObjectHeader\` value (a Proxy's small registered id, a boxed-String/Date cell, a closure / builtin-method value, or a null match result NaN-boxed as a pointer) being dereferenced as a heap object — reading/writing past the allocation.

Four focused commits, each its own version bump + CHANGELOG entry:

### Proxy (v0.5.1126)
`Object.*` / operators on a Proxy dereferenced the proxy id (`[0xF0000,0x100000)`) as an `ObjectHeader`. Routed `has`/`delete`/`getOwnPropertyDescriptor`/`defineProperty`/`isExtensible`/`preventExtensions`/`setPrototypeOf`/`hasOwnProperty`/`propertyIsEnumerable` and `String(proxy)` through the existing Reflect/proxy-trap machinery; added no-trap recursion for a proxy whose target is itself a proxy.
**`built-ins/Proxy` parity 20.4% → 55.8%, "(no output)" crashes 56 → 0.**

### String — match / localeCompare / RegExp (v0.5.1127)
- `s.match(...)` returning null was NaN-boxed as a pointer-to-address-0; downstream `JSON.stringify`/`.length` deref'd it. Map 0 → `TAG_NULL`.
- `match`/`matchAll`/`localeCompare` didn't ToString-coerce a boxed-String receiver/arg → misread as `StringHeader`.
- `RegExp(undefined)` / `new RegExp()` stored a garbage `pattern_ptr`; `.exec`'s FANCY_CACHE probe deref'd it. Materialize from the computed pattern string. (Fixes the `match/S15.5.4.10_A1_T6/8/9` oracle.)

### Object.create / defineProperties / freeze (v0.5.1128)
Exotic objects (Date/Array/closure/builtin-method) read where a `GC_TYPE_OBJECT` `ObjectHeader` was assumed → `keys_array` (offset 16) read past the cell → heap corruption (often a delayed crash).
- `js_put_value_set`: no-op for Date receivers (`descObj.configurable = true` was corrupting the heap — root cause of `Object/create/15.2.3.5-4-118/171/197`).
- `own_key_present` + `js_object_define_properties`: gate the `keys_array` read on `GC_TYPE_OBJECT` (exotic descriptor / function props bag → `-4-28`).
- `mark_all_keys` + freeze/seal/preventExtensions: gate on a live `GC_TYPE_OBJECT` / `is_valid_obj_ptr` (`Object.freeze(Array.prototype.forEach)` → `Array/prototype/forEach/S15.4.4.18_A1/A2` now pass). Plain-object/array freeze unchanged (isFrozen + non-writable verified).
**`built-ins/Object/create` crash sweep → 0.**

### Array.prototype.concat over a Proxy (v0.5.1129)
`[...].concat(proxy)` deref'd the proxy id as an `ArrayHeader`. Now evaluates IsConcatSpreadable and, when spreading, materializes the element list through the proxy `get` dispatch. No regression on ordinary concat.

### Known remaining (separate, deeper — documented in CHANGELOG)
- `Array.prototype.slice.call(proxy, …)` with a 2^53-range length.
- Far-sparse length truncation (`x[4294967294]=v; x.length=2`, `length/S15.4.5.2_A3_T4`).

### Verification
- `built-ins/Proxy` harness: 56 → 0 crashes, parity 20.4% → 55.8%.
- `built-ins/Object/create` crash scan: 0 remaining.
- Named String/Array tests re-run green; regression-checked freeze (plain objects + arrays) and concat (arrays/primitives/objects/0-arg/Set).