### PR TITLE
fix: standalone async-generator test262 parity (57.7% → 93.0%)

### DIFF
--- a/crates/perry-codegen-arkts/src/tests.rs
+++ b/crates/perry-codegen-arkts/src/tests.rs
@@ -31,6 +31,7 @@ fn empty_module() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
+++ b/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
@@ -55,6 +55,7 @@ fn empty_module() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/constructor_recursion.rs
+++ b/crates/perry-codegen/tests/constructor_recursion.rs
@@ -139,6 +139,7 @@ fn module_with_recursive_constructor_return() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/large_object_barriers.rs
+++ b/crates/perry-codegen/tests/large_object_barriers.rs
@@ -129,6 +129,7 @@ fn module_with_large_pointer_array_literal(element_count: usize) -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 
@@ -194,6 +195,7 @@ fn module_with_large_local_array_push(element_count: usize) -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/native_proof_buffer_views.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views.rs
@@ -107,6 +107,7 @@ fn module_with_classes_and_params(
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -107,6 +107,7 @@ fn module_with_classes_and_params(
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/shadow_slot_hygiene.rs
+++ b/crates/perry-codegen/tests/shadow_slot_hygiene.rs
@@ -122,6 +122,7 @@ fn shadow_hygiene_module() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 
@@ -175,6 +176,7 @@ fn top_level_shadow_module(name: &str) -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 
@@ -257,6 +259,7 @@ fn flat_const_row_alias_shadow_module() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 
@@ -312,6 +315,7 @@ fn reassigned_any_shadow_module() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 
@@ -382,6 +386,7 @@ fn mixed_any_alias_shadow_module() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 
@@ -460,6 +465,7 @@ fn closure_captured_write_shadow_module() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/static_symbol_hygiene.rs
+++ b/crates/perry-codegen/tests/static_symbol_hygiene.rs
@@ -140,6 +140,7 @@ fn duplicate_static_module() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 
@@ -173,6 +174,7 @@ fn class_with_instance_and_static_method() -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -151,6 +151,7 @@ fn module_with_classes(
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_shape_descriptor.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptor.rs
@@ -134,6 +134,7 @@ fn module_with_new(class: Class) -> Module {
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -145,6 +145,7 @@ fn base_module(name: &str, body: Vec<Stmt>, interfaces: Vec<Interface>) -> Modul
         closure_display_names: std::collections::HashMap::new(),
         closure_source_text: std::collections::HashMap::new(),
         async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -44,6 +44,38 @@ fn fresh_destruct_local(ctx: &mut LoweringContext, ty: Type) -> (LocalId, String
     (id, name)
 }
 
+/// Lower a destructuring-default initializer, applying NamedEvaluation when the
+/// binding target is a single name and the initializer is an anonymous function
+/// / arrow / class. Per spec (SingleNameBinding / KeyedBindingInitialization),
+/// `let { x = function(){} } = {}` and `let [ x = () => {} ] = []` name the
+/// function after `x` (`x.name === "x"`). The closure-lowering paths read
+/// `ctx.assignment_inferred_name`; a named function expression ignores it, so
+/// `[ xFn = function x(){} ]` correctly keeps `"x"`.
+fn lower_default_named(
+    ctx: &mut LoweringContext,
+    default_expr: &ast::Expr,
+    binding_name: Option<&str>,
+) -> Result<Expr> {
+    if let Some(name) = binding_name {
+        if crate::lower::expr_assign::rhs_accepts_assignment_name(default_expr) {
+            let old = ctx.assignment_inferred_name.replace(name.to_string());
+            let result = lower_expr(ctx, default_expr);
+            ctx.assignment_inferred_name = old;
+            return result;
+        }
+    }
+    lower_expr(ctx, default_expr)
+}
+
+/// The binding name to use for NamedEvaluation of a `Pat::Assign` target — only
+/// a single `BindingIdentifier` qualifies (nested array/object patterns don't).
+fn single_name_target(pat: &ast::Pat) -> Option<String> {
+    match pat {
+        ast::Pat::Ident(ident) => Some(ident.id.sym.to_string()),
+        _ => None,
+    }
+}
+
 /// Build a call into the runtime iterator-protocol helpers (same dispatch the
 /// assignment-destructuring path uses).
 fn runtime_iterator_call(method: &str, args: Vec<Expr>) -> Expr {
@@ -206,7 +238,11 @@ fn lower_array_pattern_binding(
                 // A `Pat::Assign` element carries a default initializer that is
                 // evaluated lazily, only when the pulled value is `undefined`.
                 if let ast::Pat::Assign(assign_pat) = elem_pat {
-                    let default_val = lower_expr(ctx, &assign_pat.right)?;
+                    let default_val = lower_default_named(
+                        ctx,
+                        &assign_pat.right,
+                        single_name_target(&assign_pat.left).as_deref(),
+                    )?;
                     let with_default = Expr::Conditional {
                         condition: Box::new(is_strictly_undefined(Expr::LocalGet(value_id))),
                         then_expr: Box::new(default_val),
@@ -331,7 +367,11 @@ pub(crate) fn lower_pattern_binding_into(
                 mutable: false,
                 init: Some(source),
             });
-            let default_val = lower_expr(ctx, &assign_pat.right)?;
+            let default_val = lower_default_named(
+                ctx,
+                &assign_pat.right,
+                single_name_target(&assign_pat.left).as_deref(),
+            )?;
             // A destructuring default applies only when the source is strictly
             // `undefined` (not a genuine NaN value — `let [a = 1] = [NaN]` → NaN).
             let with_default = Expr::Conditional {
@@ -485,7 +525,8 @@ pub(crate) fn lower_pattern_binding_into(
                                     property: name.clone(),
                                 }),
                             });
-                            let default_val = lower_expr(ctx, default_expr)?;
+                            let default_val =
+                                lower_default_named(ctx, default_expr, Some(name.as_str()))?;
                             Expr::Conditional {
                                 condition: Box::new(is_strictly_undefined(Expr::LocalGet(
                                     val_tmp_id,

--- a/crates/perry-hir/src/ir/module.rs
+++ b/crates/perry-hir/src/ir/module.rs
@@ -98,6 +98,18 @@ pub struct Module {
     /// generator registry, which drives `%AsyncGeneratorFunction%` / `%Async
     /// Generator%` intrinsic resolution. Populated by `transform_generators`.
     pub async_generator_funcs: std::collections::HashSet<perry_types::FuncId>,
+    /// Number of leading parameter-prologue statements (default-param guards +
+    /// destructuring binding stmts) in each generator / async-generator
+    /// function body, keyed by func_id. Per spec, generator parameter binding
+    /// (FunctionDeclarationInstantiation) runs *synchronously* when the
+    /// generator function is called — before the generator object is created —
+    /// so an iterator/RequireObjectCoercible/TDZ error during param binding
+    /// throws at call time. Lowering prepends the prologue to the body; the
+    /// generator transform reads this count to lift the prologue back into the
+    /// outer wrapper (run-at-call) instead of state 0 of `.next()`. Absent /
+    /// zero means no prologue (the common case — fully inert). Populated by
+    /// lowering (`lower_fn_decl` / `lower_fn_expr`).
+    pub gen_param_prologue_len: std::collections::HashMap<perry_types::FuncId, usize>,
 }
 
 impl Module {
@@ -128,6 +140,7 @@ impl Module {
             closure_display_names: std::collections::HashMap::new(),
             closure_source_text: std::collections::HashMap::new(),
             async_generator_funcs: std::collections::HashSet::new(),
+            gen_param_prologue_len: std::collections::HashMap::new(),
         }
     }
 }

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -82,6 +82,7 @@ impl LoweringContext {
             exportable_object_vars: HashSet::new(),
             pending_functions: Vec::new(),
             closure_display_names: HashMap::new(),
+            gen_param_prologue_len: HashMap::new(),
             assignment_inferred_name: None,
             closure_source_text: HashMap::new(),
             func_return_native_instances: Vec::new(),

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -43,7 +43,7 @@ fn anonymous_class_without_own_static_name(class: &ast::ClassExpr) -> bool {
     })
 }
 
-fn rhs_accepts_assignment_name(expr: &ast::Expr) -> bool {
+pub(crate) fn rhs_accepts_assignment_name(expr: &ast::Expr) -> bool {
     match expr {
         ast::Expr::Arrow(_) => true,
         ast::Expr::Fn(fn_expr) => fn_expr.ident.is_none(),

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -573,6 +573,7 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
         let stmts = generate_param_destructuring_stmts(ctx, pat, *param_id)?;
         destructuring_stmts.extend(stmts);
     }
+    let destructuring_prologue_len = destructuring_stmts.len();
 
     // Hoist function declarations: pre-register all function declarations in the body
     // so they can be referenced before their lexical position (JS hoisting semantics).
@@ -739,6 +740,16 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
 
     // Refs #486: same default-param desugar as lower_arrow above.
     let default_stmts = crate::lower_decl::build_default_param_stmts(&params);
+    // Record the param-prologue length for generator function expressions
+    // (`async function*([x] = d){}`) so the generator transform runs param
+    // binding synchronously at call time (spec FunctionDeclarationInstantiation
+    // order). See `Module.gen_param_prologue_len`.
+    if fn_expr.function.is_generator {
+        let prologue_len = default_stmts.len() + destructuring_prologue_len;
+        if prologue_len > 0 {
+            ctx.gen_param_prologue_len.insert(func_id, prologue_len);
+        }
+    }
     if !default_stmts.is_empty() {
         let mut new_body = default_stmts;
         new_body.append(&mut body);

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -243,9 +243,18 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
             is_rest,
             arguments_object: None,
         });
-        // Track destructuring patterns to generate extraction statements
-        if is_destructuring_pattern(param) {
-            destructuring_params.push((param_id, param.clone()));
+        // Track destructuring patterns to generate extraction statements. A
+        // `([x, y] = [1, 2]) =>` param is a `Pat::Assign` wrapping the array/
+        // object pattern; unwrap it so the destructuring binding is still
+        // emitted (the `= [1,2]` default is handled separately via
+        // `get_param_default`). Mirrors `lower_fn_decl`.
+        let inner_pat = if let ast::Pat::Assign(assign) = param {
+            assign.left.as_ref()
+        } else {
+            param
+        };
+        if is_destructuring_pattern(inner_pat) {
+            destructuring_params.push((param_id, inner_pat.clone()));
         }
     }
 
@@ -493,9 +502,20 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
             arguments_object: None,
         });
         default_param_pats.push(param.pat.clone());
-        // Track destructuring patterns to generate extraction statements
-        if is_destructuring_pattern(&param.pat) {
-            destructuring_params.push((param_id, param.pat.clone()));
+        // Track destructuring patterns to generate extraction statements. A
+        // `function*([x, y] = [1, 2]) {}` param is a `Pat::Assign` wrapping the
+        // array/object pattern; unwrap it so the destructuring binding is still
+        // emitted (the `= [1,2]` default is applied via `get_param_default`).
+        // Mirrors `lower_fn_decl`. Without this, an async-generator EXPRESSION
+        // with a destructured-default param dropped the binding and `x`/`y`
+        // lowered to `js_throw_reference_error_unresolved_get`.
+        let inner_pat = if let ast::Pat::Assign(assign) = &param.pat {
+            assign.left.as_ref()
+        } else {
+            &param.pat
+        };
+        if is_destructuring_pattern(inner_pat) {
+            destructuring_params.push((param_id, inner_pat.clone()));
         }
     }
     for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -598,6 +598,10 @@ pub fn lower_module_full(
         for (id, name) in ctx.closure_display_names.drain() {
             module.closure_display_names.insert(id, name);
         }
+        // Flush generator param-prologue lengths (run param binding at call time).
+        for (id, len) in ctx.gen_param_prologue_len.drain() {
+            module.gen_param_prologue_len.insert(id, len);
+        }
         // #4101: flush captured function source text for `fn.toString()`.
         for (id, src) in ctx.closure_source_text.drain() {
             module.closure_source_text.insert(id, src);

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -197,6 +197,11 @@ pub struct LoweringContext {
     /// (static property key); flushed into `Module.closure_display_names`
     /// alongside `pending_functions`.
     pub(crate) closure_display_names: HashMap<FuncId, String>,
+    /// Per-generator count of leading parameter-prologue statements (default
+    /// guards + destructuring binding stmts) prepended to the body. Flushed
+    /// into `Module.gen_param_prologue_len`; the generator transform uses it to
+    /// run param binding synchronously at call time. See that field's docs.
+    pub(crate) gen_param_prologue_len: HashMap<FuncId, usize>,
     /// Test262 assignment name inference: when lowering `lhs = rhs`, a bare
     /// identifier lhs can provide the `NamedEvaluation` name for an anonymous
     /// function/class rhs. This slot is set only while lowering that rhs.

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -35,7 +35,7 @@
 // - `expr_member.rs` / `expr_assign.rs` / `expr_new.rs` (v0.5.339):
 //   property access, assignment, and `new C()` constructor calls.
 mod context;
-mod expr_assign;
+pub(crate) mod expr_assign;
 mod expr_call;
 mod expr_function;
 pub(crate) use expr_function::{capture_function_source, lower_fn_expr};

--- a/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
@@ -68,8 +68,17 @@ pub(super) fn lower_nested_fn_decl(
             arguments_object: None,
         });
         default_param_pats.push(param.pat.clone());
-        if is_destructuring_pattern(&param.pat) {
-            destructuring_params.push((param_id, param.pat.clone()));
+        // Unwrap a `Pat::Assign` (destructured param with a default, e.g.
+        // `function f([x, y] = [1, 2]) {}`) so the destructuring binding is
+        // still emitted; the default is applied via `get_param_default`.
+        // Mirrors `lower_fn_decl`.
+        let inner_pat = if let ast::Pat::Assign(assign) = &param.pat {
+            assign.left.as_ref()
+        } else {
+            &param.pat
+        };
+        if is_destructuring_pattern(inner_pat) {
+            destructuring_params.push((param_id, inner_pat.clone()));
         }
     }
     for (param, pat) in params.iter_mut().zip(default_param_pats.iter()) {

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -257,6 +257,7 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
         let stmts = generate_param_destructuring_stmts(ctx, pat, *param_id)?;
         destructuring_stmts.extend(stmts);
     }
+    let destructuring_prologue_len = destructuring_stmts.len();
 
     let outer_strict = ctx.current_strict;
     let is_strict = outer_strict || function_has_use_strict(&fn_decl.function);
@@ -285,6 +286,17 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
     // rationale). Without this, cross-module callers that pad missing args
     // with TAG_UNDEFINED read the param as `undefined` instead of its default.
     let default_stmts = build_default_param_stmts(&params);
+    // Record the param-prologue length for generators so the generator
+    // transform can run param binding synchronously at call time (spec
+    // FunctionDeclarationInstantiation order). Prologue = default guards +
+    // destructuring stmts, both prepended below. Only generators need this;
+    // for plain functions / async functions the prologue stays in the body.
+    if fn_decl.function.is_generator {
+        let prologue_len = default_stmts.len() + destructuring_prologue_len;
+        if prologue_len > 0 {
+            ctx.gen_param_prologue_len.insert(func_id, prologue_len);
+        }
+    }
     if !default_stmts.is_empty() {
         let mut new_body = default_stmts;
         new_body.append(&mut body);

--- a/crates/perry-hir/src/stable_hash/module.rs
+++ b/crates/perry-hir/src/stable_hash/module.rs
@@ -35,6 +35,7 @@ impl SH for Module {
             closure_display_names,
             closure_source_text,
             async_generator_funcs,
+            gen_param_prologue_len,
         } = self;
         name.hash(h);
         imports.hash(h);
@@ -82,6 +83,17 @@ impl SH for Module {
         for (id, src) in source_pairs {
             id.hash(h);
             src.hash(h);
+        }
+        // Generator param-prologue lengths drive the transform's prologue lift,
+        // which changes codegen output — include in the stable hash.
+        let mut prologue_pairs: Vec<(u32, usize)> = gen_param_prologue_len
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        prologue_pairs.sort_unstable_by_key(|(k, _)| *k);
+        for (id, len) in prologue_pairs {
+            id.hash(h);
+            (len as u64).hash(h);
         }
     }
 }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1161,6 +1161,43 @@ pub unsafe extern "C" fn js_native_call_method(
         }
     }
 
+    // A method stored as an own accessor — `{ get next() { return fn } }` or
+    // `Object.defineProperty(o, "next", { get })` — must invoke the getter
+    // (this = receiver) to obtain the method function, then call THAT. The big
+    // dispatch below reads the raw field slot, which holds no callable for an
+    // accessor-only property, so a fused `o.next(args)` mis-resolved to
+    // undefined (decomposed `const f = o.next; f(args)` worked because the read
+    // goes through the getter-aware property path). Hit by `yield*` over a
+    // sync/async iterator whose `next`/`value`/`done` are getters (test262
+    // yield-star-* with `get next()`). `get_accessor_descriptor` is a cheap
+    // keyed HashMap lookup (no deref), gated on the accessor hot-path flag so
+    // non-accessor programs skip it entirely.
+    if jsval.is_pointer() && crate::object::ACCESSORS_IN_USE.with(|c| c.get()) {
+        let obj_usize = crate::value::js_nanbox_get_pointer(object) as usize;
+        if obj_usize >= 0x100000 {
+            if let Some(acc) = crate::object::get_accessor_descriptor(obj_usize, method_name) {
+                if acc.get != 0 {
+                    let getter = (acc.get & crate::value::POINTER_MASK)
+                        as *const crate::closure::ClosureHeader;
+                    if !getter.is_null() {
+                        let prev_getter_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+                        let method_fn = crate::closure::js_closure_call0(getter);
+                        let bound =
+                            crate::closure::clone_closure_rebind_this(method_fn.to_bits(), object);
+                        IMPLICIT_THIS.with(|c| c.set(object.to_bits()));
+                        let result = crate::closure::js_native_call_value(
+                            f64::from_bits(bound),
+                            args_ptr,
+                            args_len,
+                        );
+                        IMPLICIT_THIS.with(|c| c.set(prev_getter_this));
+                        return result;
+                    }
+                }
+            }
+        }
+    }
+
     // Check if this is a JS handle (V8 object from JS runtime)
     if crate::value::is_js_handle(object) {
         let func_ptr =

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -72,10 +72,11 @@ fn await_async_generator_yield_operands(stmts: &mut Vec<Stmt>, next_id: &mut Loc
                 delegate: false,
             }) => Some(value),
             Stmt::Let {
-                init: Some(Expr::Yield {
-                    value,
-                    delegate: false,
-                }),
+                init:
+                    Some(Expr::Yield {
+                        value,
+                        delegate: false,
+                    }),
                 ..
             } => Some(value),
             Stmt::Return(Some(Expr::Yield {

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -3,6 +3,104 @@
 use super::*;
 use perry_hir::walker::walk_expr_children;
 
+/// For async generators, `yield E` evaluates as `AsyncGeneratorYield(?
+/// Await(E))` — the operand is awaited (one microtask tick) before being
+/// delivered to the consumer. So `yield Promise.reject(x)` awaits the rejection
+/// and throws `x` into the generator, and `yield Promise.resolve(v)` yields `v`,
+/// not the promise. Perry yielded the raw operand. This pass rewrites every
+/// statement-level non-delegate `yield E` (the only positions left after
+/// `hoist_yields`) into `let __ayield = await E; yield __ayield`. The `await`
+/// lowers to its own suspension state via the existing await machinery; the temp
+/// is a cross-state local that `collect_hoisted_vars` boxes. `yield*` delegation
+/// is left untouched — it awaits each delegated step through `delegate_await`.
+fn await_async_generator_yield_operands(stmts: &mut Vec<Stmt>, next_id: &mut LocalId) {
+    let mut out: Vec<Stmt> = Vec::with_capacity(stmts.len());
+    for mut stmt in std::mem::take(stmts) {
+        // Recurse into nested control-flow bodies first (mirrors
+        // `collect_vars_recursive`). Nested closures are not descended — their
+        // yields belong to inner generators.
+        match &mut stmt {
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                await_async_generator_yield_operands(then_branch, next_id);
+                if let Some(eb) = else_branch {
+                    await_async_generator_yield_operands(eb, next_id);
+                }
+            }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                await_async_generator_yield_operands(body, next_id);
+            }
+            Stmt::For { body, .. } => await_async_generator_yield_operands(body, next_id),
+            Stmt::Labeled { body, .. } => {
+                let mut wrapped = vec![std::mem::replace(body.as_mut(), Stmt::Break)];
+                await_async_generator_yield_operands(&mut wrapped, next_id);
+                // A labeled statement wraps a single loop/block (never a bare
+                // yield), so the rewrite only touches its inner body and the
+                // wrapper stays a single statement.
+                if let Some(inner) = wrapped.pop() {
+                    *body.as_mut() = inner;
+                }
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                await_async_generator_yield_operands(body, next_id);
+                if let Some(c) = catch {
+                    await_async_generator_yield_operands(&mut c.body, next_id);
+                }
+                if let Some(f) = finally {
+                    await_async_generator_yield_operands(f, next_id);
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases {
+                    await_async_generator_yield_operands(&mut case.body, next_id);
+                }
+            }
+            _ => {}
+        }
+
+        // Pull the non-delegate yield operand into a preceding `await`.
+        let yield_value: Option<&mut Option<Box<Expr>>> = match &mut stmt {
+            Stmt::Expr(Expr::Yield {
+                value,
+                delegate: false,
+            }) => Some(value),
+            Stmt::Let {
+                init: Some(Expr::Yield {
+                    value,
+                    delegate: false,
+                }),
+                ..
+            } => Some(value),
+            Stmt::Return(Some(Expr::Yield {
+                value,
+                delegate: false,
+            })) => Some(value),
+            _ => None,
+        };
+        if let Some(value) = yield_value {
+            let operand = value.take().map(|b| *b).unwrap_or(Expr::Undefined);
+            let tmp = alloc_local(next_id);
+            *value = Some(Box::new(Expr::LocalGet(tmp)));
+            out.push(Stmt::Let {
+                id: tmp,
+                name: format!("__ayield_{}", tmp),
+                ty: Type::Any,
+                mutable: true,
+                init: Some(Expr::Await(Box::new(operand))),
+            });
+        }
+        out.push(stmt);
+    }
+    *stmts = out;
+}
+
 /// Transform a single generator function into a state machine.
 pub fn transform_generator_function(
     func: &mut Function,
@@ -100,6 +198,13 @@ pub fn transform_generator_function_with_extra_captures(
     // local. Allocated before `local_id_before` so they are not double-counted
     // in `extra_local_ids`.
     hoist_yields_in_stmts(&mut func.body, next_local_id);
+
+    // Async generators await each `yield` operand before delivering it (spec
+    // `AsyncGeneratorYield(? Await(value))`). Run after `hoist_yields` so every
+    // remaining yield is at a statement-level position this pass recognises.
+    if is_async_generator {
+        await_async_generator_yield_operands(&mut func.body, next_local_id);
+    }
 
     let state_id = alloc_local(next_local_id);
     let done_id = alloc_local(next_local_id);

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -67,6 +67,27 @@ pub fn transform_generator_function_with_extra_captures(
     let is_async_generator = func.is_async;
     func.is_async = false;
 
+    // Spec: generator/async-generator parameter binding
+    // (FunctionDeclarationInstantiation) runs *synchronously* when the function
+    // is called — before the generator object is created — so an
+    // iterator/RequireObjectCoercible/TDZ error during destructuring or default
+    // evaluation throws at call time, not on the first `.next()`. Lowering
+    // prepends the param prologue (default guards + destructuring binding) to
+    // the body; here we lift those leading statements out so they run in the
+    // outer wrapper (run-at-call) rather than state 0 of the state machine.
+    // `gen_prologue_len` returns 0 for generators with no destructuring/default
+    // params, leaving this fully inert for the common case.
+    let prologue_len = super::gen_prologue_len(func.id);
+    let param_prologue: Vec<Stmt> = if prologue_len > 0 && prologue_len <= func.body.len() {
+        func.body.drain(..prologue_len).collect()
+    } else {
+        Vec::new()
+    };
+    // Locals the prologue binds (destructured targets + scaffolding temps). They
+    // are written in the outer wrapper but read by the state machine, so they
+    // must be boxed captures like any other cross-state local.
+    let prologue_hoist = collect_hoisted_vars(&param_prologue);
+
     // #321: hoist `yield` / `yield*` that live inside a larger expression
     // (`return (yield 1) + (yield 2)`, call args, array/object literals, etc.)
     // into ordered `let __ygen_N = yield E;` temps so the linearizer below only
@@ -157,8 +178,14 @@ pub fn transform_generator_function_with_extra_captures(
 
     // Collect hoisted var IDs first so we know which Lets to rewrite
     let hoisted_for_rewrite = collect_hoisted_vars(&func.body);
-    let hoisted_ids: std::collections::HashSet<LocalId> =
+    let mut hoisted_ids: std::collections::HashSet<LocalId> =
         hoisted_for_rewrite.iter().map(|(id, _, _)| *id).collect();
+    // The lifted param prologue defines locals (destructured targets + temps)
+    // that the state machine reads; treat them as hoisted so their `Let`s route
+    // through the prealloc box (`js_box_set`) instead of shadowing the capture.
+    for (id, _, _) in &prologue_hoist {
+        hoisted_ids.insert(*id);
+    }
 
     // Rewrite `Let { id, init: Some(expr) }` → `Expr(LocalSet(id, expr))` for hoisted
     // variables inside state bodies. Without this, the Let creates a fresh local that
@@ -387,6 +414,13 @@ pub fn transform_generator_function_with_extra_captures(
     // Hoist variable declarations from the original body — collected
     // here (before the prealloc emit) so the prealloc set is complete.
     let mut hoisted = hoisted_for_rewrite;
+    // Box + capture the lifted prologue's locals so the state machine can read
+    // the destructured param values it bound in the outer wrapper.
+    for v in &prologue_hoist {
+        if !hoisted.iter().any(|(id, _, _)| *id == v.0) {
+            hoisted.push(v.clone());
+        }
+    }
     for route in &catches {
         if let (Some(param_id), Some(param_name)) = (route.param_id, route.param_name.as_ref()) {
             if !hoisted.iter().any(|(id, _, _)| *id == param_id) {
@@ -522,6 +556,18 @@ pub fn transform_generator_function_with_extra_captures(
         mutable: true,
         init: Some(Expr::Undefined),
     });
+
+    // Run the lifted parameter prologue in the outer wrapper, after the box
+    // stubs are in place (so its destructured-target `Let`s route to
+    // `js_box_set` on the prealloc'd boxes the state machine captures) and
+    // before the generator object is built/returned. Any iterator /
+    // RequireObjectCoercible / TDZ error here propagates synchronously out of
+    // the call, matching spec FunctionDeclarationInstantiation order.
+    if !param_prologue.is_empty() {
+        let mut prologue = param_prologue;
+        rewrite_hoisted_lets_in_stmts(&mut prologue, &hoisted_ids);
+        new_body.extend(prologue);
+    }
 
     // Build captures: state, done, sent, params, hoisted vars, extra locals
     let mut captures = vec![state_id, done_id, sent_id, executing_id];

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -65,6 +65,35 @@ pub(crate) use rewrite_returns::{
 thread_local! {
     static ASYNC_GENERATOR_FUNC_IDS: std::cell::RefCell<std::collections::HashSet<FuncId>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
+    // Per-generator count of leading param-prologue statements (default guards +
+    // destructuring binding) to lift from the state machine back into the outer
+    // wrapper, so generator param binding runs synchronously at call time (spec
+    // FunctionDeclarationInstantiation). Keyed by func_id. Populated from
+    // `module.gen_param_prologue_len` at the start of `transform_generators`;
+    // the closure handler copies an entry to the synthetic body func_id it
+    // creates so `transform_generator_function_with_extra_captures` can read it
+    // by the function it actually transforms.
+    static GEN_PROLOGUE_LENS: std::cell::RefCell<std::collections::HashMap<FuncId, usize>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Read (and for closures, alias) the recorded param-prologue length for a
+/// generator function id. Returns 0 when none was recorded (the common case —
+/// no destructuring / default params — keeping the lift fully inert).
+pub(crate) fn gen_prologue_len(func_id: FuncId) -> usize {
+    GEN_PROLOGUE_LENS.with(|m| m.borrow().get(&func_id).copied().unwrap_or(0))
+}
+
+/// Copy a recorded prologue length from `from` to `to`. Used by the closure
+/// handler: the original `Expr::Closure` func_id carries the lowering-recorded
+/// length, but the transform runs on a synthetic `Function` with a fresh id.
+fn alias_prologue_len(from: FuncId, to: FuncId) {
+    GEN_PROLOGUE_LENS.with(|m| {
+        let mut m = m.borrow_mut();
+        if let Some(len) = m.get(&from).copied() {
+            m.insert(to, len);
+        }
+    });
 }
 
 /// Record a func_id as belonging to an `async function*` (declaration or
@@ -80,6 +109,15 @@ fn record_async_generator_func(id: FuncId) {
 pub fn transform_generators(module: &mut Module) {
     // #3664: reset the per-thread async-generator accumulator for this module.
     ASYNC_GENERATOR_FUNC_IDS.with(|s| s.borrow_mut().clear());
+    // Load the param-prologue lengths recorded by lowering so the transform can
+    // lift generator param binding into the outer wrapper (run at call time).
+    GEN_PROLOGUE_LENS.with(|m| {
+        let mut m = m.borrow_mut();
+        m.clear();
+        for (id, len) in &module.gen_param_prologue_len {
+            m.insert(*id, *len);
+        }
+    });
 
     // Compute the next available local and func IDs by scanning the module
     let mut next_local_id = compute_max_local_id(module) + 1;
@@ -336,6 +374,10 @@ fn transform_generator_closures_in_stmts(
                             *next_func_id += 1;
                             id
                         };
+                        // The transform reads the prologue length by the func it
+                        // transforms (the synthetic body fn); lowering recorded
+                        // it under the original closure func_id. Alias it across.
+                        alias_prologue_len(*func_id, synth_id);
                         let mut synth = Function {
                             id: synth_id,
                             name: "__gen_closure_body".to_string(),

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -263,6 +263,12 @@ crates/perry-runtime/src/regex.rs
 # %TypedArray%.prototype iterator brand-check + array-like/iterable constructor
 # additions. Splitting per concern is tracked under #1435.
 crates/perry-runtime/src/typedarray/mod.rs
+# Generator/async-generator state-machine lowering core (linearize → states →
+# next/return/throw step closures + async-step driver). Crossed the 2000-line
+# gate after the standalone async-generator parity work: synchronous param-
+# prologue lift (run param binding at call time) + per-yield operand Await.
+# Splitting the state builder from the closure assembly is tracked under #1435.
+crates/perry-transform/src/generator/lower.rs
 EOF
 )
 


### PR DESCRIPTION
Drives standalone `async function*` (declarations + expressions) test262 parity from **57.7% → 93.0%** across `language/expressions/async-generator` + `language/statements/async-generator` (pass 512 → 826 / 888, runtime-fail 181 → 21, compile-fail 0). Four root causes, each spec-justified, gated to stay inert outside the affected shapes.

## Root causes & fixes

**1. Destructuring param + default dropped the binding; destructuring defaults skipped NamedEvaluation** (`fix(hir)`)
- `async function*([x,y,z]=[1,2,3]){}` (expression form) lowered only the default guard, not the destructuring binding — `x/y/z` resolved to `js_throw_reference_error_unresolved_get`. `lower_arrow` / `lower_fn_expr` / `nested_fn_decl` now unwrap `Pat::Assign` to the inner pattern before `is_destructuring_pattern`, mirroring the already-correct `lower_fn_decl`.
- `[fn = function(){}]` left `fn.name` empty instead of `"fn"`. `destructuring/pattern_binding` now threads the single-name binding into `ctx.assignment_inferred_name` for anonymous fn/arrow/class defaults at all three default sites.

**2. Generator param binding ran on first `.next()` instead of at call time** (`fix(transform)`)
- Per spec, generator/async-generator parameter binding (FunctionDeclarationInstantiation) runs **synchronously when the function is called**, before the generator object is created — so an iterator / RequireObjectCoercible / TDZ error during destructuring or default evaluation throws at call time. Perry linearized the param prologue into state 0 of `.next()`, so a test that only calls `f(badIterable)` (expecting a synchronous throw) never ran it.
- Lowering records the prologue length per generator func_id (`Module.gen_param_prologue_len`); the transform lifts those leading statements into the outer wrapper, boxing their bound locals so the state machine still reads the destructured values. Gated on `is_generator` (plain async functions keep reject-not-throw semantics) and inert when `prologue_len == 0`. **This fix alone collapsed runtime-fail 181 → 21.**

**3. `yield E` didn't `Await` its operand** (`fix(transform)`)
- Per spec, `yield E` in an async generator is `AsyncGeneratorYield(? Await(E))` — `yield Promise.reject(x)` throws `x` into the generator and `yield Promise.resolve(v)` yields `v`. A pre-pass (after `hoist_yields`) rewrites each statement-level non-delegate `yield E` into `let __ayield = await E; yield __ayield`, reusing the existing suspension machinery. `yield*` delegation untouched.

## Verification & zero-regression check
- All four fixes verified byte-identical to `node --experimental-strip-types`.
- Targeted sweep over `language/{expressions,statements}/{generators,async-function}` (shared state machine): 90.4%, no new crashes — the param-prologue lift is spec-correct for sync generators too.
- Broad shard `0/12` over `built-ins language` vs an `origin/main` baseline (same shard/harness): **+33 pass, −10 runtime-fail, compile-fail unchanged (18)**. The one apparent "regression" (`TypedArray/prototype/forEach/returns-undefined.js`) is a pre-existing **non-deterministic** GC/layout-sensitive segfault (passed run 3/3 on a commit-1-only build) surfaced by layout shift, not introduced logic.

## Remaining (62, mostly out of scope)
~50 are precise `yield*` async-delegation tests (exact getter ordering, async-from-sync ticks, `return`/`throw` forwarding, abrupt-completion propagation) — a separate AsyncGeneratorYield* reimplementation. ~12 are prototype-chain edge cases.