### PR TITLE
fix(runtime): Temporal.ZonedDateTime test262 parity 34%→84%

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -639,7 +639,13 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                         let native_module = if let ast::Expr::Ident(obj_ident) = member.obj.as_ref()
                         {
                             let obj_name = obj_ident.sym.as_ref();
-                            ctx.lookup_builtin_module_alias(obj_name).is_some()
+                            // `Temporal.<X>` constructors dispatch via brand arms,
+                            // not a class chain, so route them through the runtime
+                            // dynamic path (`js_instanceof_dynamic` →
+                            // `temporal_ctor_kind`) by lowering the constructor to
+                            // its closure value here.
+                            obj_name == "Temporal"
+                                || ctx.lookup_builtin_module_alias(obj_name).is_some()
                                 || matches!(ctx.lookup_native_module(obj_name), Some((_, None)))
                         } else {
                             false

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3160,6 +3160,190 @@ fn install_temporal_constructor(
     closure
 }
 
+/// Read a built-in closure's installed `name` dynamic prop as a Rust `String`
+/// (used by the shared Temporal prototype thunks to recover which getter /
+/// method they back). Empty string if absent.
+fn temporal_closure_name(closure: *const crate::closure::ClosureHeader) -> String {
+    let v = crate::closure::closure_get_dynamic_prop(closure as usize, "name");
+    if !JSValue::from_bits(v.to_bits()).is_string() {
+        return String::new();
+    }
+    let ptr = crate::value::js_get_string_pointer_unified(v) as *const crate::string::StringHeader;
+    if ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+    }
+}
+
+/// Throw `TypeError: <type>.prototype.<member> called on incompatible receiver`
+/// for a Temporal prototype getter / method invoked on a non-branded `this`
+/// (the spec brand check). Used by the reflective `.call`/`.apply` paths;
+/// normal `zdt.foo()` dispatches via the brand arm and never reaches here.
+fn temporal_brand_type_error(type_name: &str, member: &str) -> ! {
+    crate::object::throw_object_type_error(
+        format!("{type_name}.prototype.{member} called on incompatible receiver").as_bytes(),
+    )
+}
+
+/// Shared body for a `Temporal.ZonedDateTime.prototype` accessor getter invoked
+/// reflectively. Resolves `this` from `IMPLICIT_THIS`, brand-checks it is a
+/// `ZonedDateTime`, and returns the getter's value.
+extern "C" fn temporal_zdt_proto_getter_thunk(
+    closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    // The accessor's name is `"get <prop>"`; recover the bare property.
+    let name = temporal_closure_name(closure);
+    let prop = name.strip_prefix("get ").unwrap_or(&name);
+    if crate::temporal::temporal_kind(this) != Some(crate::temporal::TemporalKind::ZonedDateTime) {
+        temporal_brand_type_error("Temporal.ZonedDateTime", prop);
+    }
+    crate::temporal::dispatch::get_property(this, prop)
+        .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED))
+}
+
+/// Shared body for a `Temporal.ZonedDateTime.prototype` method invoked
+/// reflectively (`.prototype.equals.call(zdt, …)`). Brand-checks `this` then
+/// dispatches to the per-type method router.
+extern "C" fn temporal_zdt_proto_method_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    let name = temporal_closure_name(closure);
+    if crate::temporal::temporal_kind(this) != Some(crate::temporal::TemporalKind::ZonedDateTime) {
+        temporal_brand_type_error("Temporal.ZonedDateTime", &name);
+    }
+    crate::temporal::dispatch::call_method(this, &name, &global_this_rest_array_values(rest))
+}
+
+/// Install one accessor getter onto a Temporal prototype with the spec
+/// descriptor (`enumerable:false, configurable:true`, `set:undefined`) and the
+/// proper getter `name` (`"get <prop>"`) / `length` (0). Mirrors the RegExp
+/// prototype getter install.
+fn install_temporal_getter(proto: *mut ObjectHeader, prop: &str, func_ptr: *const u8) {
+    unsafe {
+        crate::closure::js_register_closure_arity(func_ptr, 0);
+        let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+        if closure.is_null() {
+            return;
+        }
+        super::native_module::set_bound_native_closure_name(closure, &format!("get {prop}"));
+        super::native_module::set_builtin_closure_length(closure as usize, 0);
+        let key = crate::string::js_string_from_bytes(prop.as_ptr(), prop.len() as u32);
+        super::object_ops::ensure_key_in_keys_array(proto, key);
+        let getter_bits = crate::value::js_nanbox_pointer(closure as i64).to_bits();
+        super::object_ops::install_builtin_getter(proto, prop, getter_bits);
+        super::set_accessor_descriptor(
+            proto as usize,
+            prop.to_string(),
+            super::AccessorDescriptor {
+                get: getter_bits,
+                set: 0,
+            },
+        );
+        super::set_property_attrs(
+            proto as usize,
+            prop.to_string(),
+            super::PropertyAttrs::new(true, false, true),
+        );
+        super::set_builtin_property_attrs(
+            closure as usize,
+            "name".to_string(),
+            super::PropertyAttrs::new(false, false, true),
+        );
+        super::set_builtin_property_attrs(
+            closure as usize,
+            "length".to_string(),
+            super::PropertyAttrs::new(false, false, true),
+        );
+    }
+}
+
+/// Build the `Temporal.ZonedDateTime.prototype` object: every getter as an
+/// accessor property + every method as a non-constructable built-in function,
+/// each with the spec `name`/`length`/descriptor, plus `[Symbol.toStringTag]`.
+/// These satisfy the reflective test262 cases (branding / prop-desc / length /
+/// name / not-a-constructor / builtin); ordinary `zdt.foo()` calls still
+/// dispatch via the Temporal brand arm and never touch this object.
+fn build_zoned_date_time_prototype() -> *mut ObjectHeader {
+    let proto = js_object_alloc(0, 0);
+    if proto.is_null() {
+        return proto;
+    }
+    const GETTERS: &[&str] = &[
+        "year",
+        "month",
+        "monthCode",
+        "day",
+        "hour",
+        "minute",
+        "second",
+        "millisecond",
+        "microsecond",
+        "nanosecond",
+        "era",
+        "eraYear",
+        "epochMilliseconds",
+        "epochNanoseconds",
+        "dayOfWeek",
+        "dayOfYear",
+        "weekOfYear",
+        "yearOfWeek",
+        "daysInWeek",
+        "daysInMonth",
+        "daysInYear",
+        "monthsInYear",
+        "inLeapYear",
+        "hoursInDay",
+        "offset",
+        "offsetNanoseconds",
+        "timeZoneId",
+        "calendarId",
+    ];
+    for g in GETTERS {
+        install_temporal_getter(proto, g, temporal_zdt_proto_getter_thunk as *const u8);
+    }
+    // (name, spec_length)
+    const METHODS: &[(&str, u32)] = &[
+        ("add", 1),
+        ("subtract", 1),
+        ("until", 1),
+        ("since", 1),
+        ("round", 1),
+        ("equals", 1),
+        ("with", 1),
+        ("withCalendar", 1),
+        ("withPlainTime", 0),
+        ("withTimeZone", 1),
+        ("toInstant", 0),
+        ("toPlainDate", 0),
+        ("toPlainTime", 0),
+        ("toPlainDateTime", 0),
+        ("toString", 0),
+        ("toJSON", 0),
+        ("toLocaleString", 0),
+        ("valueOf", 0),
+        ("startOfDay", 0),
+        ("getTimeZoneTransition", 0),
+    ];
+    for (name, len) in METHODS {
+        install_proto_method_rest_with_length(
+            proto,
+            name,
+            temporal_zdt_proto_method_thunk as *const u8,
+            *len,
+            0,
+        );
+    }
+    set_intrinsic_to_string_tag(proto, "Temporal.ZonedDateTime");
+    proto
+}
+
 /// Map a value to the [`TemporalKind`] it constructs *iff* it is one of the
 /// eight `Temporal.<X>` constructor closures (matched by func-ptr, so a
 /// same-named user closure never matches). Used by `instanceof` to make
@@ -3421,6 +3605,26 @@ fn install_temporal_namespace(ns_obj: *mut ObjectHeader) {
             temporal_zoned_date_time_from_thunk as *const u8,
             temporal_zoned_date_time_compare_thunk as *const u8,
         );
+        // Real `Temporal.ZonedDateTime.prototype` with getter/method descriptors
+        // so reflective test262 cases resolve (branding / prop-desc / length /
+        // name / not-a-constructor). `ctor.prototype` is non-writable/non-enum/
+        // non-config; `proto.constructor` is writable/non-enum/config (spec).
+        let proto = build_zoned_date_time_prototype();
+        if !proto.is_null() {
+            let proto_value = crate::value::js_nanbox_pointer(proto as i64);
+            crate::closure::closure_set_dynamic_prop(zoned as usize, "prototype", proto_value);
+            super::set_builtin_property_attrs(
+                zoned as usize,
+                "prototype".to_string(),
+                super::PropertyAttrs::new(false, false, false),
+            );
+            set_intrinsic_data_prop(
+                proto,
+                "constructor",
+                crate::value::js_nanbox_pointer(zoned as i64),
+                super::PropertyAttrs::new(true, false, true),
+            );
+        }
     }
 
     // Temporal.Now namespace (#4689)

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3160,6 +3160,66 @@ fn install_temporal_constructor(
     closure
 }
 
+/// Map a value to the [`TemporalKind`] it constructs *iff* it is one of the
+/// eight `Temporal.<X>` constructor closures (matched by func-ptr, so a
+/// same-named user closure never matches). Used by `instanceof` to make
+/// `zdt instanceof Temporal.ZonedDateTime` resolve to `true` even though
+/// Temporal values dispatch via brand arms, not a real prototype chain.
+pub(crate) fn temporal_ctor_kind(type_ref: f64) -> Option<crate::temporal::TemporalKind> {
+    use crate::temporal::TemporalKind;
+    let jv = JSValue::from_bits(type_ref.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let closure = jv.as_pointer::<crate::closure::ClosureHeader>();
+    if closure.is_null() {
+        return None;
+    }
+    let (tag, fp) = unsafe { ((*closure).type_tag, (*closure).func_ptr) };
+    if tag != crate::closure::CLOSURE_MAGIC {
+        return None;
+    }
+    let fp = fp as usize;
+    let table: [(*const u8, TemporalKind); 8] = [
+        (
+            temporal_duration_ctor_thunk as *const u8,
+            TemporalKind::Duration,
+        ),
+        (
+            temporal_instant_ctor_thunk as *const u8,
+            TemporalKind::Instant,
+        ),
+        (
+            temporal_plain_date_ctor_thunk as *const u8,
+            TemporalKind::PlainDate,
+        ),
+        (
+            temporal_plain_time_ctor_thunk as *const u8,
+            TemporalKind::PlainTime,
+        ),
+        (
+            temporal_plain_date_time_ctor_thunk as *const u8,
+            TemporalKind::PlainDateTime,
+        ),
+        (
+            temporal_plain_year_month_ctor_thunk as *const u8,
+            TemporalKind::PlainYearMonth,
+        ),
+        (
+            temporal_plain_month_day_ctor_thunk as *const u8,
+            TemporalKind::PlainMonthDay,
+        ),
+        (
+            temporal_zoned_date_time_ctor_thunk as *const u8,
+            TemporalKind::ZonedDateTime,
+        ),
+    ];
+    table
+        .iter()
+        .find(|(ptr, _)| *ptr as usize == fp)
+        .map(|(_, k)| *k)
+}
+
 fn install_temporal_namespace(ns_obj: *mut ObjectHeader) {
     if ns_obj.is_null() {
         return;

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -99,6 +99,17 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             depth += 1;
         }
     }
+    // `temporalValue instanceof Temporal.<X>` — Temporal values dispatch via
+    // brand arms (not a real prototype chain), so resolve the constructor to
+    // its kind and compare against the value's brand. A non-Temporal value, or
+    // a Temporal value of a different kind, yields `false`.
+    if let Some(kind) = super::global_this::temporal_ctor_kind(type_ref) {
+        return if crate::temporal::temporal_kind(value) == Some(kind) {
+            f64::from_bits(crate::value::TAG_TRUE)
+        } else {
+            f64::from_bits(TAG_FALSE)
+        };
+    }
     let bits = type_ref.to_bits();
     let top16 = bits >> 48;
     if top16 == 0x7FFE {

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -559,12 +559,16 @@ pub fn optional_instant_timezone(arg: f64) -> Option<TimeZone> {
 /// `Temporal.ZonedDateTime` whose zone is reused.
 pub fn timezone(v: f64) -> TimeZone {
     if JSValue::from_bits(v.to_bits()).is_string() {
+        // A string identifier: an invalid one is a `RangeError`.
         return ok_or_throw(TimeZone::try_from_str(&read_string(v)));
     }
     if let Some(super::TemporalValue::ZonedDateTime(z)) = super::temporal_value_ref(v) {
         return *z.time_zone();
     }
-    range("expected a time-zone identifier string");
+    // `ToTemporalTimeZoneIdentifier`: a non-string, non-Temporal value (symbol,
+    // plain object, number, boolean, null, bigint) is never a valid time-zone
+    // identifier and cannot convert to one → `TypeError` (not `RangeError`).
+    type_error("time zone must be a string identifier or Temporal.ZonedDateTime".to_string());
 }
 
 /// Parse a `getTimeZoneTransition` direction argument — a `"next"`/`"previous"`

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -19,9 +19,9 @@ use temporal_rs::options::{
     ToStringRoundingOptions, Unit,
 };
 use temporal_rs::parsers::Precision;
-use temporal_rs::partial::PartialTime;
+use temporal_rs::partial::{PartialTime, PartialZonedDateTime};
 use temporal_rs::provider::TransitionDirection;
-use temporal_rs::{MonthCode, PlainTime, TimeZone, TinyAsciiStr};
+use temporal_rs::{Calendar, MonthCode, PlainTime, TimeZone, TinyAsciiStr, UtcOffset};
 
 // ---- low-level JS object field reads --------------------------------------
 
@@ -465,14 +465,51 @@ pub fn datetime_fields(obj: *const crate::object::ObjectHeader) -> DateTimeField
     f
 }
 
-/// Populate a [`ZonedDateTimeFields`] (calendar fields + time) for
-/// `ZonedDateTime.with`. The `offset` partial is left unset (rarely used in
-/// `.with` and would require UTC-offset parsing).
+/// Populate a [`ZonedDateTimeFields`] (calendar fields + time + offset) for
+/// `ZonedDateTime.with`.
 pub fn zoned_fields(obj: *const crate::object::ObjectHeader) -> ZonedDateTimeFields {
     let mut f = ZonedDateTimeFields::new();
     f.calendar_fields = calendar_fields(obj);
     f.time = partial_time(obj);
+    f.offset = offset_field(obj);
     f
+}
+
+/// Read an optional `offset` string field → [`UtcOffset`] (a `RangeError` for a
+/// malformed string).
+fn offset_field(obj: *const crate::object::ObjectHeader) -> Option<UtcOffset> {
+    str_field(obj, "offset").map(|s| ok_or_throw(UtcOffset::from_utf8(s.as_bytes())))
+}
+
+/// Resolve the `timeZone` field of a property bag to a [`TimeZone`] — a
+/// tz-identifier string or another `Temporal.ZonedDateTime` (whose zone is
+/// reused). A missing `timeZone` is a `TypeError` (it is a required field of a
+/// `ZonedDateTime` property bag).
+fn timezone_field(obj: *const crate::object::ObjectHeader) -> TimeZone {
+    let raw = field(obj, "timeZone");
+    if is_undefined(raw) {
+        type_error(
+            "ZonedDateTime property bag is missing a required \"timeZone\" field".to_string(),
+        );
+    }
+    timezone(raw)
+}
+
+/// Build a [`PartialZonedDateTime`] from a JS property bag for
+/// `Temporal.ZonedDateTime.from`. Returns `None` if `v` is not a plain object.
+pub fn zoned_partial(v: f64) -> Option<PartialZonedDateTime> {
+    let obj = as_obj(v)?;
+    let calendar = match str_field(obj, "calendar") {
+        Some(s) => ok_or_throw(s.parse::<Calendar>()),
+        None => Calendar::default(),
+    };
+    let mut p = PartialZonedDateTime::new();
+    p.calendar = calendar;
+    p.fields.calendar_fields = calendar_fields(obj);
+    p.fields.time = partial_time(obj);
+    p.fields.offset = offset_field(obj);
+    p.timezone = Some(timezone_field(obj));
+    Some(p)
 }
 
 // ---- conversion helpers ---------------------------------------------------

--- a/crates/perry-runtime/src/temporal/zoned_date_time.rs
+++ b/crates/perry-runtime/src/temporal/zoned_date_time.rs
@@ -18,13 +18,35 @@ fn wrap(z: ZonedDateTime) -> f64 {
     alloc_temporal_cell(TemporalValue::ZonedDateTime(z))
 }
 
+/// `ToBigInt(epochNanoseconds)` for the constructor's first argument: a BigInt
+/// passes through, a boolean coerces to `0n`/`1n`, a string parses; a Number /
+/// `undefined` / `null` / Symbol all throw `TypeError` (ToBigInt never accepts a
+/// Number, even an integer one).
 fn require_ns(v: f64) -> i128 {
-    match read_bigint_i128(v) {
-        Some(n) => n,
-        None => crate::fs::validate::throw_range_error_with_code(
-            "Temporal.ZonedDateTime requires a BigInt epoch-nanoseconds value",
-        ),
+    let jv = JSValue::from_bits(v.to_bits());
+    if jv.is_bigint() {
+        return read_bigint_i128(v).unwrap_or_else(|| {
+            crate::fs::validate::throw_range_error_with_code("Invalid epoch-nanoseconds BigInt")
+        });
     }
+    match v.to_bits() {
+        b if b == crate::value::TAG_TRUE => return 1,
+        b if b == crate::value::TAG_FALSE => return 0,
+        _ => {}
+    }
+    if jv.is_string() {
+        return dispatch::read_string(v)
+            .trim()
+            .parse::<i128>()
+            .unwrap_or_else(|_| {
+                crate::fs::validate::throw_range_error_with_code(
+                    "Cannot convert string to a BigInt epoch-nanoseconds value",
+                )
+            });
+    }
+    crate::object::throw_object_type_error(
+        b"Temporal.ZonedDateTime epochNanoseconds must be a BigInt",
+    )
 }
 
 fn timezone_arg(v: f64) -> TimeZone {

--- a/crates/perry-runtime/src/temporal/zoned_date_time.rs
+++ b/crates/perry-runtime/src/temporal/zoned_date_time.rs
@@ -9,7 +9,7 @@ use super::dispatch::{
 };
 use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
 use crate::value::JSValue;
-use temporal_rs::options::{DifferenceSettings, Disambiguation, OffsetDisambiguation};
+use temporal_rs::options::{Disambiguation, OffsetDisambiguation};
 use temporal_rs::{Calendar, TimeZone, ZonedDateTime};
 
 const TYPE_NAME: &str = "Temporal.ZonedDateTime";
@@ -57,15 +57,31 @@ pub fn construct(args: &[f64]) -> f64 {
 }
 
 fn coerce_zdt(v: f64) -> ZonedDateTime {
+    coerce_zdt_with_options(v, undefined())
+}
+
+/// `ToTemporalZonedDateTime(item, options)` — a `Temporal.ZonedDateTime` (cloned),
+/// an IXDTF string, or a property bag with a `timeZone` (built via
+/// `from_partial`). `opts` supplies `overflow`/`disambiguation`/`offset` (only
+/// consulted for the string + property-bag forms).
+fn coerce_zdt_with_options(v: f64, opts: f64) -> ZonedDateTime {
     if let Some(TemporalValue::ZonedDateTime(z)) = temporal_value_ref(v) {
         return z.clone();
+    }
+    if let Some(partial) = super::options::zoned_partial(v) {
+        return ok_or_throw(ZonedDateTime::from_partial(
+            partial,
+            super::options::overflow(opts),
+            super::options::disambiguation(opts),
+            super::options::offset_option(opts),
+        ));
     }
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_string() {
         return ok_or_throw(ZonedDateTime::from_utf8(
             dispatch::read_string(v).as_bytes(),
-            Disambiguation::default(),
-            OffsetDisambiguation::Reject,
+            super::options::disambiguation(opts).unwrap_or(Disambiguation::Compatible),
+            super::options::offset_option(opts).unwrap_or(OffsetDisambiguation::Reject),
         ));
     }
     crate::fs::validate::throw_range_error_with_code(
@@ -74,7 +90,7 @@ fn coerce_zdt(v: f64) -> ZonedDateTime {
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
-    wrap(coerce_zdt(raw_arg(args, 0)))
+    wrap(coerce_zdt_with_options(raw_arg(args, 0), raw_arg(args, 1)))
 }
 
 pub fn compare_static(args: &[f64]) -> f64 {
@@ -101,6 +117,29 @@ pub fn get(z: &ZonedDateTime, name: &str) -> Option<f64> {
         "microsecond" => z.microsecond() as f64,
         "nanosecond" => z.nanosecond() as f64,
         "dayOfWeek" => z.day_of_week() as f64,
+        "dayOfYear" => z.day_of_year() as f64,
+        "daysInWeek" => z.days_in_week() as f64,
+        "daysInMonth" => z.days_in_month() as f64,
+        "daysInYear" => z.days_in_year() as f64,
+        "monthsInYear" => z.months_in_year() as f64,
+        "inLeapYear" => boolean(z.in_leap_year()),
+        "monthCode" => string(z.month_code().as_str()),
+        "weekOfYear" => match z.week_of_year() {
+            Some(w) => w as f64,
+            None => return Some(undefined()),
+        },
+        "yearOfWeek" => match z.year_of_week() {
+            Some(y) => y as f64,
+            None => return Some(undefined()),
+        },
+        "era" => match z.era() {
+            Some(e) => string(e.as_str()),
+            None => return Some(undefined()),
+        },
+        "eraYear" => match z.era_year() {
+            Some(y) => y as f64,
+            None => return Some(undefined()),
+        },
         "epochMilliseconds" => z.epoch_milliseconds() as f64,
         "epochNanoseconds" => bigint_from_i128(z.to_instant().as_i128()),
         "offsetNanoseconds" => z.offset_nanoseconds() as f64,
@@ -117,18 +156,22 @@ pub fn get(z: &ZonedDateTime, name: &str) -> Option<f64> {
 
 pub fn call(recv: f64, z: &ZonedDateTime, name: &str, args: &[f64]) -> f64 {
     match name {
-        "add" => wrap(ok_or_throw(
-            z.add(&super::duration::coerce_duration(raw_arg(args, 0)), None),
-        )),
-        "subtract" => wrap(ok_or_throw(
-            z.subtract(&super::duration::coerce_duration(raw_arg(args, 0)), None),
-        )),
-        "until" => super::duration::wrap(ok_or_throw(
-            z.until(&coerce_zdt(raw_arg(args, 0)), DifferenceSettings::default()),
-        )),
-        "since" => super::duration::wrap(ok_or_throw(
-            z.since(&coerce_zdt(raw_arg(args, 0)), DifferenceSettings::default()),
-        )),
+        "add" => wrap(ok_or_throw(z.add(
+            &super::duration::coerce_duration(raw_arg(args, 0)),
+            super::options::overflow(raw_arg(args, 1)),
+        ))),
+        "subtract" => wrap(ok_or_throw(z.subtract(
+            &super::duration::coerce_duration(raw_arg(args, 0)),
+            super::options::overflow(raw_arg(args, 1)),
+        ))),
+        "until" => super::duration::wrap(ok_or_throw(z.until(
+            &coerce_zdt(raw_arg(args, 0)),
+            super::options::difference_settings(raw_arg(args, 1)),
+        ))),
+        "since" => super::duration::wrap(ok_or_throw(z.since(
+            &coerce_zdt(raw_arg(args, 0)),
+            super::options::difference_settings(raw_arg(args, 1)),
+        ))),
         "equals" => boolean(ok_or_throw(z.equals(&coerce_zdt(raw_arg(args, 0))))),
         "toInstant" => alloc_temporal_cell(TemporalValue::Instant(z.to_instant())),
         "toPlainDate" => alloc_temporal_cell(TemporalValue::PlainDate(z.to_plain_date())),


### PR DESCRIPTION
## Summary

Raises **Temporal.ZonedDateTime** test262 conformance from **33.7% → 84.0%** (304 → 757 / 901 passing, **+453**, 0 compile-fail), with several fixes in **shared** Temporal + closure-dispatch machinery that lift every type.

Verified zero regressions: on a `built-ins + language` 1/12 shard this branch passes **+96** more than `origin/main` (2179 vs 2083), with **103 newly-fixed** and the only non-Temporal "newly-failing" case confirmed a contention flake (passes on both binaries in isolation). The 5 other-Temporal-type toString cases the work initially perturbed were re-scoped away (see commit 5) and confirmed restored.

## Root causes & fixes

1. **`instanceof` never matched Temporal values** (`zdt instanceof Temporal.ZonedDateTime` → `false`). Temporal values dispatch via brand arms, not a prototype chain. Added `temporal_ctor_kind` (func-ptr match of the 8 ctor closures) wired into `js_instanceof_dynamic`, and routed `Temporal.<X>` RHS through the dynamic path in HIR. *(shared: all types)*

2. **No real `Temporal.ZonedDateTime.prototype`** — reflective tests (`branding` / `prop-desc` / `length` / `name` / `not-a-constructor` / `builtin`, ~150 cases) read getter/method descriptors off the prototype, which didn't exist. Built a real prototype: every getter as an accessor property, every method as a non-constructable built-in (correct `name`/`length`/descriptor), `@@toStringTag`, wired `ctor.prototype` (non-writable) ↔ `proto.constructor`. Brand-checking thunks dispatch reflective `.call`/`.apply`; ordinary `zdt.foo()` still uses the brand arm.

3. **Object-literal shorthand methods dropped args past the 5th/8th** — `obj.m(a,…,k)` (FuncRef singleton → `__perry_wrap_*` wrapper) truncated to 5 args, and `js_native_call_value`'s arity match collapsed everything >7 to `js_closure_call8`. This broke `temporalHelpers.assertDuration` (12 params) across **all** Temporal types. Wrapper now forwards all params (≤16); dispatch extended to `js_closure_call9..16`. *(shared: general codegen/runtime fix)*

4. **`from()` / coercion ignored property bags** — `ZonedDateTime.from({year,…,timeZone})` threw. Added `PartialZonedDateTime` construction (calendar fields + time + offset + timeZone), plus string-with-options.

5. **Methods ignored their options** — `until`/`since` ignored `DifferenceSettings`, `add`/`subtract` ignored `overflow`, `toString` ignored its options bag (and mis-routed through the numeric `.toString(radix)` path → bogus RangeError). Added shared `difference_settings` / `to_string_options`, plus a ZonedDateTime-scoped radix guard.

6. **Validation gaps** — `GetOptionsObject` (TypeError for non-object options), `ToTemporalTimeZoneIdentifier` (TypeError, not RangeError, for non-string time zones), constructor `ToBigInt` (boolean→0n/1n, Number/undefined/Symbol→TypeError). Added the missing getters (`monthCode`/`era`/`eraYear`/`dayOf*`/`weekOfYear`/`yearOfWeek`/`daysIn*`/`monthsInYear`/`inLeapYear`).

## Files
- `crates/perry-runtime/src/temporal/{zoned_date_time,options}.rs` — getters, from()-fields, options/toString, validation
- `crates/perry-runtime/src/object/global_this.rs` — Temporal prototype builder + `temporal_ctor_kind`
- `crates/perry-runtime/src/object/instanceof.rs`, `crates/perry-hir/src/lower/lower_expr.rs` — instanceof routing
- `crates/perry-codegen/src/codegen/artifacts.rs`, `crates/perry-runtime/src/closure/dispatch.rs` — closure-call arg-cap fix
- `crates/perry-runtime/src/value/to_string.rs` — ZonedDateTime toString radix guard
