### PR TITLE
fix(ui-windows): Mica-by-default + WM_DPICHANGED relayout (#4681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1145 — Win32 Fluent polish: Mica-by-default + WM_DPICHANGED relayout (#4681)
+
+Continues the #4681 Win32/GDI modernization (after #4682 default DWM chrome and
+#4683 comctl32 v6 themed controls). Three remaining items land here:
+
+- **Mica backdrop by default.** `dwm::apply_default_window_chrome` now also
+  requests `DWMWA_SYSTEMBACKDROP_TYPE = DWMSBT_MAINWINDOW` (Mica) at window
+  creation, alongside the existing rounded corners + theme-aware title bar. On
+  Windows 11 22H2+ the DWM-drawn non-client frame (title bar) picks up the Mica
+  material; older systems reject the attribute (`E_INVALIDARG`) and silently
+  ignore it, same as the corner-preference attribute. This deliberately does
+  **not** make the client area transparent — Perry still paints an opaque client
+  background via the class brush / `WM_ERASEBKGND` root-background path — so it
+  cannot reintroduce the #1542 "black area after resize" regression. Full
+  client-area Mica/Acrylic blur-through (which extends the frame and clears the
+  client) remains the explicit `app.setVibrancy(...)` opt-in.
+
+- **Per-monitor-v2 DPI: `WM_DPICHANGED` handling.** The main window proc now
+  handles `WM_DPICHANGED` (0x02E0): it honors the OS-suggested, DPI-scaled window
+  rect via `SetWindowPos` and relayouts the root (mirroring `WM_SIZE`) instead of
+  letting `DefWindowProc` bitmap-stretch. Windows now stay crisp when dragged
+  between monitors with mixed scaling. DPI awareness was already opted into at
+  startup (`dpi_compat::set_process_dpi_awareness_compat`, per-monitor-v2 →
+  v1 → system fallback chain); this closes the runtime side.
+
+- **Doc accuracy.** Refreshed the stale `geisterhand_style.rs` caveat that
+  described `set_opacity` / `set_border_*` / shadow as "stub-with-state". Those
+  apply paths are real now (layered window, `WM_PAINT` border subclass,
+  `SetWindowRgn` corner clip, parent shadow-paint subclass); #210 and #230 are
+  closed.
+
 ## v0.5.1144 — `new <imported-function>()` runs the constructor body (zod v4 checks; #4698)
 
 `new F(args)` where `F` is a **function (or a `const`/`let` holding a closure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1144
+**Current Version:** 0.5.1145
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1144"
+version = "0.5.1145"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1144"
+version = "0.5.1145"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1144"
+version = "0.5.1145"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1144"
+version = "0.5.1145"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1144"
+version = "0.5.1145"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -1086,6 +1086,37 @@ unsafe extern "system" fn wnd_proc(
             }
             LRESULT(0)
         }
+        // WM_DPICHANGED (0x02E0) — fired when the window moves to a monitor with
+        // a different DPI (per-monitor-v2; #4681 DPI task). lparam is a
+        // `*const RECT` with the suggested new window position+size Windows has
+        // already scaled for the target monitor. Honoring it (instead of
+        // letting DefWindowProc bitmap-stretch) keeps text and controls crisp
+        // when the window is dragged across monitors with mixed scaling.
+        x if x == 0x02E0 => {
+            if lparam.0 != 0 {
+                let suggested = &*(lparam.0 as *const RECT);
+                let _ = SetWindowPos(
+                    hwnd,
+                    None,
+                    suggested.left,
+                    suggested.top,
+                    suggested.right - suggested.left,
+                    suggested.bottom - suggested.top,
+                    SWP_NOZORDER | SWP_NOACTIVATE,
+                );
+            }
+            // Relayout the root to the new client size (mirrors WM_SIZE) so
+            // child widgets pick up the new DPI-scaled metrics.
+            let mut client = RECT::default();
+            let _ = GetClientRect(hwnd, &mut client);
+            if let Some(root) = get_root_widget(1) {
+                if let Some(child_hwnd) = crate::widgets::get_hwnd(root) {
+                    let _ = MoveWindow(child_hwnd, 0, 0, client.right, client.bottom, true);
+                    crate::layout::layout_widget(root, client.right, client.bottom);
+                }
+            }
+            LRESULT(0)
+        }
         WM_PAINT => {
             // Main window has no content to paint — just validate the region
             let mut ps = PAINTSTRUCT::default();

--- a/crates/perry-ui-windows/src/dwm.rs
+++ b/crates/perry-ui-windows/src/dwm.rs
@@ -30,6 +30,12 @@ const DWMWA_SYSTEMBACKDROP_TYPE: u32 = 38;
 /// (full radius) on Windows 11.
 const DWMWCP_ROUND: i32 = 2;
 
+/// `DWM_SYSTEMBACKDROP_TYPE::DWMSBT_MAINWINDOW` — the Mica material, the
+/// recommended default backdrop for long-lived top-level app windows
+/// (Windows 11 22H2+). Older systems reject it (`E_INVALIDARG`) and we
+/// silently ignore that, so requesting it unconditionally is safe.
+const DWMSBT_MAINWINDOW: i32 = 2;
+
 extern "system" {
     fn DwmSetWindowAttribute(hwnd: isize, attr: u32, value: *const i32, size: u32) -> i32;
 }
@@ -65,12 +71,25 @@ pub fn apply_rounded_corners(hwnd: HWND) {
     set_attr_i32(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND);
 }
 
+/// Request the Mica backdrop by default (`DWMSBT_MAINWINDOW`). On Windows 11
+/// 22H2+ this gives the DWM-drawn non-client frame (title bar) the Fluent Mica
+/// material; older systems ignore it. This deliberately does NOT make the
+/// client area transparent — Perry still paints an opaque client background
+/// (the class brush / `WM_ERASEBKGND` root-background path), so this can never
+/// reintroduce the #1542 "black area after resize" regression. Full
+/// client-area Mica blur-through (which requires extending the frame and a
+/// transparent client) remains the explicit `app.setVibrancy(...)` opt-in.
+pub fn apply_default_backdrop(hwnd: HWND) {
+    set_attr_i32(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, DWMSBT_MAINWINDOW);
+}
+
 /// The default Fluent-leaning chrome Perry applies to every top-level window:
-/// rounded corners + a theme-aware title bar. Called once at window creation,
-/// before the window is shown.
+/// rounded corners, a theme-aware title bar, and the Mica backdrop. Called once
+/// at window creation, before the window is shown.
 pub fn apply_default_window_chrome(hwnd: HWND) {
     apply_rounded_corners(hwnd);
     apply_titlebar_theme(hwnd);
+    apply_default_backdrop(hwnd);
 }
 
 /// Set the system backdrop material via `DWMWA_SYSTEMBACKDROP_TYPE`

--- a/crates/perry-ui-windows/src/geisterhand_style.rs
+++ b/crates/perry-ui-windows/src/geisterhand_style.rs
@@ -4,15 +4,15 @@
 //! `widgets::set_*` helper. Called on the main thread by the
 //! geisterhand pump.
 //!
-//! Win32 caveat: `set_opacity` / `set_border_color` / `set_border_width`
-//! are stub-with-state on Windows today (#210 wired the storage but
-//! the apply paths flow through layered-window / WM_PAINT subclassing
-//! that's still partial — see `widgets::mod.rs::apply_opacity` /
-//! `ensure_border_subclass`). So an inspector edit on Windows will
-//! update the per-handle state and trigger the layout/paint pipeline,
-//! but the rendered effect mirrors however much the underlying setter
-//! has wired up. Border / opacity are visible per #210; shadow is
-//! still tracked via #230.
+//! Win32 status: all of these now render, not just store state.
+//! `set_opacity` applies via a layered window (`WS_EX_LAYERED` +
+//! `SetLayeredWindowAttributes`), `set_border_color` / `set_border_width`
+//! draw through a per-handle `WM_PAINT` subclass (`ensure_border_subclass`),
+//! `set_corner_radius` clips via `SetWindowRgn`, and drop shadow renders
+//! through the parent's shadow-paint subclass (`apply_shadow` /
+//! `paint_shadow_for_child`). Border / opacity closed #210; shadow closed
+//! #230. So an inspector edit on Windows updates the per-handle state,
+//! triggers the layout/paint pipeline, and the effect is visible.
 
 use crate::widgets;
 


### PR DESCRIPTION
Continues #4681 (Win32/GDI Fluent polish) after #4682 (default DWM chrome) and #4683 (comctl32 v6 themed controls). Lands the three remaining items.

## Changes

### Mica backdrop by default
`dwm::apply_default_window_chrome` now also requests `DWMWA_SYSTEMBACKDROP_TYPE = DWMSBT_MAINWINDOW` (Mica) at window creation, alongside the existing rounded corners + theme-aware title bar. On Win11 22H2+ the DWM-drawn non-client frame (title bar) picks up the Mica material; older systems reject the attribute (`E_INVALIDARG`) and silently ignore it — same safety model as the corner-preference attribute.

It deliberately does **not** make the client area transparent: Perry still paints an opaque client background (class brush / `WM_ERASEBKGND` root path), so this cannot reintroduce the #1542 "black area after resize" regression. Full client-area Mica/Acrylic blur-through (extend frame + transparent client) stays the explicit `app.setVibrancy(...)` opt-in.

### Per-monitor-v2 DPI: `WM_DPICHANGED`
The main window proc now handles `WM_DPICHANGED` (0x02E0): it honors the OS-suggested DPI-scaled window rect via `SetWindowPos` and relayouts the root (mirroring `WM_SIZE`) instead of letting `DefWindowProc` bitmap-stretch. Windows stay crisp when dragged between monitors with mixed scaling. DPI awareness was already opted in at startup (`dpi_compat::set_process_dpi_awareness_compat`); this closes the runtime side.

### Doc accuracy
Refreshed the stale `geisterhand_style.rs` caveat describing `set_opacity`/`set_border_*`/shadow as "stub-with-state". Those apply paths are real now (layered window, `WM_PAINT` border subclass, `SetWindowRgn` corner clip, parent shadow-paint subclass); #210 and #230 are closed.

## Verification
- `perry-ui-windows` builds clean (only pre-existing warnings).
- `perry` links a minimal UI app; the binary creates its window (running the new chrome path including Mica) and stays in the message loop — no startup crash.
- All 18 `perry` `windows_link` tests pass, including the #4683 manifest tests.

## Remaining in #4681
None of the listed tasks remain. Note: visual confirmation of the Mica tint requires a human on a Win11 22H2+ display; the code path is exercised but the blur material itself isn't asserted in an automated test.