### PR TITLE
fix(ui-windows): WebView2 COM init + sync-pump use-after-take; unblock crate build (#4835)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6174,6 +6174,7 @@ dependencies = [
  "qrcodegen",
  "webview2-com",
  "windows",
+ "windows-core 0.58.0",
 ]
 
 [[package]]

--- a/crates/perry-ui-windows/Cargo.toml
+++ b/crates/perry-ui-windows/Cargo.toml
@@ -34,6 +34,11 @@ webview2-com = "=0.34"
 geisterhand = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
+# The `#[implement]` macro from `windows` 0.58 expands to absolute
+# `::windows_core::` paths, so the consuming crate must depend on
+# `windows-core` directly or the COM authoring in drag_drop.rs fails to
+# resolve `windows_core` (E0433). Pinned to 0.58 to match `windows`.
+windows-core = "0.58"
 windows = { version = "0.58", features = [
     # `#[implement]` — needed to author the IDropTarget / IDropSource /
     # IDataObject COM objects for native drag-and-drop (#4773).

--- a/crates/perry-ui-windows/src/drag_drop.rs
+++ b/crates/perry-ui-windows/src/drag_drop.rs
@@ -239,7 +239,7 @@ mod imp {
     }
 
     #[allow(non_snake_case)]
-    impl IDataObject_Impl for PerryDataObject {
+    impl IDataObject_Impl for PerryDataObject_Impl {
         fn GetData(&self, pformatetcin: *const FORMATETC) -> windows::core::Result<STGMEDIUM> {
             let fmt = unsafe { &*pformatetcin };
             let Some(stored) = self.matches(fmt) else {
@@ -329,7 +329,7 @@ mod imp {
     struct PerryDropSource;
 
     #[allow(non_snake_case)]
-    impl IDropSource_Impl for PerryDropSource {
+    impl IDropSource_Impl for PerryDropSource_Impl {
         fn QueryContinueDrag(
             &self,
             fescapepressed: BOOL,
@@ -362,7 +362,7 @@ mod imp {
     }
 
     #[allow(non_snake_case)]
-    impl IDropTarget_Impl for PerryDropTarget {
+    impl IDropTarget_Impl for PerryDropTarget_Impl {
         fn DragEnter(
             &self,
             _pdataobj: Option<&IDataObject>,

--- a/crates/perry-ui-windows/src/widgets/webview.rs
+++ b/crates/perry-ui-windows/src/widgets/webview.rs
@@ -97,6 +97,24 @@ fn to_wide(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
+/// Initialize COM as a single-threaded apartment for the current (UI) thread.
+/// WebView2 environment creation requires an STA with a running message pump;
+/// without it the async completion handler never fires. Idempotent — a thread
+/// already in an apartment returns `S_FALSE` / `RPC_E_CHANGED_MODE`, both of
+/// which are fine for our purposes (we just need an STA to exist).
+#[cfg(target_os = "windows")]
+fn ensure_com_sta() {
+    use std::sync::Once;
+    use windows::Win32::System::Com::{CoInitializeEx, COINIT_APARTMENTTHREADED};
+    static COM_INIT: Once = Once::new();
+    COM_INIT.call_once(|| unsafe {
+        // Result intentionally ignored: S_OK on first init, S_FALSE if already
+        // initialized STA, RPC_E_CHANGED_MODE if the thread is already MTA
+        // (in which case WebView2 still works via the existing apartment).
+        let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+    });
+}
+
 #[cfg(target_os = "windows")]
 fn host_of_url_string(s: &str) -> String {
     let after_scheme = match s.find("://") {
@@ -176,6 +194,17 @@ pub fn create(url_ptr: *const u8, width: f64, height: f64, ephemeral_hint: f64) 
 
     #[cfg(target_os = "windows")]
     {
+        // WebView2's `CreateCoreWebView2EnvironmentWithOptions` requires the
+        // calling thread to be a COM single-threaded apartment (STA) with a
+        // running message loop — otherwise the async environment-creation
+        // completion handler is never posted back to our pump and init times
+        // out with HRESULT(0x80070005) "no result", leaving the pane blank
+        // and firing no navigation events (issue #4835). The dialog / file
+        // picker paths already call `CoInitializeEx(APARTMENTTHREADED)` for
+        // the same reason; WebView never did. This call is idempotent and
+        // tolerates a prior init (`S_FALSE` / `RPC_E_CHANGED_MODE`).
+        ensure_com_sta();
+
         let class_name = to_wide("STATIC");
         let window_text = to_wide("");
         let host = unsafe {
@@ -288,9 +317,18 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
         None => return Ok(()),
     };
 
+    // `env_done` holds the (non-Copy) result; `env_ready` is a separate Copy
+    // flag the message-pump predicate can poll *without* consuming the result.
+    // The previous code polled `env_done.take().is_some()`, which removed the
+    // value inside the predicate — so the subsequent `env_done.take()` always
+    // saw `None` and reported a spurious "no result" error even on a fully
+    // successful init (issue #4835). Keep the result intact; only `take()` it
+    // once, after the loop exits.
     let env_done: Rc<Cell<Option<windows::core::Result<ICoreWebView2Environment>>>> =
         Rc::new(Cell::new(None));
+    let env_ready: Rc<Cell<bool>> = Rc::new(Cell::new(false));
     let env_done_clone = env_done.clone();
+    let env_ready_clone = env_ready.clone();
 
     let user_data_wide = to_wide(user_data_dir.to_string_lossy().as_ref());
 
@@ -305,6 +343,7 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
             } else {
                 env_done_clone.set(Some(Err(windows::core::Error::from_win32())));
             }
+            env_ready_clone.set(true);
             Ok(())
         },
     ));
@@ -317,8 +356,7 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
             &env_handler,
         )?;
     }
-    pump_messages_until(|| env_done.take().is_some());
-    // We just took the result. We need to re-set it to retrieve below.
+    pump_messages_until(|| env_ready.get());
     let env_result = env_done.take().unwrap_or_else(|| {
         Err(windows::core::Error::new(
             windows::core::HRESULT(0x8007_0005_u32 as i32),
@@ -330,7 +368,9 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
     // Step 2: create controller bound to host_hwnd.
     let ctrl_done: Rc<Cell<Option<windows::core::Result<ICoreWebView2Controller>>>> =
         Rc::new(Cell::new(None));
+    let ctrl_ready: Rc<Cell<bool>> = Rc::new(Cell::new(false));
     let ctrl_done_clone = ctrl_done.clone();
+    let ctrl_ready_clone = ctrl_ready.clone();
 
     let ctrl_handler = CreateCoreWebView2ControllerCompletedHandler::create(Box::new(
         move |error_code, controller| {
@@ -343,6 +383,7 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
             } else {
                 ctrl_done_clone.set(Some(Err(windows::core::Error::from_win32())));
             }
+            ctrl_ready_clone.set(true);
             Ok(())
         },
     ));
@@ -350,7 +391,8 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
     unsafe {
         env.CreateCoreWebView2Controller(host_hwnd, &ctrl_handler)?;
     }
-    pump_messages_until(|| ctrl_done.take().is_some());
+    // Same peek-don't-consume pattern as the environment handler above.
+    pump_messages_until(|| ctrl_ready.get());
     let ctrl_result = ctrl_done.take().unwrap_or_else(|| {
         Err(windows::core::Error::new(
             windows::core::HRESULT(0x8007_0005_u32 as i32),


### PR DESCRIPTION
Fixes #4835.

## Problem
WebView didn't render on Windows 11: the pane stayed blank, no page loaded, and `onError` never fired. Reproduced on a Windows 11 host with WebView2 Runtime 148 installed.

## Diagnosis
Windows WebView is a **full WebView2 backend** (all 4 widget wiring points present) — implemented but broken by two runtime bugs, plus a pre-existing build break that stopped the crate from compiling on a Windows host at all.

## Root causes & fixes
1. **Missing COM initialization.** `WebView::create()` called `CreateCoreWebView2EnvironmentWithOptions` without ever putting the UI thread into a COM apartment. WebView2 env creation requires an STA, so it failed with `HRESULT(0x800401F0)` ("CoInitialize has not been called") and the async completion handler never ran. Added an idempotent `ensure_com_sta()` (the dialog/file-picker code already did `CoInitializeEx(APARTMENTTHREADED)`; WebView never did).
2. **Use-after-`take()` in the sync message pump.** `init_webview2_sync` polled completion with `pump_messages_until(|| env_done.take().is_some())`. `Cell::take()` *removes* the value, so the predicate consumed the result the instant the handler delivered it; the later `env_done.take()` then saw `None` and returned a bogus `0x80070005` even on success — and masked bug #1. Fixed by polling a separate `Cell<bool>` ready-flag (peek, don't consume) and `take()`ing the result once after the loop, for both env and controller handlers.

## Build break unblocked (pre-existing, from #4791 — not #4835)
`perry-ui-windows` did not compile on Windows: `drag_drop.rs` used the pre-0.58 `windows`-crate `#[implement]` idiom (`impl Trait_Impl for Struct`); `windows` 0.58 requires the macro-generated `_Impl` wrapper (`for Struct_Impl`), matching how `webview2-com` 0.34 does it. Also added `windows-core = "0.58"` so the macro's `::windows_core::` expansion resolves. Without this, WebView couldn't build or be tested. **Flagging for the #4773/#4791 owner — that PR's drag-and-drop was never compiled on Windows.**

## Verification
- Full build of `-p perry-ui-windows -p perry-runtime -p perry-stdlib -p perry` succeeds; `cargo test -p perry-ui-windows` passes.
- A probe app (`WebView({url, onLoaded, onError})` + `process.exit`) runs to exit 0 with `onLoaded` returning `https://example.com/` — env+controller init, navigation, and event callbacks all work end-to-end.
- The exact issue repro (google.com + `allowedDomains` + `onError`→`alert`) runs without the silent failure.
- Isolated each fix: with COM init removed (take-bug fixed), init fails with the clear `0x800401F0` — proving **both** fixes are required.

**Could not verify:** did not visually observe rendered pixels (headless-ish session). The successful `NavigationCompleted(success=true)` + `onLoaded` URL is strong functional evidence the page rendered.

Files: `crates/perry-ui-windows/src/widgets/webview.rs`, `crates/perry-ui-windows/src/drag_drop.rs`, `crates/perry-ui-windows/Cargo.toml`.