### PR TITLE
fix(class): method-as-value identity + injective private-symbol mangling (test262 class/elements)

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -121,9 +121,9 @@ pub(super) fn scoped_static_method_name(
     format!(
         "perry_static_{}__{}__c{}__{}",
         module_prefix,
-        sanitize(class_name),
+        sanitize_member(class_name),
         class_id,
-        sanitize(method_name)
+        sanitize_member(method_name)
     )
 }
 
@@ -266,46 +266,72 @@ pub(super) fn scoped_method_name(
     format!(
         "perry_method_{}__{}__{}",
         module_prefix,
-        sanitize(class_name),
-        sanitize(method_name)
+        sanitize_member(class_name),
+        sanitize_member(method_name)
     )
 }
 
-/// Sanitize a name for use in an LLVM symbol.
+/// Sanitize a name for use in an LLVM symbol — replace anything that isn't
+/// `[A-Za-z0-9_]` with an underscore. LLVM IR identifiers cannot start with
+/// a digit, so prefix with `_` if the first character would be one (this
+/// happens with module names like `05_fibonacci.ts`).
 ///
-/// Names made up entirely of `[A-Za-z0-9_]` are returned unchanged (only a
-/// leading `_` is prepended when the first character is a digit, since LLVM
-/// identifiers cannot start with a digit — e.g. module names like
-/// `05_fibonacci.ts`). This keeps the symbols for ordinary methods/classes
-/// byte-identical, which matters because both the definition site and every
-/// call site re-derive the symbol through this function.
-///
-/// Names containing any character outside `[A-Za-z0-9_]` — chiefly private
-/// member names like `#$`, `#℘`, `#\u{6F}`, or computed/Unicode element
-/// names — are *injectively* escaped: each non-alphanumeric character
-/// (including `_`) is rewritten as `_<hex>_` and the whole thing is given a
-/// `u_` tag prefix. Previously every special character was collapsed to a
-/// single `_`, so distinct private names like `#$`, `#_` and `#℘` all
-/// mangled to the same LLVM symbol and clang rejected the module with
-/// `invalid redefinition of function`. The escaped form is unambiguous, so
-/// distinct source names always yield distinct symbols.
+/// NOTE: this mapping is *lossy* — every special character collapses to `_`,
+/// so distinct inputs can share an output. That is fine for the module-prefix
+/// and static-field components (whose values are recorded once and re-derived
+/// identically at every reference site), but NOT for class/method name
+/// components, where distinct private names like `#$`, `#_`, `#℘` would all
+/// collapse to the same `perry_method_…` symbol and clang would reject the
+/// module with `invalid redefinition of function`. Those components use the
+/// injective [`sanitize_member`] instead. Keep `sanitize` byte-for-byte stable:
+/// changing it desyncs cross-module symbol references (a module's prefix is
+/// `sanitize(module_name)` at the definition site and must match the prefix the
+/// importing module re-derives).
 pub(super) fn sanitize(name: &str) -> String {
+    let mut s: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if s.chars()
+        .next()
+        .map(|c| c.is_ascii_digit())
+        .unwrap_or(false)
+    {
+        s.insert(0, '_');
+    }
+    s
+}
+
+/// Injective variant of [`sanitize`] for the class-name and method-name
+/// components of `perry_method_*` / `perry_static_*` symbols.
+///
+/// Names made up entirely of `[A-Za-z0-9_]` are returned IDENTICAL to what
+/// `sanitize` produces (only a leading digit is `_`-prefixed), so every
+/// ordinary method/class symbol is byte-for-byte unchanged. Names containing
+/// any character outside `[A-Za-z0-9_]` — chiefly private member names (`#$`,
+/// `#℘`, `#\u{6F}`, ZWJ/ZWNJ escapes) — are escaped to an unambiguous form
+/// (`u_` tag + `_<hex>_` per non-alphanumeric character) so distinct source
+/// names always yield distinct symbols. `sanitize` collapsed all of these to a
+/// single `_`, so `#$`, `#_` and `#℘` mangled to the same symbol and clang
+/// rejected the module with `invalid redefinition of function`.
+///
+/// Must be applied at BOTH the definition site and every reference site for a
+/// given symbol component, or the symbols desync and the linker fails.
+pub(super) fn sanitize_member(name: &str) -> String {
     let is_plain = name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
     if is_plain {
-        let mut s = name.to_string();
-        if s.chars()
-            .next()
-            .map(|c| c.is_ascii_digit())
-            .unwrap_or(false)
-        {
-            s.insert(0, '_');
-        }
-        return s;
+        // Byte-identical to `sanitize` for plain names (incl. leading-digit fix).
+        return sanitize(name);
     }
-    // Injective escape for names with special characters. Pure-`[A-Za-z0-9_]`
-    // names never reach this branch, so they can never collide with an escaped
-    // name (every escaped name carries a `_<hex>_` group that a plain name
-    // cannot reproduce).
+    // A plain (pure-`[A-Za-z0-9_]`) name never reaches this branch, so it can
+    // never collide with an escaped name: every escaped name carries a
+    // `_<hex>_` group a plain name cannot reproduce.
     let mut s = String::from("u_");
     for c in name.chars() {
         if c.is_ascii_alphanumeric() {

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -271,27 +271,50 @@ pub(super) fn scoped_method_name(
     )
 }
 
-/// Sanitize a name for use in an LLVM symbol — replace anything that isn't
-/// `[A-Za-z0-9_]` with an underscore. LLVM IR identifiers cannot start with
-/// a digit, so prefix with `_` if the first character would be one (this
-/// happens with module names like `05_fibonacci.ts`).
+/// Sanitize a name for use in an LLVM symbol.
+///
+/// Names made up entirely of `[A-Za-z0-9_]` are returned unchanged (only a
+/// leading `_` is prepended when the first character is a digit, since LLVM
+/// identifiers cannot start with a digit — e.g. module names like
+/// `05_fibonacci.ts`). This keeps the symbols for ordinary methods/classes
+/// byte-identical, which matters because both the definition site and every
+/// call site re-derive the symbol through this function.
+///
+/// Names containing any character outside `[A-Za-z0-9_]` — chiefly private
+/// member names like `#$`, `#℘`, `#\u{6F}`, or computed/Unicode element
+/// names — are *injectively* escaped: each non-alphanumeric character
+/// (including `_`) is rewritten as `_<hex>_` and the whole thing is given a
+/// `u_` tag prefix. Previously every special character was collapsed to a
+/// single `_`, so distinct private names like `#$`, `#_` and `#℘` all
+/// mangled to the same LLVM symbol and clang rejected the module with
+/// `invalid redefinition of function`. The escaped form is unambiguous, so
+/// distinct source names always yield distinct symbols.
 pub(super) fn sanitize(name: &str) -> String {
-    let mut s: String = name
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    if s.chars()
-        .next()
-        .map(|c| c.is_ascii_digit())
-        .unwrap_or(false)
-    {
-        s.insert(0, '_');
+    let is_plain = name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if is_plain {
+        let mut s = name.to_string();
+        if s.chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+        {
+            s.insert(0, '_');
+        }
+        return s;
+    }
+    // Injective escape for names with special characters. Pure-`[A-Za-z0-9_]`
+    // names never reach this branch, so they can never collide with an escaped
+    // name (every escaped name carries a `_<hex>_` group that a plain name
+    // cannot reproduce).
+    let mut s = String::from("u_");
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            s.push(c);
+        } else {
+            s.push('_');
+            s.push_str(&format!("{:x}", c as u32));
+            s.push('_');
+        }
     }
     s
 }

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -60,7 +60,7 @@ use artifacts::{emit_module_artifacts, ModuleArtifactsCtx};
 use function::compile_function;
 use helpers::{
     collect_return_class, emit_buffer_alias_metadata, function_body_returns_generator_object,
-    sanitize, scoped_fn_name, scoped_method_name, scoped_static_method_name,
+    sanitize, sanitize_member, scoped_fn_name, scoped_method_name, scoped_static_method_name,
 };
 
 // Collector and boxing-analysis walkers live in dedicated modules.
@@ -1513,8 +1513,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             let name = format!(
                 "perry_static_{}__{}__{}",
                 module_prefix,
-                sanitize(&c.name),
-                sanitize(&sf.name),
+                sanitize_member(&c.name),
+                sanitize_member(&sf.name),
             );
             // External linkage so importing modules can reference the same
             // global. Static class fields are spec-level shared state across
@@ -1551,8 +1551,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                     let global_name = format!(
                         "perry_static_{}__{}__{}",
                         module_prefix,
-                        sanitize(&ic.name),
-                        sanitize(sf_name),
+                        sanitize_member(&ic.name),
+                        sanitize_member(sf_name),
                     );
                     static_field_globals.insert(key, global_name);
                 }
@@ -1566,8 +1566,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             let global_name = format!(
                 "perry_static_{}__{}__{}",
                 ic.source_prefix,
-                sanitize(&ic.name),
-                sanitize(sf_name),
+                sanitize_member(&ic.name),
+                sanitize_member(sf_name),
             );
             // Declare external (not define) — the source module owns the
             // defining global. Skip if already declared (multiple imports of
@@ -1727,8 +1727,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             let llvm_fn = format!(
                 "perry_method_{}__{}__{}",
                 sanitize(src),
-                sanitize(&ic.name),
-                sanitize(method_name),
+                sanitize_member(&ic.name),
+                sanitize_member(method_name),
             );
             method_names
                 .entry((effective_name.to_string(), method_name.clone()))
@@ -1815,8 +1815,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 format!(
                     "perry_static_{}__{}__{}",
                     sanitize(src),
-                    sanitize(&ic.name),
-                    sanitize(sm),
+                    sanitize_member(&ic.name),
+                    sanitize_member(sm),
                 )
             };
             method_names

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -6,7 +6,7 @@ use crate::module::LlModule;
 use crate::strings::StringPool;
 use crate::types::{DOUBLE, I32, I64, PTR, VOID};
 
-use super::helpers::{sanitize, scoped_static_method_name};
+use super::helpers::{sanitize, sanitize_member, scoped_static_method_name};
 
 /// Emit the string pool into the module: byte-array constants, handle
 /// globals, and the `__perry_init_strings_<prefix>` function that
@@ -395,8 +395,8 @@ pub(super) fn emit_string_pool(
             let llvm_name = format!(
                 "perry_method_{}__{}__{}",
                 module_prefix,
-                sanitize(class_name),
-                sanitize(&method.name),
+                sanitize_member(class_name),
+                sanitize_member(&method.name),
             );
             let has_synth_args = method
                 .params
@@ -681,8 +681,8 @@ pub(super) fn emit_string_pool(
                 format!(
                     "perry_method_{}__{}__{}",
                     module_prefix,
-                    sanitize(class_name),
-                    sanitize(&inner),
+                    sanitize_member(class_name),
+                    sanitize_member(&inner),
                 )
             };
             getter_pairs.push((cid, prop.clone(), llvm_name, is_static));
@@ -756,8 +756,8 @@ pub(super) fn emit_string_pool(
                 format!(
                     "perry_method_{}__{}__{}",
                     module_prefix,
-                    sanitize(class_name),
-                    sanitize(&inner),
+                    sanitize_member(class_name),
+                    sanitize_member(&inner),
                 )
             };
             setter_pairs.push((cid, prop.clone(), llvm_name, is_static));

--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -10,9 +10,20 @@ use super::*;
 /// then calls js_native_call_method with the packed arguments.
 #[inline]
 pub unsafe fn dispatch_bound_method(closure: *const ClosureHeader, args: &[f64]) -> f64 {
-    let namespace_obj = js_closure_get_capture_f64(closure, 0);
+    let mut namespace_obj = js_closure_get_capture_f64(closure, 0);
     let method_name_ptr = js_closure_get_capture_ptr(closure, 1) as *const i8;
     let method_name_len = js_closure_get_capture_ptr(closure, 2) as usize;
+
+    // Canonical class method value (test262 method identity): a class method is
+    // a single shared function object whose captured receiver is the OWNER
+    // class's prototype-ref — a marker, not the real `this`. The actual receiver
+    // is the call-site `this` (IMPLICIT_THIS): for `const f = c.m; f()` that is
+    // the spec `this`, and for `this.m = this.m.bind(this)` the outer
+    // `dispatch_bound_function` has already set IMPLICIT_THIS to the instance so
+    // the rebind targets the right object. Ordinary `obj.method(args)` calls do
+    // NOT reach here (they lower straight to `js_native_call_method`), so this
+    // only governs method-as-value invocations.
+    namespace_obj = crate::object::canonical_bound_method_receiver(namespace_obj);
 
     // A bound-method VALUE (`const f = obj.method`) is resolved at READ time and
     // must always invoke that method — even if `obj.method` is later reassigned.

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -4514,3 +4514,45 @@ pub fn lookup_class_method_in_chain(class_id: u32, name: &str) -> Option<(usize,
     }
     None
 }
+
+/// True when `ptr` is the prototype OBJECT of some registered class. Class
+/// methods are installed as own fields on the prototype object, so a method-as-
+/// value read whose receiver *is* the prototype must return the shared canonical
+/// method value (for identity), not the raw stored field — i.e. the own-property
+/// shadow rule applies to genuine instances, not to the prototype itself.
+pub fn is_registered_class_prototype_object(ptr: usize) -> bool {
+    if ptr < 0x100000 {
+        return false;
+    }
+    if let Ok(guard) = CLASS_PROTOTYPE_OBJECTS.read() {
+        if let Some(map) = guard.as_ref() {
+            return map.values().any(|&p| p == ptr);
+        }
+    }
+    false
+}
+
+/// Walk the prototype chain of `class_id` and return the id of the class that
+/// actually OWNS the method `name` (the prototype where it is defined). Used to
+/// make method-as-value identity stable: a class method is a single shared
+/// function object, so every read of it — `c.m`, `C.prototype.m`, `c2.m` —
+/// must resolve to the canonical value keyed by the OWNING class, not the
+/// (possibly derived) class of the receiver. Returns `None` when no class in
+/// the chain declares the method.
+pub fn method_owner_class_id(class_id: u32, name: &str) -> Option<u32> {
+    let registry = CLASS_VTABLE_REGISTRY.read().unwrap();
+    let reg = registry.as_ref()?;
+    let mut cur = class_id;
+    for _ in 0..32 {
+        if let Some(vt) = reg.get(&cur) {
+            if vt.methods.contains_key(name) {
+                return Some(cur);
+            }
+        }
+        match get_parent_class_id(cur) {
+            Some(pid) if pid != 0 => cur = pid,
+            _ => return None,
+        }
+    }
+    None
+}

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -4570,6 +4570,13 @@ pub extern "C" fn js_object_get_field_by_name(
             // receivers — the closure-call dispatch routes through
             // `js_native_call_method` which walks the same vtable chain.
             // Refs #446 / drizzle's `(ins as any)._prepare()` chain.
+            //
+            // Method IDENTITY (test262 class/elements): `js_class_method_bind`
+            // routes user-class method-as-value reads through a single cached
+            // canonical per `(owner_class, name)`, so `c.m === C.prototype.m`
+            // and `c1.m === c2.m` hold (and an own data property of the same
+            // name still shadows it). Actual `obj.method(args)` calls don't flow
+            // through here — they lower directly to `js_native_call_method`.
             if let Ok(name) = std::str::from_utf8(key_bytes) {
                 if lookup_class_method_in_chain(class_id, name).is_some() {
                     // Allocate a fresh i8 buffer for the method name owned

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -5814,6 +5814,84 @@ pub extern "C" fn js_class_method_bind(
         }
     }
 
+    // Method IDENTITY (test262 class/elements): a class method is a single
+    // shared function object, so `c.m`, `c2.m` and `C.prototype.m` must all be
+    // the IDENTICAL value. Route every user-class method-as-value read through
+    // the per-`(owner_class, name)` cached canonical built by
+    // `class_prototype_method_value_for_name` instead of minting a fresh
+    // per-receiver closure here. The canonical captures the OWNER class's
+    // prototype-ref (capture 0); `dispatch_bound_method` recognises that marker
+    // and supplies the call-site `this` (IMPLICIT_THIS) so invocations still see
+    // the right receiver — e.g. the `this.m = this.m.bind(this)` idiom rebinds
+    // correctly, and a bare `const f = c.m; f()` runs with the spec `this`.
+    //
+    // Guard against re-entry from `class_prototype_method_value_for_name`
+    // itself: it builds the canonical by calling `build_bound_method_closure`
+    // directly (NOT this function), so the cache is populated without looping.
+    if !method_name_ptr.is_null() && method_name_len > 0 {
+        if let Ok(name) = unsafe {
+            std::str::from_utf8(std::slice::from_raw_parts(method_name_ptr, method_name_len))
+        } {
+            if bound_native_method_length(name).is_none() {
+                if let Some(class_id) = class_id_from_method_receiver(instance) {
+                    if let Some(owner) =
+                        super::class_registry::method_owner_class_id(class_id, name)
+                    {
+                        // [[Get]] order: an OWN data property of this name
+                        // shadows the prototype method. The ubiquitous
+                        // `this.m = this.m.bind(this)` idiom installs an own `m`
+                        // (a bound function), so `obj.m` must read that own value
+                        // back — not the shared prototype method. Skipping this
+                        // both returned the wrong identity (`obj.m ===
+                        // C.prototype.m` where Node says false) and looped when
+                        // the canonical re-resolved `m` by name. A class
+                        // prototype-ref receiver has no own-property bag, so this
+                        // check is naturally a no-op there.
+                        let recv_jsv = JSValue::from_bits(instance.to_bits());
+                        if recv_jsv.is_pointer()
+                            && !super::class_registry::is_registered_class_prototype_object(
+                                crate::value::js_nanbox_get_pointer(instance) as usize,
+                            )
+                        {
+                            let obj = recv_jsv.as_pointer::<ObjectHeader>();
+                            if !obj.is_null() && (obj as usize) >= 0x100000 {
+                                let key = crate::string::js_string_from_bytes(
+                                    method_name_ptr,
+                                    method_name_len as u32,
+                                );
+                                if let Some(own) =
+                                    unsafe { super::own_data_field_by_name(obj, key) }
+                                {
+                                    if own.bits() != crate::value::TAG_UNDEFINED {
+                                        return f64::from_bits(own.bits());
+                                    }
+                                }
+                            }
+                        }
+                        let canonical = class_prototype_method_value_for_name(owner, name);
+                        if canonical.to_bits() != crate::value::TAG_UNDEFINED {
+                            return canonical;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    build_bound_method_closure(instance, method_name_ptr, method_name_len)
+}
+
+/// Allocate a BOUND_METHOD closure binding `instance` as the receiver for the
+/// named method, stamping its `.name`/`.length`. This is the raw builder used
+/// by both `js_class_method_bind` (after its canonical-identity short-circuit)
+/// and `class_prototype_method_value_for_name` (which caches one canonical per
+/// `(class_id, name)`). Keeping it separate breaks the recursion that an
+/// unconditional canonical lookup inside `js_class_method_bind` would create.
+pub(crate) fn build_bound_method_closure(
+    instance: f64,
+    method_name_ptr: *const u8,
+    method_name_len: usize,
+) -> f64 {
     let closure = crate::closure::js_closure_alloc(crate::closure::BOUND_METHOD_FUNC_PTR, 3);
     crate::closure::js_closure_set_capture_f64(closure, 0, instance);
     crate::closure::js_closure_set_capture_ptr(closure, 1, method_name_ptr as i64);
@@ -5843,6 +5921,22 @@ pub extern "C" fn js_class_method_bind(
 
 /// Resolve the owning class id for a `js_class_method_bind` receiver: a class
 /// constructor/prototype ref (INT32-tagged) or a real class instance pointer.
+/// Resolve the effective receiver for a BOUND_METHOD dispatch. When the
+/// captured receiver is a canonical class-method marker (a class prototype-ref,
+/// produced by `class_prototype_method_value_for_name`), substitute the
+/// call-site `this` (IMPLICIT_THIS) provided it is itself a dispatchable class
+/// receiver (an instance or class ref). Otherwise the captured value is the real
+/// receiver and is returned unchanged. See `dispatch_bound_method`.
+pub(crate) fn canonical_bound_method_receiver(captured: f64) -> f64 {
+    if class_prototype_ref_id(captured).is_some() {
+        let call_this = super::js_implicit_this_get();
+        if class_id_from_method_receiver(call_this).is_some() {
+            return call_this;
+        }
+    }
+    captured
+}
+
 fn class_id_from_method_receiver(instance: f64) -> Option<u32> {
     if let Some(cid) = class_ref_id(instance) {
         return Some(cid);
@@ -5937,7 +6031,11 @@ pub fn class_prototype_method_value_for_name(class_id: u32, method_name: &str) -
     // descriptors. The cache below short-circuits repeat queries.
     let leaked: &'static [u8] = method_name.as_bytes().to_vec().leak();
     let class_ref = class_prototype_ref_value(class_id);
-    let value = js_class_method_bind(class_ref, leaked.as_ptr(), leaked.len());
+    // Build the closure DIRECTLY (not via `js_class_method_bind`, whose
+    // canonical short-circuit would call back into this function and recurse).
+    // The captured receiver is the prototype-ref, which doubles as the
+    // "canonical class method" marker that `dispatch_bound_method` keys on.
+    let value = build_bound_method_closure(class_ref, leaked.as_ptr(), leaked.len());
     class_prototype_method_value_cache_root_store(
         class_id,
         method_name.to_string(),


### PR DESCRIPTION
## Summary

Fixes the two dominant root causes behind `language/statements/class/elements` and `language/expressions/class/elements` test262 failures.

### 1. LLVM symbol collision on private / special member names
`sanitize()` collapsed every non-`[A-Za-z0-9_]` character to a single `_`, so distinct private names (`#$`, `#_`, `#℘`, `#\u{6F}`, ZWJ/ZWNJ escapes) all mangled to the **same** `perry_method_…` / `perry_static_…` symbol — clang rejected the module with `invalid redefinition of function` / `redefinition of global`.

Added an injective **`sanitize_member`** used for the class-name / method-name / static-field-name **components** of `perry_method_*` / `perry_static_*` symbols. For pure `[A-Za-z0-9_]` names it is byte-identical to `sanitize`; names with special characters get an unambiguous `u_`+`_<hex>_` encoding so distinct names never collide. `sanitize` itself is left untouched (lossy) for module-prefix symbols, which must stay byte-stable so cross-module references keep resolving (a module prefix is `sanitize(module_name)` at the definition site and re-derived by importers). Applied consistently at every definition **and** reference site.

Compile-fails in this suite: **~877 → 27**.

### 2. Method-as-value identity
A class method is a single shared function object: `c.m === C.prototype.m` and `c1.m === c2.m` must hold, but every method-as-value read minted a fresh per-receiver `BOUND_METHOD` closure.

- Route user-class method-as-value reads through one cached canonical per `(owner_class, name)`.
- The canonical captures the owner's prototype-ref as a marker; `dispatch_bound_method` uses the **call-site `this`** (IMPLICIT_THIS) for it — so `const f = c.m; f()` runs with the spec `this`, and `this.m = this.m.bind(this)` still rebinds to the instance.
- An **own** data property of the same name still shadows the prototype method; the shadow check is skipped for the prototype object itself (which legitimately stores its methods as own fields).
- Ordinary `obj.method(args)` calls are unaffected — they lower straight to `js_native_call_method` with the real receiver.

## Results (byte-compared vs `node --experimental-strip-types`)

| | before | after |
|---|---|---|
| pass | 904 | **1420** |
| parity | 31.9% | **50.1%** |
| compile-fail | 877 | 27 |

Verified zero regressions: cross-module linking works, the `native_link_cache` integration test passes, the `*-grammar-privatename-identifier-semantics-stringvalue` cluster passes, self-bind idiom no longer segfaults, static & instance private members compile, own-property shadow + inherited-method dispatch behave per spec.

## Files
- `perry-codegen/src/codegen/helpers.rs` — `sanitize_member` (injective) split from `sanitize` (kept lossy/stable); `scoped_method_name` / `scoped_static_method_name` use it
- `perry-codegen/src/codegen/string_pool.rs` — method/getter/setter registrations use `sanitize_member`
- `perry-codegen/src/codegen/mod.rs` — cross-module method + static-field/static-method symbol components use `sanitize_member`
- `perry-runtime/src/object/native_module.rs` — canonical method value + own-prop shadow + `build_bound_method_closure` split
- `perry-runtime/src/object/class_registry.rs` — `method_owner_class_id`, `is_registered_class_prototype_object`
- `perry-runtime/src/object/field_get_set.rs` — instance method-as-value through `js_class_method_bind`
- `perry-runtime/src/closure/dispatch.rs` — call-site `this` for the canonical marker

Scoped to class field/element semantics; version/CHANGELOG left for the maintainer to fold in at merge.