### PR TITLE
fix(http): park async request handlers instead of synthesizing a premature empty response (#4728)

### DIFF
--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -394,9 +394,12 @@ pub(crate) fn process_pending_https(pending: HttpPendingRequest) {
             js_promise_run_microtasks();
         }
     }
-    crate::server::synthesize_default_response_if_needed(pending.response_handle);
-    perry_ffi::drop_handle(pending.request_handle);
-    perry_ffi::drop_handle(pending.response_handle);
+    // #4728 — an async handler (outbound `fetch()`, `setTimeout`, `await`
+    // chain) returns before `res.end()` runs. Finalize now if the response
+    // is already flushed, otherwise park it for the reaper instead of
+    // synthesizing a premature empty response and freeing the handles out
+    // from under the pending work.
+    crate::server::finalize_or_park_request(&pending);
 }
 
 /// `httpsServer.address()` mirroring `http.Server.address()`.

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -6,7 +6,8 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
@@ -839,7 +840,151 @@ pub extern "C" fn js_node_http_server_has_active() -> i32 {
     if active == 0 && crate::http2_server::has_active_h2_clients() {
         active = 1;
     }
+    // #4728 — a request parked awaiting an async handler keeps the loop
+    // alive so the deferred `res.end()` can still flush before exit.
+    if active == 0 && has_in_flight_requests() {
+        active = 1;
+    }
     active
+}
+
+// ============================================================================
+// #4728 — in-flight (async-handler) request tracking.
+//
+// A `(req, res) => { … }` handler that finishes the response on a *later*
+// event-loop tick — an outbound `fetch()`, a `setTimeout`, any `await`
+// chain that calls `res.end()` from a microtask/timer/tokio resolution —
+// returns to `process_pending` before `res.end()` has run. Pre-#4728,
+// `process_pending` then synthesized a default empty 200 and freed the
+// per-request handles immediately, so the real `res.end(...)` later fired
+// on a dropped handle (no-op) and the client saw an empty/closed reply.
+//
+// Fix: when the handler returns without ending the response, park the
+// request here instead of synthesizing+freeing. The reaper runs each pump
+// tick (the codegen-emitted main loop keeps ticking while the server is a
+// live handle, draining timers / fetch resolutions / microtasks), and
+// finalizes a parked request once `res.end()` has flushed the real
+// response — or, as a safety net mirroring Node's `requestTimeout`,
+// synthesizes the default response and frees the handles if the handler
+// never responds within the grace window so a buggy handler can't pin a
+// hyper connection (and its request handles) forever.
+// ============================================================================
+
+/// A request whose handler returned before finishing the response.
+struct InFlightRequest {
+    request_handle: i64,
+    response_handle: i64,
+    /// Mirrors `HttpPendingRequest::skip_default_response`: when true the
+    /// response is driven elsewhere (e.g. an upgraded/stream path) so the
+    /// reaper must not synthesize a default on timeout.
+    skip_default_response: bool,
+    /// Grace deadline. Past this, synthesize the default response (unless
+    /// `skip_default_response`) and free the handles regardless.
+    deadline: Instant,
+}
+
+static IN_FLIGHT: Mutex<Vec<InFlightRequest>> = Mutex::new(Vec::new());
+
+/// True iff `res.end()` has flushed the response (or the handle is already
+/// gone). A missing handle reads as "done" so a stray entry can't wedge
+/// the reaper.
+fn response_writable_ended(response_handle: i64) -> bool {
+    get_handle::<ServerResponse>(response_handle)
+        .map(|sr| sr.writable_ended)
+        .unwrap_or(true)
+}
+
+/// Free the per-request request + response handles. Mirrors the tail of
+/// the synchronous-handler path in `process_pending`.
+fn finalize_request_handles(request_handle: i64, response_handle: i64) {
+    close_incoming_message(request_handle);
+    perry_ffi::drop_handle(request_handle);
+    perry_ffi::drop_handle(response_handle);
+}
+
+/// True iff any request is parked awaiting an async handler — keeps the
+/// server's handle "active" so the main loop doesn't exit before the
+/// pending response is flushed.
+fn has_in_flight_requests() -> bool {
+    IN_FLIGHT.lock().map(|g| !g.is_empty()).unwrap_or(false)
+}
+
+/// Finalize parked requests whose handler has now called `res.end()` (the
+/// common case — fetch/timer/await resolved on a later tick), or whose
+/// grace deadline has elapsed (a handler that never responds). Called each
+/// pump tick. #4728.
+fn reap_in_flight_requests() {
+    // (request_handle, response_handle, needs_synthesize)
+    let mut to_finalize: Vec<(i64, i64, bool)> = Vec::new();
+    {
+        let mut guard = match IN_FLIGHT.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if guard.is_empty() {
+            return;
+        }
+        let now = Instant::now();
+        guard.retain(|e| {
+            let ended = response_writable_ended(e.response_handle);
+            let expired = now >= e.deadline;
+            if ended || expired {
+                to_finalize.push((
+                    e.request_handle,
+                    e.response_handle,
+                    // Only synthesize when we're giving up on a handler
+                    // that never ended the response — not when it ended
+                    // it itself, and never for skip-default paths.
+                    !ended && !e.skip_default_response,
+                ));
+                false
+            } else {
+                true
+            }
+        });
+    }
+    // Finalize outside the lock — `synthesize_default_response_if_needed`
+    // and `drop_handle` don't touch `IN_FLIGHT`, but keeping them off the
+    // lock avoids any future re-entrancy surprise.
+    for (req, res, needs_synth) in to_finalize {
+        if needs_synth {
+            synthesize_default_response_if_needed(res);
+        }
+        finalize_request_handles(req, res);
+    }
+}
+
+/// Finalize a just-dispatched request, or park it for the reaper if its
+/// handler returned before finishing the response (an async handler that
+/// will call `res.end()` on a later tick). Shared by the HTTP/1 and HTTPS
+/// dispatch paths. #4728.
+pub(crate) fn finalize_or_park_request(pending: &HttpPendingRequest) {
+    if response_writable_ended(pending.response_handle) {
+        finalize_request_handles(pending.request_handle, pending.response_handle);
+        return;
+    }
+    // Grace window mirrors Node's `requestTimeout` (default 300s; `0` =
+    // disabled, so fall back to the default rather than parking forever).
+    let grace_ms = get_handle::<HttpServer>(pending.server_handle)
+        .map(|s| s.request_timeout)
+        .filter(|t| *t > 0.0)
+        .unwrap_or(300_000.0);
+    let deadline = Instant::now() + Duration::from_millis(grace_ms as u64);
+    if let Ok(mut guard) = IN_FLIGHT.lock() {
+        guard.push(InFlightRequest {
+            request_handle: pending.request_handle,
+            response_handle: pending.response_handle,
+            skip_default_response: pending.skip_default_response,
+            deadline,
+        });
+    } else {
+        // Lock poisoned — fall back to the old immediate behavior so we
+        // never leak the handles.
+        if !pending.skip_default_response {
+            synthesize_default_response_if_needed(pending.response_handle);
+        }
+        finalize_request_handles(pending.request_handle, pending.response_handle);
+    }
 }
 
 /// Drain pending requests + upgrades from every registered server,
@@ -869,6 +1014,10 @@ pub extern "C" fn js_node_http_server_has_active() -> i32 {
 #[no_mangle]
 pub extern "C" fn js_node_http_server_process_pending() -> i32 {
     let mut count = 0i32;
+
+    // #4728 — finalize any async-handler requests that have flushed their
+    // response since the last tick (or timed out) before draining new ones.
+    reap_in_flight_requests();
 
     // Snapshot handle ids first so we can mutate handle state
     // (drain channels, free per-request handles) without the
@@ -1011,17 +1160,17 @@ fn process_pending(pending: HttpPendingRequest) {
         }
     }
 
-    // If the handler didn't call `res.end()` (still has the channel),
-    // synthesize a default 200 with empty body so hyper's service fn
-    // doesn't hang.
-    if !pending.skip_default_response {
-        synthesize_default_response_if_needed(pending.response_handle);
-    }
-
-    // Free the per-request handles.
-    close_incoming_message(pending.request_handle);
-    perry_ffi::drop_handle(pending.request_handle);
-    perry_ffi::drop_handle(pending.response_handle);
+    // #4728 — if the handler already finished the response (the common
+    // synchronous `res.end(...)` shape, or an async handler whose
+    // microtasks all settled within this tick), finalize now. Otherwise
+    // it launched async work — an outbound `fetch()`, a `setTimeout`, an
+    // `await` chain — that will call `res.end()` on a later event-loop
+    // tick. Synthesizing a default response and freeing the handles here
+    // would race that work: the real response is dropped and the client
+    // sees an empty (or no) reply. Park the request for the reaper, which
+    // finalizes it once `res.end()` flushes the real response (or the
+    // grace deadline elapses for a handler that never responds).
+    finalize_or_park_request(&pending);
 }
 
 /// If the handler didn't call `res.end()`, finish the response

--- a/test-files/test_issue_4728_async_handler_res_end.ts
+++ b/test-files/test_issue_4728_async_handler_res_end.ts
@@ -1,0 +1,48 @@
+// Issue #4728 — a `node:http` request handler that finishes the response
+// on a *later* event-loop tick (an async handler: `setTimeout`, an
+// outbound `fetch()`, any `await` chain that calls `res.end()` from a
+// microtask/timer/tokio resolution) must still flush the real response.
+//
+// Pre-fix, `process_pending` synthesized a premature empty 200 and freed
+// the per-request handles the moment the handler returned, so the real
+// `res.end(...)` later fired on a dropped handle (no-op) and the client
+// saw an empty/closed reply. Now such requests are parked until the
+// response is actually flushed.
+import http from 'node:http';
+
+// Backend: responds 150ms after the request arrives (async res.end via
+// setTimeout). Exercises the "handler returns before res.end()" path.
+const backend = http.createServer((req, res) => {
+  setTimeout(() => {
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ hello: 'backend' }));
+  }, 150);
+});
+
+// Front: fetch()es the backend *inside* the request handler, then writes
+// the result. Exercises the "outbound fetch inside handler" path that the
+// issue's Hono/SSR adapter hit.
+const front = http.createServer((req, res) => {
+  void (async () => {
+    const r = await fetch(`http://127.0.0.1:18841/`);
+    const body = await r.text();
+    res.statusCode = 200;
+    res.end('fetched:' + body);
+  })();
+});
+
+await new Promise<void>(resolve => backend.listen(18841, '127.0.0.1', () => resolve()));
+await new Promise<void>(resolve => front.listen(18840, '127.0.0.1', () => resolve()));
+
+// 1) Async res.end (setTimeout) on the backend, hit directly.
+const direct = await fetch('http://127.0.0.1:18841/');
+console.log('direct:', direct.status, (await direct.text()));
+
+// 2) fetch()-inside-handler on the front (which itself depends on the
+//    backend's async res.end resolving).
+const chained = await fetch('http://127.0.0.1:18840/');
+console.log('chained:', chained.status, (await chained.text()));
+
+backend.close();
+front.close();


### PR DESCRIPTION
Fixes #4728.

## Symptom
A `node:http` server (e.g. a Hono SSR app on a `node:http`→`fetch` adapter) serves routes that call `res.end()` **synchronously** fine, but **hangs / sends an empty response** on any route whose handler finishes the response on a *later* event-loop tick — an outbound `fetch()` to a backend, a `setTimeout`, or any `await` chain. A standalone top-level `fetch()` works; the hang is specific to a deferred `res.end()` invoked *inside* the request handler.

## Root cause
Since the #604 non-blocking `listen()` change, `process_pending` (HTTP/1) and `process_pending_https` (HTTPS) dispatched the handler, pumped microtasks *once*, then **immediately** `synthesize_default_response_if_needed(...)` (sending an empty 200 down the per-request oneshot) and freed the `IncomingMessage`/`ServerResponse` handles.

A synchronous `res.end(...)` flushes the real response inside that one microtask drain, so static/simple routes work. But an async handler returns *before* `res.end()` runs — its `fetch()`/timer resolution lands on a later tick (drained by the outer codegen-emitted event loop, not the nested `js_promise_run_microtasks()` call). By then the synthesized empty response has already been sent and the handles freed, so the real `res.end(...)` fires on a dropped handle and is a silent no-op.

(This also explains the issue's "minimal server" confusion: a server-as-backend whose handler used `setTimeout(...res.end())` returned empty too, so a front server fetching it saw an empty body.)

## Fix
When the handler returns **without** having ended the response (`!writable_ended`), the request is now **parked** in a process-global in-flight set instead of being synthesized + freed. A reaper (`reap_in_flight_requests`, run each pump tick from `js_node_http_server_process_pending`) finalizes a parked request once `res.end()` has flushed the real response — or, as a safety net mirroring Node's `requestTimeout` (default 300s; `0`/disabled falls back to the default), synthesizes the default response and frees the handles if the handler never responds, so a buggy handler can't pin a hyper connection forever.

- The park/finalize tail is factored into `finalize_or_park_request(...)` and shared by both the HTTP/1 and HTTPS dispatch paths.
- `js_node_http_server_has_active` now also reports active while any request is parked, so the event loop doesn't exit before a deferred `res.end()` flushes.
- Parked handles stay in the registry and so remain rooted by the existing GC scanner (which already visits all live `IncomingMessage`/`ServerResponse` listeners).

Synchronous handlers are unchanged (they finalize immediately, as before).

## Validation
- `setTimeout`→`res.end()` → returns `delayed-ok` (was empty)
- `fetch()` inside handler → full body (was empty/hung), including a slow 300ms backend end-to-end through two servers
- 8 concurrent + keep-alive requests: all correct, no leaks/cross-talk
- New regression fixture `test-files/test_issue_4728_async_handler_res_end.ts` covers both the `setTimeout`→`res.end()` and `fetch()`-inside-handler paths plus clean `server.close()` exit
- Existing http fixtures (`test_node_http_basic`, `test_http_createserver_v8`) and the 19 `perry-ext-http-server` unit tests still pass

> Note: version bump + CHANGELOG entry left out for the maintainer to fold in at merge.