### PR TITLE
feat(annexb): String HTML methods, Object accessor methods, RegExp.compile, escape/unescape ToString (#4796)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -49,7 +49,16 @@ fn is_date_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {
 fn is_inherited_object_prototype_method(name: &str) -> bool {
     matches!(
         name,
-        "hasOwnProperty" | "propertyIsEnumerable" | "isPrototypeOf" | "valueOf"
+        "hasOwnProperty"
+            | "propertyIsEnumerable"
+            | "isPrototypeOf"
+            | "valueOf"
+            // Annex B §B.2.2 legacy accessor helpers — inherited from
+            // Object.prototype by every instance (incl. class instances).
+            | "__defineGetter__"
+            | "__defineSetter__"
+            | "__lookupGetter__"
+            | "__lookupSetter__"
     )
 }
 
@@ -302,7 +311,10 @@ pub fn try_lower_property_get_method_call(
             "split" | "charCodeAt" | "charAt" | "trim" | "trimStart" | "trimEnd" | "substring"
             | "substr" | "toLowerCase" | "toUpperCase" | "toLocaleLowerCase"
             | "toLocaleUpperCase" | "replaceAll" | "padStart" | "padEnd" | "repeat"
-            | "normalize" | "codePointAt" | "localeCompare" => true,
+            | "normalize" | "codePointAt" | "localeCompare"
+            // Annex B §B.2.2 HTML wrappers — string-only, no array/map/set form.
+            | "anchor" | "big" | "blink" | "bold" | "fixed" | "fontcolor" | "fontsize"
+            | "italics" | "link" | "small" | "strike" | "sub" | "sup" => true,
             // Issue #638: `replace` is also string-exclusive, but routing
             // it here unconditionally caused regressions in async dispatch
             // pathways. Only fire when args[1] is statically detectable as

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -25,7 +25,21 @@ fn regexp_search_method_id(property: &str) -> String {
 pub(crate) fn is_known_string_method_name(name: &str) -> bool {
     matches!(
         name,
-        "at" | "charAt"
+        "anchor"
+            | "big"
+            | "blink"
+            | "bold"
+            | "fixed"
+            | "fontcolor"
+            | "fontsize"
+            | "italics"
+            | "link"
+            | "small"
+            | "strike"
+            | "sub"
+            | "sup"
+            | "at"
+            | "charAt"
             | "charCodeAt"
             | "codePointAt"
             | "concat"
@@ -295,6 +309,57 @@ pub(crate) fn lower_string_method(
                 _ => unreachable!(),
             };
             let result = blk.call(I64, runtime_fn, &[(I64, &recv_handle)]);
+            Ok(nanbox_string_inline(blk, &result))
+        }
+        // Annex B §B.2.2 HTML wrappers — no-arg tag wrappers. Extra args are
+        // evaluated for side effects (JS ignores them) then discarded.
+        "big" | "blink" | "bold" | "fixed" | "italics" | "small" | "strike" | "sub" | "sup" => {
+            for extra in args.iter() {
+                let _ = lower_expr(ctx, extra)?;
+            }
+            let blk = ctx.block();
+            let recv_handle = unbox_str_handle(blk, &recv_box);
+            let runtime_fn = match property {
+                "big" => "js_string_big",
+                "blink" => "js_string_blink",
+                "bold" => "js_string_bold",
+                "fixed" => "js_string_fixed",
+                "italics" => "js_string_italics",
+                "small" => "js_string_small",
+                "strike" => "js_string_strike",
+                "sub" => "js_string_sub",
+                "sup" => "js_string_sup",
+                _ => unreachable!(),
+            };
+            let result = blk.call(I64, runtime_fn, &[(I64, &recv_handle)]);
+            Ok(nanbox_string_inline(blk, &result))
+        }
+        // Annex B §B.2.2 HTML wrappers that take an attribute value. A missing
+        // arg coerces `undefined` -> "undefined" via `js_string_coerce`.
+        "anchor" | "link" | "fontcolor" | "fontsize" => {
+            let value_d = if args.is_empty() {
+                crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+            } else {
+                lower_expr(ctx, &args[0])?
+            };
+            for extra in args.iter().skip(1) {
+                let _ = lower_expr(ctx, extra)?;
+            }
+            let blk = ctx.block();
+            let recv_handle = unbox_str_handle(blk, &recv_box);
+            let value_handle = blk.call(I64, "js_string_coerce", &[(DOUBLE, &value_d)]);
+            let runtime_fn = match property {
+                "anchor" => "js_string_anchor",
+                "link" => "js_string_link",
+                "fontcolor" => "js_string_fontcolor",
+                "fontsize" => "js_string_fontsize",
+                _ => unreachable!(),
+            };
+            let result = blk.call(
+                I64,
+                runtime_fn,
+                &[(I64, &recv_handle), (I64, &value_handle)],
+            );
             Ok(nanbox_string_inline(blk, &result))
         }
         "charAt" => {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -522,6 +522,22 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_string_trim", I64, &[I64]);
     module.declare_function("js_string_trim_start", I64, &[I64]);
     module.declare_function("js_string_trim_end", I64, &[I64]);
+    // Annex B §B.2.2 HTML wrappers. No-arg tag wrappers take only the receiver;
+    // anchor/link/fontcolor/fontsize take an already-coerced attribute-value
+    // string handle as the 2nd arg.
+    module.declare_function("js_string_big", I64, &[I64]);
+    module.declare_function("js_string_blink", I64, &[I64]);
+    module.declare_function("js_string_bold", I64, &[I64]);
+    module.declare_function("js_string_fixed", I64, &[I64]);
+    module.declare_function("js_string_italics", I64, &[I64]);
+    module.declare_function("js_string_small", I64, &[I64]);
+    module.declare_function("js_string_strike", I64, &[I64]);
+    module.declare_function("js_string_sub", I64, &[I64]);
+    module.declare_function("js_string_sup", I64, &[I64]);
+    module.declare_function("js_string_anchor", I64, &[I64, I64]);
+    module.declare_function("js_string_link", I64, &[I64, I64]);
+    module.declare_function("js_string_fontcolor", I64, &[I64, I64]);
+    module.declare_function("js_string_fontsize", I64, &[I64, I64]);
     module.declare_function("js_string_char_at", I64, &[I64, I32]);
     // #3987: `s[key]` canonical-index read — returns the char (NaN-boxed string)
     // for a valid array index, else NaN-boxed `undefined`. Takes the raw key.

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -145,6 +145,12 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE],
     );
+    // Annex B §B.2.2 accessor helpers — `Object.prototype.__defineGetter__`
+    // etc., reached via the `.call(obj, key[, fn])` rewrite.
+    module.declare_function("js_object_define_getter", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_object_define_setter", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_object_lookup_getter", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_object_lookup_setter", DOUBLE, &[DOUBLE, DOUBLE]);
     // Issue #620: own-property override probe used by class-method dispatch.
     // Returns the stored value if `name` is in obj's own keys_array (data
     // property only — no vtable getter walk), else TAG_UNDEFINED. Lets

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -186,6 +186,11 @@ pub(crate) fn is_known_object_prototype_method(name: &str) -> bool {
             | "toString"
             | "valueOf"
             | "constructor"
+            // Annex B §B.2.2 legacy accessor helpers.
+            | "__defineGetter__"
+            | "__defineSetter__"
+            | "__lookupGetter__"
+            | "__lookupSetter__"
     )
 }
 

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1145,7 +1145,22 @@ fn is_string_prototype_generic_method(recv: &ast::Expr, method: &str) -> bool {
             // as the generic `string_proto_generic_thunk`. Keep in lock-step with
             // `string_proto_thunks::GENERIC_STRING_PROTO_METHODS`. Excluded:
             // `toString`/`valueOf` (brand-checked, not ToString-coercing).
-            "at" | "charAt"
+            // Annex B §B.2.2 HTML wrappers.
+            "anchor"
+                | "big"
+                | "blink"
+                | "bold"
+                | "fixed"
+                | "fontcolor"
+                | "fontsize"
+                | "italics"
+                | "link"
+                | "small"
+                | "strike"
+                | "sub"
+                | "sup"
+                | "at"
+                | "charAt"
                 | "charCodeAt"
                 | "codePointAt"
                 | "concat"

--- a/crates/perry-hir/src/lower/expr_call/post_args_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_call/post_args_dispatch.rs
@@ -229,7 +229,7 @@ pub(super) fn try_object_prototype_call(
     args: Vec<Expr>,
     has_spread: bool,
 ) -> Result<Expr, Vec<Expr>> {
-    if !has_spread && (args.len() == 1 || args.len() == 2) {
+    if !has_spread && (1..=3).contains(&args.len()) {
         if let ast::Callee::Expr(callee_expr) = &call.callee {
             if let ast::Expr::Member(outer) = callee_expr.as_ref() {
                 if let (ast::MemberProp::Ident(outer_prop), ast::Expr::Member(mid)) =
@@ -246,6 +246,11 @@ pub(super) fn try_object_prototype_call(
                                 ("propertyIsEnumerable", 2) => {
                                     Some("js_object_property_is_enumerable")
                                 }
+                                // Annex B accessor helpers: .call(obj, key[, fn]).
+                                ("__defineGetter__", 3) => Some("js_object_define_getter"),
+                                ("__defineSetter__", 3) => Some("js_object_define_setter"),
+                                ("__lookupGetter__", 2) => Some("js_object_lookup_getter"),
+                                ("__lookupSetter__", 2) => Some("js_object_lookup_setter"),
                                 _ => None,
                             };
                             if let Some(runtime_fn) = runtime_fn {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -475,7 +475,7 @@ impl SH for Expr {
             Expr::DateToString(e) => { tag(h, 1339); e.as_ref().hash(h); }
             Expr::DateToDateString(e) => { tag(h, 339); e.as_ref().hash(h); }
             Expr::DateToTimeString(e) => { tag(h, 340); e.as_ref().hash(h); }
-            Expr::DateToUTCString(e) => { tag(h, 12507); e.as_ref().hash(h); }
+            Expr::DateToUTCString(e) => { tag(h, 12508); e.as_ref().hash(h); }
             Expr::DateToLocaleDateString(e) => { tag(h, 341); e.as_ref().hash(h); }
             Expr::DateToLocaleTimeString(e) => { tag(h, 342); e.as_ref().hash(h); }
             Expr::DateToLocaleString(e) => { tag(h, 343); e.as_ref().hash(h); }

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -104,7 +104,11 @@ fn hex_digit(b: u8) -> Option<u8> {
 }
 
 fn extract_str_from_nanbox(value: f64) -> String {
-    let str_ptr = crate::value::js_get_string_pointer_unified(value);
+    // Spec: escape/unescape/decodeURI apply `ToString` to the argument, so
+    // `undefined`/`null`/booleans/objects coerce ("undefined", "null", …)
+    // rather than yielding the empty string (`js_get_string_pointer_unified`
+    // only coerces numbers). Strings pass through unchanged.
+    let str_ptr = crate::builtins::js_string_coerce(value);
     if (str_ptr as usize) < 0x1000 {
         return String::new();
     }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -1402,6 +1402,43 @@ extern "C" fn object_prototype_property_is_enumerable_thunk(
     super::js_object_property_is_enumerable(this_value, key)
 }
 
+// Annex B §B.2.2 Object.prototype accessor methods — real thunks so reflective
+// access (`Object.prototype.__defineGetter__.call(o, k, fn)`, `typeof`) works,
+// not just the direct `o.__defineGetter__(...)` native-dispatch path.
+extern "C" fn object_prototype_define_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    key: f64,
+    getter: f64,
+) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    super::js_object_define_getter(this_value, key, getter)
+}
+
+extern "C" fn object_prototype_define_setter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    key: f64,
+    setter: f64,
+) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    super::js_object_define_setter(this_value, key, setter)
+}
+
+extern "C" fn object_prototype_lookup_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    key: f64,
+) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    super::js_object_lookup_getter(this_value, key)
+}
+
+extern "C" fn object_prototype_lookup_setter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    key: f64,
+) -> f64 {
+    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    super::js_object_lookup_setter(this_value, key)
+}
+
 extern "C" fn error_prototype_to_string_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
@@ -5296,6 +5333,11 @@ fn install_noop_proto_methods(proto_obj: *mut ObjectHeader, methods: &[(&str, u3
     for (name, arity) in methods.iter().copied() {
         let func_ptr = match name {
             "isPrototypeOf" => object_prototype_is_prototype_of_thunk as *const u8,
+            // Annex B accessor methods get real thunks (reflective `.call`).
+            "__defineGetter__" => object_prototype_define_getter_thunk as *const u8,
+            "__defineSetter__" => object_prototype_define_setter_thunk as *const u8,
+            "__lookupGetter__" => object_prototype_lookup_getter_thunk as *const u8,
+            "__lookupSetter__" => object_prototype_lookup_setter_thunk as *const u8,
             _ => global_this_builtin_noop_thunk as *const u8,
         };
         install_proto_method(proto_obj, name, func_ptr, arity);
@@ -5347,6 +5389,11 @@ const OBJECT_PROTO_METHODS: &[(&str, u32)] = &[
     ("propertyIsEnumerable", 1),
     ("toLocaleString", 0),
     ("valueOf", 0),
+    // Annex B §B.2.2 legacy accessor helpers.
+    ("__defineGetter__", 2),
+    ("__defineSetter__", 2),
+    ("__lookupGetter__", 1),
+    ("__lookupSetter__", 1),
     // `toString` is installed separately on Object/typed arrays etc. with
     // dedicated thunks; do not include it here to avoid clobbering those.
 ];

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1547,6 +1547,24 @@ pub unsafe extern "C" fn js_native_call_method(
         }
     }
 
+    // `RegExp.prototype.compile(pattern, flags)` (Annex B) re-initializes the
+    // receiver in place. Needs both args, so it is dispatched here rather than
+    // through the single-arg `dispatch_regex_receiver_method`.
+    if method_name == "compile" && jsval.is_pointer() {
+        let p = jsval.as_pointer::<u8>();
+        if crate::regex::is_regex_pointer(p) {
+            let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+            let args = refreshed_args();
+            let pat = args.first().copied().unwrap_or(undef);
+            let flags = args.get(1).copied().unwrap_or(undef);
+            return crate::regex::js_regexp_compile_value(
+                p as *mut crate::regex::RegExpHeader,
+                pat,
+                flags,
+            );
+        }
+    }
+
     // Node timer handles are represented in Perry as small integer ids
     // NaN-boxed as pointers. Provide the common Timeout/Immediate methods
     // directly so `timeout.ref().unref().hasRef()` style probes behave like
@@ -2341,6 +2359,44 @@ pub unsafe extern "C" fn js_native_call_method(
                 }
                 "toWellFormed" => {
                     let r = crate::string::js_string_to_well_formed(receiver_string());
+                    return f64::from_bits(JSValue::string_ptr(r).bits());
+                }
+                // Annex B §B.2.2 HTML wrapper methods. No-arg tag wrappers;
+                // the receiver body is never escaped.
+                "big" | "blink" | "bold" | "fixed" | "italics" | "small" | "strike" | "sub"
+                | "sup" => {
+                    let s = receiver_string();
+                    let r = match method_name {
+                        "big" => crate::string::js_string_big(s),
+                        "blink" => crate::string::js_string_blink(s),
+                        "bold" => crate::string::js_string_bold(s),
+                        "fixed" => crate::string::js_string_fixed(s),
+                        "italics" => crate::string::js_string_italics(s),
+                        "small" => crate::string::js_string_small(s),
+                        "strike" => crate::string::js_string_strike(s),
+                        "sub" => crate::string::js_string_sub(s),
+                        "sup" => crate::string::js_string_sup(s),
+                        _ => unreachable!(),
+                    };
+                    return f64::from_bits(JSValue::string_ptr(r).bits());
+                }
+                // Annex B §B.2.2 HTML wrappers that take an attribute value;
+                // a missing arg coerces `undefined` -> "undefined", and `"`
+                // in the value is escaped to `&quot;`.
+                "anchor" | "link" | "fontcolor" | "fontsize" => {
+                    let value = crate::builtins::js_string_coerce(
+                        arg_at(0).unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits())),
+                    );
+                    let value_h = root_scope.root_string_ptr(value);
+                    let s = receiver_string();
+                    let v = value_h.get_raw_const_ptr::<crate::StringHeader>();
+                    let r = match method_name {
+                        "anchor" => crate::string::js_string_anchor(s, v),
+                        "link" => crate::string::js_string_link(s, v),
+                        "fontcolor" => crate::string::js_string_fontcolor(s, v),
+                        "fontsize" => crate::string::js_string_fontsize(s, v),
+                        _ => unreachable!(),
+                    };
                     return f64::from_bits(JSValue::string_ptr(r).bits());
                 }
                 _ => {} // not a handled string method — fall through to TypeError catch-all
@@ -3893,6 +3949,39 @@ pub unsafe extern "C" fn js_native_call_method(
             return f64::from_bits(
                 JSValue::bool(js_object_is_prototype_of_value(object, arg)).bits(),
             );
+        }
+
+        // Annex B §B.2.2 Object.prototype accessor helpers.
+        "__defineGetter__" | "__defineSetter__" => {
+            let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+            let key = if args_len >= 1 && !args_ptr.is_null() {
+                *args_ptr
+            } else {
+                undef
+            };
+            let func = if args_len >= 2 && !args_ptr.is_null() {
+                *args_ptr.add(1)
+            } else {
+                undef
+            };
+            return if method_name == "__defineGetter__" {
+                super::js_object_define_getter(object, key, func)
+            } else {
+                super::js_object_define_setter(object, key, func)
+            };
+        }
+        "__lookupGetter__" | "__lookupSetter__" => {
+            let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+            let key = if args_len >= 1 && !args_ptr.is_null() {
+                *args_ptr
+            } else {
+                undef
+            };
+            return if method_name == "__lookupGetter__" {
+                super::js_object_lookup_getter(object, key)
+            } else {
+                super::js_object_lookup_setter(object, key)
+            };
         }
 
         // `Object.prototype.valueOf` returns the receiver after ToObject.

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -1912,6 +1912,96 @@ pub(crate) unsafe fn own_key_present(
     false
 }
 
+/// `Object.prototype.__defineGetter__(key, getter)` (Annex B §B.2.2.2).
+/// Installs an accessor with the given getter and `enumerable: true,
+/// configurable: true`. A non-callable getter throws a TypeError. Returns
+/// `undefined`.
+#[no_mangle]
+pub extern "C" fn js_object_define_getter(this: f64, key: f64, getter: f64) -> f64 {
+    unsafe { define_accessor_annexb(this, key, getter, true) }
+}
+
+/// `Object.prototype.__defineSetter__(key, setter)` (Annex B §B.2.2.3).
+#[no_mangle]
+pub extern "C" fn js_object_define_setter(this: f64, key: f64, setter: f64) -> f64 {
+    unsafe { define_accessor_annexb(this, key, setter, false) }
+}
+
+/// Shared `__defineGetter__`/`__defineSetter__` body. Builds an accessor
+/// descriptor `{ [get|set]: func, enumerable: true, configurable: true }` and
+/// delegates to `js_object_define_property`, so the function's `this`-binding
+/// and the closure/class-ref/symbol-key paths all behave like a normal
+/// accessor define.
+unsafe fn define_accessor_annexb(this: f64, key: f64, func: f64, is_getter: bool) -> f64 {
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    if !value_is_callable(func) {
+        let which = if is_getter {
+            "__defineGetter__"
+        } else {
+            "__defineSetter__"
+        };
+        throw_object_type_error(format!("Object.prototype.{which}: Expecting function").as_bytes());
+    }
+    let desc = js_object_alloc(0, 3);
+    if desc.is_null() {
+        return undef;
+    }
+    let field = if is_getter { "get" } else { "set" };
+    let fkey = crate::string::js_string_from_bytes(field.as_ptr(), field.len() as u32);
+    js_object_set_field_by_name(desc, fkey, func);
+    let true_v = f64::from_bits(crate::value::JSValue::bool(true).bits());
+    let enum_key = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
+    js_object_set_field_by_name(desc, enum_key, true_v);
+    let cfg_key = crate::string::js_string_from_bytes(b"configurable".as_ptr(), 12);
+    js_object_set_field_by_name(desc, cfg_key, true_v);
+    let desc_val = f64::from_bits(crate::value::JSValue::pointer(desc as *const u8).bits());
+    js_object_define_property(this, key, desc_val);
+    undef
+}
+
+/// `Object.prototype.__lookupGetter__(key)` (Annex B §B.2.2.4). Walks the
+/// receiver's own + prototype chain; returns the getter of the first own
+/// accessor property found (or `undefined`).
+#[no_mangle]
+pub extern "C" fn js_object_lookup_getter(this: f64, key: f64) -> f64 {
+    unsafe { lookup_accessor_annexb(this, key, true) }
+}
+
+/// `Object.prototype.__lookupSetter__(key)` (Annex B §B.2.2.5).
+#[no_mangle]
+pub extern "C" fn js_object_lookup_setter(this: f64, key: f64) -> f64 {
+    unsafe { lookup_accessor_annexb(this, key, false) }
+}
+
+/// Shared `__lookupGetter__`/`__lookupSetter__` body. Walks own + proto chain
+/// via `getOwnPropertyDescriptor`/`getPrototypeOf`; the first own property
+/// found stops the walk — its `get`/`set` field is returned (`undefined` for a
+/// data property or the opposite-only accessor case).
+unsafe fn lookup_accessor_annexb(this: f64, key: f64, want_getter: bool) -> f64 {
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let field = if want_getter { "get" } else { "set" };
+    let fkey = crate::string::js_string_from_bytes(field.as_ptr(), field.len() as u32);
+    let mut cur = this;
+    // Cap the walk so a pathological/cyclic prototype can't spin forever.
+    for _ in 0..100_000 {
+        let jv = crate::value::JSValue::from_bits(cur.to_bits());
+        if jv.is_null() || jv.is_undefined() {
+            return undef;
+        }
+        let desc = js_object_get_own_property_descriptor(cur, key);
+        if !crate::value::JSValue::from_bits(desc.to_bits()).is_undefined() {
+            let desc_ptr = extract_obj_ptr(desc);
+            if desc_ptr.is_null() {
+                return undef;
+            }
+            let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, fkey);
+            return f64::from_bits(v.bits());
+        }
+        cur = js_object_get_prototype_of(cur);
+    }
+    undef
+}
+
 /// Issue #620: returns the OWN-property value at `name` if one exists in the
 /// receiver's own keys_array (a string-keyed data property), otherwise
 /// returns TAG_UNDEFINED. Used by class-method dispatch to detect override

--- a/crates/perry-runtime/src/object/string_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/string_proto_thunks.rs
@@ -65,6 +65,21 @@ pub(super) fn install_string_proto_methods(
 /// the reflective path reaches the thunk instead of being folded to
 /// `receiver.<m>()` (which would dispatch on the receiver's own type).
 const GENERIC_STRING_PROTO_METHODS: &[(&str, u32)] = &[
+    // Annex B §B.2.2 HTML wrappers. Attribute-taking ones (anchor/link/
+    // fontcolor/fontsize) have spec `.length` 1; the no-arg tag wrappers 0.
+    ("anchor", 1),
+    ("big", 0),
+    ("blink", 0),
+    ("bold", 0),
+    ("fixed", 0),
+    ("fontcolor", 1),
+    ("fontsize", 1),
+    ("italics", 0),
+    ("link", 1),
+    ("small", 0),
+    ("strike", 0),
+    ("sub", 0),
+    ("sup", 0),
     ("concat", 1),
     ("endsWith", 1),
     ("includes", 1),

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -15,11 +15,13 @@ use crate::value::js_nanbox_string;
 
 use crate::object::ObjectHeader;
 
+mod compile;
 mod escape;
 mod grammar;
 mod match_all;
 mod replace_expand;
 mod replace_fn;
+pub use compile::js_regexp_compile_value;
 pub use escape::js_regexp_escape;
 use grammar::{has_invalid_repeated_quantifier, js_regex_to_rust};
 pub use match_all::{

--- a/crates/perry-runtime/src/regex/compile.rs
+++ b/crates/perry-runtime/src/regex/compile.rs
@@ -1,0 +1,124 @@
+//! `RegExp.prototype.compile(pattern, flags)` (Annex B §B.2.4.1).
+//!
+//! Split out of `regex.rs` to keep that file under the 2000-line size gate.
+
+use std::sync::Arc;
+
+use regex::Regex;
+
+use super::grammar::{has_invalid_repeated_quantifier, js_regex_to_rust};
+use super::{
+    get_or_compile_regex, is_regex_pointer, is_valid_ptr, is_valid_regex_ptr, js_regexp_get_flags,
+    js_regexp_get_source, js_string_from_str, string_as_str, throw_regexp_syntax_error,
+    validate_and_canonicalize_flags, RegExpHeader,
+};
+
+/// `RegExp.prototype.compile(pattern, flags)`. Re-initializes the receiver
+/// RegExp *in place*: re-validates and recompiles the pattern, updates
+/// `.source`/`.flags`, and resets `lastIndex` to 0. Returns the receiver
+/// (NaN-boxed). When `pattern` is itself a RegExp its source+flags are adopted
+/// and a non-`undefined` `flags` argument is a TypeError.
+#[no_mangle]
+pub extern "C" fn js_regexp_compile_value(
+    re: *mut RegExpHeader,
+    pattern_val: f64,
+    flags_val: f64,
+) -> f64 {
+    if !is_valid_regex_ptr(re) {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let pj = crate::value::JSValue::from_bits(pattern_val.to_bits());
+    let fj = crate::value::JSValue::from_bits(flags_val.to_bits());
+
+    let (pattern_owned, flags_owned) = if pj.is_pointer() && is_regex_pointer(pj.as_pointer::<u8>())
+    {
+        // RegExp source: adopt source+flags; supplying flags is a TypeError.
+        if !fj.is_undefined() {
+            crate::collection_iter::throw_type_error(
+                "Cannot supply flags when constructing one RegExp from another",
+            );
+        }
+        let src_re = pj.as_pointer::<RegExpHeader>();
+        let src = js_regexp_get_source(src_re);
+        let flg = js_regexp_get_flags(src_re);
+        let src_s = if is_valid_ptr(src) {
+            string_as_str(src).to_string()
+        } else {
+            String::new()
+        };
+        let flg_s = if is_valid_ptr(flg) {
+            string_as_str(flg).to_string()
+        } else {
+            String::new()
+        };
+        (src_s, flg_s)
+    } else {
+        // ToString(pattern), with `undefined` -> "" (spec); same for flags.
+        let pat = if pj.is_undefined() {
+            String::new()
+        } else {
+            let p = crate::builtins::js_string_coerce(pattern_val);
+            if is_valid_ptr(p) {
+                string_as_str(p).to_string()
+            } else {
+                String::new()
+            }
+        };
+        let flg = if fj.is_undefined() {
+            String::new()
+        } else {
+            let f = crate::builtins::js_string_coerce(flags_val);
+            if is_valid_ptr(f) {
+                string_as_str(f).to_string()
+            } else {
+                String::new()
+            }
+        };
+        (pat, flg)
+    };
+
+    let canonical_flags = validate_and_canonicalize_flags(&flags_owned);
+    let flags_str = canonical_flags.as_str();
+    let pattern_str = pattern_owned.as_str();
+
+    // Same SyntaxError validation as `js_regexp_new`: only reject patterns that
+    // neither the `regex` crate nor `fancy-regex` accept.
+    if has_invalid_repeated_quantifier(pattern_str) {
+        throw_regexp_syntax_error(&format!(
+            "Invalid regular expression: /{}/: invalid pattern",
+            pattern_str
+        ));
+    }
+    let translated = js_regex_to_rust(pattern_str);
+    if regex::Regex::new(&translated).is_err() && fancy_regex::Regex::new(&translated).is_err() {
+        throw_regexp_syntax_error(&format!(
+            "Invalid regular expression: /{}/: invalid pattern",
+            pattern_str
+        ));
+    }
+
+    let arc = get_or_compile_regex(pattern_str, flags_str);
+    let regex_ptr = Arc::as_ptr(&arc) as *mut Regex;
+    let canonical_flags_ptr = js_string_from_str(flags_str);
+    let pattern_ptr = js_string_from_str(pattern_str);
+    unsafe {
+        (*re).regex_ptr = regex_ptr;
+        (*re).pattern_ptr = pattern_ptr;
+        (*re).flags_ptr = canonical_flags_ptr;
+        (*re).case_insensitive = flags_str.contains('i');
+        (*re).global = flags_str.contains('g');
+        (*re).multiline = flags_str.contains('m');
+        (*re).sticky = flags_str.contains('y');
+        (*re).dot_all = flags_str.contains('s');
+        (*re).unicode = flags_str.contains('u') || flags_str.contains('v');
+        (*re).has_indices = flags_str.contains('d');
+        (*re).last_index = 0;
+        super::REGEX_SOURCE_TABLE.with(|t| {
+            t.borrow_mut().insert(
+                re as usize,
+                (pattern_str.to_string(), flags_str.to_string()),
+            );
+        });
+    }
+    f64::from_bits(crate::value::JSValue::pointer(re as *const u8).bits())
+}

--- a/crates/perry-runtime/src/string/html.rs
+++ b/crates/perry-runtime/src/string/html.rs
@@ -1,0 +1,92 @@
+//! Annex B §B.2.2 — `String.prototype` HTML wrapper methods.
+//!
+//! These legacy, web-compat methods wrap the receiver string in an HTML tag.
+//! Per the `CreateHTML` abstract operation (§B.2.2.1) the receiver is
+//! `ToString(this)` (the *body*, never escaped) and the optional attribute
+//! value is `ToString(value)` with every `"` replaced by `&quot;`.
+//!
+//! The caller (codegen fast path or the `js_native_call_method` string tower)
+//! supplies the already-coerced attribute-value `StringHeader`; a null value
+//! is treated as the empty string.
+
+use super::*;
+
+/// `CreateHTML(string, tag, attribute, value)` (ECMA-262 Annex B §B.2.2.1).
+/// `attr == ""` means no attribute (`big`/`bold`/…); otherwise the attribute
+/// is emitted as `attr="<escaped value>"`.
+fn create_html(
+    s: *const StringHeader,
+    tag: &str,
+    attr: &str,
+    value: *const StringHeader,
+) -> *mut StringHeader {
+    let body = if is_valid_string_ptr(s) {
+        string_as_str(s)
+    } else {
+        ""
+    };
+    let mut out = String::with_capacity(body.len() + tag.len() * 2 + attr.len() + 8);
+    out.push('<');
+    out.push_str(tag);
+    if !attr.is_empty() {
+        let v = if is_valid_string_ptr(value) {
+            string_as_str(value)
+        } else {
+            ""
+        };
+        out.push(' ');
+        out.push_str(attr);
+        out.push_str("=\"");
+        // Only `"` is escaped (to `&quot;`); `<`, `>`, `&` pass through, per spec.
+        for ch in v.chars() {
+            if ch == '"' {
+                out.push_str("&quot;");
+            } else {
+                out.push(ch);
+            }
+        }
+        out.push('"');
+    }
+    out.push('>');
+    out.push_str(body);
+    out.push_str("</");
+    out.push_str(tag);
+    out.push('>');
+    js_string_from_str(&out)
+}
+
+macro_rules! html_noarg {
+    ($name:ident, $tag:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(s: *const StringHeader) -> *mut StringHeader {
+            create_html(s, $tag, "", ptr::null())
+        }
+    };
+}
+
+macro_rules! html_attr {
+    ($name:ident, $tag:literal, $attr:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            s: *const StringHeader,
+            value: *const StringHeader,
+        ) -> *mut StringHeader {
+            create_html(s, $tag, $attr, value)
+        }
+    };
+}
+
+html_noarg!(js_string_big, "big");
+html_noarg!(js_string_blink, "blink");
+html_noarg!(js_string_bold, "b");
+html_noarg!(js_string_fixed, "tt");
+html_noarg!(js_string_italics, "i");
+html_noarg!(js_string_small, "small");
+html_noarg!(js_string_strike, "strike");
+html_noarg!(js_string_sub, "sub");
+html_noarg!(js_string_sup, "sup");
+
+html_attr!(js_string_anchor, "a", "name");
+html_attr!(js_string_link, "a", "href");
+html_attr!(js_string_fontcolor, "font", "color");
+html_attr!(js_string_fontsize, "font", "size");

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -25,6 +25,7 @@ mod char_ops;
 mod compare;
 mod concat;
 mod format;
+mod html;
 mod intern;
 mod io;
 mod iter_object;
@@ -71,6 +72,11 @@ pub(crate) use format::js_format_f64;
 pub use format::{
     js_number_to_exponential, js_number_to_fixed, js_number_to_precision, js_number_to_string,
     scan_small_int_cache_roots, scan_small_int_cache_roots_mut,
+};
+pub use html::{
+    js_string_anchor, js_string_big, js_string_blink, js_string_bold, js_string_fixed,
+    js_string_fontcolor, js_string_fontsize, js_string_italics, js_string_link, js_string_small,
+    js_string_strike, js_string_sub, js_string_sup,
 };
 pub use intern::{js_string_intern, scan_intern_table_roots, scan_intern_table_roots_mut};
 pub use io::{js_string_error, js_string_print, js_string_warn};


### PR DESCRIPTION
Implements the remaining sub-items of #4796 (Annex B / web-compat tails). All behaviors verified byte-for-byte against `node --experimental-strip-types`.

> **Note:** the Date sub-item (`toUTCString`/`toGMTString`/`getYear`/`setYear`) was already shipped on `main` via #4807/#4808 while this branch was in progress, so it is intentionally **not** included here — this branch was rebased onto current `main` and the redundant Date work dropped.

## What's included

- **`String.prototype` HTML methods** (Annex B §B.2.2) — all 13: `anchor`, `big`, `blink`, `bold`, `fixed`, `fontcolor`, `fontsize`, `italics`, `link`, `small`, `strike`, `sub`, `sup`. New `string/html.rs` (CreateHTML; only `"`→`&quot;` escaped, body never escaped). Works for direct typed calls, reflective `String.prototype.bold.call(x)`, any-typed receivers, and reports correct `.length`.
- **`Object.prototype` accessor methods** (Annex B §B.2.2) — `__defineGetter__`, `__defineSetter__`, `__lookupGetter__`, `__lookupSetter__`. Direct calls, reflective `Object.prototype.X.call(...)`, `typeof` detection, and `getOwnPropertyDescriptor` integration all match Node. Define delegates to `js_object_define_property` so getter/setter `this`-binding and closure/class-ref/symbol-key paths are reused.
- **`RegExp.prototype.compile(pattern, flags)`** (Annex B §B.2.4.1) — re-initializes the `RegExpHeader` in place (recompile, reset `lastIndex`, update `.source`/`.flags`); adopts source+flags from a RegExp arg and throws on a non-`undefined` flags arg; bad flags → `SyntaxError`.
- **`escape`/`unescape`/`decodeURI` argument coercion** — these now apply `ToString`, so `escape(undefined)` → `"undefined"` (previously `""`).
- **Drive-by fix:** a pre-existing stable-hash tag collision on `main` (`NewDynamicSpread` and `DateToUTCString` both used `12507`, from #4807) that was failing `expr_variant_stable_hash_tags_are_unique` — reassigned `DateToUTCString` to a unique tag.

## Testing

- `perry-hir` + `perry-codegen` test suites: all green.
- `perry-runtime`: 994 pass. The 3 failures are pre-existing and unrelated to this branch (verified `date.rs` is byte-identical to `main`): a `main` Date-setter test regression, the known-flaky `stream_constructors_expose_static_method_values` (passes in isolation), and an environment-dependent temp-path test.
- All four features diffed byte-for-byte against Node and match.

## Known limitations (out of scope)

- Class-instance direct `instance.__defineGetter__(...)` isn't routed (class vtable-miss → native fallback is a separate codegen path); plain-object direct, reflective `.call`, and `typeof` all work.
- Reading the method **value's** `.length` (e.g. `Object.prototype.__defineGetter__.length`) is a Perry-wide limitation shared by `hasOwnProperty` etc.