### PR TITLE
fix(runtime): function-object descriptors + proxy SetIntegrityLevel parity (built-ins/Object)

### DIFF
--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -124,11 +124,88 @@ unsafe fn registered_buffer_index_own_property_present(
 /// present (e.g. `Object.defineProperty(o, k, child)` where `child`'s prototype
 /// carries `value`). `descriptor_value` is the NaN-boxed descriptor object.
 pub(crate) unsafe fn desc_has_field(descriptor_value: f64, name: &[u8]) -> bool {
+    // A function object used as a descriptor (`Object.defineProperty(o, k,
+    // funObj)`, test262 15.2.3.6-3-139-1 …) is a closure, not an
+    // `ObjectHeader`. `js_object_has_property` can't walk a closure's own
+    // dynamic props nor its `[[Prototype]]` (`Function.prototype`), so
+    // `ToPropertyDescriptor` would miss an inherited `value`/`get`/… field.
+    // Route closures through the closure-aware presence check.
+    if let Some(ptr) = closure_ptr_from_value(descriptor_value) {
+        if let Ok(key_str) = std::str::from_utf8(name) {
+            if super::has_own_helpers::closure_own_key_present(ptr, key_str) {
+                return true;
+            }
+            // Inherited from `Function.prototype` (and its own chain).
+            let fp = crate::object::builtin_prototype_value("Function");
+            if value_is_object_like(fp) {
+                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                let key_f64 = crate::value::JSValue::string_ptr(key).bits();
+                const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+                return crate::object::js_object_has_property(fp, f64::from_bits(key_f64))
+                    .to_bits()
+                    == TAG_TRUE;
+            }
+            return false;
+        }
+    }
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
     let key_f64 = crate::value::JSValue::string_ptr(key).bits();
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     crate::object::js_object_has_property(descriptor_value, f64::from_bits(key_f64)).to_bits()
         == TAG_TRUE
+}
+
+/// If `value` is a closure (function object), return its heap pointer. Mirrors
+/// the closure-pointer recovery used elsewhere in `js_object_define_property`:
+/// closures arrive either NaN-boxed with `POINTER_TAG` (function-local) or as a
+/// raw in-range I64 (module-level), and `is_closure_ptr` confirms the magic.
+pub(crate) unsafe fn closure_ptr_from_value(value: f64) -> Option<usize> {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    let raw = if jv.is_pointer() {
+        jv.as_pointer::<u8>() as usize
+    } else {
+        let bits = value.to_bits();
+        if bits != 0 && bits <= 0x0000_FFFF_FFFF_FFFF && bits > 0x10000 {
+            bits as usize
+        } else {
+            0
+        }
+    };
+    if raw >= 0x10000 && crate::closure::is_closure_ptr(raw) {
+        Some(raw)
+    } else {
+        None
+    }
+}
+
+/// `Get(descriptor, name)` as a value-level read. For an ordinary object the raw
+/// `js_object_get_field_by_name` read is sufficient, but a closure descriptor
+/// (`Object.defineProperty(o, k, funObj)`) requires reading its own dynamic
+/// props and then walking its `[[Prototype]]` (`Function.prototype`) — Perry's
+/// `[[Get]]` for the descriptor's `value`/`get`/`set`/attribute fields. Returns
+/// `undefined` when the field is absent.
+pub(crate) unsafe fn desc_read_field(descriptor_value: f64, name: &[u8]) -> crate::value::JSValue {
+    if let Some(ptr) = closure_ptr_from_value(descriptor_value) {
+        if let Ok(key_str) = std::str::from_utf8(name) {
+            if super::has_own_helpers::closure_own_key_present(ptr, key_str) {
+                let v = crate::closure::closure_get_dynamic_prop(ptr, key_str);
+                return crate::value::JSValue::from_bits(v.to_bits());
+            }
+            let fp = crate::object::builtin_prototype_value("Function");
+            let fp_ptr = extract_obj_ptr(fp);
+            if !fp_ptr.is_null() {
+                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                return js_object_get_field_by_name(fp_ptr as *const ObjectHeader, key);
+            }
+            return crate::value::JSValue::from_bits(crate::value::TAG_UNDEFINED);
+        }
+    }
+    let desc_ptr = extract_obj_ptr(descriptor_value);
+    if desc_ptr.is_null() {
+        return crate::value::JSValue::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_get_field_by_name(desc_ptr as *const ObjectHeader, key)
 }
 
 /// Validate a property descriptor object per ES `ToPropertyDescriptor`
@@ -1494,12 +1571,10 @@ pub extern "C" fn js_object_define_property(
         // PRESENCE (HasProperty — own OR inherited) on the descriptor object,
         // not by `is_undefined`: `{ get: undefined }` is an explicit (present)
         // accessor field, and an *inherited* `value`/`get` counts as present.
-        let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
-        let set_key = crate::string::js_string_from_bytes(b"set".as_ptr(), 3);
         let desc_has_get = desc_has_field(descriptor_value, b"get");
         let desc_has_set = desc_has_field(descriptor_value, b"set");
-        let get_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, get_key);
-        let set_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, set_key);
+        let get_field = desc_read_field(descriptor_value, b"get");
+        let set_field = desc_read_field(descriptor_value, b"set");
         let has_accessor = desc_has_get || desc_has_set;
 
         // The existing accessor (if the property is currently an accessor) —
@@ -1564,7 +1639,6 @@ pub extern "C" fn js_object_define_property(
             // descriptor (only `enumerable`/`configurable`). Detect by own-field
             // presence so `{ value: undefined }` (present) stores `undefined`,
             // while a generic descriptor on an existing accessor leaves it intact.
-            let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
             let desc_has_value = desc_has_field(descriptor_value, b"value");
             let desc_has_writable = desc_has_field(descriptor_value, b"writable");
             let is_data = desc_has_value || desc_has_writable;
@@ -1581,8 +1655,7 @@ pub extern "C" fn js_object_define_property(
                     });
                     clear_property_attrs(obj as usize, k);
                 }
-                let value_field =
-                    js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
+                let value_field = desc_read_field(descriptor_value, b"value");
                 // Ensure the key exists; store the (possibly `undefined`) value
                 // via `[[DefineOwnProperty]]`, bypassing the `[[Set]]` writability
                 // / frozen guard (invariants already enforced above). When
@@ -1617,8 +1690,7 @@ pub extern "C" fn js_object_define_property(
         // Read attribute flags from descriptor. JS defaults when omitted in
         // `Object.defineProperty` are `false` (NOT `true` like for direct assignment).
         let read_bool = |name: &[u8]| -> Option<bool> {
-            let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-            let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
+            let v = desc_read_field(descriptor_value, name);
             if v.is_undefined() {
                 None
             } else {

--- a/crates/perry-runtime/src/object/object_ops_frozen.rs
+++ b/crates/perry-runtime/src/object/object_ops_frozen.rs
@@ -29,8 +29,110 @@ unsafe fn mark_all_symbol_keys(
     }
 }
 
+/// Build a partial property descriptor object for `SetIntegrityLevel`:
+/// `{ configurable: false }` (sealed, or a frozen accessor) or
+/// `{ configurable: false, writable: false }` (a frozen data property).
+unsafe fn build_integrity_descriptor(set_writable_false: bool) -> f64 {
+    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    let obj = js_object_alloc(0, 2);
+    let false_v = f64::from_bits(TAG_FALSE);
+    let ck = crate::string::js_string_from_bytes(b"configurable".as_ptr(), 12);
+    js_object_set_field_by_name(obj, ck, false_v);
+    if set_writable_false {
+        let wk = crate::string::js_string_from_bytes(b"writable".as_ptr(), 8);
+        js_object_set_field_by_name(obj, wk, false_v);
+    }
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+/// `SetIntegrityLevel(O, level)` (ECMA-262 7.3.16) for a Proxy receiver. A
+/// Proxy is a small registered id, not a heap object — `extract_obj_ptr` yields
+/// the fake pointer and `gc_header_for` would deref unmapped memory (the
+/// `Object.seal`/`Object.freeze` proxy crash cluster). Route through the proxy
+/// `[[PreventExtensions]]`, `[[OwnPropertyKeys]]`, `[[GetOwnProperty]]` and
+/// `[[DefineOwnProperty]]` traps. Returns the proxy; throws a `TypeError` when a
+/// trap reports failure (`PreventExtensions` false ⇒ `SetIntegrityLevel` false
+/// ⇒ `Object.seal`/`Object.freeze` throw).
+unsafe fn set_integrity_level_proxy(obj_value: f64, frozen: bool) -> f64 {
+    let ok = crate::proxy::js_reflect_prevent_extensions(obj_value);
+    if crate::value::js_is_truthy(ok) == 0 {
+        throw_object_type_error(
+            b"Cannot set integrity level: 'preventExtensions' trap returned falsish",
+        );
+    }
+    let keys = crate::proxy::js_proxy_own_keys(obj_value);
+    let keys_ptr = extract_obj_ptr(keys) as *const crate::array::ArrayHeader;
+    if keys_ptr.is_null() {
+        return obj_value;
+    }
+    let len = crate::array::js_array_length(keys_ptr);
+    for i in 0..len {
+        let k = crate::array::js_array_get_f64(keys_ptr, i);
+        let desc = if frozen {
+            let cur = crate::proxy::js_reflect_get_own_property_descriptor(obj_value, k);
+            if crate::value::JSValue::from_bits(cur.to_bits()).is_undefined() {
+                continue;
+            }
+            let is_accessor = desc_has_field(cur, b"get") || desc_has_field(cur, b"set");
+            build_integrity_descriptor(!is_accessor)
+        } else {
+            build_integrity_descriptor(false)
+        };
+        // DefinePropertyOrThrow: js_object_define_property routes the proxy
+        // through the `[[DefineOwnProperty]]` trap and throws if it reports
+        // failure, propagating the abrupt completion just like the spec.
+        js_object_define_property(obj_value, k, desc);
+    }
+    obj_value
+}
+
+/// Truthiness of a boolean descriptor field (`configurable`/`writable`).
+unsafe fn desc_field_true(desc: f64, name: &[u8]) -> bool {
+    let v = desc_read_field(desc, name);
+    crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0
+}
+
+/// `TestIntegrityLevel(O, level)` (ECMA-262 7.3.15) for a Proxy receiver. Drives
+/// the `[[IsExtensible]]`, `[[OwnPropertyKeys]]` and `[[GetOwnProperty]]` traps
+/// in spec order (test262 `isSealed`/`isFrozen` `proxy-no-ownkeys-returned-keys-order`
+/// asserts each key returned by `ownKeys` is queried via `getOwnPropertyDescriptor`).
+unsafe fn test_integrity_level_proxy(obj_value: f64, frozen: bool) -> bool {
+    let ext = crate::proxy::js_reflect_is_extensible(obj_value);
+    if crate::value::js_is_truthy(ext) != 0 {
+        return false;
+    }
+    let keys = crate::proxy::js_proxy_own_keys(obj_value);
+    let keys_ptr = extract_obj_ptr(keys) as *const crate::array::ArrayHeader;
+    if keys_ptr.is_null() {
+        return true;
+    }
+    let len = crate::array::js_array_length(keys_ptr);
+    for i in 0..len {
+        let k = crate::array::js_array_get_f64(keys_ptr, i);
+        let cur = crate::proxy::js_reflect_get_own_property_descriptor(obj_value, k);
+        if crate::value::JSValue::from_bits(cur.to_bits()).is_undefined() {
+            continue;
+        }
+        if desc_field_true(cur, b"configurable") {
+            return false;
+        }
+        if frozen {
+            let is_data = desc_has_field(cur, b"value") || desc_has_field(cur, b"writable");
+            if is_data && desc_field_true(cur, b"writable") {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 #[no_mangle]
 pub extern "C" fn js_object_freeze(obj_value: f64) -> f64 {
+    if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        return unsafe {
+            set_integrity_level_proxy(obj_value, /*frozen=*/ true)
+        };
+    }
     unsafe {
         let obj = extract_obj_ptr(obj_value);
         if !obj.is_null() && (obj as usize) > 0x10000 {
@@ -54,6 +156,11 @@ pub extern "C" fn js_object_freeze(obj_value: f64) -> f64 {
 /// existing key. Writable is preserved (sealed ≠ frozen). Returns the object.
 #[no_mangle]
 pub extern "C" fn js_object_seal(obj_value: f64) -> f64 {
+    if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        return unsafe {
+            set_integrity_level_proxy(obj_value, /*frozen=*/ false)
+        };
+    }
     unsafe {
         let obj = extract_obj_ptr(obj_value);
         if !obj.is_null() && (obj as usize) > 0x10000 {
@@ -197,10 +304,9 @@ pub extern "C" fn js_object_is_frozen(obj_value: f64) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
     if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
-        // Proxy: a frozen proxy is one whose target is non-extensible with all
-        // own props non-configurable/non-writable. Fall back to extensibility.
-        let ext = crate::proxy::js_reflect_is_extensible(obj_value);
-        return if crate::value::js_is_truthy(ext) == 0 {
+        return if unsafe {
+            test_integrity_level_proxy(obj_value, /*frozen=*/ true)
+        } {
             f64::from_bits(TAG_TRUE)
         } else {
             f64::from_bits(TAG_FALSE)
@@ -230,8 +336,9 @@ pub extern "C" fn js_object_is_sealed(obj_value: f64) -> f64 {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
     if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
-        let ext = crate::proxy::js_reflect_is_extensible(obj_value);
-        return if crate::value::js_is_truthy(ext) == 0 {
+        return if unsafe {
+            test_integrity_level_proxy(obj_value, /*frozen=*/ false)
+        } {
             f64::from_bits(TAG_TRUE)
         } else {
             f64::from_bits(TAG_FALSE)


### PR DESCRIPTION
## Summary

Extends the built-ins/Object test262 long-tail work from #4784. Two self-contained, spec-driven fixes that share no code with the array hot path:

**built-ins/Object: 2813 → 2828 pass (88.7% → 89.2%), +15 tests, zero regressions.**

Verified against a clean from-scratch build of this branch's merge-base (`ad1e7d947` = #4784 tip): base `2813 pass / 359 fail`, dev `2828 / 344`, per-test diff `dev_fail − base_fail = ∅`.

### Cluster 5 — function-object descriptors (+6)
A function used as a property descriptor — `Object.defineProperty(o, k, funObj)` (test262 `15.2.3.6-3-139-1`, `-165-1`, `-218-1`, `-248-1`, `-33-1`, `-86-1`) — is a closure, not an `ObjectHeader`. `js_object_has_property` / `js_object_get_field_by_name` could not walk a closure's own dynamic props nor its `[[Prototype]]` (`Function.prototype`), so `ToPropertyDescriptor` missed `value`/`get`/`set`/attribute fields inherited from `Function.prototype` and `obj.property` came back `undefined`.

- `desc_has_field` is now closure-aware (own dynamic props, then a `Function.prototype` `[[HasProperty]]`).
- New `desc_read_field` performs the value-level `[[Get]]` (own dynamic prop, else the `Function.prototype` chain); every descriptor field read in `js_object_define_property` (`get`/`set`/`value`/`writable`/`enumerable`/`configurable`) routes through it.
- **Ordinary-object descriptors are byte-for-byte unchanged** — `desc_read_field` falls straight back to the prior `extract_obj_ptr` + `js_object_get_field_by_name` path, so the only behavioural change is for function-object descriptors.

### Cluster 3 — proxy `SetIntegrityLevel` / `TestIntegrityLevel` (+9)
`Object.seal`/`Object.freeze` dereferenced the fake proxy registered-id pointer (`extract_obj_ptr` → `gc_header_for`) and **segfaulted** (`seal/seal-proxy`, `freeze/throws-when-false`, `*/abrupt-completion`, `*/proxy-no-ownkeys-returned-keys-order`). They now run `SetIntegrityLevel` through the proxy `[[PreventExtensions]]` / `[[OwnPropertyKeys]]` / `[[GetOwnProperty]]` / `[[DefineOwnProperty]]` traps, throwing a `TypeError` when `[[PreventExtensions]]` reports false. `Object.isSealed`/`isFrozen` on a proxy now run the full `TestIntegrityLevel` (`[[IsExtensible]]` + per-key `[[GetOwnProperty]]` in `ownKeys` order) instead of an extensibility-only approximation. Mirrors the proxy-routing guard already present in `Object.preventExtensions`/`isExtensible`/`defineProperty`.

## Files
- `crates/perry-runtime/src/object/object_ops.rs` — `desc_has_field` closure-awareness, new `desc_read_field` / `closure_ptr_from_value`, define-property field reads routed through them.
- `crates/perry-runtime/src/object/object_ops_frozen.rs` — `set_integrity_level_proxy` / `test_integrity_level_proxy` + proxy guards on `freeze`/`seal`/`isFrozen`/`isSealed`.

## Regression gate
Clean `ad1e7d947` base (full rebuild) vs this branch on built-ins/Object: **0 pass→fail**, 15 fail→pass. built-ins/Reflect unchanged (94/94 on both). Both touched files are already in the `check_file_size.sh` allowlist; `cargo fmt` clean.

## Deferred (separate subsystems, not regressed)
- Math/JSON/Error/arguments descriptors inheriting fields from **`Object.prototype`** — blocked on Perry not implementing `Object.prototype` inheritance for general property *reads* (`Object.prototype.b = 42; ({}).b` → `undefined`); a read-hot-path change out of scope here.
- RegExp/Date descriptors (`.value` expando) and the builtin-function reflection registry (`Object.is.name`/`.length`, `typeof Object.is === "number"`) — exotic-object expando + sentinel subsystems.
- Array-element accessor get/set (cluster 1) — untouched; the array hot path is not modified by this PR.