### PR TITLE
fix(hir): expression-semantics test262 tail (object-literal NamedEval/gen-method dstr, delete, interleaved spread)

### DIFF
--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -307,63 +307,109 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             //      spread_arr_handle: i64) -> f64
             let cb_box = lower_expr(ctx, callee)?;
 
-            // Marshal regular args into a stack buffer (or null/0 if none).
-            let (regs_ptr, regs_len) = if regular_count == 0 {
-                ("null".to_string(), "0".to_string())
-            } else {
-                let buf_reg = ctx.func.alloca_entry_array(DOUBLE, regular_count);
-                let mut idx = 0usize;
-                for a in args {
-                    if let CallArg::Expr(e) = a {
-                        let v = lower_expr(ctx, e)?;
-                        let slot = ctx
-                            .block()
-                            .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", idx))]);
-                        ctx.block().store(DOUBLE, &v, &slot);
-                        idx += 1;
-                    }
-                }
-                let ptr_reg = ctx.block().next_reg();
-                ctx.block().emit_raw(format!(
-                    "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
-                    ptr_reg, regular_count, buf_reg
-                ));
-                (ptr_reg, regular_count.to_string())
-            };
+            // `js_closure_call_apply_with_spread` appends the spread array
+            // AFTER the register args, which silently reorders interleaved
+            // calls like `f(5, ...[6,7,8], 9)` → `[5, 9, 6, 7, 8]`. Detect a
+            // regular arg appearing *after* a spread and, in that case, build a
+            // single source-ordered array and pass everything through the
+            // spread channel (regs = none) so positional order is preserved
+            // (spec ArgumentListEvaluation). The split path stays for the
+            // common `f(a, b, ...c)` shape (regs strictly before spreads).
+            let first_spread = args.iter().position(|a| matches!(a, CallArg::Spread(_)));
+            let interleaved = first_spread
+                .map(|fs| args[fs + 1..].iter().any(|a| matches!(a, CallArg::Expr(_))))
+                .unwrap_or(false);
 
-            // Marshal spread sources. 0 → "0" handle; 1 → unbox the one
-            // array; multiple → concat onto a fresh array.
-            let spread_handle = if spread_count == 0 {
-                "0".to_string()
-            } else if spread_count == 1 {
-                let spread_expr = args
-                    .iter()
-                    .find_map(|a| match a {
-                        CallArg::Spread(e) => Some(e),
-                        _ => None,
-                    })
-                    .expect("spread_count == 1 guarantees one Spread");
-                let arr_box = lower_expr(ctx, spread_expr)?;
-                let blk = ctx.block();
-                blk.call(I64, "js_array_like_to_array", &[(DOUBLE, &arr_box)])
-            } else {
-                // Concat all spread sources into a fresh array.
-                let acc = ctx.block().call(I64, "js_array_alloc", &[(I32, "0")]);
-                let mut acc_handle = acc;
+            let (regs_ptr, regs_len, spread_handle) = if interleaved {
+                // Build one array containing every arg in source order, then
+                // apply it as the entire argument list.
+                let mut acc_handle = ctx.block().call(I64, "js_array_alloc", &[(I32, "0")]);
                 for a in args {
-                    if let CallArg::Spread(e) = a {
-                        let part_box = lower_expr(ctx, e)?;
-                        let blk = ctx.block();
-                        let part_handle =
-                            blk.call(I64, "js_array_like_to_array", &[(DOUBLE, &part_box)]);
-                        acc_handle = ctx.block().call(
-                            I64,
-                            "js_array_concat",
-                            &[(I64, &acc_handle), (I64, &part_handle)],
-                        );
+                    match a {
+                        CallArg::Expr(e) => {
+                            let v = lower_expr(ctx, e)?;
+                            acc_handle = ctx.block().call(
+                                I64,
+                                "js_array_push_f64",
+                                &[(I64, &acc_handle), (DOUBLE, &v)],
+                            );
+                        }
+                        CallArg::Spread(e) => {
+                            let part_box = lower_expr(ctx, e)?;
+                            let part_handle = ctx.block().call(
+                                I64,
+                                "js_array_like_to_array",
+                                &[(DOUBLE, &part_box)],
+                            );
+                            acc_handle = ctx.block().call(
+                                I64,
+                                "js_array_concat",
+                                &[(I64, &acc_handle), (I64, &part_handle)],
+                            );
+                        }
                     }
                 }
-                acc_handle
+                ("null".to_string(), "0".to_string(), acc_handle)
+            } else {
+                // Marshal regular args into a stack buffer (or null/0 if none).
+                let (regs_ptr, regs_len) = if regular_count == 0 {
+                    ("null".to_string(), "0".to_string())
+                } else {
+                    let buf_reg = ctx.func.alloca_entry_array(DOUBLE, regular_count);
+                    let mut idx = 0usize;
+                    for a in args {
+                        if let CallArg::Expr(e) = a {
+                            let v = lower_expr(ctx, e)?;
+                            let slot =
+                                ctx.block()
+                                    .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", idx))]);
+                            ctx.block().store(DOUBLE, &v, &slot);
+                            idx += 1;
+                        }
+                    }
+                    let ptr_reg = ctx.block().next_reg();
+                    ctx.block().emit_raw(format!(
+                        "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                        ptr_reg, regular_count, buf_reg
+                    ));
+                    (ptr_reg, regular_count.to_string())
+                };
+
+                // Marshal spread sources. 0 → "0" handle; 1 → unbox the one
+                // array; multiple → concat onto a fresh array.
+                let spread_handle = if spread_count == 0 {
+                    "0".to_string()
+                } else if spread_count == 1 {
+                    let spread_expr = args
+                        .iter()
+                        .find_map(|a| match a {
+                            CallArg::Spread(e) => Some(e),
+                            _ => None,
+                        })
+                        .expect("spread_count == 1 guarantees one Spread");
+                    let arr_box = lower_expr(ctx, spread_expr)?;
+                    let blk = ctx.block();
+                    blk.call(I64, "js_array_like_to_array", &[(DOUBLE, &arr_box)])
+                } else {
+                    // Concat all spread sources into a fresh array.
+                    let acc = ctx.block().call(I64, "js_array_alloc", &[(I32, "0")]);
+                    let mut acc_handle = acc;
+                    for a in args {
+                        if let CallArg::Spread(e) = a {
+                            let part_box = lower_expr(ctx, e)?;
+                            let blk = ctx.block();
+                            let part_handle =
+                                blk.call(I64, "js_array_like_to_array", &[(DOUBLE, &part_box)]);
+                            acc_handle = ctx.block().call(
+                                I64,
+                                "js_array_concat",
+                                &[(I64, &acc_handle), (I64, &part_handle)],
+                            );
+                        }
+                    }
+                    acc_handle
+                };
+                (regs_ptr, regs_len, spread_handle)
             };
 
             let result = ctx.block().call(

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -30,6 +30,23 @@ use crate::lower_types::{extract_param_type_with_ctx, extract_ts_type_with_ctx};
 
 use super::{lower_expr, LoweringContext};
 
+/// Lower an object-literal property *value* with NamedEvaluation: when the
+/// value is an anonymous function / arrow / class expression and the property
+/// has a static string key, the resulting function's `.name` is the key
+/// (spec PropertyDefinitionEvaluation → SetFunctionName). Mirrors the
+/// assignment / destructuring-default paths via `ctx.assignment_inferred_name`;
+/// a *named* function expression ignores the hint and keeps its own name.
+fn lower_prop_value_named(ctx: &mut LoweringContext, key: &str, value: &ast::Expr) -> Result<Expr> {
+    if crate::lower::expr_assign::rhs_accepts_assignment_name(value) {
+        let old = ctx.assignment_inferred_name.replace(key.to_string());
+        let lowered = lower_expr(ctx, value);
+        ctx.assignment_inferred_name = old;
+        lowered
+    } else {
+        lower_expr(ctx, value)
+    }
+}
+
 fn is_fetch_global_value_name(name: &str) -> bool {
     matches!(
         name,
@@ -232,6 +249,7 @@ fn lower_method_prop(
         let stmts = generate_param_destructuring_stmts(ctx, pat, *param_id)?;
         destructuring_stmts.extend(stmts);
     }
+    let destructuring_prologue_len = destructuring_stmts.len();
     let return_type = method
         .function
         .return_type
@@ -280,6 +298,18 @@ fn lower_method_prop(
     // `{ m(a = 23) {} }; obj.m(undefined)` reads `a === undefined`. Defaults
     // must run BEFORE destructuring (`m([x] = [1]) {}`), so prepend them last.
     let default_stmts = crate::lower_decl::build_default_param_stmts(&params);
+    // Record the param-prologue length for generator methods so the generator
+    // transform lifts param binding (default guards + destructuring) into the
+    // outer wrapper and runs it synchronously at call time (spec
+    // FunctionDeclarationInstantiation). Without this, `{ *m({}) {} }.m(null)`
+    // and async-generator equivalents defer the destructuring TypeError into
+    // the state machine instead of throwing at the call. Mirrors fn_decl.rs.
+    if method.function.is_generator {
+        let prologue_len = default_stmts.len() + destructuring_prologue_len;
+        if prologue_len > 0 {
+            ctx.gen_param_prologue_len.insert(func_id, prologue_len);
+        }
+    }
     if !default_stmts.is_empty() {
         let mut new_body = default_stmts;
         new_body.append(&mut body);
@@ -569,7 +599,7 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                         break;
                     }
                     let ty = crate::lower_types::infer_type_from_expr(&kv.value, ctx);
-                    let value = lower_expr(ctx, &kv.value)?;
+                    let value = lower_prop_value_named(ctx, &key, &kv.value)?;
                     fields.push((key, ty, value));
                 }
                 ast::Prop::Shorthand(ident) => {
@@ -768,10 +798,11 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                     ast::Prop::KeyValue(kv) => match resolve_keyvalue_key(ctx, &kv.key) {
                         KeyResolution::Skip => {}
                         KeyResolution::Static(key) => {
-                            let value = lower_expr(ctx, &kv.value)?;
                             if is_noncomputed_proto_key(&kv.key) {
+                                let value = lower_expr(ctx, &kv.value)?;
                                 ops.push(SpreadOp::SetPrototype { value });
                             } else {
+                                let value = lower_prop_value_named(ctx, &key, &kv.value)?;
                                 ops.push(SpreadOp::Set {
                                     key: Expr::String(key),
                                     value,

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1258,7 +1258,11 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                     }
                 }
             }
-            if unary.op == ast::UnaryOp::Delete {
+            // Static `delete` folding only applies when no `with` environment
+            // is active: inside `with(o) { delete x }`, `x` may resolve to a
+            // configurable property of `o` and must be deleted at runtime
+            // (Test262 11.4.1-4.a-6), so we leave those to the dynamic path.
+            if unary.op == ast::UnaryOp::Delete && ctx.with_env_stack.is_empty() {
                 // Peel parens: `delete (x)` deletes the inner reference.
                 let mut bare = unary.arg.as_ref();
                 while let ast::Expr::Paren(p) = bare {
@@ -1321,16 +1325,43 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 // ReferenceError the operand-evaluation path would throw.
                 if let ast::Expr::Ident(id) = bare {
                     let name = id.sym.as_ref();
-                    if name == "arguments"
-                        || matches!(name, "undefined" | "NaN" | "Infinity")
-                        || ctx.lookup_local(name).is_some()
-                        || ctx.lookup_func(name).is_some()
+                    // Bare globals that are non-configurable → false.
+                    if name == "arguments" || matches!(name, "undefined" | "NaN" | "Infinity") {
+                        return Ok(Expr::Bool(false));
+                    }
+                    if let Some(lid) = ctx.lookup_local(name) {
+                        // `x = 1` with no declaration creates a *configurable*
+                        // global property (`delete x` → true); a real
+                        // var/let/const/param binding is non-configurable
+                        // (→ false). Distinguish via the implicit-global set.
+                        if ctx.sloppy_implicit_global_ids.contains(&lid) {
+                            return Ok(Expr::Bool(true));
+                        }
+                        // At module top level a bare `x = 1` becomes an ordinary
+                        // module-level local indistinguishable from `var x = 1`
+                        // (the implicit-global path isn't taken there), so we
+                        // can't statically tell a non-configurable `var`/`let`
+                        // binding from a configurable implicit global — defer to
+                        // the runtime delete (Test262 S11.4.1_A3.2_T1). Inside a
+                        // function, an implicit global *does* go through the
+                        // sloppy-global set, so a plain local here is a genuine
+                        // binding → false.
+                        if !ctx.module_level_ids.contains(&lid) {
+                            return Ok(Expr::Bool(false));
+                        }
+                        // module-level local: fall through to the dynamic path.
+                    } else if ctx.lookup_func(name).is_some()
                         || ctx.lookup_class(name).is_some()
                         || ctx.lookup_imported_func(name).is_some()
                     {
                         return Ok(Expr::Bool(false));
+                    } else {
+                        // Truly unresolvable bare identifier (no binding, no
+                        // known global) → `true` in sloppy mode; lowering it as
+                        // a literal avoids a spurious ReferenceError from the
+                        // operand-evaluation path.
+                        return Ok(Expr::Bool(true));
                     }
-                    return Ok(Expr::Bool(true));
                 }
             }
             let operand = Box::new(lower_expr(ctx, &unary.arg)?);

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1259,15 +1259,21 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 }
             }
             if unary.op == ast::UnaryOp::Delete {
-                if let ast::Expr::Member(member) = unary.arg.as_ref() {
+                // Peel parens: `delete (x)` deletes the inner reference.
+                let mut bare = unary.arg.as_ref();
+                while let ast::Expr::Paren(p) = bare {
+                    bare = p.expr.as_ref();
+                }
+                if let ast::Expr::Member(member) = bare {
                     if let (ast::Expr::Ident(obj), ast::MemberProp::Ident(prop)) =
                         (member.obj.as_ref(), &member.prop)
                     {
                         let obj_name = obj.sym.as_ref();
                         let prop_name = prop.sym.as_ref();
-                        if obj_name == "Number"
-                            && ctx.lookup_local(obj_name).is_none()
-                            && ctx.lookup_func(obj_name).is_none()
+                        let is_global = ctx.lookup_local(obj_name).is_none()
+                            && ctx.lookup_func(obj_name).is_none();
+                        if is_global
+                            && obj_name == "Number"
                             && matches!(
                                 prop_name,
                                 "NaN"
@@ -1282,7 +1288,49 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                         {
                             return Ok(Expr::Bool(false));
                         }
+                        // `Math`'s numeric constants are non-configurable, so
+                        // `delete Math.PI` is `false` (Math's *methods* stay
+                        // configurable, hence `delete Math.abs` is `true` and
+                        // is left to the generic path). Test262 S8.12.7_A1.
+                        if is_global
+                            && obj_name == "Math"
+                            && matches!(
+                                prop_name,
+                                "E" | "LN10"
+                                    | "LN2"
+                                    | "LOG10E"
+                                    | "LOG2E"
+                                    | "PI"
+                                    | "SQRT1_2"
+                                    | "SQRT2"
+                            )
+                        {
+                            return Ok(Expr::Bool(false));
+                        }
                     }
+                }
+                // `delete <BindingIdentifier>` — deleting a reference to a
+                // resolvable binding (var / let / const / function / param /
+                // class / import) is non-configurable, so it evaluates to
+                // `false` without removing anything (spec 13.5.1.2). The bare
+                // globals `undefined` / `NaN` / `Infinity` are likewise
+                // non-configurable global properties → `false`. Any other
+                // unresolvable bare identifier (an implicit global from
+                // `x = 1`, or a configurable global builtin) is `true` in
+                // sloppy mode — lowering it as a literal avoids the spurious
+                // ReferenceError the operand-evaluation path would throw.
+                if let ast::Expr::Ident(id) = bare {
+                    let name = id.sym.as_ref();
+                    if name == "arguments"
+                        || matches!(name, "undefined" | "NaN" | "Infinity")
+                        || ctx.lookup_local(name).is_some()
+                        || ctx.lookup_func(name).is_some()
+                        || ctx.lookup_class(name).is_some()
+                        || ctx.lookup_imported_func(name).is_some()
+                    {
+                        return Ok(Expr::Bool(false));
+                    }
+                    return Ok(Expr::Bool(true));
                 }
             }
             let operand = Box::new(lower_expr(ctx, &unary.arg)?);

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -656,7 +656,10 @@ pub(crate) unsafe fn js_object_define_symbol_accessor(
     obj_f64
 }
 
-unsafe fn infer_symbol_function_name(sym_key: usize, val_bits: u64) {
+/// Set a closure value's `.name` (if not already named) given its NaN-boxed
+/// bits. Returns silently for non-closure values. Shared by the symbol-key and
+/// string-key computed-name inference paths.
+unsafe fn register_closure_name_if_absent(val_bits: u64, name: &str) {
     let val_tag = val_bits & 0xFFFF_0000_0000_0000;
     if val_tag != POINTER_TAG {
         return;
@@ -674,12 +677,23 @@ unsafe fn infer_symbol_function_name(sym_key: usize, val_bits: u64) {
     if func_ptr.is_null() {
         return;
     }
+    crate::builtins::register_function_name_if_absent(func_ptr as usize, name);
+}
+
+unsafe fn infer_symbol_function_name(sym_key: usize, val_bits: u64) {
     let sym_ptr = sym_key as *const SymbolHeader;
+    // Spec: a symbol key with an *undefined* description names the function the
+    // empty string `""`; a symbol with a (possibly empty) string description
+    // names it `"[" + description + "]"`. Distinguish "no description" (→ `""`)
+    // from `Symbol("")` (→ `"[]"`).
     let desc = registered_symbol_description(sym_ptr as usize)
         .map(|s| s.as_ref().to_string())
-        .unwrap_or_else(|| str_from_header((*sym_ptr).description).unwrap_or_default());
-    let inferred = format!("[{}]", desc);
-    crate::builtins::register_function_name_if_absent(func_ptr as usize, &inferred);
+        .or_else(|| str_from_header((*sym_ptr).description));
+    let inferred = match desc {
+        Some(d) => format!("[{}]", d),
+        None => String::new(),
+    };
+    register_closure_name_if_absent(val_bits, &inferred);
 }
 
 fn publish_symbol_side_table_root_edges(sym_key: usize, value_bits: u64) {
@@ -800,6 +814,15 @@ pub unsafe extern "C" fn js_object_literal_infer_computed_function_name(
     let sym_key = sym_key_from_f64(key_f64);
     if sym_key != 0 {
         infer_symbol_function_name(sym_key, value_f64.to_bits());
+        return value_f64;
+    }
+    // A computed *string* (or stringified numeric) key names the function after
+    // the key itself: `{ ["sk"]: function(){} }.sk.name === "sk"`,
+    // `{ [1]: () => {} }[1].name === "1"`. The key arriving here has already
+    // passed through ToPropertyKey, so a non-symbol key is a string value.
+    let key_ptr = crate::value::js_get_string_pointer_unified(key_f64) as *const StringHeader;
+    if let Some(name) = str_from_header(key_ptr) {
+        register_closure_name_if_absent(value_f64.to_bits(), &name);
     }
     value_f64
 }


### PR DESCRIPTION
## Summary

Drives the `language/expressions/*` test262 tail. Across the 10 swept dirs:
**pass 1518 → 1591 (+73), parity 83.9% → 87.9% (+4.0pp), runtime-fail 252 → 179, compile-fail unchanged (14).**

Verified **zero regressions** by diffing failure *sets* against a from-scratch
`main` baseline (branch point `bc0d1d2b9`) over a `built-ins language` shard
(`--shard 0/12`): 0 newly-failing, 8 newly-passing (incl. bonus fixes in
`language/eval-code/direct/*`).

### Per-dir (failures before → after)
| dir | before | after | Δ |
|---|---|---|---|
| object | 109 | 45 | **-64** |
| delete | 19 | 11 | **-8** |
| call | 15 | 14 | -1 |
| super / yield / async-generator / generators / new / optional-chaining / tagged-template | — | — | 0 (untouched) |

## Root causes & fixes

**1. Object-literal generator/async-generator methods deferred param binding (~58 tests).**
`{ *m({}) {} }.m(null)` and async-gen equivalents must throw the destructuring
`TypeError` *synchronously at the call* (spec FunctionDeclarationInstantiation),
but `lower_method_prop` never recorded `gen_param_prologue_len`, so the generator
transform left param binding inside the state machine. Now recorded, mirroring
`fn_decl.rs`. (`crates/perry-hir/src/lower/expr_object.rs`)

**2. NamedEvaluation for object-literal property values.**
An anonymous fn/arrow/class under a static key takes the key as its `.name`
(`{ id: function(){} }.id.name === "id"`) — wired via `assignment_inferred_name`
(`lower_prop_value_named`). Computed-key inference fixed too: string keys now name
the function (`["sk"] -> "sk"`), and a symbol with *undefined* description names it
`""` not `"[]"`. (`expr_object.rs`, `crates/perry-runtime/src/symbol.rs`)

**3. `delete` semantics.** `delete <function-scoped binding>` -> `false`;
`delete undefined/NaN/Infinity/arguments` -> `false`; `delete Math.<const>` ->
`false`; truly-unresolvable bare ident -> `true` (no spurious ReferenceError).
Carefully scoped to avoid regressions: folding is skipped inside a `with`
environment (the name may bind a configurable with-object property — runtime must
delete it), and module-level locals defer to the dynamic path since `x = 1` and
`var x = 1` are indistinguishable there. (`crates/perry-hir/src/lower/lower_expr.rs`)

**4. Interleaved spread args lost source order.** `f(5, ...[6,7,8], 9)` produced
`[5,9,6,7,8]` — the closure-callee spread path marshalled all register args
before all spreads. When a regular arg follows a spread, it now builds one
source-ordered array and applies it as the whole argument list (spec
ArgumentListEvaluation). Common reg-then-spread shape keeps the fast path.
(`crates/perry-codegen/src/expr/call_spread.rs`)

## Out of scope (deferred)
`super(...spread)` (SuperCall carries no spread info; shared across ~30 sites +
class-lowering files owned by parallel workers), `yield*` return/throw delegation
forwarding (state-machine), named-function-expression self-binding immutability.