### PR TITLE
fix(runtime): built-ins/Function bind/length/dynamic-construct parity

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -79,6 +79,22 @@ pub unsafe fn dispatch_bound_function(closure: *const ClosureHeader, args: &[f64
     result
 }
 
+/// Read a callable's own `name` *property* as a Rust `String`, if present and a
+/// String value. Covers names installed by `Object.defineProperty(fn, "name",
+/// …)` and the `"bound …"` name a prior `.bind()` stores, neither of which is
+/// visible through the declared-name func-ptr registry. Returns `None` when no
+/// such property exists or it isn't a String.
+unsafe fn read_function_name_property(closure_ptr: usize) -> Option<String> {
+    use crate::value::JSValue;
+    let name_val = crate::closure::closure_get_dynamic_prop(closure_ptr, "name");
+    let name_jv = JSValue::from_bits(name_val.to_bits());
+    if !name_jv.is_any_string() {
+        return None;
+    }
+    let hdr = crate::builtins::js_string_coerce(name_val);
+    crate::object::has_own_helpers::str_from_string_header(hdr).map(str::to_owned)
+}
+
 /// `Function.prototype.bind(thisArg, ...boundArgs)` — create a distinct bound
 /// function closure. Captures the target closure value, the bound `this`, and
 /// the partial-applied leading args (as a JS array). The returned closure uses
@@ -136,8 +152,15 @@ pub unsafe extern "C" fn js_function_bind(
     let bound_len = target_len.saturating_sub(bound_arg_count as u32);
     crate::object::set_builtin_closure_length(bound as usize, bound_len);
 
-    // Spec `.name` = "bound " + target.name.
-    let target_name = crate::builtins::function_name_for_ptr((*target_closure).func_ptr as usize)
+    // Spec `.name` = "bound " + targetName, where targetName is `Get(Target,
+    // "name")` (the empty string when that is not a String). Read the target's
+    // `name` *property* first — it reflects an `Object.defineProperty(fn,
+    // "name", …)` override and a previous `.bind()`'s `"bound …"` name (so
+    // `f.bind().bind().name` chains to `"bound bound …"`). Fall back to the
+    // declared name from the func-ptr registry for plain named functions, which
+    // don't materialize a `name` data property.
+    let target_name = read_function_name_property(target_closure as usize)
+        .or_else(|| crate::builtins::function_name_for_ptr((*target_closure).func_ptr as usize))
         .unwrap_or_default();
     let bound_name = format!("bound {target_name}");
     let name_ptr =

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -2078,4 +2078,31 @@ mod tests {
             assert!(!re.is_null(), "pattern failed to construct: {pat}");
         }
     }
+
+    #[test]
+    fn surrogate_pairs_fold_to_astral_scalars() {
+        // High escape + low class → contiguous astral range.
+        assert_eq!(
+            js_regex_to_rust(r"\uD800[\uDC00-\uDC0B]"),
+            r"[\x{10000}-\x{1000b}]"
+        );
+        // Two consecutive surrogate escapes → single astral scalar.
+        assert_eq!(js_regex_to_rust(r"\uD83D\uDE00"), r"\x{1f600}");
+        // High class + full low class → coalesced astral block.
+        assert_eq!(
+            js_regex_to_rust(r"[\uD80C\uD81C-\uD820][\uDC00-\uDFFF]"),
+            r"[\x{13000}-\x{133ff}\x{17000}-\x{183ff}]"
+        );
+        // Non-surrogate escapes and ordinary classes are untouched.
+        assert_eq!(js_regex_to_rust(r"[ˁ\xAA]"), r"[ˁ\xAA]");
+        assert_eq!(js_regex_to_rust(r"[A-Za-z]"), r"[A-Za-z]");
+        // A lone high surrogate (no following low unit) is left as-is.
+        assert_eq!(js_regex_to_rust(r"\uD800x"), r"\uD800x");
+
+        // The Test262 `nativeFunctionMatcher.js` ID regexes must now compile.
+        let pat = r"(?:[A-Za-z\xAA]|\uD800[\uDC00-\uDC0B\uDC0D-\uDC26]|\uD801[\uDC00-\uDC9D])";
+        let flags = make_string("");
+        let re = js_regexp_new(make_string(pat), flags);
+        assert!(!re.is_null(), "ID_Start-shaped pattern failed to construct");
+    }
 }

--- a/crates/perry-runtime/src/regex/grammar.rs
+++ b/crates/perry-runtime/src/regex/grammar.rs
@@ -210,12 +210,175 @@ pub(super) fn has_invalid_repeated_quantifier(pattern: &str) -> bool {
     false
 }
 
+#[inline]
+fn is_surrogate(v: u32) -> bool {
+    (0xD800..=0xDFFF).contains(&v)
+}
+#[inline]
+fn is_high_surrogate(v: u32) -> bool {
+    (0xD800..=0xDBFF).contains(&v)
+}
+#[inline]
+fn is_low_surrogate(v: u32) -> bool {
+    (0xDC00..=0xDFFF).contains(&v)
+}
+
+/// Parse a `\uXXXX` (exactly four hex digits, no braces) escape at `chars[i]`.
+/// Returns the code-unit value and the index just past the escape.
+fn parse_u4_escape(chars: &[char], i: usize) -> Option<(u32, usize)> {
+    if chars.get(i) != Some(&'\\') || chars.get(i + 1) != Some(&'u') {
+        return None;
+    }
+    let mut v = 0u32;
+    for k in 0..4 {
+        let d = chars.get(i + 2 + k)?.to_digit(16)?;
+        v = v * 16 + d;
+    }
+    Some((v, i + 6))
+}
+
+/// Parse a "surrogate unit" at `chars[i]`: either a single `\uXXXX` escape or a
+/// `[...]` class whose every element is a `\uXXXX` escape (singletons or
+/// `\uA-\uB` ranges). Returns the code-unit ranges and the index just past the
+/// unit — but ONLY when *every* code unit is a UTF-16 surrogate
+/// (`0xD800..=0xDFFF`). Returns `None` for anything else, so ordinary escapes
+/// and character classes pass through `fold_surrogate_pairs` untouched.
+fn parse_surrogate_unit(chars: &[char], i: usize) -> Option<(Vec<(u32, u32)>, usize)> {
+    if let Some((v, j)) = parse_u4_escape(chars, i) {
+        return is_surrogate(v).then_some((vec![(v, v)], j));
+    }
+    if chars.get(i) != Some(&'[') {
+        return None;
+    }
+    let mut k = i + 1;
+    if chars.get(k) == Some(&'^') {
+        return None; // negated class is never a plain surrogate set
+    }
+    let mut ranges: Vec<(u32, u32)> = Vec::new();
+    while chars.get(k).is_some_and(|c| *c != ']') {
+        let (lo, k2) = parse_u4_escape(chars, k)?;
+        if chars.get(k2) == Some(&'-') && chars.get(k2 + 1) == Some(&'\\') {
+            let (hi, k3) = parse_u4_escape(chars, k2 + 1)?;
+            ranges.push((lo, hi));
+            k = k3;
+        } else {
+            ranges.push((lo, lo));
+            k = k2;
+        }
+    }
+    if chars.get(k) != Some(&']') || ranges.is_empty() {
+        return None;
+    }
+    ranges
+        .iter()
+        .all(|(a, b)| is_surrogate(*a) && is_surrogate(*b))
+        .then_some((ranges, k + 1))
+}
+
+/// Combine adjacent high-surrogate ranges with low-surrogate ranges into the
+/// equivalent astral (supplementary-plane) scalar ranges, coalescing the
+/// result. `cp = 0x10000 + (high - 0xD800) * 0x400 + (low - 0xDC00)`.
+fn combine_surrogate_ranges(hi: &[(u32, u32)], lo: &[(u32, u32)]) -> Vec<(u32, u32)> {
+    let mut pts: Vec<(u32, u32)> = Vec::new();
+    for &(h1, h2) in hi {
+        for h in h1..=h2 {
+            let base = 0x10000 + (h - 0xD800) * 0x400;
+            for &(l1, l2) in lo {
+                pts.push((base + (l1 - 0xDC00), base + (l2 - 0xDC00)));
+            }
+        }
+    }
+    pts.sort_unstable();
+    let mut merged: Vec<(u32, u32)> = Vec::new();
+    for (a, b) in pts {
+        match merged.last_mut() {
+            Some(last) if a <= last.1 + 1 => {
+                if b > last.1 {
+                    last.1 = b;
+                }
+            }
+            _ => merged.push((a, b)),
+        }
+    }
+    merged
+}
+
+/// Emit astral scalar ranges as a Rust-regex `\x{..}` class (or a bare `\x{..}`
+/// for a single scalar).
+fn emit_astral_class(out: &mut String, ranges: &[(u32, u32)]) {
+    if let [(a, b)] = ranges {
+        if a == b {
+            out.push_str(&format!("\\x{{{a:x}}}"));
+            return;
+        }
+    }
+    out.push('[');
+    for &(a, b) in ranges {
+        if a == b {
+            out.push_str(&format!("\\x{{{a:x}}}"));
+        } else {
+            out.push_str(&format!("\\x{{{a:x}}}-\\x{{{b:x}}}"));
+        }
+    }
+    out.push(']');
+}
+
+/// Rewrite UTF-16 surrogate-pair escape sequences into the astral scalar values
+/// they encode, so the Rust `regex` crate (which works on Unicode scalars and
+/// rejects lone-surrogate code points) can compile them.
+///
+/// JS regexes that target the supplementary planes without the `u` flag spell
+/// each astral code point as a high-surrogate escape immediately followed by a
+/// low-surrogate escape — either as bare `\uXXXX` escapes or as `[...]` classes
+/// of them, e.g. `\uD800[\uDC00-\uDC0B]` or
+/// `[\uD80C\uD81C-\uD820][\uDC00-\uDFFF]`. Test262's `nativeFunctionMatcher.js`
+/// (the `\p{ID_Start}` / `\p{ID_Continue}` shims used across `built-ins/`)
+/// relies on this form; before this fold every `Function.prototype.toString`
+/// conformance case threw `SyntaxError: invalid pattern` at regex-literal
+/// evaluation. The transform only fires when a high-surrogate unit is directly
+/// followed by a low-surrogate unit (a genuine pair); anything else is left
+/// byte-for-byte unchanged, so patterns that compile today are unaffected.
+fn fold_surrogate_pairs(pattern: &str) -> String {
+    if !pattern.contains("\\u") {
+        return pattern.to_string();
+    }
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut out = String::with_capacity(pattern.len());
+    let mut i = 0;
+    while i < chars.len() {
+        let at_unit_start = (chars[i] == '\\' && chars.get(i + 1) == Some(&'u')) || chars[i] == '[';
+        if at_unit_start {
+            if let Some((hi, j)) = parse_surrogate_unit(&chars, i) {
+                if hi
+                    .iter()
+                    .all(|(a, b)| is_high_surrogate(*a) && is_high_surrogate(*b))
+                {
+                    if let Some((lo, k)) = parse_surrogate_unit(&chars, j) {
+                        if lo
+                            .iter()
+                            .all(|(a, b)| is_low_surrogate(*a) && is_low_surrogate(*b))
+                        {
+                            emit_astral_class(&mut out, &combine_surrogate_ranges(&hi, &lo));
+                            i = k;
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
 /// Translate a JavaScript regex pattern to a Rust regex-crate compatible pattern.
 /// Handles JS-specific escape sequences not supported by the Rust regex crate.
 /// Also converts JS-style named groups `(?<name>...)` to Rust-style `(?P<name>...)`.
 pub(super) fn js_regex_to_rust(pattern: &str) -> String {
-    let mut result = String::with_capacity(pattern.len());
-    let chars: Vec<char> = pattern.chars().collect();
+    let folded = fold_surrogate_pairs(pattern);
+    let mut result = String::with_capacity(folded.len());
+    let chars: Vec<char> = folded.chars().collect();
     let capture_spans = collect_capture_spans(&chars);
     let mut i = 0;
     // Track whether we're inside a `[...]` character class. JS and the Rust


### PR DESCRIPTION
## Summary

Two root-cause fixes for the `built-ins/Function` test262 slice: **248/457 → 288/457 (54.3% → 63.0%)**, building on #4752.

### 1. Regex surrogate-pair fold (`regex/grammar.rs`) — the big one

Perry's regex engine rejected UTF-16 **surrogate-pair escape sequences** like `\uD800[\uDC00-\uDC0B]` and `[\uD80C\uD81C-\uD820][\uDC00-\uDFFF]` with `invalid pattern` — the Rust `regex` crate works on Unicode *scalars* and has no lone-surrogate code points.

Test262's `nativeFunctionMatcher.js` (the `\p{ID_Start}`/`\p{ID_Continue}` shims used to validate `Function.prototype.toString` output **across the whole `built-ins/` tree**) spells its identifier classes exactly this way, so *every* `assertNativeFunction` call threw `SyntaxError` at regex-literal evaluation — failing ~20 `toString` conformance cases (methods, getters/setters, generators, async, private methods, bound functions, symbol-named built-ins).

`fold_surrogate_pairs` now rewrites a high-surrogate unit immediately followed by a low-surrogate unit into the astral scalar range(s) it encodes (`\x{..}` form). It fires **only on genuine pairs**, so patterns that compile today are byte-for-byte unchanged; surrogate-pair *escapes* that previously errored now compile (and match correctly — `/😀/` now matches `😀`).

### 2. `Function.prototype.bind` `.name` derivation (`closure/dispatch.rs`)

Bind read the target's declared name from the func-ptr registry, which is empty for an anonymous target named via `Object.defineProperty(fn, "name", …)` or a prior `.bind()`. Per spec `.name` is `"bound " + Get(Target, "name")`, so bind now reads the target's `name` **property** first (falling back to the declared name for plain named functions). Fixes `instance-name.js` and `instance-name-chained.js` (`f.bind().bind().name === "bound bound target"`).

## Verification

- `python3 scripts/test262_subset.py --dir built-ins/Function`: **288/457 pass** (from 248).
- Two independent re-runs are **byte-identical at 288** — stable.
- `cargo test -p perry-runtime regex::` green, incl. new `surrogate_pairs_fold_to_astral_scalars`.
- Regex non-regression spot-check (groups, named groups, classes, quantifiers, `\-`-in-class, split/replace) matches Node.

**Zero real regressions.** The 4 deltas vs the original *contended* baseline are deterministic node-rejects/perry-runs-clean cases driven by Node's CommonJS top-level `this`=`module.exports` (and strict `.caller`) harness semantics — un-winnable artifacts that were timeout false-passes in the first, heavily-loaded sweep. Neither fix can affect them.