### PR TITLE
fix(runtime): symbol-keyed write on a native handle no longer throws (fixes Hono POST/PUT 500)

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -568,6 +568,18 @@ fn small_handle_from_value(value: f64) -> Option<i64> {
 fn set_handle_property(target: f64, key: f64, value: f64) -> Option<bool> {
     let handle = small_handle_from_value(target)?;
     let Some(name) = key_to_rust_string(key) else {
+        // A SYMBOL-keyed write on a small native handle (e.g. the
+        // @hono/node-server `incoming[wrapBodyStream] = true` on the HTTP
+        // IncomingMessage handle). The handle is not a heap ObjectHeader, so
+        // it has no field storage; route the write to the per-object symbol
+        // side table (keyed by the handle pointer, exactly like a plain
+        // object) and report success. Returning `Some(false)` here made
+        // strict-mode assignment throw `TypeError: Cannot assign to read only
+        // property` and 500 every POST/PUT served by Hono's node adapter.
+        if unsafe { crate::symbol::js_is_symbol(key) } != 0 {
+            unsafe { crate::symbol::js_object_set_symbol_property(target, key, value) };
+            return Some(true);
+        }
         return Some(false);
     };
     if let Some(dispatch) = crate::object::handle_property_set_dispatch() {

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1657,6 +1657,15 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             && !crate::object::is_valid_obj_ptr(id as *const u8)
             && crate::proxy::js_proxy_is_proxy(obj_f64) == 0
         {
+            // A user-stored symbol property (set via the symbol side table,
+            // keyed by the handle pointer — e.g. @hono/node-server's
+            // `incoming[wrapBodyStream] = true`) round-trips here. The side
+            // table is a pointer-keyed map, so this read does NOT dereference
+            // the small handle id as an ObjectHeader (which would EXC_BAD_ACCESS
+            // / segfault); it is safe for native handles.
+            if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
+                return v;
+            }
             return f64::from_bits(TAG_UNDEFINED);
         }
     }

--- a/tests/test_http_post_symbol_handle.sh
+++ b/tests/test_http_post_symbol_handle.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression: a SYMBOL-keyed property write on a native node:http
+# `IncomingMessage` handle (e.g. @hono/node-server's
+# `incoming[wrapBodyStream] = true` on the POST/PUT body path) used to throw
+# `TypeError: Cannot assign to read only property 'property'` under strict mode,
+# because `set_handle_property` reported the symbol write as a failed [[Set]].
+# That rejected write surfaced as Hono's `handleFetchError` returning a 500 for
+# every POST/PUT (GET/HEAD have no body and skip the write), so the native HTTP
+# server replied 500 to all body-carrying requests before the route ran.
+#
+# Fix: route symbol-keyed writes on a native handle into the per-object symbol
+# side table (and read them back from it). This test drives a real node:http
+# server with a POST body and asserts the symbol round-trips AND the body is
+# delivered to the handler.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/srv.ts" <<'TS'
+import * as http from "node:http";
+
+const wrapBodyStream = Symbol("wrapBodyStream");
+
+const server = http.createServer((req: any, res: any) => {
+  // The @hono/node-server adapter does exactly this on every non-GET/HEAD
+  // request. It must not throw, and must round-trip through the side table.
+  let symOk = false;
+  try {
+    req[wrapBodyStream] = true;
+    symOk = req[wrapBodyStream] === true;
+  } catch (e: any) {
+    res.statusCode = 500;
+    res.end("SYMBOL_THREW:" + (e && e.message));
+    return;
+  }
+
+  let body = "";
+  req.on("data", (d: any) => { body += d; });
+  req.on("end", () => {
+    res.statusCode = 200;
+    res.end("sym=" + symOk + ";body=" + body);
+  });
+});
+
+server.listen(0, () => {
+  const port = (server.address() as any).port;
+  const data = "hello-post-body";
+  const r = http.request(
+    { host: "127.0.0.1", port, path: "/", method: "POST",
+      headers: { "content-type": "text/plain", "content-length": data.length } },
+    (resp: any) => {
+      let out = "";
+      resp.setEncoding("utf8");
+      resp.on("data", (c: any) => { out += c; });
+      resp.on("end", () => {
+        console.log("STATUS=" + resp.statusCode);
+        console.log("RESP=" + out);
+        server.close();
+      });
+    },
+  );
+  r.write(data);
+  r.end();
+});
+TS
+
+# Run inside the tmpdir so `perry run` does not leave its compiled artifact
+# (e.g. `srv`) in the caller's cwd / the repo tree.
+OUT="$(cd "$TMPDIR" && "$PERRY" run "$TMPDIR/srv.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+
+if ! grep -q "^STATUS=200$" <<<"$OUT"; then
+  echo "FAIL: expected POST status 200, got:"; echo "$OUT"; exit 1;
+fi
+if ! grep -q "^RESP=sym=true;body=hello-post-body$" <<<"$OUT"; then
+  echo "FAIL: symbol round-trip or POST body wrong, got:"; echo "$OUT"; exit 1;
+fi
+echo "PASS: symbol-keyed write on a native IncomingMessage handle round-trips; POST body delivered"


### PR DESCRIPTION
## Problem

A Perry-compiled **Hono + @hono/node-server** app returned HTTP **500 for every POST and PUT** (GET/HEAD worked). The 500 fired before the route handler did real work.

## Root cause

@hono/node-server's request adapter runs `incoming[wrapBodyStream] = true` on the node:http `IncomingMessage` for every non-GET/HEAD request — a **Symbol-keyed write on a native handle**.

The `IncomingMessage` is a small registry handle NaN-boxed as a POINTER (not a heap `ObjectHeader`). A strict-mode `obj[sym] = v` lowers to `js_put_value_set(..., strict=1)`, which calls `set_handle_property`. There, `key_to_rust_string(key)` fails for a Symbol key, so the function returned `Some(false)`. `js_put_value_set` treated that as a failed `[[Set]]` and, under strict mode, threw:

```
TypeError: Cannot assign to read only property 'property' of object '#<Object>'
```

That rejected write surfaced as the adapter's `handleFetchError` → a 500 on every body-carrying request. (Plain objects were unaffected — they route symbol writes through the symbol side table.)

## Fix

- **Write** (`proxy.rs::set_handle_property`): when the key is a Symbol on a native handle, store it in the per-object symbol side table (keyed by the handle pointer, exactly like a plain object) and return `Some(true)`.
- **Read** (`symbol.rs::js_object_get_symbol_property`): for a small native handle, consult the side table before the existing undefined short-circuit, so the property round-trips.

Both paths use the pointer-keyed side table and never dereference the small handle id as an `ObjectHeader`, so they remain segfault-safe for native handles.

## Test

`tests/test_http_post_symbol_handle.sh` — drives a real node:http server with a POST body, sets a Symbol on the `IncomingMessage` handle (the exact Hono pattern), and asserts the Symbol round-trips **and** the body reaches the handler. Fails (TypeError) before the fix; PASSes after.

## Verification on the real app (billing.skelpo.com)

- Before: every POST → handler never ran past `newRequest`; 500.
- After: POST reaches the Hono router and route handler; a 50-POST burst all respond with the server staying alive; GET routes unaffected.

Note: a **separate, pre-existing** bug remains downstream for this app (subclassing the native global `Request` — `class Request extends GlobalRequest` — yields instances missing `.text()`/`.json()` because those resolve via native handle dispatch, not a JS prototype). That is independent of this native-HTTP-server fix and is the next blocker for a 2xx on the JSON-body route.