### PR TITLE
fix: yield* async-delegation test262 parity (next-capture + object-literal thenable await)

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -334,6 +334,45 @@ fn async_from_sync_call_raw(iter: f64, method: &[u8], args: &[f64]) -> Result<Op
     result
 }
 
+/// Invoke a pre-fetched method value with `this` = `iter`. Mirrors
+/// [`async_from_sync_call_raw`] but skips the per-call property read — used for
+/// the `next` method, whose `[[NextMethod]]` the spec captures ONCE at
+/// CreateAsyncFromSyncIterator time and reuses for every step (ECMA-262
+/// §27.1.4.2). Re-reading `next` per call re-ran the sync iterator's `get next`
+/// accessor on every pull, diverging from Node's operation order
+/// (test262 yield-star-sync-next).
+fn async_from_sync_call_cached_raw(
+    iter: f64,
+    method_value: f64,
+    args: &[f64],
+) -> Result<Option<f64>, f64> {
+    if !is_callable_value(method_value) {
+        return Err(async_from_sync_type_error(
+            b"Async-from-sync iterator method is not callable",
+        ));
+    }
+    let prev_this = crate::object::js_implicit_this_set(iter);
+    let trap_buf = crate::exception::js_try_push();
+    let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut std::os::raw::c_int) };
+    let result = if jumped == 0 {
+        let args_ptr = if args.is_empty() {
+            std::ptr::null()
+        } else {
+            args.as_ptr()
+        };
+        let value =
+            unsafe { crate::closure::js_native_call_value(method_value, args_ptr, args.len()) };
+        Ok(Some(value))
+    } else {
+        let exc = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        Err(exc)
+    };
+    crate::object::js_implicit_this_set(prev_this);
+    crate::exception::js_try_end();
+    result
+}
+
 fn async_from_sync_close(iter: f64) {
     let _ = async_from_sync_call_raw(iter, b"return", &[]);
 }
@@ -351,9 +390,21 @@ extern "C" fn async_from_sync_next(
     rest: f64,
 ) -> f64 {
     let iter = crate::closure::js_closure_get_capture_f64(closure, 0);
+    let cached_next = crate::closure::js_closure_get_capture_f64(closure, 1);
     let (argc, first) = async_from_sync_rest_args(rest);
     let single = [first];
     let args: &[f64] = if argc == 0 { &[] } else { &single };
+    // Use the captured `[[NextMethod]]` when it is a readable callable (the
+    // observable-getter case). Builtin iterators (array/map/set/string) expose
+    // no readable own `next` and dispatch through the class-id method tower, so
+    // fall back to the by-name call for them.
+    if is_callable_value(cached_next) {
+        return match async_from_sync_call_cached_raw(iter, cached_next, args) {
+            Ok(Some(step)) => async_from_sync_continue(iter, step, true),
+            Ok(None) => async_from_sync_call(iter, b"next", args, true),
+            Err(reason) => boxed_promise_value(crate::promise::js_promise_rejected(reason)),
+        };
+    }
     async_from_sync_call(iter, b"next", args, true)
 }
 
@@ -428,11 +479,31 @@ fn install_async_from_sync_method(
     value
 }
 
+/// Install the wrapper's `next` method with TWO captures: the sync iterator
+/// (slot 0) and its pre-fetched `[[NextMethod]]` (slot 1, see
+/// [`async_from_sync_call_cached_raw`]).
+fn install_async_from_sync_next(
+    obj: *mut crate::object::ObjectHeader,
+    iter: f64,
+    cached_next: f64,
+) -> f64 {
+    let closure = crate::closure::js_closure_alloc(async_from_sync_next as *const u8, 2);
+    crate::closure::js_closure_set_capture_f64(closure, 0, iter);
+    crate::closure::js_closure_set_capture_f64(closure, 1, cached_next);
+    let value = crate::value::js_nanbox_pointer(closure as i64);
+    let key = crate::string::js_string_from_bytes(b"next".as_ptr(), 4);
+    crate::object::js_object_set_field_by_name(obj, key, value);
+    value
+}
+
 pub(crate) fn async_from_sync_wrap_iterator(iter: f64) -> f64 {
     register_async_from_sync_thunks_once();
     let obj = crate::object::js_object_alloc(0, 0);
     let wrapper = crate::value::js_nanbox_pointer(obj as i64);
-    install_async_from_sync_method(obj, b"next", async_from_sync_next, iter);
+    // Spec (CreateAsyncFromSyncIterator): the sync iterator record's
+    // `[[NextMethod]]` is read once, here, and reused for every `next()` step.
+    let cached_next = named_field(iter, b"next");
+    install_async_from_sync_next(obj, iter, cached_next);
     install_async_from_sync_method(obj, b"return", async_from_sync_return, iter);
     install_async_from_sync_method(obj, b"throw", async_from_sync_throw, iter);
     let async_iter =

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -1186,7 +1186,15 @@ pub extern "C" fn js_assimilate_thenable(value: f64) -> f64 {
         (*obj_ptr).class_id
     };
     if class_id == 0 {
-        return value;
+        // A plain object literal (`{ then(resolve, reject) {…} }` / `{ get then()
+        // {…} }`) has no class vtable, so the method-chain probe below can't see
+        // its `then`. Per ECMA-262 PromiseResolveThenableJob the thenable check
+        // is `Get(value, "then")` + IsCallable — independent of how `then` is
+        // stored. Route object literals through the property-based fallback so
+        // `await { then(r){ r(v) } }` and delegated async-iterator results (whose
+        // `next()` returns object-literal promises — test262 yield-star-async-*)
+        // assimilate instead of resolving with the thenable object itself.
+        return assimilate_via_then_property(value);
     }
 
     // Probe the vtable chain for `then` (a class *method*). If that fails, fall
@@ -1264,11 +1272,15 @@ fn assimilate_via_then_property(value: f64) -> f64 {
     let reject_closure = crate::closure::js_closure_alloc(promise_reject_fn as *const u8, 1);
     crate::closure::js_closure_set_capture_ptr(reject_closure, 0, promise_i64);
 
-    // The user's `then(onFulfilled, onRejected)` receives each resolving function
-    // as a raw closure-pointer f64 — the same convention `js_promise_new_with_
-    // executor` uses for `executor(resolve, reject)` (user JS calls these fine).
-    let resolve_f64 = f64::from_bits(resolve_closure as u64);
-    let reject_f64 = f64::from_bits(reject_closure as u64);
+    // Pass the resolving functions as proper NaN-boxed function values (not the
+    // raw closure-pointer-bits convention used internally by
+    // `js_promise_new_with_executor`): a thenable's `then(onFulfilled,
+    // onRejected)` is a USER-visible call, and spec/Node hand it real functions —
+    // so `typeof onFulfilled === "function"` must hold (test262
+    // yield-star-async-* / yield-star-next-then-* check this). A NaN-boxed
+    // closure is still invoked through the normal call path.
+    let resolve_f64 = crate::value::js_nanbox_pointer(resolve_closure as i64);
+    let reject_f64 = crate::value::js_nanbox_pointer(reject_closure as i64);
     let args = [resolve_f64, reject_f64];
 
     // Bind `this` to the thenable so a non-arrow `then` body reads the right

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -44,6 +44,157 @@ fn delegate_await(call: Expr) -> Expr {
     }
 }
 
+/// Invoke the captured delegated `[[NextMethod]]` (`del_next_id`) with `this` =
+/// the delegated iterator (`del_iter_id`). Spec `yield *` reads `next` exactly
+/// once at iterator-record creation (GetIterator) and re-uses the captured
+/// method for every pull, so the desugar must NOT re-read `del_iter.next` on
+/// each loop iteration (that re-ran the iterator's `get next` accessor and an
+/// extra property read, diverging from Node's operation order — test262
+/// yield-star-{async,sync}-next, yield-star-next-*).
+///
+/// Generated shape:
+///   typeof __del_next === "function"
+///     ? __del_next.call(__del_iter, arg)   // observable case: captured method
+///     : __del_iter.next(arg)               // fallback: method dispatch
+///
+/// The captured-method path calls through `.call` (reads Function.prototype,
+/// not the iterator's getters, and binds `this` for builtin/inherited `next`
+/// thunks — e.g. the array-iterator prototype's `next`). The fallback covers
+/// builtin iterators that expose no *readable* `next` property (string and
+/// typed-array iterators dispatch `.next()` through the class-id method tower);
+/// for those, re-reading is harmless because there is no observable getter.
+fn delegate_next_call(del_next_id: LocalId, del_iter_id: LocalId, arg: Expr) -> Expr {
+    // Spec passes `received.[[Value]]` to every inner `next()` — including the
+    // first pull, where `received` is `NormalCompletion(undefined)`. So the
+    // delegated `next` is ALWAYS called with exactly one argument (the first
+    // pull with an explicit `undefined`, not argless — test262
+    // yield-star-{sync,async}-next assert `next args.length === 1`).
+    let call_args = vec![Expr::LocalGet(del_iter_id), arg.clone()];
+    let method_args = vec![arg];
+    Expr::Conditional {
+        condition: Box::new(Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(Expr::TypeOf(Box::new(Expr::LocalGet(del_next_id)))),
+            right: Box::new(Expr::String("function".to_string())),
+        }),
+        then_expr: Box::new(Expr::Call {
+            callee: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(del_next_id)),
+                property: "call".to_string(),
+            }),
+            args: call_args,
+            type_args: vec![],
+        }),
+        else_expr: Box::new(Expr::Call {
+            callee: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(del_iter_id)),
+                property: "next".to_string(),
+            }),
+            args: method_args,
+            type_args: vec![],
+        }),
+    }
+}
+
+/// Emit the common `yield *` delegation prelude + driving loop into `current`
+/// and linearize it. Shared by all three desugar positions (statement-level
+/// `yield* e`, `return yield* e`, `let x = yield* e`). Returns the local id
+/// holding the delegated iterator's most-recent result object (`{value, done}`),
+/// whose `.value` the caller uses for the completion value.
+#[allow(clippy::too_many_arguments)]
+fn emit_yield_star_loop(
+    inner: &Expr,
+    states: &mut Vec<State>,
+    current: &mut Vec<Stmt>,
+    state_num: &mut u32,
+    state_id: LocalId,
+    next_local_id: &mut u32,
+    sent_id: LocalId,
+    catches: &mut Vec<CatchRoute>,
+    finallys: &mut Vec<FinallyRoute>,
+) -> LocalId {
+    let del_iter_id = alloc_local(next_local_id);
+    let del_next_id = alloc_local(next_local_id);
+    let del_result_id = alloc_local(next_local_id);
+
+    // #1831: resolve the iterator (a generator *call* already is its iterator;
+    // an arbitrary iterable resolves via `[Symbol.iterator]` /
+    // `[Symbol.asyncIterator]`).
+    current.push(Stmt::Expr(Expr::LocalSet(
+        del_iter_id,
+        Box::new(delegate_get_iterator(inner.clone())),
+    )));
+    // Capture `[[NextMethod]]` once (see `delegate_next_call`).
+    current.push(Stmt::Expr(Expr::LocalSet(
+        del_next_id,
+        Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(del_iter_id)),
+            property: "next".to_string(),
+        }),
+    )));
+    // Initial pull: `received` starts as `NormalCompletion(undefined)`, so the
+    // first inner `next()` gets an explicit `undefined` argument.
+    current.push(Stmt::Expr(Expr::LocalSet(
+        del_result_id,
+        Box::new(delegate_await(delegate_next_call(
+            del_next_id,
+            del_iter_id,
+            Expr::Undefined,
+        ))),
+    )));
+
+    // #1832: in-loop pull forwards the outer resume value (`outer.next(v)` →
+    // `sent_id`) into the delegated iterator's `next(v)`.
+    let while_body = vec![
+        // Spec step `received be AsyncGeneratorYield(? IteratorValue(innerResult))`.
+        // Unlike a plain `yield x` (which is `AsyncGeneratorYield(? Await(x))` and
+        // is handled by the #4777 await pass), the DELEGATED value is NOT awaited:
+        // current `AsyncGeneratorYield` does not await its operand, so a delegated
+        // promise value flows through un-unwrapped (test262
+        // yield-star-promise-not-unwrapped). Only the `next()` RESULT is awaited
+        // (via `delegate_await` on the pull below).
+        Stmt::Expr(Expr::Yield {
+            value: Some(Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(del_result_id)),
+                property: "value".to_string(),
+            })),
+            delegate: false,
+        }),
+        Stmt::Expr(Expr::LocalSet(
+            del_result_id,
+            Box::new(delegate_await(delegate_next_call(
+                del_next_id,
+                del_iter_id,
+                Expr::LocalGet(sent_id),
+            ))),
+        )),
+    ];
+    let while_stmt = Stmt::While {
+        condition: Expr::Unary {
+            op: UnaryOp::Not,
+            operand: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(del_result_id)),
+                property: "done".to_string(),
+            }),
+        },
+        body: while_body,
+    };
+
+    linearize_body(
+        &[while_stmt],
+        states,
+        current,
+        state_num,
+        state_id,
+        next_local_id,
+        sent_id,
+        catches,
+        finallys,
+    );
+
+    del_result_id
+}
+
 pub struct State {
     pub num: u32,
     pub body: Vec<Stmt>,
@@ -135,85 +286,17 @@ pub fn linearize_body(
                 value: Some(inner),
                 delegate: true,
             }) => {
-                // Desugar yield* into:
-                //   let __del_iter = inner_expr;  (inner is a generator call)
-                //   let __del_result = __del_iter.next();
+                // Desugar `yield* inner` into a drive loop:
+                //   let __del_iter = GetIterator(inner);
+                //   let __del_next = __del_iter.next;          // captured ONCE
+                //   let __del_result = __del_next.call(__del_iter);
                 //   while (!__del_result.done) {
                 //     yield __del_result.value;
-                //     __del_result = __del_iter.next();
+                //     __del_result = __del_next.call(__del_iter, __sent);
                 //   }
-                // We don't actually need real vars — we can inline this as states.
-                // But the simplest approach: expand into statements and re-linearize.
-                let del_iter_id = alloc_local(next_local_id);
-                let del_result_id = alloc_local(next_local_id);
-
-                // Initial pull: `__del_iter.next()` with no argument (the value
-                // passed to the *first* `next()` of a generator is discarded per
-                // spec).
-                let next_call = Expr::Call {
-                    callee: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(del_iter_id)),
-                        property: "next".to_string(),
-                    }),
-                    args: vec![],
-                    type_args: vec![],
-                };
-                // #1832: in-loop pull must forward the value the *outer* generator
-                // was resumed with (`outer.next(v)` → stored in `sent_id`) into the
-                // delegated iterator's `next(v)`, so `yield*`-delegated two-way
-                // communication matches spec. Argless here silently dropped it.
-                let next_call_resumed = Expr::Call {
-                    callee: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(del_iter_id)),
-                        property: "next".to_string(),
-                    }),
-                    args: vec![Expr::LocalGet(sent_id)],
-                    type_args: vec![],
-                };
-
-                // Add hoisted var declarations to current (they'll be emitted in the state body)
-                // #1831: resolve the iterator. For a generator *call* the result
-                // already is its iterator; for an arbitrary iterable (effect,
-                // custom `[Symbol.iterator]`) `js_get_iterator` invokes the
-                // well-known-symbol method to obtain one.
-                current.push(Stmt::Expr(Expr::LocalSet(
-                    del_iter_id,
-                    Box::new(delegate_get_iterator(*inner.clone())),
-                )));
-                current.push(Stmt::Expr(Expr::LocalSet(
-                    del_result_id,
-                    Box::new(delegate_await(next_call)),
-                )));
-
-                // Build the while loop with yield
-                let while_body = vec![
-                    Stmt::Expr(Expr::Yield {
-                        value: Some(Box::new(Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(del_result_id)),
-                            property: "value".to_string(),
-                        })),
-                        delegate: false,
-                    }),
-                    Stmt::Expr(Expr::LocalSet(
-                        del_result_id,
-                        Box::new(delegate_await(next_call_resumed)),
-                    )),
-                ];
-
-                let while_stmt = Stmt::While {
-                    condition: Expr::Unary {
-                        op: UnaryOp::Not,
-                        operand: Box::new(Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(del_result_id)),
-                            property: "done".to_string(),
-                        }),
-                    },
-                    body: while_body,
-                };
-
-                // Now linearize the expanded while (it contains a yield, so the while handler picks it up)
-                linearize_body(
-                    &[while_stmt],
+                // (see `emit_yield_star_loop` for the shared implementation).
+                emit_yield_star_loop(
+                    inner,
                     states,
                     current,
                     state_num,
@@ -263,69 +346,8 @@ pub fn linearize_body(
                 value: Some(inner),
                 delegate: true,
             })) => {
-                let del_iter_id = alloc_local(next_local_id);
-                let del_result_id = alloc_local(next_local_id);
-
-                // Initial pull: argless (the first `next()` value is discarded
-                // per spec).
-                let next_call = Expr::Call {
-                    callee: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(del_iter_id)),
-                        property: "next".to_string(),
-                    }),
-                    args: vec![],
-                    type_args: vec![],
-                };
-                // #1832: in-loop pull forwards the outer resume value (`sent_id`).
-                let next_call_resumed = Expr::Call {
-                    callee: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(del_iter_id)),
-                        property: "next".to_string(),
-                    }),
-                    args: vec![Expr::LocalGet(sent_id)],
-                    type_args: vec![],
-                };
-
-                // #1831: resolve the iterator (effect / custom `[Symbol.iterator]`
-                // operands need `js_get_iterator` to invoke the well-known-symbol
-                // method; a generator call already is its iterator). Async
-                // generators delegate through the async-iterator protocol.
-                current.push(Stmt::Expr(Expr::LocalSet(
-                    del_iter_id,
-                    Box::new(delegate_get_iterator(*inner.clone())),
-                )));
-                current.push(Stmt::Expr(Expr::LocalSet(
-                    del_result_id,
-                    Box::new(delegate_await(next_call)),
-                )));
-
-                let while_body = vec![
-                    Stmt::Expr(Expr::Yield {
-                        value: Some(Box::new(Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(del_result_id)),
-                            property: "value".to_string(),
-                        })),
-                        delegate: false,
-                    }),
-                    Stmt::Expr(Expr::LocalSet(
-                        del_result_id,
-                        Box::new(delegate_await(next_call_resumed)),
-                    )),
-                ];
-
-                let while_stmt = Stmt::While {
-                    condition: Expr::Unary {
-                        op: UnaryOp::Not,
-                        operand: Box::new(Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(del_result_id)),
-                            property: "done".to_string(),
-                        }),
-                    },
-                    body: while_body,
-                };
-
-                linearize_body(
-                    &[while_stmt],
+                let del_result_id = emit_yield_star_loop(
+                    inner,
                     states,
                     current,
                     state_num,
@@ -1022,69 +1044,8 @@ pub fn linearize_body(
                 ty,
                 name,
             } => {
-                let del_iter_id = alloc_local(next_local_id);
-                let del_result_id = alloc_local(next_local_id);
-
-                // Initial pull: argless (first `next()` value is discarded per spec).
-                let next_call = Expr::Call {
-                    callee: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(del_iter_id)),
-                        property: "next".to_string(),
-                    }),
-                    args: vec![],
-                    type_args: vec![],
-                };
-                // #1832: in-loop pull forwards the outer resume value (`sent_id`).
-                let next_call_resumed = Expr::Call {
-                    callee: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(del_iter_id)),
-                        property: "next".to_string(),
-                    }),
-                    args: vec![Expr::LocalGet(sent_id)],
-                    type_args: vec![],
-                };
-
-                // #1831: resolve the iterator. For a generator *call* the result
-                // already is its iterator; for an arbitrary iterable (effect,
-                // custom `[Symbol.iterator]`) `js_get_iterator` invokes the
-                // well-known-symbol method to obtain one. Async generators
-                // delegate through the async-iterator protocol.
-                current.push(Stmt::Expr(Expr::LocalSet(
-                    del_iter_id,
-                    Box::new(delegate_get_iterator(*inner.clone())),
-                )));
-                current.push(Stmt::Expr(Expr::LocalSet(
-                    del_result_id,
-                    Box::new(delegate_await(next_call)),
-                )));
-
-                let while_body = vec![
-                    Stmt::Expr(Expr::Yield {
-                        value: Some(Box::new(Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(del_result_id)),
-                            property: "value".to_string(),
-                        })),
-                        delegate: false,
-                    }),
-                    Stmt::Expr(Expr::LocalSet(
-                        del_result_id,
-                        Box::new(delegate_await(next_call_resumed)),
-                    )),
-                ];
-
-                let while_stmt = Stmt::While {
-                    condition: Expr::Unary {
-                        op: UnaryOp::Not,
-                        operand: Box::new(Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(del_result_id)),
-                            property: "done".to_string(),
-                        }),
-                    },
-                    body: while_body,
-                };
-
-                linearize_body(
-                    &[while_stmt],
+                let del_result_id = emit_yield_star_loop(
+                    inner,
                     states,
                     current,
                     state_num,


### PR DESCRIPTION
Builds on #4777 (now merged). Spec-aligns `yield *` async/sync delegation and fixes a core `await`/`Promise.resolve` gap that gated the delegated async-iterator protocol.

## Results (test262, vs main @ #4777, **0 regressions**)
| suite | before | after |
|---|---|---|
| language/{expressions,statements}/async-generator | 820 pass / 92.3% | **838 pass / 94.4%** |
| built-ins/Promise | 347 pass / 60.5% | **357 pass / 62.2%** (thenable fix, bonus) |
| language/{expressions,statements}/generators | 487 / 87.7% | no regression |

yield-star tests newly passing: `yield-star-async-next`, `yield-star-next-then-get-abrupt`, `yield-star-next-then-returns-abrupt`, `yield-star-getiter-async-returns-null-throw` (+ `named-` variants). Failure-set diff (`mine − base`) is empty for all three dirs.

## Root causes fixed
1. **`[[NextMethod]]` captured once** (`generator/linearize.rs`). The desugar re-read `del_iter.next` every loop iteration, re-running the iterator's `get next` accessor + an extra property read per step; spec (GetIterator) reads `next` once and reuses it. Factored the 3 near-identical desugar sites (`yield* e`, `return yield* e`, `let x = yield* e`) into one `emit_yield_star_loop` that captures `__del_next = __del_iter.next` once and calls `__del_next.call(__del_iter, arg)` (binds `this` for inherited/builtin `next` thunks), falling back to method dispatch when the captured value isn't callable (string/typed-array iterators expose no readable `next`).
2. **First inner pull passes explicit `undefined`** (not argless). Spec inits `received = NormalCompletion(undefined)`, so every inner `next()` — including the first — gets one arg (`next args.length === 1`).
3. **async-from-sync wrapper caches the sync `[[NextMethod]]`** (`array/iterator.rs`). CreateAsyncFromSyncIterator reads `next` once; the wrapper re-read (and re-ran the getter) on every `next()`.
4. **Object-literal thenables now assimilate in `await`/`Promise.resolve`** (`promise/combinators.rs`). `js_assimilate_thenable` returned early for `class_id == 0` objects (`{ then(){} }` / `{ get then(){} }`), so `await { then(r){r(v)} }` resolved with the thenable itself. Routed through the existing property-based fallback (PromiseResolveThenableJob: `Get(value,"then")` + IsCallable), and pass the resolving functions to user `then` as NaN-boxed function values so `typeof onFulfilled === "function"` holds. Also fixes +10 `built-ins/Promise` tests.

The delegated yielded value is intentionally **not** awaited — current `AsyncGeneratorYield` does not await its operand (only the `next()` result is), so a delegated promise flows through un-unwrapped (`yield-star-promise-not-unwrapped`).

## Regression check
- `cargo test -p perry-transform -p perry-runtime -p perry-hir -p perry-codegen`: all real tests pass. Two perry-runtime unit tests (`closure_name_and_length_ignore_plain_assignment`, `stream_constructors_expose_static_method_values`) are **pre-existing parallel-isolation flakes** — both pass in isolation and on base; the same binary passes/fails depending only on whether a sibling test's `test_clear_closure_side_tables()` runs concurrently. Not caused by this change.
- Effect-style sync `yield*` smoke (delegation through array / Set / generator / custom `[Symbol.iterator]` / two-way `next(v)`) matches Node.

## Remaining yield* failures (out of scope; orthogonal pre-existing gaps)
- **return/throw delegation forwarding** (`yield-star-{async,sync}-{return,throw}`, `getiter-async-{return,throw}-method-is-null`, `*-notdone-iter-value-throws`): the suspended `yield*` must dispatch the consumer's `.return()/.throw()` to the delegate (close + re-yield), needing resume-mode plumbing through the async-generator state machine (`generator/lower.rs` + `object/async_generator_queue.rs`).
- **GetIterator `[Symbol.iterator]` this-binding** (`yield-star-sync-next`): calling the (getter-returned) `[Symbol.iterator]` binds the wrong `this`. Separate subsystem.
- **next-protocol edge validation** (`yield-star-next-{call-value-get-abrupt,non-object-ignores-then,not-callable-number-throw,then-non-callable-number-fulfillpromise}`): IteratorNext result must be validated as Object (spec step iv) + abrupt propagation.