### PR TITLE
fix(runtime): stop dereferencing Web-Fetch/native handles as heap objects (Hono response SIGSEGV)

### DIFF
--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -271,7 +271,17 @@ pub fn scan_closure_dynamic_props_roots_mut(visitor: &mut crate::gc::RuntimeRoot
 /// Check if a raw pointer points to a ClosureHeader by checking CLOSURE_MAGIC at offset 12.
 /// Safe to call with any non-null, sufficiently aligned pointer >= 0x10000.
 pub fn is_closure_ptr(ptr: usize) -> bool {
-    if ptr < 0x10000 {
+    // Reject the native / Web-Fetch small-handle band (< 0x100000). Fetch
+    // handles (Headers/Request/Response/Blob, [0x40000, 0x100000)), node:http
+    // handles, and revocable-proxy ids ([0xF0000, 0x100000)) are NaN-boxed
+    // POINTER_TAG values holding a small registry id, not heap pointers — a
+    // real closure is always a heap allocation well above 0x100000. The old
+    // 0x10000 floor let a 0x40000 Headers handle through, so the
+    // `*(ptr + 12)` CLOSURE_MAGIC probe below dereferenced unmapped low
+    // memory and SIGSEGVd on Linux (macOS masked it via the much higher
+    // is_valid_obj_ptr heap floor). 0x100000 matches the cutoff used across
+    // the object field-read paths (field_get_set.rs / class_registry.rs).
+    if ptr < 0x100000 {
         return false;
     }
     if ptr % std::mem::align_of::<ClosureHeader>() != 0 {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -4614,20 +4614,32 @@ pub extern "C" fn js_object_get_field_ic_miss(
             }
         }
     }
-    unsafe {
-        if let Some(val) = closure_dynamic_prop_by_key(obj as usize, key) {
-            return val;
-        }
-        // Buffers have no GcHeader. The generic IC-miss object path below may
-        // inspect GC/object metadata, so mirror js_object_get_field_by_name's
-        // buffer-first dispatch here.
-        if crate::buffer::is_registered_buffer(obj as usize) {
-            let value = js_object_get_field_by_name(obj, key);
-            return f64::from_bits(value.bits());
-        }
-        if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
-            let value = js_object_get_field_by_name(obj, key);
-            return f64::from_bits(value.bits());
+    // Only run the closure / buffer / typedarray probes on real heap
+    // receivers (>= 0x100000). A Web-Fetch handle (Headers/Request/Response/
+    // Blob, id in [0x40000, 0x100000)) or any other small native handle is NOT
+    // a heap pointer; `closure_dynamic_prop_by_key` reaches `is_closure_ptr`,
+    // which dereferences `[obj + 12]` for CLOSURE_MAGIC and SIGSEGVs on the
+    // handle's unmapped low address (hit by hono's logger reading a property
+    // off a Response/Headers handle). Small handles fall through to the
+    // `< 0x100000` proxy / HANDLE_PROPERTY_DISPATCH routing below — matching
+    // the ordering in `js_object_get_field_by_name`. The macOS heap floor
+    // (0x200_0000_0000 in is_valid_obj_ptr) masked this; Linux's is 0x1000.
+    if (obj as usize) >= 0x100000 {
+        unsafe {
+            if let Some(val) = closure_dynamic_prop_by_key(obj as usize, key) {
+                return val;
+            }
+            // Buffers have no GcHeader. The generic IC-miss object path below may
+            // inspect GC/object metadata, so mirror js_object_get_field_by_name's
+            // buffer-first dispatch here.
+            if crate::buffer::is_registered_buffer(obj as usize) {
+                let value = js_object_get_field_by_name(obj, key);
+                return f64::from_bits(value.bits());
+            }
+            if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
+                let value = js_object_get_field_by_name(obj, key);
+                return f64::from_bits(value.bits());
+            }
         }
     }
     // Issue #340: small-handle receivers (axios, fastify, ioredis,

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1781,7 +1781,18 @@ pub extern "C" fn js_object_get_own_field_or_undef(
     }
     unsafe {
         let obj = extract_obj_ptr(obj_value);
-        if obj.is_null() || (obj as usize) < 0x10000 {
+        // Reject anything in the native / Web-Fetch small-handle range
+        // (< 0x100000). Headers/Request/Response/Blob and node:http handles
+        // are NaN-boxed POINTER_TAG values holding a small registry id in
+        // [0x40000, 0x100000) (perry-stdlib `FETCH_HANDLE_ID_{START,END}`),
+        // not heap object pointers. The old `< 0x10000` floor let a Headers
+        // handle (first id = 0x40000) through; this fn then dereferenced
+        // `[handle - GC_HEADER_SIZE]` as a GcHeader and segfaulted. macOS's
+        // `is_valid_obj_ptr` floor (0x200_0000_0000) masked this, but on
+        // Linux/Android/iOS the floor is 0x1000, so the bad deref reached.
+        // 0x100000 matches the cutoff in `js_object_get_field_by_name`
+        // (field_get_set.rs) and `class_registry` handle guards.
+        if obj.is_null() || (obj as usize) < 0x100000 {
             return f64::from_bits(TAG_UNDEF);
         }
         if (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {

--- a/tests/test_headers_handle_field_probe_segfault.sh
+++ b/tests/test_headers_handle_field_probe_segfault.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Regression (fix/object-field-read-segfault): js_object_get_own_field_or_undef
+# must not dereference a Web-Fetch handle (Headers/Request/Response/Blob) as a
+# heap object.
+#
+# A `new Headers()` is a NaN-boxed small handle id in [0x40000, 0x100000), not a
+# heap pointer. When a user class declares a method whose name collides with a
+# Headers method (`.set`/`.delete`/`.append`), the codegen dynamic-dispatch tower
+# fires an own-property override probe (`js_object_get_own_field_or_undef`) on the
+# receiver before dispatch. Pre-fix that probe floored pointer validation at
+# 0x10000, so the 0x40000 Headers handle slipped through and the runtime
+# dereferenced `[handle - GC_HEADER_SIZE]` as a GcHeader -> SIGSEGV. This crashed
+# every Hono HTTP response (c.json -> #newResponse -> responseHeaders.set) on
+# Linux x86_64. macOS arm64 masked it via is_valid_obj_ptr's higher heap floor.
+#
+# Expected: prints PASS and exits 0. Pre-fix: SIGSEGV (exit 139), no "PASS".
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC="$SCRIPT_DIR/test_headers_handle_field_probe_segfault.ts"
+OUTPUT="/tmp/perry_test_headers_handle_field_probe_segfault"
+PERRY="${PERRY:-perry}"
+
+if ! command -v "$PERRY" >/dev/null 2>&1 && [ ! -x "$PERRY" ]; then
+  echo "SKIP: perry binary not found (set PERRY=/path/to/perry)"
+  exit 0
+fi
+
+"$PERRY" compile "$SRC" -o "$OUTPUT" >/tmp/perry_test_hh_compile.log 2>&1
+if [ $? -ne 0 ]; then
+  echo "FAIL: compile error"
+  tail -20 /tmp/perry_test_hh_compile.log
+  exit 1
+fi
+
+RUN_OUTPUT="$("$OUTPUT" 2>&1)"
+RUN_EXIT=$?
+rm -f "$OUTPUT"
+
+if [ $RUN_EXIT -ne 0 ]; then
+  echo "FAIL: runtime exited $RUN_EXIT (139 = SIGSEGV = the regression)"
+  echo "$RUN_OUTPUT"
+  exit 1
+fi
+
+if echo "$RUN_OUTPUT" | grep -q "PASS"; then
+  echo "PASS"
+  exit 0
+else
+  echo "FAIL: unexpected output"
+  echo "$RUN_OUTPUT"
+  exit 1
+fi

--- a/tests/test_headers_handle_field_probe_segfault.ts
+++ b/tests/test_headers_handle_field_probe_segfault.ts
@@ -1,0 +1,45 @@
+// Regression: js_object_get_own_field_or_undef must not dereference a
+// Web-Fetch handle (Headers/Request/Response/Blob) as a heap object.
+//
+// A `new Headers()` is a NaN-boxed small handle id in [0x40000, 0x100000),
+// not a heap pointer. When a user class in the same program declares a
+// method whose name collides with a Headers method (here `.set`), the
+// codegen dynamic-dispatch tower fires an own-property override probe
+// (`js_object_get_own_field_or_undef`) on the receiver before dispatch.
+// Pre-fix, that probe floored pointer validation at 0x10000, so the
+// 0x40000 Headers handle slipped through and the runtime dereferenced
+// `[handle - GC_HEADER_SIZE]` -> SIGSEGV (crashed every Hono HTTP
+// response on Linux x86_64; macOS masked it via a higher heap floor).
+//
+// A user class that ALSO has `.set` / `.delete` is what makes the call
+// site polymorphic and routes `headers.set(...)` through the override
+// probe instead of a direct Headers native dispatch.
+class Updater {
+  v: number = 0;
+  set(x: number): number { this.v = x; return this.v; }
+  delete(x: number): number { this.v -= x; return this.v; }
+}
+
+function exercise(): string {
+  const u = new Updater();
+  u.set(41);
+  u.delete(1);
+
+  const h = new Headers();
+  // These dispatch through the same `.set` / `.delete` / `.append` tower
+  // and would segfault pre-fix when probing the Headers handle.
+  h.set("content-type", "application/json");
+  h.append("x-extra", "1");
+  h.set("x-extra", "2");
+  h.delete("x-extra");
+
+  const ct = h.get("content-type") ?? "MISSING";
+  return `${u.v}:${ct}`;
+}
+
+const result = exercise();
+if (result === "40:application/json") {
+  console.log("PASS");
+} else {
+  console.log("FAIL got=" + result);
+}


### PR DESCRIPTION
## Summary

A Perry-compiled **Hono** web app (Hono + Drizzle + mysql2) **segfaulted on every HTTP response** on Linux x86_64 — even `GET /healthz`. The exact same app ran fine (200 requests, 0 crashes) when compiled with an older Perry on **macOS arm64**.

Symbolized crash:
```
#0 js_object_get_own_field_or_undef
#1 Context.#newResponse        <- responseHeaders.set(k, v)
#2 js_native_call_method
#3 src/http/app.ts  (c) => c.json(...)
```

## Root cause

Web-Fetch objects (`Headers`/`Request`/`Response`/`Blob`) and `node:http` handles are **not heap objects** — they are NaN-boxed `POINTER_TAG` values holding a small registry id in the band `[0x40000, 0x100000)` (see perry-stdlib `FETCH_HANDLE_ID_{START,END}`), deliberately kept **below the `0x100000` small-handle cutoff**.

Several object field-read functions floored pointer validation at `0x10000` instead of `0x100000`, so a Headers handle (first id = `0x40000`) slipped through and got **dereferenced as a real heap object** → SIGSEGV.

Two crash sites on the Hono response path:

1. `js_object_get_own_field_or_undef` — the dynamic method-override probe fired before any `obj.method()` whose name a user class also defines (drizzle's `MySqlUpdateBuilder.set` / `MySqlDatabase.delete` collide with `Headers.set/.delete`). `c.json()` → `#newResponse` building `responseHeaders.set(k, v)` probed the Headers handle, dereferencing `[handle − GC_HEADER_SIZE]` as a `GcHeader`.

2. `js_object_get_field_ic_miss` → `closure_dynamic_prop_by_key` → `is_closure_ptr` — Hono's logger reads `c.res.status` off the Response handle; `is_closure_ptr` floored at `0x10000` and dereferenced `[handle + 12]` for `CLOSURE_MAGIC`.

**Why macOS was fine:** `is_valid_obj_ptr`'s heap floor is `0x200_0000_0000` on macOS, which rejects every handle in `[0x40000, 0x100000)`. On Linux/Android/iOS the floor is `0x1000`, so the bad derefs reached. This is a platform-specific bug, not a regression between the two main commits — the macOS-good build simply never exercised the vulnerable path.

## Fix

Raise the small-handle floor to `0x100000` (matching the existing cutoff in `js_object_get_field_by_name` / `class_registry` handle guards):

- `js_object_get_own_field_or_undef`: floor `0x10000` → `0x100000`.
- `is_closure_ptr`: floor `0x10000` → `0x100000` (defense-in-depth for every caller — a real closure is always a heap allocation above `0x100000`).
- `js_object_get_field_ic_miss`: gate the closure/buffer/typedarray probes on `obj >= 0x100000` so small handles fall through to the proxy / `HANDLE_PROPERTY_DISPATCH` routing, matching `js_object_get_field_by_name`.

Behavior-preserving: real heap objects/closures/buffers all live above `0x100000`; only non-heap handles are now rejected from these deref paths.

## Repro before / after

Before: `GET /healthz` → SIGSEGV on the first request.
After (real app `billing-server`, recompiled, `NODE_ENV=development`):
- `/healthz` → `200 {"ok":true}` with `content-type: application/json`
- `/` → `302`, `/nonexistent` → `404`
- **200/200 requests succeed, server stays alive**, on both the debug and release binaries.

## Test

`tests/test_headers_handle_field_probe_segfault.{sh,ts}` — standalone repro: a user class with `.set`/`.delete` makes a `new Headers().set(...)` call site polymorphic, routing it through the override probe. Prints `PASS`; pre-fix it SIGSEGVs (exit 139). Verified `PASS` with the patched runtime.
