### PR TITLE
fix(link): link libc++/libc++abi in cross-Apple (iOS/tvOS/macOS) branches

### DIFF
--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -273,6 +273,13 @@ pub fn select_linker_command(
             .arg("-F")
             .arg(format!("{}/System/Library/Frameworks", sysroot))
             .arg("-lSystem")
+            // Native C++ deps (bloom engine, Jolt physics, …) reference libc++ /
+            // libc++abi symbols (exceptions, RTTI, operator new/delete, vtables).
+            // ld64 only auto-links those from C++ *inputs*; we hand it .o/.a, so
+            // request them explicitly — mirrors the native (on-Mac) iOS branch.
+            // The .tbd stubs live in the sysroot usr/lib already on the -L path.
+            .arg("-lc++")
+            .arg("-lc++abi")
             .arg("-dead_strip");
         c
     } else if is_ios {
@@ -380,6 +387,13 @@ pub fn select_linker_command(
             .arg("-F")
             .arg(format!("{}/System/Library/Frameworks", sysroot))
             .arg("-lSystem")
+            // Native C++ deps (bloom engine, Jolt physics, …) reference libc++ /
+            // libc++abi symbols (exceptions, RTTI, operator new/delete, vtables).
+            // ld64 only auto-links those from C++ *inputs*; we hand it .o/.a, so
+            // request them explicitly — mirrors the native (on-Mac) iOS branch.
+            // The .tbd stubs live in the sysroot usr/lib already on the -L path.
+            .arg("-lc++")
+            .arg("-lc++abi")
             .arg("-dead_strip");
         c
     } else if is_tvos {
@@ -689,6 +703,13 @@ pub fn select_linker_command(
             .arg("-F")
             .arg(format!("{}/System/Library/Frameworks", sysroot))
             .arg("-lSystem")
+            // Native C++ deps (bloom engine, Jolt physics, …) reference libc++ /
+            // libc++abi symbols (exceptions, RTTI, operator new/delete, vtables).
+            // ld64 only auto-links those from C++ *inputs*; we hand it .o/.a, so
+            // request them explicitly — mirrors the native (on-Mac) iOS branch.
+            // The .tbd stubs live in the sysroot usr/lib already on the -L path.
+            .arg("-lc++")
+            .arg("-lc++abi")
             .arg("-dead_strip");
         c
     } else {


### PR DESCRIPTION
## Summary

The Linux→Apple cross-link branches in `link/platform_cmd.rs` — `is_ios && is_cross_ios`, `is_tvos && is_cross_tvos`, and `is_cross_macos` — invoke `ld64.lld` with `-lSystem` but **never `-lc++ -lc++abi`**. The *native* (on-Mac) iOS branch links them, and its comment even claims to "mirror the cross-iOS branch" — but the cross branches were never given the flags.

## Symptom

As soon as an app's native code uses any C++ runtime feature, the cross-link fails:

```
ld64.lld: error: undefined symbol: ___cxa_begin_catch
ld64.lld: error: undefined symbol: __ZSt9terminatev
ld64.lld: error: undefined symbol: ___cxa_pure_virtual
ld64.lld: error: undefined symbol: __Znwm        # operator new
ld64.lld: error: undefined symbol: __ZdlPv        # operator delete
ld64.lld: error: undefined symbol: ___gxx_personality_v0
ld64.lld: error: undefined symbol: __ZNSt3__15mutex4lockEv
```

These are libc++ / libc++abi symbols (exceptions, RTTI/vtables, `operator new/delete`, `std::mutex`). `ld64` only auto-links the C++ runtime when it sees C++ *inputs*; perry hands it `.o`/`.a` archives, so the libs must be requested explicitly — exactly as the native iOS branch already does.

Hit in production cross-compiling a TS app with a C++ native engine (bloom/Jolt) for iOS and tvOS on the Linux build worker; macOS has the same latent gap.

## Fix

Add `-lc++ -lc++abi` after `-lSystem` in all three cross-Apple `ld64.lld` branches. The `.tbd` stubs (`libc++.tbd`, `libc++abi.tbd`) already live in the sysroot `usr/lib`, which is on the `-L` path — no other change needed.

## Test

Cross-compiling an iOS/tvOS app whose native deps use C++ exceptions/RTTI now links instead of erroring on the libc++abi symbols above.