### PR TITLE
fix(ci): raise perf-gate noise floors to match observed runner variance

### DIFF
--- a/benchmarks/compare.sh
+++ b/benchmarks/compare.sh
@@ -439,8 +439,15 @@ print("-" * 72)
 # Noise floors: percentage swings on tiny measurements are unreliable.
 # A 7ms jitter on a 9ms benchmark is 78% but means nothing. Require both
 # the absolute delta AND percentage to exceed the threshold.
-MIN_SPEED_DELTA_MS = 20   # need at least 20ms absolute change to flag
-MIN_RAM_DELTA_KB = 2048   # need at least 2MB absolute change to flag
+#
+# 20ms was too tight for macos-14 runner-to-runner variance: at v0.5.1151
+# bench_string_heavy measured 60/81/104ms across three same-commit runs
+# (the 21-44ms swings hard-failed the release gate twice on pure noise,
+# while every CPU-bound row over ~300ms tracked within ~10%). Any release
+# regression worth hard-failing on (the v0.5.1129 hang was a ~4000x case)
+# clears 100ms by orders of magnitude.
+MIN_SPEED_DELTA_MS = 100  # need at least 100ms absolute change to flag
+MIN_RAM_DELTA_KB = 4096   # need at least 4MB absolute change to flag
 
 for name, cur in current["benchmarks"].items():
     correctness = cur.get("correctness", {})


### PR DESCRIPTION
The v0.5.1151 **release-mode** Regression Check hard-failed twice on `bench_string_heavy` (+73.3%: 60→104ms, then +35.0%: 60→81ms on re-run) while the **push-mode** run on the *same commit* reported *7 improvements, no regressions*.

Three same-commit macos-14 runs measured that row at 60 / 81 / 104 ms — the 20ms absolute noise floor (`MIN_SPEED_DELTA_MS`) lets pure runner-to-runner variance hard-fail releases on any sub-150ms benchmark.

- `MIN_SPEED_DELTA_MS`: 20 → **100ms**. Every real regression we'd want a release gate to catch clears this by orders of magnitude (the v0.5.1129 dense-array hang was ~4000x / +6h). CPU-bound rows over ~300ms tracked within ~10% across runners.
- `MIN_RAM_DELTA_KB`: 2MB → **4MB**. `10_nested_loops` RSS swings ±1.8MB (+51%) between same-commit runs with no allocation change.

Follow-up to #4857 (which made the gate compare anything at all). Note: re-runs of the v0.5.1151 tag's Regression Check use the tag's checkout, so this only hardens future tags.