### PR TITLE
fix(runtime): honor dangerouslySetInnerHTML in hono/jsx rendering (#4827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 Detailed changelog for Perry. See CLAUDE.md for concise summaries.
 
+## v0.5.1149 — Honor `dangerouslySetInnerHTML` in hono/jsx rendering (#4827)
+
+Perry's built-in JSX server renderer (`crates/perry-runtime/src/jsx.rs`, which
+`hono/jsx`'s `jsx`/`jsxs` thunks forward into) treated the React/hono special
+prop `dangerouslySetInnerHTML={{ __html }}` as an ordinary attribute. The
+attribute-serialization loop in `render_props_attrs` stringified its object
+value via the canonical stringifier, producing `[object Object]`, so
+`<div dangerouslySetInnerHTML={{ __html: "<b>hi</b>" }} />` rendered as
+`<div dangerouslySetInnerHTML="[object Object]"></div>` and the raw HTML (e.g.
+`<style dangerouslySetInnerHTML={{ __html: baseCss }} />`) was dropped entirely.
+
+Fix: match upstream hono/jsx (and React) semantics. A new `dangerous_inner_html`
+helper reads the prop's `__html` field; when present, `dispatch` splices that
+string as the element's inner content **unescaped** in place of normal
+`children`, and forces a normal (non-void) element so the raw HTML has a body
+even when the source used a self-closing tag (`<div .../>` → `<div>...</div>`).
+`render_props_attrs` now skips the `dangerouslySetInnerHTML` key so it is never
+emitted as an attribute. Void elements without the prop (e.g. `<br />`) and
+ordinary text/attribute escaping are unchanged.
+
 ## v0.5.1147 — Wire the fancy-regex fallback through every RegExp operation (#4797)
 
 `fancy-regex` (lookbehind, lookahead, backreferences, named groups) was already

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1147
+**Current Version:** 0.5.1149
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5274,7 +5274,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "base64",
@@ -5329,14 +5329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "cc",
  "libc",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "log",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5376,7 +5376,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "serde",
  "serde_json",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1147"
+version = "0.5.1149"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "clap",
@@ -5486,14 +5486,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5592,14 +5592,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "bytes",
  "h2",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "bson",
  "futures-util",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "image",
@@ -5786,14 +5786,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "brotli",
  "flate2",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "base64",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6017,14 +6017,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "itoa",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "block2",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1147"
+version = "0.5.1149"
 
 [[package]]
 name = "perry-ui-test"
@@ -6113,11 +6113,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1147"
+version = "0.5.1149"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "block2",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "block2",
  "libc",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "libc",
@@ -6178,14 +6178,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6199,7 +6199,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1147"
+version = "0.5.1149"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1147"
+version = "0.5.1149"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/jsx.rs
+++ b/crates/perry-runtime/src/jsx.rs
@@ -67,10 +67,20 @@ fn dispatch(type_arg: f64, props: f64) -> f64 {
             return make_jsx_node(&html);
         }
         let attrs = render_props_attrs(props);
-        let html = if is_void_element(&tag) {
+        // `dangerouslySetInnerHTML={{ __html }}` (React/hono semantics): the
+        // element's inner content is the raw, *unescaped* `__html` string, and
+        // the prop is never serialized as an attribute (handled in
+        // `render_props_attrs`). Its presence forces a normal (non-void)
+        // element so the raw HTML has somewhere to live — e.g. `<div .../>`
+        // with `__html` renders as `<div>...</div>`.
+        let raw_inner_html = dangerous_inner_html(props);
+        let html = if raw_inner_html.is_none() && is_void_element(&tag) {
             format!("<{tag}{attrs}/>")
         } else {
-            let children = render_children(get_field_by_name(props, "children"));
+            let children = match raw_inner_html {
+                Some(raw) => raw,
+                None => render_children(get_field_by_name(props, "children")),
+            };
             format!("<{tag}{attrs}>{children}</{tag}>")
         };
         return make_jsx_node(&html);
@@ -142,6 +152,26 @@ fn get_field_by_name(obj_value: f64, name: &str) -> f64 {
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
     let v = crate::object::js_object_get_field_by_name(obj, key);
     f64::from_bits(v.bits())
+}
+
+/// React/hono `dangerouslySetInnerHTML={{ __html }}` support. If the props
+/// object carries a `dangerouslySetInnerHTML` prop whose value is an object
+/// with an `__html` field, return that field's raw string (to be spliced as
+/// the element's inner content *unescaped*). Returns `None` when the prop is
+/// absent or malformed (a non-object value, or no `__html`), in which case the
+/// element renders normally.
+fn dangerous_inner_html(props: f64) -> Option<String> {
+    let prop = get_field_by_name(props, "dangerouslySetInnerHTML");
+    let pjs = JSValue::from_bits(prop.to_bits());
+    if pjs.is_undefined() || pjs.is_null() || !pjs.is_pointer() {
+        return None;
+    }
+    let html_val = get_field_by_name(prop, "__html");
+    let hjs = JSValue::from_bits(html_val.to_bits());
+    if hjs.is_undefined() || hjs.is_null() {
+        return None;
+    }
+    Some(jsvalue_to_owned_string(html_val))
 }
 
 /// If `value` is a boxed JSX node, return its rendered HTML.
@@ -237,6 +267,12 @@ fn render_props_attrs(props: f64) -> String {
         if key == "children" || key == "key" || key == "ref" {
             continue;
         }
+        // `dangerouslySetInnerHTML` is consumed as raw inner content by the
+        // caller (`dangerous_inner_html`), never serialized as an attribute —
+        // otherwise it stringifies to `[object Object]` (#4827).
+        if key == "dangerouslySetInnerHTML" {
+            continue;
+        }
         let val = get_field_by_name(props, &key);
         let vjs = JSValue::from_bits(val.to_bits());
         if vjs.is_undefined() || vjs.is_null() {
@@ -273,4 +309,75 @@ fn is_valid_closure(ptr: *const ClosureHeader) -> bool {
     }
     let tag = unsafe { std::ptr::read_volatile((ptr as *const u8).add(12) as *const u32) };
     tag == CLOSURE_MAGIC
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Box a Rust string as a NaN-boxed JSValue string.
+    fn str_val(s: &str) -> f64 {
+        let p = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        f64::from_bits(JSValue::string_ptr(p).bits())
+    }
+
+    /// Build a plain object (class id 0) with the given named string fields.
+    fn obj_with(fields: &[(&str, f64)]) -> f64 {
+        let obj = crate::object::js_object_alloc(0, 0);
+        for (k, v) in fields {
+            let key = crate::string::js_string_from_bytes(k.as_ptr(), k.len() as u32);
+            crate::object::js_object_set_field_by_name(obj, key, *v);
+        }
+        f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+    }
+
+    /// Render a JSX node value back to its HTML string.
+    fn node_html(node: f64) -> String {
+        jsx_node_html(node).expect("expected a boxed JSX node")
+    }
+
+    /// #4827: `dangerouslySetInnerHTML={{ __html }}` injects the raw,
+    /// unescaped HTML as the element's children, never as an attribute. A
+    /// self-closing source tag becomes a normal open/close pair.
+    #[test]
+    fn dangerously_set_inner_html_renders_raw_children() {
+        let inner = obj_with(&[("__html", str_val("<b>hi</b>"))]);
+        let props = obj_with(&[("dangerouslySetInnerHTML", inner)]);
+        let node = js_jsx(str_val("div"), props);
+        assert_eq!(node_html(node), "<div><b>hi</b></div>");
+    }
+
+    /// Real-world `<style dangerouslySetInnerHTML={{ __html: css }} />` case.
+    #[test]
+    fn dangerously_set_inner_html_style_keeps_css() {
+        let inner = obj_with(&[("__html", str_val("body { color: red; }"))]);
+        let props = obj_with(&[("dangerouslySetInnerHTML", inner)]);
+        let node = js_jsx(str_val("style"), props);
+        assert_eq!(node_html(node), "<style>body { color: red; }</style>");
+    }
+
+    /// The special prop must not leak into attribute serialization.
+    #[test]
+    fn dangerously_set_inner_html_not_emitted_as_attribute() {
+        let inner = obj_with(&[("__html", str_val("x"))]);
+        let props = obj_with(&[("dangerouslySetInnerHTML", inner)]);
+        let node = js_jsx(str_val("div"), props);
+        assert!(!node_html(node).contains("dangerouslySetInnerHTML"));
+        assert!(!node_html(node).contains("[object Object]"));
+    }
+
+    /// Ordinary elements (and attribute/text escaping) are unaffected.
+    #[test]
+    fn ordinary_element_unaffected() {
+        let props = obj_with(&[("className", str_val("x")), ("children", str_val("a<b"))]);
+        let node = js_jsx(str_val("div"), props);
+        assert_eq!(node_html(node), "<div class=\"x\">a&lt;b</div>");
+    }
+
+    /// A void element with no `dangerouslySetInnerHTML` stays self-closing.
+    #[test]
+    fn void_element_stays_self_closing() {
+        let node = js_jsx(str_val("br"), f64::from_bits(TAG_UNDEFINED));
+        assert_eq!(node_html(node), "<br/>");
+    }
 }


### PR DESCRIPTION
Fixes #4827.

## Problem
Perry's `hono/jsx` server renderer treated `dangerouslySetInnerHTML={{ __html }}` as an ordinary attribute, stringifying its object to `[object Object]` and dropping the raw HTML — so `<style dangerouslySetInnerHTML={{ __html: baseCss }} />` rendered as `<style dangerouslySetInnerHTML="[object Object]"></style>` (no CSS at all).

## Root cause
The JSX renderer (`crates/perry-runtime/src/jsx.rs`, which the hono/jsx thunks forward into) had no special case for the React/hono `dangerouslySetInnerHTML` prop.

## Fix (single file: `crates/perry-runtime/src/jsx.rs`)
- Read the prop's `__html` field and splice it as **unescaped** inner content in place of normal children.
- Force a non-void element so a self-closing source tag (`<div .../>`) gets a body → `<div>...</div>`.
- Skip the `dangerouslySetInnerHTML` key in attribute serialization so it never leaks as an attribute.

## Verification
`cargo test --release -p perry-runtime jsx::tests` — 5 unit tests pass, asserting `<div><b>hi</b></div>` and `<style>body { color: red; }</style>` with no `[object Object]` and no leaked attribute; escaping and void-element cases unaffected. Full runtime+stdlib+perry build compiles clean.