### PR TITLE
test(#4841): Stripe protoExtend regression + readable unhandled rejections + handled-rejection false-positive fix

### DIFF
--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -201,7 +201,7 @@ pub extern "C" fn js_leave_finally() {
 }
 
 /// Read a StringHeader into an owned Rust String (empty on null/garbage).
-unsafe fn string_header_to_string(ptr: *const crate::string::StringHeader) -> String {
+pub(crate) unsafe fn string_header_to_string(ptr: *const crate::string::StringHeader) -> String {
     if ptr.is_null() || (ptr as usize) < 0x10000 {
         return String::new();
     }

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -234,6 +234,17 @@ pub extern "C" fn js_async_step_chain(value: f64, step_closure: ClosurePtr) -> *
                     )
                 }
                 PromiseState::Rejected => {
+                    // `await`ing an already-rejected promise delivers its
+                    // reason to this async step (which re-throws it into the
+                    // suspended function body, where a surrounding try/catch
+                    // can catch it) — so the rejection IS handled. The
+                    // Pending arm below routes through `js_promise_then`, which
+                    // marks the rejection handled; this fast path reads the
+                    // reason field directly, so it must mark it explicitly or
+                    // the program-end detector reports a spurious
+                    // "Uncaught (in promise)" for a rejection that `await`
+                    // already consumed (and exits non-zero).
+                    crate::promise::mark_rejection_handled(inner);
                     let reason = unsafe { (*inner).reason };
                     (
                         if can_reuse {

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -87,20 +87,42 @@ pub extern "C" fn js_promise_report_unhandled_rejections() {
     // these fields, so `attach_settle_listener` removes them from the set at
     // attach time.) This makes the detector robust to internal machinery
     // (async generators, async-from-sync iterators) adopting a rejection.
-    let any_unhandled = UNHANDLED_REJECTIONS.with(|m| {
-        m.borrow().iter().any(|&p| {
-            let pr = p as *const Promise;
-            unsafe {
-                (*pr).state == PromiseState::Rejected
-                    && (*pr).on_rejected.is_null()
-                    && (*pr).next.is_null()
-            }
-        })
+    let unhandled_reasons: Vec<f64> = UNHANDLED_REJECTIONS.with(|m| {
+        m.borrow()
+            .iter()
+            .filter_map(|&p| {
+                let pr = p as *const Promise;
+                unsafe {
+                    if (*pr).state == PromiseState::Rejected
+                        && (*pr).on_rejected.is_null()
+                        && (*pr).next.is_null()
+                    {
+                        Some((*pr).reason)
+                    } else {
+                        None
+                    }
+                }
+            })
+            .collect()
     });
-    if !any_unhandled {
+    if unhandled_reasons.is_empty() {
         return;
     }
-    eprintln!("Uncaught (in promise)");
+    // Surface the rejection reason instead of the bare, opaque
+    // "Uncaught (in promise)" line (#4841): an unhandled rejection that
+    // carried a `TypeError: ...` previously printed nothing useful, forcing
+    // users to wrap every call in `.catch` just to learn what failed.
+    // `js_jsvalue_to_string` renders Error values as `<Name>: <message>` and
+    // everything else via ordinary ToString, matching the synchronous
+    // uncaught-throw header.
+    let reason = unhandled_reasons[0];
+    let reason_str_ptr = crate::value::js_jsvalue_to_string(reason);
+    let reason_str = unsafe { crate::exception::string_header_to_string(reason_str_ptr) };
+    if reason_str.is_empty() {
+        eprintln!("Uncaught (in promise)");
+    } else {
+        eprintln!("Uncaught (in promise) {reason_str}");
+    }
     // Match Node's unhandled-rejection exit code (1). The event loop has
     // already drained, so there is no pending work to lose.
     std::process::exit(1);

--- a/test-files/test_await_rejected_promise_handled.ts
+++ b/test-files/test_await_rejected_promise_handled.ts
@@ -1,0 +1,41 @@
+// Regression: awaiting an already-rejected promise inside try/catch (or
+// returning a rejected promise from an async fn) caught the rejection but
+// STILL reported a spurious "Uncaught (in promise)" and exited non-zero.
+//
+// Root cause: `js_async_step_chain`'s fast path for an already-rejected
+// awaited promise read the reason field directly and queued the async step
+// without calling `mark_rejection_handled`, so the program-end unhandled-
+// rejection detector still saw the (actually-handled) rejection. The Pending
+// arm already marks via `js_promise_then`; the fast path now does too.
+//
+// Expected (matches Node): only the three "caught:" lines, then "done",
+// with a clean exit — no "Uncaught (in promise)".
+
+async function returnsRejected() {
+  return Promise.reject(new Error("via-return"));
+}
+
+async function main() {
+  // 1. await a directly-rejected promise
+  try {
+    await Promise.reject(new Error("direct"));
+  } catch (e: any) {
+    console.log("caught:", e.message);
+  }
+  // 2. await an async fn that *returns* a rejected promise (adoption)
+  try {
+    await returnsRejected();
+  } catch (e: any) {
+    console.log("caught:", e.message);
+  }
+  // 3. await an already-settled rejected promise bound earlier
+  const r = Promise.reject(new Error("presettled"));
+  try {
+    await r;
+  } catch (e: any) {
+    console.log("caught:", e.message);
+  }
+  console.log("done");
+}
+
+main();

--- a/test-files/test_issue_4841_stripe_proto_identity.ts
+++ b/test-files/test_issue_4841_stripe_proto_identity.ts
@@ -1,0 +1,65 @@
+// Issue #4841: Stripe SDK — `stripe.<resource>.<method>` dispatched to the
+// WRONG resource (`stripe.products.create` ran webhook_endpoints' method),
+// surfacing on Linux as `TypeError: replace is not a function` deep in the
+// request layer.
+//
+// Root cause (a #4831 follow-up): Stripe builds every resource with
+//   const Constructor = function (...a) { Super.apply(this, a); };
+//   Constructor.prototype = Object.create(Super.prototype);
+//   Object.assign(Constructor.prototype, methods);   // {create, retrieve, …}
+//   return Constructor;
+// `Constructor` is a non-arrow function expression that captures only the
+// constant `Super`. Perry's closure allocator shared ONE cached function
+// object (and therefore ONE `.prototype`) for every evaluation with the same
+// (func_ptr, capture-bits) key, so all resources aliased a single prototype.
+// Each `Object.assign(Constructor.prototype, methods)` clobbered the prior
+// resource's methods, leaving every `stripe.<resource>.<method>` pointing at
+// the last-registered resource.
+//
+// Fix: a non-arrow `function` expression that could be used as a constructor
+// (no captures, or capturing an unboxed value) gets a FRESH function object —
+// and a fresh `.prototype` — on every evaluation, per JS identity semantics.
+// (crates/perry-codegen/src/expr/closure.rs)
+
+function makeMethod(spec: any) {
+  return function (this: any) {
+    return spec.path;
+  };
+}
+
+function Base(this: any) {}
+(Base as any).prototype = { basePath: "/v1" };
+
+function protoExtend(this: any, sub: any) {
+  const Super = this;
+  const Constructor: any = function (this: any) {
+    Super.apply(this, arguments);
+  };
+  Object.assign(Constructor, Super);
+  Constructor.prototype = Object.create(Super.prototype);
+  Object.assign(Constructor.prototype, sub);
+  return Constructor;
+}
+(Base as any).extend = protoExtend;
+
+const Products = (Base as any).extend({ create: makeMethod({ path: "/products" }) });
+const Customers = (Base as any).extend({ create: makeMethod({ path: "/customers" }) });
+const Webhooks = (Base as any).extend({ create: makeMethod({ path: "/webhooks" }) });
+
+// Each resource constructor must own a DISTINCT prototype object.
+console.log("Products.prototype === Webhooks.prototype:", Products.prototype === Webhooks.prototype); // false
+console.log("Products.prototype.create === Webhooks.prototype.create:", Products.prototype.create === Webhooks.prototype.create); // false
+
+// Instantiate through a ResourceNamespace-style loop, like Stripe does.
+const resources: any = { products: Products, customers: Customers, webhooks: Webhooks };
+function Namespace(this: any) {
+  for (const name in resources) {
+    this[name] = new resources[name]();
+  }
+}
+const stripe: any = new (Namespace as any)();
+
+// The crux: each method must dispatch to its OWN resource, not the last one.
+console.log("products.create():", stripe.products.create()); // /products
+console.log("customers.create():", stripe.customers.create()); // /customers
+console.log("webhooks.create():", stripe.webhooks.create()); // /webhooks


### PR DESCRIPTION
## What & why

Follow-ups to #4841 (Stripe SDK `replace is not a function`). The root-cause fix for #4841 itself already landed on `main` as **#4849** (closure identity for `protoExtend` constructors), which I verified resolves the reported repro — #4841 is now closed. This PR adds:

1. **Regression test for #4849 / #4841** — `test_issue_4841_stripe_proto_identity.ts` reproduces the Stripe `protoExtend` pattern (per-resource `Object.create` + `Object.assign` constructors) and asserts each resource gets a distinct `.prototype` / method. Matches Node byte-for-byte. #4849 shipped without a test.

2. **Surface the unhandled-rejection reason** — an unhandled rejection printed only the opaque line `Uncaught (in promise)` with no indication of what failed (the exact pain the #4841 reporter called out). Now prints the reason via the same ToString path as a synchronous uncaught throw, e.g. `Uncaught (in promise) TypeError: (number).replace is not a function`.

3. **Fix a spurious unhandled-rejection false-positive** — `try { await Promise.reject(e) } catch {}` (and `return Promise.reject(e)` from an async fn) caught the rejection but still reported `Uncaught (in promise)` and exited non-zero. `js_async_step_chain`'s fast path for an already-rejected awaited promise read the reason field directly and queued the step **without** calling `mark_rejection_handled` (the Pending arm already marks via `js_promise_then`). Now the fast path marks it too. Covered by `test_await_rejected_promise_handled.ts`.

## Not included (filed as #4851)

While debugging the Stripe end-to-end flow I found a separate, deeper bug: `await someFn()` never resumes when `someFn` returns a promise that had `Object.assign(promise, { ≥2 function-valued props })` applied — exactly Stripe's auto-pagination shape. I narrowed it to a codegen miscompile of `await <call-expression>` (binding the call to a temp first works; it's **not** runtime promise corruption, **not** the `INLINE_TRAP` reuse, **not** GC). Full root-cause writeup and minimal repros are in **#4851**. I deliberately left the speculative runtime guards out of this PR since they don't fix that hang.

## Testing

- `cargo test -p perry-runtime` (UTC): 1005 passed, 0 failed.
- Both new fixtures match `node --experimental-strip-types` byte-for-byte.
- Verified the real Stripe SDK `products.create({ name })` now dispatches to `/v1/products` and reaches Stripe's server (with #4849, already on main).
