### PR TITLE
fix(runtime): built-ins/Object test262 parity (v2)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -892,20 +892,28 @@ pub(super) fn try_native_module_methods(
                                 // Static descriptor literal — desugar to a Sequence
                                 // of `defineProperty(target, key, desc)` calls and
                                 // yield `target` as the result value.
-                                let target = target;
-                                let mut exprs: Vec<Expr> = Vec::with_capacity(props.len() + 1);
-                                for (key_name, desc_expr) in props {
-                                    exprs.push(Expr::ObjectDefineProperty(
-                                        Box::new(target.clone()),
-                                        Box::new(Expr::String(key_name.clone())),
-                                        Box::new(desc_expr.clone()),
-                                    ));
+                                //
+                                // An EMPTY literal must NOT fold to a bare `target`:
+                                // `Object.defineProperties(O, {})` still performs the
+                                // spec's step-1 `If Type(O) is not Object, throw a
+                                // TypeError`, so `Object.defineProperties(undefined,
+                                // {})` must throw. With no keys there is no per-key
+                                // `defineProperty` to enforce that, so route the
+                                // empty case through the runtime helper (which
+                                // validates the target).
+                                if !props.is_empty() {
+                                    let target = target;
+                                    let mut exprs: Vec<Expr> = Vec::with_capacity(props.len() + 1);
+                                    for (key_name, desc_expr) in props {
+                                        exprs.push(Expr::ObjectDefineProperty(
+                                            Box::new(target.clone()),
+                                            Box::new(Expr::String(key_name.clone())),
+                                            Box::new(desc_expr.clone()),
+                                        ));
+                                    }
+                                    exprs.push(target);
+                                    return Ok(Ok(Expr::Sequence(exprs)));
                                 }
-                                exprs.push(target);
-                                if exprs.len() == 1 {
-                                    return Ok(Ok(exprs.into_iter().next().unwrap()));
-                                }
-                                return Ok(Ok(Expr::Sequence(exprs)));
                             }
                             return Ok(Ok(Expr::ObjectDefineProperties(
                                 Box::new(target),

--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -30,13 +30,14 @@ pub(crate) unsafe fn array_property_is_enumerable(
     if !super::has_own_helpers::array_own_key_present(arr, key_str) {
         return Some(f64::from_bits(TAG_FALSE));
     }
-    let enumerable = if super::canonical_array_index(key_name).is_some() {
-        true
-    } else {
-        super::get_property_attrs(obj as usize, key_name)
-            .map(|attrs| attrs.enumerable())
-            .unwrap_or(true)
-    };
+    // Both index and named properties default to enumerable when no explicit
+    // descriptor was recorded; an index redefined via
+    // `Object.defineProperty(arr, i, { enumerable: false })` carries a
+    // side-table entry that must be honored (it previously hard-coded `true`
+    // for canonical indices, so a non-enumerable index still reported `true`).
+    let enumerable = super::get_property_attrs(obj as usize, key_name)
+        .map(|attrs| attrs.enumerable())
+        .unwrap_or(true);
     Some(f64::from_bits(if enumerable {
         TAG_TRUE
     } else {
@@ -355,6 +356,17 @@ pub(crate) unsafe fn define_array_property(
 
         if has_value {
             crate::array::js_array_set_f64_extend(arr, index, value);
+        } else if !exists {
+            // A NEW index defined with an attributes-only / generic descriptor
+            // (`Object.defineProperty(arr, i, { enumerable: true })`, no `value`)
+            // still becomes an own data property whose value defaults to
+            // `undefined`. Materialize the slot so the index counts as an own
+            // property for reflection (`hasOwnProperty`, `verifyProperty`).
+            crate::array::js_array_set_f64_extend(
+                arr,
+                index,
+                f64::from_bits(crate::value::TAG_UNDEFINED),
+            );
         }
 
         // Compute final attributes. New property: omitted ⇒ false. Redefine:

--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -142,22 +142,61 @@ pub(crate) unsafe fn array_set_length_from_descriptor(
         }
     }
 
-    // Apply. Shrinking deletes the now-out-of-range indices (handled by
-    // `js_array_set_length`, which holes the truncated slots); growing pads with
-    // holes. `js_array_set_length` doesn't consult the writable side table, and
-    // we've already validated the write above.
+    // Apply. Growing pads with holes. Shrinking must delete the now-out-of-range
+    // indices from the TOP down (ECMA-262 10.4.2.4 ArraySetLength steps 15-17):
+    // if a deletion target is a NON-configurable index, `length` can only shrink
+    // to just above it and the operation is rejected. `js_array_set_length`
+    // doesn't consult the per-index descriptor side table, so do the spec walk
+    // here. The new writability (if `writable:false` was requested) is persisted
+    // even on the reject path, matching the spec's step-16/17 ordering.
+    let mut rejected = false;
     if let Some(n) = new_len {
-        crate::array::js_array_set_length(arr, n as f64);
+        if n < old_len {
+            // Find the highest non-configurable index in [n, old_len): length
+            // can shrink no further than one past it.
+            let mut target = n;
+            let mut i = old_len;
+            while i > n {
+                i -= 1;
+                let key = i.to_string();
+                let configurable = super::get_property_attrs(obj as usize, &key)
+                    .map(|a| a.configurable())
+                    .unwrap_or(true);
+                if !configurable {
+                    target = i + 1;
+                    rejected = true;
+                    break;
+                }
+            }
+            // Drop the per-index descriptor entries for the indices actually
+            // removed so stale attrs can't resurrect a deleted index.
+            let mut j = old_len;
+            while j > target {
+                j -= 1;
+                super::clear_property_attrs(obj as usize, &j.to_string());
+            }
+            crate::array::js_array_set_length(arr, target as f64);
+        } else {
+            crate::array::js_array_set_length(arr, n as f64);
+        }
     }
-    if has_writable {
-        // Persist the new writability (enumerable/configurable stay false).
+    if has_writable && !new_writable {
+        // A `writable:false` length define is applied even when a shrink was
+        // rejected (the property becomes non-writable; only the truncation
+        // partially failed).
+        super::set_property_attrs(
+            obj as usize,
+            "length".to_string(),
+            PropertyAttrs::new(false, false, false),
+        );
+    } else if has_writable {
         super::set_property_attrs(
             obj as usize,
             "length".to_string(),
             PropertyAttrs::new(new_writable, false, false),
         );
     }
-    true
+    !rejected
 }
 
 /// `Reflect.defineProperty` hook for the array `length` property. Returns
@@ -230,6 +269,19 @@ pub(crate) unsafe fn define_array_property(
 
     if let Some(index) = super::canonical_array_index(key_name) {
         let exists = super::has_own_helpers::array_own_key_present(arr, key_str);
+
+        // Array exotic `[[DefineOwnProperty]]` (ECMA-262 10.4.2.1) step 3.b: a
+        // NEW index at or beyond `length` requires extending `length`, which is
+        // forbidden when the `length` property is non-writable — reject (the
+        // caller turns this into a `TypeError`).
+        if !exists && index >= (*arr).length {
+            let len_writable = super::get_property_attrs(obj as usize, "length")
+                .map(|a| a.writable())
+                .unwrap_or(true);
+            if !len_writable {
+                return Some(false);
+            }
+        }
 
         // Accessor descriptor on an array index: store get/set in the side table
         // (the dense element store can't hold a getter/setter). Routing this

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -993,7 +993,8 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
             return f64::from_bits((empty as u64) | 0x7FFD_0000_0000_0000);
         }
         {
-            let gc = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            let gc =
+                (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
             if (*gc).obj_type != crate::gc::GC_TYPE_OBJECT {
                 let empty = crate::array::js_array_alloc(0);
                 return f64::from_bits((empty as u64) | 0x7FFD_0000_0000_0000);

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -982,6 +982,23 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
             let empty = crate::array::js_array_alloc(0);
             return f64::from_bits((empty as u64) | 0x7FFD_0000_0000_0000);
         }
+        // A heap value that isn't a plain ordinary object (Date `DateCell`,
+        // RegExp, Map/Set, Promise, …) has no `ObjectHeader.keys_array` — reading
+        // one off its header dereferences garbage and segfaults. `Object.create({},
+        // new Date(0))` / `Object.defineProperties(obj, new RegExp())` reach here
+        // with such a value. Perry doesn't model expando properties on these
+        // exotic objects, so report no own keys rather than crashing.
+        if !is_valid_obj_ptr(obj as *const u8) {
+            let empty = crate::array::js_array_alloc(0);
+            return f64::from_bits((empty as u64) | 0x7FFD_0000_0000_0000);
+        }
+        {
+            let gc = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if (*gc).obj_type != crate::gc::GC_TYPE_OBJECT {
+                let empty = crate::array::js_array_alloc(0);
+                return f64::from_bits((empty as u64) | 0x7FFD_0000_0000_0000);
+            }
+        }
         let keys = (*obj).keys_array;
         if keys.is_null() {
             let empty = crate::array::js_array_alloc(0);

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1609,6 +1609,15 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                 let elements = (arr as *const u8)
                     .add(std::mem::size_of::<crate::array::ArrayHeader>())
                     as *const u64;
+                // Index properties may carry a non-default descriptor
+                // (`Object.defineProperty(arr, i, { enumerable: false })`).
+                // Object.keys / for-in must skip non-enumerable indices — but
+                // the per-index side-table lookup is only needed when this array
+                // actually has descriptor entries, so the common all-default
+                // array stays on the fast path.
+                let owner = stripped as usize;
+                let has_idx_descriptors = PROPERTY_DESCRIPTORS
+                    .with(|m| m.borrow().keys().any(|(ptr, _)| *ptr == owner));
                 let result = crate::array::js_array_alloc(length);
                 for i in 0..length {
                     if std::ptr::read(elements.add(i as usize)) == crate::value::TAG_HOLE {
@@ -1618,6 +1627,13 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                     // 0..=99999 (≤5 bytes), and a length-100k array hits the
                     // sanity-cap above so we never need a heap StringHeader.
                     let s = i.to_string();
+                    if has_idx_descriptors {
+                        if let Some(attrs) = get_property_attrs(owner, &s) {
+                            if !attrs.enumerable() {
+                                continue;
+                            }
+                        }
+                    }
                     let key_box = crate::string::js_string_new_sso(s.as_ptr(), s.len() as u32);
                     crate::array::js_array_push_f64(result, key_box);
                 }
@@ -2317,28 +2333,85 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     let key_str = crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
 
     unsafe {
-        let keys = (*obj_ptr).keys_array;
-        if keys.is_null() {
-            return nanbox_false;
+        if ordinary_has_property(obj_ptr, key_str) {
+            nanbox_true
+        } else {
+            nanbox_false
         }
+    }
+}
 
-        let key_count = crate::array::js_array_length(keys) as usize;
-        for i in 0..key_count {
-            let stored_key_val = crate::array::js_array_get(keys, i as u32);
-            // #1781: accept inline SSO short keys (the closure-style
-            // `key in obj` path previously dropped them too).
-            if crate::string::js_string_key_matches(stored_key_val, key_str) {
-                // Check if the field was deleted (set to undefined by delete operator)
-                let field_val = js_object_get_field(obj_ptr, i as u32);
-                if field_val.is_undefined() {
-                    return nanbox_false;
-                }
-                return nanbox_true;
+/// `OrdinaryHasProperty(O, P)` (ECMA-262 10.1.7.1) for ordinary heap objects:
+/// true when `P` is an own property of `O` OR of any object in `O`'s
+/// `[[Prototype]]` chain.
+///
+/// Pre-fix the `in`-operator tail only scanned the receiver's own `keys_array`
+/// and, fatally, treated a present key whose stored value is `undefined` as
+/// absent. That conflated three distinct cases: a deleted property (`delete`
+/// actually removes the key from `keys_array`, so it never reaches here), an
+/// explicit `obj.x = undefined` (own, present), and an own *accessor* whose
+/// backing slot reads `undefined`. It also never walked the prototype chain, so
+/// inherited data/accessor properties — and `ToPropertyDescriptor`'s
+/// `HasProperty(desc, "value"/"get"/...)` reads on a descriptor whose fields are
+/// inherited or accessor-backed — wrongly reported absent.
+///
+/// This implements the spec walk: at each level check own-key presence (a key in
+/// `keys_array`, regardless of stored value) and the own-accessor side table,
+/// then advance to the recorded `[[Prototype]]`. When the chain ends without an
+/// explicit prototype, an inherited `Object.prototype` method still counts.
+unsafe fn ordinary_has_property(
+    obj_ptr: *const ObjectHeader,
+    key: *const crate::StringHeader,
+) -> bool {
+    const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
+    let key_name = super::has_own_helpers::str_from_string_header(key);
+    let mut cur = obj_ptr;
+    let mut last_valid = obj_ptr;
+    let mut guard = 0u32;
+    loop {
+        guard += 1;
+        if guard > 1024 || cur.is_null() || !super::is_valid_obj_ptr(cur as *const u8) {
+            break;
+        }
+        last_valid = cur;
+        // Own data / overflow key present (value-agnostic: `delete` removes the
+        // key, so a present key — even one holding `undefined` — is an own
+        // property).
+        if super::own_key_present(cur as *mut ObjectHeader, key) {
+            return true;
+        }
+        // Own accessor property (also mirrored into `keys_array`, but check the
+        // side table directly so a get-only accessor is never missed).
+        if let Some(name) = key_name {
+            if get_accessor_descriptor(cur as usize, name).is_some() {
+                return true;
             }
         }
-
-        nanbox_false
+        // Advance to the recorded `[[Prototype]]`.
+        let cur_addr = cur as usize;
+        match super::prototype_chain::object_static_prototype(cur_addr) {
+            Some(b) if b == TAG_NULL => return false,
+            Some(b) => {
+                let top16 = b >> 48;
+                let p = if top16 == 0x7FFD {
+                    (b & crate::value::POINTER_MASK) as usize
+                } else if top16 == 0 && b > 0x10000 {
+                    b as usize
+                } else {
+                    break;
+                };
+                if p == 0 || p == cur_addr {
+                    break;
+                }
+                cur = p as *const ObjectHeader;
+            }
+            // No explicit prototype recorded — the default `Object.prototype`
+            // applies (handled below), so stop the explicit walk here.
+            None => break,
+        }
     }
+    // Inherited `Object.prototype` methods (`toString`, `hasOwnProperty`, …).
+    ordinary_object_prototype_method_value(last_valid, key).is_some()
 }
 
 /// Get a field by its string key name

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -1616,8 +1616,8 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                 // actually has descriptor entries, so the common all-default
                 // array stays on the fast path.
                 let owner = stripped as usize;
-                let has_idx_descriptors = PROPERTY_DESCRIPTORS
-                    .with(|m| m.borrow().keys().any(|(ptr, _)| *ptr == owner));
+                let has_idx_descriptors =
+                    PROPERTY_DESCRIPTORS.with(|m| m.borrow().keys().any(|(ptr, _)| *ptr == owner));
                 let result = crate::array::js_array_alloc(length);
                 for i in 0..length {
                     if std::ptr::read(elements.add(i as usize)) == crate::value::TAG_HOLE {

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -2437,8 +2437,27 @@ pub extern "C" fn js_object_define_properties(target: f64, descriptors: f64) -> 
     for k in keys {
         // Read the descriptor through `[[Get]]` so accessors on the properties
         // bag are honored, then ToPropertyDescriptor + DefinePropertyOrThrow.
+        //
+        // Use the value-level getter (keyed off the `descriptors` *value*, not a
+        // raw `ObjectHeader` deref): the properties bag is `ToObject(Properties)`
+        // and may be ANY object — a Date, array, boxed primitive, class
+        // instance, etc. `Object.create({}, new Date(0))` previously bit-cast the
+        // Date's `DateCell` pointer to an `ObjectHeader` and segfaulted. The
+        // dynamic getter dispatches on the receiver's real type.
+        let key_str = str_from_value(k);
         let descriptor = unsafe {
-            js_object_get_field_by_name_f64(desc_obj as *const ObjectHeader, str_from_value(k))
+            if key_str.is_null() {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            } else {
+                let name_ptr =
+                    (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_len = (*key_str).byte_len as usize;
+                crate::value::js_dynamic_object_get_property(
+                    descriptors,
+                    name_ptr as *const i8,
+                    name_len,
+                )
+            }
         };
         js_object_define_property(target, k, descriptor);
     }


### PR DESCRIPTION
## Summary

Drives `built-ins/Object` test262 parity from **79.1% → 88.7%** (pass **2510 → 2813**, runtime-fail **571 → 359**, compile-fail **91 → 0**), building on #4743. Zero regressions verified against a same-base baseline on the broader `built-ins`+`language` shard 0/12 (**+22 pass, 0 pass→fail**).

## Root causes & fixes

**1. `OrdinaryHasProperty` was own-keys-only (dominant — ~170 tests).**
`js_object_has_property` (the `in` operator and `ToPropertyDescriptor`'s `HasProperty(desc, "value"/"get"/...)` field-presence) only scanned the receiver's own `keys_array` and treated a present key holding `undefined` as absent. It missed: own accessor properties, explicit `obj.x = undefined` (`delete` removes the key, so a present `undefined` slot IS an own prop), and the entire prototype chain. So `Object.defineProperty(o, k, child)` with an inherited/accessor-backed `value`/`get`/... silently dropped the field, and `"x" in o` was wrong for inherited and accessor props. Replaced the plain-object tail with a spec `OrdinaryHasProperty` walk (own data/overflow/accessor presence at each level → recorded `[[Prototype]]` chain → inherited `Object.prototype` methods). `field_get_set.rs`.

**2. Array-index enumerability ignored the descriptor (~70 tests).**
`Object.defineProperty(arr, i, { enumerable: false })` recorded the attr (gOPD saw it) but `Object.keys`/for-in (`js_object_keys`) and `propertyIsEnumerable` (`array_property_is_enumerable`, which hard-coded `true` for canonical indices) ignored it. Both now honor the per-index side table; the keys filter is gated on the array having descriptor entries so the all-default hot path is untouched. `field_get_set.rs`, `array_object_ops.rs`.

**3. Array exotic `[[DefineOwnProperty]]` for `length`/index (~20 tests).**
`ArraySetLength` shrink just holed the slots; it now walks top-down and rejects (TypeError) when a deletion target is a non-configurable index, leaving `length` one past it. A new index at/after a non-writable `length` now rejects. A new index defined with an attributes-only descriptor (no `value`) now materializes the slot so it counts as an own property. `array_object_ops.rs`.

**4. `Object.defineProperties(O, {})` skipped the target check.**
The empty-object-literal fold collapsed to a bare `target`, so `Object.defineProperties(undefined, {})` didn't throw the spec step-1 TypeError. Empty literals now route through the runtime helper (which validates). `native_module.rs` (HIR).

**5. Exotic props bag / receiver crashes.**
`Object.defineProperties`/`Object.create(O, props)` read descriptors by bit-casting `props` to `ObjectHeader`; a Date/array/boxed props bag segfaulted. Now reads each descriptor through the value-level dynamic getter. `getOwnPropertyNames` also guards non-ordinary heap receivers (Date/RegExp/Map/Set) against a `keys_array` deref segfault. `object_ops.rs`, `descriptors.rs`.

## Files
- `crates/perry-runtime/src/object/field_get_set.rs` — `OrdinaryHasProperty`; array-keys enumerable filter
- `crates/perry-runtime/src/object/array_object_ops.rs` — index enumerability; ArraySetLength; index-vs-length; attrs-only index
- `crates/perry-runtime/src/object/object_ops.rs` — defineProperties value-level descriptor read
- `crates/perry-runtime/src/object/descriptors.rs` — gOPN non-ordinary-receiver guard
- `crates/perry-hir/src/lower/expr_call/native_module.rs` — empty-literal defineProperties target validation

## Not addressed (separate subsystems, out of Object-semantics scope)
Builtin-function reflection (`gOPD(Object.is, "length")`), Proxy trap crashes in seal/freeze/toString, and expando read/write on Date/RegExp/boxed primitives (the props-bag tests crash in their own Date `obj.prop = ...` setup, unrelated to Object.*). Array-element accessor get/set invocation needs array-hot-path codegen changes and was left out to preserve the zero-regression guarantee.

## Validation
- `built-ins/Object`: 2510→2813 pass, 0 compile-fail, 88.7% parity
- `built-ins`+`language` shard 0/12: +22 pass, **0 regressions** vs same-base baseline