### PR TITLE
fix(runtime): built-ins/Array test262 parity (v2)

### DIFF
--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -321,13 +321,19 @@ pub(crate) fn lower_array_method(
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
         "reduce" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.reduce expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let cb_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → runtime TypeError (callback validation on undefined),
+            // not compile-fail.
+            let cb_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             let (has_initial, initial_box) = if args.len() == 2 {
                 let init = lower_expr(ctx, &args[1])?;
                 (1i32, init)
@@ -351,13 +357,19 @@ pub(crate) fn lower_array_method(
             ))
         }
         "reduceRight" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.reduceRight expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let cb_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → runtime TypeError (callback validation on undefined),
+            // not compile-fail.
+            let cb_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             let (has_initial, initial_box) = if args.len() == 2 {
                 let init = lower_expr(ctx, &args[1])?;
                 (1i32, init)
@@ -441,13 +453,18 @@ pub(crate) fn lower_array_method(
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)))
         }
         "includes" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.includes expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let val_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → includes(undefined), not compile-fail.
+            let val_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             // #2804: optional fromIndex (2nd arg). has_from=1 + lowered index
             // when present; otherwise has_from=0 with a placeholder DOUBLE.
             let (from_box, has_from) = if args.len() == 2 {
@@ -484,13 +501,18 @@ pub(crate) fn lower_array_method(
             Ok(blk.bitcast_i64_to_double(&tagged))
         }
         "indexOf" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.indexOf expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let val_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → search for `undefined` from index 0, not compile-fail.
+            let val_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             // #2804: optional fromIndex (2nd arg). has_from=1 + lowered index
             // when present; otherwise has_from=0 with a placeholder DOUBLE.
             let (from_box, has_from) = if args.len() == 2 {
@@ -519,13 +541,18 @@ pub(crate) fn lower_array_method(
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
         "lastIndexOf" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
                     "perry-codegen: Array.lastIndexOf expects 1-2 args, got {}",
                     args.len()
                 );
             }
-            let val_box = lower_expr(ctx, &args[0])?;
+            // 0-arg → search for `undefined`, not compile-fail.
+            let val_box = if let Some(arg) = args.first() {
+                lower_expr(ctx, arg)?
+            } else {
+                crate::nanbox::double_literal(f64::from_bits(TAG_UNDEFINED))
+            };
             // Optional fromIndex: with has_from=1 pass the lowered index;
             // when absent pass has_from=0 (runtime defaults to length-1) and
             // reuse `val_box` as an ignored placeholder DOUBLE operand.

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -521,8 +521,15 @@ pub(super) fn try_array_only_methods(
                 if !recv_is_class
                     && matches!(
                         method_name,
-                        "map" | "filter" | "forEach" | "find" | "findIndex" | "findLast"
-                            | "findLastIndex" | "some" | "every"
+                        "map"
+                            | "filter"
+                            | "forEach"
+                            | "find"
+                            | "findIndex"
+                            | "findLast"
+                            | "findLastIndex"
+                            | "some"
+                            | "every"
                     )
                     && call.args.len() >= 2
                     && call.args.iter().all(|a| a.spread.is_none())

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -506,6 +506,34 @@ pub(super) fn try_array_only_methods(
                     || chain_roots_at_stream(ctx, member_obj)
                     || chain_roots_at_iterator_from(member_obj)
                     || is_util_mime_params_receiver(ctx, member_obj);
+                // thisArg routing: the dense `Expr::Array<Method>` fast paths
+                // carry only the callback and silently drop a 2nd positional
+                // `thisArg` argument, so `[x].every(cb, thisArg)` ran the
+                // callback with `this === undefined` (test262 §15.4.4.* `-5-*`
+                // / `-7-*`). The generic `Expr::ArrayLikeMethod` lowering binds
+                // the callback `this` via the spec-complete `js_arraylike_*`
+                // runtime entry points (ToObject + LengthOfArrayLike + a
+                // ThisGuard around each invocation), so when an explicit thisArg
+                // is supplied route the callback iterators through it. Gated on
+                // `!recv_is_class` (which already excludes Map/Set/class
+                // receivers — those keep their own forEach contract) and on the
+                // 2nd argument being a plain positional (no spread).
+                if !recv_is_class
+                    && matches!(
+                        method_name,
+                        "map" | "filter" | "forEach" | "find" | "findIndex" | "findLast"
+                            | "findLastIndex" | "some" | "every"
+                    )
+                    && call.args.len() >= 2
+                    && call.args.iter().all(|a| a.spread.is_none())
+                {
+                    let receiver = Box::new(lower_expr(ctx, &member.obj)?);
+                    return Ok(Ok(Expr::ArrayLikeMethod {
+                        method: method_name.to_string(),
+                        receiver,
+                        args,
+                    }));
+                }
                 match method_name {
                     "reduce" if !args.is_empty() && !recv_is_class => {
                         let array_expr = lower_expr(ctx, &member.obj)?;

--- a/crates/perry-hir/src/lower/expr_call/inline_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/inline_array_methods.rs
@@ -36,8 +36,15 @@ pub(super) fn try_inline_array_methods(
                     // explicit thisArg is supplied with no spread.
                     if matches!(
                         method_name,
-                        "map" | "filter" | "forEach" | "find" | "findIndex" | "findLast"
-                            | "findLastIndex" | "some" | "every"
+                        "map"
+                            | "filter"
+                            | "forEach"
+                            | "find"
+                            | "findIndex"
+                            | "findLast"
+                            | "findLastIndex"
+                            | "some"
+                            | "every"
                     ) && call.args.len() >= 2
                         && call.args.iter().all(|a| a.spread.is_none())
                     {

--- a/crates/perry-hir/src/lower/expr_call/inline_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/inline_array_methods.rs
@@ -27,6 +27,26 @@ pub(super) fn try_inline_array_methods(
                 if let ast::Expr::Array(_arr_lit) = member.obj.as_ref() {
                     // Lower the array literal
                     let array_expr = lower_expr(ctx, &member.obj)?;
+                    // thisArg routing: the dense `Expr::Array<Method>` fast
+                    // paths drop a 2nd positional `thisArg`, so
+                    // `[x].map(cb, thisArg)` ran the callback with
+                    // `this === undefined`. Route the callback iterators
+                    // through the spec-complete `Expr::ArrayLikeMethod`
+                    // lowering (which binds the callback `this`) when an
+                    // explicit thisArg is supplied with no spread.
+                    if matches!(
+                        method_name,
+                        "map" | "filter" | "forEach" | "find" | "findIndex" | "findLast"
+                            | "findLastIndex" | "some" | "every"
+                    ) && call.args.len() >= 2
+                        && call.args.iter().all(|a| a.spread.is_none())
+                    {
+                        return Ok(Ok(Expr::ArrayLikeMethod {
+                            method: method_name.to_string(),
+                            receiver: Box::new(array_expr),
+                            args,
+                        }));
+                    }
                     match method_name {
                         "join" => {
                             // ['a', 'b'].join(separator?) -> string

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -164,6 +164,26 @@ pub(super) fn try_local_array_methods(
                 // runtime but built-in constructors aren't first-class closure objects.
                 if is_not_string {
                     if let Some(array_id) = ctx.lookup_local(&arr_name) {
+                        // thisArg routing: the dense `Expr::Array<Method>` fast
+                        // paths drop a 2nd positional `thisArg`, so
+                        // `arr.every(cb, thisArg)` ran the callback with
+                        // `this === undefined`. Route the callback iterators
+                        // through the spec-complete `Expr::ArrayLikeMethod`
+                        // lowering (which binds the callback `this`) when an
+                        // explicit thisArg is supplied with no spread.
+                        if matches!(
+                            method_name,
+                            "map" | "filter" | "forEach" | "find" | "findIndex" | "findLast"
+                                | "findLastIndex" | "some" | "every"
+                        ) && call.args.len() >= 2
+                            && call.args.iter().all(|a| a.spread.is_none())
+                        {
+                            return Ok(Ok(Expr::ArrayLikeMethod {
+                                method: method_name.to_string(),
+                                receiver: Box::new(Expr::LocalGet(array_id)),
+                                args,
+                            }));
+                        }
                         match method_name {
                             "push" => {
                                 if args.is_empty() {

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -173,8 +173,15 @@ pub(super) fn try_local_array_methods(
                         // explicit thisArg is supplied with no spread.
                         if matches!(
                             method_name,
-                            "map" | "filter" | "forEach" | "find" | "findIndex" | "findLast"
-                                | "findLastIndex" | "some" | "every"
+                            "map"
+                                | "filter"
+                                | "forEach"
+                                | "find"
+                                | "findIndex"
+                                | "findLast"
+                                | "findLastIndex"
+                                | "some"
+                                | "every"
                         ) && call.args.len() >= 2
                             && call.args.iter().all(|a| a.spread.is_none())
                         {

--- a/crates/perry-runtime/src/array/concat_reverse.rs
+++ b/crates/perry-runtime/src/array/concat_reverse.rs
@@ -387,6 +387,14 @@ pub extern "C" fn js_array_fill_range(
             end,
         ) as *mut ArrayHeader;
     }
+    // ECMA-262 §23.1.3.6: ToIntegerOrInfinity(start) then (end) run BEFORE the
+    // length==0 early-out, and each fires `valueOf` / `Symbol.toPrimitive`
+    // (propagating abrupt completions — test262 fill/return-abrupt-from-start/
+    // end). The previous `idx.is_nan()` clamp silently mapped a NaN-boxed
+    // object argument to 0 and never threw. The default-end sentinel
+    // (+Infinity from codegen) is a real f64 and survives coercion unchanged.
+    let start = crate::builtins::js_to_integer_or_infinity(start);
+    let end = crate::builtins::js_to_integer_or_infinity(end);
     unsafe {
         let len = (*arr).length as i64;
         if len == 0 {

--- a/crates/perry-runtime/src/array/generic.rs
+++ b/crates/perry-runtime/src/array/generic.rs
@@ -690,7 +690,7 @@ pub extern "C" fn js_arraylike_indexOf(recv: f64, value: f64, from: f64, has_fro
     let mut start = if has_from == 0 {
         0
     } else {
-        let n = if from.is_nan() { 0.0 } else { from.trunc() };
+        let n = crate::array::search::from_index_to_integer(from);
         if n >= len as f64 {
             return -1.0;
         } else if n >= 0.0 {
@@ -726,7 +726,7 @@ pub extern "C" fn js_arraylike_lastIndexOf(recv: f64, value: f64, from: f64, has
     let mut start = if has_from == 0 {
         len - 1
     } else {
-        let n = if from.is_nan() { 0.0 } else { from.trunc() };
+        let n = crate::array::search::from_index_to_integer(from);
         if n >= 0.0 {
             (n as i64).min(len - 1)
         } else if n >= -(len as f64) {
@@ -757,7 +757,7 @@ pub extern "C" fn js_arraylike_includes(recv: f64, value: f64, from: f64, has_fr
     let mut start = if has_from == 0 {
         0
     } else {
-        let n = if from.is_nan() { 0.0 } else { from.trunc() };
+        let n = crate::array::search::from_index_to_integer(from);
         if n >= len as f64 {
             return boxed_bool(false);
         } else if n >= 0.0 {

--- a/crates/perry-runtime/src/array/immutable.rs
+++ b/crates/perry-runtime/src/array/immutable.rs
@@ -283,39 +283,24 @@ pub extern "C" fn js_array_copy_within(
             end_value,
         ) as *mut ArrayHeader;
     }
+    // Spec order (ECMA-262 §23.1.3.4): ToIntegerOrInfinity(target), then
+    // (start), then (end). Each coerces via ToNumber → fires `valueOf` /
+    // `Symbol.toPrimitive` and propagates abrupt completions (test262
+    // copyWithin/return-abrupt-from-target/start/end). The previous `as isize`
+    // raw cast on a NaN-boxed object argument silently produced garbage and
+    // never threw.
+    let len_i64 = unsafe { (*arr).length as i64 };
+    let t = copy_within_relative_index(target, len_i64);
+    let s = copy_within_relative_index(start, len_i64);
+    let e = if has_end != 0 && !crate::value::JSValue::from_bits(end.to_bits()).is_undefined() {
+        copy_within_relative_index(end, len_i64)
+    } else {
+        len_i64
+    };
     unsafe {
-        let len = (*arr).length as isize;
+        let len = len_i64 as isize;
+        let (t, s, e) = (t as isize, s as isize, e as isize);
         let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-
-        // Normalize target
-        let mut t = target as isize;
-        if t < 0 {
-            t += len;
-        }
-        if t < 0 {
-            t = 0;
-        }
-
-        // Normalize start
-        let mut s = start as isize;
-        if s < 0 {
-            s += len;
-        }
-        if s < 0 {
-            s = 0;
-        }
-
-        // Normalize end
-        let mut e = if has_end != 0 { end as isize } else { len };
-        if e < 0 {
-            e += len;
-        }
-        if e < 0 {
-            e = 0;
-        }
-        if e > len {
-            e = len;
-        }
 
         let count = (e - s).min(len - t);
         if count <= 0 {

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -93,12 +93,23 @@ pub extern "C" fn js_array_map(
     unsafe {
         let length = (*arr).length;
         let elements_ptr = array_elements_ptr(arr);
-
-        // Allocate at the source length so skipped sparse slots remain holes.
-        let result = js_array_alloc_with_length(length);
-        let result_elements =
-            (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
         let arr_value = array_receiver_value(arr);
+
+        // ECMA-262 §23.1.3.20 step 5: ArraySpeciesCreate(O, len) runs BEFORE
+        // the iteration — it reads `O.constructor` / `@@species` (firing any
+        // accessor, propagating a poison throw) and throws TypeError on a
+        // non-constructor species, so a bad constructor aborts before the
+        // callback is ever invoked. For the common case (plain array whose
+        // constructor is the intrinsic `Array`) this returns a fresh plain
+        // array, identical to the prior `js_array_alloc_with_length`.
+        let result_box = crate::array::species::array_species_create(arr_value, length as usize);
+        let is_plain = crate::array::species::species_result_is_plain_array(result_box);
+        let result = crate::value::js_nanbox_get_pointer(result_box) as *mut ArrayHeader;
+        let result_elements = if is_plain {
+            (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64
+        } else {
+            ptr::null_mut()
+        };
 
         for i in 0..length as usize {
             let Some(element) = present_array_element(elements_ptr, i) else {
@@ -106,24 +117,18 @@ pub extern "C" fn js_array_map(
             };
             // JS .map() callback receives (element, index, array).
             let mapped = js_closure_call3(callback, element, i as f64, arr_value);
-            // GC_STORE_AUDIT(INIT): map result is unpublished; slot layout is noted immediately below.
-            ptr::write(result_elements.add(i), mapped);
-            let mapped_bits = mapped.to_bits();
-            if length <= 64 {
-                // Fast path: skip the generational write barrier.
-                // `result` was just allocated; for length ≤ 64 it stays
-                // in the nursery for the whole loop in practice, so the
-                // young→old barrier is redundant — only the layout slot
-                // metadata is needed for GC tracing. If a future GC
-                // policy starts tenuring nursery objects mid-loop
-                // (e.g. aggressive evacuation under
-                // `PERRY_GC_FORCE_EVACUATE=1` triggered by the callback
-                // allocating), this path needs the full barrier helper
-                // because subsequent stores would miss the remembered
-                // set. The 64-element cap keeps that probability low.
-                note_array_slot_layout_only(result, i, mapped_bits);
+            if is_plain {
+                // GC_STORE_AUDIT(INIT): plain result is unpublished; slot layout noted below.
+                ptr::write(result_elements.add(i), mapped);
+                let mapped_bits = mapped.to_bits();
+                if length <= 64 {
+                    note_array_slot_layout_only(result, i, mapped_bits);
+                } else {
+                    note_array_slot(result, i, mapped_bits);
+                }
             } else {
-                note_array_slot(result, i, mapped_bits);
+                // Custom species container: CreateDataPropertyOrThrow via [[Set]].
+                crate::array::species::species_result_set(result_box, i, mapped);
             }
         }
 
@@ -173,12 +178,16 @@ pub extern "C" fn js_array_filter(
     unsafe {
         let length = (*arr).length;
         let elements_ptr = array_elements_ptr(arr);
-
-        // Allocate result array with same capacity (might be smaller)
-        let mut result = js_array_alloc(length);
         let arr_value = array_receiver_value(arr);
-        // #854: `js_array_push_f64` already maintains `(*result).length`, so the
-        // separate `result_len` counter that used to live here was dead.
+
+        // ECMA-262 §23.1.3.7 step 5: ArraySpeciesCreate(O, 0) runs before the
+        // iteration (validates `O.constructor` / `@@species`, throwing on a
+        // poisoned getter or non-constructor species before the callback runs).
+        let result_box = crate::array::species::array_species_create(arr_value, 0);
+        let is_plain = crate::array::species::species_result_is_plain_array(result_box);
+        let mut result = crate::value::js_nanbox_get_pointer(result_box) as *mut ArrayHeader;
+        // #854: `js_array_push_f64` already maintains `(*result).length`.
+        let mut to = 0usize;
 
         for i in 0..length as usize {
             let Some(element) = present_array_element(elements_ptr, i) else {
@@ -187,7 +196,12 @@ pub extern "C" fn js_array_filter(
             let keep = js_closure_call3(callback, element, i as f64, arr_value);
             // Proper truthy check: handles NaN-boxed booleans (TAG_FALSE != 0.0 but is falsy)
             if crate::value::js_is_truthy(keep) != 0 {
-                result = js_array_push_f64(result, element);
+                if is_plain {
+                    result = js_array_push_f64(result, element);
+                } else {
+                    crate::array::species::species_result_set(result_box, to, element);
+                    to += 1;
+                }
             }
         }
 

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -16,6 +16,7 @@ mod push_pop;
 mod reduce_right;
 mod search;
 mod sort;
+mod species;
 mod splice_slice;
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/array/search.rs
+++ b/crates/perry-runtime/src/array/search.rs
@@ -17,6 +17,22 @@ unsafe fn present_array_element(elements_ptr: *const f64, index: usize) -> Optio
     (element.to_bits() != crate::value::TAG_HOLE).then_some(element)
 }
 
+/// ECMA-262 ToIntegerOrInfinity applied to a possibly non-numeric `fromIndex`
+/// argument. The codegen passes the raw (NaN-boxed) value through, so a string
+/// / boolean / null / object `fromIndex` (`"3E0"`, `"0x0003"`, `true`, `null`,
+/// `{valueOf}`) must be ToNumber-coerced first — the previous `from.is_nan()`
+/// shortcut treated every NaN-boxed value as NaN→0. Returns the truncated
+/// integer (or ±Infinity, whose `trunc()` is itself).
+#[inline]
+pub(crate) fn from_index_to_integer(from: f64) -> f64 {
+    let n = crate::builtins::js_number_coerce(from);
+    if n.is_nan() {
+        0.0
+    } else {
+        n.trunc()
+    }
+}
+
 #[inline(always)]
 unsafe fn array_element_get_value(elements_ptr: *const f64, index: usize) -> f64 {
     let element = *elements_ptr.add(index);
@@ -75,11 +91,7 @@ fn forward_start_index(length: i64, from_index: f64, has_from: i32) -> Option<i6
     if has_from == 0 {
         return Some(0);
     }
-    let n = if from_index.is_nan() {
-        0.0
-    } else {
-        from_index.trunc()
-    };
+    let n = from_index_to_integer(from_index);
     if n >= length as f64 {
         // Covers +Infinity and any fromIndex past the end.
         None
@@ -166,11 +178,7 @@ pub extern "C" fn js_array_last_index_of_jsvalue(
         let start: i64 = if has_from == 0 {
             length - 1
         } else {
-            let n = if from_index.is_nan() {
-                0.0
-            } else {
-                from_index.trunc()
-            };
+            let n = from_index_to_integer(from_index);
             if n >= length as f64 {
                 length - 1
             } else if n >= 0.0 {
@@ -203,11 +211,7 @@ pub extern "C" fn js_array_last_index_of_jsvalue(
         let start: i64 = if has_from == 0 {
             length - 1
         } else {
-            let n = if from_index.is_nan() {
-                0.0
-            } else {
-                from_index.trunc()
-            };
+            let n = from_index_to_integer(from_index);
             if n >= length as f64 {
                 length - 1
             } else if n >= 0.0 {

--- a/crates/perry-runtime/src/array/species.rs
+++ b/crates/perry-runtime/src/array/species.rs
@@ -1,0 +1,181 @@
+//! `ArraySpeciesCreate` (ECMA-262 §23.1.5.1) and its `SpeciesConstructor`
+//! reads for the `Array.prototype` methods that allocate a fresh result —
+//! `map`, `filter`, `slice`, `splice`, `concat`.
+//!
+//! Each of those methods must, before populating the result:
+//!   1. `Get(O, "constructor")` — runs any own accessor (observable, may throw).
+//!   2. If that is an object, `Get(C, @@species)` (observable, may throw).
+//!   3. Validate the resolved species is a constructor (else **TypeError**).
+//!   4. `Construct(species, « length »)` for the result container.
+//!
+//! When there is no custom species (the overwhelmingly common case — a plain
+//! array whose `constructor` resolves to the intrinsic `Array`) we take a fast
+//! path that allocates a plain `ArrayHeader` directly: observationally
+//! identical, since `Array[@@species]` returns `Array` itself.
+
+use super::ArrayHeader;
+use crate::value::{JSValue, TAG_NULL, TAG_UNDEFINED};
+
+/// The resolved species for an `ArraySpeciesCreate`: either the default
+/// intrinsic (fast plain-array allocation) or a user `Construct` target.
+pub(crate) enum SpeciesChoice {
+    Default,
+    Custom(f64),
+}
+
+/// `Type(value) is Object` — a heap pointer that is not a Symbol.
+fn is_object_value(value: f64) -> bool {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+    let raw = crate::value::js_nanbox_get_pointer(value) as usize;
+    raw >= 0x10000 && !crate::symbol::is_registered_symbol(raw)
+}
+
+/// `IsConstructor(value)` — a user `class` ref, or a callable that is not a
+/// non-constructable built-in. Mirrors the typed-array species check.
+fn is_constructor(value: f64) -> bool {
+    if crate::object::class_ref_id(value).is_some() {
+        return true;
+    }
+    crate::collection_iter::is_callable(value)
+        && !crate::object::builtin_closure_is_non_constructable_value(value)
+}
+
+/// `Get(originalArray, "constructor")` — fires an own accessor and walks the
+/// prototype chain (resolving to `Array.prototype.constructor` = the intrinsic
+/// `Array` for an ordinary array). Propagates a poisoned-getter exception.
+unsafe fn read_constructor(original: f64) -> f64 {
+    let key = crate::string::js_string_from_bytes(b"constructor".as_ptr(), 11);
+    let key_v = f64::from_bits(JSValue::string_ptr(key).bits());
+    crate::object::js_object_get_property_key(original, key_v)
+}
+
+/// `Get(C, @@species)` — runs any species getter, propagating exceptions.
+unsafe fn get_species(c: f64) -> f64 {
+    let sp = crate::symbol::well_known_symbol("species");
+    if sp.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let sym_f64 = f64::from_bits(JSValue::pointer(sp as *const u8).bits());
+    crate::symbol::js_object_get_symbol_property(c, sym_f64)
+}
+
+/// The intrinsic `Array` constructor value (for the default fast-path check).
+fn intrinsic_array() -> f64 {
+    crate::object::js_get_global_this_builtin_value(b"Array".as_ptr(), 5)
+}
+
+/// `SpeciesConstructor` portion of `ArraySpeciesCreate`: resolve the result
+/// constructor, returning `Default` for the intrinsic / undefined case and
+/// `Custom(S)` for a usable user constructor. Throws on a non-constructor
+/// species; propagates any user getter exception.
+unsafe fn resolve_species(original: f64) -> SpeciesChoice {
+    // ECMA-262 §23.1.5.1: only arrays consult `constructor`; a non-array
+    // receiver (the generic `.call(arrayLike)` form) always gets a plain array.
+    if crate::value::js_is_truthy(crate::array::js_array_is_array(original)) == 0 {
+        return SpeciesChoice::Default;
+    }
+    let c = read_constructor(original);
+    let cv = JSValue::from_bits(c.to_bits());
+    // step 5: if Type(C) is Object, C = Get(C, @@species); null → undefined.
+    let mut c = c;
+    if is_object_value(c) {
+        let s = get_species(c);
+        let sv = JSValue::from_bits(s.to_bits());
+        c = if sv.to_bits() == TAG_NULL {
+            f64::from_bits(TAG_UNDEFINED)
+        } else {
+            s
+        };
+    }
+    let cv = JSValue::from_bits(c.to_bits());
+    // step 6: undefined → default ArrayCreate.
+    if cv.is_undefined() {
+        return SpeciesChoice::Default;
+    }
+    // Fast path: the intrinsic Array constructor → plain allocation
+    // (observationally identical to Construct(%Array%, « len »)).
+    if c.to_bits() == intrinsic_array().to_bits() {
+        return SpeciesChoice::Default;
+    }
+    // step 7: a non-constructor (number/string/null/non-callable) → TypeError.
+    if !is_constructor(c) {
+        let _ = cv;
+        throw_not_constructor();
+    }
+    SpeciesChoice::Custom(c)
+}
+
+#[cold]
+fn throw_not_constructor() -> ! {
+    crate::collection_iter::throw_type_error("Array species constructor is not a constructor");
+}
+
+/// `ArraySpeciesCreate(originalArray, length)` — returns the result container
+/// as a NaN-boxed value (a plain array for the default case, or the
+/// `Construct(species, « length »)` result). The caller populates its
+/// elements (via [[Set]] / CreateDataProperty for the custom case). May throw
+/// (poisoned constructor/@@species getter, or a non-constructor species).
+pub(crate) unsafe fn array_species_create(original: f64, length: usize) -> f64 {
+    match resolve_species(original) {
+        SpeciesChoice::Default => {
+            let out = crate::array::js_array_alloc_with_length(length as u32);
+            f64::from_bits(JSValue::pointer(out as *const u8).bits())
+        }
+        SpeciesChoice::Custom(c) => {
+            let args = [length as f64];
+            crate::object::js_new_function_construct(c, args.as_ptr(), args.len())
+        }
+    }
+}
+
+/// `true` when `array_species_create` would take the default fast path — used
+/// by callers that only need to *validate* the constructor (throwing on a bad
+/// one) while keeping their existing plain-array result building, and want to
+/// know whether a custom container must instead be populated element-by-element.
+pub(crate) unsafe fn species_is_default(original: f64) -> bool {
+    matches!(resolve_species(original), SpeciesChoice::Default)
+}
+
+/// `true` when a species `result` (NaN-boxed) is an ordinary `ArrayHeader` —
+/// i.e. the default fast path — so the caller can use direct slot writes.
+pub(crate) unsafe fn species_result_is_plain_array(result: f64) -> bool {
+    let jv = JSValue::from_bits(result.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+    let raw = crate::value::js_nanbox_get_pointer(result) as usize;
+    if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return false;
+    }
+    let obj_type = {
+        let hdr = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*hdr).obj_type
+    };
+    obj_type == crate::gc::GC_TYPE_ARRAY || obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
+}
+
+/// Store `value` at `index` on a species `result` (NaN-boxed). A plain array
+/// gets a direct slot write (+ length bump + GC slot note); any other object
+/// gets a polymorphic indexed [[Set]] / data-property define.
+pub(crate) unsafe fn species_result_set(result: f64, index: usize, value: f64) {
+    let jv = JSValue::from_bits(result.to_bits());
+    if jv.is_pointer() {
+        let raw = crate::value::js_nanbox_get_pointer(result) as usize;
+        if raw >= crate::gc::GC_HEADER_SIZE + 0x1000 {
+            let obj_type = {
+                let hdr =
+                    (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+                (*hdr).obj_type
+            };
+            if obj_type == crate::gc::GC_TYPE_ARRAY || obj_type == crate::gc::GC_TYPE_LAZY_ARRAY {
+                let arr = raw as *mut ArrayHeader;
+                super::js_array_set_f64(arr, index as u32, value);
+                return;
+            }
+        }
+        crate::object::js_object_set_index_polymorphic(raw as i64, index as f64, value);
+    }
+}

--- a/crates/perry-runtime/src/array/species.rs
+++ b/crates/perry-runtime/src/array/species.rs
@@ -77,22 +77,19 @@ unsafe fn resolve_species(original: f64) -> SpeciesChoice {
     if crate::value::js_is_truthy(crate::array::js_array_is_array(original)) == 0 {
         return SpeciesChoice::Default;
     }
-    let c = read_constructor(original);
-    let cv = JSValue::from_bits(c.to_bits());
-    // step 5: if Type(C) is Object, C = Get(C, @@species); null → undefined.
-    let mut c = c;
+    // step 3: C = Get(O, "constructor"). step 5: if Type(C) is Object,
+    // C = Get(C, @@species); a null species → undefined.
+    let mut c = read_constructor(original);
     if is_object_value(c) {
         let s = get_species(c);
-        let sv = JSValue::from_bits(s.to_bits());
-        c = if sv.to_bits() == TAG_NULL {
+        c = if s.to_bits() == TAG_NULL {
             f64::from_bits(TAG_UNDEFINED)
         } else {
             s
         };
     }
-    let cv = JSValue::from_bits(c.to_bits());
     // step 6: undefined → default ArrayCreate.
-    if cv.is_undefined() {
+    if JSValue::from_bits(c.to_bits()).is_undefined() {
         return SpeciesChoice::Default;
     }
     // Fast path: the intrinsic Array constructor → plain allocation
@@ -102,7 +99,6 @@ unsafe fn resolve_species(original: f64) -> SpeciesChoice {
     }
     // step 7: a non-constructor (number/string/null/non-callable) → TypeError.
     if !is_constructor(c) {
-        let _ = cv;
         throw_not_constructor();
     }
     SpeciesChoice::Custom(c)

--- a/crates/perry-runtime/src/array/splice_slice.rs
+++ b/crates/perry-runtime/src/array/splice_slice.rs
@@ -204,7 +204,8 @@ pub extern "C" fn js_array_slice(
         // `O.constructor` / `@@species` and throws on a poisoned getter or
         // non-constructor species before any element is copied.
         let recv_value = f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits());
-        let result_box = crate::array::species::array_species_create(recv_value, slice_len as usize);
+        let result_box =
+            crate::array::species::array_species_create(recv_value, slice_len as usize);
         let is_plain = crate::array::species::species_result_is_plain_array(result_box);
         let result = crate::value::js_nanbox_get_pointer(result_box) as *mut ArrayHeader;
 

--- a/crates/perry-runtime/src/array/splice_slice.rs
+++ b/crates/perry-runtime/src/array/splice_slice.rs
@@ -43,23 +43,37 @@ pub extern "C" fn js_array_splice(
             (delete_count as u32).min(len as u32 - start_idx)
         };
 
-        // Create array of deleted elements
-        let deleted = js_array_alloc(actual_delete);
-        (*deleted).length = actual_delete;
+        // Create array of deleted elements via ArraySpeciesCreate (ECMA-262
+        // §23.1.3.31 step 11): reads `O.constructor` / `@@species` and throws
+        // on a poisoned getter or non-constructor species before the receiver
+        // is mutated.
+        let recv_value = f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits());
+        let deleted_box =
+            crate::array::species::array_species_create(recv_value, actual_delete as usize);
+        let deleted_is_plain = crate::array::species::species_result_is_plain_array(deleted_box);
+        let deleted = crate::value::js_nanbox_get_pointer(deleted_box) as *mut ArrayHeader;
 
         let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-        let deleted_elements =
-            (deleted as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
 
         // Copy deleted elements to return array
-        for i in 0..actual_delete as usize {
-            // GC_STORE_AUDIT(BARRIERED): deleted-array initialization is followed by layout/barrier rebuild.
-            ptr::write(
-                deleted_elements.add(i),
-                *elements_ptr.add(start_idx as usize + i),
-            );
+        if deleted_is_plain {
+            (*deleted).length = actual_delete;
+            let deleted_elements =
+                (deleted as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+            for i in 0..actual_delete as usize {
+                // GC_STORE_AUDIT(BARRIERED): deleted-array init is followed by layout/barrier rebuild.
+                ptr::write(
+                    deleted_elements.add(i),
+                    *elements_ptr.add(start_idx as usize + i),
+                );
+            }
+            rebuild_array_layout(deleted);
+        } else {
+            for i in 0..actual_delete as usize {
+                let v = *elements_ptr.add(start_idx as usize + i);
+                crate::array::species::species_result_set(deleted_box, i, v);
+            }
         }
-        rebuild_array_layout(deleted);
 
         // Calculate new length
         let new_len = (len as u32 - actual_delete + items_count) as u32;
@@ -186,22 +200,35 @@ pub extern "C" fn js_array_slice(
         // Calculate slice length
         let slice_len = end_idx.saturating_sub(start_idx);
 
-        // Allocate new array
-        let result = js_array_alloc(slice_len);
-        (*result).length = slice_len;
+        // ECMA-262 §23.1.3.25 step 8: ArraySpeciesCreate(O, count) — reads
+        // `O.constructor` / `@@species` and throws on a poisoned getter or
+        // non-constructor species before any element is copied.
+        let recv_value = f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits());
+        let result_box = crate::array::species::array_species_create(recv_value, slice_len as usize);
+        let is_plain = crate::array::species::species_result_is_plain_array(result_box);
+        let result = crate::value::js_nanbox_get_pointer(result_box) as *mut ArrayHeader;
 
         // Copy elements
         let src_elements = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
-        let dst_elements = (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-
-        for i in 0..slice_len as usize {
-            // GC_STORE_AUDIT(BARRIERED): slice result initialization is followed by layout/barrier rebuild.
-            ptr::write(
-                dst_elements.add(i),
-                ptr::read(src_elements.add(start_idx as usize + i)),
-            );
+        if is_plain {
+            (*result).length = slice_len;
+            let dst_elements =
+                (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+            for i in 0..slice_len as usize {
+                // GC_STORE_AUDIT(BARRIERED): slice result init is followed by layout/barrier rebuild.
+                ptr::write(
+                    dst_elements.add(i),
+                    ptr::read(src_elements.add(start_idx as usize + i)),
+                );
+            }
+            rebuild_array_layout(result);
+        } else {
+            // Custom species container: CreateDataPropertyOrThrow per element.
+            for i in 0..slice_len as usize {
+                let v = ptr::read(src_elements.add(start_idx as usize + i));
+                crate::array::species::species_result_set(result_box, i, v);
+            }
         }
-        rebuild_array_layout(result);
 
         result
     }

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -103,6 +103,7 @@ pub(crate) use globals::{drain_queued_microtasks_count, queued_microtasks_pendin
 pub use numbers::{
     js_is_finite, js_is_nan, js_number_coerce, js_number_is_finite, js_number_is_integer,
     js_number_is_nan, js_number_is_safe_integer, js_parse_float, js_parse_int, js_string_coerce,
+    js_to_integer_or_infinity,
 };
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -315,6 +315,23 @@ mod parse_float_tests {
 /// Marked `#[inline]` so the bitcode-link path can inline + DCE the
 /// branches when the input type is statically known.
 #[no_mangle]
+/// ECMA-262 ToIntegerOrInfinity (§7.1.5): ToNumber, then map NaN→0, truncate
+/// toward zero, preserving ±Infinity. Exposed for codegen so Array index
+/// arguments (`fill`/`copyWithin` start/end/target, etc.) fire
+/// `valueOf` / `Symbol.toPrimitive` and propagate their throws (and the
+/// `Symbol`→TypeError) at the spec-mandated point instead of being silently
+/// swallowed by a downstream `is_nan()` shortcut.
+#[no_mangle]
+pub extern "C" fn js_to_integer_or_infinity(value: f64) -> f64 {
+    let n = js_number_coerce(value);
+    if n.is_nan() {
+        0.0
+    } else {
+        n.trunc()
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn js_number_coerce(value: f64) -> f64 {
     let jsval = JSValue::from_bits(value.to_bits());
 

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -3808,6 +3808,16 @@ pub extern "C" fn js_object_get_field_by_name(
                 // through the singleton so this returns the same closure
                 // pointer as the bare `Array` identifier.
                 if key_bytes == b"constructor" {
+                    // An own `constructor` expando (`arr.constructor = Foo`)
+                    // shadows the intrinsic — observable via ArraySpeciesCreate
+                    // (map/filter/slice/splice/concat) and reflection. Only fall
+                    // back to the global `Array` when there is no own write.
+                    if let Some(v) = own_data_field_by_name(obj, key) {
+                        return v;
+                    }
+                    if let Some(v) = crate::array::array_named_property_get(arr, key) {
+                        return JSValue::from_bits(v.to_bits());
+                    }
                     let v = js_get_global_this_builtin_value(b"Array".as_ptr(), 5);
                     return JSValue::from_bits(v.to_bits());
                 }


### PR DESCRIPTION
## built-ins/Array test262 parity (v2)

Builds on #4742 (generic array-like + stored-method semantics, 1650→1939). This push takes the long tail of `Array.prototype` method edge cases.

**built-ins/Array: 1939 → 2092 pass (parity 76.7% → 82.8%), 4 → 0 compile-fail.**

Regression-gated against `origin/main` on an identical `built-ins`+`language` shard: **+17 net pass, 0 true regressions** (the one path-level diff, `TypedArray/prototype/forEach/returns-undefined`, is a flaky `(no output)` test that fails intermittently on both binaries — in isolation main has 4 TA-forEach failures, this branch has 1, because the thisArg fix also repairs the TA `callbackfn-this` cases).

### Root causes fixed

1. **Callback `thisArg` was silently dropped** (`map`/`filter`/`forEach`/`find`/`findIndex`/`findLast`/`findLastIndex`/`some`/`every`). The dense `Expr::Array<Method>` HIR variants carry only the callback, so `[x].every(cb, thisArg)` ran the callback with `this === undefined`. When an explicit `thisArg` is supplied (2nd positional, no spread) the call is now routed to the existing spec-complete `Expr::ArrayLikeMethod` lowering → `js_arraylike_*(recv, cb, this_arg)` which binds the callback `this` via a `ThisGuard`. Patched all three fold sites (`inline_array_methods.rs`, `array_only_methods.rs`, `local_array_methods.rs`).

2. **`fromIndex` not ToNumber-coerced** (`indexOf`/`lastIndexOf`/`includes`). A non-numeric `fromIndex` (`"3E0"`, `"0x0003"`, `true`, `{valueOf}`) is NaN-boxed, and the old `from.is_nan()` shortcut mapped every boxed value to `0`. New shared `from_index_to_integer` helper runs ToNumber (`js_number_coerce`) before ToIntegerOrInfinity, used by both the dense `search.rs` and generic `generic.rs` paths.

3. **0-arg methods compile-failed** (`reduce`/`reduceRight`/`indexOf`/`lastIndexOf`/`includes`). Codegen `bail!`'d on zero args; now pads `undefined` and lets the runtime decide (callback TypeError / search for `undefined`). Eliminates the 4 compile-fails.

4. **`copyWithin`/`fill` index args not ToIntegerOrInfinity-coerced.** The direct array paths used a raw `as isize` cast / `is_nan()→0`, silently swallowing a `Symbol` / poisoned-`valueOf` / object argument. They now coerce via the new `js_to_integer_or_infinity` runtime helper, which fires `valueOf`/`@@toPrimitive` and propagates the abrupt completion (`fill` coerces before the `length==0` early-out, per spec order).

5. **ArraySpeciesCreate** for `map`/`filter`/`slice`/`splice`. New `array/species.rs` (mirrors `typedarray/species.rs`): reads `O.constructor` / `@@species`, throws `TypeError` on a non-constructor species, and either `Construct`s a custom container or fast-allocates a plain array for the intrinsic/undefined case. Enabler: the array `.constructor` **read** previously returned the intrinsic `Array` unconditionally — it now honors an own `constructor` expando (`arr.constructor = Foo`), which the write side already persisted.

### Files
- `crates/perry-hir/src/lower/expr_call/{inline,array_only,local}_array_methods.rs` — thisArg routing
- `crates/perry-codegen/src/lower_array_method.rs` — 0-arg padding
- `crates/perry-runtime/src/array/{search,generic}.rs` — fromIndex ToNumber
- `crates/perry-runtime/src/array/{immutable,concat_reverse}.rs` + `builtins/numbers.rs` — copyWithin/fill ToIntegerOrInfinity
- `crates/perry-runtime/src/array/species.rs` (new), `iter_methods.rs`, `splice_slice.rs`, `object/field_get_set.rs` — ArraySpeciesCreate + own-constructor read

Maintainer to apply version bump + CHANGELOG at merge.
