### PR TITLE
fix(hir): statement-semantics (for-of iterator protocol, with, eval completion-values) test262 parity

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -694,8 +694,7 @@ fn try_const_fold_eval(
     //                            __perry_cv = undefined;   (reset/assign template)
     //                            return __perry_cv;]
     let template_src = "(function () {\nvar __perry_cv = undefined;\n__perry_cv = undefined;\nreturn __perry_cv;\n});\n";
-    let template_module = match perry_parser::parse_typescript(template_src, "<eval wrapper>.cjs")
-    {
+    let template_module = match perry_parser::parse_typescript(template_src, "<eval wrapper>.cjs") {
         Ok(m) => m,
         Err(_) => return Ok(None),
     };

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -493,6 +493,13 @@ pub(crate) fn try_eval_function_call_fold(
             call.span,
         );
     }
+    if id.sym.as_ref() == "eval"
+        && ctx.lookup_local("eval").is_none()
+        && ctx.lookup_func("eval").is_none()
+        && ctx.lookup_imported_func("eval").is_none()
+    {
+        return try_const_fold_eval(ctx, &call.args, call.span);
+    }
     Ok(None)
 }
 
@@ -511,4 +518,216 @@ fn extract_fn_expr(module: &ast::Module) -> Option<&ast::FnExpr> {
         ast::Expr::Fn(fn_expr) => Some(fn_expr),
         _ => None,
     }
+}
+
+/// Owning variant of [`extract_fn_expr`] — consumes the module so the caller
+/// can mutate the function body before lowering.
+fn extract_fn_expr_owned(module: ast::Module) -> Option<ast::FnExpr> {
+    let item = module.body.into_iter().next()?;
+    let ast::ModuleItem::Stmt(ast::Stmt::Expr(expr_stmt)) = item else {
+        return None;
+    };
+    let mut e = *expr_stmt.expr;
+    loop {
+        match e {
+            ast::Expr::Paren(p) => e = *p.expr,
+            ast::Expr::Fn(fn_expr) => return Some(fn_expr),
+            _ => return None,
+        }
+    }
+}
+
+/// Build `__perry_cv = <value>` by cloning a parsed `__perry_cv = undefined`
+/// assignment template and swapping its right-hand side. Avoids hand-building
+/// version-sensitive SWC `AssignExpr` nodes.
+fn cv_assign_from_template(reset_template: &ast::Stmt, value: Box<ast::Expr>) -> Box<ast::Expr> {
+    let ast::Stmt::Expr(es) = reset_template else {
+        // Caller guarantees the template is an expression statement.
+        return value;
+    };
+    let mut assign = es.expr.clone();
+    if let ast::Expr::Assign(a) = assign.as_mut() {
+        a.right = value;
+    }
+    assign
+}
+
+/// Statements whose ECMAScript completion value is `UpdateEmpty(..., undefined)`
+/// or accumulates from `undefined` — i.e. evaluating them resets the running
+/// statement-list completion value to `undefined` before their inner
+/// (value-producing) statements may overwrite it. See §13/§14 of the spec
+/// (IfStatement / IterationStatement / SwitchStatement / TryStatement all wrap
+/// their result in `UpdateEmpty(_, undefined)`).
+fn stmt_resets_completion(stmt: &ast::Stmt) -> bool {
+    matches!(
+        stmt,
+        ast::Stmt::If(_)
+            | ast::Stmt::While(_)
+            | ast::Stmt::DoWhile(_)
+            | ast::Stmt::For(_)
+            | ast::Stmt::ForIn(_)
+            | ast::Stmt::ForOf(_)
+            | ast::Stmt::Switch(_)
+            | ast::Stmt::Try(_)
+    )
+}
+
+/// Recurse into a single nested statement, treating it as a one-element
+/// statement list. If completion tracking inserts statements (e.g. a reset),
+/// the result is re-wrapped in a block so it remains a single `Stmt`.
+fn track_completion_single(stmt: &mut ast::Stmt, reset_template: &ast::Stmt) {
+    let placeholder = ast::Stmt::Empty(ast::EmptyStmt {
+        span: swc_common::DUMMY_SP,
+    });
+    let mut list = vec![std::mem::replace(stmt, placeholder)];
+    track_completion(&mut list, reset_template);
+    if list.len() == 1 {
+        *stmt = list.pop().unwrap();
+    } else {
+        *stmt = ast::Stmt::Block(ast::BlockStmt {
+            span: swc_common::DUMMY_SP,
+            ctxt: Default::default(),
+            stmts: list,
+        });
+    }
+}
+
+/// Recurse into the nested statement lists / bodies of a compound statement so
+/// their expression statements are tracked too. The `finally` block is
+/// intentionally skipped: a normally-completing `finally` does not contribute
+/// to the `try` statement's completion value.
+fn track_completion_inner(stmt: &mut ast::Stmt, reset_template: &ast::Stmt) {
+    match stmt {
+        ast::Stmt::Block(b) => track_completion(&mut b.stmts, reset_template),
+        ast::Stmt::If(s) => {
+            track_completion_single(&mut s.cons, reset_template);
+            if let Some(alt) = s.alt.as_mut() {
+                track_completion_single(alt, reset_template);
+            }
+        }
+        ast::Stmt::While(s) => track_completion_single(&mut s.body, reset_template),
+        ast::Stmt::DoWhile(s) => track_completion_single(&mut s.body, reset_template),
+        ast::Stmt::For(s) => track_completion_single(&mut s.body, reset_template),
+        ast::Stmt::ForIn(s) => track_completion_single(&mut s.body, reset_template),
+        ast::Stmt::ForOf(s) => track_completion_single(&mut s.body, reset_template),
+        ast::Stmt::Labeled(s) => track_completion_single(&mut s.body, reset_template),
+        ast::Stmt::Switch(s) => {
+            for case in s.cases.iter_mut() {
+                track_completion(&mut case.cons, reset_template);
+            }
+        }
+        ast::Stmt::Try(s) => {
+            track_completion(&mut s.block.stmts, reset_template);
+            if let Some(handler) = s.handler.as_mut() {
+                track_completion(&mut handler.body.stmts, reset_template);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Rewrite a statement list so that, after evaluation, `__perry_cv` holds the
+/// list's ECMAScript completion value. Each `ExpressionStatement e` becomes
+/// `__perry_cv = e`; each statement whose completion value is
+/// `UpdateEmpty(_, undefined)` is preceded by a `__perry_cv = undefined` reset;
+/// declarations / empty statements leave `__perry_cv` unchanged. Recurses into
+/// nested statement lists so the rule holds at every depth.
+fn track_completion(stmts: &mut Vec<ast::Stmt>, reset_template: &ast::Stmt) {
+    let mut out: Vec<ast::Stmt> = Vec::with_capacity(stmts.len());
+    for mut stmt in stmts.drain(..) {
+        let resets = stmt_resets_completion(&stmt);
+        track_completion_inner(&mut stmt, reset_template);
+        if let ast::Stmt::Expr(es) = &mut stmt {
+            let inner = std::mem::replace(
+                &mut es.expr,
+                Box::new(ast::Expr::Invalid(ast::Invalid {
+                    span: swc_common::DUMMY_SP,
+                })),
+            );
+            es.expr = cv_assign_from_template(reset_template, inner);
+        }
+        if resets {
+            out.push(reset_template.clone());
+        }
+        out.push(stmt);
+    }
+    *stmts = out;
+}
+
+/// #1679: fold a direct `eval("<constant string>")` into a scope-capturing
+/// IIFE — `(function () { var __perry_cv; <tracked body>; return __perry_cv })()`
+/// — so the program runs the code string AOT and yields its ECMAScript
+/// completion value. The wrapper is lowered in sloppy mode (the eval body may
+/// use `with`, undeclared assignments, etc.) and captures the enclosing scope,
+/// so `eval("with(o){p=1}")` mutates the surrounding `o`. Only single
+/// string-constant arguments fold; everything else bails to the runtime path.
+fn try_const_fold_eval(
+    ctx: &mut LoweringContext,
+    args: &[ast::ExprOrSpread],
+    span: swc_common::Span,
+) -> Result<Option<Expr>> {
+    if args.len() != 1 || args[0].spread.is_some() {
+        return Ok(None);
+    }
+    let Some(body_src) = const_string_of(&args[0].expr) else {
+        return Ok(None);
+    };
+
+    // Parse the eval body as sloppy-mode statements (`.cjs` → script, not
+    // module, so `with` is allowed). A parse failure is a runtime SyntaxError.
+    let body_module = match perry_parser::parse_typescript(&body_src, "<eval body>.cjs") {
+        Ok(m) => m,
+        Err(_) => return synth_function_syntax_error(ctx, EvalSurface::Eval, span).map(Some),
+    };
+    let mut body_stmts: Vec<ast::Stmt> = Vec::with_capacity(body_module.body.len());
+    for item in body_module.body {
+        match item {
+            ast::ModuleItem::Stmt(s) => body_stmts.push(s),
+            // `import` / `export` inside eval is a SyntaxError.
+            _ => return synth_function_syntax_error(ctx, EvalSurface::Eval, span).map(Some),
+        }
+    }
+
+    // Wrapper template: stmts == [var __perry_cv = undefined;
+    //                            __perry_cv = undefined;   (reset/assign template)
+    //                            return __perry_cv;]
+    let template_src = "(function () {\nvar __perry_cv = undefined;\n__perry_cv = undefined;\nreturn __perry_cv;\n});\n";
+    let template_module = match perry_parser::parse_typescript(template_src, "<eval wrapper>.cjs")
+    {
+        Ok(m) => m,
+        Err(_) => return Ok(None),
+    };
+    let Some(mut fn_expr) = extract_fn_expr_owned(template_module) else {
+        return Ok(None);
+    };
+    let Some(body) = fn_expr.function.body.as_mut() else {
+        return Ok(None);
+    };
+    if body.stmts.len() != 3 {
+        return Ok(None);
+    }
+    let reset_template = body.stmts.remove(1);
+
+    // Track completion values, then splice the tracked body before `return`.
+    track_completion(&mut body_stmts, &reset_template);
+    let mut insert_at = 1; // after the `var __perry_cv` decl
+    for s in body_stmts {
+        body.stmts.insert(insert_at, s);
+        insert_at += 1;
+    }
+
+    // Lower the wrapper (sloppy) and immediately call it: `(function(){…})()`.
+    let outer_strict = ctx.current_strict;
+    ctx.current_strict = false;
+    let lowered = lower_fn_expr(ctx, &fn_expr);
+    ctx.current_strict = outer_strict;
+    let closure = match lowered {
+        Ok(l) => l,
+        Err(_) => return synth_function_syntax_error(ctx, EvalSurface::Eval, span).map(Some),
+    };
+    Ok(Some(Expr::Call {
+        callee: Box::new(closure),
+        args: vec![],
+        type_args: vec![],
+    }))
 }

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -569,6 +569,7 @@ fn stmt_resets_completion(stmt: &ast::Stmt) -> bool {
             | ast::Stmt::ForOf(_)
             | ast::Stmt::Switch(_)
             | ast::Stmt::Try(_)
+            | ast::Stmt::With(_)
     )
 }
 
@@ -611,6 +612,7 @@ fn track_completion_inner(stmt: &mut ast::Stmt, reset_template: &ast::Stmt) {
         ast::Stmt::ForIn(s) => track_completion_single(&mut s.body, reset_template),
         ast::Stmt::ForOf(s) => track_completion_single(&mut s.body, reset_template),
         ast::Stmt::Labeled(s) => track_completion_single(&mut s.body, reset_template),
+        ast::Stmt::With(s) => track_completion_single(&mut s.body, reset_template),
         ast::Stmt::Switch(s) => {
             for case in s.cases.iter_mut() {
                 track_completion(&mut case.cons, reset_template);

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -48,7 +48,10 @@ pub(crate) use context::*;
 mod stmt;
 pub(crate) use stmt::*;
 mod stmt_loops;
-pub(crate) use stmt_loops::{lower_stmt_for_in, lower_stmt_for_of};
+pub(crate) use stmt_loops::{
+    insert_iterator_close_on_abrupt, iterator_close_guarded_stmt, iterator_next_call,
+    lazy_or_index_elem, lower_stmt_for_in, lower_stmt_for_of,
+};
 mod module_decl;
 pub(crate) use module_decl::*;
 mod misc;

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -50,7 +50,7 @@ pub(crate) use stmt::*;
 mod stmt_loops;
 pub(crate) use stmt_loops::{
     insert_iterator_close_on_abrupt, iterator_close_guarded_stmt, iterator_next_call,
-    lazy_or_index_elem, lower_stmt_for_in, lower_stmt_for_of,
+    lazy_iter_for_stmt, lazy_or_index_elem, lower_stmt_for_in, lower_stmt_for_of,
 };
 mod module_decl;
 pub(crate) use module_decl::*;

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -441,12 +441,7 @@ pub(crate) fn insert_iterator_close_on_abrupt(
                     );
                 }
                 if let Some(f) = finally.as_mut() {
-                    insert_iterator_close_on_abrupt(
-                        f,
-                        iter_id,
-                        break_capture_depth,
-                        inner_labels,
-                    );
+                    insert_iterator_close_on_abrupt(f, iter_id, break_capture_depth, inner_labels);
                 }
                 rewritten.push(Stmt::Try {
                     body,
@@ -1731,12 +1726,7 @@ pub(crate) fn lower_stmt_for_of(
                 name,
                 ty: Type::Any,
                 mutable: false,
-                init: Some(lazy_or_index_elem(
-                    use_lazy_iter,
-                    arr_id,
-                    idx_id,
-                    result_id,
-                )),
+                init: Some(lazy_or_index_elem(use_lazy_iter, arr_id, idx_id, result_id)),
             }]
         }
         _ => return Err(anyhow!("Unsupported for-of left-hand side")),
@@ -1775,7 +1765,10 @@ pub(crate) fn lower_stmt_for_of(
                     property: "done".to_string(),
                 }),
             }),
-            update: Some(Expr::LocalSet(result_id, Box::new(iterator_next_call(arr_id)))),
+            update: Some(Expr::LocalSet(
+                result_id,
+                Box::new(iterator_next_call(arr_id)),
+            )),
             body: loop_body,
         });
         ctx.pop_block_scope(for_scope_mark);

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -307,6 +307,232 @@ fn insert_iterator_return_before_abrupts(
     *stmts = rewritten;
 }
 
+/// Element source for a `for...of` binding: `__result.value` on the lazy
+/// iterator path, `__arr[__idx]` on the materialized-array path.
+pub(crate) fn lazy_or_index_elem(
+    use_lazy_iter: bool,
+    arr_id: LocalId,
+    idx_id: LocalId,
+    result_id: LocalId,
+) -> Expr {
+    if use_lazy_iter {
+        Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(result_id)),
+            property: "value".to_string(),
+        }
+    } else {
+        Expr::IndexGet {
+            object: Box::new(Expr::LocalGet(arr_id)),
+            index: Box::new(Expr::LocalGet(idx_id)),
+        }
+    }
+}
+
+/// `__iter.next()`.
+pub(crate) fn iterator_next_call(iter_id: LocalId) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(iter_id)),
+            property: "next".to_string(),
+        }),
+        args: vec![],
+        type_args: vec![],
+    }
+}
+
+/// Spec IteratorClose, guarded: `if (__iter.return != null) __iter.return();`.
+/// Array iterators have no `return` method, so the guard makes close a no-op
+/// for them (closing an array iterator is a spec no-op); generators / custom
+/// iterators run their `return` (which executes pending `finally` blocks).
+pub(crate) fn iterator_close_guarded_stmt(iter_id: LocalId) -> Stmt {
+    Stmt::If {
+        condition: Expr::Compare {
+            op: CompareOp::LooseNe,
+            left: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(iter_id)),
+                property: "return".to_string(),
+            }),
+            right: Box::new(Expr::Null),
+        },
+        then_branch: vec![Stmt::Expr(iterator_return_call(iter_id, false))],
+        else_branch: None,
+    }
+}
+
+/// Rewrite a synchronous `for...of` body so every abrupt completion that
+/// escapes the loop runs IteratorClose first. Per spec ForIn/OfBodyEvaluation:
+/// an unlabeled `break` that targets this loop, a labeled `break`/`continue`
+/// that targets an enclosing construct, and a `return` all close the iterator.
+/// Unlabeled `continue` (next iteration) and `break`/`continue` captured by a
+/// loop/switch nested *within* the body do not. `throw` is intentionally not
+/// rewritten here: a `throw` caught by an in-body `try/catch` must not close,
+/// and the uncaught case is handled separately.
+///
+/// `break_capture_depth` counts enclosing loops/switches inside the body (which
+/// capture an unlabeled `break`); `inner_labels` are labels declared within the
+/// body (which capture a matching labeled `break`/`continue`).
+pub(crate) fn insert_iterator_close_on_abrupt(
+    stmts: &mut Vec<Stmt>,
+    iter_id: LocalId,
+    break_capture_depth: usize,
+    inner_labels: &[String],
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    for stmt in stmts.drain(..) {
+        match stmt {
+            Stmt::Break if break_capture_depth == 0 => {
+                rewritten.push(iterator_close_guarded_stmt(iter_id));
+                rewritten.push(Stmt::Break);
+            }
+            Stmt::LabeledBreak(label) if !inner_labels.contains(&label) => {
+                rewritten.push(iterator_close_guarded_stmt(iter_id));
+                rewritten.push(Stmt::LabeledBreak(label));
+            }
+            Stmt::LabeledContinue(label) if !inner_labels.contains(&label) => {
+                rewritten.push(iterator_close_guarded_stmt(iter_id));
+                rewritten.push(Stmt::LabeledContinue(label));
+            }
+            Stmt::Return(value) => {
+                rewritten.push(iterator_close_guarded_stmt(iter_id));
+                rewritten.push(Stmt::Return(value));
+            }
+            Stmt::If {
+                condition,
+                mut then_branch,
+                mut else_branch,
+            } => {
+                insert_iterator_close_on_abrupt(
+                    &mut then_branch,
+                    iter_id,
+                    break_capture_depth,
+                    inner_labels,
+                );
+                if let Some(else_stmts) = else_branch.as_mut() {
+                    insert_iterator_close_on_abrupt(
+                        else_stmts,
+                        iter_id,
+                        break_capture_depth,
+                        inner_labels,
+                    );
+                }
+                rewritten.push(Stmt::If {
+                    condition,
+                    then_branch,
+                    else_branch,
+                });
+            }
+            Stmt::Try {
+                mut body,
+                mut catch,
+                mut finally,
+            } => {
+                insert_iterator_close_on_abrupt(
+                    &mut body,
+                    iter_id,
+                    break_capture_depth,
+                    inner_labels,
+                );
+                if let Some(c) = catch.as_mut() {
+                    insert_iterator_close_on_abrupt(
+                        &mut c.body,
+                        iter_id,
+                        break_capture_depth,
+                        inner_labels,
+                    );
+                }
+                if let Some(f) = finally.as_mut() {
+                    insert_iterator_close_on_abrupt(
+                        f,
+                        iter_id,
+                        break_capture_depth,
+                        inner_labels,
+                    );
+                }
+                rewritten.push(Stmt::Try {
+                    body,
+                    catch,
+                    finally,
+                });
+            }
+            Stmt::While {
+                condition,
+                mut body,
+            } => {
+                insert_iterator_close_on_abrupt(
+                    &mut body,
+                    iter_id,
+                    break_capture_depth + 1,
+                    inner_labels,
+                );
+                rewritten.push(Stmt::While { condition, body });
+            }
+            Stmt::DoWhile {
+                mut body,
+                condition,
+            } => {
+                insert_iterator_close_on_abrupt(
+                    &mut body,
+                    iter_id,
+                    break_capture_depth + 1,
+                    inner_labels,
+                );
+                rewritten.push(Stmt::DoWhile { body, condition });
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                mut body,
+            } => {
+                insert_iterator_close_on_abrupt(
+                    &mut body,
+                    iter_id,
+                    break_capture_depth + 1,
+                    inner_labels,
+                );
+                rewritten.push(Stmt::For {
+                    init,
+                    condition,
+                    update,
+                    body,
+                });
+            }
+            Stmt::Switch {
+                discriminant,
+                mut cases,
+            } => {
+                for case in cases.iter_mut() {
+                    insert_iterator_close_on_abrupt(
+                        &mut case.body,
+                        iter_id,
+                        break_capture_depth + 1,
+                        inner_labels,
+                    );
+                }
+                rewritten.push(Stmt::Switch {
+                    discriminant,
+                    cases,
+                });
+            }
+            Stmt::Labeled { label, mut body } => {
+                let mut labels = inner_labels.to_vec();
+                labels.push(label.clone());
+                let mut body_vec = vec![*body];
+                insert_iterator_close_on_abrupt(
+                    &mut body_vec,
+                    iter_id,
+                    break_capture_depth,
+                    &labels,
+                );
+                body = Box::new(body_vec.into_iter().next().unwrap());
+                rewritten.push(Stmt::Labeled { label, body });
+            }
+            other => rewritten.push(other),
+        }
+    }
+    *stmts = rewritten;
+}
+
 fn lower_runtime_for_await_iterator(
     ctx: &mut LoweringContext,
     module: &mut Module,
@@ -1058,6 +1284,16 @@ pub(crate) fn lower_stmt_for_of(
     if for_of_stmt.is_await && needs_runtime_iterator {
         return lower_runtime_for_await_iterator(ctx, module, for_of_stmt, arr_expr);
     }
+    // #for-of lazy iterator protocol: a generic/untyped iterable (custom
+    // iterator, generator object, any-typed value) must be driven lazily —
+    // pull one element via `__iter.next()` per iteration and run IteratorClose
+    // (`__iter.return()`) on an abrupt completion (break / labeled break /
+    // labeled continue escaping the loop / return). The previous
+    // `ForOfToArray` materialization eagerly drained the iterator up front,
+    // which (a) runs a generator past the point a `break` should have closed
+    // it and (b) made IteratorClose impossible. `is_await` is already handled
+    // by the early return above, so this is always the synchronous path.
+    let use_lazy_iter = needs_runtime_iterator;
     let arr_expr = if is_iterable_map {
         if let Some(args) = map_type_args.as_ref() {
             if args.len() >= 2 {
@@ -1078,12 +1314,9 @@ pub(crate) fn lower_stmt_for_of(
         }
     } else if is_iterable_typed_array {
         Expr::ArrayFrom(Box::new(arr_expr))
-    } else if needs_runtime_iterator {
-        if for_of_stmt.is_await {
-            Expr::Await(Box::new(Expr::ForAwaitToArray(Box::new(arr_expr))))
-        } else {
-            Expr::ForOfToArray(Box::new(arr_expr))
-        }
+    } else if use_lazy_iter {
+        // GetIterator(obj): obj[Symbol.iterator](). Drives the lazy loop below.
+        Expr::GetIterator(Box::new(arr_expr))
     } else {
         arr_expr
     };
@@ -1133,6 +1366,9 @@ pub(crate) fn lower_stmt_for_of(
             base: "Set".to_string(),
             type_args: vec![elem_type.clone()],
         }
+    } else if use_lazy_iter {
+        // Holds the iterator object, not an array.
+        Type::Any
     } else {
         Type::Array(Box::new(elem_type.clone()))
     };
@@ -1146,7 +1382,15 @@ pub(crate) fn lower_stmt_for_of(
     ctx.locals
         .push((format!("__idx_{}", idx_id), idx_id, Type::Number));
 
-    // Store array reference: let __arr = arr
+    // For the lazy iterator path `arr_id` holds the iterator and `result_id`
+    // holds the most recent `__iter.next()` result `{ value, done }`.
+    let result_id = ctx.fresh_local();
+    if use_lazy_iter {
+        ctx.locals
+            .push((format!("__result_{}", result_id), result_id, Type::Any));
+    }
+
+    // Store array reference: let __arr = arr (or `let __iter = GetIterator(..)`).
     module.init.push(Stmt::Let {
         id: arr_id,
         name: format!("__arr_{}", arr_id),
@@ -1252,14 +1496,22 @@ pub(crate) fn lower_stmt_for_of(
                 // wraps the `__iter.next()` call in `Expr::Await` for
                 // async generators; this brings the array-iteration
                 // path to parity.
-                let raw_item_expr = Expr::IndexGet {
-                    object: Box::new(Expr::LocalGet(arr_id)),
-                    index: Box::new(Expr::LocalGet(idx_id)),
-                };
-                let item_expr = if for_of_stmt.is_await {
-                    Expr::Await(Box::new(raw_item_expr))
+                let item_expr = if use_lazy_iter {
+                    // Lazy path: the element is `__result.value`.
+                    Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(result_id)),
+                        property: "value".to_string(),
+                    }
                 } else {
-                    raw_item_expr
+                    let raw_item_expr = Expr::IndexGet {
+                        object: Box::new(Expr::LocalGet(arr_id)),
+                        index: Box::new(Expr::LocalGet(idx_id)),
+                    };
+                    if for_of_stmt.is_await {
+                        Expr::Await(Box::new(raw_item_expr))
+                    } else {
+                        raw_item_expr
+                    }
                 };
 
                 match &decl.name {
@@ -1459,10 +1711,12 @@ pub(crate) fn lower_stmt_for_of(
                             name,
                             ty: Type::Any,
                             mutable: false,
-                            init: Some(Expr::IndexGet {
-                                object: Box::new(Expr::LocalGet(arr_id)),
-                                index: Box::new(Expr::LocalGet(idx_id)),
-                            }),
+                            init: Some(lazy_or_index_elem(
+                                use_lazy_iter,
+                                arr_id,
+                                idx_id,
+                                result_id,
+                            )),
                         }]
                     }
                 }
@@ -1477,18 +1731,55 @@ pub(crate) fn lower_stmt_for_of(
                 name,
                 ty: Type::Any,
                 mutable: false,
-                init: Some(Expr::IndexGet {
-                    object: Box::new(Expr::LocalGet(arr_id)),
-                    index: Box::new(Expr::LocalGet(idx_id)),
-                }),
+                init: Some(lazy_or_index_elem(
+                    use_lazy_iter,
+                    arr_id,
+                    idx_id,
+                    result_id,
+                )),
             }]
         }
         _ => return Err(anyhow!("Unsupported for-of left-hand side")),
     };
 
+    // Lazy iterator path: rewrite the user body so every abrupt completion
+    // escaping the loop runs IteratorClose (`__iter.return()`) first.
+    if use_lazy_iter {
+        insert_iterator_close_on_abrupt(&mut loop_body, arr_id, 0, &[]);
+    }
+
     // Prepend the binding statements to the loop body
     for (i, stmt) in binding_stmts.into_iter().enumerate() {
         loop_body.insert(i, stmt);
+    }
+
+    if use_lazy_iter {
+        // Lazy iterator loop, modeled as a `for` so the advance lives in the
+        // update clause and `continue` re-pulls the iterator (a `while` with
+        // the advance at the body tail would skip it on `continue` and spin):
+        //   for (let __result = __iter.next();
+        //        !__result.done;
+        //        __result = __iter.next()) { bindings; body }
+        module.init.push(Stmt::For {
+            init: Some(Box::new(Stmt::Let {
+                id: result_id,
+                name: format!("__result_{}", result_id),
+                ty: Type::Any,
+                mutable: true,
+                init: Some(iterator_next_call(arr_id)),
+            })),
+            condition: Some(Expr::Unary {
+                op: UnaryOp::Not,
+                operand: Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(result_id)),
+                    property: "done".to_string(),
+                }),
+            }),
+            update: Some(Expr::LocalSet(result_id, Box::new(iterator_next_call(arr_id)))),
+            body: loop_body,
+        });
+        ctx.pop_block_scope(for_scope_mark);
+        return Ok(());
     }
 
     // Loop bound. Map/Set fast paths read `.size` (lowered by

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -340,6 +340,41 @@ pub(crate) fn iterator_next_call(iter_id: LocalId) -> Expr {
     }
 }
 
+/// The lazy `for...of` driver loop, modeled as a `for` so `continue` re-pulls
+/// the iterator via the update clause (a `while` with the advance at the body
+/// tail would skip it on `continue` and spin):
+///   for (let __result = __iter.next();
+///        !__result.done;
+///        __result = __iter.next()) { <loop_body> }
+/// `iter_id` holds the iterator, `result_id` the latest `{ value, done }`.
+pub(crate) fn lazy_iter_for_stmt(
+    iter_id: LocalId,
+    result_id: LocalId,
+    loop_body: Vec<Stmt>,
+) -> Stmt {
+    Stmt::For {
+        init: Some(Box::new(Stmt::Let {
+            id: result_id,
+            name: format!("__result_{}", result_id),
+            ty: Type::Any,
+            mutable: true,
+            init: Some(iterator_next_call(iter_id)),
+        })),
+        condition: Some(Expr::Unary {
+            op: UnaryOp::Not,
+            operand: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(result_id)),
+                property: "done".to_string(),
+            }),
+        }),
+        update: Some(Expr::LocalSet(
+            result_id,
+            Box::new(iterator_next_call(iter_id)),
+        )),
+        body: loop_body,
+    }
+}
+
 /// Spec IteratorClose, guarded: `if (__iter.return != null) __iter.return();`.
 /// Array iterators have no `return` method, so the guard makes close a no-op
 /// for them (closing an array iterator is a spec no-op); generators / custom
@@ -1744,33 +1779,9 @@ pub(crate) fn lower_stmt_for_of(
     }
 
     if use_lazy_iter {
-        // Lazy iterator loop, modeled as a `for` so the advance lives in the
-        // update clause and `continue` re-pulls the iterator (a `while` with
-        // the advance at the body tail would skip it on `continue` and spin):
-        //   for (let __result = __iter.next();
-        //        !__result.done;
-        //        __result = __iter.next()) { bindings; body }
-        module.init.push(Stmt::For {
-            init: Some(Box::new(Stmt::Let {
-                id: result_id,
-                name: format!("__result_{}", result_id),
-                ty: Type::Any,
-                mutable: true,
-                init: Some(iterator_next_call(arr_id)),
-            })),
-            condition: Some(Expr::Unary {
-                op: UnaryOp::Not,
-                operand: Box::new(Expr::PropertyGet {
-                    object: Box::new(Expr::LocalGet(result_id)),
-                    property: "done".to_string(),
-                }),
-            }),
-            update: Some(Expr::LocalSet(
-                result_id,
-                Box::new(iterator_next_call(arr_id)),
-            )),
-            body: loop_body,
-        });
+        module
+            .init
+            .push(lazy_iter_for_stmt(arr_id, result_id, loop_body));
         ctx.pop_block_scope(for_scope_mark);
         return Ok(());
     }

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -6,7 +6,8 @@ use crate::analysis::*;
 use crate::destructuring::*;
 use crate::ir::*;
 use crate::lower::{
-    collect_for_of_pattern_leaves, emit_for_of_pattern_binding, lower_expr, LoweringContext,
+    collect_for_of_pattern_leaves, emit_for_of_pattern_binding, insert_iterator_close_on_abrupt,
+    iterator_next_call, lazy_or_index_elem, lower_expr, LoweringContext,
 };
 use crate::lower_patterns::*;
 use crate::lower_types::*;
@@ -1319,6 +1320,12 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             if for_of_stmt.is_await && needs_runtime_iterator {
                 return lower_runtime_for_await_iterator_body(ctx, for_of_stmt, arr_expr);
             }
+            // Lazy iterator protocol for generic/untyped iterables — see the
+            // matching comment in `lower/stmt_loops.rs`. Drives the loop with
+            // `__iter.next()` and runs IteratorClose on abrupt completion so a
+            // `break`/`return` closes a generator instead of draining it.
+            // `is_await` is already handled by the early return above.
+            let use_lazy_iter = needs_runtime_iterator;
             let arr_expr = if is_iterable_map {
                 if map_kv_fastpath {
                     arr_expr
@@ -1333,10 +1340,8 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 }
             } else if is_iterable_typed_array {
                 Expr::ArrayFrom(Box::new(arr_expr))
-            } else if needs_runtime_iterator && for_of_stmt.is_await {
-                Expr::Await(Box::new(Expr::ForAwaitToArray(Box::new(arr_expr))))
-            } else if needs_runtime_iterator {
-                Expr::ForOfToArray(Box::new(arr_expr))
+            } else if use_lazy_iter {
+                Expr::GetIterator(Box::new(arr_expr))
             } else {
                 arr_expr
             };
@@ -1401,6 +1406,9 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 } else {
                     Type::Any
                 }
+            } else if use_lazy_iter {
+                // Holds the iterator object, not an array.
+                Type::Any
             } else if let Some(ref elem) = inferred_elem_type {
                 Type::Array(Box::new(elem.clone()))
             } else {
@@ -1424,7 +1432,15 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             ctx.locals
                 .push((format!("__idx_{}", idx_id), idx_id, Type::Number));
 
-            // Store array reference
+            // Lazy iterator path: `arr_id` holds the iterator, `result_id` the
+            // most recent `__iter.next()` result.
+            let result_id = ctx.fresh_local();
+            if use_lazy_iter {
+                ctx.locals
+                    .push((format!("__result_{}", result_id), result_id, Type::Any));
+            }
+
+            // Store array reference (or `let __iter = GetIterator(..)`).
             result.push(Stmt::Let {
                 id: arr_id,
                 name: format!("__arr_{}", arr_id),
@@ -1529,14 +1545,21 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         // raw Promise object and `sum += x` produces NaN.
                         // Mirrors the same fix in `lower.rs::lower_stmt`'s
                         // module-init for-of arm.
-                        let raw_item_expr = Expr::IndexGet {
-                            object: Box::new(Expr::LocalGet(arr_id)),
-                            index: Box::new(Expr::LocalGet(idx_id)),
-                        };
-                        let item_expr = if for_of_stmt.is_await {
-                            Expr::Await(Box::new(raw_item_expr))
+                        let item_expr = if use_lazy_iter {
+                            Expr::PropertyGet {
+                                object: Box::new(Expr::LocalGet(result_id)),
+                                property: "value".to_string(),
+                            }
                         } else {
-                            raw_item_expr
+                            let raw_item_expr = Expr::IndexGet {
+                                object: Box::new(Expr::LocalGet(arr_id)),
+                                index: Box::new(Expr::LocalGet(idx_id)),
+                            };
+                            if for_of_stmt.is_await {
+                                Expr::Await(Box::new(raw_item_expr))
+                            } else {
+                                raw_item_expr
+                            }
                         };
 
                         match &decl.name {
@@ -1718,10 +1741,12 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                                     name,
                                     ty: Type::Any,
                                     mutable: false,
-                                    init: Some(Expr::IndexGet {
-                                        object: Box::new(Expr::LocalGet(arr_id)),
-                                        index: Box::new(Expr::LocalGet(idx_id)),
-                                    }),
+                                    init: Some(lazy_or_index_elem(
+                                        use_lazy_iter,
+                                        arr_id,
+                                        idx_id,
+                                        result_id,
+                                    )),
                                 }]
                             }
                         }
@@ -1736,18 +1761,56 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         name,
                         ty: Type::Any,
                         mutable: false,
-                        init: Some(Expr::IndexGet {
-                            object: Box::new(Expr::LocalGet(arr_id)),
-                            index: Box::new(Expr::LocalGet(idx_id)),
-                        }),
+                        init: Some(lazy_or_index_elem(
+                            use_lazy_iter,
+                            arr_id,
+                            idx_id,
+                            result_id,
+                        )),
                     }]
                 }
                 _ => return Err(anyhow!("Unsupported for-of left-hand side")),
             };
 
+            // Lazy iterator path: run IteratorClose on abrupt completions.
+            if use_lazy_iter {
+                insert_iterator_close_on_abrupt(&mut loop_body, arr_id, 0, &[]);
+            }
+
             // Prepend the binding statements to the loop body
             for (i, stmt) in binding_stmts.into_iter().enumerate() {
                 loop_body.insert(i, stmt);
+            }
+
+            if use_lazy_iter {
+                // Modeled as a `for` so `continue` re-pulls the iterator via the
+                // update clause (see the matching comment in stmt_loops.rs):
+                //   for (let __result = __iter.next();
+                //        !__result.done;
+                //        __result = __iter.next()) { bindings; body }
+                result.push(Stmt::For {
+                    init: Some(Box::new(Stmt::Let {
+                        id: result_id,
+                        name: format!("__result_{}", result_id),
+                        ty: Type::Any,
+                        mutable: true,
+                        init: Some(iterator_next_call(arr_id)),
+                    })),
+                    condition: Some(Expr::Unary {
+                        op: UnaryOp::Not,
+                        operand: Box::new(Expr::PropertyGet {
+                            object: Box::new(Expr::LocalGet(result_id)),
+                            property: "done".to_string(),
+                        }),
+                    }),
+                    update: Some(Expr::LocalSet(
+                        result_id,
+                        Box::new(iterator_next_call(arr_id)),
+                    )),
+                    body: loop_body,
+                });
+                ctx.pop_block_scope(for_scope_mark);
+                return Ok(result);
             }
 
             // Loop bound: Map/Set fast paths use `.size` (codegen-recognized,

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -7,7 +7,7 @@ use crate::destructuring::*;
 use crate::ir::*;
 use crate::lower::{
     collect_for_of_pattern_leaves, emit_for_of_pattern_binding, insert_iterator_close_on_abrupt,
-    iterator_next_call, lazy_or_index_elem, lower_expr, LoweringContext,
+    lazy_iter_for_stmt, lazy_or_index_elem, lower_expr, LoweringContext,
 };
 use crate::lower_patterns::*;
 use crate::lower_types::*;
@@ -1320,11 +1320,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             if for_of_stmt.is_await && needs_runtime_iterator {
                 return lower_runtime_for_await_iterator_body(ctx, for_of_stmt, arr_expr);
             }
-            // Lazy iterator protocol for generic/untyped iterables — see the
-            // matching comment in `lower/stmt_loops.rs`. Drives the loop with
-            // `__iter.next()` and runs IteratorClose on abrupt completion so a
-            // `break`/`return` closes a generator instead of draining it.
-            // `is_await` is already handled by the early return above.
+            // Lazy iterator protocol for generic iterables (see stmt_loops.rs).
             let use_lazy_iter = needs_runtime_iterator;
             let arr_expr = if is_iterable_map {
                 if map_kv_fastpath {
@@ -1407,8 +1403,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     Type::Any
                 }
             } else if use_lazy_iter {
-                // Holds the iterator object, not an array.
-                Type::Any
+                Type::Any // holds the iterator, not an array
             } else if let Some(ref elem) = inferred_elem_type {
                 Type::Array(Box::new(elem.clone()))
             } else {
@@ -1431,16 +1426,12 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 .push((format!("__arr_{}", arr_id), arr_id, holder_type.clone()));
             ctx.locals
                 .push((format!("__idx_{}", idx_id), idx_id, Type::Number));
-
-            // Lazy iterator path: `arr_id` holds the iterator, `result_id` the
-            // most recent `__iter.next()` result.
+            // Lazy path: `arr_id` holds the iterator, `result_id` the last next().
             let result_id = ctx.fresh_local();
             if use_lazy_iter {
                 ctx.locals
                     .push((format!("__result_{}", result_id), result_id, Type::Any));
             }
-
-            // Store array reference (or `let __iter = GetIterator(..)`).
             result.push(Stmt::Let {
                 id: arr_id,
                 name: format!("__arr_{}", arr_id),
@@ -1544,22 +1535,16 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         // [Promise.resolve(1), …]) sum += x` binds `x` to a
                         // raw Promise object and `sum += x` produces NaN.
                         // Mirrors the same fix in `lower.rs::lower_stmt`'s
-                        // module-init for-of arm.
-                        let item_expr = if use_lazy_iter {
-                            Expr::PropertyGet {
-                                object: Box::new(Expr::LocalGet(result_id)),
-                                property: "value".to_string(),
-                            }
-                        } else {
+                        // module-init for-of arm. `use_lazy_iter` implies
+                        // `!is_await`, so the await arm is always the index path.
+                        let item_expr = if for_of_stmt.is_await {
                             let raw_item_expr = Expr::IndexGet {
                                 object: Box::new(Expr::LocalGet(arr_id)),
                                 index: Box::new(Expr::LocalGet(idx_id)),
                             };
-                            if for_of_stmt.is_await {
-                                Expr::Await(Box::new(raw_item_expr))
-                            } else {
-                                raw_item_expr
-                            }
+                            Expr::Await(Box::new(raw_item_expr))
+                        } else {
+                            lazy_or_index_elem(use_lazy_iter, arr_id, idx_id, result_id)
                         };
 
                         match &decl.name {
@@ -1767,43 +1752,16 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 _ => return Err(anyhow!("Unsupported for-of left-hand side")),
             };
 
-            // Lazy iterator path: run IteratorClose on abrupt completions.
+            // Lazy path: run IteratorClose on abrupt completions.
             if use_lazy_iter {
                 insert_iterator_close_on_abrupt(&mut loop_body, arr_id, 0, &[]);
             }
-
             // Prepend the binding statements to the loop body
             for (i, stmt) in binding_stmts.into_iter().enumerate() {
                 loop_body.insert(i, stmt);
             }
-
             if use_lazy_iter {
-                // Modeled as a `for` so `continue` re-pulls the iterator via the
-                // update clause (see the matching comment in stmt_loops.rs):
-                //   for (let __result = __iter.next();
-                //        !__result.done;
-                //        __result = __iter.next()) { bindings; body }
-                result.push(Stmt::For {
-                    init: Some(Box::new(Stmt::Let {
-                        id: result_id,
-                        name: format!("__result_{}", result_id),
-                        ty: Type::Any,
-                        mutable: true,
-                        init: Some(iterator_next_call(arr_id)),
-                    })),
-                    condition: Some(Expr::Unary {
-                        op: UnaryOp::Not,
-                        operand: Box::new(Expr::PropertyGet {
-                            object: Box::new(Expr::LocalGet(result_id)),
-                            property: "done".to_string(),
-                        }),
-                    }),
-                    update: Some(Expr::LocalSet(
-                        result_id,
-                        Box::new(iterator_next_call(arr_id)),
-                    )),
-                    body: loop_body,
-                });
+                result.push(lazy_iter_for_stmt(arr_id, result_id, loop_body));
                 ctx.pop_block_scope(for_scope_mark);
                 return Ok(result);
             }

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1761,12 +1761,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         name,
                         ty: Type::Any,
                         mutable: false,
-                        init: Some(lazy_or_index_elem(
-                            use_lazy_iter,
-                            arr_id,
-                            idx_id,
-                            result_id,
-                        )),
+                        init: Some(lazy_or_index_elem(use_lazy_iter, arr_id, idx_id, result_id)),
                     }]
                 }
                 _ => return Err(anyhow!("Unsupported for-of left-hand side")),

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -836,6 +836,15 @@ pub(crate) fn predeclare_implicit_assignment_targets(
 
     let mut stmts = Vec::new();
     for name in names {
+        // Inside a `with` body, an assignment to an otherwise-undeclared name
+        // must route through the with object's environment record (lowered to
+        // `WithSet`), not be hoisted as an implicit local that would shadow the
+        // with env and capture the write locally. `WithSet` itself falls back
+        // to the outer scope when the object lacks the property, so skipping
+        // predeclaration here is safe for the not-on-object case too.
+        if !ctx.active_with_envs_for_ident(&name).is_empty() {
+            continue;
+        }
         // Inside a closure (scope_depth > 0), an assignment to a name that
         // resolves to a MODULE-LEVEL binding (e.g. a `var` declared later at
         // module scope) must NOT be re-declared as a closure-local: doing so

--- a/crates/perry-runtime/src/object/with_env.rs
+++ b/crates/perry-runtime/src/object/with_env.rs
@@ -20,16 +20,33 @@ fn key_as_value(key: *const StringHeader) -> f64 {
     js_nanbox_string(key as i64)
 }
 
+/// `ToObject(bindings)` as the `with` object environment record: null /
+/// undefined throw a TypeError; a primitive (number / string / boolean /
+/// bigint / symbol) is boxed into its wrapper object; an object passes through.
+/// Returns the (possibly boxed) value as a NaN-boxed-pointer f64 so callers can
+/// use it for both `HasProperty` probes and field access on a single, stable
+/// object. Without the boxing, `with (2)` / `with ("str")` threw instead of
+/// probing the wrapper's own properties (and falling back to the outer scope).
 #[inline]
-fn object_ptr(bindings: f64) -> *mut ObjectHeader {
+fn to_object_bindings(bindings: f64) -> f64 {
     let value = JSValue::from_bits(bindings.to_bits());
     if value.is_null() || value.is_undefined() {
         throw_type_error(b"Cannot convert undefined or null to object");
     }
-    if !value.is_pointer() {
+    if value.is_pointer() {
+        return bindings;
+    }
+    crate::object::alloc::js_object_coerce(bindings)
+}
+
+#[inline]
+fn object_ptr(bindings: f64) -> *mut ObjectHeader {
+    let coerced = to_object_bindings(bindings);
+    let coerced_val = JSValue::from_bits(coerced.to_bits());
+    if !coerced_val.is_pointer() {
         throw_type_error(b"with object environment requires an object");
     }
-    let ptr = value.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+    let ptr = coerced_val.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
     if ptr.is_null() || (ptr as usize) < 0x10000 {
         throw_type_error(b"with object environment requires an object");
     }
@@ -46,7 +63,7 @@ pub extern "C" fn js_with_has_binding(bindings: f64, key: *const StringHeader) -
     if key.is_null() {
         return 0;
     }
-    let _ = object_ptr(bindings);
+    let bindings = to_object_bindings(bindings);
     if !has_property(bindings, key) {
         return 0;
     }
@@ -80,8 +97,9 @@ pub extern "C" fn js_with_set_binding(
     value: f64,
     strict: i32,
 ) -> f64 {
-    let ptr = object_ptr(bindings);
-    if strict != 0 && !has_property(bindings, key) {
+    let coerced = to_object_bindings(bindings);
+    let ptr = object_ptr(coerced);
+    if strict != 0 && !has_property(coerced, key) {
         crate::error::js_throw_reference_error_unresolvable_assignment(key_as_value(key));
     }
     js_object_set_field_by_name(ptr, key, value);

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -2040,6 +2040,17 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
             }
         }
     }
+    // A primitive number / boolean / null / undefined is not iterable. Per
+    // GetIterator this is a TypeError; bail before the `[Symbol.iterator]`
+    // lookup, which would otherwise dereference a raw (non-NaN-boxed) double as
+    // an object pointer and crash (`for (x of 37) {}`). Strings ARE iterable, so
+    // they fall through to the symbol lookup below.
+    {
+        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
+        if !jsv.is_pointer() && !jsv.is_any_string() {
+            throw_value_not_iterable();
+        }
+    }
     let iter_wk = well_known_symbol("iterator");
     if !iter_wk.is_null() {
         let sym_f64 = f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
@@ -2073,17 +2084,6 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
                 }
                 return iter;
             }
-        }
-    }
-    // No usable `[Symbol.iterator]` was found. A primitive number / boolean /
-    // null / undefined is not iterable — per GetIterator this is a TypeError,
-    // and returning the value unchanged would crash a downstream `.next()`
-    // call (`for (x of 37) {}`). Strings and objects/arrays are handled above
-    // or carry a real iterator, so only the non-iterable primitives throw here.
-    {
-        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
-        if !jsv.is_pointer() && !jsv.is_any_string() {
-            throw_value_not_iterable();
         }
     }
     val_f64

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1981,6 +1981,13 @@ fn throw_iterator_result_not_object() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
 }
 
+fn throw_value_not_iterable() -> ! {
+    let msg = b"is not iterable";
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(msg_str);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+}
+
 /// #1831: resolve the iterator for a `yield*` operand.
 ///
 /// `yield* X` must drive `X[Symbol.iterator]()` — for a generator **call** the
@@ -2066,6 +2073,17 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
                 }
                 return iter;
             }
+        }
+    }
+    // No usable `[Symbol.iterator]` was found. A primitive number / boolean /
+    // null / undefined is not iterable — per GetIterator this is a TypeError,
+    // and returning the value unchanged would crash a downstream `.next()`
+    // call (`for (x of 37) {}`). Strings and objects/arrays are handled above
+    // or carry a real iterator, so only the non-iterable primitives throw here.
+    {
+        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
+        if !jsv.is_pointer() && !jsv.is_any_string() {
+            throw_value_not_iterable();
         }
     }
     val_f64


### PR DESCRIPTION
## Summary

Drives test262 **control-flow / binding statement** parity from **75.2% → 82.8%** across the nine `language/statements/*` suites (for-of, for-in, for, while, switch, with, try, function, variable): **834 → 918 passing (+84), zero regressions**. Broad `built-ins + language` shard (0/12): net **+11 pass, 16 fixed, 0 real regressions** (the 5 apparently-new failures fail identically on the pre-branch baseline binary in isolation — pre-existing flakiness, not caused by this branch).

## Root causes fixed (grouped)

### 1. for-of eagerly drained iterators instead of lazy protocol (+22)
The generic/untyped for-of path materialized the whole iterable up front (`ForOfToArray`), which (a) ran a generator past the point a `break` should have closed it (firing post-`yield` code) and (b) made `IteratorClose` impossible. Replaced with a **lazy iterator-protocol** lowering for the `needs_runtime_iterator` case (both the module-level path in `stmt_loops.rs` and the duplicate function-body path in `lower_decl/body_stmt.rs`):
- `GetIterator(obj)` → drive with `__iter.next()` per iteration, element from `__result.value`.
- Modeled as a `for` loop so the advance lives in the **update clause** — `continue` re-pulls the iterator instead of spinning forever.
- New `insert_iterator_close_on_abrupt`: rewrites the body so `break` / labeled `break` / labeled `continue` escaping the loop / `return` run a **guarded** `IteratorClose` (`if (__iter.return != null) __iter.return()`) first — recursing through `if`/`try`/`block`/nested-loop/`switch`/`labeled` with correct break-capture-depth and label-scope tracking. Closes `break-from-try`, `return-from-finally`, `break-label`, `generator-close-via-{break,continue,return}`, etc.

### 2. `eval("<constant string>")` did nothing → real AOT completion-value eval (+~56)
Const-string `eval` returned `undefined` without running. Now folds into a **scope-capturing IIFE** — `(function () { var __perry_cv; <tracked body>; return __perry_cv })()` — parsed via the existing `new Function` infrastructure, lowered sloppy (so the body can use `with`, undeclared assignments, etc.) and capturing the enclosing scope. A small AST transform threads the ECMAScript **statement completion value** into `__perry_cv` (expression statements assign it; `if`/loops/`switch`/`try`/`with` reset to `undefined` per `UpdateEmpty(_, undefined)`; declarations leave it untouched). Unblocks the `cptn-*` suites across switch/try/while/with/for-of/for-in/for and the `eval("with(o){…})"` tests.

### 3. `with` statement: write-through + ToObject coercion (+~7)
- Assignment to an undeclared name inside a `with` body was hoisted as an implicit local that shadowed the with-env, so `with(o){ p = v }` never reached `o`. `predeclare_implicit_assignment_targets` now skips names captured by an active with-env (routing them to `WithSet`).
- `with(primitive)` (`with(2)`, `with("str")`) threw instead of `ToObject`-coercing; `js_with_*` helpers now box primitives to their wrapper while still throwing on `null`/`undefined`.

### 4. `GetIterator` crashed on non-iterable primitives (+1, plus broad built-ins fixes)
`for (x of 37)` segfaulted: `js_get_iterator` dereferenced a raw (non-NaN-boxed) double during the `[Symbol.iterator]` lookup. Now throws `TypeError` for non-iterable primitives before the lookup; strings/objects unaffected.

## Files
- `crates/perry-hir/src/lower/stmt_loops.rs` — lazy for-of + IteratorClose helpers
- `crates/perry-hir/src/lower_decl/body_stmt.rs` — same for the function-body for-of path
- `crates/perry-hir/src/lower/const_fold_fn.rs` — `eval` const-string fold + completion-value transform
- `crates/perry-hir/src/lower/mod.rs` — re-export iterator-close helpers
- `crates/perry-hir/src/lower_patterns.rs` — skip implicit-local hoist under `with`
- `crates/perry-runtime/src/object/with_env.rs` — `with` ToObject coercion
- `crates/perry-runtime/src/symbol.rs` — `GetIterator` non-iterable TypeError

## Validation
Box build (48-core), test262 pinned. Per-suite `language/statements`: 834→918 pass, diff=0. Broad `built-ins+language` shard 0/12 diffed test-by-test vs the `origin/main` branch-point binary: 16 fixed, 0 real regressions.

## Known follow-ups
- Destructuring / member-expression loop heads (`for (x.y of …)`, `for (let [a,b] in …)`).
- Sloppy `var` hoisting out of nested blocks to module/global scope.
- Parser early-errors (the `function`/`variable` "expected SyntaxError" negative tests).
- Live typed-array / Map iteration during mutation (underlying builtin iterators snapshot).
- `finally`-with-abrupt-completion completion value; non-callable iterator `.return` GetMethod TypeError.