### PR TITLE
fix(runtime): built-ins/String boxed-receiver methods + arg coercion

### DIFF
--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -363,11 +363,21 @@ pub(crate) fn lower_string_method(
             // Detect a string literal that includes $<name> back-refs
             // so we route to the named-group-aware runtime variant.
             let repl_has_named = matches!(&args[1], Expr::String(s) if s.contains("$<"));
+            // A non-RegExp, non-static-string `searchValue` is `ToString`-coerced
+            // (running user `toString`/`valueOf`, may throw) BEFORE the
+            // replacement is coerced, per ECMA-262 §22.1.3.19. Likewise a
+            // non-function, non-static-string `replaceValue`.
+            let needle_is_str = is_string_expr(ctx, &args[0]);
+            let repl_is_str = is_string_expr(ctx, &args[1]);
             let needle_box = lower_expr(ctx, &args[0])?;
             let repl_box = lower_expr(ctx, &args[1])?;
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let needle_handle = unbox_str_handle(blk, &needle_box);
+            let needle_handle = if needle_is_regex || needle_is_str {
+                unbox_str_handle(blk, &needle_box)
+            } else {
+                blk.call(I64, "js_string_coerce", &[(DOUBLE, &needle_box)])
+            };
             if repl_is_function {
                 // repl_box is a NaN-boxed closure pointer (double).
                 // The callback helpers take the callback as f64.
@@ -388,8 +398,13 @@ pub(crate) fn lower_string_method(
                 );
                 return Ok(nanbox_string_inline(blk, &result));
             }
-            // Issue #214: SSO-safe unbox of replacement string.
-            let repl_handle = unbox_str_handle(blk, &repl_box);
+            // Issue #214: SSO-safe unbox of replacement string; a non-static-
+            // string replacement is `ToString`-coerced (after `searchValue`).
+            let repl_handle = if repl_is_str {
+                unbox_str_handle(blk, &repl_box)
+            } else {
+                blk.call(I64, "js_string_coerce", &[(DOUBLE, &repl_box)])
+            };
             let runtime_fn = if needle_is_regex {
                 if property == "replaceAll" {
                     if repl_has_named {
@@ -542,11 +557,16 @@ pub(crate) fn lower_string_method(
                 );
             }
             let len_d = lower_expr(ctx, &args[0])?;
-            // Optional pad string; defaults to " " when missing.
+            // Optional pad string; defaults to " " when missing. A provided
+            // fill is `ToString`-coerced (ECMA-262 §22.1.3.16) via
+            // `js_string_pad_fill` — `undefined` → null handle (runtime falls
+            // back to " "), otherwise ToString — so non-string fills (numbers,
+            // booleans, `null`, `{ toString }`) render correctly instead of
+            // being bit-cast and dropped.
             let pad_handle = if args.len() == 2 {
                 let pad_box = lower_expr(ctx, &args[1])?;
                 let blk = ctx.block();
-                unbox_str_handle(blk, &pad_box)
+                blk.call(I64, "js_string_pad_fill", &[(DOUBLE, &pad_box)])
             } else {
                 let sp_idx = ctx.strings.intern(" ");
                 let sp_global = format!("@{}", ctx.strings.entry(sp_idx).handle_global);
@@ -749,14 +769,22 @@ pub(crate) fn lower_string_method(
             Ok(nanbox_string_inline(blk, &result))
         }
         "concat" => {
-            // str.concat(s1, s2, …) = str + s1 + s2 + … . Sequential
-            // js_string_concat calls; each op returns a new handle.
+            // str.concat(s1, s2, …) = str + ToString(s1) + ToString(s2) + … .
+            // Each arg is `ToString`-coerced (ECMA-262 §22.1.3.5) — a non-string
+            // arg (`undefined`, a boolean, a `{ toString }` object) must render
+            // as its string form, not be bit-cast as a string handle (which
+            // dropped `undefined`/booleans). A static string arg skips coercion.
             let blk = ctx.block();
             let mut acc_handle = unbox_str_handle(blk, &recv_box);
             for a in args {
+                let a_is_str = is_string_expr(ctx, a);
                 let s_box = lower_expr(ctx, a)?;
                 let blk = ctx.block();
-                let s_handle = unbox_str_handle(blk, &s_box);
+                let s_handle = if a_is_str {
+                    unbox_str_handle(blk, &s_box)
+                } else {
+                    blk.call(I64, "js_string_coerce", &[(DOUBLE, &s_box)])
+                };
                 acc_handle = blk.call(
                     I64,
                     "js_string_concat",

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -308,6 +308,8 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_string_normalize", I64, &[I64, DOUBLE]);
     module.declare_function("js_string_pad_start", I64, &[I64, DOUBLE, I64]);
     module.declare_function("js_string_pad_end", I64, &[I64, DOUBLE, I64]);
+    // ToString-coerce a padStart/padEnd fillString (undefined → null → " ").
+    module.declare_function("js_string_pad_fill", I64, &[DOUBLE]);
     module.declare_function("js_string_is_well_formed", DOUBLE, &[I64]);
     module.declare_function("js_string_to_well_formed", I64, &[I64]);
     module.declare_function("js_string_match_all", I64, &[I64, I64]);

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -44,10 +44,20 @@ pub(super) fn try_local_array_methods(
                     type_info,
                     Some(Type::Union(variants)) if variants.iter().any(|v| matches!(v, Type::String))
                 );
+                // A boxed `String` wrapper (`new String("x")`, type `Named("String")`)
+                // is NOT an array: the ambiguous methods shared with Array
+                // (`indexOf`/`includes`/`slice`/`lastIndexOf`) must route to the
+                // string dispatch (which `ToString`-coerces the wrapper), not to
+                // `ArrayIndexOf`/`ArrayIncludes` (which read it as an array and
+                // return -1/false). `search`/`match`/`split` already bypass this
+                // file because they aren't Array methods.
+                let is_boxed_string_wrapper =
+                    matches!(type_info, Some(Type::Named(n)) if n == "String");
                 let is_known_string = type_info
                     .map(|ty| matches!(ty, Type::String))
                     .unwrap_or(false)
-                    || is_union_with_string;
+                    || is_union_with_string
+                    || is_boxed_string_wrapper;
                 // A user-defined class instance is NOT an array — must skip the array
                 // fast path so user-defined methods like Stack<T>.push() are dispatched
                 // to the class method, not runtime js_array_push. Map/Set/Promise are

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1821,7 +1821,11 @@ pub unsafe extern "C" fn js_native_call_method(
                     let regex_val =
                         arg_at(0).unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()));
                     let i32_v = crate::regex::js_string_search_value(s_ptr, regex_val);
-                    return f64::from_bits(JSValue::int32(i32_v).bits());
+                    // Return a RAW `f64` (not NaN-boxed INT32_TAG): a boxed-int
+                    // result fails `aString.search(x) === 5` strict-equality
+                    // against a plain number literal. Mirrors the `indexOf`
+                    // arm's `as f64` convention.
+                    return i32_v as f64;
                 }
                 // Refs #421 — common string methods on any-typed receivers.
                 // Hono's compiled JS (and most npm packages with stripped TS

--- a/crates/perry-runtime/src/string/pad.rs
+++ b/crates/perry-runtime/src/string/pad.rs
@@ -9,6 +9,27 @@ pub extern "C" fn js_string_alloc_space() -> *mut StringHeader {
     js_string_from_bytes(" ".as_ptr(), 1)
 }
 
+/// Coerce a `padStart`/`padEnd` `fillString` argument (ECMA-262 §22.1.3.16
+/// `StringPad`): `undefined` keeps the default — returned as a null pointer so
+/// `js_string_pad_*` substitutes `" "` — while any other value is
+/// `ToString`-coerced (a number/boolean/null/`{ toString }` object renders to
+/// its string form, may run user code and throw). A raw `unbox_str_handle` of
+/// such an arg bit-cast it as a string handle, dropping non-string fills.
+#[no_mangle]
+pub extern "C" fn js_string_pad_fill(value: f64) -> *mut StringHeader {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() {
+        return std::ptr::null_mut();
+    }
+    crate::builtins::js_string_coerce(value)
+}
+
+// `#[used]` keepalive: `js_string_pad_fill` is reached only from generated
+// `.o`, so the whole-program auto-optimize bitcode rebuild would dead-strip it
+// without an anchor (see project_auto_optimize_keepalive_3320).
+#[used]
+static KEEP_PAD_FILL: extern "C" fn(f64) -> *mut StringHeader = js_string_pad_fill;
+
 /// Maximum string length Perry/V8 supports as a single `String`. This
 /// mirrors the value Node v25 reports via `buffer.constants.MAX_STRING_LENGTH`
 /// (536_870_888 = `(1 << 29) - 24` on this V8 build). `padStart`/`padEnd`


### PR DESCRIPTION
Follow-up to #4754 (merged). Lifts **built-ins/String** another **814 → 840 passing**, **zero regressions** (`prototype/search` 19/31 → **31/31**). Differential vs Node on the pinned corpus (tc39/test262 @ 4249661388). Default compile path.

## Root causes

**1. `String.prototype.search` returned a NaN-boxed INT32 (+12).** The runtime dispatch arm returned `JSValue::int32(i)` instead of a raw `f64`. The index was *correct*, but `new String(s).search(x) === N` and the generic-`this` `__o.search = String.prototype.search; __o.search(x)` forms strict-compared **unequal** to a plain number literal (a NaN-boxed int and an IEEE double differ in bits). Now returns `i32 as f64`, matching the `indexOf` arm.

**2. Boxed `new String(...)` wrapper mis-routed Array/String shared methods.** A receiver of type `Named("String")` was treated as "definitely not a string" in `try_local_array_methods`, so `indexOf`/`includes`/`slice`/`lastIndexOf` lowered to `ArrayIndexOf`/`ArrayIncludes`/… and read the wrapper as an array → `-1`/`false`. (`search`/`match`/`split` were unaffected — not Array methods.) Now treated as a string → routes to the `ToString`-coercing string dispatch.

**3. `replace`/`replaceAll` argument coercion.** A non-RegExp `searchValue` / non-function `replaceValue` were bit-cast as string handles instead of `ToString`-coerced, so `"...".replace({toString(){throw …}}, …)` didn’t throw. Now coerces per ECMA-262 §22.1.3.19 (`searchValue` before `replaceValue`).

**4. `concat` dropped non-string args.** Args were bit-cast as string handles, so `"lego".concat(undefined)` → `"lego"` and `"a".concat("b",1,true)` → `"ab1"`. Now `ToString`-coerces each non-static-string arg (§22.1.3.5) → `"legoundefined"` / `"ab1true"`.

**5. `padStart`/`padEnd` dropped non-string `fillString`.** `"abc".padStart(10, false)` ignored the fill. New runtime `js_string_pad_fill` `ToString`-coerces the fill (`undefined` → default `" "`) → `"falsefaabc"`.

## Files
- `crates/perry-runtime/src/object/native_call_method.rs` — `search` arm returns raw `f64`
- `crates/perry-runtime/src/string/pad.rs` — `js_string_pad_fill`
- `crates/perry-codegen/src/lower_string_method.rs` — `replace`/`concat`/`padStart`/`padEnd` arg coercion
- `crates/perry-codegen/src/runtime_decls/strings_part2.rs` — declare `js_string_pad_fill`
- `crates/perry-hir/src/lower/expr_call/local_array_methods.rs` — treat the boxed `String` wrapper as a string

## Validation
`built-ins/String`: **814 → 840 pass, 0 regressions**. Verified vs Node for boxed-receiver indexOf/includes/slice/lastIndexOf, search on boxed/generic-`this` receivers, replace/concat/padStart/padEnd arg coercion. Together with #4754: built-ins/String **752 → 840**.