### PR TITLE
fix(runtime): TypedArray element-store coercion (ToUint32 modular) + f16 rounding

### DIFF
--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -618,6 +618,22 @@ fn jsvalue_to_f64(v: f64) -> f64 {
     f64::NAN
 }
 
+/// ECMA-262 `ToUint32` (§7.1.7) on a double, returning the raw 32-bit pattern.
+/// `NaN`/±`Inf`/±0 → 0; otherwise truncate toward zero, then reduce modulo
+/// 2^32. Done in f64 space so values past `i64::MAX` (e.g. `1e21`) wrap
+/// correctly instead of saturating — `value as i64` would clamp to `i64::MAX`
+/// and produce the wrong low bits. The signed integer kinds (`Int8`/`Int16`/
+/// `Int32`) all derive from these bits via a width-narrowing reinterpret, which
+/// matches `ToInt8`/`ToInt16`/`ToInt32` (they share `ToUint32`'s modular step
+/// and differ only in the final two's-complement reinterpretation).
+fn to_uint32_bits(value: f64) -> u32 {
+    if !value.is_finite() || value == 0.0 {
+        return 0;
+    }
+    let m = value.trunc().rem_euclid(4294967296.0); // value mod 2^32, in [0, 2^32)
+    m as u32
+}
+
 /// Store a number into the typed array slot, performing the per-kind cast.
 pub(super) unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64) {
     let kind = (*ta).kind;
@@ -626,13 +642,11 @@ pub(super) unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64)
     let off = idx * elem_size;
     match kind {
         KIND_INT8 => {
-            let v = value as i32 as i8;
+            let v = to_uint32_bits(value) as u8 as i8;
             *(base.add(off) as *mut i8) = v;
         }
         KIND_UINT8 => {
-            let mut v = value as i64;
-            v = v.rem_euclid(256);
-            *base.add(off) = v as u8;
+            *base.add(off) = to_uint32_bits(value) as u8;
         }
         KIND_UINT8_CLAMPED => {
             // ToUint8Clamp: NaN → 0, v ≤ 0 → 0, v ≥ 255 → 255,
@@ -658,21 +672,18 @@ pub(super) unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64)
             *base.add(off) = byte;
         }
         KIND_INT16 => {
-            let v = value as i32 as i16;
+            let v = to_uint32_bits(value) as u16 as i16;
             *(base.add(off) as *mut i16) = v;
         }
         KIND_UINT16 => {
-            let mut v = value as i64;
-            v = v.rem_euclid(65536);
-            *(base.add(off) as *mut u16) = v as u16;
+            *(base.add(off) as *mut u16) = to_uint32_bits(value) as u16;
         }
         KIND_INT32 => {
-            let v = value as i32;
+            let v = to_uint32_bits(value) as i32;
             *(base.add(off) as *mut i32) = v;
         }
         KIND_UINT32 => {
-            let v = value as i64 as u32;
-            *(base.add(off) as *mut u32) = v;
+            *(base.add(off) as *mut u32) = to_uint32_bits(value);
         }
         KIND_FLOAT16 => {
             *(base.add(off) as *mut u16) = f64_to_f16_bits(value);
@@ -2058,5 +2069,40 @@ mod tests {
             js_typed_array_get(ta, crate::gc::LARGE_OBJECT_THRESHOLD_BYTES as i32 - 1),
             99.0
         );
+    }
+
+    #[test]
+    fn to_uint32_bits_wraps_modularly_not_saturating() {
+        // NaN / ±Inf / ±0 → 0.
+        assert_eq!(to_uint32_bits(f64::NAN), 0);
+        assert_eq!(to_uint32_bits(f64::INFINITY), 0);
+        assert_eq!(to_uint32_bits(f64::NEG_INFINITY), 0);
+        assert_eq!(to_uint32_bits(0.0), 0);
+        assert_eq!(to_uint32_bits(-0.0), 0);
+        // Truncate toward zero, then mod 2^32.
+        assert_eq!(to_uint32_bits(7.9), 7);
+        assert_eq!(to_uint32_bits(-1.0), 0xFFFF_FFFF);
+        assert_eq!(to_uint32_bits(4294967296.0 + 7.0), 7); // 2^32 + 7
+                                                           // 1e21 is exactly representable; ToUint32 wraps (NOT i32::MAX saturate).
+        assert_eq!(to_uint32_bits(1e21) as i32, -559939584);
+    }
+
+    #[test]
+    fn store_at_integer_kinds_wrap_per_spec() {
+        unsafe {
+            let check = |kind: u8, v: f64| -> f64 {
+                let ta = typed_array_alloc(kind, 1);
+                store_at(ta, 0, v);
+                load_at(ta, 0)
+            };
+            assert_eq!(check(KIND_INT8, 300.0), 44.0);
+            assert_eq!(check(KIND_UINT8, 261.0), 5.0);
+            assert_eq!(check(KIND_INT16, 105536.0), -25536.0);
+            assert_eq!(check(KIND_UINT16, 1e21), 0.0);
+            assert_eq!(check(KIND_INT32, 4294967303.0), 7.0);
+            assert_eq!(check(KIND_INT32, 1e21), -559939584.0);
+            assert_eq!(check(KIND_UINT32, -1.0), 4294967295.0);
+            assert_eq!(check(KIND_INT8, 1e21), 0.0);
+        }
     }
 }

--- a/crates/perry-runtime/src/typedarray_half.rs
+++ b/crates/perry-runtime/src/typedarray_half.rs
@@ -6,16 +6,18 @@
 /// Round-to-nearest-even, with overflow → ±Inf and subnormal/underflow → ±0.
 /// Mirrors the V8 / `Math.f16round`-then-store semantics used by Float16Array.
 pub fn f64_to_f16_bits(value: f64) -> u16 {
-    // Work from the f32 rounding of the value first (matches JS, which stores
-    // through the double→half path; an intermediate f32 keeps the mantissa
-    // handling simple and is exact for all f16-representable inputs).
-    let f = value as f32;
-    let bits = f.to_bits();
-    let sign = ((bits >> 16) & 0x8000) as u16;
-    let exp = ((bits >> 23) & 0xFF) as i32; // f32 biased exponent
-    let mantissa = bits & 0x007F_FFFF;
+    // Convert DIRECTLY from the f64 (no intermediate f32). Going through f32
+    // first double-rounds: a value just past a half-ulp boundary gets rounded
+    // to the exact halfway point by the f32 step, losing the sticky bit, so the
+    // f16 round-to-even step then rounds the wrong way (e.g. the smallest f16
+    // subnormal boundary `2^-25 + ε` collapsed to `2^-25` → 0 instead of
+    // `2^-24`). Operating on the 52-bit f64 mantissa keeps the sticky bits.
+    let bits = value.to_bits();
+    let sign = (((bits >> 48) & 0x8000) as u16) & 0x8000;
+    let exp = ((bits >> 52) & 0x7FF) as i32; // f64 biased exponent
+    let mantissa = bits & 0x000F_FFFF_FFFF_FFFF; // 52-bit fraction
 
-    if exp == 0xFF {
+    if exp == 0x7FF {
         // Inf / NaN.
         if mantissa != 0 {
             // NaN: keep it a NaN (set a mantissa bit), drop payload.
@@ -24,8 +26,13 @@ pub fn f64_to_f16_bits(value: f64) -> u16 {
         return sign | 0x7C00; // Inf
     }
 
-    // Unbias f32 exponent, rebias for f16 (bias 15).
-    let unbiased = exp - 127;
+    // ±0 (and f64 subnormals, which are far below the f16 range → ±0).
+    if exp == 0 {
+        return sign;
+    }
+
+    // Unbias f64 exponent (bias 1023), rebias for f16 (bias 15).
+    let unbiased = exp - 1023;
     let half_exp = unbiased + 15;
 
     if half_exp >= 0x1F {
@@ -33,35 +40,49 @@ pub fn f64_to_f16_bits(value: f64) -> u16 {
         return sign | 0x7C00;
     }
 
+    // 53-bit significand with the implicit leading 1 restored.
+    let significand = mantissa | 0x0010_0000_0000_0000; // bit 52 set
+
+    // Round-half-to-even: shift `significand` right by `shift`, rounding the
+    // discarded low bits to nearest, ties to even. Returns the rounded value
+    // (which may carry up one extra bit).
+    let round = |shift: u32| -> u64 {
+        let kept = significand >> shift;
+        let remainder = significand & ((1u64 << shift) - 1);
+        let halfway = 1u64 << (shift - 1);
+        if remainder > halfway || (remainder == halfway && (kept & 1) == 1) {
+            kept + 1
+        } else {
+            kept
+        }
+    };
+
     if half_exp <= 0 {
-        // Subnormal or underflow to zero.
-        if half_exp < -10 {
-            return sign; // too small → ±0
+        // Subnormal or underflow to zero. Express the value as a count of f16
+        // subnormal units (2^-24), rounding to nearest-even. A carry out of the
+        // top subnormal bit naturally yields the smallest normal (0x0400).
+        // shift = 52 (f64 frac width) - 10 (f16 frac width) + (1 - half_exp)
+        let shift = (43 - half_exp) as u32;
+        if shift >= 64 {
+            return sign; // far below the smallest subnormal → ±0
         }
-        // Build the f16 subnormal mantissa with round-to-nearest-even.
-        // Implicit leading 1 of the f32 mantissa is restored, then shifted.
-        let m = mantissa | 0x0080_0000; // 24-bit significand (1.mantissa)
-        let shift = (14 - half_exp) as u32; // 14 = 23 - 10 + 1
-        let half_m = m >> shift;
-        // Round half to even.
-        let remainder = m & ((1u32 << shift) - 1);
-        let halfway = 1u32 << (shift - 1);
-        let mut result = half_m as u16;
-        if remainder > halfway || (remainder == halfway && (half_m & 1) == 1) {
-            result += 1;
+        if shift == 0 {
+            return sign | (significand as u16);
         }
-        return sign | result;
+        return sign | (round(shift) as u16);
     }
 
-    // Normal f16. Take top 10 mantissa bits, round-to-nearest-even on the rest.
-    let half_m = (mantissa >> 13) as u16;
-    let remainder = mantissa & 0x1FFF;
-    let halfway = 0x1000;
-    let mut result = ((half_exp as u16) << 10) | half_m;
-    if remainder > halfway || (remainder == halfway && (half_m & 1) == 1) {
-        result += 1; // carry naturally rolls into exponent if mantissa overflows
+    // Normal f16. `round(42)` yields an 11-bit value `1.ffffffffff` (implicit
+    // leading 1 in bit 10 + 10 fraction bits), or `0x800` if rounding carried.
+    // Encoding = (half_exp << 10) | frac, so subtract the implicit 0x400 from
+    // both sides: result = ((half_exp - 1) << 10) + rounded. A rounding carry
+    // (rounded == 0x800) then bumps the exponent for free.
+    let rounded = round(42);
+    let result = (((half_exp as u32) - 1) << 10) + rounded as u32;
+    if (result >> 10) >= 0x1F {
+        return sign | 0x7C00; // rounding overflowed to Inf
     }
-    sign | result
+    sign | (result as u16)
 }
 
 /// Decode an IEEE-754 binary16 bit pattern into an f64.
@@ -121,5 +142,27 @@ mod tests {
         assert_eq!(f64_to_f16_bits(-2.0), 0xC000);
         assert_eq!(f64_to_f16_bits(0.0), 0x0000);
         assert_eq!(f64_to_f16_bits(65504.0), 0x7BFF); // max finite half
+    }
+
+    #[test]
+    fn direct_rounding_no_double_round() {
+        // Oracle values from Node's `new Float16Array([v])` DataView bits.
+        // The key non-regression: a value just above the smallest-subnormal
+        // half-ulp boundary must round UP to 0x0001, not collapse to 0 — which
+        // the old f64→f32→f16 double-rounding path got wrong.
+        assert_eq!(f64_to_f16_bits(2.980232238769532e-8), 0x0001);
+        assert_eq!(f64_to_f16_bits(5.960464477539063e-8), 0x0001); // smallest subnormal
+        assert_eq!(f64_to_f16_bits(2.9802e-8), 0x0000); // just below → ties to even 0
+        assert_eq!(f64_to_f16_bits(1e-7), 0x0002);
+        assert_eq!(f64_to_f16_bits(0.1), 0x2E66);
+        assert_eq!(f64_to_f16_bits(0.2), 0x3266);
+        assert_eq!(f64_to_f16_bits(100.0), 0x5640);
+        assert_eq!(f64_to_f16_bits(3.141592653589793), 0x4248);
+        assert_eq!(f64_to_f16_bits(6.0997555e-5), 0x03FF); // largest subnormal-ish
+        assert_eq!(f64_to_f16_bits(6.103515625e-5), 0x0400); // smallest normal
+        assert_eq!(f64_to_f16_bits(70000.0), 0x7C00); // overflow → +Inf
+        assert_eq!(f64_to_f16_bits(65520.0), 0x7C00); // rounds up past max → +Inf
+        assert_eq!(f64_to_f16_bits(65504.1), 0x7BFF); // stays max finite
+        assert_eq!(f64_to_f16_bits(32768.0), 0x7800);
     }
 }


### PR DESCRIPTION
## What
Fixes `built-ins/TypedArray` (baseline 945/1328, 71.2%) — two element-store coercion bugs, with unit tests.

### Root causes
1. **Integer element store saturated instead of wrapping.** Storing into Int/Uint typed arrays now uses a spec `ToUint32`/`ToInt8/16/32` computed in f64 space (NaN/±Inf/±0 → 0; truncate toward zero; reduce mod 2³²). The old `value as i64` path saturated at `i64::MAX`, so values past `i64::MAX` (e.g. `1e21`) produced wrong low bits instead of the spec's modular wrap.
2. **Float16 double-rounding.** f16 store converted via an intermediate f32, double-rounding at half-ulp boundaries (the smallest f16 subnormal collapsed to 0 instead of 2⁻²⁴). Now converts directly from the f64 mantissa, preserving sticky bits.

### Files
`typedarray/mod.rs`, `typedarray_half.rs` (+ unit tests)

Delta confirmed by post-merge resweep. (No version/CHANGELOG bump — maintainer folds in.)