### PR TITLE
fix(runtime): built-ins/Object test262 parity (v3) — exotic expandos, array descriptors, Object statics

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -838,6 +838,36 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &ctor_handle), (I64, &key_raw)],
                     ));
                 }
+                // Object statics read as VALUES (`var f = Object.seal`,
+                // `typeof Object.defineProperties`, `Object.is.length`).
+                // The receiver name is collapsed to GlobalGet(0), so route by
+                // property name — but ONLY names unique to `Object` among the
+                // builtin globals: the Reflect-overlapping ones
+                // (defineProperty / getOwnPropertyDescriptor / getPrototypeOf /
+                // setPrototypeOf / isExtensible / preventExtensions) and
+                // Map-overlapping `groupBy` must keep their current behavior.
+                // Resolves the reified ctor closure installed by
+                // `install_builtin_constructor_statics`.
+                if matches!(
+                    property.as_str(),
+                    "keys"
+                        | "values"
+                        | "entries"
+                        | "fromEntries"
+                        | "assign"
+                        | "create"
+                        | "seal"
+                        | "freeze"
+                        | "isFrozen"
+                        | "isSealed"
+                        | "is"
+                        | "getOwnPropertyNames"
+                        | "getOwnPropertySymbols"
+                        | "getOwnPropertyDescriptors"
+                        | "defineProperties"
+                ) {
+                    return Ok(lower_global_builtin_static_value(ctx, "Object", property));
+                }
                 // #3527: `Object.hasOwn` read as a VALUE (not a direct call) —
                 // e.g. iconv-lite's merge-exports does
                 // `var hasOwn = typeof Object.hasOwn === "undefined" ? … :

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -952,6 +952,11 @@ pub(crate) unsafe fn array_numeric_raw_f64_get(arr: *mut ArrayHeader, index: u32
     if arr.is_null() {
         return None;
     }
+    // An index converted to an accessor (or given custom attrs) via
+    // `Object.defineProperty` must dispatch through the slow path.
+    if array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
+        return None;
+    }
     if index >= (*arr).length {
         return None;
     }
@@ -970,6 +975,10 @@ pub(crate) unsafe fn array_numeric_raw_f64_set_inbounds(
 ) -> bool {
     let arr = clean_arr_ptr_mut(arr);
     if arr.is_null() || index >= (*arr).length {
+        return false;
+    }
+    // Accessor setters / non-writable attrs on indices need the slow path.
+    if array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
         return false;
     }
     let original_bits = value.to_bits();

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -195,6 +195,11 @@ pub extern "C" fn js_array_get_f64_unchecked(arr: *const ArrayHeader, index: u32
     if arr.is_null() {
         return f64::NAN;
     }
+    // Index accessors / custom attrs installed via `Object.defineProperty`
+    // need the descriptor-aware getter.
+    if array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
+        return js_array_get_f64(arr, index);
+    }
     const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
     unsafe {
         let length = (*arr).length;
@@ -368,6 +373,11 @@ pub extern "C" fn js_array_set_f64_unchecked(arr: *mut ArrayHeader, index: u32, 
     if array_is_frozen(arr) {
         return;
     }
+    // Index accessors / non-writable attrs need the descriptor-aware setter.
+    if array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
+        js_array_set_f64_extend(arr, index, value);
+        return;
+    }
     unsafe {
         let length = (*arr).length;
         if index >= length {
@@ -497,6 +507,38 @@ pub extern "C" fn js_array_set_f64_extend(
 
         if index == u32::MAX {
             return arr;
+        }
+
+        // Index properties customized via `Object.defineProperty`: dispatch
+        // accessor setters and honor non-writable data attributes before the
+        // dense-element store. Gated on the per-array descriptor flag so the
+        // common fast path pays one header-flag test.
+        if flags & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
+            let key = index.to_string();
+            if let Some(acc) = crate::object::get_accessor_descriptor(arr as usize, &key) {
+                if acc.set != 0 {
+                    crate::object::invoke_accessor_setter(
+                        acc.set,
+                        crate::value::js_nanbox_pointer(arr as i64),
+                        value_handle.get_nanbox_f64(),
+                    );
+                }
+                return arr;
+            }
+            if let Some(attrs) = crate::object::get_property_attrs(arr as usize, &key) {
+                if !attrs.writable() {
+                    return arr;
+                }
+            }
+            // Extending past `length` requires a writable `length`.
+            if index >= length {
+                let len_writable = crate::object::get_property_attrs(arr as usize, "length")
+                    .map(|a| a.writable())
+                    .unwrap_or(true);
+                if !len_writable {
+                    return arr;
+                }
+            }
         }
 
         // If index is within bounds, just set it
@@ -655,6 +697,22 @@ pub extern "C" fn js_array_set_string_key(
     let existing = unsafe { array_named_property_get(arr, key).is_some() };
     if !existing && array_is_sealed_or_no_extend(arr) {
         return arr;
+    }
+    // Named accessor installed via `Object.defineProperty(arr, "prop",
+    // {get,set})`: dispatch the setter instead of the expando store.
+    if crate::object::descriptors_in_use() {
+        if let Some(acc) = crate::object::get_accessor_descriptor(arr as usize, key_str) {
+            if acc.set != 0 {
+                unsafe {
+                    crate::object::invoke_accessor_setter(
+                        acc.set,
+                        crate::value::js_nanbox_pointer(arr as i64),
+                        value,
+                    );
+                }
+            }
+            return arr;
+        }
     }
     if let Some(attrs) = crate::object::get_property_attrs(arr as usize, key_str) {
         if !attrs.writable() {

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -297,6 +297,17 @@ pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
         if flags & (crate::gc::OBJ_FLAG_SEALED | crate::gc::OBJ_FLAG_NO_EXTEND) != 0 && n != cur {
             return;
         }
+        // `defineProperty(arr, "length", {writable:false})` records the flag
+        // in the attrs side table; an ordinary `arr.length = n` write must
+        // then no-op (strict-mode throw is handled by the caller's PutValue).
+        if n != cur
+            && flags & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0
+            && crate::object::get_property_attrs(arr as usize, "length")
+                .map(|a| !a.writable())
+                .unwrap_or(false)
+        {
+            return;
+        }
         if n < cur {
             // Truncate: clear elements at indices [n..cur) to TAG_HOLE so
             // any code that resurrects the slot via `arr[i]` reads `undefined`,

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -41,6 +41,9 @@ pub fn alloc_date_cell(ts: f64) -> f64 {
             crate::gc::GC_TYPE_DATE_CELL,
         ) as *mut DateCell;
         (*ptr).ts = ts;
+        // A previous (collected) Date at this address may have left expando
+        // properties in the side table; a fresh Date must start clean.
+        crate::object::exotic_expando::expando_clear_on_alloc(ptr as usize);
         f64::from_bits(crate::value::JSValue::pointer(ptr as *const u8).bits())
     }
 }

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -315,6 +315,7 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(async_hooks_mutable_root_scanner);
     gc_register_mutable_root_scanner(shape_cache_mutable_root_scanner);
     gc_register_mutable_root_scanner(crate::regex::scan_last_exec_groups_root_mut);
+    gc_register_mutable_root_scanner(crate::object::scan_exotic_expando_roots_mut);
     gc_register_mutable_root_scanner(crate::array::scan_template_raw_roots_mut);
     gc_register_mutable_root_scanner(crate::perf_hooks::scan_perf_entries_roots_mut);
     gc_register_mutable_root_scanner(crate::v8::scan_v8_promise_hook_roots_mut);

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -804,6 +804,14 @@ pub const OBJ_FLAG_NO_EXTEND: u16 = 0x04;
 // (`GC_COPY_SURVIVAL_AGE_MASK = 0x0038`) and bits 14..15 the layout state,
 // so 0x08 would be clobbered on every minor GC. Bits 6..13 are free.
 pub const OBJ_FLAG_NULL_PROTO: u16 = 0x40;
+// Array carries per-index property descriptors (accessors or custom attrs
+// installed via `Object.defineProperty`, or a non-writable `length`). The
+// raw-f64 numeric fast paths must decline and route through the
+// descriptor-aware element get/set. Bit 10 — bits 7/8/9 are taken by
+// `GC_ARRAY_RAW_F64_LAYOUT` (0x80), `OBJ_FLAG_TYPED_ARRAY_PROTO` (0x100),
+// and `GC_ARRAY_ARGUMENTS_OBJECT` (0x200). Only meaningful for
+// `GC_TYPE_ARRAY`.
+pub const OBJ_FLAG_ARRAY_DESCRIPTORS: u16 = 0x400;
 // #2145: this object is a per-kind `<TypedArrayCtor>.prototype` whose
 // `[[Prototype]]` is the shared `%TypedArray%.prototype` intrinsic.
 // `Object.getPrototypeOf(Int8Array.prototype)` returns the cached

--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -576,6 +576,21 @@ pub fn error_user_prop(error_ptr: usize, key: &str) -> Option<f64> {
     })
 }
 
+/// Remove a user-assigned own property from an Error object. Returns true
+/// when the property existed (used by `delete err.prop` and data↔accessor
+/// descriptor conversions).
+pub fn remove_error_user_prop(error_ptr: usize, key: &str) -> bool {
+    if error_ptr == 0 {
+        return false;
+    }
+    ERROR_USER_PROPS.with(|m| {
+        m.borrow_mut()
+            .get_mut(&error_ptr)
+            .map(|props| props.remove(key).is_some())
+            .unwrap_or(false)
+    })
+}
+
 /// Return user-assigned own properties on an Error object as materialized JS
 /// values so util.inspect/console formatting can show them.
 pub fn error_user_props(error_ptr: usize) -> Vec<(String, f64)> {

--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -69,6 +69,13 @@ pub(crate) unsafe fn array_set_length_from_descriptor(
     if desc_ptr.is_null() {
         return true;
     }
+    // A customized `length` (e.g. writable:false) gates the raw numeric
+    // fast paths — see OBJ_FLAG_ARRAY_DESCRIPTORS in define_array_property.
+    // Set here too so the `Reflect.defineProperty` entry point is covered.
+    {
+        let gc = gc_header_for(obj);
+        (*gc)._reserved |= crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS;
+    }
     let arr = obj as *mut crate::array::ArrayHeader;
 
     let read_present = |name: &[u8]| -> bool {
@@ -238,6 +245,15 @@ pub(crate) unsafe fn define_array_property(
         return Some(true);
     };
 
+    // Any explicit per-index/named/length descriptor makes the raw numeric
+    // fast paths ineligible for this array — they can't see accessors or
+    // attribute overrides, so they must decline to the descriptor-aware
+    // element get/set (OBJ_FLAG_ARRAY_DESCRIPTORS gates them).
+    {
+        let gc = gc_header_for(obj);
+        (*gc)._reserved |= crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS;
+    }
+
     if key_name == "length" {
         return Some(array_set_length_from_descriptor(obj, descriptor_value));
     }
@@ -324,6 +340,16 @@ pub(crate) unsafe fn define_array_property(
             } else {
                 prior.map(|a| a.set).unwrap_or(0)
             };
+            // Materialize BEFORE storing the accessor — the extend helper
+            // dispatches accessor setters, so installing the accessor first
+            // would turn this internal materialization into a setter call.
+            if !exists {
+                crate::array::js_array_set_f64_extend(
+                    arr,
+                    index,
+                    f64::from_bits(crate::value::TAG_UNDEFINED),
+                );
+            }
             set_accessor_descriptor(
                 obj as usize,
                 key_name.to_string(),
@@ -332,18 +358,15 @@ pub(crate) unsafe fn define_array_property(
                     set: set_bits,
                 },
             );
-            // Ensure the index counts as an own key for reflection.
-            if !exists {
-                crate::array::js_array_set_f64_extend(
-                    arr,
-                    index,
-                    f64::from_bits(crate::value::TAG_UNDEFINED),
-                );
-            }
             // Retain existing attrs the descriptor omits when redefining; new
-            // accessor defaults to non-enumerable / non-configurable.
+            // accessor defaults to non-enumerable / non-configurable. An
+            // existing dense element with no side-table entry has default
+            // all-true attributes (so data→accessor keeps enumerable:true).
             let cur = if exists {
-                super::get_property_attrs(obj as usize, key_name)
+                Some(
+                    super::get_property_attrs(obj as usize, key_name)
+                        .unwrap_or_else(|| PropertyAttrs::new(true, true, true)),
+                )
             } else {
                 None
             };
@@ -400,11 +423,35 @@ pub(crate) unsafe fn define_array_property(
             }
         }
 
+        // A GENERIC descriptor (attrs only, no value/writable/get/set) on an
+        // existing ACCESSOR property just updates the attributes — it must
+        // NOT convert the accessor back to data (spec ValidateAndApply step:
+        // IsGenericDescriptor → no [[Get]]/[[Set]]/[[Value]] changes).
+        if !has_value
+            && !super::desc_has_field(descriptor_value, b"writable")
+            && super::get_accessor_descriptor(obj as usize, key_name).is_some()
+        {
+            let cur = cur_attrs.unwrap_or(PropertyAttrs::new(false, false, false));
+            let enumerable = read_bool(b"enumerable").unwrap_or_else(|| cur.enumerable());
+            let configurable = read_bool(b"configurable").unwrap_or_else(|| cur.configurable());
+            set_property_attrs(
+                obj as usize,
+                key_name.to_string(),
+                PropertyAttrs::new(false, enumerable, configurable),
+            );
+            return Some(true);
+        }
+
         // Redefining an index that was previously an accessor back to a data
         // property: drop the stale accessor entry.
         ACCESSOR_DESCRIPTORS.with(|m| {
             m.borrow_mut().remove(&(obj as usize, key_name.to_string()));
         });
+        // [[DefineOwnProperty]] writes the slot directly — clear any stale
+        // attrs first so the extend helper's [[Set]]-side writability check
+        // (added for ordinary `arr[i] = v` writes) can't reject this store.
+        // The final attributes are recorded below after the write.
+        super::clear_property_attrs(obj as usize, key_name);
 
         if has_value {
             crate::array::js_array_set_f64_extend(arr, index, value);
@@ -436,6 +483,58 @@ pub(crate) unsafe fn define_array_property(
         );
         let _ = obj_value;
         return Some(true);
+    }
+
+    // Named (non-index) accessor on an array target: store get/set in the
+    // side table, exactly like the index path above. Without this, a
+    // `defineProperty(arr, "prop", {get,set})` silently stored `undefined`
+    // as a data property and dropped the accessors.
+    {
+        let desc_has_get = super::desc_has_field(descriptor_value, b"get");
+        let desc_has_set = super::desc_has_field(descriptor_value, b"set");
+        if desc_has_get || desc_has_set {
+            let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
+            let set_key = crate::string::js_string_from_bytes(b"set".as_ptr(), 3);
+            let get_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, get_key);
+            let set_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, set_key);
+            let recv = crate::value::js_nanbox_pointer(obj as i64);
+            let prior = super::get_accessor_descriptor(obj as usize, key_name);
+            let get_bits = if desc_has_get {
+                if get_field.is_undefined() {
+                    0
+                } else {
+                    crate::closure::clone_closure_rebind_this(get_field.bits(), recv)
+                }
+            } else {
+                prior.map(|a| a.get).unwrap_or(0)
+            };
+            let set_bits = if desc_has_set {
+                if set_field.is_undefined() {
+                    0
+                } else {
+                    crate::closure::clone_closure_rebind_this(set_field.bits(), recv)
+                }
+            } else {
+                prior.map(|a| a.set).unwrap_or(0)
+            };
+            set_accessor_descriptor(
+                obj as usize,
+                key_name.to_string(),
+                AccessorDescriptor {
+                    get: get_bits,
+                    set: set_bits,
+                },
+            );
+            let enumerable = read_bool(b"enumerable").unwrap_or(false);
+            let configurable = read_bool(b"configurable").unwrap_or(false);
+            set_property_attrs(
+                obj as usize,
+                key_name.to_string(),
+                PropertyAttrs::new(false, enumerable, configurable),
+            );
+            let _ = obj_value;
+            return Some(true);
+        }
     }
 
     crate::array::array_named_property_set(arr, key_str, value);

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -78,6 +78,26 @@ pub extern "C" fn js_object_delete_field(
         if let Some(result) = super::arguments_object_before_delete(obj, key) {
             return result;
         }
+        // Date / RegExp / Error exotic instances: expando props live in side
+        // tables; the keys_array scan below would bit-cast the cell. Builtin
+        // own slots (`lastIndex`) are non-configurable → delete fails.
+        if let Some(kind) = super::exotic_expando::exotic_expando_kind(obj as usize) {
+            use super::exotic_expando::ExoticKind;
+            if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
+                if let Some(attrs) = get_property_attrs(obj as usize, name) {
+                    if !attrs.configurable() {
+                        return 0;
+                    }
+                }
+                if kind == ExoticKind::RegExp && name == "lastIndex" {
+                    return 0;
+                }
+                super::exotic_expando::value_remove(kind, obj as usize, name);
+                super::clear_accessor_descriptor(obj as usize, name);
+                super::clear_property_attrs(obj as usize, name);
+            }
+            return 1;
+        }
         if (obj as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
             let gc_header =
                 (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -212,6 +212,68 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             );
         }
 
+        // Date / RegExp / Error exotic instances: own properties live in the
+        // expando side tables (plus a few builtin own slots), never in an
+        // `ObjectHeader` — the ordinary path below would bit-cast the cell.
+        if let Some((addr, kind)) = super::exotic_expando::exotic_expando_kind_of_value(obj_value) {
+            use super::exotic_expando::ExoticKind;
+            let Some(name) = super::metadata_key_to_string(key_value) else {
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            };
+            if let Some(acc) = super::get_accessor_descriptor(addr, &name) {
+                let attrs = super::get_property_attrs(addr, &name)
+                    .unwrap_or(PropertyAttrs::new(false, false, false));
+                let undef = crate::value::TAG_UNDEFINED;
+                return build_accessor_descriptor(
+                    f64::from_bits(if acc.get == 0 { undef } else { acc.get }),
+                    f64::from_bits(if acc.set == 0 { undef } else { acc.set }),
+                    attrs.enumerable(),
+                    attrs.configurable(),
+                );
+            }
+            if let Some(bits) = super::exotic_expando::value_lookup(kind, addr, &name) {
+                let attrs = super::get_property_attrs(addr, &name)
+                    .unwrap_or(PropertyAttrs::new(true, true, true));
+                return build_data_descriptor(
+                    f64::from_bits(bits),
+                    attrs.writable(),
+                    attrs.enumerable(),
+                    attrs.configurable(),
+                );
+            }
+            // Builtin own slots: RegExp `lastIndex` (writable, non-enum,
+            // non-config) and Error `message`/`stack` (writable, non-enum,
+            // configurable).
+            if kind == ExoticKind::RegExp && name == "lastIndex" {
+                let attrs = super::get_property_attrs(addr, &name)
+                    .unwrap_or(PropertyAttrs::new(true, false, false));
+                let re = addr as *const crate::regex::RegExpHeader;
+                return build_data_descriptor(
+                    f64::from_bits((*re).last_index),
+                    attrs.writable(),
+                    attrs.enumerable(),
+                    attrs.configurable(),
+                );
+            }
+            if kind == ExoticKind::Error && matches!(name.as_str(), "message" | "stack") {
+                let attrs = super::get_property_attrs(addr, &name)
+                    .unwrap_or(PropertyAttrs::new(true, false, true));
+                let err = addr as *mut crate::error::ErrorHeader;
+                let s = if name == "message" {
+                    crate::error::js_error_get_message(err)
+                } else {
+                    crate::error::js_error_get_stack(err)
+                };
+                return build_data_descriptor(
+                    f64::from_bits(crate::js_nanbox_string(s as i64).to_bits()),
+                    attrs.writable(),
+                    attrs.enumerable(),
+                    attrs.configurable(),
+                );
+            }
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+
         if let Some(class_id) = class_ref_id(obj_value) {
             let method_name = metadata_key_to_string(key_value);
             if let Some(method_name) = method_name {
@@ -477,9 +539,15 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                 };
                 let is_frozen = crate::array::array_is_frozen(arr);
                 if name == "length" {
+                    // `defineProperty(arr, "length", {writable:false})` records
+                    // the flag in the attrs side table — honor it here.
+                    let writable = !is_frozen
+                        && get_property_attrs(obj as usize, "length")
+                            .map(|a| a.writable())
+                            .unwrap_or(true);
                     return build_data_descriptor(
                         crate::array::js_array_length(arr) as f64,
-                        !is_frozen,
+                        writable,
                         false,
                         false,
                     );
@@ -524,6 +592,18 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                         );
                     }
                     return f64::from_bits(crate::value::TAG_UNDEFINED);
+                }
+                // Named (non-index) accessor installed via defineProperty.
+                if let Some(acc) = get_accessor_descriptor(obj as usize, name) {
+                    let attrs = get_property_attrs(obj as usize, name)
+                        .unwrap_or(PropertyAttrs::new(false, false, false));
+                    let undef = crate::value::TAG_UNDEFINED;
+                    return build_accessor_descriptor(
+                        f64::from_bits(if acc.get == 0 { undef } else { acc.get }),
+                        f64::from_bits(if acc.set == 0 { undef } else { acc.set }),
+                        attrs.enumerable(),
+                        attrs.configurable(),
+                    );
                 }
                 if let Some(value) = crate::array::array_named_property_get(arr, key_str) {
                     let attrs = get_property_attrs(obj as usize, name)
@@ -806,6 +886,28 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
             );
             return f64::from_bits((result as u64) | 0x7FFD_0000_0000_0000);
         }
+        // Date / RegExp / Error exotic instances: expando keys (including
+        // non-enumerable ones) + per-kind builtin own slots.
+        if let Some((addr, kind)) = super::exotic_expando::exotic_expando_kind_of_value(obj_value) {
+            use super::exotic_expando::ExoticKind;
+            let mut names = match kind {
+                ExoticKind::RegExp => vec!["lastIndex".to_string()],
+                ExoticKind::Error => vec!["message".to_string(), "stack".to_string()],
+                ExoticKind::Date => Vec::new(),
+            };
+            for key in super::exotic_expando::exotic_own_keys(kind, addr, false) {
+                if !names.contains(&key) {
+                    names.push(key);
+                }
+            }
+            let arr = crate::array::js_array_alloc(names.len().max(1) as u32);
+            let mut out = arr;
+            for name in names {
+                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                out = crate::array::js_array_push(out, crate::value::JSValue::string_ptr(key));
+            }
+            return f64::from_bits((out as u64) | 0x7FFD_0000_0000_0000);
+        }
         if let Some(class_id) = class_ref_id(obj_value) {
             let is_prototype_ref = super::class_prototype_ref_id(obj_value).is_some();
             let mut names: Vec<String> = if is_prototype_ref {
@@ -921,10 +1023,27 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                     }
                     let lk = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
                     crate::array::js_array_push(result, JSValue::string_ptr(lk));
-                    for name in crate::array::array_named_property_names(ap, false) {
+                    let named = crate::array::array_named_property_names(ap, false);
+                    for name in &named {
                         let k =
                             crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
                         crate::array::js_array_push(result, JSValue::string_ptr(k));
+                    }
+                    // Accessor-only named properties (defineProperty {get/set})
+                    // are own keys too (gOPN includes non-enumerable).
+                    if super::descriptors_in_use() {
+                        for name in super::accessor_descriptor_keys_for_obj(ap as usize) {
+                            if super::canonical_array_index(&name).is_some()
+                                || named.contains(&name)
+                            {
+                                continue;
+                            }
+                            let k = crate::string::js_string_from_bytes(
+                                name.as_ptr(),
+                                name.len() as u32,
+                            );
+                            crate::array::js_array_push(result, JSValue::string_ptr(k));
+                        }
                     }
                 } else {
                     for i in 0..n {

--- a/crates/perry-runtime/src/object/exotic_expando.rs
+++ b/crates/perry-runtime/src/object/exotic_expando.rs
@@ -1,0 +1,506 @@
+//! Expando (user-defined own) properties for exotic instances whose heap
+//! representation is NOT an `ObjectHeader`: `Date` (an 8-byte `DateCell`),
+//! `RegExp` (a `RegExpHeader`), and `Error` (an `ErrorHeader`). Plain
+//! property writes on these previously either no-op'd (Date guard in
+//! `js_object_set_field_by_name`) or wrote through garbage field offsets
+//! (RegExp), and reads fell through to cell-as-`ObjectHeader` derefs that
+//! could segfault. test262 exercises both directions heavily: exotic
+//! instances as `Object.defineProperty` targets AND as the *attributes*
+//! object (`dateObj.value = "x"; defineProperty(o, k, dateObj)`).
+//!
+//! Date/RegExp values are stored as NaN-boxed bits keyed by the cell
+//! address, in insertion order (spec OrdinaryOwnPropertyKeys for string
+//! keys). Error values delegate to the pre-existing `ERROR_USER_PROPS`
+//! side table so the dedicated error get/set arms and `assert.throws`
+//! consumers keep seeing one store. Attribute flags and accessor get/set
+//! closures piggyback on the generic side tables (`PROPERTY_DESCRIPTORS` /
+//! `ACCESSOR_DESCRIPTORS`), which are already keyed by raw address.
+//!
+//! GC: all three cell kinds are non-movable, so the address key is stable
+//! for the cell's lifetime. Stored values are kept alive via a registered
+//! mutable root scanner. Address reuse after a sweep is handled by clearing
+//! the table slot at allocation time (`expando_clear_on_alloc`).
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExoticKind {
+    Date,
+    RegExp,
+    Error,
+}
+
+/// Classify `addr` as a Date cell, RegExp header, or Error header. Returns
+/// `None` for everything else (including the small-handle band). One
+/// `GcHeader` read; the RegExp set probe only runs for `GC_TYPE_OBJECT`.
+pub(crate) fn exotic_expando_kind(addr: usize) -> Option<ExoticKind> {
+    if addr < 0x100000 || !super::is_valid_obj_ptr(addr as *const u8) {
+        return None;
+    }
+    let gc = (addr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    match unsafe { (*gc).obj_type } {
+        crate::gc::GC_TYPE_DATE_CELL => Some(ExoticKind::Date),
+        crate::gc::GC_TYPE_ERROR => Some(ExoticKind::Error),
+        crate::gc::GC_TYPE_OBJECT if crate::regex::is_regex_pointer(addr as *const u8) => {
+            Some(ExoticKind::RegExp)
+        }
+        _ => None,
+    }
+}
+
+/// Classify a NaN-boxed (or raw-I64) value as an exotic-expando receiver.
+/// Returns the cleaned address alongside the kind.
+pub(crate) fn exotic_expando_kind_of_value(value: f64) -> Option<(usize, ExoticKind)> {
+    let bits = value.to_bits();
+    let top16 = bits >> 48;
+    let addr = if top16 == 0x7FFD {
+        (bits & crate::value::POINTER_MASK) as usize
+    } else if top16 == 0 {
+        bits as usize
+    } else {
+        return None;
+    };
+    if addr == 0 {
+        return None;
+    }
+    exotic_expando_kind(addr).map(|kind| (addr, kind))
+}
+
+thread_local! {
+    /// addr -> insertion-ordered (key, nanboxed value bits) pairs (Date/RegExp).
+    static EXOTIC_EXPANDO: RefCell<HashMap<usize, Vec<(String, u64)>>> =
+        RefCell::new(HashMap::new());
+    /// Fast-path gate so hot get/set paths skip the map lookup until the
+    /// first expando is installed on this thread.
+    static EXPANDO_IN_USE: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(crate) fn expando_in_use() -> bool {
+    EXPANDO_IN_USE.with(|c| c.get())
+}
+
+fn expando_store(addr: usize, key: &str, bits: u64) {
+    EXPANDO_IN_USE.with(|c| c.set(true));
+    EXOTIC_EXPANDO.with(|m| {
+        let mut map = m.borrow_mut();
+        let entries = map.entry(addr).or_default();
+        if let Some(slot) = entries.iter_mut().find(|(k, _)| k == key) {
+            slot.1 = bits;
+        } else {
+            entries.push((key.to_string(), bits));
+        }
+    });
+}
+
+fn expando_lookup(addr: usize, key: &str) -> Option<u64> {
+    if !expando_in_use() {
+        return None;
+    }
+    EXOTIC_EXPANDO.with(|m| {
+        m.borrow()
+            .get(&addr)
+            .and_then(|entries| entries.iter().find(|(k, _)| k == key).map(|(_, v)| *v))
+    })
+}
+
+fn expando_remove(addr: usize, key: &str) -> bool {
+    if !expando_in_use() {
+        return false;
+    }
+    EXOTIC_EXPANDO.with(|m| {
+        let mut map = m.borrow_mut();
+        if let Some(entries) = map.get_mut(&addr) {
+            let before = entries.len();
+            entries.retain(|(k, _)| k != key);
+            return entries.len() != before;
+        }
+        false
+    })
+}
+
+/// Kind-dispatched own data-property store: Error delegates to the
+/// pre-existing `ERROR_USER_PROPS` table, Date/RegExp use `EXOTIC_EXPANDO`.
+pub(crate) fn value_store(kind: ExoticKind, addr: usize, key: &str, bits: u64) {
+    match kind {
+        ExoticKind::Error => {
+            crate::node_submodules::set_error_user_prop(addr, key, f64::from_bits(bits))
+        }
+        _ => expando_store(addr, key, bits),
+    }
+}
+
+pub(crate) fn value_lookup(kind: ExoticKind, addr: usize, key: &str) -> Option<u64> {
+    match kind {
+        ExoticKind::Error => {
+            crate::node_submodules::error_user_prop(addr, key).map(|v| v.to_bits())
+        }
+        _ => expando_lookup(addr, key),
+    }
+}
+
+pub(crate) fn value_remove(kind: ExoticKind, addr: usize, key: &str) -> bool {
+    match kind {
+        ExoticKind::Error => crate::node_submodules::remove_error_user_prop(addr, key),
+        _ => expando_remove(addr, key),
+    }
+}
+
+fn value_keys(kind: ExoticKind, addr: usize) -> Vec<String> {
+    match kind {
+        ExoticKind::Error => crate::node_submodules::error_user_props(addr)
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect(),
+        _ => {
+            if !expando_in_use() {
+                return Vec::new();
+            }
+            EXOTIC_EXPANDO.with(|m| {
+                m.borrow()
+                    .get(&addr)
+                    .map(|entries| entries.iter().map(|(k, _)| k.clone()).collect())
+                    .unwrap_or_default()
+            })
+        }
+    }
+}
+
+/// Drop any stale expando entries left at `addr` by a previous (collected)
+/// cell. Called from Date / RegExp allocation so address reuse can't leak
+/// the old instance's properties onto the new one.
+pub(crate) fn expando_clear_on_alloc(addr: usize) {
+    if !expando_in_use() {
+        return;
+    }
+    EXOTIC_EXPANDO.with(|m| {
+        m.borrow_mut().remove(&addr);
+    });
+}
+
+/// `[[Set]]` on a Date/RegExp/Error instance. Honors accessor descriptors
+/// and attribute writability from the generic side tables, plus the RegExp
+/// `lastIndex` header slot and non-extensibility for new keys. Returns
+/// `false` when the write is rejected (caller decides strict-mode throw).
+pub(crate) unsafe fn exotic_set_property(
+    addr: usize,
+    kind: ExoticKind,
+    name: &str,
+    value: f64,
+    receiver: f64,
+) -> bool {
+    // RegExp `lastIndex` is a writable data property living in the header.
+    if kind == ExoticKind::RegExp && name == "lastIndex" {
+        if let Some(attrs) = super::get_property_attrs(addr, name) {
+            if !attrs.writable() {
+                return false;
+            }
+        }
+        crate::regex::js_regexp_set_last_index(addr as *mut crate::regex::RegExpHeader, value);
+        return true;
+    }
+    if super::descriptors_in_use() {
+        if let Some(acc) = super::get_accessor_descriptor(addr, name) {
+            if acc.set == 0 {
+                return false;
+            }
+            super::invoke_accessor_setter(acc.set, receiver, value);
+            return true;
+        }
+        if let Some(attrs) = super::get_property_attrs(addr, name) {
+            if !attrs.writable() {
+                return false;
+            }
+            value_store(kind, addr, name, value.to_bits());
+            return true;
+        }
+    }
+    if value_lookup(kind, addr, name).is_some() {
+        value_store(kind, addr, name, value.to_bits());
+        return true;
+    }
+    // No own property: an accessor inherited from the builtin prototype
+    // (`Object.defineProperty(Date.prototype, "prop", {set})`) consumes the
+    // write — the setter runs with the instance receiver and NO own expando
+    // is created (spec OrdinarySetWithOwnDescriptor walking the chain).
+    if super::descriptors_in_use() {
+        let proto_name = match kind {
+            ExoticKind::Date => "Date",
+            ExoticKind::RegExp => "RegExp",
+            ExoticKind::Error => "Error",
+        };
+        let proto = super::builtin_prototype_value(proto_name);
+        let proto_bits = proto.to_bits();
+        if (proto_bits >> 48) == 0x7FFD {
+            let proto_addr = (proto_bits & crate::value::POINTER_MASK) as usize;
+            if proto_addr != 0 {
+                if let Some(acc) = super::get_accessor_descriptor(proto_addr, name) {
+                    if acc.set == 0 {
+                        return false;
+                    }
+                    super::invoke_accessor_setter(acc.set, receiver, value);
+                    return true;
+                }
+            }
+        }
+    }
+    // New property: reject when the instance was made non-extensible.
+    let gc = (addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0 {
+        return false;
+    }
+    value_store(kind, addr, name, value.to_bits());
+    true
+}
+
+/// `[[Get]]` of an own expando / accessor property on an exotic instance.
+/// Returns `None` when no own property exists (caller continues with
+/// builtin header props / prototype methods).
+pub(crate) unsafe fn exotic_get_own_property(
+    addr: usize,
+    kind: ExoticKind,
+    name: &str,
+    receiver: f64,
+) -> Option<f64> {
+    if kind != ExoticKind::Error && !expando_in_use() && !super::descriptors_in_use() {
+        return None;
+    }
+    if super::descriptors_in_use() {
+        if let Some(acc) = super::get_accessor_descriptor(addr, name) {
+            if acc.get == 0 {
+                return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+            }
+            return Some(f64::from_bits(
+                super::invoke_accessor_getter(acc.get, receiver).bits(),
+            ));
+        }
+    }
+    value_lookup(kind, addr, name).map(f64::from_bits)
+}
+
+/// True when (addr, name) resolves to an own expando data property OR an
+/// installed accessor descriptor (HasOwnProperty for exotic instances).
+pub(crate) fn exotic_has_own_property(kind: ExoticKind, addr: usize, name: &str) -> bool {
+    value_lookup(kind, addr, name).is_some()
+        || (super::descriptors_in_use() && super::get_accessor_descriptor(addr, name).is_some())
+}
+
+/// Own expando string keys: data props in insertion order, then
+/// accessor-only keys. Optionally filtered to enumerable ones.
+pub(crate) fn exotic_own_keys(kind: ExoticKind, addr: usize, enumerable_only: bool) -> Vec<String> {
+    let mut keys = value_keys(kind, addr);
+    if super::descriptors_in_use() {
+        for key in super::accessor_descriptor_keys_for_obj(addr) {
+            if !keys.contains(&key) {
+                keys.push(key);
+            }
+        }
+    }
+    if enumerable_only {
+        keys.retain(|k| {
+            super::get_property_attrs(addr, k)
+                .map(|a| a.enumerable())
+                .unwrap_or(true)
+        });
+    }
+    keys
+}
+
+/// `[[DefineOwnProperty]]` on a Date/RegExp/Error instance
+/// (`Object.defineProperty(dateObj, "prop", {...})`). Mirrors the ordinary
+/// ValidateAndApplyPropertyDescriptor flow against the side tables: absent
+/// fields default to `false`/`undefined` for NEW properties and are
+/// retained from the current state when REDEFINING. Throws TypeError on
+/// forbidden non-configurable redefines and non-extensible additions.
+pub(crate) unsafe fn exotic_define_own_property(
+    addr: usize,
+    kind: ExoticKind,
+    name: &str,
+    descriptor_value: f64,
+) {
+    let is_last_index = kind == ExoticKind::RegExp && name == "lastIndex";
+    // Error instances expose `message`/`stack` as builtin own properties
+    // (writable, non-enumerable, configurable) even before any user write.
+    let is_error_builtin = kind == ExoticKind::Error && matches!(name, "message" | "stack");
+    let existing_accessor = if super::descriptors_in_use() {
+        super::get_accessor_descriptor(addr, name)
+    } else {
+        None
+    };
+    let existing_value = value_lookup(kind, addr, name);
+    let exists = is_last_index
+        || is_error_builtin
+        || existing_accessor.is_some()
+        || existing_value.is_some();
+
+    let cur_attrs = if exists {
+        Some(super::get_property_attrs(addr, name).unwrap_or({
+            if is_last_index {
+                // lastIndex: writable, non-enumerable, non-configurable.
+                super::PropertyAttrs::new(true, false, false)
+            } else if is_error_builtin {
+                super::PropertyAttrs::new(true, false, true)
+            } else {
+                super::PropertyAttrs::new(true, true, true)
+            }
+        }))
+    } else {
+        None
+    };
+
+    let has_get = super::desc_has_field(descriptor_value, b"get");
+    let has_set = super::desc_has_field(descriptor_value, b"set");
+    let has_value = super::desc_has_field(descriptor_value, b"value");
+    let has_writable = super::desc_has_field(descriptor_value, b"writable");
+    let has_enumerable = super::desc_has_field(descriptor_value, b"enumerable");
+    let has_configurable = super::desc_has_field(descriptor_value, b"configurable");
+    let read_bool = |field: &[u8]| -> bool {
+        let v = super::desc_read_field(descriptor_value, field);
+        crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0
+    };
+
+    if let Some(cur) = cur_attrs {
+        if !cur.configurable() {
+            let cur_value = existing_value.map(f64::from_bits).unwrap_or_else(|| {
+                if is_last_index {
+                    f64::from_bits((*(addr as *const crate::regex::RegExpHeader)).last_index)
+                } else {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                }
+            });
+            super::validate_nonconfigurable_redefine(
+                name,
+                cur,
+                existing_accessor,
+                cur_value,
+                descriptor_value,
+            );
+        }
+    } else {
+        let gc = (addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0 {
+            super::throw_object_type_error_with_suffix(
+                "Cannot define property ",
+                &format!("{name}, object is not extensible"),
+            );
+        }
+    }
+
+    // Defaults: retained from current state on redefine, false for new.
+    let defaults = cur_attrs.unwrap_or(super::PropertyAttrs::new(false, false, false));
+    let writable = if has_writable {
+        read_bool(b"writable")
+    } else {
+        defaults.writable()
+    };
+    let enumerable = if has_enumerable {
+        read_bool(b"enumerable")
+    } else {
+        defaults.enumerable()
+    };
+    let configurable = if has_configurable {
+        read_bool(b"configurable")
+    } else {
+        defaults.configurable()
+    };
+
+    if has_get || has_set {
+        let get_field = super::desc_read_field(descriptor_value, b"get");
+        let set_field = super::desc_read_field(descriptor_value, b"set");
+        let merged = super::AccessorDescriptor {
+            get: if has_get {
+                if get_field.is_undefined() {
+                    0
+                } else {
+                    get_field.bits()
+                }
+            } else {
+                existing_accessor.map(|a| a.get).unwrap_or(0)
+            },
+            set: if has_set {
+                if set_field.is_undefined() {
+                    0
+                } else {
+                    set_field.bits()
+                }
+            } else {
+                existing_accessor.map(|a| a.set).unwrap_or(0)
+            },
+        };
+        super::set_accessor_descriptor(addr, name.to_string(), merged);
+        // Data → accessor conversion drops the stored value.
+        value_remove(kind, addr, name);
+        super::set_property_attrs(
+            addr,
+            name.to_string(),
+            super::PropertyAttrs::new(false, enumerable, configurable),
+        );
+        return;
+    }
+
+    if existing_accessor.is_some() && (has_value || has_writable) {
+        // Accessor → data conversion.
+        super::clear_accessor_descriptor(addr, name);
+    }
+    if has_value {
+        let v = super::desc_read_field(descriptor_value, b"value");
+        if is_last_index {
+            crate::regex::js_regexp_set_last_index(
+                addr as *mut crate::regex::RegExpHeader,
+                f64::from_bits(v.bits()),
+            );
+        } else {
+            value_store(kind, addr, name, v.bits());
+        }
+    } else if !exists {
+        // New property with absent [[Value]] reads as undefined.
+        value_store(kind, addr, name, crate::value::TAG_UNDEFINED);
+    } else if existing_accessor.is_some() {
+        // Accessor → data with no value: slot becomes undefined.
+        value_store(kind, addr, name, crate::value::TAG_UNDEFINED);
+    }
+    super::set_property_attrs(
+        addr,
+        name.to_string(),
+        super::PropertyAttrs::new(writable, enumerable, configurable),
+    );
+}
+
+/// Assignment `PutValue` arm for exotic receivers, used by
+/// `js_put_value_set`: a Date/RegExp/Error target must not flow into the
+/// ordinary `ObjectHeader` set path (bit-cast / corruption). Returns
+/// `Some(assigned value)` when the receiver was exotic and handled here,
+/// `None` to continue with the ordinary path. Throws on a rejected strict
+/// write.
+pub(crate) fn exotic_put_value_set(
+    target: f64,
+    property_key: f64,
+    value: f64,
+    receiver: f64,
+    strict: i32,
+) -> Option<f64> {
+    let (addr, kind) = exotic_expando_kind_of_value(target)?;
+    if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
+        unsafe { crate::symbol::js_object_set_symbol_property(target, property_key, value) };
+        return Some(value);
+    }
+    let name = unsafe { super::metadata_key_to_string(property_key) }?;
+    let ok = unsafe { exotic_set_property(addr, kind, &name, value, receiver) };
+    if !ok && strict != 0 {
+        crate::error::throw_immutable_write(0, &name);
+    }
+    Some(value)
+}
+
+/// GC mutable-root scanner: keeps expando values alive (and rewrites them if
+/// the collector relocates the referenced heap objects).
+pub fn scan_exotic_expando_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    EXOTIC_EXPANDO.with(|m| {
+        let mut map = m.borrow_mut();
+        for (_, entries) in map.iter_mut() {
+            for (_, bits) in entries.iter_mut() {
+                visitor.visit_nanbox_u64_slot(bits);
+            }
+        }
+    });
+}

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -480,6 +480,23 @@ pub(crate) unsafe fn invoke_accessor_getter(get_bits: u64, receiver: f64) -> JSV
     JSValue::from_bits(result_f64.to_bits())
 }
 
+/// Setter analog of [`invoke_accessor_getter`]: rebinds `this` to the
+/// receiver and invokes the setter closure with the assigned value.
+pub(crate) unsafe fn invoke_accessor_setter(set_bits: u64, receiver: f64, value: f64) {
+    let closure = (set_bits & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
+    if closure.is_null() {
+        return;
+    }
+    let call_bits = crate::closure::clone_closure_rebind_this(set_bits, receiver);
+    let closure = (call_bits & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
+    if closure.is_null() {
+        return;
+    }
+    let prev = super::js_implicit_this_set(receiver);
+    let _ = crate::closure::js_closure_call1(closure, value);
+    super::js_implicit_this_set(prev);
+}
+
 /// #4140: builtin *reflection-only* accessors — most prominently the four
 /// `%TypedArray%.prototype` getters (`length`/`byteLength`/`byteOffset`/
 /// `buffer`) — are installed via [`super::set_builtin_accessor_descriptor`],
@@ -1168,22 +1185,17 @@ pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
         if crate::closure::is_closure_ptr(ptr) {
             return js_closure_dynamic_keys(ptr);
         }
-        if ptr >= crate::gc::GC_HEADER_SIZE + 0x1000 {
-            unsafe {
-                let gc_header =
-                    (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-                if (*gc_header).obj_type == crate::gc::GC_TYPE_ERROR {
-                    let props = crate::node_submodules::error_user_props(ptr);
-                    let arr = crate::array::js_array_alloc(props.len() as u32);
-                    let mut out = arr;
-                    for (name, _) in props {
-                        let key =
-                            crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-                        out = crate::array::js_array_push(out, JSValue::string_ptr(key));
-                    }
-                    return out;
-                }
+        // Date / RegExp / Error exotic instances: enumerable own expando
+        // keys from the side tables (the cell is not an `ObjectHeader`).
+        if let Some(kind) = super::exotic_expando::exotic_expando_kind(ptr) {
+            let keys = super::exotic_expando::exotic_own_keys(kind, ptr, true);
+            let arr = crate::array::js_array_alloc(keys.len().max(1) as u32);
+            let mut out = arr;
+            for name in keys {
+                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                out = crate::array::js_array_push(out, JSValue::string_ptr(key));
             }
+            return out;
         }
         return js_object_keys(ptr as *const ObjectHeader);
     }
@@ -1676,9 +1688,28 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
                     let key_box = crate::string::js_string_new_sso(s.as_ptr(), s.len() as u32);
                     crate::array::js_array_push_f64(result, key_box);
                 }
-                for name in crate::array::array_named_property_names(arr, true) {
+                let named = crate::array::array_named_property_names(arr, true);
+                for name in &named {
                     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
                     crate::array::js_array_push(result, JSValue::string_ptr(key));
+                }
+                // Accessor-only named properties (defineProperty {get/set})
+                // live solely in the accessor side table — include the
+                // enumerable ones.
+                if super::descriptors_in_use() {
+                    for name in accessor_descriptor_keys_for_obj(owner) {
+                        if super::canonical_array_index(&name).is_some()
+                            || named.contains(&name)
+                            || !get_property_attrs(owner, &name)
+                                .map(|a| a.enumerable())
+                                .unwrap_or(false)
+                        {
+                            continue;
+                        }
+                        let key =
+                            crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                        crate::array::js_array_push(result, JSValue::string_ptr(key));
+                    }
                 }
                 return result;
             }
@@ -2160,6 +2191,43 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     }
 
     let obj_addr = obj_val.bits() & 0x0000_FFFF_FFFF_FFFF;
+    // Date / RegExp / Error exotic instances: own expando props + builtin
+    // slots + prototype methods. The generic pointer path below would
+    // bit-cast the cell as an `ObjectHeader`.
+    if let Some(kind) = super::exotic_expando::exotic_expando_kind(obj_addr as usize) {
+        use super::exotic_expando::ExoticKind;
+        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let Some(kb) = (unsafe { crate::string::js_string_key_bytes(key_val, &mut sso) }) else {
+            return nanbox_false;
+        };
+        let Ok(name) = std::str::from_utf8(kb) else {
+            return nanbox_false;
+        };
+        if super::exotic_expando::exotic_has_own_property(kind, obj_addr as usize, name) {
+            return nanbox_true;
+        }
+        let builtin_own = match kind {
+            ExoticKind::RegExp => name == "lastIndex",
+            ExoticKind::Error => matches!(name, "message" | "stack"),
+            ExoticKind::Date => false,
+        };
+        if builtin_own {
+            return nanbox_true;
+        }
+        // Inherited prototype members (`"getTime" in date`, `"exec" in re`,
+        // `"name" in err`, `"toString" in any`): the per-kind get arms in
+        // `js_object_get_field_by_name` already resolve prototype methods,
+        // so reuse them via a value-level read.
+        let key_hdr =
+            crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+        if !key_hdr.is_null() {
+            let v = js_object_get_field_by_name(obj_addr as *const ObjectHeader, key_hdr);
+            if !v.is_undefined() {
+                return nanbox_true;
+            }
+        }
+        return nanbox_false;
+    }
     if obj_addr >= 0x10000 {
         if crate::typedarray::lookup_typed_array_kind(obj_addr as usize).is_some() {
             let ta = obj_addr as *const crate::typedarray::TypedArrayHeader;
@@ -2817,6 +2885,20 @@ pub extern "C" fn js_object_get_field_by_name(
                         (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                     let key_len = (*key).byte_len as usize;
                     let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+                    // User expando / defineProperty'd own properties first.
+                    if let Ok(name) = std::str::from_utf8(key_bytes) {
+                        let receiver = f64::from_bits(
+                            crate::value::JSValue::pointer(addr as *const u8).bits(),
+                        );
+                        if let Some(v) = super::exotic_expando::exotic_get_own_property(
+                            addr,
+                            super::exotic_expando::ExoticKind::Date,
+                            name,
+                            receiver,
+                        ) {
+                            return JSValue::from_bits(v.to_bits());
+                        }
+                    }
                     if key_bytes == b"constructor" {
                         let v = js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
                         return JSValue::from_bits(v.to_bits());
@@ -3853,11 +3935,18 @@ pub extern "C" fn js_object_get_field_by_name(
                 // User-assigned own properties (`err.code = "X"`,
                 // `err.errno = -2`, custom fields) take precedence over the
                 // built-in accessors below — they were recorded in the
-                // per-error side table by the setter (#2014).
+                // per-error side table by the setter (#2014). Routed through
+                // the exotic helper so `Object.defineProperty(err, k, {get})`
+                // accessors fire too.
                 if let Ok(key_str) = std::str::from_utf8(key_bytes) {
-                    if let Some(v) =
-                        crate::node_submodules::error_user_prop(err_ptr as usize, key_str)
-                    {
+                    let receiver =
+                        f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                    if let Some(v) = super::exotic_expando::exotic_get_own_property(
+                        err_ptr as usize,
+                        super::exotic_expando::ExoticKind::Error,
+                        key_str,
+                        receiver,
+                    ) {
                         return JSValue::from_bits(v.to_bits());
                     }
                 }
@@ -3969,7 +4058,32 @@ pub extern "C" fn js_object_get_field_by_name(
                         }
                         return JSValue::undefined();
                     }
-                    _ => return JSValue::undefined(),
+                    _ => {
+                        // Inherited members: user-defined props/accessors on
+                        // `Error.prototype` (or the kind-specific prototype)
+                        // resolve through the prototype object — e.g.
+                        // `Object.defineProperty(Error.prototype, "prop",
+                        // {value}); new Error().prop`.
+                        let kind_name =
+                            crate::error::error_kind_constructor_name((*err_ptr).error_kind);
+                        for proto_name in [kind_name, "Error"] {
+                            let proto = crate::object::builtin_prototype_value(proto_name);
+                            let pv = JSValue::from_bits(proto.to_bits());
+                            if pv.is_pointer() {
+                                let proto_ptr = pv.as_pointer::<ObjectHeader>();
+                                if !proto_ptr.is_null() {
+                                    let v = js_object_get_field_by_name(proto_ptr, key);
+                                    if !v.is_undefined() {
+                                        return JSValue::from_bits(v.bits());
+                                    }
+                                }
+                            }
+                            if proto_name == "Error" {
+                                break;
+                            }
+                        }
+                        return JSValue::undefined();
+                    }
                 }
             }
             return JSValue::undefined();
@@ -4029,6 +4143,17 @@ pub extern "C" fn js_object_get_field_by_name(
                             return v;
                         }
                         return JSValue::undefined();
+                    }
+                    // Named (non-index) accessor installed via
+                    // `Object.defineProperty(arr, "prop", {get,set})`.
+                    if ACCESSORS_IN_USE.with(|c| c.get()) {
+                        if let Some(acc) = get_accessor_descriptor(obj as usize, name) {
+                            if acc.get != 0 {
+                                let receiver = crate::value::js_nanbox_pointer(obj as i64);
+                                return invoke_accessor_getter(acc.get, receiver);
+                            }
+                            return JSValue::undefined();
+                        }
                     }
                     if let Some(v) = own_data_field_by_name(obj, key) {
                         return v;
@@ -4198,6 +4323,35 @@ pub extern "C" fn js_object_get_field_by_name(
                 let key_len = (*key).byte_len as usize;
                 let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
                 let re = obj as *const crate::regex::RegExpHeader;
+                // User expando / defineProperty'd own properties shadow the
+                // prototype fallthrough but NOT the spec header props above
+                // (source/flags/lastIndex/... are non-configurable).
+                if !matches!(
+                    key_bytes,
+                    b"source"
+                        | b"flags"
+                        | b"lastIndex"
+                        | b"global"
+                        | b"ignoreCase"
+                        | b"multiline"
+                        | b"sticky"
+                        | b"unicode"
+                        | b"dotAll"
+                        | b"hasIndices"
+                ) {
+                    if let Ok(name) = std::str::from_utf8(key_bytes) {
+                        let receiver =
+                            f64::from_bits(crate::value::JSValue::pointer(obj as *const u8).bits());
+                        if let Some(v) = super::exotic_expando::exotic_get_own_property(
+                            obj as usize,
+                            super::exotic_expando::ExoticKind::RegExp,
+                            name,
+                            receiver,
+                        ) {
+                            return JSValue::from_bits(v.to_bits());
+                        }
+                    }
+                }
                 match key_bytes {
                     b"source" => {
                         let s = crate::regex::js_regexp_get_source(re);

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -303,12 +303,12 @@ pub extern "C" fn js_object_set_field_by_name(
             return;
         }
     }
-    // #2089: a `Date` is a NaN-boxed pointer to an 8-byte `DateCell`. Setting
-    // an arbitrary property on it (`date.foo = x`) must NOT deref the small
-    // cell as an `ObjectHeader` below (memory corruption). Perry doesn't model
-    // expando properties on Date objects, so treat it as a no-op — the same
-    // observable result as the old value-type representation (a property set
-    // on a primitive number).
+    // #2089: a `Date` is a NaN-boxed pointer to an 8-byte `DateCell`, and a
+    // RegExp is a `RegExpHeader` — neither is an `ObjectHeader`, so a write
+    // must NOT fall through to the object deref below (memory corruption).
+    // Expando properties on these exotic instances live in the side table
+    // (`object::exotic_expando`), honoring accessor descriptors and
+    // attribute writability installed by `Object.defineProperty`.
     {
         let bits = obj as u64;
         let top16 = bits >> 48;
@@ -319,8 +319,28 @@ pub extern "C" fn js_object_set_field_by_name(
         } else {
             0
         };
-        if addr != 0 && crate::date::is_date_cell_addr(addr) {
-            return;
+        if addr != 0 {
+            if let Some(kind) = super::exotic_expando::exotic_expando_kind(addr) {
+                if !key.is_null() {
+                    unsafe {
+                        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+                        if let Some(name_bytes) = crate::string::js_string_key_bytes(
+                            crate::value::JSValue::string_ptr(key as *mut _),
+                            &mut sso,
+                        ) {
+                            if let Ok(name) = std::str::from_utf8(name_bytes) {
+                                let receiver = f64::from_bits(
+                                    crate::value::JSValue::pointer(addr as *const u8).bits(),
+                                );
+                                let _ = super::exotic_expando::exotic_set_property(
+                                    addr, kind, name, value, receiver,
+                                );
+                            }
+                        }
+                    }
+                }
+                return;
+            }
         }
     }
     // Strip NaN-boxing tags if present (defensive: handle POINTER_TAG, UNDEFINED, NULL, etc.)

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -4808,8 +4808,92 @@ extern "C" fn object_freeze_thunk(
 extern "C" fn object_create_thunk(
     _closure: *const crate::closure::ClosureHeader,
     value: f64,
+    props: f64,
 ) -> f64 {
-    super::js_object_create(value)
+    if props.to_bits() == crate::value::TAG_UNDEFINED {
+        super::js_object_create(value)
+    } else {
+        super::js_object_create_with_props(value, props)
+    }
+}
+
+extern "C" fn object_seal_thunk(_closure: *const crate::closure::ClosureHeader, value: f64) -> f64 {
+    super::js_object_seal(value)
+}
+
+extern "C" fn object_is_sealed_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    super::js_object_is_sealed(value)
+}
+
+extern "C" fn object_is_frozen_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    super::js_object_is_frozen(value)
+}
+
+extern "C" fn object_is_extensible_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    super::js_object_is_extensible(value)
+}
+
+extern "C" fn object_prevent_extensions_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    super::js_object_prevent_extensions(value)
+}
+
+extern "C" fn object_is_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    a: f64,
+    b: f64,
+) -> f64 {
+    super::js_object_is(a, b)
+}
+
+extern "C" fn object_set_prototype_of_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    obj: f64,
+    proto: f64,
+) -> f64 {
+    super::js_object_set_prototype_of(obj, proto)
+}
+
+extern "C" fn object_get_own_property_symbols_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    let arr = unsafe { crate::symbol::js_object_get_own_property_symbols(value) };
+    crate::value::js_nanbox_pointer(arr)
+}
+
+extern "C" fn object_get_own_property_descriptors_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+) -> f64 {
+    super::js_object_get_own_property_descriptors(value)
+}
+
+extern "C" fn object_define_properties_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    target: f64,
+    descriptors: f64,
+) -> f64 {
+    super::js_object_define_properties(target, descriptors)
+}
+
+extern "C" fn object_group_by_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    items: f64,
+    callback: f64,
+) -> f64 {
+    super::js_object_group_by(items, callback)
 }
 
 extern "C" fn object_get_prototype_of_thunk(
@@ -5654,7 +5738,72 @@ fn install_builtin_constructor_statics(name: &str, ctor: *mut crate::closure::Cl
                 false,
             );
             install_constructor_static(ctor, "freeze", object_freeze_thunk as *const u8, 1, false);
-            install_constructor_static(ctor, "create", object_create_thunk as *const u8, 1, false);
+            install_constructor_static(ctor, "create", object_create_thunk as *const u8, 2, false);
+            install_constructor_static(ctor, "seal", object_seal_thunk as *const u8, 1, false);
+            install_constructor_static(
+                ctor,
+                "isSealed",
+                object_is_sealed_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "isFrozen",
+                object_is_frozen_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "isExtensible",
+                object_is_extensible_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "preventExtensions",
+                object_prevent_extensions_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(ctor, "is", object_is_thunk as *const u8, 2, false);
+            install_constructor_static(
+                ctor,
+                "setPrototypeOf",
+                object_set_prototype_of_thunk as *const u8,
+                2,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "getOwnPropertySymbols",
+                object_get_own_property_symbols_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "getOwnPropertyDescriptors",
+                object_get_own_property_descriptors_thunk as *const u8,
+                1,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "defineProperties",
+                object_define_properties_thunk as *const u8,
+                2,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "groupBy",
+                object_group_by_thunk as *const u8,
+                2,
+                false,
+            );
             install_constructor_static(
                 ctor,
                 "getPrototypeOf",

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -35,6 +35,7 @@ mod date_proto_thunks;
 mod delete_rest;
 mod descriptors;
 mod disposable_proto_thunks;
+pub(crate) mod exotic_expando;
 mod field_get_set;
 mod field_set_by_name;
 mod global_fetch;
@@ -90,6 +91,7 @@ pub(crate) use collection_proto_thunks::{is_builtin_map_set_value, is_builtin_se
 pub(crate) use data_view_registry::extends_builtin_data_view;
 pub use delete_rest::*;
 pub use descriptors::*;
+pub use exotic_expando::scan_exotic_expando_roots_mut;
 pub use field_get_set::*;
 pub use field_set_by_name::*;
 pub use global_this::*;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -4037,6 +4037,25 @@ pub unsafe extern "C" fn js_native_call_method(
                         .unwrap_or(false);
                     return f64::from_bits(JSValue::bool(present).bits());
                 }
+                // Date / RegExp / Error exotic receivers: own expando props
+                // (side tables) + per-kind builtin own slots.
+                if let Some(kind) = super::exotic_expando::exotic_expando_kind(raw) {
+                    use super::exotic_expando::ExoticKind;
+                    let present = super::has_own_helpers::str_from_string_header(key_str)
+                        .map(|key| {
+                            super::exotic_expando::exotic_has_own_property(kind, raw, key)
+                                || match kind {
+                                    ExoticKind::RegExp => key == "lastIndex",
+                                    ExoticKind::Error => crate::error::js_error_has_own_property(
+                                        raw as *mut crate::error::ErrorHeader,
+                                        key,
+                                    ),
+                                    ExoticKind::Date => false,
+                                }
+                        })
+                        .unwrap_or(false);
+                    return f64::from_bits(JSValue::bool(present).bits());
+                }
                 if raw >= crate::gc::GC_HEADER_SIZE + 0x1000 {
                     let gc_header = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE)
                         as *const crate::gc::GcHeader;

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -828,6 +828,25 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
                 );
                 return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
             }
+            // Date / RegExp / Error exotic instances: own expando props
+            // (side tables) + per-kind builtin own slots.
+            if let Some(kind) = super::exotic_expando::exotic_expando_kind(ptr) {
+                use super::exotic_expando::ExoticKind;
+                let present = super::has_own_helpers::str_from_string_header(key_str)
+                    .map(|key| {
+                        super::exotic_expando::exotic_has_own_property(kind, ptr, key)
+                            || match kind {
+                                ExoticKind::RegExp => key == "lastIndex",
+                                ExoticKind::Error => crate::error::js_error_has_own_property(
+                                    ptr as *mut crate::error::ErrorHeader,
+                                    key,
+                                ),
+                                ExoticKind::Date => false,
+                            }
+                    })
+                    .unwrap_or(false);
+                return f64::from_bits(if present { TAG_TRUE } else { TAG_FALSE });
+            }
             if crate::closure::is_closure_ptr(ptr) {
                 let present = super::has_own_helpers::str_from_string_header(key_str)
                     .map(|k| super::has_own_helpers::closure_own_key_present(ptr, k))
@@ -980,6 +999,22 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
                 addr as *const crate::typedarray::TypedArrayHeader,
                 key_str,
             );
+            return f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE });
+        }
+
+        // Date / RegExp / Error exotic instances: expando/accessor own props
+        // report their side-table enumerability (default true for plain
+        // expando writes); builtin own slots are non-enumerable.
+        if let Some((addr, kind)) = super::exotic_expando::exotic_expando_kind_of_value(obj_value) {
+            let Some(key_name) = super::has_own_helpers::str_from_string_header(key_str) else {
+                return f64::from_bits(TAG_FALSE);
+            };
+            if !super::exotic_expando::exotic_has_own_property(kind, addr, key_name) {
+                return f64::from_bits(TAG_FALSE);
+            }
+            let enumerable = super::get_property_attrs(addr, key_name)
+                .map(|a| a.enumerable())
+                .unwrap_or(true);
             return f64::from_bits(if enumerable { TAG_TRUE } else { TAG_FALSE });
         }
 
@@ -1233,6 +1268,31 @@ pub extern "C" fn js_object_define_property(
                 throw_object_type_error(b"Cannot redefine property")
             }
             super::TypedArrayDefineOutcome::NotTypedArray => {}
+        }
+
+        // Date / RegExp / Error instances are exotic cells, not
+        // `ObjectHeader`s — the ordinary define path below would bit-cast
+        // them and corrupt memory. Route through the expando-aware
+        // [[DefineOwnProperty]] (side-table storage + attrs + accessors).
+        if let Some((addr, kind)) = super::exotic_expando::exotic_expando_kind_of_value(obj_value) {
+            if crate::symbol::js_is_symbol(key_value) != 0 {
+                let value_field = desc_read_field(descriptor_value, b"value");
+                crate::symbol::js_object_set_symbol_property(
+                    obj_value,
+                    key_value,
+                    f64::from_bits(value_field.bits()),
+                );
+                return obj_value;
+            }
+            if let Some(name) = super::metadata_key_to_string(key_value) {
+                super::exotic_expando::exotic_define_own_property(
+                    addr,
+                    kind,
+                    &name,
+                    descriptor_value,
+                );
+            }
+            return obj_value;
         }
 
         // #2159: when the receiver is a class-ref (`Class.prototype` evaluates
@@ -1712,8 +1772,21 @@ pub extern "C" fn js_object_define_property(
         // `writable`; for a brand-new accessor we leave it `true` (via
         // `has_accessor`) so data lookups before the accessor override don't
         // reject a legitimate fallthrough write.
-        let writable = read_bool(b"writable")
-            .unwrap_or_else(|| existing_attrs.map(|a| a.writable()).unwrap_or(has_accessor));
+        //
+        // Accessor → data conversion: the current property has no
+        // [[Writable]], so an omitted `writable` defaults to FALSE (the
+        // retained-attrs rule doesn't apply across the kind switch).
+        let accessor_to_data = existing_accessor.is_some()
+            && !has_accessor
+            && (desc_has_field(descriptor_value, b"value")
+                || desc_has_field(descriptor_value, b"writable"));
+        let writable = read_bool(b"writable").unwrap_or_else(|| {
+            if accessor_to_data {
+                false
+            } else {
+                existing_attrs.map(|a| a.writable()).unwrap_or(has_accessor)
+            }
+        });
         let enumerable = read_bool(b"enumerable")
             .unwrap_or_else(|| existing_attrs.map(|a| a.enumerable()).unwrap_or(false));
         let configurable = read_bool(b"configurable")
@@ -2239,6 +2312,38 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     // than faulting on the cell.
     if crate::temporal::is_temporal_value(obj_value) {
         return f64::from_bits(TAG_NULL);
+    }
+    // ES2015 ToObject(primitive): `Object.getPrototypeOf(0 | "s" | true |
+    // 1n | sym)` resolves to the wrapper class prototype, not a TypeError /
+    // null (15.2.3.2-1*).
+    {
+        let jv = crate::value::JSValue::from_bits(obj_value.to_bits());
+        // An INT32-tagged value may be a class ref (same 0x7FFE tag as small
+        // integers) — those must keep flowing to the class resolution below.
+        let is_class_ref =
+            (obj_value.to_bits() >> 48) == 0x7FFE && super::class_ref_id(obj_value).is_some();
+        let wrapper = if is_class_ref {
+            None
+        } else if jv.is_number() {
+            Some("Number")
+        } else if jv.is_any_string() {
+            Some("String")
+        } else if jv.is_bool() {
+            Some("Boolean")
+        } else if jv.is_bigint() {
+            Some("BigInt")
+        } else if unsafe { crate::symbol::js_is_symbol(obj_value) } != 0 {
+            Some("Symbol")
+        } else {
+            None
+        };
+        if let Some(name) = wrapper {
+            let proto = crate::object::builtin_prototype_value(name);
+            if proto.to_bits() != crate::value::TAG_UNDEFINED {
+                return proto;
+            }
+            return f64::from_bits(TAG_NULL);
+        }
     }
     let bits = obj_value.to_bits();
     let top16 = bits >> 48;

--- a/crates/perry-runtime/src/object/object_ops_frozen.rs
+++ b/crates/perry-runtime/src/object/object_ops_frozen.rs
@@ -140,6 +140,55 @@ pub extern "C" fn js_object_freeze(obj_value: f64) -> f64 {
             (*gc)._reserved |= crate::gc::OBJ_FLAG_FROZEN
                 | crate::gc::OBJ_FLAG_SEALED
                 | crate::gc::OBJ_FLAG_NO_EXTEND;
+            // TypedArray receivers are NOT `ObjectHeader`s — the key walk
+            // below would read a garbage `keys_array` off the TA header and
+            // can fault depending on heap layout. The GC flags above are the
+            // entire integrity state for them.
+            if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some()
+                || crate::typedarray_props::typed_array_addr_from_value(obj_value).is_some()
+            {
+                return obj_value;
+            }
+            // Closures: own props are `name`/`length` + dynamic props — the
+            // keys_array walk below would read garbage off the ClosureHeader.
+            // Record explicit non-writable/non-configurable attrs.
+            if crate::closure::is_closure_ptr(obj as usize) {
+                let owner = obj as usize;
+                for builtin in ["name", "length"] {
+                    super::set_property_attrs(
+                        owner,
+                        builtin.to_string(),
+                        PropertyAttrs::new(false, false, false),
+                    );
+                }
+                for (name, _) in crate::closure::closure_dynamic_props_snapshot(owner) {
+                    let cur = super::get_property_attrs(owner, &name)
+                        .unwrap_or(PropertyAttrs::new(true, true, true));
+                    super::set_property_attrs(
+                        owner,
+                        name,
+                        PropertyAttrs::new(false, cur.enumerable(), false),
+                    );
+                }
+                mark_all_symbol_keys(
+                    obj, /*drop_writable=*/ true, /*drop_configurable=*/ true,
+                );
+                return obj_value;
+            }
+            // Date / RegExp / Error exotic instances: their own props live in
+            // the side tables, so freeze them there instead of the key walk.
+            if let Some(kind) = super::exotic_expando::exotic_expando_kind(obj as usize) {
+                for key in super::exotic_expando::exotic_own_keys(kind, obj as usize, false) {
+                    let cur = super::get_property_attrs(obj as usize, &key)
+                        .unwrap_or(PropertyAttrs::new(true, true, true));
+                    super::set_property_attrs(
+                        obj as usize,
+                        key,
+                        PropertyAttrs::new(false, cur.enumerable(), false),
+                    );
+                }
+                return obj_value;
+            }
             // Drop writable + configurable for every existing key.
             mark_all_keys(
                 obj, /*drop_writable=*/ true, false, /*drop_configurable=*/ true,
@@ -166,6 +215,53 @@ pub extern "C" fn js_object_seal(obj_value: f64) -> f64 {
         if !obj.is_null() && (obj as usize) > 0x10000 {
             let gc = gc_header_for(obj);
             (*gc)._reserved |= crate::gc::OBJ_FLAG_SEALED | crate::gc::OBJ_FLAG_NO_EXTEND;
+            // TypedArray receivers: GC flags only — see `js_object_freeze`.
+            if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some()
+                || crate::typedarray_props::typed_array_addr_from_value(obj_value).is_some()
+            {
+                return obj_value;
+            }
+            // Closures: seal via the side tables (drop configurable only) —
+            // see the matching arm in `js_object_freeze`.
+            if crate::closure::is_closure_ptr(obj as usize) {
+                let owner = obj as usize;
+                for builtin in ["name", "length"] {
+                    let cur = super::get_property_attrs(owner, builtin)
+                        .unwrap_or(PropertyAttrs::new(false, false, true));
+                    super::set_property_attrs(
+                        owner,
+                        builtin.to_string(),
+                        PropertyAttrs::new(cur.writable(), cur.enumerable(), false),
+                    );
+                }
+                for (name, _) in crate::closure::closure_dynamic_props_snapshot(owner) {
+                    let cur = super::get_property_attrs(owner, &name)
+                        .unwrap_or(PropertyAttrs::new(true, true, true));
+                    super::set_property_attrs(
+                        owner,
+                        name,
+                        PropertyAttrs::new(cur.writable(), cur.enumerable(), false),
+                    );
+                }
+                mark_all_symbol_keys(
+                    obj, /*drop_writable=*/ false, /*drop_configurable=*/ true,
+                );
+                return obj_value;
+            }
+            // Date / RegExp / Error exotic instances: seal via the side
+            // tables (drop configurable only) — see `js_object_freeze`.
+            if let Some(kind) = super::exotic_expando::exotic_expando_kind(obj as usize) {
+                for key in super::exotic_expando::exotic_own_keys(kind, obj as usize, false) {
+                    let cur = super::get_property_attrs(obj as usize, &key)
+                        .unwrap_or(PropertyAttrs::new(true, true, true));
+                    super::set_property_attrs(
+                        obj as usize,
+                        key,
+                        PropertyAttrs::new(cur.writable(), cur.enumerable(), false),
+                    );
+                }
+                return obj_value;
+            }
             // Drop configurable for every existing key (but leave writable intact).
             mark_all_keys(
                 obj, /*drop_writable=*/ false, false, /*drop_configurable=*/ true,
@@ -216,6 +312,61 @@ unsafe fn object_integrity_level(obj: *mut ObjectHeader, frozen: bool) -> bool {
     let gc = gc_header_for(obj);
     if (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND == 0 {
         return false;
+    }
+    // Closures: own props are `name`/`length` + dynamic props (side-table
+    // attrs), NOT a `keys_array` — the walk below would read garbage off the
+    // ClosureHeader. `name`/`length` are non-writable but configurable by
+    // default, so an un-frozen function fails both levels; `js_object_freeze`
+    // / `seal` record explicit attrs that satisfy them.
+    if (*gc).obj_type == crate::gc::GC_TYPE_CLOSURE || crate::closure::is_closure_ptr(obj as usize)
+    {
+        let owner = obj as usize;
+        for builtin in ["name", "length"] {
+            if crate::closure::closure_is_key_deleted(owner, builtin) {
+                continue;
+            }
+            let attrs = get_property_attrs(owner, builtin)
+                .unwrap_or(PropertyAttrs::new(false, false, true));
+            if attrs.configurable() {
+                return false;
+            }
+        }
+        for (name, _) in crate::closure::closure_dynamic_props_snapshot(owner) {
+            if crate::closure::closure_is_key_deleted(owner, &name) {
+                continue;
+            }
+            let Some(attrs) = get_property_attrs(owner, &name) else {
+                return false;
+            };
+            if attrs.configurable() {
+                return false;
+            }
+            if frozen
+                && get_accessor_descriptor(owner, &name).is_none()
+                && attrs.writable()
+                && name != "prototype"
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+    // Date / RegExp / Error exotic instances: own props live in the side
+    // tables; the keys_array walk below would bit-cast the cell.
+    if let Some(kind) = super::exotic_expando::exotic_expando_kind(obj as usize) {
+        let owner = obj as usize;
+        for name in super::exotic_expando::exotic_own_keys(kind, owner, false) {
+            let Some(attrs) = get_property_attrs(owner, &name) else {
+                return false;
+            };
+            if attrs.configurable() {
+                return false;
+            }
+            if frozen && get_accessor_descriptor(owner, &name).is_none() && attrs.writable() {
+                return false;
+            }
+        }
+        return true;
     }
     // Arrays: a non-empty array's dense elements are configurable/writable
     // unless frozen/sealed dropped those bits (tracked by the array flags).

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -21,6 +21,8 @@ use std::collections::HashMap;
 use crate::closure::{js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3};
 
 mod invariants;
+mod put_value;
+pub use put_value::js_put_value_set;
 mod json;
 mod metadata;
 mod own_keys;
@@ -1048,83 +1050,6 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
         current = proto;
     }
     false
-}
-
-/// Assignment PutValue for a property reference. Returns the assigned RHS value
-/// on success or sloppy failure, and throws TypeError when strict code attempts
-/// a failed [[Set]].
-#[no_mangle]
-pub extern "C" fn js_put_value_set(
-    target: f64,
-    key: f64,
-    value: f64,
-    receiver: f64,
-    strict: i32,
-) -> f64 {
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let target_handle = scope.root_nanbox_f64(target);
-    let key_handle = scope.root_nanbox_f64(key);
-    let value_handle = scope.root_nanbox_f64(value);
-    let receiver_handle = scope.root_nanbox_f64(receiver);
-    let target = target_handle.get_nanbox_f64();
-    let key = key_handle.get_nanbox_f64();
-    let value = value_handle.get_nanbox_f64();
-    let receiver = receiver_handle.get_nanbox_f64();
-    let property_key_handle =
-        scope.root_nanbox_f64(unsafe { crate::object::js_to_property_key(key) });
-    let property_key = property_key_handle.get_nanbox_f64();
-
-    if lookup(target).is_none() {
-        if set_integer_indexed_exotic(target, property_key, value) {
-            return value;
-        }
-        // Integer-Indexed exotic objects: a key that is *not* a CanonicalNumeric
-        // index does OrdinarySet, creating/looking-up a normal own property on
-        // the typed array (ECMA-262 §10.4.5.5). The generic
-        // `ordinary_set_with_receiver` path below mis-reads the typed-array
-        // header as an `ObjectHeader` and segfaults, so route typed-array
-        // targets to the TA-aware setters (mirroring `js_object_set_field_by_name`).
-        // A CanonicalNumeric-but-out-of-bounds key (`"1.5"`, `"NaN"`, `"-0"`)
-        // is classified `IntegerIndex` inside `typed_array_set_property_by_name`
-        // and silently ignored — never materialized as an ordinary property.
-        if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(target) {
-            if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
-                unsafe {
-                    crate::symbol::js_object_set_symbol_property(target, property_key, value);
-                }
-                return value;
-            }
-            if let Some(name) = key_to_rust_string(property_key) {
-                unsafe {
-                    crate::typedarray_props::typed_array_set_property_by_name(addr, &name, value);
-                }
-                return value;
-            }
-        }
-        if target.to_bits() == receiver.to_bits() && key_is_length(property_key) {
-            if let Some(arr) = array_ptr_from_value(target) {
-                crate::array::js_array_set_length(arr, value);
-                return value;
-            }
-        }
-    }
-
-    let target_bits = target.to_bits();
-    if target_bits == TAG_NULL || target_bits == TAG_UNDEFINED {
-        let key_name = key_to_rust_string(property_key).unwrap_or_else(|| "property".to_string());
-        let msg = format!("Cannot set properties of null or undefined (setting '{key_name}')");
-        return throw_type_error(&msg);
-    }
-    let ok = if lookup(target).is_some() {
-        js_proxy_set(target, property_key, value).to_bits() == TAG_TRUE
-    } else {
-        ordinary_set_with_receiver(target, property_key, value, receiver)
-    };
-    if !ok && strict != 0 {
-        let key_name = key_to_rust_string(property_key).unwrap_or_else(|| "property".to_string());
-        crate::error::throw_immutable_write(0, &key_name);
-    }
-    value_handle.get_nanbox_f64()
 }
 
 fn class_super_accessor_set(

--- a/crates/perry-runtime/src/proxy/put_value.rs
+++ b/crates/perry-runtime/src/proxy/put_value.rs
@@ -1,0 +1,95 @@
+//! `PutValue` for property references (`obj.k = v` / `obj[k] = v` runtime
+//! dispatch), split out of `proxy.rs` to keep it under the file-size gate.
+//! Routes Proxy traps, integer-indexed exotics, exotic expando cells, and
+//! the ordinary receiver-aware `[[Set]]` walk.
+
+use super::*;
+
+/// Assignment PutValue for a property reference. Returns the assigned RHS value
+/// on success or sloppy failure, and throws TypeError when strict code attempts
+/// a failed [[Set]].
+#[no_mangle]
+pub extern "C" fn js_put_value_set(
+    target: f64,
+    key: f64,
+    value: f64,
+    receiver: f64,
+    strict: i32,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let value_handle = scope.root_nanbox_f64(value);
+    let receiver_handle = scope.root_nanbox_f64(receiver);
+    let target = target_handle.get_nanbox_f64();
+    let key = key_handle.get_nanbox_f64();
+    let value = value_handle.get_nanbox_f64();
+    let receiver = receiver_handle.get_nanbox_f64();
+    let property_key_handle =
+        scope.root_nanbox_f64(unsafe { crate::object::js_to_property_key(key) });
+    let property_key = property_key_handle.get_nanbox_f64();
+
+    if lookup(target).is_none() {
+        if set_integer_indexed_exotic(target, property_key, value) {
+            return value;
+        }
+        // Integer-Indexed exotic objects: a key that is *not* a CanonicalNumeric
+        // index does OrdinarySet, creating/looking-up a normal own property on
+        // the typed array (ECMA-262 §10.4.5.5). The generic
+        // `ordinary_set_with_receiver` path below mis-reads the typed-array
+        // header as an `ObjectHeader` and segfaults, so route typed-array
+        // targets to the TA-aware setters (mirroring `js_object_set_field_by_name`).
+        // A CanonicalNumeric-but-out-of-bounds key (`"1.5"`, `"NaN"`, `"-0"`)
+        // is classified `IntegerIndex` inside `typed_array_set_property_by_name`
+        // and silently ignored — never materialized as an ordinary property.
+        if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(target) {
+            if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
+                unsafe {
+                    crate::symbol::js_object_set_symbol_property(target, property_key, value);
+                }
+                return value;
+            }
+            if let Some(name) = key_to_rust_string(property_key) {
+                unsafe {
+                    crate::typedarray_props::typed_array_set_property_by_name(addr, &name, value);
+                }
+                return value;
+            }
+        }
+        // Date / RegExp / Error exotic cells: route to the expando-aware
+        // setter — the ordinary path below would bit-cast them. Throws on a
+        // rejected strict write. (See `object::exotic_expando`.)
+        if let Some(v) = crate::object::exotic_expando::exotic_put_value_set(
+            target,
+            property_key,
+            value,
+            receiver,
+            strict,
+        ) {
+            return v;
+        }
+        if target.to_bits() == receiver.to_bits() && key_is_length(property_key) {
+            if let Some(arr) = array_ptr_from_value(target) {
+                crate::array::js_array_set_length(arr, value);
+                return value;
+            }
+        }
+    }
+
+    let target_bits = target.to_bits();
+    if target_bits == TAG_NULL || target_bits == TAG_UNDEFINED {
+        let key_name = key_to_rust_string(property_key).unwrap_or_else(|| "property".to_string());
+        let msg = format!("Cannot set properties of null or undefined (setting '{key_name}')");
+        return throw_type_error(&msg);
+    }
+    let ok = if lookup(target).is_some() {
+        js_proxy_set(target, property_key, value).to_bits() == TAG_TRUE
+    } else {
+        ordinary_set_with_receiver(target, property_key, value, receiver)
+    };
+    if !ok && strict != 0 {
+        let key_name = key_to_rust_string(property_key).unwrap_or_else(|| "property".to_string());
+        crate::error::throw_immutable_write(0, &key_name);
+    }
+    value_handle.get_nanbox_f64()
+}

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -433,6 +433,9 @@ pub extern "C" fn js_regexp_new(
             panic!("Failed to allocate RegExp");
         }
         let ptr = raw as *mut RegExpHeader;
+        // A previous (collected) RegExp at this address may have left expando
+        // properties in the side table; a fresh RegExp must start clean.
+        crate::object::exotic_expando::expando_clear_on_alloc(ptr as usize);
 
         (*ptr).regex_ptr = regex_ptr;
         (*ptr).pattern_ptr = pattern;

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -752,6 +752,29 @@ unsafe fn set_symbol_property(obj_f64: f64, sym_f64: f64, value_f64: f64) -> f64
         return value_f64;
     }
     let has_own_data = object_symbol_data_property_exists(obj_key, sym_key);
+    // Frozen / sealed / non-extensible receivers reject symbol-keyed writes
+    // like string-keyed ones: an existing prop is non-writable when frozen
+    // (or its per-symbol attrs say so), a new prop is forbidden when
+    // non-extensible. Only heap receivers carry the GC flag word.
+    if (obj_f64.to_bits() >> 48) == 0x7FFD
+        && obj_key >= 0x10000
+        && crate::object::is_valid_obj_ptr(obj_key as *const u8)
+    {
+        let gc = (obj_key - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        let flags = (*gc)._reserved;
+        if has_own_data {
+            if flags & crate::gc::OBJ_FLAG_FROZEN != 0 {
+                return value_f64;
+            }
+            if let Some(attrs) = get_symbol_property_attrs(obj_key, sym_key) {
+                if !attrs.writable() {
+                    return value_f64;
+                }
+            }
+        } else if flags & crate::gc::OBJ_FLAG_NO_EXTEND != 0 {
+            return value_f64;
+        }
+    }
     if !has_own_data {
         let bits = obj_f64.to_bits();
         if (bits >> 48) == 0x7FFE {


### PR DESCRIPTION
## Summary

Third pass on `built-ins/Object` test262 parity (after #4784 / #4789). Groups the remaining ~311 failures by root cause and fixes the five biggest clusters.

**built-ins/Object: 2862/3173 (90.2%) → 3006/3173 (94.7%), +144 tests, zero regressions.**

## Root causes

### 1. Exotic expando properties — Date / RegExp / Error (~90 tests)
New `crates/perry-runtime/src/object/exotic_expando.rs`: own user properties for instances whose heap form is not an `ObjectHeader` (`DateCell` / `RegExpHeader` / `ErrorHeader`). test262 exercises these in both directions: as `defineProperty` **targets** and as the **attributes bag** (`dateObj.value = "x"; Object.defineProperty(o, k, dateObj)`).

- Values in an insertion-ordered side table keyed by cell address (Error delegates to the existing `ERROR_USER_PROPS` store); attributes/accessors reuse the generic `PROPERTY_DESCRIPTORS` / `ACCESSOR_DESCRIPTORS` tables.
- Wired into set (`js_object_set_field_by_name` guard + `js_put_value_set`), get (per-kind arms), `defineProperty`, `getOwnPropertyDescriptor`, `getOwnPropertyNames`, `keys`, `has`/`hasOwnProperty`, `delete`, `propertyIsEnumerable`, `freeze`/`seal`, `TestIntegrityLevel`.
- A registered GC mutable-root scanner keeps stored values alive; Date/RegExp allocation clears stale entries on address reuse.
- Writes that resolve to an accessor on the builtin prototype (`Object.defineProperty(Date.prototype, "p", {set})`) invoke the setter instead of creating an own property; Error reads fall back to `<Kind>.prototype` → `Error.prototype`.

Previously: Date expando sets **segfaulted** (`ordinary_set_with_receiver` bit-cast the 8-byte cell as `ObjectHeader`), RegExp sets wrote through garbage field offsets, Error attribute bags read as empty.

### 2. Array descriptor semantics (~70 tests)
- Named-key accessors on array targets were silently dropped (`define_array_property` stored `undefined` as data and discarded get/set).
- Accessor/attrs dispatch added to the raw numeric fast paths (`array_numeric_raw_f64_get/set_inbounds`, `js_array_get/set_f64_unchecked`, `js_array_set_f64_extend`), gated by a new per-array `OBJ_FLAG_ARRAY_DESCRIPTORS` header bit (set on first `defineProperty` against the array) so ordinary arrays pay one header-flag test, not a side-table probe.
- `defineProperty(arr, "length", {writable:false})` now honored by `getOwnPropertyDescriptor`, `arr.length =` writes, and extending index stores.
- A generic (attrs-only) redefine no longer converts an accessor index back to data; accessor→data conversions default `writable` to `false` (spec: retained-attrs rule doesn't cross the kind switch — both the array and ordinary-object paths); data→accessor keeps the existing dense element's enumerability.
- `[[DefineOwnProperty]]` stores clear stale attrs first (so the new `[[Set]]`-side writability gate can't reject them) and materialize the element **before** installing the accessor (so the internal write doesn't fire the brand-new setter).

### 3. Object statics reified (~35 tests)
`install_builtin_constructor_statics` was missing `seal` / `isSealed` / `isFrozen` / `isExtensible` / `preventExtensions` / `is` / `setPrototypeOf` / `getOwnPropertySymbols` / `getOwnPropertyDescriptors` / `defineProperties` / `groupBy` (and `Object.create` had `length` 1 with no Properties-arg support). Reading e.g. `Object.seal` as a *value* produced a raw function-pointer **number** — `typeof` said `"number"`, `.length`/`.name`/`hasOwnProperty` all failed. Codegen value reads now route through the reified closures for names unique to `Object`; the Reflect-overlapping names (`defineProperty`, `getOwnPropertyDescriptor`, `get/setPrototypeOf`, `isExtensible`, `preventExtensions`) and Map-overlapping `groupBy` keep their old behavior because the HIR collapses the receiver to a `GlobalGet(0)` sentinel (documented; ~8 tests deferred).

### 4. freeze/seal/TestIntegrityLevel on non-`ObjectHeader` receivers
`mark_all_keys` bit-cast TypedArray / closure / exotic receivers as `ObjectHeader` and walked a garbage `keys_array`. The `Object.seal(new Int8Array())` crash was **latent on main** — this PR's extra closure installs shifted the heap layout and surfaced it. TypedArrays now use the GC flag bits only; closures and exotics freeze/seal via side-table attrs; `object_integrity_level` got matching arms.

### 5. Smaller fixes
- Symbol-keyed writes honor `FROZEN` / `NO_EXTEND` / per-symbol writability (silent rejection, matching the sloppy-mode oracle).
- `Object.getPrototypeOf(primitive)` returns the wrapper prototype (`Number.prototype` etc.); INT32-tagged class refs are explicitly excluded from the number arm.
- Array `Object.keys` / `getOwnPropertyNames` include accessor-only properties.
- `js_put_value_set` relocated to `proxy/put_value.rs` (`proxy.rs` sat at 1999 lines, over the 2000-line gate with any addition).

## Validation

- **built-ins/Object sweep** (box, jobs 24–40, node v26 oracle): 2862 → 3006 pass; failure-**set** diff against the baseline run shows +144 fixed / 0 regressed (4–6 transient "compile-fail: Wrote executable" entries under load all pass isolated, including 20× stress runs of the seal-TA tests).
- **Broad regression shard** `--shard 0/12` over `built-ins language` vs a clean main (8ff2c819b) build: main 279 fails → branch 261 fails; **18 fixed, 0 regressed** (bonus fixes in RegExp/Array/Temporal/literals).
- `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime`: green (the two raw-f64 layout tests initially tripped the process-global descriptor gate — that's what motivated the per-array `OBJ_FLAG_ARRAY_DESCRIPTORS` bit).
- `cargo fmt --all` + `scripts/check_file_size.sh` green.

## Deferred (documented for the next pass)
arguments-object `defineProperty` tail; `Array.prototype`-as-target index defines; `entries`/`values` observable-operations ordering; `Object.assign` OwnPropertyKeys ordering + proxy source traps; gOPD of global builtins (`eval`/`parseInt`); Reflect-overlap static value reads; bound-function writes through inherited `Function.prototype` accessors.

Per CONTRIBUTING guidance for external PRs, no version bump / changelog edits — maintainer folds those in at merge.
