### PR TITLE
fix(runtime): built-ins/Object ToPropertyDescriptor field presence is HasProperty

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -693,6 +693,51 @@ pub unsafe extern "C" fn js_object_assign_validate_target(target_f64: f64) -> f6
     js_object_coerce(target_f64)
 }
 
+/// Spec `Set(to, key, value, true)` inside `Object.assign` uses the strict
+/// receiver, so a write that the ordinary `[[Set]]` would reject throws a
+/// `TypeError`. Perry's `js_object_set_field_by_name` silently no-ops those
+/// cases, so detect them up front: a non-writable existing own data property,
+/// an accessor own property with no setter, or a new property on a
+/// non-extensible target. Throws when the write must fail.
+unsafe fn object_assign_throw_if_set_rejected(
+    target: *mut ObjectHeader,
+    key_ptr: *const crate::StringHeader,
+    name: &str,
+) {
+    if target.is_null() || (target as usize) <= 0x10000 {
+        return;
+    }
+    let exists = own_key_present(target, key_ptr);
+    if exists {
+        // Accessor own property: a setter must exist, else the write fails.
+        if let Some(acc) = super::get_accessor_descriptor(target as usize, name) {
+            if acc.set == 0 {
+                throw_object_assign_readonly(name);
+            }
+            return;
+        }
+        // Data own property: must be writable.
+        if let Some(attrs) = super::get_property_attrs(target as usize, name) {
+            if !attrs.writable() {
+                throw_object_assign_readonly(name);
+            }
+        }
+        return;
+    }
+    // New property: target must be extensible.
+    let gc = gc_header_for(target);
+    if (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0 {
+        throw_object_assign_readonly(name);
+    }
+}
+
+fn throw_object_assign_readonly(name: &str) -> ! {
+    throw_object_type_error_with_suffix(
+        "Cannot assign to read only property '",
+        &format!("{name}' of object '#<Object>'"),
+    )
+}
+
 unsafe fn object_assign_set_string_key(
     target: *mut ObjectHeader,
     target_is_array: bool,
@@ -708,6 +753,17 @@ unsafe fn object_assign_set_string_key(
             value_f64,
         );
     } else {
+        // Strict `Set` semantics: reject (throw) a write the ordinary `[[Set]]`
+        // would silently drop.
+        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        if let Some(name_bytes) = crate::string::js_string_key_bytes(
+            crate::value::JSValue::string_ptr(key_ptr as *mut _),
+            &mut sso,
+        ) {
+            if let Ok(name) = std::str::from_utf8(name_bytes) {
+                object_assign_throw_if_set_rejected(target, key_ptr, name);
+            }
+        }
         js_object_set_field_by_name(target, key_ptr, value_f64);
     }
 }
@@ -867,6 +923,31 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
         }
         let sym_f64 = f64::from_bits(JSValue::pointer(sym_ptr as *const u8).bits());
         let value_f64 = f64::from_bits(value_bits);
+        // Strict `Set` semantics for symbol-keyed writes too.
+        {
+            let owner = tgt_raw;
+            let existing = crate::symbol::symbol_property_root_bits(owner, sym_ptr).is_some()
+                || crate::symbol::symbol_accessor_descriptor_bits(owner, sym_ptr).is_some();
+            if existing {
+                if let Some((_get, set)) =
+                    crate::symbol::symbol_accessor_descriptor_bits(owner, sym_ptr)
+                {
+                    if set == 0 {
+                        throw_object_assign_readonly("Symbol()");
+                    }
+                } else if let Some(attrs) = crate::symbol::get_symbol_property_attrs(owner, sym_ptr)
+                {
+                    if !attrs.writable() {
+                        throw_object_assign_readonly("Symbol()");
+                    }
+                }
+            } else {
+                let gc = gc_header_for(target);
+                if (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0 {
+                    throw_object_assign_readonly("Symbol()");
+                }
+            }
+        }
         crate::symbol::js_object_set_symbol_property(target_f64, sym_f64, value_f64);
     }
 

--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -215,18 +215,7 @@ pub(crate) unsafe fn define_array_property(
         f64::from_bits(crate::value::TAG_UNDEFINED)
     };
 
-    if let Some(index) = super::canonical_array_index(key_name) {
-        if has_value {
-            crate::array::js_array_set_f64_extend(
-                obj as *mut crate::array::ArrayHeader,
-                index,
-                value,
-            );
-        }
-        return Some(true);
-    }
-
-    crate::array::array_named_property_set(obj as *mut crate::array::ArrayHeader, key_str, value);
+    let arr = obj as *mut crate::array::ArrayHeader;
 
     let read_bool = |name: &[u8]| -> Option<bool> {
         let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
@@ -236,6 +225,156 @@ pub(crate) unsafe fn define_array_property(
         let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
         Some(crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0)
     };
+
+    if let Some(index) = super::canonical_array_index(key_name) {
+        let exists = super::has_own_helpers::array_own_key_present(arr, key_str);
+
+        // Accessor descriptor on an array index: store get/set in the side table
+        // (the dense element store can't hold a getter/setter). Routing this
+        // through the generic object path would deref the array as an
+        // ObjectHeader and corrupt it, so handle it here.
+        let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
+        let set_key = crate::string::js_string_from_bytes(b"set".as_ptr(), 3);
+        let desc_has_get = own_key_present(desc_ptr, get_key);
+        let desc_has_set = own_key_present(desc_ptr, set_key);
+        if desc_has_get || desc_has_set {
+            // Non-configurable existing index can't switch to an accessor.
+            if exists {
+                let cur = super::get_property_attrs(obj as usize, key_name)
+                    .unwrap_or_else(|| PropertyAttrs::new(true, true, true));
+                let already_accessor =
+                    super::get_accessor_descriptor(obj as usize, key_name).is_some();
+                if !cur.configurable() && !already_accessor {
+                    return Some(false);
+                }
+            }
+            let get_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, get_key);
+            let set_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, set_key);
+            let recv = crate::value::js_nanbox_pointer(obj as i64);
+            let prior = super::get_accessor_descriptor(obj as usize, key_name);
+            let get_bits = if desc_has_get {
+                if get_field.is_undefined() {
+                    0
+                } else {
+                    crate::closure::clone_closure_rebind_this(get_field.bits(), recv)
+                }
+            } else {
+                prior.map(|a| a.get).unwrap_or(0)
+            };
+            let set_bits = if desc_has_set {
+                if set_field.is_undefined() {
+                    0
+                } else {
+                    crate::closure::clone_closure_rebind_this(set_field.bits(), recv)
+                }
+            } else {
+                prior.map(|a| a.set).unwrap_or(0)
+            };
+            set_accessor_descriptor(
+                obj as usize,
+                key_name.to_string(),
+                AccessorDescriptor {
+                    get: get_bits,
+                    set: set_bits,
+                },
+            );
+            // Ensure the index counts as an own key for reflection.
+            if !exists {
+                crate::array::js_array_set_f64_extend(
+                    arr,
+                    index,
+                    f64::from_bits(crate::value::TAG_UNDEFINED),
+                );
+            }
+            // Retain existing attrs the descriptor omits when redefining; new
+            // accessor defaults to non-enumerable / non-configurable.
+            let cur = if exists {
+                super::get_property_attrs(obj as usize, key_name)
+            } else {
+                None
+            };
+            let enumerable = read_bool(b"enumerable")
+                .unwrap_or_else(|| cur.map(|a| a.enumerable()).unwrap_or(false));
+            let configurable = read_bool(b"configurable")
+                .unwrap_or_else(|| cur.map(|a| a.configurable()).unwrap_or(false));
+            set_property_attrs(
+                obj as usize,
+                key_name.to_string(),
+                PropertyAttrs::new(false, enumerable, configurable),
+            );
+            return Some(true);
+        }
+
+        // The element's current attributes: an explicit side-table entry wins;
+        // otherwise a present dense element defaults to all-true (writable,
+        // enumerable, configurable).
+        let cur_attrs: Option<PropertyAttrs> = if exists {
+            Some(
+                super::get_property_attrs(obj as usize, key_name)
+                    .unwrap_or_else(|| PropertyAttrs::new(true, true, true)),
+            )
+        } else {
+            None
+        };
+
+        // ValidateAndApplyPropertyDescriptor for the existing-non-configurable
+        // case: reject the spec-forbidden changes (make configurable, flip
+        // enumerable, re-enable writability, or change a non-writable value).
+        if let Some(cur) = cur_attrs {
+            if !cur.configurable() {
+                if read_bool(b"configurable") == Some(true) {
+                    return Some(false);
+                }
+                if let Some(want_enum) = read_bool(b"enumerable") {
+                    if want_enum != cur.enumerable() {
+                        return Some(false);
+                    }
+                }
+                if !cur.writable() {
+                    if read_bool(b"writable") == Some(true) {
+                        return Some(false);
+                    }
+                    if has_value {
+                        let cur_value = crate::array::js_array_get_f64(arr, index);
+                        if js_object_is(value, cur_value).to_bits()
+                            != crate::value::JSValue::bool(true).bits()
+                        {
+                            return Some(false);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Redefining an index that was previously an accessor back to a data
+        // property: drop the stale accessor entry.
+        ACCESSOR_DESCRIPTORS.with(|m| {
+            m.borrow_mut().remove(&(obj as usize, key_name.to_string()));
+        });
+
+        if has_value {
+            crate::array::js_array_set_f64_extend(arr, index, value);
+        }
+
+        // Compute final attributes. New property: omitted ⇒ false. Redefine:
+        // omitted ⇒ retain current.
+        let writable = read_bool(b"writable")
+            .unwrap_or_else(|| cur_attrs.map(|a| a.writable()).unwrap_or(false));
+        let enumerable = read_bool(b"enumerable")
+            .unwrap_or_else(|| cur_attrs.map(|a| a.enumerable()).unwrap_or(false));
+        let configurable = read_bool(b"configurable")
+            .unwrap_or_else(|| cur_attrs.map(|a| a.configurable()).unwrap_or(false));
+        set_property_attrs(
+            obj as usize,
+            key_name.to_string(),
+            PropertyAttrs::new(writable, enumerable, configurable),
+        );
+        let _ = obj_value;
+        return Some(true);
+    }
+
+    crate::array::array_named_property_set(arr, key_str, value);
+
     let writable = read_bool(b"writable").unwrap_or(false);
     let enumerable = read_bool(b"enumerable").unwrap_or(false);
     let configurable = read_bool(b"configurable").unwrap_or(false);

--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -207,7 +207,8 @@ pub(crate) unsafe fn define_array_property(
         return Some(true);
     }
     let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-    let has_value = own_key_present(desc_ptr, value_key);
+    // `ToPropertyDescriptor` field presence is HasProperty (own OR inherited).
+    let has_value = super::desc_has_field(descriptor_value, b"value");
     let value_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
     let value = if has_value {
         f64::from_bits(value_field.bits())
@@ -218,10 +219,10 @@ pub(crate) unsafe fn define_array_property(
     let arr = obj as *mut crate::array::ArrayHeader;
 
     let read_bool = |name: &[u8]| -> Option<bool> {
-        let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        if !own_key_present(desc_ptr, k) {
+        if !super::desc_has_field(descriptor_value, name) {
             return None;
         }
+        let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
         let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
         Some(crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0)
     };
@@ -235,8 +236,8 @@ pub(crate) unsafe fn define_array_property(
         // ObjectHeader and corrupt it, so handle it here.
         let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
         let set_key = crate::string::js_string_from_bytes(b"set".as_ptr(), 3);
-        let desc_has_get = own_key_present(desc_ptr, get_key);
-        let desc_has_set = own_key_present(desc_ptr, set_key);
+        let desc_has_get = super::desc_has_field(descriptor_value, b"get");
+        let desc_has_set = super::desc_has_field(descriptor_value, b"set");
         if desc_has_get || desc_has_set {
             // Non-configurable existing index can't switch to an accessor.
             if exists {

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -433,9 +433,43 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                     );
                 }
                 if let Some(index) = super::canonical_array_index(name) {
+                    // An array index converted to an accessor via
+                    // `Object.defineProperty(arr, i, { get/set })` is recorded in
+                    // the accessor side table; report it as an accessor descriptor.
+                    if let Some(acc) = get_accessor_descriptor(obj as usize, name) {
+                        let attrs = get_property_attrs(obj as usize, name)
+                            .unwrap_or(PropertyAttrs::new(false, false, false));
+                        let get = if acc.get == 0 {
+                            f64::from_bits(crate::value::TAG_UNDEFINED)
+                        } else {
+                            f64::from_bits(acc.get)
+                        };
+                        let set = if acc.set == 0 {
+                            f64::from_bits(crate::value::TAG_UNDEFINED)
+                        } else {
+                            f64::from_bits(acc.set)
+                        };
+                        return build_accessor_descriptor(
+                            get,
+                            set,
+                            attrs.enumerable(),
+                            attrs.configurable(),
+                        );
+                    }
                     if super::has_own_helpers::array_own_key_present(arr, key_str) {
                         let value = crate::array::js_array_get_f64(arr, index);
-                        return build_data_descriptor(value, !is_frozen, true, !is_frozen);
+                        // A dense element defaults to writable/enumerable/
+                        // configurable (frozen drops writable+configurable). A
+                        // prior `Object.defineProperty(arr, i, {...})` records
+                        // explicit attributes in the side table — honor those.
+                        let attrs = get_property_attrs(obj as usize, name)
+                            .unwrap_or_else(|| PropertyAttrs::new(!is_frozen, true, !is_frozen));
+                        return build_data_descriptor(
+                            value,
+                            attrs.writable(),
+                            attrs.enumerable(),
+                            attrs.configurable(),
+                        );
                     }
                     return f64::from_bits(crate::value::TAG_UNDEFINED);
                 }
@@ -971,11 +1005,14 @@ pub extern "C" fn js_object_get_own_property_descriptors(obj_value: f64) -> f64 
 /// `TypeError: Object prototype may only be an Object or null`.
 #[no_mangle]
 pub extern "C" fn js_object_create_with_props(proto_value: f64, props_value: f64) -> f64 {
-    // #2816 prototype validation: only an object or `null` is permitted.
+    // #2816 prototype validation: only an object or `null` is permitted. A
+    // Symbol is pointer-tagged but not an object, so reject it explicitly.
     let proto_jv = crate::value::JSValue::from_bits(proto_value.to_bits());
+    let proto_is_symbol = unsafe { crate::symbol::js_is_symbol(proto_value) != 0 };
     let proto_ok = proto_jv.is_null()
-        || unsafe { value_is_object_like(proto_value) }
-        || super::class_ref_id(proto_value).is_some();
+        || (!proto_is_symbol
+            && (unsafe { value_is_object_like(proto_value) }
+                || super::class_ref_id(proto_value).is_some()));
     if !proto_ok {
         // V8 renders the offending value: `... an Object or null: 5`.
         let rendered = unsafe { describe_value_for_type_error(proto_value) };

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1430,9 +1430,11 @@ pub extern "C" fn js_object_define_property(
                 return obj_value;
             }
             // A rejected array `[[DefineOwnProperty]]` (e.g. redefining the
-            // non-configurable / non-writable `length`) throws under
+            // non-configurable / non-writable `length`, or a forbidden change to
+            // a non-configurable index property) throws under
             // `Object.defineProperty`.
-            throw_object_type_error(b"Cannot redefine property: length");
+            let k = key_rust.as_deref().unwrap_or("length");
+            throw_object_type_error_with_suffix("Cannot redefine property: ", k);
         }
         // #2843: enforce frozen / sealed / non-extensible invariants BEFORE any
         // mutation, so a rejected definition leaves the object untouched and the
@@ -1464,13 +1466,23 @@ pub extern "C" fn js_object_define_property(
             }
         });
 
-        // Detect accessor descriptor (has `get` and/or `set`) vs. data descriptor (has `value`).
-        // JS disallows mixing them, but we only check for `get`/`set` presence.
+        // Detect accessor descriptor (has `get` and/or `set`) vs. data
+        // descriptor (has `value`/`writable`) by OWN-FIELD PRESENCE on the
+        // descriptor object — not by `is_undefined`, since `{ get: undefined }`
+        // is an explicit (present) accessor field distinct from omitting it.
         let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
         let set_key = crate::string::js_string_from_bytes(b"set".as_ptr(), 3);
+        let desc_has_get = own_key_present(desc_ptr, get_key);
+        let desc_has_set = own_key_present(desc_ptr, set_key);
         let get_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, get_key);
         let set_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, set_key);
-        let has_accessor = !get_field.is_undefined() || !set_field.is_undefined();
+        let has_accessor = desc_has_get || desc_has_set;
+
+        // The existing accessor (if the property is currently an accessor) —
+        // used to retain `get`/`set` fields the redefining descriptor omits.
+        let existing_accessor: Option<AccessorDescriptor> = key_rust
+            .as_ref()
+            .and_then(|k| super::get_accessor_descriptor(obj as usize, k));
 
         if has_accessor {
             // Store the accessor closures in the side table. Ensure the key is present
@@ -1488,16 +1500,31 @@ pub extern "C" fn js_object_define_property(
                 // correct receiver. Closures without CAPTURES_THIS_FLAG (e.g. arrow-form
                 // `get: () => this._backing` written as a field rather than a method
                 // shorthand) pass through unchanged.
+                //
+                // Spec retention (ValidateAndApplyPropertyDescriptor): redefining
+                // an existing accessor with a descriptor that omits `get` (or
+                // `set`) keeps the current accessor's `get` (or `set`). When the
+                // current property is a data property being converted to an
+                // accessor, omitted fields default to `undefined` (0).
                 let recv_box = crate::value::js_nanbox_pointer(obj as i64);
-                let get_bits = if get_field.is_undefined() {
-                    0u64
+                let prior = existing_accessor;
+                let get_bits = if desc_has_get {
+                    if get_field.is_undefined() {
+                        0u64
+                    } else {
+                        crate::closure::clone_closure_rebind_this(get_field.bits(), recv_box)
+                    }
                 } else {
-                    crate::closure::clone_closure_rebind_this(get_field.bits(), recv_box)
+                    prior.map(|a| a.get).unwrap_or(0)
                 };
-                let set_bits = if set_field.is_undefined() {
-                    0u64
+                let set_bits = if desc_has_set {
+                    if set_field.is_undefined() {
+                        0u64
+                    } else {
+                        crate::closure::clone_closure_rebind_this(set_field.bits(), recv_box)
+                    }
                 } else {
-                    crate::closure::clone_closure_rebind_this(set_field.bits(), recv_box)
+                    prior.map(|a| a.set).unwrap_or(0)
                 };
                 set_accessor_descriptor(
                     obj as usize,
@@ -1509,30 +1536,58 @@ pub extern "C" fn js_object_define_property(
                 );
             }
         } else {
-            // Data descriptor: look for "value" field and store it.
+            // Either a data descriptor (`value`/`writable` present) or a generic
+            // descriptor (only `enumerable`/`configurable`). Detect by own-field
+            // presence so `{ value: undefined }` (present) stores `undefined`,
+            // while a generic descriptor on an existing accessor leaves it intact.
             let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-            let value_field =
-                js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
-            // Clear any existing accessor for this key so the write doesn't fire
-            // the setter, and clear any stale per-key descriptor so a prior
-            // `writable: false` doesn't reject the forced store below. The final
-            // attributes are (re)applied a few lines down.
-            if let Some(ref k) = key_rust {
-                ACCESSOR_DESCRIPTORS.with(|m| {
-                    m.borrow_mut().remove(&(obj as usize, k.clone()));
-                });
-                clear_property_attrs(obj as usize, k);
-            }
-            // Ensure the key exists even if the descriptor's value is undefined —
-            // the property still "exists" per JS semantics.
-            if value_field.is_undefined() {
-                ensure_key_in_keys_array(obj, key_str);
+            let writable_key = crate::string::js_string_from_bytes(b"writable".as_ptr(), 8);
+            let desc_has_value = own_key_present(desc_ptr, value_key);
+            let desc_has_writable = own_key_present(desc_ptr, writable_key);
+            let is_data = desc_has_value || desc_has_writable;
+
+            if is_data {
+                // Converting to / redefining as a data property. Clear any
+                // existing accessor for this key so the write doesn't fire the
+                // setter, and clear any stale per-key descriptor so a prior
+                // `writable: false` doesn't reject the forced store below. The
+                // final attributes are (re)applied a few lines down.
+                if let Some(ref k) = key_rust {
+                    ACCESSOR_DESCRIPTORS.with(|m| {
+                        m.borrow_mut().remove(&(obj as usize, k.clone()));
+                    });
+                    clear_property_attrs(obj as usize, k);
+                }
+                let value_field =
+                    js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
+                // Ensure the key exists; store the (possibly `undefined`) value
+                // via `[[DefineOwnProperty]]`, bypassing the `[[Set]]` writability
+                // / frozen guard (invariants already enforced above). When
+                // `value` is omitted (a `{ writable: ... }`-only descriptor on a
+                // brand-new property) the value defaults to `undefined`.
+                if desc_has_value {
+                    define_property_force_store_value(
+                        obj,
+                        key_str,
+                        f64::from_bits(value_field.bits()),
+                    );
+                } else if existing_accessor.is_some() {
+                    // Accessor → data with no `value`: the value becomes the
+                    // data default `undefined`.
+                    define_property_force_store_value(
+                        obj,
+                        key_str,
+                        f64::from_bits(crate::value::TAG_UNDEFINED),
+                    );
+                } else {
+                    ensure_key_in_keys_array(obj, key_str);
+                }
             } else {
-                // `Object.defineProperty` stores the value via
-                // `[[DefineOwnProperty]]`, bypassing the `[[Set]]` writability /
-                // frozen guard (the spec invariants were already enforced by
-                // `enforce_define_property_invariants`).
-                define_property_force_store_value(obj, key_str, f64::from_bits(value_field.bits()));
+                // Generic descriptor: no value/writable/get/set. It only adjusts
+                // enumerable/configurable and never converts the property kind.
+                // Leave any existing accessor / data value untouched; just make
+                // sure the key is present (for a brand-new generic define).
+                ensure_key_in_keys_array(obj, key_str);
             }
         }
 
@@ -2312,23 +2367,36 @@ pub extern "C" fn js_object_define_properties(target: f64, descriptors: f64) -> 
     // — descriptors and target are usually different objects, but a
     // defensive copy costs ~ngc and protects against a user who passes
     // `Object.defineProperties(obj, obj)` aliasing.
-    let key_array_ptr: *const crate::array::ArrayHeader = unsafe { (*desc_obj).keys_array };
-    if key_array_ptr.is_null() {
-        return target;
-    }
-    let len = unsafe { crate::array::js_array_length(key_array_ptr) } as usize;
-    let mut keys: Vec<f64> = Vec::with_capacity(len);
-    for i in 0..len {
-        let k = unsafe { crate::array::js_array_get(key_array_ptr, i as u32) };
-        keys.push(f64::from_bits(k.bits()));
+    // Spec (ObjectDefineProperties): the property keys come from the properties
+    // object's own keys, but only the ones whose own descriptor is ENUMERABLE
+    // participate — and the descriptor object for each is read through `[[Get]]`
+    // (so accessors on the properties bag run). Using the full own-key set is
+    // wrong for native namespaces like `Math` (whose `E`/`PI`/... are
+    // non-enumerable) and for any object with non-enumerable own props.
+    let names_value = js_object_get_own_property_names(descriptors);
+    let names_arr =
+        crate::value::js_nanbox_get_pointer(names_value) as *const crate::array::ArrayHeader;
+    let mut keys: Vec<f64> = Vec::new();
+    if !names_arr.is_null() {
+        let len = unsafe { crate::array::js_array_length(names_arr) } as usize;
+        for i in 0..len {
+            let k = unsafe { crate::array::js_array_get(names_arr, i as u32) };
+            let k_f64 = f64::from_bits(k.bits());
+            // Skip non-enumerable own keys (spec step: descriptor must be
+            // enumerable). `propertyIsEnumerable` returns false for absent or
+            // non-enumerable keys.
+            const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+            if js_object_property_is_enumerable(descriptors, k_f64).to_bits() == TAG_TRUE {
+                keys.push(k_f64);
+            }
+        }
     }
     for k in keys {
+        // Read the descriptor through `[[Get]]` so accessors on the properties
+        // bag are honored, then ToPropertyDescriptor + DefinePropertyOrThrow.
         let descriptor = unsafe {
             js_object_get_field_by_name_f64(desc_obj as *const ObjectHeader, str_from_value(k))
         };
-        if descriptor.to_bits() == TAG_UNDEFINED_LOCAL {
-            continue;
-        }
         js_object_define_property(target, k, descriptor);
     }
     target
@@ -2403,11 +2471,13 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
     }
 
     // #2820: `proto` must be an object or `null`. A primitive / undefined proto
-    // throws `TypeError: Object prototype may only be an Object or null`.
+    // throws `TypeError: Object prototype may only be an Object or null`. A
+    // Symbol is pointer-tagged but is NOT an object, so reject it explicitly.
     let proto_is_null = proto_bits == TAG_NULL;
+    let proto_is_symbol = unsafe { crate::symbol::js_is_symbol(proto) != 0 };
     let proto_ok = proto_is_null
-        || unsafe { value_is_object_like(proto) }
-        || super::class_ref_id(proto).is_some();
+        || (!proto_is_symbol
+            && (unsafe { value_is_object_like(proto) } || super::class_ref_id(proto).is_some()));
     if !proto_ok {
         // V8 renders the offending value: `... an Object or null: 5`.
         let rendered = unsafe { describe_value_for_type_error(proto) };

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -118,6 +118,19 @@ unsafe fn registered_buffer_index_own_property_present(
     Some(idx < (*buf).length as u32)
 }
 
+/// `ToPropertyDescriptor` field presence: `HasProperty(descriptor, name)` —
+/// own OR inherited. Spec §6.2.6.5 reads each descriptor field with
+/// `HasProperty` then `Get`, so an inherited `value`/`get`/... counts as
+/// present (e.g. `Object.defineProperty(o, k, child)` where `child`'s prototype
+/// carries `value`). `descriptor_value` is the NaN-boxed descriptor object.
+pub(crate) unsafe fn desc_has_field(descriptor_value: f64, name: &[u8]) -> bool {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let key_f64 = crate::value::JSValue::string_ptr(key).bits();
+    const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+    crate::object::js_object_has_property(descriptor_value, f64::from_bits(key_f64)).to_bits()
+        == TAG_TRUE
+}
+
 /// Validate a property descriptor object per ES `ToPropertyDescriptor`
 /// invariants that Node surfaces as `TypeError`s (#2817). Assumes
 /// `descriptor_value` is already known to be an object. Throws on:
@@ -131,10 +144,8 @@ unsafe fn validate_property_descriptor(descriptor_value: f64) {
     }
     let desc = desc_ptr as *const ObjectHeader;
 
-    let has_field = |name: &[u8]| -> bool {
-        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        own_key_present(desc_ptr, key)
-    };
+    // `ToPropertyDescriptor` field presence is HasProperty (own OR inherited).
+    let has_field = |name: &[u8]| -> bool { desc_has_field(descriptor_value, name) };
     let read = |name: &[u8]| -> crate::value::JSValue {
         let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
         js_object_get_field_by_name(desc, key)
@@ -257,10 +268,8 @@ pub(crate) unsafe fn validate_nonconfigurable_redefine(
     }
     let reject = || throw_object_type_error_with_suffix("Cannot redefine property: ", key_name);
 
-    let has_field = |name: &[u8]| -> bool {
-        let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        own_key_present(desc_ptr, k)
-    };
+    // `ToPropertyDescriptor` field presence is HasProperty (own OR inherited).
+    let has_field = |name: &[u8]| -> bool { desc_has_field(descriptor_value, name) };
     let read = |name: &[u8]| -> crate::value::JSValue {
         let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
         js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k)
@@ -1467,13 +1476,14 @@ pub extern "C" fn js_object_define_property(
         });
 
         // Detect accessor descriptor (has `get` and/or `set`) vs. data
-        // descriptor (has `value`/`writable`) by OWN-FIELD PRESENCE on the
-        // descriptor object — not by `is_undefined`, since `{ get: undefined }`
-        // is an explicit (present) accessor field distinct from omitting it.
+        // descriptor (has `value`/`writable`) by `ToPropertyDescriptor` field
+        // PRESENCE (HasProperty — own OR inherited) on the descriptor object,
+        // not by `is_undefined`: `{ get: undefined }` is an explicit (present)
+        // accessor field, and an *inherited* `value`/`get` counts as present.
         let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
         let set_key = crate::string::js_string_from_bytes(b"set".as_ptr(), 3);
-        let desc_has_get = own_key_present(desc_ptr, get_key);
-        let desc_has_set = own_key_present(desc_ptr, set_key);
+        let desc_has_get = desc_has_field(descriptor_value, b"get");
+        let desc_has_set = desc_has_field(descriptor_value, b"set");
         let get_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, get_key);
         let set_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, set_key);
         let has_accessor = desc_has_get || desc_has_set;
@@ -1541,9 +1551,8 @@ pub extern "C" fn js_object_define_property(
             // presence so `{ value: undefined }` (present) stores `undefined`,
             // while a generic descriptor on an existing accessor leaves it intact.
             let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-            let writable_key = crate::string::js_string_from_bytes(b"writable".as_ptr(), 8);
-            let desc_has_value = own_key_present(desc_ptr, value_key);
-            let desc_has_writable = own_key_present(desc_ptr, writable_key);
+            let desc_has_value = desc_has_field(descriptor_value, b"value");
+            let desc_has_writable = desc_has_field(descriptor_value, b"writable");
             let is_data = desc_has_value || desc_has_writable;
 
             if is_data {

--- a/crates/perry-runtime/src/object/object_ops_frozen.rs
+++ b/crates/perry-runtime/src/object/object_ops_frozen.rs
@@ -5,6 +5,30 @@
 
 use super::*;
 
+/// Drop `writable`/`configurable` on every own **symbol-keyed** property of
+/// `obj`. The string-keyed table is handled by `mark_all_keys`; symbol props
+/// live in a separate side table, so `Object.freeze`/`Object.seal` must walk
+/// it too (else a frozen object's symbol props stay writable and strict writes
+/// to them wrongly succeed).
+unsafe fn mark_all_symbol_keys(
+    obj: *mut ObjectHeader,
+    drop_writable: bool,
+    drop_configurable: bool,
+) {
+    let owner = obj as usize;
+    for (sym_ptr, _) in crate::symbol::clone_symbol_entries_for_obj_ptr(owner) {
+        let mut attrs = crate::symbol::get_symbol_property_attrs(owner, sym_ptr)
+            .unwrap_or_else(|| PropertyAttrs::new(true, true, true));
+        if drop_writable {
+            attrs.bits &= !PropertyAttrs::WRITABLE;
+        }
+        if drop_configurable {
+            attrs.bits &= !PropertyAttrs::CONFIGURABLE;
+        }
+        crate::symbol::set_symbol_property_attrs(owner, sym_ptr, attrs);
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_object_freeze(obj_value: f64) -> f64 {
     unsafe {
@@ -17,6 +41,9 @@ pub extern "C" fn js_object_freeze(obj_value: f64) -> f64 {
             // Drop writable + configurable for every existing key.
             mark_all_keys(
                 obj, /*drop_writable=*/ true, false, /*drop_configurable=*/ true,
+            );
+            mark_all_symbol_keys(
+                obj, /*drop_writable=*/ true, /*drop_configurable=*/ true,
             );
         }
     }
@@ -35,6 +62,9 @@ pub extern "C" fn js_object_seal(obj_value: f64) -> f64 {
             // Drop configurable for every existing key (but leave writable intact).
             mark_all_keys(
                 obj, /*drop_writable=*/ false, false, /*drop_configurable=*/ true,
+            );
+            mark_all_symbol_keys(
+                obj, /*drop_writable=*/ false, /*drop_configurable=*/ true,
             );
         }
     }
@@ -65,18 +95,128 @@ pub extern "C" fn js_object_prevent_extensions(obj_value: f64) -> f64 {
     obj_value
 }
 
+/// `TestIntegrityLevel(O, level)` (ECMA-262 7.3.16) for an ordinary heap
+/// object: the object must be non-extensible, and every own property must be
+/// non-configurable — plus, for the `frozen` level, every own *data* property
+/// must be non-writable. Returns `true` if the object satisfies the level.
+///
+/// A key with no side-table descriptor entry uses the default
+/// `{writable: true, enumerable: true, configurable: true}`, which is
+/// configurable (and writable), so any such key fails both levels — matching
+/// the behaviour of `Object.freeze`/`Object.seal`, which populate the table.
+unsafe fn object_integrity_level(obj: *mut ObjectHeader, frozen: bool) -> bool {
+    // Must be non-extensible first.
+    let gc = gc_header_for(obj);
+    if (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND == 0 {
+        return false;
+    }
+    // Arrays: a non-empty array's dense elements are configurable/writable
+    // unless frozen/sealed dropped those bits (tracked by the array flags).
+    if (*gc).obj_type == crate::gc::GC_TYPE_ARRAY {
+        let arr = obj as *const crate::array::ArrayHeader;
+        let len = crate::array::js_array_length(arr);
+        if len > 0 {
+            // Has index properties: frozen iff the FROZEN flag is set; sealed
+            // iff SEALED (frozen implies sealed).
+            let flag = if frozen {
+                crate::gc::OBJ_FLAG_FROZEN
+            } else {
+                crate::gc::OBJ_FLAG_SEALED
+            };
+            return (*gc)._reserved & flag != 0;
+        }
+        // Empty array + non-extensible ⇒ integrity holds.
+        return true;
+    }
+    let keys = (*obj).keys_array;
+    if keys.is_null() {
+        return true; // no own keys + non-extensible ⇒ frozen/sealed
+    }
+    let keys_ptr = keys as usize;
+    if (keys_ptr as u64) >> 48 != 0 || keys_ptr < 0x10000 {
+        return true;
+    }
+    let key_count = crate::array::js_array_length(keys) as usize;
+    if key_count > 65536 {
+        return false;
+    }
+    for i in 0..key_count {
+        let key_val = crate::array::js_array_get(keys, i as u32);
+        if !key_val.is_string() {
+            continue;
+        }
+        let stored_key = key_val.as_string_ptr();
+        if stored_key.is_null() {
+            continue;
+        }
+        let name_ptr = (stored_key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_len = (*stored_key).byte_len as usize;
+        let name = match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        // No side-table entry ⇒ default {w,e,c}=true ⇒ configurable ⇒ fails.
+        let Some(attrs) = get_property_attrs(obj as usize, name) else {
+            return false;
+        };
+        if attrs.configurable() {
+            return false;
+        }
+        if frozen {
+            // Data properties must be non-writable; accessor properties have no
+            // writability constraint.
+            let is_accessor = get_accessor_descriptor(obj as usize, name).is_some();
+            if !is_accessor && attrs.writable() {
+                return false;
+            }
+        }
+    }
+    // Symbol-keyed own properties must satisfy the same constraints.
+    let owner = obj as usize;
+    for (sym_ptr, _) in crate::symbol::clone_symbol_entries_for_obj_ptr(owner) {
+        let Some(attrs) = crate::symbol::get_symbol_property_attrs(owner, sym_ptr) else {
+            return false; // default {w,e,c}=true ⇒ configurable ⇒ fails
+        };
+        if attrs.configurable() {
+            return false;
+        }
+        if frozen {
+            let is_accessor =
+                crate::symbol::symbol_accessor_descriptor_bits(owner, sym_ptr).is_some();
+            if !is_accessor && attrs.writable() {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 /// Object.isFrozen(obj) — returns NaN-boxed boolean.
 #[no_mangle]
 pub extern "C" fn js_object_is_frozen(obj_value: f64) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        // Proxy: a frozen proxy is one whose target is non-extensible with all
+        // own props non-configurable/non-writable. Fall back to extensibility.
+        let ext = crate::proxy::js_reflect_is_extensible(obj_value);
+        return if crate::value::js_is_truthy(ext) == 0 {
+            f64::from_bits(TAG_TRUE)
+        } else {
+            f64::from_bits(TAG_FALSE)
+        };
+    }
     unsafe {
         let obj = extract_obj_ptr(obj_value);
         if obj.is_null() || (obj as usize) <= 0x10000 {
             return f64::from_bits(TAG_TRUE); // non-objects are vacuously frozen
         }
         let gc = gc_header_for(obj);
+        // Fast path: the FROZEN flag is authoritative when set.
         if (*gc)._reserved & crate::gc::OBJ_FLAG_FROZEN != 0 {
+            return f64::from_bits(TAG_TRUE);
+        }
+        if object_integrity_level(obj, /*frozen=*/ true) {
             f64::from_bits(TAG_TRUE)
         } else {
             f64::from_bits(TAG_FALSE)
@@ -89,6 +229,14 @@ pub extern "C" fn js_object_is_frozen(obj_value: f64) -> f64 {
 pub extern "C" fn js_object_is_sealed(obj_value: f64) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        let ext = crate::proxy::js_reflect_is_extensible(obj_value);
+        return if crate::value::js_is_truthy(ext) == 0 {
+            f64::from_bits(TAG_TRUE)
+        } else {
+            f64::from_bits(TAG_FALSE)
+        };
+    }
     unsafe {
         let obj = extract_obj_ptr(obj_value);
         if obj.is_null() || (obj as usize) <= 0x10000 {
@@ -96,6 +244,9 @@ pub extern "C" fn js_object_is_sealed(obj_value: f64) -> f64 {
         }
         let gc = gc_header_for(obj);
         if (*gc)._reserved & crate::gc::OBJ_FLAG_SEALED != 0 {
+            return f64::from_bits(TAG_TRUE);
+        }
+        if object_integrity_level(obj, /*frozen=*/ false) {
             f64::from_bits(TAG_TRUE)
         } else {
             f64::from_bits(TAG_FALSE)


### PR DESCRIPTION
## What
ToPropertyDescriptor (ES §6.2.6.5) reads each descriptor field with **HasProperty(desc, name)** then Get — so an *inherited* `value`/`get`/`set`/`writable`/`enumerable`/`configurable` counts as present. Perry tested **own-key presence only**, so e.g. `Object.defineProperty(o, k, childDesc)` where `childDesc` inherits `value` from its prototype mis-detected data-vs-accessor and dropped fields.

Factored a shared `desc_has_field` (HasProperty) and routed all descriptor field-presence checks through it:
- `validate_property_descriptor`, `validate_nonconfigurable_redefine`
- `js_object_define_property` (get/set/value/writable detection)
- `define_array_property` (array index defines)

### Files
- `crates/perry-runtime/src/object/object_ops.rs`
- `crates/perry-runtime/src/object/array_object_ops.rs`

### Verification
Baseline `built-ins/Object` = 2390/3172 (75.3%) on the full-sweep oracle. Pure spec-correctness (own→own-or-inherited presence); confirmed by post-merge resweep. (No version/CHANGELOG bump — maintainer folds in.)