### PR TITLE
fix(runtime): class subclass + async-method + definition test262 tail

### DIFF
--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -367,7 +367,7 @@ pub(super) fn emit_string_pool(
     // subclass whose parent is a class-expression value inherits the parent's
     // static methods (`class Sub extends make(...) {}; Sub.greet()`); has_rest
     // tells the dispatcher to bundle trailing args for a `...rest` param.
-    let mut static_method_triples: Vec<(u32, String, String, u32, bool)> = Vec::new();
+    let mut static_method_triples: Vec<(u32, String, String, u32, bool, u32)> = Vec::new();
     // #1787: (cid, standalone-constructor symbol, total_param_count).
     // Registered into CLASS_CONSTRUCTORS so `new <classObjectValue>()` (a
     // class-expression value constructed dynamically) can replay the class's
@@ -446,12 +446,25 @@ pub(super) fn emit_string_pool(
         for sm in &class.static_methods {
             let llvm_name = scoped_static_method_name(module_prefix, cid, class_name, &sm.name);
             let has_rest = sm.params.last().map(|p| p.is_rest).unwrap_or(false);
+            // Spec `.length`: leading formal params before the first default/rest
+            // (and excluding the synthesized `arguments` slot). For static
+            // generator/async methods the raw param_count over-counts (`static
+            // *gen(a, b = 1,).length === 1`, not 2). (Test262 *-method-static
+            // dflt-params-trailing-comma / -length.)
+            let mut spec_length = 0u32;
+            for p in &sm.params {
+                if p.arguments_object.is_some() || p.is_rest || p.default.is_some() {
+                    break;
+                }
+                spec_length += 1;
+            }
             static_method_triples.push((
                 cid,
                 sm.name.clone(),
                 llvm_name,
                 sm.params.len() as u32,
                 has_rest,
+                spec_length,
             ));
         }
         // #1787: the standalone constructor `<prefix>__<class>_constructor`
@@ -522,7 +535,7 @@ pub(super) fn emit_string_pool(
     // static methods (subclass extends a class-expression value) resolve at
     // runtime via the class_id parent-chain walk.
     static_method_triples.sort_unstable();
-    for (cid, method_name, llvm_name, param_count, has_rest) in static_method_triples {
+    for (cid, method_name, llvm_name, param_count, has_rest, spec_length) in static_method_triples {
         let entry = match strings.iter().find(|e| e.value == method_name) {
             Some(e) => e,
             None => continue,
@@ -542,6 +555,18 @@ pub(super) fn emit_string_pool(
                 (I64, &func_i64),
                 (I64, &param_count.to_string()),
                 (I64, has_rest_str),
+            ],
+        );
+        // Record the default-aware spec `.length` for the static method so
+        // `C.staticGen.length` reflects params-before-first-default rather than
+        // the raw param count (which over-counts generator/async methods).
+        blk.call_void(
+            "js_register_class_static_method_bind_length",
+            &[
+                (I64, &cid.to_string()),
+                (I64, &bytes_i64),
+                (I64, &len_str),
+                (I64, &spec_length.to_string()),
             ],
         );
     }

--- a/crates/perry-codegen/src/expr/closure.rs
+++ b/crates/perry-codegen/src/expr/closure.rs
@@ -323,6 +323,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 )
             };
 
+            // Register an `async function(){}` *expression* closure (one with
+            // no `await` — bodies that await are rewritten to a state machine
+            // upstream and arrive with `is_async: false`) in the async-function
+            // registry so `IsConstructor`/`util.types.isAsyncFunction` recognize
+            // it. Generators are hoisted to top-level and registered elsewhere.
+            // (Test262 subclass/superclass-async-function.)
+            if *is_async {
+                ctx.block()
+                    .call_void("js_register_closure_async_function", &[(PTR, &func_ref)]);
+            }
+
             // The captured-singleton helper writes captures internally
             // (so the cached layout matches a fresh allocation). The
             // other paths still need explicit per-slot writes.

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -431,8 +431,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 let key_box = blk.load(DOUBLE, &key_handle_global);
                                 let key_bits = blk.bitcast_double_to_i64(&key_box);
                                 let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                                // Spec: `super(message)` into a built-in Error
+                                // sets `message` via DefinePropertyOrThrow with
+                                // `{ enumerable: false }` (Test262 NativeError/
+                                // *-message), not an enumerable assignment.
                                 blk.call_void(
-                                    "js_object_set_field_by_name",
+                                    "js_object_set_field_by_name_nonenum",
                                     &[(I64, &this_handle), (I64, &key_raw), (DOUBLE, msg_val)],
                                 );
                             }
@@ -583,8 +587,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let key_box = blk.load(DOUBLE, &key_handle_global);
                         let key_bits = blk.bitcast_double_to_i64(&key_box);
                         let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                        // Spec: built-in Error sets `message` non-enumerable.
                         blk.call_void(
-                            "js_object_set_field_by_name",
+                            "js_object_set_field_by_name_nonenum",
                             &[(I64, &this_handle), (I64, &key_raw), (DOUBLE, msg_val)],
                         );
                     }

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1084,8 +1084,10 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                     let key_box = blk.load(DOUBLE, &key_handle_global);
                     let key_bits = blk.bitcast_double_to_i64(&key_box);
                     let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    // Spec: built-in Error sets `message` non-enumerable via
+                    // DefinePropertyOrThrow (Test262 NativeError/*-message).
                     blk.call_void(
-                        "js_object_set_field_by_name",
+                        "js_object_set_field_by_name_nonenum",
                         &[(I64, &this_handle), (I64, &key_raw), (DOUBLE, msg_val)],
                     );
                 }

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -53,6 +53,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function("js_object_set_unboxed_f64_field", VOID, &[I64, I32, DOUBLE]);
     module.declare_function("js_object_get_unboxed_f64_field", DOUBLE, &[I64, I32]);
     module.declare_function("js_object_set_field_by_name", VOID, &[I64, I64, DOUBLE]);
+    module.declare_function("js_object_set_field_by_name_nonenum", VOID, &[I64, I64, DOUBLE]);
     module.declare_function("js_with_has_binding", I32, &[DOUBLE, I64]);
     module.declare_function("js_with_get_binding", DOUBLE, &[DOUBLE, I64]);
     module.declare_function("js_with_set_binding", DOUBLE, &[DOUBLE, I64, DOUBLE, I32]);

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1811,6 +1811,11 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
         VOID,
         &[I64, I64, I64, I64],
     );
+    module.declare_function(
+        "js_register_class_static_method_bind_length",
+        VOID,
+        &[I64, I64, I64, I64],
+    );
     // Static accessors register on the class constructor (CLASS_STATIC_ACCESSORS).
     module.declare_function(
         "js_register_class_static_getter",

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -504,6 +504,44 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 // member keys for their spec-mandated side effects. See
                 // `push_deduped_class_computed_keys`.
                 push_deduped_class_computed_keys(ctx, &class_decl.class, &mut result)?;
+                // A duplicate-named class is skipped above, so its `extends`
+                // expression is never evaluated and its IsConstructor check
+                // never fires. Test262's superclass-* / invalid-extends cases
+                // reuse the SAME class name (`class C extends X`) across several
+                // `assert.throws` blocks, so without this the 2nd+ `class C
+                // extends <non-constructor>` silently fails to throw. Re-evaluate
+                // a dynamic (non-statically-resolvable) super-class here and run
+                // its IsConstructor check via `RegisterClassParentDynamic` (which
+                // throws before touching the conflated parent edge).
+                if let Some(super_class) = class_decl.class.super_class.as_deref() {
+                    let dynamic_parent = match super_class {
+                        ast::Expr::Ident(ident) => {
+                            let parent_name = ident.sym.to_string();
+                            let is_native = matches!(
+                                parent_name.as_str(),
+                                "EventEmitter"
+                                    | "EventEmitterAsyncResource"
+                                    | "AsyncLocalStorage"
+                                    | "AsyncResource"
+                                    | "WebSocketServer"
+                                    | "ReadableStream"
+                                    | "WritableStream"
+                                    | "TransformStream"
+                            );
+                            !is_native && ctx.lookup_class(&parent_name).is_none()
+                        }
+                        ast::Expr::Member(_) => false,
+                        _ => true,
+                    };
+                    if dynamic_parent {
+                        if let Ok(expr) = lower_expr(ctx, super_class) {
+                            result.push(Stmt::Expr(Expr::RegisterClassParentDynamic {
+                                class_name,
+                                parent_expr: Box::new(expr),
+                            }));
+                        }
+                    }
+                }
             }
         }
         ast::Stmt::Decl(ast::Decl::Fn(fn_decl)) => {

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -25,7 +25,8 @@ pub use alloc::{
 };
 
 pub use registry::{
-    build_rest_array, closure_arity, closure_is_arrow, closure_length, dispatch_rest_bundled,
+    build_rest_array, closure_arity, closure_is_arrow, closure_is_bound_method, closure_length,
+    dispatch_rest_bundled,
     dispatch_with_arity, is_registered_arrow_function, is_registered_async_function,
     is_registered_async_generator_function, is_registered_generator_function,
     js_register_closure_arity, js_register_closure_arrow_function,

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -334,6 +334,16 @@ pub fn closure_is_arrow(closure: *const ClosureHeader) -> bool {
     is_registered_arrow_function(func_ptr)
 }
 
+/// True if `closure` is a bound-method / bound-function value (its body is the
+/// `BOUND_METHOD_FUNC_PTR` sentinel). Class method/getter/setter values read
+/// via `C.prototype.m`, instance method reads, and `Function.prototype.bind`
+/// results all use this sentinel. None of them are constructors, so they have
+/// no `prototype` own property (ECMA-262: methods, accessors, and bound
+/// functions are non-constructors).
+pub fn closure_is_bound_method(closure: *const ClosureHeader) -> bool {
+    get_valid_func_ptr(closure) == BOUND_METHOD_FUNC_PTR
+}
+
 #[no_mangle]
 pub extern "C" fn js_register_closure_generator_function(func_ptr: *const u8) {
     if func_ptr.is_null() {

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -153,6 +153,14 @@ pub static CLASS_STATIC_ACCESSORS: RwLock<Option<HashMap<u32, HashMap<String, (u
 pub static CLASS_METHOD_BIND_LENGTHS: RwLock<Option<HashMap<(u32, String), u32>>> =
     RwLock::new(None);
 
+/// Default-aware spec `.length` for STATIC methods, keyed (class_id, name).
+/// Distinct from `CLASS_METHOD_BIND_LENGTHS` (instance methods) so a class with
+/// both `static m(a, b = 1)` and `m(c)` keeps independent lengths instead of
+/// colliding on the (class_id, name) key. (Test262 *-method-static
+/// dflt-params-trailing-comma.)
+pub static CLASS_STATIC_METHOD_BIND_LENGTHS: RwLock<Option<HashMap<(u32, String), u32>>> =
+    RwLock::new(None);
+
 pub static CLASS_SYMBOL_METHODS: RwLock<Option<HashMap<(u32, usize, bool), (usize, u32, bool)>>> =
     RwLock::new(None);
 
@@ -2167,6 +2175,68 @@ pub(crate) fn js_value_is_constructor(value: f64) -> bool {
     true
 }
 
+/// Spec ClassDefinitionEvaluation: a non-`null` superclass that is not a
+/// constructor makes `class X extends <value>` throw a TypeError before any
+/// `.prototype` access. Returns true when `value` is a *definitively* invalid
+/// superclass (so the caller throws). `null` is a valid superclass (creates a
+/// null-`[[Prototype]]` class) and never throws. Ambiguous heap values (not
+/// recognized as callable) return false so legitimate dynamic-extends shapes
+/// (mixins, factory-returned classes) keep their parentless baseline rather
+/// than mis-throwing. (Test262 subclass/superclass-* and definition/invalid-extends.)
+fn extends_target_must_throw(value: f64) -> bool {
+    use crate::value::JSValue;
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_null() {
+        return false;
+    }
+    // Registered class refs / heap class objects are constructors.
+    if constructor_class_ref_id(value).is_some() || is_class_object_value(value) {
+        return false;
+    }
+    // A Proxy is a constructor iff its `[[ProxyTarget]]` is — recurse.
+    if crate::proxy::js_proxy_is_proxy(value) == 1 {
+        return extends_target_must_throw(crate::proxy::js_proxy_target(value));
+    }
+    // Non-object primitives (number, string, boolean, undefined, symbol, bigint)
+    // can never be a superclass.
+    if !jv.is_pointer() {
+        return true;
+    }
+    if is_callable_function_value(value) {
+        if is_arrow_function_value(value) || is_non_constructable_builtin_function_value(value) {
+            return true;
+        }
+        let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
+        if !ptr.is_null() && is_valid_obj_ptr(ptr as *const u8) {
+            // A bound *method* (class/instance method read as a value) is never
+            // a constructor.
+            if crate::closure::closure_is_bound_method(ptr) {
+                return true;
+            }
+            let fp = crate::closure::get_valid_func_ptr(ptr);
+            // A bound *function* (`fn.bind(...)`) is a constructor iff its bound
+            // target is — recurse on the captured target.
+            if fp == crate::closure::BOUND_FUNCTION_FUNC_PTR {
+                let target = crate::closure::js_closure_get_capture_f64(ptr, 0);
+                return extends_target_must_throw(target);
+            }
+            // Arrow / async / generator / async-generator function bodies are
+            // non-constructors.
+            if crate::closure::is_registered_arrow_function(fp)
+                || crate::closure::is_registered_async_function(fp)
+                || crate::closure::is_registered_generator_function(fp)
+                || crate::closure::is_registered_async_generator_function(fp)
+            {
+                return true;
+            }
+        }
+        // Ordinary function — a constructor.
+        return false;
+    }
+    // A pointer we don't recognize as callable: stay conservative (no throw).
+    false
+}
+
 fn class_object_class_id(value: f64) -> Option<u32> {
     if !is_class_object_value(value) {
         return None;
@@ -2478,6 +2548,23 @@ fn is_arrow_function_value(value: f64) -> bool {
 pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Option<f64> {
     if !is_callable_function_value(func_value) || is_arrow_function_value(func_value) {
         return None;
+    }
+    // Bound-method / bound-function values (class method/getter/setter reads via
+    // `C.prototype.m`, instance method reads, `fn.bind(...)`) are non-constructors
+    // and have NO `prototype` own property (`C.prototype.m.prototype === undefined`,
+    // `'prototype' in C.prototype.m === false`). (Test262 definition method/accessor
+    // prop-desc.)
+    {
+        let jv = crate::value::JSValue::from_bits(func_value.to_bits());
+        if jv.is_pointer() {
+            let cptr = jv.as_pointer::<crate::closure::ClosureHeader>();
+            if !cptr.is_null()
+                && is_valid_obj_ptr(cptr as *const u8)
+                && crate::closure::closure_is_bound_method(cptr)
+            {
+                return None;
+            }
+        }
     }
     // Built-in methods (`String.prototype.charAt`, `Array.prototype.map`, …) are
     // not constructors and have NO `prototype` own property — `String.prototype.
@@ -3321,6 +3408,39 @@ pub unsafe extern "C" fn js_register_class_method_bind_length(
 static KEEP_REGISTER_METHOD_BIND_LENGTH: unsafe extern "C" fn(i64, *const u8, i64, i64) =
     js_register_class_method_bind_length;
 
+/// Record the spec `.length` for a STATIC method (params before the first
+/// default/rest). Codegen emits one call per static method at module init.
+#[no_mangle]
+pub unsafe extern "C" fn js_register_class_static_method_bind_length(
+    class_id: i64,
+    name_ptr: *const u8,
+    name_len: i64,
+    length: i64,
+) {
+    if name_ptr.is_null() || name_len < 0 {
+        return;
+    }
+    let name = match std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len as usize)) {
+        Ok(s) => s.to_string(),
+        Err(_) => return,
+    };
+    let mut guard = match CLASS_STATIC_METHOD_BIND_LENGTHS.write() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    if guard.is_none() {
+        *guard = Some(HashMap::new());
+    }
+    guard
+        .as_mut()
+        .unwrap()
+        .insert((class_id as u32, name), length as u32);
+}
+
+#[used]
+static KEEP_REGISTER_STATIC_METHOD_BIND_LENGTH: unsafe extern "C" fn(i64, *const u8, i64, i64) =
+    js_register_class_static_method_bind_length;
+
 unsafe fn register_class_static_accessor_half(
     class_id: i64,
     name_ptr: *const u8,
@@ -3783,6 +3903,13 @@ pub extern "C" fn js_register_class_parent(class_id: u32, parent_class_id: u32) 
 /// recursive helper that returns its receiver can't create a cycle.
 #[no_mangle]
 pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: f64) {
+    // Spec: a non-`null` superclass that is not a constructor throws a TypeError
+    // at class-definition time (before any `.prototype` access). (Test262
+    // subclass/superclass-* and definition/invalid-extends.)
+    if extends_target_must_throw(parent_value) {
+        super::object_ops::throw_object_type_error(b"Class extends value is not a constructor");
+    }
+
     let bits = parent_value.to_bits();
     let tag = bits & 0xFFFF_0000_0000_0000;
     const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
@@ -4489,7 +4616,28 @@ pub(crate) fn class_method_bind_length(class_id: u32, name: &str) -> Option<u32>
             }
         }
     }
-    // Static methods: CLASS_STATIC_METHODS stores (func_ptr, param_count, has_rest).
+    // Static methods: prefer the default-aware spec length recorded by codegen
+    // (params before the first default/rest), walking the parent chain; fall
+    // back to the raw `CLASS_STATIC_METHODS` param_count otherwise.
+    if let Ok(guard) = CLASS_STATIC_METHOD_BIND_LENGTHS.read() {
+        if let Some(map) = guard.as_ref() {
+            let mut cid = class_id;
+            let mut depth = 0usize;
+            while cid != 0 && depth < 32 {
+                if let Some(&len) = map.get(&(cid, name.to_string())) {
+                    return Some(len);
+                }
+                match get_parent_class_id(cid) {
+                    Some(p) if p != 0 && p != cid => {
+                        cid = p;
+                        depth += 1;
+                    }
+                    _ => break,
+                }
+            }
+        }
+    }
+    // CLASS_STATIC_METHODS stores (func_ptr, param_count, has_rest).
     if let Some((_, param_count, has_rest)) = lookup_static_method_in_chain(class_id, name) {
         let mut len = param_count;
         if has_rest {

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -4681,11 +4681,53 @@ pub(crate) unsafe fn call_static_method(
             a(args_ptr, args_len, 1),
             a(args_ptr, args_len, 2),
         ),
-        _ => (std::mem::transmute::<usize, extern "C" fn(f64, f64, f64, f64) -> f64>(func_ptr))(
+        4 => (std::mem::transmute::<usize, extern "C" fn(f64, f64, f64, f64) -> f64>(func_ptr))(
             a(args_ptr, args_len, 0),
             a(args_ptr, args_len, 1),
             a(args_ptr, args_len, 2),
             a(args_ptr, args_len, 3),
+        ),
+        5 => (std::mem::transmute::<usize, extern "C" fn(f64, f64, f64, f64, f64) -> f64>(func_ptr))(
+            a(args_ptr, args_len, 0),
+            a(args_ptr, args_len, 1),
+            a(args_ptr, args_len, 2),
+            a(args_ptr, args_len, 3),
+            a(args_ptr, args_len, 4),
+        ),
+        6 => (std::mem::transmute::<usize, extern "C" fn(f64, f64, f64, f64, f64, f64) -> f64>(
+            func_ptr,
+        ))(
+            a(args_ptr, args_len, 0),
+            a(args_ptr, args_len, 1),
+            a(args_ptr, args_len, 2),
+            a(args_ptr, args_len, 3),
+            a(args_ptr, args_len, 4),
+            a(args_ptr, args_len, 5),
+        ),
+        7 => (std::mem::transmute::<
+            usize,
+            extern "C" fn(f64, f64, f64, f64, f64, f64, f64) -> f64,
+        >(func_ptr))(
+            a(args_ptr, args_len, 0),
+            a(args_ptr, args_len, 1),
+            a(args_ptr, args_len, 2),
+            a(args_ptr, args_len, 3),
+            a(args_ptr, args_len, 4),
+            a(args_ptr, args_len, 5),
+            a(args_ptr, args_len, 6),
+        ),
+        _ => (std::mem::transmute::<
+            usize,
+            extern "C" fn(f64, f64, f64, f64, f64, f64, f64, f64) -> f64,
+        >(func_ptr))(
+            a(args_ptr, args_len, 0),
+            a(args_ptr, args_len, 1),
+            a(args_ptr, args_len, 2),
+            a(args_ptr, args_len, 3),
+            a(args_ptr, args_len, 4),
+            a(args_ptr, args_len, 5),
+            a(args_ptr, args_len, 6),
+            a(args_ptr, args_len, 7),
         ),
     }
 }

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -218,6 +218,17 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                 if super::class_registry::class_is_key_deleted(class_id, &method_name) {
                     return f64::from_bits(crate::value::TAG_UNDEFINED);
                 }
+                // `C.prototype` is a non-writable, non-enumerable, non-configurable
+                // own data property of the class constructor (ECMA-262
+                // MakeConstructor). Only the constructor ref carries it — the
+                // prototype ref's own `prototype` lookup falls through.
+                // (Test262 definition/prototype-property.)
+                if method_name == "prototype"
+                    && super::class_prototype_ref_id(obj_value).is_none()
+                {
+                    let proto = super::native_module::class_prototype_ref_value(class_id);
+                    return build_data_descriptor(proto, false, false, false);
+                }
                 if method_name == "name"
                     && super::class_prototype_ref_id(obj_value).is_none()
                     && super::class_registry::lookup_static_method_in_chain(class_id, "name")

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -1140,3 +1140,39 @@ pub extern "C" fn js_object_set_field_by_name(
         );
     }
 }
+
+/// Set `obj[key] = value` as a non-enumerable (but writable + configurable)
+/// own data property. Used by derived-class `super(message)` into a built-in
+/// `Error`/`NativeError`: the spec sets `message` via DefinePropertyOrThrow
+/// with `{ writable: true, enumerable: false, configurable: true }`, whereas an
+/// ordinary assignment would create an enumerable property. (Test262
+/// subclass/.../NativeError/*-message.)
+#[no_mangle]
+pub extern "C" fn js_object_set_field_by_name_nonenum(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+    value: f64,
+) {
+    js_object_set_field_by_name(obj, key, value);
+    // Only ordinary heap objects carry the attrs side-table. Class refs,
+    // TypedArrays, Temporal cells, etc. are handled by `set_field_by_name`'s own
+    // routing and never reach the ordinary enumerable default, so skip them.
+    let bits = obj as u64;
+    if (bits >> 48) == 0x7FFE || obj.is_null() || (obj as usize) < 0x100000 || key.is_null() {
+        return;
+    }
+    unsafe {
+        if !crate::object::is_valid_obj_ptr(obj as *const u8) {
+            return;
+        }
+        let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_len = (*key).byte_len as usize;
+        if let Ok(name) = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+            crate::object::set_property_attrs(
+                obj as usize,
+                name.to_string(),
+                crate::object::PropertyAttrs::new(true, false, true),
+            );
+        }
+    }
+}

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1229,11 +1229,13 @@ pub extern "C" fn js_super_put_value_set(
         return js_put_value_set(target, key, value, receiver, strict);
     }
 
-    if strict != 0 {
-        let key_name = key_to_rust_string(key).unwrap_or_else(|| "property".to_string());
-        crate::error::throw_immutable_write(0, &key_name);
-    }
-    value
+    // No resolvable parent-class prototype — `super` is `Object.prototype`
+    // (e.g. `class A {}` with no `extends`). Per spec `super.x = v` performs
+    // the home object's prototype `[[Set]]` with `this` as the receiver, which
+    // for a missing key + no inherited setter creates an own data property on
+    // the receiver. Do that ordinary set instead of throwing. (Test262
+    // syntax/class-body-method-definition-super-property.)
+    js_put_value_set(receiver, key, value, receiver, strict)
 }
 
 /// `key in proxy` — if handler.has exists, call it; otherwise delegate to


### PR DESCRIPTION
## Summary
Fixes the class test262 tail across subclass / async-method / definition / syntax. Target suite (15 dirs) **662 → 685 pass (+23)**, parity **84.8% → 87.7%**, **zero regressions** (verified via `--shard 0/12` over `built-ins language` + isolated re-runs of every concurrent-shard flaky diff).

## Root causes & fixes
1. **Methods/getters/setters/bound functions had a `prototype` own property.** `ordinary_function_prototype_value_for_read` synthesized `.prototype` for any non-arrow callable incl. bound-method values (`C.prototype.m`, `c.m`, `fn.bind()`). Added `closure_is_bound_method` and suppress it. (definition/methods, numeric-property-names)
2. **Derived `super(message)` into a built-in Error set `message` enumerable.** Spec uses DefinePropertyOrThrow `{enumerable:false}`. Added `js_object_set_field_by_name_nonenum`, routed all 3 Error-init codegen sites through it. (NativeError/*-message, Error/message-property-assignment)
3. **Static gen/async method `.length` over-counted.** New `CLASS_STATIC_METHOD_BIND_LENGTHS` table (distinct from instance table) + codegen registration with default-aware spec length. (*-method-static dflt-params-trailing-comma)
4. **`class X extends <non-constructor>` didn't throw TypeError.** New `extends_target_must_throw` (null OK; primitive/arrow/async/generator/async-gen/non-constructable-builtin/bound-method throw; bound-function + proxy recurse) in `js_register_class_parent_dynamic`. Also registered `async function(){}` *expression* closures as async (they weren't) and made duplicate-named classes re-run the IsConstructor check (test262 reuses `class C` across blocks). (superclass-arrow/async/generator/async-generator-function)
5. **`getOwnPropertyDescriptor(C,'prototype')` returned undefined.** Added the non-writable/non-enum/non-config `prototype` data-descriptor arm. (prototype-property)
6. **`call_static_method` capped at 4 args** — `const ref=C.m; ref(a..f)` for a static async/gen method dropped args ≥4. Extended to 8 positional params. (*-method-static dflt-params-arg-val-not-undefined)
7. **`super.x=v` in a class with no `extends` threw "read only".** When `super` is `Object.prototype` the fallback now ordinary-`[[Set]]`s on the receiver. (syntax/class-body-method-definition-super-property)

## Before → after (per dir, target suite)
- language/statements: 400 → 419 pass; language/expressions: 262 → 266 pass.
- subclass +4, definition +~5, async/gen/async-gen-method-static +~8, syntax +1, gen-method-static +1.

## Files
- runtime: `closure/{registry,mod}.rs`, `object/{class_registry,field_set_by_name,descriptors}.rs`, `proxy.rs`
- hir: `lower_decl/body_stmt.rs`
- codegen: `expr/{closure,this_super_call}.rs`, `lower_call/new.rs`, `codegen/string_pool.rs`, `runtime_decls/{objects,stdlib_ffi}.rs`

## Validation
- Target suite 662 → 685 (+23), 0 regressions.
- `--shard 0/12` over `built-ins language` (2645 judged): 249 rt-fail vs baseline 251 — **0 regressions / 2 fixed**.
- Shards 3/12 & 7/12 surfaced 17 apparent diffs; all re-ran clean in isolation (concurrent-shard contention, mostly Temporal).

## Deferred (larger separate work)
async-gen `yield*` return/throw delegation (~34); subclass-of-builtins exotics; derived-ctor `this`-TDZ / return-override + null-proto; class accessor descriptor callable get/set; symbol-keyed method retrieval; named-class-expression name leaking to outer scope.