### PR TITLE
fix(cjs): prune dead platform guarded requires

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -55,7 +55,7 @@ pub(self) use hoist_classes::{
 
 // Public API consumed by `compile.rs` / `collect_modules.rs`.
 pub(super) use detect::is_commonjs;
-pub(super) use wrap::wrap_commonjs;
+pub(super) use wrap::wrap_commonjs_for_target;
 
 #[cfg(test)]
 mod tests {
@@ -67,7 +67,7 @@ mod tests {
     use super::extract_requires::{
         extract_require_aliases_with_ranges, extract_require_specifiers,
     };
-    use super::wrap::wrap_commonjs;
+    use super::wrap::{wrap_commonjs, wrap_commonjs_for_target};
     use std::fs;
     use std::path::PathBuf;
 
@@ -276,6 +276,70 @@ module.exports = inner;
         assert!(
             wrapped.contains("if (specifier === './dep') return dep;"),
             "expected require dispatch through aliased import, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
+    fn wrap_prunes_dead_process_platform_require_for_windows_target() {
+        let src = r#"
+var terminalCtor;
+if (process.platform === 'win32') {
+    terminalCtor = require('./windowsTerminal').WindowsTerminal;
+}
+else {
+    terminalCtor = require('./unixTerminal').UnixTerminal;
+}
+exports.spawn = function spawn() { return terminalCtor; };
+"#;
+        let wrapped = wrap_commonjs_for_target(
+            src,
+            &PathBuf::from("/tmp/node_modules/node-pty/lib/index.js"),
+            Some("windows"),
+        );
+        assert!(
+            wrapped.contains("import _req_0 from './windowsTerminal';")
+                || wrapped.contains("import terminalCtor from './windowsTerminal';"),
+            "expected live Windows require to stay hoisted, got:\n{}",
+            wrapped
+        );
+        assert!(
+            !wrapped.contains("from './unixTerminal'"),
+            "dead Unix require must not become an eager ESM import on Windows, got:\n{}",
+            wrapped
+        );
+        assert!(
+            !wrapped.contains("if (specifier === './unixTerminal')"),
+            "dead Unix require must not be dispatchable on Windows, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
+    fn wrap_prunes_dead_process_platform_require_for_linux_target() {
+        let src = r#"
+var terminalCtor;
+if (process.platform === 'win32') {
+    terminalCtor = require('./windowsTerminal').WindowsTerminal;
+}
+else {
+    terminalCtor = require('./unixTerminal').UnixTerminal;
+}
+exports.spawn = function spawn() { return terminalCtor; };
+"#;
+        let wrapped = wrap_commonjs_for_target(
+            src,
+            &PathBuf::from("/tmp/node_modules/node-pty/lib/index.js"),
+            Some("linux"),
+        );
+        assert!(
+            wrapped.contains("from './unixTerminal'"),
+            "expected live Unix require to stay hoisted, got:\n{}",
+            wrapped
+        );
+        assert!(
+            !wrapped.contains("from './windowsTerminal'"),
+            "dead Windows require must not become an eager ESM import on Linux, got:\n{}",
             wrapped
         );
     }

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -8,7 +8,16 @@ use std::path::Path;
 /// Wrap CJS source as ESM. `source_path` is the absolute path of the file
 /// being wrapped — used to resolve `require('./relative')` targets when
 /// peeking at re-export wrappers' transitive named exports.
+#[cfg(test)]
 pub(in crate::commands::compile) fn wrap_commonjs(source: &str, source_path: &Path) -> String {
+    wrap_commonjs_for_target(source, source_path, None)
+}
+
+pub(in crate::commands::compile) fn wrap_commonjs_for_target(
+    source: &str,
+    source_path: &Path,
+    target: Option<&str>,
+) -> String {
     let mut source_cow = Cow::Borrowed(source);
 
     if is_depd_index_path(source_path) {
@@ -46,7 +55,11 @@ pub(in crate::commands::compile) fn wrap_commonjs(source: &str, source_path: &Pa
     }
     let source: &str = source_cow.as_ref();
 
-    let require_specs = extract_require_specifiers(source);
+    let mut require_specs = extract_require_specifiers(source);
+    let dead_platform_requires = inactive_platform_guarded_requires(source, target);
+    if !dead_platform_requires.is_empty() {
+        require_specs.retain(|spec| !dead_platform_requires.contains(spec));
+    }
 
     // Issue #652: hoist top-level `class X { ... }` declarations OUT of the
     // IIFE so the consumer's `import { X } from "pkg"` resolves to the real
@@ -475,6 +488,88 @@ const _cjs = (function() {{
         );
     }
     wrapped
+}
+
+fn target_node_platform(target: Option<&str>) -> Option<&'static str> {
+    match target {
+        Some("windows") | Some("windows-winui") => Some("win32"),
+        Some("linux") | Some("linux-x86_64") | Some("linux-arm64") | Some("linux-aarch64") => {
+            Some("linux")
+        }
+        Some("macos")
+        | Some("ios")
+        | Some("ios-simulator")
+        | Some("ios-widget")
+        | Some("ios-widget-simulator")
+        | Some("visionos")
+        | Some("visionos-simulator")
+        | Some("watchos")
+        | Some("watchos-simulator")
+        | Some("watchos-widget")
+        | Some("watchos-widget-simulator")
+        | Some("tvos")
+        | Some("tvos-simulator") => Some("darwin"),
+        Some(_) => None,
+        None => {
+            #[cfg(target_os = "windows")]
+            {
+                Some("win32")
+            }
+            #[cfg(target_os = "linux")]
+            {
+                Some("linux")
+            }
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            {
+                Some("darwin")
+            }
+            #[cfg(not(any(
+                target_os = "windows",
+                target_os = "linux",
+                target_os = "macos",
+                target_os = "ios"
+            )))]
+            {
+                None
+            }
+        }
+    }
+}
+
+fn inactive_platform_guarded_requires(
+    source: &str,
+    target: Option<&str>,
+) -> std::collections::HashSet<String> {
+    let Some(platform) = target_node_platform(target) else {
+        return std::collections::HashSet::new();
+    };
+    let re = regex::Regex::new(
+        r#"(?s)if\s*\(\s*process\.platform\s*(===|!==)\s*['"]([^'"]+)['"]\s*\)\s*\{(?P<then>.*?)\}\s*else\s*\{(?P<else>.*?)\}"#,
+    )
+    .unwrap();
+    let mut inactive = std::collections::HashSet::new();
+    for cap in re.captures_iter(source) {
+        let Some(op) = cap.get(1).map(|m| m.as_str()) else {
+            continue;
+        };
+        let Some(expected) = cap.get(2).map(|m| m.as_str()) else {
+            continue;
+        };
+        let condition_true = match op {
+            "===" => platform == expected,
+            "!==" => platform != expected,
+            _ => continue,
+        };
+        let dead_body = if condition_true {
+            cap.name("else")
+        } else {
+            cap.name("then")
+        };
+        if let Some(body) = dead_body {
+            inactive.extend(extract_require_specifiers(body.as_str()));
+        }
+    }
+    inactive
 }
 
 fn is_depd_index_path(source_path: &Path) -> bool {

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -455,7 +455,7 @@ fn collect_module_one(
     let was_cjs_wrapped =
         (is_in_compiled_pkg || !is_in_node_modules) && super::cjs_wrap::is_commonjs(&raw_source);
     let source = if was_cjs_wrapped {
-        super::cjs_wrap::wrap_commonjs(&raw_source, &canonical)
+        super::cjs_wrap::wrap_commonjs_for_target(&raw_source, &canonical, target)
     } else {
         raw_source
     };


### PR DESCRIPTION
## Summary

- pass the compile target into CJS wrapping
- skip eager ESM hoists for requires inside unreachable process.platform branches
- add regression coverage for the node-pty Windows/Unix terminal split

## Why

The CJS wrapper currently hoists every static require(...) into an ESM import. That changes lazy CommonJS behavior: in node-pty/lib/index.js, Windows should only require ./windowsTerminal, while non-Windows should only require ./unixTerminal. Because Perry hoisted both, the Windows compile path eagerly initialized ./unixTerminal and hit its top-level native pty.node load before the process.platform branch could exclude it.

This keeps the existing hoisting behavior for ordinary requires, but prunes the dead side of simple if (process.platform ===/!== '...') { ... } else { ... } guards when the compile target maps to a Node platform string.

## Test plan

- cargo test -p perry commands::compile::cjs_wrap --message-format=short
- git diff --check