### PR TITLE
fix(runtime): built-ins/RegExp (non-lookbehind) test262 parity

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -1031,10 +1031,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let str_box = lower_expr(ctx, string)?;
             let blk = ctx.block();
             let regex_handle = unbox_to_i64(blk, &regex_box);
-            // String pointer extraction goes through the unified
-            // helper because the receiver may be a literal, a local,
-            // or a concat result.
-            let str_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &str_box)]);
+            // Per spec `RegExp.prototype.test` does `ToString(argument)`, so a
+            // String wrapper (`re.test(new String("x"))`), a number
+            // (`re.test(123)`), or an object with a custom `toString` must be
+            // coerced — and a throwing `toString`/`valueOf` must propagate.
+            // `js_get_string_pointer_unified` only unwraps real strings, so use
+            // the coercing ToString that dispatches `toString` on objects.
+            let str_handle = blk.call(I64, "js_jsvalue_to_string_coerce", &[(DOUBLE, &str_box)]);
             let i32_v = blk.call(
                 I32,
                 "js_regexp_test",
@@ -1052,7 +1055,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let str_box = lower_expr(ctx, string)?;
             let blk = ctx.block();
             let regex_handle = unbox_to_i64(blk, &regex_box);
-            let str_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &str_box)]);
+            // `RegExp.prototype.exec` does `ToString(argument)` — coerce String
+            // wrappers / numbers / objects (and propagate a throwing toString)
+            // rather than only unwrapping real strings (see RegExpTest above).
+            let str_handle = blk.call(I64, "js_jsvalue_to_string_coerce", &[(DOUBLE, &str_box)]);
             let result = blk.call(
                 I64,
                 "js_regexp_exec",

--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -601,29 +601,23 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // `js_regexp_new` always sees a real `StringHeader*`. Followup
         // to #957 / PR #959.
         Expr::RegExpDynamic { pattern, flags } => {
+            // Route through the full ECMAScript constructor: it handles a RegExp
+            // pattern (copy / flag override), an `undefined`/`null` pattern
+            // (`ToString` → `""`/`"null"`), an object pattern, and ToString-
+            // coerced flags (an object flags → `"[object Object]"` → SyntaxError).
+            // Passing the NaN-boxed values verbatim (NOT `unbox_str_handle`,
+            // which mis-reads a non-string pattern as a StringHeader → garbage).
             let pattern_box = lower_expr(ctx, pattern)?;
-            let flags_handle = if let Some(flags_expr) = flags {
-                let flags_box = lower_expr(ctx, flags_expr)?;
-                let blk = ctx.block();
-                unbox_str_handle(blk, &flags_box)
+            let flags_box = if let Some(flags_expr) = flags {
+                lower_expr(ctx, flags_expr)?
             } else {
-                // Intern an empty string and use its handle so the
-                // runtime sees a valid `StringHeader*` (the
-                // `is_valid_ptr` check inside `js_regexp_new` already
-                // accepts null, but the LLVM type system needs a real
-                // i64 here, not a `null` typed `ptr`).
-                let empty_idx = ctx.strings.intern("");
-                let empty_global = format!("@{}", ctx.strings.entry(empty_idx).handle_global);
-                let blk = ctx.block();
-                let empty_box = blk.load(DOUBLE, &empty_global);
-                unbox_to_i64(blk, &empty_box)
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
             };
             let blk = ctx.block();
-            let pattern_handle = unbox_str_handle(blk, &pattern_box);
             let result = blk.call(
                 I64,
-                "js_regexp_new",
-                &[(I64, &pattern_handle), (I64, &flags_handle)],
+                "js_regexp_construct",
+                &[(DOUBLE, &pattern_box), (DOUBLE, &flags_box)],
             );
             Ok(nanbox_pointer_inline(blk, &result))
         }

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -215,23 +215,26 @@ pub(super) fn lower_builtin_new(
             )))
         }
         "RegExp" => {
+            // Pass the NaN-boxed pattern/flags straight to the full constructor
+            // so a RegExp pattern (flag override / copy), an `undefined` pattern,
+            // or an object `flags` (ToString → SyntaxError) are all handled per
+            // spec. Defaults are `undefined` (NOT 0.0) so `new RegExp()` builds
+            // an empty source.
             let pattern_box = if !args.is_empty() {
                 lower_expr(ctx, &args[0])?
             } else {
-                double_literal(0.0)
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
             };
             let flags_box = if args.len() > 1 {
                 lower_expr(ctx, &args[1])?
             } else {
-                double_literal(0.0)
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
             };
             let blk = ctx.block();
-            let pattern_handle = unbox_to_i64(blk, &pattern_box);
-            let flags_handle = unbox_to_i64(blk, &flags_box);
             let handle = blk.call(
                 I64,
-                "js_regexp_new",
-                &[(I64, &pattern_handle), (I64, &flags_handle)],
+                "js_regexp_construct",
+                &[(DOUBLE, &pattern_box), (DOUBLE, &flags_box)],
             );
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -22,6 +22,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_jsvalue_to_string", I64, &[DOUBLE]);
     // #3146: nullish-guarded `.toString()` member-call variant.
     module.declare_function("js_jsvalue_to_string_method", I64, &[DOUBLE]);
+    // ToString coercion (undefined→"undefined", null→"null", objects dispatch
+    // toString) — used by RegExp exec/test arg + constructor coercion.
+    module.declare_function("js_jsvalue_to_string_coerce", I64, &[DOUBLE]);
 
     // Fused string+value concat (issue #58): collapses js_jsvalue_to_string +
     // js_string_concat into a single allocation for number operands.
@@ -995,6 +998,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
         &[DOUBLE, DOUBLE, DOUBLE, I32, DOUBLE],
     );
     module.declare_function("js_regexp_new", I64, &[I64, I64]);
+    // Full ECMAScript RegExp constructor: NaN-boxed pattern + flags in, handles
+    // RegExp/undefined/object patterns and ToString-coerced flags.
+    module.declare_function("js_regexp_construct", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_regexp_test", I32, &[I64, I64]);
     // RegExp.escape(str) — #2899. Takes/returns NaN-boxed f64 (string).
     module.declare_function("js_regexp_escape", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -1163,11 +1163,27 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                         _ => None,
                     })
                     .unwrap_or_default();
+                // Only take the constant-folded literal path when the flags
+                // argument is absent or itself a string literal. If a flags
+                // argument is present but NOT a string literal (e.g. an object
+                // `{ toString() {…} }`, a variable, or a number), it must be
+                // `ToString`-coerced at runtime — and a throwing `toString`
+                // must propagate — so fall through to `RegExpDynamic`. Folding
+                // those to `Expr::RegExp` here silently dropped the flags.
+                let flags_arg_is_string_literal_or_absent = match args_ast {
+                    Some(args) => match args.get(1) {
+                        None => true,
+                        Some(a) => matches!(a.expr.as_ref(), ast::Expr::Lit(ast::Lit::Str(_))),
+                    },
+                    None => true,
+                };
                 if let Some(pattern) = pattern_lit {
-                    return Ok(Expr::RegExp {
-                        pattern,
-                        flags: flags_lit,
-                    });
+                    if flags_arg_is_string_literal_or_absent {
+                        return Ok(Expr::RegExp {
+                            pattern,
+                            flags: flags_lit,
+                        });
+                    }
                 }
                 // Dynamic-arg `new RegExp(...)`: pattern (or flags) is
                 // a runtime value. Fold to the same `RegExpDynamic`

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -4110,7 +4110,9 @@ pub extern "C" fn js_object_get_field_by_name(
                         return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
                     }
                     b"lastIndex" => {
-                        return JSValue::number((*re).last_index as f64);
+                        // lastIndex stores the raw NaN-boxed value (usually a
+                        // number, but any value is assignable).
+                        return JSValue::from_bits((*re).last_index);
                     }
                     b"global" => {
                         return JSValue::bool((*re).global);
@@ -4136,7 +4138,26 @@ pub extern "C" fn js_object_get_field_by_name(
                     b"hasIndices" => {
                         return JSValue::bool((*re).has_indices);
                     }
-                    _ => return JSValue::undefined(),
+                    // Inherited `RegExp.prototype` members read off an instance
+                    // (`re.constructor`, `re.exec`, `re.toString`, a user-added
+                    // `RegExp.prototype.x`) resolve through the prototype chain.
+                    // The RegExpHeader isn't a plain object, so walk to
+                    // %RegExp.prototype% and return its own data field — this is
+                    // what makes `re.constructor === RegExp` and reflective
+                    // method reads work. `source`/`flags`/the flag accessors are
+                    // handled by the arms above and never reach here, so we never
+                    // return an un-invoked getter closure.
+                    _ => {
+                        let proto = crate::object::builtin_prototype_value("RegExp");
+                        let proto_ptr =
+                            crate::value::js_nanbox_get_pointer(proto) as *const ObjectHeader;
+                        if !proto_ptr.is_null() {
+                            if let Some(v) = own_data_field_by_name(proto_ptr, key) {
+                                return v;
+                            }
+                        }
+                        return JSValue::undefined();
+                    }
                 }
             }
             return JSValue::undefined();

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -5814,10 +5814,14 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
             );
         }
         "RegExp" => {
-            install_noop_proto_methods(
-                proto_obj,
-                &[("exec", 1), ("test", 1), ("toString", 0), ("compile", 2)],
-            );
+            // Real accessor getters (`source`/`flags`/`global`/…) so reflection
+            // (`getOwnPropertyDescriptor(RegExp.prototype, "source").get`) and
+            // brand-checked `.call(this)` work, and instances inherit them.
+            super::regex_proto_thunks::install_regex_proto_accessors(proto_obj);
+            // Real brand-checking `exec`/`test`/`toString`; `compile` stays a
+            // no-op (Annex B).
+            super::regex_proto_thunks::install_regex_proto_methods(proto_obj);
+            install_noop_proto_methods(proto_obj, &[("compile", 2)]);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }
         "URLPattern" => {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -60,6 +60,7 @@ mod property_key;
 pub(crate) mod prototype_chain;
 mod prototype_helpers;
 mod reflect_support;
+mod regex_proto_thunks;
 mod string_proto_thunks;
 mod typed_array_define;
 mod typed_array_proto_thunks;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -568,6 +568,25 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
         return false;
     }
 
+    // A RegExp's `[[Prototype]]` chain is `RegExp.prototype → Object.prototype`.
+    // The RegExpHeader isn't a plain GC_TYPE_OBJECT with a registered class
+    // prototype, so the generic class-id walk below misses it (which is why
+    // `RegExp.prototype.isPrototypeOf(re)` returned false). Handle it directly.
+    {
+        let tv = JSValue::from_bits(target.to_bits());
+        if tv.is_pointer() && crate::regex::is_regex_pointer(tv.as_pointer::<u8>()) {
+            for name in ["RegExp", "Object"] {
+                let proto = crate::object::builtin_prototype_value(name);
+                if let Some(proto_addr) = heap_addr(proto) {
+                    if proto_addr == receiver_addr {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
     let target_jsval = JSValue::from_bits(target.to_bits());
     if !target_jsval.is_pointer() && gc_pointer_and_type_from_value(target).is_none() {
         return false;

--- a/crates/perry-runtime/src/object/regex_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/regex_proto_thunks.rs
@@ -1,0 +1,358 @@
+//! RegExp.prototype accessor getters (`source`, `flags`, `global`,
+//! `ignoreCase`, `multiline`, `dotAll`, `sticky`, `unicode`, `unicodeSets`,
+//! `hasIndices`).
+//!
+//! Per ECMA-262 these are *accessor* properties living on `RegExp.prototype`
+//! with a native getter function and `set: undefined`, `enumerable: false`,
+//! `configurable: true`. Instances expose them through the prototype chain, so
+//! `re.global` works via the inherited getter and reflection
+//! (`Object.getOwnPropertyDescriptor(RegExp.prototype, "global").get`) finds the
+//! real getter. Each getter brand-checks `this`:
+//!
+//!   * a real RegExp instance → read the flag/source,
+//!   * exactly `RegExp.prototype` → return the spec sentinel (`undefined` for
+//!     the boolean flags, `"(?:)"` for `source`, `""` for `flags`),
+//!   * anything else → `TypeError`.
+//!
+//! The `flags` getter is special: per spec it does NOT brand-check
+//! `[[OriginalFlags]]`; it reads `hasIndices`/`global`/… off the (generic)
+//! receiver via `Get` + `ToBoolean` and assembles the string. So
+//! `RegExp.prototype.flags.call({ global: 1, … })` works on a plain object.
+//!
+//! Installed onto `RegExp.prototype` by
+//! `global_this::populate_builtin_prototype_methods`.
+
+use super::*;
+
+/// Result of resolving the `this` receiver for a brand-checked flag/source
+/// getter.
+enum RegexReceiver {
+    /// A live RegExp instance.
+    Regex(*const crate::regex::RegExpHeader),
+    /// Exactly `RegExp.prototype` — getters return the spec sentinel.
+    Prototype,
+}
+
+/// Resolve `IMPLICIT_THIS` to a RegExp instance or `RegExp.prototype`, throwing
+/// `TypeError` otherwise (matching the spec brand check shared by every
+/// flag/`source` getter).
+fn regex_receiver_or_throw(getter: &str) -> RegexReceiver {
+    let receiver = crate::value::JSValue::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    if receiver.is_pointer() {
+        let ptr = receiver.as_pointer::<u8>() as usize;
+        if crate::regex::is_registered_regex(ptr) {
+            return RegexReceiver::Regex(ptr as *const crate::regex::RegExpHeader);
+        }
+        let proto = crate::value::JSValue::from_bits(
+            super::global_this::builtin_prototype_value("RegExp").to_bits(),
+        );
+        if proto.is_pointer() && proto.as_pointer::<u8>() as usize == ptr {
+            return RegexReceiver::Prototype;
+        }
+    }
+    throw_regex_brand_error(getter)
+}
+
+fn throw_regex_brand_error(getter: &str) -> ! {
+    let msg = format!("get RegExp.prototype.{getter} called on incompatible receiver");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(f64::from_bits(
+        crate::value::JSValue::pointer(err as *const u8).bits(),
+    ))
+}
+
+/// Does the regex's (canonical) flags string contain `flag`?
+fn regex_has_flag(re: *const crate::regex::RegExpHeader, flag: char) -> bool {
+    let s = crate::regex::js_regexp_get_flags(re);
+    if s.is_null() {
+        return false;
+    }
+    unsafe {
+        let len = (*s).byte_len as usize;
+        let data = (s as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let bytes = std::slice::from_raw_parts(data, len);
+        bytes.iter().any(|&b| b as char == flag)
+    }
+}
+
+/// Shared body for the boolean flag getters: regex → boolean, prototype →
+/// undefined, else TypeError.
+fn flag_getter(getter: &str, flag: char) -> f64 {
+    match regex_receiver_or_throw(getter) {
+        RegexReceiver::Regex(re) => {
+            f64::from_bits(crate::value::JSValue::bool(regex_has_flag(re, flag)).bits())
+        }
+        RegexReceiver::Prototype => f64::from_bits(crate::value::TAG_UNDEFINED),
+    }
+}
+
+pub(super) extern "C" fn regex_proto_global_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    flag_getter("global", 'g')
+}
+pub(super) extern "C" fn regex_proto_ignore_case_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    flag_getter("ignoreCase", 'i')
+}
+pub(super) extern "C" fn regex_proto_multiline_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    flag_getter("multiline", 'm')
+}
+pub(super) extern "C" fn regex_proto_dot_all_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    flag_getter("dotAll", 's')
+}
+pub(super) extern "C" fn regex_proto_sticky_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    flag_getter("sticky", 'y')
+}
+pub(super) extern "C" fn regex_proto_unicode_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    flag_getter("unicode", 'u')
+}
+pub(super) extern "C" fn regex_proto_unicode_sets_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    flag_getter("unicodeSets", 'v')
+}
+pub(super) extern "C" fn regex_proto_has_indices_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    flag_getter("hasIndices", 'd')
+}
+
+pub(super) extern "C" fn regex_proto_source_getter(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    match regex_receiver_or_throw("source") {
+        RegexReceiver::Regex(re) => {
+            // `js_regexp_get_source` returns the *escaped* source string.
+            let s = crate::regex::js_regexp_get_source(re);
+            f64::from_bits(crate::js_nanbox_string(s as i64).to_bits())
+        }
+        RegexReceiver::Prototype => {
+            let s = crate::regex::js_regexp_empty_source();
+            f64::from_bits(crate::js_nanbox_string(s as i64).to_bits())
+        }
+    }
+}
+
+/// `get RegExp.prototype.flags` — spec 22.2.6.4. Reads each flag property off
+/// the (generic) receiver via `Get` + `ToBoolean` and assembles in canonical
+/// order `d g i m s u v y`. Throws `TypeError` only if `this` is not an Object.
+pub(super) extern "C" fn regex_proto_flags_getter(_c: *const crate::closure::ClosureHeader) -> f64 {
+    let receiver = crate::value::JSValue::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    // Type(R) must be Object. Pointer-tagged values are objects EXCEPT Symbols
+    // (which are also pointer-tagged via the symbol side-table); a Symbol `this`
+    // must throw a TypeError, not silently assemble "".
+    if !receiver.is_pointer()
+        || crate::symbol::is_registered_symbol(receiver.as_pointer::<u8>() as usize)
+    {
+        throw_regex_brand_error("flags");
+    }
+    let recv_bits = receiver.bits();
+    let recv_f64 = f64::from_bits(recv_bits);
+    let mut out = String::with_capacity(8);
+    for (name, ch) in [
+        ("hasIndices", 'd'),
+        ("global", 'g'),
+        ("ignoreCase", 'i'),
+        ("multiline", 'm'),
+        ("dotAll", 's'),
+        ("unicode", 'u'),
+        ("unicodeSets", 'v'),
+        ("sticky", 'y'),
+    ] {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let key_val = crate::js_nanbox_string(key as i64);
+        let v = crate::value::js_dyn_index_get(recv_f64, key_val);
+        if crate::value::js_is_truthy(v) != 0 {
+            out.push(ch);
+        }
+    }
+    let s = crate::string::js_string_from_bytes(out.as_ptr(), out.len() as u32);
+    f64::from_bits(crate::js_nanbox_string(s as i64).to_bits())
+}
+
+/// Install one accessor getter (`set: undefined`) onto `proto_obj` with the
+/// spec attributes (`enumerable: false`, `configurable: true`) and the proper
+/// getter `name` (`"get <prop>"`) / `length` (`0`).
+fn install_getter(proto_obj: *mut ObjectHeader, name: &str, func_ptr: *const u8) {
+    if proto_obj.is_null() {
+        return;
+    }
+    unsafe {
+        crate::closure::js_register_closure_arity(func_ptr, 0);
+        let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+        if closure.is_null() {
+            return;
+        }
+        super::native_module::set_bound_native_closure_name(closure, &format!("get {name}"));
+        super::native_module::set_builtin_closure_length(closure as usize, 0);
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        super::object_ops::ensure_key_in_keys_array(proto_obj, key);
+        let getter_bits = crate::value::js_nanbox_pointer(closure as i64).to_bits();
+        super::object_ops::install_builtin_getter(proto_obj, name, getter_bits);
+        super::set_accessor_descriptor(
+            proto_obj as usize,
+            name.to_string(),
+            super::AccessorDescriptor {
+                get: getter_bits,
+                set: 0,
+            },
+        );
+        super::set_property_attrs(
+            proto_obj as usize,
+            name.to_string(),
+            super::PropertyAttrs::new(true, false, true),
+        );
+        super::set_builtin_property_attrs(
+            closure as usize,
+            "name".to_string(),
+            super::PropertyAttrs::new(false, false, true),
+        );
+        super::set_builtin_property_attrs(
+            closure as usize,
+            "length".to_string(),
+            super::PropertyAttrs::new(false, false, true),
+        );
+    }
+}
+
+/// `RegExp.prototype.exec(string)` — brand-checks `this` has `[[RegExpMatcher]]`
+/// (a registered RegExp; `RegExp.prototype` itself throws), `ToString`s the
+/// argument, and runs the match. Reflective: `RegExp.prototype.exec.call(re, s)`
+/// and `re.exec(s)` extracted off the prototype both route here.
+pub(super) extern "C" fn regex_proto_exec_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    let re = regex_instance_or_throw("exec");
+    let s = crate::value::js_jsvalue_to_string_coerce(arg);
+    let arr = crate::regex::js_regexp_exec(re as *mut crate::regex::RegExpHeader, s);
+    if arr.is_null() {
+        f64::from_bits(crate::value::TAG_NULL)
+    } else {
+        f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits())
+    }
+}
+
+/// `RegExp.prototype.test(string)` — brand-checks `this`, `ToString`s the arg,
+/// returns a boolean.
+pub(super) extern "C" fn regex_proto_test_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    arg: f64,
+) -> f64 {
+    let re = regex_instance_or_throw("test");
+    let s = crate::value::js_jsvalue_to_string_coerce(arg);
+    let matched = crate::regex::js_regexp_test(re as *const crate::regex::RegExpHeader, s) != 0;
+    f64::from_bits(crate::value::JSValue::bool(matched).bits())
+}
+
+/// `RegExp.prototype.toString()` — per spec reads `source`/`flags` off the
+/// (generic) receiver via `Get` and returns `/source/flags`. Throws `TypeError`
+/// only when `this` is not an Object, so
+/// `RegExp.prototype.toString.call({ source: "x", flags: "g" })` works.
+pub(super) extern "C" fn regex_proto_to_string_thunk(
+    _c: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let receiver = crate::value::JSValue::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    if !receiver.is_pointer()
+        || crate::symbol::is_registered_symbol(receiver.as_pointer::<u8>() as usize)
+    {
+        throw_regex_brand_error("toString");
+    }
+    let recv_f64 = f64::from_bits(receiver.bits());
+    let read = |name: &str| -> String {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let key_val = crate::js_nanbox_string(key as i64);
+        let v = crate::value::js_dyn_index_get(recv_f64, key_val);
+        let s = crate::value::js_jsvalue_to_string_coerce(v);
+        if s.is_null() {
+            String::new()
+        } else {
+            unsafe {
+                let len = (*s).byte_len as usize;
+                let data = (s as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len)).to_string()
+            }
+        }
+    };
+    let out = format!("/{}/{}", read("source"), read("flags"));
+    let s = crate::string::js_string_from_bytes(out.as_ptr(), out.len() as u32);
+    f64::from_bits(crate::js_nanbox_string(s as i64).to_bits())
+}
+
+/// Resolve `IMPLICIT_THIS` to a live RegExp instance (with `[[RegExpMatcher]]`),
+/// throwing `TypeError` otherwise. Unlike the flag/`source` getters, this does
+/// NOT treat `RegExp.prototype` specially — `exec`/`test` require a real matcher.
+fn regex_instance_or_throw(method: &str) -> *const crate::regex::RegExpHeader {
+    let receiver = crate::value::JSValue::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    if receiver.is_pointer() {
+        let ptr = receiver.as_pointer::<u8>() as usize;
+        if crate::regex::is_registered_regex(ptr) {
+            return ptr as *const crate::regex::RegExpHeader;
+        }
+    }
+    let msg = format!("RegExp.prototype.{method} called on incompatible receiver");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(f64::from_bits(
+        crate::value::JSValue::pointer(err as *const u8).bits(),
+    ))
+}
+
+/// Install the real (brand-checking) `exec`/`test`/`toString` prototype methods.
+/// `compile` stays a no-op (Annex B, rarely exercised).
+pub(super) fn install_regex_proto_methods(proto_obj: *mut ObjectHeader) {
+    use super::global_this::install_proto_method as ipm;
+    ipm(proto_obj, "exec", regex_proto_exec_thunk as *const u8, 1);
+    ipm(proto_obj, "test", regex_proto_test_thunk as *const u8, 1);
+    ipm(
+        proto_obj,
+        "toString",
+        regex_proto_to_string_thunk as *const u8,
+        0,
+    );
+}
+
+/// Install all RegExp.prototype accessor getters.
+pub(super) fn install_regex_proto_accessors(proto_obj: *mut ObjectHeader) {
+    install_getter(proto_obj, "flags", regex_proto_flags_getter as *const u8);
+    install_getter(proto_obj, "source", regex_proto_source_getter as *const u8);
+    install_getter(proto_obj, "global", regex_proto_global_getter as *const u8);
+    install_getter(
+        proto_obj,
+        "ignoreCase",
+        regex_proto_ignore_case_getter as *const u8,
+    );
+    install_getter(
+        proto_obj,
+        "multiline",
+        regex_proto_multiline_getter as *const u8,
+    );
+    install_getter(proto_obj, "dotAll", regex_proto_dot_all_getter as *const u8);
+    install_getter(proto_obj, "sticky", regex_proto_sticky_getter as *const u8);
+    install_getter(
+        proto_obj,
+        "unicode",
+        regex_proto_unicode_getter as *const u8,
+    );
+    install_getter(
+        proto_obj,
+        "unicodeSets",
+        regex_proto_unicode_sets_getter as *const u8,
+    );
+    install_getter(
+        proto_obj,
+        "hasIndices",
+        regex_proto_has_indices_getter as *const u8,
+    );
+}

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -15,10 +15,12 @@ use crate::value::js_nanbox_string;
 
 use crate::object::ObjectHeader;
 
+mod escape;
 mod grammar;
 mod match_all;
 mod replace_expand;
 mod replace_fn;
+pub use escape::js_regexp_escape;
 use grammar::{has_invalid_repeated_quantifier, js_regex_to_rust};
 pub use match_all::{
     dispatch_regexp_string_iterator_method, js_string_match_all, js_string_match_all_value,
@@ -156,8 +158,32 @@ pub struct RegExpHeader {
     pub dot_all: bool,
     pub unicode: bool,
     pub has_indices: bool,
-    /// lastIndex for global/sticky regexes (byte offset into the string for stateful exec)
-    pub last_index: u32,
+    /// `lastIndex` is a writable data property holding an *arbitrary* JSValue
+    /// (spec: `Set(R, "lastIndex", v)` with no coercion on write). Stored as the
+    /// raw NaN-boxed bits; `exec`/`test` apply `ToLength` on read to derive the
+    /// match offset. Initialized to the number `0`.
+    pub last_index: u64,
+}
+
+/// `ToLength(Get(R, "lastIndex"))` → a non-negative integer match offset. The
+/// stored value may be any JSValue (e.g. `re.lastIndex = { valueOf() {…} }`), so
+/// coerce via `ToNumber` (which invokes `valueOf`/`toString`), then `ToInteger`,
+/// clamped to ≥ 0.
+pub(crate) fn regex_last_index_offset(re: *const RegExpHeader) -> usize {
+    let stored = f64::from_bits(unsafe { (*re).last_index });
+    let n = crate::builtins::js_number_coerce(stored);
+    if n.is_nan() || n <= 0.0 {
+        0
+    } else {
+        n.floor() as usize
+    }
+}
+
+#[inline]
+fn store_last_index_number(re: *mut RegExpHeader, n: usize) {
+    unsafe {
+        (*re).last_index = crate::value::JSValue::number(n as f64).bits();
+    }
 }
 
 /// Check if a pointer is valid (not null and not a small invalid value from bad NaN-unboxing)
@@ -416,7 +442,7 @@ pub extern "C" fn js_regexp_new(
         (*ptr).dot_all = dot_all;
         (*ptr).unicode = unicode;
         (*ptr).has_indices = has_indices;
-        (*ptr).last_index = 0;
+        (*ptr).last_index = crate::value::JSValue::number(0.0).bits();
 
         // Record the pointer so that js_string_split can detect
         // `s.split(regex)` without a dedicated runtime decl.
@@ -437,6 +463,64 @@ pub extern "C" fn js_regexp_new(
     }
 }
 
+/// ECMA-262 RegExp constructor (`new RegExp(pattern, flags)`), spec 22.2.4.
+/// Handles every argument shape the string/string `js_regexp_new` cannot:
+///
+///   * `pattern` is a RegExp → reuse its `[[OriginalSource]]`; if `flags` is
+///     `undefined`, reuse its `[[OriginalFlags]]`, else `ToString(flags)`.
+///   * `pattern` is `undefined` → empty source.
+///   * `pattern` is anything else → `ToString(pattern)`.
+///   * `flags` is `undefined` → empty (unless inherited from a RegExp pattern);
+///     anything else → `ToString(flags)` (so `{}` becomes `"[object Object]"`,
+///     which `js_regexp_new` then rejects with a SyntaxError).
+///
+/// `ToString` runs through the coercing method path so a throwing
+/// `toString`/`valueOf` propagates.
+#[no_mangle]
+pub extern "C" fn js_regexp_construct(pattern: f64, flags: f64) -> *mut RegExpHeader {
+    let pv = crate::value::JSValue::from_bits(pattern.to_bits());
+    let fv = crate::value::JSValue::from_bits(flags.to_bits());
+    let flags_undef = fv.is_undefined();
+
+    let pattern_is_regex = pv.is_pointer() && is_registered_regex(pv.as_pointer::<u8>() as usize);
+
+    let (source_string, inherited_flags) = if pattern_is_regex {
+        let re = pv.as_pointer::<RegExpHeader>();
+        let entry = REGEX_SOURCE_TABLE.with(|t| t.borrow().get(&(re as usize)).cloned());
+        match entry {
+            Some((pat, fl)) => (pat, Some(fl)),
+            None => (String::new(), Some(String::new())),
+        }
+    } else if pv.is_undefined() {
+        (String::new(), None)
+    } else {
+        let s = crate::value::js_jsvalue_to_string_coerce(pattern);
+        (
+            if is_valid_ptr(s) {
+                string_as_str(s).to_string()
+            } else {
+                String::new()
+            },
+            None,
+        )
+    };
+
+    let flags_string = if flags_undef {
+        inherited_flags.unwrap_or_default()
+    } else {
+        let s = crate::value::js_jsvalue_to_string_coerce(flags);
+        if is_valid_ptr(s) {
+            string_as_str(s).to_string()
+        } else {
+            String::new()
+        }
+    };
+
+    let pat_ptr = js_string_from_str(&source_string);
+    let flags_ptr = js_string_from_str(&flags_string);
+    js_regexp_new(pat_ptr, flags_ptr)
+}
+
 /// Test if a string matches the regex pattern
 /// regex.test(string) -> boolean
 #[no_mangle]
@@ -448,6 +532,15 @@ pub extern "C" fn js_regexp_test(re: *const RegExpHeader, s: *const StringHeader
     let str_data = string_as_str(s);
 
     unsafe {
+        // For global/sticky regexes `test` is stateful — it must consult and
+        // advance `lastIndex` (and anchor for sticky) exactly like `exec`. Route
+        // through `exec` so the lastIndex bookkeeping stays in one place; `test`
+        // just reports whether a match was produced.
+        if (*re).global || (*re).sticky {
+            let arr = js_regexp_exec(re as *mut RegExpHeader, s);
+            return if arr.is_null() { 0 } else { 1 };
+        }
+
         if let Some(fre) = lookup_fancy_regex(re) {
             return match fre.is_match(str_data) {
                 Ok(true) => 1,
@@ -1171,9 +1264,21 @@ pub extern "C" fn js_regexp_exec(
     unsafe {
         let regex = &*(*re).regex_ptr;
         let global = (*re).global;
-        let last_index = (*re).last_index as usize;
+        let sticky = (*re).sticky;
+        // Per spec RegExpBuiltinExec, `lastIndex` drives the search start for
+        // BOTH global and sticky regexes (and lastIndex is reset/updated for
+        // either). A sticky match must additionally *anchor* at lastIndex.
+        let use_last_index = global || sticky;
+        // Spec: for non-global/non-sticky, lastIndex is treated as 0 and NOT
+        // read (so a `valueOf`-bearing lastIndex isn't observed). Only consult
+        // (and ToLength-coerce) it when stateful.
+        let last_index = if use_last_index {
+            regex_last_index_offset(re)
+        } else {
+            0
+        };
 
-        let search_start_byte = if global && last_index > 0 {
+        let search_start_byte = if use_last_index && last_index > 0 {
             let mut byte_off = 0;
             let mut char_count = 0;
             for ch in str_data.chars() {
@@ -1189,8 +1294,8 @@ pub extern "C" fn js_regexp_exec(
         };
 
         if search_start_byte > str_data.len() {
-            if global {
-                (*re).last_index = 0;
+            if use_last_index {
+                store_last_index_number(re, 0);
             }
             LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
             LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
@@ -1207,6 +1312,11 @@ pub extern "C" fn js_regexp_exec(
             if let Some(fre) = fc.get(&(pat.to_string(), flags_str.to_string())) {
                 if let Ok(Some(caps)) = fre.captures(search_str) {
                     let full = caps.get(0).unwrap();
+                    // Sticky (`y`) requires the match to start exactly at
+                    // lastIndex — i.e. offset 0 of the sliced search string.
+                    if sticky && full.start() != 0 {
+                        return Some(ptr::null_mut());
+                    }
                     let match_byte_offset = full.start() + search_start_byte;
                     let match_char_offset = str_data[..match_byte_offset].chars().count();
                     let arr = crate::array::js_array_alloc(caps.len() as u32);
@@ -1226,9 +1336,9 @@ pub extern "C" fn js_regexp_exec(
                             crate::array::store_array_slot(arr, i, undefined.to_bits());
                         }
                     }
-                    if global {
+                    if use_last_index {
                         let match_str = full.as_str();
-                        (*re).last_index = (match_char_offset + match_str.chars().count()) as u32;
+                        store_last_index_number(re, match_char_offset + match_str.chars().count());
                     }
                     set_exec_array_metadata(
                         arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
@@ -1250,8 +1360,8 @@ pub extern "C" fn js_regexp_exec(
         });
         if let Some(result) = fancy_captures {
             if result.is_null() {
-                if global {
-                    (*re).last_index = 0;
+                if use_last_index {
+                    store_last_index_number(re, 0);
                 }
                 LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
                 LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
@@ -1260,15 +1370,20 @@ pub extern "C" fn js_regexp_exec(
             return result;
         }
 
-        match regex.captures(search_str) {
+        let standard_caps = regex.captures(search_str).filter(|caps| {
+            // Sticky (`y`) requires the match to start at lastIndex (offset 0 of
+            // the slice); a leftmost match further in does not count.
+            !sticky || caps.get(0).map(|m| m.start() == 0).unwrap_or(false)
+        });
+        match standard_caps {
             Some(caps) => {
                 let match_byte_offset = caps.get(0).unwrap().start() + search_start_byte;
                 let match_char_offset = str_data[..match_byte_offset].chars().count();
 
-                if global {
+                if use_last_index {
                     let match_end_byte = caps.get(0).unwrap().end() + search_start_byte;
                     let match_end_char = str_data[..match_end_byte].chars().count();
-                    (*re).last_index = match_end_char as u32;
+                    store_last_index_number(re, match_end_char);
                 }
 
                 // Create match array: [fullMatch, group1, group2, ...]
@@ -1349,8 +1464,8 @@ pub extern "C" fn js_regexp_exec(
                 arr_handle.get_raw_mut_ptr::<ArrayHeader>()
             }
             None => {
-                if global {
-                    (*re).last_index = 0;
+                if use_last_index {
+                    store_last_index_number(re, 0);
                 }
                 LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
                 LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
@@ -1457,24 +1572,72 @@ pub(crate) fn test_last_exec_groups() -> usize {
 #[no_mangle]
 pub extern "C" fn js_regexp_get_source(re: *const RegExpHeader) -> *mut StringHeader {
     if !is_valid_regex_ptr(re) {
-        return js_string_from_str("");
+        return js_string_from_str("(?:)");
     }
     // Issue #637: prefer the side-tabled owned copy so we survive GC
     // of the input StringHeader (e.g. template-literal temporary).
     if let Some(pat) =
         REGEX_SOURCE_TABLE.with(|t| t.borrow().get(&(re as usize)).map(|(p, _)| p.clone()))
     {
-        return js_string_from_str(&pat);
+        return js_string_from_str(&escape_regexp_source(&pat));
     }
     unsafe {
         if is_valid_ptr((*re).pattern_ptr) {
             // Return a copy of the pattern string
             let pattern_str = string_as_str((*re).pattern_ptr);
-            js_string_from_str(pattern_str)
+            js_string_from_str(&escape_regexp_source(pattern_str))
         } else {
-            js_string_from_str("")
+            js_string_from_str("(?:)")
         }
     }
+}
+
+/// `RegExp.prototype.source` for the prototype object itself (no
+/// `[[OriginalSource]]`) returns the canonical empty source `"(?:)"`.
+#[no_mangle]
+pub extern "C" fn js_regexp_empty_source() -> *mut StringHeader {
+    js_string_from_str("(?:)")
+}
+
+/// ECMA-262 22.2.6.10 EscapeRegExpPattern: produce a string that, placed
+/// between two `/` characters, parses as the same pattern. An empty pattern
+/// becomes `"(?:)"`; an unescaped `/` outside a character class becomes `\/`;
+/// the four LineTerminators become their `\n`/`\r`/` `/` ` escapes
+/// (even inside a character class). A backslash escapes the following code
+/// point, which is copied verbatim.
+fn escape_regexp_source(pattern: &str) -> String {
+    if pattern.is_empty() {
+        return "(?:)".to_string();
+    }
+    let mut out = String::with_capacity(pattern.len() + 2);
+    let mut in_class = false;
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => {
+                out.push('\\');
+                if let Some(&next) = chars.peek() {
+                    out.push(next);
+                    chars.next();
+                }
+            }
+            '[' if !in_class => {
+                in_class = true;
+                out.push('[');
+            }
+            ']' if in_class => {
+                in_class = false;
+                out.push(']');
+            }
+            '/' if !in_class => out.push_str("\\/"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 /// Get regex.flags — returns the flags string
@@ -1510,165 +1673,27 @@ pub extern "C" fn js_regexp_to_string(re: *const RegExpHeader) -> *mut StringHea
     js_string_from_str(&out)
 }
 
-/// Get regex.lastIndex — returns the current lastIndex value as f64
+/// Get regex.lastIndex — returns the stored value (NaN-boxed JSValue bits as
+/// f64). Usually a number, but `re.lastIndex = obj` round-trips the object.
 #[no_mangle]
 pub extern "C" fn js_regexp_get_last_index(re: *const RegExpHeader) -> f64 {
     if !is_valid_regex_ptr(re) {
         return 0.0;
     }
-    unsafe { (*re).last_index as f64 }
+    unsafe { f64::from_bits((*re).last_index) }
 }
 
-/// Set regex.lastIndex
+/// Set regex.lastIndex — stores the value verbatim (no coercion on write, per
+/// spec `Set(R, "lastIndex", v)`).
 #[no_mangle]
 pub extern "C" fn js_regexp_set_last_index(re: *mut RegExpHeader, value: f64) {
     if !is_valid_regex_ptr(re) {
         return;
     }
     unsafe {
-        (*re).last_index = value as u32;
+        (*re).last_index = value.to_bits();
     }
 }
-
-// ============================================================================
-// RegExp.escape (TC39 proposal, shipped in Node 24+) — issue #2899
-// ============================================================================
-
-/// ECMAScript `WhiteSpace` set: TAB/VT/FF/SP, NBSP, ZWNBSP, and all
-/// Unicode `Space_Separator` (Zs) code points. (TAB/VT/FF are handled by
-/// the named control-escape table first; included here for completeness.)
-fn regexp_escape_is_whitespace(cp: u32) -> bool {
-    matches!(
-        cp,
-        0x0009 // TAB
-            | 0x000B // VT
-            | 0x000C // FF
-            | 0x0020 // SP
-            | 0x00A0 // NBSP
-            | 0xFEFF // ZWNBSP
-            // Unicode Space_Separator (Zs):
-            | 0x1680
-            | 0x2000..=0x200A | 0x202F | 0x205F | 0x3000
-    )
-}
-
-/// ECMAScript `LineTerminator` set: LF, CR, LS (U+2028), PS (U+2029).
-fn regexp_escape_is_line_terminator(cp: u32) -> bool {
-    matches!(cp, 0x000A | 0x000D | 0x2028 | 0x2029)
-}
-
-/// `EncodeForRegExpEscape` unicode-escape emitter: `\xHH` for ≤ 0xFF,
-/// `\uHHHH` otherwise (callers only pass BMP code units here).
-fn regexp_escape_unicode(out: &mut String, unit: u16) {
-    if unit <= 0xFF {
-        out.push_str(&format!("\\x{:02x}", unit));
-    } else {
-        out.push_str(&format!("\\u{:04x}", unit));
-    }
-}
-
-/// `RegExp.escape(str)` — escape `str` so it can be embedded literally in a
-/// regular expression pattern without changing match semantics. Operates on
-/// UTF-16 code units to match JS string semantics. The argument MUST be a
-/// string (TypeError otherwise). Returns a NaN-boxed string.
-#[no_mangle]
-pub extern "C" fn js_regexp_escape(input: f64) -> f64 {
-    let jsv = crate::value::JSValue::from_bits(input.to_bits());
-    if !jsv.is_any_string() {
-        let msg = js_string_from_str("input argument must be a string");
-        let err = crate::error::js_typeerror_new(msg);
-        crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
-    }
-
-    let str_ptr = crate::value::js_get_string_pointer_unified(input) as *const StringHeader;
-    let s = string_as_str(str_ptr);
-
-    // Encode to UTF-16 code units: JS escaping is defined per code unit.
-    let units: Vec<u16> = s.encode_utf16().collect();
-    let mut out = String::with_capacity(units.len() * 2);
-
-    for (i, &unit) in units.iter().enumerate() {
-        let c = char::from_u32(unit as u32);
-
-        // First code unit: if ASCII alphanumeric, force a unicode escape so a
-        // leading letter/digit can't combine with a preceding backslash when
-        // concatenated (e.g. avoid forming `\c`, `\1`, etc.).
-        if i == 0 {
-            if let Some(ch) = c {
-                if ch.is_ascii_alphanumeric() {
-                    regexp_escape_unicode(&mut out, unit);
-                    continue;
-                }
-            }
-        }
-
-        match c {
-            // Syntax characters and `/` → backslash escape.
-            Some('^') | Some('$') | Some('\\') | Some('.') | Some('*') | Some('+') | Some('?')
-            | Some('(') | Some(')') | Some('[') | Some(']') | Some('{') | Some('}') | Some('|')
-            | Some('/') => {
-                out.push('\\');
-                out.push(c.unwrap());
-            }
-            // Named control escapes.
-            Some('\t') => out.push_str("\\t"),
-            Some('\n') => out.push_str("\\n"),
-            Some('\u{000B}') => out.push_str("\\v"),
-            Some('\u{000C}') => out.push_str("\\f"),
-            Some('\r') => out.push_str("\\r"),
-            _ => {
-                let cp = unit as u32;
-                let is_other_punctuator = matches!(
-                    c,
-                    Some(',')
-                        | Some('-')
-                        | Some('=')
-                        | Some('<')
-                        | Some('>')
-                        | Some('#')
-                        | Some('&')
-                        | Some('!')
-                        | Some('%')
-                        | Some(':')
-                        | Some(';')
-                        | Some('@')
-                        | Some('~')
-                        | Some('\'')
-                        | Some('`')
-                        | Some('"')
-                );
-                if is_other_punctuator
-                    || regexp_escape_is_whitespace(cp)
-                    || regexp_escape_is_line_terminator(cp)
-                {
-                    regexp_escape_unicode(&mut out, unit);
-                } else {
-                    // Pass through. Use the original code unit so lone
-                    // surrogates round-trip (char::from_u32 returns None for
-                    // surrogate halves; push the decoded char when valid).
-                    match c {
-                        Some(ch) => out.push(ch),
-                        None => {
-                            // Lone surrogate: re-encode the single code unit.
-                            let mut buf = [0u16; 1];
-                            buf[0] = unit;
-                            out.push_str(&String::from_utf16_lossy(&buf));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    let result = js_string_from_str(&out);
-    js_nanbox_string(result as i64)
-}
-
-/// Keepalive anchor: `js_regexp_escape` is only called from codegen-emitted
-/// `.o`, so the auto-optimize whole-program LLVM rebuild would dead-strip it
-/// without this `#[used]` reference (see #3320).
-#[used]
-static KEEP_REGEXP_ESCAPE: extern "C" fn(f64) -> f64 = js_regexp_escape;
 
 #[cfg(test)]
 mod tests {

--- a/crates/perry-runtime/src/regex/escape.rs
+++ b/crates/perry-runtime/src/regex/escape.rs
@@ -1,0 +1,143 @@
+//! `RegExp.escape(str)` (ECMAScript `EncodeForRegExpEscape`) and its helpers.
+//!
+//! Split out of `regex.rs` to keep that file under the 2000-line size gate.
+
+use super::{js_string_from_str, string_as_str};
+use crate::string::StringHeader;
+use crate::value::js_nanbox_string;
+
+/// ECMAScript `WhiteSpace` set: TAB/VT/FF/SP, NBSP, ZWNBSP, and all
+/// Unicode `Space_Separator` (Zs) code points. (TAB/VT/FF are handled by
+/// the named control-escape table first; included here for completeness.)
+fn regexp_escape_is_whitespace(cp: u32) -> bool {
+    matches!(
+        cp,
+        0x0009 // TAB
+            | 0x000B // VT
+            | 0x000C // FF
+            | 0x0020 // SP
+            | 0x00A0 // NBSP
+            | 0xFEFF // ZWNBSP
+            // Unicode Space_Separator (Zs):
+            | 0x1680
+            | 0x2000..=0x200A | 0x202F | 0x205F | 0x3000
+    )
+}
+
+/// ECMAScript `LineTerminator` set: LF, CR, LS (U+2028), PS (U+2029).
+fn regexp_escape_is_line_terminator(cp: u32) -> bool {
+    matches!(cp, 0x000A | 0x000D | 0x2028 | 0x2029)
+}
+
+/// `EncodeForRegExpEscape` unicode-escape emitter: `\xHH` for ≤ 0xFF,
+/// `\uHHHH` otherwise (callers only pass BMP code units here).
+fn regexp_escape_unicode(out: &mut String, unit: u16) {
+    if unit <= 0xFF {
+        out.push_str(&format!("\\x{:02x}", unit));
+    } else {
+        out.push_str(&format!("\\u{:04x}", unit));
+    }
+}
+
+/// `RegExp.escape(str)` — escape `str` so it can be embedded literally in a
+/// regular expression pattern without changing match semantics. Operates on
+/// UTF-16 code units to match JS string semantics. The argument MUST be a
+/// string (TypeError otherwise). Returns a NaN-boxed string.
+#[no_mangle]
+pub extern "C" fn js_regexp_escape(input: f64) -> f64 {
+    let jsv = crate::value::JSValue::from_bits(input.to_bits());
+    if !jsv.is_any_string() {
+        let msg = js_string_from_str("input argument must be a string");
+        let err = crate::error::js_typeerror_new(msg);
+        crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+    }
+
+    let str_ptr = crate::value::js_get_string_pointer_unified(input) as *const StringHeader;
+    let s = string_as_str(str_ptr);
+
+    // Encode to UTF-16 code units: JS escaping is defined per code unit.
+    let units: Vec<u16> = s.encode_utf16().collect();
+    let mut out = String::with_capacity(units.len() * 2);
+
+    for (i, &unit) in units.iter().enumerate() {
+        let c = char::from_u32(unit as u32);
+
+        // First code unit: if ASCII alphanumeric, force a unicode escape so a
+        // leading letter/digit can't combine with a preceding backslash when
+        // concatenated (e.g. avoid forming `\c`, `\1`, etc.).
+        if i == 0 {
+            if let Some(ch) = c {
+                if ch.is_ascii_alphanumeric() {
+                    regexp_escape_unicode(&mut out, unit);
+                    continue;
+                }
+            }
+        }
+
+        match c {
+            // Syntax characters and `/` → backslash escape.
+            Some('^') | Some('$') | Some('\\') | Some('.') | Some('*') | Some('+') | Some('?')
+            | Some('(') | Some(')') | Some('[') | Some(']') | Some('{') | Some('}') | Some('|')
+            | Some('/') => {
+                out.push('\\');
+                out.push(c.unwrap());
+            }
+            // Named control escapes.
+            Some('\t') => out.push_str("\\t"),
+            Some('\n') => out.push_str("\\n"),
+            Some('\u{000B}') => out.push_str("\\v"),
+            Some('\u{000C}') => out.push_str("\\f"),
+            Some('\r') => out.push_str("\\r"),
+            _ => {
+                let cp = unit as u32;
+                let is_other_punctuator = matches!(
+                    c,
+                    Some(',')
+                        | Some('-')
+                        | Some('=')
+                        | Some('<')
+                        | Some('>')
+                        | Some('#')
+                        | Some('&')
+                        | Some('!')
+                        | Some('%')
+                        | Some(':')
+                        | Some(';')
+                        | Some('@')
+                        | Some('~')
+                        | Some('\'')
+                        | Some('`')
+                        | Some('"')
+                );
+                if is_other_punctuator
+                    || regexp_escape_is_whitespace(cp)
+                    || regexp_escape_is_line_terminator(cp)
+                {
+                    regexp_escape_unicode(&mut out, unit);
+                } else {
+                    // Pass through. Use the original code unit so lone
+                    // surrogates round-trip (char::from_u32 returns None for
+                    // surrogate halves; push the decoded char when valid).
+                    match c {
+                        Some(ch) => out.push(ch),
+                        None => {
+                            // Lone surrogate: re-encode the single code unit.
+                            let mut buf = [0u16; 1];
+                            buf[0] = unit;
+                            out.push_str(&String::from_utf16_lossy(&buf));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let result = js_string_from_str(&out);
+    js_nanbox_string(result as i64)
+}
+
+/// Keepalive anchor: `js_regexp_escape` is only called from codegen-emitted
+/// `.o`, so the auto-optimize whole-program LLVM rebuild would dead-strip it
+/// without this `#[used]` reference (see #3320).
+#[used]
+static KEEP_REGEXP_ESCAPE: extern "C" fn(f64) -> f64 = js_regexp_escape;

--- a/crates/perry-runtime/src/regex/grammar.rs
+++ b/crates/perry-runtime/src/regex/grammar.rs
@@ -451,11 +451,24 @@ pub(super) fn js_regex_to_rust(pattern: &str) -> String {
             if in_class {
                 result.push('\\');
                 result.push('[');
+                i += 1;
+            } else if chars.get(i + 1) == Some(&']') {
+                // JS: `[]` is an *empty* character class that never matches
+                // (the `]` immediately after `[` closes the class). The Rust
+                // `regex` crate rejects `[]`, so emit an unsatisfiable class.
+                result.push_str("[^\\s\\S]");
+                i += 2;
+            } else if chars.get(i + 1) == Some(&'^') && chars.get(i + 2) == Some(&']') {
+                // JS: `[^]` is a negated empty class — it matches *any* code
+                // point, including line terminators. Rust rejects `[^]`, so
+                // emit the equivalent `[\s\S]`.
+                result.push_str("[\\s\\S]");
+                i += 3;
             } else {
                 in_class = true;
                 result.push('[');
+                i += 1;
             }
-            i += 1;
         } else if chars[i] == ']' {
             // An unescaped `]` closes the current class (an escaped `\]` was
             // consumed by the backslash branch above and never reaches here).

--- a/crates/perry-runtime/src/regex/match_all.rs
+++ b/crates/perry-runtime/src/regex/match_all.rs
@@ -206,7 +206,7 @@ pub extern "C" fn js_string_match_all_value(
             if !(*re).global {
                 throw_match_all_non_global_regex();
             }
-            (re, (*re).last_index as usize)
+            (re, crate::regex::regex_last_index_offset(re))
         }
     } else {
         (
@@ -233,7 +233,8 @@ pub extern "C" fn js_string_match_all(
         if !(*re).global {
             throw_match_all_non_global_regex();
         }
-        let matches = materialize_match_all_results(s, re, (*re).last_index as usize);
+        let matches =
+            materialize_match_all_results(s, re, crate::regex::regex_last_index_offset(re));
         alloc_regexp_string_iterator(matches)
     }
 }

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -113,8 +113,8 @@ pub(crate) use to_string::{
     to_primitive_number, OrdinaryToPrimitiveOutcome,
 };
 pub use to_string::{
-    js_ensure_string_ptr, js_jsvalue_to_string, js_jsvalue_to_string_radix,
-    js_value_to_str_ptr_for_ffi,
+    js_ensure_string_ptr, js_jsvalue_to_string, js_jsvalue_to_string_coerce,
+    js_jsvalue_to_string_method, js_jsvalue_to_string_radix, js_value_to_str_ptr_for_ffi,
 };
 
 // ----- Equality, comparison, SameValueZero, dynamic string equality -----

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -799,6 +799,25 @@ pub extern "C" fn js_jsvalue_to_string_method(value: f64) -> *mut crate::string:
     js_jsvalue_to_string(value)
 }
 
+/// Spec `ToString(value)` for argument coercion (e.g. `RegExp.prototype.exec`'s
+/// `ToString(string)`, the RegExp constructor's pattern/flags). Unlike
+/// [`js_jsvalue_to_string_method`] — which models an explicit `x.toString()`
+/// method call and therefore throws on `undefined`/`null` — `ToString(undefined)`
+/// is `"undefined"` and `ToString(null)` is `"null"`. For every other value it
+/// defers to the method path so object receivers dispatch their own
+/// `toString`/`valueOf` (and a throwing one propagates).
+#[no_mangle]
+pub extern "C" fn js_jsvalue_to_string_coerce(value: f64) -> *mut crate::string::StringHeader {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if jsval.is_undefined() {
+        return crate::string::js_string_from_bytes(b"undefined".as_ptr(), 9);
+    }
+    if jsval.is_null() {
+        return crate::string::js_string_from_bytes(b"null".as_ptr(), 4);
+    }
+    js_jsvalue_to_string_method(value)
+}
+
 fn throw_radix_range_error() -> ! {
     // Node/V8 message verbatim: includes the word "argument" (#3146).
     let message = b"toString() radix argument must be between 2 and 36";


### PR DESCRIPTION
## Summary

Raises **built-ins/RegExp** test262 parity from **71.0% → 92.9%** (**421 → 551 pass**, +130) measured against the branch's merge-base, with **zero regressions** validated across a broad `built-ins` + `language` shard.

### Validation (merge-base `dcfdfd8f3` vs branch, same pinned test262, jobs=40)
| Suite | Baseline | Branch |
|---|---|---|
| built-ins/RegExp | 421 pass / 71.0% | **551 pass / 92.9%** |
| broad shard `built-ins`+`language` (1/12, strided) | 1999 pass | **2013 pass** |

Failure-set diff on the broad shard: **0 tests went pass→fail (zero regressions)**; 14 newly-passing (13 RegExp + 1 Proxy bonus from the constructor/source fixes).

## Root causes fixed (grouped)

1. **RegExp.prototype accessor getters** — `source`, `flags`, `global`, `ignoreCase`, `multiline`, `dotAll`, `sticky`, `unicode`, `unicodeSets`, `hasIndices` are now real **accessor descriptors** on `RegExp.prototype` (brand-checked native getters; `set: undefined`, `enumerable: false`, `configurable: true`). Reflection (`getOwnPropertyDescriptor(RegExp.prototype, "source").get`) and `.call(this)` work, and instances inherit them. New module `object/regex_proto_thunks.rs`. The `flags` getter is spec-generic (assembles `d g i m s u v y` from `Get`+`ToBoolean` on the receiver); a Symbol/non-object `this` throws `TypeError`.
2. **`source` escaping** — `EscapeRegExpPattern`: empty → `(?:)`, `/` → `\/` outside a char class, line terminators escaped.
3. **Sticky `y`** — `exec`/`test` consult and advance `lastIndex` and *anchor* the match for sticky (previously only `global` was stateful); `test` routes through `exec` for stateful regexes.
4. **`lastIndex` semantics** — now stores an arbitrary value (`re.lastIndex = obj` round-trips) with `ToLength` applied on read, per spec, instead of a coerced `u32`.
5. **exec/test argument `ToString`** — String wrappers / numbers / objects (incl. a throwing `toString`) are coerced via new `js_jsvalue_to_string_coerce` (`undefined`→`"undefined"`, `null`→`"null"`, objects dispatch `toString`).
6. **Brand-checked `exec`/`test`/`toString`** prototype methods.
7. **Full RegExp constructor** (`js_regexp_construct`) — RegExp pattern (copy / flag override), `undefined`/`null`/object pattern (`ToString`), object flags (`ToString` → `SyntaxError`). Fixes garbage output from a RegExp pattern being read as a string, and a HIR fold that silently dropped object-literal flags.
8. **Empty character classes** — `[]` (never matches) and `[^]` (any) translate to `[^\s\S]` / `[\s\S]` (the `regex` crate rejects them).
9. RegExp instances walk `RegExp.prototype` for inherited members (`re.constructor`, reflective method reads).

## Lookbehind (out of scope)

18 built-ins/RegExp tests use lookbehind (`(?<=…)`/`(?<!…)`). The Rust `regex` crate doesn't support it; these are served by the pre-existing `fancy-regex` fallback and were **not** targeted here (`skip=0` — none are among the remaining failures).

## Remaining (not addressed — deep object-model or crate limits)
- `lastIndex` as a full *own property* (`hasOwnProperty`/non-writable attr), expando storage on the non-`ObjectHeader` regex, and call-vs-`new` identity (`RegExp(re)` returns `re`) — require object-model changes.
- `u`-mode strict early errors (lone `]`/`{`, alpha identity escapes, incomplete quantifiers) — skipped to avoid false-positives on valid `\p{…}`/`\u{…}` patterns (zero-regression mandate).
- `regex`-crate limits: lone surrogates, `b{9007199254740991}`, JS `\s` vs Unicode `\s` (U+0085).
- `propertyIsEnumerable` over inherited accessor descriptors (attr plumbing); `isPrototypeOf` for built-in instances (pre-existing, also affects Map/Set).
- `prototype/source/value*` tests rely on `eval()`, which Perry (AOT) cannot evaluate.

## Files
`regex.rs`, `regex/grammar.rs`, `regex/match_all.rs`, `object/regex_proto_thunks.rs` (new), `object/global_this.rs`, `object/field_get_set.rs`, `object/native_call_method.rs`, `object/mod.rs`, `value/to_string.rs`, `value/mod.rs`; codegen: `expr/instance_misc1.rs`, `expr/logical_collections.rs`, `lower_call/builtin.rs`, `runtime_decls/strings.rs`, `hir lower/expr_new.rs`.