### PR TITLE
fix(hir): class destructuring (dstr) test262 tail (v2)

### DIFF
--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -17,7 +17,7 @@ use crate::expr::{
     emit_typed_feedback_register_site, lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx,
     TypedFeedbackContract, TypedFeedbackKind,
 };
-use crate::nanbox::double_literal;
+use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::type_analysis::{is_global_constructor_expr, receiver_class_name};
 use crate::types::{DOUBLE, I32, I64, PTR};
 
@@ -855,6 +855,24 @@ pub fn try_lower_class_static_accessor_call(
     Ok(None)
 }
 
+/// A method-call receiver that must be lowered exactly once because
+/// re-evaluating it would re-run side effects (or re-construct a fresh
+/// value). The closure-call fallthrough otherwise lowers the receiver
+/// twice — once for the `this` binding and once inside the full callee
+/// PropertyGet — which double-runs these.
+fn receiver_must_eval_once(e: &Expr) -> bool {
+    matches!(
+        e,
+        Expr::Call { .. }
+            | Expr::CallSpread { .. }
+            | Expr::NativeMethodCall { .. }
+            | Expr::StaticMethodCall { .. }
+            | Expr::New { .. }
+            | Expr::NewDynamic { .. }
+            | Expr::Await(_)
+    )
+}
+
 pub fn try_lower_closure_call_fallthrough(
     ctx: &mut FnCtx<'_>,
     callee: &Expr,
@@ -892,7 +910,29 @@ pub fn try_lower_closure_call_fallthrough(
     // `js_closure_call17`+ exists) marshal the args through a stack buffer
     // and dispatch via `js_closure_call_array`. Refs #3527 (qs's recursive
     // `stringify` self-calls with 18 args).
-    let method_recv: Option<String> = if let Expr::PropertyGet { object, .. } = callee {
+    // When the receiver is itself side-effecting (a call / construct /
+    // await — e.g. a chained `C.staticMethod(g()).next()`), it MUST be
+    // evaluated exactly once. The straightforward shape below lowers
+    // `object` for the `this` binding AND lowers the full `callee`
+    // PropertyGet for the closure value, which re-lowers `object` and so
+    // re-runs its side effects. That double-stepped `g()` in test262
+    // `language/{statements,expressions}/class/dstr/async-gen-meth-static-*`
+    // (`C.method(g()).next()`). For a side-effecting receiver, evaluate it
+    // once here and read the method off that value directly.
+    let prelowered_recv: Option<(String, String)> =
+        if let Expr::PropertyGet { object, property } = callee {
+            if receiver_must_eval_once(object.as_ref()) {
+                Some((lower_expr(ctx, object)?, property.clone()))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+    let method_recv: Option<String> = if let Some((ref obj_v, _)) = prelowered_recv {
+        Some(obj_v.clone())
+    } else if let Expr::PropertyGet { object, .. } = callee {
         // Skip the method-binding when the receiver is a global,
         // namespace import, or NativeModuleRef — those aren't
         // user objects and shouldn't influence `this`.
@@ -908,7 +948,26 @@ pub fn try_lower_closure_call_fallthrough(
         None
     };
 
-    let recv_box = lower_expr(ctx, callee)?;
+    let recv_box = if let Some((ref obj_v, ref property)) = prelowered_recv {
+        // Read `property` off the once-lowered receiver value via the
+        // generic by-name getter (walks the prototype chain, so
+        // `gen.next` etc. resolve). Mirrors the dynamic by-name read in
+        // `expr::property_get::lower`.
+        let key_idx = ctx.strings.intern(property);
+        let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+        let blk = ctx.block();
+        let obj_bits = blk.bitcast_double_to_i64(obj_v);
+        let key_box = blk.load(DOUBLE, &key_handle_global);
+        let key_bits = blk.bitcast_double_to_i64(&key_box);
+        let key_handle = blk.and(I64, &key_bits, POINTER_MASK_I64);
+        blk.call(
+            DOUBLE,
+            "js_object_get_field_by_name_f64",
+            &[(I64, &obj_bits), (I64, &key_handle)],
+        )
+    } else {
+        lower_expr(ctx, callee)?
+    };
     let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
     for a in args {
         lowered_args.push(lower_expr(ctx, a)?);

--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -583,6 +583,10 @@ pub fn lower_class_method_with_name(
         Vec::new()
     };
 
+    // Capture the destructuring-prologue length before it is drained into the
+    // body, so generator methods can replay param binding synchronously at call
+    // time (see the `gen_param_prologue_len` recording below).
+    let destructuring_prologue_len = destructuring_stmts.len();
     if !destructuring_stmts.is_empty() {
         destructuring_stmts.append(&mut body);
         body = destructuring_stmts;
@@ -598,6 +602,7 @@ pub fn lower_class_method_with_name(
     // `undefined` post-padding because the method body just did `return a + b`
     // with no default check.
     let default_stmts = build_default_param_stmts(&params);
+    let default_prologue_len = default_stmts.len();
     if !default_stmts.is_empty() {
         let mut new_body = default_stmts;
         new_body.extend(body);
@@ -634,8 +639,22 @@ pub fn lower_class_method_with_name(
     // Exit method's type param scope
     ctx.exit_type_param_scope();
 
+    let func_id = ctx.fresh_func();
+    // Record the param-prologue length for generator methods so the generator
+    // transform runs param binding (default guards + destructuring) synchronously
+    // at call time per spec FunctionDeclarationInstantiation order. Without this,
+    // a `*method`/`async *method` with a destructuring/default param leaves the
+    // binding inside the lazy state-machine body, so a throwing default
+    // initializer never fires at call time (test262 class/dstr async-gen-meth-*).
+    if method.function.is_generator {
+        let prologue_len = default_prologue_len + destructuring_prologue_len;
+        if prologue_len > 0 {
+            ctx.gen_param_prologue_len.insert(func_id, prologue_len);
+        }
+    }
+
     Ok(Function {
-        id: ctx.fresh_func(),
+        id: func_id,
         name,
         type_params,
         params,

--- a/crates/perry-hir/src/lower_decl/private_members.rs
+++ b/crates/perry-hir/src/lower_decl/private_members.rs
@@ -113,6 +113,10 @@ pub fn lower_private_method(
         Vec::new()
     };
 
+    // Capture the destructuring-prologue length before it is drained into the
+    // body so generator methods can replay param binding synchronously at call
+    // time (see the `gen_param_prologue_len` recording below).
+    let destructuring_prologue_len = destructuring_stmts.len();
     if !destructuring_stmts.is_empty() {
         destructuring_stmts.append(&mut body);
         body = destructuring_stmts;
@@ -125,6 +129,7 @@ pub fn lower_private_method(
     // destructuring prologue, matching the public-method ordering in
     // `lower_method`.
     let default_stmts = build_default_param_stmts(&params);
+    let default_prologue_len = default_stmts.len();
     if !default_stmts.is_empty() {
         let mut new_body = default_stmts;
         new_body.extend(body);
@@ -135,8 +140,20 @@ pub fn lower_private_method(
     ctx.exit_scope(scope_mark);
     ctx.exit_type_param_scope();
 
+    let func_id = ctx.fresh_func();
+    // Record the param-prologue length for private generator methods so the
+    // generator transform replays param binding synchronously at call time
+    // (spec FunctionDeclarationInstantiation order). See the matching comment
+    // in `lower_class_method_with_name` (test262 class/dstr private-gen-meth-*).
+    if method.function.is_generator {
+        let prologue_len = default_prologue_len + destructuring_prologue_len;
+        if prologue_len > 0 {
+            ctx.gen_param_prologue_len.insert(func_id, prologue_len);
+        }
+    }
+
     Ok(Function {
-        id: ctx.fresh_func(),
+        id: func_id,
         name,
         type_params,
         params,

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -5945,6 +5945,20 @@ fn class_id_from_method_receiver(instance: f64) -> Option<u32> {
     if jsv.is_pointer() {
         let obj = jsv.as_pointer::<ObjectHeader>();
         if !obj.is_null() && (obj as usize) >= 0x100000 {
+            // A callable (closure / function object) is never a class-method
+            // receiver for bound-method marker substitution. Its allocation is a
+            // `ClosureHeader`, so reading `class_id` off it as an `ObjectHeader`
+            // is a type confusion that can yield a stray non-zero id. Without
+            // this guard, a free call to a `C.prototype.method` bound-method
+            // value made from inside a function-object method body (e.g.
+            // test262's `assert.throws(…, function(){ m(...) })`, where
+            // `IMPLICIT_THIS` is the `assert` function) would mis-substitute the
+            // function object as the receiver and dispatch `assert.method(...)`
+            // instead of `C.prototype.method`, bypassing the generator wrapper's
+            // param prologue. See `canonical_bound_method_receiver`.
+            if crate::closure::is_closure_ptr(obj as usize) {
+                return None;
+            }
             let cid = unsafe { (*obj).class_id };
             if cid != 0 {
                 return Some(cid);


### PR DESCRIPTION
## Summary

Finishes the class destructuring (`dstr`) test262 tail. Async-generator-method destructuring params now bind synchronously at call time, function-object method dispatch no longer mis-binds nested free calls, and chained static-method-call receivers are evaluated exactly once.

`language/{statements,expressions}/class/dstr`: **81.8% → 98.1%** (224 → 12 failures), **zero regressions**.

## Root causes & fixes

1. **Generator-method param prologue never recorded** (`lower_decl/class_members.rs`, `lower_decl/private_members.rs`)
   `lower_class_method_with_name` and the private-method lowering built the destructuring + default-param prologue but — unlike `lower_fn_decl` — never recorded `gen_param_prologue_len`. So for `async *m([x = throws()])` the param binding stayed inside the lazy state-machine body and never ran at call time; a throwing default / iterator error never fired (spec `FunctionDeclarationInstantiation` runs synchronously at call for (async) generators). Now records the prologue length so the generator transform lifts it to the outer wrapper. (~80 tests)

2. **Bound-method receiver type-confusion on function-objects** (`runtime/object/native_module.rs`)
   `class_id_from_method_receiver` read `class_id` off a `ClosureHeader` cast as an `ObjectHeader` (stray non-zero id), so `canonical_bound_method_receiver` substituted a function-object `IMPLICIT_THIS` as the receiver of a `C.prototype.method` bound-method value. A free call to such a value from inside a function-object method body — e.g. test262's `assert.throws(T, function(){ m(...) })`, where `IMPLICIT_THIS` is the `assert` function — mis-dispatched to `assert.method(...)` and bypassed the generator wrapper prologue. Now excludes closures from being treated as class-method receivers. (~100 tests)

3. **Chained static-method-call receiver double-evaluated** (`codegen/lower_call/console_promise.rs`)
   `try_lower_closure_call_fallthrough` lowered the method-call receiver twice — once for the `this` binding and again inside the full callee `PropertyGet` — re-running side effects. `C.method(g()).next()` stepped `g()` twice. Now a side-effecting receiver is lowered once and the method is read off that value. (~20 tests)

## Remaining (out of scope)

The remaining 12 `dstr` failures are a **general** array-destructuring gap: an array-literal source bypasses `Array.prototype[Symbol.iterator]`, so deleting/patching the iterator isn't observed. Not class-specific — a separate, broad change.

## Verification

- `language/{statements,expressions}/class/dstr` (full): 1008 → 1208 pass, 224 → 12 fail, 0 regressions.
- Broad regression diff (`built-ins` + `language`, shard 0/12, my build vs `origin/main`): **0 regressions**, +20 fixed, runtime-fail 305 → 289, compile-fail 17 → 15.

## Files
- `crates/perry-hir/src/lower_decl/class_members.rs`
- `crates/perry-hir/src/lower_decl/private_members.rs`
- `crates/perry-runtime/src/object/native_module.rs`
- `crates/perry-codegen/src/lower_call/console_promise.rs`