### PR TITLE
fix(hir): class destructuring (dstr) + default-parameter parity (test262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1143 — Class destructuring (dstr) + default-parameter parity (test262)
+
+Brought `language/{statements,expressions}/class/dstr` from 512→664 passing (41.6%→53.9%) with **zero regressions**, and lifted the wider `built-ins`+`language` sweep by ~6–9% per shard (0 regressions across sampled shards). These are method/constructor/accessor parameter-destructuring tests across plain, generator, async-generator, static, and private class methods.
+
+Root causes fixed:
+
+- **Array binding patterns now use the iterator protocol.** `lower_pattern_binding` lowered `let [a, b] = x` (and every method/param destructuring) to raw index reads (`x[0]`, `x[1]`), so it never invoked `Symbol.iterator`, never closed the iterator, mishandled holes/rest, and couldn't destructure non-array iterables. Rewrote the `Pat::Array` arm to emit `GetIterator` → `IteratorStep`/`IteratorValue` per element, draining a rest element via the new `js_iterator_rest_to_array`, advancing the iterator for elisions, and performing `IteratorClose` on both normal completion (when not exhausted) and any abrupt completion from a default initializer or nested pattern. Destructuring defaults now use a strict `=== undefined` check (a genuine `NaN` element no longer triggers the default).
+- **Object binding patterns enforce `RequireObjectCoercible`.** New `js_require_object_coercible` throws a `TypeError` for a `null`/`undefined` source even for an empty pattern `{}`, before any property read.
+- **Static-method calls now pad omitted arguments with `undefined`.** `Expr::StaticMethodCall` (non-rest path) forwarded only the supplied args, so a static method called with fewer args than declared read uninitialized parameter slots; `static f(a = 1)` returned `0` and `static m([x] = [])` threw. It now pads to the declared arity.
+- **Private methods emit their default-parameter prologue.** `lower_private_method` computed `param.default` but never called `build_default_param_stmts`, so `#m(a = 1)` silently dropped the default.
+- **Method-as-value calls pad omitted arguments with `undefined`.** `call_vtable_method` padded missing args with a bare IEEE `NaN`; that path is reached without call-site padding when a method is invoked as a value (`const f = obj.m; f()`, or a `get m(){ return this.#m }` accessor exposing a private method), so a defaulted/destructuring param never saw `undefined`. It now pads with `undefined`.
+
+Files: `crates/perry-hir/src/destructuring/pattern_binding.rs`, `crates/perry-hir/src/lower_decl/private_members.rs`, `crates/perry-codegen/src/expr/static_method.rs`, `crates/perry-codegen/src/lower_call/native/mod.rs`, `crates/perry-codegen/src/runtime_decls/{arrays,objects}.rs`, `crates/perry-runtime/src/array/iterator.rs`, `crates/perry-runtime/src/object/{class_registry,has_own_helpers}.rs`.
+
 ## v0.5.1142 — @hono/node-server `c.req.text()`/`.json()`/`.formData()` work on POST/PUT
 
 Fixes `TypeError: text is not a function` (and `formData is not a function`) on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1142
+**Current Version:** 0.5.1143
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1142"
+version = "0.5.1143"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/static_method.rs
+++ b/crates/perry-codegen/src/expr/static_method.rs
@@ -137,6 +137,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             lowered.insert(idx, undef);
                         }
                     }
+                } else {
+                    // Issue #235: a static method called with fewer args than
+                    // declared (`C.f()` for `static f(a = 1)`, or
+                    // `C.m([x] = [])`) must hand the callee `undefined` for the
+                    // missing slots — otherwise the LLVM function reads an
+                    // uninitialized parameter register (0.0), so its
+                    // default-param prologue (`if (p === undefined) p = …`) and
+                    // destructuring (`GetIterator(p)`) never fire.
+                    let declared_count = ctx.method_param_counts.get(&key).copied().unwrap_or(0);
+                    let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                    while lowered.len() < declared_count {
+                        lowered.push(undef.clone());
+                    }
                 }
                 let arg_slices: Vec<(crate::types::LlvmType, &str)> =
                     lowered.iter().map(|s| (DOUBLE, s.as_str())).collect();

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -107,6 +107,32 @@ pub(crate) fn lower_native_method_call(
                     &[(DOUBLE, &iter), (DOUBLE, &done)],
                 ));
             }
+            "requireObjectCoercible" => {
+                let val = args.first().map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_require_object_coercible",
+                    &[(DOUBLE, &val)],
+                ));
+            }
+            "iteratorRestToArray" => {
+                let iter = args.first().map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                let done = args.get(1).map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_iterator_rest_to_array",
+                    &[(DOUBLE, &iter), (DOUBLE, &done)],
+                ));
+            }
             _ => {}
         }
     }

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -197,6 +197,7 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     module.declare_function("js_iterator_to_array", I64, &[DOUBLE]);
     module.declare_function("js_iterator_next_result", DOUBLE, &[DOUBLE]);
     module.declare_function("js_iterator_close_if_not_done", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_iterator_rest_to_array", DOUBLE, &[DOUBLE, DOUBLE]);
     // #1831: `yield*` iterator resolution — `operand[Symbol.iterator]()` or the
     // operand itself when already an iterator. Returns a NaN-boxed JSValue.
     module.declare_function("js_get_iterator", DOUBLE, &[DOUBLE]);

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -166,6 +166,8 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     // Takes a src object ptr and an array of NaN-boxed strings (the excluded keys),
     // returns a new object pointer.
     module.declare_function("js_object_rest", I64, &[I64, I64]);
+    // RequireObjectCoercible for object destructuring (throws on null/undefined).
+    module.declare_function("js_require_object_coercible", DOUBLE, &[DOUBLE]);
     // Array alloc variant that pre-sets length to N (for exclude_keys array filling).
     module.declare_function("js_array_alloc_with_length", I64, &[I32]);
     // Unchecked array set (plain array, no buffer/Set/Map dispatch).

--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -36,6 +36,233 @@ fn is_global_this_fetch_constructor(name: &str) -> bool {
     )
 }
 
+/// Allocate a fresh internal local for destructuring scaffolding.
+fn fresh_destruct_local(ctx: &mut LoweringContext, ty: Type) -> (LocalId, String) {
+    let id = ctx.fresh_local();
+    let name = format!("__destruct_{}", id);
+    ctx.locals.push((name.clone(), id, ty));
+    (id, name)
+}
+
+/// Build a call into the runtime iterator-protocol helpers (same dispatch the
+/// assignment-destructuring path uses).
+fn runtime_iterator_call(method: &str, args: Vec<Expr>) -> Expr {
+    Expr::NativeMethodCall {
+        module: "__perry_runtime".to_string(),
+        class_name: None,
+        object: None,
+        method: method.to_string(),
+        args,
+    }
+}
+
+/// `value === undefined` — the spec check that gates a destructuring default
+/// (`[a = d]`, `{a = d}`). Distinct from `IsUndefinedOrBareNan`: a genuine NaN
+/// element/property must NOT trigger the default (`let [a = 1] = [NaN]` → NaN).
+fn is_strictly_undefined(value: Expr) -> Expr {
+    Expr::Compare {
+        op: CompareOp::Eq,
+        left: Box::new(value),
+        right: Box::new(Expr::Undefined),
+    }
+}
+
+/// Pull the next value from `iter` into `value_id`, honoring the `done` flag.
+/// Mirrors the assignment-destructuring `iterator_next_value_stmts`:
+///   if (done) { value = undefined; }
+///   else { step = IteratorNext(iter); if (step.done) { done = true; value = undefined } else value = step.value }
+fn iterator_next_value_stmts(
+    ctx: &mut LoweringContext,
+    iter_id: LocalId,
+    done_id: LocalId,
+    value_id: LocalId,
+) -> Vec<Stmt> {
+    let (step_id, step_name) = fresh_destruct_local(ctx, Type::Any);
+    let pull_next = vec![
+        Stmt::Let {
+            id: step_id,
+            name: step_name,
+            ty: Type::Any,
+            mutable: false,
+            init: Some(runtime_iterator_call(
+                "iteratorNextResult",
+                vec![Expr::LocalGet(iter_id)],
+            )),
+        },
+        Stmt::If {
+            condition: Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(step_id)),
+                property: "done".to_string(),
+            },
+            then_branch: vec![
+                Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))),
+                Stmt::Expr(Expr::LocalSet(value_id, Box::new(Expr::Undefined))),
+            ],
+            else_branch: Some(vec![Stmt::Expr(Expr::LocalSet(
+                value_id,
+                Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(step_id)),
+                    property: "value".to_string(),
+                }),
+            ))]),
+        },
+    ];
+
+    vec![Stmt::If {
+        condition: Expr::LocalGet(done_id),
+        then_branch: vec![Stmt::Expr(Expr::LocalSet(
+            value_id,
+            Box::new(Expr::Undefined),
+        ))],
+        else_branch: Some(pull_next),
+    }]
+}
+
+/// Lower an array binding pattern using the iterator protocol (spec
+/// §8.5.2/8.5.3 IteratorBindingInitialization). Replaces the legacy index-based
+/// (`tmp[0]`, `tmp[1]`) lowering, which never invoked `Symbol.iterator`, never
+/// closed the iterator, and could not destructure non-array iterables. Each
+/// element pulls via `IteratorStep`/`IteratorValue`; holes still advance the
+/// iterator; a rest element drains the remainder; and the iterator is closed
+/// (`IteratorClose`) on both normal completion (when not exhausted) and on any
+/// abrupt completion from a default initializer or nested pattern.
+fn lower_array_pattern_binding(
+    ctx: &mut LoweringContext,
+    arr_pat: &ast::ArrayPat,
+    source: Expr,
+    mutable: bool,
+    result: &mut Vec<Stmt>,
+) -> Result<()> {
+    let (iter_id, iter_name) = fresh_destruct_local(ctx, Type::Any);
+    result.push(Stmt::Let {
+        id: iter_id,
+        name: iter_name,
+        ty: Type::Any,
+        mutable: false,
+        init: Some(Expr::GetIterator(Box::new(source))),
+    });
+    let (done_id, done_name) = fresh_destruct_local(ctx, Type::Boolean);
+    result.push(Stmt::Let {
+        id: done_id,
+        name: done_name,
+        ty: Type::Boolean,
+        mutable: true,
+        init: Some(Expr::Bool(false)),
+    });
+
+    let mut body: Vec<Stmt> = Vec::new();
+    for elem in &arr_pat.elems {
+        match elem {
+            // Elision (`[, x]`) — advance the iterator and discard the value.
+            None => {
+                let (value_id, value_name) = fresh_destruct_local(ctx, Type::Any);
+                body.push(Stmt::Let {
+                    id: value_id,
+                    name: value_name,
+                    ty: Type::Any,
+                    mutable: true,
+                    init: Some(Expr::Undefined),
+                });
+                body.extend(iterator_next_value_stmts(ctx, iter_id, done_id, value_id));
+            }
+            // Rest element (`[...rest]`) — drain the remainder into an array.
+            Some(ast::Pat::Rest(rest_pat)) => {
+                let (rest_id, rest_name) = fresh_destruct_local(ctx, Type::Any);
+                body.push(Stmt::Let {
+                    id: rest_id,
+                    name: rest_name,
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(runtime_iterator_call(
+                        "iteratorRestToArray",
+                        vec![Expr::LocalGet(iter_id), Expr::LocalGet(done_id)],
+                    )),
+                });
+                // Draining exhausts the iterator, so it is now done.
+                body.push(Stmt::Expr(Expr::LocalSet(
+                    done_id,
+                    Box::new(Expr::Bool(true)),
+                )));
+                lower_pattern_binding_into(
+                    ctx,
+                    &rest_pat.arg,
+                    Expr::LocalGet(rest_id),
+                    mutable,
+                    &mut body,
+                )?;
+                break;
+            }
+            Some(elem_pat) => {
+                let (value_id, value_name) = fresh_destruct_local(ctx, Type::Any);
+                body.push(Stmt::Let {
+                    id: value_id,
+                    name: value_name,
+                    ty: Type::Any,
+                    mutable: true,
+                    init: Some(Expr::Undefined),
+                });
+                body.extend(iterator_next_value_stmts(ctx, iter_id, done_id, value_id));
+
+                // A `Pat::Assign` element carries a default initializer that is
+                // evaluated lazily, only when the pulled value is `undefined`.
+                if let ast::Pat::Assign(assign_pat) = elem_pat {
+                    let default_val = lower_expr(ctx, &assign_pat.right)?;
+                    let with_default = Expr::Conditional {
+                        condition: Box::new(is_strictly_undefined(Expr::LocalGet(value_id))),
+                        then_expr: Box::new(default_val),
+                        else_expr: Box::new(Expr::LocalGet(value_id)),
+                    };
+                    lower_pattern_binding_into(
+                        ctx,
+                        &assign_pat.left,
+                        with_default,
+                        mutable,
+                        &mut body,
+                    )?;
+                } else {
+                    lower_pattern_binding_into(
+                        ctx,
+                        elem_pat,
+                        Expr::LocalGet(value_id),
+                        mutable,
+                        &mut body,
+                    )?;
+                }
+            }
+        }
+    }
+
+    // Close the iterator: on any abrupt completion from the body (default
+    // initializer / nested pattern throwing), and again on normal completion
+    // when the iterator was not exhausted.
+    let close_stmt = Stmt::Expr(runtime_iterator_call(
+        "iteratorCloseIfNotDone",
+        vec![Expr::LocalGet(iter_id), Expr::LocalGet(done_id)],
+    ));
+    let (exc_id, exc_name) = fresh_destruct_local(ctx, Type::Any);
+    result.push(Stmt::Try {
+        body,
+        catch: Some(CatchClause {
+            param: Some((exc_id, exc_name)),
+            body: vec![
+                Stmt::Try {
+                    body: vec![close_stmt.clone()],
+                    catch: Some(CatchClause {
+                        param: None,
+                        body: Vec::new(),
+                    }),
+                    finally: None,
+                },
+                Stmt::Throw(Expr::LocalGet(exc_id)),
+            ],
+        }),
+        finally: None,
+    });
+    result.push(close_stmt);
+
+    Ok(())
+}
+
 /// Recursively lower a binding pattern against a source expression, producing
 /// `Let` statements that declare each bound variable.
 ///
@@ -105,53 +332,20 @@ pub(crate) fn lower_pattern_binding_into(
                 init: Some(source),
             });
             let default_val = lower_expr(ctx, &assign_pat.right)?;
-            // If `IsUndefinedOrBareNan(tmp)` then use default, else use tmp.
+            // A destructuring default applies only when the source is strictly
+            // `undefined` (not a genuine NaN value — `let [a = 1] = [NaN]` → NaN).
             let with_default = Expr::Conditional {
-                condition: Box::new(Expr::IsUndefinedOrBareNan(Box::new(Expr::LocalGet(tmp_id)))),
+                condition: Box::new(is_strictly_undefined(Expr::LocalGet(tmp_id))),
                 then_expr: Box::new(default_val),
                 else_expr: Box::new(Expr::LocalGet(tmp_id)),
             };
             lower_pattern_binding_into(ctx, &assign_pat.left, with_default, mutable, result)
         }
         ast::Pat::Array(arr_pat) => {
-            // Materialize source into a temp
-            let arr_ty = arr_pat
-                .type_ann
-                .as_ref()
-                .map(|ann| extract_ts_type(&ann.type_ann))
-                .unwrap_or(Type::Array(Box::new(Type::Any)));
-            let tmp_id = ctx.fresh_local();
-            let tmp_name = format!("__destruct_{}", tmp_id);
-            ctx.locals.push((tmp_name.clone(), tmp_id, arr_ty.clone()));
-            result.push(Stmt::Let {
-                id: tmp_id,
-                name: tmp_name,
-                ty: arr_ty,
-                mutable: false,
-                init: Some(source),
-            });
-
-            for (idx, elem) in arr_pat.elems.iter().enumerate() {
-                let Some(elem_pat) = elem else { continue }; // hole — skip
-
-                if let ast::Pat::Rest(rest_pat) = elem_pat {
-                    // Rest element `...rest` — take remaining elements as an array
-                    let slice_expr = Expr::ArraySlice {
-                        array: Box::new(Expr::LocalGet(tmp_id)),
-                        start: Box::new(Expr::Number(idx as f64)),
-                        end: None,
-                    };
-                    lower_pattern_binding_into(ctx, &rest_pat.arg, slice_expr, mutable, result)?;
-                    break; // Rest must be last
-                }
-
-                let element_source = Expr::IndexGet {
-                    object: Box::new(Expr::LocalGet(tmp_id)),
-                    index: Box::new(Expr::Number(idx as f64)),
-                };
-                lower_pattern_binding_into(ctx, elem_pat, element_source, mutable, result)?;
-            }
-            Ok(())
+            // Array binding patterns use the iterator protocol (GetIterator /
+            // IteratorStep / IteratorValue / IteratorClose), per spec — not raw
+            // index reads. See `lower_array_pattern_binding`.
+            lower_array_pattern_binding(ctx, arr_pat, source, mutable, result)
         }
         ast::Pat::Object(obj_pat) => {
             // Materialize source into a temp
@@ -164,12 +358,18 @@ pub(crate) fn lower_pattern_binding_into(
             let tmp_id = ctx.fresh_local();
             let tmp_name = format!("__destruct_{}", tmp_id);
             ctx.locals.push((tmp_name.clone(), tmp_id, obj_ty.clone()));
+            // RequireObjectCoercible: destructuring a `null`/`undefined` source
+            // throws a TypeError even for an empty pattern `{}`, before any
+            // property is read.
             result.push(Stmt::Let {
                 id: tmp_id,
                 name: tmp_name,
                 ty: obj_ty,
                 mutable: false,
-                init: Some(source),
+                init: Some(runtime_iterator_call(
+                    "requireObjectCoercible",
+                    vec![source],
+                )),
             });
 
             // Collect statically-known keys for rest exclusion tracking.
@@ -287,8 +487,8 @@ pub(crate) fn lower_pattern_binding_into(
                             });
                             let default_val = lower_expr(ctx, default_expr)?;
                             Expr::Conditional {
-                                condition: Box::new(Expr::IsUndefinedOrBareNan(Box::new(
-                                    Expr::LocalGet(val_tmp_id),
+                                condition: Box::new(is_strictly_undefined(Expr::LocalGet(
+                                    val_tmp_id,
                                 ))),
                                 then_expr: Box::new(default_val),
                                 else_expr: Box::new(Expr::LocalGet(val_tmp_id)),

--- a/crates/perry-hir/src/lower_decl/private_members.rs
+++ b/crates/perry-hir/src/lower_decl/private_members.rs
@@ -118,6 +118,19 @@ pub fn lower_private_method(
         body = destructuring_stmts;
     }
 
+    // Default-parameter prologue (`if (p === undefined) p = <default>`) — this
+    // was missing for private methods, so `#m(a = 1)` silently dropped the
+    // default and `#m([x] = [])` left the destructuring source `undefined`
+    // (→ a thrown TypeError under the iterator protocol). Prepend BEFORE the
+    // destructuring prologue, matching the public-method ordering in
+    // `lower_method`.
+    let default_stmts = build_default_param_stmts(&params);
+    if !default_stmts.is_empty() {
+        let mut new_body = default_stmts;
+        new_body.extend(body);
+        body = new_body;
+    }
+
     ctx.exit_strict_mode();
     ctx.exit_scope(scope_mark);
     ctx.exit_type_param_scope();

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -928,6 +928,23 @@ pub extern "C" fn js_iterator_to_array(iter_f64: f64) -> *mut ArrayHeader {
     result
 }
 
+/// `BindingRestElement` / `AssignmentRestElement` iterator drain for
+/// destructuring (`let [...rest] = src`, `method([...rest]) {}`). Spec §8.5.3
+/// ArrayBindingPattern step for a rest element: if the iterator is already
+/// done, the rest is an empty array; otherwise drain the remaining values into
+/// a fresh array (which leaves the iterator exhausted). `done_f64` carries the
+/// destructuring `[[Done]]` flag so a rest after an exhausted iterator
+/// (`let [a, b, ...r] = [1]`) yields `[]` without re-invoking `next()`.
+#[no_mangle]
+pub extern "C" fn js_iterator_rest_to_array(iter_f64: f64, done_f64: f64) -> f64 {
+    if crate::value::js_is_truthy(done_f64) != 0 {
+        let arr = js_array_alloc(0);
+        return crate::value::js_nanbox_pointer(arr as i64);
+    }
+    let arr = js_iterator_to_array(iter_f64);
+    crate::value::js_nanbox_pointer(arr as i64)
+}
+
 fn js_async_iterator_to_array(iter_f64: f64) -> *mut ArrayHeader {
     use crate::closure;
     use crate::object::{js_object_get_field_by_name, ObjectHeader};

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -3346,7 +3346,12 @@ pub(crate) unsafe fn call_vtable_method(
         if idx < args_len {
             *args_ptr.add(idx)
         } else {
-            f64::NAN
+            // A missing argument is `undefined` per spec, not a bare IEEE NaN.
+            // This vtable path is reached without call-site padding when a
+            // method is invoked as a value (`const f = obj.m; f()`, or a bound
+            // method from a getter), so NaN here defeated the callee's
+            // default-param / destructuring prologue (`if (p === undefined)`).
+            f64::from_bits(crate::value::TAG_UNDEFINED)
         }
     }
 

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -27,6 +27,20 @@ pub(crate) fn closure_own_key_present(ptr: usize, key: &str) -> bool {
     }
 }
 
+/// `RequireObjectCoercible(value)` for object destructuring binding/assignment
+/// (`let {a} = src`, `method({a}) {}`). Throws a TypeError when `value` is
+/// `null` or `undefined` (so even an empty pattern `{}` rejects nullish input),
+/// otherwise returns the value unchanged. Property reads happen afterward via
+/// the ordinary `[[Get]]` path, which boxes primitives as needed.
+#[no_mangle]
+pub extern "C" fn js_require_object_coercible(value: f64) -> f64 {
+    let bits = value.to_bits();
+    if bits == crate::value::TAG_UNDEFINED || bits == crate::value::TAG_NULL {
+        throw_to_object_nullish_type_error();
+    }
+    value
+}
+
 pub(crate) fn throw_to_object_nullish_type_error() -> ! {
     let message = "Cannot convert undefined or null to object";
     let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);


### PR DESCRIPTION
## Summary

Brings `language/{statements,expressions}/class/dstr` from **512 → 664** passing (**41.6% → 53.9%**) with **zero regressions**, and lifts the wider `built-ins`+`language` sweep by **~6–9% per shard** (0 regressions across 4 sampled shards `0,3,6,9 of 12`). These are method / constructor / accessor parameter-destructuring tests across plain, generator, async-generator, static, and private class methods.

## Root causes fixed

1. **Array binding patterns now use the iterator protocol.** `lower_pattern_binding` lowered `let [a,b] = x` (and every method/param destructuring) to raw index reads (`x[0]`, `x[1]`) — never invoking `Symbol.iterator`, never closing the iterator, mishandling holes/rest, and unable to destructure non-array iterables. Rewrote the `Pat::Array` arm to emit `GetIterator` → `IteratorStep`/`IteratorValue` per element, drain a rest element via a new `js_iterator_rest_to_array`, advance the iterator on elisions, and `IteratorClose` on both normal completion (when not exhausted) and any abrupt completion. Destructuring defaults now use strict `=== undefined` (a genuine `NaN` element no longer triggers the default).
2. **Object binding patterns enforce `RequireObjectCoercible`** (new `js_require_object_coercible`) — `TypeError` for a `null`/`undefined` source even for an empty pattern `{}`.
3. **Static-method calls pad omitted args with `undefined`.** `Expr::StaticMethodCall` (non-rest path) forwarded only supplied args, so a static method called with fewer args read uninitialized parameter slots — `static f(a=1)` returned `0`, `static m([x]=[])` threw.
4. **Private methods emit their default-parameter prologue** — `lower_private_method` computed `param.default` but never called `build_default_param_stmts`.
5. **Method-as-value calls pad omitted args with `undefined`** — `call_vtable_method` padded a bare IEEE `NaN`; reached without call-site padding when a method is invoked as a value (`const f = obj.m; f()`, or a `get m(){ return this.#m }` accessor exposing a private method).

## Validation

- Cluster (class/dstr): **0 regressed, 152 fixed** vs `main` baseline.
- Wider sweep (`built-ins`+`language`, shards 0/3/6/9 of 12): **0 regressed**, +20/+20/+19/+26 fixed.
- Built + tested on a Linux box against the pinned test262 corpus.

Remaining class/dstr failures are concentrated in `*-init-fn-name-*` (NamedEvaluation of anonymous function/arrow/class defaults) and generator throw-timing (eager param destructuring) — distinct features left for follow-ups.