### PR TITLE
fix(hir): language/expressions/object literal semantics test262 parity

### DIFF
--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -22,7 +22,10 @@ use crate::analysis::{
 };
 use crate::ir::{EnumValue, Expr, Function, Param, Stmt};
 use crate::lower_decl::{append_synthetic_arguments_param, body_uses_arguments, lower_block_stmt};
-use crate::lower_patterns::{get_param_default, get_pat_name, is_rest_param};
+use crate::lower_patterns::{
+    generate_param_destructuring_stmts, get_param_default, get_pat_name, is_destructuring_pattern,
+    is_rest_param,
+};
 use crate::lower_types::{extract_param_type_with_ctx, extract_ts_type_with_ctx};
 
 use super::{lower_expr, LoweringContext};
@@ -174,6 +177,12 @@ fn lower_method_prop(
     ctx.enter_strict_mode(true);
     let mut params = Vec::new();
     let mut default_param_pats: Vec<ast::Pat> = Vec::new();
+    // Destructuring method params (`method([x, y]) {}` / `m({a, b}) {}`) need
+    // extraction statements prepended to the body, mirroring `fn_decl` /
+    // `expr_function`. Without this the bound names (`x`, `y`, `a`, `b`) never
+    // get a `Let`, so the body throws `ReferenceError: identifier is not
+    // defined` — every `dstr/{,gen-,async-gen-}meth-*` test262 case.
+    let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
     for param in method.function.params.iter() {
         let param_name = get_pat_name(&param.pat)?;
         // TypeScript's `this: T` is a TYPE-only marker (SWC emits it as a
@@ -200,9 +209,28 @@ fn lower_method_prop(
             arguments_object: None,
         });
         default_param_pats.push(param.pat.clone());
+        // Unwrap `Pat::Assign` (`[x, y] = [1, 2]`) to the inner array/object
+        // pattern — the default value is applied separately via
+        // `build_default_param_stmts`, and the destructuring extracts from the
+        // (possibly defaulted) param. Mirrors `lower_decl/class_members.rs`.
+        let inner_pat = if let ast::Pat::Assign(assign) = &param.pat {
+            assign.left.as_ref()
+        } else {
+            &param.pat
+        };
+        if is_destructuring_pattern(inner_pat) {
+            destructuring_params.push((param_id, inner_pat.clone()));
+        }
     }
     for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {
         param.default = get_param_default(ctx, pat)?;
+    }
+    // Generate extraction `Let`s BEFORE lowering the body so the destructured
+    // bindings are in scope when the body references them.
+    let mut destructuring_stmts = Vec::new();
+    for (param_id, pat) in &destructuring_params {
+        let stmts = generate_param_destructuring_stmts(ctx, pat, *param_id)?;
+        destructuring_stmts.extend(stmts);
     }
     let return_type = method
         .function
@@ -234,11 +262,29 @@ fn lower_method_prop(
         append_synthetic_arguments_param(ctx, &mut params, true, false, true, Vec::new());
     }
 
-    let body = if let Some(ref block) = method.function.body {
+    let mut body = if let Some(ref block) = method.function.body {
         lower_block_stmt(ctx, block)?
     } else {
         Vec::new()
     };
+    // Prepend destructuring extraction statements (mirrors expr_function).
+    if !destructuring_stmts.is_empty() {
+        let mut new_body = destructuring_stmts;
+        new_body.append(&mut body);
+        body = new_body;
+    }
+    // Prepend default-parameter fill statements. Object-literal methods never
+    // dispatch through the `__perry_wrap_<name>` prologue that applies a
+    // top-level function's defaults, so the body must carry the
+    // `if (p === undefined) p = <default>` checks itself — otherwise
+    // `{ m(a = 23) {} }; obj.m(undefined)` reads `a === undefined`. Defaults
+    // must run BEFORE destructuring (`m([x] = [1]) {}`), so prepend them last.
+    let default_stmts = crate::lower_decl::build_default_param_stmts(&params);
+    if !default_stmts.is_empty() {
+        let mut new_body = default_stmts;
+        new_body.append(&mut body);
+        body = new_body;
+    }
     ctx.exit_strict_mode();
     ctx.exit_scope(scope_mark);
 


### PR DESCRIPTION
## Root cause

Object-literal **method definitions** (`{ m([x, y]) {} }`, `{ m(a = 23) {} }`) lowered their parameters in `crates/perry-hir/src/lower/expr_object.rs` (`lower_method_prop`) **without**:

1. **destructuring-extraction statements** — a method param like `[x, y, z]` never produced a `Let` for `x`/`y`/`z`, so the body threw `ReferenceError: identifier is not defined`;
2. **default-parameter fill statements** — object methods never dispatch through the `__perry_wrap_<name>` prologue that applies a top-level function's *registered* defaults, so without the body carrying its own `if (p === undefined) p = <default>` checks, every defaulted param read as `undefined`.

Plain functions (`lower_fn_decl`/`expr_function`) and class methods (`lower_decl/class_members.rs`) already do both; the object-literal method path was the one site missing it.

## Fix

Mirror `lower_decl/class_members.rs` exactly:

- **Unwrap `Pat::Assign`** to the inner array/object pattern before the `is_destructuring_pattern` check — `[x] = [1]` is a `Pat::Assign` wrapping the pattern, so checking the raw `param.pat` missed the defaulted-destructuring form.
- **`generate_param_destructuring_stmts` before lowering the body**, so the destructured bindings are in scope when the body references them.
- **Prepend `build_default_param_stmts`** last, so defaults run *before* destructuring (`m([x] = [1]) {}`).

Files touched: `crates/perry-hir/src/lower/expr_object.rs` (only).

## Results — `language/expressions/object`

**453 → 557 pass (+104), zero regressions.**

Measured with two isolated runs of both baseline (`origin/main` @ 25ccfbb27) and fix; both pairs were byte-identical (0 flaky), 0 tests that passed before now fail. Default compile path (no env flags).

Fixed families (all the same root cause):
- `dstr/` `meth` / `gen-meth` / `async-gen-meth` (+ `-dflt` variants) destructuring params — ~90 tests
- `method-definition/` `meth-dflt-params` / `gen-meth-dflt-params` / `async-meth-dflt-params` default-param edge cases
- `scope-{,gen-}meth-param-*` var-scope cases

Remaining failures in the directory are unrelated (lone `eval(...)` of string code, `fn.name` descriptor edge cases, `super`-in-object-method, async-generator `yield*` delegation).