### PR TITLE
fix(compile): resolve barrel/type-only default-import link wall — nestjs reaches runtime (#4872)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_validation.rs
+++ b/crates/perry-hir/src/lower_decl/class_validation.rs
@@ -86,8 +86,16 @@ pub fn validate_class_element_early_errors(class: &ast::Class, class_name: &str)
     for member in &class.body {
         match member {
             // `constructor(){}` (the ordinary one) parses as a dedicated
-            // Constructor node; count them to catch duplicates.
-            ast::ClassMember::Constructor(_) => constructor_count += 1,
+            // Constructor node; count them to catch duplicates. TypeScript
+            // overload SIGNATURES (`constructor(kind: 'N');` with no body)
+            // are type-only declarations, not constructors — only the
+            // implementation (the one with a body) counts (#4872, rxjs's
+            // `Notification` has 3 overload signatures + 1 implementation).
+            ast::ClassMember::Constructor(c) => {
+                if c.body.is_some() {
+                    constructor_count += 1;
+                }
+            }
             ast::ClassMember::Method(m) => {
                 let Some(name) = static_prop_name(&m.key) else {
                     continue;

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -1139,6 +1139,17 @@ pub fn run_with_parse_cache(
                             if let Some(source_exports) = all_module_exports.get(&source_path_str) {
                                 let current_exports = all_module_exports.get(&path_str);
                                 for (name, origin) in source_exports {
+                                    // ESM semantics: `export * from "src"`
+                                    // re-exports every named export EXCEPT
+                                    // `default`. Leaking it made barrels
+                                    // claim a default binding they never
+                                    // define, which breaks the #4872
+                                    // has-default probe that decides whether
+                                    // a default import can bind to
+                                    // `perry_fn_<src>__default`.
+                                    if name == "default" {
+                                        continue;
+                                    }
                                     let already_exists = current_exports
                                         .map(|e| e.contains_key(name))
                                         .unwrap_or(false);
@@ -2423,8 +2434,36 @@ pub fn run_with_parse_cache(
                     .find(|nl| nl.module == import.source);
 
                 for spec in &import.specifiers {
-                    // Handle namespace imports (import * as X)
-                    if let perry_hir::ImportSpecifier::Namespace { local } = spec {
+                    // Handle namespace imports (import * as X).
+                    //
+                    // Issue #4872: a DEFAULT import of a compiled module that
+                    // has NO `default` export gets the same treatment. The
+                    // CJS wrap lowers every `require('X')` to `import _req_N
+                    // from 'X'`; when X resolves to an ESM barrel with only
+                    // named exports (rxjs's src/index.ts, uid's index.mjs) or
+                    // to a type-only interface surface with no exports at all
+                    // (nestjs dist `*.interface.js`), there is no
+                    // `perry_fn_<src>__default` symbol for the consumer to
+                    // bind — the old fall-through registered the local as a
+                    // callable function import and the link died on
+                    // `__perry_wrap_perry_fn_<src>__default`. Node's
+                    // `require(esm)` semantics hand back the module namespace
+                    // object, so route the local through the namespace
+                    // machinery: member reads resolve per-export to origin
+                    // symbols, and a whole-value read materializes the
+                    // namespace object (empty for zero-export modules).
+                    let namespace_like_local: Option<&String> = match spec {
+                        perry_hir::ImportSpecifier::Namespace { local } => Some(local),
+                        perry_hir::ImportSpecifier::Default { local }
+                            if !all_module_exports
+                                .get(&resolved_path_str)
+                                .is_some_and(|exports| exports.contains_key("default")) =>
+                        {
+                            Some(local)
+                        }
+                        _ => None,
+                    };
+                    if let Some(local) = namespace_like_local {
                         namespace_imports.push(local.clone());
                         // Register all exports from the source module
                         if let Some(exports) = all_module_exports.get(&resolved_path_str) {

--- a/crates/perry/src/commands/compile/cjs_wrap/detect.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/detect.rs
@@ -28,6 +28,13 @@ pub(in crate::commands::compile) fn is_commonjs(source: &str) -> bool {
     }
     source.contains("module.exports")
         || source.contains("exports.")
+        // Issue #4872: tsc-compiled type-only modules (nestjs dist
+        // `*.interface.js`) contain ONLY the interop marker
+        // `Object.defineProperty(exports, "__esModule", { value: true });`
+        // — no `exports.X =`, no `require(`. Without this arm they fall
+        // through to the ESM pipeline, where the bare `exports` identifier
+        // throws a ReferenceError at module init.
+        || source.contains("defineProperty(exports,")
         || (source.contains("require(") && !source.contains("import "))
 }
 

--- a/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
@@ -21,6 +21,31 @@ pub fn extract_require_specifiers(source: &str) -> Vec<String> {
     specs
 }
 
+/// Issue #4872: extract `__exportStar(require('SPEC'), exports)` re-export
+/// calls — the tsc-emitted CJS lowering of `export * from 'SPEC'`. Matches
+/// the bare inline-helper form (`__exportStar(require("./x"), exports)`),
+/// the tslib member form (`tslib_1.__exportStar(require("./x"), exports)`),
+/// and the comma-sequenced form (`(0, tslib_1.__exportStar)(require("./x"),
+/// exports)`). The helper *definition* (`var __exportStar = (this && ...)`)
+/// never matches because the pattern requires a `require('...')` literal as
+/// the first argument. Order preserved, deduped.
+pub fn extract_export_star_specs(source: &str) -> Vec<String> {
+    let re = regex::Regex::new(
+        r#"(?:[A-Za-z_$][A-Za-z0-9_$]*\s*\.\s*)?__exportStar\s*\)?\s*\(\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)\s*,\s*exports\s*\)"#,
+    )
+    .unwrap();
+    let mut specs = Vec::new();
+    for cap in re.captures_iter(source) {
+        if let Some(m) = cap.get(1) {
+            let s = m.as_str().to_string();
+            if !specs.contains(&s) {
+                specs.push(s);
+            }
+        }
+    }
+    specs
+}
+
 /// Refs #488 drizzle-sqlite: extract `var <alias> = require("<spec>");`
 /// declarations from the source as `(alias_name, spec, (start_byte,
 /// end_byte))`. The byte range covers the whole matched statement so

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -48,7 +48,9 @@ pub(self) use extract_exports::{
     extract_exports_from_source, extract_named_exports_from_require,
     extract_object_literal_exports_from_require, extract_single_module_exports_assignment,
 };
-pub(self) use extract_requires::{extract_require_aliases_with_ranges, extract_require_specifiers};
+pub(self) use extract_requires::{
+    extract_export_star_specs, extract_require_aliases_with_ranges, extract_require_specifiers,
+};
 pub(self) use hoist_classes::{
     extract_top_level_class_decls, rewrite_module_exports_class_expression,
 };

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -177,6 +177,18 @@ pub(in crate::commands::compile) fn wrap_commonjs_for_target(
 
     let mut named_exports = extract_exports_from_source(source);
 
+    // Issue #4872: `__exportStar(require('X'), exports)` is tsc's CJS
+    // lowering of `export * from 'X'` — emit exactly that as a real ESM
+    // re-export at module scope. The static `export *` lets compile.rs's
+    // transitive re-export propagation resolve names through multi-level
+    // barrels to their defining module (nestjs's `@nestjs/common/index.js`
+    // → `decorators/index.js` → `core/index.js` → `controller.decorator.js`),
+    // so a consumer's `import { Controller } from '@nestjs/common'` binds
+    // the origin's symbol instead of link-failing on
+    // `perry_fn_<common_index_js>__Controller`. The runtime copy inside the
+    // IIFE still runs, so `_cjs.X` property reads keep working too.
+    let export_star_specs = extract_export_star_specs(source);
+
     // For trivial re-export wrappers (`module.exports = require('./X')`),
     // recursively pull in the target's named exports. Without this,
     // react/index.js — which has zero `exports.X =` patterns of its own —
@@ -184,6 +196,15 @@ pub(in crate::commands::compile) fn wrap_commonjs_for_target(
     // "react"` link-fails.
     for spec in &require_specs {
         if !spec.starts_with("./") && !spec.starts_with("../") {
+            continue;
+        }
+        // #4872: specs re-exported via `__exportStar` surface through the
+        // static `export * from` emitted below — resolving to the ORIGIN
+        // module's symbols. Pulling the target's textual exports here would
+        // emit explicit `export const X = _cjs.X;` bindings that shadow the
+        // star re-export (ESM precedence) and degrade those names back to
+        // runtime property reads.
+        if export_star_specs.contains(spec) {
             continue;
         }
         let Some(target) = super::super::resolve::resolve_relative_import_path(spec, source_path)
@@ -368,6 +389,14 @@ pub(in crate::commands::compile) fn wrap_commonjs_for_target(
         None => "export default _cjs;".to_string(),
     };
 
+    // #4872: ESM `export * from` declarations for every `__exportStar`
+    // call detected above.
+    let export_star_decls = export_star_specs
+        .iter()
+        .map(|spec| format!("export * from '{}';", spec))
+        .collect::<Vec<_>>()
+        .join("\n");
+
     let wrapped = format!(
         r#"{imports}
 {import_aliases}
@@ -478,6 +507,7 @@ const _cjs = (function() {{
 {direct_class_exports}
 {direct_named_reexports}
 {named_export_decls}
+{export_star_decls}
 "#
     );
     if std::env::var("PERRY_DEBUG_CJS_WRAP").is_ok() {

--- a/crates/perry/tests/issue_4872_barrel_default_reexports.rs
+++ b/crates/perry/tests/issue_4872_barrel_default_reexports.rs
@@ -1,0 +1,163 @@
+//! Regression test for #4872: undefined default-wrapper symbols for
+//! re-exported barrel modules (the nestjs link wall).
+//!
+//! Three shapes, all taken from the `tests/release/packages/nestjs-hello`
+//! fixture's failure:
+//!
+//! 1. A tsc-emitted TYPE-ONLY module whose entire body is
+//!    `Object.defineProperty(exports, "__esModule", { value: true });`
+//!    (nestjs dist `*.interface.js`). Pre-fix it wasn't detected as CJS, so
+//!    it compiled as a zero-export ES module; the consumer's synthetic
+//!    `require()` still value-read its default import and the link died on
+//!    `__perry_wrap_perry_fn_<src>__default` (and, once that was fixed, the
+//!    unwrapped module threw `ReferenceError: exports is not defined` at
+//!    init).
+//!
+//! 2. `__exportStar(require("./x"), exports)` barrels (tsc's CJS lowering of
+//!    `export * from "./x"`), nested two levels deep
+//!    (`@nestjs/common/index.js` → `decorators/index.js` → leaf). Pre-fix
+//!    the wrap surfaced no static re-export, so the consumer's named import
+//!    bound `perry_fn_<barrel>__Controller` — which no object file defines.
+//!
+//! 3. A default import (synthesized by the CJS wrap from `require(...)`) of
+//!    an ES module that has ONLY named exports (rxjs `src/index.ts`, uid
+//!    `dist/index.mjs`). There is no `default` binding to call, so the local
+//!    now binds the module NAMESPACE (Node `require(esm)` semantics) and
+//!    member calls resolve per-export to origin symbols.
+//!
+//! Fixes (see PR for #4872): cjs_wrap emits `export * from '<spec>'` for
+//! `__exportStar` calls; `is_commonjs` detects `defineProperty(exports,`;
+//! compile.rs routes default imports of no-default modules through the
+//! namespace machinery; `export *` propagation no longer leaks `default`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn barrel_default_imports_and_export_star_chains_link_and_run() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "barrel-default-reexports",
+  "type": "module",
+  "perry": {
+    "compilePackages": ["fakepkg"],
+    "allow": { "compilePackages": ["fakepkg"] }
+  }
+}"#,
+    )
+    .expect("write consumer package.json");
+
+    let pkg = root.join("node_modules").join("fakepkg");
+    std::fs::create_dir_all(&pkg).expect("mkdir fakepkg");
+    std::fs::write(
+        pkg.join("package.json"),
+        r#"{ "name": "fakepkg", "version": "1.0.0", "main": "index.js" }"#,
+    )
+    .expect("write fakepkg package.json");
+
+    // Shape 1: type-only interface surface — the nestjs `*.interface.js`
+    // dist output. No exports, no require, just the interop marker.
+    std::fs::write(
+        pkg.join("iface.js"),
+        "\"use strict\";\nObject.defineProperty(exports, \"__esModule\", { value: true });\n",
+    )
+    .expect("write iface.js");
+
+    // Shape 3: ES module with ONLY named exports — no default binding.
+    std::fs::write(
+        pkg.join("esm-barrel.mjs"),
+        "export const uid = (n) => \"U:\" + n;\n",
+    )
+    .expect("write esm-barrel.mjs");
+
+    // Shape 2: two-level `__exportStar` chain down to a concrete leaf.
+    std::fs::write(
+        pkg.join("leaf.js"),
+        r#""use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Controller = void 0;
+function Controller() { return "CTRL"; }
+exports.Controller = Controller;
+"#,
+    )
+    .expect("write leaf.js");
+    std::fs::write(
+        pkg.join("mid.js"),
+        r#""use strict";
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) exports[p] = m[p];
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./leaf"), exports);
+"#,
+    )
+    .expect("write mid.js");
+
+    // The package barrel: star re-exports the type-only surface AND the
+    // mid-level barrel, plus a member call on the no-default ES module.
+    std::fs::write(
+        pkg.join("index.js"),
+        r#""use strict";
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) exports[p] = m[p];
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./iface"), exports);
+__exportStar(require("./mid"), exports);
+const esm_1 = require("./esm-barrel.mjs");
+exports.greet = function greet() { return esm_1.uid(7); };
+"#,
+    )
+    .expect("write index.js");
+
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { greet, Controller } from "fakepkg";
+// Shape 3: member call on a default-import of a no-default ES module.
+console.log(greet());
+// Shape 2: named import resolved through the two-level __exportStar chain.
+console.log(Controller());
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed (link wall regressed?)\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout, "U:7\nCTRL\n",
+        "barrel re-exports must resolve to concrete origin bindings"
+    );
+}

--- a/tests/release/packages/nestjs-hello/WALLS.md
+++ b/tests/release/packages/nestjs-hello/WALLS.md
@@ -31,33 +31,64 @@ npm install
 - Legacy CommonJS inheritance patterns that call `Stream.call(this)` or
   `EventEmitter.call(this)` now lower to the same receiver initialization shape
   this fixture needs from Express/readable-stream.
+- **Wall 1 (resolved, #4872)** — undefined default-wrapper symbols for
+  re-exported barrel modules (`__perry_wrap_perry_fn_..._rxjs_src_index_ts__default`,
+  the nestjs `*.interface.js` family, `uid_dist_index_mjs__default`,
+  `perry_fn_..._common_index_js__Controller`, …). Four coordinated fixes:
+  a default import of a compiled module with no `default` export now binds
+  the module namespace (Node `require(esm)` semantics) instead of a phantom
+  callable; `__exportStar(require("./x"), exports)` in CJS-wrapped sources
+  now also emits a real `export * from './x'` so multi-level tsc barrels
+  resolve named imports to the defining module; `export *` propagation no
+  longer leaks `default` across hops; and tsc-emitted type-only modules
+  whose only statement is `Object.defineProperty(exports, "__esModule", …)`
+  are now detected as CJS (previously they compiled as zero-export ESM and
+  threw `ReferenceError: exports is not defined` at init). A TS constructor
+  overload-signature miscount (rxjs `Notification` rejected with "may only
+  have one constructor") was fixed alongside. The fixture now **links**:
+  `Wrote executable` (~41 MB).
 
 ## Open
 
-### Wall 1 - default-wrapper symbols for re-exported modules
+### Wall 2 - `.prototype` of a capturing class expression is undefined (tslib `__decorate`)
 
-After the resolved walls above, the fixture reaches native linking and then
-fails with undefined default-wrapper symbols. Current representative symbols:
+The binary now links but the server dies during module init with
+`TypeError: Cannot convert undefined or null to object`. Root cause, bisected
+to `@nestjs/common/services/logger.service.js`: tsc's class-decorator output
 
-```text
-undefined reference to `__perry_wrap_perry_fn_node_modules_rxjs_src_index_ts__default'
-undefined reference to `perry_fn_node_modules_rxjs_src_index_ts__default'
-undefined reference to `perry_fn_node_modules_rxjs_src_operators_index_ts__default'
-undefined reference to `perry_fn_node_modules_uid_dist_index_mjs__default'
-undefined reference to `__perry_wrap_perry_fn_node_modules__nestjs_core_router_interfaces_routes_interface_js__default'
-undefined reference to `__perry_wrap_perry_fn_node_modules__nestjs_platform_express_interfaces_nest_express_application_interface_js__default'
+```js
+let Logger = Logger_1 = class Logger { ... };
+tslib_1.__decorate([Logger.WrapBuffer, ...], Logger.prototype, "error", null);
 ```
 
-These modules are import barrels or type/interface re-export surfaces rather
-than concrete default function definitions. Call sites still emit default-call
-and default-wrapper references for them, but no object file defines the matching
-symbols. The next focused fix should make default-import/default-call lowering
-follow re-exported module surfaces back to a concrete binding, or avoid emitting
-callable default references for type-only/interface barrels.
+calls `Object.getOwnPropertyDescriptor(Logger.prototype, "error")`, and
+`Logger.prototype` reads as `undefined` (while `typeof Logger` is
+`"function"`). Minimal repro — no CJS wrap needed; the trigger is a class
+EXPRESSION inside a closure whose **getter captures an outer variable**,
+which routes the class through the `ClassExprFresh` lowering
+(`captured_args: [LocalGet(..)]` in HIR), and `.prototype` on a
+`ClassExprFresh` value is not wired:
+
+```ts
+const r = (function() {
+  var L_1: any;
+  let L: any = L_1 = class L {
+    get gi() { return L_1.staticRef; }  // getter capture → ClassExprFresh
+    e(m: any) { return m; }
+  };
+  return [typeof L, typeof L.prototype];
+})();
+// Perry: ["function", "undefined"] — node: ["function", "object"]
+```
+
+Without the capturing getter the same shape keeps a real `.prototype`. The
+next focused fix should give `ClassExprFresh` values a live `.prototype`
+object (tslib `__decorate` then mutates it via `defineProperty`, so instances
+must observe the decorated methods).
 
 ## When this fixture flips to PASS
 
-Once the open linker wall is gone and `fixture.sh` succeeds end-to-end, delete
+Once the open runtime wall is gone and `fixture.sh` succeeds end-to-end, delete
 this `WALLS.md`. The fixture driver treats `WALLS.md` as the marker that turns
 compile/startup failures into SKIP; removing it converts those into hard FAILs
 so regressions past this baseline are visible.


### PR DESCRIPTION
Fixes the native-link wall from #4872: undefined `…__default` / `__perry_wrap_perry_fn_…__default` symbols for import barrels and type-only re-export surfaces. The `nestjs-hello` fixture now compiles and **links end-to-end**; it proceeds to a new (different) runtime wall documented in its `WALLS.md`.

## Root causes & fixes

The CJS wrap lowers every `require('X')` to `import _req_N from 'X'` (a default import). Four gaps compounded behind that:

1. **Default import of a module with no `default` export** (`crates/perry/src/commands/compile.rs`) — rxjs resolves to its TS source `src/index.ts`, a barrel with only named exports; `uid` ships `dist/index.mjs`, same shape. The classifier unconditionally registered the local as a callable function import, so value reads emitted `__perry_wrap_perry_fn_<src>__default` and direct reads emitted `perry_fn_<src>__default` — symbols nothing defines. Now, when the resolved origin module has no `default` in its (propagated) export map, the local routes through the existing **namespace-import machinery** — Node's `require(esm)` semantics: member calls (`rxjs_1.lastValueFrom(...)`) resolve per-export to origin symbols, and whole-value reads materialize the namespace object.

2. **`__exportStar(require("./x"), exports)` barrels** (`cjs_wrap/wrap.rs`, `extract_requires.rs`) — tsc's CJS lowering of `export * from './x'` was invisible to the wrap, so multi-level barrels (`@nestjs/common/index.js` → `decorators/index.js` → `core/index.js` → `controller.decorator.js`) surfaced no static re-exports and `import { Controller } from '@nestjs/common'` link-failed on `perry_fn_<common_index_js>__Controller`. The wrap now also emits a real `export * from '<spec>'` for each `__exportStar` call (bare, `tslib_1.`-member, and `(0, …)`-sequenced forms), letting the existing transitive re-export propagation resolve names to their defining module. Specs covered by the star re-export are excluded from the recursive named-export pull so the static origin binding isn't shadowed by an `export const X = _cjs.X` runtime read.

3. **Type-only interface modules** (`cjs_wrap/detect.rs`) — nestjs dist `*.interface.js` files contain only `Object.defineProperty(exports, "__esModule", { value: true });` — no `exports.X =`, no `require(` — so `is_commonjs` missed them and they compiled as zero-export ES modules, throwing `ReferenceError: exports is not defined` at init once the link succeeded. `defineProperty(exports,` is now a CJS marker.

4. **`export *` leaked `default` across hops** (`compile.rs` propagation loop) — spec-incorrect, and it would poison the has-default probe in (1) for barrels whose star sources have defaults.

**Drive-by:** `perry-hir/lower_decl/class_validation.rs` counted TS constructor **overload signatures** (body-less `constructor(…);`) as real constructors, rejecting rxjs's `Notification` (3 signatures + 1 implementation) with `SyntaxError: class may only have one constructor`. Only constructors with bodies count now.

## Fixture status

`tests/release/packages/nestjs-hello` now reaches `Wrote executable` (~41 MB). It still SKIPs (WALLS.md retained): the boot dies in `@nestjs/common/services/logger.service.js` init because `.prototype` of a **capturing class expression** (`ClassExprFresh` lowering — trigger is a getter capturing an outer variable) reads `undefined`, so tslib's `__decorate` throws `Cannot convert undefined or null to object`. WALLS.md Wall 2 has a 10-line minimal repro for that follow-up.

## Validation

- New e2e test `crates/perry/tests/issue_4872_barrel_default_reexports.rs` covers all three shapes (type-only surface, 2-level `__exportStar` chain, no-default ESM member call) — compile, link, run, byte-exact output.
- Full `cargo test --release -p perry` green, including the #4841 namespace-CJS classifier regression test (closest neighbor to the changed code).
- Release fixtures: `hono-basic` PASS, `node-http-serve` PASS. `axios-get` / `ws-echo` fail identically with the pre-change baseline binary (pre-existing, unrelated).
- `cargo fmt --all -- --check` and `scripts/check_file_size.sh` clean.

No version bump / changelog per contributor convention — maintainer folds in at merge.

Refs #4872 (link wall — resolved here; runtime wall remains tracked in the fixture's WALLS.md).