### PR TITLE
fix(codegen): destructured-value copies no longer truncate to i32 (#4766 regression)

### DIFF
--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -503,4 +503,128 @@ mod tests {
             .scalar_replaceable_object_locals
             .contains(&3));
     }
+
+    // Regression: a mutable `let __d = undefined` seed (the shape the
+    // iterator-protocol array-destructuring lowering emits for each binding
+    // element) must NOT leak integer-ness into its immutable `const` copy
+    // chain. `cbBase = __d` then `cb = cbBase` previously ended up in
+    // `integer_locals` + `strictly_i32_bounded_locals`, giving `cb` an i32
+    // shadow slot that fptosi'd a NaN-boxed object/string to i32::MIN
+    // (`(number).setName is not a function` in drizzle's column builders).
+    #[test]
+    fn destructure_undefined_seed_does_not_leak_into_const_copy_chain() {
+        // let __d = undefined        (id 1, mutable seed)
+        // if (cond) { __d = undefined } else { __d = src.value }  (non-int writes)
+        // const cbBase = __d         (id 2)
+        // const cb = cbBase          (id 3)
+        let stmts = vec![
+            mutable_number_let(1, Expr::Undefined),
+            Stmt::If {
+                condition: Expr::LocalGet(98),
+                then_branch: vec![Stmt::Expr(Expr::LocalSet(1, Box::new(Expr::Undefined)))],
+                else_branch: Some(vec![Stmt::Expr(Expr::LocalSet(
+                    1,
+                    Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(99)),
+                        property: "value".to_string(),
+                    }),
+                ))]),
+            },
+            const_let(2, Expr::LocalGet(1)),
+            const_let(3, Expr::LocalGet(2)),
+        ];
+
+        let ints = super::super::integer_locals::collect_integer_locals(
+            &stmts,
+            &HashSet::new(),
+            &HashSet::new(),
+        );
+
+        assert!(
+            !ints.contains(&1),
+            "mutable undefined seed must be disqualified"
+        );
+        assert!(
+            !ints.contains(&2),
+            "const copy of a disqualified seed must not be integer"
+        );
+        assert!(
+            !ints.contains(&3),
+            "second-hop const copy must not be integer (the regressing slot)"
+        );
+    }
+
+    // Guard against over-pruning: a `const` whose source is a *legitimately*
+    // integer mutable accumulator (every write `| 0`) must stay in the set so
+    // image_convolution-style i32 chains keep their shadow slots.
+    #[test]
+    fn const_copy_of_live_integer_accumulator_stays_integer() {
+        let bitor0 = |left: Expr| Expr::Binary {
+            op: BinaryOp::BitOr,
+            left: Box::new(left),
+            right: Box::new(Expr::Integer(0)),
+        };
+        // let acc = 0|0 ; acc = (acc) | 0 ; const snap = acc;
+        let stmts = vec![
+            mutable_number_let(1, bitor0(Expr::Integer(0))),
+            Stmt::Expr(Expr::LocalSet(1, Box::new(bitor0(Expr::LocalGet(1))))),
+            const_let(2, Expr::LocalGet(1)),
+        ];
+
+        let ints = super::super::integer_locals::collect_integer_locals(
+            &stmts,
+            &HashSet::new(),
+            &HashSet::new(),
+        );
+
+        assert!(ints.contains(&1), "live |0 accumulator must stay integer");
+        assert!(
+            ints.contains(&2),
+            "const copy of a live integer accumulator must stay integer"
+        );
+    }
+
+    // Regression (parameter-destructuring path): the bindings the *param*
+    // destructure lowering emits are `mutable: true` with no reassignment, so
+    // they escape an immutable-only re-validation. They must still be pruned
+    // via their init-only definition when their `undefined`-seed source is
+    // disqualified.
+    #[test]
+    fn destructure_mutable_param_bindings_do_not_leak_into_copy() {
+        // let __d = undefined           (id 1, mutable seed, has non-int writes)
+        // __d = src.value
+        // let cbBase = __d              (id 2, mutable binding, NO LocalSet)
+        // const cb = cbBase             (id 3)
+        let stmts = vec![
+            mutable_number_let(1, Expr::Undefined),
+            Stmt::Expr(Expr::LocalSet(
+                1,
+                Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(99)),
+                    property: "value".to_string(),
+                }),
+            )),
+            mutable_number_let(2, Expr::LocalGet(1)),
+            const_let(3, Expr::LocalGet(2)),
+        ];
+
+        let ints = super::super::integer_locals::collect_integer_locals(
+            &stmts,
+            &HashSet::new(),
+            &HashSet::new(),
+        );
+
+        assert!(
+            !ints.contains(&1),
+            "mutable undefined seed must be disqualified"
+        );
+        assert!(
+            !ints.contains(&2),
+            "mutable param binding copied from a disqualified seed must not be integer"
+        );
+        assert!(
+            !ints.contains(&3),
+            "const copy of the mutable param binding must not be integer"
+        );
+    }
 }

--- a/crates/perry-codegen/src/collectors/integer_locals.rs
+++ b/crates/perry-codegen/src/collectors/integer_locals.rs
@@ -62,12 +62,45 @@ pub fn collect_integer_locals(
     // disqualifying one candidate may cascade to other candidates whose
     // rhs referenced the first via LocalGet. Iterate until the set
     // stabilizes.
+    // Locals that are ever the target of a `LocalSet` are governed by the
+    // write-based disqualifier above; locals that are NOT (their `Let` init is
+    // their sole definition — every `const`, plus never-reassigned `let`s such
+    // as the mutable bindings the *parameter* destructuring path emits) must be
+    // re-validated through that init when their source leaves the set.
+    let mut localset_written: HashSet<u32> = HashSet::new();
+    collect_localset_ids_in_stmts(stmts, &mut localset_written);
     loop {
         let mut disqualified: HashSet<u32> = HashSet::new();
         collect_non_int_localset_ids_in_stmts(
             stmts,
             &mut disqualified,
             &candidates,
+            flat_const_ids,
+            &flat_row_alias_ids,
+            clamp_fn_ids,
+        );
+        // Re-validate init-only candidates against the *current*
+        // (shrinking) set. The forward pass above adds a `y = x` (an init-only
+        // Let whose init is `LocalGet(x)` / an int-producing expr) the moment
+        // `x` is a candidate — but the LocalSet-based disqualifier never
+        // revisits it, because the binding's defining init is not a `LocalSet`.
+        // So when `x` later leaves the set (e.g. a mutable `undefined` seed
+        // disqualified by a non-int write), `y` was left stranded as a stale
+        // integer local, and any further `z = y` copy then qualified for an i32
+        // shadow slot — fptosi'ing a NaN-boxed value to i32::MIN. This is the
+        // destructuring-scaffolding regression: the iterator-protocol
+        // array-binding lowering emits `let __destruct = undefined`
+        // (mutable+Undefined seed), whose binding copies (`cb = cbBase`, where
+        // the *parameter* path even makes those bindings `mutable` with no
+        // reassignment) were mis-typed as integers. Pruning any init-only
+        // candidate whose init is no longer int-producing closes that hop.
+        // Locals with real `LocalSet` writes (clampIdx's `xx`) stay governed by
+        // those writes above.
+        collect_non_int_init_only_let_ids(
+            stmts,
+            &mut disqualified,
+            &candidates,
+            &localset_written,
             flat_const_ids,
             &flat_row_alias_ids,
             clamp_fn_ids,
@@ -79,6 +112,172 @@ pub fn collect_integer_locals(
         }
     }
     candidates
+}
+
+/// Walk all `Stmt::Let { id, init: Some(e), .. }` whose `id` is a current
+/// candidate, has NO `LocalSet` write (`!localset_written.contains(id)` — its
+/// init is its sole definition), and whose init `e` is NOT
+/// `is_int32_producing_expr` against the current candidate set, recording `id`
+/// in `out`. Used inside `collect_integer_locals`'s disqualify fixed point to
+/// prune init-only members (every `const`, plus never-reassigned `let`s like
+/// the parameter-destructuring bindings) that the forward propagation added
+/// from a source local which has since been disqualified — those carry no
+/// `LocalSet` write for `collect_non_int_localset_ids_in_stmts` to catch, so
+/// they must be re-validated through their defining init here.
+#[allow(clippy::too_many_arguments)]
+pub fn collect_non_int_init_only_let_ids(
+    stmts: &[perry_hir::Stmt],
+    out: &mut HashSet<u32>,
+    candidates: &HashSet<u32>,
+    localset_written: &HashSet<u32>,
+    flat_const_ids: &HashSet<u32>,
+    flat_row_alias_ids: &HashSet<u32>,
+    clamp_fn_ids: &HashSet<u32>,
+) {
+    use perry_hir::Stmt;
+    for s in stmts {
+        match s {
+            Stmt::Let {
+                id,
+                init: Some(init),
+                ..
+            } => {
+                if candidates.contains(id)
+                    && !localset_written.contains(id)
+                    && !is_int32_producing_expr(
+                        init,
+                        candidates,
+                        flat_const_ids,
+                        flat_row_alias_ids,
+                        clamp_fn_ids,
+                    )
+                {
+                    out.insert(*id);
+                }
+            }
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                collect_non_int_init_only_let_ids(
+                    then_branch,
+                    out,
+                    candidates,
+                    localset_written,
+                    flat_const_ids,
+                    flat_row_alias_ids,
+                    clamp_fn_ids,
+                );
+                if let Some(eb) = else_branch {
+                    collect_non_int_init_only_let_ids(
+                        eb,
+                        out,
+                        candidates,
+                        localset_written,
+                        flat_const_ids,
+                        flat_row_alias_ids,
+                        clamp_fn_ids,
+                    );
+                }
+            }
+            Stmt::For { init, body, .. } => {
+                if let Some(init_stmt) = init {
+                    collect_non_int_init_only_let_ids(
+                        std::slice::from_ref(init_stmt),
+                        out,
+                        candidates,
+                        localset_written,
+                        flat_const_ids,
+                        flat_row_alias_ids,
+                        clamp_fn_ids,
+                    );
+                }
+                collect_non_int_init_only_let_ids(
+                    body,
+                    out,
+                    candidates,
+                    localset_written,
+                    flat_const_ids,
+                    flat_row_alias_ids,
+                    clamp_fn_ids,
+                );
+            }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                collect_non_int_init_only_let_ids(
+                    body,
+                    out,
+                    candidates,
+                    localset_written,
+                    flat_const_ids,
+                    flat_row_alias_ids,
+                    clamp_fn_ids,
+                );
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                collect_non_int_init_only_let_ids(
+                    body,
+                    out,
+                    candidates,
+                    localset_written,
+                    flat_const_ids,
+                    flat_row_alias_ids,
+                    clamp_fn_ids,
+                );
+                if let Some(c) = catch {
+                    collect_non_int_init_only_let_ids(
+                        &c.body,
+                        out,
+                        candidates,
+                        localset_written,
+                        flat_const_ids,
+                        flat_row_alias_ids,
+                        clamp_fn_ids,
+                    );
+                }
+                if let Some(f) = finally {
+                    collect_non_int_init_only_let_ids(
+                        f,
+                        out,
+                        candidates,
+                        localset_written,
+                        flat_const_ids,
+                        flat_row_alias_ids,
+                        clamp_fn_ids,
+                    );
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for c in cases {
+                    collect_non_int_init_only_let_ids(
+                        &c.body,
+                        out,
+                        candidates,
+                        localset_written,
+                        flat_const_ids,
+                        flat_row_alias_ids,
+                        clamp_fn_ids,
+                    );
+                }
+            }
+            Stmt::Labeled { body, .. } => {
+                collect_non_int_init_only_let_ids(
+                    std::slice::from_ref(body.as_ref()),
+                    out,
+                    candidates,
+                    localset_written,
+                    flat_const_ids,
+                    flat_row_alias_ids,
+                    clamp_fn_ids,
+                );
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Walk all `Stmt::Let { id, init: Some(e), .. }` and add `id` to


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #4766 (iterator-protocol array destructuring): a value pulled from an array binding pattern (`const [k, v] = pair`, or the parameter form `([k, v]) => …`) and then **copied** into another local (`const cb = v`) read back as `-2147483648` (`i32::MIN`) instead of the original object/string. Calling a method on it threw `TypeError: (number).<method> is not a function`.

This broke **every drizzle-orm schema**:
```ts
mysqlTable("t", { id: varchar("id", { length: 36 }) })
// drizzle does: Object.fromEntries(Object.entries(columns).map(([name, col]) => { col.setName(name); … }))
```
so any app using drizzle crashed at startup with `(number).setName is not a function`.

## Regression window

- Works at `cf56a6faf` (#4765)
- Broken at `08a588ecc`
- Regressing commit: **#4766** (`fix(hir): class destructuring (dstr) + default-parameter parity`)

## Root cause

The new array-destructuring lowering emits a scaffolding local `let __destruct_N = undefined` (mutable, init `Undefined`) per binding element. That mutable+`undefined` shape is one of `collect_integer_let_ids`'s seeds (it targets the clampIdx `let xx = undefined; do { xx = clampIdx(…) } while(false)` pattern), so the scaffolding local was optimistically seeded into `integer_locals`.

The forward closure (`collect_extra_integer_let_ids`) then propagated integer-ness down the init-only copy chain: `cbBase = __destruct_N` → `cb = cbBase`.

The disqualify fixed point only prunes locals via non-int `LocalSet` **writes**. It correctly removed the scaffolding local (its writes are `undefined` / `step.value`), but the forward-propagated copies have **no `LocalSet` write** — their defining `Let`-init is their sole definition — so they were never re-validated and stayed stale-integer. The first copy escaped (its source left the set, so it was no longer `strictly_i32_bounded`), but the **second hop** (`const cb = cbBase`) was both in `integer_locals` and `strictly_i32_bounded_locals`, qualifying it for an i32 shadow slot. Storing a NaN-boxed value there did `fptosi(NaN) = i32::MIN`.

This is why direct `obj.id` was always correct (read from the double slot) but the value mis-read as a number only when copied out of a destructure.

## Fix

In the disqualify fixed point, also re-validate any candidate `Let` that has **no `LocalSet` write** (`collect_non_int_init_only_let_ids`) — every `const`, plus never-reassigned `let`s such as the mutable bindings the *parameter*-destructuring path emits — against its defining init over the current (shrinking) candidate set. When the init's source local is disqualified, the copy is pruned too, cascading through the chain.

Locals with real int-producing `LocalSet` writes (clampIdx's `xx`) remain governed by those writes, so the image_convolution i32 fast paths are preserved.

## Validation

Minimal repro (drizzle-free) before → after:
```
entry id typeof cb = number   →   entry id typeof cb = object
ISOLATE THREW: (number).setName is not a function   →   ISOLATE OK: id,email
```
- Real-drizzle repro prints `DRIZZLE OK: columns = id,name`.
- Deployed Hono + Drizzle + mysql2 app (billing.skelpo.com) now **boots and serves HTTP** without the `(number).setName is not a function` startup crash (previously it could not start at all).
- Full `perry-codegen` test suite green.

Regression tests in `collectors/hir_facts.rs`:
- `destructure_undefined_seed_does_not_leak_into_const_copy_chain` (immutable body-`let` path)
- `destructure_mutable_param_bindings_do_not_leak_into_copy` (mutable parameter path)
- `const_copy_of_live_integer_accumulator_stays_integer` (over-pruning guard)

Refs #793.
