### PR TITLE
fix(operators): abstract relational comparison (< <= > >=) + logical-assignment NamedEvaluation

### DIFF
--- a/crates/perry-codegen/src/expr/compare.rs
+++ b/crates/perry-codegen/src/expr/compare.rs
@@ -53,7 +53,24 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // are unordered under fcmp (NaN), so `a > b` on two bigints
             // always returns false. Route through js_bigint_cmp which
             // returns -1/0/1 for the three bigint ordering outcomes.
-            if is_bigint_expr(ctx, left) || is_bigint_expr(ctx, right) {
+            //
+            // For RELATIONAL ops (`<`, `<=`, `>`, `>=`) this direct cmp is only
+            // valid when BOTH operands are statically BigInt — `js_bigint_cmp`
+            // dereferences both as BigInt pointers. A *mixed* relational like
+            // `1n < Infinity` or `0n < "1"` needs the full abstract relational
+            // comparison (BigInt-vs-Number / BigInt-vs-String coercion), so it
+            // falls through to `js_rel_*` below. Equality (`===`/`==`) keeps the
+            // either-side gate (its own cross-type handling is unchanged).
+            let is_relational_op = matches!(
+                op,
+                CompareOp::Lt | CompareOp::Le | CompareOp::Gt | CompareOp::Ge
+            );
+            let bigint_fast_path = if is_relational_op {
+                is_bigint_expr(ctx, left) && is_bigint_expr(ctx, right)
+            } else {
+                is_bigint_expr(ctx, left) || is_bigint_expr(ctx, right)
+            };
+            if bigint_fast_path {
                 let l = lower_expr(ctx, left)?;
                 let r = lower_expr(ctx, right)?;
                 let blk = ctx.block();
@@ -370,18 +387,33 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 return Ok(blk.bitcast_i64_to_double(&result_bits));
             }
 
-            // #2089: an ordered relational compare (`<`, `<=`, `>`, `>=`)
-            // whose operands aren't statically numeric may be Date values —
-            // NaN-boxed `DateCell` pointers whose raw bits are NaN, so a bare
-            // `fcmp` would be unordered (always false). Coerce each operand to
-            // its ms timestamp via `js_date_coerce_number` first; plain numbers
-            // pass through unchanged, so the statically-numeric case keeps its
-            // bare `fcmp` fast path (no call emitted).
-            let coerce_relational_dates = matches!(
-                op,
-                CompareOp::Lt | CompareOp::Le | CompareOp::Gt | CompareOp::Ge
-            ) && !(is_numeric_expr(ctx, left)
-                && is_numeric_expr(ctx, right));
+            // An ordered relational compare (`<`, `<=`, `>`, `>=`) whose
+            // operands aren't BOTH statically numeric needs the full ECMAScript
+            // Abstract Relational Comparison: ToPrimitive (`{valueOf}`/`Date`),
+            // lexicographic string compare, BigInt-vs-Number/String coercion,
+            // and null/boolean/string ToNumber. A bare `fcmp` mishandles all of
+            // these (NaN-boxed operands are unordered → always `false`). Route
+            // through the runtime `js_rel_*` helpers, which return a NaN-boxed
+            // boolean. The statically-numeric case keeps the bare `fcmp` fast
+            // path below (and Dates are subsumed — they aren't numeric_expr).
+            let both_numeric = is_numeric_expr(ctx, left)
+                && is_numeric_expr(ctx, right)
+                && !is_bigint_expr(ctx, left)
+                && !is_bigint_expr(ctx, right);
+            if is_relational_op && !both_numeric {
+                let l = lower_expr(ctx, left)?;
+                let r = lower_expr(ctx, right)?;
+                let blk = ctx.block();
+                let fname = match op {
+                    CompareOp::Lt => "js_rel_lt",
+                    CompareOp::Le => "js_rel_le",
+                    CompareOp::Gt => "js_rel_gt",
+                    CompareOp::Ge => "js_rel_ge",
+                    _ => unreachable!(),
+                };
+                let res = blk.call(DOUBLE, fname, &[(DOUBLE, &l), (DOUBLE, &r)]);
+                return Ok(res);
+            }
             let l = lower_expr(ctx, left)?;
             let r = lower_expr(ctx, right)?;
             let pred = match op {
@@ -399,13 +431,6 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 CompareOp::LooseEq | CompareOp::LooseNe => unreachable!(),
             };
             let blk = ctx.block();
-            let (l, r) = if coerce_relational_dates {
-                let lc = blk.call(DOUBLE, "js_date_coerce_number", &[(DOUBLE, &l)]);
-                let rc = blk.call(DOUBLE, "js_date_coerce_number", &[(DOUBLE, &r)]);
-                (lc, rc)
-            } else {
-                (l, r)
-            };
             let bit = blk.fcmp(pred, &l, &r);
             let tag_true_i64 = crate::nanbox::TAG_TRUE_I64;
             let tag_false_i64 = crate::nanbox::TAG_FALSE_I64;

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -62,6 +62,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_string_substr", I64, &[I64, I32, I32]);
     module.declare_function("js_string_split", I64, &[I64, I64]);
     module.declare_function("js_string_split_n", I64, &[I64, I64, I32]);
+    // Boxed separator + boxed limit; full ToUint32(limit)/ToString(separator)
+    // coercion + undefined/RegExp handling (ECMA-262 §22.1.3.21).
+    module.declare_function("js_string_split_value", I64, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_math_pow", DOUBLE, &[DOUBLE, DOUBLE]);
 
     // Math.* unary functions: use LLVM intrinsics directly so we
@@ -891,6 +894,13 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // #2089: deref a Date (NaN-boxed DateCell pointer) to its ms timestamp for
     // ordered relational compares; a plain number passes through unchanged.
     module.declare_function("js_date_coerce_number", DOUBLE, &[DOUBLE]);
+    // Abstract relational comparison (`<`, `<=`, `>`, `>=`) for operands that
+    // aren't both statically numeric: full ToPrimitive / string / BigInt /
+    // mixed-numeric semantics. Each returns a NaN-boxed boolean.
+    module.declare_function("js_rel_lt", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_rel_le", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_rel_gt", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_rel_ge", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_date_to_string", I64, &[DOUBLE]);
     module.declare_function("js_date_to_iso_string", I64, &[DOUBLE]);
     module.declare_function("js_date_to_iso_string_or_throw", I64, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -234,10 +234,22 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
         }
     }
 
+    // NamedEvaluation also applies to logical assignment (`x ||= function(){}`,
+    // `x &&= () => {}`, `x ??= class {}`): when the LHS is a plain identifier and
+    // the RHS is an anonymous function/class, the function's `.name` becomes the
+    // identifier (ES2024 §13.15.2). Plain compound assignments (`+=`, `*=`, …)
+    // are NOT NamedEvaluation contexts, so they stay name-less.
+    let inferred_name_op = matches!(
+        assign.op,
+        ast::AssignOp::Assign
+            | ast::AssignOp::AndAssign
+            | ast::AssignOp::OrAssign
+            | ast::AssignOp::NullishAssign
+    );
     let rhs = lower_rhs_with_assignment_name(
         ctx,
         &assign.right,
-        (assign.op == ast::AssignOp::Assign)
+        inferred_name_op
             .then(|| assignment_target_inferred_name(&assign.left))
             .flatten(),
     )?;

--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -1103,6 +1103,47 @@ pub extern "C" fn js_bigint_cmp(a: *const BigIntHeader, b: *const BigIntHeader) 
     }
 }
 
+/// `StringToBigInt` (ES2024 §7.1.14), non-throwing. Returns `None` when the
+/// string is not a valid BigInt literal — the abstract relational comparison
+/// treats that as `undefined` (so the comparison yields `false`) rather than a
+/// thrown `SyntaxError`. Leading/trailing whitespace is trimmed, an empty
+/// string is `0n`, and the `0x`/`0o`/`0b` radix prefixes are accepted.
+pub(crate) fn string_to_bigint(raw: &str) -> Option<*mut BigIntHeader> {
+    parse_bigint_string(raw).ok().map(bigint_alloc_with_limbs)
+}
+
+/// Mathematically compare a BigInt `x` against a Number `y` (ES2024 §7.2.13,
+/// the mixed BigInt/Number step). Comparison is exact — no precision loss from
+/// `BigInt → f64` — because `y` is decomposed into its integer floor (converted
+/// to a BigInt without rounding) and any leftover fraction.
+///
+/// Returns `-1` (x < y), `0` (x == y), `1` (x > y), or `2` (undefined: `y` is
+/// `NaN`, the one incomparable case).
+pub(crate) fn bigint_cmp_f64(x: *const BigIntHeader, y: f64) -> i32 {
+    if y.is_nan() {
+        return 2;
+    }
+    if y == f64::INFINITY {
+        return -1; // x < +Infinity for every finite BigInt
+    }
+    if y == f64::NEG_INFINITY {
+        return 1; // x > -Infinity
+    }
+    // `y` is finite. Compare `x` with `floor(y)` as exact integers; if equal,
+    // a positive fractional part of `y` makes `x` strictly smaller.
+    let floor = y.floor();
+    let floor_big = js_bigint_from_f64(floor);
+    let c = js_bigint_cmp(x, floor_big);
+    if c != 0 {
+        return c;
+    }
+    if y > floor {
+        -1
+    } else {
+        0
+    }
+}
+
 /// Check if two BigInts are equal
 #[no_mangle]
 pub extern "C" fn js_bigint_eq(a: *const BigIntHeader, b: *const BigIntHeader) -> i32 {

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -125,24 +125,233 @@ pub extern "C" fn js_loose_eq(a: JSValue, b: JSValue) -> JSValue {
     JSValue::bool(false)
 }
 
+// ----------------------------------------------------------------------------
+// Abstract Relational Comparison (ES2024 §7.2.13: `IsLessThan(x, y, LeftFirst)`)
+// ----------------------------------------------------------------------------
+//
+// The previous `js_lt`/`le`/`gt`/`ge` did a bare `a.to_number() < b.to_number()`,
+// which is wrong for every non-numeric operand: it never runs `ToPrimitive`
+// (`{ valueOf() {…} } < 1`), never lexicographically compares two strings, and
+// derefs BigInt / object operands as raw doubles (NaN → unordered → always
+// `false`). The codegen keeps a bare-`fcmp` fast path for *statically numeric*
+// operands; everything else now routes through `js_rel_{lt,le,gt,ge}` which call
+// the full abstract relational comparison below.
+
+const REL_FALSE: i32 = 0;
+const REL_TRUE: i32 = 1;
+const REL_UNDEFINED: i32 = 2;
+
+const TAG_TRUE_BITS: u64 = 0x7FFC_0000_0000_0004;
+const TAG_FALSE_BITS: u64 = 0x7FFC_0000_0000_0003;
+
+#[inline]
+fn rel_bool_f64(b: bool) -> f64 {
+    f64::from_bits(if b { TAG_TRUE_BITS } else { TAG_FALSE_BITS })
+}
+
+/// `ToPrimitive(value, NUMBER)` returning the primitive as a NaN-boxed `f64`.
+/// A `Date` coerces to its millisecond timestamp; an object with no usable
+/// `valueOf`/`toString` primitive falls back to the ordinary `ToString`
+/// (`"[object Object]"`, a function's source, …). Propagates any user
+/// exception or `TypeError` by unwinding.
+unsafe fn rel_to_primitive(value: f64) -> f64 {
+    if crate::date::is_date_value(value) {
+        // ToPrimitive(date, number) → Date.prototype.valueOf → the ms timestamp,
+        // which is itself a Number (a plain `f64` is its own NaN-box).
+        return crate::date::js_date_coerce_number(value);
+    }
+    match crate::value::to_primitive_number(value) {
+        crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => p,
+        crate::value::OrdinaryToPrimitiveOutcome::DefaultString => {
+            let s = crate::value::js_jsvalue_to_string(value);
+            crate::value::js_nanbox_string(s as i64)
+        }
+        crate::value::OrdinaryToPrimitiveOutcome::TypeError => {
+            crate::collection_iter::throw_type_error("Cannot convert object to primitive value")
+        }
+    }
+}
+
+/// Lexicographic (byte-order) compare of two already-`ToPrimitive`'d string
+/// values. Returns `< 0`, `0`, `> 0` like `memcmp`. (Lone-surrogate / true
+/// UTF-16 code-unit ordering is a separate pre-existing WTF-8 gap.)
+unsafe fn rel_string_compare(a: f64, b: f64) -> i32 {
+    let pa = crate::value::js_get_string_pointer_unified(a) as *const crate::string::StringHeader;
+    let pb = crate::value::js_get_string_pointer_unified(b) as *const crate::string::StringHeader;
+    crate::string::js_string_compare(pa, pb)
+}
+
+/// `IsLessThan(x, y, LeftFirst)` — the abstract relational comparison.
+/// `x_first` is `LeftFirst`: it controls only the order in which `ToPrimitive`
+/// runs on the two operands (observable when a `valueOf`/`toString` has side
+/// effects). Returns [`REL_TRUE`], [`REL_FALSE`], or [`REL_UNDEFINED`].
+unsafe fn abstract_relational(x: f64, y: f64, x_first: bool) -> i32 {
+    let (px, py) = if x_first {
+        let px = rel_to_primitive(x);
+        let py = rel_to_primitive(y);
+        (px, py)
+    } else {
+        let py = rel_to_primitive(y);
+        let px = rel_to_primitive(x);
+        (px, py)
+    };
+
+    let vx = JSValue::from_bits(px.to_bits());
+    let vy = JSValue::from_bits(py.to_bits());
+
+    // Both String → code-unit (byte) compare; never `undefined`.
+    if vx.is_any_string() && vy.is_any_string() {
+        return if rel_string_compare(px, py) < 0 {
+            REL_TRUE
+        } else {
+            REL_FALSE
+        };
+    }
+
+    let x_big = vx.is_bigint();
+    let y_big = vy.is_bigint();
+
+    // BigInt vs String / String vs BigInt: parse the string as a BigInt
+    // (StringToBigInt); a non-numeric string makes the comparison `undefined`.
+    if x_big && vy.is_any_string() {
+        let s = string_content_for_bigint(py);
+        return match crate::bigint::string_to_bigint(&s) {
+            None => REL_UNDEFINED,
+            Some(ny) => {
+                if crate::bigint::js_bigint_cmp(vx.as_bigint_ptr(), ny) < 0 {
+                    REL_TRUE
+                } else {
+                    REL_FALSE
+                }
+            }
+        };
+    }
+    if vx.is_any_string() && y_big {
+        let s = string_content_for_bigint(px);
+        return match crate::bigint::string_to_bigint(&s) {
+            None => REL_UNDEFINED,
+            Some(nx) => {
+                if crate::bigint::js_bigint_cmp(nx, vy.as_bigint_ptr()) < 0 {
+                    REL_TRUE
+                } else {
+                    REL_FALSE
+                }
+            }
+        };
+    }
+
+    // Both BigInt → exact integer compare.
+    if x_big && y_big {
+        return if crate::bigint::js_bigint_cmp(vx.as_bigint_ptr(), vy.as_bigint_ptr()) < 0 {
+            REL_TRUE
+        } else {
+            REL_FALSE
+        };
+    }
+
+    // BigInt vs Number (mixed): exact mathematical compare. `js_number_coerce`
+    // is `ToNumber` and throws on a Symbol operand, as the spec requires.
+    if x_big {
+        let yn = js_number_coerce(py);
+        return match crate::bigint::bigint_cmp_f64(vx.as_bigint_ptr(), yn) {
+            2 => REL_UNDEFINED,
+            c if c < 0 => REL_TRUE,
+            _ => REL_FALSE,
+        };
+    }
+    if y_big {
+        let xn = js_number_coerce(px);
+        // `bigint_cmp_f64(y, xn)` is the sign of (y − x); x < y ⇔ that is positive.
+        return match crate::bigint::bigint_cmp_f64(vy.as_bigint_ptr(), xn) {
+            2 => REL_UNDEFINED,
+            c if c > 0 => REL_TRUE,
+            _ => REL_FALSE,
+        };
+    }
+
+    // Both Number (after ToNumber). NaN on either side → undefined.
+    let xn = js_number_coerce(px);
+    let yn = js_number_coerce(py);
+    if xn.is_nan() || yn.is_nan() {
+        return REL_UNDEFINED;
+    }
+    if xn < yn {
+        REL_TRUE
+    } else {
+        REL_FALSE
+    }
+}
+
+/// Materialize a string primitive's bytes into an owned `String` for
+/// `StringToBigInt`. Handles both heap (`STRING_TAG`) and inline SSO strings.
+unsafe fn string_content_for_bigint(value: f64) -> String {
+    let ptr =
+        crate::value::js_get_string_pointer_unified(value) as *const crate::string::StringHeader;
+    if ptr.is_null() {
+        return String::new();
+    }
+    let len = (*ptr).byte_len as usize;
+    let data = (ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+/// `x < y` — codegen routes here for any relational `<` whose operands are not
+/// both statically numeric. Returns a NaN-boxed boolean (`f64`).
+#[no_mangle]
+pub extern "C" fn js_rel_lt(x: f64, y: f64) -> f64 {
+    rel_bool_f64(unsafe { abstract_relational(x, y, true) } == REL_TRUE)
+}
+
+/// `x > y` ⇔ `IsLessThan(y, x, false)` is true (right operand `ToPrimitive`'d first).
+#[no_mangle]
+pub extern "C" fn js_rel_gt(x: f64, y: f64) -> f64 {
+    rel_bool_f64(unsafe { abstract_relational(y, x, false) } == REL_TRUE)
+}
+
+/// `x <= y` ⇔ `IsLessThan(y, x, false)` is `false` (not `true`, not `undefined`).
+#[no_mangle]
+pub extern "C" fn js_rel_le(x: f64, y: f64) -> f64 {
+    rel_bool_f64(unsafe { abstract_relational(y, x, false) } == REL_FALSE)
+}
+
+/// `x >= y` ⇔ `IsLessThan(x, y, true)` is `false` (not `true`, not `undefined`).
+#[no_mangle]
+pub extern "C" fn js_rel_ge(x: f64, y: f64) -> f64 {
+    rel_bool_f64(unsafe { abstract_relational(x, y, true) } == REL_FALSE)
+}
+
+// The `js_rel_*` helpers are reached only from Perry-emitted LLVM (the relational
+// fallthrough in codegen), so a bitcode/auto-optimize link can dead-strip them
+// and leave `undefined _js_rel_lt …`. Pin them with `#[used]` statics — same
+// pattern as the write-barrier roots in `gc/barrier.rs`.
+#[used]
+static KEEP_REL_LT: extern "C" fn(f64, f64) -> f64 = js_rel_lt;
+#[used]
+static KEEP_REL_GT: extern "C" fn(f64, f64) -> f64 = js_rel_gt;
+#[used]
+static KEEP_REL_LE: extern "C" fn(f64, f64) -> f64 = js_rel_le;
+#[used]
+static KEEP_REL_GE: extern "C" fn(f64, f64) -> f64 = js_rel_ge;
+
 #[no_mangle]
 pub extern "C" fn js_lt(a: JSValue, b: JSValue) -> JSValue {
-    JSValue::bool(a.to_number() < b.to_number())
+    JSValue::from_bits(js_rel_lt(f64::from_bits(a.bits()), f64::from_bits(b.bits())).to_bits())
 }
 
 #[no_mangle]
 pub extern "C" fn js_le(a: JSValue, b: JSValue) -> JSValue {
-    JSValue::bool(a.to_number() <= b.to_number())
+    JSValue::from_bits(js_rel_le(f64::from_bits(a.bits()), f64::from_bits(b.bits())).to_bits())
 }
 
 #[no_mangle]
 pub extern "C" fn js_gt(a: JSValue, b: JSValue) -> JSValue {
-    JSValue::bool(a.to_number() > b.to_number())
+    JSValue::from_bits(js_rel_gt(f64::from_bits(a.bits()), f64::from_bits(b.bits())).to_bits())
 }
 
 #[no_mangle]
 pub extern "C" fn js_ge(a: JSValue, b: JSValue) -> JSValue {
-    JSValue::bool(a.to_number() >= b.to_number())
+    JSValue::from_bits(js_rel_ge(f64::from_bits(a.bits()), f64::from_bits(b.bits())).to_bits())
 }
 
 /// Return the typeof a value as a string

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -50,8 +50,8 @@ mod table;
 // `crate::builtins::js_*` path).
 
 pub use arithmetic::{
-    js_add, js_div, js_eq, js_ge, js_gt, js_le, js_loose_eq, js_lt, js_mod, js_mul, js_sub,
-    js_value_typeof,
+    js_add, js_div, js_eq, js_ge, js_gt, js_le, js_loose_eq, js_lt, js_mod, js_mul, js_rel_ge,
+    js_rel_gt, js_rel_le, js_rel_lt, js_sub, js_value_typeof,
 };
 
 pub use console::{


### PR DESCRIPTION
## Summary

Implements the full ECMAScript **Abstract Relational Comparison** (ES2024 §7.2.13) for `<`, `<=`, `>`, `>=`, plus **NamedEvaluation** for `&&=`/`||=`/`??=`. Targets the `language/expressions` operator suites in test262.

## Root causes fixed

**1. Relational operators did `a.to_number() < b.to_number()` — no spec coercion.**
That mishandles every non-numeric operand: it never runs `ToPrimitive` (`{valueOf(){return 0}} < 1` → `false`), never lexicographically compares two strings, and dereferences BigInt/object operands as raw doubles (NaN → `fcmp` unordered → always `false`). So `null < 1`, `true <= 1`, `"1" <= 1`, `new Number(1) <= 1`, `({} <= fn)`, and the entire `bigint-and-*` family were wrong.

New runtime helpers `js_rel_{lt,le,gt,ge}` implement `IsLessThan(x, y, LeftFirst)`:
- `ToPrimitive(NUMBER)` on both operands in the correct (LeftFirst) order; Dates coerce to their timestamp, objects fall back to `ToString` (`"[object Object]"`, function source).
- Both-String → code-unit (byte) compare.
- BigInt-vs-String → `StringToBigInt` (non-throwing; invalid string → `undefined` → `false`).
- BigInt-vs-Number → **exact** mathematical compare (decompose the number into `floor` + fraction; no `BigInt→f64` precision loss).
- `ToNumber` for null/boolean/string; Symbol → `TypeError`; `NaN` → `undefined` → `false`.

Codegen routes any relational compare whose operands are **not both statically numeric** through these helpers. The statically-numeric path keeps its bare `fcmp` (hot loops unaffected); the Date-coercion shim it replaces is subsumed. The mixed-BigInt relational fast path now requires **both** operands to be statically BigInt (a mixed `1n < Infinity` / `0n < "1"` now coerces correctly instead of dereferencing a Number/String as a BigInt pointer).

**2. Logical assignment is a NamedEvaluation context.** `value ||= function(){}` must set the function's `.name` to `"value"` (ES2024 §13.15.2). The inferred name was only applied for plain `=`; now `&&=`/`||=`/`??=` with an identifier LHS and an anonymous function/class RHS get the name too. (Plain compound `+=` etc. are *not* NamedEvaluation contexts and stay name-less.)

## Results (test262 @ 4249661388, Node v25.8 oracle)

| dir | before | after | Δ |
|---|---|---|---|
| less-than | 29 | 42 | **+13** |
| less-than-or-equal | 22 | 44 | **+22** |
| greater-than | 29 | 46 | **+17** |
| greater-than-or-equal | 22 | 40 | **+18** |
| logical-assignment | 57 | 66 | **+9** |
| compound-assignment | 375 | 375 | 0 |
| **total** | **534** | **613** | **+79** |

**Zero regressions** — no test that passed before now fails (verified by diffing the failure sets per dir). The one `perry-runtime` unit-test failure under the *full* suite (`native_module_stream::…stream_constructors_expose_static_method_values`) is a pre-existing parallel-ordering flake: it fails identically on clean `main` and passes in isolation both with and without this change.

Remaining relational failures are out of scope: `eval`-based whitespace tests, lone-surrogate UTF-16 ordering (WTF-8 gap), and one `bigint-and-number-extremes` case needing >1024-bit BigInt width. Compound-assignment's remaining gaps are class-private references and `eval`/`with` evaluation-order edge cases.

## Files
- `crates/perry-runtime/src/builtins/arithmetic.rs` — ARC + `js_rel_*` (+ `#[used]` keepalive anchors)
- `crates/perry-runtime/src/bigint.rs` — `string_to_bigint`, exact `bigint_cmp_f64`
- `crates/perry-runtime/src/builtins/mod.rs` — re-exports
- `crates/perry-codegen/src/expr/compare.rs`, `runtime_decls/strings.rs` — relational routing + decls
- `crates/perry-hir/src/lower/expr_assign.rs` — NamedEvaluation for logical assignment