### PR TITLE
feat(ui-windows): WinUI 3 backend scaffold + --target windows-winui (#4680)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -63,6 +63,7 @@ jobs:
             --exclude perry-ui-gtk4 \
             --exclude perry-ui-android \
             --exclude perry-ui-windows \
+            --exclude perry-ui-windows-winui \
             --html --output-dir target/llvm-cov-html
           cargo llvm-cov report --no-fail-fast \
             --exclude perry-doc-fixture-my-bindings \
@@ -74,6 +75,7 @@ jobs:
             --exclude perry-ui-gtk4 \
             --exclude perry-ui-android \
             --exclude perry-ui-windows \
+            --exclude perry-ui-windows-winui \
             --lcov --output-path target/lcov.info
           cargo llvm-cov report --no-fail-fast \
             --exclude perry-doc-fixture-my-bindings \
@@ -85,6 +87,7 @@ jobs:
             --exclude perry-ui-gtk4 \
             --exclude perry-ui-android \
             --exclude perry-ui-windows \
+            --exclude perry-ui-windows-winui \
             --summary-only > target/summary.txt
         # Don't fail the workflow on a non-zero exit — the artifacts
         # below are still useful, and a missing test in one crate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,8 @@ jobs:
         #   image doesn't have libgtk-4-dev installed by default.
         # - perry-ui-android: needs Android NDK.
         # - perry-ui-windows: needs win32 headers.
+        # - perry-ui-windows-winui: re-exports perry-ui-windows, so it inherits
+        #   the same win32 / webview2-com dependency that won't build on Linux.
         env:
           # Rust's Ubuntu target can drive `cc` with `-fuse-ld=lld`; on the
           # shared runner this has repeatedly terminated large test links with
@@ -215,6 +217,7 @@ jobs:
               "perry-ui-gtk4",
               "perry-ui-android",
               "perry-ui-windows",
+              "perry-ui-windows-winui",
               "perry-doc-fixture-my-bindings",
           }
           metadata = json.load(sys.stdin)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6177,6 +6177,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "perry-ui-windows-winui"
+version = "0.5.1145"
+dependencies = [
+ "perry-ui-windows",
+]
+
+[[package]]
 name = "perry-updater"
 version = "0.5.1145"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "crates/perry-audio-miniaudio",
     "crates/perry-ui-gtk4",
     "crates/perry-ui-windows",
+    "crates/perry-ui-windows-winui",
     "crates/perry-ui-watchos",
     "crates/perry-ui-tvos",
     "crates/perry-ui-geisterhand",
@@ -163,6 +164,12 @@ strip = false
 codegen-units = 16
 
 [profile.release.package.perry-ui-windows]
+strip = false
+codegen-units = 16
+
+# WinUI scaffold (#4680): re-exports perry-ui-windows; the staticlib bundles
+# its #[no_mangle] extern "C" symbols, so it must not be stripped either.
+[profile.release.package.perry-ui-windows-winui]
 strip = false
 codegen-units = 16
 

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -406,7 +406,7 @@ pub fn resolve_target_triple(name: &str) -> Option<String> {
         "linux-aarch64" => Some("aarch64-unknown-linux-gnu".to_string()),
         "macos" => Some("arm64-apple-macosx15.0.0".to_string()),
         "macos-x86_64" => Some("x86_64-apple-macosx15.0.0".to_string()),
-        "windows" => Some("x86_64-pc-windows-msvc".to_string()),
+        "windows" | "windows-winui" => Some("x86_64-pc-windows-msvc".to_string()),
         _ => None,
     }
 }

--- a/crates/perry-ui-windows-winui/Cargo.toml
+++ b/crates/perry-ui-windows-winui/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "perry-ui-windows-winui"
+version.workspace = true
+edition.workspace = true
+
+# Opt-in WinUI 3 (Fluent) Windows backend — issue #4680. Selected via
+# `--target windows-winui`. This is the SCAFFOLD: the crate re-exports the
+# Win32/GDI backend (`perry-ui-windows`) verbatim so the full `perry_ui_*`
+# FFI ABI is satisfied and apps built for `windows-winui` link and run today
+# (rendering through Win32). The WinUI/XAML widget mapping then lands
+# incrementally in the `winui` module, replacing Win32 widget creation one
+# widget at a time, without ever breaking the link surface.
+
+[lib]
+# Same shape as perry-ui-windows: an rlib for Rust consumers and a staticlib
+# the perry driver /WHOLEARCHIVE's into the final executable. The staticlib
+# bundles perry-ui-windows's object code (all its #[no_mangle] extern "C"
+# symbols), so no symbol is lost by going through this crate.
+crate-type = ["rlib", "staticlib"]
+
+[dependencies]
+# The entire current Windows backend. Re-exported wholesale (see src/lib.rs).
+perry-ui-windows = { path = "../perry-ui-windows" }
+
+# Future (XAML widget mapping, #4680 steps 1-6): driving WinAppSDK +
+# Microsoft.UI.Xaml through the windows-rs WinRT projections. Intentionally
+# NOT added yet — the WinAppSDK runtime + bootstrapper
+# (Microsoft.WindowsAppRuntime.Bootstrap) is acquired out-of-band (NuGet /
+# redistributable), not as a cargo dependency, so wiring it is its own step.
+# When that lands, add:
+#   windows = { version = "0.58", features = [
+#       "UI_Xaml", "UI_Xaml_Controls", "UI_Xaml_Hosting", ... ] }
+# and the bootstrap link to Microsoft.WindowsAppRuntime.Bootstrap.lib.
+
+[features]
+geisterhand = ["perry-ui-windows/geisterhand"]

--- a/crates/perry-ui-windows-winui/src/lib.rs
+++ b/crates/perry-ui-windows-winui/src/lib.rs
@@ -1,0 +1,50 @@
+//! Opt-in WinUI 3 (Fluent) Windows backend — issue #4680.
+//!
+//! Selected via `--target windows-winui`. Motivation (discussion #3486): the
+//! default Win32/GDI chrome looks dated; WinUI 3 / Fluent brings rounded
+//! corners, Mica/Acrylic materials, smooth animation, and crisp auto-DPI —
+//! the closest Windows analog to Perry's iOS/Android look-and-feel.
+//!
+//! # Why a separate target (not the default)
+//!
+//! WinUI 3 requires the **Windows App SDK runtime** plus an MSIX/bootstrapper
+//! packaging story, which conflicts with Perry's single-native-`.exe` model.
+//! So Win32 (`perry-ui-windows`, `--target windows`) stays the default and the
+//! Fluent backend is opt-in, mirroring how Perry ships multiple Apple targets.
+//!
+//! # Scaffold status (this crate today)
+//!
+//! This crate currently **re-exports `perry-ui-windows` verbatim**. That makes
+//! `--target windows-winui` a real, selectable target immediately: apps build,
+//! link, and run — rendering through the Win32 backend for now. Building the
+//! staticlib bundles every `#[no_mangle] extern "C"` `perry_ui_*` symbol from
+//! `perry-ui-windows`, so the FFI surface the perry driver links against is
+//! identical to the `windows` target. Nothing regresses, and there is a stable
+//! place to grow the real Fluent backend.
+//!
+//! # The incremental plan (#4680 work breakdown)
+//!
+//! The XAML widget mapping lands one widget at a time in [`winui`], each
+//! replacing the corresponding Win32 widget creation with a
+//! `Microsoft.UI.Xaml` control driven through the windows-rs WinRT
+//! projections, until the whole ~40-widget set is Fluent. Steps, in order:
+//!
+//! 1. WinAppSDK + `Microsoft.UI.Xaml` projections wired in (`Cargo.toml`).
+//! 2. Bootstrapper / runtime acquisition ([`winui::bootstrap`]).
+//! 3. Widget mapping layer (perry-ui widget set → XAML controls).
+//! 4. Window chrome: Mica/Acrylic backdrop, Fluent title bar, light/dark/system.
+//! 5. Packaging: MSIX or unpackaged WinAppSDK bootstrap; document the runtime.
+//! 6. `apply_style` (geisterhand) dispatcher parity with the other backends.
+//!
+//! Tracks discussion #3486. Near-term Win32 polish on the default target lives
+//! in #4681.
+
+// Re-export the entire Win32 backend. For Rust consumers this exposes the same
+// module API as `perry-ui-windows`; for the C ABI it is a no-op (the
+// `#[no_mangle]` entry points are emitted when `perry-ui-windows` is compiled
+// and bundled into this crate's staticlib regardless of Rust-level re-export),
+// but it documents that this crate IS the Win32 surface until XAML supersedes
+// it widget-by-widget.
+pub use perry_ui_windows::*;
+
+pub mod winui;

--- a/crates/perry-ui-windows-winui/src/winui.rs
+++ b/crates/perry-ui-windows-winui/src/winui.rs
@@ -1,0 +1,52 @@
+//! WinUI 3 / Fluent backend internals — issue #4680.
+//!
+//! This module is where the Win32 widget creation is progressively replaced by
+//! `Microsoft.UI.Xaml` controls. It is empty of real XAML today (scaffold);
+//! see the crate-level docs for the incremental plan. Each future widget gets a
+//! submodule here that drives the corresponding XAML control and is wired into
+//! the dispatch path in place of the `perry-ui-windows` Win32 path.
+
+/// Windows App SDK bootstrap (#4680 step 2).
+///
+/// A WinUI 3 / unpackaged app must initialize the Windows App SDK runtime
+/// before any `Microsoft.UI.Xaml` type is constructed — normally via the
+/// bootstrapper API (`MddBootstrapInitialize2` from
+/// `Microsoft.WindowsAppRuntime.Bootstrap`, acquired as a redistributable, not
+/// a cargo crate).
+///
+/// This is a **stub**: it links nothing and is a no-op, so the scaffold builds
+/// and runs anywhere (the Win32 re-export path needs no runtime). When the
+/// XAML mapping lands, this becomes the real `MddBootstrapInitialize2` call,
+/// gated behind the WinAppSDK link dependency, and is invoked from app startup
+/// before the first XAML object is created.
+pub mod bootstrap {
+    /// Outcome of attempting to initialize the Windows App SDK runtime.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum InitStatus {
+        /// Runtime is ready (or not yet required — current scaffold state).
+        Ready,
+        /// The Windows App SDK runtime is not installed; the caller should
+        /// fall back to the Win32 backend rather than crash.
+        RuntimeMissing,
+    }
+
+    /// Initialize the Windows App SDK runtime. Currently a no-op returning
+    /// [`InitStatus::Ready`] because the scaffold renders through Win32 and
+    /// needs no WinAppSDK runtime. Replaced by the real bootstrapper call in
+    /// #4680 step 2.
+    pub fn initialize() -> InitStatus {
+        InitStatus::Ready
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bootstrap::{initialize, InitStatus};
+
+    #[test]
+    fn bootstrap_scaffold_is_ready() {
+        // The scaffold must never report a missing runtime — it renders via
+        // the re-exported Win32 backend, which has no WinAppSDK dependency.
+        assert_eq!(initialize(), InitStatus::Ready);
+    }
+}

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4344,8 +4344,9 @@ pub fn run_with_parse_cache(
             .or_else(|| find_runtime_library(target.as_deref()).ok());
         let stdlib_lib_path = stdlib_lib_resolved.clone();
         // Check if stdlib will be linked - if so, it provides perry_runtime symbols (no stubs needed)
-        let target_is_windows = matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
-            || (cfg!(target_os = "windows") && target.is_none());
+        let target_is_windows =
+            matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
+                || (cfg!(target_os = "windows") && target.is_none());
         let will_link_stdlib = (ctx.needs_stdlib || target_is_windows) && stdlib_lib_path.is_some();
         // Issue #76 — when the wasm host is
         // being linked, scan its archive so the `perry_wasm_host_*` symbols
@@ -4933,8 +4934,9 @@ pub fn run_with_parse_cache(
     // emits `perry_module_init` instead of `main` (see is_dylib branch in
     // codegen/entry.rs, which now also covers `staticlib`).
     if is_staticlib {
-        let is_windows_target = matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
-            || (target.is_none() && cfg!(target_os = "windows"));
+        let is_windows_target =
+            matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
+                || (target.is_none() && cfg!(target_os = "windows"));
         // Best-effort: drop a stale archive first so `ar` doesn't append to a
         // previous build's contents.
         let _ = fs::remove_file(&exe_path);

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -4344,7 +4344,7 @@ pub fn run_with_parse_cache(
             .or_else(|| find_runtime_library(target.as_deref()).ok());
         let stdlib_lib_path = stdlib_lib_resolved.clone();
         // Check if stdlib will be linked - if so, it provides perry_runtime symbols (no stubs needed)
-        let target_is_windows = matches!(target.as_deref(), Some("windows"))
+        let target_is_windows = matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
             || (cfg!(target_os = "windows") && target.is_none());
         let will_link_stdlib = (ctx.needs_stdlib || target_is_windows) && stdlib_lib_path.is_some();
         // Issue #76 — when the wasm host is
@@ -4392,7 +4392,7 @@ pub fn run_with_parse_cache(
         );
         let is_linux = matches!(target.as_deref(), Some("linux"))
             || (!cfg!(target_os = "macos") && !cfg!(target_os = "windows") && target.is_none());
-        let is_windows = matches!(target.as_deref(), Some("windows"))
+        let is_windows = matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
             || (cfg!(target_os = "windows") && target.is_none());
         // Symbol prefix depends on object format:
         // Mach-O targets (macOS, iOS, watchOS, tvOS): nm shows `_` prefix
@@ -4711,7 +4711,7 @@ pub fn run_with_parse_cache(
             // #1088 — Windows hosts expect `.lib`; everywhere else uses
             // the Unix `lib<stem>.a` convention so the archive is reachable
             // from `-l<stem>` at the host's link step.
-            if matches!(target.as_deref(), Some("windows"))
+            if matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
                 || (target.is_none() && cfg!(target_os = "windows"))
             {
                 PathBuf::from(format!("{}.lib", stem))
@@ -4727,7 +4727,7 @@ pub fn run_with_parse_cache(
             // shipping shape. `lib` prefix matches the dlopen name used by
             // the generated ArkTS shim (`import entry from 'libapp.so'`).
             PathBuf::from(format!("lib{}.so", stem))
-        } else if matches!(target.as_deref(), Some("windows"))
+        } else if matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
             || (target.is_none() && cfg!(target_os = "windows"))
         {
             PathBuf::from(format!("{}.exe", stem))
@@ -4920,7 +4920,7 @@ pub fn run_with_parse_cache(
     );
     let is_linux = matches!(target.as_deref(), Some("linux"))
         || (target.is_none() && cfg!(target_os = "linux"));
-    let _is_windows = matches!(target.as_deref(), Some("windows"))
+    let _is_windows = matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
         || (target.is_none() && cfg!(target_os = "windows"));
     // is_watchos / is_tvos are defined below (near the per-platform link step).
     // The is_cross_* bindings used to live here, but they're now derived
@@ -4933,7 +4933,7 @@ pub fn run_with_parse_cache(
     // emits `perry_module_init` instead of `main` (see is_dylib branch in
     // codegen/entry.rs, which now also covers `staticlib`).
     if is_staticlib {
-        let is_windows_target = matches!(target.as_deref(), Some("windows"))
+        let is_windows_target = matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
             || (target.is_none() && cfg!(target_os = "windows"));
         // Best-effort: drop a stale archive first so `ar` doesn't append to a
         // previous build's contents.

--- a/crates/perry/src/commands/compile/app_metadata.rs
+++ b/crates/perry/src/commands/compile/app_metadata.rs
@@ -17,7 +17,8 @@ pub(super) fn target_bundle_section(target: Option<&str>) -> Option<&'static str
         Some("tvos") | Some("tvos-simulator") => Some("tvos"),
         Some("android") => Some("android"),
         Some("macos") => Some("macos"),
-        Some("windows") => Some("windows"),
+        // WinUI shares the [windows] perry.toml section (#4680).
+        Some("windows") | Some("windows-winui") => Some("windows"),
         Some("linux") => Some("linux"),
         None if cfg!(target_os = "macos") => Some("macos"),
         None if cfg!(target_os = "windows") => Some("windows"),
@@ -161,7 +162,7 @@ pub(super) fn rust_target_triple(target: Option<&str>) -> Option<&'static str> {
         Some("android") => Some("aarch64-linux-android"),
         Some("linux") | Some("linux-x86_64") => Some("x86_64-unknown-linux-gnu"),
         Some("linux-arm64") | Some("linux-aarch64") => Some("aarch64-unknown-linux-gnu"),
-        Some("windows") => Some("x86_64-pc-windows-msvc"),
+        Some("windows") | Some("windows-winui") => Some("x86_64-pc-windows-msvc"),
         Some("macos") => Some("aarch64-apple-darwin"),
         _ => None,
     }

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -459,8 +459,10 @@ fn default_output_path(args: &CompileArgs) -> PathBuf {
         .and_then(|s| s.to_str())
         .unwrap_or("output");
     let stem = crate::commands::sanitize::sanitize_for_linker_argv(raw_stem);
-    if matches!(args.target.as_deref(), Some("windows") | Some("windows-winui"))
-        || (args.target.is_none() && cfg!(target_os = "windows"))
+    if matches!(
+        args.target.as_deref(),
+        Some("windows") | Some("windows-winui")
+    ) || (args.target.is_none() && cfg!(target_os = "windows"))
     {
         PathBuf::from(format!("{stem}.exe"))
     } else {

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -459,7 +459,7 @@ fn default_output_path(args: &CompileArgs) -> PathBuf {
         .and_then(|s| s.to_str())
         .unwrap_or("output");
     let stem = crate::commands::sanitize::sanitize_for_linker_argv(raw_stem);
-    if matches!(args.target.as_deref(), Some("windows"))
+    if matches!(args.target.as_deref(), Some("windows") | Some("windows-winui"))
         || (args.target.is_none() && cfg!(target_os = "windows"))
     {
         PathBuf::from(format!("{stem}.exe"))

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -114,8 +114,8 @@ fn lib_name_variants(lib_name: &str, target: Option<&str>) -> Vec<String> {
     if std::path::Path::new(lib_name).extension().is_some() {
         return out;
     }
-    let is_windows =
-        matches!(target, Some("windows")) || (target.is_none() && cfg!(target_os = "windows"));
+    let is_windows = matches!(target, Some("windows") | Some("windows-winui"))
+        || (target.is_none() && cfg!(target_os = "windows"));
     let is_macos = matches!(
         target,
         Some("ios")
@@ -732,7 +732,7 @@ pub(super) fn collect_library_candidates(name: &str, target: Option<&str>) -> Ve
         // also check the default target/release/ directory since native builds
         // put libraries there without the triple subdirectory.
         #[cfg(target_os = "windows")]
-        if matches!(target, Some("windows")) {
+        if matches!(target, Some("windows") | Some("windows-winui")) {
             candidates.push(PathBuf::from(format!("target/release/{}", name)));
             candidates.push(PathBuf::from(format!("target/debug/{}", name)));
             candidates.extend(winget_lib_candidates(name));
@@ -848,7 +848,7 @@ pub(super) fn collect_library_candidates(name: &str, target: Option<&str>) -> Ve
 /// Find the runtime library for linking
 pub(super) fn find_runtime_library(target: Option<&str>) -> Result<PathBuf> {
     let lib_name = match target {
-        Some("windows") => "perry_runtime.lib",
+        Some("windows") | Some("windows-winui") => "perry_runtime.lib",
         #[cfg(target_os = "windows")]
         None => "perry_runtime.lib",
         _ => "libperry_runtime.a",
@@ -885,7 +885,7 @@ pub(super) fn find_runtime_library(target: Option<&str>) -> Result<PathBuf> {
 /// Find the stdlib library for linking (optional - only needed for native modules)
 pub(super) fn find_stdlib_library(target: Option<&str>) -> Option<PathBuf> {
     let lib_name = match target {
-        Some("windows") => "perry_stdlib.lib",
+        Some("windows") | Some("windows-winui") => "perry_stdlib.lib",
         #[cfg(target_os = "windows")]
         None => "perry_stdlib.lib",
         _ => "libperry_stdlib.a",
@@ -897,7 +897,7 @@ pub(super) fn find_stdlib_library(target: Option<&str>) -> Option<PathBuf> {
 /// when `--enable-wasm-runtime` is set, see issue #76).
 pub(super) fn find_wasm_host_library(target: Option<&str>) -> Option<PathBuf> {
     let lib_name = match target {
-        Some("windows") => "perry_wasm_host.lib",
+        Some("windows") | Some("windows-winui") => "perry_wasm_host.lib",
         #[cfg(target_os = "windows")]
         None => "perry_wasm_host.lib",
         _ => "libperry_wasm_host.a",
@@ -924,6 +924,10 @@ pub(super) fn find_ui_library(target: Option<&str>) -> Option<PathBuf> {
         Some("tvos-simulator") | Some("tvos") => "libperry_ui_tvos.a",
         Some("linux") => "libperry_ui_gtk4.a",
         Some("macos") => "libperry_ui_macos.a",
+        // Opt-in WinUI 3 backend (#4680) — its own staticlib. It bundles the
+        // perry-ui-windows Win32 symbols today (scaffold), so the FFI surface
+        // is identical to the `windows` lib.
+        Some("windows-winui") => "perry_ui_windows_winui.lib",
         Some("windows") => "perry_ui_windows.lib",
         #[cfg(target_os = "windows")]
         None => "perry_ui_windows.lib",
@@ -1186,7 +1190,7 @@ pub(super) fn find_geisterhand_lib(name: &str, target: Option<&str>) -> Option<P
 }
 
 pub(super) fn find_geisterhand_library(target: Option<&str>) -> Option<PathBuf> {
-    let name = if matches!(target, Some("windows")) || cfg!(target_os = "windows") {
+    let name = if matches!(target, Some("windows") | Some("windows-winui")) || cfg!(target_os = "windows") {
         "perry_ui_geisterhand.lib"
     } else {
         "libperry_ui_geisterhand.a"
@@ -1195,7 +1199,7 @@ pub(super) fn find_geisterhand_library(target: Option<&str>) -> Option<PathBuf> 
 }
 
 pub(super) fn find_geisterhand_runtime(target: Option<&str>) -> Option<PathBuf> {
-    let name = if matches!(target, Some("windows")) || cfg!(target_os = "windows") {
+    let name = if matches!(target, Some("windows") | Some("windows-winui")) || cfg!(target_os = "windows") {
         "perry_runtime.lib"
     } else {
         "libperry_runtime.a"
@@ -1213,7 +1217,7 @@ pub(super) fn find_geisterhand_stdlib(target: Option<&str>) -> Option<PathBuf> {
     // so we never select the auto-optimized stdlib, whose feature set is
     // computed from the app's TS imports and omits async-runtime when the async
     // surface comes from a native binding — the #1383 link failure.
-    let name = if matches!(target, Some("windows")) || cfg!(target_os = "windows") {
+    let name = if matches!(target, Some("windows") | Some("windows-winui")) || cfg!(target_os = "windows") {
         "perry_stdlib.lib"
     } else {
         "libperry_stdlib.a"
@@ -1230,6 +1234,8 @@ pub(super) fn find_geisterhand_ui(target: Option<&str>) -> Option<PathBuf> {
         "libperry_ui_android.a"
     } else if matches!(target, Some("linux")) || cfg!(target_os = "linux") {
         "libperry_ui_gtk4.a"
+    } else if matches!(target, Some("windows-winui")) {
+        "perry_ui_windows_winui.lib"
     } else if matches!(target, Some("windows")) || cfg!(target_os = "windows") {
         "perry_ui_windows.lib"
     } else {
@@ -1249,6 +1255,7 @@ pub(super) fn build_geisterhand_libs(target: Option<&str>, format: OutputFormat)
         Some("ios-simulator") | Some("ios") => "perry-ui-ios",
         Some("android") => "perry-ui-android",
         Some("linux") => "perry-ui-gtk4",
+        Some("windows-winui") => "perry-ui-windows-winui",
         Some("windows") => "perry-ui-windows",
         _ if cfg!(target_os = "linux") => "perry-ui-gtk4",
         _ if cfg!(target_os = "windows") => "perry-ui-windows",

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1190,7 +1190,9 @@ pub(super) fn find_geisterhand_lib(name: &str, target: Option<&str>) -> Option<P
 }
 
 pub(super) fn find_geisterhand_library(target: Option<&str>) -> Option<PathBuf> {
-    let name = if matches!(target, Some("windows") | Some("windows-winui")) || cfg!(target_os = "windows") {
+    let name = if matches!(target, Some("windows") | Some("windows-winui"))
+        || cfg!(target_os = "windows")
+    {
         "perry_ui_geisterhand.lib"
     } else {
         "libperry_ui_geisterhand.a"
@@ -1199,7 +1201,9 @@ pub(super) fn find_geisterhand_library(target: Option<&str>) -> Option<PathBuf> 
 }
 
 pub(super) fn find_geisterhand_runtime(target: Option<&str>) -> Option<PathBuf> {
-    let name = if matches!(target, Some("windows") | Some("windows-winui")) || cfg!(target_os = "windows") {
+    let name = if matches!(target, Some("windows") | Some("windows-winui"))
+        || cfg!(target_os = "windows")
+    {
         "perry_runtime.lib"
     } else {
         "libperry_runtime.a"
@@ -1217,7 +1221,9 @@ pub(super) fn find_geisterhand_stdlib(target: Option<&str>) -> Option<PathBuf> {
     // so we never select the auto-optimized stdlib, whose feature set is
     // computed from the app's TS imports and omits async-runtime when the async
     // surface comes from a native binding — the #1383 link failure.
-    let name = if matches!(target, Some("windows") | Some("windows-winui")) || cfg!(target_os = "windows") {
+    let name = if matches!(target, Some("windows") | Some("windows-winui"))
+        || cfg!(target_os = "windows")
+    {
         "perry_stdlib.lib"
     } else {
         "libperry_stdlib.a"

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -273,8 +273,8 @@ pub(super) fn build_and_run_link(
     let is_harmonyos = matches!(target, Some("harmonyos") | Some("harmonyos-simulator"));
     let is_linux = matches!(target, Some(t) if t.starts_with("linux"))
         || (target.is_none() && cfg!(target_os = "linux"));
-    let is_windows =
-        matches!(target, Some("windows")) || (target.is_none() && cfg!(target_os = "windows"));
+    let is_windows = matches!(target, Some("windows") | Some("windows-winui"))
+        || (target.is_none() && cfg!(target_os = "windows"));
     let is_cross_windows = is_windows && !cfg!(target_os = "windows");
     let is_cross_ios = is_ios && !cfg!(target_os = "macos");
     let is_cross_visionos = is_visionos && !cfg!(target_os = "macos");
@@ -1248,6 +1248,11 @@ pub(super) fn build_and_run_link(
                 (
                     "libperry_ui_gtk4.a",
                     "cargo build --release -p perry-ui-gtk4 --target x86_64-unknown-linux-gnu",
+                )
+            } else if matches!(target, Some("windows-winui")) {
+                (
+                    "perry_ui_windows_winui.lib",
+                    "cargo build --release -p perry-ui-windows-winui --target x86_64-pc-windows-msvc",
                 )
             } else if is_windows {
                 (

--- a/crates/perry/src/commands/compile/lock_scan.rs
+++ b/crates/perry/src/commands/compile/lock_scan.rs
@@ -146,7 +146,7 @@ fn derive_target_key(target: Option<&str>) -> String {
         None => format!("{}-{}", std::env::consts::OS, arch),
         Some("macos") => format!("macos-{}", arch),
         Some("linux") => format!("linux-{}", arch),
-        Some("windows") => format!("windows-{}", arch),
+        Some("windows") | Some("windows-winui") => format!("windows-{}", arch),
         Some("ios") => "ios".to_string(),
         Some("ios-simulator") => "ios-simulator".to_string(),
         Some("tvos") => "tvos".to_string(),

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -549,7 +549,9 @@ pub(super) fn build_optimized_libs(
         None => {
             if matches!(format, OutputFormat::Text) && verbose > 0 {
                 let (rt_name, std_name) = match target {
-                    Some("windows") => ("perry_runtime.lib", "perry_stdlib.lib"),
+                    Some("windows") | Some("windows-winui") => {
+                        ("perry_runtime.lib", "perry_stdlib.lib")
+                    }
                     None if cfg!(target_os = "windows") => {
                         ("perry_runtime.lib", "perry_stdlib.lib")
                     }
@@ -804,13 +806,13 @@ pub(super) fn build_optimized_libs(
 
     // Resolve both archive paths.
     let runtime_name = match target {
-        Some("windows") => "perry_runtime.lib",
+        Some("windows") | Some("windows-winui") => "perry_runtime.lib",
         #[cfg(target_os = "windows")]
         None => "perry_runtime.lib",
         _ => "libperry_runtime.a",
     };
     let stdlib_name = match target {
-        Some("windows") => "perry_stdlib.lib",
+        Some("windows") | Some("windows-winui") => "perry_stdlib.lib",
         #[cfg(target_os = "windows")]
         None => "perry_stdlib.lib",
         _ => "libperry_stdlib.a",
@@ -1033,6 +1035,7 @@ pub(super) fn build_optimized_libs(
                 Some("watchos-simulator") | Some("watchos") => "perry-ui-watchos",
                 Some("tvos-simulator") | Some("tvos") => "perry-ui-tvos",
                 Some("linux") => "perry-ui-gtk4",
+                Some("windows-winui") => "perry-ui-windows-winui",
                 Some("windows") => "perry-ui-windows",
                 Some("macos") => "perry-ui-macos",
                 _ => {

--- a/crates/perry/src/commands/compile/resolve/native_library.rs
+++ b/crates/perry/src/commands/compile/resolve/native_library.rs
@@ -60,7 +60,9 @@ pub(super) fn native_manifest_target_key(target: Option<&str>) -> &'static str {
         Some("watchos-simulator") | Some("watchos") => "watchos",
         Some("harmonyos-simulator") | Some("harmonyos") => "harmonyos",
         Some("linux") => "linux",
-        Some("windows") => "windows",
+        // WinUI (#4680) is the same OS/arch as the Win32 target for native
+        // library resolution (D3d12/Vulkan backends, x64 prebuilts).
+        Some("windows") | Some("windows-winui") => "windows",
         Some("web") => "web",
         Some("macos") => "macos",
         None if cfg!(target_os = "linux") => "linux",
@@ -1304,7 +1306,7 @@ fn arch_for_target_key(target: Option<&str>) -> Option<&'static str> {
         // prebuilts.
         Some("macos") => Some("arm64"),
         Some("linux") => Some("x64"),
-        Some("windows") => Some("x64"),
+        Some("windows") | Some("windows-winui") => Some("x64"),
         Some("android") => Some("arm64"),
         Some("harmonyos") => Some("arm64"),
         Some("harmonyos-simulator") => Some("x64"),

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -33,7 +33,8 @@ Use `--target` to cross-compile:
 | `wearos-tile` | Wear OS Tile | Wear OS Tile (TileService) |
 | `wasm` | WebAssembly | Self-contained HTML with WASM or raw `.wasm` binary |
 | `web` | Web | Outputs HTML file with JS |
-| `windows` | Windows | Win32 executable |
+| `windows` | Windows | Win32/GDI executable (default Windows backend) |
+| `windows-winui` | Windows (Fluent) | Opt-in WinUI 3 / Fluent backend (#4680). **Scaffold:** currently renders via Win32 while the XAML widget mapping lands incrementally; selects the `perry-ui-windows-winui` static library. Build that lib first: `cargo build --release -p perry-ui-windows-winui`. |
 | `linux` | Linux | GTK4 executable |
 
 ## Output Types


### PR DESCRIPTION
Scaffolds the opt-in **WinUI 3 / Fluent** Windows backend requested in #4680 (discussion #3486). This is the **foundation** — the XAML widget mapping is the multi-day follow-up that lands incrementally on top of this.

> **Note:** No version bump / changelog entry in this PR by request — the maintainer will fold in the metadata at merge time (like a contributor PR).

## What's here

### New crate `perry-ui-windows-winui`
Re-exports `perry-ui-windows` verbatim. Building it as a staticlib bundles **all 311 `perry_ui_*` `#[no_mangle] extern "C"` symbols**, so the FFI surface the perry driver links against is identical to the `windows` target. Apps built for `windows-winui` therefore **build, link, and run today** (rendering through Win32) while the Fluent/XAML layer is developed in the crate's `winui` module — which ships with a Windows App SDK bootstrap stub (`winui::bootstrap`) and crate-level docs spelling out the #4680 step sequence. `strip = false` profile; forwards a `geisterhand` feature.

### New target `--target windows-winui`
Threaded through the whole compile/link pipeline so it behaves **exactly like `windows`** — same `x86_64-pc-windows-msvc` triple, `/SUBSYSTEM`, comctl32 v6 manifest, `[windows]` perry.toml section, native-library/D3d12 resolution, `.exe`/`.lib` naming, runtime-first link + `/WHOLEARCHIVE` — **except** it selects `perry_ui_windows_winui.lib` and the `perry-ui-windows-winui` crate for bitcode/geisterhand builds.

Touched: `library_search.rs`, `optimized_libs.rs`, `app_metadata.rs`, `codegen/helpers.rs`, `compile.rs`, `link/mod.rs`, `resolve/native_library.rs`, `lock_scan.rs`, `build_cache.rs`. The Win32 `windows` target and the host-default (no `--target`) path are unchanged.

Documented in `docs/src/cli/flags.md`.

## Verification
- New crate + `perry` build clean (rebased on current main).
- An app compiled with `--target windows-winui` links `perry_ui_windows_winui.lib` and **creates its window at runtime** (the bundled Win32 symbols drive it) — no startup crash.
- `perry-ui-windows-winui` test (1) + `perry` `windows_link` tests (18) pass.

## Not in this PR (the #4680 follow-up work)
The actual `Microsoft.UI.Xaml` widget mapping (steps 1-6 in the issue): WinAppSDK projections in Cargo.toml, the real bootstrapper, per-widget XAML controls replacing Win32 creation, Mica/Fluent chrome, MSIX/unpackaged packaging, and the geisterhand `apply_style` parity pass. Each lands on this scaffold without breaking the link surface.

## Note on rendering
Until the XAML layer lands, `--target windows-winui` renders via Win32. That's intentional for the scaffold — it keeps the target real and apps runnable while the Fluent backend is built incrementally. The docs say so explicitly.