### PR TITLE
feat(publish): add [android] version_code override

### DIFF
--- a/crates/perry/src/commands/publish/config_types.rs
+++ b/crates/perry/src/commands/publish/config_types.rs
@@ -155,6 +155,12 @@ pub(super) struct AndroidConfig {
     pub(super) key_alias: Option<String>,
     pub(super) google_play_key: Option<String>,
     pub(super) entry: Option<String>,
+    /// Explicit Android `versionCode`. When set, it overrides the value derived
+    /// from `build_number` (`version_to_code`). Use this to keep `versionCode`
+    /// monotonic across CI/build-number changes, or to clear a higher code
+    /// already on Play, without touching the marketing version. Play requires it
+    /// to be strictly greater than any code previously uploaded (max 2100000000).
+    pub(super) version_code: Option<u32>,
 }
 
 // #854: deserialized [watchos] table; not every key is read.

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -1256,7 +1256,11 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
             None
         },
         android_distribute: if is_android { android_distribute } else { None },
-        android_version_code: if is_android { android_version_code } else { None },
+        android_version_code: if is_android {
+            android_version_code
+        } else {
+            None
+        },
         linux_format: if is_linux {
             config.linux.as_ref().and_then(|l| l.format.clone())
         } else {

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -454,6 +454,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
     // Android-specific config from perry.toml
     let android_min_sdk = config.android.as_ref().and_then(|a| a.min_sdk.clone());
     let android_target_sdk = config.android.as_ref().and_then(|a| a.target_sdk.clone());
+    let android_version_code = config.android.as_ref().and_then(|a| a.version_code);
     let android_permissions = config.android.as_ref().and_then(|a| a.permissions.clone());
     let android_distribute = config.android.as_ref().and_then(|a| a.distribute.clone());
 
@@ -1255,6 +1256,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
             None
         },
         android_distribute: if is_android { android_distribute } else { None },
+        android_version_code: if is_android { android_version_code } else { None },
         linux_format: if is_linux {
             config.linux.as_ref().and_then(|l| l.format.clone())
         } else {

--- a/crates/perry/src/commands/publish/server_api.rs
+++ b/crates/perry/src/commands/publish/server_api.rs
@@ -133,6 +133,8 @@ pub(super) struct BuildManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) android_distribute: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) android_version_code: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) linux_format: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) linux_category: Option<String>,

--- a/crates/perry/src/commands/publish/tarball.rs
+++ b/crates/perry/src/commands/publish/tarball.rs
@@ -155,7 +155,10 @@ pub(crate) fn create_project_tarball(
         if builtin_exclude_dirs.iter().any(|ex| name == *ex) {
             return false;
         }
-        if extra_excludes.iter().any(|ex| exclude_matches(ex, e.path(), project_dir)) {
+        if extra_excludes
+            .iter()
+            .any(|ex| exclude_matches(ex, e.path(), project_dir))
+        {
             return false;
         }
         if name.ends_with(".app") {
@@ -299,11 +302,7 @@ mod force_include_tests {
         ));
         // A leading slash is an explicit root anchor, equivalent to the bare name.
         assert!(exclude_matches("/jump", Path::new("/proj/jump"), root));
-        assert!(!exclude_matches(
-            "/jump",
-            Path::new("/proj/a/jump"),
-            root
-        ));
+        assert!(!exclude_matches("/jump", Path::new("/proj/a/jump"), root));
         // Path patterns match the named subtree from the project root.
         assert!(exclude_matches(
             "android/app/build",
@@ -351,9 +350,9 @@ mod force_include_tests {
             "root `jump` artifact should be excluded, got {entries:?}"
         );
         assert!(
-            entries.iter().any(|p| p.ends_with(
-                "com/bloomengine/jump/BloomActivity.kt"
-            )),
+            entries
+                .iter()
+                .any(|p| p.ends_with("com/bloomengine/jump/BloomActivity.kt")),
             "deep jump/ package must be kept, got {entries:?}"
         );
     }

--- a/docs/src/cli/perry-toml.md
+++ b/docs/src/cli/perry-toml.md
@@ -329,6 +329,7 @@ Android-specific configuration for `perry publish android`, `perry run android`,
 | `package_name` | string | Falls back to bundle_id chain | Java package name (e.g., `"com.example.myapp"`) |
 | `min_sdk` | string | — | Minimum Android SDK version (e.g., `"26"` for Android 8.0) |
 | `target_sdk` | string | — | Target Android SDK version (e.g., `"34"` for Android 14) |
+| `version_code` | integer | Derived from `build_number` | Explicit Play `versionCode`. Overrides the derived value; must be strictly greater than any code already uploaded to Play (max `2100000000`). Use it to keep `versionCode` monotonic across CI/build-number changes without touching the marketing version. |
 | `permissions` | string[] | — | Android permissions (e.g., `["INTERNET", "CAMERA", "ACCESS_FINE_LOCATION"]`) |
 | `distribute` | string | — | Distribution method: `"playstore"` |
 | `keystore` | string | — | Path to `.jks` or `.keystore` signing keystore |


### PR DESCRIPTION
Adds an explicit `[android] version_code` integer to perry.toml. Android versionCode is otherwise derived from `build_number` (`build_number * 10000`), which regresses if a project's CI/run number resets — Google Play then rejects the upload. The override is sent in the build manifest and wins over the derived value on the worker, letting projects pin a monotonic code (or clear an existing higher floor) without changing the marketing version.

Worker support: PerryTS/builder-linux + PerryTS/builder-macos (companion PRs). Docs table updated.