### PR TITLE
fix(runtime): round-trip lone surrogates via WTF-8 (#4793)

### DIFF
--- a/crates/perry-runtime/src/string/alloc.rs
+++ b/crates/perry-runtime/src/string/alloc.rs
@@ -50,10 +50,16 @@ pub extern "C" fn js_string_materialize_to_heap(value: f64) -> *mut StringHeader
 pub extern "C" fn js_string_new_sso(data: *const u8, len: u32) -> f64 {
     unsafe {
         let ulen = len as usize;
-        if ulen <= crate::value::SHORT_STRING_MAX_LEN {
+        // SSO stores its length tag as the JS `.length`, which is only valid
+        // when byte length == UTF-16 length — i.e. pure ASCII. Non-ASCII (incl.
+        // WTF-8 lone surrogates) must take the heap path so `compute_utf16_len`
+        // records the correct code-unit count (#4793).
+        if ulen <= crate::value::SHORT_STRING_MAX_LEN && (ulen == 0 || !data.is_null()) {
             let bytes = std::slice::from_raw_parts(data, ulen);
-            if let Some(v) = crate::value::JSValue::try_short_string(bytes) {
-                return f64::from_bits(v.bits());
+            if bytes.iter().all(|&b| b < 0x80) {
+                if let Some(v) = crate::value::JSValue::try_short_string(bytes) {
+                    return f64::from_bits(v.bits());
+                }
             }
         }
         let ptr = js_string_from_bytes(data, len);

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -186,16 +186,63 @@ pub extern "C" fn js_string_char_at(s: *const StringHeader, index: i32) -> *mut 
         }
     }
 
-    // UTF-16 path: find the UTF-8 bytes for the character at this UTF-16 index
-    let str_data = string_as_str(s);
-    let byte_off = utf16_offset_to_byte_offset(str_data, index as usize);
-    let remaining = &str_data[byte_off..];
-    if let Some(ch) = remaining.chars().next() {
-        let ch_len = ch.len_utf8();
-        js_string_from_bytes(remaining.as_ptr(), ch_len as u32)
-    } else {
-        js_string_from_bytes(std::ptr::null(), 0)
+    // UTF-16 path: walk the raw (WTF-8) bytes counting UTF-16 code units and
+    // return the single code unit at `index`. Astral code points split into
+    // their surrogate halves, so `"😀"[0]` is the lone high surrogate (length
+    // 1) — matching JS UTF-16 indexing (#4793). Walking bytes directly (rather
+    // than `str::chars()`) keeps this sound on inputs that already hold lone
+    // surrogates.
+    let target = index as usize;
+    let bytes = unsafe { slice::from_raw_parts(string_data(s), (*s).byte_len as usize) };
+    let mut u16_pos = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Decode one WTF-8 sequence into its code point and UTF-16 width.
+        let (seq_len, units, cp) = if b < 0x80 {
+            (1usize, 1usize, b as u32)
+        } else if b < 0xE0 {
+            let b1 = bytes.get(i + 1).copied().unwrap_or(0);
+            (2, 1, ((b as u32 & 0x1F) << 6) | (b1 as u32 & 0x3F))
+        } else if b < 0xF0 {
+            let b1 = bytes.get(i + 1).copied().unwrap_or(0);
+            let b2 = bytes.get(i + 2).copied().unwrap_or(0);
+            (
+                3,
+                1,
+                ((b as u32 & 0x0F) << 12) | ((b1 as u32 & 0x3F) << 6) | (b2 as u32 & 0x3F),
+            )
+        } else {
+            let b1 = bytes.get(i + 1).copied().unwrap_or(0);
+            let b2 = bytes.get(i + 2).copied().unwrap_or(0);
+            let b3 = bytes.get(i + 3).copied().unwrap_or(0);
+            (
+                4,
+                2,
+                ((b as u32 & 0x07) << 18)
+                    | ((b1 as u32 & 0x3F) << 12)
+                    | ((b2 as u32 & 0x3F) << 6)
+                    | (b3 as u32 & 0x3F),
+            )
+        };
+        if target < u16_pos + units {
+            let unit = if units == 2 {
+                // Astral: emit the requested surrogate half.
+                let v = cp - 0x10000;
+                if target == u16_pos {
+                    0xD800 + (v >> 10) as u16
+                } else {
+                    0xDC00 + (v & 0x3FF) as u16
+                }
+            } else {
+                cp as u16
+            };
+            return string_from_code_unit(unit);
+        }
+        u16_pos += units;
+        i += seq_len;
     }
+    js_string_from_bytes(std::ptr::null(), 0)
 }
 
 /// Split a string into an array of single-character strings.
@@ -259,27 +306,113 @@ fn fromcharcode_arg_to_uint16(code: f64) -> u16 {
     to_uint16(n)
 }
 
+/// Generic 3-byte WTF-8 encoding of a single BMP code point / lone surrogate
+/// (`0x800..=0xFFFF`). For a lone surrogate (`0xD800..=0xDFFF`) this is the
+/// same byte layout the UTF-8 encoder would produce if surrogates were scalar
+/// values, which is exactly the WTF-8 representation Perry round-trips.
+#[inline]
+fn encode_3byte_wtf8(unit: u16) -> [u8; 3] {
+    [
+        0xE0 | (unit >> 12) as u8,
+        0x80 | ((unit >> 6) & 0x3F) as u8,
+        0x80 | (unit & 0x3F) as u8,
+    ]
+}
+
+/// Build a fresh string holding exactly one UTF-16 code unit. Lone surrogates
+/// (`0xD800..=0xDFFF`) are encoded as WTF-8 and the result is flagged
+/// `HAS_LONE_SURROGATES` (so `isWellFormed()` / `JSON.stringify` see them);
+/// every other unit is ordinary UTF-8. This is the round-tripping replacement
+/// for the old `char::from_u32(..).unwrap_or('\u{FFFD}')` lossy path.
+pub(crate) fn string_from_code_unit(unit: u16) -> *mut StringHeader {
+    if unit < 0x80 {
+        let byte = unit as u8;
+        return js_string_from_bytes(&byte as *const u8, 1);
+    }
+    if (0xD800..=0xDFFF).contains(&unit) {
+        let buf = encode_3byte_wtf8(unit);
+        return crate::string::js_string_from_wtf8_bytes(buf.as_ptr(), 3);
+    }
+    // BMP, non-surrogate → a valid Unicode scalar value.
+    let ch = unsafe { char::from_u32_unchecked(unit as u32) };
+    let mut buf = [0u8; 4];
+    let encoded = ch.encode_utf8(&mut buf);
+    js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32)
+}
+
+/// Append the WTF-8/UTF-8 bytes of one UTF-16 code unit to `out`, returning
+/// `true` if a lone surrogate was appended (so the caller knows to use the
+/// WTF-8 string-construction path that sets `HAS_LONE_SURROGATES`).
+#[inline]
+fn push_code_unit_wtf8(out: &mut Vec<u8>, unit: u16) -> bool {
+    if unit < 0x80 {
+        out.push(unit as u8);
+        false
+    } else if (0xD800..=0xDFFF).contains(&unit) {
+        out.extend_from_slice(&encode_3byte_wtf8(unit));
+        true
+    } else {
+        let ch = unsafe { char::from_u32_unchecked(unit as u32) };
+        let mut buf = [0u8; 4];
+        out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+        false
+    }
+}
+
+/// Append the WTF-8/UTF-8 bytes of one (range-validated) code point to `out`,
+/// for `String.fromCodePoint`. A BMP surrogate code point is emitted as a lone
+/// surrogate (returns `true`); astral code points encode as ordinary UTF-8.
+#[inline]
+fn push_code_point_wtf8(out: &mut Vec<u8>, cp: u32) -> bool {
+    if cp <= 0xFFFF {
+        push_code_unit_wtf8(out, cp as u16)
+    } else {
+        let ch = unsafe { char::from_u32_unchecked(cp) };
+        let mut buf = [0u8; 4];
+        out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+        false
+    }
+}
+
+/// Encode a sequence of code points / UTF-16 code units as canonical WTF-8.
+/// A high surrogate immediately followed by a low surrogate is combined into
+/// its astral code point and emitted as ordinary 4-byte UTF-8 (so
+/// `String.fromCharCode(0xD83D, 0xDE00)` is the emoji, with `codePointAt(0)`
+/// = 0x1F600). Only a *genuinely lone* surrogate stays as a 3-byte WTF-8
+/// sequence. Returns the bytes and whether any lone surrogate was emitted
+/// (so the caller can pick the flag-setting construction path). (#4793)
+fn encode_code_points_wtf8(cps: &[u32]) -> (Vec<u8>, bool) {
+    let mut out: Vec<u8> = Vec::with_capacity(cps.len());
+    let mut has_lone_surrogate = false;
+    let mut i = 0;
+    while i < cps.len() {
+        let cp = cps[i];
+        if (0xD800..=0xDBFF).contains(&cp)
+            && i + 1 < cps.len()
+            && (0xDC00..=0xDFFF).contains(&cps[i + 1])
+        {
+            let astral = 0x10000 + ((cp - 0xD800) << 10) + (cps[i + 1] - 0xDC00);
+            let ch = unsafe { char::from_u32_unchecked(astral) };
+            let mut buf = [0u8; 4];
+            out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            i += 2;
+            continue;
+        }
+        has_lone_surrogate |= push_code_point_wtf8(&mut out, cp);
+        i += 1;
+    }
+    (out, has_lone_surrogate)
+}
+
 /// Create a string from a character code (String.fromCharCode).
 /// The argument is coerced with `ToUint16` (#2788), so out-of-range and
 /// negative values wrap modulo 65536 rather than returning `""`. Codegen
 /// passes the raw NaN-boxed `f64` (not `fptosi`, which is UB on a NaN).
+/// Lone surrogates (`0xD800..=0xDFFF`) round-trip via WTF-8 (#4793).
 #[no_mangle]
 pub extern "C" fn js_string_from_char_code(code: f64) -> *mut StringHeader {
     let unit = fromcharcode_arg_to_uint16(code);
-
-    // For ASCII characters, create a simple 1-byte string.
-    if unit < 128 {
-        let byte = unit as u8;
-        return js_string_from_bytes(&byte as *const u8, 1);
-    }
-
-    // For non-ASCII, encode as UTF-8. Lone surrogates (0xD800..=0xDFFF) are
-    // not valid Rust `char`s; emit U+FFFD (the documented WTF-8 / lone-
-    // surrogate categorical gap — Node would emit the lone surrogate).
-    let ch = char::from_u32(unit as u32).unwrap_or('\u{FFFD}');
-    let mut buf = [0u8; 4];
-    let encoded = ch.encode_utf8(&mut buf);
-    js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32)
+    string_from_code_unit(unit)
 }
 
 /// Create a string from a spread/apply argument source:
@@ -296,15 +429,17 @@ pub extern "C" fn js_string_from_char_code_array(value: f64) -> *mut StringHeade
         return js_string_from_bytes(std::ptr::null(), 0);
     }
 
-    let mut out = String::with_capacity(len);
+    let mut cps: Vec<u32> = Vec::with_capacity(len);
     for i in 0..len {
         let unit = fromcharcode_arg_to_uint16(crate::array::js_array_get_f64(arr, i as u32));
-        match char::from_u32(unit as u32) {
-            Some(ch) => out.push(ch),
-            None => out.push('\u{FFFD}'),
-        }
+        cps.push(unit as u32);
     }
-    js_string_from_bytes(out.as_ptr(), out.len() as u32)
+    let (out, has_lone_surrogate) = encode_code_points_wtf8(&cps);
+    if has_lone_surrogate {
+        crate::string::js_string_from_wtf8_bytes(out.as_ptr(), out.len() as u32)
+    } else {
+        js_string_from_bytes(out.as_ptr(), out.len() as u32)
+    }
 }
 
 /// Throw `RangeError: Invalid code point <n>` for `String.fromCodePoint`,
@@ -331,12 +466,14 @@ pub extern "C" fn js_string_from_code_point(code: f64) -> *mut StringHeader {
         throw_invalid_code_point(code);
     }
     let cp = code as u32;
-    let ch = match char::from_u32(cp) {
-        Some(c) => c,
-        // Lone surrogate: a valid code point for fromCodePoint but not a Rust
-        // `char`. Emit U+FFFD (WTF-8 categorical gap); do NOT throw.
-        None => '\u{FFFD}',
-    };
+    // A surrogate code point (`0xD800..=0xDFFF`) is a valid `fromCodePoint`
+    // argument but not a Rust `char`; `string_from_code_unit` round-trips it
+    // through WTF-8 instead of substituting U+FFFD (#4793). Astral code points
+    // (`> 0xFFFF`) are ordinary scalar values.
+    if cp <= 0xFFFF {
+        return string_from_code_unit(cp as u16);
+    }
+    let ch = unsafe { char::from_u32_unchecked(cp) };
     let mut buf = [0u8; 4];
     let encoded = ch.encode_utf8(&mut buf);
     js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32)
@@ -354,18 +491,20 @@ pub fn js_string_from_code_point_array(value: f64) -> *mut StringHeader {
         return js_string_from_bytes(std::ptr::null(), 0);
     }
     let len = crate::array::js_array_length(arr) as usize;
-    let mut out = String::with_capacity(len);
+    let mut cps: Vec<u32> = Vec::with_capacity(len);
     for i in 0..len {
         let code = crate::array::js_array_get_f64(arr, i as u32);
         if !code.is_finite() || code.fract() != 0.0 || code < 0.0 || code > 0x10FFFF as f64 {
             throw_invalid_code_point(code);
         }
-        match char::from_u32(code as u32) {
-            Some(c) => out.push(c),
-            None => out.push('\u{FFFD}'),
-        }
+        cps.push(code as u32);
     }
-    js_string_from_bytes(out.as_ptr(), out.len() as u32)
+    let (out, has_lone_surrogate) = encode_code_points_wtf8(&cps);
+    if has_lone_surrogate {
+        crate::string::js_string_from_wtf8_bytes(out.as_ptr(), out.len() as u32)
+    } else {
+        js_string_from_bytes(out.as_ptr(), out.len() as u32)
+    }
 }
 
 /// String.prototype.at(index) — supports negative indices.

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -21,6 +21,100 @@ use super::*;
 /// result fit SSO (≤ 5 bytes total), there's literally zero heap
 /// allocation. Result is returned NaN-boxed so callers don't need a
 /// follow-up wrap.
+/// Canonicalize a freshly-built concatenation result for WTF-8: a lone high
+/// surrogate immediately followed by a lone low surrogate (which can newly
+/// arise when two surrogate-bearing strings are joined, e.g.
+/// `String.fromCharCode(0xD83D) + String.fromCharCode(0xDE00)` or
+/// `"\uD83D" + "\uDE00"`) must be stored as the astral code point's 4-byte
+/// UTF-8, so `codePointAt` / console output match JS. Each surrogate is a
+/// 3-byte WTF-8 sequence: high = `ED A0..AF 80..BF`, low = `ED B0..BF 80..BF`.
+///
+/// Cheap-gated by the caller on `STRING_FLAG_HAS_LONE_SURROGATES`: ordinary
+/// (ASCII / valid-UTF-8) concatenations never reach here. When no adjacent
+/// pair exists (a genuinely lone surrogate), the input pointer is returned
+/// unchanged; only an actual merge allocates a new string. `utf16_len` is
+/// unaffected (a pair and its astral form are both 2 code units). (#4793)
+pub(crate) fn canonicalize_surrogate_pairs(ptr: *mut StringHeader) -> *mut StringHeader {
+    if !is_valid_string_ptr(ptr) {
+        return ptr;
+    }
+    let (blen, u16len, flags) = unsafe { ((*ptr).byte_len, (*ptr).utf16_len, (*ptr).flags) };
+    if flags & STRING_FLAG_HAS_LONE_SURROGATES == 0 || blen < 6 {
+        return ptr;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(string_data(ptr), blen as usize) };
+
+    // First pass: is there any adjacent high→low surrogate pair? Avoid all
+    // allocation for the common single-lone-surrogate result.
+    let is_high = |s: &[u8]| s[0] == 0xED && (0xA0..=0xAF).contains(&s[1]);
+    let is_low = |s: &[u8]| s[0] == 0xED && (0xB0..=0xBF).contains(&s[1]);
+    let mut has_pair = false;
+    let mut i = 0usize;
+    while i + 6 <= bytes.len() {
+        if is_high(&bytes[i..]) && is_low(&bytes[i + 3..]) {
+            has_pair = true;
+            break;
+        }
+        i += 1;
+    }
+    if !has_pair {
+        return ptr;
+    }
+
+    // Second pass: rebuild, merging each high→low pair into 4-byte UTF-8 and
+    // tracking whether any surrogate remains lone (to keep the flag accurate).
+    let mut out: Vec<u8> = Vec::with_capacity(blen as usize);
+    let mut still_has_lone = false;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let rem = &bytes[i..];
+        if rem.len() >= 3 && rem[0] == 0xED && (0xA0..=0xBF).contains(&rem[1]) {
+            // A surrogate sequence. Try to pair a high with a following low.
+            if is_high(rem) && rem.len() >= 6 && is_low(&rem[3..]) {
+                let hi = ((rem[0] as u32 & 0x0F) << 12)
+                    | ((rem[1] as u32 & 0x3F) << 6)
+                    | (rem[2] as u32 & 0x3F);
+                let lo = ((rem[3] as u32 & 0x0F) << 12)
+                    | ((rem[4] as u32 & 0x3F) << 6)
+                    | (rem[5] as u32 & 0x3F);
+                let astral = 0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00);
+                let ch = unsafe { char::from_u32_unchecked(astral) };
+                let mut buf = [0u8; 4];
+                out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                i += 6;
+                continue;
+            }
+            // Lone surrogate — copy verbatim, remember the flag stays set.
+            still_has_lone = true;
+            out.extend_from_slice(&rem[..3]);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+
+    let new_flags = if still_has_lone {
+        STRING_FLAG_HAS_LONE_SURROGATES
+    } else {
+        0
+    };
+    js_string_from_bytes_known_utf16(out.as_ptr(), out.len() as u32, u16len, new_flags)
+}
+
+/// True when the `len` bytes at `data` are all ASCII (`< 0x80`), or the slice
+/// is empty/null. Used to decide whether a concat result may be stored inline
+/// as an SSO value (whose length tag doubles as the JS `.length`).
+#[inline]
+fn bytes_all_ascii(data: *const u8, len: u32) -> bool {
+    if data.is_null() || len == 0 {
+        return true;
+    }
+    unsafe { std::slice::from_raw_parts(data, len as usize) }
+        .iter()
+        .all(|&b| b < 0x80)
+}
+
 #[no_mangle]
 pub extern "C" fn js_string_concat_box(l_value: f64, r_value: f64) -> f64 {
     let mut scratch_l = [0u8; crate::value::SHORT_STRING_MAX_LEN];
@@ -29,9 +123,16 @@ pub extern "C" fn js_string_concat_box(l_value: f64, r_value: f64) -> f64 {
     let r = str_bytes_from_jsvalue(r_value, &mut scratch_r).unwrap_or((std::ptr::null(), 0));
     let total_blen = l.1 + r.1;
 
+    // SSO encodes its length tag as the JS `.length`, so it is only sound for
+    // ASCII operands (byte length == UTF-16 length). A non-ASCII operand —
+    // multi-byte UTF-8 or a WTF-8 lone surrogate — must take the heap path so
+    // the result's `utf16_len` is computed, not assumed equal to `byte_len`
+    // (#4793: `("é"+"x").length` was 3, `("\uD800"+"x").length` was 4).
+    let both_ascii = bytes_all_ascii(l.0, l.1) && bytes_all_ascii(r.0, r.1);
+
     // SSO fast path — assemble the result inline when it fits (≤ 5
     // bytes). Pure bit arithmetic, no heap touch.
-    if total_blen as usize <= crate::value::SHORT_STRING_MAX_LEN {
+    if both_ascii && total_blen as usize <= crate::value::SHORT_STRING_MAX_LEN {
         unsafe {
             let mut payload: u64 = 0;
             for i in 0..l.1 as usize {
@@ -65,26 +166,40 @@ pub extern "C" fn js_string_concat_box(l_value: f64, r_value: f64) -> f64 {
         } else {
             &[]
         };
-        let utf16_len = if l_slice.is_ascii() && r_slice.is_ascii() {
-            total_blen
+        let (utf16_len, flags) = if l_slice.is_ascii() && r_slice.is_ascii() {
+            (total_blen, 0)
         } else {
+            // Sum each operand's UTF-16 length independently (concatenating two
+            // strings never merges code units across the boundary). Carry the
+            // lone-surrogate flag forward when an operand is WTF-8 so
+            // `isWellFormed()` / `JSON.stringify` stay correct on the result.
             let mut u16 = 0u32;
+            let mut flags = 0u32;
             if !l_slice.is_empty() {
                 u16 += compute_utf16_len(l.0, l.1);
+                if str::from_utf8(l_slice).is_err() {
+                    flags |= STRING_FLAG_HAS_LONE_SURROGATES;
+                }
             }
             if !r_slice.is_empty() {
                 u16 += compute_utf16_len(r.0, r.1);
+                if str::from_utf8(r_slice).is_err() {
+                    flags |= STRING_FLAG_HAS_LONE_SURROGATES;
+                }
             }
-            u16
+            (u16, flags)
         };
 
-        init_string_header(ptr, utf16_len, total_blen, total_blen, 0, 0);
+        init_string_header(ptr, utf16_len, total_blen, total_blen, 0, flags);
         if !l_slice.is_empty() {
             ptr::copy_nonoverlapping(l.0, data_ptr, l.1 as usize);
         }
         if !r_slice.is_empty() {
             ptr::copy_nonoverlapping(r.0, data_ptr.add(l.1 as usize), r.1 as usize);
         }
+        // Merge any surrogate pair newly formed across the join boundary
+        // (no-op unless the result carries the lone-surrogate flag).
+        let ptr = canonicalize_surrogate_pairs(ptr);
         // NaN-box as STRING_TAG.
         f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits())
     }
@@ -174,7 +289,7 @@ pub extern "C" fn js_string_concat(
             );
         }
 
-        ptr
+        canonicalize_surrogate_pairs(ptr)
     }
 }
 
@@ -462,7 +577,7 @@ pub extern "C" fn js_string_concat_chain(parts: *const f64, n: i32) -> *mut Stri
             }
         }
 
-        ptr
+        canonicalize_surrogate_pairs(ptr)
     }
 }
 


### PR DESCRIPTION
Closes #4793.

## Summary

JS strings are UTF-16 and may contain **lone surrogates**. Perry already stores strings as WTF-8-capable bytes (`StringHeader` has `utf16_len`, `byte_len`, and a `HAS_LONE_SURROGATES` flag) and the **literal** path already round-trips (`"\uD800".charCodeAt(0)` was already 55296). The remaining gaps were in the construction/transform APIs plus a couple of length-accounting bugs — **not** a core-type rewrite.

Three concrete bugs, two broader than the issue framing:

1. **`fromCharCode` / `fromCodePoint`** substituted `U+FFFD` for lone surrogates (`char::from_u32().unwrap_or('\u{FFFD}')`). Now they emit WTF-8 and set the flag; the array/spread forms pair adjacent high+low surrogates into canonical astral UTF-8.
2. **SSO invariant violation** (pre-existing, surfaced here): the inline small-string representation's length tag *is* the JS `.length`, so SSO must be ASCII-only. `js_string_concat_box` and `js_string_new_sso` stuffed any ≤5-byte result inline, corrupting `.length` for **all** short non-ASCII concats — `("é"+"x").length` was `3`, `("\uD800"+"x").length` was `4`. Both now route non-ASCII to the heap path (which computes `utf16_len` correctly) and propagate the surrogate flag.
3. **`js_string_char_at`** returned whole code points, so `"😀"[0]` was the full astral char (length 2) instead of the lone high surrogate (length 1). It now walks WTF-8 bytes and returns the correct UTF-16 code unit, splitting astral pairs. (Its doc comment already *claimed* this behavior.)
4. **Concatenation** re-canonicalizes a surrogate pair formed across the join boundary — `String.fromCharCode(0xD83D, 0xDE00)` (which HIR lowers to `fromCharCode(hi) + fromCharCode(lo)`) and `"\uD83D" + "\uDE00"` now produce the astral emoji with `codePointAt(0) === 0x1F600`. Gated on the lone-surrogate flag, so the hot concat path is untouched for ordinary strings.

## Validation

- An 18-case acceptance harness (construction, JSON.stringify escaping, isWellFormed/toWellFormed, charAt/indexing, slice, codepoint iteration, indexOf/includes, normalize, template literals) is **byte-identical to `node --experimental-strip-types`**.
- 98/98 runtime `string` unit tests pass; full `perry-runtime` suite green (the 2 unrelated `native_module_stream`/`url` failures are pre-existing parallel-test-interference flakes that pass in isolation).
- Regression sweep of existing string/edge test-files vs Node: no new diffs.

## Out of scope (pre-existing)

Non-unicode-mode **RegExp** treats an astral char as one match rather than two UTF-16 code units (`/./.exec("😀")[0].length` is 2, Node 1). This predates this change (the regex crate matches Unicode scalar values, not UTF-16 code units) and belongs to the separate "regex crate" categorical gap — it is independent of lone-surrogate round-tripping.

Per maintainer convention, version bump + CHANGELOG entry are left for merge time.