### PR TITLE
fix(runtime): wire fancy-regex fallback through every RegExp operation (#4797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1147 — Wire the fancy-regex fallback through every RegExp operation (#4797)
+
+`fancy-regex` (lookbehind, lookahead, backreferences, named groups) was already
+a dependency with a partial fallback in `crates/perry-runtime/src/regex.rs`, but
+the fallback was only consulted by `test`, `exec`, `match`, and the
+callback form of `replace`. For any pattern the `regex` crate can't compile,
+`get_or_compile_regex` stores a never-match `[^\s\S]` placeholder in the
+`RegExpHeader` and stashes the real engine in `FANCY_CACHE`; operations that
+read `regex_ptr` directly therefore silently returned no-match results. This
+finishes the integration so a lookbehind/backreference pattern behaves the same
+as in V8/Node across the whole `String.prototype`/`RegExp.prototype` surface.
+
+Changes (all in `regex.rs` / `regex/match_all.rs`):
+
+- **`String.prototype.search`** — fancy fallback via `fre.find` (was always -1).
+- **`String.prototype.split`** — `fancy_regex` has no `split`, so walk
+  non-overlapping matches and slice between them, mirroring the `regex` crate's
+  split semantics (delimiter dropped, captured groups not spliced — unchanged
+  from the standard path). Zero-width lookbehind splits (`"a1b2c3".split(/(?<=\d)/)`
+  → `["a1","b2","c3",""]`) now work.
+- **`String.prototype.replace`/`replaceAll` (string replacement)** — new
+  `replace_regex_str_fancy` drives the match loop with `fancy_regex` and a
+  `fancy_regex`-typed twin of `expand_js_replacement`, so `$1`/`$<name>`/`$&`/
+  `` $` ``/`$'`/`$$` substitution works under lookbehind/backreferences. The
+  `$<name>` (`js_string_replace_regex_named`) path routes through it too.
+- **Named-capture `groups`** now come through the fallback for `match`
+  (non-global), `exec`, and `matchAll` via a shared `build_fancy_groups`
+  helper (fancy-regex exposes `capture_names()` just like the `regex` crate);
+  previously the fancy branches hard-coded `groups = undefined`.
+- **`String.prototype.matchAll`** — fancy branch in
+  `materialize_match_all_results` (was an empty iterator for fancy patterns).
+
+Zero regressions on the fast `regex`-crate path: simple patterns never enter
+the fallback (it's gated on the `regex` crate failing to compile), and all
+prior regex unit tests pass alongside six new fancy-path tests.
+
+Not in scope (tracked separately under #4797's umbrella): the `v` flag's
+set-notation matching (`[[...]]`, `\q{}`) — fancy-regex shares the `regex`
+crate's class syntax and can't express nested set operations — and the `d`-flag
+indices array, which is not built on the standard path either.
+
 ## v0.5.1146 — Default Windows output extension by type (#4771)
 
 On Windows, `perry compile .\src\main.ts -o main` produced an extension-less

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1146
+**Current Version:** 0.5.1147
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1146"
+version = "0.5.1147"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1146"
+version = "0.5.1147"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1146"
+version = "0.5.1147"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "libc",
@@ -6178,14 +6178,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6199,7 +6199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1146"
+version = "0.5.1147"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1146"
+version = "0.5.1147"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -25,7 +25,9 @@ pub use match_all::{
     REGEXP_STRING_ITERATOR_CLASS_ID,
 };
 use replace_expand::{expand_js_replacement, replace_regex_fn_fancy};
-pub use replace_expand::{js_string_replace_all_regex_fn, js_string_replace_regex_fn};
+pub use replace_expand::{
+    js_string_replace_all_regex_fn, js_string_replace_regex_fn, js_string_replace_regex_named,
+};
 use replace_fn::call_replace_callback;
 pub use replace_fn::{
     js_string_replace_all_string, js_string_replace_all_string_fn, js_string_replace_string,
@@ -612,12 +614,15 @@ pub extern "C" fn js_string_match(
                             str_data,
                             match_char_offset as f64,
                         );
-                        LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
-                        // fancy-regex path doesn't extract named groups; mirror
-                        // the thread-local (`undefined`) on the result object.
+                        // Extract named-capture groups through the fancy path
+                        // (fancy-regex exposes `capture_names()` just like the
+                        // `regex` crate), so `s.match(/(?<=x)(?<y>\d+)/).groups`
+                        // works for lookbehind+named patterns.
+                        let groups_obj = build_fancy_groups(&fre, &caps, &scope);
+                        LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = groups_obj);
                         set_exec_array_groups(
                             arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            ptr::null_mut(),
+                            groups_obj,
                         );
                         return arr_handle.get_raw_mut_ptr::<ArrayHeader>();
                     }
@@ -764,6 +769,186 @@ pub extern "C" fn js_string_match(
 /// Replace matches in a string
 /// Expand a JS replacement string against one match, supporting the full set
 
+/// Fancy-regex twin of [`expand_js_replacement`]. The two `Captures` types
+/// (`regex::Captures` / `fancy_regex::Captures`) expose the same surface used
+/// here — `get(0)`, `len()`, `get(n)`, `name(s)`, `Match::{as_str,start,end}` —
+/// so the body is a deliberate duplicate of the standard expander with the
+/// capture type swapped, mirroring the `replace_regex_fn_fancy` ↔
+/// `js_string_replace_regex_fn` pairing already in this file. Used so a pattern
+/// the `regex` crate can't compile (lookbehind/backreferences) still gets full
+/// `$1`/`$<name>`/`$&`/`` $` ``/`$'`/`$$` substitution.
+fn expand_js_replacement_fancy(
+    repl: &str,
+    caps: &fancy_regex::Captures,
+    subject: &str,
+    has_named_groups: bool,
+) -> String {
+    let m0 = match caps.get(0) {
+        Some(m) => m,
+        None => return String::new(),
+    };
+    let (mstart, mend) = (m0.start(), m0.end());
+    let ngroups = caps.len();
+    let b = repl.as_bytes();
+    let mut out = String::with_capacity(repl.len() + 16);
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] != b'$' {
+            let start = i;
+            while i < b.len() && b[i] != b'$' {
+                i += 1;
+            }
+            out.push_str(&repl[start..i]);
+            continue;
+        }
+        if i + 1 >= b.len() {
+            out.push('$');
+            i += 1;
+            continue;
+        }
+        match b[i + 1] {
+            b'$' => {
+                out.push('$');
+                i += 2;
+            }
+            b'&' => {
+                out.push_str(&subject[mstart..mend]);
+                i += 2;
+            }
+            b'`' => {
+                out.push_str(&subject[..mstart]);
+                i += 2;
+            }
+            b'\'' => {
+                out.push_str(&subject[mend..]);
+                i += 2;
+            }
+            b'0'..=b'9' => {
+                let d1 = (b[i + 1] - b'0') as usize;
+                let (group, consumed) = if i + 2 < b.len() && b[i + 2].is_ascii_digit() {
+                    let two = d1 * 10 + (b[i + 2] - b'0') as usize;
+                    if two >= 1 && two < ngroups {
+                        (Some(two), 2)
+                    } else if d1 >= 1 && d1 < ngroups {
+                        (Some(d1), 1)
+                    } else {
+                        (None, 0)
+                    }
+                } else if d1 >= 1 && d1 < ngroups {
+                    (Some(d1), 1)
+                } else {
+                    (None, 0)
+                };
+                match group {
+                    Some(g) => {
+                        if let Some(m) = caps.get(g) {
+                            out.push_str(m.as_str());
+                        }
+                        i += 1 + consumed;
+                    }
+                    None => {
+                        out.push('$');
+                        i += 1;
+                    }
+                }
+            }
+            b'<' => {
+                if has_named_groups {
+                    if let Some(rel) = repl[i + 2..].find('>') {
+                        let name = &repl[i + 2..i + 2 + rel];
+                        if let Some(m) = caps.name(name) {
+                            out.push_str(m.as_str());
+                        }
+                        i += 2 + rel + 1;
+                    } else {
+                        out.push('$');
+                        i += 1;
+                    }
+                } else {
+                    out.push('$');
+                    i += 1;
+                }
+            }
+            _ => {
+                out.push('$');
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Build a named-capture `groups` object from a fancy-regex match, or return
+/// null when the pattern declares no named capture groups. Mirrors the
+/// named-group construction in the standard-engine `js_regexp_exec` path
+/// (fresh per-result object + by-name setters so each match grows its own
+/// shape). The returned object must be stored into a GC-visible slot by the
+/// caller immediately; it is rooted via `scope` until then.
+pub(crate) unsafe fn build_fancy_groups(
+    fre: &fancy_regex::Regex,
+    caps: &fancy_regex::Captures,
+    scope: &crate::gc::RuntimeHandleScope,
+) -> *mut ObjectHeader {
+    let group_names: Vec<(&str, Option<fancy_regex::Match>)> = fre
+        .capture_names()
+        .enumerate()
+        .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
+        .collect();
+    if group_names.is_empty() {
+        return ptr::null_mut();
+    }
+    let groups_obj = crate::object::js_object_alloc(0, 0);
+    let groups_handle = scope.root_raw_mut_ptr(groups_obj);
+    for (name, m) in &group_names {
+        let val = if let Some(m) = m {
+            js_nanbox_string(js_string_from_str(m.as_str()) as i64)
+        } else {
+            f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+        };
+        let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+        crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
+    }
+    groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>()
+}
+
+/// Fancy-regex fallback for the string-replacement (non-callback) forms of
+/// `String.prototype.replace`/`replaceAll`. Drives a manual non-overlapping
+/// match loop with `fancy_regex` and expands the replacement string via
+/// [`expand_js_replacement_fancy`]. Used when the pattern needs
+/// lookbehind/backreferences the `regex` crate can't compile.
+unsafe fn replace_regex_str_fancy(
+    str_data: &str,
+    fre: &fancy_regex::Regex,
+    global: bool,
+    repl_str: &str,
+) -> *mut StringHeader {
+    let has_named_groups = fre.capture_names().any(|n| n.is_some());
+    let mut captures_list: Vec<fancy_regex::Captures> = Vec::new();
+    let mut iter = fre.captures_iter(str_data);
+    while let Some(Ok(caps)) = iter.next() {
+        captures_list.push(caps);
+        if !global {
+            break;
+        }
+    }
+    let mut result = String::new();
+    let mut last_end = 0usize;
+    for caps in &captures_list {
+        let full_match = caps.get(0).unwrap();
+        result.push_str(&str_data[last_end..full_match.start()]);
+        result.push_str(&expand_js_replacement_fancy(
+            repl_str,
+            caps,
+            str_data,
+            has_named_groups,
+        ));
+        last_end = full_match.end();
+    }
+    result.push_str(&str_data[last_end..]);
+    js_string_from_str(&result)
+}
+
 /// string.replace(regex, replacement) -> string
 #[no_mangle]
 pub extern "C" fn js_string_replace_regex(
@@ -788,6 +973,13 @@ pub extern "C" fn js_string_replace_regex(
     }
 
     unsafe {
+        // Pattern the `regex` crate couldn't compile (lookbehind/backreferences)
+        // → drive the replacement through fancy-regex. Otherwise the never-match
+        // placeholder in `regex_ptr` would leave the input unchanged.
+        if let Some(fre) = lookup_fancy_regex(re) {
+            return replace_regex_str_fancy(str_data, &fre, (*re).global, repl_str);
+        }
+
         let regex = &*(*re).regex_ptr;
         let global = (*re).global;
         let has_named_groups = regex.capture_names().any(|n| n.is_some());
@@ -879,8 +1071,24 @@ pub extern "C" fn js_string_split_regex_n(
     }
 
     unsafe {
-        let regex = &*(*re).regex_ptr;
-        let mut parts: Vec<&str> = regex.split(&str_data).collect();
+        // Fancy-regex fallback (lookbehind/backreferences): `fancy_regex` has no
+        // `split`, so walk non-overlapping matches and slice between them. This
+        // mirrors the `regex` crate's `split` (delimiter text dropped, captured
+        // groups NOT spliced into the result — same as the standard path here).
+        let mut parts: Vec<&str> = if let Some(fre) = lookup_fancy_regex(re) {
+            let mut v: Vec<&str> = Vec::new();
+            let mut last = 0usize;
+            let mut iter = fre.find_iter(&str_data);
+            while let Some(Ok(m)) = iter.next() {
+                v.push(&str_data[last..m.start()]);
+                last = m.end();
+            }
+            v.push(&str_data[last..]);
+            v
+        } else {
+            let regex = &*(*re).regex_ptr;
+            regex.split(&str_data).collect()
+        };
         if limit > 0 && (parts.len() as i64) > (limit as i64) {
             parts.truncate(limit as usize);
         }
@@ -911,6 +1119,15 @@ pub extern "C" fn js_string_search_regex(s: *const StringHeader, re: *const RegE
     let str_data = string_as_str(s);
 
     unsafe {
+        // Fancy-regex fallback (lookbehind/backreferences): the never-match
+        // placeholder in `regex_ptr` would always report -1 otherwise.
+        if let Some(fre) = lookup_fancy_regex(re) {
+            return match fre.find(str_data) {
+                Ok(Some(m)) => str_data[..m.start()].chars().count() as i32,
+                _ => -1,
+            };
+        }
+
         let regex = &*(*re).regex_ptr;
         match regex.find(str_data) {
             Some(m) => {
@@ -1019,12 +1236,14 @@ pub extern "C" fn js_regexp_exec(
                         match_char_offset as f64,
                     );
                     LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = match_char_offset as f64);
-                    LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
-                    // fancy-regex path doesn't extract named groups; mirror the
-                    // thread-local (`undefined`) on the result object.
+                    // Extract named-capture groups through the fancy path so
+                    // `/(?<=x)(?<y>\d+)/.exec(s).groups` works for patterns the
+                    // `regex` crate can't compile.
+                    let groups_obj = build_fancy_groups(fre, &caps, &scope);
+                    LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = groups_obj);
                     set_exec_array_groups(
                         arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                        ptr::null_mut(),
+                        groups_obj,
                     );
                     return Some(arr_handle.get_raw_mut_ptr::<ArrayHeader>());
                 }
@@ -1523,6 +1742,74 @@ mod tests {
             expand_js_replacement("[$<missing>]", &caps2, subj2, true),
             "[]"
         );
+    }
+
+    // ---- #4797: fancy-regex fallback wired through every operation ----
+
+    #[test]
+    fn fancy_backreference_match() {
+        // `(\w)\1` needs backreferences → fancy-regex fallback.
+        let re = js_regexp_new(make_string(r"(\w)\1"), make_string(""));
+        let result = js_string_match(make_string("hello"), re);
+        assert!(!result.is_null());
+        unsafe {
+            let v = crate::array::js_array_get_f64(result, 0);
+            let sp = crate::value::js_get_string_pointer_unified(v) as *const StringHeader;
+            assert_eq!(string_as_str(sp), "ll");
+        }
+    }
+
+    #[test]
+    fn fancy_lookbehind_search() {
+        let re = js_regexp_new(make_string(r"(?<==)\w+"), make_string(""));
+        assert_eq!(js_string_search_regex(make_string("foo=bar"), re), 4);
+        // No match → -1.
+        let re2 = js_regexp_new(make_string(r"(?<==)\w+"), make_string(""));
+        assert_eq!(js_string_search_regex(make_string("nomatch"), re2), -1);
+    }
+
+    #[test]
+    fn fancy_lookbehind_split() {
+        // Zero-width lookbehind split: "a1b2c3" → ["a1","b2","c3",""].
+        let re = js_regexp_new(make_string(r"(?<=\d)"), make_string(""));
+        let arr = js_string_split_regex(make_string("a1b2c3"), re);
+        unsafe {
+            assert_eq!((*arr).length, 4);
+            let first = crate::array::js_array_get_f64(arr, 0);
+            let sp = crate::value::js_get_string_pointer_unified(first) as *const StringHeader;
+            assert_eq!(string_as_str(sp), "a1");
+        }
+    }
+
+    #[test]
+    fn fancy_lookbehind_replace_string() {
+        // `$&` substitution under a lookbehind pattern the regex crate rejects.
+        let re = js_regexp_new(make_string(r"(?<=\$)\d+"), make_string("g"));
+        let out = js_string_replace_regex(make_string("$5 and $10"), re, make_string("[$&]"));
+        assert_eq!(string_as_str(out), "$[5] and $[10]");
+    }
+
+    #[test]
+    fn fancy_named_group_replace() {
+        // `$<n>` named-group substitution through the fancy fallback.
+        let re = js_regexp_new(make_string(r"(?<=\$)(?<n>\d+)"), make_string("g"));
+        let out =
+            js_string_replace_regex_named(make_string("$5 and $10"), re, make_string("[$<n>]"));
+        assert_eq!(string_as_str(out), "$[5] and $[10]");
+    }
+
+    #[test]
+    fn fancy_lookbehind_exec_index() {
+        // exec() through the fancy path reports the char index of the match.
+        let re = js_regexp_new(make_string(r"(?<=\$)\d+"), make_string(""));
+        let result = js_regexp_exec(re, make_string("price: $42"));
+        assert!(!result.is_null());
+        assert_eq!(js_regexp_exec_get_index(), 8.0);
+        unsafe {
+            let v = crate::array::js_array_get_f64(result, 0);
+            let sp = crate::value::js_get_string_pointer_unified(v) as *const StringHeader;
+            assert_eq!(string_as_str(sp), "42");
+        }
     }
 
     #[test]

--- a/crates/perry-runtime/src/regex/match_all.rs
+++ b/crates/perry-runtime/src/regex/match_all.rs
@@ -64,6 +64,59 @@ unsafe fn materialize_match_all_results(
     let str_data = string_as_str(s);
     let search_start = char_index_to_byte(str_data, start_char_index);
     let search_str = &str_data[search_start..];
+
+    // Fancy-regex fallback (lookbehind/backreferences): the never-match
+    // placeholder in `regex_ptr` would yield an empty iterator otherwise.
+    // Mirrors the standard-engine loop below, including named-group `groups`.
+    if let Some(fre) = super::lookup_fancy_regex(re) {
+        let mut all_caps: Vec<fancy_regex::Captures> = Vec::new();
+        let mut it = fre.captures_iter(search_str);
+        while let Some(Ok(c)) = it.next() {
+            all_caps.push(c);
+        }
+        let outer = crate::array::js_array_alloc(all_caps.len() as u32);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let outer_handle = scope.root_raw_mut_ptr(outer);
+        (*outer_handle.get_raw_mut_ptr::<ArrayHeader>()).length = all_caps.len() as u32;
+
+        for (i, caps) in all_caps.iter().enumerate() {
+            let inner = crate::array::js_array_alloc(caps.len() as u32);
+            let inner_handle = scope.root_raw_mut_ptr(inner);
+            (*inner_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
+
+            for j in 0..caps.len() {
+                let value = if let Some(m) = caps.get(j) {
+                    let str_ptr = js_string_from_str(m.as_str());
+                    js_nanbox_string(str_ptr as i64)
+                } else {
+                    f64::from_bits(TAG_UNDEFINED)
+                };
+                let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
+                crate::array::store_array_slot(inner, j, value.to_bits());
+            }
+
+            let match_index = caps
+                .get(0)
+                .map(|m| byte_index_to_char_index(str_data, search_start + m.start()))
+                .unwrap_or_else(|| start_char_index as f64);
+            let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
+            set_exec_array_metadata(inner, str_data, match_index);
+            let groups_ptr = super::build_fancy_groups(&fre, caps, &scope);
+            let groups_value = if groups_ptr.is_null() {
+                f64::from_bits(TAG_UNDEFINED)
+            } else {
+                js_nanbox_pointer(groups_ptr as i64)
+            };
+            set_match_all_groups(inner, groups_value);
+
+            let inner_boxed = js_nanbox_pointer(inner as i64);
+            let outer = outer_handle.get_raw_mut_ptr::<ArrayHeader>();
+            crate::array::store_array_slot(outer, i, inner_boxed.to_bits());
+        }
+
+        return outer_handle.get_raw_mut_ptr::<ArrayHeader>();
+    }
+
     let regex = &*(*re).regex_ptr;
     let all_caps: Vec<regex::Captures<'_>> = regex.captures_iter(search_str).collect();
     let outer = crate::array::js_array_alloc(all_caps.len() as u32);

--- a/crates/perry-runtime/src/regex/replace_expand.rs
+++ b/crates/perry-runtime/src/regex/replace_expand.rs
@@ -403,6 +403,13 @@ pub extern "C" fn js_string_replace_regex_named(
     }
 
     unsafe {
+        // Fancy-regex fallback (lookbehind/backreferences): expand `$<name>`
+        // and friends against the fancy captures instead of the never-match
+        // placeholder stored in `regex_ptr`.
+        if let Some(fre) = lookup_fancy_regex(re) {
+            return replace_regex_str_fancy(str_data, &fre, (*re).global, repl_str);
+        }
+
         let regex = &*(*re).regex_ptr;
         let global = (*re).global;
         let has_named_groups = regex.capture_names().any(|n| n.is_some());


### PR DESCRIPTION
Closes #4797 (the integration portion).

## Summary

`fancy-regex` (lookbehind, lookahead, backreferences, named groups) is already a dependency with a partial fallback in `crates/perry-runtime/src/regex.rs`, but it was only wired into `test`, `exec`, `match`, and the **callback** form of `replace`. For any pattern the `regex` crate can't compile, `get_or_compile_regex` stores a never-match `[^\s\S]` placeholder in the `RegExpHeader` and stashes the real engine in `FANCY_CACHE` — so every operation that reads `regex_ptr` directly silently returned no-match results, and the fancy `match`/`exec` branches hard-coded `groups = undefined`.

This PR finishes the integration so a lookbehind/backreference pattern behaves like V8/Node across the whole `String.prototype` / `RegExp.prototype` surface.

## Changes (`regex.rs`, `regex/match_all.rs`)

| Operation | Before | After |
|-----------|--------|-------|
| `String.prototype.search` | always `-1` for fancy patterns | `fre.find` fallback |
| `String.prototype.split` | returned the whole string unsplit | non-overlapping match walk (`fancy_regex` has no `split`) |
| `replace`/`replaceAll` (string repl, incl. `$<name>`) | input unchanged | `replace_regex_str_fancy` + a `fancy_regex`-typed twin of `expand_js_replacement` — full `$1`/`$<name>`/`$&`/`` $` ``/`$'`/`$$` |
| named-capture `groups` on `match`/`exec`/`matchAll` | `undefined` | extracted via shared `build_fancy_groups` (fancy-regex exposes `capture_names()`) |
| `matchAll` | empty iterator | fancy branch in `materialize_match_all_results` |

Split semantics intentionally mirror the existing standard path (delimiter dropped, captured groups not spliced into the result). Zero-width lookbehind splits now work, e.g. `"a1b2c3".split(/(?<=\d)/)` → `["a1","b2","c3",""]`.

## Zero regressions on the fast path

The fallback is gated on the `regex` crate *failing* to compile the pattern, so simple patterns never enter it. All prior regex unit tests pass, plus six new fancy-path tests (`fancy_backreference_match`, `fancy_lookbehind_search`, `fancy_lookbehind_split`, `fancy_lookbehind_replace_string`, `fancy_named_group_replace`, `fancy_lookbehind_exec_index`).

Validated end-to-end by compiling a TS sample (lookbehind + named groups across `match`/`exec`/`search`/`split`/`replace`/`replaceFn`/`matchAll` + backreferences), with simple-pattern regression checks — all outputs match ECMAScript semantics.

## Not in scope

Tracked separately under #4797's umbrella, called out in the changelog:

- **`v`-flag set notation** (`[[...]]`, `\q{}`): fancy-regex shares the `regex` crate's character-class syntax and can't express nested set operations, so this needs a different engine/translation layer.
- **`d`-flag indices array**: not built on the standard path either, so there's nothing to route through the fallback yet.
