### PR TITLE
feat(ui): drag & drop across all platforms (#4773)

### DIFF
--- a/crates/perry-dispatch/src/ui_table.rs
+++ b/crates/perry-dispatch/src/ui_table.rs
@@ -1949,4 +1949,36 @@ pub const PERRY_UI_TABLE: &[MethodRow] = &[
         args: &[ArgKind::F64, ArgKind::F64],
         ret: ReturnKind::Widget,
     },
+    // ---- Drag & drop (issue #4773) ----
+    // Widget-level setters that attach drag/drop behavior to an existing
+    // widget handle. `widgetOnDrop` registers a drop destination; the
+    // callback receives a `{ text?, files?, urls? }` object built natively.
+    // The three `widgetSetDrag*` setters register a drag source; each
+    // provider closure returns the string payload for its pasteboard type
+    // (text / file-path / url). Real behavior is implemented per platform;
+    // every backend exports these symbols (no-op where the OS has no DnD).
+    MethodRow {
+        method: "widgetOnDrop",
+        runtime: "perry_ui_widget_on_drop",
+        args: &[ArgKind::Widget, ArgKind::Closure],
+        ret: ReturnKind::Void,
+    },
+    MethodRow {
+        method: "widgetSetDragText",
+        runtime: "perry_ui_widget_set_drag_text",
+        args: &[ArgKind::Widget, ArgKind::Closure],
+        ret: ReturnKind::Void,
+    },
+    MethodRow {
+        method: "widgetSetDragFile",
+        runtime: "perry_ui_widget_set_drag_file",
+        args: &[ArgKind::Widget, ArgKind::Closure],
+        ret: ReturnKind::Void,
+    },
+    MethodRow {
+        method: "widgetSetDragUrl",
+        runtime: "perry_ui_widget_set_drag_url",
+        args: &[ArgKind::Widget, ArgKind::Closure],
+        ret: ReturnKind::Void,
+    },
 ];

--- a/crates/perry-ui-android/src/drag_drop.rs
+++ b/crates/perry-ui-android/src/drag_drop.rs
@@ -1,0 +1,354 @@
+//! Android drag & drop (issue #4773).
+//!
+//! Widget-level drag/drop setters that attach behavior to an existing widget
+//! handle, mirroring the macOS/UIKit backends at the JS boundary. Android's
+//! drag/drop is built on `View.setOnDragListener` (drop destination) and
+//! `View.startDragAndDrop` (drag source); both require a Java/Kotlin
+//! `View.OnDragListener` instance, so — exactly like buttons
+//! (`widgets/button.rs`) and continuous pointer events (`pointer.rs`) — the
+//! native side delegates the listener wiring to the host `PerryBridge` Java
+//! class and exchanges per-widget closure *keys* (see [`crate::callback`])
+//! across the JNI boundary. The closures themselves stay on the native side
+//! and are invoked from the UI thread via the `nativeInvoke*` entry points
+//! below, which pump the promise microtask queue afterwards just like every
+//! other callback in this crate.
+//!
+//! Drop destination (`widgetOnDrop`): we register the callback under a key and
+//! ask `PerryBridge.setOnDropCallback(view, key)` to install an
+//! `OnDragListener` that advertises a copy operation and, on `ACTION_DROP`,
+//! reads the `DragEvent`'s `ClipData`: each item's `getText()` becomes `text`,
+//! each `getUri()` is sorted into `files` (a `content://`/`file://` URI) or
+//! `urls` (an `http`/`https` web URL). The Java side passes those back through
+//! [`Java_com_perry_app_PerryBridge_nativeInvokeDropCallback`], which builds the
+//! `{ text?, files?, urls? }` object and invokes the callback closure.
+//!
+//! Drag source (`widgetSetDrag*`): each representation registers its provider
+//! closure under a key; `PerryBridge.setDragSource(view, textKey, fileKey,
+//! urlKey)` installs a long-press handler that, when a drag begins, calls back
+//! into native via [`Java_com_perry_app_PerryBridge_nativeInvokeDragProvider`]
+//! for each non-zero key to obtain that representation's payload string, builds
+//! a single `ClipData` (newPlainText for text, a `ClipData.Item` with a `Uri`
+//! for file/url), and calls `view.startDragAndDrop(clip, shadowBuilder, …)`.
+//! Multiple `widgetSetDrag*` may be set on one widget; they share one
+//! `ClipData` with one item per registered representation. `0` is used as the
+//! "no provider" sentinel key (real keys from `callback::register` start at 1).
+//!
+//! Java-side glue still required (NOT yet present in this crate's companion
+//! Kotlin sources — a reviewer/integrator must add it to `PerryBridge`):
+//!   - `static void setOnDropCallback(View view, long key)` — installs an
+//!     `OnDragListener`; on `ACTION_DRAG_STARTED`/`ACTION_DRAG_ENTERED` return
+//!     `true` to accept, on `ACTION_DROP` parse `event.getClipData()` and call
+//!     `nativeInvokeDropCallback(key, text, files[], urls[])`.
+//!   - `static void setDragSource(View view, long textKey, long fileKey, long
+//!     urlKey)` — installs an `OnLongClickListener` (or equivalent) that, on a
+//!     drag gesture, calls `nativeInvokeDragProvider(key)` for each non-zero
+//!     key, assembles a `ClipData`, and calls
+//!     `view.startDragAndDrop(clip, new View.DragShadowBuilder(view), null,
+//!     0)` (`startDrag` pre-API-24).
+//! The three `nativeInvoke*` symbols below are the native counterparts those
+//! Java methods must call.
+//!
+//! NOTE: like all `perry-ui-android` code, this module is **compile-unverified
+//! in CI** — PR CI does not build the cross-host UI crates (no Android NDK
+//! linker is available), so it needs on-device testing. The JNI calls and
+//! signatures here mirror the existing `button.rs` / `pointer.rs` /
+//! `image_picker.rs` bridges, but the new `PerryBridge` Java methods above must
+//! be implemented before drag/drop does anything at runtime.
+
+use crate::app::str_from_header;
+use crate::callback;
+use crate::jni_bridge;
+use jni::objects::JValue;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+extern "C" {
+    // Signatures copied from the existing in-crate declarations so they match
+    // the rest of the static library:
+    //   js_object_alloc / js_object_set_field_by_name / js_string_from_bytes →
+    //     `widgets/canvas.rs`
+    //   js_array_alloc / js_array_push_f64 / js_nanbox_* / js_closure_call0 →
+    //     `callback.rs`
+    fn js_object_alloc(class_id: u32, field_count: u32) -> *mut c_void;
+    fn js_object_set_field_by_name(obj: *mut c_void, key: *const c_void, value: f64);
+    fn js_string_from_bytes(data: *const u8, len: u32) -> *mut c_void;
+    fn js_array_alloc(capacity: u32) -> *mut c_void;
+    fn js_array_push_f64(arr: *mut c_void, value: f64) -> *mut c_void;
+    fn js_nanbox_pointer(ptr: i64) -> f64;
+    fn js_nanbox_string(ptr: i64) -> f64;
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    // Converts an arbitrary JS value to a runtime `StringHeader` (typed here as
+    // `*const u8` so it feeds `str_from_header`, the same way `clipboard.rs`
+    // treats runtime string pointers). Defined in
+    // `perry-runtime/src/value/to_string.rs`.
+    fn js_jsvalue_to_string(value: f64) -> *const u8;
+    fn js_promise_run_microtasks() -> i32;
+}
+
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+thread_local! {
+    /// Per-widget drag-source provider keys `(textKey, fileKey, urlKey)`. A key
+    /// of `0` means "no provider for this representation". Kept so that setting
+    /// a second representation on the same widget re-uses the existing
+    /// `OnLongClickListener` and only fills in the missing slot — the same
+    /// approach `pointer.rs` uses for its `(down, move, up)` key triple.
+    static DRAG_KEYS: RefCell<HashMap<i64, (i64, i64, i64)>> = RefCell::new(HashMap::new());
+}
+
+/// Allocate a NaN-boxed Perry string key for a JS object field name.
+fn js_key(name: &[u8]) -> *const c_void {
+    unsafe { js_string_from_bytes(name.as_ptr(), name.len() as u32) as *const c_void }
+}
+
+/// Allocate a NaN-boxed Perry string from a Rust string.
+unsafe fn nanbox_str(s: &str) -> f64 {
+    let bytes = s.as_bytes();
+    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    js_nanbox_string(ptr as i64)
+}
+
+/// Drain the promise microtask queue so any `.then`/`await` continuations
+/// scheduled by the drop/drag callback run before control returns to Java.
+/// Mirrors `callback::pump_microtasks`.
+fn pump_microtasks() {
+    unsafe { while js_promise_run_microtasks() > 0 {} }
+}
+
+// --- drag-source key bookkeeping --------------------------------------------
+
+/// Fetch (creating if needed) the `(textKey, fileKey, urlKey)` triple for a
+/// widget. Newly-created slots start at `0` (no provider); the caller fills in
+/// whichever slot it owns and then (re-)installs the Java drag source so the
+/// listener sees the updated key set.
+fn ensure_keys(handle: i64) -> (i64, i64, i64) {
+    DRAG_KEYS.with(|m| *m.borrow_mut().entry(handle).or_insert((0, 0, 0)))
+}
+
+fn store_keys(handle: i64, keys: (i64, i64, i64)) {
+    DRAG_KEYS.with(|m| {
+        m.borrow_mut().insert(handle, keys);
+    });
+}
+
+/// (Re-)install the Java-side drag source for `handle` with the current key
+/// triple via `PerryBridge.setDragSource(View, J, J, J)`.
+fn install_drag_source(handle: i64, keys: (i64, i64, i64)) {
+    let Some(view_ref) = crate::widgets::get_widget(handle) else {
+        return;
+    };
+    let (text_key, file_key, url_key) = keys;
+    let mut env = jni_bridge::get_env();
+    let _ = env.push_local_frame(8);
+    let bridge_class =
+        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+    let _ = env.call_static_method(
+        bridge_cls,
+        "setDragSource",
+        "(Landroid/view/View;JJJ)V",
+        &[
+            JValue::Object(view_ref.as_obj()),
+            JValue::Long(text_key),
+            JValue::Long(file_key),
+            JValue::Long(url_key),
+        ],
+    );
+    unsafe {
+        env.pop_local_frame(&jni::objects::JObject::null());
+    }
+}
+
+// --- FFI: drop destination ---------------------------------------------------
+
+/// Register `widget` as a drop destination. `callback` (a NaN-boxed closure) is
+/// invoked with a `{ text?, files?, urls? }` object describing the payload when
+/// text, files, or URLs are dropped onto the widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_on_drop(widget: i64, callback: f64) {
+    let Some(view_ref) = crate::widgets::get_widget(widget) else {
+        return;
+    };
+    let key = callback::register(callback);
+    let mut env = jni_bridge::get_env();
+    let _ = env.push_local_frame(8);
+    let bridge_class =
+        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+    let _ = env.call_static_method(
+        bridge_cls,
+        "setOnDropCallback",
+        "(Landroid/view/View;J)V",
+        &[JValue::Object(view_ref.as_obj()), JValue::Long(key)],
+    );
+    unsafe {
+        env.pop_local_frame(&jni::objects::JObject::null());
+    }
+}
+
+// --- FFI: drag source --------------------------------------------------------
+
+/// Register `widget` as a drag source offering plain text. `provider` (a
+/// NaN-boxed closure) returns the text payload when a drag begins.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_text(widget: i64, provider: f64) {
+    let key = callback::register(provider);
+    let (_, file, url) = ensure_keys(widget);
+    let keys = (key, file, url);
+    store_keys(widget, keys);
+    install_drag_source(widget, keys);
+}
+
+/// Register `widget` as a drag source offering a file. `provider` returns the
+/// absolute path of the file to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_file(widget: i64, provider: f64) {
+    let key = callback::register(provider);
+    let (text, _, url) = ensure_keys(widget);
+    let keys = (text, key, url);
+    store_keys(widget, keys);
+    install_drag_source(widget, keys);
+}
+
+/// Register `widget` as a drag source offering a web URL. `provider` returns
+/// the URL string to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_url(widget: i64, provider: f64) {
+    let key = callback::register(provider);
+    let (text, file, _) = ensure_keys(widget);
+    let keys = (text, file, key);
+    store_keys(widget, keys);
+    install_drag_source(widget, keys);
+}
+
+// --- JNI entry points --------------------------------------------------------
+
+/// Called from `PerryBridge` on `ACTION_DROP`. Builds the `{ text?, files?,
+/// urls? }` object from whichever Java arguments are non-null/non-empty and
+/// invokes the registered drop callback. `text` may be null; `files` and
+/// `urls` may be null or empty arrays. Runs on the UI thread, so it pumps
+/// microtasks afterwards (matching every other callback in this crate).
+#[no_mangle]
+pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeDropCallback(
+    mut env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    key: jni::sys::jlong,
+    text: jni::objects::JString,
+    files: jni::objects::JObjectArray,
+    urls: jni::objects::JObjectArray,
+) {
+    let Some(closure_f64) = callback::get(key as i64) else {
+        return;
+    };
+    let closure_ptr = closure_f64.to_bits() as *const u8;
+    if closure_ptr.is_null() {
+        return;
+    }
+
+    // Read the optional `text` representation.
+    let text_str: Option<String> = if text.is_null() {
+        None
+    } else {
+        env.get_string(&text).map(|s| s.into()).ok()
+    };
+
+    let files_vec = read_string_array(&mut env, &files);
+    let urls_vec = read_string_array(&mut env, &urls);
+
+    unsafe {
+        // Up to three fields: text, files, urls.
+        let obj = js_object_alloc(0, 3);
+        if obj.is_null() {
+            return;
+        }
+        if let Some(t) = text_str {
+            js_object_set_field_by_name(obj, js_key(b"text"), nanbox_str(&t));
+        }
+        if !files_vec.is_empty() {
+            let arr = build_string_array(&files_vec);
+            js_object_set_field_by_name(obj, js_key(b"files"), js_nanbox_pointer(arr as i64));
+        }
+        if !urls_vec.is_empty() {
+            let arr = build_string_array(&urls_vec);
+            js_object_set_field_by_name(obj, js_key(b"urls"), js_nanbox_pointer(arr as i64));
+        }
+        let payload = js_nanbox_pointer(obj as i64);
+        js_closure_call1(closure_ptr, payload);
+    }
+    pump_microtasks();
+}
+
+/// Called from `PerryBridge` when a drag is starting, once per registered
+/// representation. `key` is the provider key handed to `setDragSource`. Invokes
+/// the provider closure (0 args), converts its return value to a string, and
+/// returns it to Java as the payload for that representation. Returns an empty
+/// string if the provider is missing or yields a non-string. Runs on the UI
+/// thread, so it pumps microtasks afterwards.
+#[no_mangle]
+pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeDragProvider<'local>(
+    mut env: jni::JNIEnv<'local>,
+    _class: jni::objects::JClass<'local>,
+    key: jni::sys::jlong,
+) -> jni::objects::JString<'local> {
+    let payload = drag_provider_payload(key as i64).unwrap_or_default();
+    pump_microtasks();
+    env.new_string(payload).unwrap_or_default()
+}
+
+/// Invoke the provider closure registered under `key` and convert its return
+/// value to a Rust string. `None` if the closure is gone, is the sentinel `0`,
+/// or returned `undefined`/`null`.
+fn drag_provider_payload(key: i64) -> Option<String> {
+    let closure_f64 = callback::get(key)?;
+    let closure_ptr = closure_f64.to_bits() as *const u8;
+    if closure_ptr.is_null() {
+        return None;
+    }
+    unsafe {
+        let ret = js_closure_call0(closure_ptr);
+        if ret.to_bits() == TAG_UNDEFINED {
+            return None;
+        }
+        let sh = js_jsvalue_to_string(ret);
+        if sh.is_null() {
+            None
+        } else {
+            Some(str_from_header(sh).to_string())
+        }
+    }
+}
+
+// --- helpers -----------------------------------------------------------------
+
+/// Read a `String[]` JNI array into a `Vec<String>`, skipping null elements.
+fn read_string_array(env: &mut jni::JNIEnv, arr: &jni::objects::JObjectArray) -> Vec<String> {
+    let mut out = Vec::new();
+    if arr.is_null() {
+        return out;
+    }
+    if let Ok(len) = env.get_array_length(arr) {
+        for i in 0..len {
+            if let Ok(item) = env.get_object_array_element(arr, i) {
+                if item.is_null() {
+                    continue;
+                }
+                let jstr: jni::objects::JString = item.into();
+                if let Ok(s) = env.get_string(&jstr) {
+                    out.push(s.into());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Build a NaN-boxed Perry array of NaN-boxed Perry strings.
+unsafe fn build_string_array(items: &[String]) -> *mut c_void {
+    let mut arr = js_array_alloc(items.len() as u32);
+    for s in items {
+        arr = js_array_push_f64(arr, nanbox_str(s));
+    }
+    arr
+}

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -13,6 +13,7 @@ pub mod camera;
 pub mod clipboard;
 pub mod deeplinks;
 pub mod dialog;
+pub mod drag_drop;
 pub mod fetch;
 pub mod ffi;
 pub mod file_dialog;

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
@@ -22,6 +22,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
 import android.util.TypedValue
+import android.view.DragEvent
 import android.view.MotionEvent
 import android.view.Surface
 import android.view.TextureView
@@ -251,6 +252,87 @@ object PerryBridge {
                 }
             }
         })
+    }
+
+    // --- Drag & drop (issue #4773) ---
+
+    // Install a drop destination on `view`. On ACTION_DROP the DragEvent's
+    // ClipData is parsed into text / file-or-content URIs / web URLs and handed
+    // to native, which builds the `{ text?, files?, urls? }` payload and invokes
+    // the JS callback registered under `callbackKey`.
+    @JvmStatic
+    fun setOnDropCallback(view: View, callbackKey: Long) {
+        view.setOnDragListener { _, event ->
+            when (event.action) {
+                DragEvent.ACTION_DROP -> {
+                    var text: String? = null
+                    val files = ArrayList<String>()
+                    val urls = ArrayList<String>()
+                    val clip = event.clipData
+                    if (clip != null) {
+                        for (i in 0 until clip.itemCount) {
+                            val item = clip.getItemAt(i)
+                            val t = item.text
+                            if (t != null && text == null) text = t.toString()
+                            val uri = item.uri
+                            if (uri != null) {
+                                val s = uri.toString()
+                                when (uri.scheme) {
+                                    "http", "https" -> urls.add(s)
+                                    else -> files.add(s) // content:// / file://
+                                }
+                            }
+                        }
+                    }
+                    nativeInvokeDropCallback(
+                        callbackKey,
+                        text,
+                        if (files.isEmpty()) null else files.toTypedArray(),
+                        if (urls.isEmpty()) null else urls.toTypedArray(),
+                    )
+                    true
+                }
+                // Accept the drag for the remaining lifecycle events.
+                else -> true
+            }
+        }
+    }
+
+    // Install a drag source on `view`. A long-press starts the drag; for each
+    // non-zero provider key, native returns the payload string for that
+    // representation (text / file path / url), which is assembled into a
+    // ClipData and handed to `startDragAndDrop`.
+    @JvmStatic
+    fun setDragSource(view: View, textKey: Long, fileKey: Long, urlKey: Long) {
+        view.setOnLongClickListener { v ->
+            val clip = buildDragClip(textKey, fileKey, urlKey)
+                ?: return@setOnLongClickListener false
+            v.startDragAndDrop(clip, View.DragShadowBuilder(v), null, 0)
+            true
+        }
+    }
+
+    private fun buildDragClip(textKey: Long, fileKey: Long, urlKey: Long): ClipData? {
+        var clip: ClipData? = null
+        if (textKey != 0L) {
+            val s = nativeInvokeDragProvider(textKey)
+            if (s.isNotEmpty()) clip = appendOrNew(clip, ClipData.newPlainText("text", s))
+        }
+        if (fileKey != 0L) {
+            val s = nativeInvokeDragProvider(fileKey)
+            if (s.isNotEmpty()) clip = appendOrNew(clip, ClipData.newRawUri("file", Uri.parse(s)))
+        }
+        if (urlKey != 0L) {
+            val s = nativeInvokeDragProvider(urlKey)
+            if (s.isNotEmpty()) clip = appendOrNew(clip, ClipData.newRawUri("url", Uri.parse(s)))
+        }
+        return clip
+    }
+
+    private fun appendOrNew(existing: ClipData?, fresh: ClipData): ClipData {
+        if (existing == null) return fresh
+        for (i in 0 until fresh.itemCount) existing.addItem(fresh.getItemAt(i))
+        return existing
     }
 
     // --- Button styling ---
@@ -2144,6 +2226,20 @@ object PerryBridge {
 
     @JvmStatic
     external fun nativeInvokeCallbackWithStringArray(key: Long, paths: Array<String>)
+
+    // Issue #4773 — drag & drop. The drop callback delivers the parsed payload
+    // (any of text/files/urls may be null); the drag provider returns the
+    // payload string for one representation when a drag begins.
+    @JvmStatic
+    external fun nativeInvokeDropCallback(
+        key: Long,
+        text: String?,
+        files: Array<String>?,
+        urls: Array<String>?,
+    )
+
+    @JvmStatic
+    external fun nativeInvokeDragProvider(key: Long): String
 
     // Issue #480 — TreeView row-tap callback.
     @JvmStatic

--- a/crates/perry-ui-gtk4/src/drag_drop.rs
+++ b/crates/perry-ui-gtk4/src/drag_drop.rs
@@ -1,0 +1,349 @@
+//! GTK4 drag & drop FFI (issue #4773).
+//!
+//! Widget-level drag/drop setters exported by every `perry-ui-*` backend so
+//! that `widgetOnDrop` / `widgetSetDrag*` compile and link on every
+//! `--target`: codegen emits a single symbol name regardless of platform (see
+//! `crates/perry-dispatch/src/ui_table.rs`), so the symbol must exist in each
+//! platform's static library or the link fails.
+//!
+//! This is the GTK4 implementation, mirroring the AppKit backend's JS-side
+//! marshalling (`crates/perry-ui-macos/src/drag_drop.rs`):
+//!
+//! * Drop destination: a `GtkDropTarget` accepting `String` / `GdkFileList` /
+//!   `GFile` / uri-list types is attached to the widget. The `"drop"` signal
+//!   reads the dropped `GValue`, builds a `{ text?, files?, urls? }` object,
+//!   and invokes the registered callback. A plain string that parses as a
+//!   `file://` / `http(s)://` URI is routed to `files` / `urls` respectively,
+//!   matching the AppKit behavior where the pasteboard carries typed reps.
+//!
+//! * Drag source: a `GtkDragSource` is attached and its `"prepare"` signal
+//!   calls whichever `widgetSetDrag*` provider closures were registered at
+//!   drag-start time, building a `GdkContentProvider` from the returned
+//!   strings (text -> `String`, file -> `GFile`, url -> uri string). Multiple
+//!   `widgetSetDrag*` calls on one widget are unioned via a single
+//!   `ContentProvider::new_union`.
+//!
+//! State lives in thread-local side tables keyed by widget handle (the GTK
+//! objects are not `Send`/`Sync` and run on the GTK main loop, exactly like
+//! the per-widget callback tables in `widgets/button.rs` / `widgets/canvas.rs`).
+//!
+//! NOTE: this module is **compile-unverified in this environment and in PR
+//! CI** — the cross-host UI crates (including `perry-ui-gtk4`) are not built by
+//! `cargo test` on macOS and are excluded from PR CI; there are no GTK4 system
+//! libraries / pkg-config here. It needs a Linux/GTK build and manual testing
+//! to confirm the `GdkContentProvider` / `GdkFileList` / `GValue` round-trips.
+
+use gtk4::gdk;
+use gtk4::gio;
+use gtk4::glib;
+use gtk4::prelude::*;
+use gtk4::{DragSource, DropTarget};
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_nanbox_pointer(ptr: i64) -> f64;
+    fn js_nanbox_string(ptr: i64) -> f64;
+    fn js_string_from_bytes(data: *const u8, len: u32) -> *mut c_void;
+    fn js_object_alloc(class_id: u32, field_count: u32) -> *mut c_void;
+    fn js_object_set_field_by_name(obj: *mut c_void, key: *const c_void, value: f64);
+    fn js_array_alloc(capacity: u32) -> *mut c_void;
+    fn js_array_push_f64(arr: *mut c_void, value: f64) -> *mut c_void;
+    fn js_jsvalue_to_string(value: f64) -> *const u8;
+}
+
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+thread_local! {
+    /// Drop callback (NaN-boxed closure) per droppable widget handle.
+    static DROP_CB: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
+    /// Drag-source providers (NaN-boxed closures) per source widget handle.
+    static DRAG_TEXT: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
+    static DRAG_FILE: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
+    static DRAG_URL: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
+    /// Widgets that already have a `GtkDragSource` attached, so repeated
+    /// `widgetSetDrag*` calls add to the side tables instead of stacking
+    /// controllers.
+    static DRAG_SOURCE_ATTACHED: RefCell<HashMap<i64, ()>> = RefCell::new(HashMap::new());
+}
+
+/// Extract a `&str` from a runtime `StringHeader` pointer (same layout as
+/// `clipboard.rs` / `widgets/button.rs`).
+fn str_from_header(ptr: *const u8) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len)).to_string()
+    }
+}
+
+/// NaN-box a Rust string into a JS string value.
+unsafe fn nanbox_str(s: &str) -> f64 {
+    let bytes = s.as_bytes();
+    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    js_nanbox_string(ptr as i64)
+}
+
+/// Allocate a JS string key for `js_object_set_field_by_name`.
+fn js_key(name: &[u8]) -> *const c_void {
+    unsafe { js_string_from_bytes(name.as_ptr(), name.len() as u32) as *const c_void }
+}
+
+/// Call a provider closure (0 args) and convert its return value to a Rust
+/// string. Returns `None` for undefined / non-string returns.
+unsafe fn call_provider(cb: f64) -> Option<String> {
+    let p = js_nanbox_get_pointer(cb) as *const u8;
+    if p.is_null() {
+        return None;
+    }
+    let ret = js_closure_call0(p);
+    let sh = js_jsvalue_to_string(ret);
+    if sh.is_null() {
+        None
+    } else {
+        Some(str_from_header(sh))
+    }
+}
+
+// --- drop destination --------------------------------------------------------
+
+/// Classify a dropped plain string. GTK delivers `file://` and `http(s)://`
+/// drags either as typed `GFile` / `GdkFileList` values or, from some sources,
+/// as a bare uri string — mirror the AppKit typed-rep split so the JS object
+/// shape is identical across platforms.
+enum DroppedText {
+    Files(Vec<String>),
+    Urls(Vec<String>),
+    Text(String),
+}
+
+fn classify_text(s: &str) -> DroppedText {
+    // A uri-list (text/uri-list) drop arrives newline-separated.
+    let lines: Vec<&str> = s
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .collect();
+    if !lines.is_empty() && lines.iter().all(|l| l.starts_with("file://")) {
+        let files = lines
+            .iter()
+            .filter_map(|l| gio::File::for_uri(l).path())
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        return DroppedText::Files(files);
+    }
+    if !lines.is_empty()
+        && lines
+            .iter()
+            .all(|l| l.starts_with("http://") || l.starts_with("https://"))
+    {
+        return DroppedText::Urls(lines.iter().map(|l| l.to_string()).collect());
+    }
+    DroppedText::Text(s.to_string())
+}
+
+/// Build a `{ text?, files?, urls? }` object from a dropped `GValue` and invoke
+/// the registered drop callback. Runs on the GTK main loop inside the `"drop"`
+/// signal handler.
+fn deliver_drop(handle: i64, value: &glib::Value) {
+    let cb = match DROP_CB.with(|m| m.borrow().get(&handle).copied()) {
+        Some(cb) => cb,
+        None => return,
+    };
+
+    let mut text: Option<String> = None;
+    let mut files: Vec<String> = Vec::new();
+    let mut urls: Vec<String> = Vec::new();
+
+    // `GdkFileList` (multi-file drag) — preferred file representation.
+    if let Ok(file_list) = value.get::<gdk::FileList>() {
+        for file in file_list.files() {
+            if let Some(path) = file.path() {
+                files.push(path.to_string_lossy().into_owned());
+            } else {
+                // A non-local file (e.g. a remote `GFile`) has no local path;
+                // surface its uri instead.
+                urls.push(file.uri().to_string());
+            }
+        }
+    } else if let Ok(file) = value.get::<gio::File>() {
+        // Single `GFile`.
+        if let Some(path) = file.path() {
+            files.push(path.to_string_lossy().into_owned());
+        } else {
+            urls.push(file.uri().to_string());
+        }
+    } else if let Ok(s) = value.get::<String>() {
+        // Plain string — split into text / files / urls by content.
+        match classify_text(&s) {
+            DroppedText::Files(f) => files.extend(f),
+            DroppedText::Urls(u) => urls.extend(u),
+            DroppedText::Text(t) => text = Some(t),
+        }
+    }
+
+    unsafe {
+        let obj = js_object_alloc(0, 3);
+        if obj.is_null() {
+            return;
+        }
+        if let Some(text) = text {
+            js_object_set_field_by_name(obj, js_key(b"text"), nanbox_str(&text));
+        }
+        if !files.is_empty() {
+            let mut arr = js_array_alloc(files.len() as u32);
+            for f in &files {
+                arr = js_array_push_f64(arr, nanbox_str(f));
+            }
+            js_object_set_field_by_name(obj, js_key(b"files"), js_nanbox_pointer(arr as i64));
+        }
+        if !urls.is_empty() {
+            let mut arr = js_array_alloc(urls.len() as u32);
+            for u in &urls {
+                arr = js_array_push_f64(arr, nanbox_str(u));
+            }
+            js_object_set_field_by_name(obj, js_key(b"urls"), js_nanbox_pointer(arr as i64));
+        }
+
+        let payload = js_nanbox_pointer(obj as i64);
+        let cb_ptr = js_nanbox_get_pointer(cb) as *const u8;
+        js_closure_call1(cb_ptr, payload);
+    }
+}
+
+// --- drag source -------------------------------------------------------------
+
+/// Build a `GdkContentProvider` from whichever providers are registered for
+/// `handle`, calling each provider closure at drag-start time. Returns `None`
+/// when nothing was produced (the drag is then cancelled by GTK).
+fn build_content_provider(handle: i64) -> Option<gdk::ContentProvider> {
+    let mut providers: Vec<gdk::ContentProvider> = Vec::new();
+
+    unsafe {
+        if let Some(cb) = DRAG_TEXT.with(|m| m.borrow().get(&handle).copied()) {
+            if let Some(s) = call_provider(cb) {
+                let v = s.to_value();
+                providers.push(gdk::ContentProvider::for_value(&v));
+            }
+        }
+        if let Some(cb) = DRAG_FILE.with(|m| m.borrow().get(&handle).copied()) {
+            if let Some(path) = call_provider(cb) {
+                let file = gio::File::for_path(&path);
+                let v = file.to_value();
+                providers.push(gdk::ContentProvider::for_value(&v));
+            }
+        }
+        if let Some(cb) = DRAG_URL.with(|m| m.borrow().get(&handle).copied()) {
+            if let Some(s) = call_provider(cb) {
+                // A web URL is carried as a plain string so text-accepting
+                // targets (browsers, editors, address bars) take it; GTK has
+                // no distinct "url" content type the way AppKit's pasteboard
+                // does, so the string representation is the portable choice.
+                let v = s.to_value();
+                providers.push(gdk::ContentProvider::for_value(&v));
+            }
+        }
+    }
+
+    match providers.len() {
+        0 => None,
+        1 => providers.into_iter().next(),
+        _ => Some(gdk::ContentProvider::new_union(&providers)),
+    }
+}
+
+/// Attach a single `GtkDragSource` to `widget` whose `"prepare"` handler builds
+/// content from the registered providers. Idempotent per handle.
+fn ensure_drag_source(handle: i64, widget: &gtk4::Widget) {
+    let already = DRAG_SOURCE_ATTACHED.with(|m| m.borrow().contains_key(&handle));
+    if already {
+        return;
+    }
+    DRAG_SOURCE_ATTACHED.with(|m| {
+        m.borrow_mut().insert(handle, ());
+    });
+
+    let source = DragSource::new();
+    source.set_actions(gdk::DragAction::COPY);
+    source.connect_prepare(move |_src, _x, _y| build_content_provider(handle));
+    widget.add_controller(source);
+}
+
+// --- FFI ---------------------------------------------------------------------
+
+/// Register `widget` as a drop destination. `callback` (a NaN-boxed closure)
+/// is invoked with a `{ text?, files?, urls? }` object describing the payload
+/// when text, files, or URLs are dropped onto the widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_on_drop(widget: i64, callback: f64) {
+    if callback.to_bits() == TAG_UNDEFINED {
+        return;
+    }
+    let Some(w) = crate::widgets::get_widget(widget) else {
+        return;
+    };
+    DROP_CB.with(|m| {
+        m.borrow_mut().insert(widget, callback);
+    });
+
+    // Accept files (GdkFileList / GFile), plain text, and uri-list strings.
+    let drop_target = DropTarget::new(glib::Type::INVALID, gdk::DragAction::COPY);
+    drop_target.set_types(&[
+        gdk::FileList::static_type(),
+        gio::File::static_type(),
+        String::static_type(),
+    ]);
+    drop_target.connect_drop(move |_target, value, _x, _y| {
+        deliver_drop(widget, value);
+        true
+    });
+    w.add_controller(drop_target);
+}
+
+/// Register `widget` as a drag source offering plain text. `provider` (a
+/// NaN-boxed closure) returns the text payload when a drag begins.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_text(widget: i64, provider: f64) {
+    let Some(w) = crate::widgets::get_widget(widget) else {
+        return;
+    };
+    DRAG_TEXT.with(|m| {
+        m.borrow_mut().insert(widget, provider);
+    });
+    ensure_drag_source(widget, &w);
+}
+
+/// Register `widget` as a drag source offering a file. `provider` returns the
+/// absolute path of the file to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_file(widget: i64, provider: f64) {
+    let Some(w) = crate::widgets::get_widget(widget) else {
+        return;
+    };
+    DRAG_FILE.with(|m| {
+        m.borrow_mut().insert(widget, provider);
+    });
+    ensure_drag_source(widget, &w);
+}
+
+/// Register `widget` as a drag source offering a web URL. `provider` returns
+/// the URL string to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_url(widget: i64, provider: f64) {
+    let Some(w) = crate::widgets::get_widget(widget) else {
+        return;
+    };
+    DRAG_URL.with(|m| {
+        m.borrow_mut().insert(widget, provider);
+    });
+    ensure_drag_source(widget, &w);
+}

--- a/crates/perry-ui-gtk4/src/lib.rs
+++ b/crates/perry-ui-gtk4/src/lib.rs
@@ -5,6 +5,7 @@ pub mod camera;
 pub mod clipboard;
 pub mod deeplinks_stub;
 pub mod dialog;
+pub mod drag_drop;
 pub mod file_dialog;
 pub mod issue_552_stub;
 pub mod keyboard;

--- a/crates/perry-ui-ios/src/drag_drop.rs
+++ b/crates/perry-ui-ios/src/drag_drop.rs
@@ -1,0 +1,416 @@
+//! UIKit drag & drop (issue #4773) — iOS / iPadOS backend.
+//!
+//! Widget-level drag/drop setters that attach behavior to an existing widget
+//! handle. Unlike AppKit, UIKit lets any `UIView` host drag/drop via
+//! `addInteraction:` — no subclassing/swizzling. We create a shared
+//! `UIDragInteraction` / `UIDropInteraction` delegate (one singleton each,
+//! mirroring `widgets/button.rs`'s `PerryButtonTarget` pattern), add the
+//! matching interaction to the target view, and key per-view state in
+//! thread-local side tables by the view pointer.
+//!
+//! Drop destination: the drop delegate advertises a copy operation and, on
+//! `performDrop`, loads `NSString` (→ `text`) and `NSURL` (file URLs → `files`,
+//! web URLs → `urls`) from the session via `loadObjectsOfClass:` and invokes
+//! the callback with a `{ text?, files?, urls? }` object.
+//!
+//! Drag source: the drag delegate returns `UIDragItem`s built from
+//! `NSItemProvider`s wrapping whichever `widgetSetDrag*` provider strings are
+//! registered (text → `NSString`, file → file `NSURL`, url → web `NSURL`).
+//!
+//! NOTE: compile-checked for `aarch64-apple-ios` but not behaviorally verified
+//! (drag gestures require a device/simulator session).
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, NSObject};
+use objc2::{class, define_class, msg_send, AnyThread, DefinedClass};
+use objc2_foundation::{NSArray, NSString};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::rc::Rc;
+
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_nanbox_pointer(ptr: i64) -> f64;
+    fn js_nanbox_string(ptr: i64) -> f64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_object_alloc(class_id: u32, field_count: u32) -> *mut c_void;
+    fn js_object_set_field_by_name(obj: *mut c_void, key: *const c_void, value: f64);
+    fn js_array_alloc(capacity: u32) -> *mut c_void;
+    fn js_array_push_f64(arr: *mut c_void, value: f64) -> *mut c_void;
+    fn js_jsvalue_to_string(value: f64) -> *const u8;
+}
+
+// UIDropOperationCopy = 2.
+const UI_DROP_OPERATION_COPY: isize = 2;
+
+thread_local! {
+    static DROP_CB: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_TEXT: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_FILE: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_URL: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+fn str_from_header(ptr: *const u8) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len)).to_string()
+    }
+}
+
+unsafe fn nanbox_str(s: &str) -> f64 {
+    let bytes = s.as_bytes();
+    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+    js_nanbox_string(ptr as i64)
+}
+
+fn js_key(name: &[u8]) -> *const c_void {
+    unsafe { js_string_from_bytes(name.as_ptr(), name.len() as i64) as *const c_void }
+}
+
+unsafe fn call_provider(cb: f64) -> Option<String> {
+    let p = js_nanbox_get_pointer(cb) as *const u8;
+    if p.is_null() {
+        return None;
+    }
+    let ret = js_closure_call0(p);
+    let sh = js_jsvalue_to_string(ret);
+    if sh.is_null() {
+        None
+    } else {
+        Some(str_from_header(sh))
+    }
+}
+
+/// The `interaction.view` pointer is the key into the side tables.
+unsafe fn interaction_view_key(interaction: *mut AnyObject) -> usize {
+    let view: *mut AnyObject = msg_send![interaction, view];
+    view as usize
+}
+
+// --- drop delegate -----------------------------------------------------------
+
+/// Zero-sized ivars — the delegate carries no per-instance state (all state
+/// lives in the thread-local side tables, keyed by view pointer).
+pub struct DragDropIvars;
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryDropDelegate"]
+    #[ivars = DragDropIvars]
+    pub struct PerryDropDelegate;
+
+    impl PerryDropDelegate {
+        #[unsafe(method(dropInteraction:canHandleSession:))]
+        fn can_handle(&self, interaction: *mut AnyObject, _session: *mut AnyObject) -> bool {
+            let key = unsafe { interaction_view_key(interaction) };
+            DROP_CB.with(|m| m.borrow().contains_key(&key))
+        }
+
+        #[unsafe(method(dropInteraction:sessionDidUpdate:))]
+        fn session_did_update(
+            &self,
+            _interaction: *mut AnyObject,
+            _session: *mut AnyObject,
+        ) -> *mut AnyObject {
+            // UIDropProposal(dropOperation: .copy), returned +0 (autoreleased).
+            unsafe {
+                let alloc: *mut AnyObject = msg_send![class!(UIDropProposal), alloc];
+                let proposal: *mut AnyObject =
+                    msg_send![alloc, initWithDropOperation: UI_DROP_OPERATION_COPY];
+                match Retained::from_raw(proposal) {
+                    Some(p) => Retained::autorelease_return(p),
+                    None => std::ptr::null_mut(),
+                }
+            }
+        }
+
+        #[unsafe(method(dropInteraction:performDrop:))]
+        fn perform_drop(&self, interaction: *mut AnyObject, session: *mut AnyObject) {
+            unsafe { perform_drop_impl(interaction, session) };
+        }
+    }
+);
+
+impl PerryDropDelegate {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(DragDropIvars);
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+unsafe fn perform_drop_impl(interaction: *mut AnyObject, session: *mut AnyObject) {
+    let key = interaction_view_key(interaction);
+    let Some(cb) = DROP_CB.with(|m| m.borrow().get(&key).copied()) else {
+        return;
+    };
+
+    // Accumulate the two async loads (strings, urls); fire the JS callback when
+    // both have completed.
+    struct Accum {
+        text: Option<String>,
+        files: Vec<String>,
+        urls: Vec<String>,
+        pending: u8,
+        cb: f64,
+    }
+    let accum = Rc::new(RefCell::new(Accum {
+        text: None,
+        files: Vec::new(),
+        urls: Vec::new(),
+        pending: 2,
+        cb,
+    }));
+
+    unsafe fn finish(accum: &Rc<RefCell<Accum>>) {
+        let mut a = accum.borrow_mut();
+        a.pending -= 1;
+        if a.pending != 0 {
+            return;
+        }
+        let obj = js_object_alloc(0, 3);
+        if obj.is_null() {
+            return;
+        }
+        if let Some(t) = &a.text {
+            js_object_set_field_by_name(obj, js_key(b"text"), nanbox_str(t));
+        }
+        if !a.files.is_empty() {
+            let mut arr = js_array_alloc(a.files.len() as u32);
+            for f in &a.files {
+                arr = js_array_push_f64(arr, nanbox_str(f));
+            }
+            js_object_set_field_by_name(obj, js_key(b"files"), js_nanbox_pointer(arr as i64));
+        }
+        if !a.urls.is_empty() {
+            let mut arr = js_array_alloc(a.urls.len() as u32);
+            for u in &a.urls {
+                arr = js_array_push_f64(arr, nanbox_str(u));
+            }
+            js_object_set_field_by_name(obj, js_key(b"urls"), js_nanbox_pointer(arr as i64));
+        }
+        let payload = js_nanbox_pointer(obj as i64);
+        let cb_ptr = js_nanbox_get_pointer(a.cb) as *const u8;
+        js_closure_call1(cb_ptr, payload);
+    }
+
+    // text
+    let a_text = accum.clone();
+    let block_text = block2::RcBlock::new(move |objs: *mut AnyObject| {
+        if !objs.is_null() {
+            let count: usize = unsafe { msg_send![objs, count] };
+            if count > 0 {
+                let s: *mut NSString = unsafe { msg_send![objs, objectAtIndex: 0usize] };
+                if !s.is_null() {
+                    a_text.borrow_mut().text = Some(unsafe { (*s).to_string() });
+                }
+            }
+        }
+        unsafe { finish(&a_text) };
+    });
+    let _: *mut AnyObject =
+        msg_send![session, loadObjectsOfClass: class!(NSString), completionHandler: &*block_text];
+
+    // urls (classified into file paths vs web urls)
+    let a_url = accum.clone();
+    let block_url = block2::RcBlock::new(move |objs: *mut AnyObject| {
+        if !objs.is_null() {
+            let count: usize = unsafe { msg_send![objs, count] };
+            for i in 0..count {
+                let url: *mut AnyObject = unsafe { msg_send![objs, objectAtIndex: i] };
+                if url.is_null() {
+                    continue;
+                }
+                let is_file: bool = unsafe { msg_send![url, isFileURL] };
+                let s: *mut NSString = if is_file {
+                    unsafe { msg_send![url, path] }
+                } else {
+                    unsafe { msg_send![url, absoluteString] }
+                };
+                if !s.is_null() {
+                    let rs = unsafe { (*s).to_string() };
+                    if is_file {
+                        a_url.borrow_mut().files.push(rs);
+                    } else {
+                        a_url.borrow_mut().urls.push(rs);
+                    }
+                }
+            }
+        }
+        unsafe { finish(&a_url) };
+    });
+    let _: *mut AnyObject =
+        msg_send![session, loadObjectsOfClass: class!(NSURL), completionHandler: &*block_url];
+}
+
+// --- drag delegate -----------------------------------------------------------
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryDragDelegate"]
+    #[ivars = DragDropIvars]
+    pub struct PerryDragDelegate;
+
+    impl PerryDragDelegate {
+        #[unsafe(method(dragInteraction:itemsForBeginningSession:))]
+        fn items_for_session(
+            &self,
+            interaction: *mut AnyObject,
+            _session: *mut AnyObject,
+        ) -> *mut NSArray {
+            // Returned +0 (autoreleased).
+            unsafe { Retained::autorelease_return(drag_items_impl(interaction)) }
+        }
+    }
+);
+
+impl PerryDragDelegate {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(DragDropIvars);
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+unsafe fn drag_items_impl(interaction: *mut AnyObject) -> Retained<NSArray> {
+    let key = interaction_view_key(interaction);
+    let mut items: Vec<Retained<AnyObject>> = Vec::new();
+
+    let mut add_item = |obj: *mut AnyObject| {
+        if obj.is_null() {
+            return;
+        }
+        let provider: *mut AnyObject = msg_send![class!(NSItemProvider), alloc];
+        let provider: *mut AnyObject = msg_send![provider, initWithObject: obj];
+        // Adopt the +1 from `initWithObject:`; UIDragItem retains it, so the
+        // provider is released back to that retain when `_provider` drops.
+        let _provider: Option<Retained<AnyObject>> = Retained::from_raw(provider);
+        let item: *mut AnyObject = msg_send![class!(UIDragItem), alloc];
+        let item: *mut AnyObject = msg_send![item, initWithItemProvider: provider];
+        // Adopt the +1 from `initWithItemProvider:`.
+        if let Some(retained) = Retained::from_raw(item) {
+            items.push(retained);
+        }
+    };
+
+    if let Some(cb) = DRAG_TEXT.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(s) = call_provider(cb) {
+            let ns = NSString::from_str(&s);
+            add_item(Retained::as_ptr(&ns) as *mut AnyObject);
+        }
+    }
+    if let Some(cb) = DRAG_FILE.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(path) = call_provider(cb) {
+            let url: *mut AnyObject =
+                msg_send![class!(NSURL), fileURLWithPath: &*NSString::from_str(&path)];
+            add_item(url);
+        }
+    }
+    if let Some(cb) = DRAG_URL.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(s) = call_provider(cb) {
+            let url: *mut AnyObject =
+                msg_send![class!(NSURL), URLWithString: &*NSString::from_str(&s)];
+            add_item(url);
+        }
+    }
+
+    let refs: Vec<&AnyObject> = items.iter().map(|r| &**r).collect();
+    NSArray::from_slice(&refs)
+}
+
+// --- shared singletons + view helpers ----------------------------------------
+
+thread_local! {
+    static DROP_DELEGATE: RefCell<Option<Retained<PerryDropDelegate>>> = RefCell::new(None);
+    static DRAG_DELEGATE: RefCell<Option<Retained<PerryDragDelegate>>> = RefCell::new(None);
+    /// Views that already have a drop / drag interaction installed.
+    static DROP_INSTALLED: RefCell<std::collections::HashSet<usize>> =
+        RefCell::new(std::collections::HashSet::new());
+    static DRAG_INSTALLED: RefCell<std::collections::HashSet<usize>> =
+        RefCell::new(std::collections::HashSet::new());
+}
+
+fn view_ptr(handle: i64) -> Option<*mut AnyObject> {
+    let view = crate::widgets::get_widget(handle)?;
+    Some(Retained::as_ptr(&view) as *mut AnyObject)
+}
+
+unsafe fn ensure_drop_interaction(view: *mut AnyObject) {
+    if DROP_INSTALLED.with(|s| s.borrow().contains(&(view as usize))) {
+        return;
+    }
+    let delegate = DROP_DELEGATE.with(|d| {
+        d.borrow_mut()
+            .get_or_insert_with(PerryDropDelegate::new)
+            .clone()
+    });
+    let interaction: *mut AnyObject = msg_send![class!(UIDropInteraction), alloc];
+    let interaction: *mut AnyObject = msg_send![interaction, initWithDelegate: &*delegate];
+    let _: () = msg_send![view, addInteraction: interaction];
+    DROP_INSTALLED.with(|s| {
+        s.borrow_mut().insert(view as usize);
+    });
+}
+
+unsafe fn ensure_drag_interaction(view: *mut AnyObject) {
+    if DRAG_INSTALLED.with(|s| s.borrow().contains(&(view as usize))) {
+        return;
+    }
+    let delegate = DRAG_DELEGATE.with(|d| {
+        d.borrow_mut()
+            .get_or_insert_with(PerryDragDelegate::new)
+            .clone()
+    });
+    let interaction: *mut AnyObject = msg_send![class!(UIDragInteraction), alloc];
+    let interaction: *mut AnyObject = msg_send![interaction, initWithDelegate: &*delegate];
+    let _: () = msg_send![view, addInteraction: interaction];
+    // Drag interactions require user interaction enabled on the view.
+    let _: () = msg_send![view, setUserInteractionEnabled: true];
+    DRAG_INSTALLED.with(|s| {
+        s.borrow_mut().insert(view as usize);
+    });
+}
+
+// --- FFI ---------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_on_drop(widget: i64, callback: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DROP_CB.with(|m| {
+        m.borrow_mut().insert(ptr as usize, callback);
+    });
+    unsafe { ensure_drop_interaction(ptr) };
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_text(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_TEXT.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_drag_interaction(ptr) };
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_file(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_FILE.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_drag_interaction(ptr) };
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_url(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_URL.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_drag_interaction(ptr) };
+}

--- a/crates/perry-ui-ios/src/lib.rs
+++ b/crates/perry-ui-ios/src/lib.rs
@@ -6,6 +6,7 @@ pub mod camera;
 pub mod clipboard;
 pub mod crash_log;
 pub mod deeplinks;
+pub mod drag_drop;
 pub mod file_dialog;
 pub mod geolocation;
 pub mod image_picker;

--- a/crates/perry-ui-macos/src/drag_drop.rs
+++ b/crates/perry-ui-macos/src/drag_drop.rs
@@ -1,0 +1,446 @@
+//! macOS AppKit drag & drop (issue #4773).
+//!
+//! Widget-level drag/drop setters that attach behavior to an existing widget
+//! handle. AppKit dragging-destination/source messages must be implemented by
+//! the view's class, so we add them to the *specific* view instance via
+//! KVO-style isa-swizzling: the first time `widgetOnDrop` / `widgetSetDrag*` is
+//! called on a view, we look up (or create) a dynamic subclass of the view's
+//! current class — `PerryDragDrop_<ClassName>` — that implements the dragging
+//! methods, then `object_setClass` the instance to it. The subclass inherits
+//! all original behavior (so an `NSButton` stays a button) and the added
+//! methods read per-view state from thread-local side tables keyed by the view
+//! pointer (the same pattern as `widgets/canvas.rs`). This is order-independent
+//! and works regardless of where the widget sits in the view hierarchy.
+//!
+//! Drop destination: `draggingEntered:`/`draggingUpdated:` advertise a copy
+//! operation, `performDragOperation:` reads `NSPasteboard` for
+//! `public.utf8-plain-text` / `public.file-url` / `public.url`, builds a
+//! `{ text?, files?, urls? }` object, and invokes the callback.
+//!
+//! Drag source: `mouseDown:` starts an `NSDraggingSession` whose
+//! `NSPasteboardItem` is populated from whichever `widgetSetDrag*` providers
+//! were registered; `draggingSession:sourceOperationMaskForDraggingContext:`
+//! advertises copy. When no provider is set, `mouseDown:` forwards to the
+//! original class's implementation so interactive controls keep working.
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Bool, ClassBuilder, Imp, Sel};
+use objc2::{msg_send, sel};
+use objc2_app_kit::NSView;
+use objc2_core_foundation::CGRect;
+use objc2_foundation::{NSArray, NSString};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::{c_void, CString};
+
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_nanbox_pointer(ptr: i64) -> f64;
+    fn js_nanbox_string(ptr: i64) -> f64;
+    fn js_string_from_bytes(ptr: *const u8, len: u32) -> *mut c_void;
+    fn js_object_alloc(class_id: u32, field_count: u32) -> *mut c_void;
+    fn js_object_set_field_by_name(obj: *mut c_void, key: *const c_void, value: f64);
+    fn js_array_alloc(capacity: u32) -> *mut c_void;
+    fn js_array_push_f64(arr: *mut c_void, value: f64) -> *mut c_void;
+    fn js_jsvalue_to_string(value: f64) -> *const u8;
+}
+
+// NSDragOperation bits (NSDragOperationCopy = 1).
+const NS_DRAG_OPERATION_NONE: usize = 0;
+const NS_DRAG_OPERATION_COPY: usize = 1;
+
+const UTI_TEXT: &str = "public.utf8-plain-text";
+const UTI_FILE_URL: &str = "public.file-url";
+const UTI_URL: &str = "public.url";
+
+thread_local! {
+    /// Drop callback (NaN-boxed closure) per droppable view pointer.
+    static DROP_CB: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    /// Drag-source providers (NaN-boxed closures) per source view pointer.
+    static DRAG_TEXT: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_FILE: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_URL: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    /// Original `mouseDown:` IMP per dynamic subclass pointer, for forwarding
+    /// when the view is not (also) a drag source.
+    static ORIG_MOUSEDOWN: RefCell<HashMap<usize, Imp>> = RefCell::new(HashMap::new());
+}
+
+/// Extract a `&str` from a runtime `StringHeader` pointer (same layout as
+/// `clipboard.rs` / `button.rs`).
+fn str_from_header(ptr: *const u8) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let header = ptr as *const crate::string_header::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<crate::string_header::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len)).to_string()
+    }
+}
+
+unsafe fn nanbox_str(s: &str) -> f64 {
+    let bytes = s.as_bytes();
+    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    js_nanbox_string(ptr as i64)
+}
+
+fn js_key(name: &[u8]) -> *const c_void {
+    unsafe { js_string_from_bytes(name.as_ptr(), name.len() as u32) as *const c_void }
+}
+
+/// Call a provider closure and convert its return value to a Rust string.
+unsafe fn call_provider(cb: f64) -> Option<String> {
+    let p = js_nanbox_get_pointer(cb) as *const u8;
+    if p.is_null() {
+        return None;
+    }
+    let ret = js_closure_call0(p);
+    let sh = js_jsvalue_to_string(ret);
+    if sh.is_null() {
+        None
+    } else {
+        Some(str_from_header(sh))
+    }
+}
+
+// --- dynamic subclass management ---------------------------------------------
+
+/// Look up or build the `PerryDragDrop_<orig>` subclass and isa-swizzle `view`
+/// to it (idempotent).
+unsafe fn ensure_swizzled(view: *mut AnyObject) {
+    let cls = (*view).class();
+    if cls.name().to_bytes().starts_with(b"PerryDragDrop_") {
+        return; // already swizzled
+    }
+    let sub = get_or_create_subclass(cls);
+    objc2::ffi::object_setClass(view, sub as *const AnyClass as *mut AnyClass);
+}
+
+unsafe fn get_or_create_subclass(orig: &AnyClass) -> &'static AnyClass {
+    let sub_name = format!("PerryDragDrop_{}", orig.name().to_str().unwrap_or("View"));
+    let c_name = CString::new(sub_name).unwrap();
+    if let Some(existing) = AnyClass::get(&c_name) {
+        return existing;
+    }
+    let mut builder =
+        ClassBuilder::new(&c_name, orig).expect("PerryDragDrop subclass name unexpectedly taken");
+
+    // Destination protocol.
+    builder.add_method(
+        sel!(draggingEntered:),
+        dragging_op as extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject) -> usize,
+    );
+    builder.add_method(
+        sel!(draggingUpdated:),
+        dragging_op as extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject) -> usize,
+    );
+    builder.add_method(
+        sel!(prepareForDragOperation:),
+        prepare_for_drag as extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject) -> Bool,
+    );
+    builder.add_method(
+        sel!(performDragOperation:),
+        perform_drag as extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject) -> Bool,
+    );
+
+    // Source protocol.
+    builder.add_method(
+        sel!(draggingSession:sourceOperationMaskForDraggingContext:),
+        source_op_mask as extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject, usize) -> usize,
+    );
+    builder.add_method(
+        sel!(mouseDown:),
+        mouse_down as extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject),
+    );
+
+    let sub = builder.register();
+
+    // Remember the original mouseDown IMP so non-source views can forward.
+    if let Some(method) = orig.instance_method(sel!(mouseDown:)) {
+        let imp = method.implementation();
+        ORIG_MOUSEDOWN.with(|m| {
+            m.borrow_mut().insert(sub as *const AnyClass as usize, imp);
+        });
+    }
+    sub
+}
+
+// --- destination methods -----------------------------------------------------
+
+extern "C-unwind" fn dragging_op(
+    this: *mut AnyObject,
+    _cmd: Sel,
+    _sender: *mut AnyObject,
+) -> usize {
+    let has = DROP_CB.with(|m| m.borrow().contains_key(&(this as usize)));
+    if has {
+        NS_DRAG_OPERATION_COPY
+    } else {
+        NS_DRAG_OPERATION_NONE
+    }
+}
+
+extern "C-unwind" fn prepare_for_drag(
+    this: *mut AnyObject,
+    _cmd: Sel,
+    _sender: *mut AnyObject,
+) -> Bool {
+    let has = DROP_CB.with(|m| m.borrow().contains_key(&(this as usize)));
+    Bool::new(has)
+}
+
+extern "C-unwind" fn perform_drag(this: *mut AnyObject, _cmd: Sel, sender: *mut AnyObject) -> Bool {
+    let cb = DROP_CB.with(|m| m.borrow().get(&(this as usize)).copied());
+    let Some(cb) = cb else {
+        return Bool::NO;
+    };
+    unsafe {
+        let pasteboard: *mut AnyObject = msg_send![sender, draggingPasteboard];
+        if pasteboard.is_null() {
+            return Bool::NO;
+        }
+
+        let obj = js_object_alloc(0, 3);
+        if obj.is_null() {
+            return Bool::NO;
+        }
+
+        // text
+        if let Some(text) = read_string_for_type(pasteboard, UTI_TEXT) {
+            js_object_set_field_by_name(obj, js_key(b"text"), nanbox_str(&text));
+        }
+        // files (absolute paths of dropped file URLs)
+        let files = read_file_paths(pasteboard);
+        if !files.is_empty() {
+            let mut arr = js_array_alloc(files.len() as u32);
+            for f in &files {
+                arr = js_array_push_f64(arr, nanbox_str(f));
+            }
+            js_object_set_field_by_name(obj, js_key(b"files"), js_nanbox_pointer(arr as i64));
+        }
+        // web urls
+        if let Some(url) = read_string_for_type(pasteboard, UTI_URL) {
+            let mut arr = js_array_alloc(1);
+            arr = js_array_push_f64(arr, nanbox_str(&url));
+            js_object_set_field_by_name(obj, js_key(b"urls"), js_nanbox_pointer(arr as i64));
+        }
+
+        let payload = js_nanbox_pointer(obj as i64);
+        let cb_ptr = js_nanbox_get_pointer(cb) as *const u8;
+        js_closure_call1(cb_ptr, payload);
+    }
+    Bool::YES
+}
+
+unsafe fn read_string_for_type(pasteboard: *mut AnyObject, uti: &str) -> Option<String> {
+    let ns_type = NSString::from_str(uti);
+    let s: *mut NSString = msg_send![pasteboard, stringForType: &*ns_type];
+    if s.is_null() {
+        None
+    } else {
+        Some((*s).to_string())
+    }
+}
+
+/// Read dropped file URLs from the pasteboard as absolute paths.
+unsafe fn read_file_paths(pasteboard: *mut AnyObject) -> Vec<String> {
+    let mut out = Vec::new();
+    // `readObjectsForClasses:[NSURL] options:nil` returns NSArray<NSURL>.
+    let url_class: &AnyClass = AnyClass::get(c"NSURL").unwrap();
+    let classes = NSArray::from_slice(&[url_class]);
+    let nil: *const AnyObject = std::ptr::null();
+    let urls: *mut AnyObject =
+        msg_send![pasteboard, readObjectsForClasses: &*classes, options: nil];
+    if urls.is_null() {
+        return out;
+    }
+    let count: usize = msg_send![urls, count];
+    for i in 0..count {
+        let url: *mut AnyObject = msg_send![urls, objectAtIndex: i];
+        if url.is_null() {
+            continue;
+        }
+        let is_file: Bool = msg_send![url, isFileURL];
+        if !is_file.as_bool() {
+            continue;
+        }
+        let path: *mut NSString = msg_send![url, path];
+        if !path.is_null() {
+            out.push((*path).to_string());
+        }
+    }
+    out
+}
+
+// --- source methods ----------------------------------------------------------
+
+extern "C-unwind" fn source_op_mask(
+    _this: *mut AnyObject,
+    _cmd: Sel,
+    _session: *mut AnyObject,
+    _ctx: usize,
+) -> usize {
+    NS_DRAG_OPERATION_COPY
+}
+
+extern "C-unwind" fn mouse_down(this: *mut AnyObject, cmd: Sel, event: *mut AnyObject) {
+    let key = this as usize;
+    let has_source = DRAG_TEXT.with(|m| m.borrow().contains_key(&key))
+        || DRAG_FILE.with(|m| m.borrow().contains_key(&key))
+        || DRAG_URL.with(|m| m.borrow().contains_key(&key));
+
+    if has_source {
+        unsafe { start_drag(this, event) };
+        return;
+    }
+
+    // Not a drag source — forward to the original class's mouseDown: so the
+    // underlying control (button, text field, …) keeps behaving normally.
+    unsafe {
+        let sub = (*this).class();
+        let imp =
+            ORIG_MOUSEDOWN.with(|m| m.borrow().get(&(sub as *const AnyClass as usize)).copied());
+        if let Some(imp) = imp {
+            let f: extern "C-unwind" fn(*mut AnyObject, Sel, *mut AnyObject) =
+                std::mem::transmute(imp);
+            f(this, cmd, event);
+        }
+    }
+}
+
+unsafe fn start_drag(view: *mut AnyObject, event: *mut AnyObject) {
+    let key = view as usize;
+
+    // Build an NSPasteboardItem with whatever representations are registered.
+    let item: *mut AnyObject = msg_send![AnyClass::get(c"NSPasteboardItem").unwrap(), new];
+    let mut wrote_any = false;
+
+    if let Some(cb) = DRAG_TEXT.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(s) = call_provider(cb) {
+            let v = NSString::from_str(&s);
+            let t = NSString::from_str(UTI_TEXT);
+            let _: Bool = msg_send![item, setString: &*v, forType: &*t];
+            wrote_any = true;
+        }
+    }
+    if let Some(cb) = DRAG_FILE.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(path) = call_provider(cb) {
+            // public.file-url wants a file URL string.
+            let url: *mut AnyObject = msg_send![AnyClass::get(c"NSURL").unwrap(), fileURLWithPath: &*NSString::from_str(&path)];
+            if !url.is_null() {
+                let abs: *mut NSString = msg_send![url, absoluteString];
+                if !abs.is_null() {
+                    let t = NSString::from_str(UTI_FILE_URL);
+                    let _: Bool = msg_send![item, setString: &*abs, forType: &*t];
+                    wrote_any = true;
+                }
+            }
+        }
+    }
+    if let Some(cb) = DRAG_URL.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(s) = call_provider(cb) {
+            let v = NSString::from_str(&s);
+            let t = NSString::from_str(UTI_URL);
+            let _: Bool = msg_send![item, setString: &*v, forType: &*t];
+            wrote_any = true;
+        }
+    }
+
+    if !wrote_any {
+        return;
+    }
+
+    // NSDraggingItem from the pasteboard writer, with a snapshot of the view.
+    let drag_item: *mut AnyObject = msg_send![AnyClass::get(c"NSDraggingItem").unwrap(), alloc];
+    let drag_item: *mut AnyObject = msg_send![drag_item, initWithPasteboardWriter: item];
+    if drag_item.is_null() {
+        return;
+    }
+    let bounds: CGRect = msg_send![view, bounds];
+    let image = snapshot_view(view, bounds);
+    let _: () = msg_send![drag_item, setDraggingFrame: bounds, contents: image];
+
+    let items = NSArray::from_slice(&[&*drag_item]);
+    let _session: *mut AnyObject = msg_send![
+        view,
+        beginDraggingSessionWithItems: &*items,
+        event: event,
+        source: view
+    ];
+}
+
+/// Render the view into an NSImage for the drag cursor. Returns nil on failure
+/// (AppKit then drags without a preview, which is acceptable).
+unsafe fn snapshot_view(view: *mut AnyObject, bounds: CGRect) -> *mut AnyObject {
+    let rep: *mut AnyObject = msg_send![view, bitmapImageRepForCachingDisplayInRect: bounds];
+    if rep.is_null() {
+        return std::ptr::null_mut();
+    }
+    let _: () = msg_send![view, cacheDisplayInRect: bounds, toBitmapImageRep: rep];
+    let img: *mut AnyObject = msg_send![AnyClass::get(c"NSImage").unwrap(), alloc];
+    let img: *mut AnyObject = msg_send![img, initWithSize: bounds.size];
+    if img.is_null() {
+        return std::ptr::null_mut();
+    }
+    let _: () = msg_send![img, addRepresentation: rep];
+    img
+}
+
+// --- FFI ---------------------------------------------------------------------
+
+fn view_ptr(handle: i64) -> Option<*mut AnyObject> {
+    let view = crate::widgets::get_widget(handle)?;
+    Some(Retained::as_ptr(&view) as *mut AnyObject)
+}
+
+/// Register `widget` as a drop destination.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_on_drop(widget: i64, callback: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DROP_CB.with(|m| {
+        m.borrow_mut().insert(ptr as usize, callback);
+    });
+    unsafe {
+        ensure_swizzled(ptr);
+        let view: &NSView = &*(ptr as *const NSView);
+        let types = NSArray::from_retained_slice(&[
+            NSString::from_str(UTI_TEXT),
+            NSString::from_str(UTI_FILE_URL),
+            NSString::from_str(UTI_URL),
+        ]);
+        let _: () = msg_send![view, registerForDraggedTypes: &*types];
+    }
+}
+
+/// Register `widget` as a drag source offering plain text.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_text(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_TEXT.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_swizzled(ptr) };
+}
+
+/// Register `widget` as a drag source offering a file path.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_file(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_FILE.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_swizzled(ptr) };
+}
+
+/// Register `widget` as a drag source offering a web URL.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_url(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_URL.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_swizzled(ptr) };
+}

--- a/crates/perry-ui-macos/src/lib.rs
+++ b/crates/perry-ui-macos/src/lib.rs
@@ -5,6 +5,7 @@ pub mod background;
 pub mod clipboard;
 pub mod crash_log;
 pub mod deeplinks;
+pub mod drag_drop;
 pub mod file_dialog;
 pub mod geolocation;
 pub mod image_picker;

--- a/crates/perry-ui-tvos/src/drag_drop.rs
+++ b/crates/perry-ui-tvos/src/drag_drop.rs
@@ -1,0 +1,34 @@
+//! Drag & drop FFI (issue #4773).
+//!
+//! Widget-level drag/drop setters exported by every `perry-ui-*` backend so
+//! that `widgetOnDrop` / `widgetSetDrag*` compile and link on every
+//! `--target`: codegen emits a single symbol name regardless of platform (see
+//! `crates/perry-dispatch/src/ui_table.rs`), so the symbol must exist in each
+//! platform's static library or the link fails.
+//!
+//! This backend currently provides no-op implementations. Native behavior is
+//! landed per platform as follow-up work (macOS AppKit `NSDraggingDestination`
+//! / `NSDraggingSource`, UIKit `UIDropInteraction` / `UIDragInteraction`,
+//! GTK4 `GtkDropTarget` / `GtkDragSource`, Win32 `IDropTarget` / `DoDragDrop`,
+//! Android `View.OnDragListener` / `startDragAndDrop`).
+
+/// Register `widget` as a drop destination. `callback` (a NaN-boxed closure)
+/// is invoked with a `{ text?, files?, urls? }` object describing the payload
+/// when text, files, or URLs are dropped onto the widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_on_drop(_widget: i64, _callback: f64) {}
+
+/// Register `widget` as a drag source offering plain text. `provider` (a
+/// NaN-boxed closure) returns the text payload when a drag begins.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_text(_widget: i64, _provider: f64) {}
+
+/// Register `widget` as a drag source offering a file. `provider` returns the
+/// absolute path of the file to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_file(_widget: i64, _provider: f64) {}
+
+/// Register `widget` as a drag source offering a web URL. `provider` returns
+/// the URL string to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_url(_widget: i64, _provider: f64) {}

--- a/crates/perry-ui-tvos/src/lib.rs
+++ b/crates/perry-ui-tvos/src/lib.rs
@@ -5,6 +5,7 @@ pub mod background;
 pub mod clipboard;
 pub mod crash_log;
 pub mod deeplinks_stub;
+pub mod drag_drop;
 pub mod file_dialog;
 pub mod issue_552_stub;
 pub mod keyboard;

--- a/crates/perry-ui-visionos/src/drag_drop.rs
+++ b/crates/perry-ui-visionos/src/drag_drop.rs
@@ -1,0 +1,422 @@
+//! UIKit drag & drop (issue #4773) — visionOS backend.
+//!
+//! visionOS shares iOS's UIKit drag/drop surface verbatim (`UIDragInteraction`
+//! / `UIDropInteraction` + `NSItemProvider`); this file is identical to the iOS
+//! backend. It is **compile-unverified in this environment** — the
+//! `aarch64-apple-visionos` target is tier-3 (requires nightly + `build-std`)
+//! and could not be checked here. Needs a visionOS build + manual testing.
+//!
+//! Widget-level drag/drop setters that attach behavior to an existing widget
+//! handle. Unlike AppKit, UIKit lets any `UIView` host drag/drop via
+//! `addInteraction:` — no subclassing/swizzling. We create a shared
+//! `UIDragInteraction` / `UIDropInteraction` delegate (one singleton each,
+//! mirroring `widgets/button.rs`'s `PerryButtonTarget` pattern), add the
+//! matching interaction to the target view, and key per-view state in
+//! thread-local side tables by the view pointer.
+//!
+//! Drop destination: the drop delegate advertises a copy operation and, on
+//! `performDrop`, loads `NSString` (→ `text`) and `NSURL` (file URLs → `files`,
+//! web URLs → `urls`) from the session via `loadObjectsOfClass:` and invokes
+//! the callback with a `{ text?, files?, urls? }` object.
+//!
+//! Drag source: the drag delegate returns `UIDragItem`s built from
+//! `NSItemProvider`s wrapping whichever `widgetSetDrag*` provider strings are
+//! registered (text → `NSString`, file → file `NSURL`, url → web `NSURL`).
+//!
+//! NOTE: compile-checked for `aarch64-apple-ios` but not behaviorally verified
+//! (drag gestures require a device/simulator session).
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, NSObject};
+use objc2::{class, define_class, msg_send, AnyThread, DefinedClass};
+use objc2_foundation::{NSArray, NSString};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::rc::Rc;
+
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_nanbox_pointer(ptr: i64) -> f64;
+    fn js_nanbox_string(ptr: i64) -> f64;
+    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+    fn js_object_alloc(class_id: u32, field_count: u32) -> *mut c_void;
+    fn js_object_set_field_by_name(obj: *mut c_void, key: *const c_void, value: f64);
+    fn js_array_alloc(capacity: u32) -> *mut c_void;
+    fn js_array_push_f64(arr: *mut c_void, value: f64) -> *mut c_void;
+    fn js_jsvalue_to_string(value: f64) -> *const u8;
+}
+
+// UIDropOperationCopy = 2.
+const UI_DROP_OPERATION_COPY: isize = 2;
+
+thread_local! {
+    static DROP_CB: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_TEXT: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_FILE: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_URL: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+fn str_from_header(ptr: *const u8) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let header = ptr as *const perry_runtime::string::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len)).to_string()
+    }
+}
+
+unsafe fn nanbox_str(s: &str) -> f64 {
+    let bytes = s.as_bytes();
+    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+    js_nanbox_string(ptr as i64)
+}
+
+fn js_key(name: &[u8]) -> *const c_void {
+    unsafe { js_string_from_bytes(name.as_ptr(), name.len() as i64) as *const c_void }
+}
+
+unsafe fn call_provider(cb: f64) -> Option<String> {
+    let p = js_nanbox_get_pointer(cb) as *const u8;
+    if p.is_null() {
+        return None;
+    }
+    let ret = js_closure_call0(p);
+    let sh = js_jsvalue_to_string(ret);
+    if sh.is_null() {
+        None
+    } else {
+        Some(str_from_header(sh))
+    }
+}
+
+/// The `interaction.view` pointer is the key into the side tables.
+unsafe fn interaction_view_key(interaction: *mut AnyObject) -> usize {
+    let view: *mut AnyObject = msg_send![interaction, view];
+    view as usize
+}
+
+// --- drop delegate -----------------------------------------------------------
+
+/// Zero-sized ivars — the delegate carries no per-instance state (all state
+/// lives in the thread-local side tables, keyed by view pointer).
+pub struct DragDropIvars;
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryDropDelegate"]
+    #[ivars = DragDropIvars]
+    pub struct PerryDropDelegate;
+
+    impl PerryDropDelegate {
+        #[unsafe(method(dropInteraction:canHandleSession:))]
+        fn can_handle(&self, interaction: *mut AnyObject, _session: *mut AnyObject) -> bool {
+            let key = unsafe { interaction_view_key(interaction) };
+            DROP_CB.with(|m| m.borrow().contains_key(&key))
+        }
+
+        #[unsafe(method(dropInteraction:sessionDidUpdate:))]
+        fn session_did_update(
+            &self,
+            _interaction: *mut AnyObject,
+            _session: *mut AnyObject,
+        ) -> *mut AnyObject {
+            // UIDropProposal(dropOperation: .copy), returned +0 (autoreleased).
+            unsafe {
+                let alloc: *mut AnyObject = msg_send![class!(UIDropProposal), alloc];
+                let proposal: *mut AnyObject =
+                    msg_send![alloc, initWithDropOperation: UI_DROP_OPERATION_COPY];
+                match Retained::from_raw(proposal) {
+                    Some(p) => Retained::autorelease_return(p),
+                    None => std::ptr::null_mut(),
+                }
+            }
+        }
+
+        #[unsafe(method(dropInteraction:performDrop:))]
+        fn perform_drop(&self, interaction: *mut AnyObject, session: *mut AnyObject) {
+            unsafe { perform_drop_impl(interaction, session) };
+        }
+    }
+);
+
+impl PerryDropDelegate {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(DragDropIvars);
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+unsafe fn perform_drop_impl(interaction: *mut AnyObject, session: *mut AnyObject) {
+    let key = interaction_view_key(interaction);
+    let Some(cb) = DROP_CB.with(|m| m.borrow().get(&key).copied()) else {
+        return;
+    };
+
+    // Accumulate the two async loads (strings, urls); fire the JS callback when
+    // both have completed.
+    struct Accum {
+        text: Option<String>,
+        files: Vec<String>,
+        urls: Vec<String>,
+        pending: u8,
+        cb: f64,
+    }
+    let accum = Rc::new(RefCell::new(Accum {
+        text: None,
+        files: Vec::new(),
+        urls: Vec::new(),
+        pending: 2,
+        cb,
+    }));
+
+    unsafe fn finish(accum: &Rc<RefCell<Accum>>) {
+        let mut a = accum.borrow_mut();
+        a.pending -= 1;
+        if a.pending != 0 {
+            return;
+        }
+        let obj = js_object_alloc(0, 3);
+        if obj.is_null() {
+            return;
+        }
+        if let Some(t) = &a.text {
+            js_object_set_field_by_name(obj, js_key(b"text"), nanbox_str(t));
+        }
+        if !a.files.is_empty() {
+            let mut arr = js_array_alloc(a.files.len() as u32);
+            for f in &a.files {
+                arr = js_array_push_f64(arr, nanbox_str(f));
+            }
+            js_object_set_field_by_name(obj, js_key(b"files"), js_nanbox_pointer(arr as i64));
+        }
+        if !a.urls.is_empty() {
+            let mut arr = js_array_alloc(a.urls.len() as u32);
+            for u in &a.urls {
+                arr = js_array_push_f64(arr, nanbox_str(u));
+            }
+            js_object_set_field_by_name(obj, js_key(b"urls"), js_nanbox_pointer(arr as i64));
+        }
+        let payload = js_nanbox_pointer(obj as i64);
+        let cb_ptr = js_nanbox_get_pointer(a.cb) as *const u8;
+        js_closure_call1(cb_ptr, payload);
+    }
+
+    // text
+    let a_text = accum.clone();
+    let block_text = block2::RcBlock::new(move |objs: *mut AnyObject| {
+        if !objs.is_null() {
+            let count: usize = unsafe { msg_send![objs, count] };
+            if count > 0 {
+                let s: *mut NSString = unsafe { msg_send![objs, objectAtIndex: 0usize] };
+                if !s.is_null() {
+                    a_text.borrow_mut().text = Some(unsafe { (*s).to_string() });
+                }
+            }
+        }
+        unsafe { finish(&a_text) };
+    });
+    let _: *mut AnyObject =
+        msg_send![session, loadObjectsOfClass: class!(NSString), completionHandler: &*block_text];
+
+    // urls (classified into file paths vs web urls)
+    let a_url = accum.clone();
+    let block_url = block2::RcBlock::new(move |objs: *mut AnyObject| {
+        if !objs.is_null() {
+            let count: usize = unsafe { msg_send![objs, count] };
+            for i in 0..count {
+                let url: *mut AnyObject = unsafe { msg_send![objs, objectAtIndex: i] };
+                if url.is_null() {
+                    continue;
+                }
+                let is_file: bool = unsafe { msg_send![url, isFileURL] };
+                let s: *mut NSString = if is_file {
+                    unsafe { msg_send![url, path] }
+                } else {
+                    unsafe { msg_send![url, absoluteString] }
+                };
+                if !s.is_null() {
+                    let rs = unsafe { (*s).to_string() };
+                    if is_file {
+                        a_url.borrow_mut().files.push(rs);
+                    } else {
+                        a_url.borrow_mut().urls.push(rs);
+                    }
+                }
+            }
+        }
+        unsafe { finish(&a_url) };
+    });
+    let _: *mut AnyObject =
+        msg_send![session, loadObjectsOfClass: class!(NSURL), completionHandler: &*block_url];
+}
+
+// --- drag delegate -----------------------------------------------------------
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryDragDelegate"]
+    #[ivars = DragDropIvars]
+    pub struct PerryDragDelegate;
+
+    impl PerryDragDelegate {
+        #[unsafe(method(dragInteraction:itemsForBeginningSession:))]
+        fn items_for_session(
+            &self,
+            interaction: *mut AnyObject,
+            _session: *mut AnyObject,
+        ) -> *mut NSArray {
+            // Returned +0 (autoreleased).
+            unsafe { Retained::autorelease_return(drag_items_impl(interaction)) }
+        }
+    }
+);
+
+impl PerryDragDelegate {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(DragDropIvars);
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+unsafe fn drag_items_impl(interaction: *mut AnyObject) -> Retained<NSArray> {
+    let key = interaction_view_key(interaction);
+    let mut items: Vec<Retained<AnyObject>> = Vec::new();
+
+    let mut add_item = |obj: *mut AnyObject| {
+        if obj.is_null() {
+            return;
+        }
+        let provider: *mut AnyObject = msg_send![class!(NSItemProvider), alloc];
+        let provider: *mut AnyObject = msg_send![provider, initWithObject: obj];
+        // Adopt the +1 from `initWithObject:`; UIDragItem retains it, so the
+        // provider is released back to that retain when `_provider` drops.
+        let _provider: Option<Retained<AnyObject>> = Retained::from_raw(provider);
+        let item: *mut AnyObject = msg_send![class!(UIDragItem), alloc];
+        let item: *mut AnyObject = msg_send![item, initWithItemProvider: provider];
+        // Adopt the +1 from `initWithItemProvider:`.
+        if let Some(retained) = Retained::from_raw(item) {
+            items.push(retained);
+        }
+    };
+
+    if let Some(cb) = DRAG_TEXT.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(s) = call_provider(cb) {
+            let ns = NSString::from_str(&s);
+            add_item(Retained::as_ptr(&ns) as *mut AnyObject);
+        }
+    }
+    if let Some(cb) = DRAG_FILE.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(path) = call_provider(cb) {
+            let url: *mut AnyObject =
+                msg_send![class!(NSURL), fileURLWithPath: &*NSString::from_str(&path)];
+            add_item(url);
+        }
+    }
+    if let Some(cb) = DRAG_URL.with(|m| m.borrow().get(&key).copied()) {
+        if let Some(s) = call_provider(cb) {
+            let url: *mut AnyObject =
+                msg_send![class!(NSURL), URLWithString: &*NSString::from_str(&s)];
+            add_item(url);
+        }
+    }
+
+    let refs: Vec<&AnyObject> = items.iter().map(|r| &**r).collect();
+    NSArray::from_slice(&refs)
+}
+
+// --- shared singletons + view helpers ----------------------------------------
+
+thread_local! {
+    static DROP_DELEGATE: RefCell<Option<Retained<PerryDropDelegate>>> = RefCell::new(None);
+    static DRAG_DELEGATE: RefCell<Option<Retained<PerryDragDelegate>>> = RefCell::new(None);
+    /// Views that already have a drop / drag interaction installed.
+    static DROP_INSTALLED: RefCell<std::collections::HashSet<usize>> =
+        RefCell::new(std::collections::HashSet::new());
+    static DRAG_INSTALLED: RefCell<std::collections::HashSet<usize>> =
+        RefCell::new(std::collections::HashSet::new());
+}
+
+fn view_ptr(handle: i64) -> Option<*mut AnyObject> {
+    let view = crate::widgets::get_widget(handle)?;
+    Some(Retained::as_ptr(&view) as *mut AnyObject)
+}
+
+unsafe fn ensure_drop_interaction(view: *mut AnyObject) {
+    if DROP_INSTALLED.with(|s| s.borrow().contains(&(view as usize))) {
+        return;
+    }
+    let delegate = DROP_DELEGATE.with(|d| {
+        d.borrow_mut()
+            .get_or_insert_with(PerryDropDelegate::new)
+            .clone()
+    });
+    let interaction: *mut AnyObject = msg_send![class!(UIDropInteraction), alloc];
+    let interaction: *mut AnyObject = msg_send![interaction, initWithDelegate: &*delegate];
+    let _: () = msg_send![view, addInteraction: interaction];
+    DROP_INSTALLED.with(|s| {
+        s.borrow_mut().insert(view as usize);
+    });
+}
+
+unsafe fn ensure_drag_interaction(view: *mut AnyObject) {
+    if DRAG_INSTALLED.with(|s| s.borrow().contains(&(view as usize))) {
+        return;
+    }
+    let delegate = DRAG_DELEGATE.with(|d| {
+        d.borrow_mut()
+            .get_or_insert_with(PerryDragDelegate::new)
+            .clone()
+    });
+    let interaction: *mut AnyObject = msg_send![class!(UIDragInteraction), alloc];
+    let interaction: *mut AnyObject = msg_send![interaction, initWithDelegate: &*delegate];
+    let _: () = msg_send![view, addInteraction: interaction];
+    // Drag interactions require user interaction enabled on the view.
+    let _: () = msg_send![view, setUserInteractionEnabled: true];
+    DRAG_INSTALLED.with(|s| {
+        s.borrow_mut().insert(view as usize);
+    });
+}
+
+// --- FFI ---------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_on_drop(widget: i64, callback: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DROP_CB.with(|m| {
+        m.borrow_mut().insert(ptr as usize, callback);
+    });
+    unsafe { ensure_drop_interaction(ptr) };
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_text(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_TEXT.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_drag_interaction(ptr) };
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_file(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_FILE.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_drag_interaction(ptr) };
+}
+
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_url(widget: i64, provider: f64) {
+    let Some(ptr) = view_ptr(widget) else { return };
+    DRAG_URL.with(|m| {
+        m.borrow_mut().insert(ptr as usize, provider);
+    });
+    unsafe { ensure_drag_interaction(ptr) };
+}

--- a/crates/perry-ui-visionos/src/lib.rs
+++ b/crates/perry-ui-visionos/src/lib.rs
@@ -6,6 +6,7 @@ pub mod camera;
 pub mod clipboard;
 pub mod crash_log;
 pub mod deeplinks_stub;
+pub mod drag_drop;
 pub mod file_dialog;
 #[cfg(feature = "geisterhand")]
 pub mod geisterhand_style;

--- a/crates/perry-ui-watchos/src/drag_drop.rs
+++ b/crates/perry-ui-watchos/src/drag_drop.rs
@@ -1,0 +1,34 @@
+//! Drag & drop FFI (issue #4773).
+//!
+//! Widget-level drag/drop setters exported by every `perry-ui-*` backend so
+//! that `widgetOnDrop` / `widgetSetDrag*` compile and link on every
+//! `--target`: codegen emits a single symbol name regardless of platform (see
+//! `crates/perry-dispatch/src/ui_table.rs`), so the symbol must exist in each
+//! platform's static library or the link fails.
+//!
+//! This backend currently provides no-op implementations. Native behavior is
+//! landed per platform as follow-up work (macOS AppKit `NSDraggingDestination`
+//! / `NSDraggingSource`, UIKit `UIDropInteraction` / `UIDragInteraction`,
+//! GTK4 `GtkDropTarget` / `GtkDragSource`, Win32 `IDropTarget` / `DoDragDrop`,
+//! Android `View.OnDragListener` / `startDragAndDrop`).
+
+/// Register `widget` as a drop destination. `callback` (a NaN-boxed closure)
+/// is invoked with a `{ text?, files?, urls? }` object describing the payload
+/// when text, files, or URLs are dropped onto the widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_on_drop(_widget: i64, _callback: f64) {}
+
+/// Register `widget` as a drag source offering plain text. `provider` (a
+/// NaN-boxed closure) returns the text payload when a drag begins.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_text(_widget: i64, _provider: f64) {}
+
+/// Register `widget` as a drag source offering a file. `provider` returns the
+/// absolute path of the file to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_file(_widget: i64, _provider: f64) {}
+
+/// Register `widget` as a drag source offering a web URL. `provider` returns
+/// the URL string to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_url(_widget: i64, _provider: f64) {}

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -8,6 +8,7 @@ pub mod app;
 pub mod audio;
 pub mod audio_playback;
 pub mod background;
+pub mod drag_drop;
 pub mod media_playback;
 pub mod state;
 pub mod tree;

--- a/crates/perry-ui-windows/Cargo.toml
+++ b/crates/perry-ui-windows/Cargo.toml
@@ -35,6 +35,9 @@ geisterhand = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [
+    # `#[implement]` — needed to author the IDropTarget / IDropSource /
+    # IDataObject COM objects for native drag-and-drop (#4773).
+    "implement",
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Controls",
@@ -44,6 +47,8 @@ windows = { version = "0.58", features = [
     "Win32_System_DataExchange",
     "Win32_System_Ole",
     "Win32_System_Com",
+    # STGMEDIUM / IDataObject marshalling for native drag-and-drop (#4773).
+    "Win32_System_Com_StructuredStorage",
     "Win32_System_Memory",
     "Win32_System_SystemServices",
     "Win32_UI_HiDpi",

--- a/crates/perry-ui-windows/src/drag_drop.rs
+++ b/crates/perry-ui-windows/src/drag_drop.rs
@@ -1,0 +1,778 @@
+//! Win32 drag & drop for `perry/ui` (issue #4773).
+//!
+//! **Compile-unverified here:** this file is written on macOS where the
+//! `x86_64-pc-windows-msvc` target cannot be `cargo check`ed in the sandbox
+//! (the `windows` crate's Win32 bindings only compile for a Windows target).
+//! The COM/Win32 code is modelled on the crate's existing OLE usage
+//! (`dialog.rs`, `file_dialog.rs`) and subclass usage (`pointer.rs`,
+//! `widgets/mod.rs`); it still needs an on-device build + smoke test.
+//!
+//! Widget-level drag/drop setters that attach behavior to an existing widget
+//! handle (1-based index into the `widgets` registry → HWND via
+//! `crate::widgets::get_hwnd`).
+//!
+//! ## Drop destination — `perry_ui_widget_on_drop`
+//! Registers an [`IDropTarget`] COM object on the widget's HWND via
+//! `RegisterDragDrop`. On `Drop`, the carried [`IDataObject`] is queried for
+//! `CF_UNICODETEXT` → `text`, `CF_HDROP` (via `DragQueryFileW`) → `files`,
+//! and the `CFSTR_INETURLW` ("UniformResourceLocatorW") format → `urls`. A
+//! `{ text?, files?, urls? }` JS object is built and the callback invoked.
+//! `DragEnter`/`DragOver` advertise `DROPEFFECT_COPY`.
+//!
+//! ## Drag source — `perry_ui_widget_set_drag_*`
+//! Each setter records a provider closure in a thread-local side table keyed
+//! by HWND, then subclasses the widget's HWND (same pattern as `pointer.rs`)
+//! so we can intercept `WM_LBUTTONDOWN`. On left-button-down for a widget
+//! that has at least one provider, we call the providers (0-arg, returning a
+//! string), build an in-process [`IDataObject`] holding the requested clipboard
+//! formats, and call `DoDragDrop` with an [`IDropSource`] advertising
+//! `DROPEFFECT_COPY`. When no provider is registered the message is forwarded
+//! to `DefSubclassProc`, so interactive controls keep working.
+//!
+//! ## Window-proc glue
+//! Drag *source* support needs to see mouse-down on the widget, which this
+//! module installs itself via `SetWindowSubclass` (no extra wiring in the
+//! crate's main WndProc). Drop *destination* support is entirely
+//! `RegisterDragDrop`-driven and needs no WndProc changes. `OleInitialize` is
+//! called once on first use (idempotent; tolerates a prior `CoInitializeEx`
+//! apartment as `RPC_E_CHANGED_MODE`/`S_FALSE`).
+
+#[cfg(target_os = "windows")]
+use std::cell::RefCell;
+#[cfg(target_os = "windows")]
+use std::collections::{HashMap, HashSet};
+#[cfg(target_os = "windows")]
+use std::sync::Once;
+
+// The runtime FFI and JS-marshalling helpers below are only referenced by the
+// Windows drag/drop implementation; gate them so non-Windows hosts don't warn
+// about unused items.
+#[cfg(target_os = "windows")]
+extern "C" {
+    fn js_closure_call0(closure: *const u8) -> f64;
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    fn js_nanbox_pointer(ptr: i64) -> f64;
+    fn js_nanbox_string(ptr: i64) -> f64;
+    fn js_string_from_bytes(data: *const u8, len: u32) -> *mut perry_runtime::string::StringHeader;
+    fn js_object_alloc(class_id: u32, field_count: u32)
+        -> *mut perry_runtime::object::ObjectHeader;
+    fn js_object_set_field_by_name(
+        obj: *mut perry_runtime::object::ObjectHeader,
+        key: *const perry_runtime::string::StringHeader,
+        value: f64,
+    );
+    fn js_array_alloc(capacity: u32) -> *mut perry_runtime::array::ArrayHeader;
+    fn js_array_push_f64(
+        arr: *mut perry_runtime::array::ArrayHeader,
+        value: f64,
+    ) -> *mut perry_runtime::array::ArrayHeader;
+    fn js_jsvalue_to_string(value: f64) -> *mut perry_runtime::string::StringHeader;
+}
+
+// ---------------------------------------------------------------------------
+// JS-side marshalling helpers (mirror macOS drag_drop.rs).
+// ---------------------------------------------------------------------------
+
+/// Read a Rust `String` from a runtime `StringHeader` pointer (same layout as
+/// `clipboard.rs` / `dialog.rs`).
+#[cfg(target_os = "windows")]
+fn str_from_header(ptr: *const perry_runtime::string::StringHeader) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data =
+            (ptr as *const u8).add(std::mem::size_of::<perry_runtime::string::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len)).to_string()
+    }
+}
+
+/// NaN-box a Rust `&str` as a JS string value.
+#[cfg(target_os = "windows")]
+unsafe fn nanbox_str(s: &str) -> f64 {
+    let bytes = s.as_bytes();
+    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    js_nanbox_string(ptr as i64)
+}
+
+/// Build a property-key `StringHeader` for `js_object_set_field_by_name`.
+#[cfg(target_os = "windows")]
+fn js_key(name: &[u8]) -> *const perry_runtime::string::StringHeader {
+    unsafe { js_string_from_bytes(name.as_ptr(), name.len() as u32) }
+}
+
+/// Call a provider closure (0-arg) and coerce its return value to a Rust
+/// `String`. Returns `None` if the closure pointer is null.
+#[cfg(target_os = "windows")]
+unsafe fn call_provider(cb: f64) -> Option<String> {
+    let p = js_nanbox_get_pointer(cb);
+    if p == 0 {
+        return None;
+    }
+    let ret = js_closure_call0(p as *const u8);
+    let sh = js_jsvalue_to_string(ret);
+    if sh.is_null() {
+        None
+    } else {
+        Some(str_from_header(sh))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Side tables (keyed by HWND-as-usize so the same widget's registrations
+// coalesce regardless of how many times the FFI is called).
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+thread_local! {
+    /// Drop callback (NaN-boxed closure) per droppable HWND.
+    static DROP_CB: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    /// Drag-source providers (NaN-boxed closures) per source HWND.
+    static DRAG_TEXT: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_FILE: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static DRAG_URL: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    /// HWNDs already registered as drop targets (so we don't double-register).
+    static DROP_REGISTERED: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+    /// HWNDs whose drag-source subclass proc is installed.
+    static DRAG_SUBCLASSED: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+}
+
+#[cfg(target_os = "windows")]
+fn has_any_drag_source(key: usize) -> bool {
+    DRAG_TEXT.with(|m| m.borrow().contains_key(&key))
+        || DRAG_FILE.with(|m| m.borrow().contains_key(&key))
+        || DRAG_URL.with(|m| m.borrow().contains_key(&key))
+}
+
+// ===========================================================================
+// Windows implementation.
+// ===========================================================================
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::*;
+    use windows::core::{implement, PCWSTR};
+    use windows::Win32::Foundation::{
+        BOOL, DRAGDROP_S_CANCEL, DRAGDROP_S_DROP, DRAGDROP_S_USEDEFAULTCURSORS, DV_E_FORMATETC,
+        DV_E_TYMED, E_NOTIMPL, HGLOBAL, HWND, LPARAM, LRESULT, OLE_E_ADVISENOTSUPPORTED, POINT,
+        POINTL, S_OK, WPARAM,
+    };
+    use windows::Win32::System::Com::{
+        IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumSTATDATA,
+        DVASPECT_CONTENT, FORMATETC, STGMEDIUM, TYMED_HGLOBAL,
+    };
+    use windows::Win32::System::DataExchange::RegisterClipboardFormatW;
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows::Win32::System::Ole::{
+        DoDragDrop, IDropSource, IDropSource_Impl, IDropTarget, IDropTarget_Impl, OleInitialize,
+        RegisterDragDrop, ReleaseStgMedium, CF_HDROP, CF_UNICODETEXT, DROPEFFECT, DROPEFFECT_COPY,
+        DROPEFFECT_NONE,
+    };
+    use windows::Win32::System::SystemServices::{MK_LBUTTON, MODIFIERKEYS_FLAGS};
+    use windows::Win32::UI::Shell::{DefSubclassProc, DragQueryFileW, SetWindowSubclass, HDROP};
+    use windows::Win32::UI::WindowsAndMessaging::WM_LBUTTONDOWN;
+
+    const DRAG_SUBCLASS_ID: usize = 0xDD_4773;
+
+    /// Ensure the OLE drag-and-drop runtime is initialized for this thread.
+    /// `OleInitialize` is idempotent per thread and returns `S_FALSE` /
+    /// `RPC_E_CHANGED_MODE` when an apartment already exists (the file dialogs
+    /// call `CoInitializeEx(APARTMENTTHREADED)`), both of which are fine — OLE
+    /// drag-and-drop only requires an STA, which APARTMENTTHREADED provides.
+    fn ensure_ole_initialized() {
+        static OLE_INIT: Once = Once::new();
+        OLE_INIT.call_once(|| unsafe {
+            let _ = OleInitialize(None);
+        });
+    }
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    /// The Windows shell URL clipboard format ("UniformResourceLocatorW").
+    fn url_clipboard_format() -> u16 {
+        let name = to_wide("UniformResourceLocatorW");
+        unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) as u16 }
+    }
+
+    /// Allocate a movable `HGLOBAL` holding `bytes` and return the handle.
+    unsafe fn hglobal_from_bytes(bytes: &[u8]) -> windows::core::Result<HGLOBAL> {
+        let h = GlobalAlloc(GMEM_MOVEABLE, bytes.len())?;
+        let dst = GlobalLock(h);
+        if !dst.is_null() {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst as *mut u8, bytes.len());
+            let _ = GlobalUnlock(h);
+        }
+        Ok(h)
+    }
+
+    // -----------------------------------------------------------------------
+    // IDataObject — minimal in-process data object for the drag SOURCE.
+    // -----------------------------------------------------------------------
+
+    /// One offered representation: (clipboard format id, raw HGLOBAL bytes).
+    struct StoredFormat {
+        cf: u16,
+        bytes: Vec<u8>,
+    }
+
+    #[implement(IDataObject)]
+    struct PerryDataObject {
+        formats: Vec<StoredFormat>,
+    }
+
+    impl PerryDataObject {
+        fn matches(&self, fmt: &FORMATETC) -> Option<&StoredFormat> {
+            if fmt.dwAspect != DVASPECT_CONTENT.0 as u32 {
+                return None;
+            }
+            if fmt.tymed & TYMED_HGLOBAL.0 as u32 == 0 {
+                return None;
+            }
+            self.formats
+                .iter()
+                .find(|f| f.cf as u32 == fmt.cfFormat as u32)
+        }
+    }
+
+    #[allow(non_snake_case)]
+    impl IDataObject_Impl for PerryDataObject {
+        fn GetData(&self, pformatetcin: *const FORMATETC) -> windows::core::Result<STGMEDIUM> {
+            let fmt = unsafe { &*pformatetcin };
+            let Some(stored) = self.matches(fmt) else {
+                return Err(DV_E_FORMATETC.into());
+            };
+            unsafe {
+                let h = hglobal_from_bytes(&stored.bytes)?;
+                Ok(STGMEDIUM {
+                    tymed: TYMED_HGLOBAL.0 as u32,
+                    u: windows::Win32::System::Com::STGMEDIUM_0 { hGlobal: h },
+                    pUnkForRelease: std::mem::ManuallyDrop::new(None),
+                })
+            }
+        }
+
+        fn GetDataHere(
+            &self,
+            _pformatetc: *const FORMATETC,
+            _pmedium: *mut STGMEDIUM,
+        ) -> windows::core::Result<()> {
+            Err(E_NOTIMPL.into())
+        }
+
+        fn QueryGetData(&self, pformatetc: *const FORMATETC) -> windows::core::HRESULT {
+            let fmt = unsafe { &*pformatetc };
+            if self.matches(fmt).is_some() {
+                S_OK
+            } else if fmt.tymed & TYMED_HGLOBAL.0 as u32 == 0 {
+                DV_E_TYMED
+            } else {
+                DV_E_FORMATETC
+            }
+        }
+
+        fn GetCanonicalFormatEtc(
+            &self,
+            _pformatectin: *const FORMATETC,
+            pformatetcout: *mut FORMATETC,
+        ) -> windows::core::HRESULT {
+            if !pformatetcout.is_null() {
+                unsafe {
+                    (*pformatetcout).ptd = std::ptr::null_mut();
+                }
+            }
+            E_NOTIMPL
+        }
+
+        fn SetData(
+            &self,
+            _pformatetc: *const FORMATETC,
+            _pmedium: *const STGMEDIUM,
+            _frelease: BOOL,
+        ) -> windows::core::Result<()> {
+            Err(E_NOTIMPL.into())
+        }
+
+        fn EnumFormatEtc(&self, _dwdirection: u32) -> windows::core::Result<IEnumFORMATETC> {
+            // A real enumerator is optional for in-process source data objects;
+            // targets we hand off to (Explorer, editors) call QueryGetData with
+            // the formats they want. Return E_NOTIMPL like many sample sources.
+            Err(E_NOTIMPL.into())
+        }
+
+        fn DAdvise(
+            &self,
+            _pformatetc: *const FORMATETC,
+            _advf: u32,
+            _padvsink: Option<&IAdviseSink>,
+        ) -> windows::core::Result<u32> {
+            Err(OLE_E_ADVISENOTSUPPORTED.into())
+        }
+
+        fn DUnadvise(&self, _dwconnection: u32) -> windows::core::Result<()> {
+            Err(OLE_E_ADVISENOTSUPPORTED.into())
+        }
+
+        fn EnumDAdvise(&self) -> windows::core::Result<IEnumSTATDATA> {
+            Err(OLE_E_ADVISENOTSUPPORTED.into())
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // IDropSource — copy-only, ends on left-button release.
+    // -----------------------------------------------------------------------
+
+    #[implement(IDropSource)]
+    struct PerryDropSource;
+
+    #[allow(non_snake_case)]
+    impl IDropSource_Impl for PerryDropSource {
+        fn QueryContinueDrag(
+            &self,
+            fescapepressed: BOOL,
+            grfkeystate: MODIFIERKEYS_FLAGS,
+        ) -> windows::core::HRESULT {
+            if fescapepressed.as_bool() {
+                return DRAGDROP_S_CANCEL;
+            }
+            // Left button released → drop.
+            if grfkeystate.0 & MK_LBUTTON.0 == 0 {
+                return DRAGDROP_S_DROP;
+            }
+            S_OK
+        }
+
+        fn GiveFeedback(&self, _dweffect: DROPEFFECT) -> windows::core::HRESULT {
+            DRAGDROP_S_USEDEFAULTCURSORS
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // IDropTarget — accepts CF_UNICODETEXT / CF_HDROP / URL, copy effect.
+    // -----------------------------------------------------------------------
+
+    #[implement(IDropTarget)]
+    struct PerryDropTarget {
+        /// HWND key into `DROP_CB` (so the callback can be looked up at Drop
+        /// time, after any re-registration).
+        hwnd_key: usize,
+    }
+
+    #[allow(non_snake_case)]
+    impl IDropTarget_Impl for PerryDropTarget {
+        fn DragEnter(
+            &self,
+            _pdataobj: Option<&IDataObject>,
+            _grfkeystate: MODIFIERKEYS_FLAGS,
+            _pt: &POINTL,
+            pdweffect: *mut DROPEFFECT,
+        ) -> windows::core::Result<()> {
+            unsafe {
+                if !pdweffect.is_null() {
+                    *pdweffect = DROPEFFECT_COPY;
+                }
+            }
+            Ok(())
+        }
+
+        fn DragOver(
+            &self,
+            _grfkeystate: MODIFIERKEYS_FLAGS,
+            _pt: &POINTL,
+            pdweffect: *mut DROPEFFECT,
+        ) -> windows::core::Result<()> {
+            unsafe {
+                if !pdweffect.is_null() {
+                    *pdweffect = DROPEFFECT_COPY;
+                }
+            }
+            Ok(())
+        }
+
+        fn DragLeave(&self) -> windows::core::Result<()> {
+            Ok(())
+        }
+
+        fn Drop(
+            &self,
+            pdataobj: Option<&IDataObject>,
+            _grfkeystate: MODIFIERKEYS_FLAGS,
+            _pt: &POINTL,
+            pdweffect: *mut DROPEFFECT,
+        ) -> windows::core::Result<()> {
+            unsafe {
+                if !pdweffect.is_null() {
+                    *pdweffect = DROPEFFECT_COPY;
+                }
+            }
+            let cb = DROP_CB.with(|m| m.borrow().get(&self.hwnd_key).copied());
+            let Some(cb) = cb else {
+                return Ok(());
+            };
+            let Some(data) = pdataobj else {
+                return Ok(());
+            };
+            unsafe {
+                dispatch_drop(data, cb);
+            }
+            Ok(())
+        }
+    }
+
+    /// Read text / file / url representations off `data` and invoke `cb` with a
+    /// `{ text?, files?, urls? }` object.
+    unsafe fn dispatch_drop(data: &IDataObject, cb: f64) {
+        let obj = js_object_alloc(0, 3);
+        if obj.is_null() {
+            return;
+        }
+
+        // text — CF_UNICODETEXT
+        if let Some(text) = read_text(data) {
+            js_object_set_field_by_name(obj, js_key(b"text"), nanbox_str(&text));
+        }
+
+        // files — CF_HDROP via DragQueryFileW
+        let files = read_files(data);
+        if !files.is_empty() {
+            let mut arr = js_array_alloc(files.len() as u32);
+            for f in &files {
+                arr = js_array_push_f64(arr, nanbox_str(f));
+            }
+            js_object_set_field_by_name(obj, js_key(b"files"), js_nanbox_pointer(arr as i64));
+        }
+
+        // urls — UniformResourceLocatorW
+        if let Some(url) = read_url(data) {
+            let mut arr = js_array_alloc(1);
+            arr = js_array_push_f64(arr, nanbox_str(&url));
+            js_object_set_field_by_name(obj, js_key(b"urls"), js_nanbox_pointer(arr as i64));
+        }
+
+        let payload = js_nanbox_pointer(obj as i64);
+        let cb_ptr = js_nanbox_get_pointer(cb);
+        if cb_ptr != 0 {
+            js_closure_call1(cb_ptr as *const u8, payload);
+        }
+    }
+
+    fn make_formatetc(cf: u16) -> FORMATETC {
+        FORMATETC {
+            cfFormat: cf,
+            ptd: std::ptr::null_mut(),
+            dwAspect: DVASPECT_CONTENT.0 as u32,
+            lindex: -1,
+            tymed: TYMED_HGLOBAL.0 as u32,
+        }
+    }
+
+    /// Pull a UTF-16 string out of a CF-format HGLOBAL medium. The medium's
+    /// payload is treated as a NUL-terminated wide string.
+    unsafe fn read_wide_string(data: &IDataObject, cf: u16) -> Option<String> {
+        let fmt = make_formatetc(cf);
+        let medium = data.GetData(&fmt).ok()?;
+        if medium.tymed != TYMED_HGLOBAL.0 as u32 {
+            ReleaseStgMedium(&medium as *const _ as *mut _);
+            return None;
+        }
+        let h = medium.u.hGlobal;
+        let result = {
+            let p = GlobalLock(h) as *const u16;
+            if p.is_null() {
+                None
+            } else {
+                let mut len = 0usize;
+                while *p.add(len) != 0 {
+                    len += 1;
+                }
+                let wide = std::slice::from_raw_parts(p, len);
+                let s = String::from_utf16_lossy(wide);
+                let _ = GlobalUnlock(h);
+                Some(s)
+            }
+        };
+        ReleaseStgMedium(&medium as *const _ as *mut _);
+        result
+    }
+
+    unsafe fn read_text(data: &IDataObject) -> Option<String> {
+        read_wide_string(data, CF_UNICODETEXT.0 as u16)
+    }
+
+    unsafe fn read_url(data: &IDataObject) -> Option<String> {
+        read_wide_string(data, url_clipboard_format())
+    }
+
+    /// Read dropped file paths from a CF_HDROP medium via `DragQueryFileW`.
+    unsafe fn read_files(data: &IDataObject) -> Vec<String> {
+        let mut out = Vec::new();
+        let fmt = make_formatetc(CF_HDROP.0 as u16);
+        let Ok(medium) = data.GetData(&fmt) else {
+            return out;
+        };
+        if medium.tymed == TYMED_HGLOBAL.0 as u32 {
+            let h = medium.u.hGlobal;
+            let locked = GlobalLock(h);
+            if !locked.is_null() {
+                let hdrop = HDROP(locked);
+                let count = DragQueryFileW(hdrop, 0xFFFF_FFFF, None);
+                for i in 0..count {
+                    // First call with empty buffer returns the char count.
+                    let needed = DragQueryFileW(hdrop, i, None);
+                    if needed == 0 {
+                        continue;
+                    }
+                    let mut buf = vec![0u16; needed as usize + 1];
+                    let written = DragQueryFileW(hdrop, i, Some(&mut buf));
+                    if written > 0 {
+                        out.push(String::from_utf16_lossy(&buf[..written as usize]));
+                    }
+                }
+                let _ = GlobalUnlock(h);
+            }
+        }
+        ReleaseStgMedium(&medium as *const _ as *mut _);
+        out
+    }
+
+    // -----------------------------------------------------------------------
+    // Drag source: subclass the widget HWND to intercept WM_LBUTTONDOWN.
+    // -----------------------------------------------------------------------
+
+    pub(super) fn install_drag_subclass(hwnd: HWND) {
+        let key = hwnd.0 as usize;
+        let already = DRAG_SUBCLASSED.with(|s| s.borrow().contains(&key));
+        if already {
+            return;
+        }
+        unsafe {
+            let _ = SetWindowSubclass(hwnd, Some(drag_subclass_proc), DRAG_SUBCLASS_ID, 0);
+        }
+        DRAG_SUBCLASSED.with(|s| {
+            s.borrow_mut().insert(key);
+        });
+    }
+
+    unsafe extern "system" fn drag_subclass_proc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+        _id: usize,
+        _refdata: usize,
+    ) -> LRESULT {
+        if msg == WM_LBUTTONDOWN {
+            let key = hwnd.0 as usize;
+            if has_any_drag_source(key) {
+                start_drag(key);
+                // Drag handled the gesture; don't forward the button-down (the
+                // OLE drag loop owns the mouse until release).
+                return LRESULT(0);
+            }
+        }
+        DefSubclassProc(hwnd, msg, wparam, lparam)
+    }
+
+    /// Build the data object from whatever providers are registered for `key`
+    /// and run the OLE drag loop.
+    fn start_drag(key: usize) {
+        ensure_ole_initialized();
+
+        let mut formats: Vec<StoredFormat> = Vec::new();
+
+        // text → CF_UNICODETEXT (UTF-16, NUL-terminated bytes)
+        if let Some(cb) = DRAG_TEXT.with(|m| m.borrow().get(&key).copied()) {
+            if let Some(s) = unsafe { call_provider(cb) } {
+                formats.push(StoredFormat {
+                    cf: CF_UNICODETEXT.0 as u16,
+                    bytes: wide_bytes(&s),
+                });
+            }
+        }
+        // file → CF_HDROP (DROPFILES header + double-NUL-terminated wide paths)
+        if let Some(cb) = DRAG_FILE.with(|m| m.borrow().get(&key).copied()) {
+            if let Some(path) = unsafe { call_provider(cb) } {
+                formats.push(StoredFormat {
+                    cf: CF_HDROP.0 as u16,
+                    bytes: build_hdrop(&[path]),
+                });
+            }
+        }
+        // url → UniformResourceLocatorW (UTF-16, NUL-terminated)
+        if let Some(cb) = DRAG_URL.with(|m| m.borrow().get(&key).copied()) {
+            if let Some(s) = unsafe { call_provider(cb) } {
+                formats.push(StoredFormat {
+                    cf: url_clipboard_format(),
+                    bytes: wide_bytes(&s),
+                });
+            }
+        }
+
+        if formats.is_empty() {
+            return;
+        }
+
+        let data: IDataObject = PerryDataObject { formats }.into();
+        let source: IDropSource = PerryDropSource.into();
+        let mut effect = DROPEFFECT_NONE;
+        unsafe {
+            let _ = DoDragDrop(&data, &source, DROPEFFECT_COPY, &mut effect);
+        }
+    }
+
+    /// UTF-16 NUL-terminated bytes for a string (little-endian, native).
+    fn wide_bytes(s: &str) -> Vec<u8> {
+        let wide: Vec<u16> = s.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut bytes = Vec::with_capacity(wide.len() * 2);
+        for w in wide {
+            bytes.extend_from_slice(&w.to_ne_bytes());
+        }
+        bytes
+    }
+
+    /// Build a CF_HDROP payload: a `DROPFILES` header followed by the
+    /// double-NUL-terminated list of wide file paths.
+    fn build_hdrop(paths: &[String]) -> Vec<u8> {
+        use windows::Win32::UI::Shell::DROPFILES;
+        let header_size = std::mem::size_of::<DROPFILES>();
+        let mut list: Vec<u16> = Vec::new();
+        for p in paths {
+            list.extend(p.encode_utf16());
+            list.push(0);
+        }
+        list.push(0); // final double-NUL terminator
+
+        let mut out = vec![0u8; header_size + list.len() * 2];
+        let df = DROPFILES {
+            pFiles: header_size as u32,
+            pt: POINT { x: 0, y: 0 },
+            fNC: BOOL(0),
+            fWide: BOOL(1),
+        };
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                &df as *const DROPFILES as *const u8,
+                out.as_mut_ptr(),
+                header_size,
+            );
+            std::ptr::copy_nonoverlapping(
+                list.as_ptr() as *const u8,
+                out.as_mut_ptr().add(header_size),
+                list.len() * 2,
+            );
+        }
+        out
+    }
+
+    // -----------------------------------------------------------------------
+    // Drop target registration.
+    // -----------------------------------------------------------------------
+
+    pub(super) fn register_drop_target(hwnd: HWND) {
+        ensure_ole_initialized();
+        let key = hwnd.0 as usize;
+        let already = DROP_REGISTERED.with(|s| s.borrow().contains(&key));
+        if already {
+            return;
+        }
+        let target: IDropTarget = PerryDropTarget { hwnd_key: key }.into();
+        unsafe {
+            // RegisterDragDrop holds a reference to the target for the HWND's
+            // lifetime; leak our local strong ref so it stays alive.
+            if RegisterDragDrop(hwnd, &target).is_ok() {
+                std::mem::forget(target);
+                DROP_REGISTERED.with(|s| {
+                    s.borrow_mut().insert(key);
+                });
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// FFI surface — identical symbols on every platform.
+// ===========================================================================
+
+/// Register `widget` as a drop destination. `callback` (a NaN-boxed closure)
+/// is invoked with a `{ text?, files?, urls? }` object describing the payload
+/// when text, files, or URLs are dropped onto the widget.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_on_drop(widget: i64, callback: f64) {
+    #[cfg(target_os = "windows")]
+    {
+        let Some(hwnd) = crate::widgets::get_hwnd(widget) else {
+            return;
+        };
+        DROP_CB.with(|m| {
+            m.borrow_mut().insert(hwnd.0 as usize, callback);
+        });
+        imp::register_drop_target(hwnd);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (widget, callback);
+    }
+}
+
+/// Register `widget` as a drag source offering plain text. `provider` (a
+/// NaN-boxed closure) returns the text payload when a drag begins.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_text(widget: i64, provider: f64) {
+    #[cfg(target_os = "windows")]
+    {
+        let Some(hwnd) = crate::widgets::get_hwnd(widget) else {
+            return;
+        };
+        DRAG_TEXT.with(|m| {
+            m.borrow_mut().insert(hwnd.0 as usize, provider);
+        });
+        imp::install_drag_subclass(hwnd);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (widget, provider);
+    }
+}
+
+/// Register `widget` as a drag source offering a file. `provider` returns the
+/// absolute path of the file to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_file(widget: i64, provider: f64) {
+    #[cfg(target_os = "windows")]
+    {
+        let Some(hwnd) = crate::widgets::get_hwnd(widget) else {
+            return;
+        };
+        DRAG_FILE.with(|m| {
+            m.borrow_mut().insert(hwnd.0 as usize, provider);
+        });
+        imp::install_drag_subclass(hwnd);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (widget, provider);
+    }
+}
+
+/// Register `widget` as a drag source offering a web URL. `provider` returns
+/// the URL string to carry.
+#[no_mangle]
+pub extern "C" fn perry_ui_widget_set_drag_url(widget: i64, provider: f64) {
+    #[cfg(target_os = "windows")]
+    {
+        let Some(hwnd) = crate::widgets::get_hwnd(widget) else {
+            return;
+        };
+        DRAG_URL.with(|m| {
+            m.borrow_mut().insert(hwnd.0 as usize, provider);
+        });
+        imp::install_drag_subclass(hwnd);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (widget, provider);
+    }
+}

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -4,6 +4,7 @@ pub mod audio_playback;
 pub mod deeplinks_stub;
 #[cfg(target_os = "windows")]
 pub mod dpi_compat;
+pub mod drag_drop;
 #[cfg(target_os = "windows")]
 pub mod dwm;
 pub mod issue_552_stub;

--- a/test-files/test_ui_drag_drop.ts
+++ b/test-files/test_ui_drag_drop.ts
@@ -1,0 +1,42 @@
+// Drag & drop API smoke test (issue #4773).
+//
+// Exercises the Phase-0 surface: the four widget-level drag/drop setters must
+// compile through codegen (PERRY_UI_TABLE dispatch) and link against the
+// platform backend's FFI symbols. On macOS the backend is currently a no-op,
+// so this verifies the call path end-to-end (compile + link + run) rather than
+// the native drag behavior itself.
+
+import {
+  App, VStack, Text,
+  widgetOnDrop, widgetSetDragText, widgetSetDragFile, widgetSetDragUrl,
+  type DropData,
+} from "perry/ui"
+
+// A drop destination: logs whatever payload is dropped onto it.
+const dropZone = Text("Drop text / files / links here")
+widgetOnDrop(dropZone, (data: DropData) => {
+  if (data.text !== undefined) {
+    console.log("dropped text:", data.text)
+  }
+  if (data.files !== undefined) {
+    console.log("dropped files:", data.files.join(", "))
+  }
+  if (data.urls !== undefined) {
+    console.log("dropped urls:", data.urls.join(", "))
+  }
+})
+
+// A drag source offering three representations of the same drag.
+const dragSource = Text("Drag me out")
+widgetSetDragText(dragSource, () => "hello from perry")
+widgetSetDragFile(dragSource, () => "/tmp/perry-drag-sample.txt")
+widgetSetDragUrl(dragSource, () => "https://perryts.com")
+
+console.log("drag/drop wired")
+
+App({
+  title: "Drag & Drop Test",
+  width: 360,
+  height: 200,
+  body: VStack(16, [dropZone, dragSource]),
+})

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -1492,6 +1492,50 @@ export function clipboardRead(): string;
 export function clipboardWrite(text: string): void;
 
 // ---------------------------------------------------------------------------
+// Drag & drop (issue #4773)
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload delivered to a {@link widgetOnDrop} handler. Each field is present
+ * only when the drag carried that representation:
+ *  - `text` — plain text (`public.utf8-plain-text`)
+ *  - `files` — absolute paths of dropped files (`public.file-url`)
+ *  - `urls` — web links (`public.url`)
+ */
+export interface DropData {
+  text?: string;
+  files?: string[];
+  urls?: string[];
+}
+
+/**
+ * Make `widget` a drop destination. `handler` fires when text, files, or URLs
+ * are dragged onto the widget, receiving a {@link DropData} describing the
+ * payload. The drop defaults to a "copy" operation.
+ */
+export function widgetOnDrop(widget: Widget, handler: (data: DropData) => void): void;
+
+/**
+ * Make `widget` a drag source that offers plain text. `provider` is called
+ * when a drag begins and returns the text to carry (`public.utf8-plain-text`).
+ * May be combined with {@link widgetSetDragFile} / {@link widgetSetDragUrl} to
+ * offer multiple representations of the same drag.
+ */
+export function widgetSetDragText(widget: Widget, provider: () => string): void;
+
+/**
+ * Make `widget` a drag source that offers a file. `provider` returns the
+ * absolute path of the file to carry (`public.file-url`).
+ */
+export function widgetSetDragFile(widget: Widget, provider: () => string): void;
+
+/**
+ * Make `widget` a drag source that offers a web link. `provider` returns the
+ * URL string to carry (`public.url`).
+ */
+export function widgetSetDragUrl(widget: Widget, provider: () => string): void;
+
+// ---------------------------------------------------------------------------
 // Dialogs
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #4773.

Adds `perry/ui` drag-and-drop: a widget can be both a **drop destination** (receive text/files/URLs dragged in) and a **drag source** (drag text/file/URL out). Wired through codegen once; implemented natively per backend.

## TypeScript surface (`types/perry/ui/index.d.ts`)
```ts
interface DropData { text?: string; files?: string[]; urls?: string[] }
widgetOnDrop(widget, (data: DropData) => void): void   // drop destination
widgetSetDragText(widget, () => string): void          // drag source: text
widgetSetDragFile(widget, () => string): void          // drag source: file path
widgetSetDragUrl(widget,  () => string): void          // drag source: web URL
```
The drop callback receives a `{ text?, files?, urls? }` object built natively; each drag-source provider returns the payload string for its representation. Multiple `widgetSetDrag*` can be combined on one widget.

## Codegen
Four rows in `PERRY_UI_TABLE` (`crates/perry-dispatch/src/ui_table.rs`) map the TS names to `perry_ui_widget_on_drop` / `perry_ui_widget_set_drag_text|file|url` (`[Widget, Closure] -> Void`). They route through the existing generic receiver-less dispatch — **no `lower_call`/HIR changes** — and JS/WASM pick them up automatically via `ui_method_to_runtime` (`dispatch_drift` tests stay green). Codegen emits one symbol name regardless of `--target`, so every backend exports the four symbols (a `drag_drop` module).

## Per-platform implementations (`crates/perry-ui-<backend>/src/drag_drop.rs`)
JS-side payload marshalling is identical everywhere; only the native toolkit binding differs.

| Platform | Mechanism |
|---|---|
| **macOS (AppKit)** | KVO-style isa-swizzle to a dynamic `PerryDragDrop_<Class>` subclass (`ClassBuilder` + `object_setClass`) implementing `NSDraggingDestination` + `NSDraggingSource`; `NSPasteboard` payloads. Order-independent, preserves original control behavior. |
| **iOS / iPadOS (UIKit)** | `UIDropInteraction` / `UIDragInteraction` via `addInteraction:` (no swizzling) + `define_class!` delegates; `loadObjectsOfClass:` / `NSItemProvider`. |
| **visionOS** | shares the iOS UIKit code verbatim. |
| **Android (JNI)** | `View.setOnDragListener` / `View.startDragAndDrop` with `ClipData`, via new `PerryBridge.setOnDropCallback` / `setDragSource` Kotlin methods + `nativeInvokeDropCallback` / `nativeInvokeDragProvider` JNI entry points. |
| **Windows (Win32 OLE)** | `IDropTarget` (`RegisterDragDrop`) + `DoDragDrop` with in-process `IDataObject` / `IDropSource`; `CF_UNICODETEXT` / `CF_HDROP` / URL format. |
| **GTK4** | `GtkDropTarget` / `GtkDragSource` + `GdkContentProvider`. |
| **tvOS / watchOS** | no OS pointer drag-and-drop — permanent no-op stubs. |

## Verification
- **macOS** — built and run end-to-end (compile + link + the swizzle/registration setup path executes without crashing; `test-files/test_ui_drag_drop.ts`).
- **iOS** (`aarch64-apple-ios`) and **Android** (`aarch64-linux-android`) Rust — `cargo check` clean.
- **visionOS, Windows, GTK4** — compile-unverified in CI/this environment (visionOS target is tier-3; Windows needs the MSVC CRT; GTK4 needs gtk4 system libs). Flagged in each module's doc comment; need an on-platform build.
- The actual drag **gestures** on every backend need manual on-device testing (a GUI gesture the build can't exercise).

> Note: version bump + CHANGELOG entry intentionally omitted (maintainer folds those in at merge).