### PR TITLE
fix(codegen): String.match no-match returns null, not a boxed null pointer

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -1290,7 +1290,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "js_string_match",
                 &[(I64, &s_handle), (I64, &r_handle)],
             );
-            Ok(nanbox_pointer_inline(blk, &result))
+            // #4858: js_string_match returns null (0) on no-match. NaN-boxing
+            // 0 with POINTER_TAG yields a value that is neither `null` nor a
+            // valid heap pointer — `s.match(/x/g) === null` was false and
+            // consumers that deref the result (JSON.stringify, .map) crashed.
+            // Branchless null → TAG_NULL select, same as RegExpExec above.
+            let is_null = blk.icmp_eq(I64, &result, "0");
+            let ptr_boxed = nanbox_pointer_inline(ctx.block(), &result);
+            let ptr_bits = ctx.block().bitcast_double_to_i64(&ptr_boxed);
+            let selected =
+                ctx.block()
+                    .select(I1, &is_null, I64, crate::nanbox::TAG_NULL_I64, &ptr_bits);
+            Ok(ctx.block().bitcast_i64_to_double(&selected))
         }
 
         // -------- string.matchAll(pattern) --------

--- a/crates/perry/tests/issue_4858_global_match_no_match.rs
+++ b/crates/perry/tests/issue_4858_global_match_no_match.rs
@@ -1,0 +1,64 @@
+//! Regression test for #4858: `String.prototype.match` with a global (`/g`)
+//! regex that finds no match must return `null` — not a POINTER_TAG-boxed
+//! null pointer that compares unequal to `null` and segfaults consumers
+//! (`JSON.stringify`, `.map`). This was the root cause of the Stripe SDK
+//! failure in #4841 (`extractUrlParams` runs `path.match(/\{\w+\}/g)` on
+//! every request path).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn global_match_no_match_returns_null() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+
+    std::fs::write(
+        &entry,
+        r#"
+const a = "abc".match(/x/g);
+console.log(a === null, JSON.stringify(a));
+const b = "abc".match(/x/);
+console.log(b === null, JSON.stringify(b));
+const stripe = "/v1/products".match(/\{\w+\}/g);
+console.log(stripe === null);
+const hit = "a1b2c3".match(/\d/g);
+console.log(JSON.stringify(hit));
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (signal/segfault = #4858 regression)\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout, "true null\ntrue null\ntrue\n[\"1\",\"2\",\"3\"]\n",
+        "global/non-global no-match must be null; matches must survive"
+    );
+}


### PR DESCRIPTION
Fixes #4858.

## Root cause

`Expr::StringMatch` codegen (`crates/perry-codegen/src/expr/instance_misc1.rs`) NaN-boxed the `js_string_match` result unconditionally. On no-match the runtime returns null (0), and `POINTER_TAG|0` is neither `null` nor a valid heap pointer:

- `"abc".match(/x/g) === null` evaluated to `false`
- consumers that dereference the result segfaulted — `JSON.stringify(a)` crashed with SIGSEGV (exit 139), and the Stripe SDK's `extractUrlParams` (`path.match(/\{\w+\}/g)` + `.map`) failed on every path without `{params}` (#4841)

The sibling `Expr::RegExpExec` arm already documents and guards this exact bug class; the `js_string_match_value` path (`lower_string_method.rs`) also had the guard. The static `Expr::StringMatch` fast path was the only one missing it.

Note: the non-global no-match case hit the identical codegen path and also segfaulted under `JSON.stringify` — the issue's "non-global works" observation only held for `console.log`, which guards small pointers.

## Fix

Branchless `result == 0 → TAG_NULL` select on the call result, mirroring `RegExpExec`.

## Validation

- Issue repro now byte-matches Node: `before` / `after: null`
- Broad match-semantics sweep (global/non-global × hit/no-match, capture groups, named groups, `.index`, regex held in a local, the Stripe `extractUrlParams` pattern) byte-matches `node --experimental-strip-types`
- New end-to-end regression test (`crates/perry/tests/issue_4858_global_match_no_match.rs`) compiles + runs the repro via `CARGO_BIN_EXE_perry` and asserts exact output
- `cargo test --release -p perry -p perry-codegen` green locally

No version bump / changelog per maintainer-at-merge convention.