### PR TITLE
fix(runtime): adopt returned promise state on async tail-return (#4828)

### DIFF
--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -315,12 +315,58 @@ pub extern "C" fn js_async_step_done(value: f64, step_closure: ClosurePtr) -> *m
     let trap = INLINE_TRAP.with(|c| c.get());
     if !trap.trap_next.is_null() && trap.current_step == step_closure as usize {
         bump(&MT_STEP_DONE_REUSE_HIT);
-        js_promise_resolve(trap.trap_next, value);
+        // Issue #4828: an async fn whose tail is `return <promise>` must
+        // ADOPT the returned promise/thenable's eventual state into its
+        // own result promise (`trap_next`), not store the promise object
+        // as the literal resolution value. The slow path below already
+        // does this via `js_promise_resolved`; the in-place reuse fast
+        // path bypassed it with a raw `js_promise_resolve`, so awaiting
+        // the outer fn yielded the inner Promise object itself (typeof
+        // "object", JSON.stringify === "", every property undefined).
+        // Mirror `js_promise_resolved`'s adoption probes here, but settle
+        // the existing `trap_next` instead of allocating a fresh promise
+        // so the runner's self-chain fast path still fires.
+        resolve_trap_next_with_adoption(trap.trap_next, value);
         trap.trap_next
     } else {
         bump(&MT_STEP_DONE_REUSE_MISS);
         js_promise_resolved(value)
     }
+}
+
+/// Settle `target` with `value`, adopting `value`'s state when it is a
+/// native Promise or an assimilable thenable (ECMAScript "Promise
+/// Resolve Functions" thenable-adoption). Used by the `js_async_step_done`
+/// reuse fast path so `return <promise>` from an async fn unwraps the
+/// inner promise into the outer result promise (Issue #4828). Mirrors the
+/// adoption arms of `js_promise_resolved`, but resolves an existing
+/// `target` rather than constructing a new one.
+fn resolve_trap_next_with_adoption(target: *mut Promise, value: f64) {
+    // Primitives can never be a promise/thenable — settle directly.
+    if is_definitely_primitive(value) {
+        js_promise_resolve(target, value);
+        return;
+    }
+    // Native Promise: chain `target` to follow its eventual state.
+    if js_value_is_promise(value) != 0 {
+        let inner = crate::value::js_nanbox_get_pointer(value) as *mut Promise;
+        if !inner.is_null() && inner != target {
+            js_promise_resolve_with_promise(target, inner);
+            return;
+        }
+    }
+    // User thenable (e.g. Drizzle QueryPromise, #586): assimilate, then
+    // chain the wrapper promise into `target`.
+    let assim = js_assimilate_thenable(value);
+    if assim.to_bits() != value.to_bits() && js_value_is_promise(assim) != 0 {
+        let inner = crate::value::js_nanbox_get_pointer(assim) as *mut Promise;
+        if !inner.is_null() && inner != target {
+            js_promise_resolve_with_promise(target, inner);
+            return;
+        }
+    }
+    // Plain object / non-thenable value: store as-is.
+    js_promise_resolve(target, value);
 }
 
 /// #691 Phase 2 helper. Returns the currently-dispatching step

--- a/test-files/test_issue_4828_async_tail_promise.ts
+++ b/test-files/test_issue_4828_async_tail_promise.ts
@@ -1,0 +1,20 @@
+// Issue #4828: an async fn whose tail returns an un-awaited promise
+// (`return someAsyncCall()`) must adopt the returned promise's eventual
+// state, not resolve to the Promise object itself.
+async function inner(): Promise<{ id: string }> {
+  await Promise.resolve();
+  return { id: "abc", n: 1 } as any;
+}
+async function outerBroken(): Promise<{ id: string }> {
+  await Promise.resolve();
+  return inner(); // un-awaited tail promise
+}
+async function outerFixed(): Promise<{ id: string }> {
+  await Promise.resolve();
+  const r = await inner(); // explicit await
+  return r;
+}
+const a = await outerBroken();
+const b = await outerFixed();
+console.log("broken: typeof=" + typeof a + " json=" + JSON.stringify(a) + " .id=" + JSON.stringify((a as any)?.id));
+console.log("fixed:  typeof=" + typeof b + " json=" + JSON.stringify(b) + " .id=" + JSON.stringify((b as any)?.id));


### PR DESCRIPTION
Fixes #4828.

## Problem
An `async` function whose tail expression returns an un-awaited promise (`return someAsyncCall()`) corrupted the resolved value. Awaiting the outer fn produced the inner Promise object itself — `typeof === "object"`, `JSON.stringify === ""`, every property `undefined` — instead of the inner promise's eventual value. Adding an explicit `await` (`const r = await someAsyncCall(); return r;`) worked. This is a very common JS pattern, so impact is broad (a `createCustomer` flow returned `""` to its caller, breaking redirects).

## Root cause
`js_async_step_done` (`crates/perry-runtime/src/promise/async_step.rs`) settles the async fn's result promise two ways. The slow path uses `js_promise_resolved(value)`, which performs ECMAScript thenable/promise adoption (native-Promise short-circuit #2823, thenable assimilation #586). The in-place **reuse fast path** — taken in steady state when the microtask runner has stashed the result promise in `INLINE_TRAP.trap_next` — bypassed adoption with the low-level `js_promise_resolve(trap_next, value)`, storing the returned Promise object as the literal resolution value. The sibling `js_async_step_chain` (the `await x` path) already adopts, which is why explicit `await` masked the bug.

## Fix
Added `resolve_trap_next_with_adoption`, mirroring `js_promise_resolved`'s adoption probes (primitive short-circuit, native-Promise chain via `js_promise_resolve_with_promise`, thenable assimilation) but settling the existing `trap_next` rather than allocating a fresh promise — so the runner's self-chain fast path still fires. The fast path now calls it instead of the raw `js_promise_resolve`.

## Verification
Compiled and ran the issue's repro (`test-files/test_issue_4828_async_tail_promise.ts`). Before: `broken: ... json="" .id=undefined`. After, both lines identical and correct:
```
broken: typeof=object json={"id":"abc","n":1} .id="abc"
fixed:  typeof=object json={"id":"abc","n":1} .id="abc"
```