### PR TITLE
fix(init): default tsconfig targets ES2023 for non-mutating array methods (#4731)

### DIFF
--- a/crates/perry-codegen-js/src/web_runtime.js
+++ b/crates/perry-codegen-js/src/web_runtime.js
@@ -3959,7 +3959,7 @@ App('Hello Hone', () => {\n\
     file("/documents/tsconfig.json",
 '{\n\
   "compilerOptions": {\n\
-    "target": "ES2022",\n\
+    "target": "ES2023",\n\
     "module": "ESNext",\n\
     "moduleResolution": "bundler",\n\
     "strict": true,\n\

--- a/crates/perry/src/commands/init.rs
+++ b/crates/perry/src/commands/init.rs
@@ -56,7 +56,7 @@ node_modules/
 
 const DEFAULT_TSCONFIG: &str = r#"{
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "preserve",
     "moduleResolution": "bundler",
     "strict": true,


### PR DESCRIPTION
## Summary

Closes #4731.

`toSorted()`, `toReversed()`, `toSpliced()`, and `with()` are **already implemented** in Perry's runtime (`crates/perry-runtime/src/array/immutable.rs`), so compiled programs run them correctly. The issue was purely the **editor type-check**: VSCode/`tsc` reported `Property 'toSorted' does not exist on type 'T[]'`.

## Root cause

Not a missing `.d.ts` — Perry doesn't ship its own `Array` interface; the editor uses TypeScript's bundled lib. Those four methods are declared in `lib.es2023.array.d.ts`. The default tsconfig that `perry init` writes used `"target": "ES2022"` with no explicit `"lib"`, so TypeScript derived the ES2022 lib set, which omits the ES2023 array additions.

## Fix

Bump the default `target` from `ES2022` → `ES2023` in:
- `crates/perry/src/commands/init.rs` (the `perry init` tsconfig template)
- `crates/perry-codegen-js/src/web_runtime.js` (web-playground scaffold)

New projects type-check these methods out of the box. Existing projects can apply the same one-line change (or add `"lib": ["ES2023"]`) to their own `tsconfig.json`.

---

_No version bump / changelog in this PR — leaving the metadata for the maintainer to fold in at merge per CLAUDE.md._