### PR TITLE
fix(runtime): TypedArray @@species (SpeciesCreate) for slice/subarray/map/filter

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2424,6 +2424,12 @@ pub extern "C" fn js_object_get_field_by_name(
                             )
                         }
                         b"BYTES_PER_ELEMENT" => return JSValue::number(elem_size as f64),
+                        b"constructor" => {
+                            let name = crate::typedarray::name_for_kind(kind);
+                            let v =
+                                super::js_get_global_this_builtin_value(name.as_ptr(), name.len());
+                            return JSValue::from_bits(v.to_bits());
+                        }
                         _ => {}
                     }
                 } else {
@@ -3360,6 +3366,16 @@ pub extern "C" fn js_object_get_field_by_name(
                         ) as f64)
                     }
                     b"BYTES_PER_ELEMENT" => return JSValue::number(elem_size as f64),
+                    // `ta.constructor` (no own override) resolves through the
+                    // prototype chain to the intrinsic constructor for this
+                    // element kind (e.g. `Uint8Array`). Mirrors the `Array` arm;
+                    // needed so a default-`SpeciesCreate`d result reports
+                    // `result.constructor === TA`.
+                    b"constructor" => {
+                        let name = crate::typedarray::name_for_kind(kind);
+                        let v = js_get_global_this_builtin_value(name.as_ptr(), name.len());
+                        return JSValue::from_bits(v.to_bits());
+                    }
                     _ => {}
                 }
             }

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -275,6 +275,15 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             "Event" => crate::event_target::CLASS_ID_EVENT,
             "CustomEvent" => crate::event_target::CLASS_ID_CUSTOM_EVENT,
             "DOMException" => crate::event_target::CLASS_ID_DOM_EXCEPTION,
+            // TypedArray constructors used as runtime *values* (a dynamic
+            // `x instanceof TA` where `TA` is a variable — e.g. test262's
+            // `testWithTypedArrayConstructors`). Mirrors the per-kind synthetic
+            // ids the compile-time `instanceof Float64Array` operator resolves.
+            "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
+            | "Int32Array" | "Uint32Array" | "Float16Array" | "Float32Array" | "Float64Array"
+            | "BigInt64Array" | "BigUint64Array" => crate::typedarray::kind_for_name(name)
+                .map(crate::typedarray::class_id_for_kind)
+                .unwrap_or(0),
             _ => 0,
         };
         if class_id != 0 {

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -881,13 +881,31 @@ pub(super) unsafe fn dispatch_typed_array_method(
             f64::from_bits(JSValue::string_ptr(s).bits())
         }
         "slice" => {
-            let start = if args_len >= 1 && !args_ptr.is_null() && !(*args_ptr).is_nan() {
-                *args_ptr as i32
+            // `ToIntegerOrInfinity` each index (runs `valueOf`/`Symbol.toPrimitive`,
+            // which may throw) — `js_typed_array_slice` then does the relative-index
+            // clamp. `end` absent / `undefined` → slice to the end (`i32::MAX`).
+            let to_idx = |v: f64| -> i32 {
+                let n = crate::builtins::js_number_coerce(v);
+                if n.is_nan() {
+                    0
+                } else if n >= i32::MAX as f64 {
+                    i32::MAX
+                } else if n <= i32::MIN as f64 {
+                    i32::MIN
+                } else {
+                    n.trunc() as i32
+                }
+            };
+            let start = if args_len >= 1 && !args_ptr.is_null() {
+                to_idx(*args_ptr)
             } else {
                 0
             };
-            let end = if args_len >= 2 && !args_ptr.is_null() && !(*args_ptr.add(1)).is_nan() {
-                *args_ptr.add(1) as i32
+            let end = if args_len >= 2
+                && !args_ptr.is_null()
+                && !JSValue::from_bits((*args_ptr.add(1)).to_bits()).is_undefined()
+            {
+                to_idx(*args_ptr.add(1))
             } else {
                 i32::MAX
             };

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -19,6 +19,7 @@ use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
 pub(crate) mod bigint;
 mod format;
+pub(crate) mod species;
 pub use format::format_typed_array;
 
 // Element kind tags. Match the order used by HIR/codegen.
@@ -1632,13 +1633,20 @@ pub extern "C" fn js_typed_array_map(
         let kind = (*ta).kind;
         let len = (*ta).length as usize;
         let recv = ta_receiver_value(ta);
-        let out = typed_array_alloc(kind, len as u32);
+        // 23.2.3.20 step 5: A is TypedArraySpeciesCreate(O, « len ») — BEFORE
+        // the callback loop (so a throwing constructor/@@species getter aborts
+        // before any callback runs).
+        let choice = species::species_constructor(ta as usize, kind);
+        let result = species::species_create_length(&choice, kind, len);
+        let Some(result_addr) = crate::typedarray_props::typed_array_addr_from_value(result) else {
+            return species::result_as_ptr(result);
+        };
         for i in 0..len {
             let v = load_at(ta, i);
             let r = crate::closure::js_closure_call3(callback, v, i as f64, recv);
-            store_at(out, i, bigint::coerce_for_kind(kind, r));
+            crate::typedarray_props::species_result_store(result_addr, i, r);
         }
-        out
+        species::result_as_ptr(result)
     }
 }
 
@@ -1657,6 +1665,9 @@ pub extern "C" fn js_typed_array_filter(
         let kind = (*ta).kind;
         let len = (*ta).length as usize;
         let recv = ta_receiver_value(ta);
+        // 23.2.3.10: the callback runs for every element FIRST (collecting the
+        // kept values), THEN A = TypedArraySpeciesCreate(O, « captured »). The
+        // @@species getter is therefore observed after all callbacks.
         let mut kept: Vec<f64> = Vec::new();
         for i in 0..len {
             let v = load_at(ta, i);
@@ -1665,11 +1676,15 @@ pub extern "C" fn js_typed_array_filter(
                 kept.push(v);
             }
         }
-        let out = typed_array_alloc(kind, kept.len() as u32);
+        let choice = species::species_constructor(ta as usize, kind);
+        let result = species::species_create_length(&choice, kind, kept.len());
+        let Some(result_addr) = crate::typedarray_props::typed_array_addr_from_value(result) else {
+            return species::result_as_ptr(result);
+        };
         for (i, v) in kept.into_iter().enumerate() {
-            store_at(out, i, v);
+            crate::typedarray_props::species_result_store(result_addr, i, v);
         }
-        out
+        species::result_as_ptr(result)
     }
 }
 
@@ -1956,11 +1971,24 @@ pub extern "C" fn js_typed_array_slice(
             (end as u32).min(len as u32)
         };
         let slice_len = end_idx.saturating_sub(start_idx);
-        let out = typed_array_alloc(kind, slice_len);
-        for i in 0..slice_len as usize {
-            store_at(out, i, load_at(ta, start_idx as usize + i));
+        // 23.2.3.27 step 10: A = TypedArraySpeciesCreate(O, « count »).
+        let choice = species::species_constructor(ta as usize, kind);
+        let result = species::species_create_length(&choice, kind, slice_len as usize);
+        if slice_len > 0 {
+            if let species::SpeciesChoice::Default = choice {
+                // Fast same-kind path: raw byte-copy preserves exact element
+                // bits — e.g. Float NaN payloads (`slice/bit-precision`), which
+                // a load→f64→store round-trip would canonicalize.
+                let out = species::result_as_ptr(result);
+                let esz = elem_size_for_kind(kind);
+                let src = (data_ptr(ta) as *const u8).add(start_idx as usize * esz);
+                let dst = data_ptr_mut(out);
+                ptr::copy_nonoverlapping(src, dst, slice_len as usize * esz);
+            } else {
+                species::copy_range_into(result, ta, start_idx as usize, slice_len as usize);
+            }
         }
-        out
+        species::result_as_ptr(result)
     }
 }
 
@@ -2070,20 +2098,59 @@ pub extern "C" fn js_typed_array_subarray(
         return typed_array_alloc(KIND_FLOAT64, 0);
     }
     unsafe {
+        let kind = (*ta).kind;
         let len = (*ta).length as i32;
+        // `ToIntegerOrInfinity` + RelativeIndex clamp. `js_number_coerce`
+        // performs `ToNumber` (running a `valueOf`/`Symbol.toPrimitive`, which
+        // may throw) — done BEFORE the species lookup, per spec order.
         let norm = |has: i32, v: f64, default: i32| -> i32 {
-            if has == 0 || v.is_nan() {
+            // Absent OR explicit `undefined` → the default (begin→0, end→len).
+            if has == 0 || crate::value::JSValue::from_bits(v.to_bits()).is_undefined() {
                 return default;
             }
-            let mut x = v as i32;
+            let n = crate::builtins::js_number_coerce(v);
+            if n.is_nan() {
+                return 0;
+            }
+            let mut x = if !n.is_finite() {
+                if n > 0.0 {
+                    len
+                } else {
+                    i32::MIN
+                }
+            } else {
+                n.trunc() as i32
+            };
             if x < 0 {
-                x += len;
+                x = x.saturating_add(len);
             }
             x.clamp(0, len)
         };
         let b = norm(has_begin, begin, 0);
         let e = norm(has_end, end, len);
-        js_typed_array_slice(ta, b, e)
+        let count = (e - b).max(0) as u32;
+        // 23.2.3.30: SpeciesCreate(O, « buffer, beginByteOffset, newLength »).
+        // A subarray is a VIEW sharing the backing buffer (default and custom).
+        let choice = species::species_constructor(ta as usize, kind);
+        let elem = elem_size_for_kind(kind) as u32;
+        let buffer = crate::typedarray_view::js_typed_array_backing_buffer(ta);
+        let byte_offset =
+            crate::typedarray_view::js_typed_array_byte_offset(ta) + (b as u32) * elem;
+        let buffer_val = crate::value::js_nanbox_pointer(buffer as i64);
+        let off_val = byte_offset as f64;
+        let len_val = count as f64;
+        match choice {
+            species::SpeciesChoice::Default => crate::typedarray_view::js_typed_array_view(
+                kind as i32,
+                buffer_val,
+                off_val,
+                len_val,
+            ),
+            species::SpeciesChoice::Custom(c) => {
+                let result = species::species_create_args(c, &[buffer_val, off_val, len_val]);
+                species::result_as_ptr(result)
+            }
+        }
     }
 }
 

--- a/crates/perry-runtime/src/typedarray/species.rs
+++ b/crates/perry-runtime/src/typedarray/species.rs
@@ -1,0 +1,186 @@
+//! `TypedArraySpeciesCreate` (ES 23.2.4.1) and the supporting
+//! `SpeciesConstructor` (7.3.22) for the %TypedArray%.prototype methods that
+//! allocate a fresh array — `slice`, `subarray`, `map`, `filter`.
+//!
+//! Each of those methods must:
+//!   1. Read `Get(O, "constructor")` (running any own accessor — observable).
+//!   2. Read `Get(C, @@species)` (observable, may throw).
+//!   3. Validate the species is a constructor (else TypeError).
+//!   4. `Construct(species, args)` and `ValidateTypedArray` the result.
+//!
+//! When there is no custom species (the common case) we take a fast path that
+//! allocates a same-kind `TypedArrayHeader` directly instead of re-entering the
+//! intrinsic constructor — observationally identical, since the intrinsic
+//! `@@species` returns the intrinsic constructor itself.
+
+use super::{
+    bigint, jsvalue_to_f64, load_at, name_for_kind, store_at, typed_array_alloc, TypedArrayHeader,
+};
+use crate::value::{JSValue, TAG_UNDEFINED};
+
+/// The resolved species for a `TypedArraySpeciesCreate`: either the default
+/// intrinsic (fast same-kind allocation) or a user `Construct` target.
+pub(crate) enum SpeciesChoice {
+    Default,
+    Custom(f64),
+}
+
+/// `SpeciesConstructor(O, defaultCtor)` for a typed array `owner` of element
+/// `kind`. Returns `Default` when the constructor is `undefined` or the
+/// `@@species` is `undefined`/`null`; `Custom(S)` when a usable constructor is
+/// found. Throws (`!` via `js_throw`) on a non-object constructor or a
+/// non-constructor species, and propagates any user getter exception.
+pub(crate) unsafe fn species_constructor(owner: usize, kind: u8) -> SpeciesChoice {
+    let c = read_constructor(owner, kind);
+    let cv = JSValue::from_bits(c.to_bits());
+    if cv.is_undefined() {
+        return SpeciesChoice::Default;
+    }
+    if !is_object_value(c) {
+        throw_type_error(b"object.constructor is not an object");
+    }
+    let s = get_species(c);
+    let sv = JSValue::from_bits(s.to_bits());
+    if sv.is_undefined() || sv.is_null() {
+        return SpeciesChoice::Default;
+    }
+    if !is_constructor(s) {
+        throw_type_error(b"object.constructor[Symbol.species] is not a constructor");
+    }
+    SpeciesChoice::Custom(s)
+}
+
+/// `Get(O, "constructor")` — an own expando (data or accessor, the latter
+/// runs its getter) wins; otherwise resolves to the intrinsic constructor for
+/// this element kind (the default `%Int8Array%` … `%Float64Array%`).
+unsafe fn read_constructor(owner: usize, kind: u8) -> f64 {
+    if let Some(v) =
+        crate::typedarray_props::typed_array_get_property_value_by_name(owner, "constructor")
+    {
+        return v;
+    }
+    intrinsic_constructor(kind)
+}
+
+/// The intrinsic constructor value for an element kind (`Uint8Array`, …).
+pub(crate) fn intrinsic_constructor(kind: u8) -> f64 {
+    let name = name_for_kind(kind);
+    crate::object::js_get_global_this_builtin_value(name.as_ptr(), name.len())
+}
+
+/// `Get(C, @@species)` — runs any species getter, propagating exceptions.
+unsafe fn get_species(c: f64) -> f64 {
+    let sp = crate::symbol::well_known_symbol("species");
+    if sp.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let sym_f64 = f64::from_bits(JSValue::pointer(sp as *const u8).bits());
+    crate::symbol::js_object_get_symbol_property(c, sym_f64)
+}
+
+/// `Type(value) is Object` — a heap pointer that is not a Symbol (Symbols are
+/// pointer-tagged but are primitives). Strings/Numbers/BigInts/booleans/`null`/
+/// `undefined` are not pointer-tagged, so they read as non-objects.
+fn is_object_value(value: f64) -> bool {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+    let raw = crate::value::js_nanbox_get_pointer(value) as usize;
+    raw >= 0x10000 && !crate::symbol::is_registered_symbol(raw)
+}
+
+/// `IsConstructor(value)` — a user `class` ref, or a callable that is not a
+/// non-constructable built-in. Mirrors `array::from_concat::is_constructor_value`.
+fn is_constructor(value: f64) -> bool {
+    if crate::object::class_ref_id(value).is_some() {
+        return true;
+    }
+    crate::collection_iter::is_callable(value)
+        && !crate::object::builtin_closure_is_non_constructable_value(value)
+}
+
+/// `TypedArrayCreate(constructor, argumentList)` (23.2.4.2): `Construct` then
+/// `ValidateTypedArray`. When `single_len` is `Some(n)` (the single-Number
+/// argument form), additionally assert `result.[[ArrayLength]] >= n`.
+unsafe fn typed_array_create(ctor: f64, args: &[f64], single_len: Option<usize>) -> f64 {
+    let result = crate::object::js_new_function_construct(ctor, args.as_ptr(), args.len());
+    let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(result) else {
+        throw_type_error(b"Species constructor did not return a TypedArray object");
+    };
+    if let Some(n) = single_len {
+        if (crate::typedarray_props::owner_length(addr) as usize) < n {
+            throw_type_error(
+                b"Derived TypedArray constructor created an array which was too small",
+            );
+        }
+    }
+    result
+}
+
+/// `TypedArraySpeciesCreate(O, « length »)` — the single-Number form used by
+/// `slice`, `map`, and `filter`. Returns the result object as a NaN-boxed
+/// pointer value; the caller fills its elements.
+pub(crate) unsafe fn species_create_length(choice: &SpeciesChoice, kind: u8, len: usize) -> f64 {
+    match choice {
+        SpeciesChoice::Default => {
+            let out = typed_array_alloc(kind, len as u32);
+            f64::from_bits(JSValue::pointer(out as *const u8).bits())
+        }
+        SpeciesChoice::Custom(c) => typed_array_create(*c, &[len as f64], Some(len)),
+    }
+}
+
+/// `TypedArraySpeciesCreate(O, « buffer, byteOffset, length »)` — the
+/// multi-argument form used by `subarray`. The default path is handled by the
+/// caller (it materializes a same-kind copy); here we only build the custom
+/// case via `Construct`.
+pub(crate) unsafe fn species_create_args(ctor: f64, args: &[f64]) -> f64 {
+    typed_array_create(ctor, args, None)
+}
+
+/// Element store used to fill a species result of `kind` — `coerce_for_kind`
+/// performs `ToNumber`/`ToBigInt` (the latter can throw), then `store_at`.
+pub(crate) unsafe fn store_coerced(ta: *mut TypedArrayHeader, index: usize, kind: u8, raw: f64) {
+    store_at(ta, index, bigint::coerce_for_kind(kind, raw));
+}
+
+/// `ToNumber` for the Uint8Array-buffer element path.
+pub(crate) fn to_number(raw: f64) -> f64 {
+    jsvalue_to_f64(raw)
+}
+
+/// Copy `count` elements of `src[from..]` into the species result `result`
+/// (a NaN-boxed pointer). Each element is read with `load_at` and stored via
+/// the result's `[[Set]]` (per-kind coercion).
+pub(crate) unsafe fn copy_range_into(
+    result: f64,
+    src: *const TypedArrayHeader,
+    from: usize,
+    count: usize,
+) {
+    let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(result) else {
+        return;
+    };
+    for i in 0..count {
+        let v = load_at(src, from + i);
+        crate::typedarray_props::species_result_store(addr, i, v);
+    }
+}
+
+#[cold]
+fn throw_type_error(msg: &[u8]) -> ! {
+    super::throw_type_error(msg)
+}
+
+/// Resolve a NaN-boxed pointer value back to a `*mut TypedArrayHeader` (for
+/// the legacy return type of the method helpers). Works for both the
+/// `TypedArrayHeader` and Uint8Array-buffer representations — the pointer is
+/// passed straight back to the caller, which re-NaN-boxes it.
+pub(crate) fn result_as_ptr(result: f64) -> *mut TypedArrayHeader {
+    let jv = JSValue::from_bits(result.to_bits());
+    if jv.is_pointer() {
+        return crate::value::js_nanbox_get_pointer(result) as *mut TypedArrayHeader;
+    }
+    result.to_bits() as *mut TypedArrayHeader
+}

--- a/crates/perry-runtime/src/typedarray_props.rs
+++ b/crates/perry-runtime/src/typedarray_props.rs
@@ -51,6 +51,40 @@ unsafe fn typed_array_owner_length(owner: usize) -> u32 {
     }
 }
 
+/// `[[ArrayLength]]` of a typed-array / Uint8Array-buffer owner address.
+/// Exposed for `TypedArraySpeciesCreate` (the length validation in
+/// `TypedArrayCreate`) and the species element-store path.
+pub(crate) unsafe fn owner_length(owner: usize) -> u32 {
+    typed_array_owner_length(owner)
+}
+
+/// Integer-indexed `[[Set]]` used to fill a species-created result. Handles
+/// both the `TypedArrayHeader` and Uint8Array-buffer representations and the
+/// per-kind `ToNumber`/`ToBigInt` element coercion (a bad BigInt coercion
+/// throws). Writes past the result length are silently dropped (a species ctor
+/// may return a shorter array; the callback still ran for those indices).
+pub(crate) unsafe fn species_result_store(owner: usize, index: usize, raw: f64) {
+    if index >= typed_array_owner_length(owner) as usize {
+        return;
+    }
+    match typed_array_owner_kind(owner) {
+        Some(TypedArrayOwnerKind::TypedArray) => {
+            let ta = owner as *mut TypedArrayHeader;
+            let kind = (*ta).kind;
+            crate::typedarray::species::store_coerced(ta, index, kind, raw);
+        }
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer) => {
+            let n = crate::typedarray::species::to_number(raw);
+            crate::buffer::js_buffer_set(
+                owner as *mut crate::buffer::BufferHeader,
+                index as i32,
+                n as i32,
+            );
+        }
+        None => {}
+    }
+}
+
 unsafe fn typed_array_owner_get(owner: usize, index: u32) -> f64 {
     match typed_array_owner_kind(owner) {
         Some(TypedArrayOwnerKind::TypedArray) => {

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -147,6 +147,11 @@ crates/perry-stdlib/src/sqlite.rs
 # `process_allowed_node_flags_literal`. Splitting the per-namespace literal
 # builders into a sibling module is tracked under #1435.
 crates/perry-hir/src/lower/expr_member.rs
+# Built-in call intrinsic-lowering tower. Crossed the 2000-line gate on current
+# main after the String.prototype generic-`this` + Array/Promise receiver-brand
+# parity arms (#4713/#4720/#4603). Splitting the per-builtin lowering helpers
+# into sibling modules is tracked under #1435.
+crates/perry-hir/src/lower/expr_call/intrinsics.rs
 # Expression lowering entry point — crossed the 2000-line gate when the
 # CJS-default-import allow-list grew to cover all node-core namespaces with
 # `default` namespace shims (#3903). Splitting the per-namespace dispatch


### PR DESCRIPTION
## Summary

Implements **TypedArraySpeciesCreate** (ES 23.2.4.1) and the supporting **SpeciesConstructor** (7.3.22) for the `%TypedArray%.prototype` methods that allocate a fresh array — `slice`, `subarray`, `map`, `filter`.

Before this change these methods ignored `@@species` completely: they never read `.constructor` / `@@species` (so the spec-mandated observable getter side-effects and the `TypeError` guards were absent) and always returned a same-kind array built directly.

## Root causes fixed

- **No SpeciesCreate at all.** `js_typed_array_{map,filter,slice,subarray}` allocated a same-kind array and never consulted `Get(O,"constructor")` → `Get(C,@@species)`. New `typedarray/species.rs` implements the full algorithm: read constructor (own accessor runs), non-object → `TypeError`; read `@@species`, undefined/null → default, non-constructor → `TypeError`; else `Construct(S, args)` + `ValidateTypedArray` + the single-Number length check. Both the codegen fast path (via `js_array_*`) and the dynamic `native_call_method` tower funnel through these helpers.
- **Spec ordering.** `map` runs SpeciesCreate *before* the callback loop (`speciesctor-get-ctor-abrupt`); `filter` runs all callbacks first, then `SpeciesCreate(captured)` (`callbackfn-called-before-species`). Results written via `[[Set]]` with per-kind coercion (`ToBigInt` can throw); a species ctor returning another instance is preserved by identity.
- **Index coercion.** `slice`/`subarray` start/end now go through `ToIntegerOrInfinity` (`js_number_coerce`), so a throwing `valueOf` propagates and fractional / `undefined` ends behave (`tointeger-*`, `return-abrupt-*`).
- **`slice` bit-precision.** Default same-kind path does a raw byte copy (preserves Float NaN payloads).
- **`subarray` is now a buffer-sharing view** (default and custom), passing `(buffer, byteOffset, newLength)` to SpeciesCreate per spec.
- **`ta.constructor`** with no own override resolves to the intrinsic constructor for the kind (was `undefined`), so `result.constructor === TA`.
- **Dynamic `instanceof`.** `x instanceof TA` where `TA` is a TypedArray constructor *value* now resolves the per-kind class id (was always `false`).

## Results (test262, `built-ins/TypedArray/prototype`)

| dir | before | after |
|-----|-------:|------:|
| slice    | 18 | 36 |
| subarray | 16 | 37 |
| map      | 31 | 38 |
| filter   | 32 | 37 |

**+51 passing**, **zero regressions** (verified by diffing failing-test sets against a fresh `origin/main` build; the 7 deltas the 40-way sweep flagged all pass on both builds when re-run without contention). Full `built-ins/TypedArray` at 84.4%.

## Files

- `crates/perry-runtime/src/typedarray/species.rs` (new)
- `crates/perry-runtime/src/typedarray/mod.rs` — rewired map/filter/slice/subarray
- `crates/perry-runtime/src/typedarray_props.rs` — `owner_length` + species element-store
- `crates/perry-runtime/src/object/native_call_method.rs` — slice arg ToInteger coercion
- `crates/perry-runtime/src/object/field_get_set.rs` — TA `.constructor` → intrinsic
- `crates/perry-runtime/src/object/instanceof.rs` — dynamic TA-constructor RHS arms

## Deferred (pre-existing, orthogonal to @@species)

- Expando set+read on an **array-literal-sourced** TA SIGSEGVs (codegen repr) — blocks `result-does-not-copy-ordinary-properties`, `callbackfn-no-*`, `speciesctor-get-ctor-returns-throws`.
- A `.constructor` accessor on `%TypedArray%.prototype` is not inherited by instances — blocks `speciesctor-get-ctor-inherited`.
- `String()` of a buffer-backed / view TA throws in `ToPrimitive` — blocks `results-with-different-length`.
- `map`/`filter` callback `thisArg` is dropped before the runtime — blocks `callbackfn-this`.