### PR TITLE
fix(hir): resolve CJS worker path joins

### DIFF
--- a/crates/perry-hir/src/dynamic_import.rs
+++ b/crates/perry-hir/src/dynamic_import.rs
@@ -1177,6 +1177,72 @@ pub fn resolve_import_path_with_context<V: Borrow<Expr>>(
 ) -> Resolution {
     match arg {
         Expr::String(s) => Resolution::Set(vec![s.clone()]),
+        Expr::Call { callee, args, .. } => match static_string_replace_target(callee, args) {
+            Some(string) => resolve_string_replace_parts(
+                string,
+                &args[0],
+                &args[1],
+                consts,
+                param_literals,
+                local_literals,
+                visiting,
+            ),
+            None if is_static_path_join_call(callee) => {
+                resolve_static_path_args(args, consts, param_literals, local_literals, visiting)
+            }
+            None => Resolution::Unresolved(
+                "path argument is not statically resolvable (supported: string literals, \
+                 ternaries of resolvable arms, template literals with const-local \
+                 interpolations, and references to module-level const string locals)"
+                    .to_string(),
+            ),
+        },
+        Expr::PathJoin(left, right) | Expr::PathResolveJoin(left, right) => {
+            let left = resolve_import_path_with_context(
+                left,
+                consts,
+                param_literals,
+                local_literals,
+                visiting,
+            );
+            let right = resolve_import_path_with_context(
+                right,
+                consts,
+                param_literals,
+                local_literals,
+                visiting,
+            );
+            match (left, right) {
+                (Resolution::Set(lefts), Resolution::Set(rights)) => {
+                    let mut out = Vec::new();
+                    for left in &lefts {
+                        for right in &rights {
+                            let joined = static_path_join(left, right);
+                            if !out.contains(&joined) {
+                                out.push(joined);
+                            }
+                        }
+                    }
+                    Resolution::Set(out)
+                }
+                (Resolution::Unresolved(reason), _) | (_, Resolution::Unresolved(reason)) => {
+                    Resolution::Unresolved(reason)
+                }
+            }
+        }
+        Expr::StringReplace {
+            string,
+            pattern,
+            replacement,
+        } => resolve_string_replace_parts(
+            string,
+            pattern,
+            replacement,
+            consts,
+            param_literals,
+            local_literals,
+            visiting,
+        ),
         Expr::Conditional {
             then_expr,
             else_expr,
@@ -1292,6 +1358,116 @@ pub fn resolve_import_path_with_context<V: Borrow<Expr>>(
     }
 }
 
+fn static_string_replace_target<'a>(callee: &'a Expr, args: &[Expr]) -> Option<&'a Expr> {
+    if args.len() < 2 {
+        return None;
+    }
+    match callee {
+        Expr::PropertyGet { object, property } if property == "replace" => Some(object),
+        _ => None,
+    }
+}
+
+fn resolve_string_replace_parts<V: Borrow<Expr>>(
+    string: &Expr,
+    pattern: &Expr,
+    replacement: &Expr,
+    consts: &std::collections::HashMap<u32, V>,
+    param_literals: &std::collections::HashMap<u32, Vec<String>>,
+    local_literals: &std::collections::HashMap<u32, Vec<String>>,
+    visiting: &mut std::collections::HashSet<u32>,
+) -> Resolution {
+    let string =
+        resolve_import_path_with_context(string, consts, param_literals, local_literals, visiting);
+    let pattern =
+        resolve_import_path_with_context(pattern, consts, param_literals, local_literals, visiting);
+    let replacement = resolve_import_path_with_context(
+        replacement,
+        consts,
+        param_literals,
+        local_literals,
+        visiting,
+    );
+    match (string, pattern, replacement) {
+        (Resolution::Set(strings), Resolution::Set(patterns), Resolution::Set(replacements)) => {
+            let mut out = Vec::new();
+            for string in &strings {
+                for pattern in &patterns {
+                    for replacement in &replacements {
+                        let replaced = string.replacen(pattern, replacement, 1);
+                        if !out.contains(&replaced) {
+                            out.push(replaced);
+                        }
+                    }
+                }
+            }
+            Resolution::Set(out)
+        }
+        (Resolution::Unresolved(reason), _, _)
+        | (_, Resolution::Unresolved(reason), _)
+        | (_, _, Resolution::Unresolved(reason)) => Resolution::Unresolved(reason),
+    }
+}
+
+fn is_static_path_join_call(callee: &Expr) -> bool {
+    let Expr::PropertyGet { object, property } = callee else {
+        return false;
+    };
+    property == "join" && is_static_path_module_expr(object)
+}
+
+fn is_static_path_module_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::NativeModuleRef(module) => module == "path" || module == "node:path",
+        Expr::PropertyGet { object, property } if property == "default" => {
+            is_static_path_module_expr(object)
+        }
+        _ => false,
+    }
+}
+
+fn resolve_static_path_args<V: Borrow<Expr>>(
+    args: &[Expr],
+    consts: &std::collections::HashMap<u32, V>,
+    param_literals: &std::collections::HashMap<u32, Vec<String>>,
+    local_literals: &std::collections::HashMap<u32, Vec<String>>,
+    visiting: &mut std::collections::HashSet<u32>,
+) -> Resolution {
+    if args.is_empty() {
+        return Resolution::Set(vec![".".to_string()]);
+    }
+    let mut sets = Vec::with_capacity(args.len());
+    for arg in args {
+        match resolve_import_path_with_context(
+            arg,
+            consts,
+            param_literals,
+            local_literals,
+            visiting,
+        ) {
+            Resolution::Set(paths) => sets.push(paths),
+            Resolution::Unresolved(reason) => return Resolution::Unresolved(reason),
+        }
+    }
+    let mut acc = vec![String::new()];
+    for set in sets {
+        let mut next = Vec::new();
+        for left in &acc {
+            for right in &set {
+                let joined = static_path_join(left, right);
+                if !next.contains(&joined) {
+                    next.push(joined);
+                }
+            }
+        }
+        acc = next;
+        if acc.len() > DYNAMIC_IMPORT_PATH_CAP {
+            return Resolution::Set(acc);
+        }
+    }
+    Resolution::Set(acc)
+}
+
 /// Flatten a left-leaning `Add` chain — produced by
 /// `expr_misc::lower_tpl` for a template literal — into the ordered
 /// list of leaf parts. e.g. `(("./locale_" + lang) + ".ts")` flattens
@@ -1308,6 +1484,76 @@ fn flatten_concat<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
     } else {
         out.push(expr);
     }
+}
+
+fn static_path_join(left: &str, right: &str) -> String {
+    let left = left.replace('\\', "/");
+    let right = right.replace('\\', "/");
+    if is_static_path_absolute(&right) {
+        return normalize_static_path(&right);
+    }
+    if left.is_empty() {
+        return normalize_static_path(&right);
+    }
+    if right.is_empty() {
+        return normalize_static_path(&left);
+    }
+    normalize_static_path(&format!(
+        "{}/{}",
+        left.trim_end_matches('/'),
+        right.trim_start_matches('/')
+    ))
+}
+
+fn is_static_path_absolute(path: &str) -> bool {
+    path.starts_with('/')
+        || path.starts_with("//")
+        || path.as_bytes().get(1).is_some_and(|b| *b == b':')
+}
+
+fn normalize_static_path(path: &str) -> String {
+    let path = path.replace('\\', "/");
+    let (prefix, rest) = split_static_path_prefix(&path);
+    let mut parts = Vec::new();
+    for part in rest.split('/') {
+        match part {
+            "" | "." => {}
+            ".." if !parts.is_empty() && parts.last() != Some(&"..") => {
+                parts.pop();
+            }
+            ".." if prefix.is_empty() => parts.push(part),
+            ".." => {}
+            _ => parts.push(part),
+        }
+    }
+    let body = parts.join("/");
+    if prefix.is_empty() {
+        if body.is_empty() {
+            ".".to_string()
+        } else {
+            body
+        }
+    } else if body.is_empty() {
+        prefix.to_string()
+    } else if prefix.ends_with('/') {
+        format!("{prefix}{body}")
+    } else {
+        format!("{prefix}/{body}")
+    }
+}
+
+fn split_static_path_prefix(path: &str) -> (&str, &str) {
+    if path.starts_with("//") {
+        let trimmed = path.trim_start_matches('/');
+        return ("//", trimmed);
+    }
+    if path.starts_with('/') {
+        return ("/", &path[1..]);
+    }
+    if path.as_bytes().get(1).is_some_and(|b| *b == b':') {
+        return (&path[..2], &path[2..]);
+    }
+    ("", path)
 }
 
 /// Scan `module.init` for an `await` expression outside any function/

--- a/crates/perry-hir/src/dynamic_import/tests.rs
+++ b/crates/perry-hir/src/dynamic_import/tests.rs
@@ -436,6 +436,140 @@ fn resolve_reassigned_local_literal_candidates() {
 }
 
 #[test]
+fn resolve_path_join_over_replaced_dirname() {
+    // node-pty's Windows conout worker uses:
+    //   new Worker(path.join(__dirname.replace('node_modules.asar',
+    //     'node_modules.asar.unpacked'), 'worker/conoutSocketWorker.js'))
+    // `__dirname` is already lowered to a string by the parser; the path
+    // resolver still needs to fold the replace + join chain to a single
+    // deterministic worker module.
+    let expr = Expr::PathJoin(
+        Box::new(Expr::StringReplace {
+            string: Box::new(Expr::String(
+                "D:/tmp/probe/node_modules/node-pty/lib".to_string(),
+            )),
+            pattern: Box::new(Expr::String("node_modules.asar".to_string())),
+            replacement: Box::new(Expr::String("node_modules.asar.unpacked".to_string())),
+        }),
+        Box::new(Expr::String("worker/conoutSocketWorker.js".to_string())),
+    );
+
+    let mut visiting = HashSet::new();
+    match resolve_import_path_with_context(
+        &expr,
+        &HashMap::<u32, Expr>::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &mut visiting,
+    ) {
+        Resolution::Set(v) => assert_eq!(
+            v,
+            vec!["D:/tmp/probe/node_modules/node-pty/lib/worker/conoutSocketWorker.js"]
+        ),
+        Resolution::Unresolved(reason) => panic!("expected Set, got Unresolved: {reason}"),
+    }
+}
+
+#[test]
+fn resolve_cjs_path_default_join_over_replaced_dirname_local() {
+    let mut module = Module::new("node-pty-windows-conout");
+    module.init.push(Stmt::Let {
+        id: 81,
+        name: "scriptPath".into(),
+        ty: Type::String,
+        mutable: true,
+        init: Some(Expr::Call {
+            callee: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::String(
+                    "D:\\tmp\\probe\\node_modules\\node-pty\\lib".to_string(),
+                )),
+                property: "replace".to_string(),
+            }),
+            args: vec![
+                Expr::String("node_modules.asar".to_string()),
+                Expr::String("node_modules.asar.unpacked".to_string()),
+            ],
+            type_args: vec![],
+        }),
+    });
+
+    let filename = Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::NativeModuleRef("path".to_string())),
+                property: "default".to_string(),
+            }),
+            property: "join".to_string(),
+        }),
+        args: vec![
+            Expr::LocalGet(81),
+            Expr::String("worker/conoutSocketWorker.js".to_string()),
+        ],
+        type_args: vec![],
+    };
+
+    let consts = collect_module_const_locals(&module);
+    let params = collect_dynamic_import_param_literals(&module);
+    let locals = collect_dynamic_import_local_candidate_literals(&module, &consts, &params);
+    let mut visiting = HashSet::new();
+    match resolve_import_path_with_context(&filename, &consts, &params, &locals, &mut visiting) {
+        Resolution::Set(v) => assert_eq!(
+            v,
+            vec!["D:/tmp/probe/node_modules/node-pty/lib/worker/conoutSocketWorker.js"]
+        ),
+        Resolution::Unresolved(reason) => panic!("expected Set, got Unresolved: {reason}"),
+    }
+}
+
+#[test]
+fn resolve_path_join_normalizes_relative_segments() {
+    let expr = Expr::PathJoin(
+        Box::new(Expr::String("/project/src/lib".to_string())),
+        Box::new(Expr::String("../worker.js".to_string())),
+    );
+
+    let mut visiting = HashSet::new();
+    match resolve_import_path_with_context(
+        &expr,
+        &HashMap::<u32, Expr>::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &mut visiting,
+    ) {
+        Resolution::Set(v) => assert_eq!(v, vec!["/project/src/worker.js"]),
+        Resolution::Unresolved(reason) => panic!("expected Set, got Unresolved: {reason}"),
+    }
+}
+
+#[test]
+fn worker_new_visitor_descends_into_closure_bodies() {
+    let mut module = Module::new("worker-closure");
+    module.init.push(Stmt::Expr(Expr::Closure {
+        func_id: 1,
+        params: vec![],
+        return_type: Type::Void,
+        body: vec![Stmt::Expr(Expr::WorkerNew {
+            paths: vec![],
+            filename: Box::new(Expr::String("./worker.js".to_string())),
+            options: None,
+        })],
+        captures: vec![],
+        mutable_captures: vec![],
+        captures_this: false,
+        captures_new_target: false,
+        enclosing_class: None,
+        is_arrow: false,
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+    }));
+
+    let mut count = 0;
+    for_each_worker_new(&module, &mut |_| count += 1);
+    assert_eq!(count, 1);
+}
+
+#[test]
 fn reassigned_local_candidates_drop_mixed_dynamic_defs() {
     let mut m = Module::new("t");
     m.init.push(Stmt::Let {

--- a/crates/perry-hir/src/dynamic_import/visitors.rs
+++ b/crates/perry-hir/src/dynamic_import/visitors.rs
@@ -692,5 +692,10 @@ fn visit_expr_for_worker_new_ref<F: FnMut(&Expr)>(expr: &Expr, f: &mut F) {
     if matches!(expr, Expr::WorkerNew { .. }) {
         f(expr);
     }
+    if let Expr::Closure { body, .. } = expr {
+        for s in body {
+            visit_stmt_for_worker_new_ref(s, f);
+        }
+    }
     walk_expr_children(expr, &mut |child| visit_expr_for_worker_new_ref(child, f));
 }

--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -284,14 +284,14 @@ pub(super) fn lower_meta_prop(
 /// Used by both the bare-`import.meta` Object synthesis above and the
 /// member-access fast path in `expr_member::lower_member`.
 pub(crate) fn import_meta_paths(ctx: &LoweringContext) -> (String, String, String) {
-    let path = &ctx.source_file_path;
+    let path = ctx.source_file_path.replace('\\', "/");
     let url = format!("file://{}", path);
     let dirname = match path.rfind('/') {
         Some(i) if i > 0 => path[..i].to_string(),
         Some(_) => "/".to_string(),
         None => String::new(),
     };
-    let filename = path.to_string();
+    let filename = path;
     (url, dirname, filename)
 }
 

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -460,7 +460,7 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 // which silently corrupts any path computation built on
                 // path.join(__dirname, ...). Mirrors the import.meta arm
                 // (expr_misc::import_meta_paths) so both surfaces agree.
-                let path = &ctx.source_file_path;
+                let path = ctx.source_file_path.replace('\\', "/");
                 let value = if name == "__filename" {
                     path.clone()
                 } else {


### PR DESCRIPTION
## Summary

- Normalize Windows source paths before lowering `__dirname` and `import.meta` path fields.
- Let the static import/worker filename resolver fold deterministic CommonJS path shapes like string `.replace(...)` and `path.default.join(...)`.
- Add regression coverage for the Windows `node-pty` worker path shape and closure-contained `WorkerNew` discovery.

## Why

Some CommonJS packages construct worker entry filenames through deterministic path expressions instead of direct literals. One concrete shape is `path.join(__dirname.replace(...), "worker/file.js")`. Before this change Perry could not resolve that worker filename, so module collection stopped before the worker module was registered.

This does not add native `.node` addon loading. In the `node-pty` probe, this change gets Perry past worker module collection and compilation; executing the compiled probe still reaches the existing native-addon boundary at `require("./prebuilds/win32-x64/pty.node")`.

## Tests

- `cargo fmt -p perry-hir --check`
- `cargo test -p perry-hir dynamic_import::tests --message-format=short`
