### PR TITLE
fix(hir): class field/element initializer test262 parity (v2, native-region-safe)

### DIFF
--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -576,15 +576,29 @@ pub(super) fn compile_static_method(
     let mut static_boxed_vars = module_boxed_vars.clone();
     super::arguments::add_arguments_mapped_boxes(&f.params, &mut static_boxed_vars);
 
-    let locals: HashMap<u32, String> = {
+    // A static method invoked as `C.m()` binds `this` to the class
+    // constructor `C`. Represent that as the class-ref NaN-box (the same
+    // INT32-tagged class-id value `Expr::ClassRef` lowers to) stored in a
+    // `this` slot so `this.x` / `this.#x()` / `this[k]` inside the body
+    // resolve against the class object via the normal dynamic-dispatch
+    // path. (Previously `this` fell through to `js_implicit_this_get` and
+    // read back `undefined`.)
+    let class_ref_cid = class_ids.get(&class.name).copied().unwrap_or(class.id);
+    let class_ref_lit = {
+        let bits = crate::nanbox::INT32_TAG | (class_ref_cid as u64 & 0xFFFF_FFFF);
+        crate::nanbox::double_literal(f64::from_bits(bits))
+    };
+    let (this_slot, locals): (String, HashMap<u32, String>) = {
         let blk = lf.block_mut(0).unwrap();
+        let this_slot = blk.alloca(DOUBLE);
+        blk.store(DOUBLE, &class_ref_lit, &this_slot);
         let mut map = HashMap::new();
         for p in &f.params {
             let arg_name = format!("%arg{}", p.id);
             let slot = super::arguments::store_param_slot(blk, p, &static_boxed_vars, &arg_name);
             map.insert(p.id, slot);
         }
-        map
+        (this_slot, map)
     };
 
     let local_types: HashMap<u32, perry_types::Type> =
@@ -627,14 +641,14 @@ pub(super) fn compile_static_method(
         label_targets: HashMap::new(),
         pending_label: None,
         classes,
-        this_stack: Vec::new(),
+        this_stack: vec![this_slot],
         inline_ctor_return: Vec::new(),
         new_target_stack: Vec::new(),
-        // Static methods have no `this` but they CAN reference
-        // sibling static methods/fields via the class name (which
-        // they handle via StaticFieldGet/StaticMethodCall, not via
-        // `this`). The class_stack is empty here.
-        class_stack: Vec::new(),
+        // A static method's `this` is the class constructor (bound above to
+        // the class-ref slot). `class_stack` carries the class name so
+        // `super.x` in a static method resolves against the parent's static
+        // side, mirroring instance-method setup.
+        class_stack: vec![class.name.clone()],
         methods,
         module_globals,
         import_function_prefixes,

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -144,6 +144,29 @@ pub(crate) fn index_object_is_class_or_proto_ref(ctx: &FnCtx<'_>, object: &Expr)
     }
 }
 
+/// Compute the receiver handle to pass to `js_object_get_field_by_name`-family
+/// helpers from a NaN-boxed receiver value (`obj_bits`). Heap objects must be
+/// masked to a raw pointer, but an INT32-tagged class ref (`0x7FFE`) must keep
+/// its tag bits so the runtime routes to the static field / method / accessor
+/// tables. When the receiver's class-ref-ness is known at compile time
+/// (`static_known`), pass full bits unconditionally; otherwise branch at runtime
+/// on the tag so a runtime class-ref value (e.g. a function parameter bound to a
+/// class — `function f(C, k){ return C[k]; }`) is handled too. (test262
+/// class/elements propertyHelper `isWritable(C, name)` does `C[name]`.)
+pub(crate) fn classref_preserving_handle(
+    blk: &mut crate::block::LlBlock,
+    obj_bits: &str,
+    static_known: bool,
+) -> String {
+    if static_known {
+        return obj_bits.to_string();
+    }
+    let top16 = blk.lshr(I64, obj_bits, "48");
+    let is_classref = blk.icmp_eq(I64, &top16, "32766"); // 0x7FFE
+    let masked = blk.and(I64, obj_bits, POINTER_MASK_I64);
+    blk.select(crate::types::I1, &is_classref, I64, obj_bits, &masked)
+}
+
 fn lower_class_method_bind(
     ctx: &mut FnCtx<'_>,
     object: &Expr,
@@ -812,11 +835,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
                 let blk = ctx.block();
                 let obj_bits = blk.bitcast_double_to_i64(&obj_box);
-                let obj_handle = if preserve_class_ref_bits {
-                    obj_bits
-                } else {
-                    blk.and(I64, &obj_bits, POINTER_MASK_I64)
-                };
+                let obj_handle =
+                    classref_preserving_handle(blk, &obj_bits, preserve_class_ref_bits);
                 let key_box = blk.load(DOUBLE, &key_handle_global);
                 let key_bits = blk.bitcast_double_to_i64(&key_box);
                 let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
@@ -844,11 +864,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let key_box = lower_expr(ctx, index)?;
                 let blk = ctx.block();
                 let obj_bits = blk.bitcast_double_to_i64(&obj_box);
-                let obj_handle = if preserve_class_ref_bits {
-                    obj_bits
-                } else {
-                    blk.and(I64, &obj_bits, POINTER_MASK_I64)
-                };
+                let obj_handle =
+                    classref_preserving_handle(blk, &obj_bits, preserve_class_ref_bits);
                 let key_handle = unbox_str_handle(blk, &key_box);
                 let site_id = emit_typed_feedback_register_site(
                     ctx,
@@ -871,11 +888,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let idx_box = lower_expr(ctx, index)?;
             let blk = ctx.block();
             let obj_bits = blk.bitcast_double_to_i64(&obj_box);
-            let obj_handle = if preserve_class_ref_bits {
-                obj_bits
-            } else {
-                blk.and(I64, &obj_bits, POINTER_MASK_I64)
-            };
+            let obj_handle = classref_preserving_handle(blk, &obj_bits, preserve_class_ref_bits);
             let is_sym_i32 = blk.call(I32, "js_is_symbol", &[(DOUBLE, &idx_box)]);
             let is_sym_bit = blk.icmp_ne(I32, &is_sym_i32, "0");
             let sym_idx = ctx.new_block("iget.sym");

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -664,9 +664,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     literal,
                     "iset.literal",
                 );
+                let static_classref =
+                    super::index_get::index_object_is_class_or_proto_ref(ctx, object.as_ref());
                 let (obj_handle, key_raw) = {
                     let blk = ctx.block();
-                    let obj_handle = blk.and(I64, &obj_bits, POINTER_MASK_I64);
+                    let obj_handle = super::index_get::classref_preserving_handle(
+                        blk,
+                        &obj_bits,
+                        static_classref,
+                    );
                     let key_box = blk.load(DOUBLE, &key_handle_global);
                     let key_bits = blk.bitcast_double_to_i64(&key_box);
                     let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
@@ -700,9 +706,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     "index",
                     "iset.string",
                 );
+                let static_classref =
+                    super::index_get::index_object_is_class_or_proto_ref(ctx, object.as_ref());
                 let (obj_handle, key_handle) = {
                     let blk = ctx.block();
-                    let obj_handle = blk.and(I64, &obj_bits, POINTER_MASK_I64);
+                    let obj_handle = super::index_get::classref_preserving_handle(
+                        blk,
+                        &obj_bits,
+                        static_classref,
+                    );
                     // SSO-safe key unbox — see IndexGet branch above for rationale.
                     let key_handle = unbox_str_handle(blk, &key_box);
                     (obj_handle, key_handle)
@@ -734,9 +746,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let val_double = lower_expr(ctx, value)?;
             let obj_bits = ctx.block().bitcast_double_to_i64(&obj_box);
             super::property_set::emit_nullish_write_guard(ctx, &obj_bits, "index", "iset");
+            let static_classref =
+                super::index_get::index_object_is_class_or_proto_ref(ctx, object.as_ref());
             let obj_handle = {
                 let blk = ctx.block();
-                unbox_to_i64(blk, &obj_box)
+                super::index_get::classref_preserving_handle(blk, &obj_bits, static_classref)
             };
             let feedback_site_id = emit_typed_feedback_register_site(
                 ctx,

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1845,6 +1845,16 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 .lookup_class_captures(&synthetic_name)
                 .map(|ids| ids.iter().map(|id| Expr::LocalGet(*id)).collect())
                 .unwrap_or_default();
+            // Static block synthetic-method names (`__perry_static_init_N`), in
+            // source order — emitted as inline `StaticMethodCall`s on the
+            // shared-template path so blocks run at class-evaluation time (the
+            // same treatment the class-declaration path gives them).
+            let static_block_names: Vec<String> = class
+                .static_methods
+                .iter()
+                .filter(|m| m.name.starts_with("__perry_static_init_"))
+                .map(|m| m.name.clone())
+                .collect();
             ctx.pending_classes.push(class);
             // #1772: a class EXPRESSION that carries per-evaluation static
             // fields and is NOT a mixin (`class extends <expr>`) lowers to a
@@ -1852,7 +1862,17 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
             // `make(a) !== make(b)` and each holds its own statics as own
             // properties. Mixins and class expressions without statics/captures
             // keep the historical (shared-template) path.
-            if parent_expr.is_none()
+            // A class expression evaluated at module top level runs exactly
+            // once, so it needs no per-evaluation freshness — route it through
+            // the shared-template `ClassRef` path (identical to a class
+            // declaration), where static field/element initializers run via
+            // `init_static_fields_late` and a static method's `this` resolves
+            // to the class-ref. The `ClassExprFresh` path is reserved for class
+            // expressions inside a function body (factories like effect's
+            // `make()`), which produce a distinct class object per call.
+            let at_module_top = ctx.scope_depth == 0 && ctx.inside_block_scope == 0;
+            if !at_module_top
+                && parent_expr.is_none()
                 && (!named_statics.is_empty()
                     || !static_symbol_registrations.is_empty()
                     || !captured_args.is_empty())
@@ -1891,6 +1911,30 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     class_name: synthetic_name.clone(),
                     key_expr: Box::new(k),
                     value_expr: Box::new(v),
+                });
+            }
+            // Inline the named static field/element initializers at the point
+            // the class expression evaluates (source order), mirroring the
+            // class-declaration path. Without this the shared-template path
+            // relied solely on the late `init_static_fields_late` pass, which
+            // runs AFTER the surrounding top-level statements — so a read like
+            // `C.x` immediately after `var C = class { static x = 1 }` saw the
+            // uninitialized (0.0) slot. (Private statics carry a `#`-prefixed
+            // name and flow through the same StaticFieldSet path.)
+            for (name, v) in named_statics {
+                seq.push(Expr::StaticFieldSet {
+                    class_name: synthetic_name.clone(),
+                    field_name: name,
+                    value: Box::new(v),
+                });
+            }
+            // Static blocks run right after the static-field initializers, in
+            // source order, with the class as `this`.
+            for block_name in static_block_names {
+                seq.push(Expr::StaticMethodCall {
+                    class_name: synthetic_name.clone(),
+                    method_name: block_name,
+                    args: Vec::new(),
                 });
             }
             if seq.is_empty() {

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -694,12 +694,61 @@ pub(crate) fn lower_stmt(
                                                 parent_expr: p,
                                             })
                                         });
+                                    // Inline static field/element initializers and
+                                    // static blocks at the class-expression's source
+                                    // position, exactly as the `Decl::Class` arm does
+                                    // for declarations. Without this the `var C =
+                                    // class { static x = 1 }` fast path relied solely
+                                    // on the late `init_static_fields_late` codegen
+                                    // pass, which runs AFTER the surrounding top-level
+                                    // statements — so `C.x` read immediately after the
+                                    // binding saw the uninitialized (0.0) slot, and a
+                                    // static method's `this.#priv` read undefined.
+                                    let static_field_inits: Vec<Stmt> = lowered_class
+                                        .static_fields
+                                        .iter()
+                                        .filter_map(|sf| {
+                                            sf.init.as_ref().map(|init| {
+                                                if let Some(key) = sf.key_expr.as_ref() {
+                                                    Stmt::Expr(Expr::ClassStaticSymbolSet {
+                                                        class_name: bind_name.clone(),
+                                                        key: Box::new(key.clone()),
+                                                        value: Box::new(init.clone()),
+                                                    })
+                                                } else {
+                                                    Stmt::Expr(Expr::StaticFieldSet {
+                                                        class_name: bind_name.clone(),
+                                                        field_name: sf.name.clone(),
+                                                        value: Box::new(init.clone()),
+                                                    })
+                                                }
+                                            })
+                                        })
+                                        .collect();
+                                    let static_block_calls: Vec<Stmt> = lowered_class
+                                        .static_methods
+                                        .iter()
+                                        .filter(|m| m.name.starts_with("__perry_static_init_"))
+                                        .map(|m| {
+                                            Stmt::Expr(Expr::StaticMethodCall {
+                                                class_name: bind_name.clone(),
+                                                method_name: m.name.clone(),
+                                                args: Vec::new(),
+                                            })
+                                        })
+                                        .collect();
                                     push_class_dedup(module, lowered_class);
                                     if let Some(reg) = parent_register {
                                         module.init.push(reg);
                                     }
                                     for reg in computed_member_registrations {
                                         module.init.push(Stmt::Expr(reg));
+                                    }
+                                    for s in static_field_inits {
+                                        module.init.push(s);
+                                    }
+                                    for s in static_block_calls {
+                                        module.init.push(s);
                                     }
                                     // Register the alias so `new X()` → `new X()`
                                     // (no-op lookup, but marks the binding as a class).

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -560,6 +560,19 @@ pub extern "C" fn js_array_set_string_key(
     if arr.is_null() || key.is_null() {
         return arr;
     }
+    // A class-ref value (INT32 tag 0x7FFE) reaching this polymorphic setter
+    // (`C[name] = v` where `C` is a runtime class-ref value) is not an array —
+    // its high bits are set, so the `is_array` GC-header probe below would
+    // dereference unmapped memory. Route to the by-name object setter, which
+    // detects the class-ref tag and stores into the static-field tables.
+    if (arr as u64) >> 48 == 0x7FFE {
+        crate::object::js_object_set_field_by_name(
+            arr as *mut crate::object::ObjectHeader,
+            key,
+            value,
+        );
+        return arr;
+    }
     // Issue #637: also called from polymorphic IndexSet — detect the
     // receiver's gc_type and route accordingly. For Object/Closure
     // (non-array) receivers, just call the object setter directly so

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -962,7 +962,15 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
     // The shape-template fast path emits every key in the shape; it can't
     // honor per-key `enumerable: false`, so fall through to the slow path
     // (which filters) whenever any descriptor exists on this thread.
-    if num_fields >= 5 && !has_overflow_fields && !crate::object::descriptors_in_use() {
+    // Class instances (class_id != 0) route through the slow path: it honours a
+    // prototype/own `toJSON` and filters private (`#x`) elements, neither of
+    // which the shape-template fast path handles. Plain data objects (class_id
+    // == 0 — the common JSON shape) keep the fast path.
+    if num_fields >= 5
+        && !has_overflow_fields
+        && !crate::object::descriptors_in_use()
+        && (*obj).class_id == 0
+    {
         if let Some(tmpl_ptr) = shape_template_for(ptr) {
             if try_emit_shape_element(make_pointer_bits(ptr), &*tmpl_ptr, buf, depth) {
                 if depth > MAX_FAST_DEPTH {
@@ -1081,6 +1089,16 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
     };
     for j in 0..actual_fields {
         let f = pos(j);
+        // Private elements (`#x`) live in a class instance's keys_array but are
+        // not serializable own properties. (`has_prototype_chain` == class_id != 0.)
+        if has_prototype_chain
+            && crate::object::instance_private_key_hidden(
+                obj,
+                JSValue::from_bits((*keys_elements.add(f as usize)).to_bits()),
+            )
+        {
+            continue;
+        }
         // Skip non-enumerable own keys (e.g. `Object.defineProperty(o, k,
         // { enumerable: false })`) before touching the value.
         if filter_non_enum && json_key_non_enumerable(obj, *keys_elements.add(f as usize)) {

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -650,6 +650,11 @@ pub unsafe extern "C" fn js_object_copy_own_fields(dst_i64: i64, src_f64: f64) {
         if !key_val.is_any_string() {
             continue;
         }
+        // Private elements (`#x`) live in a class instance's keys_array but are
+        // never copied by object spread / Object.assign.
+        if crate::object::instance_private_key_hidden(src, key_val) {
+            continue;
+        }
         let key_f64 = f64::from_bits(key_val.bits());
         let key_ptr =
             crate::value::js_get_string_pointer_unified(key_f64) as *const crate::StringHeader;
@@ -889,6 +894,11 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(src_keys, i as u32);
             if !key_val.is_any_string() {
+                continue;
+            }
+            // Private elements (`#x`) live in a class instance's keys_array but
+            // are never copied by Object.assign / object spread.
+            if crate::object::instance_private_key_hidden(src, key_val) {
                 continue;
             }
             let key_f64 = f64::from_bits(key_val.bits());

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -122,6 +122,29 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             return crate::proxy::js_reflect_get_own_property_descriptor(obj_value, key_value);
         }
 
+        // Private elements (`#x`) are stored on the static side / in a class
+        // instance's keys_array but are never reflectable own properties, so
+        // their descriptor is always undefined. (Plain `{"#fff": 1}` literals
+        // carry class_id 0 and are handled by the ordinary path below.)
+        {
+            let kjv = crate::JSValue::from_bits(key_value.to_bits());
+            let mut buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+            if let Some(b) = crate::string::js_string_key_bytes(kjv, &mut buf) {
+                if b.first() == Some(&b'#') {
+                    let is_class = class_ref_id(obj_value).is_some() || {
+                        let obj = extract_obj_ptr(obj_value);
+                        !obj.is_null()
+                            && (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000
+                            && crate::object::is_valid_obj_ptr(obj as *const u8)
+                            && (*obj).class_id != 0
+                    };
+                    if is_class {
+                        return f64::from_bits(crate::value::TAG_UNDEFINED);
+                    }
+                }
+            }
+        }
+
         // #2818: string primitives box to String objects whose own
         // properties are the index keys "0".."len-1" (writable:false,
         // enumerable:true, configurable:false) plus "length"
@@ -839,6 +862,10 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                     }
                 });
             }
+            // Private elements (`#x`) live on the static side / prototype
+            // vtable under `#`-prefixed keys but are never reflectable own
+            // properties of `C` or `C.prototype`.
+            names.retain(|n| !n.starts_with('#'));
             sort_property_names_ecma(&mut names);
             let result = crate::array::js_array_alloc(names.len() as u32);
             for name in names {
@@ -969,9 +996,21 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                 None => j as u32,
             }
         };
+        // Private elements (`#x`) live in a class instance's keys_array but are
+        // never reflectable own properties. Drop them for class instances
+        // (class_id != 0); plain `{"#fff": 1}` literals keep class_id 0.
+        let hide_private = (*obj).class_id != 0;
         let result = crate::array::js_array_alloc(len as u32);
+        let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         for i in 0..len {
             let key_val = crate::array::js_array_get(keys, pos(i));
+            if hide_private {
+                if let Some(b) = crate::string::js_string_key_bytes(key_val, &mut sso_buf) {
+                    if b.first() == Some(&b'#') {
+                        continue;
+                    }
+                }
+            }
             crate::array::js_array_push_f64(result, f64::from_bits(key_val.bits()));
         }
         f64::from_bits((result as u64) | 0x7FFD_0000_0000_0000)

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1683,7 +1683,12 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                 None => j as u32,
             }
         };
-        if !has_descriptors {
+        // Private elements (`#x`) are stored in a class instance's keys_array
+        // but are never enumerable/reflectable properties. Take the filtering
+        // path for class instances (class_id != 0) so they are dropped. Plain
+        // object literals keep class_id 0, so `{"#fff": 1}` stays visible.
+        let hide_private = (*obj).class_id != 0;
+        if !has_descriptors && !hide_private {
             let out = crate::array::js_array_alloc(len as u32);
             for j in 0..len {
                 let key_val = crate::array::js_array_get(keys, pos(j));
@@ -1691,7 +1696,7 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
             }
             return out;
         }
-        // Slow path: filter out non-enumerable keys.
+        // Slow path: filter out non-enumerable and private (`#`) keys.
         let filtered = crate::array::js_array_alloc(len as u32);
         let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         for j in 0..len {
@@ -1707,10 +1712,15 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                 Ok(s) => s,
                 Err(_) => continue,
             };
+            if hide_private && key_str.starts_with('#') {
+                continue;
+            }
             // If a descriptor explicitly marks this key non-enumerable, skip it.
-            if let Some(attrs) = get_property_attrs(obj as usize, key_str) {
-                if !attrs.enumerable() {
-                    continue;
+            if has_descriptors {
+                if let Some(attrs) = get_property_attrs(obj as usize, key_str) {
+                    if !attrs.enumerable() {
+                        continue;
+                    }
                 }
             }
             crate::array::js_array_push_f64(filtered, f64::from_bits(key_val.bits()));
@@ -1720,6 +1730,23 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
 }
 
 /// Get the values of an object as an array
+/// True when `obj` is a class instance (`class_id != 0`) and `key_val` names a
+/// private element (`#x`). Private elements physically live in the instance
+/// keys_array but are never enumerable/reflectable properties. Plain object
+/// literals keep `class_id == 0`, so `{"#fff": 1}` stays visible.
+pub(crate) unsafe fn instance_private_key_hidden(
+    obj: *const ObjectHeader,
+    key_val: crate::JSValue,
+) -> bool {
+    if obj.is_null() || (*obj).class_id == 0 {
+        return false;
+    }
+    let mut buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    crate::string::js_string_key_bytes(key_val, &mut buf)
+        .map(|b| b.first() == Some(&b'#'))
+        .unwrap_or(false)
+}
+
 /// Returns an array of the object's field values
 #[no_mangle]
 pub extern "C" fn js_object_values(obj: *const ObjectHeader) -> *mut ArrayHeader {
@@ -1810,7 +1837,14 @@ pub extern "C" fn js_object_values(obj: *const ObjectHeader) -> *mut ArrayHeader
             }
         };
         for j in 0..count {
-            let value = js_object_get_field(obj as *mut ObjectHeader, pos(j));
+            let i = pos(j);
+            if !keys.is_null() && i < crate::array::js_array_length(keys) {
+                let key_val = crate::array::js_array_get(keys, i);
+                if instance_private_key_hidden(obj, key_val) {
+                    continue;
+                }
+            }
+            let value = js_object_get_field(obj as *mut ObjectHeader, i);
             crate::array::js_array_push_f64(result, f64::from_bits(value.bits()));
         }
 
@@ -1942,6 +1976,12 @@ pub extern "C" fn js_object_entries(obj: *const ObjectHeader) -> *mut ArrayHeade
         };
         for j in 0..count {
             let i = pos(j);
+            if !keys.is_null() && i < crate::array::js_array_length(keys) {
+                let key_val = crate::array::js_array_get(keys, i);
+                if instance_private_key_hidden(obj, key_val) {
+                    continue;
+                }
+            }
             // Create a pair array [key, value]
             let pair = crate::array::js_array_alloc(2);
 

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -695,7 +695,11 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
         if let Some(class_id) = super::class_ref_id(obj_value) {
             let present = super::has_own_helpers::str_from_string_header(key_str)
                 .map(|key| {
-                    if super::class_registry::class_is_key_deleted(class_id, key) {
+                    if key.starts_with('#') {
+                        // Private static elements are never reflectable own
+                        // properties of the class constructor.
+                        false
+                    } else if super::class_registry::class_is_key_deleted(class_id, key) {
                         false
                     } else if matches!(key, "length" | "prototype") {
                         true
@@ -806,6 +810,16 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
                 .as_deref()
                 .is_some_and(|module_name| native_module_has_enumerable_key(module_name, key_name));
             return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+        }
+
+        // Private elements (`#x`) sit in a class instance's keys_array but are
+        // never reflectable own properties. Plain literals keep class_id 0.
+        if (*obj).class_id != 0 {
+            if let Some(key) = super::has_own_helpers::str_from_string_header(key_str) {
+                if key.starts_with('#') {
+                    return f64::from_bits(TAG_FALSE);
+                }
+            }
         }
 
         if own_key_present(obj, key_str) {

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1596,6 +1596,12 @@ pub extern "C" fn js_typed_feedback_array_set_string_key(
     key: *const crate::StringHeader,
     value: f64,
 ) -> *mut ArrayHeader {
+    // Class-ref receivers (INT32 tag 0x7FFE) are not arrays; skip the array
+    // shape observation (which would probe the GC header of a non-pointer) and
+    // route straight to the class-ref-aware string-key setter.
+    if (arr as u64) >> 48 == 0x7FFE {
+        return crate::array::js_array_set_string_key(arr, key, value);
+    }
     observe_array(site_id, arr, u32::MAX);
     record_guard_fail(site_id);
     record_fallback_call(site_id);

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -27,6 +27,30 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         }
         return f64::from_bits(JSValue::string_ptr(result).bits());
     }
+    // Class-ref value (INT32-tagged, top16 == 0x7FFE): `C[key]` where `C` is a
+    // runtime class-ref value (e.g. a function parameter). Member-expression
+    // access (`C.key`) already routes through `js_object_get_field_by_name_f64`,
+    // which detects the class-ref tag and consults the static method / field /
+    // CLASS_DYNAMIC_PROPS tables; the computed form must do the same instead of
+    // falling through to the not-a-pointer `undefined` path below. (test262
+    // class/elements propertyHelper `isWritable(C, "m")` does `C[name] = v`.)
+    if (bits >> 48) == 0x7FFE {
+        let idx_top16 = index.to_bits() >> 48;
+        let key_ptr = if idx_top16 == 0x7FFF || idx_top16 == 0x7FF9 {
+            js_get_string_pointer_unified(index) as *const crate::StringHeader
+        } else {
+            // Numeric / other index → ToString for the class-ref lookup.
+            let s = crate::builtins::js_string_coerce(index);
+            s as *const crate::StringHeader
+        };
+        if key_ptr.is_null() {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        return crate::object::js_object_get_field_by_name_f64(
+            bits as *const crate::object::ObjectHeader,
+            key_ptr,
+        );
+    }
     let raw_ptr = if jsval.is_pointer() {
         (bits & POINTER_MASK) as usize
     } else if !value.is_nan()
@@ -201,6 +225,29 @@ pub extern "C" fn js_dyn_index_set(obj: f64, index: f64, value: f64) -> f64 {
     let bits = obj.to_bits();
     let jsval = JSValue::from_bits(bits);
     if jsval.is_string() || jsval.is_short_string() {
+        return value;
+    }
+    // Class-ref value (INT32-tagged, top16 == 0x7FFE): `C[key] = v` where `C` is
+    // a runtime class-ref value (e.g. a function parameter). Route to the
+    // by-name setter, which detects the class-ref tag and stores into the
+    // static-field / CLASS_DYNAMIC_PROPS side table — matching the member-write
+    // form (`C.key = v`). Without this the write was silently dropped, so
+    // propertyHelper's `isWritable(C, name)` (`C[name] = v`) reported a static
+    // method as non-writable. (Mirrors the get arm above.)
+    if (bits >> 48) == 0x7FFE {
+        let idx_top16 = index.to_bits() >> 48;
+        let key_ptr = if idx_top16 == 0x7FFF || idx_top16 == 0x7FF9 {
+            js_get_string_pointer_unified(index) as *const crate::StringHeader
+        } else {
+            crate::builtins::js_string_coerce(index) as *const crate::StringHeader
+        };
+        if !key_ptr.is_null() {
+            crate::object::js_object_set_field_by_name(
+                bits as *mut crate::object::ObjectHeader,
+                key_ptr,
+                value,
+            );
+        }
         return value;
     }
     let raw_ptr = if jsval.is_pointer() {


### PR DESCRIPTION
Re-do of #4764 (correct on test262 but failed the `compiler-output-regression` / native-region-proof gate). This version keeps that gate **green** and scopes changes to class field/element semantics.

## Results
- `language/statements/class/elements` + `language/expressions/class/elements`: **50.1% → 75.5%** (+722 tests; 1420 → 2142 pass).
- **native-region-proof gate: `status: pass`, NO `failed_workloads`** on a debug build locally (the config CI uses). The class-field codegen change does not perturb the generic array/buffer native-region proofs.
- **Zero real regressions**: broad `built-ins language` shard 0/12 went 76.9% → 77.9% (+61 gains). The 40 apparent shard "regressions" each pass in isolation on *both* this branch and origin/main — parallel-run timeout flakiness (the shard ran while a build saturated the shared box), confirmed by re-running all 40 individually (`isolated-pass=40, isolated-fail=0`).

## Root causes fixed
1. **`this` undefined in static methods.** `C.m()` binds `this` to the class; `compile_static_method` now seeds the `this` slot with the class-ref value and sets `class_stack`, so `this.x` / `this.#x()` / `this[k]` resolve.
2. **Private (`#x`) elements leaked into reflection.** Now hidden (gated on `class_id != 0`, so `{"#fff":1}` literals stay visible) from `Object.keys/values/entries`, `getOwnPropertyNames`, `getOwnPropertyDescriptor`, `hasOwnProperty`, `JSON.stringify`, and object spread / `Object.assign` — on instances *and* the class constructor (class-ref).
3. **Static field/element initializers never ran for class EXPRESSIONS** (`var C = class { static x = 1 }`). The `var C = class {…}` fast path and the general class-expression arm now emit inline `StaticFieldSet`/`ClassStaticSymbolSet`/static-block calls in source order (matching declarations); the per-evaluation `ClassExprFresh` path is reserved for class expressions inside function bodies (factories).
4. **Dynamic get/set on a runtime class-ref VALUE returned/dropped silently** (`C[key]` / `C[key]=v` where `C` is e.g. a function param — propertyHelper's `isWritable(C, name)`). `js_dyn_index_get/set` now handle the `0x7FFE` tag; codegen preserves class-ref tag bits at runtime for runtime-unknown receivers (`classref_preserving_handle`); the array string-key setter guards class-ref receivers instead of dereferencing them as a GC header.

## Files
- **perry-codegen**: `codegen/method.rs`, `expr/index_get.rs`, `expr/index_set.rs`
- **perry-hir**: `lower/lower_expr.rs`, `lower/stmt.rs`
- **perry-runtime**: `object/{descriptors,object_ops,field_get_set,alloc}.rs`, `json/stringify.rs`, `value/dyn_index.rs`, `array/indexing.rs`, `typed_feedback.rs`

## Out of scope (separate feature areas; follow-up PRs)
- async-generator `yield*` / async-iterator delegation semantics (the largest remaining class/elements cluster, but a generator-runtime feature)
- parser-level grammar early-errors (invalid private-name `SyntaxError`s)