### PR TITLE
test(runtime): regression unit test for is_closure_ptr small-handle floor (#4740)

### DIFF
--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -548,6 +548,28 @@ mod tests_1802 {
             props.remove(&owner);
         }
     }
+
+    /// #4740: `is_closure_ptr` must NOT dereference an address in the
+    /// `[0x10000, 0x100000)` native-handle band. Web Fetch response handles
+    /// (`0x40000+`), node:http / axios / fastify ids live there and are not
+    /// real pointers — probing `*(ptr + 12)` for `CLOSURE_MAGIC` on one reads
+    /// a tiny unmapped address (the reported `0x4000c`) and SIGSEGVs on the
+    /// IC-miss property-lookup path. With the floor at `0x100000` the probe is
+    /// skipped and these return `false` without touching memory. Complements
+    /// the #4739 own-field-probe integration repro with a direct unit assertion
+    /// on the predicate's floor.
+    #[test]
+    fn small_handle_band_is_not_a_closure_ptr() {
+        // These would have dereferenced 0x4000c / 0x40014 / 0xF000c under the
+        // old 0x10000 floor; under the fix they short-circuit to false.
+        for handle in [0x10000usize, 0x40000, 0x40008, 0x4_0000, 0xF_0000, 0xF_FFF8] {
+            assert!(
+                !is_closure_ptr(handle),
+                "is_closure_ptr({handle:#x}) must be false (small-handle band) \
+                 without dereferencing the handle as a pointer",
+            );
+        }
+    }
 }
 
 /// Issue #450: clone an accessor closure (from `Object.defineProperty(obj, k, { get, set })`)


### PR DESCRIPTION
Relates to #4740.

The #4740 SIGSEGV — a Web-Fetch/native handle (a NaN-boxed small registry id in `[0x40000, 0x100000)`) dereferenced as a closure pointer when `is_closure_ptr` probed `*(ptr + 12)` for `CLOSURE_MAGIC` on the IC-miss property-lookup path — was **already fixed on `main` via #4739**, which raised the `is_closure_ptr` floor from `0x10000` to `0x100000` (plus the sibling `js_object_get_own_field_or_undef` guard).

This PR therefore no longer carries a code fix (it would be a no-op after rebasing onto #4739). It keeps only a small additive **unit test**, `small_handle_band_is_not_a_closure_ptr`, that asserts `is_closure_ptr` returns `false` across the entire `[0x10000, 0x100000)` native-handle band without dereferencing the handle — a direct assertion on the predicate's floor, complementing #4739's full-compile own-field-probe repro.

Verified: both original #4740 repros (raw `fetch` loop and `@skelpo/cms-client@0.1.3`) run clean on current `main`. New unit test passes.

Feel free to close as superseded by #4739 if the extra unit test isn't wanted.