### PR TITLE
fix(runtime): collection constructor obtained as a value no longer throws "requires 'new'" (fixes qs.stringify on nested objects)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -929,6 +929,19 @@ pub(super) fn identify_global_builtin_constructor(func_value: f64) -> Option<&'s
             || func_ptr == eval_error_constructor_call_thunk as *const u8 as usize
             || func_ptr == uri_error_constructor_call_thunk as *const u8 as usize
             || func_ptr == webcrypto_illegal_constructor_thunk as *const u8 as usize
+            // Map/Set/WeakMap/WeakSet/WeakRef constructor *values* carry their
+            // own "requires 'new'" thunks (global_this.rs). When obtained as a
+            // value and constructed via `new $WeakMap()` (e.g. qs's
+            // `side-channel`/`get-intrinsic` reads `%WeakMap%` into a variable),
+            // the call lands here, not the static codegen path. Accept the
+            // thunks so the singleton walk recovers the name and the match arms
+            // below dispatch into the real factory instead of invoking the
+            // bare-call thunk (which throws "Constructor WeakMap requires 'new'").
+            || func_ptr == map_constructor_call_thunk as *const u8 as usize
+            || func_ptr == set_constructor_call_thunk as *const u8 as usize
+            || func_ptr == weak_map_constructor_call_thunk as *const u8 as usize
+            || func_ptr == weak_set_constructor_call_thunk as *const u8 as usize
+            || func_ptr == weak_ref_constructor_call_thunk as *const u8 as usize
             || func_ptr
                 == crate::messaging::js_message_channel_constructor_call_error as *const u8
                     as usize
@@ -1653,6 +1666,65 @@ pub unsafe extern "C" fn js_new_function_construct(
                     .copied()
                     .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
                 return crate::object::js_object_coerce(value);
+            }
+            // `new $Map()` / `new $Set()` / `new $WeakMap()` / … where the
+            // constructor was obtained as a value (alias variable, intrinsic
+            // lookup, cross-module re-export). Mirror the static codegen
+            // construction in lower_call/builtin.rs: allocate, NaN-box, then
+            // initialize from the optional iterable argument.
+            "Map" => {
+                let map = crate::map::js_map_alloc(4);
+                let boxed = crate::value::js_nanbox_pointer(map as i64);
+                if let Some(&iterable) = args.first() {
+                    let ij = crate::value::JSValue::from_bits(iterable.to_bits());
+                    if !ij.is_undefined() && !ij.is_null() {
+                        let from = crate::map::js_map_from_iterable(iterable);
+                        return crate::value::js_nanbox_pointer(from as i64);
+                    }
+                }
+                return boxed;
+            }
+            "Set" => {
+                let set = crate::set::js_set_alloc(4);
+                let boxed = crate::value::js_nanbox_pointer(set as i64);
+                if let Some(&iterable) = args.first() {
+                    let ij = crate::value::JSValue::from_bits(iterable.to_bits());
+                    if !ij.is_undefined() && !ij.is_null() {
+                        let from = crate::set::js_set_from_iterable(iterable);
+                        return crate::value::js_nanbox_pointer(from as i64);
+                    }
+                }
+                return boxed;
+            }
+            "WeakMap" => {
+                let map = crate::weakref::js_weakmap_new();
+                let boxed = crate::value::js_nanbox_pointer(map as i64);
+                if let Some(&iterable) = args.first() {
+                    let ij = crate::value::JSValue::from_bits(iterable.to_bits());
+                    if !ij.is_undefined() && !ij.is_null() {
+                        return crate::weakref::js_weakmap_init_iterable(boxed, iterable);
+                    }
+                }
+                return boxed;
+            }
+            "WeakSet" => {
+                let set = crate::weakref::js_weakset_new();
+                let boxed = crate::value::js_nanbox_pointer(set as i64);
+                if let Some(&iterable) = args.first() {
+                    let ij = crate::value::JSValue::from_bits(iterable.to_bits());
+                    if !ij.is_undefined() && !ij.is_null() {
+                        return crate::weakref::js_weakset_init_iterable(boxed, iterable);
+                    }
+                }
+                return boxed;
+            }
+            "WeakRef" => {
+                let target = args
+                    .first()
+                    .copied()
+                    .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+                let wr = crate::weakref::js_weakref_new(target);
+                return crate::value::js_nanbox_pointer(wr as i64);
             }
             "Blob" => {
                 let parts = args


### PR DESCRIPTION
## Problem

`qs.stringify()` (qs v6 — used by Express and the Stripe SDK body encoder) throws on **any** nested object/array; flat objects work:

```
simple: name=hello%20world
TypeError: Constructor WeakMap requires 'new'
```

qs's `side-channel` dependency builds its channel with `new WeakMap()` — but it obtains the constructor as a **value** via `get-intrinsic` (`%WeakMap%` → a variable), then does `new $WeakMap()`.

## Root cause

A constructor obtained as a *value* (alias variable, intrinsic lookup, cross-module re-export) does **not** take the static codegen `new` path (which special-cases `class_name == "WeakMap"` → `js_weakmap_new`). It routes through the runtime value-construct path, `js_new_function_construct` in `class_registry.rs`.

That path consults `identify_global_builtin_constructor`, which only treats a closure as a known builtin if its `func_ptr` is in an allow-list. The `Map`/`Set`/`WeakMap`/`WeakSet`/`WeakRef` "requires 'new'" thunks (`*_constructor_call_thunk`) were **missing** from that list → it returned `None` → the call fell through and invoked the thunk as a plain function call → `throw "Constructor WeakMap requires 'new'"`.

## Fix (`crates/perry-runtime/src/object/class_registry.rs`)

1. Add the five collection-constructor thunks to the `is_global_builtin_func` allow-list so the singleton walk can recover their names.
2. Add `Map`/`Set`/`WeakMap`/`WeakSet`/`WeakRef` arms to `js_new_function_construct` that dispatch into the real factories (`js_map_alloc`+`js_map_from_iterable`, `js_set_alloc`+`js_set_from_iterable`, `js_weakmap_new`+`js_weakmap_init_iterable`, weakset same, `js_weakref_new`), honoring the optional iterable argument — mirroring the static codegen in `lower_call/builtin.rs`.

## Verification

- **Real `qs` 6.15.2**: `qs.stringify({ name: "x", meta: { a: 1 }, arr: [1, 2] }, { arrayFormat: "indices" })` → `name=x&meta%5Ba%5D=1&arr%5B0%5D=1&arr%5B1%5D=2` ✅ (matches the issue's expected output).
- **Arbitrary nesting** (deep objects, nested arrays, arrays-of-objects, round-trip `qs.parse`): byte-for-byte identical to `node`.
- Direct `new WeakMap()/Map()/Set()/WeakSet()/WeakRef()` still work — no regression on the static path.
- `cargo test -p perry-runtime`: 1003 pass; the single `date::tests::test_full_year_setters_revive_invalid_date_only` failure is **pre-existing** (fails identically on `main` with this change reverted).

## Notes

- Orthogonal pre-existing gap (not touched here, qs doesn't use it): dynamic `wr.deref()` on an *opaque* WeakRef value throws "deref is not a function" — `Expr::WeakRefDeref` is only emitted for statically-tracked WeakRef locals. That's a method-dispatch issue, not a construction one.
- No version bump / CHANGELOG entry — left for the maintainer to fold in at merge time.