### PR TITLE
fix(runtime): built-ins/Proxy test262 parity

### DIFF
--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -743,6 +743,12 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
         if obj_jv.is_null() || obj_jv.is_undefined() {
             super::has_own_helpers::throw_to_object_nullish_type_error();
         }
+        // A Proxy is a small registered id, not a heap object — route it to the
+        // `ownKeys` trap (string subset) before the handle-dispatch fallback,
+        // which would mis-read the fake pointer and return an empty array.
+        if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+            return crate::proxy::proxy_own_property_names(obj_value);
+        }
         if obj_jv.is_pointer() {
             let raw = crate::value::js_nanbox_get_pointer(obj_value) as usize;
             if raw > 0 && raw < 0x100000 {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -993,6 +993,12 @@ pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
     if jv.is_null() || jv.is_undefined() {
         super::has_own_helpers::throw_to_object_nullish_type_error();
     }
+    // A Proxy is a small registered id — route through the `ownKeys` trap +
+    // enumerability filter rather than the handle-dispatch fallback below.
+    if crate::proxy::js_proxy_is_proxy(value) != 0 {
+        let arr = crate::proxy::proxy_enum_own_keys(value);
+        return (arr.to_bits() & crate::value::POINTER_MASK) as *mut ArrayHeader;
+    }
     if jv.is_any_string() {
         let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         let len = match crate::string::str_bytes_from_jsvalue(value, &mut scratch) {

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -20,9 +20,18 @@ use std::collections::HashMap;
 
 use crate::closure::{js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3};
 
+mod invariants;
 mod json;
 mod metadata;
+mod own_keys;
+mod prototype;
 mod reflect;
+
+pub use own_keys::js_proxy_own_keys;
+pub(crate) use own_keys::{
+    proxy_enum_own_keys, proxy_own_property_names, proxy_own_property_symbols,
+};
+pub use prototype::js_reflect_set_prototype_of;
 
 pub(crate) use json::{
     js_proxy_checked_target, js_proxy_checked_target_for_is_array, js_proxy_own_keys_for_json,
@@ -310,6 +319,35 @@ fn coerce_trap_bool(value: f64) -> f64 {
     nanbox_bool(crate::value::js_is_truthy(value) != 0)
 }
 
+/// Invoke a present (already-confirmed-callable) handler trap with the handler
+/// bound as the trap's `this` (ECMA-262: traps are called as
+/// `Call(trap, handler, args)`). Object-literal/method traps read `this` from a
+/// reserved closure slot, while free-function traps fall back to
+/// `IMPLICIT_THIS`; we set both so either style observes the handler. Mirrors
+/// the apply/construct/getOwnPropertyDescriptor trap-call dance, which the
+/// per-trap paths (get/set/has/deleteProperty/defineProperty/…) previously
+/// skipped — they called the trap with the wrong `this` and, for get/set,
+/// dropped the trailing `receiver` argument.
+fn call_trap(handler: f64, trap: f64, args: &[f64]) -> f64 {
+    let rebound = crate::closure::clone_closure_rebind_this(trap.to_bits(), handler);
+    let closure = closure_from(f64::from_bits(rebound));
+    if closure.is_null() {
+        return throw_type_error("proxy trap is not a function");
+    }
+    let undef = f64::from_bits(TAG_UNDEFINED);
+    let a = |i: usize| -> f64 { args.get(i).copied().unwrap_or(undef) };
+    let prev = crate::object::js_implicit_this_set(handler);
+    let result = match args.len() {
+        0 => js_closure_call0(closure),
+        1 => js_closure_call1(closure, a(0)),
+        2 => js_closure_call2(closure, a(0), a(1)),
+        3 => js_closure_call3(closure, a(0), a(1), a(2)),
+        _ => crate::closure::js_closure_call4(closure, a(0), a(1), a(2), a(3)),
+    };
+    crate::object::js_implicit_this_set(prev);
+    result
+}
+
 /// Throw `TypeError: Reflect.<op> called on non-object`. Does not return.
 fn reflect_non_object_typeerror(op: &str) -> f64 {
     let msg = format!("Reflect.{op} called on non-object");
@@ -469,9 +507,32 @@ pub extern "C" fn js_proxy_get(proxy_boxed: f64, key: f64) -> f64 {
     }
     let trap = handler_trap(handler, "get");
     if is_callable(trap) {
-        return js_closure_call2(closure_from(trap), target, key);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let target_h = scope.root_nanbox_f64(target);
+        let key_h = scope.root_nanbox_f64(key);
+        let result = call_trap(
+            handler,
+            trap,
+            &[
+                target_h.get_nanbox_f64(),
+                key_h.get_nanbox_f64(),
+                proxy_boxed,
+            ],
+        );
+        let result_h = scope.root_nanbox_f64(result);
+        invariants::enforce_get_invariant(
+            target_h.get_nanbox_f64(),
+            key_h.get_nanbox_f64(),
+            result_h.get_nanbox_f64(),
+        );
+        return result_h.get_nanbox_f64();
     }
-    // No get trap — forward to target.
+    // No get trap — forward to the target's `[[Get]]`. A proxy target must
+    // recurse through proxy dispatch rather than `target_get`, which would deref
+    // the fake pointer.
+    if lookup(target).is_some() {
+        return js_proxy_get(target, key);
+    }
     target_get(target, key)
 }
 
@@ -568,9 +629,33 @@ pub extern "C" fn js_proxy_set(proxy_boxed: f64, key: f64, value: f64) -> f64 {
     if is_callable(trap) {
         // #2756: the `set` trap's boolean result is observable through
         // `Reflect.set(proxy, …)` (and strict-mode assignment). Coerce and
-        // return it rather than discarding it.
-        let trap_result = js_closure_call3(closure_from(trap), target, key, value);
-        return coerce_trap_bool(trap_result);
+        // return it rather than discarding it. The trap receives the spec
+        // argument list `(target, key, value, receiver)` with `this` bound to
+        // the handler.
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let target_h = scope.root_nanbox_f64(target);
+        let key_h = scope.root_nanbox_f64(key);
+        let value_h = scope.root_nanbox_f64(value);
+        let trap_result = call_trap(
+            handler,
+            trap,
+            &[
+                target_h.get_nanbox_f64(),
+                key_h.get_nanbox_f64(),
+                value_h.get_nanbox_f64(),
+                proxy_boxed,
+            ],
+        );
+        // A falsy trap result means the assignment failed; no invariant check.
+        if crate::value::js_is_truthy(trap_result) == 0 {
+            return nanbox_bool(false);
+        }
+        invariants::enforce_set_invariant(
+            target_h.get_nanbox_f64(),
+            key_h.get_nanbox_f64(),
+            value_h.get_nanbox_f64(),
+        );
+        return nanbox_bool(true);
     }
     // No set trap — forward to the target's `[[Set]]`. When the target is
     // itself a Proxy, recurse through the proxy dispatch (its own trap or
@@ -1119,7 +1204,30 @@ pub extern "C" fn js_proxy_has(proxy_boxed: f64, key: f64) -> f64 {
     }
     let trap = handler_trap(handler, "has");
     if is_callable(trap) {
-        return js_closure_call2(closure_from(trap), target, key);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let target_h = scope.root_nanbox_f64(target);
+        let key_h = scope.root_nanbox_f64(key);
+        let trap_result = call_trap(
+            handler,
+            trap,
+            &[target_h.get_nanbox_f64(), key_h.get_nanbox_f64()],
+        );
+        // [[HasProperty]] invariant: a `false` trap result is rejected when the
+        // target owns the key non-configurably, or the target is non-extensible
+        // and owns the key.
+        if crate::value::js_is_truthy(trap_result) == 0 {
+            invariants::enforce_has_false_invariant(
+                target_h.get_nanbox_f64(),
+                key_h.get_nanbox_f64(),
+            );
+            return nanbox_bool(false);
+        }
+        return nanbox_bool(true);
+    }
+    // No has trap — forward to the target's `[[HasProperty]]`, recursing through
+    // a proxy target.
+    if lookup(target).is_some() {
+        return js_proxy_has(target, key);
     }
     crate::object::js_object_has_property(target, key)
 }
@@ -1150,10 +1258,27 @@ pub extern "C" fn js_proxy_delete(proxy_boxed: f64, key: f64) -> f64 {
     if is_callable(trap) {
         // #2760: the `deleteProperty` trap's boolean result is observable
         // through `Reflect.deleteProperty(proxy, …)`.
-        let trap_result = js_closure_call2(closure_from(trap), target, key);
-        return coerce_trap_bool(trap_result);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let target_h = scope.root_nanbox_f64(target);
+        let key_h = scope.root_nanbox_f64(key);
+        let trap_result = call_trap(
+            handler,
+            trap,
+            &[target_h.get_nanbox_f64(), key_h.get_nanbox_f64()],
+        );
+        if crate::value::js_is_truthy(trap_result) == 0 {
+            return nanbox_bool(false);
+        }
+        // [[Delete]] invariant: a `true` result is rejected when the target owns
+        // the key non-configurably, or owns it and is non-extensible.
+        invariants::enforce_delete_invariant(target_h.get_nanbox_f64(), key_h.get_nanbox_f64());
+        return nanbox_bool(true);
     }
-    // Forward to target with ordinary `[[Delete]]` semantics.
+    // No trap — forward to the target's `[[Delete]]`, recursing through a proxy
+    // target.
+    if lookup(target).is_some() {
+        return js_proxy_delete(target, key);
+    }
     reflect_ordinary_delete(target, key)
 }
 
@@ -1432,22 +1557,14 @@ pub extern "C" fn js_reflect_construct(target: f64, args_like: f64, new_target: 
 /// followed by own symbol keys (Node order: integer-index then insertion-order
 /// string keys, then symbols). Throws `TypeError` for a non-object target.
 ///
-/// Proxy `ownKeys` traps are out of scope (Perry has no `ownKeys` trap
-/// dispatch); a proxy target falls through to its registered target's keys.
+/// For a proxy, dispatches the `ownKeys` trap (with type/duplicate/invariant
+/// validation) via [`js_proxy_own_keys`].
 #[no_mangle]
 pub extern "C" fn js_reflect_own_keys(target: f64) -> f64 {
-    // Resolve a proxy to its target so we enumerate real keys.
-    let real = if let Some(id) = lookup(target) {
-        PROXIES.with(|p| {
-            p.borrow()
-                .get(id as usize)
-                .and_then(|o| o.as_ref())
-                .map(|e| e.target)
-                .unwrap_or(f64::from_bits(TAG_UNDEFINED))
-        })
-    } else {
-        target
-    };
+    if lookup(target).is_some() {
+        return own_keys::js_proxy_own_keys(target);
+    }
+    let real = target;
     if !reflect_value_is_object(real) {
         return reflect_non_object_typeerror("ownKeys");
     }
@@ -1524,8 +1641,28 @@ pub extern "C" fn js_reflect_define_property(obj: f64, key: f64, descriptor: f64
         }
         let trap = handler_trap(handler, "defineProperty");
         if is_callable(trap) {
-            let trap_result = js_closure_call3(closure_from(trap), target, key, descriptor);
-            return coerce_trap_bool(trap_result);
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let target_h = scope.root_nanbox_f64(target);
+            let key_h = scope.root_nanbox_f64(key);
+            let desc_h = scope.root_nanbox_f64(descriptor);
+            let trap_result = call_trap(
+                handler,
+                trap,
+                &[
+                    target_h.get_nanbox_f64(),
+                    key_h.get_nanbox_f64(),
+                    desc_h.get_nanbox_f64(),
+                ],
+            );
+            if crate::value::js_is_truthy(trap_result) == 0 {
+                return nanbox_bool(false);
+            }
+            invariants::enforce_define_property_invariant(
+                target_h.get_nanbox_f64(),
+                key_h.get_nanbox_f64(),
+                desc_h.get_nanbox_f64(),
+            );
+            return nanbox_bool(true);
         }
         // No trap — define on the underlying target. When the target is itself
         // a Proxy, recurse through the proxy dispatch rather than the ordinary
@@ -1547,6 +1684,18 @@ pub extern "C" fn js_reflect_define_property(obj: f64, key: f64, descriptor: f64
 /// `getPrototypeOf(value).constructor`, crashing on `null.constructor`).
 /// Callers must have already confirmed `obj` is a registered proxy.
 pub(crate) fn js_proxy_get_prototype_of(obj: f64) -> f64 {
+    if lookup(obj).is_none() {
+        return crate::object::js_object_get_prototype_of(obj);
+    }
+    proxy_get_prototype_of_impl(obj)
+}
+
+/// Shared Proxy `[[GetPrototypeOf]]` (ECMA-262 §10.5.1): dispatch the trap
+/// bound to the handler, validate the result is an Object or `null`, and (when
+/// the target is non-extensible) enforce that the trap result matches the
+/// target's actual prototype. Used by both `Object.getPrototypeOf(proxy)` and
+/// `Reflect.getPrototypeOf(proxy)` so they validate identically.
+fn proxy_get_prototype_of_impl(obj: f64) -> f64 {
     let Some(id) = lookup(obj) else {
         return crate::object::js_object_get_prototype_of(obj);
     };
@@ -1565,11 +1714,28 @@ pub(crate) fn js_proxy_get_prototype_of(obj: f64) -> f64 {
         return revoked_return();
     }
     let trap = handler_trap(handler, "getPrototypeOf");
-    if is_callable(trap) {
-        return js_closure_call1(closure_from(trap), target);
+    let trap_bits = trap.to_bits();
+    if trap_bits == TAG_UNDEFINED || trap_bits == TAG_NULL {
+        return reflect_target_get_prototype_of(target);
     }
-    // No trap — the prototype is the target's prototype.
-    crate::object::js_object_get_prototype_of(target)
+    if !is_callable_function(trap) {
+        return throw_type_error("proxy getPrototypeOf trap is not a function");
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_h = scope.root_nanbox_f64(target);
+    let result = call_trap(handler, trap, &[target_h.get_nanbox_f64()]);
+    let result_bits = result.to_bits();
+    if result_bits != TAG_NULL && !reflect_value_is_object(result) {
+        return throw_type_error("proxy getPrototypeOf trap returned non-object");
+    }
+    let target = target_h.get_nanbox_f64();
+    if crate::object::obj_value_no_extend(target) {
+        let actual = reflect_target_get_prototype_of(target);
+        if actual.to_bits() != result_bits {
+            return throw_type_error("proxy getPrototypeOf trap violates target invariant");
+        }
+    }
+    result
 }
 
 /// `Reflect.getPrototypeOf(obj)` — shares the actual prototype lookup with
@@ -1581,54 +1747,11 @@ pub extern "C" fn js_reflect_get_prototype_of(obj: f64) -> f64 {
     // step 1). Note `Object.getPrototypeOf` is more lenient (ToObject-coerces
     // primitives), so guard here before delegating. Proxies have a registered
     // entry and are objects, so they pass this check and dispatch below.
-    if let Some(id) = lookup(obj) {
-        let (target, handler, revoked) = PROXIES.with(|p| {
-            p.borrow()
-                .get(id as usize)
-                .and_then(|o| o.as_ref())
-                .map(|e| (e.target, e.handler, e.revoked))
-                .unwrap_or((
-                    f64::from_bits(TAG_UNDEFINED),
-                    f64::from_bits(TAG_UNDEFINED),
-                    false,
-                ))
-        });
-        if revoked {
-            return revoked_return();
-        }
-        let trap = handler_trap(handler, "getPrototypeOf");
-        let trap_bits = trap.to_bits();
-        if trap_bits == TAG_UNDEFINED || trap_bits == TAG_NULL {
-            return reflect_target_get_prototype_of(target);
-        }
-        if !is_callable_function(trap) {
-            return throw_type_error("proxy getPrototypeOf trap is not a function");
-        }
-        let rebound = crate::closure::clone_closure_rebind_this(trap_bits, handler);
-        let closure = closure_from(f64::from_bits(rebound));
-        if closure.is_null() {
-            return throw_type_error("proxy getPrototypeOf trap is not a function");
-        }
-        let prev = crate::object::js_implicit_this_set(handler);
-        let result = js_closure_call1(closure, target);
-        crate::object::js_implicit_this_set(prev);
-        let result_bits = result.to_bits();
-        if result_bits != TAG_NULL && !reflect_value_is_object(result) {
-            return throw_type_error("proxy getPrototypeOf trap returned non-object");
-        }
-        if crate::object::obj_value_no_extend(target) {
-            let actual = reflect_target_get_prototype_of(target);
-            if actual.to_bits() != result_bits {
-                return throw_type_error("proxy getPrototypeOf trap violates target invariant");
-            }
-        }
-        return result;
+    if lookup(obj).is_some() {
+        return proxy_get_prototype_of_impl(obj);
     }
     if !reflect_value_is_object(obj) {
         return reflect_non_object_typeerror("getPrototypeOf");
-    }
-    if lookup(obj).is_some() {
-        return js_proxy_get_prototype_of(obj);
     }
     crate::object::js_object_get_prototype_of(obj)
 }
@@ -1655,8 +1778,21 @@ pub extern "C" fn js_reflect_is_extensible(target: f64) -> f64 {
         }
         let trap = handler_trap(handler, "isExtensible");
         if is_callable(trap) {
-            let trap_result = js_closure_call1(closure_from(trap), inner);
-            return coerce_trap_bool(trap_result);
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let inner_h = scope.root_nanbox_f64(inner);
+            let trap_result = call_trap(handler, trap, &[inner_h.get_nanbox_f64()]);
+            let booleanized = crate::value::js_is_truthy(trap_result) != 0;
+            // Invariant: the trap result must equal the target's actual
+            // extensibility.
+            let target_ext = crate::value::js_is_truthy(crate::object::js_object_is_extensible(
+                inner_h.get_nanbox_f64(),
+            )) != 0;
+            if booleanized != target_ext {
+                return throw_type_error(
+                    "proxy isExtensible trap result does not match target extensibility",
+                );
+            }
+            return nanbox_bool(booleanized);
         }
         return crate::object::js_object_is_extensible(inner);
     }
@@ -1689,8 +1825,22 @@ pub extern "C" fn js_reflect_prevent_extensions(target: f64) -> f64 {
         }
         let trap = handler_trap(handler, "preventExtensions");
         if is_callable(trap) {
-            let trap_result = js_closure_call1(closure_from(trap), inner);
-            return coerce_trap_bool(trap_result);
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let inner_h = scope.root_nanbox_f64(inner);
+            let trap_result = call_trap(handler, trap, &[inner_h.get_nanbox_f64()]);
+            let booleanized = crate::value::js_is_truthy(trap_result) != 0;
+            // Invariant: a `true` result requires the target to be non-extensible.
+            if booleanized {
+                let target_ext = crate::value::js_is_truthy(
+                    crate::object::js_object_is_extensible(inner_h.get_nanbox_f64()),
+                ) != 0;
+                if target_ext {
+                    return throw_type_error(
+                        "proxy preventExtensions trap returned true but target is extensible",
+                    );
+                }
+            }
+            return nanbox_bool(booleanized);
         }
         crate::object::js_object_prevent_extensions(inner);
         return nanbox_bool(true);
@@ -1699,65 +1849,6 @@ pub extern "C" fn js_reflect_prevent_extensions(target: f64) -> f64 {
         return reflect_non_object_typeerror("preventExtensions");
     }
     crate::object::js_object_prevent_extensions(target);
-    nanbox_bool(true)
-}
-
-/// `Reflect.setPrototypeOf(target, proto)` (#2761).
-///
-/// Returns a boolean: `true` when the prototype change is applied, `false`
-/// when it is rejected (target is non-extensible and the proto actually
-/// changes). Throws `TypeError` for a non-object target or a proto that is
-/// neither an object nor `null`.
-///
-/// Proxy `setPrototypeOf` traps are out of scope (no trap dispatch); a proxy
-/// target reports `true` after recording the change on its underlying target.
-#[no_mangle]
-pub extern "C" fn js_reflect_set_prototype_of(target: f64, proto: f64) -> f64 {
-    // Resolve a proxy to its underlying target. A proxy's target can itself be
-    // a proxy, so unwrap to the innermost non-proxy object — operating on a
-    // proxy via the ordinary `obj_value_no_extend` / set-prototype helpers below
-    // would deref the fake pointer and segfault. (setPrototypeOf trap dispatch
-    // is out of scope; this just avoids the crash.)
-    let mut real = target;
-    for _ in 0..64 {
-        match lookup(real) {
-            Some(id) => {
-                real = PROXIES.with(|p| {
-                    p.borrow()
-                        .get(id as usize)
-                        .and_then(|o| o.as_ref())
-                        .map(|e| e.target)
-                        .unwrap_or(f64::from_bits(TAG_UNDEFINED))
-                });
-            }
-            None => break,
-        }
-    }
-
-    // Target must be an object.
-    if !reflect_value_is_object(real) {
-        return reflect_non_object_typeerror("setPrototypeOf");
-    }
-
-    // Proto must be an object or null.
-    let proto_bits = proto.to_bits();
-    let proto_ok = proto_bits == TAG_NULL || reflect_value_is_object(proto);
-    if !proto_ok {
-        return throw_type_error("Object prototype may only be an Object or null");
-    }
-
-    // #2761: a non-extensible target rejects a *changing* prototype. If the
-    // current prototype already equals `proto`, the no-op set still succeeds.
-    if crate::object::obj_value_no_extend(real) {
-        let current = crate::object::js_object_get_prototype_of(real);
-        if current.to_bits() != proto_bits {
-            return nanbox_bool(false);
-        }
-        return nanbox_bool(true);
-    }
-
-    // Apply via the shared Object-side helper (records in the side-table).
-    crate::object::js_object_set_prototype_of(real, proto);
     nanbox_bool(true)
 }
 

--- a/crates/perry-runtime/src/proxy/invariants.rs
+++ b/crates/perry-runtime/src/proxy/invariants.rs
@@ -1,0 +1,246 @@
+//! Proxy trap result invariant enforcement (ECMA-262 §10.5).
+//!
+//! After a `get`/`set`/`has`/`deleteProperty`/`defineProperty` trap runs, the
+//! spec re-reads the *target's* own property descriptor and throws a
+//! `TypeError` when the trap result is inconsistent with a non-configurable (or
+//! non-extensible) target. These checks make a Proxy unable to lie about the
+//! invariant parts of its target — they are what the bulk of the
+//! `built-ins/Proxy/*/...throws` tests exercise.
+
+use super::{extract_pointer, throw_type_error, TAG_NULL, TAG_UNDEFINED};
+
+/// A target's own-property descriptor, reduced to the fields the invariant
+/// checks need. Built from `[[GetOwnProperty]]` (FromPropertyDescriptor), so a
+/// data descriptor populates `value`/`writable` and an accessor descriptor
+/// populates `getter_undefined`/`setter_undefined`.
+struct TargetProp {
+    configurable: bool,
+    is_accessor: bool,
+    writable: bool,
+    value: f64,
+    getter_undefined: bool,
+    setter_undefined: bool,
+}
+
+fn truthy(v: f64) -> bool {
+    crate::value::js_is_truthy(v) != 0
+}
+
+fn desc_field(desc_ptr: *const crate::ObjectHeader, name: &[u8]) -> f64 {
+    if desc_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::object::js_object_get_field_by_name_f64(desc_ptr, key)
+}
+
+fn desc_has(desc: f64, name: &[u8]) -> bool {
+    let ptr = extract_pointer(desc.to_bits()) as *mut crate::ObjectHeader;
+    if ptr.is_null() {
+        return false;
+    }
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    unsafe { crate::object::own_key_present(ptr, key) }
+}
+
+/// Read `target.[[GetOwnProperty]](property_key)` as a `TargetProp`. Returns
+/// `None` when the target has no such own property (descriptor is `undefined`).
+fn target_own_prop(target: f64, property_key: f64) -> Option<TargetProp> {
+    let desc = crate::object::js_object_get_own_property_descriptor(target, property_key);
+    if desc.to_bits() == TAG_UNDEFINED {
+        return None;
+    }
+    let ptr = extract_pointer(desc.to_bits()) as *const crate::ObjectHeader;
+    if ptr.is_null() {
+        return None;
+    }
+    let is_accessor = desc_has(desc, b"get") || desc_has(desc, b"set");
+    Some(TargetProp {
+        configurable: truthy(desc_field(ptr, b"configurable")),
+        is_accessor,
+        writable: truthy(desc_field(ptr, b"writable")),
+        value: desc_field(ptr, b"value"),
+        getter_undefined: desc_field(ptr, b"get").to_bits() == TAG_UNDEFINED,
+        setter_undefined: desc_field(ptr, b"set").to_bits() == TAG_UNDEFINED,
+    })
+}
+
+fn same_value(a: f64, b: f64) -> bool {
+    crate::value::js_jsvalue_same_value_zero(a, b) != 0
+}
+
+fn target_is_extensible(target: f64) -> bool {
+    !crate::object::obj_value_no_extend(target)
+}
+
+/// `[[Get]]` invariant: a non-configurable, non-writable data property forces
+/// the trap result to SameValue the target value; a non-configurable accessor
+/// with no getter forces an `undefined` trap result.
+pub(super) fn enforce_get_invariant(target: f64, property_key: f64, trap_result: f64) {
+    let Some(prop) = target_own_prop(target, property_key) else {
+        return;
+    };
+    if prop.configurable {
+        return;
+    }
+    if !prop.is_accessor {
+        if !prop.writable && !same_value(trap_result, prop.value) {
+            throw_type_error(
+                "proxy get trap returned a different value for a non-writable, non-configurable property",
+            );
+        }
+    } else if prop.getter_undefined && trap_result.to_bits() != TAG_UNDEFINED {
+        throw_type_error(
+            "proxy get trap returned a value for a non-configurable accessor with an undefined getter",
+        );
+    }
+}
+
+/// `[[Set]]` invariant (checked only when the trap returned a truthy result): a
+/// non-configurable, non-writable data property requires the written value to
+/// SameValue the target value; a non-configurable accessor requires a setter.
+pub(super) fn enforce_set_invariant(target: f64, property_key: f64, value: f64) {
+    let Some(prop) = target_own_prop(target, property_key) else {
+        return;
+    };
+    if prop.configurable {
+        return;
+    }
+    if !prop.is_accessor {
+        if !prop.writable && !same_value(value, prop.value) {
+            throw_type_error(
+                "proxy set trap reported success for a non-writable, non-configurable property",
+            );
+        }
+    } else if prop.setter_undefined {
+        throw_type_error(
+            "proxy set trap reported success for a non-configurable accessor with an undefined setter",
+        );
+    }
+}
+
+/// `[[HasProperty]]` invariant (checked only when the trap returned `false`): a
+/// non-configurable own key, or any own key on a non-extensible target, cannot
+/// be hidden.
+pub(super) fn enforce_has_false_invariant(target: f64, property_key: f64) {
+    let Some(prop) = target_own_prop(target, property_key) else {
+        return;
+    };
+    if !prop.configurable {
+        throw_type_error("proxy has trap returned false for a non-configurable property");
+    }
+    if !target_is_extensible(target) {
+        throw_type_error("proxy has trap returned false for a property of a non-extensible target");
+    }
+}
+
+/// `[[Delete]]` invariant (checked only when the trap returned a truthy result):
+/// a non-configurable own key, or any own key on a non-extensible target,
+/// cannot be reported as deleted.
+pub(super) fn enforce_delete_invariant(target: f64, property_key: f64) {
+    let Some(prop) = target_own_prop(target, property_key) else {
+        return;
+    };
+    if !prop.configurable {
+        throw_type_error(
+            "proxy deleteProperty trap reported success for a non-configurable property",
+        );
+    }
+    if !target_is_extensible(target) {
+        throw_type_error(
+            "proxy deleteProperty trap reported success for a property of a non-extensible target",
+        );
+    }
+}
+
+/// `[[DefineOwnProperty]]` invariant (checked only when the trap returned a
+/// truthy result). Implements the key rejections from ValidateAndApplyProperty
+/// against the target:
+///  * defining a new property on a non-extensible target,
+///  * adding a non-configurable property the target doesn't have,
+///  * redefining a non-configurable target property in an incompatible way.
+pub(super) fn enforce_define_property_invariant(target: f64, property_key: f64, descriptor: f64) {
+    let extensible = target_is_extensible(target);
+    let setting_config_false = desc_has(descriptor, b"configurable")
+        && !truthy({
+            let ptr = extract_pointer(descriptor.to_bits()) as *const crate::ObjectHeader;
+            desc_field(ptr, b"configurable")
+        });
+
+    match target_own_prop(target, property_key) {
+        None => {
+            if !extensible {
+                throw_type_error(
+                    "proxy defineProperty trap added a property to a non-extensible target",
+                );
+            }
+            if setting_config_false {
+                throw_type_error(
+                    "proxy defineProperty trap added a non-configurable property absent from the target",
+                );
+            }
+        }
+        Some(prop) => {
+            if !is_compatible_descriptor(&prop, descriptor) {
+                throw_type_error(
+                    "proxy defineProperty trap reported an incompatible descriptor for the target",
+                );
+            }
+            if setting_config_false && prop.configurable {
+                throw_type_error(
+                    "proxy defineProperty trap made a configurable target property non-configurable",
+                );
+            }
+        }
+    }
+}
+
+/// A conservative IsCompatiblePropertyDescriptor check against a
+/// non-configurable existing target property. For a configurable target
+/// property any redefinition is compatible.
+fn is_compatible_descriptor(current: &TargetProp, descriptor: f64) -> bool {
+    if current.configurable {
+        return true;
+    }
+    let ptr = extract_pointer(descriptor.to_bits()) as *const crate::ObjectHeader;
+    let desc_is_accessor = desc_has(descriptor, b"get") || desc_has(descriptor, b"set");
+
+    // A non-configurable property cannot switch between data and accessor.
+    if desc_is_accessor != current.is_accessor {
+        return false;
+    }
+    if current.is_accessor {
+        // Accessor: a specified get/set must SameValue the current one.
+        if desc_has(descriptor, b"get") {
+            let g = desc_field(ptr, b"get");
+            let cur_undef = current.getter_undefined;
+            if (g.to_bits() == TAG_UNDEFINED) != cur_undef {
+                return false;
+            }
+        }
+        if desc_has(descriptor, b"set") {
+            let s = desc_field(ptr, b"set");
+            if (s.to_bits() == TAG_UNDEFINED) != current.setter_undefined {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Data: a non-writable property cannot become writable, and its value
+    // cannot change (unless made writable, which is itself forbidden above).
+    if desc_has(descriptor, b"writable") {
+        let w = truthy(desc_field(ptr, b"writable"));
+        if w && !current.writable {
+            return false;
+        }
+    }
+    if !current.writable && desc_has(descriptor, b"value") {
+        let v = desc_field(ptr, b"value");
+        if !same_value(v, current.value) {
+            return false;
+        }
+    }
+    let _ = TAG_NULL;
+    true
+}

--- a/crates/perry-runtime/src/proxy/own_keys.rs
+++ b/crates/perry-runtime/src/proxy/own_keys.rs
@@ -1,0 +1,254 @@
+//! Proxy `[[OwnPropertyKeys]]` (ECMA-262 §10.5.11) — the `ownKeys` trap.
+//!
+//! `Object.keys` / `Object.getOwnPropertyNames` / `Object.getOwnPropertySymbols`
+//! / `Reflect.ownKeys` on a Proxy all funnel through here. The trap result is
+//! validated as a duplicate-free list of String/Symbol keys, then checked
+//! against the target's non-configurable / non-extensible invariants.
+
+use super::{
+    call_trap, create_list_from_array_like, handler_trap, is_callable_function, lookup,
+    revoked_return, throw_type_error, POINTER_MASK, POINTER_TAG, PROXIES, TAG_NULL, TAG_UNDEFINED,
+};
+
+fn alloc_key_array(keys: &[f64]) -> f64 {
+    let mut arr = crate::array::js_array_alloc(keys.len() as u32);
+    for &k in keys {
+        arr = crate::array::js_array_push_f64(arr, k);
+    }
+    f64::from_bits(POINTER_TAG | ((arr as u64) & POINTER_MASK))
+}
+
+fn is_string_key(v: f64) -> bool {
+    crate::value::JSValue::from_bits(v.to_bits()).is_any_string()
+}
+
+fn is_symbol_key(v: f64) -> bool {
+    unsafe { crate::symbol::js_is_symbol(v) != 0 }
+}
+
+/// A stable identity for duplicate detection: string content for string keys,
+/// raw bits for symbol keys.
+fn key_identity(v: f64) -> Option<String> {
+    if is_symbol_key(v) {
+        return Some(format!("sym:{:016x}", v.to_bits()));
+    }
+    let s = crate::builtins::js_string_coerce(v);
+    if s.is_null() {
+        return None;
+    }
+    unsafe {
+        let name_ptr = (s as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_len = (*s).byte_len as usize;
+        std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+            .ok()
+            .map(|x| format!("str:{x}"))
+    }
+}
+
+/// Collect a (possibly proxy) value's own keys (string names then symbols),
+/// recursing through proxy targets so the no-trap path forwards correctly.
+fn target_own_keys(target: f64) -> Vec<f64> {
+    if lookup(target).is_some() {
+        let arr = js_proxy_own_keys(target);
+        return read_array(arr);
+    }
+    let mut out = Vec::new();
+    let names = crate::object::js_object_get_own_property_names(target);
+    out.extend(read_array(names));
+    let syms = unsafe { crate::symbol::js_object_get_own_property_symbols(target) };
+    let syms_ptr = syms as *const crate::array::ArrayHeader;
+    if !syms_ptr.is_null() {
+        let n = crate::array::js_array_length(syms_ptr) as usize;
+        for i in 0..n {
+            let s = crate::array::js_array_get(syms_ptr, i as u32);
+            out.push(f64::from_bits(s.bits()));
+        }
+    }
+    out
+}
+
+fn read_array(arr_value: f64) -> Vec<f64> {
+    let ptr = (arr_value.to_bits() & POINTER_MASK) as *const crate::array::ArrayHeader;
+    if ptr.is_null() {
+        return Vec::new();
+    }
+    let n = crate::array::js_array_length(ptr) as usize;
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        out.push(f64::from_bits(
+            crate::array::js_array_get(ptr, i as u32).bits(),
+        ));
+    }
+    out
+}
+
+fn target_key_is_configurable(target: f64, key: f64) -> bool {
+    let desc = crate::object::js_object_get_own_property_descriptor(target, key);
+    if desc.to_bits() == TAG_UNDEFINED {
+        // Not an own property of the target; treat as configurable (no
+        // invariant to enforce for it).
+        return true;
+    }
+    let ptr = (desc.to_bits() & POINTER_MASK) as *const crate::ObjectHeader;
+    if ptr.is_null() {
+        return true;
+    }
+    let k = crate::string::js_string_from_bytes(b"configurable".as_ptr(), 12);
+    crate::value::js_is_truthy(crate::object::js_object_get_field_by_name_f64(ptr, k)) != 0
+}
+
+/// Proxy `[[OwnPropertyKeys]]`: returns a fresh Array JSValue holding the own
+/// keys (strings + symbols). Dispatches the `ownKeys` trap with the handler
+/// bound as `this`, applies the element-type / duplicate / invariant checks, or
+/// forwards to the target when no trap is present.
+#[no_mangle]
+pub extern "C" fn js_proxy_own_keys(proxy_boxed: f64) -> f64 {
+    let id = match lookup(proxy_boxed) {
+        Some(id) => id,
+        None => return alloc_key_array(&[]),
+    };
+    let (target, handler, revoked) = PROXIES.with(|p| {
+        p.borrow()
+            .get(id as usize)
+            .and_then(|o| o.as_ref())
+            .map(|e| (e.target, e.handler, e.revoked))
+            .unwrap_or((
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+                false,
+            ))
+    });
+    if revoked {
+        return revoked_return();
+    }
+    let trap = handler_trap(handler, "ownKeys");
+    let trap_bits = trap.to_bits();
+    if trap_bits == TAG_UNDEFINED || trap_bits == TAG_NULL {
+        return alloc_key_array(&target_own_keys(target));
+    }
+    if !is_callable_function(trap) {
+        return throw_type_error("proxy ownKeys trap is not a function");
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_h = scope.root_nanbox_f64(target);
+    let trap_result = call_trap(handler, trap, &[target_h.get_nanbox_f64()]);
+
+    // CreateListFromArrayLike(trapResult, « String, Symbol »): throws for a
+    // non-object result and for any element that is neither a string nor a
+    // symbol.
+    let trap_keys = create_list_from_array_like(trap_result);
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for &k in &trap_keys {
+        if !is_string_key(k) && !is_symbol_key(k) {
+            return throw_type_error("proxy ownKeys trap returned a non-string, non-symbol key");
+        }
+        let Some(idy) = key_identity(k) else {
+            return throw_type_error("proxy ownKeys trap returned an invalid key");
+        };
+        if !seen.insert(idy) {
+            return throw_type_error("proxy ownKeys trap returned duplicate keys");
+        }
+    }
+
+    let target = target_h.get_nanbox_f64();
+    let extensible = !crate::object::obj_value_no_extend(target);
+    let target_keys = target_own_keys(target);
+
+    // Partition the target's own keys by configurability.
+    let mut nonconfig: Vec<f64> = Vec::new();
+    let mut config: Vec<f64> = Vec::new();
+    for &tk in &target_keys {
+        if target_key_is_configurable(target, tk) {
+            config.push(tk);
+        } else {
+            nonconfig.push(tk);
+        }
+    }
+
+    // Fast path: an extensible target with only configurable keys imposes no
+    // invariant — return the trap result verbatim.
+    if extensible && nonconfig.is_empty() {
+        return alloc_key_array(&trap_keys);
+    }
+
+    let mut unchecked: Vec<String> = trap_keys.iter().filter_map(|&k| key_identity(k)).collect();
+    let remove = |unchecked: &mut Vec<String>, key: f64| -> bool {
+        if let Some(idy) = key_identity(key) {
+            if let Some(pos) = unchecked.iter().position(|x| *x == idy) {
+                unchecked.remove(pos);
+                return true;
+            }
+        }
+        false
+    };
+
+    // Every non-configurable target key must appear in the trap result.
+    for &k in &nonconfig {
+        if !remove(&mut unchecked, k) {
+            return throw_type_error(
+                "proxy ownKeys trap omitted a non-configurable target property",
+            );
+        }
+    }
+    if extensible {
+        return alloc_key_array(&trap_keys);
+    }
+    // A non-extensible target additionally requires every configurable key to
+    // be present and forbids extra keys.
+    for &k in &config {
+        if !remove(&mut unchecked, k) {
+            return throw_type_error(
+                "proxy ownKeys trap omitted a property of a non-extensible target",
+            );
+        }
+    }
+    if !unchecked.is_empty() {
+        return throw_type_error(
+            "proxy ownKeys trap returned an extra key for a non-extensible target",
+        );
+    }
+    alloc_key_array(&trap_keys)
+}
+
+/// `Object.getOwnPropertyNames(proxy)` — the string subset of the proxy's own
+/// keys.
+pub(crate) fn proxy_own_property_names(proxy_boxed: f64) -> f64 {
+    let keys = read_array(js_proxy_own_keys(proxy_boxed));
+    let names: Vec<f64> = keys.into_iter().filter(|&k| is_string_key(k)).collect();
+    alloc_key_array(&names)
+}
+
+/// `Object.getOwnPropertySymbols(proxy)` — the symbol subset.
+pub(crate) fn proxy_own_property_symbols(proxy_boxed: f64) -> f64 {
+    let keys = read_array(js_proxy_own_keys(proxy_boxed));
+    let syms: Vec<f64> = keys.into_iter().filter(|&k| is_symbol_key(k)).collect();
+    alloc_key_array(&syms)
+}
+
+/// `Object.keys(proxy)` — EnumerableOwnPropertyNames: string keys whose proxy
+/// `[[GetOwnProperty]]` reports `enumerable: true`.
+pub(crate) fn proxy_enum_own_keys(proxy_boxed: f64) -> f64 {
+    let keys = read_array(js_proxy_own_keys(proxy_boxed));
+    let mut out: Vec<f64> = Vec::new();
+    for k in keys {
+        if !is_string_key(k) {
+            continue;
+        }
+        let desc = super::js_reflect_get_own_property_descriptor(proxy_boxed, k);
+        if desc.to_bits() == TAG_UNDEFINED {
+            continue;
+        }
+        let ptr = (desc.to_bits() & POINTER_MASK) as *const crate::ObjectHeader;
+        if ptr.is_null() {
+            continue;
+        }
+        let ek = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
+        if crate::value::js_is_truthy(crate::object::js_object_get_field_by_name_f64(ptr, ek)) != 0
+        {
+            out.push(k);
+        }
+    }
+    let _ = TAG_NULL;
+    alloc_key_array(&out)
+}

--- a/crates/perry-runtime/src/proxy/prototype.rs
+++ b/crates/perry-runtime/src/proxy/prototype.rs
@@ -1,0 +1,109 @@
+//! Proxy `[[SetPrototypeOf]]` (ECMA-262 §10.5.2) and the `Reflect.setPrototypeOf`
+//! entry point. Split out of `proxy.rs` to keep that file under the size gate.
+
+use super::{
+    call_trap, handler_trap, is_callable_function, lookup, nanbox_bool,
+    reflect_non_object_typeerror, reflect_target_get_prototype_of, reflect_value_is_object,
+    revoked_return, throw_type_error, PROXIES, TAG_NULL, TAG_UNDEFINED,
+};
+
+/// `Reflect.setPrototypeOf(target, proto)` (#2761).
+///
+/// Returns a boolean: `true` when the prototype change is applied, `false`
+/// when it is rejected (target is non-extensible and the proto actually
+/// changes). Throws `TypeError` for a non-object target or a proto that is
+/// neither an object nor `null`. For a proxy, dispatches the `setPrototypeOf`
+/// trap.
+#[no_mangle]
+pub extern "C" fn js_reflect_set_prototype_of(target: f64, proto: f64) -> f64 {
+    // Target must be an object (a proxy qualifies).
+    if !reflect_value_is_object(target) {
+        return reflect_non_object_typeerror("setPrototypeOf");
+    }
+
+    // Proto must be an object or null.
+    let proto_bits = proto.to_bits();
+    let proto_ok = proto_bits == TAG_NULL || reflect_value_is_object(proto);
+    if !proto_ok {
+        return throw_type_error("Object prototype may only be an Object or null");
+    }
+
+    // Proxy `[[SetPrototypeOf]]`: dispatch the trap (or forward through the
+    // target chain) before the ordinary path, which would deref the fake
+    // proxy pointer.
+    if lookup(target).is_some() {
+        return proxy_set_prototype_of(target, proto);
+    }
+
+    // #2761: a non-extensible target rejects a *changing* prototype. If the
+    // current prototype already equals `proto`, the no-op set still succeeds.
+    if crate::object::obj_value_no_extend(target) {
+        let current = crate::object::js_object_get_prototype_of(target);
+        if current.to_bits() != proto_bits {
+            return nanbox_bool(false);
+        }
+        return nanbox_bool(true);
+    }
+
+    // Apply via the shared Object-side helper (records in the side-table).
+    crate::object::js_object_set_prototype_of(target, proto);
+    nanbox_bool(true)
+}
+
+/// Proxy `[[SetPrototypeOf]]` (ECMA-262 §10.5.2): invoke the `setPrototypeOf`
+/// trap (bound to the handler) when present, otherwise forward to the target's
+/// `[[SetPrototypeOf]]` (recursing through proxy targets). Enforces the
+/// non-extensible-target invariant: a `true` result requires the new proto to
+/// SameValue the target's current proto.
+fn proxy_set_prototype_of(proxy_boxed: f64, proto: f64) -> f64 {
+    let id = match lookup(proxy_boxed) {
+        Some(id) => id,
+        None => return nanbox_bool(false),
+    };
+    let (target, handler, revoked) = PROXIES.with(|p| {
+        p.borrow()
+            .get(id as usize)
+            .and_then(|o| o.as_ref())
+            .map(|e| (e.target, e.handler, e.revoked))
+            .unwrap_or((
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+                false,
+            ))
+    });
+    if revoked {
+        return revoked_return();
+    }
+    let trap = handler_trap(handler, "setPrototypeOf");
+    let trap_bits = trap.to_bits();
+    if trap_bits == TAG_UNDEFINED || trap_bits == TAG_NULL {
+        // No trap — forward to the target's [[SetPrototypeOf]].
+        return js_reflect_set_prototype_of(target, proto);
+    }
+    if !is_callable_function(trap) {
+        return throw_type_error("proxy setPrototypeOf trap is not a function");
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_h = scope.root_nanbox_f64(target);
+    let proto_h = scope.root_nanbox_f64(proto);
+    let trap_result = call_trap(
+        handler,
+        trap,
+        &[target_h.get_nanbox_f64(), proto_h.get_nanbox_f64()],
+    );
+    if crate::value::js_is_truthy(trap_result) == 0 {
+        return nanbox_bool(false);
+    }
+    // Invariant: if the target is non-extensible, the proto must not change.
+    let target = target_h.get_nanbox_f64();
+    let proto = proto_h.get_nanbox_f64();
+    if crate::object::obj_value_no_extend(target) {
+        let current = reflect_target_get_prototype_of(target);
+        if current.to_bits() != proto.to_bits() {
+            return throw_type_error(
+                "proxy setPrototypeOf trap violates non-extensible target invariant",
+            );
+        }
+    }
+    nanbox_bool(true)
+}

--- a/crates/perry-runtime/src/proxy/reflect.rs
+++ b/crates/perry-runtime/src/proxy/reflect.rs
@@ -367,5 +367,17 @@ pub extern "C" fn js_reflect_get_own_property_descriptor(target: f64, key: f64) 
         );
     }
 
+    // [[GetOwnProperty]] step 21.a: a non-configurable result descriptor is only
+    // valid for a non-configurable existing target property.
+    if unsafe { descriptor_bool_field(result, b"configurable") } == Some(false) {
+        let target_configurable = target_desc.to_bits() == TAG_UNDEFINED
+            || unsafe { descriptor_bool_field(target_desc, b"configurable") } != Some(false);
+        if target_configurable {
+            return throw_type_error(
+                "proxy getOwnPropertyDescriptor trap reports a non-configurable descriptor for a configurable or absent target property",
+            );
+        }
+    }
+
     result
 }

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -2076,6 +2076,12 @@ pub unsafe extern "C" fn js_object_get_own_property_symbols(obj_f64: f64) -> i64
     if jv.is_null() || jv.is_undefined() {
         crate::object::has_own_helpers::throw_to_object_nullish_type_error();
     }
+    // A Proxy is a small registered id — route through the `ownKeys` trap
+    // (symbol subset) before the heap-object paths below.
+    if crate::proxy::js_proxy_is_proxy(obj_f64) != 0 {
+        let arr = crate::proxy::proxy_own_property_symbols(obj_f64);
+        return (arr.to_bits() & POINTER_MASK) as i64;
+    }
     if let Some(class_id) = crate::object::class_ref_id(obj_f64) {
         let mut entries = if crate::object::class_prototype_ref_id(obj_f64).is_some() {
             crate::object::class_own_symbol_member_keys(class_id, false)


### PR DESCRIPTION
## Summary

Implements the missing/incomplete Proxy exotic-object behaviors exercised by the test262 `built-ins/Proxy` suite.

**`built-ins/Proxy`: 133 → 200 pass (55.4% → 83.3%), +67 fixed, ZERO regressions** (test262 @ `4249661388`, oracle = Node).

## Root causes fixed

1. **Trap `this`-binding + receiver argument.** `get`/`set`/`has`/`deleteProperty`/`defineProperty` traps were invoked by calling the trap closure directly — dropping the spec-required `this = handler` binding and, for `get`/`set`, the trailing `receiver` argument. Factored a shared `call_trap(handler, trap, args)` helper (rebinds `this` + sets `IMPLICIT_THIS` + arity dispatch, mirroring the existing apply/construct path). `get` now passes `(target, key, proxy)`, `set` passes `(target, key, value, proxy)`.

2. **`ownKeys` trap was unimplemented.** `Object.getOwnPropertyNames` / `Object.keys` / `Object.getOwnPropertySymbols` / `Reflect.ownKeys` on a proxy hit the small-handle dispatch fallback and returned `[]`. New `proxy/own_keys.rs` dispatches the trap with `CreateListFromArrayLike` (String/Symbol element-type check), duplicate-key rejection, and the non-configurable / non-extensible target invariants; the four reflection entry points now route through it.

3. **Trap-result invariant enforcement.** New `proxy/invariants.rs` enforces the `get`/`set`/`has`/`deleteProperty`/`defineProperty` result invariants against the target's own descriptor (e.g. a non-configurable non-writable data property forces `get` to return the same value; `has` cannot hide a non-configurable key). `getOwnPropertyDescriptor` gains the missing "non-configurable result for a configurable/absent target property" check.

4. **`setPrototypeOf` trap was not dispatched**, and `Object.getPrototypeOf(proxy)` skipped trap-result validation. `setPrototypeOf` now invokes the trap (with the non-extensible invariant); `getPrototypeOf` validation is shared by both the `Object.*` and `Reflect.*` entry points.

5. **No-trap `get`/`has`/`deleteProperty` now forward to a proxy *target*** (recurse through proxy dispatch) instead of dereferencing the fake proxy handle — a crash fix for proxy-wrapping-proxy.

## Files

- `crates/perry-runtime/src/proxy.rs` — `call_trap`; rework get/set/has/delete/defineProperty/isExtensible/preventExtensions/setPrototypeOf/getPrototypeOf trap paths
- `crates/perry-runtime/src/proxy/invariants.rs` *(new)* — trap-result invariants
- `crates/perry-runtime/src/proxy/own_keys.rs` *(new)* — `ownKeys` trap + reflection routing
- `crates/perry-runtime/src/proxy/reflect.rs` — `getOwnPropertyDescriptor` non-configurable-result invariant
- `crates/perry-runtime/src/object/descriptors.rs`, `crates/perry-runtime/src/object/field_get_set.rs`, `crates/perry-runtime/src/symbol.rs` — route `getOwnPropertyNames`/`keys`/`getOwnPropertySymbols` on a proxy through the `ownKeys` trap

## Validation

`scripts/test262_subset.py --dir built-ins/Proxy` (default compile path):
- Before: pass=133, runtime-fail=107 (55.4%)
- After: pass=200, runtime-fail=40 (83.3%)
- Differential vs base: **67 fixed, 0 regressions** (no previously-passing test now fails).

Per-dir improvements include `ownKeys` 0→25, `getPrototypeOf` 8→16, `has` 9→17, `setPrototypeOf` 0→5, `getOwnPropertyDescriptor` 12→16, `defineProperty` 8→13. Remaining 40 failures are mostly deep receiver-aware `OrdinarySet` cases and pre-existing Symbol/revoked-edge handling outside this change's scope.

`cargo fmt --all -- --check` clean.