### PR TITLE
fix: zod v4 `safeParse` on invalid input — crash + readable error (#4699)

### DIFF
--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -463,6 +463,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // Array / Object thunks and dispatches into the matching
             // real factory; non-matching closures still get the
             // class_id=0 empty-object baseline.
+            // `Expr::Logical` covers `new (A ?? B)()` / `new (A || B)()` /
+            // `new (A && B)()` — picking a constructor with a short-circuit
+            // operator. zod v4's `safeParse` builds its error via
+            // `new (_Err ?? errors.$ZodError)(issues)` (#4699): without this
+            // the callee fell through to the Case-4 empty-object placeholder,
+            // so the `ZodError` constructor never ran and `r.error.issues`
+            // was `undefined`. The whole logical expression lowers to a single
+            // closure value, which `js_new_function_construct` handles exactly
+            // like a `LocalGet` callee (and still falls back to the class_id=0
+            // empty object if the value turns out non-callable).
             let routes_through_function_construct = matches!(
                 callee.as_ref(),
                 Expr::FuncRef(_)
@@ -471,6 +481,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     | Expr::PropertyGet { .. }
                     | Expr::IndexGet { .. }
                     | Expr::Closure { .. }
+                    | Expr::Logical { .. }
             );
             if routes_through_function_construct {
                 let func_double = lower_expr(ctx, callee)?;

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1500,6 +1500,16 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     // Lower callee as plain MemberExpr, unwrapping inner OptChain.
                     // SWC may wrap the callee member access in an OptChain too.
                     // We must NOT re-lower via lower_expr which would nest Conditionals.
+                    //
+                    // `callee_from_chain` records the `foo?.bar?.(args)` shape: the
+                    // callee is itself an optional chain, so `check_expr` is the
+                    // *receiver* (`foo`) rather than the function value. In that
+                    // case the receiver short-circuit alone is not enough — the
+                    // function value (`foo.bar`) must ALSO be null-checked before
+                    // the call, or an `undefined` property is invoked and throws
+                    // "X is not a function" (issue #4699: zod `safeParse`'s
+                    // `iss.inst?._zod.def?.error?.(iss)` error-map probe).
+                    let mut callee_from_chain = false;
                     let (check_expr, callee_expr) = {
                         let mut lower_member_flat =
                             |member: &ast::MemberExpr| -> Result<(Expr, Expr)> {
@@ -1532,12 +1542,15 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                                 (prop.clone(), prop)
                             }
                             ast::Expr::OptChain(inner) => match &*inner.base {
-                                // Chained `foo?.bar?.(args)`: keep checking the
-                                // receiver (foo) so the inner `?.` short-circuit
-                                // still works. A separate null-check on the
-                                // function value (foo.bar) is a known gap — see
-                                // the comment above the final Conditional below.
-                                ast::OptChainBase::Member(m) => lower_member_flat(m)?,
+                                // Chained `foo?.bar?.(args)`: check the receiver
+                                // (foo) so the inner `?.` short-circuit still works,
+                                // AND flag that the function value (foo.bar) needs
+                                // its own null-check before the call (added in the
+                                // final assembly below).
+                                ast::OptChainBase::Member(m) => {
+                                    callee_from_chain = true;
+                                    lower_member_flat(m)?
+                                }
                                 _ => {
                                     let ce = lower_expr(ctx, callee)?;
                                     (ce.clone(), ce)
@@ -1572,16 +1585,41 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             other => other,
                         };
                         let outer_call = Expr::Call {
-                            callee: Box::new(fixed_callee),
+                            callee: Box::new(fixed_callee.clone()),
                             args,
                             type_args: Vec::new(),
+                        };
+                        // For `foo?.bar?.(args)` the function value (`bar` on the
+                        // un-short-circuited receiver) must itself be null-checked
+                        // before calling — otherwise an `undefined` property is
+                        // invoked and throws "X is not a function" (#4699).
+                        let else_expr: Box<Expr> = if callee_from_chain {
+                            Box::new(Expr::Conditional {
+                                condition: Box::new(Expr::Compare {
+                                    op: CompareOp::LooseEq,
+                                    left: Box::new(fixed_callee),
+                                    right: Box::new(Expr::Null),
+                                }),
+                                then_expr: Box::new(Expr::Undefined),
+                                else_expr: Box::new(outer_call),
+                            })
+                        } else {
+                            Box::new(outer_call)
                         };
                         return Ok(Expr::Conditional {
                             condition: inner_cond,
                             then_expr: inner_then,
-                            else_expr: Box::new(outer_call),
+                            else_expr,
                         });
                     }
+
+                    // Keep the function value for the `foo?.bar?.(args)` guard
+                    // (see callee_from_chain) before it is moved into the call.
+                    let func_value_for_guard = if callee_from_chain {
+                        Some(callee_expr.clone())
+                    } else {
+                        None
+                    };
 
                     // Build the call expression
                     let call_expr = if has_spread {
@@ -1615,6 +1653,23 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                         })
                     };
 
+                    // For `foo?.bar?.(args)` the receiver check below guards `foo`,
+                    // but the function value `foo.bar` must ALSO be null-checked
+                    // before the call — otherwise an `undefined` property is
+                    // invoked and throws "X is not a function" (#4699).
+                    let else_expr: Box<Expr> = match func_value_for_guard {
+                        Some(func_value) => Box::new(Expr::Conditional {
+                            condition: Box::new(Expr::Compare {
+                                op: CompareOp::LooseEq,
+                                left: Box::new(func_value),
+                                right: Box::new(Expr::Null),
+                            }),
+                            then_expr: Box::new(Expr::Undefined),
+                            else_expr: Box::new(call_expr),
+                        }),
+                        None => Box::new(call_expr),
+                    };
+
                     // Issue #388: optional chaining short-circuits on
                     // null OR undefined per spec. Use `LooseEq` so the
                     // comparison `check_expr == null` matches both —
@@ -1629,7 +1684,7 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                             right: Box::new(Expr::Null),
                         }),
                         then_expr: Box::new(Expr::Undefined),
-                        else_expr: Box::new(call_expr),
+                        else_expr,
                     })
                 }
             }

--- a/test-files/test_issue_4699_new_logical_callee.ts
+++ b/test-files/test_issue_4699_new_logical_callee.ts
@@ -1,0 +1,35 @@
+// Regression for #4699 (part 2): `new (A ?? B)(args)` — constructing via a
+// short-circuit operator callee — must run the constructor body, not return
+// an empty object. zod v4's `safeParse` builds its error with
+// `new (_Err ?? errors.$ZodError)(issues)`; pre-fix the `??` callee fell
+// through to codegen's empty-object placeholder so the `ZodError` constructor
+// never ran and `r.error.issues` was `undefined`.
+
+function makeCtor(tag: string) {
+  return function (this: any, def: any) {
+    this.def = def;
+    this.tag = tag;
+  } as any;
+}
+const Primary = makeCtor("primary");
+const Fallback = makeCtor("fallback");
+
+// `??` — left operand non-null, so Primary is used.
+const a = new (Primary ?? Fallback)([1, 2]);
+console.log("a:", a.tag, a.def);
+
+// `??` — left operand nullish, so Fallback is used.
+const nullish: any = undefined;
+const b = new (nullish ?? Fallback)([3, 4]);
+console.log("b:", b.tag, b.def);
+
+// `||` — falsy left operand falls to the right.
+const falsy: any = null;
+const c = new (falsy || Primary)([5]);
+console.log("c:", c.tag, c.def);
+
+// `&&` — truthy left operand yields the right operand.
+const d = new (Primary && Fallback)([6]);
+console.log("d:", d.tag, d.def);
+
+console.log("new (logical) callee tests passed!");

--- a/test-files/test_issue_4699_optional_call_chain.ts
+++ b/test-files/test_issue_4699_optional_call_chain.ts
@@ -1,0 +1,36 @@
+// Regression for #4699: a chained optional call `foo?.bar?.(args)` must
+// short-circuit when the *function value* (`foo.bar`) is null/undefined,
+// not only when the receiver (`foo`) is. Pre-fix, the lowering checked
+// only the receiver, so `def?.error?.(5)` (with `def.error === undefined`)
+// invoked `undefined(5)` and threw "X is not a function" — the crash that
+// blocked zod v4 `safeParse` on the validation-failure path.
+
+// Receiver present, function value missing -> short-circuit to undefined.
+const def: any = { foo: 1 };
+console.log("a:", def?.error?.(5)); // undefined
+
+// Function value present -> the call runs.
+const obj: any = { greet: (n: string) => `hi ${n}` };
+console.log("b:", obj?.greet?.("x")); // hi x
+
+// Receiver missing -> inner ?. short-circuits.
+const nul: any = null;
+console.log("c:", nul?.error?.(5)); // undefined
+
+// Deep chain mirroring zod's `iss.inst?._zod.def?.error?.(iss)`.
+const iss: any = { inst: { _zod: { def: {} } } };
+console.log("d:", iss.inst?._zod.def?.error?.(iss)); // undefined
+
+const iss2: any = { inst: { _zod: { def: { error: (x: any) => `got ${x.v}` } } } };
+console.log("e:", iss2.inst?._zod.def?.error?.({ v: 7 })); // got 7
+
+// Missing intermediate link in the deep chain still short-circuits.
+const iss3: any = { inst: null };
+console.log("f:", iss3.inst?._zod.def?.error?.(iss3)); // undefined
+
+// Computed-key variant: `foo?.[k]?.(args)`.
+const tbl: any = { handler: undefined };
+const k = "handler";
+console.log("g:", tbl?.[k]?.(1)); // undefined
+
+console.log("Optional-call chain tests passed!");


### PR DESCRIPTION
## Summary

Fixes #4699. `z.object({ a: z.string() }).safeParse({ a: 123 })` under `perry.compilePackages: ["zod"]` (a) threw `TypeError: error is not a function` instead of returning `{ success: false }`, and (b) once that was fixed, the returned `r.error` was an empty object so `r.error.issues` was `undefined`. Both are **general compiler bugs**, not zod-specific. After this PR, `safeParse` returns `success: false` and a fully-populated `ZodError` whose `.issues` match Node.

Two independent root causes:

### 1. Chained optional-call dropped the function-value null-check (HIR)

The lowering of `foo?.bar?.(args)` (an optional call whose callee is itself an optional chain) only short-circuited on the **receiver** (`foo`), never on the **function value** (`foo.bar`). When `foo` is a valid object but `foo.bar` is `undefined`, it emitted `foo == null ? undefined : foo.bar(args)` → `undefined(args)` → "X is not a function". The gap was a documented "known gap" in `lower_expr.rs`'s `OptChainBase::Call` arm.

zod hits it via `finalizeIssue`'s `iss.inst?._zod.def?.error?.(iss)` / `config.localeError?.(iss)` error-map probes (callbacks normally absent). The simple `obj.method?.(args)` shape already worked because there the receiver check *was* the function-value check.

**Fix (`crates/perry-hir/src/lower/lower_expr.rs`):** flag the `foo?.bar?.(args)` shape and wrap the call in an additional `LooseEq` null-check on the function value: `foo == null ? undefined : (foo.bar == null ? undefined : foo.bar(args))`. Applied to both the non-nested and nested-Conditional (deep-chain) paths. Plain `obj.method?.(args)` is untouched.

### 2. `new (A ?? B)(args)` returned an empty object (codegen)

zod builds the error with `new (_Err ?? errors.$ZodError)(issues)`. The `??` callee lowers to `Expr::Logical { Coalesce }`, which codegen's `NewDynamic` handler did **not** route through `js_new_function_construct` — so the callee fell to the empty-object placeholder and the `ZodError` constructor never ran (`r.error.issues === undefined`). Reduced to a single-module repro: `new (Ctor ?? Fallback)(args)` produced `{}` while `new Ctor(args)` worked.

**Fix (`crates/perry-codegen/src/expr/new_dynamic.rs`):** add `Expr::Logical { .. }` to `routes_through_function_construct`. The logical expression lowers to a single closure value handled exactly like a `LocalGet` callee (binds `this`, runs the body), with the existing class_id=0 empty-object fallback for non-callables. Covers `new (A ?? B)()`, `new (A || B)()`, `new (A && B)()`.

## Validation

- `safeParse({ a: 123 })` → `success: false`; `r.error.issues` is the populated issue array (`expected`/`code`/`path`/`message`), `"issues" in r.error` is `true`, `r.error.name === "ZodError"` — all matching Node.
- New tests (byte-for-byte vs Node): `test_issue_4699_optional_call_chain.ts` (presence permutations, deep `iss.inst?._zod.def?.error?.(iss)` chain, computed-key `foo?.[k]?.(args)`) and `test_issue_4699_new_logical_callee.ts` (`??`/`||`/`&&` callees).
- Regression vs Node: `test_issue_836_zod_class_reexports`, `test_optional_chain`, `test_issue_388_optional_chain_loose_eq`, `test_issue_1111_gcm_auth_tag_optchain`, `test_issue_542_map_keys_optional` — all pass. `cargo test -p perry-hir -p perry-codegen` green.

## Known remaining (cosmetic, out of scope, pre-existing)

- `r.error.constructor.name` reports `Object` instead of `ZodError` — dynamically-created `class extends Error` + `Object.defineProperty(Definition, "name", …)` identity.
- Nested object-in-array `console.log` indentation differs (`util.inspect` formatting).