### PR TITLE
fix(hir): class field/element initializer test262 tail (v3, native-region-safe)

### DIFF
--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -546,6 +546,32 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 ],
             ))
         }
+        Expr::PrivateGuard {
+            class_name,
+            field_name,
+            kind,
+            op,
+            object,
+        } => {
+            // Evaluate the receiver once, brand+kind check it, and return it
+            // unchanged (or throw TypeError). The enclosing PropertyGet /
+            // PropertySet / method-call lowering then operates on the result.
+            let obj = lower_expr(ctx, object)?;
+            let class_id = ctx.class_ids.get(class_name).copied().unwrap_or(0);
+            let key_label = emit_string_literal_global(ctx, field_name);
+            Ok(ctx.block().call(
+                DOUBLE,
+                "js_private_guard",
+                &[
+                    (DOUBLE, &obj),
+                    (I32, &class_id.to_string()),
+                    (PTR, &key_label),
+                    (I32, &field_name.len().to_string()),
+                    (I32, &kind.to_string()),
+                    (I32, &op.to_string()),
+                ],
+            ))
+        }
 
         // -------- fs.writeFileSync(path, content) --------
         // The runtime takes both args as NaN-boxed doubles directly.

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1521,6 +1521,7 @@ pub(crate) fn lower_expr(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         | Expr::SetNew
         | Expr::In { .. }
         | Expr::PrivateBrandCheck { .. }
+        | Expr::PrivateGuard { .. }
         | Expr::ParseInt { .. }
         | Expr::ParseFloat(..)
         | Expr::RegExp { .. }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -331,6 +331,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_map_from_iterable", I64, &[DOUBLE]);
     module.declare_function("js_object_has_property", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_private_brand_check", DOUBLE, &[DOUBLE, I32, PTR, I32]);
+    module.declare_function(
+        "js_private_guard",
+        DOUBLE,
+        &[DOUBLE, I32, PTR, I32, I32, I32],
+    );
     module.declare_function("js_fs_to_unix_timestamp", DOUBLE, &[DOUBLE]);
     module.declare_function("js_fs_write_file_sync", I32, &[DOUBLE, DOUBLE]);
     module.declare_function(

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1666,6 +1666,9 @@ pub(crate) fn receiver_class_name(ctx: &FnCtx<'_>, e: &Expr) -> Option<String> {
         // at the top of class_stack (for inlined constructors) or comes
         // from the enclosing method's owning class.
         Expr::This => ctx.class_stack.last().cloned(),
+        // A private-access brand guard returns its receiver unchanged; see
+        // through it so shadowed private-field slot resolution stays accurate.
+        Expr::PrivateGuard { object, .. } => receiver_class_name(ctx, object),
         // `arr[i]` where `arr: ClassFoo[]` — the element type is the
         // array's parameter. Lets `items[2].display()` resolve the
         // method dispatch.

--- a/crates/perry-hir/src/destructuring/assignment_expr.rs
+++ b/crates/perry-hir/src/destructuring/assignment_expr.rs
@@ -72,6 +72,22 @@ pub(crate) fn lower_destructuring_assignment(
                                                 value: Box::new(index_expr),
                                             });
                                         }
+                                        // `[this.#field] = arr` — brand-guard the
+                                        // receiver so a wrong-receiver write throws.
+                                        ast::MemberProp::PrivateName(private) => {
+                                            let property = format!("#{}", private.name);
+                                            let object = crate::lower::wrap_private_guard(
+                                                ctx,
+                                                object,
+                                                &property,
+                                                crate::lower::PRIV_OP_WRITE,
+                                            );
+                                            exprs.push(Expr::PropertySet {
+                                                object,
+                                                property,
+                                                value: Box::new(index_expr),
+                                            });
+                                        }
                                         _ => {
                                             return Err(anyhow!(
                                                 "Unsupported member expression in destructuring"

--- a/crates/perry-hir/src/destructuring/assignment_stmt.rs
+++ b/crates/perry-hir/src/destructuring/assignment_stmt.rs
@@ -389,6 +389,28 @@ fn prepare_assignment_target(
                             None,
                         ))
                     }
+                    // Private-field assignment target, e.g.
+                    // `[this.#field] = [v]` or `({a: this.#field} = src)`. Brand
+                    // -guard the receiver so a write to a wrong receiver (or to
+                    // a getter-only accessor / private method) throws TypeError,
+                    // matching `this.#field = v`.
+                    ast::MemberProp::PrivateName(private) => {
+                        let property = format!("#{}", private.name);
+                        let guarded = crate::lower::wrap_private_guard(
+                            ctx,
+                            Box::new(Expr::LocalGet(object_id)),
+                            &property,
+                            crate::lower::PRIV_OP_WRITE,
+                        );
+                        Ok((
+                            prepare,
+                            PreparedTarget::Property {
+                                object: *guarded,
+                                property,
+                            },
+                            None,
+                        ))
+                    }
                     _ => Err(anyhow!(
                         "Unsupported member expression in destructuring assignment"
                     )),

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -251,6 +251,30 @@ pub enum Expr {
         object: Box<Expr>,
     },
 
+    /// Brand+kind guard wrapping the receiver of a private member access
+    /// `obj.#name`. Evaluates `object` exactly once and returns its value
+    /// UNCHANGED when the access is legal; otherwise throws a `TypeError`.
+    ///
+    /// Two checks run, in spec order:
+    ///   1. Brand check — `object` must be an instance of `class_name` (the
+    ///      class that lexically declares `#name`). A wrong receiver (an
+    ///      ordinary object, or an instance of an unrelated/outer class)
+    ///      throws.
+    ///   2. Kind/op check — reading a setter-only accessor, writing a
+    ///      getter-only accessor, or writing a private method all throw.
+    ///
+    /// Because it returns the receiver, it composes with the existing
+    /// `PropertyGet` / `PropertySet` / method-call lowering: those operate on
+    /// the guard's result and need no private-specific changes. `kind` and
+    /// `op` are the wire codes defined by `PrivKind` / 0=get,1=set.
+    PrivateGuard {
+        class_name: String,
+        field_name: String,
+        kind: u8,
+        op: u8,
+        object: Box<Expr>,
+    },
+
     // Await expression (for async functions)
     Await(Box<Expr>),
 

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -76,6 +76,7 @@ impl LoweringContext {
             ui_widget_type_aliases: HashMap::new(),
             current_class: None,
             current_class_member_is_static: false,
+            private_scopes: Vec::new(),
             object_super_home_stack: Vec::new(),
             extern_func_types: Vec::new(),
             source_file_path,
@@ -254,6 +255,29 @@ impl LoweringContext {
         let id = self.next_local_id;
         self.next_local_id += 1;
         id
+    }
+
+    /// Push a private-name scope for a class body (innermost last). Built by
+    /// pre-scanning the class members. See `private_scopes`.
+    pub(crate) fn push_private_scope(&mut self, scope: PrivateScope) {
+        self.private_scopes.push(scope);
+    }
+
+    pub(crate) fn pop_private_scope(&mut self) {
+        self.private_scopes.pop();
+    }
+
+    /// Resolve a private name (`#name`, with the leading `#`) to its declaring
+    /// class and member kind by walking the private-scope stack innermost
+    /// outward — matching the lexical resolution rule for private names. A
+    /// nested class that redeclares the same name shadows the outer one.
+    pub(crate) fn resolve_private(&self, field_name: &str) -> Option<(String, PrivMember)> {
+        for scope in self.private_scopes.iter().rev() {
+            if let Some(m) = scope.members.get(field_name) {
+                return Some((scope.class_name.clone(), *m));
+            }
+        }
+        None
     }
 
     pub(crate) fn mark_local_immutable(&mut self, id: LocalId) {

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -966,8 +966,16 @@ fn lower_assignment_target(
                     })
                 }
                 ast::MemberProp::PrivateName(private) => {
-                    // Private field assignment: this.#field = value
+                    // Private field assignment: this.#field = value. Guard the
+                    // receiver so a write to a wrong receiver — or to a
+                    // getter-only accessor / a private method — throws.
                     let property = format!("#{}", private.name);
+                    let object = super::expr_member::wrap_private_guard(
+                        ctx,
+                        object,
+                        &property,
+                        super::expr_member::PRIV_OP_WRITE,
+                    );
                     Ok(Expr::PropertySet {
                         object,
                         property,

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -2408,11 +2408,48 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
             Ok(Expr::IndexGet { object, index })
         }
         ast::MemberProp::PrivateName(private) => {
-            // Private field access: this.#field -> PropertyGet with "#field"
+            // Private field access: this.#field -> PropertyGet with "#field".
+            // Wrap the receiver in a brand+kind guard so accessing the private
+            // member on a wrong receiver throws TypeError per spec.
             let property = format!("#{}", private.name);
+            let object = wrap_private_guard(ctx, object, &property, PRIV_OP_READ);
             Ok(Expr::PropertyGet { object, property })
         }
     }
+}
+
+/// Wire codes for `Expr::PrivateGuard.op` — the operation a private member
+/// access performs. Keep in sync with the `js_private_guard` runtime helper:
+/// 0/1 are instance read/write, 2/3 are static read/write.
+pub(crate) const PRIV_OP_READ: u8 = 0;
+pub(crate) const PRIV_OP_WRITE: u8 = 1;
+
+/// Wrap the receiver of a private member access `obj.#name` in a brand+kind
+/// guard so an access on a non-conforming receiver throws `TypeError`. If the
+/// name cannot be resolved to a declaring class in scope, the object is
+/// returned unwrapped (falls back to the pre-existing string-keyed behavior so
+/// this can never reject a legal access). A STATIC member emits a static-brand
+/// guard (the receiver must be the declaring class constructor itself).
+/// `op` is `PRIV_OP_READ` / `PRIV_OP_WRITE`.
+pub(crate) fn wrap_private_guard(
+    ctx: &LoweringContext,
+    object: Box<Expr>,
+    field_name: &str,
+    op: u8,
+) -> Box<Expr> {
+    if let Some((class_name, member)) = ctx.resolve_private(field_name) {
+        // Static members get a static brand (op + 2); instance members the
+        // ordinary op code.
+        let op = if member.is_static { op + 2 } else { op };
+        return Box::new(Expr::PrivateGuard {
+            class_name,
+            field_name: field_name.to_string(),
+            kind: member.kind as u8,
+            op,
+            object,
+        });
+    }
+    object
 }
 
 /// #503 — Node-core stdlib namespace receivers whose dynamic (`obj[x]`)

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -324,6 +324,12 @@ pub(crate) fn lower_expr_assignment(
                 }
                 ast::MemberProp::PrivateName(private) => {
                     let property = format!("#{}", private.name);
+                    let object = expr_member::wrap_private_guard(
+                        ctx,
+                        object,
+                        &property,
+                        expr_member::PRIV_OP_WRITE,
+                    );
                     Ok(Expr::PropertySet {
                         object,
                         property,
@@ -1557,10 +1563,16 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                                 index: Box::new(index),
                             }
                         }
-                        ast::MemberProp::PrivateName(private) => Expr::PropertyGet {
-                            object: Box::new(obj_expr.clone()),
-                            property: format!("#{}", private.name),
-                        },
+                        ast::MemberProp::PrivateName(private) => {
+                            let property = format!("#{}", private.name);
+                            let object = expr_member::wrap_private_guard(
+                                ctx,
+                                Box::new(obj_expr.clone()),
+                                &property,
+                                expr_member::PRIV_OP_READ,
+                            );
+                            Expr::PropertyGet { object, property }
+                        }
                     };
 
                     // Issue #388: optional chaining short-circuits on
@@ -1629,10 +1641,19 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                                             index: Box::new(idx),
                                         }
                                     }
-                                    ast::MemberProp::PrivateName(private) => Expr::PropertyGet {
-                                        object: Box::new(obj.clone()),
-                                        property: format!("#{}", private.name),
-                                    },
+                                    ast::MemberProp::PrivateName(private) => {
+                                        let property = format!("#{}", private.name);
+                                        let guarded = expr_member::wrap_private_guard(
+                                            ctx,
+                                            Box::new(obj.clone()),
+                                            &property,
+                                            expr_member::PRIV_OP_READ,
+                                        );
+                                        Expr::PropertyGet {
+                                            object: guarded,
+                                            property,
+                                        }
+                                    }
                                 };
                                 Ok((obj, prop))
                             };

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -17,6 +17,34 @@ pub(crate) struct WithEnvFrame {
     pub(crate) local_mark: usize,
 }
 
+/// Kind of a private class element, for the read/write legality checks that
+/// `obj.#name` access performs (in addition to the brand check). The numeric
+/// values are the wire codes passed to the `js_private_guard` runtime helper —
+/// keep them in sync with `crates/perry-runtime/src/object/field_get_set.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrivKind {
+    Field = 0,
+    Method = 1,
+    Get = 2,
+    Set = 3,
+    GetSet = 4,
+}
+
+/// One private element declared by a class: its kind and whether it is static.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PrivMember {
+    pub(crate) kind: PrivKind,
+    pub(crate) is_static: bool,
+}
+
+/// Private-name scope for one class body. `members` is keyed by the
+/// `#name` string (with the leading `#`).
+#[derive(Debug, Clone)]
+pub(crate) struct PrivateScope {
+    pub(crate) class_name: String,
+    pub(crate) members: HashMap<String, PrivMember>,
+}
+
 pub struct LoweringContext {
     /// Counter for generating unique local IDs
     pub(crate) next_local_id: LocalId,
@@ -176,6 +204,15 @@ pub struct LoweringContext {
     pub(crate) current_class: Option<String>,
     /// True while lowering a static class member body.
     pub(crate) current_class_member_is_static: bool,
+    /// Lexical stack of private-name scopes — one entry per enclosing class
+    /// body, innermost last. Each access of `obj.#name` resolves `#name` to
+    /// the nearest enclosing class that DECLARES it, yielding the declaring
+    /// class (for the brand check) and the member kind (for the
+    /// read-on-setter-only / write-on-method etc. TypeError checks). This is
+    /// kept on the context (not derived from `current_class`) so it survives
+    /// nested plain-function / arrow lowering — a private name referenced from
+    /// an inner function still lexically resolves to its declaring class.
+    pub(crate) private_scopes: Vec<PrivateScope>,
     /// Home-object local for object-literal methods while their bodies are
     /// lowered. Used to preserve `super` in object methods.
     pub(crate) object_super_home_stack: Vec<LocalId>,

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -40,6 +40,7 @@ mod expr_call;
 mod expr_function;
 pub(crate) use expr_function::{capture_function_source, lower_fn_expr};
 mod expr_member;
+pub(crate) use expr_member::{wrap_private_guard, PRIV_OP_READ, PRIV_OP_WRITE};
 mod expr_misc;
 mod expr_new;
 mod expr_object;
@@ -74,7 +75,9 @@ pub(crate) use widget_decl::*;
 // transitively when downstream files reach into `crate::lower::Name`,
 // so spelling them out keeps the public-and-internal API stable.
 mod lowering_context;
-pub(crate) use lowering_context::{LoweringContext, WithEnvFrame};
+pub(crate) use lowering_context::{
+    LoweringContext, PrivKind, PrivMember, PrivateScope, WithEnvFrame,
+};
 
 mod typed_parse;
 pub(crate) use typed_parse::{extract_typed_parse_source_order, resolve_typed_parse_ty};

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -152,6 +152,11 @@ pub fn lower_class_decl(
     let old_class = ctx.current_class.take();
     ctx.current_class = Some(name.clone());
 
+    // Push the private-name scope for this class body so `obj.#name` accesses
+    // brand-check against the declaring class and reject illegal read/write
+    // operations. Popped at the matching restore below.
+    ctx.push_private_scope(super::build_private_scope(&class_decl.class, &name));
+
     // Issue #562: track the parent class identifier so the `super({...})`
     // pre-scan in expr_call.rs can register the controller param as a
     // readable_stream instance for stream subclass constructors. Set
@@ -1009,6 +1014,7 @@ pub fn lower_class_decl(
 
     // Restore previous current_class
     ctx.current_class = old_class;
+    ctx.pop_private_scope();
     // Issue #562: restore the prior super-ident slot.
     ctx.current_class_super_ident = old_super_ident;
 
@@ -1097,6 +1103,9 @@ pub fn lower_class_from_ast(
 
     let old_class = ctx.current_class.take();
     ctx.current_class = Some(name.to_string());
+
+    // Private-name scope for this class-expression body (see lower_class_decl).
+    ctx.push_private_scope(super::build_private_scope(class, name));
 
     // Issue #562: same as the parallel `lower_class_decl` arm — track the
     // parent class identifier so super({...}) controller-param pre-scan
@@ -1400,6 +1409,7 @@ pub fn lower_class_from_ast(
         ctx.register_class_native_extends(name.to_string(), module.clone(), class.clone());
     }
     ctx.current_class = old_class;
+    ctx.pop_private_scope();
     // Issue #562: restore prior super-ident slot.
     ctx.current_class_super_ident = old_super_ident;
 

--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -849,6 +849,10 @@ pub fn lower_class_prop(ctx: &mut LoweringContext, prop: &ast::ClassProp) -> Res
     let (name, key_expr) = match &prop.key {
         ast::PropName::Ident(ident) => (ident.sym.to_string(), None),
         ast::PropName::Str(s) => (s.value.as_str().unwrap_or("").to_string(), None),
+        // Numeric field keys (`0 = 'bar'`, `1e-7;`) use the canonical JS number
+        // -to-string conversion so reads via `c[0]` / `c['1e-7']` agree.
+        ast::PropName::Num(n) => (crate::lower::number_to_js_key(n.value), None),
+        ast::PropName::BigInt(b) => (b.value.to_string(), None),
         ast::PropName::Computed(c) => {
             let key = lower_expr(ctx, &c.expr)?;
             // Synthetic name — uniqueness within a class is enforced by the
@@ -859,7 +863,6 @@ pub fn lower_class_prop(ctx: &mut LoweringContext, prop: &ast::ClassProp) -> Res
             let synth = format!("__computed_field_{}_{}", c.span.lo.0, c.span.hi.0);
             (synth, Some(key))
         }
-        _ => return Err(anyhow!("Unsupported property key")),
     };
 
     // Extract type from type annotation (using context for class type param resolution).

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -53,6 +53,7 @@ pub(crate) use helpers::{
 };
 pub(crate) use interface_decl::lower_interface_decl;
 pub(crate) use private_members::{
-    lower_private_getter, lower_private_method, lower_private_prop, lower_private_setter,
+    build_private_scope, lower_private_getter, lower_private_method, lower_private_prop,
+    lower_private_setter,
 };
 pub(crate) use type_alias::lower_type_alias_decl;

--- a/crates/perry-hir/src/lower_decl/private_members.rs
+++ b/crates/perry-hir/src/lower_decl/private_members.rs
@@ -13,6 +13,60 @@ use crate::lower_types::*;
 
 use super::*;
 
+/// Pre-scan a class body and build the private-name scope for it: every
+/// private field / method / accessor it declares, with its kind and
+/// static-ness. Getter+setter pairs of the same name collapse to
+/// `PrivKind::GetSet`. Used to push a `PrivateScope` for the duration of the
+/// class body lowering so `obj.#name` accesses can brand-check on the correct
+/// declaring class and reject illegal read/write operations.
+pub fn build_private_scope(class: &ast::Class, class_name: &str) -> crate::lower::PrivateScope {
+    use crate::lower::{PrivKind, PrivMember, PrivateScope};
+    let mut members: std::collections::HashMap<String, PrivMember> =
+        std::collections::HashMap::new();
+    for member in &class.body {
+        match member {
+            ast::ClassMember::PrivateProp(prop) => {
+                let name = format!("#{}", prop.key.name);
+                members.insert(
+                    name,
+                    PrivMember {
+                        kind: PrivKind::Field,
+                        is_static: prop.is_static,
+                    },
+                );
+            }
+            ast::ClassMember::PrivateMethod(method) => {
+                let name = format!("#{}", method.key.name);
+                let kind = match method.kind {
+                    ast::MethodKind::Getter => PrivKind::Get,
+                    ast::MethodKind::Setter => PrivKind::Set,
+                    ast::MethodKind::Method => PrivKind::Method,
+                };
+                // Collapse a getter+setter pair declared under the same name
+                // into GetSet so a read or a write is legal for either.
+                let merged = match members.get(&name).map(|m| m.kind) {
+                    Some(PrivKind::Get) if kind == PrivKind::Set => PrivKind::GetSet,
+                    Some(PrivKind::Set) if kind == PrivKind::Get => PrivKind::GetSet,
+                    Some(existing) => existing,
+                    None => kind,
+                };
+                members.insert(
+                    name,
+                    PrivMember {
+                        kind: merged,
+                        is_static: method.is_static,
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+    PrivateScope {
+        class_name: class_name.to_string(),
+        members,
+    }
+}
+
 pub fn lower_private_method(
     ctx: &mut LoweringContext,
     method: &ast::PrivateMethod,

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -74,6 +74,7 @@ impl SH for Expr {
             Expr::InstanceOf { expr, ty, ty_expr } => { tag(h, 38); expr.as_ref().hash(h); ty.hash(h); ty_expr.hash(h); }
             Expr::In { property, object } => { tag(h, 39); property.as_ref().hash(h); object.as_ref().hash(h); }
             Expr::PrivateBrandCheck { class_name, field_name, object } => { tag(h, 12401); class_name.hash(h); field_name.hash(h); object.as_ref().hash(h); }
+            Expr::PrivateGuard { class_name, field_name, kind, op, object } => { tag(h, 12402); class_name.hash(h); field_name.hash(h); kind.hash(h); op.hash(h); object.as_ref().hash(h); }
             Expr::Await(e) => { tag(h, 40); e.as_ref().hash(h); }
             Expr::Yield { value, delegate } => { tag(h, 41); value.hash(h); delegate.hash(h); }
             Expr::New { class_name, args, type_args, } => { tag(h, 42); class_name.hash(h); args.hash(h); type_args.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -644,6 +644,9 @@ where
         Expr::PrivateBrandCheck { object, .. } => {
             f(object);
         }
+        Expr::PrivateGuard { object, .. } => {
+            f(object);
+        }
         Expr::FsWriteFileSync(a, b)
         | Expr::FsAppendFileSync(a, b)
         | Expr::PathJoin(a, b)

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -645,6 +645,9 @@ where
         Expr::PrivateBrandCheck { object, .. } => {
             f(object);
         }
+        Expr::PrivateGuard { object, .. } => {
+            f(object);
+        }
         Expr::FsWriteFileSync(a, b)
         | Expr::FsAppendFileSync(a, b)
         | Expr::PathJoin(a, b)

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2199,6 +2199,22 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
         return nanbox_false;
     }
 
+    // Private names are never reflectable via `Reflect.has` / `in`: a
+    // `#name`-prefixed string key on a class instance is a private element
+    // stored in an internal slot, invisible to ordinary [[HasProperty]]. The
+    // genuine private brand check (`#name in obj`) routes through
+    // `js_private_brand_check`, not here. Mirrors `js_object_has_own`'s
+    // `#`-hiding (gated on `class_id != 0`).
+    if unsafe { (*obj_ptr).class_id != 0 } && key_val.is_any_string() {
+        let key_ptr =
+            crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+        if let Some(k) = unsafe { super::has_own_helpers::str_from_string_header(key_ptr) } {
+            if k.starts_with('#') {
+                return nanbox_false;
+            }
+        }
+    }
+
     if unsafe { (*obj_ptr).class_id == NATIVE_MODULE_CLASS_ID } {
         if !key_val.is_any_string() {
             return nanbox_false;
@@ -5308,6 +5324,112 @@ pub extern "C" fn js_private_brand_check(
     }
 
     true_value
+}
+
+/// Throw a `TypeError` with `msg` through Perry's exception machinery so a
+/// surrounding `try { ... } catch (e) { ... }` catches it. Diverges.
+fn throw_private_type_error(msg: &str) -> ! {
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    let v = crate::value::JSValue::pointer(err as *const u8).bits();
+    crate::exception::js_throw(f64::from_bits(v))
+}
+
+/// Brand check core shared with `js_private_brand_check`: does `obj` carry the
+/// brand of `declaring_class_id` (it is an instance of that class or a
+/// subclass)? Walks the class-id parent chain.
+unsafe fn private_object_has_brand(obj: f64, declaring_class_id: u32) -> bool {
+    if declaring_class_id == 0 {
+        return false;
+    }
+    let value = JSValue::from_bits(obj.to_bits());
+    if !value.is_pointer() {
+        return false;
+    }
+    let obj_ptr = value.as_pointer::<ObjectHeader>();
+    if obj_ptr.is_null() {
+        return false;
+    }
+    let obj_class_id = js_object_get_class_id(obj_ptr);
+    if obj_class_id == 0 {
+        return false;
+    }
+    let mut cur = obj_class_id;
+    for _ in 0..32 {
+        if cur == declaring_class_id {
+            return true;
+        }
+        match super::class_registry::get_parent_class_id(cur) {
+            Some(parent) if parent != 0 && parent != cur => cur = parent,
+            _ => break,
+        }
+    }
+    false
+}
+
+/// Brand + kind/op guard for a private member access `obj.#name`. Returns
+/// `obj` unchanged when the access is legal; otherwise throws a `TypeError`.
+///
+/// The enclosing `PropertyGet` / `PropertySet` / method-call lowering operates
+/// on the returned receiver, so this helper only enforces the two access
+/// preconditions the spec attaches to a PrivateReference:
+///   1. The receiver must carry the private brand (be an instance of the
+///      declaring class). A plain object, or an instance of an unrelated /
+///      enclosing class, throws.
+///   2. The operation must match the member kind — reading a setter-only
+///      accessor, or writing a getter-only accessor or a private method,
+///      throws.
+///
+/// `kind`: 0=field, 1=method, 2=getter-only, 3=setter-only, 4=getter+setter.
+/// `op`:   0=read, 1=write (instance); 2=read, 3=write (static).
+///
+/// For a STATIC private member the brand is identity-based: the receiver must
+/// BE the declaring class constructor itself (static private elements are not
+/// inherited, so a subclass constructor does not carry them). For an INSTANCE
+/// member the receiver must be an instance of the declaring class (or a
+/// subclass).
+///
+/// `declaring_class_id == 0` means codegen could not resolve the declaring
+/// class (e.g. an unusual class-expression shape); the guard then degrades to
+/// a no-op so it can never reject a legal access.
+#[no_mangle]
+pub extern "C" fn js_private_guard(
+    obj: f64,
+    declaring_class_id: u32,
+    _field_name_ptr: *const u8,
+    _field_name_len: u32,
+    kind: u32,
+    op: u32,
+) -> f64 {
+    if declaring_class_id == 0 {
+        return obj;
+    }
+    let is_static = op >= 2;
+    let read_write = op & 1; // 0=read, 1=write
+    let has_brand = if is_static {
+        // Static private brand: the receiver must be exactly the declaring
+        // class constructor (identity), not an instance or a subclass.
+        super::class_ref_id(obj) == Some(declaring_class_id)
+    } else {
+        unsafe { private_object_has_brand(obj, declaring_class_id) }
+    };
+    if !has_brand {
+        throw_private_type_error(
+            "Cannot access private member from an object whose class did not declare it",
+        );
+    }
+    let op = read_write;
+    // Kind/op legality, after the brand check (spec order).
+    let illegal = matches!(
+        (op, kind),
+        (0, 3) /* read setter-only: [[Get]] of accessor without getter */
+            | (1, 2) /* write getter-only: [[Set]] of accessor without setter */
+            | (1, 1) /* write private method */
+    );
+    if illegal {
+        throw_private_type_error("Invalid private member operation for its kind");
+    }
+    obj
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Finishes the class field/element initializer tail by implementing **private-member brand-checking on access**. Previously `obj.#name` lowered to a plain string-keyed `PropertyGet "#name"`, so accessing a private member on the wrong receiver silently returned `undefined` instead of throwing `TypeError`. This PR enforces the spec preconditions of a PrivateReference.

### What now throws TypeError (per spec)
1. **Brand check** — receiver must carry the private brand: an instance of the declaring class (or subclass) for instance members; the declaring class constructor *itself* for static members (statics are not inherited). Ordinary objects, unrelated/outer-class instances, and subclass constructors all throw.
2. **Kind/op check** — reading a setter-only accessor, or writing a getter-only accessor or a private method, throws.

## Design

A single additive HIR node `Expr::PrivateGuard { class_name, field_name, kind, op, object }` wraps the receiver of every private get / set / method-call. It evaluates the receiver once and returns it **unchanged** when the access is legal, otherwise throws via `js_private_guard`. Because it returns the receiver, it composes with the existing `PropertyGet` / `PropertySet` / method-call lowering — no private-specific changes needed there.

- A lexical `private_scopes` stack on `LoweringContext` resolves each `#name` to its declaring class + member kind, walking innermost-out (so a nested class that redeclares a name shadows correctly) and surviving nested function/arrow lowering (a private name referenced from an inner function still resolves to its lexical declaring class).
- `receiver_class_name` sees through `PrivateGuard` so shadowed private-field slot resolution (subclass field with the same `#name`) stays class-accurate — this is what keeps regressions at zero.
- `declaring_class_id == 0` degrades the guard to a no-op so it can never reject a legal access (defensive against unresolved class-expression shapes).

## Also in this pass
- `Reflect.has` / `in` hide `#name` keys on class instances (private elements live in internal slots, invisible to ordinary `[[HasProperty]]`).
- Private-field destructuring-assignment targets (`[this.#x] = v`, `({a: this.#x} = src)`) lower + brand-guard instead of failing to compile.
- Numeric / bigint class-field keys (`0 = 'bar'`, `1e-7;`) lower via canonical JS number-to-key conversion instead of `Unsupported property key`.

## Results

| dir | before | after |
|-----|--------|-------|
| language/expressions/class/elements | 87% | 89% |
| language/statements/class/elements | 83% | 86% |
| **combined** | **84.9%** | **87.8%** (+82 pass) |

- **Zero regressions** (failure-set diff vs `main` on the two class/elements dirs AND a broad `built-ins language` shard).
- **native-region-proof gate: pass.**

## Files
HIR: `ir/expr.rs`, `lower/{lowering_context,context,mod,expr_member,lower_expr,expr_assign}.rs`, `lower_decl/{class_decl,class_members,private_members,mod}.rs`, `destructuring/{assignment_stmt,assignment_expr}.rs`, `walker/*`, `stable_hash/expr.rs`. Codegen: `expr/{logical_collections,mod}.rs`, `type_analysis.rs`, `runtime_decls/strings.rs`. Runtime: `object/field_get_set.rs`.

## Deferred (model limitations / out of scope)
- Static-method dynamic `this` binding on `.call()` (static methods hardcode the class-ref receiver) — blocks ~13 static-private `.call(wrongObj)` / inner-function tests.
- eval-of-private-name early errors (needs context-sensitive eval-time SyntaxError detection).
- Per-field install-order brand (before-`super()` / before-declaration) — the class-id brand model treats all members as present from allocation.
