### PR TITLE
fix(runtime): #4876 keep js_promise_report_unhandled_rejections alive through auto-optimize LTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v0.5.1153 — fix: keep `js_promise_report_unhandled_rejections` alive through auto-optimize LTO (#4876)
+
+**Regression fix (v0.5.1151 → all native links broken).** Codegen emits an
+unconditional call to `js_promise_report_unhandled_rejections` in the generated
+`_main` (the program-end unhandled-rejection hook from the #4838/#4852 readable
+unhandled-rejection work), but the runtime symbol was being dropped by the
+auto-optimize whole-program-bitcode internalize+dead-strip pass. The function is
+`#[no_mangle] pub extern "C"` and reachable only from generated `.o`, so without a
+`#[used]` anchor LTO internalized and stripped it — every native link
+(`aarch64-apple-{darwin,ios,tvos}`, `x86_64-unknown-linux-gnu`) failed with
+`undefined symbol: js_promise_report_unhandled_rejections`. (Android linked because
+it doesn't go through the same auto-optimize bitcode path.)
+
+- **Fix**: added a `#[used] static KEEP_PROMISE_REPORT_UNHANDLED_REJECTIONS` anchor in
+  `crates/perry-runtime/src/promise/then.rs`, matching the existing keepalive pattern
+  used for codegen-only FFIs in `error.rs` and `promise/combinators.rs`.
+- **Validation**: built perry + runtime/stdlib, cleared `.perry-cache`, compiled a
+  minimal program with an unhandled `Promise.reject` — the auto-optimize path
+  (rebuilds runtime+stdlib with LTO) now links cleanly and prints
+  `Uncaught (in promise) Error: boom` with exit code 1.
+
 ## v0.5.1152 — install.sh download/extraction progress + per-distro Linux toolchain docs (#4869)
 
 External contribution from @nglmercer, with a maintainer fixup at review time:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1152
+**Current Version:** 0.5.1153
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5289,7 +5289,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "base64",
@@ -5344,14 +5344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "cc",
  "libc",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "log",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "base64",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5460,14 +5460,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "serde",
  "serde_json",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1152"
+version = "0.5.1153"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "clap",
@@ -5501,14 +5501,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "bytes",
  "h2",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "bson",
  "futures-util",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "image",
@@ -5801,14 +5801,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "brotli",
  "flate2",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "base64",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6033,14 +6033,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "itoa",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "block2",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "block2",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1152"
+version = "0.5.1153"
 
 [[package]]
 name = "perry-ui-test"
@@ -6129,11 +6129,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1152"
+version = "0.5.1153"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "block2",
@@ -6165,7 +6165,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "block2",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "libc",
@@ -6195,14 +6195,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1152"
+version = "0.5.1153"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1152"
+version = "0.5.1153"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -128,6 +128,16 @@ pub extern "C" fn js_promise_report_unhandled_rejections() {
     std::process::exit(1);
 }
 
+// #4876: keep the codegen-emitted program-end hook alive through the
+// auto-optimize whole-program-bitcode link. `js_promise_report_unhandled_rejections`
+// is emitted unconditionally into `_main` but is reachable only from generated
+// `.o`; without a `#[used]` anchor the internalize+dead-strip pass drops it and
+// every native link fails with "undefined symbol" (see the error.rs/combinators.rs
+// anchors for the same pattern).
+#[used]
+static KEEP_PROMISE_REPORT_UNHANDLED_REJECTIONS: extern "C" fn() =
+    js_promise_report_unhandled_rejections;
+
 pub(super) struct PromiseSettleListener {
     pub(super) on_fulfilled: ClosurePtr,
     pub(super) on_rejected: ClosurePtr,


### PR DESCRIPTION
Fixes #4876.

## Problem

Starting with v0.5.1151, every native link fails with:

```
undefined symbol: _js_promise_report_unhandled_rejections
  >>> referenced by _main
Error: Linking failed
```

Codegen emits an **unconditional** call to `js_promise_report_unhandled_rejections` in the generated `_main` (the program-end unhandled-rejection hook added by the #4838/#4852 readable-unhandled-rejection work). The runtime *defines* the symbol (`#[no_mangle] pub extern "C"` in `promise/then.rs`), but the auto-optimize whole-program-bitcode **internalize + dead-strip** pass drops it: the function is reachable only from generated `.o`, and without a `#[used]` anchor LTO internalizes then strips it.

Affected: `aarch64-apple-{darwin,ios,tvos}`, `x86_64-unknown-linux-gnu`. Android linked because it doesn't go through the same auto-optimize bitcode path.

## Fix

Add a `#[used] static KEEP_PROMISE_REPORT_UNHANDLED_REJECTIONS` anchor in `crates/perry-runtime/src/promise/then.rs`, matching the established keepalive pattern for codegen-only FFIs in `error.rs` and `promise/combinators.rs`.

## Validation

Built perry + runtime/stdlib, cleared `.perry-cache`, compiled a minimal program with an unhandled `Promise.reject`. The auto-optimize path (rebuilds runtime+stdlib with LTO) now links cleanly:

```
$ perry t.ts -o t && ./t
hello
Uncaught (in promise) Error: boom   # exit 1
```

Before this fix the same compile failed at link with the undefined symbol.