### PR TITLE
fix(stdlib): emit one header line per array-valued header in node:http (#4826)

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/http_server.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http_server.rs
@@ -399,7 +399,10 @@ pub(super) const HTTP_SERVER_ROWS: &[NativeModSig] = &[
         method: "setHeader",
         class_filter: Some("ServerResponse"),
         runtime: "js_node_http_res_set_header_self",
-        args: &[NA_STR, NA_STR],
+        // #4826: value passed as a raw JSValue (NA_F64) so array values
+        // (e.g. Set-Cookie) are detected and emitted as one wire line per
+        // element instead of a single comma-joined / JSON-stringified line.
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -205,8 +205,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_http_res_set_status", VOID, &[I64, DOUBLE]);
     module.declare_function("js_node_http_res_get_status", DOUBLE, &[I64]);
     module.declare_function("js_node_http_res_set_status_message", VOID, &[I64, I64]);
-    module.declare_function("js_node_http_res_set_header", VOID, &[I64, I64, I64]);
-    module.declare_function("js_node_http_res_set_header_self", I64, &[I64, I64, I64]);
+    module.declare_function("js_node_http_res_set_header", VOID, &[I64, I64, DOUBLE]);
+    module.declare_function("js_node_http_res_set_header_self", I64, &[I64, I64, DOUBLE]);
     module.declare_function("js_node_http_res_get_header", DOUBLE, &[I64, I64]);
     module.declare_function("js_node_http_res_remove_header", VOID, &[I64, I64]);
     module.declare_function("js_node_http_res_has_header", I32, &[I64, I64]);

--- a/crates/perry-ext-http-server/src/handle_dispatch.rs
+++ b/crates/perry-ext-http-server/src/handle_dispatch.rs
@@ -113,11 +113,7 @@ extern "C" {
     fn js_node_http_res_set_status(handle: i64, code: f64);
     fn js_node_http_res_get_status(handle: i64) -> f64;
     fn js_node_http_res_set_status_message(handle: i64, msg_ptr: *const StringHeader);
-    fn js_node_http_res_set_header(
-        handle: i64,
-        name_ptr: *const StringHeader,
-        value_ptr: *const StringHeader,
-    );
+    fn js_node_http_res_set_header(handle: i64, name_ptr: *const StringHeader, value: f64);
     fn js_node_http_res_get_header(handle: i64, name_ptr: *const StringHeader) -> f64;
     fn js_node_http_res_remove_header(handle: i64, name_ptr: *const StringHeader);
     fn js_node_http_res_has_header(handle: i64, name_ptr: *const StringHeader) -> i32;
@@ -518,7 +514,9 @@ pub unsafe extern "C" fn js_ext_http_server_response_dispatch_method(
         "setHeader" if args.len() >= 2 => {
             let name = string_value_arg(args[0]);
             if !name.is_null() {
-                js_node_http_res_set_header(handle, name, string_value_arg(args[1]));
+                // Pass the raw JSValue so array values (Set-Cookie) keep their
+                // per-element structure for one-line-per-element wire output.
+                js_node_http_res_set_header(handle, name, args[1]);
             }
             self_ref
         }

--- a/crates/perry-ext-http-server/src/response.rs
+++ b/crates/perry-ext-http-server/src/response.rs
@@ -21,8 +21,8 @@ use tokio::sync::oneshot;
 
 use crate::request::{emit_no_arg_to_listeners, handle_to_pointer_f64};
 use crate::types::{
-    js_json_stringify, jsvalue_to_body_bytes, jsvalue_to_owned_string, read_string_header, PTR_MASK,
-    STRING_TAG, TAG_NULL, TAG_UNDEFINED,
+    js_json_stringify, jsvalue_to_body_bytes, jsvalue_to_owned_string, read_string_header,
+    PTR_MASK, STRING_TAG, TAG_NULL, TAG_UNDEFINED,
 };
 
 pub type ResponseBody = BoxBody<Bytes, Infallible>;
@@ -360,8 +360,10 @@ pub unsafe extern "C" fn js_node_http_res_set_header(
                 sr.headers.insert(lower.clone(), elems.join(", "));
                 sr.header_value_lists.insert(lower.clone(), elems);
             } else {
-                sr.headers
-                    .insert(lower.clone(), jsvalue_to_owned_string(value).unwrap_or_default());
+                sr.headers.insert(
+                    lower.clone(),
+                    jsvalue_to_owned_string(value).unwrap_or_default(),
+                );
                 sr.header_value_lists.remove(&lower);
             }
             sr.raw_header_names.insert(lower, name);

--- a/crates/perry-ext-http-server/src/response.rs
+++ b/crates/perry-ext-http-server/src/response.rs
@@ -21,8 +21,8 @@ use tokio::sync::oneshot;
 
 use crate::request::{emit_no_arg_to_listeners, handle_to_pointer_f64};
 use crate::types::{
-    js_json_stringify, jsvalue_to_body_bytes, read_string_header, PTR_MASK, STRING_TAG, TAG_NULL,
-    TAG_UNDEFINED,
+    js_json_stringify, jsvalue_to_body_bytes, jsvalue_to_owned_string, read_string_header, PTR_MASK,
+    STRING_TAG, TAG_NULL, TAG_UNDEFINED,
 };
 
 pub type ResponseBody = BoxBody<Bytes, Infallible>;
@@ -60,8 +60,16 @@ impl Body for TrailerBody {
 pub struct ServerResponse {
     pub status_code: u16,
     pub status_message: Option<String>,
-    /// Lowercase-keyed header map (the lookup table).
+    /// Lowercase-keyed header map (the lookup table). For array-valued
+    /// headers this holds Node's scalar coercion (the array's elements
+    /// joined with `, `); the per-element values live in
+    /// `header_value_lists` so the wire layer can emit one line each.
     pub headers: HashMap<String, String>,
+    /// Lowercase-keyed multi-value header map. Populated when a header is
+    /// assigned an array value (e.g. `Set-Cookie`): Node emits one header
+    /// line per element rather than a single comma-joined line, so the wire
+    /// serializer expands these into repeated `name: value` lines (#4826).
+    pub header_value_lists: HashMap<String, Vec<String>>,
     /// Lowercase-keyed trailer map for HTTP trailers emitted after the
     /// response body, per Node's `ServerResponse.addTrailers` contract.
     pub trailers: HashMap<String, String>,
@@ -187,6 +195,7 @@ impl ServerResponse {
             status_code: 200,
             status_message: None,
             headers: HashMap::new(),
+            header_value_lists: HashMap::new(),
             trailers: HashMap::new(),
             raw_header_names: HashMap::new(),
             raw_trailer_names: HashMap::new(),
@@ -208,8 +217,10 @@ impl ServerResponse {
     }
 
     /// Snapshot the current header map as `Vec<(orig_name, value)>`
-    /// preserving original case.
-    fn snapshot_headers(&self) -> Vec<(String, String)> {
+    /// preserving original case. Array-valued headers (tracked in
+    /// `header_value_lists`) expand to one entry per element so the wire
+    /// layer emits a separate header line each (#4826).
+    pub fn snapshot_headers(&self) -> Vec<(String, String)> {
         let mut out = Vec::with_capacity(self.headers.len());
         for (lower_k, v) in &self.headers {
             let orig = self
@@ -217,7 +228,13 @@ impl ServerResponse {
                 .get(lower_k)
                 .cloned()
                 .unwrap_or_else(|| lower_k.clone());
-            out.push((orig, v.clone()));
+            if let Some(values) = self.header_value_lists.get(lower_k) {
+                for elem in values {
+                    out.push((orig.clone(), elem.clone()));
+                }
+            } else {
+                out.push((orig, v.clone()));
+            }
         }
         out
     }
@@ -292,24 +309,61 @@ pub unsafe extern "C" fn js_node_http_res_set_status_message(
     }
 }
 
-/// `res.setHeader(name, value)` — string value form. Object/array
-/// values get JSON-stringified by the TS-side wrapper before reaching
-/// here so the FFI surface stays simple.
+/// `res.setHeader(name, value)`. `value` arrives as a raw NaN-boxed
+/// JSValue (`NA_F64`) so array values (e.g. `Set-Cookie`) can be detected
+/// and stored as a per-element list — Node emits one header line per array
+/// element rather than a single comma-joined / JSON-stringified line
+/// (#4826). Scalar values are coerced to a string as before.
 #[no_mangle]
 pub unsafe extern "C" fn js_node_http_res_set_header(
     handle: i64,
     name_ptr: *const StringHeader,
-    value_ptr: *const StringHeader,
+    value: f64,
 ) {
     let name = read_string_header(name_ptr as *mut _).unwrap_or_default();
-    let value = read_string_header(value_ptr as *mut _).unwrap_or_default();
     if name.is_empty() {
         return;
     }
     let lower = name.to_lowercase();
+
+    // Detect an array value via JSON: an array serializes to `[ … ]` and
+    // parses back to `serde_json::Value::Array`. Anything else is coerced
+    // to its string form (matching the previous `NA_STR` behavior).
+    let jsv = JsValue::from_bits(value.to_bits());
+    let array_elems: Option<Vec<String>> = if jsv.is_pointer() {
+        let ptr = js_json_stringify(value, 0);
+        if ptr.is_null() {
+            None
+        } else {
+            read_string_header(ptr).and_then(|json| {
+                match serde_json::from_str::<serde_json::Value>(&json) {
+                    Ok(serde_json::Value::Array(items)) => Some(
+                        items
+                            .into_iter()
+                            .map(|item| match item {
+                                serde_json::Value::String(s) => s,
+                                other => other.to_string(),
+                            })
+                            .collect(),
+                    ),
+                    _ => None,
+                }
+            })
+        }
+    } else {
+        None
+    };
+
     if let Some(sr) = get_handle_mut::<ServerResponse>(handle) {
         if !sr.headers_sent {
-            sr.headers.insert(lower.clone(), value);
+            if let Some(elems) = array_elems {
+                sr.headers.insert(lower.clone(), elems.join(", "));
+                sr.header_value_lists.insert(lower.clone(), elems);
+            } else {
+                sr.headers
+                    .insert(lower.clone(), jsvalue_to_owned_string(value).unwrap_or_default());
+                sr.header_value_lists.remove(&lower);
+            }
             sr.raw_header_names.insert(lower, name);
         }
     }
@@ -320,9 +374,9 @@ pub unsafe extern "C" fn js_node_http_res_set_header(
 pub unsafe extern "C" fn js_node_http_res_set_header_self(
     handle: i64,
     name_ptr: *const StringHeader,
-    value_ptr: *const StringHeader,
+    value: f64,
 ) -> i64 {
-    js_node_http_res_set_header(handle, name_ptr, value_ptr);
+    js_node_http_res_set_header(handle, name_ptr, value);
     handle
 }
 
@@ -359,6 +413,7 @@ pub unsafe extern "C" fn js_node_http_res_remove_header(
     if let Some(sr) = get_handle_mut::<ServerResponse>(handle) {
         if !sr.headers_sent {
             sr.headers.remove(&name);
+            sr.header_value_lists.remove(&name);
             sr.raw_header_names.remove(&name);
         }
     }
@@ -408,13 +463,21 @@ pub unsafe extern "C" fn js_node_http_res_append_header(
     let lower = name.to_lowercase();
     if let Some(sr) = get_handle_mut::<ServerResponse>(handle) {
         if !sr.headers_sent {
-            sr.headers
-                .entry(lower.clone())
-                .and_modify(|existing| {
-                    existing.push(',');
-                    existing.push_str(&value);
-                })
-                .or_insert(value);
+            if let Some(list) = sr.header_value_lists.get_mut(&lower) {
+                // Already a multi-value header (e.g. Set-Cookie): append a new
+                // element so it emits its own wire line (#4826).
+                list.push(value.clone());
+                let joined = list.join(", ");
+                sr.headers.insert(lower.clone(), joined);
+            } else {
+                sr.headers
+                    .entry(lower.clone())
+                    .and_modify(|existing| {
+                        existing.push(',');
+                        existing.push_str(&value);
+                    })
+                    .or_insert(value);
+            }
             sr.raw_header_names.entry(lower).or_insert(name);
         }
     }
@@ -561,11 +624,29 @@ fn apply_headers_json(sr: &mut ServerResponse, json: &str) {
     if let Ok(serde_json::Value::Object(obj)) = serde_json::from_str::<serde_json::Value>(json) {
         for (k, v) in obj {
             let lower = k.to_lowercase();
+            // Array values (e.g. Set-Cookie) emit one wire line per element.
+            // Node coerces the scalar `getHeader`/lookup value to the
+            // elements joined with `, `, and keeps the per-element list so
+            // the response serializer can emit each on its own line (#4826).
+            if let serde_json::Value::Array(items) = v {
+                let elems: Vec<String> = items
+                    .into_iter()
+                    .map(|item| match item {
+                        serde_json::Value::String(s) => s,
+                        other => other.to_string(),
+                    })
+                    .collect();
+                sr.headers.insert(lower.clone(), elems.join(", "));
+                sr.header_value_lists.insert(lower.clone(), elems);
+                sr.raw_header_names.insert(lower, k);
+                continue;
+            }
             let value = match v {
                 serde_json::Value::String(s) => s,
                 other => other.to_string(),
             };
             sr.headers.insert(lower.clone(), value);
+            sr.header_value_lists.remove(&lower);
             sr.raw_header_names.insert(lower, k);
         }
     }

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -1183,15 +1183,10 @@ pub(crate) fn synthesize_default_response_if_needed(response_handle: i64) {
             sr.headers_sent = true;
             sr.writable_finished = true;
             let body = std::mem::take(&mut sr.buffered_body);
-            let mut headers = Vec::with_capacity(sr.headers.len());
-            for (lower_k, v) in &sr.headers {
-                let orig = sr
-                    .raw_header_names
-                    .get(lower_k)
-                    .cloned()
-                    .unwrap_or_else(|| lower_k.clone());
-                headers.push((orig, v.clone()));
-            }
+            // `snapshot_headers` expands array-valued headers (e.g.
+            // Set-Cookie) into one entry per element so they emit a separate
+            // wire line each (#4826).
+            let mut headers = sr.snapshot_headers();
             if !sr.headers.contains_key("content-length")
                 && !sr.headers.contains_key("transfer-encoding")
             {

--- a/test-files/test_issue_4826_array_headers.ts
+++ b/test-files/test_issue_4826_array_headers.ts
@@ -1,0 +1,19 @@
+import { createServer } from "node:http";
+
+const s = createServer((req, res) => {
+  if (req.url === "/wh") {
+    // writeHead bulk-header array path
+    res.writeHead(200, { "set-cookie": ["a=1; Path=/", "b=2; Path=/"] });
+    res.end("ok");
+  } else {
+    // setHeader array path + scalar header
+    res.setHeader("set-cookie", ["c=3; Path=/", "d=4; Path=/"]);
+    res.setHeader("content-type", "text/plain");
+    res.writeHead(200);
+    res.end("ok");
+  }
+});
+
+s.listen(3456, () => {
+  console.log("listening");
+});


### PR DESCRIPTION
Fixes #4826.

## Problem
`ServerResponse.writeHead(status, headers)` and `setHeader` JSON-stringified array-valued headers (e.g. `Set-Cookie`) into a single wire line instead of emitting one line per element, breaking all cookie-based auth via `@hono/node-server`.

## Root cause
`ServerResponse` stored headers as `HashMap<String, String>` — one scalar per name — so an array value was coerced to a literal JSON array string. Both the `writeHead` bulk path (`apply_headers_json`) and `setHeader` collapsed the array.

## Fix
- Added a parallel `header_value_lists: HashMap<String, Vec<String>>` to preserve per-element values; `snapshot_headers()` expands them into one wire line per element.
- `apply_headers_json` detects `Value::Array`; `setHeader` now receives the raw JSValue and detects arrays; `appendHeader`/`removeHeader` maintain the list.
- Codegen `setHeader` arg kind `NA_STR` → `NA_F64` and FFI signature widened so the raw array reaches the runtime.

## Verification
Compiled a repro server and read raw HTTP/1.1 bytes over a TCP socket: both `writeHead` and `setHeader` emit two distinct `set-cookie:` lines; scalar headers (e.g. `content-type`) stay single-line. Regression test added at `test-files/test_issue_4826_array_headers.ts`.