### PR TITLE
fix: eval-code / function-code / arguments-object test262 parity

### DIFF
--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -217,10 +217,35 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // (the previous `FuncRef` arm catches the FuncRef case; ExternFuncRef
             // here means a top-level imported function reference, not a method).
             if let Expr::PropertyGet { object, property } = callee.as_ref() {
-                let skip = matches!(
+                let mut skip = matches!(
                     object.as_ref(),
                     Expr::GlobalGet(_) | Expr::NativeModuleRef(_) | Expr::ExternFuncRef { .. }
                 );
+                // `recv.prop(...args)` where `prop` is an instance ACCESSOR
+                // (`get prop()`) is NOT a method call: it must READ the accessor
+                // (running the getter, which yields a function) and CALL that
+                // function with the spread args. The method-apply path below
+                // dispatches `prop` by name via `js_native_call_method`, which
+                // looks up a same-named METHOD and throws "prop is not a
+                // function" for an accessor. Skip it so the closure-callee path
+                // lowers the callee `PropertyGet{recv, prop}` (invoking the
+                // getter) and applies the spread to its result. Refs test262
+                // language/arguments-object cls-*-spread-operator getter calls.
+                if !skip {
+                    if let Some(cls) = receiver_class_name(ctx, object) {
+                        let mut cur = Some(cls);
+                        while let Some(c) = cur {
+                            let Some(ci) = ctx.classes.get(&c) else {
+                                break;
+                            };
+                            if ci.getters.iter().any(|(n, _)| n == property) {
+                                skip = true;
+                                break;
+                            }
+                            cur = ci.extends_name.clone();
+                        }
+                    }
+                }
                 if !skip {
                     let recv_box = lower_expr(ctx, object)?;
                     // Build a single JS array containing every arg in order.

--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -818,6 +818,37 @@ fn is_message_port_closure_method(object: &Expr, property: &str) -> bool {
     )
 }
 
+/// `C.prop(args)` where `prop` names a static ACCESSOR (`static get prop()`)
+/// anywhere on `cls_name`'s chain is NOT a static-method dispatch: it must READ
+/// the accessor (running the getter, which yields a function) and CALL that
+/// function with `args`. We emit that value-call via the closure-callee
+/// fallthrough — which lowers the callee `PropertyGet{<class>, prop}` (invoking
+/// the getter with `this` bound to the class) and dispatches the result through
+/// `js_closure_call` — instead of letting a downstream by-name dispatcher
+/// (`js_native_call_method` / `js_class_static_method_call`) silently drop the
+/// call (those miss because the name lives in CLASS_STATIC_ACCESSORS, not
+/// CLASS_STATIC_METHODS). Returns `None` when `prop` is not a static accessor on
+/// the chain. Refs test262 language/arguments-object cls-*-static-* getter calls.
+pub fn try_lower_class_static_accessor_call(
+    ctx: &mut FnCtx<'_>,
+    cls_name: &str,
+    property: &str,
+    callee: &Expr,
+    args: &[Expr],
+) -> Result<Option<String>> {
+    let mut cur = Some(cls_name.to_string());
+    while let Some(c) = cur {
+        let Some(ci) = ctx.classes.get(&c) else {
+            break;
+        };
+        if ci.static_accessor_names.iter().any(|n| n == property) {
+            return try_lower_closure_call_fallthrough(ctx, callee, args);
+        }
+        cur = ci.extends_name.clone();
+    }
+    Ok(None)
+}
+
 pub fn try_lower_closure_call_fallthrough(
     ctx: &mut FnCtx<'_>,
     callee: &Expr,

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -977,6 +977,13 @@ pub fn try_lower_property_get_method_call(
         &ctx.class_ids,
     );
     if let Some(cls_name) = static_dispatch_cls {
+        // `C.prop(args)` where `prop` is a static ACCESSOR reads the accessor and
+        // calls its result — handle before the by-name tower (which would miss).
+        if let Some(v) = super::console_promise::try_lower_class_static_accessor_call(
+            ctx, &cls_name, property, callee, args,
+        )? {
+            return Ok(Some(v));
+        }
         // (fn_name, is_static, declared_param_count, has_rest, is_synthetic_arguments)
         let mut resolved: Option<(String, bool, usize, bool, bool)> = None;
         let mut cur = Some(cls_name.clone());

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -386,13 +386,26 @@ fn try_direct_eval_simple_assignment_fold(ctx: &mut LoweringContext, body: &str)
     };
     let name = parse_eval_ident_name(trim_js_eval_ws(name_raw))?;
     let value = parse_eval_literal(value_raw)?;
+    // A `var x = <v>` DECLARATION runs the binding initialization as a side
+    // effect, but its completion value is empty (→ `undefined`) per spec
+    // (VariableStatement yields an empty completion). A bare `x = <v>`
+    // AssignmentExpression has completion value `<v>`. Wrap the var-declaration
+    // form so it still stores but yields `undefined`. Refs test262
+    // language/eval-code cptn-nrml-empty-var (`eval("var x = 1") === undefined`).
+    let finish = |assign: Expr| -> Expr {
+        if is_var_assignment {
+            Expr::Sequence(vec![assign, Expr::Undefined])
+        } else {
+            assign
+        }
+    };
     if let Some(id) = ctx.lookup_local(name) {
         if is_var_assignment && !ctx.var_hoisted_ids.contains(&id) {
             return Some(Expr::SyntaxErrorNew(Box::new(Expr::String(format!(
                 "eval var declaration conflicts with lexical binding `{name}`"
             )))));
         }
-        Some(Expr::LocalSet(id, Box::new(value)))
+        Some(finish(Expr::LocalSet(id, Box::new(value))))
     } else if ctx.current_strict {
         Some(super::throw_reference_error_expr(&format!(
             "eval assignment to undeclared identifier `{name}`"
@@ -400,7 +413,7 @@ fn try_direct_eval_simple_assignment_fold(ctx: &mut LoweringContext, body: &str)
     } else {
         let id = ctx.define_local(name.to_string(), perry_types::Type::Any);
         ctx.var_hoisted_ids.insert(id);
-        Some(Expr::LocalSet(id, Box::new(value)))
+        Some(finish(Expr::LocalSet(id, Box::new(value))))
     }
 }
 

--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -61,11 +61,20 @@ fn is_node_stream_iterator_helper_instance_method(
 pub(super) fn try_static_method_and_instance(
     ctx: &mut LoweringContext,
     // #854: kept for the uniform `try_*` dispatch-helper signature; this arm
-    // works off `expr`, not the raw `CallExpr`.
-    _call: &ast::CallExpr,
+    // works off `expr`, not the raw `CallExpr` — except for the spread check.
+    call: &ast::CallExpr,
     expr: &ast::Expr,
     args: Vec<Expr>,
 ) -> Result<Result<Expr, Vec<Expr>>> {
+    // `StaticMethodCall` carries plain positional `args: Vec<Expr>` with no way
+    // to express argument spreads, so routing a spread call (`C.method(...xs)`)
+    // here would silently drop the spread markers — the spread sources land as
+    // single positional args and `arguments.length` undercounts. When the call
+    // spreads, skip the static-method production below and let the generic
+    // `CallSpread` path (which expands spreads into the runtime args array)
+    // handle it. Refs test262 language/arguments-object
+    // cls-*-static-*-spread-operator.
+    let static_call_has_spread = call.args.iter().any(|a| a.spread.is_some());
     // Check for static method calls (e.g., Counter.increment())
     if let ast::Expr::Member(member) = expr {
         if let ast::Expr::Ident(obj_ident) = unwrap_ts_wrappers(member.obj.as_ref()) {
@@ -141,7 +150,9 @@ pub(super) fn try_static_method_and_instance(
                                 args,
                             }));
                         }
-                        if ctx.has_static_method(&obj_name, &method_name) || is_imported_upper {
+                        if (ctx.has_static_method(&obj_name, &method_name) || is_imported_upper)
+                            && !static_call_has_spread
+                        {
                             return Ok(Ok(Expr::StaticMethodCall {
                                 class_name: obj_name,
                                 method_name,
@@ -152,7 +163,8 @@ pub(super) fn try_static_method_and_instance(
                     // Private static method: WithPrivateStatic.#helper()
                     ast::MemberProp::PrivateName(priv_ident) => {
                         let method_name = format!("#{}", priv_ident.name);
-                        if ctx.has_static_method(&obj_name, &method_name) {
+                        if ctx.has_static_method(&obj_name, &method_name) && !static_call_has_spread
+                        {
                             return Ok(Ok(Expr::StaticMethodCall {
                                 class_name: obj_name,
                                 method_name,

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -550,12 +550,24 @@ pub fn lower_module_full(
             let mut static_method_names = Vec::new();
             for member in &cd.class.body {
                 match member {
-                    ast::ClassMember::Method(method) if method.is_static => {
+                    // Only true static *methods* register as callable statics.
+                    // Static accessors (`static get foo()`) are NOT methods —
+                    // `C.foo(...)` must read the accessor (invoking the getter)
+                    // and call its result, not dispatch a static method named
+                    // `foo`. Registering them here makes `has_static_method`
+                    // hijack the call into a StaticMethodCall whose target
+                    // doesn't exist, silently dropping the call. Refs test262
+                    // language/arguments-object cls-*-static-* getter calls.
+                    ast::ClassMember::Method(method)
+                        if method.is_static && matches!(method.kind, ast::MethodKind::Method) =>
+                    {
                         if let ast::PropName::Ident(ident) = &method.key {
                             static_method_names.push(ident.sym.to_string());
                         }
                     }
-                    ast::ClassMember::PrivateMethod(method) if method.is_static => {
+                    ast::ClassMember::PrivateMethod(method)
+                        if method.is_static && matches!(method.kind, ast::MethodKind::Method) =>
+                    {
                         static_method_names.push(format!("#{}", method.key.name));
                     }
                     ast::ClassMember::ClassProp(prop) if prop.is_static => {

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -290,12 +290,21 @@ pub fn lower_class_decl(
     let mut static_method_names = Vec::new();
     for member in &class_decl.class.body {
         match member {
-            ast::ClassMember::Method(method) if method.is_static => {
+            // Static accessors (`static get foo()`) are not callable static
+            // methods: `C.foo(...)` must read the accessor and call its result.
+            // Excluding getter/setter kinds keeps `has_static_method` from
+            // hijacking the call into a non-existent StaticMethodCall. Refs
+            // test262 language/arguments-object cls-*-static-* getter calls.
+            ast::ClassMember::Method(method)
+                if method.is_static && matches!(method.kind, ast::MethodKind::Method) =>
+            {
                 if let ast::PropName::Ident(ident) = &method.key {
                     static_method_names.push(ident.sym.to_string());
                 }
             }
-            ast::ClassMember::PrivateMethod(method) if method.is_static => {
+            ast::ClassMember::PrivateMethod(method)
+                if method.is_static && matches!(method.kind, ast::MethodKind::Method) =>
+            {
                 // Register as "#name" so WithPrivateStatic.#helper()
                 // call-site lookup via has_static_method() succeeds.
                 static_method_names.push(format!("#{}", method.key.name));
@@ -1185,12 +1194,17 @@ pub fn lower_class_from_ast(
     let mut static_method_names = Vec::new();
     for member in &class.body {
         match member {
-            ast::ClassMember::Method(method) if method.is_static => {
+            // See note above: static getters/setters are not callable methods.
+            ast::ClassMember::Method(method)
+                if method.is_static && matches!(method.kind, ast::MethodKind::Method) =>
+            {
                 if let ast::PropName::Ident(ident) = &method.key {
                     static_method_names.push(ident.sym.to_string());
                 }
             }
-            ast::ClassMember::PrivateMethod(method) if method.is_static => {
+            ast::ClassMember::PrivateMethod(method)
+                if method.is_static && matches!(method.kind, ast::MethodKind::Method) =>
+            {
                 static_method_names.push(format!("#{}", method.key.name));
             }
             ast::ClassMember::ClassProp(prop) if prop.is_static => {

--- a/crates/perry-transform/src/inline/analysis.rs
+++ b/crates/perry-transform/src/inline/analysis.rs
@@ -109,6 +109,18 @@ pub fn is_inlinable(func: &Function) -> bool {
         return false;
     }
 
+    // Don't inline functions that reference the dynamic `this` / `new.target`
+    // bindings. Those belong to the callee's own invocation, but the inliner
+    // substitutes the body into the CALLER's frame, where `this`/`new.target`
+    // resolve to the caller's binding. A strict callee called as `f()` has
+    // `this === undefined`; inlined into a sloppy caller it would instead read
+    // the caller's `this` (the global object), so `typeof this` flips from
+    // `"undefined"` to `"object"`. Refs test262 language/function-code
+    // `10.4.3-1-*`.
+    if body_references_dynamic_this(&func.body) {
+        return false;
+    }
+
     // Don't inline functions that call themselves. The single-Return-of-Call
     // pattern in `try_inline_simple_call` (and the multi-Let-then-Return
     // pattern) substitutes the body verbatim; when the body is

--- a/crates/perry-transform/src/inline/closure_analysis.rs
+++ b/crates/perry-transform/src/inline/closure_analysis.rs
@@ -69,6 +69,85 @@ pub fn body_contains_super_call(stmts: &[Stmt]) -> bool {
     stmts.iter().any(check_stmt)
 }
 
+/// Returns true if the body references the dynamic `this` or `new.target`
+/// bindings — directly (`Expr::This` / `Expr::NewTarget`) or through a nested
+/// arrow that lexically captures them (`captures_this` / `captures_new_target`).
+///
+/// These bindings belong to the function's OWN invocation: spec
+/// `OrdinaryCallBindThis` binds `this` from the call's thisArgument (which for a
+/// plain `f()` call is `undefined` in strict code, the global object in sloppy
+/// code), and `new.target` from the construct. Substituting the body into the
+/// caller (what the inliner does) silently rebinds them to the CALLER's frame —
+/// a strict callee whose `this` is `undefined` would instead read the caller's
+/// `this` (e.g. the global object), and `typeof this` flips from `"undefined"`
+/// to `"object"`. Refs test262 language/function-code `10.4.3-1-*` strict-mode
+/// `this`. Reject inlining of any such function.
+pub fn body_references_dynamic_this(stmts: &[Stmt]) -> bool {
+    fn check_expr(expr: &Expr) -> bool {
+        if matches!(expr, Expr::This | Expr::NewTarget) {
+            return true;
+        }
+        // An arrow that lexically uses the enclosing `this`/`new.target` records
+        // it via these flags. We do NOT descend into the closure body for a bare
+        // `Expr::This` (that one is the closure's OWN binding when it isn't an
+        // arrow); `walk_expr_children` only yields a closure's param defaults,
+        // which DO execute in the enclosing frame, so those are still checked.
+        if let Expr::Closure {
+            captures_this,
+            captures_new_target,
+            ..
+        } = expr
+        {
+            if *captures_this || *captures_new_target {
+                return true;
+            }
+        }
+        let mut found = false;
+        walk_expr_children(expr, &mut |child| {
+            if !found && check_expr(child) {
+                found = true;
+            }
+        });
+        found
+    }
+
+    fn check_stmt(stmt: &Stmt) -> bool {
+        match stmt {
+            Stmt::Let { init, .. } => init.as_ref().is_some_and(check_expr),
+            Stmt::Expr(expr) | Stmt::Throw(expr) => check_expr(expr),
+            Stmt::Return(expr) => expr.as_ref().is_some_and(check_expr),
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                check_expr(condition)
+                    || then_branch.iter().any(check_stmt)
+                    || else_branch
+                        .as_ref()
+                        .is_some_and(|b| b.iter().any(check_stmt))
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { condition, body } => {
+                check_expr(condition) || body.iter().any(check_stmt)
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                init.as_ref().is_some_and(|i| check_stmt(i))
+                    || condition.as_ref().is_some_and(check_expr)
+                    || update.as_ref().is_some_and(check_expr)
+                    || body.iter().any(check_stmt)
+            }
+            _ => false,
+        }
+    }
+
+    stmts.iter().any(check_stmt)
+}
+
 /// Check if statements contain a closure that captures any of the given local IDs
 pub fn body_contains_closure_capturing(
     stmts: &[Stmt],

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -37,8 +37,9 @@ pub(crate) use call_inliner::{
 };
 pub(crate) use clamp::{is_clamp3, is_clamp_u8};
 pub(crate) use closure_analysis::{
-    body_contains_closure_capturing, body_contains_super_call, collect_closure_captured_local_ids,
-    find_max_local_id, has_simple_control_flow, is_pure_function,
+    body_contains_closure_capturing, body_contains_super_call, body_references_dynamic_this,
+    collect_closure_captured_local_ids, find_max_local_id, has_simple_control_flow,
+    is_pure_function,
 };
 pub(crate) use cross_module::{
     body_references_class_in_set, collect_nonexported_class_names,

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -248,6 +248,12 @@ crates/perry-runtime/src/node_stream_constructors.rs
 # LOC) on main after recent dispatch-arm additions. Splitting per receiver-type
 # family is tracked under #1435.
 crates/perry-codegen/src/expr/property_get.rs
+# Codegen call-site method-dispatch tower (string/array/class/Map/Set/Promise +
+# static/instance method resolution). Sat at 1998 LOC on main; crossed the
+# 2000-line gate after the class static-accessor call route (test262
+# arguments-object cls-*-static-* getter calls). Splitting the per-receiver-type
+# dispatch helpers into sibling modules is tracked under #1435.
+crates/perry-codegen/src/lower_call/property_get.rs
 # TypedArray root — constructor/view-metadata/element load-store/iterator tower.
 # Crossed the 2000-line gate (2062 LOC) on current main after the #4702
 # %TypedArray%.prototype iterator brand-check + array-like/iterable constructor


### PR DESCRIPTION
## Summary

Five root causes across the inliner, class static/accessor dispatch, spread-call lowering, and eval completion-value folding. Driving `language/eval-code`, `language/function-code`, and `language/arguments-object` parity against the `node` oracle.

| dir | before | after |
|-----|--------|-------|
| language/eval-code | 280 | **281** |
| language/function-code | 167 | **169** |
| language/arguments-object | 205 | **239** |

Parity **79.5% → 84.0%** on the three dirs (+36 pass).

## Root causes & fixes

**1. Inliner substituted `this`/`new.target` across the call boundary** (function-code `10.4.3-1-*` strict-`this`). `is_inlinable` rejected `super` but not bare `this`/`new.target`, so `function g(){ return typeof this }` got its body spliced into a sloppy caller, rebinding `this` to the caller's global object — `typeof this` flipped `"undefined"`→`"object"`. New `body_references_dynamic_this` guard rejects such bodies (and arrows that lexically capture `this`/`new.target`).

**2. Static accessors were registered as callable static methods** (arguments-object `cls-*-static-*` getter calls). `static get foo()` was pushed into `static_method_names`, so `C.foo(...)` was hijacked into a `StaticMethodCall` whose target didn't exist and the call was silently dropped. Excluded getter/setter kinds from the static-method registry (3 collection sites) and routed static-accessor calls through the value-call fallthrough in codegen (new `try_lower_class_static_accessor_call`): read the accessor, then call its result with `this` bound to the class.

**3. Instance-accessor calls with spread threw "not a function"** (arguments-object `cls-*-spread-operator`). `recv.getter(...args)` dispatched `getter` by name via `js_native_call_method_apply`. Skip the method-apply path when `getter` is an instance accessor so the getter is invoked and its result spread-called.

**4. Static method/getter calls with spread dropped the spread** (arguments-object `cls-*-static-*-spread-operator`). `StaticMethodCall` carries plain positional args with no spread representation, so spread sources landed as single positional args and `arguments.length` undercounted. Gate `StaticMethodCall` production on `!has_spread` so the call routes through the spread-aware `CallSpread` path.

**5. `eval("var x = 1")` completion value** (eval-code `cptn-nrml-empty-var`). A `VariableStatement` yields an empty completion (→ `undefined`), but the direct-eval assignment fold returned the assigned value. Wrap the `var x = <v>` form so it stores but yields `undefined`.

## Regression check

Broad shard `0/12` over `built-ins language`, my binary vs the exact merge-base binary:

- **mine 1914 pass vs base 1874 pass (+40)**, identical compile-fail count (18).
- Per-test diff: **41 improvements, 0 real regressions.** The single apparent diff (`built-ins/TypedArray/prototype/forEach/returns-undefined`) is a pre-existing nondeterministic GC flake — it fails identically on the merge-base binary in isolation (6/6).

`cargo test` green for `perry-transform`, `perry-hir`, `perry-codegen`. `cargo fmt` + file-size gate clean.

## Deferred (separate root causes, pre-existing failures)

- Generator/async-generator static methods called via getter+spread (generator calling convention through a value-call).
- Mapped `arguments` exotic-object `[[DefineOwnProperty]]`/`[[Delete]]`/`[[Set]]` semantics (`mapped/*`).
- The bulk of remaining function-code/eval-code failures are the node-CJS environment quirk (top-level `this` = `module.exports`, indirect eval not seeing module-scoped vars) where `node` *rejects* but a spec-correct script runtime runs clean — matching them would mean emulating CommonJS module scoping, which risks broad regressions.