### PR TITLE
fix(runtime): subclassing native Request/Response exposes working body methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1130 — subclassing native `Request`/`Response` exposes working body methods
+
+Subclassing the native global `Request` (or `Response`) produced instances that
+were missing the body-reading methods (`text`/`json`/`arrayBuffer`/`blob`/
+`formData`/`bytes`) and the inherited property getters, and `sub instanceof
+Request` was `false`. This broke `@hono/node-server`, which does
+`class Request extends GlobalRequest { ... }` — every `c.req.text()` /
+`c.req.json()` on a POST/PUT route threw, turning webhooks and form posts into
+500s.
+
+**Root cause.** A Web-Fetch `Request`/`Response` in Perry is not a heap JS
+object — it is a native registry handle (a small id NaN-boxed as a pointer)
+whose methods are resolved by native handle dispatch, not via a JS prototype
+chain. `class X extends Request {}` + `new X(...)` produced an ordinary heap JS
+object with no link to any native handle: property/method lookup walked the JS
+prototype chain, found nothing (the body methods live in native dispatch, not on
+`Request.prototype`), and returned `undefined`.
+
+**Fix.** `super(input, init)` on a `Request`/`Response` parent now allocates the
+underlying native handle and stashes its id on `this` under the hidden field
+`__perry_fetch_handle__` (mirrors the Web-Streams `__perry_stream_handle__`
+mechanism from #562). Both the explicit-constructor path (`Expr::SuperCall`,
+`expr/this_super_call.rs`) and the implicit default-constructor path
+(`lower_call/new.rs`, parallel to the node-stream `*_subclass_init` hooks) are
+wired, via two new runtime shims `js_request_subclass_init` /
+`js_response_subclass_init` (`object/global_this.rs`). At access time:
+
+- method calls (`object/native_call_method.rs`): inherited body methods on a
+  subclass receiver are forwarded to the native handle dispatcher (gated on the
+  fetch body-method name set, and only after all user-defined dispatch — own
+  fields, vtable, prototype walk — has missed, so a subclass override still
+  wins);
+- property reads (`object/field_get_set.rs`): a missed read on a subclass
+  instance is forwarded to the handle, so `url`/`method`/`headers`/`body`/
+  `bodyUsed`/… and body-method-as-value reads resolve;
+- `instanceof` (`object/instanceof.rs`): the `Request`/`Response`/`Headers`/
+  `Blob` arm unwraps the stashed handle and runs the existing fetch kind-probe.
+
+Non-subclassed `Request`/`Response` and other native-builtin subclasses are
+unaffected (the new paths only trigger when a heap object carries
+`__perry_fetch_handle__`). Regression test:
+`tests/test_request_subclass_body.sh`.
+
+
 ## v0.5.1129 — fix(windows): `perry update` extracts the `.zip` artifact instead of failing with "invalid gzip header" (#4715)
 
 `perform_self_update` in `crates/perry/src/update_checker.rs` always decoded the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1129
+**Current Version:** 0.5.1130
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1129"
+version = "0.5.1130"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1129"
+version = "0.5.1130"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1129"
+version = "0.5.1130"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1129"
+version = "0.5.1130"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1129"
+version = "0.5.1130"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -151,6 +151,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             | "ReadableStream"
                             | "WritableStream"
                             | "TransformStream"
+                            | "Request"
+                            | "Response"
                     );
                     if !is_builtin_parent_name {
                         if let Some(extends_expr) = current_class.extends_expr.as_deref() {
@@ -204,24 +206,25 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
                                 }
                             };
-                            let prev_this = ctx.block().call(
-                                DOUBLE,
-                                "js_implicit_this_set",
-                                &[(DOUBLE, &this_box)],
-                            );
+                            // Route runtime-value super() through the
+                            // fetch-aware dispatcher: when `parent_val` is the
+                            // global Request/Response constructor (possibly via
+                            // an alias like `@hono/node-server`'s
+                            // `GlobalRequest = global.Request`), it allocates the
+                            // native fetch handle and stashes it on `this` so
+                            // inherited body methods resolve; otherwise it falls
+                            // back to the ordinary implicit-`this`-bound
+                            // `js_native_call_value` (unchanged behavior for
+                            // every other runtime-value parent).
                             let _ = ctx.block().call(
                                 DOUBLE,
-                                "js_native_call_value",
+                                "js_fetch_or_value_super",
                                 &[
                                     (DOUBLE, &parent_val),
+                                    (DOUBLE, &this_box),
                                     (crate::types::PTR, &args_ptr),
                                     (I64, &args_len),
                                 ],
-                            );
-                            ctx.block().call(
-                                DOUBLE,
-                                "js_implicit_this_set",
-                                &[(DOUBLE, &prev_this)],
                             );
 
                             // Per JS spec: subclass field initializers run AFTER
@@ -302,6 +305,47 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             crate::lower_call::FieldInitMode::SelfOnly,
                         )?;
                         return Ok(result);
+                    }
+                    // `class X extends Request` / `extends Response`:
+                    // `super(input, init)` allocates the underlying native
+                    // Web-Fetch handle and stashes its id on `this` under
+                    // `__perry_fetch_handle__`. Inherited body methods
+                    // (`text`/`json`/…) and property getters route through that
+                    // handle at runtime (see `fetch_subclass_handle_id`). This
+                    // makes `class Request extends GlobalRequest {}` — exactly
+                    // what `@hono/node-server` does — produce a working Request.
+                    let fetch_subclass_fn = match parent_name.as_str() {
+                        "Request" => Some("js_request_subclass_init"),
+                        "Response" => Some("js_response_subclass_init"),
+                        _ => None,
+                    };
+                    if let Some(runtime_fn) = fetch_subclass_fn {
+                        let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                        let mut lowered: Vec<String> = Vec::with_capacity(super_args.len());
+                        for a in super_args {
+                            lowered.push(lower_expr(ctx, a)?);
+                        }
+                        let arg0 = lowered.first().cloned().unwrap_or_else(|| undef.clone());
+                        let arg1 = lowered.get(1).cloned().unwrap_or_else(|| undef.clone());
+                        let this_box = match ctx.this_stack.last().cloned() {
+                            Some(slot) => ctx.block().load(DOUBLE, &slot),
+                            None => undef.clone(),
+                        };
+                        ctx.block().call(
+                            DOUBLE,
+                            runtime_fn,
+                            &[(DOUBLE, &this_box), (DOUBLE, &arg0), (DOUBLE, &arg1)],
+                        );
+                        // Per JS spec, subclass field initializers run after
+                        // super() returns (mirrors the stream/error arms above).
+                        let current_class_name =
+                            ctx.class_stack.last().cloned().unwrap_or_default();
+                        crate::lower_call::apply_field_initializers_recursive(
+                            ctx,
+                            &current_class_name,
+                            crate::lower_call::FieldInitMode::SelfOnly,
+                        )?;
+                        return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
                     }
                     // Built-in parent (Error, TypeError, RangeError, etc.)
                     // — user classes extending them need `super(message)` to

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -699,6 +699,19 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
     } else {
         None
     };
+    // `class X extends Request/Response {}` with no own constructor — forward
+    // `new X(input, init)` to the native fetch subclass-init shim (stashes the
+    // underlying handle on `this`). Two user args (input/init), unlike the
+    // single-opts stream shims above, so it has its own emit block below.
+    let fetch_parent_runtime = if !has_own_ctor && !has_imported_ctor {
+        match class.extends_name.as_deref() {
+            Some("Request") => Some("js_request_subclass_init"),
+            Some("Response") => Some("js_response_subclass_init"),
+            _ => None,
+        }
+    } else {
+        None
+    };
     let inherited_ctor_class: Option<String> = if !has_own_ctor && has_extends {
         // Walk the inheritance chain to find the closest ancestor with
         // an explicit ctor — same logic as the body-inlining loop below.
@@ -952,6 +965,29 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                 .call(DOUBLE, runtime_fn, &[(DOUBLE, &this_box), (DOUBLE, &opts)]);
             found_inherited_ctor = true;
         }
+        if let Some(runtime_fn) = fetch_parent_runtime {
+            let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            let arg0 = lowered_args
+                .first()
+                .cloned()
+                .unwrap_or_else(|| undef_lit.clone());
+            let arg1 = lowered_args
+                .get(1)
+                .cloned()
+                .unwrap_or_else(|| undef_lit.clone());
+            let this_box = ctx
+                .this_stack
+                .last()
+                .cloned()
+                .map(|slot| ctx.block().load(DOUBLE, &slot))
+                .unwrap_or_else(|| undef_lit.clone());
+            ctx.block().call(
+                DOUBLE,
+                runtime_fn,
+                &[(DOUBLE, &this_box), (DOUBLE, &arg0), (DOUBLE, &arg1)],
+            );
+            found_inherited_ctor = true;
+        }
         // If no parent constructor was found (imported class with no
         // inlineable constructor body), call the cross-module constructor.
         // Refs #420: walk past empty-bodied ancestors with param_count==0
@@ -1085,7 +1121,7 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
     // `BetterSQLiteSession` (explicit ctor) and arrow-field cross-
     // module classes are both load-bearing. Refs #420 / #618 followup.
     if !has_own_ctor && has_extends && !has_imported_ctor {
-        if builtin_parent_runtime.is_some() {
+        if builtin_parent_runtime.is_some() || fetch_parent_runtime.is_some() {
             apply_field_initializers_recursive(ctx, class_name, FieldInitMode::SelfOnly)?;
         } else if let Some(stop_at) = inherited_ctor_class {
             apply_field_initializers_recursive(

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -1102,6 +1102,27 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE, DOUBLE],
     );
+    // `class X extends Request` / `extends Response`: `super(...)` shims that
+    // allocate the underlying native fetch handle and stash it on `this`.
+    // Invoked from the `Expr::SuperCall` Request/Response arm.
+    module.declare_function(
+        "js_request_subclass_init",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE],
+    );
+    module.declare_function(
+        "js_response_subclass_init",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE],
+    );
+    // Runtime-value super() dispatcher: identifies an aliased global
+    // Request/Response constructor parent (e.g. `extends GlobalRequest`) and
+    // stashes the native handle on `this`, else forwards to js_native_call_value.
+    module.declare_function(
+        "js_fetch_or_value_super",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, PTR, I64],
+    );
 
     // ──────────────────────────────────────────────────────────────────
     // AbortController / AbortSignal — perry-runtime/src/url.rs.

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1922,6 +1922,16 @@ pub unsafe extern "C" fn js_new_function_construct(
             super::class_constructors::replay_class_object_constructor(
                 func_value, class_cid, inst, args_ptr, args_len,
             );
+            // `class X extends Request/Response {}` constructed via the dynamic
+            // (class-expression value) path: the replayed ctor's `super()`
+            // can't statically route an aliased parent, so attach the native
+            // fetch handle here when the registered parent is a fetch builtin
+            // and the instance didn't already get one. Refs `@hono/node-server`.
+            if let Some(kind) = fetch_parent_kind_in_chain(class_cid) {
+                if super::field_get_set::fetch_subclass_handle_id(inst as usize).is_none() {
+                    super::attach_fetch_handle_for_construction(inst, kind, args_ptr, args_len);
+                }
+            }
             return crate::value::js_nanbox_pointer(inst as i64);
         }
     }
@@ -2045,6 +2055,13 @@ unsafe fn construct_registered_class_ref(
     super::class_constructors::replay_registered_class_constructor(
         target_cid, inst, args_ptr, args_len,
     );
+    // ClassRef `new` of a Request/Response subclass — attach the native fetch
+    // handle on the dynamic path (mirrors the class-expression arm above).
+    if let Some(kind) = fetch_parent_kind_in_chain(target_cid) {
+        if super::field_get_set::fetch_subclass_handle_id(inst as usize).is_none() {
+            super::attach_fetch_handle_for_construction(inst, kind, args_ptr, args_len);
+        }
+    }
     crate::value::js_nanbox_pointer(inst as i64)
 }
 
@@ -3449,6 +3466,27 @@ pub(crate) unsafe fn call_vtable_method(
     }
 }
 
+/// Walk the class parent chain looking for a recorded fetch-builtin parent
+/// (Request = 1, Response = 2). Returns the kind for the first ancestor (incl.
+/// `class_id` itself) that directly extends a global Request/Response.
+pub(crate) fn fetch_parent_kind_in_chain(class_id: u32) -> Option<u8> {
+    let mut cid = class_id;
+    let mut depth = 0u32;
+    while depth < 32 {
+        if let Some(kind) = super::fetch_parent_kind(cid) {
+            return Some(kind);
+        }
+        match get_parent_class_id(cid) {
+            Some(p) if p != 0 && p != cid => {
+                cid = p;
+                depth += 1;
+            }
+            _ => break,
+        }
+    }
+    None
+}
+
 /// Register a class with its parent class ID in the global registry
 pub(crate) fn register_class(class_id: u32, parent_class_id: u32) {
     let mut registry = CLASS_REGISTRY.write().unwrap();
@@ -3542,6 +3580,20 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
 
     if parent_cid != 0 && parent_cid != class_id {
         register_class(class_id, parent_cid);
+    }
+
+    // Record whether the parent value is the global Request/Response
+    // constructor (possibly via an alias like `GlobalRequest = global.Request`),
+    // resolved here in the scope where the alias is live. The runtime
+    // dynamic-construction path (`new (classExprValue)(...)`) consults this to
+    // attach the underlying native fetch handle on the instance — the static
+    // codegen `super()` path can't, because the textual parent name is the
+    // alias, not "Request". Refs `@hono/node-server`'s `class Request extends
+    // GlobalRequest`.
+    match identify_global_builtin_constructor(parent_value) {
+        Some("Request") => super::register_fetch_parent_kind(class_id, 1),
+        Some("Response") => super::register_fetch_parent_kind(class_id, 2),
+        _ => {}
     }
 
     // #1788: when the parent is a per-evaluation class OBJECT (a class

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -8,6 +8,44 @@
 
 use super::*;
 
+/// Hidden own-field name under which a `class X extends Request/Response`
+/// instance stashes the id of its underlying native Web-Fetch handle. Written
+/// by the `js_request_subclass_init` / `js_response_subclass_init` super-init
+/// shims (global_this.rs); read here (property forward), in
+/// `native_call_method.rs` (body-method forward), and in `instanceof.rs`
+/// (`x instanceof Request/Response`). A Request/Response is a registry-backed
+/// native handle, not a heap object whose methods live on the JS prototype
+/// chain, so a subclass instance can only reach those members via the handle.
+pub(crate) const FETCH_SUBCLASS_HANDLE_FIELD: &[u8] = b"__perry_fetch_handle__";
+
+/// If `obj` (a raw heap object address) is a `class X extends Request/Response`
+/// instance, return the id of its underlying native fetch handle. Returns
+/// `None` for any non-object / non-subclass receiver, so callers can fall
+/// through to their normal dispatch unchanged.
+pub(crate) unsafe fn fetch_subclass_handle_id(obj: usize) -> Option<i64> {
+    if obj < crate::gc::GC_HEADER_SIZE + 0x1000 || !is_valid_obj_ptr(obj as *const u8) {
+        return None;
+    }
+    let gc_header = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+        return None;
+    }
+    let key = crate::string::js_string_from_bytes(
+        FETCH_SUBCLASS_HANDLE_FIELD.as_ptr(),
+        FETCH_SUBCLASS_HANDLE_FIELD.len() as u32,
+    );
+    let v = js_object_get_field_by_name(obj as *const ObjectHeader, key);
+    if v.is_undefined() {
+        return None;
+    }
+    let id = f64::from_bits(v.bits());
+    if id.is_finite() && id > 0.0 && id.fract() == 0.0 {
+        Some(id as i64)
+    } else {
+        None
+    }
+}
+
 const CLASS_ID_BOXED_NUMBER: u32 = 0xFFFF_00D0;
 const CLASS_ID_BOXED_STRING: u32 = 0xFFFF_00D1;
 const CLASS_ID_BOXED_BOOLEAN: u32 = 0xFFFF_00D2;
@@ -4562,6 +4600,20 @@ pub extern "C" fn js_object_get_field_by_name(
             }
             if let Some(v) = ordinary_object_prototype_method_value(obj, key) {
                 return v;
+            }
+        }
+
+        // `class X extends Request/Response`: inherited native members
+        // (`url`/`method`/`headers`/`body`/`bodyUsed`/… and body methods read
+        // as values) live on the underlying fetch handle, not the JS prototype
+        // chain. Forward the read to the handle when this object stashes one
+        // and the key isn't the marker field itself. Refs Hono `c.req` body.
+        if !key.is_null() && key_bytes != FETCH_SUBCLASS_HANDLE_FIELD {
+            if let Some(id) = fetch_subclass_handle_id(obj as usize) {
+                let v = js_object_get_field_by_name(id as usize as *const ObjectHeader, key);
+                if !v.is_undefined() {
+                    return v;
+                }
             }
         }
 

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -255,6 +255,150 @@ pub(crate) extern "C" fn global_this_request_thunk(
     )
 }
 
+/// Resolve a NaN-boxed `this` value to a heap `ObjectHeader` pointer, or
+/// `None` for a non-pointer / small-handle / null receiver.
+unsafe fn subclass_this_object_ptr(this_box: f64) -> Option<*mut ObjectHeader> {
+    let bits = this_box.to_bits();
+    if (bits >> 48) != 0x7FFD {
+        return None;
+    }
+    let raw = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if raw < 0x100000 || !crate::object::is_valid_obj_ptr(raw as *const u8) {
+        return None;
+    }
+    Some(raw as *mut ObjectHeader)
+}
+
+/// Stash the id of a freshly-created native Web-Fetch handle (`handle_box` is
+/// the NaN-boxed pointer-tagged value the Request/Response thunk returns) on a
+/// subclass instance's `this` under `__perry_fetch_handle__`. Stored as a
+/// plain numeric f64 — `fetch_subclass_handle_id` reads it back.
+unsafe fn attach_fetch_handle_to_this(this_box: f64, handle_box: f64) {
+    if let Some(obj) = subclass_this_object_ptr(this_box) {
+        let id = crate::value::js_nanbox_get_pointer(handle_box);
+        let key = crate::string::js_string_from_bytes(
+            FETCH_SUBCLASS_HANDLE_FIELD.as_ptr(),
+            FETCH_SUBCLASS_HANDLE_FIELD.len() as u32,
+        );
+        crate::object::js_object_set_field_by_name(obj, key, id as f64);
+    }
+}
+
+/// Attach a native fetch handle to a freshly dynamically-constructed
+/// Request/Response subclass instance, building it from the `new` arguments.
+/// `kind` is 1 (Request) or 2 (Response). Used by the runtime
+/// dynamic-construction path (`js_new_function_construct`) for class-expression
+/// / ClassRef subclasses whose `super()` couldn't statically route the parent.
+pub(crate) unsafe fn attach_fetch_handle_for_construction(
+    inst: *mut ObjectHeader,
+    kind: u8,
+    args_ptr: *const f64,
+    args_len: usize,
+) {
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let arg0 = if args_len >= 1 && !args_ptr.is_null() {
+        *args_ptr
+    } else {
+        undef
+    };
+    let arg1 = if args_len >= 2 && !args_ptr.is_null() {
+        *args_ptr.add(1)
+    } else {
+        undef
+    };
+    let handle = if kind == 1 {
+        global_this_request_thunk(std::ptr::null(), arg0, arg1)
+    } else {
+        global_this_response_thunk(std::ptr::null(), arg0, arg1)
+    };
+    let this_box = crate::value::js_nanbox_pointer(inst as i64);
+    attach_fetch_handle_to_this(this_box, handle);
+}
+
+/// `super(input, init)` for `class X extends Request`. Allocates the underlying
+/// native Request handle and stashes it on `this`; inherited body methods /
+/// property getters are forwarded to the handle at access time. Returns
+/// `undefined` (the super-call value).
+#[no_mangle]
+pub extern "C" fn js_request_subclass_init(this_box: f64, input: f64, init: f64) -> f64 {
+    let handle = global_this_request_thunk(std::ptr::null(), input, init);
+    unsafe { attach_fetch_handle_to_this(this_box, handle) };
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// `super(body, init)` for `class X extends Response`. Mirror of
+/// `js_request_subclass_init` for the Response handle.
+#[no_mangle]
+pub extern "C" fn js_response_subclass_init(this_box: f64, body: f64, init: f64) -> f64 {
+    let handle = global_this_response_thunk(std::ptr::null(), body, init);
+    unsafe { attach_fetch_handle_to_this(this_box, handle) };
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+// The two shims above are reached only from codegen-emitted IR (the
+// `Expr::SuperCall` Request/Response arm); pin them so the auto-optimize
+// bitcode rebuild's dead-strip can't drop them (see
+// project_auto_optimize_keepalive_3320).
+#[used]
+static KEEP_JS_REQUEST_SUBCLASS_INIT: extern "C" fn(f64, f64, f64) -> f64 =
+    js_request_subclass_init;
+#[used]
+static KEEP_JS_RESPONSE_SUBCLASS_INIT: extern "C" fn(f64, f64, f64) -> f64 =
+    js_response_subclass_init;
+
+/// `super(...)` for `class X extends <runtime-value constructor>` where the
+/// parent expression is an alias of the global `Request`/`Response` constructor
+/// — e.g. `@hono/node-server`'s `class Request extends GlobalRequest` with
+/// `GlobalRequest = global.Request`. The textual parent name is the alias
+/// ("GlobalRequest"), not "Request", so codegen can't statically route it;
+/// instead every runtime-value `super()` dispatches through here. When
+/// `parent_val` resolves to the Request/Response constructor we allocate the
+/// native handle and stash it on `this` (so inherited body methods work);
+/// otherwise we fall back to the ordinary implicit-`this`-bound
+/// `js_native_call_value`, preserving the prior behavior for every other
+/// runtime-value parent (Effect's `Data.Class`, etc.).
+#[no_mangle]
+pub unsafe extern "C" fn js_fetch_or_value_super(
+    parent_val: f64,
+    this_box: f64,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let kind = super::class_registry::identify_global_builtin_constructor(parent_val);
+    match kind {
+        Some("Request") | Some("Response") => {
+            let arg0 = if args_len >= 1 && !args_ptr.is_null() {
+                *args_ptr
+            } else {
+                undef
+            };
+            let arg1 = if args_len >= 2 && !args_ptr.is_null() {
+                *args_ptr.add(1)
+            } else {
+                undef
+            };
+            let handle = if kind == Some("Request") {
+                global_this_request_thunk(std::ptr::null(), arg0, arg1)
+            } else {
+                global_this_response_thunk(std::ptr::null(), arg0, arg1)
+            };
+            attach_fetch_handle_to_this(this_box, handle);
+            undef
+        }
+        _ => {
+            let prev = crate::object::js_implicit_this_set(this_box);
+            let r = crate::closure::js_native_call_value(parent_val, args_ptr, args_len);
+            crate::object::js_implicit_this_set(prev);
+            r
+        }
+    }
+}
+
+#[used]
+static KEEP_JS_FETCH_OR_VALUE_SUPER: unsafe extern "C" fn(f64, f64, *const f64, usize) -> f64 =
+    js_fetch_or_value_super;
+
 extern "C" fn global_this_response_error_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -689,16 +689,30 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         || class_id == CLASS_ID_HEADERS
         || class_id == CLASS_ID_BLOB
     {
+        let want = match class_id {
+            CLASS_ID_RESPONSE => 1u8,
+            CLASS_ID_REQUEST => 2,
+            CLASS_ID_HEADERS => 3,
+            _ => 4, // CLASS_ID_BLOB
+        };
         if let Some(handle) = small_native_handle_id(value) {
             if let Some(probe) = crate::object::fetch_handle_kind_probe() {
-                let want = match class_id {
-                    CLASS_ID_RESPONSE => 1u8,
-                    CLASS_ID_REQUEST => 2,
-                    CLASS_ID_HEADERS => 3,
-                    _ => 4, // CLASS_ID_BLOB
-                };
                 if unsafe { probe(handle as usize) } == want {
                     return true_val;
+                }
+            }
+        }
+        // `class X extends Request/Response` instance: a heap object that
+        // stashes the underlying native fetch handle id under
+        // `__perry_fetch_handle__`. Unwrap and probe so `sub instanceof
+        // Request` is true, matching a bare handle.
+        if jsval.is_pointer() {
+            let raw = jsval.as_pointer::<u8>() as usize;
+            if let Some(id) = unsafe { crate::object::fetch_subclass_handle_id(raw) } {
+                if let Some(probe) = crate::object::fetch_handle_kind_probe() {
+                    if unsafe { probe(id as usize) } == want {
+                        return true_val;
+                    }
                 }
             }
         }

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1721,6 +1721,31 @@ pub fn overflow_fields_is_empty() -> bool {
 /// Global class registry mapping class_id -> parent_class_id for inheritance chain lookups
 static CLASS_REGISTRY: RwLock<Option<HashMap<u32, u32>>> = RwLock::new(None);
 
+/// class_id -> fetch-builtin parent kind (1 = Request, 2 = Response). Recorded
+/// when a class is registered (at module init / class-expression evaluation)
+/// whose parent value identifies as the global `Request`/`Response`
+/// constructor — including via an alias such as `@hono/node-server`'s
+/// `GlobalRequest = global.Request`. Lets the runtime dynamic-construction
+/// path (`new (classExprValue)(...)` / ClassRef `new`) attach the underlying
+/// native fetch handle, matching what the static codegen `super()` path does.
+static FETCH_PARENT_KIND: RwLock<Option<HashMap<u32, u8>>> = RwLock::new(None);
+
+/// Record that `class_id` directly extends the global Request (kind 1) or
+/// Response (kind 2) constructor.
+pub(crate) fn register_fetch_parent_kind(class_id: u32, kind: u8) {
+    let mut g = FETCH_PARENT_KIND.write().unwrap();
+    if g.is_none() {
+        *g = Some(HashMap::new());
+    }
+    g.as_mut().unwrap().insert(class_id, kind);
+}
+
+/// The directly-recorded fetch parent kind for `class_id` (no chain walk).
+pub(crate) fn fetch_parent_kind(class_id: u32) -> Option<u8> {
+    let g = FETCH_PARENT_KIND.read().ok()?;
+    g.as_ref()?.get(&class_id).copied()
+}
+
 /// Global registry of class IDs that extend the built-in Error class
 static EXTENDS_ERROR_REGISTRY: RwLock<Option<std::collections::HashSet<u32>>> = RwLock::new(None);
 

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -4403,6 +4403,32 @@ pub unsafe extern "C" fn js_native_call_method(
     // surfaces far downstream as a stray `{}` — hiding the real call site. Print
     // a located report first so `PERRY_DISPATCH_DIAG=1` names the missing
     // method+receiver before the throw is caught.
+    // `class X extends Request/Response`: the body methods (`text`/`json`/
+    // `arrayBuffer`/`blob`/`bytes`/`formData`/`clone`) live on the underlying
+    // native fetch handle, not the JS prototype chain. All user-defined
+    // dispatch (own fields, vtable, prototype walk) has missed by here, so a
+    // subclass that overrides one of these still wins; only genuinely
+    // inherited body methods reach this forward. Refs Hono `c.req.text()`.
+    if matches!(
+        method_name,
+        "text" | "json" | "arrayBuffer" | "blob" | "bytes" | "formData" | "clone"
+    ) && jsval.is_pointer()
+    {
+        let raw = crate::value::js_nanbox_get_pointer(object) as usize;
+        if let Some(id) = crate::object::fetch_subclass_handle_id(raw) {
+            if let Some(dispatch) = handle_method_dispatch() {
+                let args = refreshed_args();
+                return dispatch(
+                    id,
+                    method_name.as_ptr(),
+                    method_name.len(),
+                    args.as_ptr(),
+                    args.len(),
+                );
+            }
+        }
+    }
+
     crate::object::class_registry::report_dispatch_miss(
         "call-method (no method/field/proto match)",
         object,

--- a/tests/test_request_subclass_body.sh
+++ b/tests/test_request_subclass_body.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Regression: subclassing the native global `Request` (or `Response`) must
+# produce instances that still expose the body-reading methods
+# (`text`/`json`/`arrayBuffer`/`blob`/`formData`) and the inherited property
+# getters (`url`/`method`/...).
+#
+# Bug: a Web-Fetch Request in Perry is a native registry handle (a small id
+# NaN-boxed as a pointer), not a heap JS object — its methods are resolved by
+# native handle dispatch, not via a JS prototype chain. `class X extends
+# Request {}` produced a plain JS object with NO link to a native handle, so
+# `sub.text` was `undefined` and `sub instanceof Request` was `false`. This
+# broke `@hono/node-server`, which does `class Request extends GlobalRequest`,
+# making every `c.req.text()`/`c.req.json()` throw on POST/PUT routes.
+#
+# Fix: `super(...)` on Request/Response allocates the underlying native handle
+# and stashes its id on `this` under `__perry_fetch_handle__`. Inherited body
+# methods, property getters, and `instanceof` are forwarded to that handle at
+# runtime.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+// No-own-constructor subclass (default ctor forwards args to super()).
+const Sub = class extends Request {};
+// Explicit-constructor subclass calling super() — mirrors @hono/node-server.
+class Req2 extends Request {
+  tag: string;
+  constructor(input: string, init?: RequestInit) {
+    super(input, init);
+    this.tag = "req2";
+  }
+}
+
+async function main() {
+  const sub = new Sub("http://x/y", { method: "POST", body: "hello" });
+  console.log("sub.text type:", typeof sub.text);
+  console.log("sub instanceof Request:", sub instanceof Request);
+  console.log("sub.text body:", await sub.text());
+
+  const r2 = new Req2("http://x/z", { method: "POST", body: '{"n":42}' });
+  console.log("r2.tag:", r2.tag);
+  console.log("r2 instanceof Request:", r2 instanceof Request);
+  console.log("r2.method:", r2.method);
+  const j = await r2.json();
+  console.log("r2.json.n:", j.n);
+}
+main();
+EOF
+
+cd "$TMPDIR"
+"$PERRY" compile main.ts --output test_bin >/dev/null 2>&1
+RUN_OUTPUT=$(./test_bin 2>&1)
+
+EXPECTED="sub.text type: function
+sub instanceof Request: true
+sub.text body: hello
+r2.tag: req2
+r2 instanceof Request: true
+r2.method: POST
+r2.json.n: 42"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: Request subclass body methods regressed"
+echo "Expected:"
+echo "$EXPECTED"
+echo ""
+echo "Got:"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Problem

Subclassing the native global `Request` (or `Response`) produced instances that were **missing the body-reading methods** (`text`/`json`/`arrayBuffer`/`blob`/`formData`/`bytes`), missing the inherited property getters, and `sub instanceof Request` was `false`:

```ts
const Sub = class extends Request {};
const sub = new Sub("http://x/y", { method: "POST", body: "hello" });
typeof sub.text            // was "undefined"  → now "function"
sub instanceof Request     // was false        → now true
await sub.text()           // threw            → now "hello"
```

This breaks `@hono/node-server`, which does `class Request extends GlobalRequest { … }`, so every `c.req.text()` / `c.req.json()` on a POST/PUT route threw, turning webhooks and form posts into 500s.

## Root cause

A Web-Fetch `Request`/`Response` in Perry is **not a heap JS object** — it's a native registry handle (a small id NaN-boxed as a pointer) whose methods are resolved by native handle dispatch, not via a JS prototype chain. `class X extends Request {}` + `new X(...)` produced an ordinary heap JS object with no link to any native handle: property/method lookup walked the JS prototype chain, found nothing (the body methods live in native dispatch, not on `Request.prototype`), and returned `undefined`.

## Fix

`super(...)` on a Request/Response parent now allocates the underlying native handle and stashes its id on `this` under the hidden field `__perry_fetch_handle__` — mirroring the Web-Streams `__perry_stream_handle__` mechanism (#562). Wired across construction paths:

- **direct `class extends Request/Response`**: codegen `Expr::SuperCall` arm + the no-constructor `lower_new` hook → `js_request_subclass_init` / `js_response_subclass_init` (`object/global_this.rs`);
- **aliased parent** (`extends GlobalRequest` where `GlobalRequest = global.Request`): the runtime-value `super()` routes through a new `js_fetch_or_value_super`, which identifies the parent constructor via `identify_global_builtin_constructor` and attaches (falling back to the ordinary `js_native_call_value` for every other runtime-value parent);
- **dynamic class-expression / ClassRef construction**: a fetch-parent side table recorded at `js_register_class_parent_dynamic` drives a construction-time attach in `js_new_function_construct`.

At access time:
- **method calls** (`native_call_method.rs`): inherited body methods on a subclass receiver are forwarded to the native handle dispatcher (only after all user-defined dispatch — own fields, vtable, prototype walk — has missed, so a subclass override still wins);
- **property reads** (`field_get_set.rs`): a missed read forwards to the handle, so `url`/`method`/`headers`/`body`/`bodyUsed`/… and body-method-as-value reads resolve;
- **`instanceof`** (`instanceof.rs`): the Request/Response/Headers/Blob arm unwraps the stashed handle and runs the existing fetch kind-probe.

Non-subclassed `Request`/`Response` and other native-builtin subclasses are unaffected — the new paths only trigger when a heap object carries `__perry_fetch_handle__`.

## Verification

- **Minimal repro passes** (the exact one from the issue): `typeof sub.text` → `"function"`, `sub instanceof Request` → `true`, `await sub.text()` → `"hello"`.
- **New regression test** `tests/test_request_subclass_body.sh` (style of existing `tests/test_*.sh`, prints PASS/FAIL): subclasses native `Request` as both a no-constructor class and an explicit-constructor class, asserts `.text()`/`.json()` round-trip a body and `instanceof Request`. **PASS.**
- Aliased `class … extends GlobalRequest` with an explicit constructor (the `@hono/node-server` shape) verified to expose working body methods when constructed via the static path.

## Known remaining gaps for the full `@hono/node-server` end-to-end (separate from this dispatch bug)

While validating against a real Hono app I found two **distinct, pre-existing** gaps that also stand between this fix and a green webhook, and are larger than the documented dispatch bug:

1. **`Request` does not read a `ReadableStream` body.** The body coercion stringifies the stream handle: `new Request(url, { body: stream }).text()` returns the handle id (e.g. `"1048576"`) instead of the bytes. `@hono/node-server` always wraps the incoming body as `Readable.toWeb(incoming)` (a pull-based stream), so even with dispatch fixed, `c.req.text()` returns garbage. Fixing this needs the request-body coercion to drain a (pull-based) web stream.
2. **Deeply-nested dynamic construction of an aliased class-*expression* Request** (node-server's `var Request = class extends GlobalRequest {…}`, built lazily inside `getRequestCache()`) does not yet wire the fetch parent in every path. This PR adds the dynamic-construction side table toward it, but the node-server shape still needs follow-up.

These are tracked as follow-ups; this PR fixes the documented root cause (subclass instances missing body methods) with a passing regression test.
