### PR TITLE
fix(runtime): bind this=iterable when calling [Symbol.iterator]() (yield* sync delegation)

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -2052,7 +2052,16 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
             let fn_ptr = crate::value::js_nanbox_get_pointer(call_target)
                 as *const crate::closure::ClosureHeader;
             if !fn_ptr.is_null() {
+                // Spec `GetIterator(obj)` → `Call(method, obj)`: the
+                // `[Symbol.iterator]()` factory runs with `this === obj`. The
+                // `clone_closure_rebind_this` above covers a closure that
+                // *captures* `this` (effect's prototype method); a plain
+                // `function(){ …this… }` factory reads `this` dynamically off
+                // IMPLICIT_THIS, so set it here too (test262 yield-star-sync-*
+                // asserts the `[Symbol.iterator]` call's thisValue === obj).
+                let prev_this = crate::object::js_implicit_this_set(val_f64);
                 let iter = crate::closure::js_closure_call0(fn_ptr);
+                crate::object::js_implicit_this_set(prev_this);
                 // Several Perry host-backed collections expose iterator
                 // helpers as eager arrays for direct `.entries()` parity. When
                 // the same function is reached through `Symbol.iterator`, wrap


### PR DESCRIPTION
Follow-up to #4777/#4783 yield* async-generator work. Fixes the `this` binding of the sync-iterator factory in `GetIterator`.

## Root cause
`js_get_iterator` invoked the `[Symbol.iterator]()` factory via `js_closure_call0` after `clone_closure_rebind_this` — which only rebinds a closure that *captures* `this`. A plain `function(){ …this… }` iterator factory reads `this` dynamically off `IMPLICIT_THIS`, which was left as the caller's `this`. So `GetIterator(obj)` ran the factory with the wrong `this` (spec: `GetIterator` → `Call(method, obj)` with `this === obj`).

## Fix
Set `IMPLICIT_THIS = iterable` around the factory call (keeping the existing `clone_closure_rebind_this` for the captures-`this` effect-prototype case).

## Impact
`language/{expressions,statements}/async-generator`: **93.8% → 94.7%** (pass 833 → 841, compile-fail 0). Fixes the `yield-star-sync-*` `thisValue` ordering cluster and array-prototype destructuring iterator cases. General correctness fix for all `for-of` / destructuring / spread over an object whose `[Symbol.iterator]` factory reads `this`; verified no regression on `for-of` with a `this`-reading custom iterator.

## Not included (return/throw delegation forwarding)
Attempted `yield*` `.throw()`/`.return()` forwarding to the delegated iterator (spec `received.[[Type]] is throw/return`). It requires the catch/return handler to re-enter the delegation loop, but Perry inlines async-generator catch bodies into the `.throw()` closure where there is no loop context (`continue` → "continue statement outside any loop"). Doing it properly is a deep state-machine rework with real regression risk to the shared `yield*` path (Effect / #321) — deferred.