### PR TITLE
fix(runtime): Temporal.PlainDate + PlainDateTime test262 parity (+ general object-method arg-cap fix)

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -620,7 +620,7 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             // Determine the local target. Prefer a real HIR function;
             // fall back to a no-op (variable/class/type rename).
             if let Some(f) = func_by_local_name.get(local.as_str()) {
-                let arity = f.params.len().min(5);
+                let arity = f.params.len().min(32);
                 let mut wrap_params: Vec<(LlvmType, String)> =
                     vec![(I64, "%this_closure".to_string())];
                 for i in 0..arity {
@@ -851,7 +851,7 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
                         .find(|(n, _)| n == exported)
                         .and_then(|(_, fid)| hir.functions.iter().find(|f| f.id == *fid));
                     if let Some(f) = aliased_func {
-                        let arity = f.params.len().min(5);
+                        let arity = f.params.len().min(32);
                         let mut wrap_params: Vec<(LlvmType, String)> =
                             vec![(I64, "%this_closure".to_string())];
                         for i in 0..arity {
@@ -910,7 +910,7 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             if !emitted_wrappers.insert(wrap_name.clone()) {
                 continue;
             }
-            let arity = method.params.len().min(5);
+            let arity = method.params.len().min(32);
             let mut wrap_params: Vec<(LlvmType, String)> = vec![(I64, "%this_closure".to_string())];
             for i in 0..arity {
                 wrap_params.push((DOUBLE, format!("%a{}", i)));

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3404,6 +3404,87 @@ pub(crate) fn temporal_ctor_kind(type_ref: f64) -> Option<crate::temporal::Tempo
         .map(|(_, k)| *k)
 }
 
+/// `Temporal.PlainDate.prototype` accessor getters and method shapes (#4691).
+const PLAIN_DATE_GETTERS: &[&str] = &[
+    "calendarId",
+    "era",
+    "eraYear",
+    "year",
+    "month",
+    "monthCode",
+    "day",
+    "dayOfWeek",
+    "dayOfYear",
+    "weekOfYear",
+    "yearOfWeek",
+    "daysInWeek",
+    "daysInMonth",
+    "daysInYear",
+    "monthsInYear",
+    "inLeapYear",
+];
+const PLAIN_DATE_METHODS: &[(&str, u32)] = &[
+    ("toPlainYearMonth", 0),
+    ("toPlainMonthDay", 0),
+    ("add", 1),
+    ("subtract", 1),
+    ("with", 1),
+    ("withCalendar", 1),
+    ("until", 1),
+    ("since", 1),
+    ("equals", 1),
+    ("toPlainDateTime", 0),
+    ("toZonedDateTime", 1),
+    ("toString", 0),
+    ("toLocaleString", 0),
+    ("toJSON", 0),
+    ("valueOf", 0),
+];
+
+/// `Temporal.PlainDateTime.prototype` accessor getters and method shapes (#4693).
+const PLAIN_DATE_TIME_GETTERS: &[&str] = &[
+    "calendarId",
+    "era",
+    "eraYear",
+    "year",
+    "month",
+    "monthCode",
+    "day",
+    "dayOfWeek",
+    "dayOfYear",
+    "weekOfYear",
+    "yearOfWeek",
+    "daysInWeek",
+    "daysInMonth",
+    "daysInYear",
+    "monthsInYear",
+    "inLeapYear",
+    "hour",
+    "minute",
+    "second",
+    "millisecond",
+    "microsecond",
+    "nanosecond",
+];
+const PLAIN_DATE_TIME_METHODS: &[(&str, u32)] = &[
+    ("with", 1),
+    ("withPlainTime", 0),
+    ("withCalendar", 1),
+    ("add", 1),
+    ("subtract", 1),
+    ("until", 1),
+    ("since", 1),
+    ("round", 1),
+    ("equals", 1),
+    ("toString", 0),
+    ("toLocaleString", 0),
+    ("toJSON", 0),
+    ("valueOf", 0),
+    ("toZonedDateTime", 1),
+    ("toPlainDate", 0),
+    ("toPlainTime", 0),
+];
+
 fn install_temporal_namespace(ns_obj: *mut ObjectHeader) {
     if ns_obj.is_null() {
         return;
@@ -3527,6 +3608,12 @@ fn install_temporal_namespace(ns_obj: *mut ObjectHeader) {
             temporal_plain_date_from_thunk as *const u8,
             temporal_plain_date_compare_thunk as *const u8,
         );
+        install_temporal_prototype(
+            plain_date,
+            crate::temporal::TemporalKind::PlainDate as u8,
+            PLAIN_DATE_GETTERS,
+            PLAIN_DATE_METHODS,
+        );
     }
 
     // Temporal.PlainTime (#4692)
@@ -3556,6 +3643,12 @@ fn install_temporal_namespace(ns_obj: *mut ObjectHeader) {
             plain_date_time,
             temporal_plain_date_time_from_thunk as *const u8,
             temporal_plain_date_time_compare_thunk as *const u8,
+        );
+        install_temporal_prototype(
+            plain_date_time,
+            crate::temporal::TemporalKind::PlainDateTime as u8,
+            PLAIN_DATE_TIME_GETTERS,
+            PLAIN_DATE_TIME_METHODS,
         );
     }
 

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -60,6 +60,81 @@ pub fn require_options_object(arg: f64) -> Option<*const crate::object::ObjectHe
     }
 }
 
+/// Build a [`temporal_rs::PlainDate`] from a property-bag object
+/// (`ToTemporalDate` step for an Object that isn't already a Temporal value):
+/// read its calendar fields + `calendar` slot into a `PartialDate` and let
+/// `temporal_rs` validate/construct under the given `overflow`. A non-object
+/// (number/boolean/null/symbol) is a `TypeError`, matching the spec's
+/// "Numbers cannot be used in place of an ISO string" wrong-type cases.
+pub fn plain_date_from_bag(v: f64, overflow: Option<Overflow>) -> temporal_rs::PlainDate {
+    let obj = match as_obj(v) {
+        Some(o) => o,
+        None => type_error("Cannot convert value to a Temporal.PlainDate".to_string()),
+    };
+    let partial = temporal_rs::partial::PartialDate {
+        calendar_fields: calendar_fields(obj),
+        calendar: calendar_slot(field(obj, "calendar")),
+    };
+    ok_or_throw(temporal_rs::PlainDate::from_partial(partial, overflow))
+}
+
+/// Build a [`temporal_rs::PlainDateTime`] from a property-bag object
+/// (`ToTemporalDateTime` for a non-Temporal Object). Mirrors
+/// [`plain_date_from_bag`] with date + time fields.
+pub fn plain_date_time_from_bag(v: f64, overflow: Option<Overflow>) -> temporal_rs::PlainDateTime {
+    let obj = match as_obj(v) {
+        Some(o) => o,
+        None => type_error("Cannot convert value to a Temporal.PlainDateTime".to_string()),
+    };
+    let partial = temporal_rs::partial::PartialDateTime {
+        fields: datetime_fields(obj),
+        calendar: calendar_slot(field(obj, "calendar")),
+    };
+    ok_or_throw(temporal_rs::PlainDateTime::from_partial(partial, overflow))
+}
+
+/// `ToTemporalCalendarSlotValue`: resolve a calendar argument to a
+/// [`temporal_rs::Calendar`]. `undefined` → ISO-8601; a calendar-id string →
+/// that calendar; a `Temporal.*` value → its own `[[Calendar]]`. Anything else
+/// (null / number / boolean / symbol / plain object) is a `TypeError` — the
+/// `calendar-wrong-type` cases.
+pub fn calendar_slot(v: f64) -> temporal_rs::Calendar {
+    use temporal_rs::Calendar;
+    if is_undefined(v) {
+        return Calendar::default();
+    }
+    let jv = JSValue::from_bits(v.to_bits());
+    if jv.is_string() {
+        return ok_or_throw(read_string(v).parse::<Calendar>());
+    }
+    if let Some(tv) = super::temporal_value_ref(v) {
+        return match tv {
+            super::TemporalValue::PlainDate(d) => d.calendar().clone(),
+            super::TemporalValue::PlainDateTime(dt) => dt.calendar().clone(),
+            super::TemporalValue::PlainYearMonth(ym) => ym.calendar().clone(),
+            super::TemporalValue::PlainMonthDay(md) => md.calendar().clone(),
+            super::TemporalValue::ZonedDateTime(z) => z.calendar().clone(),
+            _ => type_error("Temporal value has no calendar".to_string()),
+        };
+    }
+    type_error("calendar must be a calendar identifier string or a Temporal object".to_string())
+}
+
+/// `GetOptionsObject`: an options argument must be `undefined` or an Object.
+/// Any other value — number, string, boolean, bigint, **symbol** — is a
+/// `TypeError`. Methods that take an options bag call this up front so a
+/// wrong-typed options arg throws before any work (every
+/// `*/options-wrong-type.js`). A Temporal value counts as an object here
+/// (its calendar fields just won't match any option name).
+pub fn validate_options_arg(arg: f64) {
+    if is_undefined(arg) {
+        return;
+    }
+    if as_obj(arg).is_none() {
+        type_error("options argument must be an object or undefined".to_string());
+    }
+}
+
 /// Raw (NaN-boxed) value of `obj.<name>`.
 fn field(obj: *const crate::object::ObjectHeader, name: &str) -> f64 {
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
@@ -347,7 +422,9 @@ fn relative_to_field(obj: *const crate::object::ObjectHeader) -> Option<Relative
 // ---- overflow / disambiguation (second-arg option objects) ----------------
 
 /// Read an optional `overflow` (`"constrain"` | `"reject"`) from an options arg.
+/// A non-object, non-undefined options arg is a `TypeError` (`GetOptionsObject`).
 pub fn overflow(arg: f64) -> Option<Overflow> {
+    validate_options_arg(arg);
     let obj = as_obj(arg)?;
     str_field_coerce(obj, "overflow").map(|s| parse_overflow(&s))
 }

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -141,7 +141,10 @@ fn field(obj: *const crate::object::ObjectHeader, name: &str) -> f64 {
     crate::object::js_object_get_field_by_name_f64(obj, key)
 }
 
-/// `obj.<name>` as a finite number, or `None` if absent / undefined / non-finite.
+/// `obj.<name>` as a finite number, or `None` if absent / `undefined`. A present
+/// field whose `ToNumber` is non-finite (`Infinity`/`-Infinity`/`NaN`) is a
+/// `RangeError` per `ToIntegerWithTruncation` — Temporal numeric fields reject
+/// non-finite input (e.g. `{ year: Infinity }`), they do not silently drop it.
 fn num_field(obj: *const crate::object::ObjectHeader, name: &str) -> Option<f64> {
     let raw = field(obj, name);
     if is_undefined(raw) {
@@ -151,7 +154,7 @@ fn num_field(obj: *const crate::object::ObjectHeader, name: &str) -> Option<f64>
     if n.is_finite() {
         Some(n)
     } else {
-        None
+        range("Temporal field cannot be Infinity or NaN");
     }
 }
 

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -15,17 +15,11 @@ fn wrap(d: PlainDate) -> f64 {
 }
 
 /// Resolve an optional calendar argument (a calendar-id string) to a
-/// `Calendar`, defaulting to ISO-8601.
+/// `Calendar`, defaulting to ISO-8601. A non-string, non-undefined calendar
+/// (null / number / boolean / symbol) is a `TypeError` per
+/// `ToTemporalCalendarSlotValue` — the `calendar-wrong-type` cases.
 fn calendar_arg(v: f64) -> Calendar {
-    if dispatch::is_undefined(v) {
-        return Calendar::default();
-    }
-    let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_string() {
-        let s = dispatch::read_string(v);
-        return ok_or_throw(s.parse::<Calendar>());
-    }
-    Calendar::default()
+    super::options::calendar_slot(v)
 }
 
 /// `new Temporal.PlainDate(year, month, day, calendar?)`.
@@ -45,36 +39,37 @@ pub fn construct(args: &[f64]) -> f64 {
 }
 
 fn coerce_date(v: f64) -> PlainDate {
-    if let Some(TemporalValue::PlainDate(d)) = temporal_value_ref(v) {
-        return d.clone();
-    }
-    let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_string() {
-        let s = dispatch::read_string(v);
-        return ok_or_throw(s.parse::<PlainDate>());
-    }
-    if jv.is_pointer() {
-        let obj = jv.as_pointer::<crate::object::ObjectHeader>();
-        if !obj.is_null() {
-            let f = |name: &str| -> f64 {
-                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-                let raw = crate::object::js_object_get_field_by_name_f64(obj, key);
-                JSValue::from_bits(raw.to_bits()).to_number()
-            };
-            let cal_key = crate::string::js_string_from_bytes(b"calendar".as_ptr(), 8);
-            let cal_raw = crate::object::js_object_get_field_by_name_f64(obj, cal_key);
-            return wrap_inner(f("year"), f("month"), f("day"), calendar_arg(cal_raw));
-        }
-    }
-    crate::fs::validate::throw_range_error_with_code("Cannot convert value to a Temporal.PlainDate")
+    coerce_date_with_overflow(v, None)
 }
 
-fn wrap_inner(year: f64, month: f64, day: f64, cal: Calendar) -> PlainDate {
-    ok_or_throw(PlainDate::new(year as i32, month as u8, day as u8, cal))
+/// `ToTemporalDate(item, overflow)`. A `PlainDate` is cloned; a `PlainDateTime`
+/// yields its date; an ISO string is parsed; a property-bag object is built via
+/// partial fields under `overflow`; anything else (number/boolean/null/symbol,
+/// or a non-date Temporal value) is a `TypeError`.
+fn coerce_date_with_overflow(
+    v: f64,
+    overflow: Option<temporal_rs::options::Overflow>,
+) -> PlainDate {
+    match temporal_value_ref(v) {
+        Some(TemporalValue::PlainDate(d)) => return d.clone(),
+        Some(TemporalValue::PlainDateTime(dt)) => return dt.to_plain_date(),
+        Some(_) => crate::object::throw_object_type_error(
+            b"Cannot convert this Temporal value to a Temporal.PlainDate",
+        ),
+        None => {}
+    }
+    if JSValue::from_bits(v.to_bits()).is_string() {
+        return ok_or_throw(dispatch::read_string(v).parse::<PlainDate>());
+    }
+    super::options::plain_date_from_bag(v, overflow)
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
-    wrap(coerce_date(raw_arg(args, 0)))
+    // `from(item, options)`: a wrong-typed options arg is a TypeError, thrown
+    // before the item is converted (GetOptionsObject). `overflow` also drives
+    // constrain/reject for a property-bag / string item.
+    let overflow = super::options::overflow(raw_arg(args, 1));
+    wrap(coerce_date_with_overflow(raw_arg(args, 0), overflow))
 }
 
 pub fn compare_static(args: &[f64]) -> f64 {
@@ -146,12 +141,20 @@ fn to_zoned_args(v: f64) -> (TimeZone, Option<PlainTime>) {
 
 pub fn call(recv: f64, d: &PlainDate, name: &str, args: &[f64]) -> f64 {
     match name {
-        "add" => wrap(ok_or_throw(
-            d.add(&super::duration::coerce_duration(raw_arg(args, 0)), None),
-        )),
-        "subtract" => wrap(ok_or_throw(
-            d.subtract(&super::duration::coerce_duration(raw_arg(args, 0)), None),
-        )),
+        "add" => {
+            let overflow = super::options::overflow(raw_arg(args, 1));
+            wrap(ok_or_throw(d.add(
+                &super::duration::coerce_duration(raw_arg(args, 0)),
+                overflow,
+            )))
+        }
+        "subtract" => {
+            let overflow = super::options::overflow(raw_arg(args, 1));
+            wrap(ok_or_throw(d.subtract(
+                &super::duration::coerce_duration(raw_arg(args, 0)),
+                overflow,
+            )))
+        }
         "until" => super::duration::wrap(ok_or_throw(d.until(
             &coerce_date(raw_arg(args, 0)),
             super::options::difference_settings(raw_arg(args, 1)),

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -53,6 +53,7 @@ fn coerce_date_with_overflow(
     match temporal_value_ref(v) {
         Some(TemporalValue::PlainDate(d)) => return d.clone(),
         Some(TemporalValue::PlainDateTime(dt)) => return dt.to_plain_date(),
+        Some(TemporalValue::ZonedDateTime(z)) => return z.to_plain_date(),
         Some(_) => crate::object::throw_object_type_error(
             b"Cannot convert this Temporal value to a Temporal.PlainDate",
         ),

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -103,6 +103,10 @@ pub fn get(d: &PlainDate, name: &str) -> Option<f64> {
             Some(w) => w as f64,
             None => return Some(undefined()),
         },
+        "yearOfWeek" => match d.year_of_week() {
+            Some(y) => y as f64,
+            None => return Some(undefined()),
+        },
         "inLeapYear" => boolean(d.in_leap_year()),
         "monthCode" => string(d.month_code().as_str()),
         "calendarId" => string(d.calendar().identifier()),

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -6,7 +6,6 @@
 use super::dispatch::{self, boolean, ok_or_throw, raw_arg, string, undefined};
 use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
 use crate::value::JSValue;
-use temporal_rs::options::DifferenceSettings;
 use temporal_rs::{Calendar, PlainDate, PlainTime, TimeZone};
 
 const TYPE_NAME: &str = "Temporal.PlainDate";
@@ -155,11 +154,11 @@ pub fn call(recv: f64, d: &PlainDate, name: &str, args: &[f64]) -> f64 {
         )),
         "until" => super::duration::wrap(ok_or_throw(d.until(
             &coerce_date(raw_arg(args, 0)),
-            DifferenceSettings::default(),
+            super::options::difference_settings(raw_arg(args, 1)),
         ))),
         "since" => super::duration::wrap(ok_or_throw(d.since(
             &coerce_date(raw_arg(args, 0)),
-            DifferenceSettings::default(),
+            super::options::difference_settings(raw_arg(args, 1)),
         ))),
         "equals" => {
             let other = coerce_date(raw_arg(args, 0));

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -109,11 +109,16 @@ pub fn get(dt: &PlainDateTime, name: &str) -> Option<f64> {
         "day" => dt.day() as f64,
         "dayOfWeek" => dt.day_of_week() as f64,
         "dayOfYear" => dt.day_of_year() as f64,
+        "daysInWeek" => dt.days_in_week() as f64,
         "daysInMonth" => dt.days_in_month() as f64,
         "daysInYear" => dt.days_in_year() as f64,
         "monthsInYear" => dt.months_in_year() as f64,
         "weekOfYear" => match dt.week_of_year() {
             Some(w) => w as f64,
+            None => return Some(undefined()),
+        },
+        "yearOfWeek" => match dt.year_of_week() {
+            Some(y) => y as f64,
             None => return Some(undefined()),
         },
         "inLeapYear" => boolean(dt.in_leap_year()),

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -17,14 +17,7 @@ fn wrap(dt: PlainDateTime) -> f64 {
 }
 
 fn calendar_arg(v: f64) -> Calendar {
-    if dispatch::is_undefined(v) {
-        return Calendar::default();
-    }
-    let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_string() {
-        return ok_or_throw(dispatch::read_string(v).parse::<Calendar>());
-    }
-    Calendar::default()
+    super::options::calendar_slot(v)
 }
 
 /// `new Temporal.PlainDateTime(year, month, day, hour?, …, nanosecond?, calendar?)`.
@@ -47,49 +40,34 @@ pub fn construct(args: &[f64]) -> f64 {
 }
 
 fn coerce_dt(v: f64) -> PlainDateTime {
-    if let Some(TemporalValue::PlainDateTime(dt)) = temporal_value_ref(v) {
-        return dt.clone();
+    coerce_dt_with_overflow(v, None)
+}
+
+/// `ToTemporalDateTime(item, overflow)`. A `PlainDateTime` is cloned; a
+/// `PlainDate` is widened to midnight; an ISO string is parsed; a property-bag
+/// object is built via partial fields under `overflow`; anything else
+/// (number/boolean/null/symbol, or a non-date Temporal value) is a `TypeError`.
+fn coerce_dt_with_overflow(
+    v: f64,
+    overflow: Option<temporal_rs::options::Overflow>,
+) -> PlainDateTime {
+    match temporal_value_ref(v) {
+        Some(TemporalValue::PlainDateTime(dt)) => return dt.clone(),
+        Some(TemporalValue::PlainDate(d)) => return ok_or_throw(d.to_plain_date_time(None)),
+        Some(_) => crate::object::throw_object_type_error(
+            b"Cannot convert this Temporal value to a Temporal.PlainDateTime",
+        ),
+        None => {}
     }
-    let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_string() {
+    if JSValue::from_bits(v.to_bits()).is_string() {
         return ok_or_throw(dispatch::read_string(v).parse::<PlainDateTime>());
     }
-    if jv.is_pointer() {
-        let obj = jv.as_pointer::<crate::object::ObjectHeader>();
-        if !obj.is_null() {
-            let f = |name: &str| -> f64 {
-                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-                let raw = crate::object::js_object_get_field_by_name_f64(obj, key);
-                let n = JSValue::from_bits(raw.to_bits()).to_number();
-                if n.is_finite() {
-                    n
-                } else {
-                    0.0
-                }
-            };
-            let cal_key = crate::string::js_string_from_bytes(b"calendar".as_ptr(), 8);
-            let cal_raw = crate::object::js_object_get_field_by_name_f64(obj, cal_key);
-            return ok_or_throw(PlainDateTime::new(
-                f("year") as i32,
-                f("month") as u8,
-                f("day") as u8,
-                f("hour") as u8,
-                f("minute") as u8,
-                f("second") as u8,
-                f("millisecond") as u16,
-                f("microsecond") as u16,
-                f("nanosecond") as u16,
-                calendar_arg(cal_raw),
-            ));
-        }
-    }
-    crate::fs::validate::throw_range_error_with_code(
-        "Cannot convert value to a Temporal.PlainDateTime",
-    )
+    super::options::plain_date_time_from_bag(v, overflow)
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
-    wrap(coerce_dt(raw_arg(args, 0)))
+    let overflow = super::options::overflow(raw_arg(args, 1));
+    wrap(coerce_dt_with_overflow(raw_arg(args, 0), overflow))
 }
 
 pub fn compare_static(args: &[f64]) -> f64 {
@@ -144,12 +122,20 @@ pub fn get(dt: &PlainDateTime, name: &str) -> Option<f64> {
 
 pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
     match name {
-        "add" => wrap(ok_or_throw(
-            dt.add(&super::duration::coerce_duration(raw_arg(args, 0)), None),
-        )),
-        "subtract" => wrap(ok_or_throw(
-            dt.subtract(&super::duration::coerce_duration(raw_arg(args, 0)), None),
-        )),
+        "add" => {
+            let overflow = super::options::overflow(raw_arg(args, 1));
+            wrap(ok_or_throw(dt.add(
+                &super::duration::coerce_duration(raw_arg(args, 0)),
+                overflow,
+            )))
+        }
+        "subtract" => {
+            let overflow = super::options::overflow(raw_arg(args, 1));
+            wrap(ok_or_throw(dt.subtract(
+                &super::duration::coerce_duration(raw_arg(args, 0)),
+                overflow,
+            )))
+        }
         "until" => super::duration::wrap(ok_or_throw(dt.until(
             &coerce_dt(raw_arg(args, 0)),
             super::options::difference_settings(raw_arg(args, 1)),

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -54,6 +54,7 @@ fn coerce_dt_with_overflow(
     match temporal_value_ref(v) {
         Some(TemporalValue::PlainDateTime(dt)) => return dt.clone(),
         Some(TemporalValue::PlainDate(d)) => return ok_or_throw(d.to_plain_date_time(None)),
+        Some(TemporalValue::ZonedDateTime(z)) => return z.to_plain_date_time(),
         Some(_) => crate::object::throw_object_type_error(
             b"Cannot convert this Temporal value to a Temporal.PlainDateTime",
         ),

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -8,7 +8,6 @@ use super::dispatch::{
 };
 use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
 use crate::value::JSValue;
-use temporal_rs::options::DifferenceSettings;
 use temporal_rs::{Calendar, PlainDateTime};
 
 const TYPE_NAME: &str = "Temporal.PlainDateTime";
@@ -151,12 +150,14 @@ pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
         "subtract" => wrap(ok_or_throw(
             dt.subtract(&super::duration::coerce_duration(raw_arg(args, 0)), None),
         )),
-        "until" => super::duration::wrap(ok_or_throw(
-            dt.until(&coerce_dt(raw_arg(args, 0)), DifferenceSettings::default()),
-        )),
-        "since" => super::duration::wrap(ok_or_throw(
-            dt.since(&coerce_dt(raw_arg(args, 0)), DifferenceSettings::default()),
-        )),
+        "until" => super::duration::wrap(ok_or_throw(dt.until(
+            &coerce_dt(raw_arg(args, 0)),
+            super::options::difference_settings(raw_arg(args, 1)),
+        ))),
+        "since" => super::duration::wrap(ok_or_throw(dt.since(
+            &coerce_dt(raw_arg(args, 0)),
+            super::options::difference_settings(raw_arg(args, 1)),
+        ))),
         "equals" => {
             let other = coerce_dt(raw_arg(args, 0));
             dispatch::boolean(

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -965,18 +965,28 @@ pub extern "C" fn js_jsvalue_to_string_radix(
         return js_jsvalue_to_string(result);
     }
 
-    // Coerce + validate the radix once up front. `None` → default radix 10.
-    let radix = match unsafe { coerce_validate_radix(radix_value) } {
-        Some(r) => r,
-        None => 10,
-    };
+    // Numeric receivers (Number / BigInt / Int32 / boxed Number): the second
+    // argument is a radix — coerce + validate it (throws on out-of-range). Other
+    // object receivers (Date, user `toString(opts)` methods) reach this with a
+    // non-radix argument, so we lazily validate the radix only on the numeric
+    // arms and otherwise dispatch the receiver's own `toString` with the
+    // argument forwarded — never ToNumber-coercing an options object as a radix.
+    macro_rules! radix {
+        () => {
+            match unsafe { coerce_validate_radix(radix_value) } {
+                Some(r) => r,
+                None => 10,
+            }
+        };
+    }
 
     if jsval.is_bigint() {
         let ptr = jsval.as_bigint_ptr();
-        crate::bigint::js_bigint_to_string_radix(ptr, radix)
+        crate::bigint::js_bigint_to_string_radix(ptr, radix!())
     } else if jsval.is_string() {
         jsval.as_string_ptr() as *mut crate::string::StringHeader
     } else if jsval.is_int32() {
+        let radix = radix!();
         let n = jsval.as_int32();
         if radix == 10 {
             let s = n.to_string();
@@ -985,21 +995,44 @@ pub extern "C" fn js_jsvalue_to_string_radix(
         let s = double_to_radix_string(n as f64, radix as u32);
         crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32)
     } else if jsval.is_number() {
-        number_to_radix_string(value, radix)
+        number_to_radix_string(value, radix!())
     } else {
         // Pointer / object receiver. `Number.prototype.toString` brand
         // semantics (ECMA-262 21.1.3): a boxed `Number` exposes its
         // [[NumberData]]; `Number.prototype` itself has [[NumberData]] +0;
-        // any other object has no number value and falls back to ordinary
-        // ToString (Object.prototype.toString, [object Object], etc.).
+        // any other object has no number value and dispatches its own
+        // `toString` with the argument forwarded (so a Temporal/Date receiver
+        // honours its options bag instead of treating it as a radix).
         const CLASS_ID_BOXED_NUMBER: u32 = 0xFFFF_00D0;
         if let Some((cid, payload)) = crate::builtins::boxed_primitive_payload(value) {
             if cid == CLASS_ID_BOXED_NUMBER {
-                return number_to_radix_string(payload, radix);
+                return number_to_radix_string(payload, radix!());
             }
         }
         if value.to_bits() == crate::object::builtin_prototype_value("Number").to_bits() {
-            return number_to_radix_string(0.0, radix);
+            return number_to_radix_string(0.0, radix!());
+        }
+        // Forward the argument to the receiver's own `toString`. A Temporal
+        // value routes to its options-aware `toString`; a plain object falls
+        // back to `Object.prototype.toString` ([object Object]).
+        if jsval.is_pointer() {
+            let args = [radix_value];
+            let result = unsafe {
+                crate::object::js_native_call_method(
+                    value,
+                    b"toString".as_ptr() as *const i8,
+                    8,
+                    args.as_ptr(),
+                    1,
+                )
+            };
+            let rjv = JSValue::from_bits(result.to_bits());
+            if rjv.is_string() {
+                return rjv.as_string_ptr() as *mut crate::string::StringHeader;
+            }
+            if rjv.is_short_string() {
+                return crate::string::js_string_materialize_to_heap(result);
+            }
         }
         js_jsvalue_to_string(value)
     }


### PR DESCRIPTION
## Summary

Raises **Temporal.PlainDate + PlainDateTime** test262 conformance from ~33% to **87%** (1244 / 1425 judged, self-validating mode), and fixes two **general (non-Temporal) codegen/runtime bugs** found along the way. Validated **zero regressions** against `main` over a `built-ins language --shard 0/12` sweep (**118 newly-passing, 0 newly-failing**).

Per-type (self-validated, jobs=8):
- Combined PlainDate + PlainDateTime: **~33% → 87%**
- Progression by fix: prototypes 44% → instanceof 48% → **arg-cap 62%** → toString/diff-settings 73% → arg/options/calendar validation 83% → option coercion 87%.

## Root causes & fixes

1. **General arg-count caps (non-Temporal!)** — closure-call wrappers (`codegen/artifacts.rs`) were hard-capped at 5 args (`%a0..%a4`) and `js_native_call_value` dispatch capped at `js_closure_call8`. Any function/object-method with >5/>8 params silently received `0`/`undefined` for the extra args. `temporalHelpers.assertPlainDateTime` takes 13 params, so this poisoned nearly every value-check. Wrappers now forward the real arity (≤32, matching `dispatch_with_arity`); the value-call dispatch covers `call0..16` + a buffered fallback. This alone fixed +192 Temporal cases and lifted the broad shard too.

2. **`.toString({…})` radix crash** — `js_jsvalue_to_string_radix` validated its 2nd arg as a radix *before* checking the receiver, so `temporalDateTime.toString({calendarName})` threw a spurious `RangeError: radix must be between 2 and 36`. Object receivers now dispatch their own `toString` with the argument forwarded.

3. **Temporal prototype reflection** — built real `Temporal.PlainDate/PlainDateTime.prototype` objects with brand-checked accessor getters + method shapes (reflectable via `getOwnPropertyDescriptor`, callable via `.call`/`.apply`), `constructor` back-link, `Symbol.toStringTag`, non-writable `.prototype`. Fixes prop-desc / branding / length / name / builtin cases.

4. **`instanceof`** — `temporalValue instanceof Temporal.PlainDate` (member + dynamic RHS) now resolves the cell's brand instead of always `false`.

5. **Options / argument / calendar validation (shared `options.rs`)** —
   - `GetOptionsObject`: non-object/non-undefined (incl. Symbol) options → TypeError.
   - Enum options ToString-coerce per `GetOption` (`{overflow:null}` → RangeError; Symbol → TypeError) instead of being silently ignored.
   - `ToTemporalCalendarSlotValue`: non-string/non-Temporal calendar → TypeError.
   - `ToTemporalDate/DateTime` via partial fields under `overflow` (monthCode/era honoured; cross-type PlainDate↔PlainDateTime↔ZonedDateTime conversion; number/null → TypeError not RangeError; fixes several segfaults).
   - Non-finite numeric field (`{year: Infinity}`) → RangeError.
   - `until`/`since` now parse their options (largestUnit/smallestUnit/roundingMode/roundingIncrement); `toString` honours `calendarName` + `fractionalSecondDigits`/`smallestUnit`/`roundingMode`.

6. **Shared `toString` options for the other Temporal types** — wired `display_calendar` / `to_string_rounding_options` into Duration/PlainTime/PlainMonthDay/PlainYearMonth `toString` (and validation for ZonedDateTime), so their invalid-option cases throw correctly. (These previously "passed" only via the spurious radix error in #2; the radix fix would otherwise have regressed them — this keeps zero net regressions and is a real improvement for those types.)

## Files
- `crates/perry-codegen/src/codegen/artifacts.rs` — wrapper arity cap 5→32 (general).
- `crates/perry-runtime/src/closure/dispatch.rs` — `js_native_call_value` dispatch 8→16 + buffered fallback (general).
- `crates/perry-runtime/src/value/to_string.rs` — radix object-receiver dispatch (general).
- `crates/perry-runtime/src/object/global_this.rs`, `object/instanceof.rs` — Temporal prototypes + instanceof.
- `crates/perry-runtime/src/temporal/{options,plain_date,plain_date_time,plain_time,duration,plain_month_day,plain_year_month,zoned_date_time}.rs` — coercion / options / toString.

## Known remaining (deferred)
- ~29 PlainDate/PlainDateTime `(no output)` segfaults trace to string-`+`/template concat of a Temporal cell read from a **multi-element array element** — a general array-element-representation / `js_string_concat_chain` issue (not Temporal-specific; `String(x)` works, `"" + x` crashes). Left for a focused follow-up to avoid touching the hot concat path here.
- Observable getter-ordering (`order-of-operations`), full overflow-on-`from` limit cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)