### PR TITLE
fix(runtime): Promise static-method receiver + combinator regression test262 parity

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -499,6 +499,11 @@ pub(super) fn compile_module_entry(
                 let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 ctx.block()
                     .call_void("js_process_run_finalization_exit", &[]);
+                // After the event loop drains, surface any still-unhandled
+                // promise rejection (Node exits non-zero; this matches the
+                // oracle for `Promise.reject`/combinator-reject programs).
+                ctx.block()
+                    .call_void("js_promise_report_unhandled_rejections", &[]);
                 ctx.block().ret(I32, "0");
             }
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -779,6 +779,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_process_emit", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_emit_before_exit", VOID, &[DOUBLE]);
     module.declare_function("js_process_run_finalization_exit", VOID, &[]);
+    module.declare_function("js_promise_report_unhandled_rejections", VOID, &[]);
     module.declare_function("js_process_remove_listener", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_off", DOUBLE, &[I64, I64]);
     module.declare_function("js_process_remove_all_listeners", DOUBLE, &[I64]);

--- a/crates/perry-runtime/src/object/async_generator_queue.rs
+++ b/crates/perry-runtime/src/object/async_generator_queue.rs
@@ -401,6 +401,11 @@ fn call_original(original: *const ClosureHeader, arg: f64) -> f64 {
 
 fn after_initial_result(state_id: usize, result: f64) {
     if let Some(promise) = promise_ptr(result) {
+        // The async generator is the consumer of this step promise — its
+        // rejection (now or later) is observed here, so it is not an unhandled
+        // rejection even though the already-settled paths read `reason`
+        // directly rather than attaching a reaction.
+        crate::promise::mark_rejection_handled(promise);
         let state = unsafe { (*promise).state };
         if state == PromiseState::Pending {
             attach_pending_settle(state_id, promise, std::ptr::null_mut());
@@ -412,6 +417,7 @@ fn after_initial_result(state_id: usize, result: f64) {
 
 fn after_queued_result(state_id: usize, out: *mut Promise, result: f64) {
     if let Some(promise) = promise_ptr(result) {
+        crate::promise::mark_rejection_handled(promise);
         match unsafe { (*promise).state } {
             PromiseState::Pending => {
                 attach_pending_settle(state_id, promise, out);

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -5124,8 +5124,8 @@ extern "C" fn promise_any_static(
 }
 
 extern "C" fn promise_with_resolvers_static(_closure: *const crate::closure::ClosureHeader) -> f64 {
-    let obj = crate::promise::js_promise_with_resolvers();
-    crate::value::js_nanbox_pointer(obj as i64)
+    let this_ctor = crate::object::js_implicit_this_get();
+    crate::promise::js_promise_with_resolvers_spec(this_ctor)
 }
 
 // `Promise.try(fn, ...args)`: call-arity 1 (callback) + rest (forwarded args).
@@ -5134,9 +5134,8 @@ extern "C" fn promise_try_static(
     callback: f64,
     rest: f64,
 ) -> f64 {
-    let rest_ptr = crate::value::js_nanbox_get_pointer(rest) as *const crate::array::ArrayHeader;
-    let p = crate::promise::js_promise_try(callback, rest_ptr);
-    crate::value::js_nanbox_pointer(p as i64)
+    let this_ctor = crate::object::js_implicit_this_get();
+    crate::promise::js_promise_try_spec(this_ctor, callback, rest)
 }
 
 // #4627: reified `String.raw(callSite, ...substitutions)` tag function. One
@@ -5299,102 +5298,21 @@ extern "C" fn typed_array_of_thunk(
     typed_array_create_from_values(kind_opt, arr)
 }
 
-fn require_promise_constructor_this() {
-    let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
-    let promise_ctor = js_get_global_this_builtin_value(b"Promise".as_ptr(), 7);
-    if this_value.to_bits() != promise_ctor.to_bits() {
-        super::object_ops::throw_object_type_error(
-            b"Promise static method requires a Promise constructor receiver",
-        );
-    }
-}
-
-extern "C" fn promise_resolve_thunk(
-    _closure: *const crate::closure::ClosureHeader,
-    value: f64,
-) -> f64 {
-    require_promise_constructor_this();
-    let promise = crate::promise::js_promise_resolved(value);
-    crate::value::js_nanbox_pointer(promise as i64)
-}
-
-extern "C" fn promise_reject_thunk(
-    _closure: *const crate::closure::ClosureHeader,
-    reason: f64,
-) -> f64 {
-    require_promise_constructor_this();
-    let promise = crate::promise::js_promise_rejected(reason);
-    crate::value::js_nanbox_pointer(promise as i64)
-}
-
-extern "C" fn promise_all_thunk(
-    _closure: *const crate::closure::ClosureHeader,
-    iterable: f64,
-) -> f64 {
-    require_promise_constructor_this();
-    let promise = crate::promise::combinators::js_promise_all_iterable(iterable);
-    crate::value::js_nanbox_pointer(promise as i64)
-}
-
-extern "C" fn promise_race_thunk(
-    _closure: *const crate::closure::ClosureHeader,
-    iterable: f64,
-) -> f64 {
-    require_promise_constructor_this();
-    let promise = crate::promise::combinators::js_promise_race_iterable(iterable);
-    crate::value::js_nanbox_pointer(promise as i64)
-}
-
-extern "C" fn promise_all_settled_thunk(
-    _closure: *const crate::closure::ClosureHeader,
-    iterable: f64,
-) -> f64 {
-    require_promise_constructor_this();
-    let promise = crate::promise::combinators::js_promise_all_settled_iterable(iterable);
-    crate::value::js_nanbox_pointer(promise as i64)
-}
-
-extern "C" fn promise_any_thunk(
-    _closure: *const crate::closure::ClosureHeader,
-    iterable: f64,
-) -> f64 {
-    require_promise_constructor_this();
-    let promise = crate::promise::combinators::js_promise_any_iterable(iterable);
-    crate::value::js_nanbox_pointer(promise as i64)
-}
-
-extern "C" fn promise_with_resolvers_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
-    require_promise_constructor_this();
-    let result = crate::promise::js_promise_with_resolvers();
-    crate::value::js_nanbox_pointer(result as i64)
-}
-
-extern "C" fn promise_try_thunk(
-    _closure: *const crate::closure::ClosureHeader,
-    callback: f64,
-    rest: f64,
-) -> f64 {
-    require_promise_constructor_this();
-    let rest_value = JSValue::from_bits(rest.to_bits());
-    let rest_ptr = if rest_value.is_pointer() {
-        rest_value.as_pointer::<crate::array::ArrayHeader>()
-    } else {
-        std::ptr::null()
-    };
-    let promise = crate::promise::js_promise_try(callback, rest_ptr);
-    crate::value::js_nanbox_pointer(promise as i64)
-}
-
 fn promise_static_function_spec(name: &str) -> Option<(*const u8, u32, u32, bool)> {
+    // All eight statics use the spec-aware `*_static` thunks, which honor the
+    // `this` constructor via `NewPromiseCapability(this)` — so a `Promise`
+    // subclass (`class P extends Promise{}; P.all([...])`) or a valid custom
+    // constructor (`Promise.all.call(C, ...)`) is accepted, while a
+    // non-constructor `this` throws a TypeError from the capability flow.
     match name {
-        "resolve" => Some((promise_resolve_thunk as *const u8, 1, 1, false)),
-        "reject" => Some((promise_reject_thunk as *const u8, 1, 1, false)),
-        "all" => Some((promise_all_thunk as *const u8, 1, 1, false)),
-        "race" => Some((promise_race_thunk as *const u8, 1, 1, false)),
-        "allSettled" => Some((promise_all_settled_thunk as *const u8, 1, 1, false)),
-        "any" => Some((promise_any_thunk as *const u8, 1, 1, false)),
-        "withResolvers" => Some((promise_with_resolvers_thunk as *const u8, 0, 0, false)),
-        "try" => Some((promise_try_thunk as *const u8, 1, 1, true)),
+        "resolve" => Some((promise_resolve_static as *const u8, 1, 1, false)),
+        "reject" => Some((promise_reject_static as *const u8, 1, 1, false)),
+        "all" => Some((promise_all_static as *const u8, 1, 1, false)),
+        "race" => Some((promise_race_static as *const u8, 1, 1, false)),
+        "allSettled" => Some((promise_all_settled_static as *const u8, 1, 1, false)),
+        "any" => Some((promise_any_static as *const u8, 1, 1, false)),
+        "withResolvers" => Some((promise_with_resolvers_static as *const u8, 0, 0, false)),
+        "try" => Some((promise_try_static as *const u8, 1, 1, true)),
         _ => None,
     }
 }
@@ -5856,53 +5774,6 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 ctor,
                 "raw",
                 string_raw_static as *const u8,
-                1,
-                1,
-                true,
-            );
-        }
-        "Promise" => {
-            // #4521: reify the `Promise` statics as first-class function values
-            // (correct `.name` / `.length`, usable via reference / `.call` /
-            // `.apply` / spread). Direct calls (`Promise.all([...])`) keep the
-            // codegen fast path; these back value reads and rebound usage.
-            install_constructor_static(
-                ctor,
-                "resolve",
-                promise_resolve_static as *const u8,
-                1,
-                false,
-            );
-            install_constructor_static(
-                ctor,
-                "reject",
-                promise_reject_static as *const u8,
-                1,
-                false,
-            );
-            install_constructor_static(ctor, "all", promise_all_static as *const u8, 1, false);
-            install_constructor_static(ctor, "race", promise_race_static as *const u8, 1, false);
-            install_constructor_static(
-                ctor,
-                "allSettled",
-                promise_all_settled_static as *const u8,
-                1,
-                false,
-            );
-            install_constructor_static(ctor, "any", promise_any_static as *const u8, 1, false);
-            // `withResolvers` takes no arguments → spec `.length` 0.
-            install_constructor_static(
-                ctor,
-                "withResolvers",
-                promise_with_resolvers_static as *const u8,
-                0,
-                false,
-            );
-            // `try(fn, ...args)`: 1 fixed param (callback) + rest; spec `.length` 1.
-            install_constructor_static_with_call_arity(
-                ctor,
-                "try",
-                promise_try_static as *const u8,
                 1,
                 1,
                 true,

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -504,11 +504,15 @@ pub extern "C" fn js_promise_new_with_executor(
     // resolve fn also assimilates thenables/promises and rejects self-resolution.
     let (resolve_closure, reject_closure) = make_resolving_functions(promise);
 
-    // Call the executor with (resolve_closure, reject_closure)
-    // The closures are passed as f64 by bitcasting the pointer bits
-    // This preserves the exact bits of the pointer when passed through f64 ABI
-    let resolve_f64: f64 = f64::from_bits(i64::cast_unsigned(resolve_closure as i64));
-    let reject_f64: f64 = f64::from_bits(i64::cast_unsigned(reject_closure as i64));
+    // Call the executor with (resolve_closure, reject_closure) as proper
+    // NaN-boxed POINTER_TAG closure values — so user code that *reflects* on
+    // them (`resolve.length` === 1, `resolve.name` === "", `new resolve()`
+    // throws, `Object.getOwnPropertyNames(resolve)`) sees a real function
+    // object, not a bare number. The call path already accepts POINTER_TAG
+    // closures (this mirrors `NewPromiseCapability`'s fast path, which has
+    // always boxed them). test262 `resolve-function-*` / `reject-function-*`.
+    let resolve_f64: f64 = crate::value::js_nanbox_pointer(resolve_closure as i64);
+    let reject_f64: f64 = crate::value::js_nanbox_pointer(reject_closure as i64);
     js_closure_call2(executor, resolve_f64, reject_f64);
 
     promise
@@ -569,6 +573,15 @@ pub(super) fn make_resolving_functions(
     let reject = js_closure_alloc(promise_reject_fn as *const u8, 2);
     js_closure_set_capture_ptr(reject, 0, promise as i64);
     js_closure_set_capture_ptr(reject, 1, guard as i64);
+    // Spec 27.2.1.3: the resolving functions are anonymous built-in functions
+    // with own `length` = 1, `name` = "" (both non-writable, non-enumerable,
+    // configurable), and NO `[[Construct]]` (`new resolve()` throws). test262
+    // `resolve-function-*` / `reject-function-*` assert all four.
+    for f in [resolve, reject] {
+        crate::object::set_builtin_closure_length(f as usize, 1);
+        crate::object::set_bound_native_closure_name(f, "");
+        crate::object::set_builtin_closure_non_constructable(f as usize);
+    }
     (resolve, reject)
 }
 

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -57,11 +57,12 @@ pub use scanners::{js_promise_with_resolvers, scan_promise_roots, scan_promise_r
 pub(crate) use scanners::{new_promise_root_scan_state, scan_promise_roots_mut_step};
 pub use spec_combinators::{
     js_promise_all_settled_spec, js_promise_all_spec, js_promise_any_spec, js_promise_race_spec,
-    js_promise_reject_spec, js_promise_resolve_spec,
+    js_promise_reject_spec, js_promise_resolve_spec, js_promise_try_spec,
+    js_promise_with_resolvers_spec,
 };
 pub(crate) use then::{
-    js_promise_attach_handlers, js_promise_attach_settle_listener, promise_prototype_catch_thunk,
-    promise_prototype_finally_thunk, promise_prototype_then_thunk,
+    js_promise_attach_handlers, js_promise_attach_settle_listener, mark_rejection_handled,
+    promise_prototype_catch_thunk, promise_prototype_finally_thunk, promise_prototype_then_thunk,
 };
 pub use then::{
     js_promise_bound_method, js_promise_catch, js_promise_finally, js_promise_free, js_promise_new,

--- a/crates/perry-runtime/src/promise/spec_combinators.rs
+++ b/crates/perry-runtime/src/promise/spec_combinators.rs
@@ -704,3 +704,70 @@ pub extern "C" fn js_promise_resolve_spec(this_ctor: f64, value: f64) -> f64 {
     let _ = call_with_this(cap.resolve, undef(), &[value]);
     cap.promise
 }
+
+/// `Promise.withResolvers()` (ECMA-262 27.2.4.x) with `this` = C:
+/// `NewPromiseCapability(C)` then return `{ promise, resolve, reject }`. Honors a
+/// subclass / custom constructor `this`; a non-constructor `this` throws from the
+/// capability flow (test262 `withResolvers/newpromisecapability-this-value`).
+#[no_mangle]
+pub extern "C" fn js_promise_with_resolvers_spec(this_ctor: f64) -> f64 {
+    ensure_arity_registered();
+    if is_default_promise_constructor(this_ctor) {
+        let obj = crate::promise::js_promise_with_resolvers();
+        return js_nanbox_pointer(obj as i64);
+    }
+    let cap = new_promise_capability(this_ctor);
+    let packed = b"promise\0resolve\0reject\0";
+    let obj = crate::object::js_object_alloc_with_shape(
+        0xFFF0_0001,
+        3,
+        packed.as_ptr(),
+        packed.len() as u32,
+    );
+    crate::object::js_object_set_field(obj, 0, JSValue::from_bits(cap.promise.to_bits()));
+    crate::object::js_object_set_field(obj, 1, JSValue::from_bits(cap.resolve.to_bits()));
+    crate::object::js_object_set_field(obj, 2, JSValue::from_bits(cap.reject.to_bits()));
+    js_nanbox_pointer(obj as i64)
+}
+
+/// `Promise.try(callbackfn, ...args)` (ECMA-262 27.2.4.x) with `this` = C:
+/// `NewPromiseCapability(C)`, call the callback synchronously, then resolve with
+/// its return value or reject with the thrown completion. Honors a subclass /
+/// custom constructor `this`; a non-object `this` throws.
+#[no_mangle]
+pub extern "C" fn js_promise_try_spec(this_ctor: f64, callback: f64, rest: f64) -> f64 {
+    ensure_arity_registered();
+    if !is_object_value(this_ctor) {
+        throw_type_error("Promise.try called on non-object");
+    }
+    // Default `Promise`: keep the optimized native path (synchronous call +
+    // resolve/reject), which also assimilates a thenable return value.
+    if is_default_promise_constructor(this_ctor) {
+        let rest_v = JSValue::from_bits(rest.to_bits());
+        let rest_ptr = if rest_v.is_pointer() {
+            rest_v.as_pointer::<crate::array::ArrayHeader>()
+        } else {
+            std::ptr::null()
+        };
+        let p = crate::promise::js_promise_try(callback, rest_ptr);
+        return js_nanbox_pointer(p as i64);
+    }
+    let cap = new_promise_capability(this_ctor);
+    let rest_v = JSValue::from_bits(rest.to_bits());
+    let args: Vec<f64> = if rest_v.is_pointer() {
+        let arr = rest_v.as_pointer::<crate::array::ArrayHeader>();
+        let n = unsafe { (*arr).length };
+        (0..n).map(|i| js_array_get_f64(arr, i)).collect()
+    } else {
+        Vec::new()
+    };
+    match call_with_this(callback, undef(), &args) {
+        Ok(value) => {
+            let _ = call_with_this(cap.resolve, undef(), &[value]);
+        }
+        Err(reason) => {
+            let _ = call_with_this(cap.reject, undef(), &[reason]);
+        }
+    }
+    cap.promise
+}

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -29,6 +29,83 @@ unsafe fn store_promise_next_slot(
     crate::gc::runtime_store_gc_heap_word_slot(promise as usize, slot as usize, value as u64);
 }
 
+// ---------------------------------------------------------------------------
+// Unhandled-rejection tracking (HostPromiseRejectionTracker, simplified).
+//
+// A promise that rejects with NO reaction attached at rejection time is
+// "currently unhandled". If, by the time the program's event loop drains, it
+// still has no handler, Node reports an unhandled rejection and exits non-zero
+// (the v15+ `--unhandled-rejections=throw` default). test262 leans on this:
+// `Promise.all` over a throwing iterator, a bare `Promise.reject(x)`, etc. all
+// leave an unhandled rejection and the oracle exits non-zero.
+//
+// We track only the promise POINTER (no reason value — the harness judges on
+// exit code, not the stderr text, and not storing a `f64` reason avoids rooting
+// a heap value across the whole program). A handler attached LATER
+// (`then`/`catch`/`finally`/`await`/settle-listener) removes the promise from
+// the set via `mark_rejection_handled`.
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static UNHANDLED_REJECTIONS: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Record a rejection that has no reaction attached yet.
+pub(crate) fn track_unhandled_rejection(promise: *mut Promise) {
+    if promise.is_null() {
+        return;
+    }
+    UNHANDLED_REJECTIONS.with(|m| m.borrow_mut().push(promise as usize));
+}
+
+/// A handler was attached to `promise` — it is no longer an unhandled rejection.
+/// Cheap no-op for the common case (the set is empty on the hot async path).
+pub(crate) fn mark_rejection_handled(promise: *mut Promise) {
+    if promise.is_null() {
+        return;
+    }
+    let key = promise as usize;
+    UNHANDLED_REJECTIONS.with(|m| {
+        let mut v = m.borrow_mut();
+        if !v.is_empty() {
+            v.retain(|p| *p != key);
+        }
+    });
+}
+
+/// Program-end hook (emitted by codegen's event-loop exit block, after the
+/// final microtask/timer drain). If any rejection went unhandled, mirror Node:
+/// print to stderr and exit with a non-zero code.
+#[no_mangle]
+pub extern "C" fn js_promise_report_unhandled_rejections() {
+    // Backstop re-check: a tracked promise is only *still* unhandled if, at
+    // program end, it is rejected AND no reaction was ever wired onto it. Any
+    // consumer — `then`/`catch`/`finally`, chaining (`resolve_with_promise`),
+    // or `attach_handlers` — sets `on_rejected` or `next` on the promise, so
+    // re-reading those fields catches handlers attached through direct-field
+    // paths we don't explicitly hook. (Settle-listener consumers don't touch
+    // these fields, so `attach_settle_listener` removes them from the set at
+    // attach time.) This makes the detector robust to internal machinery
+    // (async generators, async-from-sync iterators) adopting a rejection.
+    let any_unhandled = UNHANDLED_REJECTIONS.with(|m| {
+        m.borrow().iter().any(|&p| {
+            let pr = p as *const Promise;
+            unsafe {
+                (*pr).state == PromiseState::Rejected
+                    && (*pr).on_rejected.is_null()
+                    && (*pr).next.is_null()
+            }
+        })
+    });
+    if !any_unhandled {
+        return;
+    }
+    eprintln!("Uncaught (in promise)");
+    // Match Node's unhandled-rejection exit code (1). The event loop has
+    // already drained, so there is no pending work to lose.
+    std::process::exit(1);
+}
+
 pub(super) struct PromiseSettleListener {
     pub(super) on_fulfilled: ClosurePtr,
     pub(super) on_rejected: ClosurePtr,
@@ -48,6 +125,7 @@ pub(crate) fn js_promise_attach_settle_listener(
     if promise.is_null() {
         return;
     }
+    mark_rejection_handled(promise);
 
     let context = capture_context();
     unsafe {
@@ -204,6 +282,13 @@ pub extern "C" fn js_promise_reason(promise: *mut Promise) -> f64 {
     if promise.is_null() {
         return 0.0;
     }
+    // Reading a promise's rejection reason to consume it (the codegen `await`
+    // lowering does exactly this on an already-settled promise) counts as
+    // handling the rejection. Marking here is the robust catch-all for the
+    // await consume path, which reads the reason directly instead of attaching
+    // a reject reaction. Eager marking is safe: it can only suppress a report,
+    // never produce a spurious one.
+    mark_rejection_handled(promise);
     unsafe { (*promise).reason }
 }
 
@@ -217,6 +302,9 @@ pub extern "C" fn js_promise_result(promise: *mut Promise) -> f64 {
     if promise.is_null() {
         return 0.0;
     }
+    // `await`/async-step consumes the settled result here — observing a
+    // rejection's reason counts as handling it (see `js_promise_reason`).
+    mark_rejection_handled(promise);
     unsafe {
         match (*promise).state {
             PromiseState::Fulfilled => (*promise).value,
@@ -302,6 +390,13 @@ pub extern "C" fn js_promise_resolve_with_promise(outer: *mut Promise, inner: *m
     if outer.is_null() || inner.is_null() {
         return;
     }
+    // `outer` is adopting `inner`'s eventual state — `inner`'s rejection (now or
+    // later) is consumed by `outer`, so `inner` is no longer an unhandled
+    // rejection (HostPromiseRejectionTracker "handle"). Without this, a thenable
+    // assimilated synchronously (`assimilate_via_then_property` rejects its
+    // wrapper before chaining) would leave that wrapper flagged unhandled even
+    // though its rejection flows into `outer`. Tracking moves to `outer`.
+    mark_rejection_handled(inner);
 
     unsafe {
         if (*outer).state != PromiseState::Pending {
@@ -425,6 +520,15 @@ pub extern "C" fn js_promise_reject(promise: *mut Promise, reason: f64) {
         let has_settle_listeners = !settle_listeners.is_empty();
         let promise_all_states = combinators::promise_all_take_all_handlers(promise);
         let has_normal_handler = !(*promise).on_rejected.is_null() || !(*promise).next.is_null();
+        if !has_settle_listeners && promise_all_states.is_empty() && !has_normal_handler {
+            // No reaction attached at rejection time → currently unhandled.
+            // A later `then`/`catch`/`await`/settle-listener removes it. If
+            // a `.then(onFulfilled)` (no reject handler) is attached, `next`
+            // is non-null so `has_normal_handler` is true here and the
+            // rejection propagates to `next`, whose own settlement re-runs
+            // this check — the leaf unhandled promise is the one tracked.
+            track_unhandled_rejection(promise);
+        }
         if has_settle_listeners || !promise_all_states.is_empty() || has_normal_handler {
             let task_context = context_for_promise(promise);
             TASK_QUEUE.with(|q| {
@@ -474,6 +578,9 @@ pub extern "C" fn js_promise_then(
     if promise.is_null() {
         return ptr::null_mut();
     }
+    // Attaching a reaction (`then`/`catch`/`finally`/`await`) marks any prior
+    // rejection on `promise` as handled, per HostPromiseRejectionTracker.
+    mark_rejection_handled(promise);
 
     // `js_promise_new_with_parent` can allocate via the GC and fire
     // `v8.promiseHooks` `init` callbacks (running JS), so root the inputs across
@@ -553,6 +660,7 @@ pub(crate) fn js_promise_attach_handlers(
     if promise.is_null() {
         return;
     }
+    mark_rejection_handled(promise);
     unsafe {
         store_promise_closure_slot(
             promise,
@@ -627,6 +735,14 @@ pub extern "C" fn js_promise_finally(
     on_finally: ClosurePtr,
 ) -> *mut Promise {
     use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
+
+    // `.finally()` is a reaction — it marks any prior rejection on `promise`
+    // handled, even though it wires the wrapper handlers via direct field
+    // stores below (not `js_promise_then`). Without this, `Promise.reject(x)
+    // .finally(cb)` leaves the source promise flagged as an unhandled
+    // rejection. Done before the GC alloc; promise objects are stable
+    // malloc-GC payloads so the address used as the tracking key is unchanged.
+    mark_rejection_handled(promise);
 
     // Create the `next` promise that callers chain off. Root inputs across the
     // allocation since `v8.promiseHooks` `init` may run JS (#3139).


### PR DESCRIPTION
## Summary

`built-ins/Promise` test262 **357/574 → 469/574 (62.2% → 81.7%)**, **112 fixed, 0 regressions**.

Validated against the full `built-ins/Promise` dir **and** a broad shard `0/12` over `built-ins`+`language` (2645 tests): 12 fixed, 0 regressed.

## Root causes & fixes

### 1. Primary (~93 failures): static-method receiver rejected valid constructors
`install_builtin_constructor_statics` had **two `"Promise"` match arms** — the spec-aware one (constructor-honoring `*_static` thunks → `NewPromiseCapability(this)`) was **unreachable dead code**, so the strict `require_promise_constructor_this()` arm won and threw *"Promise static method requires a Promise constructor"* for every valid subclass / custom constructor:

```js
class P extends Promise {}
P.all([1, 2]);            // must work  — was thrown
Promise.all.call(Object, []); // must throw — still throws
```

Routed `promise_static_function_spec` (backing both the install path and the value-read/`.call`/`.apply` path) to the spec-aware thunks, deleted the dead arm + strict thunks, and added constructor-honoring `js_promise_with_resolvers_spec` / `js_promise_try_spec`.

### 2. resolve/reject function reflection (~8)
The `resolve`/`reject` handed to a `new Promise(executor)` were **raw closure-pointer bits**, not NaN-boxed `POINTER_TAG`, so reflection saw a number: `resolve.length === 0`, no own props, `new resolve()` didn't throw. Now NaN-boxed with spec `.length = 1`, `.name = ""`, non-constructable (also satisfies the `invoke-then` length asserts on the per-element/capability functions).

### 3. unhandled-rejection (~12, incl. the 2 capability-resolve cases the receiver fix exposed)
Perry never surfaced unhandled rejections, so a program that leaves one exited `0` while Node (v15+ default) exits non-zero. Added HostPromiseRejectionTracker-style tracking: a rejection with no reaction is recorded; `then`/`catch`/`finally`/`await`/chaining/settle-listener/async-generator consume paths mark it handled; codegen's event-loop exit reports any survivor and exits 1. `js_promise_reason`/`js_promise_result` mark handled (the `await` consume path reads the reason directly) — the robust catch-all that cleared async-generator / async-from-sync false positives.

## Files
- `object/global_this.rs` — receiver fix (dead-arm removal, −160 lines)
- `promise/spec_combinators.rs` — constructor-honoring `withResolvers`/`try`
- `promise/combinators.rs` — resolving-function reflection + NaN-boxing
- `promise/then.rs` — unhandled-rejection tracking
- `object/async_generator_queue.rs` — async-gen consume hook
- `codegen/entry.rs` + `runtime_decls/strings.rs` — epilogue report call

## Remaining (deferred, not regressions)
`AsyncTestFailure` microtask-ordering (~46) and full Promise-subclass `super(executor)` invocation (builtin subclassing, ~9) are the next large buckets.