### PR TITLE
fix(class): computed-key evaluation order + ToPropertyKey TypeError on null-proto key

### DIFF
--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -11,40 +11,11 @@ use crate::lower::{
 use crate::lower_patterns::*;
 use crate::lower_types::*;
 
+use super::class_computed::{
+    class_computed_member_registration_expr, push_deduped_class_computed_keys,
+};
 use super::helpers::{async_iterator_method_call, is_filehandle_readlines_for_await_target};
 use super::*;
-
-fn class_computed_member_registration_expr(class_name: &str, member: &ClassComputedMember) -> Expr {
-    match member.kind {
-        ClassComputedMemberKind::Method => Expr::RegisterClassComputedMethod {
-            class_name: class_name.to_string(),
-            key_expr: Box::new(member.key_expr.clone()),
-            method_name: member.function.name.clone(),
-            is_static: member.is_static,
-            param_count: member.function.params.len() as u32,
-            has_rest: member
-                .function
-                .params
-                .last()
-                .map(|p| p.is_rest)
-                .unwrap_or(false),
-        },
-        ClassComputedMemberKind::Getter => Expr::RegisterClassComputedAccessor {
-            class_name: class_name.to_string(),
-            key_expr: Box::new(member.key_expr.clone()),
-            getter_name: Some(member.function.name.clone()),
-            setter_name: None,
-            is_static: member.is_static,
-        },
-        ClassComputedMemberKind::Setter => Expr::RegisterClassComputedAccessor {
-            class_name: class_name.to_string(),
-            key_expr: Box::new(member.key_expr.clone()),
-            getter_name: None,
-            setter_name: Some(member.function.name.clone()),
-            is_static: member.is_static,
-        },
-    }
-}
 
 mod nested_fn_decl;
 
@@ -525,46 +496,10 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 }
                 ctx.pending_classes.push(class);
             } else {
-                // The class is name-deduped against an earlier same-named class
-                // (Perry's codegen is name-keyed; #336). But ECMA-262
-                // ClassDefinitionEvaluation still evaluates every `class`
-                // expression's ComputedPropertyName in source order, so a
-                // computed member key with side effects (a throw, an
-                // assignment, a call) must still run — e.g. two
-                // `assert.throws(() => { class C { set [unresolvable](_) {} } })`
-                // helpers both named `C` (Test262 accessor-name-*/computed-err).
-                // Evaluate just the key expressions; the (duplicate) class body
-                // itself stays deduped.
-                for member in &class_decl.class.body {
-                    let computed_key = match member {
-                        ast::ClassMember::Method(m) => match &m.key {
-                            ast::PropName::Computed(c) => Some(c.expr.as_ref()),
-                            _ => None,
-                        },
-                        ast::ClassMember::ClassProp(p) => match &p.key {
-                            ast::PropName::Computed(c) => Some(c.expr.as_ref()),
-                            _ => None,
-                        },
-                        _ => None,
-                    };
-                    if let Some(key_ast) = computed_key {
-                        let lowered = lower_expr(ctx, key_ast)?;
-                        // ComputedPropertyName is `ToPropertyKey(GetValue(eval))`
-                        // — apply ToPropertyKey too so a non-primitive key with
-                        // no callable toString/valueOf (e.g. `Object.create(null)`)
-                        // throws TypeError, matching the non-deduped registration
-                        // path (Test262 computed-err-to-prop-key).
-                        result.push(Stmt::Expr(Expr::Call {
-                            callee: Box::new(Expr::ExternFuncRef {
-                                name: "js_to_property_key".to_string(),
-                                param_types: vec![Type::Any],
-                                return_type: Type::Any,
-                            }),
-                            args: vec![lowered],
-                            type_args: Vec::new(),
-                        }));
-                    }
-                }
+                // Duplicate same-named class: still evaluate its computed
+                // member keys for their spec-mandated side effects. See
+                // `push_deduped_class_computed_keys`.
+                push_deduped_class_computed_keys(ctx, &class_decl.class, &mut result)?;
             }
         }
         ast::Stmt::Decl(ast::Decl::Fn(fn_decl)) => {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -524,6 +524,34 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     )));
                 }
                 ctx.pending_classes.push(class);
+            } else {
+                // The class is name-deduped against an earlier same-named class
+                // (Perry's codegen is name-keyed; #336). But ECMA-262
+                // ClassDefinitionEvaluation still evaluates every `class`
+                // expression's ComputedPropertyName in source order, so a
+                // computed member key with side effects (a throw, an
+                // assignment, a call) must still run — e.g. two
+                // `assert.throws(() => { class C { set [unresolvable](_) {} } })`
+                // helpers both named `C` (Test262 accessor-name-*/computed-err).
+                // Evaluate just the key expressions; the (duplicate) class body
+                // itself stays deduped.
+                for member in &class_decl.class.body {
+                    let computed_key = match member {
+                        ast::ClassMember::Method(m) => match &m.key {
+                            ast::PropName::Computed(c) => Some(c.expr.as_ref()),
+                            _ => None,
+                        },
+                        ast::ClassMember::ClassProp(p) => match &p.key {
+                            ast::PropName::Computed(c) => Some(c.expr.as_ref()),
+                            _ => None,
+                        },
+                        _ => None,
+                    };
+                    if let Some(key_ast) = computed_key {
+                        let lowered = lower_expr(ctx, key_ast)?;
+                        result.push(Stmt::Expr(lowered));
+                    }
+                }
             }
         }
         ast::Stmt::Decl(ast::Decl::Fn(fn_decl)) => {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -549,7 +549,20 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     };
                     if let Some(key_ast) = computed_key {
                         let lowered = lower_expr(ctx, key_ast)?;
-                        result.push(Stmt::Expr(lowered));
+                        // ComputedPropertyName is `ToPropertyKey(GetValue(eval))`
+                        // — apply ToPropertyKey too so a non-primitive key with
+                        // no callable toString/valueOf (e.g. `Object.create(null)`)
+                        // throws TypeError, matching the non-deduped registration
+                        // path (Test262 computed-err-to-prop-key).
+                        result.push(Stmt::Expr(Expr::Call {
+                            callee: Box::new(Expr::ExternFuncRef {
+                                name: "js_to_property_key".to_string(),
+                                param_types: vec![Type::Any],
+                                return_type: Type::Any,
+                            }),
+                            args: vec![lowered],
+                            type_args: Vec::new(),
+                        }));
                     }
                 }
             }

--- a/crates/perry-hir/src/lower_decl/class_computed.rs
+++ b/crates/perry-hir/src/lower_decl/class_computed.rs
@@ -1,0 +1,96 @@
+//! Helpers for lowering a class's computed-key members (methods / accessors)
+//! declared inside a function body. Extracted from `body_stmt.rs` to keep that
+//! file under the source-size gate.
+
+use anyhow::Result;
+use perry_types::Type;
+use swc_ecma_ast as ast;
+
+use crate::ir::*;
+use crate::lower::{lower_expr, LoweringContext};
+
+/// Build the registration expression for one computed-key class member
+/// (`[expr]() {}` / `get [expr]() {}` / `set [expr](v) {}`). Codegen lowers
+/// these to `js_register_class_computed_{method,accessor}` calls that evaluate
+/// the key at the class-definition site.
+pub(crate) fn class_computed_member_registration_expr(
+    class_name: &str,
+    member: &ClassComputedMember,
+) -> Expr {
+    match member.kind {
+        ClassComputedMemberKind::Method => Expr::RegisterClassComputedMethod {
+            class_name: class_name.to_string(),
+            key_expr: Box::new(member.key_expr.clone()),
+            method_name: member.function.name.clone(),
+            is_static: member.is_static,
+            param_count: member.function.params.len() as u32,
+            has_rest: member
+                .function
+                .params
+                .last()
+                .map(|p| p.is_rest)
+                .unwrap_or(false),
+        },
+        ClassComputedMemberKind::Getter => Expr::RegisterClassComputedAccessor {
+            class_name: class_name.to_string(),
+            key_expr: Box::new(member.key_expr.clone()),
+            getter_name: Some(member.function.name.clone()),
+            setter_name: None,
+            is_static: member.is_static,
+        },
+        ClassComputedMemberKind::Setter => Expr::RegisterClassComputedAccessor {
+            class_name: class_name.to_string(),
+            key_expr: Box::new(member.key_expr.clone()),
+            getter_name: None,
+            setter_name: Some(member.function.name.clone()),
+            is_static: member.is_static,
+        },
+    }
+}
+
+/// A class declared inside a function body is name-deduped against an earlier
+/// same-named class (Perry's codegen is name-keyed; #336). But ECMA-262
+/// ClassDefinitionEvaluation still evaluates every `class` expression's
+/// ComputedPropertyName in source order, so a computed member key with side
+/// effects (a throw, an assignment, a call) must still run — e.g. two
+/// `assert.throws(() => { class C { set [unresolvable](_) {} } })` helpers both
+/// named `C` (Test262 accessor-name-*/computed-err). Evaluate just the key
+/// expressions (applying `ToPropertyKey`); the duplicate class body stays
+/// deduped.
+pub(crate) fn push_deduped_class_computed_keys(
+    ctx: &mut LoweringContext,
+    class: &ast::Class,
+    result: &mut Vec<Stmt>,
+) -> Result<()> {
+    for member in &class.body {
+        let computed_key = match member {
+            ast::ClassMember::Method(m) => match &m.key {
+                ast::PropName::Computed(c) => Some(c.expr.as_ref()),
+                _ => None,
+            },
+            ast::ClassMember::ClassProp(p) => match &p.key {
+                ast::PropName::Computed(c) => Some(c.expr.as_ref()),
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(key_ast) = computed_key {
+            let lowered = lower_expr(ctx, key_ast)?;
+            // ComputedPropertyName is `ToPropertyKey(GetValue(eval))` — apply
+            // ToPropertyKey too so a non-primitive key with no callable
+            // toString/valueOf (e.g. `Object.create(null)`) throws TypeError,
+            // matching the non-deduped registration path (Test262
+            // computed-err-to-prop-key).
+            result.push(Stmt::Expr(Expr::Call {
+                callee: Box::new(Expr::ExternFuncRef {
+                    name: "js_to_property_key".to_string(),
+                    param_types: vec![Type::Any],
+                    return_type: Type::Any,
+                }),
+                args: vec![lowered],
+                type_args: Vec::new(),
+            }));
+        }
+    }
+    Ok(())
+}

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -11,6 +11,7 @@
 mod block;
 mod body_stmt;
 mod class_captures;
+mod class_computed;
 mod class_decl;
 mod class_members;
 mod class_validation;

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -66,9 +66,18 @@ unsafe fn ordinary_to_primitive_string_inner(value: f64) -> Option<f64> {
         // Custom toString returned a non-primitive (object): per spec, fall
         // through to `valueOf`.
         MethodOutcome::NonPrimitive => {}
-        // No callable custom toString — this is the default
-        // `Object.prototype.toString` → `"[object Object]"`. Stop here.
-        MethodOutcome::Absent => return None,
+        // No callable custom toString. For an ordinary object this stands in
+        // for the default `Object.prototype.toString` → `"[object Object]"`
+        // (stop here). But a null-`[[Prototype]]` object (`Object.create(null)`)
+        // genuinely has NO toString/valueOf, so OrdinaryToPrimitive must fall
+        // through to `valueOf` and, finding none, throw — matching Node
+        // (`String(Object.create(null))` throws; Test262 ToPropertyKey on a
+        // null-proto computed key).
+        MethodOutcome::Absent => {
+            if !value_is_null_proto_object(value) {
+                return None;
+            }
+        }
     }
 
     match call_method_for_primitive(&scope, &value_handle, b"valueOf") {
@@ -82,6 +91,28 @@ unsafe fn ordinary_to_primitive_string_inner(value: f64) -> Option<f64> {
         // custom `toString` never reaches this throw.
         MethodOutcome::NonPrimitive | MethodOutcome::Absent => throw_cannot_convert_to_primitive(),
     }
+}
+
+/// True iff `value` is a heap object stamped `OBJ_FLAG_NULL_PROTO`
+/// (`Object.create(null)` and friends) — i.e. it has no `[[Prototype]]`, so it
+/// does not inherit the default `Object.prototype.toString`/`valueOf`.
+unsafe fn value_is_null_proto_object(value: f64) -> bool {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return false;
+    }
+    let obj = jsval.as_pointer::<crate::ObjectHeader>();
+    if obj.is_null() || (obj as usize) < 0x10000 {
+        return false;
+    }
+    if !crate::object::is_valid_obj_ptr(obj as *const u8) {
+        return false;
+    }
+    if (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return false;
+    }
+    let gc = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0
 }
 
 #[cold]


### PR DESCRIPTION
Continues the deferred class-element accessor items from #4730/#4736/#4738. Brings **accessor-name (statements, inst+static) to 42/42 = 100%**.

## 1. Evaluate computed member keys of a name-deduped class

A class declared inside a function body is name-deduped against an earlier same-named class (Perry's codegen is name-keyed, #336). But ECMA-262 ClassDefinitionEvaluation still evaluates *every* class's `ComputedPropertyName` in source order. The dedup skipped the second class entirely, so a computed member key with side effects never ran — e.g. the two `assert.throws(() => { class C { get/set [expr]() {} } })` helpers in the `computed-err-*` tests are both named `C`, so only the first (getter) evaluated its key. The deduped branch now still lowers each computed key expression (and applies `ToPropertyKey`) for its side effects. Fixes the `unresolvable` / `evaluation` cases for getter, setter, method, and field computed keys.

## 2. ToPropertyKey throws TypeError for a null-`[[Prototype]]` key

`ordinary_to_primitive_string` treated an absent `toString` as the default `Object.prototype.toString` (→ `"[object Object]"`), so `Object.create(null)` (no prototype) coerced to a string instead of throwing. It now checks `OBJ_FLAG_NULL_PROTO`: such an object genuinely has no `toString`/`valueOf`, so OrdinaryToPrimitive falls through and throws *"Cannot convert object to primitive value"*, matching Node (`String(Object.create(null))` throws). Fixes the `computed-err-to-prop-key` cases.

## Verification
- `accessor-name` statements (inst+static): **42/42 (100%)**.
- Object→primitive coercion unchanged for ordinary objects: `String({a:1})`→`[object Object]`, `String({toString(){return 'X'}})`→`X`, `` `${{}}` ``→`[object Object]`, `String([1,2])`→`1,2`; only `String(Object.create(null))` now throws (matches Node). A bounded coercion regression sweep (addition / template-literal / Object.create/keys) is green.

## Still deferred (separate, larger)
**Class-*expression* static accessors** (`(class { static get 0(){} })['0']`). The per-evaluation class object (#1772) doesn't route static accessors through the same registration declarations use — mixed static+instance accessors hit codegen symbol collisions / `perry_method`↔`perry_static` mismatches, and numeric static keys mis-dispatch. That's a dedicated codegen feature, tracked separately.