### PR TITLE
fix(compile): normalize Windows auto-optimize target paths

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -123,6 +123,62 @@ impl NativeObjectArtifact {
     }
 }
 
+fn native_object_file_stem(module_name: &str) -> String {
+    let mut stem = module_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('_')
+        .to_string();
+
+    if stem.is_empty() {
+        stem.push('_');
+    }
+
+    #[cfg(windows)]
+    if is_windows_reserved_file_stem(&stem) {
+        stem.push('_');
+    }
+
+    stem
+}
+
+#[cfg(windows)]
+fn is_windows_reserved_file_stem(stem: &str) -> bool {
+    let lower = stem.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "con"
+            | "prn"
+            | "aux"
+            | "nul"
+            | "com1"
+            | "com2"
+            | "com3"
+            | "com4"
+            | "com5"
+            | "com6"
+            | "com7"
+            | "com8"
+            | "com9"
+            | "lpt1"
+            | "lpt2"
+            | "lpt3"
+            | "lpt4"
+            | "lpt5"
+            | "lpt6"
+            | "lpt7"
+            | "lpt8"
+            | "lpt9"
+    )
+}
+
 fn canonical_class_source_prefix(
     class: &perry_hir::Class,
     class_canonical_path: &HashMap<perry_hir::ClassId, String>,
@@ -179,6 +235,27 @@ mod tests {
             ),
             "node_modules_rxjs_src_internal_Observable_ts"
         );
+    }
+
+    #[test]
+    fn native_object_file_stem_sanitizes_module_names() {
+        assert_eq!(
+            native_object_file_stem("table-parser/lib/index"),
+            "table_parser_lib_index"
+        );
+        assert_eq!(native_object_file_stem("///"), "_");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn native_object_file_stem_avoids_windows_reserved_names() {
+        assert_eq!(native_object_file_stem("con"), "con_");
+        assert_eq!(
+            native_object_file_stem("connected-domain"),
+            "connected_domain"
+        );
+        assert_eq!(native_object_file_stem("aux"), "aux_");
+        assert_eq!(native_object_file_stem("COM1"), "COM1_");
     }
 }
 
@@ -3856,11 +3933,7 @@ pub fn run_with_parse_cache(
             } else {
                 (None, None)
             };
-            let obj_name = hir_module
-                .name
-                .replace(|c: char| !c.is_alphanumeric() && c != '_', "_")
-                .trim_matches('_')
-                .to_string();
+            let obj_name = native_object_file_stem(&hir_module.name);
             // In bitcode mode the bytes are .ll text; use .ll extension.
             let ext = if bitcode_link { "ll" } else { "o" };
             let obj_path = object_output_dir.join(format!("{}.{}", obj_name, ext));
@@ -3998,21 +4071,24 @@ pub fn run_with_parse_cache(
         .map(NativeObjectArtifact::materialized_bytes)
         .sum();
 
-    let write_results: Vec<Result<(), std::io::Error>> = artifacts
+    let write_results: Vec<Result<(), (PathBuf, std::io::Error)>> = artifacts
         .par_iter()
         .filter_map(|artifact| {
-            artifact
-                .bytes
-                .as_ref()
-                .map(|bytes| fs::write(&artifact.path, bytes))
+            artifact.bytes.as_ref().map(|bytes| {
+                fs::write(&artifact.path, bytes).map_err(|err| (artifact.path.clone(), err))
+            })
         })
         .collect();
 
     // Bail on first write failure (I/O errors are usually disk-full /
     // permission, not per-file recoverable).
     for r in write_results {
-        if let Err(e) = r {
-            return Err(e.into());
+        if let Err((path, e)) = r {
+            return Err(anyhow!(
+                "failed to write object file {}: {}",
+                path.display(),
+                e
+            ));
         }
     }
 

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -49,6 +49,23 @@ pub(crate) fn android_global_dynamic_tls_rustflag(cmd: &mut Command) -> &'static
     }
 }
 
+#[cfg(windows)]
+fn cargo_target_dir_path(path: PathBuf) -> PathBuf {
+    let raw = path.to_string_lossy();
+    if let Some(rest) = raw.strip_prefix(r"\\?\UNC\") {
+        PathBuf::from(format!(r"\\{}", rest))
+    } else if let Some(rest) = raw.strip_prefix(r"\\?\") {
+        PathBuf::from(rest)
+    } else {
+        path
+    }
+}
+
+#[cfg(not(windows))]
+fn cargo_target_dir_path(path: PathBuf) -> PathBuf {
+    path
+}
+
 pub struct OptimizedLibs {
     /// Path to the rebuilt `libperry_runtime.a` (or `perry_runtime.lib`).
     /// `None` means "fall back to the prebuilt one in target/release/".
@@ -587,7 +604,8 @@ pub(super) fn build_optimized_libs(
     for b in key_input.as_bytes() {
         hash = hash.wrapping_mul(33).wrapping_add(*b as u64);
     }
-    let target_dir = workspace_root.join(format!("target/perry-auto-{:016x}", hash));
+    let target_dir =
+        cargo_target_dir_path(workspace_root.join(format!("target/perry-auto-{:016x}", hash)));
 
     if matches!(format, OutputFormat::Text) {
         let panic_str = if panic_abort_safe { "abort" } else { "unwind" };
@@ -1448,6 +1466,26 @@ mod tests {
             libs.well_known_libs.contains(&ws_lib),
             "expected no-auto well-known libs to include {ws_lib:?}, got {:?}",
             libs.well_known_libs
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cargo_target_dir_strips_windows_verbatim_prefixes() {
+        let drive = cargo_target_dir_path(PathBuf::from(
+            r"\\?\D:\Projects\perry\target\perry-auto-deadbeef",
+        ));
+        assert_eq!(
+            drive,
+            PathBuf::from(r"D:\Projects\perry\target\perry-auto-deadbeef")
+        );
+
+        let unc = cargo_target_dir_path(PathBuf::from(
+            r"\\?\UNC\server\share\perry\target\perry-auto-deadbeef",
+        ));
+        assert_eq!(
+            unc,
+            PathBuf::from(r"\\server\share\perry\target\perry-auto-deadbeef")
         );
     }
 


### PR DESCRIPTION
## Summary
- strip Windows verbatim prefixes from the generated auto-optimize Cargo target dir before passing it as `CARGO_TARGET_DIR`
- reuse a single helper for native object file stems and avoid Windows reserved device stems
- include the exact object output path when object writes fail

## Why
A Windows `compilePackages` probe for `ps-node` reached Perry's auto-optimized runtime rebuild and failed inside `libmimalloc-sys`. Cargo/cc-rs passed an extended-length `\\?\...` target dir through to MSVC, then `cl.exe` failed to open the generated `mimalloc-static.cc` source.

Perry generates this auto target dir itself, so this normalizes only that generated `target/perry-auto-<hash>` path before setting `CARGO_TARGET_DIR`. Normal Windows paths still build under the same cache directory, while avoiding the toolchain-specific failure.

The object-path diagnostic is included because the same investigation also hit a generic object write failure. Returning `failed to write object file <path>: <error>` makes that class of failure actionable instead of hiding the path that failed.

## Testing
- `cargo fmt -p perry --check`
- `cargo test -p perry native_object_file_stem --message-format=short`
- `cargo test -p perry cargo_target_dir_strips_windows_verbatim_prefixes --message-format=short`
- `cargo build -p perry`
- from the local `ps-node` probe directory: `target/debug/perry.exe compile index.ts -o ps-node-probe-upstream.exe --no-cache`