### PR TITLE
fix(runtime): nested-Proxy Object.getPrototypeOf segfaults on Linux (Drizzle relational queries)

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -920,6 +920,27 @@ fn prototype_of_for_set(value: f64) -> Option<f64> {
     if !reflect_value_is_object(value) {
         return None;
     }
+    // A Proxy is a small registered id (`POINTER_TAG | (PROXY_TAG_BASE + id)`),
+    // NOT a heap object. The POINTER_TAG block below would treat that id as a
+    // raw pointer; on Linux (`is_valid_obj_ptr` HEAP_MIN = 0x1000) the ~1MB id
+    // passes the range check and dereferences unmapped low memory → SIGSEGV.
+    // drizzle nests proxies (a proxy whose target is itself a proxy), so this is
+    // reachable when `is(value, type)` walks `getPrototypeOf` over a
+    // proxy-wrapped table/column. Route it through the Proxy `[[GetPrototypeOf]]`
+    // (no-trap → the target's prototype) instead. Returns `None` for a null /
+    // self prototype, matching the heap-object handling below.
+    if lookup(value).is_some() {
+        let proto = proxy_get_prototype_of_impl(value);
+        let proto_bits = proto.to_bits();
+        return if proto_bits == TAG_NULL
+            || proto_bits == TAG_UNDEFINED
+            || proto_bits == value.to_bits()
+        {
+            None
+        } else {
+            Some(proto)
+        };
+    }
     let bits = value.to_bits();
     if (bits >> 48) == (POINTER_TAG >> 48) {
         let raw = (bits & POINTER_MASK) as usize;


### PR DESCRIPTION
## Problem

`Object.getPrototypeOf()` on a Drizzle-created Proxy segfaults (SIGSEGV, exit 139) in `perry_runtime::proxy::prototype_of_for_set`, crashing **all** Drizzle relational queries (`db.query.*.findMany/findFirst`) while building SQL — before any DB I/O.

```
#0 perry_runtime::proxy::prototype_of_for_set
#1 perry_runtime::proxy::proxy_get_prototype_of_impl
#2 js_object_get_prototype_of
#3 drizzle-orm/entity.js  is()
...  MySqlDialect.buildSelection / buildSelectQuery / buildRelationalQuery
```

## Root cause

It's a **nested-proxy** bug on the no-trap `[[GetPrototypeOf]]` path, and it's **Linux-specific**.

Drizzle wraps its tables/columns in proxies, and those proxies' *targets* are themselves proxies. When `is(value, type)` walks `Object.getPrototypeOf`:

1. `js_object_get_prototype_of(proxy)` → `proxy_get_prototype_of_impl` → no trap → `reflect_target_get_prototype_of(target)` → `prototype_of_for_set(target)`.
2. `target` is **itself a proxy**, NaN-boxed as `POINTER_TAG | (PROXY_TAG_BASE + id)` = `POINTER_TAG | ~0x000F_xxxx`.
3. `prototype_of_for_set` saw `POINTER_TAG`, extracted `raw ≈ 0x000F_xxxx` (~1 MB), which clears the `raw >= GC_HEADER_SIZE + 0x1000` gate.
4. `is_valid_obj_ptr(raw)` — on **Linux** `HEAP_MIN = 0x1000`, so `0x000F_xxxx ∈ [0x1000, 0x8000_0000_0000)` → **true**.
5. `(*obj).class_id` dereferences unmapped low memory → **SIGSEGV**.

On **macOS** `HEAP_MIN = 0x200_0000_0000`, so step 4 fails and it falls through harmlessly — which is exactly why this never reproduced locally but crashed the deployed (Linux) billing app. A plain `new Proxy({}, {})` has a real heap-object target, so it never enters this band — matching the report that *some* proxies work.

## Fix

In `prototype_of_for_set`, intercept a proxy value **before** the heap-pointer block and route it through the canonical Proxy `[[GetPrototypeOf]]` (`proxy_get_prototype_of_impl` → no-trap → the target's prototype), so a proxy id is never dereferenced as a raw pointer. Recursion unwraps one proxy layer per step and terminates.

## Verification

Regression suite (compiles + runs, exit 0):

- `Object.getPrototypeOf(new Proxy({}, {})) === Object.prototype` → `true` ✅ (acceptance #2)
- nested proxy (`new Proxy(new Proxy({}, {}), {})`) → resolves to `Object.prototype`, no segfault ✅
- multi-step proxy chain-walk like Drizzle's `is()` → walks cleanly ✅
- proxy-over-class-instance chain → resolves correctly ✅

The two pre-existing `perry-runtime` unit-test failures (`test_array_exotic_descriptors_and_global_prototype_identity`, `builtin_prototype_methods_reject_dynamic_new`) fail identically on the base — unrelated to this change.

The actual crash is masked on macOS by the higher `HEAP_MIN`, so the Linux end-to-end (`GET /admin/customers` → 200, acceptance #3) couldn't be exercised locally, but the guard provably prevents the offending deref on every platform.

## Notes

No version bump / CHANGELOG entry — left for merge time per the maintainer convention.
