### PR TITLE
feat(ui): cross-platform DatePicker widget (#4772)

### DIFF
--- a/crates/perry-codegen-arkts/src/emit_widget.rs
+++ b/crates/perry-codegen-arkts/src/emit_widget.rs
@@ -154,6 +154,10 @@ pub(crate) fn emit_widget(
                 // picker variant is simpler than the full Calendar
                 // (which would need a builder for cell rendering).
                 "Calendar" => emit_calendar(args, callbacks),
+                // Issue #4772 — DatePicker(year, month, onChange) maps to
+                // ArkUI's native DatePicker (compact field complement to
+                // Calendar's CalendarPicker grid).
+                "DatePicker" => emit_date_picker(args, callbacks),
                 "ProgressView" => emit_progressview(args),
                 "Section" => emit_section(
                     args,

--- a/crates/perry-codegen-arkts/src/tests.rs
+++ b/crates/perry-codegen-arkts/src/tests.rs
@@ -1339,6 +1339,47 @@ fn calendar_without_literal_args_falls_back_to_today() {
 }
 
 #[test]
+fn date_picker_emits_arkui_date_picker() {
+    // Issue #4772 — DatePicker(2026, 5, onChange) → DatePicker
+    // with selected = new Date(2026, 4, 1) (month is 0-indexed in
+    // JS Date) and an onDateChange that converts the Date payload to
+    // an ISO yyyy-MM-dd string before invoking the TS callback.
+    let mut m = empty_module();
+    m.init.push(app_with_body(nmc(
+        "DatePicker",
+        vec![Expr::Number(2026.0), Expr::Number(5.0), closure_stub()],
+    )));
+    let r = emit_index_ets(&mut m).unwrap().unwrap();
+    assert!(r.ets_source.contains("DatePicker("));
+    // 1-based month 5 (May) → 0-based monthIndex 4
+    assert!(r.ets_source.contains("new Date(2026, 4, 1)"));
+    assert!(r.ets_source.contains(".onDateChange((value: Date) => {"));
+    assert!(r.ets_source.contains("value.toISOString().split('T')[0]"));
+    assert!(r
+        .ets_source
+        .contains("perryEntry.invokeCallback1(0, __iso)"));
+    assert_eq!(r.callbacks.len(), 1);
+}
+
+#[test]
+fn date_picker_without_literal_args_falls_back_to_today() {
+    // DatePicker(yearLocal, monthLocal, _) — args don't resolve to
+    // numeric literals, so the selected date defaults to `new Date()`.
+    let mut m = empty_module();
+    m.init.push(app_with_body(nmc(
+        "DatePicker",
+        vec![
+            Expr::String("not-a-number".into()),
+            Expr::String("nope".into()),
+            Expr::Number(0.0),
+        ],
+    )));
+    let r = emit_index_ets(&mut m).unwrap().unwrap();
+    assert!(r.ets_source.contains("DatePicker("));
+    assert!(r.ets_source.contains("selected: new Date()"));
+}
+
+#[test]
 fn rich_text_editor_zero_size_skips_width_height_modifiers() {
     // 0 width/height means "use intrinsic" — emitting .width(0)
     // would zero the editor. Test confirms the elision.

--- a/crates/perry-codegen-arkts/src/widgets/date_picker.rs
+++ b/crates/perry-codegen-arkts/src/widgets/date_picker.rs
@@ -1,0 +1,57 @@
+// This module is part of the perry-codegen-arkts crate (issue #4772).
+#![allow(clippy::too_many_arguments)]
+use crate::*;
+
+/// Issue #4772 — `DatePicker(year, month, onChange)` → ArkUI
+/// `DatePicker({selected: new Date(year, month-1, 1)}).onDateChange(...)`.
+/// ArkUI's `DatePicker` fires `.onDateChange((value: Date) => ...)` when
+/// the user picks a date. Perry's `onChange` receives an ISO `yyyy-MM-dd`
+/// string (POSIX-locale), so the forwarded payload is
+/// `value.toISOString().split('T')[0]`.
+///
+/// JavaScript's `Date` constructor takes `(year, monthIndex, day)` where
+/// monthIndex is 0-based; Perry passes a 1-based month per its TS
+/// signature, so we emit `month - 1` literally when both args resolve.
+/// When the args don't resolve to literals, we fall back to today's
+/// date (`new Date()`) — the user can still pick a date even if the
+/// initial highlight is wrong, which is strictly better than emitting
+/// an invalid Date object. This mirrors `emit_calendar`.
+pub(crate) fn emit_date_picker(args: &[Expr], callbacks: &mut Vec<Expr>) -> String {
+    let year = numeric_arg(args, 0);
+    let month = numeric_arg(args, 1);
+    let selected = match (year, month) {
+        (Some(y), Some(m)) => {
+            // ArkUI's Date constructor wants (year, monthIndex, day).
+            let m_idx = (m as i64).saturating_sub(1).max(0);
+            format!("new Date({}, {}, 1)", y as i64, m_idx)
+        }
+        _ => "new Date()".to_string(),
+    };
+
+    let ondatechange = match args.get(2) {
+        Some(closure @ Expr::Closure { .. }) => {
+            let idx = callbacks.len();
+            callbacks.push(closure.clone());
+            // ArkUI's DatePicker.onDateChange hands us a `Date`; convert
+            // to the ISO yyyy-MM-dd shape Perry's TS surface promises.
+            // .toISOString() returns "yyyy-MM-ddTHH:mm:ss.sssZ" — split
+            // at 'T' and take the date half.
+            format!(
+                ".onDateChange((value: Date) => {{\n    \
+                 const __iso = value.toISOString().split('T')[0];\n    \
+                 perryEntry.invokeCallback1({}, __iso);\n    \
+                 {drain}\
+                 }})",
+                idx,
+                drain = drain_loop_body()
+            )
+        }
+        _ => String::new(),
+    };
+
+    format!(
+        "DatePicker({{ selected: {sel} }}){ondatechange}",
+        sel = selected,
+        ondatechange = ondatechange,
+    )
+}

--- a/crates/perry-codegen-arkts/src/widgets/mod.rs
+++ b/crates/perry-codegen-arkts/src/widgets/mod.rs
@@ -2,6 +2,7 @@
 
 mod calendar;
 mod chart;
+mod date_picker;
 mod foreach;
 mod image;
 mod inputs;
@@ -14,6 +15,7 @@ mod tree;
 
 pub(crate) use calendar::*;
 pub(crate) use chart::*;
+pub(crate) use date_picker::*;
 pub(crate) use foreach::*;
 pub(crate) use image::*;
 pub(crate) use inputs::*;

--- a/crates/perry-dispatch/src/ui_table.rs
+++ b/crates/perry-dispatch/src/ui_table.rs
@@ -1037,6 +1037,30 @@ pub const PERRY_UI_TABLE: &[MethodRow] = &[
         args: &[ArgKind::Widget],
         ret: ReturnKind::Str,
     },
+    // ---- DatePicker (issue #4772) ----
+    MethodRow {
+        method: "DatePicker",
+        runtime: "perry_ui_date_picker_create",
+        args: &[ArgKind::I64Raw, ArgKind::I64Raw, ArgKind::Closure],
+        ret: ReturnKind::Widget,
+    },
+    MethodRow {
+        method: "datePickerSetDate",
+        runtime: "perry_ui_date_picker_set_date",
+        args: &[
+            ArgKind::Widget,
+            ArgKind::I64Raw,
+            ArgKind::I64Raw,
+            ArgKind::I64Raw,
+        ],
+        ret: ReturnKind::Void,
+    },
+    MethodRow {
+        method: "datePickerGetSelectedDate",
+        runtime: "perry_ui_date_picker_get_selected_date",
+        args: &[ArgKind::Widget],
+        ret: ReturnKind::Str,
+    },
     // ---- Chart (issue #474) ----
     MethodRow {
         method: "Chart",

--- a/crates/perry-ui-android/src/ffi/canvas_picker.rs
+++ b/crates/perry-ui-android/src/ffi/canvas_picker.rs
@@ -220,6 +220,20 @@ pub extern "C" fn perry_ui_calendar_get_selected_date(h: i64) -> f64 {
     widgets::calendar::get_selected_date(h)
 }
 
+// Issue #4772 — DatePicker widget (android.widget.DatePicker).
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_create(year: i64, month: i64, on_change: f64) -> i64 {
+    widgets::date_picker::create(year, month, on_change)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_set_date(h: i64, y: i64, m: i64, d: i64) {
+    widgets::date_picker::set_date(h, y, m, d);
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_get_selected_date(h: i64) -> f64 {
+    widgets::date_picker::get_selected_date(h)
+}
+
 // Issue #473 — table sort/filter/multi-select stubs.
 #[no_mangle]
 pub extern "C" fn perry_ui_table_set_on_sort_change(_h: i64, _cb: f64) {}

--- a/crates/perry-ui-android/src/widgets/date_picker.rs
+++ b/crates/perry-ui-android/src/widgets/date_picker.rs
@@ -1,0 +1,149 @@
+//! Android DatePicker widget — issue #4772. Backed by
+//! `android.widget.DatePicker` through the PerryBridge.kt static helpers
+//! (`datePickerCreate`, `datePickerSetDate`, `datePickerGetSelectedDate`).
+//! The Kotlin side wires `DatePicker.init`'s `OnDateChangedListener` to
+//! `nativeInvokeCallbackWithString(key, iso)` where `iso` is `yyyy-MM-dd`;
+//! the Rust side NaN-boxes it as a Perry string, matching the macOS / iOS
+//! / gtk4 / Windows twins. The compact, dialog-friendly complement to the
+//! `CalendarView`-backed `Calendar` widget.
+
+use crate::callback;
+use crate::jni_bridge;
+use jni::objects::{JObject, JValue};
+
+extern "C" {
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+    fn __android_log_print(prio: i32, tag: *const u8, fmt: *const u8, ...) -> i32;
+}
+
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+/// Create a `DatePicker` with the given initial year/month (month is 1-based).
+/// `on_change` is the Perry closure invoked with a `yyyy-MM-dd` string each
+/// time the user picks a new date.
+pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
+    let mut env = jni_bridge::get_env();
+    let _ = env.push_local_frame(16);
+
+    let cb_key = if on_change != 0.0 {
+        callback::register(on_change)
+    } else {
+        0
+    };
+
+    let bridge_class =
+        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+
+    let result = env.call_static_method(
+        bridge_cls,
+        "datePickerCreate",
+        "(JJJ)Landroid/widget/DatePicker;",
+        &[
+            JValue::Long(year),
+            JValue::Long(month),
+            JValue::Long(cb_key),
+        ],
+    );
+
+    let handle = match result {
+        Ok(jv) => match jv.l() {
+            Ok(obj) if !obj.is_null() => {
+                let g = env
+                    .new_global_ref(obj)
+                    .expect("Failed to global-ref DatePicker");
+                super::register_widget(g)
+            }
+            _ => 0,
+        },
+        Err(e) => {
+            unsafe {
+                let msg = format!("datePickerCreate failed: {:?}\0", e);
+                __android_log_print(
+                    6,
+                    b"PerryDatePicker\0".as_ptr(),
+                    b"%s\0".as_ptr(),
+                    msg.as_ptr(),
+                );
+                if env.exception_check().unwrap_or(false) {
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+            }
+            0
+        }
+    };
+
+    unsafe {
+        env.pop_local_frame(&JObject::null());
+    }
+    handle
+}
+
+/// Programmatically set the selected date (year, 1-based month, day).
+pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
+    if let Some(view) = super::get_widget(handle) {
+        let mut env = jni_bridge::get_env();
+        let _ = env.push_local_frame(8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let _ = env.call_static_method(
+            bridge_cls,
+            "datePickerSetDate",
+            "(Landroid/widget/DatePicker;JJJ)V",
+            &[
+                JValue::Object(view.as_obj()),
+                JValue::Long(year),
+                JValue::Long(month),
+                JValue::Long(day),
+            ],
+        );
+        unsafe {
+            env.pop_local_frame(&JObject::null());
+        }
+    }
+}
+
+/// Get the selected date as a NaN-boxed Perry string (`yyyy-MM-dd`). Returns
+/// undefined if the widget handle is unknown or JNI errors.
+pub fn get_selected_date(handle: i64) -> f64 {
+    let Some(view) = super::get_widget(handle) else {
+        return f64::from_bits(TAG_UNDEFINED);
+    };
+    let mut env = jni_bridge::get_env();
+    let _ = env.push_local_frame(8);
+    let bridge_class =
+        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+    let result = env.call_static_method(
+        bridge_cls,
+        "datePickerGetSelectedDate",
+        "(Landroid/widget/DatePicker;)Ljava/lang/String;",
+        &[JValue::Object(view.as_obj())],
+    );
+    let date_str: Option<String> = match result {
+        Ok(jv) => match jv.l() {
+            Ok(obj) if !obj.is_null() => {
+                let jstr: jni::objects::JString = obj.into();
+                env.get_string(&jstr).map(|s| s.into()).ok()
+            }
+            _ => None,
+        },
+        Err(_) => None,
+    };
+    unsafe {
+        env.pop_local_frame(&JObject::null());
+    }
+    match date_str {
+        Some(s) if !s.is_empty() => {
+            let bytes = s.as_bytes();
+            unsafe {
+                let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                js_nanbox_string(ptr as i64)
+            }
+        }
+        _ => f64::from_bits(TAG_UNDEFINED),
+    }
+}

--- a/crates/perry-ui-android/src/widgets/mod.rs
+++ b/crates/perry-ui-android/src/widgets/mod.rs
@@ -5,6 +5,7 @@ pub mod calendar;
 pub mod canvas;
 pub mod chart;
 pub mod combobox;
+pub mod date_picker;
 pub mod divider;
 pub mod form;
 pub mod hstack;

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
@@ -1664,6 +1664,47 @@ object PerryBridge {
     }
 
     // ============================================================
+    // Issue #4772 — DatePicker (android.widget.DatePicker).
+    // ============================================================
+    //
+    // The compact, spinner-style complement to the CalendarView-backed
+    // Calendar widget. `DatePicker.init` installs an OnDateChangedListener
+    // that fires with (year, monthZeroBased, day); we format `yyyy-MM-dd`
+    // (POSIX/ISO) here so the cross-platform string matches the macOS /
+    // iOS / gtk4 / Windows twins exactly.
+
+    @JvmStatic
+    fun datePickerCreate(year: Long, month: Long, callbackKey: Long): android.widget.DatePicker {
+        val dp = android.widget.DatePicker(activity)
+        val cal = java.util.Calendar.getInstance()
+        val initYear = if (year > 0L) year.toInt() else cal.get(java.util.Calendar.YEAR)
+        val initMonth = if (month in 1L..12L) (month - 1).toInt() else cal.get(java.util.Calendar.MONTH)
+        dp.init(initYear, initMonth, 1) { _, y, m, d ->
+            if (callbackKey != 0L) {
+                val iso = String.format("%04d-%02d-%02d", y, m + 1, d)
+                nativeInvokeCallbackWithString(callbackKey, iso)
+            }
+        }
+        return dp
+    }
+
+    @JvmStatic
+    fun datePickerSetDate(dp: android.widget.DatePicker, year: Long, month: Long, day: Long) {
+        if (year <= 0L || month !in 1L..12L || day !in 1L..31L) return
+        uiHandler.post {
+            dp.updateDate(year.toInt(), (month - 1).toInt(), day.toInt())
+        }
+    }
+
+    @JvmStatic
+    fun datePickerGetSelectedDate(dp: android.widget.DatePicker): String {
+        val y = dp.year
+        val m = dp.month + 1
+        val d = dp.dayOfMonth
+        return String.format("%04d-%02d-%02d", y, m, d)
+    }
+
+    // ============================================================
     // Issue #475 — Combobox (android.widget.AutoCompleteTextView).
     // ============================================================
     //

--- a/crates/perry-ui-gtk4/src/ffi/chart_cal_table_tree_combo_picker.rs
+++ b/crates/perry-ui-gtk4/src/ffi/chart_cal_table_tree_combo_picker.rs
@@ -38,6 +38,21 @@ pub extern "C" fn perry_ui_calendar_get_selected_date(h: i64) -> f64 {
     widgets::calendar::get_selected_date(h)
 }
 
+// Issue #4772 — DatePicker — GTK4 reuses GtkCalendar (no native compact
+// date field exists on GTK).
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_create(year: i64, month: i64, on_change: f64) -> i64 {
+    widgets::date_picker::create(year, month, on_change)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_set_date(h: i64, y: i64, m: i64, d: i64) {
+    widgets::date_picker::set_date(h, y, m, d)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_get_selected_date(h: i64) -> f64 {
+    widgets::date_picker::get_selected_date(h)
+}
+
 // Issue #473 — table sort/filter/multi-select stubs.
 #[no_mangle]
 pub extern "C" fn perry_ui_table_set_on_sort_change(_h: i64, _cb: f64) {}

--- a/crates/perry-ui-gtk4/src/widgets/date_picker.rs
+++ b/crates/perry-ui-gtk4/src/widgets/date_picker.rs
@@ -1,0 +1,96 @@
+//! GTK4 DatePicker widget — wraps `gtk4::Calendar` (issue #4772).
+//!
+//! GTK has no native compact date-field control (no `SysDateTimePick32` /
+//! `UIDatePicker.compact` equivalent), so the `DatePicker` widget reuses
+//! `gtk4::Calendar` — the same primitive backing the `Calendar` widget.
+//! Behavior is otherwise identical to the macOS / iOS / Windows / Android
+//! twins: `connect_day_selected` fires when the user picks a date and we
+//! format the selection as `yyyy-MM-dd` (POSIX-locale ISO).
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+thread_local! {
+    static DATE_PICKERS: RefCell<HashMap<i64, gtk4::Calendar>> = RefCell::new(HashMap::new());
+}
+
+fn iso_date(cal: &gtk4::Calendar) -> String {
+    let dt: glib::DateTime = cal.date();
+    format!(
+        "{:04}-{:02}-{:02}",
+        dt.year(),
+        dt.month(),
+        dt.day_of_month()
+    )
+}
+
+pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
+    crate::app::ensure_gtk_init();
+    let cal = gtk4::Calendar::new();
+
+    // gtk4::Calendar.set_year/set_month exist as setters.
+    if year > 0 {
+        cal.set_year(year as i32);
+    }
+    if (1..=12).contains(&month) {
+        // GTK months are 0-based.
+        cal.set_month((month - 1) as i32);
+    }
+
+    if on_change != 0.0 {
+        let on = on_change;
+        cal.connect_day_selected(move |c| {
+            let iso = iso_date(c);
+            let bytes = iso.as_bytes();
+            unsafe {
+                let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                let arg = js_nanbox_string(header as i64);
+                let closure_ptr = js_nanbox_get_pointer(on) as *const u8;
+                js_closure_call1(closure_ptr, arg);
+            }
+        });
+    }
+
+    let handle = super::register_widget(cal.clone().upcast());
+    DATE_PICKERS.with(|m| m.borrow_mut().insert(handle, cal));
+    handle
+}
+
+pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
+    let cal = DATE_PICKERS.with(|m| m.borrow().get(&handle).cloned());
+    let Some(cal) = cal else { return };
+    let target = match glib::DateTime::from_local(
+        year as i32,
+        month.clamp(1, 12) as i32,
+        day.clamp(1, 31) as i32,
+        0,
+        0,
+        0.0,
+    ) {
+        Ok(dt) => dt,
+        Err(_) => return,
+    };
+    cal.select_day(&target);
+}
+
+pub fn get_selected_date(handle: i64) -> f64 {
+    let cal = DATE_PICKERS.with(|m| m.borrow().get(&handle).cloned());
+    let Some(cal) = cal else {
+        return f64::from_bits(0x7FFC_0000_0000_0001);
+    };
+    let iso = iso_date(&cal);
+    let bytes = iso.as_bytes();
+    unsafe {
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        js_nanbox_string(header as i64)
+    }
+}

--- a/crates/perry-ui-gtk4/src/widgets/mod.rs
+++ b/crates/perry-ui-gtk4/src/widgets/mod.rs
@@ -6,6 +6,7 @@ pub mod canvas;
 pub mod chart;
 pub mod combobox;
 pub mod command_palette;
+pub mod date_picker;
 pub mod divider;
 pub mod form;
 pub mod hstack;

--- a/crates/perry-ui-ios/src/ffi/widgets_advanced.rs
+++ b/crates/perry-ui-ios/src/ffi/widgets_advanced.rs
@@ -331,6 +331,20 @@ pub extern "C" fn perry_ui_calendar_get_selected_date(h: i64) -> f64 {
     widgets::calendar::get_selected_date(h)
 }
 
+// Issue #4772 — DatePicker widget — real iOS impl via UIDatePicker.compact.
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_create(year: i64, month: i64, on_change: f64) -> i64 {
+    widgets::date_picker::create(year, month, on_change)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_set_date(h: i64, y: i64, m: i64, d: i64) {
+    widgets::date_picker::set_date(h, y, m, d)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_get_selected_date(h: i64) -> f64 {
+    widgets::date_picker::get_selected_date(h)
+}
+
 // Issue #473 — table sort/filter/multi-select stubs.
 #[no_mangle]
 pub extern "C" fn perry_ui_table_set_on_sort_change(_h: i64, _cb: f64) {}

--- a/crates/perry-ui-ios/src/widgets/date_picker.rs
+++ b/crates/perry-ui-ios/src/widgets/date_picker.rs
@@ -1,0 +1,168 @@
+//! iOS DatePicker widget — `UIDatePicker` in compact style (issue #4772).
+//!
+//! The space-saving complement to the inline-graphical `Calendar` widget.
+//! `UIDatePicker.preferredDatePickerStyle = .compact` (iOS 14+) renders a
+//! tappable date field that expands to a calendar popover on demand, the
+//! natural compact date picker on iOS. `onChange` fires with the selected
+//! date as an ISO `yyyy-MM-dd` string (POSIX-locale) — matching the macOS
+//! / Windows / GTK4 / Android twins.
+
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use objc2::{define_class, AnyThread, DefinedClass};
+use objc2_foundation::{MainThreadMarker, NSObject, NSString};
+use objc2_ui_kit::UIView;
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+thread_local! {
+    static DATEPICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+pub struct PerryDatePickerTargetIvars {
+    pub handle: Cell<i64>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryDatePickerTarget"]
+    #[ivars = PerryDatePickerTargetIvars]
+    pub struct PerryDatePickerTarget;
+
+    impl PerryDatePickerTarget {
+        #[unsafe(method(dateChanged:))]
+        fn date_changed(&self, sender: &AnyObject) {
+            let addr = self as *const Self as usize;
+            let handle = self.ivars().handle.get();
+            let cb = DATEPICKER_CALLBACKS.with(|m| m.borrow().get(&addr).copied());
+            let Some(callback) = cb else { return };
+            let _ = handle;
+            unsafe {
+                let date_obj: *mut AnyObject = msg_send![sender, date];
+                if date_obj.is_null() {
+                    return;
+                }
+                let iso = format_iso_date(date_obj);
+                let bytes = iso.as_bytes();
+                let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                let arg = js_nanbox_string(header as i64);
+                let closure_ptr = js_nanbox_get_pointer(callback) as *const u8;
+                js_closure_call1(closure_ptr, arg);
+            }
+        }
+    }
+);
+
+impl PerryDatePickerTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryDatePickerTargetIvars {
+            handle: Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+unsafe fn format_iso_date(date_obj: *mut AnyObject) -> String {
+    let fmt_cls = AnyClass::get(c"NSDateFormatter").unwrap();
+    let alloc: *mut AnyObject = msg_send![fmt_cls, alloc];
+    let fmt: Retained<AnyObject> = Retained::from_raw(msg_send![alloc, init]).unwrap();
+    let fmt_str = NSString::from_str("yyyy-MM-dd");
+    let _: () = msg_send![&*fmt, setDateFormat: &*fmt_str];
+    let locale_cls = AnyClass::get(c"NSLocale").unwrap();
+    let posix_id = NSString::from_str("en_US_POSIX");
+    let alloc_l: *mut AnyObject = msg_send![locale_cls, alloc];
+    let locale: Retained<AnyObject> =
+        Retained::from_raw(msg_send![alloc_l, initWithLocaleIdentifier: &*posix_id]).unwrap();
+    let _: () = msg_send![&*fmt, setLocale: &*locale];
+    let str_obj: Retained<NSString> = msg_send![&*fmt, stringFromDate: date_obj];
+    str_obj.to_string()
+}
+
+unsafe fn make_date(year: i64, month: i64, day: i64) -> *mut AnyObject {
+    let comp_cls = AnyClass::get(c"NSDateComponents").unwrap();
+    let alloc: *mut AnyObject = msg_send![comp_cls, alloc];
+    let comps: *mut AnyObject = msg_send![alloc, init];
+    let _: () = msg_send![comps, setYear: year];
+    let _: () = msg_send![comps, setMonth: month];
+    let _: () = msg_send![comps, setDay: day];
+    let cal_cls = AnyClass::get(c"NSCalendar").unwrap();
+    let cal: *mut AnyObject = msg_send![cal_cls, currentCalendar];
+    msg_send![cal, dateFromComponents: comps]
+}
+
+pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        let cls = AnyClass::get(c"UIDatePicker").unwrap();
+        let alloc: *mut AnyObject = msg_send![cls, alloc];
+        let raw: *mut AnyObject = msg_send![alloc, init];
+        let picker: Retained<AnyObject> = Retained::from_raw(raw).expect("UIDatePicker init nil");
+
+        // UIDatePickerMode.date = 1
+        let _: () = msg_send![&*picker, setDatePickerMode: 1i64];
+        // UIDatePickerStyle.compact = 2 (iOS 14+ tappable date field).
+        let _: () = msg_send![&*picker, setPreferredDatePickerStyle: 2i64];
+
+        let initial_year = if year > 0 { year } else { 2026 };
+        let initial_month = if (1..=12).contains(&month) { month } else { 1 };
+        let initial = make_date(initial_year, initial_month, 1);
+        if !initial.is_null() {
+            let _: () = msg_send![&*picker, setDate: initial];
+        }
+
+        let view: Retained<UIView> = Retained::cast_unchecked(picker);
+        let handle = super::register_widget(view);
+
+        let target = PerryDatePickerTarget::new();
+        target.ivars().handle.set(handle);
+        let target_addr = Retained::as_ptr(&target) as usize;
+        DATEPICKER_CALLBACKS.with(|m| {
+            m.borrow_mut().insert(target_addr, on_change);
+        });
+
+        let picker_view = super::get_widget(handle).unwrap();
+        let sel = Sel::register(c"dateChanged:");
+        // UIControlEventValueChanged = 1 << 12 = 4096
+        let _: () =
+            msg_send![&*picker_view, addTarget: &*target, action: sel, forControlEvents: 4096u64];
+        std::mem::forget(target);
+        handle
+    }
+}
+
+pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
+    let Some(view) = super::get_widget(handle) else {
+        return;
+    };
+    unsafe {
+        let date = make_date(year, month, day);
+        if !date.is_null() {
+            let _: () = msg_send![&*view, setDate: date];
+        }
+    }
+}
+
+pub fn get_selected_date(handle: i64) -> f64 {
+    let Some(view) = super::get_widget(handle) else {
+        return f64::from_bits(0x7FFC_0000_0000_0001);
+    };
+    unsafe {
+        let date_obj: *mut AnyObject = msg_send![&*view, date];
+        if date_obj.is_null() {
+            return f64::from_bits(0x7FFC_0000_0000_0001);
+        }
+        let iso = format_iso_date(date_obj);
+        let bytes = iso.as_bytes();
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        js_nanbox_string(header as i64)
+    }
+}

--- a/crates/perry-ui-ios/src/widgets/mod.rs
+++ b/crates/perry-ui-ios/src/widgets/mod.rs
@@ -6,6 +6,7 @@ pub mod calendar;
 pub mod canvas;
 pub mod chart;
 pub mod combobox;
+pub mod date_picker;
 pub mod divider;
 pub mod form;
 pub mod hstack;

--- a/crates/perry-ui-macos/src/lib_ffi/advanced_widgets.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/advanced_widgets.rs
@@ -314,6 +314,26 @@ pub extern "C" fn perry_ui_calendar_get_selected_date(handle: i64) -> f64 {
     widgets::calendar::get_selected_date(handle)
 }
 
+// ---- DatePicker (issue #4772) ----
+
+/// Create an `NSDatePicker` in compact text-field-and-stepper mode.
+/// `year` and `month` are 1-based; pass <=0 / out-of-range to default
+/// to 2026-01. `on_change` fires with the selected date as `yyyy-MM-dd`.
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_create(year: i64, month: i64, on_change: f64) -> i64 {
+    widgets::date_picker::create(year, month, on_change)
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_set_date(handle: i64, year: i64, month: i64, day: i64) {
+    widgets::date_picker::set_date(handle, year, month, day);
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_get_selected_date(handle: i64) -> f64 {
+    widgets::date_picker::get_selected_date(handle)
+}
+
 // ---- TreeView (issue #480) ----
 
 /// Register a tree node with `id` and `label`. Standalone — wire into

--- a/crates/perry-ui-macos/src/widgets/date_picker.rs
+++ b/crates/perry-ui-macos/src/widgets/date_picker.rs
@@ -1,0 +1,184 @@
+//! macOS DatePicker widget (issue #4772).
+//!
+//! The compact, space-saving complement to the graphical month-grid
+//! `Calendar` widget. Wraps `NSDatePicker` with
+//! `NSDatePickerStyleTextFieldAndStepper` (a date field with up/down
+//! steppers), elements limited to year/month/day so the clock face is
+//! hidden. The user gets a compact date field with a selection callback.
+//!
+//! `onChange` fires with the selected date as an ISO `yyyy-MM-dd` string
+//! (POSIX-locale formatter, stable across user locales) — matching the
+//! `Calendar` twin.
+
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use objc2::{define_class, AnyThread, DefinedClass};
+use objc2_app_kit::NSView;
+use objc2_foundation::NSObject;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+thread_local! {
+    static DATEPICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+pub struct PerryDatePickerTargetIvars {
+    pub handle: Cell<i64>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryDatePickerTarget"]
+    #[ivars = PerryDatePickerTargetIvars]
+    pub struct PerryDatePickerTarget;
+
+    impl PerryDatePickerTarget {
+        #[unsafe(method(dateChanged:))]
+        fn date_changed(&self, _sender: &AnyObject) {
+            let handle = self.ivars().handle.get();
+            let addr = self as *const Self as usize;
+            crate::catch_callback_panic("date picker callback", std::panic::AssertUnwindSafe(|| {
+                let cb = DATEPICKER_CALLBACKS.with(|m| m.borrow().get(&addr).copied());
+                let Some(callback) = cb else { return };
+                let Some(view) = super::get_widget(handle) else { return };
+                unsafe {
+                    let date_obj: *mut AnyObject = msg_send![&*view, dateValue];
+                    if date_obj.is_null() {
+                        return;
+                    }
+                    let iso = format_iso_date(date_obj);
+                    let bytes = iso.as_bytes();
+                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    let arg = js_nanbox_string(header as i64);
+                    let closure_ptr = js_nanbox_get_pointer(callback) as *const u8;
+                    js_closure_call1(closure_ptr, arg);
+                }
+            }));
+        }
+    }
+);
+
+impl PerryDatePickerTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryDatePickerTargetIvars {
+            handle: Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+unsafe fn format_iso_date(date_obj: *mut AnyObject) -> String {
+    // Use NSDateFormatter with "yyyy-MM-dd" — fixed-locale POSIX so
+    // the JS side gets a parsable string regardless of user locale.
+    let fmt_cls = AnyClass::get(c"NSDateFormatter").unwrap();
+    let alloc: *mut AnyObject = msg_send![fmt_cls, alloc];
+    let fmt: Retained<AnyObject> = Retained::from_raw(msg_send![alloc, init]).unwrap();
+    let fmt_str = objc2_foundation::NSString::from_str("yyyy-MM-dd");
+    let _: () = msg_send![&*fmt, setDateFormat: &*fmt_str];
+    // Force locale to POSIX so the format is stable.
+    let locale_cls = AnyClass::get(c"NSLocale").unwrap();
+    let posix_id = objc2_foundation::NSString::from_str("en_US_POSIX");
+    let alloc_l: *mut AnyObject = msg_send![locale_cls, alloc];
+    let locale: Retained<AnyObject> =
+        Retained::from_raw(msg_send![alloc_l, initWithLocaleIdentifier: &*posix_id]).unwrap();
+    let _: () = msg_send![&*fmt, setLocale: &*locale];
+    let str_obj: Retained<objc2_foundation::NSString> = msg_send![&*fmt, stringFromDate: date_obj];
+    str_obj.to_string()
+}
+
+unsafe fn make_date(year: i64, month: i64, day: i64) -> *mut AnyObject {
+    let comp_cls = AnyClass::get(c"NSDateComponents").unwrap();
+    let alloc: *mut AnyObject = msg_send![comp_cls, alloc];
+    let comps: *mut AnyObject = msg_send![alloc, init];
+    let _: () = msg_send![comps, setYear: year];
+    let _: () = msg_send![comps, setMonth: month];
+    let _: () = msg_send![comps, setDay: day];
+    let cal_cls = AnyClass::get(c"NSCalendar").unwrap();
+    let cal: *mut AnyObject = msg_send![cal_cls, currentCalendar];
+    msg_send![cal, dateFromComponents: comps]
+}
+
+/// Create an `NSDatePicker` configured as a compact text-field-and-stepper
+/// date field. Elements are limited to year-month-day (no clock face).
+pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
+    unsafe {
+        let cls = AnyClass::get(c"NSDatePicker").unwrap();
+        let alloc: *mut AnyObject = msg_send![cls, alloc];
+        let frame = objc2_core_foundation::CGRect::new(
+            objc2_core_foundation::CGPoint::new(0.0, 0.0),
+            objc2_core_foundation::CGSize::new(140.0, 24.0),
+        );
+        let raw: *mut AnyObject = msg_send![alloc, initWithFrame: frame];
+        let picker: Retained<AnyObject> = Retained::from_raw(raw).unwrap();
+
+        // NSDatePickerStyleTextFieldAndStepper = 0 (compact field).
+        let _: () = msg_send![&*picker, setDatePickerStyle: 0u64];
+        // Limit to year/month/day — drop the clock face.
+        // NSDatePickerElementFlagYearMonthDay = 0xC0
+        let _: () = msg_send![&*picker, setDatePickerElements: 0xC0u64];
+
+        // Initial date.
+        let initial_year = if year > 0 { year } else { 2026 };
+        let initial_month = if (1..=12).contains(&month) { month } else { 1 };
+        let initial_date = make_date(initial_year, initial_month, 1);
+        if !initial_date.is_null() {
+            let _: () = msg_send![&*picker, setDateValue: initial_date];
+        }
+
+        let view: Retained<NSView> = Retained::cast_unchecked(picker);
+        let handle = super::register_widget(view);
+
+        let target = PerryDatePickerTarget::new();
+        target.ivars().handle.set(handle);
+        let target_addr = Retained::as_ptr(&target) as usize;
+        DATEPICKER_CALLBACKS.with(|m| {
+            m.borrow_mut().insert(target_addr, on_change);
+        });
+
+        let picker_view = super::get_widget(handle).unwrap();
+        let sel = Sel::register(c"dateChanged:");
+        let _: () = msg_send![&*picker_view, setTarget: &*target];
+        let _: () = msg_send![&*picker_view, setAction: sel];
+
+        std::mem::forget(target);
+        handle
+    }
+}
+
+/// Programmatically set the selected date (1-based month + day).
+pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
+    let Some(view) = super::get_widget(handle) else {
+        return;
+    };
+    unsafe {
+        let date = make_date(year, month, day);
+        if !date.is_null() {
+            let _: () = msg_send![&*view, setDateValue: date];
+        }
+    }
+}
+
+/// Get the selected date as a NaN-boxed STRING in `yyyy-MM-dd` form.
+pub fn get_selected_date(handle: i64) -> f64 {
+    let Some(view) = super::get_widget(handle) else {
+        return f64::from_bits(0x7FFC_0000_0000_0001);
+    };
+    unsafe {
+        let date_obj: *mut AnyObject = msg_send![&*view, dateValue];
+        if date_obj.is_null() {
+            return f64::from_bits(0x7FFC_0000_0000_0001);
+        }
+        let iso = format_iso_date(date_obj);
+        let bytes = iso.as_bytes();
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        js_nanbox_string(header as i64)
+    }
+}

--- a/crates/perry-ui-macos/src/widgets/mod.rs
+++ b/crates/perry-ui-macos/src/widgets/mod.rs
@@ -7,6 +7,7 @@ pub mod canvas;
 pub mod chart;
 pub mod combobox;
 pub mod command_palette;
+pub mod date_picker;
 pub mod divider;
 pub mod foreach_registry;
 pub mod form;

--- a/crates/perry-ui-tvos/src/ffi/advanced_widgets.rs
+++ b/crates/perry-ui-tvos/src/ffi/advanced_widgets.rs
@@ -173,6 +173,18 @@ pub extern "C" fn perry_ui_calendar_get_selected_date(_h: i64) -> f64 {
     f64::from_bits(0x7FFC_0000_0000_0001)
 }
 
+// Issue #4772 — DatePicker widget stubs.
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_create(_year: i64, _month: i64, _on_change: f64) -> i64 {
+    0
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_set_date(_h: i64, _y: i64, _m: i64, _d: i64) {}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_get_selected_date(_h: i64) -> f64 {
+    f64::from_bits(0x7FFC_0000_0000_0001)
+}
+
 // Issue #473 — table sort/filter/multi-select stubs.
 #[no_mangle]
 pub extern "C" fn perry_ui_table_set_on_sort_change(_h: i64, _cb: f64) {}

--- a/crates/perry-ui-visionos/src/ffi_widgets_extra.rs
+++ b/crates/perry-ui-visionos/src/ffi_widgets_extra.rs
@@ -192,6 +192,20 @@ pub extern "C" fn perry_ui_calendar_get_selected_date(h: i64) -> f64 {
     widgets::calendar::get_selected_date(h)
 }
 
+// Issue #4772 — DatePicker — visionOS impl via UIDatePicker.compact.
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_create(year: i64, month: i64, on_change: f64) -> i64 {
+    widgets::date_picker::create(year, month, on_change)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_set_date(h: i64, y: i64, m: i64, d: i64) {
+    widgets::date_picker::set_date(h, y, m, d)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_get_selected_date(h: i64) -> f64 {
+    widgets::date_picker::get_selected_date(h)
+}
+
 // Issue #473 — table sort/filter/multi-select stubs.
 #[no_mangle]
 pub extern "C" fn perry_ui_table_set_on_sort_change(_h: i64, _cb: f64) {}

--- a/crates/perry-ui-visionos/src/widgets/date_picker.rs
+++ b/crates/perry-ui-visionos/src/widgets/date_picker.rs
@@ -1,0 +1,168 @@
+//! visionOS DatePicker widget — `UIDatePicker` in compact style
+//! (issue #4772).
+//!
+//! The space-saving complement to the inline-graphical `Calendar` widget.
+//! `UIDatePicker.preferredDatePickerStyle = .compact` renders a tappable
+//! date field that expands to a calendar popover on demand. `onChange`
+//! fires with the selected date as an ISO `yyyy-MM-dd` string (POSIX-locale)
+//! — matching the macOS / iOS / Windows / GTK4 / Android twins.
+
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+use objc2::{define_class, AnyThread, DefinedClass};
+use objc2_foundation::{MainThreadMarker, NSObject, NSString};
+use objc2_ui_kit::UIView;
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+thread_local! {
+    static DATEPICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+pub struct PerryDatePickerTargetVisionOSIvars {
+    pub handle: Cell<i64>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryDatePickerTargetVisionOS"]
+    #[ivars = PerryDatePickerTargetVisionOSIvars]
+    pub struct PerryDatePickerTargetVisionOS;
+
+    impl PerryDatePickerTargetVisionOS {
+        #[unsafe(method(dateChanged:))]
+        fn date_changed(&self, sender: &AnyObject) {
+            let addr = self as *const Self as usize;
+            let handle = self.ivars().handle.get();
+            let cb = DATEPICKER_CALLBACKS.with(|m| m.borrow().get(&addr).copied());
+            let Some(callback) = cb else { return };
+            let _ = handle;
+            unsafe {
+                let date_obj: *mut AnyObject = msg_send![sender, date];
+                if date_obj.is_null() {
+                    return;
+                }
+                let iso = format_iso_date(date_obj);
+                let bytes = iso.as_bytes();
+                let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                let arg = js_nanbox_string(header as i64);
+                let closure_ptr = js_nanbox_get_pointer(callback) as *const u8;
+                js_closure_call1(closure_ptr, arg);
+            }
+        }
+    }
+);
+
+impl PerryDatePickerTargetVisionOS {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryDatePickerTargetVisionOSIvars {
+            handle: Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+unsafe fn format_iso_date(date_obj: *mut AnyObject) -> String {
+    let fmt_cls = AnyClass::get(c"NSDateFormatter").unwrap();
+    let alloc: *mut AnyObject = msg_send![fmt_cls, alloc];
+    let fmt: Retained<AnyObject> = Retained::from_raw(msg_send![alloc, init]).unwrap();
+    let fmt_str = NSString::from_str("yyyy-MM-dd");
+    let _: () = msg_send![&*fmt, setDateFormat: &*fmt_str];
+    let locale_cls = AnyClass::get(c"NSLocale").unwrap();
+    let posix_id = NSString::from_str("en_US_POSIX");
+    let alloc_l: *mut AnyObject = msg_send![locale_cls, alloc];
+    let locale: Retained<AnyObject> =
+        Retained::from_raw(msg_send![alloc_l, initWithLocaleIdentifier: &*posix_id]).unwrap();
+    let _: () = msg_send![&*fmt, setLocale: &*locale];
+    let str_obj: Retained<NSString> = msg_send![&*fmt, stringFromDate: date_obj];
+    str_obj.to_string()
+}
+
+unsafe fn make_date(year: i64, month: i64, day: i64) -> *mut AnyObject {
+    let comp_cls = AnyClass::get(c"NSDateComponents").unwrap();
+    let alloc: *mut AnyObject = msg_send![comp_cls, alloc];
+    let comps: *mut AnyObject = msg_send![alloc, init];
+    let _: () = msg_send![comps, setYear: year];
+    let _: () = msg_send![comps, setMonth: month];
+    let _: () = msg_send![comps, setDay: day];
+    let cal_cls = AnyClass::get(c"NSCalendar").unwrap();
+    let cal: *mut AnyObject = msg_send![cal_cls, currentCalendar];
+    msg_send![cal, dateFromComponents: comps]
+}
+
+pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+    unsafe {
+        let cls = AnyClass::get(c"UIDatePicker").unwrap();
+        let alloc: *mut AnyObject = msg_send![cls, alloc];
+        let raw: *mut AnyObject = msg_send![alloc, init];
+        let picker: Retained<AnyObject> = Retained::from_raw(raw).expect("UIDatePicker init nil");
+
+        // UIDatePickerMode.date = 1
+        let _: () = msg_send![&*picker, setDatePickerMode: 1i64];
+        // UIDatePickerStyle.compact = 2 (tappable date field).
+        let _: () = msg_send![&*picker, setPreferredDatePickerStyle: 2i64];
+
+        let initial_year = if year > 0 { year } else { 2026 };
+        let initial_month = if (1..=12).contains(&month) { month } else { 1 };
+        let initial = make_date(initial_year, initial_month, 1);
+        if !initial.is_null() {
+            let _: () = msg_send![&*picker, setDate: initial];
+        }
+
+        let view: Retained<UIView> = Retained::cast_unchecked(picker);
+        let handle = super::register_widget(view);
+
+        let target = PerryDatePickerTargetVisionOS::new();
+        target.ivars().handle.set(handle);
+        let target_addr = Retained::as_ptr(&target) as usize;
+        DATEPICKER_CALLBACKS.with(|m| {
+            m.borrow_mut().insert(target_addr, on_change);
+        });
+
+        let picker_view = super::get_widget(handle).unwrap();
+        let sel = Sel::register(c"dateChanged:");
+        // UIControlEventValueChanged = 1 << 12 = 4096
+        let _: () =
+            msg_send![&*picker_view, addTarget: &*target, action: sel, forControlEvents: 4096u64];
+        std::mem::forget(target);
+        handle
+    }
+}
+
+pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
+    let Some(view) = super::get_widget(handle) else {
+        return;
+    };
+    unsafe {
+        let date = make_date(year, month, day);
+        if !date.is_null() {
+            let _: () = msg_send![&*view, setDate: date];
+        }
+    }
+}
+
+pub fn get_selected_date(handle: i64) -> f64 {
+    let Some(view) = super::get_widget(handle) else {
+        return f64::from_bits(0x7FFC_0000_0000_0001);
+    };
+    unsafe {
+        let date_obj: *mut AnyObject = msg_send![&*view, date];
+        if date_obj.is_null() {
+            return f64::from_bits(0x7FFC_0000_0000_0001);
+        }
+        let iso = format_iso_date(date_obj);
+        let bytes = iso.as_bytes();
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        js_nanbox_string(header as i64)
+    }
+}

--- a/crates/perry-ui-visionos/src/widgets/mod.rs
+++ b/crates/perry-ui-visionos/src/widgets/mod.rs
@@ -6,6 +6,7 @@ pub mod calendar;
 pub mod canvas;
 pub mod chart;
 pub mod combobox;
+pub mod date_picker;
 pub mod divider;
 pub mod form;
 pub mod hstack;

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1043,6 +1043,19 @@ pub extern "C" fn perry_ui_calendar_get_selected_date(_h: i64) -> f64 {
     f64::from_bits(0x7FFC_0000_0000_0001)
 }
 
+// Issue #4772 — DatePicker widget stubs (watchOS screen real estate
+// makes an inline date field impractical).
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_create(_y: i64, _m: i64, _cb: f64) -> i64 {
+    0
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_set_date(_h: i64, _y: i64, _m: i64, _d: i64) {}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_get_selected_date(_h: i64) -> f64 {
+    f64::from_bits(0x7FFC_0000_0000_0001)
+}
+
 // Issue #473 — table sort/filter/multi-select stubs.
 #[no_mangle]
 pub extern "C" fn perry_ui_table_set_on_sort_change(_h: i64, _cb: f64) {}

--- a/crates/perry-ui-windows/src/ffi/cmd_chart_cal.rs
+++ b/crates/perry-ui-windows/src/ffi/cmd_chart_cal.rs
@@ -68,3 +68,17 @@ pub extern "C" fn perry_ui_calendar_set_date(h: i64, y: i64, m: i64, d: i64) {
 pub extern "C" fn perry_ui_calendar_get_selected_date(h: i64) -> f64 {
     widgets::calendar::get_selected_date(h)
 }
+
+// Issue #4772 — DatePicker widget — real Windows impl via SysDateTimePick32.
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_create(year: i64, month: i64, on_change: f64) -> i64 {
+    widgets::date_picker::create(year, month, on_change)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_set_date(h: i64, y: i64, m: i64, d: i64) {
+    widgets::date_picker::set_date(h, y, m, d)
+}
+#[no_mangle]
+pub extern "C" fn perry_ui_date_picker_get_selected_date(h: i64) -> f64 {
+    widgets::date_picker::get_selected_date(h)
+}

--- a/crates/perry-ui-windows/src/layout.rs
+++ b/crates/perry-ui-windows/src/layout.rs
@@ -471,6 +471,14 @@ fn measure_intrinsic(handle: i64, kind: &WidgetKind, vertical: bool, cross_size:
                 280
             }
         }
+        WidgetKind::DatePicker => {
+            // Compact date field — a single row, narrow like a textfield.
+            if vertical {
+                28
+            } else {
+                160
+            }
+        }
         WidgetKind::Combobox => {
             if vertical {
                 28

--- a/crates/perry-ui-windows/src/widgets/date_picker.rs
+++ b/crates/perry-ui-windows/src/widgets/date_picker.rs
@@ -1,0 +1,228 @@
+//! DatePicker widget — Win32 `SysDateTimePick32` (DateTimePicker control).
+//!
+//! The compact, space-saving complement to the `SysMonthCal32`-backed
+//! `Calendar` widget (issue #4772). `DTM_SETSYSTEMTIME` /
+//! `DTM_GETSYSTEMTIME` round-trip through a Win32 `SYSTEMTIME` struct.
+//! `DTN_DATETIMECHANGE` (delivered as `WM_NOTIFY`) posts the
+//! selection-change event; the per-handle callback is resolved through
+//! `DATEPICKER_CALLBACKS` and invoked by the central WM_NOTIFY router in
+//! `widgets::mod`.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+#[cfg(target_os = "windows")]
+use windows::Win32::Foundation::*;
+#[cfg(target_os = "windows")]
+use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::Controls::{InitCommonControlsEx, ICC_DATE_CLASSES, INITCOMMONCONTROLSEX};
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::WindowsAndMessaging::*;
+
+use super::{alloc_control_id, register_widget, WidgetKind};
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_nanbox_string(ptr: i64) -> f64;
+}
+
+#[cfg(target_os = "windows")]
+fn to_wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(target_os = "windows")]
+const DTM_FIRST: u32 = 0x1000;
+#[cfg(target_os = "windows")]
+const DTM_GETSYSTEMTIME: u32 = DTM_FIRST + 1;
+#[cfg(target_os = "windows")]
+const DTM_SETSYSTEMTIME: u32 = DTM_FIRST + 2;
+/// `GDT_VALID` — the date/time is valid (not "no date" state).
+#[cfg(target_os = "windows")]
+const GDT_VALID: usize = 0;
+/// `DTN_DATETIMECHANGE` (= `DTN_FIRST2 - 6`, where `DTN_FIRST2 = -753`).
+/// The control sends the Unicode (`DTN_FIRST2`) variant.
+#[cfg(target_os = "windows")]
+pub const DTN_DATETIMECHANGE: i32 = -759;
+
+thread_local! {
+    static DATEPICKER_CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
+}
+
+#[cfg(target_os = "windows")]
+#[repr(C)]
+#[derive(Default, Copy, Clone)]
+struct SystemTime {
+    year: u16,
+    month: u16,
+    day_of_week: u16,
+    day: u16,
+    hour: u16,
+    minute: u16,
+    second: u16,
+    millis: u16,
+}
+
+pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
+    let control_id = alloc_control_id();
+
+    #[cfg(target_os = "windows")]
+    {
+        // SysDateTimePick32 lives in the date/calendar common-control
+        // class. Register it explicitly (idempotent) so the widget works
+        // regardless of which other controls have already initialized.
+        unsafe {
+            let icc = INITCOMMONCONTROLSEX {
+                dwSize: std::mem::size_of::<INITCOMMONCONTROLSEX>() as u32,
+                dwICC: ICC_DATE_CLASSES,
+            };
+            let _ = InitCommonControlsEx(&icc);
+        }
+
+        let class_name = to_wide("SysDateTimePick32");
+        unsafe {
+            let hinstance = GetModuleHandleW(None).unwrap();
+            let hwnd = CreateWindowExW(
+                WINDOW_EX_STYLE::default(),
+                windows::core::PCWSTR(class_name.as_ptr()),
+                windows::core::PCWSTR(std::ptr::null()),
+                WINDOW_STYLE(WS_CHILD.0 | WS_VISIBLE.0 | WS_TABSTOP.0),
+                0,
+                0,
+                160,
+                28,
+                super::get_parking_hwnd(),
+                HMENU(control_id as *mut _),
+                HINSTANCE::from(hinstance),
+                None,
+            );
+            let Ok(hwnd) = hwnd else {
+                return register_widget(
+                    HWND(std::ptr::null_mut()),
+                    WidgetKind::DatePicker,
+                    control_id,
+                );
+            };
+
+            let handle = register_widget(hwnd, WidgetKind::DatePicker, control_id);
+            DATEPICKER_CALLBACKS.with(|m| {
+                m.borrow_mut().insert(handle, on_change);
+            });
+
+            // Initial selected date — defaults to today if year/month are
+            // out of range. The control needs a valid SYSTEMTIME so we
+            // pick day=1 when the caller didn't specify one.
+            let mut st = SystemTime::default();
+            st.year = if year > 0 { year as u16 } else { 2026 };
+            st.month = if (1..=12).contains(&month) {
+                month as u16
+            } else {
+                1
+            };
+            st.day = 1;
+            st.day_of_week = 0;
+            let _ = SendMessageW(
+                hwnd,
+                DTM_SETSYSTEMTIME,
+                WPARAM(GDT_VALID),
+                LPARAM(&st as *const _ as isize),
+            );
+            handle
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (year, month, on_change);
+        register_widget(0, WidgetKind::DatePicker, control_id)
+    }
+}
+
+pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
+    #[cfg(target_os = "windows")]
+    {
+        let Some(hwnd) = super::get_hwnd(handle) else {
+            return;
+        };
+        let mut st = SystemTime::default();
+        st.year = year.clamp(1, 9999) as u16;
+        st.month = month.clamp(1, 12) as u16;
+        st.day = day.clamp(1, 31) as u16;
+        unsafe {
+            SendMessageW(
+                hwnd,
+                DTM_SETSYSTEMTIME,
+                WPARAM(GDT_VALID),
+                LPARAM(&st as *const _ as isize),
+            );
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (handle, year, month, day);
+    }
+}
+
+pub fn get_selected_date(handle: i64) -> f64 {
+    let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
+    #[cfg(target_os = "windows")]
+    {
+        let Some(hwnd) = super::get_hwnd(handle) else {
+            return undefined;
+        };
+        let mut st = SystemTime::default();
+        unsafe {
+            SendMessageW(
+                hwnd,
+                DTM_GETSYSTEMTIME,
+                WPARAM(0),
+                LPARAM(&mut st as *mut _ as isize),
+            );
+        }
+        let iso = format!("{:04}-{:02}-{:02}", st.year, st.month, st.day);
+        let bytes = iso.as_bytes();
+        unsafe {
+            let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+            js_nanbox_string(header as i64)
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = handle;
+        undefined
+    }
+}
+
+/// Called by the WM_NOTIFY router when `DTN_DATETIMECHANGE` arrives.
+/// Reads the current selection via `DTM_GETSYSTEMTIME` and fires the
+/// registered callback with `yyyy-MM-dd`.
+#[cfg(target_os = "windows")]
+pub fn handle_selection_change(handle: i64) {
+    let Some(hwnd) = super::get_hwnd(handle) else {
+        return;
+    };
+    let on = DATEPICKER_CALLBACKS.with(|m| m.borrow().get(&handle).copied().unwrap_or(0.0));
+    if on == 0.0 {
+        return;
+    }
+    let mut st = SystemTime::default();
+    unsafe {
+        SendMessageW(
+            hwnd,
+            DTM_GETSYSTEMTIME,
+            WPARAM(0),
+            LPARAM(&mut st as *mut _ as isize),
+        );
+    }
+    let iso = format!("{:04}-{:02}-{:02}", st.year, st.month, st.day);
+    let bytes = iso.as_bytes();
+    unsafe {
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let arg = js_nanbox_string(header as i64);
+        let closure_ptr = js_nanbox_get_pointer(on) as *const u8;
+        js_closure_call1(closure_ptr, arg);
+    }
+}

--- a/crates/perry-ui-windows/src/widgets/mod.rs
+++ b/crates/perry-ui-windows/src/widgets/mod.rs
@@ -9,6 +9,7 @@ pub mod canvas;
 pub mod chart;
 pub mod combobox;
 pub mod command_palette;
+pub mod date_picker;
 pub mod divider;
 pub mod foreach_registry;
 pub mod form;
@@ -80,6 +81,7 @@ pub enum WidgetKind {
     LazyVStack,
     Image,
     Calendar,
+    DatePicker,
     Combobox,
     TreeView,
     RichText,
@@ -814,6 +816,11 @@ pub fn handle_notify(lparam: LPARAM) {
     // MCN_SELCHANGE = -749 (calendar)
     if hdr.code == -749 && matches!(kind, Some(WidgetKind::Calendar)) {
         calendar::handle_selection_change(handle);
+        return;
+    }
+    // DTN_DATETIMECHANGE = -759 (date picker)
+    if hdr.code == date_picker::DTN_DATETIMECHANGE && matches!(kind, Some(WidgetKind::DatePicker)) {
+        date_picker::handle_selection_change(handle);
         return;
     }
     // TVN_SELCHANGEDW = -411 (tree view — actual tree, not the table-shaped

--- a/docs/src/ui/widgets.md
+++ b/docs/src/ui/widgets.md
@@ -287,6 +287,22 @@ import { Calendar, calendarGetSelectedDate } from "perry/ui";
 const cal = Calendar(2026, 5, (iso) => console.log("date:", iso));
 ```
 
+### DatePicker (issue #4772)
+
+Compact field-style date picker — the space-saving complement to the
+month-grid `Calendar`. Each platform uses its native compact date control:
+macOS `NSDatePicker` (text-field-and-stepper), iOS / visionOS
+`UIDatePicker` (`.compact`), Windows `SysDateTimePick32`, Android
+`android.widget.DatePicker`. GTK4 has no native compact date field, so it
+reuses `GtkCalendar`; tvOS / watchOS stub. `onChange` receives the selected
+date as an ISO `yyyy-MM-dd` string.
+
+```typescript,no-test
+import { DatePicker, datePickerGetSelectedDate } from "perry/ui";
+
+const picker = DatePicker(2026, 5, (iso) => console.log("date:", iso));
+```
+
 ### Chart (issue #474)
 
 Line / bar / pie via CoreGraphics on macOS. `kind` is `0=line`, `1=bar`,

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -836,6 +836,28 @@ export function calendarSetDate(widget: Widget, year: number, month: number, day
 export function calendarGetSelectedDate(widget: Widget): string;
 
 // ---------------------------------------------------------------------------
+// DatePicker widget (issue #4772, v1) — compact field-style date picker, the
+// space-saving complement to the month-grid `Calendar`. Backends use each
+// platform's native compact date control:
+//   macOS    NSDatePicker, text-field-and-stepper style (year-month-day)
+//   iOS/visionOS  UIDatePicker, .compact style, .date mode
+//   Windows  SysDateTimePick32 (DateTimePicker dropdown)
+//   Android  android.widget.DatePicker
+//   GTK4     GtkCalendar (GTK has no native compact date field, so the
+//            month grid is reused; behavior is otherwise identical)
+//   tvOS/watchOS  stub the FFI (returns 0 on create, undefined on get-date)
+//
+// `year` and `month` are 1-based; pass <=0 / out-of-range to default to
+// 2026-01. `onChange` receives the selected date as an ISO `yyyy-MM-dd`
+// string (POSIX-locale formatter, stable across user locales) — matching
+// `Calendar`.
+// ---------------------------------------------------------------------------
+
+export function DatePicker(year: number, month: number, onChange: (isoDate: string) => void): Widget;
+export function datePickerSetDate(widget: Widget, year: number, month: number, day: number): void;
+export function datePickerGetSelectedDate(widget: Widget): string;
+
+// ---------------------------------------------------------------------------
 // Chart widget (issue #474, v1) — line / bar / pie via CoreGraphics on macOS.
 // `kind` is 0=line, 1=bar, 2=pie. iOS / tvOS / visionOS / watchOS / Android /
 // Windows / GTK4 stub the FFI today (returns 0 on create, no-op on data


### PR DESCRIPTION
Closes #4772.

Adds a cross-platform `DatePicker` widget to `perry/ui` — a compact, field-style date picker, the space-saving complement to the existing month-grid `Calendar` (#481). It shares `Calendar`'s TypeScript surface and ISO `yyyy-MM-dd` (POSIX-locale) callback contract.

## TS surface

```ts
import { DatePicker, datePickerGetSelectedDate } from "perry/ui";

const picker = DatePicker(2026, 5, (iso) => console.log("date:", iso));
// datePickerSetDate(picker, 2026, 12, 25)
// datePickerGetSelectedDate(picker) -> "2026-12-25"
```

`year`/`month` are 1-based and seed the initial date (out-of-range -> 2026-01).

## Per-platform mapping

Each backend uses its native **compact** date control (vs. `Calendar`'s month grid):

| Platform | Control |
|----------|---------|
| macOS | `NSDatePicker`, text-field-and-stepper style (year/month/day) |
| iOS / visionOS | `UIDatePicker`, `.date` mode, `.compact` style |
| Windows | `SysDateTimePick32` (DateTimePicker dropdown) |
| Android | `android.widget.DatePicker` (new `PerryBridge.kt` helpers) |
| GTK4 | reuses `GtkCalendar` (GTK has no native compact date field) |
| HarmonyOS | ArkTS codegen emits ArkUI `DatePicker` + `.onDateChange` |
| tvOS / watchOS | FFI stubs (matching `Calendar`) |

On Windows, `DTN_DATETIMECHANGE` (-759) is routed through the central `WM_NOTIFY` dispatcher via a new `WidgetKind::DatePicker`, and `ICC_DATE_CLASSES` is registered on create.

## Wiring

- Dispatch row in `perry-dispatch::PERRY_UI_TABLE` (JS/WASM backends pick it up automatically via `ui_method_to_runtime`)
- `types/perry/ui/index.d.ts` declarations
- Docs in `docs/src/ui/widgets.md`
- ArkTS codegen unit tests

## Verification

Built and tested on the Windows host (Apple/Android/GTK backends compile on their own platforms, as usual):
- `cargo build` of `perry`, `perry-dispatch`, `perry-codegen-arkts`, `perry-ui-windows` — green
- `perry-dispatch` tests incl. the dispatch-drift contract test — pass
- 2 new ArkTS DatePicker codegen tests — pass
- End-to-end compile **and link** of a `DatePicker` app on Windows — produced a working executable (`perry_ui_date_picker_create` resolves through the full pipeline)
