### PR TITLE
fix(codegen): materialize cross-module method call on imported function (Stripe extend) (#4831)

### DIFF
--- a/crates/perry-codegen/src/expr/static_method.rs
+++ b/crates/perry-codegen/src/expr/static_method.rs
@@ -301,6 +301,73 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     &lowered,
                 ));
             }
+            // #4831 (Stripe-style `StripeResource.extend(...)`): the receiver
+            // is an imported *function* (or class-ref) that carries the called
+            // method as a DYNAMIC own property — e.g. `function StripeResource()
+            // {}; StripeResource.extend = protoExtend;` in one module, then
+            // `StripeResource.extend({...})` in another. The HIR's "uppercase
+            // imported Ident looks like a class" rule lifts this to a
+            // `StaticMethodCall`, but there is no compile-time class static to
+            // resolve (`ctx.methods` miss above), it isn't a namespace import,
+            // and it isn't a V8-fallback specifier — so the pre-fix code fell
+            // here and returned the literal `0`. That made every Stripe resource
+            // method (`stripe.products.create`, etc.) `undefined`/non-callable.
+            //
+            // When the receiver name resolves to a materializable imported value
+            // (a native `import_function_prefixes` symbol or a `class_ids`
+            // class-ref), route the call through the runtime method dispatcher:
+            // materialize the receiver, read the named method off its dynamic
+            // props, and invoke it with `this` bound to the receiver. This is
+            // the same dispatch the same-module `Base.extend()` path already
+            // uses, and it is strictly better than the `0` stub for every other
+            // case that reached here. Related: #4656 (general prototype-chain
+            // `[[Get]]` inheritance); this fix is scoped to the cross-module
+            // dynamic-method-on-imported-function call shape.
+            if ctx.import_function_prefixes.contains_key(class_name)
+                || ctx.class_ids.contains_key(class_name)
+            {
+                let recv_box = lower_expr(
+                    ctx,
+                    &Expr::ExternFuncRef {
+                        name: class_name.clone(),
+                        param_types: vec![],
+                        return_type: HirType::Any,
+                    },
+                )?;
+                let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
+                for a in args {
+                    lowered_args.push(lower_expr(ctx, a)?);
+                }
+                let (args_ptr, args_len) = if lowered_args.is_empty() {
+                    ("null".to_string(), "0".to_string())
+                } else {
+                    let n = lowered_args.len();
+                    let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+                    {
+                        let blk = ctx.block();
+                        for (i, value) in lowered_args.iter().enumerate() {
+                            let slot = blk.gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
+                            blk.store(DOUBLE, value, &slot);
+                        }
+                    }
+                    (buf, n.to_string())
+                };
+                let method_idx = ctx.strings.intern(method_name);
+                let entry = ctx.strings.entry(method_idx);
+                let bytes_global = format!("@{}", entry.bytes_global);
+                let name_len = entry.byte_len.to_string();
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_native_call_method",
+                    &[
+                        (DOUBLE, &recv_box),
+                        (PTR, &bytes_global),
+                        (I64, &name_len),
+                        (PTR, &args_ptr),
+                        (I64, &args_len),
+                    ],
+                ));
+            }
             for a in args {
                 let _ = lower_expr(ctx, a)?;
             }

--- a/test-files/fixtures/issue_4831_stripe/products.ts
+++ b/test-files/fixtures/issue_4831_stripe/products.ts
@@ -1,0 +1,9 @@
+// Mirrors Stripe's compiled `resources/Products.js`: builds the resource via
+// the cross-module `StripeResource.extend({ create: stripeMethod(...) })`.
+import { StripeResource } from "./resource";
+const stripeMethod = (StripeResource as any).method;
+
+export const Products: any = (StripeResource as any).extend({
+  create: stripeMethod({ method: "POST", fullPath: "/v1/products" }),
+  retrieve: stripeMethod({ method: "GET", fullPath: "/v1/products/{id}" }),
+});

--- a/test-files/fixtures/issue_4831_stripe/resource.ts
+++ b/test-files/fixtures/issue_4831_stripe/resource.ts
@@ -1,0 +1,39 @@
+// Mirrors Stripe's compiled `StripeResource.js` + `utils.protoExtend` +
+// `StripeMethod.stripeMethod`: a plain constructor FUNCTION whose `.prototype`
+// is reassigned to an object literal, a Backbone-style `extend` factory, and a
+// `stripeMethod` closure factory. Defined in its OWN module so the consumer
+// reaches `extend`/`method` cross-module (this is the shape that broke #4831).
+export function stripeMethod(spec: any) {
+  return function (this: any, ...args: any[]) {
+    return "called:" + spec.method + " path:" + this.path;
+  };
+}
+
+function protoExtend(this: any, sub: any) {
+  const Super: any = this;
+  const Constructor: any = Object.prototype.hasOwnProperty.call(sub, "constructor")
+    ? sub.constructor
+    : function (this: any, ...args: any[]) {
+        Super.apply(this, args);
+      };
+  Object.assign(Constructor, Super);
+  Constructor.prototype = Object.create(Super.prototype);
+  Object.assign(Constructor.prototype, sub);
+  return Constructor;
+}
+
+export function StripeResource(this: any, stripe: any) {
+  this._stripe = stripe;
+  this.path = "init-path";
+  this.initialize();
+}
+(StripeResource as any).extend = protoExtend;
+(StripeResource as any).method = stripeMethod;
+(StripeResource as any).prototype = {
+  _stripe: null,
+  path: "",
+  initialize() {},
+  _makeRequest() {
+    return "req";
+  },
+};

--- a/test-files/test_issue_4831_stripe_proto_methods.ts
+++ b/test-files/test_issue_4831_stripe_proto_methods.ts
@@ -1,0 +1,46 @@
+// Issue #4831: Stripe Node SDK — all resource methods undefined
+// (`stripe.products.create` etc. is not a function).
+//
+// Root cause: the Stripe SDK builds resource methods cross-module via
+// `StripeResource.extend({ create: stripeMethod(...) })`. `StripeResource` is a
+// plain FUNCTION imported from another module, and `extend`/`method` are
+// DYNAMIC own properties (closures) assigned onto it. Perry's HIR lowering
+// lifts the call `StripeResource.extend(...)` to a `StaticMethodCall` because
+// the receiver is an uppercase imported identifier that "looks like a class".
+// At codegen, that StaticMethodCall resolved through none of the known paths
+// (it is not a same-module class static, not a namespace import, not a
+// V8-fallback specifier), so the fallback returned the literal `0` — the call
+// never invoked `protoExtend`, the resource constructor was garbage, and every
+// resource method (`create`, `retrieve`, …) was missing/undefined.
+//
+// Fix: when the StaticMethodCall receiver resolves to a materializable imported
+// value (a native imported-function symbol or an imported class-ref), route the
+// call through the runtime method dispatcher (`js_native_call_method`), which
+// reads the named method off the receiver's dynamic props and invokes it with
+// `this` bound to the receiver — the same dispatch the same-module path uses.
+// (Related to #4656, the general prototype-chain `[[Get]]` inheritance gap;
+// this fix is scoped to the cross-module dynamic-method-on-imported-function
+// call shape that Stripe exercises.)
+//
+// File: crates/perry-codegen/src/expr/static_method.rs
+import { Products } from "./fixtures/issue_4831_stripe/products";
+
+// ResourceNamespace-style instantiation: `new resources[name](stripe)` — a
+// computed-member `new` whose constructor is the cross-module `extend` result.
+const resources: any = { Products: Products };
+
+function ResourceNamespace(this: any, stripe: any, res: any) {
+  for (const name in res) {
+    if (!Object.prototype.hasOwnProperty.call(res, name)) continue;
+    const camel = name[0].toLowerCase() + name.substring(1);
+    this[camel] = new res[name](stripe);
+  }
+}
+
+const stripe: any = new (ResourceNamespace as any)("sk_test_dummy", resources);
+
+console.log("typeof stripe.products?.create:", typeof stripe.products?.create);
+console.log("typeof stripe.products?.retrieve:", typeof stripe.products?.retrieve);
+console.log("stripe.products.create():", stripe.products.create());
+console.log("stripe.products._stripe:", stripe.products._stripe);
+console.log("typeof stripe.products._makeRequest:", typeof stripe.products._makeRequest);


### PR DESCRIPTION
Fixes #4831.

## Problem
The official Stripe Node SDK (v17) compiled with Perry had resource namespaces present (`stripe.products`, `stripe.customers`, …) but EVERY resource method was `undefined` (`stripe.products.create`, etc.), so any call threw `TypeError: create is not a function` — blocking all Stripe operations.

## Root cause
**Not** a prototype-chain `[[Get]]` bug (the suspected shared defect with #4656 — that path works in isolation; all primitive/same-module repros pass). The bug is in HIR-lowering + codegen of a **method call on an imported function**, and only reproduces **cross-module**:

- Stripe defines `StripeResource` as a plain *function* in one module, with `extend`/`method` attached as dynamic own properties. Resource modules call `StripeResource.extend({...})` cross-module.
- HIR lowering (`static_and_instance.rs`) treats any uppercase imported identifier as a candidate class and lifts `StripeResource.extend(...)` to `Expr::StaticMethodCall` (it lacks cross-module metadata to distinguish a real class from a plain function).
- At codegen (`crates/perry-codegen/src/expr/static_method.rs`) that `StaticMethodCall` matched none of the resolution paths and the terminal fallback returned the literal `0`. So `extend` was never invoked → the resource constructor was `0` → every method missing.

## Fix
In `static_method.rs`, before the `double_literal(0.0)` stub: when the receiver resolves to a materializable imported value (`import_function_prefixes` symbol or `class_ids` class-ref), route through the runtime method dispatcher `js_native_call_method` (materialize receiver, read the named dynamic-prop method, invoke with `this` bound to the receiver) — the same dispatch the working same-module path already uses. Strictly better than the `0` stub.

## Verification
Dependency-free repros of each Stripe sub-mechanism (Object.create chain lookup, copying own props onto a prototype, methods-as-closures on a prototype, the full Backbone-style `extend`, and the exact `StripeResource.extend({create: stripeMethod(...)})` shape). Before: cross-module `Base.extend()` returned `0`/`undefined`. After:
```
typeof stripe.products?.create: function          (was: undefined)
stripe.products.create(): called:POST path:init-path
stripe.products._stripe: sk_test_dummy
typeof stripe.products._makeRequest: function     (inherited from base prototype)
```
All `perry-codegen`/`perry-hir` unit tests pass; imported-class statics (`Widget.make()`) and cross-module tests still pass. Regression test: `test-files/test_issue_4831_stripe_proto_methods.ts` (+ fixtures). Real `stripe` v17 needs `perry.compilePackages` + transitive JS deps to compile end-to-end (compile-as-package path, out of scope); the minimal repro reproduces the exact failing mechanism.

## Relationship to #4656
Different bug — left untouched. #4656 is general prototype `[[Get]]` inheritance (works in isolation here); #4831 was cross-module dynamic-method-on-imported-function *call* lowering.