### PR TITLE
feat: add download/extraction progress to install.sh, expand distro coverage in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Linux linker by distro:
 # Debian / Ubuntu / Pop!_OS / Mint
 sudo apt install build-essential
 
-# Arch / Manjaro / Cachy OS / EndeavourOS
+# Arch / Manjaro / CachyOS / EndeavourOS
 sudo pacman -S base-devel gcc
 
 # Fedora / RHEL / CentOS Stream

--- a/README.md
+++ b/README.md
@@ -173,8 +173,30 @@ cargo build --release
 
 Perry requires a C linker to link compiled executables:
 - **macOS:** Xcode Command Line Tools (`xcode-select --install`)
-- **Linux:** GCC or Clang (`sudo apt install build-essential`)
+- **Linux:** GCC or Clang (see below for your distro)
 - **Windows:** MSVC (Visual Studio Build Tools)
+
+Linux linker by distro:
+
+```bash
+# Debian / Ubuntu / Pop!_OS / Mint
+sudo apt install build-essential
+
+# Arch / Manjaro / Cachy OS / EndeavourOS
+sudo pacman -S base-devel gcc
+
+# Fedora / RHEL / CentOS Stream
+sudo dnf install gcc gcc-c++ glibc-devel
+
+# openSUSE
+sudo zypper install -t pattern devel_basis
+
+# Alpine / musl-based
+sudo apk add build-base
+
+# Void Linux
+sudo xbps-install -S base-devel
+```
 
 Run `perry doctor` to verify your environment.
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -5,8 +5,30 @@
 Perry compiles TypeScript to native binaries by linking with your system's C toolchain, so every install path needs a linker:
 
 - **macOS**: Xcode Command Line Tools (`xcode-select --install`)
-- **Linux**: `gcc` or `clang` (`apt install build-essential` on Debian/Ubuntu, `apk add build-base` on Alpine)
+- **Linux**: `gcc` or `clang` — see your distro below
 - **Windows**: LLVM (`winget install LLVM.LLVM`) + `perry setup windows` (lightweight, ~1.5 GB, no Visual Studio needed), or MSVC Build Tools with the "Desktop development with C++" workload — see the [Windows platform guide](../platforms/windows.md) for both options
+
+Linux C toolchain by distribution:
+
+```bash
+# Debian / Ubuntu / Pop!_OS / Mint
+sudo apt install build-essential
+
+# Arch / Manjaro / Cachy OS / EndeavourOS
+sudo pacman -S base-devel gcc
+
+# Fedora / RHEL / CentOS Stream
+sudo dnf install gcc gcc-c++ glibc-devel
+
+# openSUSE
+sudo zypper install -t pattern devel_basis
+
+# Alpine / musl-based
+sudo apk add build-base
+
+# Void Linux
+sudo xbps-install -S base-devel
+```
 
 The source install additionally needs the **Rust toolchain** via [rustup](https://rustup.rs/).
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -14,7 +14,7 @@ Linux C toolchain by distribution:
 # Debian / Ubuntu / Pop!_OS / Mint
 sudo apt install build-essential
 
-# Arch / Manjaro / Cachy OS / EndeavourOS
+# Arch / Manjaro / CachyOS / EndeavourOS
 sudo pacman -S base-devel gcc
 
 # Fedora / RHEL / CentOS Stream

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -48,8 +48,17 @@ ARTIFACT="perry-${OS}-${ARCH}.tar.gz"
 echo "Detecting platform: ${OS}/${ARCH}"
 
 # Find the most recent release that actually has our platform asset.
+#
+# We can't blindly use `releases/latest`: when the release-packages workflow
+# fails its test gate (or hasn't finished yet), the tag still publishes but
+# arrives with zero assets. Pre-fix the script downloaded `releases/latest`
+# unconditionally and 404'd on every Linux install when the most recent
+# tagged release happened to have no assets. Instead, list recent tags and
+# probe each tarball URL until one returns 200/302.
 echo "Locating most recent release with $ARTIFACT..."
 
+# Pull the tag_name of the 30 most recent releases. Stays POSIX (sed + grep)
+# rather than relying on jq/gawk so the script runs on any /bin/sh.
 TAGS=$(
   curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
     | grep '"tag_name":' \
@@ -59,8 +68,16 @@ TAGS=$(
 LATEST=""
 for tag in $TAGS; do
   url="https://github.com/$REPO/releases/download/$tag/$ARTIFACT"
+  # -I = HEAD, -L = follow redirects, -o /dev/null + -w "%{http_code}"
+  # gives just the final status. 200 (direct) and 302 (the GitHub release
+  # download → S3 redirect, when followed lands on 200) both mean asset
+  # present. We accept 200 only since -L was passed.
+  # `curl -L -I` issues HEAD against each redirect hop; -w "%{http_code}"
+  # then prints every hop's status concatenated (e.g. "404000" if the first
+  # response is 404 and curl continues). The final hop's status is always
+  # the last 3 chars; "200" there means "asset exists and downloads cleanly".
   status=$(curl -fsSLI -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
-  final="${status#"${status%???}"}"
+  final="${status#"${status%???}"}"  # last 3 chars, POSIX-portable
   if [ "$final" = "200" ]; then
     LATEST="$tag"
     break
@@ -83,7 +100,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 echo "Downloading $ARTIFACT..."
 START=$(date +%s 2>/dev/null || echo 0)
-curl -L $CURL_PROGRESS -o "$TMPDIR/perry.tar.gz" "$URL"
+curl -fL $CURL_PROGRESS -o "$TMPDIR/perry.tar.gz" "$URL"
 END=$(date +%s 2>/dev/null || echo 0)
 
 if [ "$END" -gt "$START" ] && [ "$START" -gt 0 ]; then
@@ -101,6 +118,7 @@ fi
 if [ -w "$INSTALL_DIR" ]; then
   cp "$TMPDIR/perry" "$INSTALL_DIR/perry"
   chmod 755 "$INSTALL_DIR/perry"
+  # Install libraries alongside binary
   for lib in "$TMPDIR"/libperry_*.a; do
     [ -f "$lib" ] && cp "$lib" "$LIB_DIR/"
   done

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -2,11 +2,23 @@
 # Perry installer — downloads the latest release from GitHub
 # Usage: curl -fsSL https://perryts.com/install.sh | sh
 
-set -e
+set -eu
 
 REPO="PerryTS/perry"
 INSTALL_DIR="/usr/local/bin"
 LIB_DIR="/usr/local/lib"
+
+# Only show progress bars on interactive terminals
+if [ -t 2 ]; then
+  CURL_PROGRESS="--progress-bar"
+  PV=""
+  if command -v pv >/dev/null 2>&1; then
+    PV="pv"
+  fi
+else
+  CURL_PROGRESS="-fsS"
+  PV=""
+fi
 
 # Detect platform
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -36,17 +48,8 @@ ARTIFACT="perry-${OS}-${ARCH}.tar.gz"
 echo "Detecting platform: ${OS}/${ARCH}"
 
 # Find the most recent release that actually has our platform asset.
-#
-# We can't blindly use `releases/latest`: when the release-packages workflow
-# fails its test gate (or hasn't finished yet), the tag still publishes but
-# arrives with zero assets. Pre-fix the script downloaded `releases/latest`
-# unconditionally and 404'd on every Linux install when the most recent
-# tagged release happened to have no assets. Instead, list recent tags and
-# probe each tarball URL until one returns 200/302.
 echo "Locating most recent release with $ARTIFACT..."
 
-# Pull the tag_name of the 30 most recent releases. Stays POSIX (sed + grep)
-# rather than relying on jq/gawk so the script runs on any /bin/sh.
 TAGS=$(
   curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
     | grep '"tag_name":' \
@@ -56,16 +59,8 @@ TAGS=$(
 LATEST=""
 for tag in $TAGS; do
   url="https://github.com/$REPO/releases/download/$tag/$ARTIFACT"
-  # -I = HEAD, -L = follow redirects, -o /dev/null + -w "%{http_code}"
-  # gives just the final status. 200 (direct) and 302 (the GitHub release
-  # download → S3 redirect, when followed lands on 200) both mean asset
-  # present. We accept 200 only since -L was passed.
-  # `curl -L -I` issues HEAD against each redirect hop; -w "%{http_code}"
-  # then prints every hop's status concatenated (e.g. "404000" if the first
-  # response is 404 and curl continues). The final hop's status is always
-  # the last 3 chars; "200" there means "asset exists and downloads cleanly".
   status=$(curl -fsSLI -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
-  final="${status#"${status%???}"}"  # last 3 chars, POSIX-portable
+  final="${status#"${status%???}"}"
   if [ "$final" = "200" ]; then
     LATEST="$tag"
     break
@@ -83,21 +78,29 @@ echo "Using version: $LATEST"
 
 URL="https://github.com/$REPO/releases/download/$LATEST/$ARTIFACT"
 
-echo "Downloading $ARTIFACT..."
-
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-curl -fsSL "$URL" -o "$TMPDIR/perry.tar.gz"
+echo "Downloading $ARTIFACT..."
+START=$(date +%s 2>/dev/null || echo 0)
+curl -L $CURL_PROGRESS -o "$TMPDIR/perry.tar.gz" "$URL"
+END=$(date +%s 2>/dev/null || echo 0)
+
+if [ "$END" -gt "$START" ] && [ "$START" -gt 0 ]; then
+  echo "  Done in $((END - START))s ($(ls -lh "$TMPDIR/perry.tar.gz" | awk '{print $5}'))"
+fi
 
 echo "Extracting..."
-tar xzf "$TMPDIR/perry.tar.gz" -C "$TMPDIR"
+if [ -n "$PV" ]; then
+  pv "$TMPDIR/perry.tar.gz" | tar xz -C "$TMPDIR"
+else
+  tar xzf "$TMPDIR/perry.tar.gz" -C "$TMPDIR"
+fi
 
 # Install binary
 if [ -w "$INSTALL_DIR" ]; then
   cp "$TMPDIR/perry" "$INSTALL_DIR/perry"
   chmod 755 "$INSTALL_DIR/perry"
-  # Install libraries alongside binary
   for lib in "$TMPDIR"/libperry_*.a; do
     [ -f "$lib" ] && cp "$lib" "$LIB_DIR/"
   done


### PR DESCRIPTION

## Summary

Two improvements to Perry's Linux installation story:

### 1. Progress indicators in `packaging/install.sh`
- **Download**: Uses `curl --progress-bar` on interactive terminals (real-time `#### 45% 12 MB/s 00:05`)
- **Extraction**: Uses `pv` if installed for pipe-through progress; silent fallback
- **Elapsed time**: Shows `Done in Xs (size)` after download
- **CI-safe**: Detects non-TTY (piped) context and falls back to `-fsS` (silent, no messy bars)
- Changed `set -e` → `set -eu` for better error handling

### 2. Per-distro C toolchain instructions in docs
Added Linux linker install commands for **Arch/Cachy OS/Manjaro** (`pacman -S base-devel gcc`), **Fedora/RHEL** (`dnf`), **openSUSE** (`zypper`), **Alpine** (`apk`), and **Void Linux** (`xbps-install`) to both:
- `README.md` Requirements section
- `docs/src/getting-started/installation.md` Prerequisites section

Previously only Debian/Ubuntu (`apt`) and Alpine were documented.
