### PR TITLE
fix(windows): #4715 `perry update` extracts the .zip artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1129 — fix(windows): `perry update` extracts the `.zip` artifact instead of failing with "invalid gzip header" (#4715)
+
+`perform_self_update` in `crates/perry/src/update_checker.rs` always decoded the
+downloaded release archive with `flate2::GzDecoder` + `tar::Archive`, regardless
+of platform. The Windows release artifact (`perry-windows-x86_64.zip`) is a real
+ZIP, not a gzip stream, so `perry update` on Windows bailed out with:
+
+```
+Error: Failed to extract archive
+Caused by:
+    0: failed to iterate over archive
+    1: invalid gzip header
+```
+
+Two fixes:
+
+- **Extraction now dispatches on the artifact extension.** Factored the inline
+  decode into a testable `extract_archive(bytes, artifact_name, dest)` helper:
+  `.zip` → `zip::ZipArchive::extract`, everything else → gzip/tar as before. The
+  extension (not the host `cfg`) chooses the decoder.
+- **Binary lookup is now platform-aware.** The post-extract step searched for a
+  file named exactly `perry`, but the Windows zip ships `perry.exe`, so the swap
+  would have failed with "Perry binary not found in archive" even once extraction
+  succeeded. Windows now looks for `perry.exe`.
+
+Added `test_extract_zip_artifact` and `test_extract_targz_artifact` unit tests
+that round-trip an in-memory archive of each kind through `extract_archive`.
+
+Not addressed here: the npm/`npmx.dev` "two 0.5.1125 versions / latest shows
+0.5.1122" registry confusion the reporter also noted is a publishing-pipeline
+issue, not a compiler bug.
+
 ## v0.5.1128 — fix(string): generic-`this` for all String.prototype methods + slice/substring index coercion (built-ins/String 60.2%→79.3%)
 
 Extends the generic-`this` work started in #4713 (which only covered the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1128
+**Current Version:** 0.5.1129
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1128"
+version = "0.5.1129"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1128"
+version = "0.5.1129"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1128"
+version = "0.5.1129"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1128"
+version = "0.5.1129"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1128"
+version = "0.5.1129"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry/src/update_checker.rs
+++ b/crates/perry/src/update_checker.rs
@@ -466,8 +466,8 @@ pub fn perform_self_update(verbose: bool) -> Result<()> {
     let binary_name = "perry.exe";
     #[cfg(not(target_os = "windows"))]
     let binary_name = "perry";
-    let new_binary = find_binary_in_dir(&tmp_dir, binary_name)
-        .context("Perry binary not found in archive")?;
+    let new_binary =
+        find_binary_in_dir(&tmp_dir, binary_name).context("Perry binary not found in archive")?;
 
     // Atomic swap
     let backup_path = current_exe.with_extension("old");
@@ -673,7 +673,9 @@ mod tests {
             header.set_size(data.len() as u64);
             header.set_mode(0o755);
             header.set_cksum();
-            builder.append_data(&mut header, "perry", &data[..]).unwrap();
+            builder
+                .append_data(&mut header, "perry", &data[..])
+                .unwrap();
             builder.finish().unwrap();
         }
         let mut gz_buf = Vec::new();
@@ -688,7 +690,8 @@ mod tests {
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(&tmp).unwrap();
 
-        extract_archive(&gz_buf, "perry-linux-x86_64.tar.gz", &tmp).expect("tarball should extract");
+        extract_archive(&gz_buf, "perry-linux-x86_64.tar.gz", &tmp)
+            .expect("tarball should extract");
         assert!(tmp.join("perry").exists(), "perry should be extracted");
 
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/perry/src/update_checker.rs
+++ b/crates/perry/src/update_checker.rs
@@ -457,16 +457,17 @@ pub fn perform_self_update(verbose: bool) -> Result<()> {
         eprintln!("Downloaded {} bytes", bytes.len());
     }
 
-    // Extract
-    let decoder = flate2::read::GzDecoder::new(&bytes[..]);
-    let mut archive = tar::Archive::new(decoder);
-    archive
-        .unpack(&tmp_dir)
-        .context("Failed to extract archive")?;
+    // Extract. Windows ships a .zip; every other platform a .tar.gz.
+    extract_archive(&bytes, artifact_name, &tmp_dir).context("Failed to extract archive")?;
 
-    // Find the perry binary in extracted files
-    let new_binary =
-        find_binary_in_dir(&tmp_dir, "perry").context("Perry binary not found in archive")?;
+    // Find the perry binary in extracted files. The Windows zip ships `perry.exe`,
+    // so an unsuffixed "perry" lookup would miss it (#4715).
+    #[cfg(target_os = "windows")]
+    let binary_name = "perry.exe";
+    #[cfg(not(target_os = "windows"))]
+    let binary_name = "perry";
+    let new_binary = find_binary_in_dir(&tmp_dir, binary_name)
+        .context("Perry binary not found in archive")?;
 
     // Atomic swap
     let backup_path = current_exe.with_extension("old");
@@ -529,6 +530,23 @@ pub fn perform_self_update(verbose: bool) -> Result<()> {
 
     println!("Updated perry: v{} -> v{}", current, cache.latest_version);
 
+    Ok(())
+}
+
+/// Unpack a downloaded release archive into `dest`, dispatching on the artifact
+/// extension. Windows ships a `.zip`; every other platform a `.tar.gz`. Feeding a
+/// zip to the gzip/tar decoder fails with "invalid gzip header" (#4715), so the
+/// extension — not the host OS — decides the decoder.
+fn extract_archive(bytes: &[u8], artifact_name: &str, dest: &std::path::Path) -> Result<()> {
+    if artifact_name.ends_with(".zip") {
+        let reader = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(reader).context("Failed to open zip archive")?;
+        archive.extract(dest).context("Failed to extract zip")?;
+    } else {
+        let decoder = flate2::read::GzDecoder::new(bytes);
+        let mut archive = tar::Archive::new(decoder);
+        archive.unpack(dest).context("Failed to extract tarball")?;
+    }
     Ok(())
 }
 
@@ -615,5 +633,64 @@ mod tests {
         let now = now_rfc3339();
         assert!(now.ends_with('Z'));
         assert!(chrono_parse_rfc3339(&now).is_some());
+    }
+
+    // #4715: the Windows artifact is a .zip, but extraction always ran the
+    // gzip/tar decoder ("invalid gzip header"). Verify a .zip is extracted by
+    // the zip path and a .tar.gz by the tar path.
+    #[test]
+    fn test_extract_zip_artifact() {
+        use std::io::Write;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            zw.start_file::<_, ()>("perry.exe", zip::write::SimpleFileOptions::default())
+                .unwrap();
+            zw.write_all(b"binary-bytes").unwrap();
+            zw.finish().unwrap();
+        }
+
+        let tmp = std::env::temp_dir().join(format!("perry-zip-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+
+        extract_archive(&buf, "perry-windows-x86_64.zip", &tmp).expect("zip should extract");
+        let extracted = tmp.join("perry.exe");
+        assert!(extracted.exists(), "perry.exe should be extracted");
+        assert_eq!(fs::read(&extracted).unwrap(), b"binary-bytes");
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_extract_targz_artifact() {
+        use std::io::Write;
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            let data = b"binary-bytes";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append_data(&mut header, "perry", &data[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz_buf = Vec::new();
+        {
+            let mut enc =
+                flate2::write::GzEncoder::new(&mut gz_buf, flate2::Compression::default());
+            enc.write_all(&tar_buf).unwrap();
+            enc.finish().unwrap();
+        }
+
+        let tmp = std::env::temp_dir().join(format!("perry-tgz-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+
+        extract_archive(&gz_buf, "perry-linux-x86_64.tar.gz", &tmp).expect("tarball should extract");
+        assert!(tmp.join("perry").exists(), "perry should be extracted");
+
+        let _ = fs::remove_dir_all(&tmp);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4715. On Windows, `perry update` failed with:

```
Error: Failed to extract archive
Caused by:
    0: failed to iterate over archive
    1: invalid gzip header
```

**Root cause:** `perform_self_update` in `crates/perry/src/update_checker.rs` always decoded the downloaded release archive with `flate2::GzDecoder` + `tar::Archive`, regardless of platform. The Windows release artifact (`perry-windows-x86_64.zip`) is a real ZIP, not a gzip stream — so extraction blew up on the gzip magic bytes.

## Changes

- **Dispatch extraction on the artifact extension.** Factored the inline decode into a testable `extract_archive(bytes, artifact_name, dest)` helper: `.zip` → `zip::ZipArchive::extract`, everything else → gzip/tar as before.
- **Platform-aware binary lookup.** The post-extract step searched for a file named exactly `perry`, but the Windows zip ships `perry.exe` — so the swap would have failed with "Perry binary not found in archive" even once extraction succeeded. Windows now looks for `perry.exe`.
- **Tests.** Added `test_extract_zip_artifact` / `test_extract_targz_artifact` round-tripping an in-memory archive of each kind.

## Not addressed here

The npm / `npmx.dev` "two 0.5.1125 versions / latest shows 0.5.1122" registry confusion the reporter also noted is a publishing-pipeline issue, not a compiler bug.

## Testing

`cargo test -p perry --bin perry update_checker` — 8 passed (incl. 2 new).