### PR TITLE
fix(macos): chdir to Contents/Resources on .app launch so assets resolve

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -141,6 +141,11 @@ pub(super) fn compile_module_entry(
             if write_barriers_enabled() {
                 blk.call_void("js_gc_write_barriers_emitted", &[(I32, "1")]);
             }
+            // macOS `.app` assets live in `Contents/Resources/`, but a Finder
+            // launch starts at CWD=`/`. chdir there before any user code or
+            // native engine init so relative asset paths (`assets/...`) resolve.
+            // No-op on non-macOS and on non-bundle binaries (see the runtime fn).
+            blk.call_void("perry_macos_bundle_chdir", &[]);
             if let Some((const_name, byte_len)) = app_group_init.as_ref() {
                 let suite_ptr = format!("@{}", const_name);
                 let len_str = byte_len.to_string();

--- a/crates/perry-codegen/src/runtime_decls/mod.rs
+++ b/crates/perry-codegen/src/runtime_decls/mod.rs
@@ -48,6 +48,11 @@ pub fn declare_phase1(module: &mut LlModule) {
     // the runtime always provides the symbol; main only emits the call
     // when `app_metadata.app_group` is `Some`.
     module.declare_function("perry_app_group_init", VOID, &[PTR, I32]);
+    // macOS asset-CWD fix: a macOS `.app` launched from Finder starts with
+    // CWD=`/`, but the worker bundles assets into `Contents/Resources/`. The
+    // `main` prelude calls this unconditionally; the runtime symbol no-ops on
+    // non-macOS targets and on binaries that aren't inside an `.app` bundle.
+    module.declare_function("perry_macos_bundle_chdir", VOID, &[]);
     // Function-name registry — populated by `main()` once per top-level
     // named function so `console.log(named)` prints `[Function: named]`
     // instead of `[Function (anonymous)]`. See #1202.

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -54,6 +54,7 @@ pub mod fs;
 pub mod gc;
 pub mod intl;
 pub mod iterator_helpers;
+pub mod macos_bundle;
 pub mod map;
 pub mod math;
 pub mod messaging;

--- a/crates/perry-runtime/src/macos_bundle.rs
+++ b/crates/perry-runtime/src/macos_bundle.rs
@@ -1,0 +1,62 @@
+//! macOS `.app` bundle working-directory fix.
+//!
+//! A macOS app launched from Finder/Dock starts with the working directory set
+//! to `/`. Perry-compiled GUI/game apps — and the native libraries they link,
+//! e.g. the Bloom engine — load assets via paths relative to the CWD, like
+//! `bloom_load_texture("assets/sprites/atlas.png")` / `fopen("assets/...")`.
+//! The build worker bundles those assets into `<App>.app/Contents/Resources/`,
+//! so on macOS we `chdir` there at startup — before any user code or native
+//! engine init runs — so the relative asset paths resolve.
+//!
+//! iOS already launches with the app bundle as the CWD base, so it needs no
+//! equivalent; this is gated to macOS *and* to executables that actually live
+//! in `…/Contents/MacOS/`, leaving plain CLI/server binaries' CWD untouched.
+
+/// Called once from `main()`'s prelude. No-op unless this is a macOS binary
+/// running inside an `.app` bundle (i.e. the executable is at
+/// `<App>.app/Contents/MacOS/<bin>`), in which case it chdir's to the sibling
+/// `Contents/Resources` so relative asset paths resolve.
+#[no_mangle]
+pub extern "C" fn perry_macos_bundle_chdir() {
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(resources) = bundle_resources_dir(&exe) {
+                if resources.is_dir() {
+                    let _ = std::env::set_current_dir(&resources);
+                }
+            }
+        }
+    }
+}
+
+/// Map an executable path `<App>.app/Contents/MacOS/<bin>` to its sibling
+/// `<App>.app/Contents/Resources`. Returns `None` when the executable is not
+/// inside a `Contents/MacOS/` directory (e.g. a plain CLI binary).
+#[cfg(any(target_os = "macos", test))]
+fn bundle_resources_dir(exe: &std::path::Path) -> Option<std::path::PathBuf> {
+    exe.parent() // …/Contents/MacOS
+        .filter(|macos| macos.file_name() == Some(std::ffi::OsStr::new("MacOS")))
+        .and_then(|macos| macos.parent()) // …/Contents
+        .map(|contents| contents.join("Resources"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bundle_resources_dir;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn resolves_resources_inside_app_bundle() {
+        assert_eq!(
+            bundle_resources_dir(Path::new("/Applications/Foo.app/Contents/MacOS/Foo")),
+            Some(PathBuf::from("/Applications/Foo.app/Contents/Resources"))
+        );
+    }
+
+    #[test]
+    fn returns_none_for_plain_binary() {
+        assert_eq!(bundle_resources_dir(Path::new("/usr/local/bin/foo")), None);
+        assert_eq!(bundle_resources_dir(Path::new("foo")), None);
+    }
+}


### PR DESCRIPTION
A macOS `.app` launched from Finder/Dock starts with `CWD=/`. Perry GUI/game apps — and native libs they link (e.g. the Bloom engine) — load assets via **CWD-relative** paths like `bloom_load_texture("assets/sprites/atlas.png")` / `fopen("assets/...")`. The build worker bundles assets into `<App>.app/Contents/Resources/`, so the app couldn't find them (no levels, no sound) — while iOS worked (it launches with the bundle as the CWD base).

Adds `perry_macos_bundle_chdir()` to the runtime, called from the `main` prelude (right after `js_gc_init`, before any user/native init). It chdir's to `Contents/Resources` **only** when the executable is at `…/Contents/MacOS/` — no-op on non-macOS and on plain CLI/server binaries (their CWD is untouched).

Verified end-to-end: a binary placed in `<App>.app/Contents/MacOS/` run from `/` reports CWD `…/Contents/Resources`; a bare binary keeps its launch CWD. Unit tests for the path mapping included.