### PR TITLE
fix(codegen): zero-fill inline-allocated object field slots (#4717)

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -570,6 +570,23 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
         // GC_STORE_AUDIT(INIT): keys_array edge is installed before publishing the new object.
         blk.store(I64, &keys_ptr, &oh_addr_3);
 
+        // PerryTS/perry#4717: zero-fill the field slots with `undefined`, mirroring
+        // `js_object_alloc_with_parent` (runtime object/alloc.rs), which deliberately
+        // initializes ALL `max(field_count, 8)` slots "to prevent stale data from
+        // previously freed GC objects from bleeding through." This inline bump path
+        // wrote only the headers and left the slots uninitialized, so a field
+        // read-before-write — or a GC that scans the still-constructing instance —
+        // observed stale arena bytes. When those bytes were a previously-freed
+        // `undefined`/pointer (e.g. `marked`'s `this.defaults`), the constructor
+        // crashed with "Cannot read properties of undefined". Slots start at
+        // raw + GcHeader(8) + ObjectHeader(24) = raw + 32.
+        for i in 0..alloc_field_count {
+            let slot_off = GC_HEADER_SIZE + OBJECT_HEADER_SIZE + i * FIELD_SLOT_SIZE;
+            let slot_ptr = blk.gep(I8, &raw, &[(I64, &slot_off.to_string())]);
+            // GC_STORE_AUDIT(INIT): freshly allocated inline object slot initialized to undefined.
+            blk.store(I64, crate::nanbox::TAG_UNDEFINED_I64, &slot_ptr);
+        }
+
         // User pointer = raw + 8 (the ObjectHeader address — what the
         // function-call path returned). Convert to i64 to match what
         // the existing nanbox_pointer_inline expects.


### PR DESCRIPTION
## Summary

Fixes the latent uninitialized-memory bug identified in the #4717 investigation: the **inline bump-allocator fast path** in `lower_new` (`crates/perry-codegen/src/lower_call/new.rs`) writes the `GcHeader` + `ObjectHeader` + `keys_ptr`, but leaves the `max(field_count, 8)` **field slots uninitialized** — diverging from the runtime allocator `js_object_alloc_with_parent` (`crates/perry-runtime/src/object/alloc.rs`), which deliberately fills every slot with `undefined`:

```rust
// js_object_alloc_with_parent:
// "Initialize ALL allocated field slots to undefined ... to prevent stale data
//  from previously freed GC objects from bleeding through."
for i in 0..alloc_field_count {
    ptr::write(fields_ptr.add(i), JSValue::undefined());
}
```

A field read-before-write on an inline-allocated instance — or a GC that scans a still-constructing object — therefore observes **stale arena bytes**. When those bytes happen to be a previously-freed `undefined`/pointer, constructors crash nondeterministically with `Cannot read properties of undefined`. This is the "works on macOS, crashes on Linux, can't reproduce on demand" shape from #4717 (e.g. `marked`'s `this.defaults`).

## Fix

Emit a `store TAG_UNDEFINED` for each of the `alloc_field_count` slots in the merge block (covers **both** the fast bump path and the slow-alloc path, since both flow through the phi'd `raw` pointer), so the inline path matches the runtime allocator's invariant. Slots start at `raw + GcHeader(8) + ObjectHeader(24) = raw + 32`.

## Validation & honesty

- ✅ Compiles cleanly; the fast-path constants (`GC_HEADER_SIZE`/`OBJECT_HEADER_SIZE`/`FIELD_SLOT_SIZE`) and `nanbox::TAG_UNDEFINED_I64` are already in scope.
- ✅ Built the CLI and confirmed no regression on macOS object-allocation paths.
- ⚠️ I could **not** produce a deterministic repro of the #4717 `marked` crash itself (neither could the maintainer in the issue thread) — it depends on stale-heap timing. So this is **not** a before/after-validated fix for that specific crash; it's the zero-fill the issue hypothesized, made to match the runtime allocator and remove the uninitialized-slot UB regardless.

## Perf note

This adds `alloc_field_count` (≥8) stores per inline `new`. For the common ≤8-field case that's 8 stores (the constant is hoisted to a register, so ~8 `mov`s) — still far cheaper than the ~140-cycle runtime-call path. A follow-up could elide the fill for slots the constructor provably writes before any read; I kept this version unconditional for correctness.

Refs #4717.
