### PR TITLE
fix(runtime): @hono/node-server c.req.text()/.json()/.formData() on POST/PUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1142 — @hono/node-server `c.req.text()`/`.json()`/`.formData()` work on POST/PUT
+
+Fixes `TypeError: text is not a function` (and `formData is not a function`) on
+every body-reading route of a Perry-compiled Hono app served by
+`@hono/node-server`. GET/HEAD were unaffected; any POST/PUT handler that read the
+body 500'd. Root cause spans three layers.
+
+**1. Parent registration dropped for `var X = class extends <alias> {}`.** The
+`var C = class {…}` fast path in `perry-hir/src/lower/stmt.rs` lowered the class
+to a bare `ClassRef` and — unlike the general class-expression arm
+(`lower_expr.rs`) and the `Decl::Class` arms — never emitted
+`RegisterClassParentDynamic`. node-server's `var Request = class extends
+GlobalRequest {}` (with `GlobalRequest = global.Request`) therefore never
+registered its fetch-builtin parent, so the constructed subclass instance got no
+underlying native fetch handle, `instanceof Request` was false, and all
+inherited body methods were missing. The fast path now emits the dynamic parent
+registration in source order (where the alias still resolves), matching the
+other class-lowering paths.
+
+**2. `super()` could not see the aliased parent.** `js_fetch_or_value_super`
+identified the parent kind solely from the runtime parent VALUE, which for an
+aliased module-var parent re-lowered to `undefined` at super-call time. It now
+falls back to the fetch-parent kind registered against the instance's class id
+(captured at module init), so the native handle attaches regardless of how the
+`extends` expression resolves at the call site.
+
+**3. Body methods were not readable, and a streamed body was not read.** Reading
+a body method as a value — `r.text` or the computed `r["text"]` that
+`@hono/node-server` uses (`this[getRequestCache]()[k]()`) — on a fetch-subclass
+returned `undefined` (the handle id was dereferenced as an `ObjectHeader`). It
+now returns a bound method that re-dispatches through the native handle. The
+`Request` thunk drains a `ReadableStream` body via the existing
+`js_response_body_init_ptr` (instead of stringifying the stream handle to its
+numeric id), and Perry's `node:http` `IncomingMessage` now exposes `rawBody`
+(the already-collected body `Buffer`). With `rawBody` present, node-server takes
+its synchronous body path and avoids the data-less `Readable.toWeb(incoming)`
+stub (the #1540 Node↔WHATWG stream-forwarding gap).
+
+Result: `c.req.text()` / `.json()` / `.formData()` return the real request body
+on POST/PUT, GET is unaffected, and a 50-POST burst is stable. Regression test:
+`tests/test_request_subclass_stream_body.sh`.
+
 ## v0.5.1141 — Node streams honor `emitClose` / `autoDestroy` close-lifecycle options
 
 `new Readable/Writable/Duplex({ emitClose: false })` now suppresses the `'close'`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1141
+**Current Version:** 0.5.1142
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1141"
+version = "0.5.1142"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1141"
+version = "0.5.1142"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1141"
+version = "0.5.1142"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1141"
+version = "0.5.1142"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1141"
+version = "0.5.1142"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ext-http-server/src/handle_dispatch.rs
+++ b/crates/perry-ext-http-server/src/handle_dispatch.rs
@@ -101,6 +101,7 @@ extern "C" {
     fn js_node_http_im_signal(handle: i64) -> f64;
     fn js_node_http_im_remote_address(handle: i64) -> *mut StringHeader;
     fn js_node_http_im_remote_port(handle: i64) -> f64;
+    fn js_node_http_im_raw_body(handle: i64) -> f64;
     fn js_node_http_im_pause(handle: i64);
     fn js_node_http_im_resume(handle: i64);
     fn js_node_http_im_destroy(handle: i64);
@@ -691,6 +692,7 @@ pub unsafe extern "C" fn js_ext_http_incoming_message_dispatch_property(
         "signal" => js_node_http_im_signal(handle),
         "remoteAddress" => string_ptr_value(js_node_http_im_remote_address(handle)),
         "remotePort" => js_node_http_im_remote_port(handle),
+        "rawBody" => js_node_http_im_raw_body(handle),
         _ => undef,
     }
 }

--- a/crates/perry-ext-http-server/src/request.rs
+++ b/crates/perry-ext-http-server/src/request.rs
@@ -303,6 +303,31 @@ pub extern "C" fn js_node_http_im_destroyed(handle: i64) -> i32 {
         .unwrap_or(0)
 }
 
+/// `req.rawBody` — the fully-collected request body as a `Buffer`.
+///
+/// Perry's HTTP server buffers the entire request body before invoking the
+/// handler (`req.collect().await`), so the bytes are available synchronously
+/// here. `@hono/node-server` checks `"rawBody" in incoming && incoming.rawBody
+/// instanceof Buffer` and, when present, builds the `Request` body from it via a
+/// synchronous single-chunk `ReadableStream` — avoiding the data-less
+/// `Readable.toWeb(incoming)` stub path (the #1540 Node↔WHATWG stream gap).
+/// Exposing it makes `await c.req.text()` / `.json()` / `.formData()` on a POST
+/// resolve to the real body instead of an empty/garbage value. Returns an empty
+/// Buffer when there is no body (harmless: node-server only consults it for
+/// non-GET/HEAD methods).
+#[no_mangle]
+pub extern "C" fn js_node_http_im_raw_body(handle: i64) -> f64 {
+    let bytes = get_handle::<IncomingMessage>(handle)
+        .map(|im| im.body_bytes.clone())
+        .unwrap_or_default();
+    let buf = alloc_buffer(&bytes);
+    if buf.is_null() {
+        f64::from_bits(crate::types::TAG_UNDEFINED)
+    } else {
+        f64::from_bits(POINTER_TAG | (buf as u64 & PTR_MASK))
+    }
+}
+
 /// `req.signal` — lazily-created AbortSignal for the request lifetime.
 #[no_mangle]
 pub extern "C" fn js_node_http_im_signal(handle: i64) -> f64 {

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -669,7 +669,35 @@ pub(crate) fn lower_stmt(
                                             )
                                         })
                                         .collect();
+                                    // Runtime-value parent (`var X = class extends
+                                    // <expr> {}` where the parent isn't a known class —
+                                    // e.g. @hono/node-server's `var Request = class
+                                    // extends GlobalRequest {}`, `GlobalRequest =
+                                    // global.Request`). The general class-expression arm
+                                    // in `lower_expr.rs` and the `Decl::Class` arms emit
+                                    // `RegisterClassParentDynamic` so the parent edge —
+                                    // and the fetch-parent kind for Request/Response
+                                    // subclasses — is wired at module init (where the
+                                    // alias still resolves). This `var C = class {…}`
+                                    // fast path emitted a bare `ClassRef` binding and
+                                    // skipped it, so the parent never registered and a
+                                    // `Request`/`Response` subclass got no native handle
+                                    // (inherited body methods threw "text is not a
+                                    // function"). Emit it here too, in source order
+                                    // before the value binding. Clone the extends
+                                    // expression before `push_class_dedup` moves the
+                                    // class out.
+                                    let parent_register =
+                                        lowered_class.extends_expr.clone().map(|p| {
+                                            Stmt::Expr(Expr::RegisterClassParentDynamic {
+                                                class_name: bind_name.clone(),
+                                                parent_expr: p,
+                                            })
+                                        });
                                     push_class_dedup(module, lowered_class);
+                                    if let Some(reg) = parent_register {
+                                        module.init.push(reg);
+                                    }
                                     for reg in computed_member_registrations {
                                         module.init.push(Stmt::Expr(reg));
                                     }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -46,6 +46,19 @@ pub(crate) unsafe fn fetch_subclass_handle_id(obj: usize) -> Option<i64> {
     }
 }
 
+/// The Web-Fetch body-reading methods (`text`/`json`/`arrayBuffer`/`blob`/
+/// `bytes`/`formData`/`clone`). On a `class X extends Request/Response`
+/// instance these live on the underlying native handle, not the JS prototype
+/// chain, so they must be made readable as callable VALUES (see the property
+/// forward in `js_object_get_field_by_name`). Mirrors the set in
+/// `native_call_method.rs` (the fused-call body-method forward).
+pub(crate) fn is_fetch_subclass_body_method(name: &[u8]) -> bool {
+    matches!(
+        name,
+        b"text" | b"json" | b"arrayBuffer" | b"blob" | b"bytes" | b"formData" | b"clone"
+    )
+}
+
 const CLASS_ID_BOXED_NUMBER: u32 = 0xFFFF_00D0;
 const CLASS_ID_BOXED_STRING: u32 = 0xFFFF_00D1;
 const CLASS_ID_BOXED_BOOLEAN: u32 = 0xFFFF_00D2;
@@ -4634,6 +4647,31 @@ pub extern "C" fn js_object_get_field_by_name(
         // and the key isn't the marker field itself. Refs Hono `c.req` body.
         if !key.is_null() && key_bytes != FETCH_SUBCLASS_HANDLE_FIELD {
             if let Some(id) = fetch_subclass_handle_id(obj as usize) {
+                // Body methods (`text`/`json`/`arrayBuffer`/`blob`/`bytes`/
+                // `formData`/`clone`) live on the native fetch handle. They must
+                // be READABLE as callable values, not just invocable as a fused
+                // `inst.text()` (handled by the `js_native_call_method`
+                // body-method arm, #4756): codegen lowers `inst.text()` to a
+                // property read + call, and @hono/node-server forwards the body
+                // through `this[getRequestCache]()[k]()` -- a *computed* read of
+                // the native handle method off a `class extends Request`
+                // instance. Forwarding that read to the handle as an object
+                // pointer yields `undefined` -> "text is not a function". Return
+                // a bound method that re-dispatches through
+                // `js_native_call_method`, whose body-method arm forwards to the
+                // handle. Refs Hono `c.req.text()` / `.json()` / `.formData()`.
+                if is_fetch_subclass_body_method(key_bytes) {
+                    let this_f64 = crate::value::js_nanbox_pointer(obj as i64);
+                    let heap_name = {
+                        let layout =
+                            std::alloc::Layout::from_size_align(key_bytes.len().max(1), 1).unwrap();
+                        let ptr = std::alloc::alloc(layout);
+                        std::ptr::copy_nonoverlapping(key_bytes.as_ptr(), ptr, key_bytes.len());
+                        ptr
+                    };
+                    let bound = js_class_method_bind(this_f64, heap_name, key_bytes.len());
+                    return JSValue::from_bits(bound.to_bits());
+                }
                 let v = js_object_get_field_by_name(id as usize as *const ObjectHeader, key);
                 if !v.is_undefined() {
                     return v;

--- a/crates/perry-runtime/src/object/global_fetch.rs
+++ b/crates/perry-runtime/src/object/global_fetch.rs
@@ -54,6 +54,31 @@ static GLOBAL_FETCH_RESPONSE_NEW: AtomicPtr<()> = AtomicPtr::new(null_mut());
 static GLOBAL_FETCH_RESPONSE_STATIC_JSON: AtomicPtr<()> = AtomicPtr::new(null_mut());
 static GLOBAL_FETCH_RESPONSE_STATIC_REDIRECT: AtomicPtr<()> = AtomicPtr::new(null_mut());
 static GLOBAL_FETCH_RESPONSE_STATIC_ERROR: AtomicPtr<()> = AtomicPtr::new(null_mut());
+static GLOBAL_FETCH_BODY_INIT_PTR: AtomicPtr<()> = AtomicPtr::new(null_mut());
+
+/// Register the stdlib body-init coercion (`js_response_body_init_ptr`), which
+/// drains a `ReadableStream` body to a `*const StringHeader` (and falls back to
+/// the ordinary string coercion for non-stream values). Used by the
+/// `Request`/`Response` thunks so a streamed request body (`@hono/node-server`
+/// wraps the incoming body as a `ReadableStream`) resolves to its bytes instead
+/// of a stringified stream handle id.
+#[no_mangle]
+pub extern "C" fn js_register_global_fetch_body_init_ptr(f: extern "C" fn(f64) -> i64) {
+    GLOBAL_FETCH_BODY_INIT_PTR.store(f as *mut (), Ordering::Release);
+}
+
+/// Coerce a fetch body-init value to a `*const StringHeader`, draining a
+/// `ReadableStream` body via the registered stdlib helper when present. Falls
+/// back to the plain unified string coercion (unchanged behavior for string
+/// bodies) when no helper is registered.
+pub(crate) fn call_global_body_init_ptr(value: f64) -> *const crate::StringHeader {
+    let f = GLOBAL_FETCH_BODY_INIT_PTR.load(Ordering::Acquire);
+    if !f.is_null() {
+        let func: extern "C" fn(f64) -> i64 = unsafe { std::mem::transmute(f) };
+        return func(value) as *const crate::StringHeader;
+    }
+    crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader
+}
 
 #[no_mangle]
 pub extern "C" fn js_register_global_fetch_with_options(f: FetchWithOptionsFn) {

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -218,7 +218,24 @@ pub(crate) extern "C" fn global_this_request_thunk(
 ) -> f64 {
     let url_ptr = crate::value::js_get_string_pointer_unified(input) as *const crate::StringHeader;
     let method_ptr = global_this_fetch_option_string_ptr(init, b"method");
-    let body_ptr = global_this_fetch_option_string_ptr(init, b"body");
+    // Body init coercion that DRAINS a `ReadableStream` body. @hono/node-server
+    // wraps the incoming request body as `Readable.toWeb(incoming)` / a
+    // `new ReadableStream({...})`, so the plain string coercion would stringify
+    // the stream HANDLE to its numeric id and `await c.req.text()` would resolve
+    // to a bogus number. Route through the registered body-init helper (stdlib
+    // `js_response_body_init_ptr`), which drains the stream's buffered chunks;
+    // string bodies fall back to the ordinary coercion. Refs Hono `c.req.text()`.
+    let body_ptr = {
+        let body_val = global_this_fetch_option(init, b"body");
+        if matches!(
+            body_val.to_bits(),
+            crate::value::TAG_UNDEFINED | crate::value::TAG_NULL
+        ) {
+            std::ptr::null()
+        } else {
+            super::global_fetch::call_global_body_init_ptr(body_val)
+        }
+    };
     let headers_handle = global_this_init_headers_handle(init);
     let referrer_ptr = global_this_fetch_option_string_ptr(init, b"referrer");
     let referrer_policy_ptr = global_this_fetch_option_string_ptr(init, b"referrerPolicy");
@@ -365,7 +382,25 @@ pub unsafe extern "C" fn js_fetch_or_value_super(
     args_len: usize,
 ) -> f64 {
     let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
-    let kind = super::class_registry::identify_global_builtin_constructor(parent_val);
+    // Resolve the parent constructor kind from the value first. When the
+    // `extends` expression is an alias of `global.Request`/`global.Response`
+    // (`@hono/node-server`'s `class Request extends GlobalRequest`), the alias
+    // var can lower to a constructor-scope local that reads `undefined` at
+    // super-time, so `identify_global_builtin_constructor(parent_val)` returns
+    // `None`. Fall back to the fetch-parent kind registered against the
+    // instance's class at module init (via `js_register_class_parent_dynamic`,
+    // where the alias resolved correctly) so the native handle still attaches.
+    let kind =
+        super::class_registry::identify_global_builtin_constructor(parent_val).or_else(|| {
+            let obj = subclass_this_object_ptr(this_box)?;
+            match super::class_registry::fetch_parent_kind_in_chain(
+                crate::object::js_object_get_class_id(obj),
+            ) {
+                Some(1) => Some("Request"),
+                Some(2) => Some("Response"),
+                _ => None,
+            }
+        });
     match kind {
         Some("Request") | Some("Response") => {
             let arg0 = if args_len >= 1 && !args_ptr.is_null() {

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -1895,6 +1895,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
             property_name,
             "method"
                 | "url"
+                | "rawBody"
                 | "httpVersion"
                 | "headers"
                 | "rawHeaders"
@@ -2766,6 +2767,8 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
             ) -> f64,
             response_static_error: extern "C" fn() -> f64,
         );
+        #[cfg(feature = "http-client")]
+        fn js_register_global_fetch_body_init_ptr(f: extern "C" fn(f64) -> i64);
         fn js_register_worker_threads_namespace_getters(
             worker_data: extern "C" fn() -> f64,
             is_main_thread: extern "C" fn() -> f64,
@@ -2798,6 +2801,8 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
         crate::fetch::js_response_static_redirect,
         crate::fetch::js_response_static_error,
     );
+    #[cfg(feature = "http-client")]
+    js_register_global_fetch_body_init_ptr(crate::fetch::js_response_body_init_ptr);
     #[cfg(feature = "bundled-events")]
     unsafe extern "C" fn event_emitter_probe(handle: i64) -> bool {
         crate::events::is_event_emitter_handle(handle)

--- a/tests/test_request_subclass_stream_body.sh
+++ b/tests/test_request_subclass_stream_body.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Regression: a `class X extends Request` instance must (1) expose the body
+# methods (`text`/`json`/`formData`/...) as READABLE callable values — both
+# `r.text` and the COMPUTED `r["text"]` (@hono/node-server reads the body via
+# `this[getRequestCache]()[k]()`, a computed member call), and (2) read a
+# `ReadableStream` body, not just a string body.
+#
+# Bug (this PR): the property READ of a body method on a fetch-subclass forwarded
+# to the native handle id as if it were an ObjectHeader and returned `undefined`,
+# so `r["text"]` was not a function ("text is not a function"). And a
+# `ReadableStream` request body was coerced as a string — the stream HANDLE got
+# stringified to its numeric id, so `await r.text()` resolved to a bogus number.
+#
+# Fix: body-method reads on a fetch-subclass return a bound method that
+# re-dispatches through the native handle; the Request thunk drains a
+# ReadableStream body (buffered chunks) into bytes via the registered
+# `js_response_body_init_ptr`.
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+cat > "$TMPDIR/main.ts" << "EOF"
+const GlobalRequest = (globalThis as any).Request;
+class Req extends GlobalRequest {
+  constructor(input: any, init?: any) { super(input, init); }
+}
+async function main() {
+  // String body via literal + computed body-method read.
+  const r = new Req("http://x/y", { method: "POST", body: "HI" });
+  console.log("typeof r.text:", typeof r.text);
+  const k = "text";
+  console.log("typeof r[k]:", typeof (r as any)[k]);
+  console.log("literal text:", await r.text());
+  // ReadableStream body (single synchronously-enqueued chunk) — drained.
+  const r2 = new Req("http://x/z", {
+    method: "POST",
+    body: new ReadableStream({
+      start(c: any) { c.enqueue(new TextEncoder().encode("STREAMED")); c.close(); },
+    }),
+  });
+  const fn = (r2 as any)["text"];
+  console.log("computed stream text:", await fn.call(r2));
+}
+main();
+EOF
+
+cd "$TMPDIR"
+"$PERRY" compile main.ts -o test_bin >/dev/null 2>&1
+RUN_OUTPUT=$(./test_bin 2>&1)
+
+EXPECTED="typeof r.text: function
+typeof r[k]: function
+literal text: HI
+computed stream text: STREAMED"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+fi
+echo "FAIL: Request subclass stream/computed body methods regressed"
+echo "Expected:"; echo "$EXPECTED"
+echo ""; echo "Got:"; echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Summary

Fixes `TypeError: text is not a function` (and `formData is not a function`) on **every body-reading POST/PUT route** of a Perry-compiled Hono app served by `@hono/node-server`. GET/HEAD worked; any handler that read the body returned HTTP 500.

A hand-rolled replica of node-server's request construction did **not** reproduce it — the bug is specific to how the real compiled package is structured. Root cause spans three layers:

### 1. Parent registration dropped for `var X = class extends <alias> {}`
The `var C = class {…}` fast path in `perry-hir/src/lower/stmt.rs` lowered the class to a bare `ClassRef` and — unlike the general class-expression arm (`lower_expr.rs`) and the `Decl::Class` arms — never emitted `RegisterClassParentDynamic`. node-server's `var Request = class extends GlobalRequest {}` (where `GlobalRequest = global.Request`) therefore never registered its fetch-builtin parent, so the constructed subclass instance got **no underlying native fetch handle**, `instanceof Request` was `false`, and all inherited body methods were missing. The fast path now emits the dynamic parent registration in source order.

### 2. `super()` couldn't see the aliased parent
`js_fetch_or_value_super` identified the parent kind only from the runtime parent VALUE, which for an aliased module-var parent re-lowered to `undefined` at super-call time. It now falls back to the fetch-parent kind registered against the instance's class id (captured at module init), attaching the native handle regardless of how `extends` resolves at the call site.

### 3. Body methods weren't readable, and a streamed body wasn't read
- Reading a body method as a value — `r.text` or the **computed** `r["text"]` that node-server uses (`this[getRequestCache]()[k]()`) — on a fetch-subclass returned `undefined` (the handle id was dereferenced as an `ObjectHeader`). It now returns a bound method that re-dispatches through the native handle.
- The `Request` thunk now drains a `ReadableStream` body via the existing `js_response_body_init_ptr` instead of stringifying the stream handle to its numeric id.
- Perry's `node:http` `IncomingMessage` now exposes `rawBody` (the already-collected body `Buffer`), so node-server takes its synchronous body path and avoids the data-less `Readable.toWeb(incoming)` stub (the #1540 Node↔WHATWG stream-forwarding gap).

## Verification

The minimal repro (`hono` + `@hono/node-server`, compiled natively) now passes:

```
GET   /g            -> 200 "get-ok"
POST  /echo  -d HI  -> 200 {"got":"HI"}
POST  /json {a,b}   -> 200 {"sum":7}      # c.req.json()
POST  /form user=.. -> 200 user=alice     # c.req.formData()
50-POST burst       -> 50/50 200
```

- Adds `tests/test_request_subclass_stream_body.sh` (computed body-method read + `ReadableStream` body drain on a `Request` subclass).
- Existing `tests/test_request_subclass_body.sh` (#4756) still passes — no regression.

## Notes

Third distinct `class extends Request` case, after #4749 (symbol-keyed writes) and #4756 (subclass body methods for the bare-`Request` static path). Runtime + one-spot HIR change; no public API changes.
