### PR TITLE
fix(hir): iteration-statement protocol test262 parity

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -954,6 +954,14 @@ impl JsEmitter {
                 self.emit_expr(obj);
                 self.output.push(')');
             }
+            // for-in enumeration keys: own + inherited enumerable, nullish-safe.
+            Expr::ForInKeys(obj) => {
+                self.output.push_str(
+                    "((__o)=>{var __a=[];for(var __k in __o)__a.push(__k);return __a;})(",
+                );
+                self.emit_expr(obj);
+                self.output.push(')');
+            }
             Expr::ObjectValues(obj) => {
                 self.output.push_str("Object.values(");
                 self.emit_expr(obj);

--- a/crates/perry-codegen/src/boxed_vars.rs
+++ b/crates/perry-codegen/src/boxed_vars.rs
@@ -1404,6 +1404,7 @@ fn refine_type_from_init_simple(init: &perry_hir::Expr) -> Option<perry_types::T
         | Expr::ArrayFlat { .. }
         | Expr::ArrayFlatMap { .. }
         | Expr::ObjectKeys(_)
+        | Expr::ForInKeys(_)
         | Expr::ObjectValues(_)
         | Expr::ObjectEntries(_)
         | Expr::ArrayEntries { .. }

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -374,6 +374,7 @@ pub fn check_escapes_in_expr(
         | Expr::IsUndefinedOrBareNan(operand)
         | Expr::ParseFloat(operand)
         | Expr::ObjectKeys(operand)
+        | Expr::ForInKeys(operand)
         | Expr::ObjectValues(operand)
         | Expr::ObjectEntries(operand)
         | Expr::SetSize(operand)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -233,6 +233,7 @@ fn collect_used_new_fields_in_expr(
         | Expr::IsUndefinedOrBareNan(operand)
         | Expr::ParseFloat(operand)
         | Expr::ObjectKeys(operand)
+        | Expr::ForInKeys(operand)
         | Expr::ObjectValues(operand)
         | Expr::ObjectEntries(operand)
         | Expr::SetSize(operand)

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1097,6 +1097,7 @@ pub fn collect_localset_ids_in_expr_filtered(
         | Expr::IsUndefinedOrBareNan(operand)
         | Expr::ParseFloat(operand)
         | Expr::ObjectKeys(operand)
+        | Expr::ForInKeys(operand)
         | Expr::ObjectValues(operand)
         | Expr::ObjectEntries(operand)
         | Expr::ObjectFromEntries(operand)

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -220,6 +220,7 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
         | Expr::IsUndefinedOrBareNan(operand)
         | Expr::ParseFloat(operand)
         | Expr::ObjectKeys(operand)
+        | Expr::ForInKeys(operand)
         | Expr::ObjectValues(operand)
         | Expr::ObjectEntries(operand)
         | Expr::ObjectFromEntries(operand)

--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -349,6 +349,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &arr_handle))
         }
 
+        // -------- for (key in obj) enumeration keys -> string[] --------
+        // Like ObjectKeys but nullish-safe (no throw) and walks the prototype
+        // chain for inherited enumerable keys. Backs the for-in desugar.
+        Expr::ForInKeys(obj) => {
+            let obj_box = lower_expr(ctx, obj)?;
+            let blk = ctx.block();
+            let arr_handle = blk.call(I64, "js_for_in_keys_value", &[(DOUBLE, &obj_box)]);
+            Ok(nanbox_pointer_inline(blk, &arr_handle))
+        }
+
         // -------- isFinite(x) — global, coerces to Number first --------
         // The runtime's js_is_finite returns NaN-tagged TAG_TRUE/TAG_FALSE
         // (not a raw 0.0/1.0), so we return the result directly. No fcmp

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1474,6 +1474,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::ArrayJoin { .. }
         | Expr::MapDelete { .. }
         | Expr::ObjectKeys(..)
+        | Expr::ForInKeys(..)
         | Expr::IsFinite(..)
         | Expr::NumberIsFinite(..)
         | Expr::IsUndefinedOrBareNan(..)

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -62,6 +62,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_string_substr", I64, &[I64, I32, I32]);
     module.declare_function("js_string_split", I64, &[I64, I64]);
     module.declare_function("js_string_split_n", I64, &[I64, I64, I32]);
+    // Boxed separator + boxed limit; full ToUint32(limit)/ToString(separator)
+    // coercion + undefined/RegExp handling (ECMA-262 §22.1.3.21).
+    module.declare_function("js_string_split_value", I64, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_math_pow", DOUBLE, &[DOUBLE, DOUBLE]);
 
     // Math.* unary functions: use LLVM intrinsics directly so we
@@ -309,6 +312,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_map_delete", I32, &[I64, DOUBLE]);
     module.declare_function("js_object_keys", I64, &[I64]);
     module.declare_function("js_object_keys_value", I64, &[DOUBLE]);
+    module.declare_function("js_for_in_keys_value", I64, &[DOUBLE]);
     module.declare_function("js_is_finite", DOUBLE, &[DOUBLE]);
     module.declare_function("js_is_undefined_or_bare_nan", I32, &[DOUBLE]);
     module.declare_function("js_math_min_array", DOUBLE, &[I64]);
@@ -891,6 +895,13 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // #2089: deref a Date (NaN-boxed DateCell pointer) to its ms timestamp for
     // ordered relational compares; a plain number passes through unchanged.
     module.declare_function("js_date_coerce_number", DOUBLE, &[DOUBLE]);
+    // Abstract relational comparison (`<`, `<=`, `>`, `>=`) for operands that
+    // aren't both statically numeric: full ToPrimitive / string / BigInt /
+    // mixed-numeric semantics. Each returns a NaN-boxed boolean.
+    module.declare_function("js_rel_lt", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_rel_le", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_rel_gt", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_rel_ge", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_date_to_string", I64, &[DOUBLE]);
     module.declare_function("js_date_to_iso_string", I64, &[DOUBLE]);
     module.declare_function("js_date_to_iso_string_or_throw", I64, &[DOUBLE]);

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -127,8 +127,10 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
             base: "Map".into(),
             type_args: Vec::new(),
         }),
-        // Object.keys() always returns string handles.
-        Expr::ObjectKeys(_) => Some(HirType::Array(Box::new(HirType::String))),
+        // Object.keys() / for-in keys always return string handles.
+        Expr::ObjectKeys(_) | Expr::ForInKeys(_) => {
+            Some(HirType::Array(Box::new(HirType::String)))
+        }
         Expr::ObjectGetOwnPropertyNames(_) => Some(HirType::Array(Box::new(HirType::String))),
         Expr::ObjectGetOwnPropertySymbols(_) => Some(HirType::Array(Box::new(HirType::Any))),
         Expr::String(_)
@@ -1893,6 +1895,7 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
         | Expr::ArrayKeys(_)
         | Expr::ArrayValues(_)
         | Expr::ObjectKeys(_)
+        | Expr::ForInKeys(_)
         | Expr::ObjectValues(_)
         | Expr::ObjectEntries(_) => Some(HirType::Array(Box::new(HirType::Any))),
         // `process.argv` is a real Array<string> at runtime (see

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -1127,7 +1127,10 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
         | Expr::GlobalThisExpr
         | Expr::NativeModuleRef(_)
         | Expr::RegExp { .. } => {}
-        Expr::ObjectKeys(obj) | Expr::ObjectValues(obj) | Expr::ObjectEntries(obj) => {
+        Expr::ObjectKeys(obj)
+        | Expr::ForInKeys(obj)
+        | Expr::ObjectValues(obj)
+        | Expr::ObjectEntries(obj) => {
             collect_assigned_locals_expr(obj, assigned);
         }
         Expr::ObjectGroupBy { items, key_fn } | Expr::MapGroupBy { items, key_fn } => {

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2032,6 +2032,11 @@ pub enum Expr {
     /// Object.keys(obj) -> string[]
     /// Returns an array of the object's own enumerable property names
     ObjectKeys(Box<Expr>),
+    /// `for (key in obj)` enumeration keys -> string[]
+    /// Like `ObjectKeys` but follows ECMA-262 EnumerateObjectProperties:
+    /// null/undefined enumerate nothing (no throw) and inherited enumerable
+    /// string keys on the prototype chain are included (deduplicated).
+    ForInKeys(Box<Expr>),
     /// Object.values(obj) -> any[]
     /// Returns an array of the object's own enumerable property values
     ObjectValues(Box<Expr>),

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -1177,7 +1177,7 @@ pub fn transform_expr(
             transform_expr(replacement, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
         // Object operations
-        Expr::ObjectKeys(e) => {
+        Expr::ObjectKeys(e) | Expr::ForInKeys(e) => {
             transform_expr(e, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
         // Parse/coerce functions

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -1462,8 +1462,12 @@ pub(crate) fn lower_stmt_for_in(
     // Lower the object expression
     let obj_expr = lower_expr(ctx, &for_in_stmt.right)?;
 
-    // Create Object.keys(obj) expression to get the array of keys
-    let keys_expr = Expr::ObjectKeys(Box::new(obj_expr));
+    // for-in enumerates the receiver's own AND inherited enumerable string
+    // keys (deduplicated), and is a no-op — not a throw — on null/undefined.
+    // `ForInKeys` carries those semantics; `ObjectKeys` (Object.keys) would
+    // throw on nullish and miss inherited keys. Refs language/statements/for-in
+    // S12.6.4_A1/A2 (nullish) and A6/A6.1 (prototype chain).
+    let keys_expr = Expr::ForInKeys(Box::new(obj_expr));
 
     // Create internal variables for the keys array and index
     let keys_id = ctx.fresh_local();

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1797,7 +1797,9 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             };
 
             let obj_expr = lower_expr(ctx, &for_in_stmt.right)?;
-            let keys_expr = Expr::ObjectKeys(Box::new(obj_expr));
+            // for-in: own + inherited enumerable keys, nullish-safe (no throw).
+            // See lower/stmt_loops.rs::lower_stmt_for_in for the rationale.
+            let keys_expr = Expr::ForInKeys(Box::new(obj_expr));
             let keys_id = ctx.fresh_local();
             let idx_id = ctx.fresh_local();
             let key_id = ctx.define_local(key_name.clone(), Type::String);

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -903,6 +903,7 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
 
         // Object.keys/values/entries
         Expr::ObjectKeys(obj) => Expr::ObjectKeys(Box::new(substitute_expr(obj, substitutions))),
+        Expr::ForInKeys(obj) => Expr::ForInKeys(Box::new(substitute_expr(obj, substitutions))),
         Expr::ObjectValues(obj) => {
             Expr::ObjectValues(Box::new(substitute_expr(obj, substitutions)))
         }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -541,6 +541,7 @@ impl SH for Expr {
             Expr::ObjectIs(a, b) => { tag(h, 389); a.as_ref().hash(h); b.as_ref().hash(h); }
             Expr::ObjectHasOwn(a, b) => { tag(h, 390); a.as_ref().hash(h); b.as_ref().hash(h); }
             Expr::ObjectKeys(e) => { tag(h, 391); e.as_ref().hash(h); }
+            Expr::ForInKeys(e) => { tag(h, 12506); e.as_ref().hash(h); }
             Expr::ObjectValues(e) => { tag(h, 392); e.as_ref().hash(h); }
             Expr::ObjectEntries(e) => { tag(h, 393); e.as_ref().hash(h); }
             Expr::ObjectGroupBy { items, key_fn } => { tag(h, 394); items.as_ref().hash(h); key_fn.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -146,6 +146,7 @@ where
         | Expr::ObjectGetPrototypeOf(v)
         | Expr::ObjectGetOwnPropertySymbols(v)
         | Expr::ObjectKeys(v)
+        | Expr::ForInKeys(v)
         | Expr::ObjectValues(v)
         | Expr::ObjectEntries(v)
         | Expr::ObjectFromEntries(v)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -147,6 +147,7 @@ where
         | Expr::ObjectGetPrototypeOf(v)
         | Expr::ObjectGetOwnPropertySymbols(v)
         | Expr::ObjectKeys(v)
+        | Expr::ForInKeys(v)
         | Expr::ObjectValues(v)
         | Expr::ObjectEntries(v)
         | Expr::ObjectFromEntries(v)

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -56,22 +56,16 @@ pub extern "C" fn js_for_of_to_array(val_f64: f64) -> f64 {
         return js_nanbox_pointer(arr_i64);
     }
 
-    // Non-pointer scalars (number/bool/null/undefined) are not iterable;
-    // hand back an empty array so the loop runs zero times rather than
-    // dereferencing a non-pointer. Web Streams are the exception here: their
-    // runtime handles are finite numeric ids, but plain `for...of` must still
-    // reject them because they are async-iterable only.
+    // Non-pointer scalars (number/bool/null/undefined/symbol) are not
+    // iterable. Per ECMA-262 §13.7.5.13 (ForIn/OfHeadEvaluation →
+    // GetIterator → ToObject/GetMethod) these MUST throw a TypeError:
+    // `for (x of null)`, `for (x of 37)`, `for (x of false)` all reject
+    // (language/statements/for-of/head-expr-to-obj,
+    // head-expr-primitive-iterator-method). Web Streams are async-iterable
+    // only, so plain `for...of` rejects them here too.
     let raw_ptr = crate::value::js_nanbox_get_pointer(val_f64);
     if raw_ptr == 0 {
-        if val_f64.is_finite()
-            && val_f64 > 0.0
-            && val_f64.fract() == 0.0
-            && crate::object::stream_handle_kind_probe()
-                .is_some_and(|probe| unsafe { probe(val_f64 as usize) != 0 })
-        {
-            throw_not_iterable(val_f64);
-        }
-        return js_nanbox_pointer(js_array_alloc(0) as i64);
+        throw_not_iterable(val_f64);
     }
 
     // Inspect the GC header's object kind to dispatch Array / Map / Set
@@ -608,10 +602,19 @@ pub extern "C" fn js_iterator_to_array(iter_f64: f64) -> *mut ArrayHeader {
         } else {
             closure::js_closure_call1(next_ptr, f64::from_bits(TAG_UNDEFINED))
         };
-        let result_ptr = js_nanbox_get_pointer(result_f64);
-        if result_ptr == 0 {
-            break;
+        // IteratorNext (ECMA-262 §7.4.2 step 3): if Type(result) is not
+        // Object, throw a TypeError. `is_pointer()` is true only for
+        // POINTER_TAG heap objects/arrays — strings, numbers, booleans,
+        // null and undefined all fail it (and would otherwise be silently
+        // treated as "done"). Symbols are pointer-tagged but are NOT objects,
+        // so exclude registered symbols too.
+        // language/statements/for-of/iterator-next-result-type.
+        let result_is_object = crate::value::JSValue::from_bits(result_f64.to_bits()).is_pointer()
+            && !crate::symbol::is_registered_symbol(js_nanbox_get_pointer(result_f64) as usize);
+        if !result_is_object {
+            throw_iterator_result_not_object();
         }
+        let result_ptr = js_nanbox_get_pointer(result_f64);
         let result_obj = result_ptr as *const ObjectHeader;
 
         // Check .done

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -993,6 +993,12 @@ pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
     if jv.is_null() || jv.is_undefined() {
         super::has_own_helpers::throw_to_object_nullish_type_error();
     }
+    // A Proxy is a small registered id — route through the `ownKeys` trap +
+    // enumerability filter rather than the handle-dispatch fallback below.
+    if crate::proxy::js_proxy_is_proxy(value) != 0 {
+        let arr = crate::proxy::proxy_enum_own_keys(value);
+        return (arr.to_bits() & crate::value::POINTER_MASK) as *mut ArrayHeader;
+    }
     if jv.is_any_string() {
         let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         let len = match crate::string::str_bytes_from_jsvalue(value, &mut scratch) {
@@ -1092,6 +1098,90 @@ pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
         return js_object_keys(ptr as *const ObjectHeader);
     }
     crate::array::js_array_alloc(0)
+}
+
+/// `for (key in value)` enumeration key set. Differs from
+/// [`js_object_keys_value`] (which backs `Object.keys`) in two ways
+/// mandated by ECMA-262 §14.7.5 / EnumerateObjectProperties:
+///
+///   * null / undefined enumerate NOTHING and must NOT throw — `Object.keys`
+///     throws `TypeError`, but `for (k in undefined) {}` is a no-op
+///     (language/statements/for-in/S12.6.4_A1, A2).
+///   * inherited enumerable string-keyed properties on the prototype chain
+///     are visited too, with shadowed/duplicate names emitted only once
+///     (S12.6.4_A6 / A6.1 — `FACTORY.prototype = {feat,hint}`).
+///
+/// Enumerable own keys at each level come from `js_object_keys_value` so every
+/// existing tag-dispatch case (arrays → index keys, strings → index keys, typed
+/// arrays, proxies, plain objects, class instances) is reused unchanged. Class /
+/// built-in prototype methods are non-enumerable, so they are correctly skipped.
+///
+/// Shadowing follows the spec exactly: a name that appears as an OWN property at
+/// a closer level — even a non-enumerable one — hides the same name on the rest
+/// of the chain (language/statements/for-in/12.6.4-2). So at each level we mark
+/// ALL own property names (`js_object_get_own_property_names`, incl
+/// non-enumerable) as "seen" after emitting that level's enumerable subset.
+#[no_mangle]
+pub extern "C" fn js_for_in_keys_value(value: f64) -> *mut ArrayHeader {
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_null() || jv.is_undefined() {
+        return crate::array::js_array_alloc(0);
+    }
+    let mut out = crate::array::js_array_alloc(8);
+    // Non-pointer primitives (number/boolean, boxed string) have only their own
+    // enumerable keys; every prototype property they inherit is non-enumerable.
+    if !jv.is_pointer() {
+        let own = js_object_keys_value(value);
+        let n = crate::array::js_array_length(own);
+        for i in 0..n {
+            let kv = crate::array::js_array_get(own, i);
+            out = crate::array::js_array_push_f64(out, f64::from_bits(kv.bits()));
+        }
+        return out;
+    }
+    let key_string = |kv: JSValue, scratch: &mut [u8; crate::value::SHORT_STRING_MAX_LEN]| {
+        unsafe { crate::string::js_string_key_bytes(kv, scratch) }
+            .and_then(|b| std::str::from_utf8(b).ok().map(|s| s.to_string()))
+    };
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let mut current = value;
+    // Depth cap guards against pathological / cyclic prototype graphs.
+    for _ in 0..1000 {
+        let cv = JSValue::from_bits(current.to_bits());
+        if cv.is_null() || cv.is_undefined() || !cv.is_pointer() {
+            break;
+        }
+        // Emit this level's enumerable own keys (OrdinaryOwnPropertyKeys order),
+        // skipping any name already shadowed by a closer level.
+        let enum_arr = js_object_keys_value(current);
+        let en = crate::array::js_array_length(enum_arr);
+        for i in 0..en {
+            let kv = crate::array::js_array_get(enum_arr, i);
+            let name = match key_string(kv, &mut scratch) {
+                Some(s) => s,
+                None => continue,
+            };
+            if seen.insert(name) {
+                out = crate::array::js_array_push_f64(out, f64::from_bits(kv.bits()));
+            }
+        }
+        // Mark ALL own names (incl non-enumerable) seen so they shadow the
+        // remainder of the chain.
+        let all_f64 = super::descriptors::js_object_get_own_property_names(current);
+        let all_arr = (all_f64.to_bits() & crate::value::POINTER_MASK) as *mut ArrayHeader;
+        if !all_arr.is_null() {
+            let an = crate::array::js_array_length(all_arr);
+            for i in 0..an {
+                let kv = crate::array::js_array_get(all_arr, i);
+                if let Some(name) = key_string(kv, &mut scratch) {
+                    seen.insert(name);
+                }
+            }
+        }
+        current = super::object_ops::js_object_get_prototype_of(current);
+    }
+    out
 }
 
 fn closure_dynamic_enumerable_props(ptr: usize) -> Vec<(String, f64)> {


### PR DESCRIPTION
Improves `language/statements/for-in`, `for-of`, and `for-await-of` test262 parity by making the iterator/enumeration protocol spec-compliant in the runtime fallback paths. **+10 tests fixed, 0 regressions** across all five iteration-statement directories.

## Root causes fixed

**1. `for (key in …)` enumeration was `Object.keys`, not the spec EnumerateObjectProperties (`for-in`).**
The for-in desugar emitted `Expr::ObjectKeys` → `js_object_keys_value`, which (a) throws `TypeError` on `null`/`undefined` and (b) returns only *own* enumerable keys. Per ECMA-262 §14.7.5, `for (k in null/undefined) {}` is a no-op (no throw) and inherited enumerable string keys on the prototype chain must be visited (deduplicated). Added a dedicated `Expr::ForInKeys` HIR node lowering to a new runtime `js_for_in_keys_value`, which: returns `[]` for nullish; reuses `js_object_keys_value` per level for the enumerable subset (so arrays→indices, strings→indices, typed arrays, proxies, class instances all keep working); and walks the `[[Prototype]]` chain. Shadowing follows the spec exactly — a name that is an *own* property at a closer level (even a non-enumerable one) hides the same name farther up, so each level marks **all** own names (`js_object_get_own_property_names`) as seen after emitting its enumerable subset.

**2. Non-iterable primitives silently no-op'd instead of throwing (`for-of`).**
`js_for_of_to_array` returned an empty array for `null`/`undefined`/number/boolean, so `for (x of null)` / `for (x of 37)` ran zero times instead of throwing `TypeError` (GetIterator → ToObject/GetMethod). Now throws `throw_not_iterable`.

**3. `IteratorNext` accepted non-object results (`for-of`).**
`js_iterator_to_array` treated a non-object `next()` result as "done" and broke. Per §7.4.2 step 3, `Type(result)` not Object must throw `TypeError`. Now throws when the result isn't a `POINTER_TAG` heap object (excluding registered symbols, which are pointer-tagged but not objects).

## Before → after (parity)

| dir | before | after | fixed |
|-----|--------|-------|-------|
| for-in | 61.0% | 68.8% | +6 (S12.6.4_A1, A2, A6, A6.1, let-block-with-newline, let-identifier-with-newline) |
| for-of | 59.0% | 60.7% | +3 (head-expr-to-obj, head-expr-primitive-iterator-method, iterator-next-result-type) |
| for-await-of | 56.5% | 60.9% | +1 (let-block-with-newline) |
| for | 88.5% | 88.5% | — |
| while | 73.0% | 73.0% | — |

**Zero regressions**: every test that passed before still passes (verified by diffing the per-dir failure sets across all five directories). The one transient for-in regression introduced by a first-cut prototype walk (`12.6.4-2`, non-enumerable own key must still shadow) was fixed before finalizing. Spread / `Math.max(...)` / `[...map]` / `[...set]` / `[...string]` / generator spread all verified byte-identical to Node.

## Files

New IR node `ForInKeys` wired through perry-hir (ir/expr.rs, lower/stmt_loops.rs, lower_decl/body_stmt.rs, analysis, js_transform, monomorph, stable_hash, walkers) and perry-codegen (logical_collections, expr/mod, type_analysis, boxed_vars, 4 collectors, runtime_decls/strings, codegen-js). Runtime: new `js_for_in_keys_value` (object/field_get_set.rs) and the two for-of throws (array/iterator.rs).