### PR TITLE
fix(runtime): low-hanging test262 tails (URI/parse/Number/collections/Reflect/lang-small)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -518,7 +518,30 @@ pub(super) fn try_array_only_methods(
                 // `!recv_is_class` (which already excludes Map/Set/class
                 // receivers — those keep their own forEach contract) and on the
                 // 2nd argument being a plain positional (no spread).
+                // `recv_is_class` does NOT cover Map/Set/URLSearchParams locals,
+                // which keep their own `forEach` contract (callback signature +
+                // thisArg binding via `js_{map,set}_foreach`). Folding a 2-arg
+                // `set.forEach(cb, thisArg)` into the array-like path here ran the
+                // callback against an array view → zero iterations (test262
+                // Set/Map forEach this-arg-explicit). Exclude them explicitly.
+                let recv_is_non_array_collection = {
+                    let is_nac = |ty: &Type| {
+                        matches!(ty, Type::Generic { base, .. } if base == "Map" || base == "Set")
+                            || matches!(ty, Type::Named(n) if n == "URLSearchParams")
+                    };
+                    match member.obj.as_ref() {
+                        ast::Expr::Ident(ident) => {
+                            match ctx.lookup_local_type(ident.sym.as_ref()) {
+                                Some(ty) if is_nac(ty) => true,
+                                Some(Type::Union(variants)) => variants.iter().any(is_nac),
+                                _ => false,
+                            }
+                        }
+                        _ => false,
+                    }
+                };
                 if !recv_is_class
+                    && !recv_is_non_array_collection
                     && matches!(
                         method_name,
                         "map"

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -171,18 +171,37 @@ pub(super) fn try_local_array_methods(
                         // through the spec-complete `Expr::ArrayLikeMethod`
                         // lowering (which binds the callback `this`) when an
                         // explicit thisArg is supplied with no spread.
-                        if matches!(
-                            method_name,
-                            "map"
-                                | "filter"
-                                | "forEach"
-                                | "find"
-                                | "findIndex"
-                                | "findLast"
-                                | "findLastIndex"
-                                | "some"
-                                | "every"
-                        ) && call.args.len() >= 2
+                        // Map/Set/URLSearchParams keep their own forEach contract
+                        // (thisArg binding via `js_{map,set}_foreach`); folding
+                        // `set.forEach(cb, thisArg)` into the array-like path ran
+                        // the callback against an array view → zero iterations
+                        // (test262 Set/Map forEach this-arg-explicit). The 1-arg
+                        // `match` below already excludes them; mirror that here.
+                        let recv_is_non_array_collection = {
+                            let is_nac = |ty: &Type| {
+                                matches!(ty, Type::Generic { base, .. } if base == "Map" || base == "Set")
+                                    || matches!(ty, Type::Named(n) if n == "URLSearchParams")
+                            };
+                            match ctx.lookup_local_type(&arr_name) {
+                                Some(ty) if is_nac(ty) => true,
+                                Some(Type::Union(variants)) => variants.iter().any(is_nac),
+                                _ => false,
+                            }
+                        };
+                        if !recv_is_non_array_collection
+                            && matches!(
+                                method_name,
+                                "map"
+                                    | "filter"
+                                    | "forEach"
+                                    | "find"
+                                    | "findIndex"
+                                    | "findLast"
+                                    | "findLastIndex"
+                                    | "some"
+                                    | "every"
+                            )
+                            && call.args.len() >= 2
                             && call.args.iter().all(|a| a.spread.is_none())
                         {
                             return Ok(Ok(Expr::ArrayLikeMethod {

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -747,14 +747,18 @@ fn dataview_to_index(value: f64, what: &str) -> i64 {
         // ToIntegerOrInfinity(NaN) = 0.
         return 0;
     }
-    if n < 0.0 {
+    // ToIndex truncates toward zero (ToIntegerOrInfinity) *before* the sign and
+    // range checks, so e.g. `-0.1`/`-0.99999` become `-0` (== 0), not a
+    // RangeError (test262 toindex-byteoffset/-bytelength).
+    let int = n.trunc();
+    if int < 0.0 {
         throw_dataview_range_error(&format!("Invalid DataView {what}"));
     }
     // ToIndex rejects values above 2^53-1 (and thus +Infinity).
-    if n > 9_007_199_254_740_991.0 {
+    if int > 9_007_199_254_740_991.0 {
         throw_dataview_range_error(&format!("Invalid DataView {what}"));
     }
-    n.trunc() as i64
+    int as i64
 }
 
 /// `new DataView(buffer, byteOffset?, byteLength?)` — Perry models a DataView

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -204,7 +204,10 @@ struct ExtractedStringBytes {
 }
 
 fn extract_string_bytes_from_nanbox(value: f64) -> ExtractedStringBytes {
-    let str_ptr = crate::value::js_get_string_pointer_unified(value);
+    // encodeURI/encodeURIComponent apply ToString to the argument (sec-encodeuri
+    // step 1), so objects/numbers coerce via toString/valueOf rather than
+    // yielding the empty string (test262 encodeURI/encodeURIComponent A6_T1).
+    let str_ptr = crate::builtins::js_string_coerce(value) as *const StringHeader;
     if (str_ptr as usize) < 0x1000 {
         return ExtractedStringBytes {
             bytes: Vec::new(),

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -58,33 +58,94 @@ fn percent_encode(input: &[u8], safe_chars: &[u8]) -> String {
     result
 }
 
-fn percent_decode(input: &str, preserve_reserved: bool) -> Result<String, ()> {
-    let bytes = input.as_bytes();
-    let mut result = Vec::with_capacity(bytes.len());
+/// Read a `%XX` escape at byte offset `i`, returning the decoded octet.
+/// Fails (URIError) when there is no `%`, the string is too short, or the two
+/// following code units are not hexadecimal digits.
+fn read_pct_octet(bytes: &[u8], i: usize) -> Result<u8, ()> {
+    if i + 2 >= bytes.len() || bytes[i] != b'%' {
+        return Err(());
+    }
+    match (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2])) {
+        (Some(h), Some(l)) => Ok(h * 16 + l),
+        _ => Err(()),
+    }
+}
+
+/// ECMAScript `Decode` (sec-decode), operating on the input's WTF-8 bytes so
+/// lone surrogates pass through unchanged. `reserved` is the set whose
+/// single-octet members are left as their original `%XX` escape (decodeURI);
+/// decodeURIComponent passes `None`.
+///
+/// Unlike a naive "decode every `%XX`, then validate the whole buffer", this
+/// validates each multi-octet UTF-8 run at the point it is decoded: a lead
+/// octet must be followed by the correct number of `%`-escaped continuation
+/// octets, and the assembled code point must be a non-overlong, non-surrogate
+/// scalar value — otherwise URIError. Non-`%` code units (including multi-byte
+/// and lone-surrogate WTF-8 bytes) are copied through verbatim.
+fn percent_decode(bytes: &[u8], reserved: Option<&[u8]>) -> Result<Vec<u8>, ()> {
+    let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'%' {
-            if i + 2 >= bytes.len() {
+        if bytes[i] != b'%' {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+        let b = read_pct_octet(bytes, i)?;
+        if b < 0x80 {
+            if reserved.is_some_and(|set| set.contains(&b)) {
+                out.extend_from_slice(&bytes[i..i + 3]);
+            } else {
+                out.push(b);
+            }
+            i += 3;
+            continue;
+        }
+        // Multi-octet sequence: derive the length from the leading 1-bits.
+        let n = if b & 0xE0 == 0xC0 {
+            2
+        } else if b & 0xF0 == 0xE0 {
+            3
+        } else if b & 0xF8 == 0xF0 {
+            4
+        } else {
+            return Err(()); // lone continuation (10xxxxxx) or 5+-byte lead
+        };
+        let mut cp: u32 = (b as u32) & (0x7F >> n);
+        let mut j = i + 3;
+        for _ in 1..n {
+            let cont = read_pct_octet(bytes, j)?;
+            if cont & 0xC0 != 0x80 {
                 return Err(());
             }
-            let hi = hex_digit(bytes[i + 1]);
-            let lo = hex_digit(bytes[i + 2]);
-            if let (Some(h), Some(l)) = (hi, lo) {
-                let decoded = h * 16 + l;
-                if preserve_reserved && URI_RESERVED.contains(&decoded) {
-                    result.extend_from_slice(&bytes[i..i + 3]);
-                } else {
-                    result.push(decoded);
-                }
-                i += 3;
-                continue;
-            }
+            cp = (cp << 6) | (cont as u32 & 0x3F);
+            j += 3;
+        }
+        let min = match n {
+            2 => 0x80,
+            3 => 0x800,
+            _ => 0x1_0000,
+        };
+        if cp < min || cp > 0x10_FFFF || (0xD800..=0xDFFF).contains(&cp) {
             return Err(());
         }
-        result.push(bytes[i]);
-        i += 1;
+        let ch = char::from_u32(cp).ok_or(())?;
+        let mut buf = [0u8; 4];
+        out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+        i = j;
     }
-    String::from_utf8(result).map_err(|_| ())
+    Ok(out)
+}
+
+/// Build a result string from decoded bytes, choosing the WTF-8 constructor
+/// when lone surrogates survived the round-trip so `.length`/`isWellFormed`
+/// stay correct.
+fn string_from_decoded(out: &[u8]) -> i64 {
+    if std::str::from_utf8(out).is_ok() {
+        js_string_from_bytes(out.as_ptr(), out.len() as u32) as i64
+    } else {
+        js_string_from_wtf8_bytes(out.as_ptr(), out.len() as u32) as i64
+    }
 }
 
 fn throw_uri_malformed() -> ! {
@@ -118,6 +179,22 @@ fn extract_str_from_nanbox(value: f64) -> String {
         let data = (header as *const u8).add(std::mem::size_of::<StringHeader>());
         let bytes = std::slice::from_raw_parts(data, len);
         std::str::from_utf8(bytes).unwrap_or("").to_string()
+    }
+}
+
+/// ToString-coerce `value` and return its raw WTF-8 bytes (lone surrogates
+/// preserved). Used by the decode family, which must operate byte-wise per the
+/// Decode algorithm rather than dropping non-UTF-8 input.
+fn extract_coerced_bytes(value: f64) -> Vec<u8> {
+    let str_ptr = crate::builtins::js_string_coerce(value);
+    if (str_ptr as usize) < 0x1000 {
+        return Vec::new();
+    }
+    unsafe {
+        let header = str_ptr as *const StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = (header as *const u8).add(std::mem::size_of::<StringHeader>());
+        std::slice::from_raw_parts(data, len).to_vec()
     }
 }
 
@@ -166,10 +243,10 @@ pub extern "C" fn js_encode_uri(value: f64) -> i64 {
 /// decodeURI(string) -> string
 #[no_mangle]
 pub extern "C" fn js_decode_uri(value: f64) -> i64 {
-    let input = extract_str_from_nanbox(value);
-    let decoded = percent_decode(&input, true).unwrap_or_else(|_| throw_uri_malformed());
-    let ptr = js_string_from_bytes(decoded.as_ptr(), decoded.len() as u32);
-    ptr as i64
+    let input = extract_coerced_bytes(value);
+    let decoded =
+        percent_decode(&input, Some(URI_RESERVED)).unwrap_or_else(|_| throw_uri_malformed());
+    string_from_decoded(&decoded)
 }
 
 /// encodeURIComponent(string) -> string
@@ -185,10 +262,9 @@ pub extern "C" fn js_encode_uri_component(value: f64) -> i64 {
 /// decodeURIComponent(string) -> string
 #[no_mangle]
 pub extern "C" fn js_decode_uri_component(value: f64) -> i64 {
-    let input = extract_str_from_nanbox(value);
-    let decoded = percent_decode(&input, false).unwrap_or_else(|_| throw_uri_malformed());
-    let ptr = js_string_from_bytes(decoded.as_ptr(), decoded.len() as u32);
-    ptr as i64
+    let input = extract_coerced_bytes(value);
+    let decoded = percent_decode(&input, None).unwrap_or_else(|_| throw_uri_malformed());
+    string_from_decoded(&decoded)
 }
 
 // ============================================================

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -35,7 +35,7 @@ macro_rules! println {
 #[cfg(feature = "ohos-napi")]
 pub(crate) use println;
 
-pub(crate) use crate::string::{js_string_from_bytes, StringHeader};
+pub(crate) use crate::string::{js_string_from_bytes, js_string_from_wtf8_bytes, StringHeader};
 pub(crate) use crate::JSValue;
 
 mod arithmetic;

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -22,7 +22,9 @@ pub extern "C" fn js_parse_int(str_ptr: *const StringHeader, radix: f64) -> f64 
         let bytes = std::slice::from_raw_parts(data, len);
 
         if let Ok(s) = std::str::from_utf8(bytes) {
-            let trimmed = s.trim_start();
+            // StrWhiteSpace per spec (NBSP/BOM in, NEL out) — not Rust's
+            // `trim_start`, whose White_Space set diverges from JS's.
+            let trimmed = s.trim_start_matches(crate::string::is_js_whitespace);
             if trimmed.is_empty() {
                 return f64::NAN;
             }
@@ -125,8 +127,12 @@ pub extern "C" fn js_parse_float(str_ptr: *const StringHeader) -> f64 {
 /// Core parseFloat logic operating on raw bytes — no heap allocation.
 /// Exposed as `pub(crate)` so unit tests can call it directly.
 pub(crate) fn parse_float_bytes(bytes: &[u8]) -> f64 {
-    // JS spec: strip leading StrWhiteSpace (ASCII subset covers all common cases)
-    let bytes = bytes.trim_ascii_start();
+    // JS spec: strip leading StrWhiteSpace — the full set (NBSP, VT, LS/PS, BOM,
+    // Unicode space separators), not just ASCII. Trim by char so multi-byte
+    // whitespace (U+00A0, U+2028, …) is consumed (test262 parseFloat A2_T3/5/8/9),
+    // but operate byte-wise so a *trailing* lone surrogate elsewhere in the WTF-8
+    // input doesn't poison the whole parse (A6: `parseFloat("0.1e1" + cu)`).
+    let bytes = trim_leading_js_whitespace(bytes);
     if bytes.is_empty() {
         return f64::NAN;
     }
@@ -155,6 +161,39 @@ pub(crate) fn parse_float_bytes(bytes: &[u8]) -> f64 {
     // from_utf8_unchecked is safe.
     let s = unsafe { std::str::from_utf8_unchecked(&bytes[..end]) };
     s.parse::<f64>().unwrap_or(f64::NAN)
+}
+
+/// Strip leading StrWhiteSpace, decoding one UTF-8 scalar at a time so that
+/// invalid bytes *after* the leading run (e.g. a lone surrogate in WTF-8 input)
+/// don't abort the whole trim. ASCII whitespace is the common case and stays a
+/// single-byte check.
+fn trim_leading_js_whitespace(bytes: &[u8]) -> &[u8] {
+    let mut start = 0;
+    while start < bytes.len() {
+        let b = bytes[start];
+        if b < 0x80 {
+            if crate::string::is_js_whitespace(b as char) {
+                start += 1;
+                continue;
+            }
+            break;
+        }
+        // Multi-byte lead: decode just the next scalar value from the valid
+        // UTF-8 prefix; stop at the first byte that isn't valid UTF-8.
+        let rest = &bytes[start..];
+        let valid = match std::str::from_utf8(rest) {
+            Ok(s) => s,
+            Err(e) if e.valid_up_to() > 0 => unsafe {
+                std::str::from_utf8_unchecked(&rest[..e.valid_up_to()])
+            },
+            Err(_) => break,
+        };
+        match valid.chars().next() {
+            Some(c) if crate::string::is_js_whitespace(c) => start += c.len_utf8(),
+            _ => break,
+        }
+    }
+    &bytes[start..]
 }
 
 /// Returns the byte length of the leading StrDecimalLiteral prefix in `bytes`.

--- a/crates/perry-runtime/src/math.rs
+++ b/crates/perry-runtime/src/math.rs
@@ -256,19 +256,26 @@ pub extern "C" fn js_math_min_array(arr_ptr: i64) -> f64 {
     if len == 0 {
         return f64::INFINITY;
     }
+    // Spec (sec-math.min) step 2: ToNumber EVERY arg first (observable via
+    // valueOf), then reduce. A NaN must not short-circuit before later args are
+    // coerced (test262 min/Math.min_each-element-coerced).
     let mut result = f64::INFINITY;
+    let mut saw_nan = false;
     for i in 0..len {
         let num = js_math_to_number(crate::array::js_array_get_f64(arr, i as u32));
         if num.is_nan() {
-            return f64::NAN;
-        }
-        // ECMAScript Math.min treats -0 as smaller than +0; IEEE `<` treats
-        // them as equal, so add an explicit sign-of-zero tiebreaker.
-        if num < result || (num == 0.0 && result == 0.0 && num.is_sign_negative()) {
+            saw_nan = true;
+        } else if num < result || (num == 0.0 && result == 0.0 && num.is_sign_negative()) {
+            // ECMAScript Math.min treats -0 as smaller than +0; IEEE `<` treats
+            // them as equal, so add an explicit sign-of-zero tiebreaker.
             result = num;
         }
     }
-    result
+    if saw_nan {
+        f64::NAN
+    } else {
+        result
+    }
 }
 
 /// Math.max(...array) -> number — find maximum value in an array
@@ -282,17 +289,24 @@ pub extern "C" fn js_math_max_array(arr_ptr: i64) -> f64 {
     if len == 0 {
         return f64::NEG_INFINITY;
     }
+    // Spec (sec-math.max) step 2: ToNumber EVERY arg first (observable via
+    // valueOf), then reduce — a NaN must not short-circuit before later args
+    // are coerced (test262 max/Math.max_each-element-coerced).
     let mut result = f64::NEG_INFINITY;
+    let mut saw_nan = false;
     for i in 0..len {
         let num = js_math_to_number(crate::array::js_array_get_f64(arr, i as u32));
         if num.is_nan() {
-            return f64::NAN;
-        }
-        // ECMAScript Math.max treats +0 as greater than -0; IEEE `>` treats
-        // them as equal, so add an explicit sign-of-zero tiebreaker.
-        if num > result || (num == 0.0 && result == 0.0 && num.is_sign_positive()) {
+            saw_nan = true;
+        } else if num > result || (num == 0.0 && result == 0.0 && num.is_sign_positive()) {
+            // ECMAScript Math.max treats +0 as greater than -0; IEEE `>` treats
+            // them as equal, so add an explicit sign-of-zero tiebreaker.
             result = num;
         }
     }
-    result
+    if saw_nan {
+        f64::NAN
+    } else {
+        result
+    }
 }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -4017,6 +4017,14 @@ pub extern "C" fn js_object_get_field_by_name(
                     let s = obj as *const crate::StringHeader;
                     return JSValue::number((*s).utf16_len as f64);
                 }
+                // A primitive string inherits `.constructor` from String.prototype:
+                // `"x".constructor === String` (test262 language/types/string/
+                // S8.4_A9/A12). Resolve to the same global `String` value bare-
+                // `String` yields so identity holds — mirrors the Array branch above.
+                if key_bytes == b"constructor" {
+                    let v = js_get_global_this_builtin_value(b"String".as_ptr(), 6);
+                    return JSValue::from_bits(v.to_bits());
+                }
                 if let Some((kind, asym_type)) = crate::buffer::asymmetric_key_meta(obj as usize) {
                     if key_bytes == b"type" {
                         let label = if kind == 1 {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2676,6 +2676,25 @@ pub extern "C" fn js_object_get_field_by_name(
             return JSValue::undefined();
         }
     }
+    // A primitive string receiver inherits `.constructor` from String.prototype:
+    // `"x".constructor === String` (test262 language/types/string/S8.4_A9/A12).
+    // The common string members (`.length`, indices, methods) are served by the
+    // codegen fast paths and never reach this generic slow path, so only the
+    // inherited `constructor` read needs routing here; resolve it to the same
+    // global `String` value bare-`String` yields so identity holds.
+    {
+        let bits = obj as u64;
+        if !key.is_null() && crate::value::JSValue::from_bits(bits).is_any_string() {
+            unsafe {
+                let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let key_len = (*key).byte_len as usize;
+                if std::slice::from_raw_parts(key_ptr, key_len) == b"constructor" {
+                    let ctor = super::js_get_global_this_builtin_value(b"String".as_ptr(), 6);
+                    return JSValue::from_bits(ctor.to_bits());
+                }
+            }
+        }
+    }
     // Native module registry handles can arrive here either as raw small
     // integers or as POINTER_TAG-boxed small integers. Route them before any
     // GC-header probes such as Date/Promise checks.

--- a/crates/perry-runtime/src/object/primitive_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/primitive_proto_thunks.rs
@@ -198,6 +198,13 @@ fn boolean_receiver_or_throw(method: &str) -> f64 {
     if jv.is_bool() {
         return receiver;
     }
+    // ECMA-262 20.3.3: `Boolean.prototype` is itself a Boolean object whose
+    // [[BooleanData]] is `false`. A method invoked with `this === Boolean.prototype`
+    // (`Boolean.prototype.valueOf()`, or `Boolean.prototype == false` coercing via
+    // valueOf) sees `false` rather than throwing (test262 prototype/valueOf/A1, S15.6.3.1_A1).
+    if receiver.to_bits() == super::global_this::builtin_prototype_value("Boolean").to_bits() {
+        return f64::from_bits(crate::value::TAG_FALSE);
+    }
     throw_incompatible_receiver("Boolean.prototype", method)
 }
 

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1728,6 +1728,11 @@ pub extern "C" fn js_reflect_define_property(obj: f64, key: f64, descriptor: f64
         }
         return crate::object::reflect_define_property(target, key, descriptor);
     }
+    // ECMA-262 28.1.3: Reflect.defineProperty throws when target is not an
+    // Object (a Symbol / BigInt primitive slips past the heap-pointer probe).
+    if !reflect_value_is_object(obj) {
+        return reflect_non_object_typeerror("defineProperty");
+    }
     crate::object::reflect_define_property(obj, key, descriptor)
 }
 
@@ -1852,7 +1857,7 @@ pub extern "C" fn js_reflect_is_extensible(target: f64) -> f64 {
         }
         return crate::object::js_object_is_extensible(inner);
     }
-    if !crate::object::js_value_is_heap_object(target) {
+    if !reflect_value_is_object(target) {
         return reflect_non_object_typeerror("isExtensible");
     }
     crate::object::js_object_is_extensible(target)
@@ -1901,7 +1906,7 @@ pub extern "C" fn js_reflect_prevent_extensions(target: f64) -> f64 {
         crate::object::js_object_prevent_extensions(inner);
         return nanbox_bool(true);
     }
-    if !crate::object::js_value_is_heap_object(target) {
+    if !reflect_value_is_object(target) {
         return reflect_non_object_typeerror("preventExtensions");
     }
     crate::object::js_object_prevent_extensions(target);

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -88,6 +88,7 @@ pub use locale::{
 };
 pub use pad::{js_string_alloc_space, js_string_pad_end, js_string_pad_start, js_string_repeat};
 pub use raw::js_string_raw;
+pub(crate) use slice_ops::is_js_whitespace;
 pub use slice_ops::{
     js_string_index_of, js_string_index_of_from, js_string_last_index_of,
     js_string_last_index_of_from, js_string_slice, js_string_substr, js_string_substring,

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -286,17 +286,20 @@ pub unsafe extern "C" fn js_symbol_new_empty() -> f64 {
 pub unsafe extern "C" fn js_symbol_new(description_f64: f64) -> f64 {
     let bits = description_f64.to_bits();
     let tag = bits & 0xFFFF_0000_0000_0000;
-    let desc_ptr: *mut StringHeader = if tag == STRING_TAG {
-        (bits & POINTER_MASK) as *mut StringHeader
-    } else if bits == TAG_UNDEFINED {
+    let desc_ptr: *mut StringHeader = if bits == TAG_UNDEFINED {
+        // `Symbol()` — no description.
         std::ptr::null_mut()
+    } else if tag == STRING_TAG {
+        (bits & POINTER_MASK) as *mut StringHeader
     } else {
-        // Try to coerce — if it's a raw pointer, trust it.
-        if (0x1000..0x0000_FFFF_FFFF_FFFF).contains(&bits) {
-            bits as *mut StringHeader
-        } else {
-            std::ptr::null_mut()
+        // Spec step 2 (sec-symbol-constructor): descString = ToString(description).
+        // ToString rejects a Symbol with a TypeError (test262 desc-to-string-symbol);
+        // objects/numbers/booleans coerce, running `toString`/`valueOf`
+        // (test262 desc-to-string). `js_string_coerce` is the full ToString.
+        if js_is_symbol(description_f64) != 0 {
+            crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a string");
         }
+        crate::builtins::js_string_coerce(description_f64) as *mut StringHeader
     };
     let sym = alloc_symbol(desc_ptr, false);
     f64::from_bits(POINTER_TAG | (sym as u64 & POINTER_MASK))
@@ -372,19 +375,14 @@ pub unsafe extern "C" fn js_symbol_for(key_f64: f64) -> f64 {
 /// string for registered symbols, or undefined for non-registered symbols.
 #[no_mangle]
 pub unsafe extern "C" fn js_symbol_key_for(sym_f64: f64) -> f64 {
+    // Spec step 1 (sec-symbol.keyfor): if Type(sym) is not Symbol, throw a
+    // TypeError — distinct from the `undefined` returned for a real-but-
+    // unregistered symbol below (test262 keyFor/arg-non-symbol).
+    if js_is_symbol(sym_f64) == 0 {
+        crate::collection_iter::throw_type_error("Symbol.keyFor requires a symbol argument");
+    }
     let bits = sym_f64.to_bits();
-    let tag = bits & 0xFFFF_0000_0000_0000;
-    let sym_ptr = if tag == POINTER_TAG {
-        (bits & POINTER_MASK) as *const SymbolHeader
-    } else {
-        return f64::from_bits(TAG_UNDEFINED);
-    };
-    if sym_ptr.is_null() || (sym_ptr as usize) < 0x1000 {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
-    if (*sym_ptr).magic != SYMBOL_MAGIC {
-        return f64::from_bits(TAG_UNDEFINED);
-    }
+    let sym_ptr = (bits & POINTER_MASK) as *const SymbolHeader;
     // Well-known symbols (Symbol.toPrimitive, etc.) are NOT in the registry.
     if is_well_known_symbol(sym_ptr as usize) {
         return f64::from_bits(TAG_UNDEFINED);


### PR DESCRIPTION
Mops up the long tail of small, high-percentage test262 clusters across the
built-ins + language corpus. **50 tests fixed, 0 regressions** (verified by
failure-set diff per dir, and by a broad `--shard 0/12 "built-ins language"`
run of this branch vs `main`: +4, 0 regressions).

Per-dir parity (the 29 sweep dirs): pass **3058 → 3108**, parity **91.2% → 92.7%**.

## Root causes & fixes

**URI decode (`decodeURI`/`decodeURIComponent`) — 18 tests.**
`extract_str_from_nanbox` ran the input through `from_utf8(..).unwrap_or("")`,
silently dropping any WTF-8 string with a lone surrogate (so `decodeURI("\uD800")`
returned `""` → "differs"), and the final `String::from_utf8` rejected passthrough
surrogates. Rewrote the decode path to operate byte-wise on WTF-8 bytes with a
spec-faithful `Decode`: each multi-octet UTF-8 run is validated as it is decoded
(lead octet → correct count of `%`-escaped continuation octets; assembled code point
must be a non-overlong, non-surrogate scalar), else URIError. Non-`%` code units
(incl. lone surrogates) pass through verbatim; output uses the WTF-8 string
constructor when surrogates survive.

**encodeURI/encodeURIComponent ToString coercion — 2 tests.**
The encode family read the argument with `js_get_string_pointer_unified` (no
coercion), so `encodeURI({valueOf...})` yielded `""`. Switched to `js_string_coerce`
(full ToString) while preserving the lone-surrogate flag for the URIError check.

**parseInt/parseFloat leading whitespace — 5 tests.**
`parseFloat` trimmed only ASCII whitespace; `parseInt` used Rust's `trim_start`
(White_Space) which wrongly includes NEL and excludes BOM. Both now trim the JS
`StrWhiteSpace` set (NBSP, VT, LS/PS, BOM, Unicode space separators). `parseFloat`
trims byte-wise so a trailing lone surrogate elsewhere in the input can't poison the
parse.

**Reflect target validation — 3 tests.**
`Reflect.isExtensible`/`preventExtensions`/`defineProperty` used a heap-pointer
probe that accepts Symbol/BigInt primitives. Routed them through the existing
`reflect_value_is_object` predicate so a non-object target throws TypeError.

**Math.max/Math.min element coercion — 2 tests.**
A `NaN` argument short-circuited `return NaN` before later args were ToNumber-coerced
(observable via `valueOf`). Now every arg is coerced before the result is reduced.

**DataView byteOffset/byteLength ToIndex — 4 tests.**
`dataview_to_index` checked `< 0` on the raw value before truncating, so `-0.1` /
`-0.99999` threw RangeError instead of becoming `-0` (== 0). Truncate
(ToIntegerOrInfinity) before the sign/range checks.

**Symbol — 3 tests.**
`Symbol.keyFor(non-symbol)` now throws TypeError (was `undefined`); the `Symbol(desc)`
constructor now applies ToString to the description (objects coerce via toString/valueOf;
a Symbol description throws), instead of bit-casting an object pointer as a StringHeader.

**Boolean.prototype.valueOf/toString receiver — 1 test.**
Added the `this === Boolean.prototype` → `false` fallback (mirrors the existing Number
branch) so `Boolean.prototype.valueOf()` and `Boolean.prototype == false` work.

**Map/Set forEach thisArg — 3 tests.**
A 2-arg `set.forEach(cb, thisArg)` was folded into the array-like fast path
(`ArrayLikeMethod`), which ran the callback against an array view → zero iterations.
The 1-arg path already excluded Map/Set/URLSearchParams; added the same guard to the
2-arg fold sites so these route to `js_{map,set}_foreach` (which binds thisArg).

**Primitive-string `.constructor` — 4 tests.**
`"x".constructor` returned `undefined` (the raw `GC_TYPE_STRING` property-get branch
handled `.length` but not `.constructor`). Resolve it to the global `String` value,
mirroring the existing Array branch, so `"x".constructor === String`.

## Files
- `crates/perry-runtime/src/builtins/globals.rs` (URI decode/encode)
- `crates/perry-runtime/src/builtins/numbers.rs` (parse whitespace)
- `crates/perry-runtime/src/builtins/mod.rs`, `string/mod.rs` (re-exports)
- `crates/perry-runtime/src/proxy.rs` (Reflect target validation)
- `crates/perry-runtime/src/math.rs` (Math.max/min coercion)
- `crates/perry-runtime/src/buffer/from.rs` (DataView ToIndex)
- `crates/perry-runtime/src/symbol.rs` (keyFor/description)
- `crates/perry-runtime/src/object/primitive_proto_thunks.rs` (Boolean.prototype)
- `crates/perry-runtime/src/object/field_get_set.rs` (string `.constructor`)
- `crates/perry-hir/src/lower/expr_call/{local,array_only}_array_methods.rs` (forEach thisArg)

## Validation
Built + swept on a Linux box against pinned test262 (node v26 oracle). Zero
regressions in the 29 target dirs (failure-set diff) and in a broad
`--shard 0/12 "built-ins language"` run vs `main`.