### PR TITLE
fix(runtime): for-of over a dynamically-typed string drives the String iterator (#4892)

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -2120,6 +2120,25 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
             throw_value_not_iterable();
         }
     }
+    // A string PRIMITIVE (heap STRING_TAG or inline SSO short string) iterates
+    // over its Unicode code points per `String.prototype[Symbol.iterator]`
+    // (ECMA-262 §22.1.3.36). The generic `[Symbol.iterator]` lookup below only
+    // resolves the method off an OBJECT — for a string primitive
+    // `js_object_get_symbol_property` finds nothing, so `js_get_iterator` used
+    // to return the string UNCHANGED, and the lazy `for…of` loop then called
+    // `.next()` on the string itself → `(string).next is not a function`
+    // (#4892). This only bit the dynamic path (`for (c of v)` where `v: any`,
+    // or a segmenter-/destructure-derived value); statically-typed string
+    // for-of never routes through here. Build the real String iterator object
+    // directly, mirroring the array short-circuit at the top.
+    {
+        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
+        if jsv.is_any_string() {
+            let sptr =
+                crate::value::js_get_string_pointer_unified(val_f64) as *const crate::StringHeader;
+            return crate::string::string_values_iter(sptr);
+        }
+    }
     let iter_wk = well_known_symbol("iterator");
     if !iter_wk.is_null() {
         let sym_f64 = f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());


### PR DESCRIPTION
## Summary

Fixes #4892. `for…of` (and spread / `Array.from` / array-destructuring) over a string value whose static type is unknown — `v: any`, or a value flowing out of a segmenter result / destructure — threw `TypeError: (string).next is not a function`. Statically-typed string for-of was unaffected.

## Root cause

The dynamic path routes through the generic iterator protocol via `js_get_iterator` (lazy for-of, #4786). That helper resolves `[Symbol.iterator]` by reading the method **off an object**. For a string *primitive* there is no object slot, so `js_object_get_symbol_property` found nothing and `js_get_iterator` fell through to `return val_f64` — handing the string itself back as the "iterator". The loop then called `.next()` on a plain string and threw.

Strings already have a correct String iterator object (`string/iter_object.rs::string_values_iter`, code-point iteration) installed on `String.prototype[Symbol.iterator]`; the dynamic path just never reached it.

## Fix

One short-circuit in `js_get_iterator` (`crates/perry-runtime/src/symbol.rs`): when the value is a string primitive (heap `STRING_TAG` or inline SSO short string), build the real String iterator via `string_values_iter`, mirroring the array short-circuit at the top of the function. SSO strings are materialized to a `*const StringHeader` via the existing `js_get_string_pointer_unified`.

## Verification

Against `node --experimental-strip-types`:

- `f(v: any){ for (const c of v) n++ }` → `f("ab")` = 2 ✅
- segmenter-destructured `for (const {segment} of seg.segment("a👍b")) for (const ch of segment) ...` = 3 ✅
- static-typed control still works ✅
- spread `[...v]`, `Array.from(v)`, `const [a,b]=v` over dynamic strings — all code-point correct ✅
- non-iterable primitive (`37`) still throws `TypeError` ✅; arrays still iterate ✅

**End-to-end (the live ink blocker):** with #4891 also on `main`, `string-width@7+` now matches Node for mixed strings — `stringWidth("a👍b")` = **4** (was the `hangulClusterWidth` → `for (const character of visibleSegment)` throw). `stringWidth` of `"abc"`/`"👍"`/`"👨‍👩‍👧"` = 3/2/2, all matching Node.

`cargo test -p perry-runtime` (RUST_TEST_THREADS=1): 1007 passed; the only failure is the pre-existing TZ-dependent `date::tests::test_full_year_setters_revive_invalid_date_only`, which fails on pristine `main` too.

## Related

- #4891 / #4889 (previous string-width wall — `\p{RGI_Emoji}`, merged)
- #4786 (lazy for-of iterator protocol — where the dynamic path was introduced)
- #348 (ink end-to-end umbrella)