### PR TITLE
fix(runtime): built-ins/String test262 parity

### DIFF
--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -103,6 +103,10 @@ pub(crate) fn lower_string_method(
                 );
             }
             let needle_box = lower_expr(ctx, &args[0])?;
+            // An object `searchString` must be `ToString`-coerced (running its
+            // user `toString`/`valueOf`) BEFORE `ToNumber(position)`, per
+            // ECMA-262 §22.1.3.8. A statically string-typed arg skips this.
+            let needle_is_str = is_string_expr(ctx, &args[0]);
             // Optional fromIndex.
             let from_idx_double = if args.len() == 2 {
                 Some(lower_expr(ctx, &args[1])?)
@@ -111,9 +115,15 @@ pub(crate) fn lower_string_method(
             };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let needle_handle = unbox_str_handle(blk, &needle_box);
+            let needle_handle = if needle_is_str {
+                unbox_str_handle(blk, &needle_box)
+            } else {
+                blk.call(I64, "js_string_coerce", &[(DOUBLE, &needle_box)])
+            };
             let result_i32 = if let Some(from_d) = from_idx_double {
-                let from_i32 = blk.fptosi(DOUBLE, &from_d, I32);
+                // `ToIntegerOrInfinity(position)` via the runtime helper (runs
+                // user `valueOf`, handles ±Infinity/NaN), NOT a raw `fptosi`.
+                let from_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &from_d)]);
                 blk.call(
                     I32,
                     "js_string_index_of_from",
@@ -195,33 +205,35 @@ pub(crate) fn lower_string_method(
                     args.len()
                 );
             }
-            // NOTE: we always call js_string_split here, even for regex
-            // delimiters — the runtime will detect regex pointers via
-            // their GC header and delegate to js_string_split_regex
-            // internally. This avoids needing a new LLVM runtime decl.
+            // Route through `js_string_split_value`, which takes the BOXED
+            // separator and limit and performs the full spec coercion:
+            // `ToUint32(limit)` before `ToString(separator)`, an `undefined`
+            // separator → `[S]`, `limit === 0` → `[]`, and RegExp-separator
+            // delegation (detected via the regex-pointer registry). A raw
+            // `unbox_str_handle` of an object/undefined separator would
+            // bit-cast garbage; a raw `fptosi` of a boxed limit skips its
+            // `valueOf`.
             let delim_box = lower_expr(ctx, &args[0])?;
-            let limit_d = if args.len() == 2 {
+            let limit_box = if args.len() == 2 {
                 Some(lower_expr(ctx, &args[1])?)
             } else {
                 None
             };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let delim_handle = unbox_str_handle(blk, &delim_box);
-            let result_arr = if let Some(limit_d) = limit_d {
-                let limit_i32 = blk.fptosi(DOUBLE, &limit_d, I32);
-                blk.call(
-                    I64,
-                    "js_string_split_n",
-                    &[(I64, &recv_handle), (I64, &delim_handle), (I32, &limit_i32)],
-                )
-            } else {
-                blk.call(
-                    I64,
-                    "js_string_split",
-                    &[(I64, &recv_handle), (I64, &delim_handle)],
-                )
+            let limit_box = match limit_box {
+                Some(v) => v,
+                None => blk.bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64),
             };
+            let result_arr = blk.call(
+                I64,
+                "js_string_split_value",
+                &[
+                    (I64, &recv_handle),
+                    (DOUBLE, &delim_box),
+                    (DOUBLE, &limit_box),
+                ],
+            );
             // Returns an array pointer (ArrayHeader*) — NaN-box with POINTER_TAG.
             Ok(crate::expr::nanbox_pointer_inline(blk, &result_arr))
         }
@@ -479,6 +491,10 @@ pub(crate) fn lower_string_method(
                 );
             }
             let needle_box = lower_expr(ctx, &args[0])?;
+            // `ToString(searchString)` runs the arg's user `toString`/`valueOf`
+            // (ECMA-262 §22.1.3.9) before `ToNumber(position)`; static strings
+            // skip the coercion.
+            let needle_is_str = is_string_expr(ctx, &args[0]);
             // Optional `position` (2nd arg). Without it, use the plain
             // last-index-of (search to the end); with it, the position-aware
             // variant. Mirrors the `indexOf` arm.
@@ -489,15 +505,22 @@ pub(crate) fn lower_string_method(
             };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let needle_handle = unbox_str_handle(blk, &needle_box);
+            let needle_handle = if needle_is_str {
+                unbox_str_handle(blk, &needle_box)
+            } else {
+                blk.call(I64, "js_string_coerce", &[(DOUBLE, &needle_box)])
+            };
             let i32_v = if let Some(pos_d) = pos_double {
+                // `ToNumber(position)` (runs user `valueOf`, preserves NaN/±Inf
+                // for the helper's clamp), NOT the raw NaN-boxed bits.
+                let pos_num = blk.call(DOUBLE, "js_number_coerce", &[(DOUBLE, &pos_d)]);
                 blk.call(
                     I32,
                     "js_string_last_index_of_from",
                     &[
                         (I64, &recv_handle),
                         (I64, &needle_handle),
-                        (DOUBLE, &pos_d),
+                        (DOUBLE, &pos_num),
                         (I32, "1"),
                     ],
                 )
@@ -621,39 +644,53 @@ pub(crate) fn lower_string_method(
             }
         }
         "search" => {
-            if args.len() != 1 {
+            if args.len() > 1 {
                 bail!(
-                    "perry-codegen: String.search expects 1 arg, got {}",
+                    "perry-codegen: String.search expects 0 or 1 arg, got {}",
                     args.len()
                 );
             }
-            // The arg is a regex (literal or local).
-            let re_box = lower_expr(ctx, &args[0])?;
+            // The arg may be a RegExp OR any value that `RegExpCreate` coerces
+            // via `ToString` (a string pattern, `undefined`, a `{ toString }`
+            // object). Pass it BOXED to `js_string_search_value`, which detects
+            // a RegExp pointer and otherwise builds `RegExpCreate(ToString(arg))`
+            // — a raw `unbox_str_handle` would bit-cast a non-regex arg as a
+            // regex header and always return -1. A missing arg is `undefined`.
+            let re_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let re_handle = unbox_str_handle(blk, &re_box);
             let i32_v = blk.call(
                 I32,
-                "js_string_search_regex",
-                &[(I64, &recv_handle), (I64, &re_handle)],
+                "js_string_search_value",
+                &[(I64, &recv_handle), (DOUBLE, &re_box)],
             );
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
         "match" => {
-            if args.len() != 1 {
+            if args.len() > 1 {
                 bail!(
-                    "perry-codegen: String.match expects 1 arg, got {}",
+                    "perry-codegen: String.match expects 0 or 1 arg, got {}",
                     args.len()
                 );
             }
-            let re_box = lower_expr(ctx, &args[0])?;
+            // Like `search`, coerce a non-RegExp arg via `RegExpCreate(ToString
+            // (arg))` by passing it BOXED to `js_string_match_value`. A missing
+            // arg is `undefined` → the empty `/(?:)/` regex.
+            let re_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let re_handle = unbox_str_handle(blk, &re_box);
             let result = blk.call(
                 I64,
-                "js_string_match",
-                &[(I64, &recv_handle), (I64, &re_handle)],
+                "js_string_match_value",
+                &[(I64, &recv_handle), (DOUBLE, &re_box)],
             );
             // Runtime may return null (0) on no-match. Convert that to
             // TAG_NULL so `s.match(re) !== null` behaves correctly.

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -313,6 +313,10 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_string_match_all", I64, &[I64, I64]);
     module.declare_function("js_string_match_all_value", I64, &[I64, DOUBLE]);
     module.declare_function("js_string_search_regex", I32, &[I64, I64]);
+    // Boxed-arg search/match: coerce a non-RegExp arg via RegExpCreate(ToString)
+    // (ECMA-262 §22.1.3.12 / §22.1.3.11).
+    module.declare_function("js_string_search_value", I32, &[I64, DOUBLE]);
+    module.declare_function("js_string_match_value", I64, &[I64, DOUBLE]);
     // Regex extras (runtime has them; codegen was stubbing).
     module.declare_function("js_regexp_exec_get_index", DOUBLE, &[]);
     module.declare_function("js_regexp_exec_get_groups", I64, &[]);

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1797,45 +1797,31 @@ pub unsafe extern "C" fn js_native_call_method(
                 // the issue #510 catch-all (`(string).match is not a
                 // function`) because no runtime arm handled `match`.
                 "match" | "matchAll" => {
-                    if args_len >= 1 && !args_ptr.is_null() {
-                        let pattern_val = unsafe { *args_ptr };
-                        if method_name == "matchAll" {
-                            let result_ptr =
-                                crate::regex::js_string_match_all_value(s_ptr, pattern_val);
-                            if result_ptr.is_null() {
-                                return f64::from_bits(JSValue::null().bits());
-                            }
-                            return f64::from_bits(JSValue::pointer(result_ptr as *mut u8).bits());
-                        }
-                        // Extract regex handle from the arg value. RegExp
-                        // values are NaN-boxed pointers; pass through the
-                        // pointer extraction the same way the HIR-level
-                        // StringMatch path does.
-                        let regex_jsval = JSValue::from_bits(pattern_val.to_bits());
-                        if !regex_jsval.is_pointer() {
-                            return f64::from_bits(JSValue::null().bits());
-                        }
-                        let regex_ptr = regex_jsval.as_pointer::<crate::regex::RegExpHeader>();
-                        let result_ptr = crate::regex::js_string_match(s_ptr, regex_ptr);
+                    // Missing arg ⇒ `undefined` (→ empty `/(?:)/` regex).
+                    let pattern_val =
+                        arg_at(0).unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+                    if method_name == "matchAll" {
+                        let result_ptr =
+                            crate::regex::js_string_match_all_value(s_ptr, pattern_val);
                         if result_ptr.is_null() {
                             return f64::from_bits(JSValue::null().bits());
                         }
                         return f64::from_bits(JSValue::pointer(result_ptr as *mut u8).bits());
                     }
-                    return f64::from_bits(JSValue::null().bits());
+                    // Coerce a non-RegExp arg via `RegExpCreate(ToString(arg))`
+                    // (a string pattern / `undefined` / `{ toString }` object),
+                    // matching the codegen path.
+                    let result_ptr = crate::regex::js_string_match_value(s_ptr, pattern_val);
+                    if result_ptr.is_null() {
+                        return f64::from_bits(JSValue::null().bits());
+                    }
+                    return f64::from_bits(JSValue::pointer(result_ptr as *mut u8).bits());
                 }
                 "search" => {
-                    if args_len >= 1 && !args_ptr.is_null() {
-                        let regex_val = unsafe { *args_ptr };
-                        let regex_jsval = JSValue::from_bits(regex_val.to_bits());
-                        if !regex_jsval.is_pointer() {
-                            return f64::from_bits(JSValue::int32(-1).bits());
-                        }
-                        let regex_ptr = regex_jsval.as_pointer::<crate::regex::RegExpHeader>();
-                        let i32_v = crate::regex::js_string_search_regex(s_ptr, regex_ptr);
-                        return f64::from_bits(JSValue::int32(i32_v).bits());
-                    }
-                    return f64::from_bits(JSValue::int32(-1).bits());
+                    let regex_val =
+                        arg_at(0).unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
+                    let i32_v = crate::regex::js_string_search_value(s_ptr, regex_val);
+                    return f64::from_bits(JSValue::int32(i32_v).bits());
                 }
                 // Refs #421 — common string methods on any-typed receivers.
                 // Hono's compiled JS (and most npm packages with stripped TS

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -474,6 +474,61 @@ fn lookup_fancy_regex(re: *const RegExpHeader) -> Option<Arc<fancy_regex::Regex>
     }
 }
 
+/// Coerce a `String.prototype.search`/`match` argument into a RegExp
+/// (ECMA-262 §22.1.3.12 / §22.1.3.20 → `RegExpCreate`). A RegExp value passes
+/// through unchanged; anything else builds a fresh regex whose source pattern
+/// is `ToString(arg)` (running user `toString`/`valueOf`, which may throw),
+/// with `undefined` mapped to the empty pattern (the `/(?:)/` regex that
+/// matches at index 0). Flags default to none.
+fn coerce_search_arg_to_regex(arg: f64) -> *const RegExpHeader {
+    let jv = crate::value::JSValue::from_bits(arg.to_bits());
+    if jv.is_pointer() {
+        let p = crate::value::js_nanbox_get_pointer(arg) as *const u8;
+        if is_regex_pointer(p) {
+            return p as *const RegExpHeader;
+        }
+    }
+    // `undefined` → empty pattern. Build a real empty `StringHeader` (NOT a
+    // null pointer): the resulting RegExp header's `pattern_ptr` is later
+    // dereferenced by `js_string_match`'s `lookup_fancy_regex`
+    // (`string_as_str((*re).pattern_ptr)`), which would SIGSEGV on null.
+    let src: *const StringHeader = if jv.is_undefined() {
+        crate::string::js_string_from_str("") as *const StringHeader
+    } else {
+        crate::builtins::js_string_coerce(arg) as *const StringHeader
+    };
+    // `flags` may be read the same way; pass an empty header rather than null.
+    let flags = crate::string::js_string_from_str("") as *const StringHeader;
+    js_regexp_new(src, flags)
+}
+
+/// `String.prototype.search(regexp)` (ECMA-262 §22.1.3.12) with full argument
+/// coercion: a non-RegExp arg is turned into `RegExpCreate(ToString(arg))`
+/// (so `"x".search("pat")`, `.search(undefined)`, and `.search({toString})`
+/// all work). `s` is the already-`ToString`-coerced `this`.
+#[no_mangle]
+pub extern "C" fn js_string_search_value(s: *const StringHeader, arg: f64) -> i32 {
+    // Root the receiver across the (possibly allocating / GC-triggering)
+    // argument coercion so a moving collector can't dangle `s`.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
+    let re = coerce_search_arg_to_regex(arg);
+    let s = s_handle.get_raw_const_ptr::<StringHeader>();
+    js_string_search_regex(s, re)
+}
+
+/// `String.prototype.match(regexp)` (ECMA-262 §22.1.3.11) with full argument
+/// coercion (see [`js_string_search_value`]). Returns the match array pointer,
+/// or null on no match.
+#[no_mangle]
+pub extern "C" fn js_string_match_value(s: *const StringHeader, arg: f64) -> *mut ArrayHeader {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
+    let re = coerce_search_arg_to_regex(arg);
+    let s = s_handle.get_raw_const_ptr::<StringHeader>();
+    js_string_match(s, re)
+}
+
 /// Find matches in a string
 /// string.match(regex) -> string[] | null (returns array pointer, null if no match)
 #[no_mangle]

--- a/crates/perry-runtime/src/string/slice_ops.rs
+++ b/crates/perry-runtime/src/string/slice_ops.rs
@@ -165,6 +165,33 @@ pub extern "C" fn js_string_substr(
 static KEEP_SUBSTR: extern "C" fn(*const StringHeader, i32, i32) -> *mut StringHeader =
     js_string_substr;
 
+/// JS `TrimString` whitespace set (ECMA-262 §22.1.3.32, `WhiteSpace` +
+/// `LineTerminator`). Differs from Rust's `char::is_whitespace` (Unicode
+/// `White_Space`): JS *includes* U+FEFF (`<ZWNBSP>` / BOM) and *excludes*
+/// U+0085 (NEL), so `str::trim()` both under- and over-trims for JS.
+#[inline]
+pub(crate) fn is_js_whitespace(c: char) -> bool {
+    matches!(
+        c,
+        '\u{0009}'        // TAB
+        | '\u{000A}'      // LF  <LineTerminator>
+        | '\u{000B}'      // VT
+        | '\u{000C}'      // FF
+        | '\u{000D}'      // CR  <LineTerminator>
+        | '\u{0020}'      // SPACE
+        | '\u{00A0}'      // NBSP
+        | '\u{1680}'      // OGHAM SPACE MARK
+        | '\u{2000}'
+            ..='\u{200A}' // EN QUAD .. HAIR SPACE
+        | '\u{2028}'      // LINE SEPARATOR      <LineTerminator>
+        | '\u{2029}'      // PARAGRAPH SEPARATOR <LineTerminator>
+        | '\u{202F}'      // NARROW NO-BREAK SPACE
+        | '\u{205F}'      // MEDIUM MATHEMATICAL SPACE
+        | '\u{3000}'      // IDEOGRAPHIC SPACE
+        | '\u{FEFF}' // ZERO WIDTH NO-BREAK SPACE / BOM
+    )
+}
+
 /// Trim whitespace from both ends of a string
 #[no_mangle]
 pub extern "C" fn js_string_trim(s: *const StringHeader) -> *mut StringHeader {
@@ -173,7 +200,7 @@ pub extern "C" fn js_string_trim(s: *const StringHeader) -> *mut StringHeader {
     }
 
     let str_data = string_as_str(s);
-    let trimmed = str_data.trim();
+    let trimmed = str_data.trim_matches(is_js_whitespace);
     js_string_from_str(trimmed)
 }
 
@@ -184,7 +211,7 @@ pub extern "C" fn js_string_trim_start(s: *const StringHeader) -> *mut StringHea
         return js_string_from_bytes(ptr::null(), 0);
     }
     let str_data = string_as_str(s);
-    js_string_from_str(str_data.trim_start())
+    js_string_from_str(str_data.trim_start_matches(is_js_whitespace))
 }
 
 /// Trim whitespace from end of a string (trimEnd/trimRight)
@@ -194,7 +221,7 @@ pub extern "C" fn js_string_trim_end(s: *const StringHeader) -> *mut StringHeade
         return js_string_from_bytes(ptr::null(), 0);
     }
     let str_data = string_as_str(s);
-    js_string_from_str(str_data.trim_end())
+    js_string_from_str(str_data.trim_end_matches(is_js_whitespace))
 }
 
 /// Convert string to lowercase

--- a/crates/perry-runtime/src/string/split.rs
+++ b/crates/perry-runtime/src/string/split.rs
@@ -117,3 +117,109 @@ pub extern "C" fn js_string_split_n(
 
     arr
 }
+
+/// `ToUint32(ToNumber(value))` (ECMA-262 §7.1.7). Runs the full `ToNumber`
+/// (so a boxed `{ valueOf }` / `{ toString }` argument is coerced and may
+/// throw), then reduces mod 2^32. `NaN`/`±Infinity`/`0` → 0.
+fn split_limit_to_uint32(boxed: f64) -> u32 {
+    let n = crate::builtins::js_number_coerce(boxed);
+    if !n.is_finite() || n == 0.0 {
+        return 0;
+    }
+    n.trunc().rem_euclid(4_294_967_296.0) as u32
+}
+
+/// Build the single-element array `[S]` (the `separator === undefined` result
+/// of `String.prototype.split`).
+fn split_single_element(s: *const StringHeader) -> *mut ArrayHeader {
+    const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
+    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+    let arr = crate::array::js_array_alloc(1);
+    unsafe {
+        (*arr).length = 1;
+        let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+        let nanboxed = STRING_TAG | (s as u64 & POINTER_MASK);
+        // GC_STORE_AUDIT(BARRIERED): slot recorded via note_array_slot.
+        std::ptr::write(elements_ptr, f64::from_bits(nanboxed));
+        crate::array::note_array_slot(arr, 0, nanboxed);
+    }
+    arr
+}
+
+/// `String.prototype.split(separator, limit)` (ECMA-262 §22.1.3.21) with full
+/// argument coercion. `s` is the already-`ToString`-coerced `this`;
+/// `separator` and `limit` arrive as boxed `JSValue`s. The codegen fast path
+/// and the runtime dispatch arm both route here so coercion is uniform:
+///   - a RegExp separator takes over via `RegExp[Symbol.split]` (detected by
+///     the regex-pointer registry), with `ToUint32(limit)`;
+///   - `lim = ToUint32(limit)` is computed BEFORE `ToString(separator)` (spec
+///     order — either may run user `valueOf`/`toString` and throw);
+///   - `limit === 0` ⇒ empty array;
+///   - `separator === undefined` ⇒ single-element `[S]`;
+///   - otherwise split by `ToString(separator)`, capped at `lim`.
+#[no_mangle]
+pub extern "C" fn js_string_split_value(
+    s: *const StringHeader,
+    separator: f64,
+    limit: f64,
+) -> *mut ArrayHeader {
+    use crate::value::JSValue;
+    let sep_jv = JSValue::from_bits(separator.to_bits());
+    let lim_jv = JSValue::from_bits(limit.to_bits());
+
+    // Step 2: a separator with a `[Symbol.split]` method (a RegExp) takes over.
+    if sep_jv.is_pointer() {
+        let ptr = crate::value::js_nanbox_get_pointer(separator) as *const u8;
+        if crate::regex::is_regex_pointer(ptr) {
+            let limit_i32 = if lim_jv.is_undefined() {
+                -1
+            } else {
+                let u = split_limit_to_uint32(limit);
+                if u > i32::MAX as u32 {
+                    i32::MAX
+                } else {
+                    u as i32
+                }
+            };
+            return crate::regex::js_string_split_regex_n(
+                s,
+                ptr as *const crate::regex::RegExpHeader,
+                limit_i32,
+            );
+        }
+    }
+
+    // Step 6: lim = limit===undefined ? 2^32-1 : ToUint32(limit) (may throw).
+    let lim: u32 = if lim_jv.is_undefined() {
+        u32::MAX
+    } else {
+        split_limit_to_uint32(limit)
+    };
+
+    // Step 7: R = ToString(separator) (may throw). For `undefined` the result
+    // is unused (step 9) and `ToString(undefined)` is side-effect-free, so we
+    // skip it.
+    let sep_is_undefined = sep_jv.is_undefined();
+    let r_str: *mut StringHeader = if sep_is_undefined {
+        std::ptr::null_mut()
+    } else {
+        crate::builtins::js_string_coerce(separator)
+    };
+
+    // Step 8: limit 0 → empty array.
+    if lim == 0 {
+        return crate::array::js_array_alloc(0);
+    }
+    // Step 9: undefined separator → [S].
+    if sep_is_undefined {
+        return split_single_element(s);
+    }
+
+    // `js_string_split_n` takes an i32 limit (< 0 ⇒ unbounded); cap `lim`.
+    let limit_i32 = if lim > i32::MAX as u32 {
+        i32::MAX
+    } else {
+        lim as i32
+    };
+    js_string_split_n(s, r_str, limit_i32)
+}


### PR DESCRIPTION
Lifts **built-ins/String** test262 parity from **752 → 814 passing** (runtime-fail 160 → 102, compile-fail 20 → 16), **zero regressions** (no test that passed before now fails). Differential vs Node on the pinned corpus (tc39/test262 @ 4249661388).

## Root causes fixed

**1. `String.prototype.split(separator, limit)` argument coercion.** Split skipped `ToString(separator)` / `ToUint32(limit)` and treated an `undefined` separator as an empty-string separator (per-character split) instead of returning `[wholeString]`. New `js_string_split_value` takes the *boxed* separator + limit and follows §22.1.3.21 exactly: `ToUint32(limit)` runs **before** `ToString(separator)` (spec order — either may run user `valueOf`/`toString` and throw), `undefined` separator → `[S]`, `limit === 0` → `[]`, and a RegExp separator delegates to the regex splitter. (~22 tests)

**2. `indexOf` / `lastIndexOf` argument coercion.** An object `searchString` was bit-cast as a string handle (→ garbage → -1) and the `position` was raw-`fptosi`d (skipping `valueOf`). Now `ToString(searchString)` via `js_string_coerce` runs **before** `ToNumber(position)` via `js_string_index_to_i32` / `js_number_coerce`. (~18 tests)

**3. `search` / `match` regex coercion.** Both required an actual RegExp argument (returned -1/null for a string/`undefined`/`{toString}` arg). New `js_string_search_value` / `js_string_match_value` coerce any non-RegExp arg via `RegExpCreate(ToString(arg))`, with `undefined` → the empty `/(?:)/` regex; `match`/`search` now also accept 0 args. `match(undefined)` previously **SIGSEGV**d — a null pattern pointer was dereferenced by `lookup_fancy_regex`; now an empty `StringHeader` is built. (~30 tests)

**4. `trim` / `trimStart` / `trimEnd` whitespace set.** Used Rust’s Unicode `White_Space`, which *excludes* U+FEFF (BOM — a JS `WhiteSpace`) and *includes* U+0085 (NEL — not JS whitespace). Added an `is_js_whitespace` predicate matching ECMA-262 §22.1.3.32 (`WhiteSpace` + `LineTerminator`). (~7 tests)

## Files
- `crates/perry-codegen/src/lower_string_method.rs` — needle/position/separator/regex-arg coercion + 0-arg `match`/`search`
- `crates/perry-codegen/src/runtime_decls/strings_part2.rs` — declare `js_string_search_value` / `js_string_match_value` (the `js_string_split_value` decl already landed on main)
- `crates/perry-runtime/src/object/native_call_method.rs` — generic-`this` dispatch arms route through the coercing entries
- `crates/perry-runtime/src/regex.rs` — `coerce_search_arg_to_regex` + `js_string_search_value` / `js_string_match_value`
- `crates/perry-runtime/src/string/slice_ops.rs` — `is_js_whitespace` trim
- `crates/perry-runtime/src/string/split.rs` — `js_string_split_value`

## Validation
Default compile path (no env flags). `built-ins/String`: **752 → 814 pass, 0 regressions**. Verified manually against Node for split/indexOf/lastIndexOf/search/match/trim incl. the previously-crashing `"abc".match(undefined)`.