### PR TITLE
fix(class): computed-key accessor setter + empty-string static accessor

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1161,6 +1161,21 @@ pub unsafe extern "C" fn js_register_prototype_method(
         Ok(s) => s.to_string(),
         Err(_) => return,
     };
+    // `C.prototype.X = v` where X is an instance accessor on the class must
+    // invoke the setter, not overwrite the accessor with a data method. This
+    // write was lowered as a prototype-method monkey-patch because computed-key
+    // accessors (`set [expr](v)`) aren't known at compile time, so the
+    // recogniser couldn't route it to the ordinary setter path. If X has a
+    // setter, invoke it with `this` = the prototype ref; if it's a getter-only
+    // accessor, the (non-strict) assignment is a silent no-op rather than a
+    // clobber (Test262 accessor-name-*/computed setters).
+    let proto_ref = class_prototype_ref_value(class_id);
+    if class_instance_setter_apply(class_id, &name, proto_ref, value) {
+        return;
+    }
+    if class_has_instance_getter(class_id, &name) {
+        return;
+    }
     class_prototype_method_root_store(class_id, name, value.to_bits());
     // Ensure the receiver class can be `typeof`-detected. Method-less
     // classes that only get extended via `Class.prototype.m = fn`
@@ -4059,6 +4074,33 @@ pub(crate) unsafe fn class_static_accessor_setter_apply(
 /// Returns `true` if a setter was found and called. Used when a write targets
 /// a class prototype ref (`C.prototype[key] = v`) whose `key` is an accessor
 /// defined on the prototype itself (Test262 accessor-name-inst setters).
+/// Whether the class (or an ancestor) has an instance `get name()` accessor.
+pub(crate) fn class_has_instance_getter(class_id: u32, name: &str) -> bool {
+    let Ok(guard) = CLASS_VTABLE_REGISTRY.read() else {
+        return false;
+    };
+    let Some(reg) = guard.as_ref() else {
+        return false;
+    };
+    let mut cid = class_id;
+    let mut depth = 0usize;
+    while cid != 0 && depth < 32 {
+        if let Some(vt) = reg.get(&cid) {
+            if vt.getters.contains_key(name) {
+                return true;
+            }
+        }
+        match get_parent_class_id(cid) {
+            Some(p) if p != 0 && p != cid => {
+                cid = p;
+                depth += 1;
+            }
+            _ => break,
+        }
+    }
+    false
+}
+
 pub(crate) unsafe fn class_instance_setter_apply(
     class_id: u32,
     name: &str,

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2631,6 +2631,19 @@ pub extern "C" fn js_object_get_field_by_name(
                     }
                     return JSValue::undefined();
                 }
+                // Empty-string is a legal static member key (`static get ''()`);
+                // the `!name.is_empty()` guard below skips it, so resolve a
+                // static accessor named "" here (Test262 accessor-name-static
+                // literal-string-empty).
+                if name.is_empty() {
+                    if let Some(v) = super::class_registry::class_static_accessor_getter_value(
+                        class_id,
+                        name,
+                        class_value,
+                    ) {
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                }
                 if !name.is_empty() {
                     if super::class_registry::class_is_key_deleted(class_id, name) {
                         return JSValue::undefined();

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -209,6 +209,25 @@ pub extern "C" fn js_object_set_field_by_name(
                 let name = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
                     .unwrap_or("")
                     .to_string();
+                // Empty-string is a legal accessor key (`set ''(v)`); the
+                // `!name.is_empty()` guard below skips it, so dispatch a
+                // prototype-ref instance setter / constructor-ref static setter
+                // named "" here (Test262 accessor-name-* literal-string-empty).
+                if name.is_empty() {
+                    let recv = f64::from_bits(bits);
+                    if super::class_prototype_ref_id(recv).is_some()
+                        && super::class_registry::class_instance_setter_apply(
+                            class_id, &name, recv, value,
+                        )
+                    {
+                        return;
+                    }
+                    if super::class_registry::class_static_accessor_setter_apply(
+                        class_id, &name, recv, value,
+                    ) {
+                        return;
+                    }
+                }
                 if !name.is_empty() {
                     if name == "name"
                         && !super::class_registry::class_is_key_deleted(class_id, &name)


### PR DESCRIPTION
Follow-up to #4730/#4736, continuing the deferred class-element accessor items.

## 1. Computed-key accessor setter (`C.prototype[key] = v`)

A computed-key accessor (`set [expr](v)`) registers its setter at runtime under the *evaluated* key, but `C.prototype[evaluatedKey] = v` was lowered as a prototype-method monkey-patch (the key isn't a compile-time-known accessor name), so it overwrote the accessor with a data method instead of invoking the setter. `js_register_prototype_method` now invokes an existing instance setter (or no-ops on a getter-only accessor, per non-strict spec) before falling back to monkey-patching. Closes `accessor-name-*/computed` setter (statements).

## 2. Empty-string static accessor (`C['']`)

`static get ''()` / `static set ''(v)` couldn't be read/written: the constructor-ref by-name read and the class-ref set path both gated their static-accessor lookups on `!name.is_empty()`. Empty-name lookups are now resolved explicitly. Closes `accessor-name-static/literal-string-empty` (statements).

## Verification
`accessor-name` (statements, low-concurrency): both fixed and match Node; no regression to the literal/numeric/static cases already passing from #4736.

## Still deferred (analysis)
These remain and are genuinely outside the class-element scope or need deeper work:
- **`computed-err-*`** (ReferenceError on undeclared var in a *setter*-only computed key; TypeError from `ToPropertyKey` on an `Object.create(null)` key): the getter halves work; the setter-only key-eval call is dropped by LLVM DCE when the registration is skipped, and the `Object.create(null)` case needs `ToPrimitive` to throw when no callable `toString`/`valueOf` exists — a general expression-semantics gap.
- **class-*expression* static accessors with numeric keys** (`(class { static get 0(){} })['0']`): a class expression evaluates to a real heap object (#1772), and `obj['0']` routes through the numeric-index read path, which skips the class's static-accessor table. String-keyed static accessors on class expressions already work.