### PR TITLE
feat(class): public class-element semantics — accessor keys, prototype-ref setters, static-method descriptors, method .length, grammar early errors

### DIFF
--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -585,6 +585,19 @@ fn lower_assignment_target(
                                     && ctx.lookup_func(&cls_name).is_none()
                                 {
                                     None
+                                } else if ctx.lookup_class(&cls_name).is_some()
+                                    && ctx
+                                        .lookup_class_accessor_names(&cls_name)
+                                        .is_some_and(|names| names.iter().any(|n| n == &method_name))
+                                {
+                                    // `C.prototype.<accessor> = v` where `<accessor>`
+                                    // is a `set`/`get` declared on the class is an
+                                    // ordinary write that must INVOKE the setter — not
+                                    // a prototype-method monkey-patch. Fall through to
+                                    // the generic PropertySet path (which reaches the
+                                    // runtime prototype-ref setter dispatch). Test262
+                                    // accessor-name-inst setters.
+                                    None
                                 } else if ctx.lookup_class(&cls_name).is_some() {
                                     Some(ProtoOwner::Class(cls_name))
                                 } else if let Some(local_id) = ctx.lookup_local(&cls_name) {

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -586,9 +586,9 @@ fn lower_assignment_target(
                                 {
                                     None
                                 } else if ctx.lookup_class(&cls_name).is_some()
-                                    && ctx
-                                        .lookup_class_accessor_names(&cls_name)
-                                        .is_some_and(|names| names.iter().any(|n| n == &method_name))
+                                    && ctx.lookup_class_accessor_names(&cls_name).is_some_and(
+                                        |names| names.iter().any(|n| n == &method_name),
+                                    )
                                 {
                                     // `C.prototype.<accessor> = v` where `<accessor>`
                                     // is a `set`/`get` declared on the class is an

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -854,6 +854,7 @@ pub fn lower_class_decl(
                     let key = match &m.key {
                         ast::PropName::Ident(i) => i.sym.to_string(),
                         ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
+                        ast::PropName::Num(n) => n.value.to_string(),
                         _ => continue,
                     };
                     accessor_names.insert(key);

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -435,6 +435,14 @@ pub fn lower_class_decl(
                 let (prop_name, can_source_order_register) = match &method.key {
                     ast::PropName::Ident(ident) => (ident.sym.to_string(), true),
                     ast::PropName::Str(s) => (s.value.as_str().unwrap_or("").to_string(), true),
+                    // Numeric-literal member names (`get 0()`, `set 1.5(v)`,
+                    // `42() {}`) are valid class element keys — their property
+                    // key is the canonical ToString of the numeric value, the
+                    // same conversion object literals use (`{ 0: ... }`).
+                    // Without this arm they fell through `_ => continue` and the
+                    // method/accessor was silently dropped, so `C.prototype[0]`
+                    // read `undefined` (Test262 accessor-name-inst/literal-numeric-*).
+                    ast::PropName::Num(n) => (n.value.to_string(), true),
                     ast::PropName::Computed(computed) => {
                         if is_symbol_iterator_key(&computed.expr) {
                             ("@@iterator".to_string(), false)
@@ -1212,6 +1220,9 @@ pub fn lower_class_from_ast(
                 let (prop_name, can_source_order_register) = match &method.key {
                     ast::PropName::Ident(ident) => (ident.sym.to_string(), true),
                     ast::PropName::Str(s) => (s.value.as_str().unwrap_or("").to_string(), true),
+                    // Numeric-literal member names — see the parallel arm in
+                    // `lower_class_decl`. Canonical ToString of the value.
+                    ast::PropName::Num(n) => (n.value.to_string(), true),
                     ast::PropName::Computed(computed)
                         if is_inspect_custom_key(ctx, &computed.expr)
                             && !method.is_static

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -138,6 +138,7 @@ pub fn lower_class_decl(
 ) -> Result<Class> {
     let name = class_decl.ident.sym.to_string();
     validate_legacy_decorator_surface(&class_decl.class, &name)?;
+    validate_class_element_early_errors(&class_decl.class, &name)?;
     let class_id = match ctx.lookup_class(&name) {
         Some(id) => id,
         None => {
@@ -1063,6 +1064,7 @@ pub fn lower_class_from_ast(
     is_exported: bool,
 ) -> Result<Class> {
     validate_legacy_decorator_surface(class, name)?;
+    validate_class_element_early_errors(class, name)?;
     let class_id = match ctx.lookup_class(name) {
         Some(id) => id,
         None => {

--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -411,6 +411,9 @@ pub fn lower_class_method(
     let name = match &method.key {
         ast::PropName::Ident(ident) => ident.sym.to_string(),
         ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
+        // Numeric-literal method name (`42() {}`): the registration key (and
+        // func name) is the canonical ToString of the value.
+        ast::PropName::Num(n) => n.value.to_string(),
         ast::PropName::Computed(computed) if is_symbol_iterator_key(&computed.expr) => {
             "@@iterator".to_string()
         }
@@ -657,6 +660,10 @@ pub fn lower_getter_method(
     let name = match &method.key {
         ast::PropName::Ident(ident) => format!("get_{}", ident.sym),
         ast::PropName::Str(s) => format!("get_{}", s.value.as_str().unwrap_or("")),
+        // Numeric-literal getter (`get 0()`): synthetic internal symbol; the
+        // accessor is registered under the canonical numeric prop key by the
+        // caller (lower_class_decl), not this name.
+        ast::PropName::Num(n) => format!("get_{}", n.value),
         ast::PropName::Computed(computed) => {
             // Well-known symbol getters (e.g., `get [Symbol.toStringTag]()`)
             // get a synthetic `get_@@<short>` name. The caller is
@@ -742,6 +749,9 @@ pub fn lower_setter_method(
     let name = match &method.key {
         ast::PropName::Ident(ident) => format!("set_{}", ident.sym),
         ast::PropName::Str(s) => format!("set_{}", s.value.as_str().unwrap_or("")),
+        // Numeric-literal setter (`set 0(v)`): synthetic internal symbol;
+        // registered under the canonical numeric prop key by the caller.
+        ast::PropName::Num(n) => format!("set_{}", n.value),
         _ => return Err(anyhow!("Unsupported setter key")),
     };
     lower_setter_method_with_name(ctx, method, name)

--- a/crates/perry-hir/src/lower_decl/class_validation.rs
+++ b/crates/perry-hir/src/lower_decl/class_validation.rs
@@ -97,11 +97,10 @@ pub fn validate_class_element_early_errors(class: &ast::Class, class_name: &str)
                 // ClassMethod (not Constructor), so the duplicate count above
                 // doesn't see them — reject here.
                 if !m.is_static && name == "constructor" {
-                    let is_special = matches!(
-                        m.kind,
-                        ast::MethodKind::Getter | ast::MethodKind::Setter
-                    ) || m.function.is_generator
-                        || m.function.is_async;
+                    let is_special =
+                        matches!(m.kind, ast::MethodKind::Getter | ast::MethodKind::Setter)
+                            || m.function.is_generator
+                            || m.function.is_async;
                     if is_special {
                         bail!(
                             "SyntaxError: class `{class_name}` constructor may not be an \

--- a/crates/perry-hir/src/lower_decl/class_validation.rs
+++ b/crates/perry-hir/src/lower_decl/class_validation.rs
@@ -59,6 +59,87 @@ pub fn validate_legacy_decorator_surface(class: &ast::Class, class_name: &str) -
     Ok(())
 }
 
+/// Resolve a non-computed PropName (`Ident` / string / numeric literal) to its
+/// property-key string. Returns `None` for computed (`[expr]`) keys — those are
+/// runtime values and never trigger the static-semantics name checks below.
+fn static_prop_name(key: &ast::PropName) -> Option<String> {
+    match key {
+        ast::PropName::Ident(i) => Some(i.sym.to_string()),
+        ast::PropName::Str(s) => Some(s.value.as_str().unwrap_or("").to_string()),
+        ast::PropName::Num(n) => Some(n.value.to_string()),
+        _ => None,
+    }
+}
+
+/// ECMA-262 Class Definitions / Static Semantics: Early Errors for the public
+/// (non-private) class element surface. These must be rejected at compile time
+/// with a SyntaxError. SWC already rejects several (async constructor, a field
+/// named `constructor`, a static field named `constructor`); this covers the
+/// ones it parses cleanly:
+///   - more than one constructor,
+///   - a constructor that is a getter / setter / generator (a SpecialMethod),
+///   - a static method or accessor named `prototype`,
+///   - a static field named `prototype`.
+/// Test262 language/.../class/elements/syntax/early-errors + definition/*.
+pub fn validate_class_element_early_errors(class: &ast::Class, class_name: &str) -> Result<()> {
+    let mut constructor_count = 0usize;
+    for member in &class.body {
+        match member {
+            // `constructor(){}` (the ordinary one) parses as a dedicated
+            // Constructor node; count them to catch duplicates.
+            ast::ClassMember::Constructor(_) => constructor_count += 1,
+            ast::ClassMember::Method(m) => {
+                let Some(name) = static_prop_name(&m.key) else {
+                    continue;
+                };
+                // A getter/setter/generator/async method named `constructor`
+                // (a SpecialMethod) is a Syntax Error. SWC routes these through
+                // ClassMethod (not Constructor), so the duplicate count above
+                // doesn't see them — reject here.
+                if !m.is_static && name == "constructor" {
+                    let is_special = matches!(
+                        m.kind,
+                        ast::MethodKind::Getter | ast::MethodKind::Setter
+                    ) || m.function.is_generator
+                        || m.function.is_async;
+                    if is_special {
+                        bail!(
+                            "SyntaxError: class `{class_name}` constructor may not be an \
+                             accessor, generator, or async method",
+                        );
+                    }
+                    // A plain non-static method literally named "constructor"
+                    // (e.g. `\"constructor\"(){}`) is the class constructor too.
+                    constructor_count += 1;
+                }
+                // `static prototype` in any method form is forbidden.
+                if m.is_static && name == "prototype" {
+                    bail!(
+                        "SyntaxError: class `{class_name}` may not have a static method \
+                         named 'prototype'",
+                    );
+                }
+            }
+            ast::ClassMember::ClassProp(p) => {
+                let Some(name) = static_prop_name(&p.key) else {
+                    continue;
+                };
+                if p.is_static && name == "prototype" {
+                    bail!(
+                        "SyntaxError: class `{class_name}` may not have a static field \
+                         named 'prototype'",
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    if constructor_count > 1 {
+        bail!("SyntaxError: class `{class_name}` may only have one constructor");
+    }
+    Ok(())
+}
+
 fn method_key_hint(key: &ast::PropName) -> String {
     match key {
         ast::PropName::Ident(i) => i.sym.to_string(),

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -39,7 +39,9 @@ pub(crate) use class_members::{
     lower_getter_method, lower_getter_method_with_name, lower_setter_method,
     lower_setter_method_with_name,
 };
-pub(crate) use class_validation::validate_legacy_decorator_surface;
+pub(crate) use class_validation::{
+    validate_class_element_early_errors, validate_legacy_decorator_surface,
+};
 pub(crate) use enum_decl::{compute_enum_members, lower_enum_decl};
 pub(crate) use fn_decl::lower_fn_decl;
 pub(crate) use helpers::{

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -3974,6 +3974,54 @@ pub(crate) unsafe fn class_instance_setter_apply(
     false
 }
 
+/// Spec `Function.prototype.length` for a class method named `name` — the
+/// count of formal parameters, excluding a trailing rest param and the
+/// synthesized `arguments` slot (neither contributes to `.length`). Walks the
+/// instance vtable chain, then the static-method table. Used to stamp the
+/// bound-method closure's length so `C.prototype.m.length` is correct
+/// (Test262 .../class/{gen,async}-method/...-trailing-comma + length tests).
+/// Note: does not subtract for default-valued params (the registry doesn't
+/// record the first-default position); methods with defaults already reported
+/// the wrong length, so this is a strict improvement, never a regression.
+pub(crate) fn class_method_bind_length(class_id: u32, name: &str) -> Option<u32> {
+    if let Ok(guard) = CLASS_VTABLE_REGISTRY.read() {
+        if let Some(reg) = guard.as_ref() {
+            let mut cid = class_id;
+            let mut depth = 0usize;
+            while cid != 0 && depth < 32 {
+                if let Some(vt) = reg.get(&cid) {
+                    if let Some(e) = vt.methods.get(name) {
+                        let mut len = e.param_count;
+                        if e.has_rest {
+                            len = len.saturating_sub(1);
+                        }
+                        if e.has_synthetic_arguments {
+                            len = len.saturating_sub(1);
+                        }
+                        return Some(len);
+                    }
+                }
+                match get_parent_class_id(cid) {
+                    Some(p) if p != 0 && p != cid => {
+                        cid = p;
+                        depth += 1;
+                    }
+                    _ => break,
+                }
+            }
+        }
+    }
+    // Static methods: CLASS_STATIC_METHODS stores (func_ptr, param_count, has_rest).
+    if let Some((_, param_count, has_rest)) = lookup_static_method_in_chain(class_id, name) {
+        let mut len = param_count;
+        if has_rest {
+            len = len.saturating_sub(1);
+        }
+        return Some(len);
+    }
+    None
+}
+
 /// Call a static method func_ptr with `args` (no `this` prepend — static
 /// methods read `this` from the implicit-this slot, set by the caller).
 /// Mirrors the arity dispatch of `call_vtable_method` minus the receiver arg.

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -3688,6 +3688,20 @@ pub unsafe extern "C" fn js_register_class_computed_accessor(
 
 /// Look up a static method by name in `CLASS_STATIC_METHODS`, walking the
 /// class_id parent chain (so a subclass inherits a parent's static method).
+/// Own-only static method lookup (no parent-chain walk) — for
+/// `getOwnPropertyDescriptor(C, name)`, where inherited statics must NOT be
+/// reported as own properties of `C`.
+pub(crate) fn class_has_own_static_method(class_id: u32, name: &str) -> bool {
+    CLASS_STATIC_METHODS
+        .read()
+        .ok()
+        .and_then(|g| {
+            g.as_ref()
+                .and_then(|m| m.get(&class_id).map(|inner| inner.contains_key(name)))
+        })
+        .unwrap_or(false)
+}
+
 pub(crate) fn lookup_static_method_in_chain(
     class_id: u32,
     name: &str,

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -3919,6 +3919,47 @@ pub(crate) unsafe fn class_static_accessor_setter_apply(
     false
 }
 
+/// Apply an instance `set name(v)` accessor from the class vtable chain,
+/// invoking it with the `(this, value)` calling convention class setters use.
+/// Returns `true` if a setter was found and called. Used when a write targets
+/// a class prototype ref (`C.prototype[key] = v`) whose `key` is an accessor
+/// defined on the prototype itself (Test262 accessor-name-inst setters).
+pub(crate) unsafe fn class_instance_setter_apply(
+    class_id: u32,
+    name: &str,
+    receiver: f64,
+    value: f64,
+) -> bool {
+    let guard = match CLASS_VTABLE_REGISTRY.read() {
+        Ok(g) => g,
+        Err(_) => return false,
+    };
+    let Some(reg) = guard.as_ref() else {
+        return false;
+    };
+    let mut cid = class_id;
+    let mut depth = 0usize;
+    while cid != 0 && depth < 32 {
+        if let Some(vtable) = reg.get(&cid) {
+            if let Some(&setter_ptr) = vtable.setters.get(name) {
+                if setter_ptr != 0 {
+                    let f: extern "C" fn(f64, f64) -> f64 = std::mem::transmute(setter_ptr);
+                    let _ = f(receiver, value);
+                }
+                return true;
+            }
+        }
+        match get_parent_class_id(cid) {
+            Some(p) if p != 0 && p != cid => {
+                cid = p;
+                depth += 1;
+            }
+            _ => break,
+        }
+    }
+    false
+}
+
 /// Call a static method func_ptr with `args` (no `this` prepend — static
 /// methods read `this` from the implicit-this slot, set by the caller).
 /// Mirrors the arity dispatch of `call_vtable_method` minus the receiver arg.

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -237,6 +237,25 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                     super::rebuild_object_field_layout(desc, 4);
                     return f64::from_bits((desc as u64) | 0x7FFD_0000_0000_0000);
                 }
+                // Static methods are own properties of the class *constructor*
+                // (not the prototype). `getOwnPropertyDescriptor(C, "m")` for a
+                // `static m() {}` must report a `{ writable, enumerable: false,
+                // configurable }` data property — `hasOwnProperty(C, "m")`
+                // already returns true, so without this the two disagreed and
+                // verifyProperty threw "reading 'enumerable'" on undefined
+                // (Test262 elements/after-same-line-static-*).
+                if super::class_prototype_ref_id(obj_value).is_none()
+                    && super::class_registry::class_has_own_static_method(class_id, &method_name)
+                {
+                    // Bind the static method to the constructor ref to produce a
+                    // callable value, mirroring the `C.m` read path. The name
+                    // bytes are leaked (bounded by the static descriptor set) so
+                    // the pointer js_class_method_bind stashes stays valid.
+                    let leaked: &'static [u8] = method_name.as_bytes().to_vec().leak();
+                    let value =
+                        super::js_class_method_bind(obj_value, leaked.as_ptr(), leaked.len());
+                    return build_data_descriptor(value, true, false, true);
+                }
             }
             return f64::from_bits(crate::value::TAG_UNDEFINED);
         }

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -222,6 +222,24 @@ pub extern "C" fn js_object_set_field_by_name(
                             .get(&class_id)
                             .is_some_and(|props| props.contains_key(&name))
                     });
+                    // `C.prototype[key] = v` where `key` is an instance
+                    // `set key(v)` accessor defined on the prototype: invoke the
+                    // setter with `this` = the prototype ref. The prototype ref
+                    // and the constructor ref are both INT32-tagged class refs;
+                    // distinguish via `class_prototype_ref_id`. Instance setters
+                    // live in the vtable; static accessors (below) live in the
+                    // constructor ref's table (Test262 accessor-name-inst).
+                    if !has_own_data
+                        && super::class_prototype_ref_id(f64::from_bits(bits)).is_some()
+                        && super::class_registry::class_instance_setter_apply(
+                            class_id,
+                            &name,
+                            f64::from_bits(bits),
+                            value,
+                        )
+                    {
+                        return;
+                    }
                     if !has_own_data
                         && super::class_registry::class_static_accessor_setter_apply(
                             class_id,

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -5825,10 +5825,39 @@ pub extern "C" fn js_class_method_bind(
             set_bound_native_closure_name(closure, name);
             if let Some(length) = bound_native_method_length(name) {
                 set_builtin_closure_length(closure as usize, length);
+            } else if let Some(class_id) = class_id_from_method_receiver(instance) {
+                // User class method bound as a value (`C.prototype.m`, `c.m`):
+                // stamp its spec `.length` from the registered param count so
+                // `C.prototype.m.length` reflects the declared arity instead of
+                // the closure's capture count (Test262 method `.length` tests).
+                if let Some(length) =
+                    super::class_registry::class_method_bind_length(class_id, name)
+                {
+                    set_builtin_closure_length(closure as usize, length);
+                }
             }
         }
     }
     crate::value::js_nanbox_pointer(closure as i64)
+}
+
+/// Resolve the owning class id for a `js_class_method_bind` receiver: a class
+/// constructor/prototype ref (INT32-tagged) or a real class instance pointer.
+fn class_id_from_method_receiver(instance: f64) -> Option<u32> {
+    if let Some(cid) = class_ref_id(instance) {
+        return Some(cid);
+    }
+    let jsv = JSValue::from_bits(instance.to_bits());
+    if jsv.is_pointer() {
+        let obj = jsv.as_pointer::<ObjectHeader>();
+        if !obj.is_null() && (obj as usize) >= 0x100000 {
+            let cid = unsafe { (*obj).class_id };
+            if cid != 0 {
+                return Some(cid);
+            }
+        }
+    }
+    None
 }
 
 pub(crate) const CLASS_PROTOTYPE_REF_FLAG: u64 = 1u64 << 32;

--- a/crates/perry-runtime/src/object/property_key.rs
+++ b/crates/perry-runtime/src/object/property_key.rs
@@ -41,6 +41,16 @@ pub unsafe extern "C" fn js_object_set_property_key(
     if key_str.is_null() {
         return value;
     }
+    // Class constructor/prototype refs are INT32-tagged values, not real
+    // `ObjectHeader`s — `extract_obj_ptr` returns null for them, so a
+    // `C.prototype[key] = v` / `C[key] = v` write silently no-op'd here. The
+    // get side already passes the raw NaN-boxed bits into the by-name dispatch
+    // (which has a dedicated 0x7FFE class-ref branch); mirror that on the set
+    // side so static-accessor and prototype instance-setter dispatch run.
+    if super::class_ref_id(obj_value).is_some() {
+        js_object_set_field_by_name(obj_value.to_bits() as *mut ObjectHeader, key_str, value);
+        return value;
+    }
     let obj = extract_obj_ptr(obj_value);
     if !obj.is_null() {
         js_object_set_field_by_name(obj, key_str, value);


### PR DESCRIPTION
Brings the public (non-private) class-element surface closer to ECMA-262, measured against Test262 `language/{statements,expressions}/class`. Five independent fixes; no version/changelog bump (maintainer folds in at merge).

## Fixes

1. **Numeric-literal member keys** (`get 0()`, `set 1.5(v)`, `42() {}`). `PropName::Num` fell into `_ => continue` in `lower_class_decl`/`lower_class_from_ast` and into `Err("Unsupported … key")` in the three internal name builders (`lower_class_method`/`lower_getter_method`/`lower_setter_method`), so numeric-keyed methods/accessors were silently dropped and `C.prototype[0]` read `undefined`. Now keyed by the canonical `ToString` of the value (matching object-literal lowering); the `#665` `accessor_names` ctor-body scan learns numeric keys too.

2. **Prototype-ref instance setters** (`C.prototype[k] = v` / `C.prototype.x = v` where `x` is `set x(v)`). Two bugs: (a) the HIR recognizer unconditionally rewrote `Class.prototype.name = v` to `RegisterPrototypeMethod` (a method monkey-patch) even when `name` is a declared accessor — now falls through to an ordinary property-set when `name ∈ lookup_class_accessor_names`; (b) `js_object_set_property_key` ran `extract_obj_ptr` first, which is null for an INT32-tagged class ref, so the write no-op'd — class refs now pass their raw NaN-boxed bits into `js_object_set_field_by_name`, whose `0x7FFE` branch gains a `class_instance_setter_apply` dispatch for prototype refs.

3. **Static-method own descriptors.** `getOwnPropertyDescriptor(C, "m")` for `static m() {}` returned `undefined` while `hasOwnProperty(C, "m")` returned `true`; verifyProperty then threw "reading 'enumerable'" on undefined. Added a constructor-ref descriptor branch (`{ writable: true, enumerable: false, configurable: true }`) via a new own-only `class_has_own_static_method`.

4. **Bound class-method `.length`.** `js_class_method_bind` only stamped a length for built-in native methods. Now resolves the owning class id from the receiver (constructor/prototype ref or instance pointer) and stamps the registered arity, minus a trailing rest param and the synthesized `arguments` slot. (Default-valued params are not yet subtracted — the registry doesn't record the first-default position — so the 8 `dflt-params-trailing-comma` cases still report the raw count.)

5. **Grammar early errors.** New `validate_class_element_early_errors` rejects, at compile time with a SyntaxError, the public static-semantics violations SWC parses cleanly: more than one constructor, a constructor that is a getter/setter/generator, and a static method or field named `prototype`. (SWC already rejects async constructors and `constructor` fields.)

## Verification

Test262 at the pinned SHA, `PERRY_NO_AUTO_OPTIMIZE=1`, all sweeps skip=0:
- `statements/class/elements`: **451 → 534 pass**, **0 regressions** from the early-error and name/length changes (each confirmed independently).
- `accessor-name-inst`: **0 → 71%**.
- `.length` repro matches Node exactly (`m=1, g=2, n=0, r=1, s=3`); method dirs ~40/48.
- Early-error probe: all 7 invalid cases reject; all 4 valid cases (`static constructor(){}`, instance `prototype(){}`, computed `["prototype"]`, static getter + constructor) still accept.

## Deferred (separate follow-ups)

- **Static accessors** (`static get/set`) are never registered into `CLASS_STATIC_ACCESSORS` — codegen registers all getters/setters into the instance vtable; the ~42 `accessor-name-static` tests need the HIR `Class` to track per-accessor static-ness.
- Computed-key accessor-evaluation error semantics; empty-string keys (`name_len <= 0` registration guard); JS-canonical numeric `ToString` for keys like `0.0000001` → `"1e-7"` (also affects object literals).