### PR TITLE
fix(watchos/visionos): find the entry object by symbol, not filename

### DIFF
--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -75,12 +75,38 @@ pub fn select_linker_command(
             .and_then(|s| s.to_str())
             .map(|s| format!("{}_ts", s))
             .unwrap_or_else(|| "main_ts".to_string());
-        if let Some(entry_obj) = obj_paths.iter().find(|f| {
-            f.file_stem()
-                .and_then(|s| s.to_str())
-                .map(|s| s == input_stem.as_str() || s.ends_with(&format!("_{}", input_stem)))
+        // The entry object is the one that defines the `_main` text symbol.
+        // Object files are content-hash-named in the per-module cache
+        // (`.perry-cache/objects/<hash>.o`), so the old filename-stem heuristic
+        // silently missed them — the objcopy rename then no-op'd and the link
+        // failed with undefined `__perry_user_main`. Query each object's symbol
+        // table instead; fall back to the stem match only if `nm` is unavailable.
+        let defines_main = |obj: &std::path::Path| -> bool {
+            Command::new("nm")
+                .arg(obj)
+                .output()
+                .ok()
+                .map(|o| {
+                    String::from_utf8_lossy(&o.stdout)
+                        .lines()
+                        .any(|l| l.ends_with(" T _main") || l.ends_with(" t _main"))
+                })
                 .unwrap_or(false)
-        }) {
+        };
+        let entry_obj = obj_paths
+            .iter()
+            .find(|f| defines_main(f.as_ref()))
+            .or_else(|| {
+                obj_paths.iter().find(|f| {
+                    f.file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(|s| {
+                            s == input_stem.as_str() || s.ends_with(&format!("_{}", input_stem))
+                        })
+                        .unwrap_or(false)
+                })
+            });
+        if let Some(entry_obj) = entry_obj {
             let objcopy = std::env::var("HOME").ok()
                 .map(|h| PathBuf::from(h).join(".rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/rust-objcopy"))
                 .filter(|p| p.exists())
@@ -205,12 +231,38 @@ pub fn select_linker_command(
             .and_then(|s| s.to_str())
             .map(|s| format!("{}_ts", s))
             .unwrap_or_else(|| "main_ts".to_string());
-        if let Some(entry_obj) = obj_paths.iter().find(|f| {
-            f.file_stem()
-                .and_then(|s| s.to_str())
-                .map(|s| s == input_stem.as_str() || s.ends_with(&format!("_{}", input_stem)))
+        // The entry object is the one that defines the `_main` text symbol.
+        // Object files are content-hash-named in the per-module cache
+        // (`.perry-cache/objects/<hash>.o`), so the old filename-stem heuristic
+        // silently missed them — the objcopy rename then no-op'd and the link
+        // failed with undefined `__perry_user_main`. Query each object's symbol
+        // table instead; fall back to the stem match only if `nm` is unavailable.
+        let defines_main = |obj: &std::path::Path| -> bool {
+            Command::new("nm")
+                .arg(obj)
+                .output()
+                .ok()
+                .map(|o| {
+                    String::from_utf8_lossy(&o.stdout)
+                        .lines()
+                        .any(|l| l.ends_with(" T _main") || l.ends_with(" t _main"))
+                })
                 .unwrap_or(false)
-        }) {
+        };
+        let entry_obj = obj_paths
+            .iter()
+            .find(|f| defines_main(f.as_ref()))
+            .or_else(|| {
+                obj_paths.iter().find(|f| {
+                    f.file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(|s| {
+                            s == input_stem.as_str() || s.ends_with(&format!("_{}", input_stem))
+                        })
+                        .unwrap_or(false)
+                })
+            });
+        if let Some(entry_obj) = entry_obj {
             let objcopy = std::env::var("HOME").ok()
                 .map(|h| PathBuf::from(h).join(".rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/rust-objcopy"))
                 .filter(|p| p.exists())


### PR DESCRIPTION
## Summary

The watchOS and visionOS linker paths rename the user module's `_main` symbol (to `__perry_user_main` for `--features watchos-swift-app` / `watchos-game-loop`, or `_perry_main_init` for the default SwiftUI shell) with `objcopy`, so the platform's `@main` Swift/Rust shell owns the process entry and calls into the renamed user `main`.

They located the entry object by matching the input file **stem** — `main.ts` → look for `main_ts.o`:

```rust
if let Some(entry_obj) = obj_paths.iter().find(|f| {
    f.file_stem()... == "main_ts" || ...
}) { /* objcopy --redefine-sym ... */ }
```

But per-module objects are **content-hash-named** in the cache (`.perry-cache/objects/<hash>.o`), so the stem match silently fails, the `objcopy` rename no-ops (its status is discarded with `let _ = …`), and the link dies with:

```
Undefined symbols for architecture arm64:
  "__perry_user_main", referenced from: … in BloomWatchApp.o
```

This only "worked" with `--no-cache` (fresh temp objects happened to be stem-named), and even then flakily.

## Fix

Find the entry object by checking each object's symbol table for a defined `_main` (via `nm`), falling back to the old filename-stem heuristic only if `nm` is unavailable. Applied to both the watchOS and visionOS branches.

```rust
let defines_main = |obj: &Path| -> bool {
    Command::new("nm").arg(obj).output().ok()
        .map(|o| String::from_utf8_lossy(&o.stdout).lines()
            .any(|l| l.ends_with(" T _main") || l.ends_with(" t _main")))
        .unwrap_or(false)
};
let entry_obj = obj_paths.iter().find(|f| defines_main(f.as_ref()))
    .or_else(|| /* old stem heuristic */);
```

## Validation

With this fix, a Bloom Engine game builds for `watchos-simulator` (`--features watchos-swift-app`) **with the object cache enabled** (no `--no-cache`) and links cleanly — `__perry_user_main` resolves from the correct (hash-named) entry object. Repeated cached rebuilds are now reliable.