### PR TITLE
GC: automate write-barrier store-site audit (CI gate), barrier structuredClone object fields, add e2e barrier stress tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,16 @@ jobs:
       - name: File size limit
         run: ./scripts/check_file_size.sh
 
+      # GC write-barrier store-site inventory: every raw heap-slot store in
+      # perry-codegen / perry-runtime / perry-stdlib must be barriered or
+      # carry a justified GC_STORE_AUDIT(...) marker (or a justified entry
+      # in scripts/gc_store_site_allowlist.txt). Catches new unbarriered
+      # old->young store paths before they become nondeterministic segfaults.
+      - name: GC store-site inventory
+        run: |
+          python3 scripts/gc_store_site_inventory.py --self-test
+          python3 scripts/gc_store_site_inventory.py
+
   # ---------------------------------------------------------------------------
   # API docs drift gate (#465)
   #

--- a/crates/perry-codegen/src/expr/native_memory.rs
+++ b/crates/perry-codegen/src/expr/native_memory.rs
@@ -336,6 +336,7 @@ fn emit_u32_fill_loop(ctx: &mut FnCtx<'_>, data_ptr: &str, len_i32: &str, value_
 
     ctx.current_block = body_idx;
     let elem_ptr = ctx.block().gep(I32, data_ptr, &[(I64, &i)]);
+    // GC_STORE_AUDIT(POINTER_FREE): i32 fill of a native-memory buffer, never a heap edge.
     ctx.block().store(I32, value_i32, &elem_ptr);
     let next = ctx.block().add(I64, &i, "1");
     ctx.block().store(I64, &next, &index_slot);

--- a/crates/perry-codegen/src/expr/pod_record.rs
+++ b/crates/perry-codegen/src/expr/pod_record.rs
@@ -290,6 +290,7 @@ pub(crate) fn store_pod_field_native(
     let ptr = pod_field_ptr(ctx, data_slot, field.offset);
     let llvm_ty =
         llvm_type_for_native_rep(&field.native_rep).expect("pod field reps have scalar LLVM types");
+    // GC_STORE_AUDIT(POINTER_FREE): POD record fields are native scalars, never heap edges.
     ctx.block()
         .store_aligned(llvm_ty, &lowered.value, &ptr, field.alignment);
     ctx.record_lowered_value(

--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -407,6 +407,7 @@ fn build_pod_temp_from_object_value(
         let ptr = pod_field_ptr(ctx, &data_slot, field.offset);
         let llvm_ty = llvm_type_for_native_rep(&field.native_rep)
             .expect("manifest POD field reps have scalar LLVM types");
+        // GC_STORE_AUDIT(POINTER_FREE): POD record fields are native scalars, never heap edges.
         ctx.block()
             .store_aligned(llvm_ty, &lowered.value, &ptr, field.alignment);
     }

--- a/crates/perry-runtime/src/array/generic.rs
+++ b/crates/perry-runtime/src/array/generic.rs
@@ -446,6 +446,7 @@ pub extern "C" fn js_arraylike_map(recv: f64, cb: f64, this_arg: f64) -> f64 {
         let v = al_get(recv, k);
         let mapped = js_closure_call3(cb, v, k as f64, recv);
         unsafe {
+            // GC_STORE_AUDIT(BARRIERED): note_array_slot below re-stores this slot with the barrier.
             ptr::write(elems.add(k as usize), mapped);
             note_array_slot(result, k as usize, mapped.to_bits());
         }
@@ -813,6 +814,7 @@ fn materialize(recv: f64) -> *mut ArrayHeader {
         }
         let v = al_get(recv, k);
         unsafe {
+            // GC_STORE_AUDIT(BARRIERED): note_array_slot below re-stores this slot with the barrier.
             ptr::write(elems.add(k as usize), v);
             note_array_slot(arr, k as usize, v.to_bits());
         }
@@ -1127,6 +1129,7 @@ fn object_splice(recv: f64, args_ptr: *const f64, args_len: usize) -> f64 {
         if al_has(recv, from) {
             let v = al_get(recv, from);
             unsafe {
+                // GC_STORE_AUDIT(BARRIERED): note_array_slot below re-stores this slot with the barrier.
                 ptr::write(removed_elems.add(k as usize), v);
                 note_array_slot(removed, k as usize, v.to_bits());
             }

--- a/crates/perry-runtime/src/array/sort.rs
+++ b/crates/perry-runtime/src/array/sort.rs
@@ -234,6 +234,7 @@ pub extern "C" fn js_array_sort_with_comparator(
                         let mut l = left;
                         let mut r = mid;
                         let mut k = left;
+                        // GC_STORE_AUDIT(STACK): merge writes go to the `defined`/`buf` Vec temporaries.
                         while l < mid && r < right {
                             let cmp = cmp_with(comparator, direct_call, *src.add(l), *src.add(r));
                             if cmp <= 0.0 {
@@ -245,11 +246,13 @@ pub extern "C" fn js_array_sort_with_comparator(
                             }
                             k += 1;
                         }
+                        // GC_STORE_AUDIT(STACK): tail copies also target the Vec temporaries.
                         while l < mid {
                             *dst.add(k) = *src.add(l);
                             l += 1;
                             k += 1;
                         }
+                        // GC_STORE_AUDIT(STACK): right-tail copy targets the Vec temporaries.
                         while r < right {
                             *dst.add(k) = *src.add(r);
                             r += 1;
@@ -262,20 +265,25 @@ pub extern "C" fn js_array_sort_with_comparator(
                 }
                 // Make sure the sorted run lives back in `defined`.
                 if src != defined.as_mut_ptr() {
+                    // GC_STORE_AUDIT(STACK): copy between the two Vec temporaries.
                     ptr::copy_nonoverlapping(src, defined.as_mut_ptr(), n);
                 }
             }
             // Write back: sorted defined values, then `undefined` ×N, then
             // holes ×N — restoring the array's exotic sparseness.
             let mut idx = 0usize;
+            // GC_STORE_AUDIT(BARRIERED): write-back is included in the rebuild below.
             for &v in &defined {
                 *elements_ptr.add(idx) = v;
                 idx += 1;
             }
+            // GC_STORE_AUDIT(POINTER_FREE): undefined/hole suffix has no child pointer;
+            // covered by the rebuild below anyway.
             for _ in 0..undef_count {
                 *elements_ptr.add(idx) = f64::from_bits(crate::value::TAG_UNDEFINED);
                 idx += 1;
             }
+            // GC_STORE_AUDIT(POINTER_FREE): hole suffix has no child pointer.
             for _ in 0..hole_count {
                 *elements_ptr.add(idx) = f64::from_bits(crate::value::TAG_HOLE);
                 idx += 1;

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -721,6 +721,7 @@ fn js_structured_clone_inner(value: f64) -> f64 {
                     for i in 0..len as usize {
                         let elem = *elements.add(i);
                         let cloned = js_structured_clone(elem);
+                        // GC_STORE_AUDIT(BARRIERED): note_array_slot below re-stores this slot with the barrier.
                         *elements.add(i) = cloned;
                         crate::array::note_array_slot(new_arr, i, cloned.to_bits());
                     }
@@ -751,7 +752,11 @@ fn js_structured_clone_inner(value: f64) -> f64 {
                             as *mut f64;
                         for i in 0..field_count as usize {
                             let field = *fields.add(i);
-                            *fields.add(i) = js_structured_clone(field);
+                            let cloned = js_structured_clone(field);
+                            // GC_STORE_AUDIT(BARRIERED): cloned field uses the shared object slot-store helper.
+                            // The recursive clone above can run minor GCs that tenure `cloned_obj`
+                            // mid-loop, so this store must be barriered like the array branch.
+                            crate::object::store_object_field_slot(cloned_obj, i, cloned.to_bits());
                         }
                     }
                     // NaN-box with POINTER_TAG

--- a/crates/perry-runtime/src/json_tape.rs
+++ b/crates/perry-runtime/src/json_tape.rs
@@ -1274,6 +1274,7 @@ pub unsafe fn alloc_lazy_array(
     }
     let hdr = hdr_handle.get_raw_mut_ptr::<LazyArrayHeader>();
     let tape_dst = (hdr as *mut u8).add(std::mem::size_of::<LazyArrayHeader>()) as *mut TapeEntry;
+    // GC_STORE_AUDIT(POINTER_FREE): TapeEntry is offset/kind/link numerics, no heap edges.
     std::ptr::copy_nonoverlapping(tape_entries.as_ptr(), tape_dst, tape_entries.len());
     hdr_handle.get_raw_mut_ptr::<LazyArrayHeader>()
 }
@@ -1557,6 +1558,7 @@ pub unsafe fn force_materialize_lazy(hdr: *mut LazyArrayHeader) -> *mut crate::a
                 .add(std::mem::size_of::<crate::array::ArrayHeader>())
                 as *mut u64;
             let value_bits = value_handle.get_nanbox_u64();
+            // GC_STORE_AUDIT(BARRIERED): note_array_slot below re-stores this slot with the barrier.
             *elements_ptr.add(i) = value_bits;
             (*arr_ptr).length = (i + 1) as u32;
             crate::array::note_array_slot(arr_ptr, i, value_bits);

--- a/crates/perry-runtime/src/object/arguments.rs
+++ b/crates/perry-runtime/src/object/arguments.rs
@@ -566,6 +566,7 @@ unsafe fn build_data_descriptor(
     let packed = b"value\0writable\0enumerable\0configurable";
     let desc = js_object_alloc_with_shape(0x0D_A6_50, 4, packed.as_ptr(), packed.len() as u32);
     let fields = (desc as *mut u8).add(std::mem::size_of::<ObjectHeader>()) as *mut f64;
+    // GC_STORE_AUDIT(BARRIERED): fresh descriptor fields are replayed by the rebuild below.
     *fields = value;
     *fields.add(1) = bool_value(writable);
     *fields.add(2) = bool_value(enumerable);
@@ -583,6 +584,7 @@ unsafe fn build_accessor_descriptor(
     let packed = b"get\0set\0enumerable\0configurable";
     let desc = js_object_alloc_with_shape(0x0D_A6_51, 4, packed.as_ptr(), packed.len() as u32);
     let fields = (desc as *mut u8).add(std::mem::size_of::<ObjectHeader>()) as *mut f64;
+    // GC_STORE_AUDIT(BARRIERED): fresh descriptor fields are replayed by the rebuild below.
     *fields = get;
     *fields.add(1) = set;
     *fields.add(2) = bool_value(enumerable);

--- a/crates/perry-runtime/src/object/namespace_create.rs
+++ b/crates/perry-runtime/src/object/namespace_create.rs
@@ -201,6 +201,7 @@ mod sso_tests_1781 {
             // (b) aligned real object, but its keys_array points at misaligned
             // garbage — the exact Express crash shape.
             let obj = super::super::alloc::js_object_alloc(0, 4);
+            // GC_STORE_AUDIT(POINTER_FREE): deliberately-misaligned unit-test sentinel, not a heap edge.
             (*obj).keys_array = 0x2800_0203usize as *mut _;
             assert!(
                 !own_key_present(obj, key),

--- a/crates/perry-runtime/src/temporal/mod.rs
+++ b/crates/perry-runtime/src/temporal/mod.rs
@@ -157,6 +157,7 @@ pub fn alloc_temporal_cell(value: TemporalValue) -> f64 {
         ) as *mut TemporalCell;
         // `arena_alloc_gc` hands back uninitialized memory; `write` moves the
         // box pointer in without dropping the (garbage) prior contents.
+        // GC_STORE_AUDIT(INIT): fresh cell; the Box payload is malloc-owned, not a GC edge.
         std::ptr::write(ptr, TemporalCell { value: boxed });
         f64::from_bits(JSValue::pointer(ptr as *const u8).bits())
     }

--- a/crates/perry/tests/gc_write_barrier_stress.rs
+++ b/crates/perry/tests/gc_write_barrier_stress.rs
@@ -1,0 +1,201 @@
+//! Write-barrier coverage stress tests for the generational GC.
+//!
+//! Failure mode under test: an old-gen (tenured or malloc-backed) object is
+//! mutated to point at a freshly allocated nursery value without a write
+//! barrier. Minor GC then either never sees the edge (child swept while
+//! live) or never rewrites the slot when evacuation moves the child —
+//! both end in nondeterministic garbage reads or segfaults.
+//!
+//! Both tests run the compiled binary with the detection-maximizing knobs:
+//! `PERRY_GC_FORCE_EVACUATE=1` (stress-copy every movable nursery survivor)
+//! and `PERRY_GC_VERIFY_EVACUATION=1` (panic if a live slot still points at
+//! a forwarded object after an evacuation/rewrite cycle).
+//!
+//! NOTE: the churn helpers use object/array *literals* and explicit `gc()`
+//! only on programs without wide dynamic objects — building thousands of
+//! dynamic properties on one object and then calling `gc()` deadlocks on a
+//! pre-existing (unrelated) bug (#4878), and structuredClone of dynamic
+//! overflow properties is a separate pre-existing gap (#4879). Wide object
+//! literals are avoided too (compile-time blowup, #4880).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(source: &str) -> std::process::Output {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    Command::new(&output)
+        .env("PERRY_GC_FORCE_EVACUATE", "1")
+        .env("PERRY_GC_VERIFY_EVACUATION", "1")
+        .output()
+        .expect("run compiled binary")
+}
+
+fn assert_ok_output(run: &std::process::Output, expected: &str) {
+    assert!(
+        run.status.success(),
+        "compiled binary failed (signal/segfault = missed write barrier)\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout,
+        expected,
+        "stderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+/// Tenure a population of objects across several GC cycles, then mutate the
+/// tenured objects (object fields, array elements, closure captures, module
+/// globals) to point at freshly allocated nursery values, GC again, and
+/// verify every value survived. Any missed barrier on those store paths
+/// shows up as corrupt reads, an evacuation-verify panic, or a crash.
+#[test]
+fn tenured_mutation_stress() {
+    let run = compile_and_run(
+        r#"
+let moduleRef: any = null;
+
+function makeCounter() {
+    let state: any = { n: 0, tag: "init" };
+    return () => {
+        state = { n: state.n + 1, tag: "c" + state.n };
+        return state.tag;
+    };
+}
+
+function churn(rounds: number) {
+    for (let c = 0; c < rounds; c++) {
+        let garbage: any[] = [];
+        for (let j = 0; j < 30000; j++) {
+            garbage.push({ x: j, s: "pad" + j });
+        }
+        gc();
+    }
+}
+
+// Phase 1: allocate keepers and tenure them (survive several GC cycles).
+const keepers: any[] = [];
+for (let i = 0; i < 300; i++) {
+    keepers.push({ id: i, payload: null, arr: [i], tag: "k" + i });
+}
+const counter = makeCounter();
+churn(5);
+
+// Phase 2: mutate tenured objects to point at fresh nursery values.
+for (let i = 0; i < 300; i++) {
+    keepers[i].payload = { value: i * 3 + 1, text: "p" + i, inner: [i, i + 1, "s" + i] };
+    keepers[i].arr.push({ deep: i });
+}
+moduleRef = { mark: "module-root", list: [1, 2, 3] };
+counter(); // closure capture slot now points at a fresh nursery object
+counter();
+
+// Phase 3: GC again so any unbarriered old->young edge gets swept or
+// left stale by evacuation.
+churn(4);
+
+// Phase 4: verify.
+let bad = 0;
+for (let i = 0; i < 300; i++) {
+    const k = keepers[i];
+    if (k.id !== i) bad++;
+    if (k.payload.value !== i * 3 + 1) bad++;
+    if (k.payload.text !== "p" + i) bad++;
+    if (k.payload.inner[2] !== "s" + i) bad++;
+    const last = k.arr[k.arr.length - 1];
+    if (last.deep !== i) bad++;
+}
+if (moduleRef.mark !== "module-root" || moduleRef.list[2] !== 3) bad++;
+// tag records the pre-increment n, so the 3rd call yields "c2".
+if (counter() !== "c2") bad++;
+console.log(bad === 0 ? "BARRIER_STRESS_OK" : "BARRIER_STRESS_CORRUPT " + bad);
+"#,
+    );
+    assert_ok_output(&run, "BARRIER_STRESS_OK\n");
+}
+
+/// structuredClone integrity under GC churn + forced evacuation. Covers the
+/// runtime-helper barrier path hardened in this change (the object-field
+/// deep-clone loop in `js_structured_clone` now routes through the shared
+/// barriered store). Uses a 300-key literal (all fields inline) plus a deep
+/// nested chain so the clone itself allocates enough to run GCs mid-clone.
+#[test]
+fn structured_clone_gc_churn_stress() {
+    let mut fields = String::new();
+    for i in 0..300 {
+        fields.push_str(&format!(
+            "    f{i}: {{ v: {i}, pad: \"x{i}\" + \"y\".repeat(96) }},\n"
+        ));
+    }
+    let source = format!(
+        r#"
+function nest(depth: number): any {{
+    let o: any = {{ leaf: true, n: depth }};
+    for (let d = 0; d < depth; d++) {{
+        o = {{ child: o, mark: "d" + d, arr: [d, "s" + d] }};
+    }}
+    return o;
+}}
+
+const src: any = {{
+{fields}
+    deep: nest(200),
+    tail: "end"
+}};
+
+const cl = structuredClone(src);
+
+for (let c = 0; c < 4; c++) {{
+    let garbage: any[] = [];
+    for (let j = 0; j < 30000; j++) {{
+        garbage.push({{ z: j, s: "g" + j }});
+    }}
+    gc();
+}}
+
+let bad = 0;
+for (let i = 0; i < 300; i++) {{
+    const f = cl["f" + i];
+    if (f === undefined || f === null) {{ bad++; continue; }}
+    if (f.v !== i) bad++;
+    else if (f.pad !== "x" + i + "y".repeat(96)) bad++;
+}}
+let cur = cl.deep;
+for (let d = 199; d >= 0; d--) {{
+    if (cur.mark !== "d" + d || cur.arr[1] !== "s" + d) {{ bad++; break; }}
+    cur = cur.child;
+}}
+if (!cur.leaf || cur.n !== 200) bad++;
+if (cl.tail !== "end") bad++;
+console.log(bad === 0 ? "CLONE_STRESS_OK" : "CLONE_STRESS_CORRUPT " + bad);
+"#
+    );
+    let run = compile_and_run(&source);
+    assert_ok_output(&run, "CLONE_STRESS_OK\n");
+}

--- a/scripts/gc_store_site_allowlist.txt
+++ b/scripts/gc_store_site_allowlist.txt
@@ -1,0 +1,12 @@
+# GC store-site inventory allowlist.
+#
+# Format: path-prefix | line-substring-or-* | justification
+# Matched findings are suppressed. Every entry MUST have a justification;
+# malformed lines fail the run (exit 2). Prefer inline GC_STORE_AUDIT(...)
+# markers next to the store — use this file only for whole-module policy
+# decisions where per-line markers would be churn.
+#
+# Audit classes for inline markers: BARRIERED, EXTERNAL_BARRIERED, ROOT,
+# INIT, POINTER_FREE, STACK. See scripts/gc_store_site_inventory.py.
+
+crates/perry-runtime/src/gc/ | * | collector-internal: the barrier implementation and GC unit tests perform raw stores by design (helpers in gc/barrier.rs ARE the barriers; gc/tests/ deliberately writes unbarriered slots to exercise detection)

--- a/scripts/gc_store_site_inventory.py
+++ b/scripts/gc_store_site_inventory.py
@@ -34,7 +34,7 @@ MARKER_RE = re.compile(
 )
 
 CODEGEN_DEST_RE = re.compile(
-    r"\.store\([^,]+,\s*[^,]+,\s*&?(?P<dest>[A-Za-z_][A-Za-z0-9_]*)\)"
+    r"\.store(?:_aligned|_volatile)?\([^,]+,\s*[^,]+,\s*&?(?P<dest>[A-Za-z_][A-Za-z0-9_]*)\s*[,)]"
 )
 CODEGEN_EMIT_RAW_STORE_RE = re.compile(r'emit_raw\(format!\("store\b')
 
@@ -67,23 +67,17 @@ RUST_ATOMIC_COMPARE_EXCHANGE_RE = re.compile(
 )
 
 
+# The whole runtime is mutator code that can store JSValues into GC-managed
+# memory; scan all of it so new modules can't land unaudited. The collector
+# itself (crates/perry-runtime/src/gc/) legitimately performs raw stores —
+# it is excluded via the allowlist file with a justification.
 SCAN_PATHS = [
     Path("crates/perry-codegen/src"),
-    Path("crates/perry-runtime/src/array"),
-    Path("crates/perry-runtime/src/object"),
-    Path("crates/perry-runtime/src/closure"),
-    Path("crates/perry-runtime/src/json"),
-    Path("crates/perry-runtime/src/regex.rs"),
-    Path("crates/perry-runtime/src/plugin.rs"),
-    Path("crates/perry-runtime/src/thread.rs"),
-    Path("crates/perry-runtime/src/promise"),
-    Path("crates/perry-runtime/src/map.rs"),
-    Path("crates/perry-runtime/src/set.rs"),
-    Path("crates/perry-runtime/src/string"),
-    Path("crates/perry-runtime/src/typedarray.rs"),
-    Path("crates/perry-runtime/src/buffer"),
+    Path("crates/perry-runtime/src"),
     Path("crates/perry-stdlib/src"),
 ]
+
+DEFAULT_ALLOWLIST = REPO_ROOT / "scripts" / "gc_store_site_allowlist.txt"
 
 
 CODEGEN_HEAP_DEST_HINTS = (
@@ -209,6 +203,66 @@ class Finding:
         return f"{rel}:{self.line_no}: {self.reason}: {self.text.strip()}"
 
 
+@dataclass
+class AllowlistEntry:
+    path_prefix: str
+    line_substring: str  # "*" matches any line
+    justification: str
+    source_line: int
+    hits: int = 0
+
+    def matches(self, finding: Finding) -> bool:
+        rel = repo_rel(finding.path)
+        if not rel.startswith(self.path_prefix):
+            return False
+        return self.line_substring == "*" or self.line_substring in finding.text
+
+
+def load_allowlist(path: Path) -> list[AllowlistEntry]:
+    """Parse `path-prefix | line-substring-or-* | justification` lines.
+
+    Every entry MUST carry a non-empty justification; a malformed line is a
+    hard error so the allowlist can't silently rot.
+    """
+
+    if not path.is_file():
+        return []
+    entries: list[AllowlistEntry] = []
+    errors: list[str] = []
+    for line_no, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = [part.strip() for part in line.split("|", 2)]
+        if len(parts) != 3 or not parts[0] or not parts[1] or not parts[2]:
+            errors.append(
+                f"{path.name}:{line_no}: expected "
+                "'path-prefix | line-substring-or-* | justification', got: " + raw
+            )
+            continue
+        entries.append(AllowlistEntry(parts[0], parts[1], parts[2], line_no))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        raise SystemExit(2)
+    return entries
+
+
+def apply_allowlist(
+    findings: list[Finding], entries: list[AllowlistEntry]
+) -> tuple[list[Finding], int]:
+    kept: list[Finding] = []
+    suppressed = 0
+    for finding in findings:
+        entry = next((e for e in entries if e.matches(finding)), None)
+        if entry is None:
+            kept.append(finding)
+        else:
+            entry.hits += 1
+            suppressed += 1
+    return kept, suppressed
+
+
 def iter_scan_roots() -> Iterable[Path]:
     for rel in SCAN_PATHS:
         root = REPO_ROOT / rel
@@ -239,6 +293,16 @@ def is_runtime_module(path: Path, module: str) -> bool:
     flat = f"crates/perry-runtime/src/{module}.rs"
     directory = f"crates/perry-runtime/src/{module}/"
     return rel == flat or rel.startswith(directory)
+
+
+def is_pointer_free_module(path: Path) -> bool:
+    """Modules whose element storage is raw bytes/numerics, never JSValues."""
+
+    return (
+        is_runtime_module(path, "buffer")
+        or is_runtime_module(path, "typedarray")
+        or is_runtime_module(path, "typedarray_view")
+    )
 
 
 def is_comment_or_blank(line: str) -> bool:
@@ -302,7 +366,7 @@ def classify_rust_store(path: Path, lines: list[str], index: int) -> str | None:
 
     deref = RUST_DEREF_ASSIGN_RE.search(line)
     if deref and any(hint in deref.group("target") for hint in RUST_DEREF_RISK_TARGETS):
-        if is_runtime_module(path, "buffer") or path.name == "typedarray.rs":
+        if is_pointer_free_module(path):
             return None
         return "raw direct slot assignment"
 
@@ -317,11 +381,7 @@ def classify_rust_store(path: Path, lines: list[str], index: int) -> str | None:
     if RUST_COPY_RE.search(line):
         if any(hint in window for hint in STACK_COPY_HINTS):
             return "raw stack/temporary argument copy"
-        if (
-            is_runtime_module(path, "string")
-            or is_runtime_module(path, "buffer")
-            or path.name == "typedarray.rs"
-        ):
+        if is_runtime_module(path, "string") or is_pointer_free_module(path):
             return None
         if any(hint in window for hint in RUST_POINTER_FREE_COPY_HINTS):
             return None
@@ -547,10 +607,44 @@ def run_self_tests() -> int:
         "raw Promise heap pointer field store",
     )
 
+    # typedarray was split from typedarray.rs into typedarray/ — the
+    # pointer-free carve-out must follow both shapes (regression guard).
+    check(
+        "crates/perry-runtime/src/typedarray/mod.rs",
+        ["*dst.add(i) = load_at(ta, i);"],
+        None,
+    )
+    check(
+        "crates/perry-runtime/src/typedarray_view.rs",
+        ["ptr::copy_nonoverlapping(src_data, dst, (count as i64 * bpe) as usize);"],
+        None,
+    )
+
+    # store_aligned/store_volatile are store emitters too.
+    if not is_risky_codegen_store('.store_aligned(I64, &val, &field_ptr, 8);'):
+        failures.append("codegen: store_aligned with heap dest not flagged")
+    if not is_risky_codegen_store('.store(DOUBLE, &val, &elem_ptr)'):
+        failures.append("codegen: plain store with heap dest not flagged")
+
+    entry = AllowlistEntry("crates/perry-runtime/src/gc/", "*", "test", 1)
+    fake = Finding(
+        REPO_ROOT / "crates/perry-runtime/src/gc/tests/barrier.rs", 1, "*fields = x;", "r"
+    )
+    other = Finding(
+        REPO_ROOT / "crates/perry-runtime/src/array/generic.rs", 1, "*fields = x;", "r"
+    )
+    if not entry.matches(fake):
+        failures.append("allowlist: gc/ prefix entry should match gc/tests finding")
+    if entry.matches(other):
+        failures.append("allowlist: gc/ prefix entry must not match array finding")
+
     scanned_paths = {repo_rel(path) for path in iter_scan_roots()}
     for expected_path in (
         "crates/perry-runtime/src/array/alloc.rs",
         "crates/perry-runtime/src/buffer/from.rs",
+        "crates/perry-runtime/src/builtins/globals.rs",
+        "crates/perry-runtime/src/json_tape.rs",
+        "crates/perry-runtime/src/temporal/mod.rs",
         "crates/perry-codegen/src/lower_call/new.rs",
     ):
         if expected_path not in scanned_paths:
@@ -619,13 +713,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--self-test", action="store_true")
     parser.add_argument("--json-out", type=Path)
     parser.add_argument("--gate", action="store_true")
+    parser.add_argument("--allowlist", type=Path, default=DEFAULT_ALLOWLIST)
     args = parser.parse_args(argv)
     if args.self_test:
         return run_self_tests()
 
+    entries = load_allowlist(args.allowlist)
     findings, files_scanned, marker_count = collect_inventory()
+    findings, suppressed = apply_allowlist(findings, entries)
     if args.json_out:
         write_inventory_json(args.json_out, findings, files_scanned, marker_count)
+
+    for entry in entries:
+        if entry.hits == 0:
+            print(
+                f"warning: unused allowlist entry "
+                f"{args.allowlist.name}:{entry.source_line} ({entry.path_prefix})"
+            )
 
     if findings:
         print("GC store-site inventory failed; add nearby GC_STORE_AUDIT markers:")
@@ -635,10 +739,14 @@ def main(argv: list[str] | None = None) -> int:
             "\nAccepted marker form: "
             "// GC_STORE_AUDIT(BARRIERED): reason, with class one of "
             + ", ".join(sorted(AUDIT_CLASSES))
+            + "\nOr add a justified entry to scripts/gc_store_site_allowlist.txt."
         )
         return 1
 
-    print(f"GC store-site inventory passed ({files_scanned} files scanned).")
+    print(
+        f"GC store-site inventory passed ({files_scanned} files scanned, "
+        f"{marker_count} audited sites, {suppressed} allowlisted)."
+    )
     return 0
 
 


### PR DESCRIPTION
## What

Automates write-barrier coverage verification for the generational GC and wires it into CI, so a new unbarriered heap-slot store path can no longer land silently. Closes the gap where `scripts/gc_store_site_inventory.py` existed but ran nowhere — it was failing with **21 unaudited store sites** that had accumulated since the last manual audit.

## Audit results — all 21 findings + expanded-coverage sites classified

| Classification | Sites | Examples |
|---|---|---|
| Already barriered (raw store immediately re-stored by `note_array_slot` / replayed by `rebuild_*_layout`) | 12 | `array/generic.rs` map/materialize/splice, `array/sort.rs` write-back, `object/arguments.rs` descriptor builders, `json_tape.rs` |
| Stack/Vec temporaries | 5 | `array/sort.rs` merge buffers |
| Pointer-free stores (i32 fills, tape numerics, unit-test sentinel, POD scalars) | 7 | `expr/native_memory.rs`, `json_tape.rs` tape copy, `pod_record.rs` |
| Init-time store of non-GC payload | 1 | `temporal/mod.rs` cell init |
| **Genuine missing barrier → fixed** | **1** | `builtins/globals.rs` structuredClone object fields |

Every benign site now carries a justified inline `GC_STORE_AUDIT(<CLASS>): reason` marker (the checker enforces marker-or-fail).

## The fix (latent gap — could **not** be made to fail; see below)

`js_structured_clone`'s object branch deep-cloned fields with a bare `*fields.add(i) = js_structured_clone(field)`, while the sibling array branch right above uses the barriered `note_array_slot`. The recursive clone can run arbitrarily many minor GCs mid-loop, and a wide clone target (>16KB) is malloc-backed — i.e. outside the nursery — while fields are still being installed. The store now routes through `object::store_object_field_slot` (same shared helper `thread.rs` deserialization uses).

**Honesty note on reproduction:** I could not make the unfixed code fail, after four targeted attempts (wide dynamic objects ± explicit `gc()`, wide literals ± `PERRY_GC_FORCE_EVACUATE/VERIFY_EVACUATION`, heavy mid-clone allocation pressure, pre/post-churn verification against a clean main build). The reason is visible in `gc/trace.rs`: minor GC currently skips tracing only objects that are *both* tenured *and* physically in the old-gen arena — malloc-backed and tenured-in-nursery parents are still traced, so the missed remembered-set entry has no observable symptom **today**. It becomes load-bearing the moment clone targets can land in arena old-gen (pretenuring, evacuation-policy changes). The fix is consistency/hardening, priced at one helper call per cloned field.

The repro attempts surfaced three real pre-existing bugs, filed separately:
- #4878 — explicit `gc()` deadlocks (pthread mutex, main thread parked) after building a wide dynamic-property object
- #4879 — structuredClone silently drops dynamically-added (overflow) properties
- #4880 — compile-time blowup on wide object literals (2100 keys ≈ 2 min)

## Checker upgrades (`scripts/gc_store_site_inventory.py`)

- **Scans all of `perry-runtime/src`** (was a hand-picked module list that missed `builtins/`, `json_tape.rs`, `temporal/`, and anything added since). Collector internals (`gc/`) are excluded via the allowlist — the barrier implementation and the GC's own unit tests perform raw stores by design.
- **Allowlist file** `scripts/gc_store_site_allowlist.txt`: `path-prefix | line-substring-or-* | justification`; entries without a justification fail the run (exit 2); unused entries warn.
- **Fixed a rotted carve-out**: the typed-array pointer-free exemption matched the filename `typedarray.rs` and silently stopped applying when the module was split into `typedarray/` — now module-based, `typedarray_view.rs` included.
- Matches `store_aligned` / `store_volatile` emitters in perry-codegen (previously only `.store(`).
- Self-tests for all of the above (`--self-test`).

Run it: `python3 scripts/gc_store_site_inventory.py` (exit 0 = clean; `--json-out <path>` for the machine-readable packet).

## CI

The `lint` job now runs the checker (self-test + gate) after the file-size gate. Current state: **808 files scanned, 213 audited sites, 60 allowlisted, 0 findings**.

## Stress tests (`crates/perry/tests/gc_write_barrier_stress.rs`)

Two e2e tests (compile with `CARGO_BIN_EXE_perry`, run with `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`):
1. `tenured_mutation_stress` — tenure 300 objects across 5 GC cycles, then point their object fields / array elements / closure captures / module globals at fresh nursery values, churn 4 more cycles, verify everything.
2. `structured_clone_gc_churn_stress` — 300-field literal + 200-deep nested chain through structuredClone, churn, full verification.

Both avoid wide dynamic objects / wide literals deliberately (#4878, #4880 — documented in the file header).

## Zero-regressions check

- `perry-runtime` (RUST_TEST_THREADS=1): 1005 passed, 1 failed — `date::tests::test_full_year_setters_revive_invalid_date_only` **fails identically on unmodified main** in a clean worktree (assertion left:1.0 right:0.0 at date.rs:1867), i.e. pre-existing on main as of today, not from this PR.
- `perry-codegen`: all green. `perry` (incl. both new stress tests): all green.
- Full-workspace run on the dev box hit the known parallel-link contention on seven `perry-ext-*` crates; each passes individually (this is the exact failure mode the CI job serializes `CARGO_BUILD_JOBS=1` for).
- `cargo fmt --check`, `check_file_size.sh`, checker self-test + gate: green.
- No symptom claim: this PR does **not** claim to explain the known flaky test262 TypedArray/forEach segfault — no currently-reproducible missed barrier was found.

Per contributor convention, no version bump / CHANGELOG edits — maintainer folds those in at merge.

Side note for CLAUDE.md (not changed here since it's metadata-adjacent): the documented workspace test one-liner is missing `--exclude perry-ui-windows-winui` (crate added in #4680); without it the suite fails to build on macOS hosts.