### PR TITLE
feat(linux): fully-static musl target (--libc musl / [linux] libc)

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -410,9 +410,7 @@ pub fn resolve_target_triple(name: &str) -> Option<String> {
         // provided.al2023, scratch/distroless containers, Cloud Run, etc.
         // (no glibc loader dependency). See link/platform_cmd.rs for the
         // `-static` musl link path and #4826.
-        "linux-musl" | "linux-x86_64-musl" => {
-            Some("x86_64-unknown-linux-musl".to_string())
-        }
+        "linux-musl" | "linux-x86_64-musl" => Some("x86_64-unknown-linux-musl".to_string()),
         "linux-aarch64-musl" => Some("aarch64-unknown-linux-musl".to_string()),
         "macos" => Some("arm64-apple-macosx15.0.0".to_string()),
         "macos-x86_64" => Some("x86_64-apple-macosx15.0.0".to_string()),

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -385,6 +385,8 @@ pub(crate) fn default_target_triple() -> String {
 ///  * `android`                        → aarch64-unknown-linux-android
 ///  * `linux` (x86_64 alias)           → x86_64-unknown-linux-gnu
 ///  * `linux-aarch64`                  → aarch64-unknown-linux-gnu
+///  * `linux-musl` (x86_64 alias)      → x86_64-unknown-linux-musl (fully static)
+///  * `linux-aarch64-musl`             → aarch64-unknown-linux-musl (fully static)
 ///  * `macos` (aarch64 alias)          → arm64-apple-macosx15.0.0
 ///  * `macos-x86_64`                   → x86_64-apple-macosx15.0.0
 ///  * `windows`                        → x86_64-pc-windows-msvc
@@ -404,6 +406,14 @@ pub fn resolve_target_triple(name: &str) -> Option<String> {
         "android" => Some("aarch64-unknown-linux-android".to_string()),
         "linux" => Some("x86_64-unknown-linux-gnu".to_string()),
         "linux-aarch64" => Some("aarch64-unknown-linux-gnu".to_string()),
+        // musl targets — fully static binaries that run on Lambda
+        // provided.al2023, scratch/distroless containers, Cloud Run, etc.
+        // (no glibc loader dependency). See link/platform_cmd.rs for the
+        // `-static` musl link path and #4826.
+        "linux-musl" | "linux-x86_64-musl" => {
+            Some("x86_64-unknown-linux-musl".to_string())
+        }
+        "linux-aarch64-musl" => Some("aarch64-unknown-linux-musl".to_string()),
         "macos" => Some("arm64-apple-macosx15.0.0".to_string()),
         "macos-x86_64" => Some("x86_64-apple-macosx15.0.0".to_string()),
         "windows" | "windows-winui" => Some("x86_64-pc-windows-msvc".to_string()),

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -278,6 +278,49 @@ pub fn run(
     run_with_parse_cache(args, None, format, use_color, verbose)
 }
 
+/// Fold the `--libc <glibc|musl>` flag into the effective `--target` (#4826).
+///
+/// `--libc musl` upgrades a Linux target to its fully-static musl variant:
+/// `linux`/`linux-x86_64`/native-host-default → `linux-musl`, and
+/// `linux-aarch64`/`linux-arm64` → `linux-aarch64-musl`. It is a no-op for an
+/// already-musl target. `glibc`/`gnu` (or no flag) leave the target untouched.
+/// `--libc musl` against a non-Linux target is a hard error rather than a
+/// silently-ignored flag.
+pub(crate) fn apply_libc_to_target(
+    target: Option<String>,
+    libc: Option<&str>,
+) -> Result<Option<String>> {
+    let libc = match libc {
+        None => return Ok(target),
+        Some(l) => l.trim().to_ascii_lowercase(),
+    };
+    match libc.as_str() {
+        // Default / explicit glibc: nothing to do.
+        "glibc" | "gnu" | "" => Ok(target),
+        "musl" => match target.as_deref() {
+            // Default (native host) or explicit x86_64 Linux → x86_64 musl.
+            None | Some("linux") | Some("linux-x86_64") => {
+                Ok(Some("linux-musl".to_string()))
+            }
+            Some("linux-aarch64") | Some("linux-arm64") => {
+                Ok(Some("linux-aarch64-musl".to_string()))
+            }
+            // Already a musl target — idempotent.
+            Some("linux-musl") | Some("linux-x86_64-musl") | Some("linux-aarch64-musl") => {
+                Ok(target)
+            }
+            Some(other) => anyhow::bail!(
+                "--libc musl only applies to Linux targets, but --target is \
+                 '{other}'. Drop --libc musl, or build a Linux target \
+                 (e.g. --target linux)."
+            ),
+        },
+        other => anyhow::bail!(
+            "unknown --libc value '{other}'. Supported: glibc (default) or musl."
+        ),
+    }
+}
+
 fn object_cache_project_root(input: &Path, fallback_project_root: &Path) -> PathBuf {
     let input_parent = input
         .canonicalize()
@@ -315,6 +358,12 @@ pub fn run_with_parse_cache(
     use_color: bool,
     verbose: u8,
 ) -> Result<CompileResult> {
+    // #4826: fold `--libc musl` into the effective target up-front (before any
+    // downstream code reads `args.target`) so the rest of the pipeline only
+    // ever sees the concrete `linux-musl` triple family.
+    let mut args = args;
+    args.target = apply_libc_to_target(args.target.take(), args.libc.as_deref())?;
+
     // #835 + #846: clear the codegen-side FFI provenance set up-front
     // so any leftover entries from a prior `perry dev` rebuild (or a
     // failed-build early-return that skipped our drain below) don't
@@ -4391,7 +4440,7 @@ pub fn run_with_parse_cache(
             target.as_deref(),
             Some("harmonyos") | Some("harmonyos-simulator")
         );
-        let is_linux = matches!(target.as_deref(), Some("linux"))
+        let is_linux = matches!(target.as_deref(), Some(t) if t.starts_with("linux"))
             || (!cfg!(target_os = "macos") && !cfg!(target_os = "windows") && target.is_none());
         let is_windows = matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
             || (cfg!(target_os = "windows") && target.is_none());
@@ -4943,7 +4992,7 @@ pub fn run_with_parse_cache(
         target.as_deref(),
         Some("harmonyos") | Some("harmonyos-simulator")
     );
-    let is_linux = matches!(target.as_deref(), Some("linux"))
+    let is_linux = matches!(target.as_deref(), Some(t) if t.starts_with("linux"))
         || (target.is_none() && cfg!(target_os = "linux"));
     let _is_windows = matches!(target.as_deref(), Some("windows") | Some("windows-winui"))
         || (target.is_none() && cfg!(target_os = "windows"));

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -299,9 +299,7 @@ pub(crate) fn apply_libc_to_target(
         "glibc" | "gnu" | "" => Ok(target),
         "musl" => match target.as_deref() {
             // Default (native host) or explicit x86_64 Linux → x86_64 musl.
-            None | Some("linux") | Some("linux-x86_64") => {
-                Ok(Some("linux-musl".to_string()))
-            }
+            None | Some("linux") | Some("linux-x86_64") => Ok(Some("linux-musl".to_string())),
             Some("linux-aarch64") | Some("linux-arm64") => {
                 Ok(Some("linux-aarch64-musl".to_string()))
             }
@@ -315,9 +313,9 @@ pub(crate) fn apply_libc_to_target(
                  (e.g. --target linux)."
             ),
         },
-        other => anyhow::bail!(
-            "unknown --libc value '{other}'. Supported: glibc (default) or musl."
-        ),
+        other => {
+            anyhow::bail!("unknown --libc value '{other}'. Supported: glibc (default) or musl.")
+        }
     }
 }
 

--- a/crates/perry/src/commands/compile/app_metadata.rs
+++ b/crates/perry/src/commands/compile/app_metadata.rs
@@ -20,7 +20,9 @@ pub(super) fn target_bundle_section(target: Option<&str>) -> Option<&'static str
         // WinUI shares the [windows] perry.toml section (#4680).
         Some("windows") | Some("windows-winui") => Some("windows"),
         // musl variants share the [linux] perry.toml section (#4826).
-        Some("linux") | Some("linux-musl") | Some("linux-x86_64-musl")
+        Some("linux")
+        | Some("linux-musl")
+        | Some("linux-x86_64-musl")
         | Some("linux-aarch64-musl") => Some("linux"),
         None if cfg!(target_os = "macos") => Some("macos"),
         None if cfg!(target_os = "windows") => Some("windows"),
@@ -166,9 +168,7 @@ pub(super) fn rust_target_triple(target: Option<&str>) -> Option<&'static str> {
         Some("linux-arm64") | Some("linux-aarch64") => Some("aarch64-unknown-linux-gnu"),
         // Fully-static musl targets (#4826). The perry-runtime / perry-stdlib
         // .a files for these triples are built by release-packages.yml.
-        Some("linux-musl") | Some("linux-x86_64-musl") => {
-            Some("x86_64-unknown-linux-musl")
-        }
+        Some("linux-musl") | Some("linux-x86_64-musl") => Some("x86_64-unknown-linux-musl"),
         Some("linux-aarch64-musl") => Some("aarch64-unknown-linux-musl"),
         Some("windows") | Some("windows-winui") => Some("x86_64-pc-windows-msvc"),
         Some("macos") => Some("aarch64-apple-darwin"),
@@ -343,7 +343,10 @@ app_group = "group.com.example.fallback"
         assert_eq!(m(Some("linux"), Some("glibc")), Some("linux".to_string()));
         // musl upgrades the Linux variants.
         assert_eq!(m(None, Some("musl")), Some("linux-musl".to_string()));
-        assert_eq!(m(Some("linux"), Some("musl")), Some("linux-musl".to_string()));
+        assert_eq!(
+            m(Some("linux"), Some("musl")),
+            Some("linux-musl".to_string())
+        );
         assert_eq!(
             m(Some("linux-aarch64"), Some("musl")),
             Some("linux-aarch64-musl".to_string())

--- a/crates/perry/src/commands/compile/app_metadata.rs
+++ b/crates/perry/src/commands/compile/app_metadata.rs
@@ -19,7 +19,9 @@ pub(super) fn target_bundle_section(target: Option<&str>) -> Option<&'static str
         Some("macos") => Some("macos"),
         // WinUI shares the [windows] perry.toml section (#4680).
         Some("windows") | Some("windows-winui") => Some("windows"),
-        Some("linux") => Some("linux"),
+        // musl variants share the [linux] perry.toml section (#4826).
+        Some("linux") | Some("linux-musl") | Some("linux-x86_64-musl")
+        | Some("linux-aarch64-musl") => Some("linux"),
         None if cfg!(target_os = "macos") => Some("macos"),
         None if cfg!(target_os = "windows") => Some("windows"),
         None if cfg!(target_os = "linux") => Some("linux"),
@@ -162,6 +164,12 @@ pub(super) fn rust_target_triple(target: Option<&str>) -> Option<&'static str> {
         Some("android") => Some("aarch64-linux-android"),
         Some("linux") | Some("linux-x86_64") => Some("x86_64-unknown-linux-gnu"),
         Some("linux-arm64") | Some("linux-aarch64") => Some("aarch64-unknown-linux-gnu"),
+        // Fully-static musl targets (#4826). The perry-runtime / perry-stdlib
+        // .a files for these triples are built by release-packages.yml.
+        Some("linux-musl") | Some("linux-x86_64-musl") => {
+            Some("x86_64-unknown-linux-musl")
+        }
+        Some("linux-aarch64-musl") => Some("aarch64-unknown-linux-musl"),
         Some("windows") | Some("windows-winui") => Some("x86_64-pc-windows-msvc"),
         Some("macos") => Some("aarch64-apple-darwin"),
         _ => None,
@@ -289,5 +297,64 @@ app_group = "group.com.example.fallback"
         assert_eq!(metadata.version, "1.0.0");
         assert_eq!(metadata.build_number, 1);
         assert_eq!(metadata.bundle_id, "com.example.pkg");
+    }
+
+    #[test]
+    fn musl_targets_resolve_consistently() {
+        // #4826: the musl target names must map to the musl rustc triple,
+        // share the [linux] perry.toml section, and agree with the codegen
+        // LLVM-triple resolver — otherwise library_search / codegen / link
+        // disagree about which target/<triple>/release dir to use.
+        for t in ["linux-musl", "linux-x86_64-musl"] {
+            assert_eq!(
+                super::rust_target_triple(Some(t)),
+                Some("x86_64-unknown-linux-musl"),
+                "rust_target_triple({t})"
+            );
+            assert_eq!(
+                perry_codegen::resolve_target_triple(t).as_deref(),
+                Some("x86_64-unknown-linux-musl"),
+                "resolve_target_triple({t})"
+            );
+            assert_eq!(super::target_bundle_section(Some(t)), Some("linux"));
+        }
+        assert_eq!(
+            super::rust_target_triple(Some("linux-aarch64-musl")),
+            Some("aarch64-unknown-linux-musl")
+        );
+        assert_eq!(
+            perry_codegen::resolve_target_triple("linux-aarch64-musl").as_deref(),
+            Some("aarch64-unknown-linux-musl")
+        );
+        assert_eq!(
+            super::target_bundle_section(Some("linux-aarch64-musl")),
+            Some("linux")
+        );
+    }
+
+    #[test]
+    fn libc_flag_upgrades_linux_targets_to_musl() {
+        use crate::commands::compile::apply_libc_to_target;
+        let m = |t: Option<&str>, libc: Option<&str>| {
+            apply_libc_to_target(t.map(str::to_string), libc).unwrap()
+        };
+        // No flag / glibc → unchanged.
+        assert_eq!(m(Some("linux"), None), Some("linux".to_string()));
+        assert_eq!(m(Some("linux"), Some("glibc")), Some("linux".to_string()));
+        // musl upgrades the Linux variants.
+        assert_eq!(m(None, Some("musl")), Some("linux-musl".to_string()));
+        assert_eq!(m(Some("linux"), Some("musl")), Some("linux-musl".to_string()));
+        assert_eq!(
+            m(Some("linux-aarch64"), Some("musl")),
+            Some("linux-aarch64-musl".to_string())
+        );
+        // Idempotent.
+        assert_eq!(
+            m(Some("linux-musl"), Some("musl")),
+            Some("linux-musl".to_string())
+        );
+        // Non-Linux target + musl, and unknown libc, are hard errors.
+        assert!(apply_libc_to_target(Some("windows".into()), Some("musl")).is_err());
+        assert!(apply_libc_to_target(Some("linux".into()), Some("uclibc")).is_err());
     }
 }

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -493,7 +493,9 @@ const _cjs = (function() {{
 fn target_node_platform(target: Option<&str>) -> Option<&'static str> {
     match target {
         Some("windows") | Some("windows-winui") => Some("win32"),
-        Some("linux") | Some("linux-x86_64") | Some("linux-arm64") | Some("linux-aarch64") => {
+        Some("linux") | Some("linux-x86_64") | Some("linux-arm64") | Some("linux-aarch64")
+        // musl shares node's `process.platform === "linux"` (#4826).
+        | Some("linux-musl") | Some("linux-x86_64-musl") | Some("linux-aarch64-musl") => {
             Some("linux")
         }
         Some("macos")

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -273,6 +273,27 @@ pub(super) fn build_and_run_link(
     let is_harmonyos = matches!(target, Some("harmonyos") | Some("harmonyos-simulator"));
     let is_linux = matches!(target, Some(t) if t.starts_with("linux"))
         || (target.is_none() && cfg!(target_os = "linux"));
+    // Fully-static musl Linux target (#4826) — a sub-case of is_linux. The
+    // link command itself is built in select_linker_command (musl driver +
+    // `-static`); here it only changes which system libs we request.
+    let is_musl = matches!(
+        target,
+        Some("linux-musl") | Some("linux-x86_64-musl") | Some("linux-aarch64-musl")
+    );
+
+    // The musl target is meant for headless/serverless binaries (Lambda,
+    // scratch, distroless). The GTK4 UI backend (perry/ui) links the system
+    // GTK/glib/webkit stack, which is only shipped for glibc and cannot be
+    // statically linked into a musl binary. Fail fast with an actionable
+    // message rather than emitting cryptic undefined-symbol errors (#4826).
+    if is_musl && ctx.needs_ui {
+        anyhow::bail!(
+            "perry/ui is not supported with the static musl Linux target \
+             (--libc musl / [linux] libc = \"musl\"): the GTK4 UI backend \
+             requires dynamic glibc. Build the GUI app with the default \
+             (glibc) Linux target, or drop perry/ui for a headless musl build."
+        );
+    }
     let is_windows = matches!(target, Some("windows") | Some("windows-winui"))
         || (target.is_none() && cfg!(target_os = "windows"));
     let is_cross_windows = is_windows && !cfg!(target_os = "windows");
@@ -879,7 +900,11 @@ pub(super) fn build_and_run_link(
             .arg("-lpthread")
             .arg("-ldl");
 
-        if ctx.needs_stdlib {
+        // -lssl/-lcrypto are vestigial — Perry's stdlib is rustls-only (no
+        // system OpenSSL). On glibc they happen to be present so the link
+        // tolerates them, but a static musl sysroot has no libssl.a/libcrypto.a
+        // and the link would fail. Skip them for musl (#4826).
+        if ctx.needs_stdlib && !is_musl {
             cmd.arg("-lssl").arg("-lcrypto");
         }
     } else if is_windows {

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -628,12 +628,9 @@ pub fn select_linker_command(
                 "x86_64-unknown-linux-musl",
             )
         };
-        let musl_gcc =
-            std::env::var(cc_env).unwrap_or_else(|_| default_musl_gcc.to_string());
+        let musl_gcc = std::env::var(cc_env).unwrap_or_else(|_| default_musl_gcc.to_string());
         let musl_gcc_on_path = std::env::var_os("PATH")
-            .map(|paths| {
-                std::env::split_paths(&paths).any(|d| d.join(&musl_gcc).is_file())
-            })
+            .map(|paths| std::env::split_paths(&paths).any(|d| d.join(&musl_gcc).is_file()))
             .unwrap_or(false);
         let mut c = if musl_gcc_on_path {
             Command::new(musl_gcc)

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -596,6 +596,61 @@ pub fn select_linker_command(
             }
             c
         }
+    } else if matches!(
+        target,
+        Some("linux-musl") | Some("linux-x86_64-musl") | Some("linux-aarch64-musl")
+    ) {
+        // Fully-static musl Linux target (#4826). Produces a binary with no
+        // dynamic-loader / glibc dependency, so it runs unchanged on AWS
+        // Lambda `provided.al2023` (glibc 2.34), scratch/distroless
+        // containers, Cloud Run, etc. — the GLIBC_2.39-not-found failures
+        // happen in the *loader*, before Perry's tiny-init ever runs, so a
+        // static binary sidesteps them entirely.
+        //
+        // Driver: prefer the musl gcc wrapper (`musl-gcc` for x86_64, from
+        // the `musl-tools` package) which carries musl's specs + sysroot +
+        // crt objects. Fall back to clang/cc with an explicit musl triple +
+        // a sysroot from PERRY_LINUX_MUSL_SYSROOT (mirrors the glibc-cross
+        // fallback below). The perry-runtime / perry-stdlib `.a` files for
+        // the musl triple are built by release-packages.yml and resolved by
+        // library_search.rs via rust_target_triple().
+        let is_musl_aarch64 = target == Some("linux-aarch64-musl");
+        let (cc_env, default_musl_gcc, clang_triple) = if is_musl_aarch64 {
+            (
+                "PERRY_LINUX_MUSL_AARCH64_CC",
+                "aarch64-linux-musl-gcc",
+                "aarch64-unknown-linux-musl",
+            )
+        } else {
+            (
+                "PERRY_LINUX_MUSL_CC",
+                "musl-gcc",
+                "x86_64-unknown-linux-musl",
+            )
+        };
+        let musl_gcc =
+            std::env::var(cc_env).unwrap_or_else(|_| default_musl_gcc.to_string());
+        let musl_gcc_on_path = std::env::var_os("PATH")
+            .map(|paths| {
+                std::env::split_paths(&paths).any(|d| d.join(&musl_gcc).is_file())
+            })
+            .unwrap_or(false);
+        let mut c = if musl_gcc_on_path {
+            Command::new(musl_gcc)
+        } else {
+            let mut c = Command::new("cc");
+            c.arg("-target").arg(clang_triple);
+            c.arg("-fuse-ld=lld");
+            if let Ok(sysroot) = std::env::var("PERRY_LINUX_MUSL_SYSROOT") {
+                c.arg(format!("--sysroot={}", sysroot));
+            }
+            c
+        };
+        // Fully static link: no interpreter, libc/libm/libpthread/libdl all
+        // folded into the executable. musl's libc.a is self-contained, so
+        // this is the supported/portable mode (unlike a fully-static glibc).
+        c.arg("-static");
+        c
     } else if is_linux {
         // Linux target: when running on Linux natively, just use "cc".
         // When cross-compiling from macOS, use clang + ld.lld + a glibc

--- a/crates/perry/src/commands/compile/lock_scan.rs
+++ b/crates/perry/src/commands/compile/lock_scan.rs
@@ -146,6 +146,10 @@ fn derive_target_key(target: Option<&str>) -> String {
         None => format!("{}-{}", std::env::consts::OS, arch),
         Some("macos") => format!("macos-{}", arch),
         Some("linux") => format!("linux-{}", arch),
+        // musl: keep the linux-<arch> lock key (#4826).
+        Some("linux-musl") | Some("linux-x86_64-musl") | Some("linux-aarch64-musl") => {
+            format!("linux-{}", arch)
+        }
         Some("windows") | Some("windows-winui") => format!("windows-{}", arch),
         Some("ios") => "ios".to_string(),
         Some("ios-simulator") => "ios-simulator".to_string(),

--- a/crates/perry/src/commands/compile/resolve/native_library.rs
+++ b/crates/perry/src/commands/compile/resolve/native_library.rs
@@ -63,7 +63,9 @@ pub(super) fn native_manifest_target_key(target: Option<&str>) -> &'static str {
         // (#4826). Prebuilt native addons are typically glibc; static-musl
         // apps using them is an inherent limitation, but the platform key
         // stays "linux" so resolution behaves consistently.
-        Some("linux") | Some("linux-musl") | Some("linux-x86_64-musl")
+        Some("linux")
+        | Some("linux-musl")
+        | Some("linux-x86_64-musl")
         | Some("linux-aarch64-musl") => "linux",
         // WinUI (#4680) is the same OS/arch as the Win32 target for native
         // library resolution (D3d12/Vulkan backends, x64 prebuilts).

--- a/crates/perry/src/commands/compile/resolve/native_library.rs
+++ b/crates/perry/src/commands/compile/resolve/native_library.rs
@@ -59,7 +59,12 @@ pub(super) fn native_manifest_target_key(target: Option<&str>) -> &'static str {
         Some("tvos-simulator") | Some("tvos") => "tvos",
         Some("watchos-simulator") | Some("watchos") => "watchos",
         Some("harmonyos-simulator") | Some("harmonyos") => "harmonyos",
-        Some("linux") => "linux",
+        // musl resolves the same native-library platform as glibc Linux
+        // (#4826). Prebuilt native addons are typically glibc; static-musl
+        // apps using them is an inherent limitation, but the platform key
+        // stays "linux" so resolution behaves consistently.
+        Some("linux") | Some("linux-musl") | Some("linux-x86_64-musl")
+        | Some("linux-aarch64-musl") => "linux",
         // WinUI (#4680) is the same OS/arch as the Win32 target for native
         // library resolution (D3d12/Vulkan backends, x64 prebuilts).
         Some("windows") | Some("windows-winui") => "windows",

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -113,6 +113,16 @@ pub struct CompileArgs {
     #[arg(long)]
     pub target: Option<String>,
 
+    /// C library / linkage for Linux targets: `glibc` (default, dynamic) or
+    /// `musl` (fully static). `--libc musl` upgrades a Linux target
+    /// (`linux` / `linux-aarch64`, or the native-host default) to its musl
+    /// variant, producing a binary with no glibc loader dependency that runs
+    /// on AWS Lambda `provided.al2023`, scratch/distroless containers, Cloud
+    /// Run, etc. Equivalent to passing `--target linux-musl`. Ignored for
+    /// non-Linux targets. See #4826.
+    #[arg(long)]
+    pub libc: Option<String>,
+
     /// App bundle identifier (required for widget targets)
     #[arg(long)]
     pub app_bundle_id: Option<String>,

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -285,6 +285,7 @@ fn build_once(
         no_codegen: false,
         enable_wasm_runtime: false,
         target: None,
+        libc: None,
         app_bundle_id: None,
         output_type: "executable".to_string(),
         bundle_extensions: None,

--- a/crates/perry/src/commands/publish/args.rs
+++ b/crates/perry/src/commands/publish/args.rs
@@ -6,6 +6,15 @@ pub struct PublishArgs {
     #[arg(value_enum)]
     pub platform: Option<Platform>,
 
+    /// C library for the `linux` target: `glibc` (default, dynamic) or
+    /// `musl` (fully static). `--libc musl` produces a binary with no glibc
+    /// loader dependency that runs on AWS Lambda `provided.al2023`,
+    /// scratch/distroless containers, and Cloud Run. Overrides the
+    /// `[linux] libc` setting in perry.toml. Ignored for non-Linux targets.
+    /// See #4826.
+    #[arg(long)]
+    pub libc: Option<String>,
+
     /// Build server URL
     #[arg(long, default_value = "https://hub.perryts.com")]
     pub server: Option<String>,

--- a/crates/perry/src/commands/publish/config_types.rs
+++ b/crates/perry/src/commands/publish/config_types.rs
@@ -193,6 +193,10 @@ pub(super) struct LinuxConfig {
     pub(super) format: Option<String>,
     pub(super) category: Option<String>,
     pub(super) description: Option<String>,
+    /// C library / linkage: `glibc` (default, dynamic) or `musl` (fully
+    /// static — runs on AWS Lambda provided.al2023, scratch/distroless,
+    /// Cloud Run, with no glibc loader dependency). #4826.
+    pub(super) libc: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -187,9 +187,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
             .or_else(|| config.linux.as_ref().and_then(|l| l.libc.clone()));
         match raw.as_deref().map(|s| s.trim().to_ascii_lowercase()) {
             None => None,
-            Some(ref s) if s == "glibc" || s == "gnu" || s.is_empty() => {
-                Some("glibc".to_string())
-            }
+            Some(ref s) if s == "glibc" || s == "gnu" || s.is_empty() => Some("glibc".to_string()),
             Some(ref s) if s == "musl" => Some("musl".to_string()),
             Some(other) => bail!(
                 "Invalid [linux] libc / --libc value '{other}'. \

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -176,6 +176,30 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
     let is_android = target_name == "android";
     let is_linux = target_name == "linux";
 
+    // --- Resolve Linux libc (#4826) ---
+    // `--libc` CLI flag wins over the `[linux] libc` perry.toml setting.
+    // Normalize + validate here so the worker only ever receives `glibc`
+    // (or absent) / `musl`. Non-Linux targets ignore it.
+    let linux_libc: Option<String> = if is_linux {
+        let raw = args
+            .libc
+            .clone()
+            .or_else(|| config.linux.as_ref().and_then(|l| l.libc.clone()));
+        match raw.as_deref().map(|s| s.trim().to_ascii_lowercase()) {
+            None => None,
+            Some(ref s) if s == "glibc" || s == "gnu" || s.is_empty() => {
+                Some("glibc".to_string())
+            }
+            Some(ref s) if s == "musl" => Some("musl".to_string()),
+            Some(other) => bail!(
+                "Invalid [linux] libc / --libc value '{other}'. \
+                 Supported: glibc (default) or musl."
+            ),
+        }
+    } else {
+        None
+    };
+
     // --- Resolve server URL ---
     let server_url = args
         .server
@@ -1280,6 +1304,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
         } else {
             None
         },
+        linux_libc: linux_libc.clone(),
         release_notes: config.release_notes.clone(),
         features: config.project.as_ref().and_then(|p| p.features.clone()),
     };

--- a/crates/perry/src/commands/publish/server_api.rs
+++ b/crates/perry/src/commands/publish/server_api.rs
@@ -140,6 +140,10 @@ pub(super) struct BuildManifest {
     pub(super) linux_category: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) linux_description: Option<String>,
+    /// `glibc` (default) or `musl` (fully static). Drives the worker's
+    /// `perry compile --target linux[-musl]` selection. #4826.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) linux_libc: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) release_notes: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -70,6 +70,12 @@ pub struct RunArgs {
     #[arg(long)]
     pub type_check: bool,
 
+    /// C library for Linux targets: `glibc` (default) or `musl` (fully
+    /// static). `--libc musl` upgrades a Linux target to its musl variant
+    /// (e.g. `perry run linux --libc musl`). See #4826.
+    #[arg(long)]
+    pub libc: Option<String>,
+
     /// Force local compilation (error if toolchain missing)
     #[arg(long)]
     pub local: bool,
@@ -206,6 +212,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         no_codegen: false,
         enable_wasm_runtime: args.enable_wasm_runtime,
         target: target.clone(),
+        libc: args.libc.clone(),
         app_bundle_id: Some(bundle_id),
         output_type: "executable".to_string(),
         bundle_extensions: None,


### PR DESCRIPTION
## Problem
Perry Hub Linux binaries are dynamically linked and require GLIBC_2.39 (+GLIBC_2.35). They fail to load on **AWS Lambda `provided.al2023`** (glibc 2.34: `/lib64/libc.so.6: version 'GLIBC_2.39' not found` → exit 1), and on minimal **scratch/distroless** containers / Cloud Run. The failure is in the dynamic loader, before Perry's tiny-init runs.

## Fix
Add a fully-static `x86_64-unknown-linux-musl` target that runs anywhere (Lambda, scratch, distroless, Cloud Run). Selectable via:
- `perry publish linux --libc musl` / `perry compile … --libc musl`
- `[linux] libc = "musl"` in `perry.toml`

Both fold into the new `linux-musl` target family (`linux-musl`/`linux-x86_64-musl` → `x86_64-unknown-linux-musl`, `linux-aarch64-musl` → aarch64).

### Why this is small
- Perry's stdlib is **rustls-only — no system OpenSSL**, so the `-lssl -lcrypto` link flags were vestigial; they're dropped for musl (a static musl sysroot has no `libssl.a`).
- Release CI **already builds** `perry-runtime` + `perry-stdlib` for the musl triple (a staticlib bakes in the musl-targeted Rust std), so the final link only needs `musl-gcc`.

## Changes
- **Target resolution** — `resolve_target_triple`, `rust_target_triple`, `target_bundle_section`, plus node-platform / native-lib / lock-scan keys.
- **Linking** — new musl branch: `musl-gcc` (fallback `clang -target … --sysroot=$PERRY_LINUX_MUSL_SYSROOT`) + `-static`; drop `-lssl/-lcrypto`; **hard-error if `perry/ui` (GTK4, glibc-only) is used with musl**.
- **CLI/manifest** — `--libc` on compile/run/publish; `[linux] libc`; `BuildManifest.linux_libc` for the remote worker.
- **Tests** — target mappings + `--libc` → target folding.

Pairs with a PerryTS/builder-linux change that passes `--target linux-musl` and fetches the musl libs on the worker.

Refs #4826