### PR TITLE
fix(runtime): Temporal ZonedDateTime/PlainDateTime/Duration tail -> ~96.7%

### DIFF
--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -926,7 +926,7 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
             let mut names = match kind {
                 ExoticKind::RegExp => vec!["lastIndex".to_string()],
                 ExoticKind::Error => vec!["message".to_string(), "stack".to_string()],
-                ExoticKind::Date => Vec::new(),
+                ExoticKind::Date | ExoticKind::Temporal => Vec::new(),
             };
             for key in super::exotic_expando::exotic_own_keys(kind, addr, false) {
                 if !names.contains(&key) {

--- a/crates/perry-runtime/src/object/exotic_expando.rs
+++ b/crates/perry-runtime/src/object/exotic_expando.rs
@@ -29,6 +29,15 @@ pub(crate) enum ExoticKind {
     Date,
     RegExp,
     Error,
+    /// A `Temporal.*` reference value (any of the 8 brand sub-kinds). Like
+    /// `Date`, it is a non-movable, pointer-free cell that is NOT an
+    /// `ObjectHeader`, so user-defined own properties (`Object.defineProperty`,
+    /// plain assignment — e.g. test262's `instance.constructor = …` and the
+    /// `checkToTemporalCalendarFastPath` getter probes) must live in the
+    /// side table rather than being written through a bit-cast that corrupts
+    /// the boxed payload. Built-in getters (`duration.years`, `plainDate.month`)
+    /// stay in the Temporal dispatch path; only true expando keys land here.
+    Temporal,
 }
 
 /// Classify `addr` as a Date cell, RegExp header, or Error header. Returns
@@ -42,6 +51,7 @@ pub(crate) fn exotic_expando_kind(addr: usize) -> Option<ExoticKind> {
     match unsafe { (*gc).obj_type } {
         crate::gc::GC_TYPE_DATE_CELL => Some(ExoticKind::Date),
         crate::gc::GC_TYPE_ERROR => Some(ExoticKind::Error),
+        crate::gc::GC_TYPE_TEMPORAL => Some(ExoticKind::Temporal),
         crate::gc::GC_TYPE_OBJECT if crate::regex::is_regex_pointer(addr as *const u8) => {
             Some(ExoticKind::RegExp)
         }
@@ -224,12 +234,22 @@ pub(crate) unsafe fn exotic_set_property(
     // write — the setter runs with the instance receiver and NO own expando
     // is created (spec OrdinarySetWithOwnDescriptor walking the chain).
     if super::descriptors_in_use() {
+        // Temporal values have 8 distinct prototypes (resolved via brand
+        // dispatch, not a single named builtin prototype), and their built-in
+        // accessors are served by the Temporal getter path, not the generic
+        // accessor side table — so there is no prototype-accessor setter to
+        // consult here. Skip straight to the own-property store.
         let proto_name = match kind {
             ExoticKind::Date => "Date",
             ExoticKind::RegExp => "RegExp",
             ExoticKind::Error => "Error",
+            ExoticKind::Temporal => "",
         };
-        let proto = super::builtin_prototype_value(proto_name);
+        let proto = if proto_name.is_empty() {
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        } else {
+            super::builtin_prototype_value(proto_name)
+        };
         let proto_bits = proto.to_bits();
         if (proto_bits >> 48) == 0x7FFD {
             let proto_addr = (proto_bits & crate::value::POINTER_MASK) as usize;

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2209,7 +2209,9 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
         let builtin_own = match kind {
             ExoticKind::RegExp => name == "lastIndex",
             ExoticKind::Error => matches!(name, "message" | "stack"),
-            ExoticKind::Date => false,
+            // Temporal built-in fields (year/month/calendar/…) are prototype
+            // getters, not own data properties (like Date).
+            ExoticKind::Date | ExoticKind::Temporal => false,
         };
         if builtin_own {
             return nanbox_true;
@@ -2965,6 +2967,17 @@ pub extern "C" fn js_object_get_field_by_name(
                     let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
                     let name = String::from_utf8_lossy(key_bytes);
                     let boxed = f64::from_bits(JSValue::pointer(addr as *const u8).bits());
+                    // A user-defined own expando property (`Object.defineProperty`
+                    // / plain assignment) shadows the built-in prototype getters,
+                    // per OrdinaryGet walking own properties before the prototype.
+                    if let Some(v) = super::exotic_expando::exotic_get_own_property(
+                        addr,
+                        super::exotic_expando::ExoticKind::Temporal,
+                        &name,
+                        boxed,
+                    ) {
+                        return JSValue::from_bits(v.to_bits());
+                    }
                     if let Some(v) = crate::temporal::dispatch::get_property(boxed, &name) {
                         return JSValue::from_bits(v.to_bits());
                     }

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -180,15 +180,29 @@ pub extern "C" fn js_object_set_field_by_name(
     key: *const crate::StringHeader,
     value: f64,
 ) {
-    // A `Temporal.*` value is an opaque, immutable NaN-boxed cell — writing an
-    // arbitrary property (e.g. test262's `instance.constructor = …` subclassing
-    // probes) must be a no-op, not interpret the cell as an `ObjectHeader` and
-    // corrupt its boxed payload (which segfaults on the next deref). `obj` still
-    // carries its NaN-box tag here (`0x7FFD…` for a real cell, `0x7FFE…` for a
-    // class-ref), so route through `is_temporal_value`, which checks the
-    // POINTER_TAG before masking to the cleaned heap address — passing the raw
-    // tagged bits to `is_temporal_cell_addr` would deref a wild address.
-    if crate::temporal::is_temporal_value(f64::from_bits(obj as u64)) {
+    // A `Temporal.*` value is an opaque, immutable NaN-boxed cell that is NOT
+    // an `ObjectHeader` — writing an arbitrary property (e.g. test262's
+    // `instance.constructor = …` subclassing probes) must NOT interpret the
+    // cell as an `ObjectHeader` and corrupt its boxed payload (which segfaults
+    // on the next deref). The cell's `temporal_rs` slots are immutable, but a
+    // user-defined *expando* property is legal and lives in the exotic side
+    // table (like Date/RegExp). `obj` still carries its NaN-box tag here
+    // (`0x7FFD…` for a real cell), so route through `exotic_expando_kind_of_value`,
+    // which checks the tag before masking to the cleaned heap address.
+    if let Some((addr, kind @ super::exotic_expando::ExoticKind::Temporal)) =
+        super::exotic_expando::exotic_expando_kind_of_value(f64::from_bits(obj as u64))
+    {
+        if !key.is_null() {
+            unsafe {
+                let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_len = (*key).byte_len as usize;
+                let name = String::from_utf8_lossy(std::slice::from_raw_parts(name_ptr, name_len))
+                    .into_owned();
+                let receiver = f64::from_bits(obj as u64);
+                let _ =
+                    super::exotic_expando::exotic_set_property(addr, kind, &name, value, receiver);
+            }
+        }
         return;
     }
     if let Some(addr) =

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -4067,7 +4067,7 @@ pub unsafe extern "C" fn js_native_call_method(
                                         raw as *mut crate::error::ErrorHeader,
                                         key,
                                     ),
-                                    ExoticKind::Date => false,
+                                    ExoticKind::Date | ExoticKind::Temporal => false,
                                 }
                         })
                         .unwrap_or(false);

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -841,7 +841,7 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
                                     ptr as *mut crate::error::ErrorHeader,
                                     key,
                                 ),
-                                ExoticKind::Date => false,
+                                ExoticKind::Date | ExoticKind::Temporal => false,
                             }
                     })
                     .unwrap_or(false);

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -2366,6 +2366,22 @@ pub unsafe extern "C" fn js_to_primitive(value: f64, hint: i32) -> f64 {
     if is_registered_symbol(obj_ptr) {
         return value;
     }
+    // A `Temporal.*` value is a cell, NOT an `ObjectHeader`: looking up
+    // `[Symbol.toPrimitive]` below would deref the boxed payload as an object
+    // and segfault. Temporal's own `[Symbol.toPrimitive]` throws a TypeError for
+    // the `"number"` hint and returns the canonical ISO string for
+    // `"string"`/`"default"` — which is exactly what `"x" + plainDateTime` and
+    // template interpolation need. (Direct `String(x)` already brand-checks; the
+    // `+`/template coercion routed here did not.)
+    if crate::temporal::is_temporal_value(value) {
+        if hint == 1 {
+            crate::object::throw_object_type_error(b"Cannot convert a Temporal value to a number");
+        }
+        if let Some(s) = crate::temporal::temporal_iso_string(value) {
+            let p = js_string_from_bytes(s.as_ptr(), s.len() as u32);
+            return crate::value::js_nanbox_string(p as i64);
+        }
+    }
     // Look up obj[Symbol.toPrimitive].
     let wk_ptr = well_known_symbol("toPrimitive");
     let sym_f64 = f64::from_bits(POINTER_TAG | (wk_ptr as u64 & POINTER_MASK));

--- a/crates/perry-runtime/src/temporal/dispatch.rs
+++ b/crates/perry-runtime/src/temporal/dispatch.rs
@@ -59,6 +59,32 @@ pub(crate) fn field_u16(v: i64) -> u16 {
     }
 }
 
+/// Spec `ToIntegerWithTruncation(value)` for a **required** constructor field:
+/// real `ToNumber` (Symbol / BigInt → TypeError), then a non-finite result
+/// (`undefined`→NaN, `Infinity`) is a `RangeError`; a fractional value is
+/// truncated toward zero (unlike `ToIntegerIfIntegral`, which rejects fractions).
+pub(crate) fn integer_with_truncation(raw: f64) -> i64 {
+    if JSValue::from_bits(raw.to_bits()).is_bigint() {
+        crate::object::throw_object_type_error(b"Cannot convert a BigInt value to a number");
+    }
+    let n = crate::builtins::js_number_coerce(raw);
+    if !n.is_finite() {
+        crate::fs::validate::throw_range_error_with_code("Temporal field must be a finite integer");
+    }
+    n.trunc() as i64
+}
+
+/// `ToIntegerWithTruncation` for an **optional** field: an absent / `undefined`
+/// argument defaults to `0`; anything present goes through
+/// [`integer_with_truncation`] (so `Infinity` still throws).
+pub(crate) fn optional_integer_with_truncation(raw: f64) -> i64 {
+    if is_undefined(raw) {
+        0
+    } else {
+        integer_with_truncation(raw)
+    }
+}
+
 /// Spec `ToIntegerIfIntegral(value)` for Temporal numeric fields: `ToNumber`
 /// the value, then throw a `RangeError` if the result is not an integral
 /// Number (non-finite or fractional). Used by the `Temporal.Duration`
@@ -67,7 +93,12 @@ pub(crate) fn field_u16(v: i64) -> u16 {
 pub(crate) fn to_integer_if_integral(raw: f64) -> i128 {
     // Real `ToNumber`: runs `valueOf`/`Symbol.toPrimitive` for objects (the
     // order-of-operations / infinity property-bag tests observe exactly one
-    // `valueOf` call) and throws `TypeError` for a Symbol.
+    // `valueOf` call) and throws `TypeError` for a Symbol. A BigInt also throws
+    // a `TypeError` here — abstract `ToNumber(BigInt)` is a TypeError (only the
+    // explicit `Number(2n)` constructor converts, which `js_number_coerce` does).
+    if JSValue::from_bits(raw.to_bits()).is_bigint() {
+        crate::object::throw_object_type_error(b"Cannot convert a BigInt value to a number");
+    }
     let n = crate::builtins::js_number_coerce(raw);
     if !n.is_finite() || n.fract() != 0.0 {
         crate::fs::validate::throw_range_error_with_code(

--- a/crates/perry-runtime/src/temporal/duration.rs
+++ b/crates/perry-runtime/src/temporal/duration.rs
@@ -15,20 +15,6 @@ use temporal_rs::Duration;
 
 const TYPE_NAME: &str = "Temporal.Duration";
 
-/// Field names in `Temporal.Duration` constructor / `from(object)` order.
-const FIELD_NAMES: [&str; 10] = [
-    "years",
-    "months",
-    "weeks",
-    "days",
-    "hours",
-    "minutes",
-    "seconds",
-    "milliseconds",
-    "microseconds",
-    "nanoseconds",
-];
-
 /// Wrap a `temporal_rs::Duration` in a fresh Temporal cell. `pub(crate)` so the
 /// other types' `add`/`subtract`/`until`/`since` (which all return a Duration)
 /// can box their results.
@@ -220,8 +206,7 @@ pub fn call(recv: f64, d: &Duration, name: &str, args: &[f64]) -> f64 {
         )),
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "round" => {
-            let opts = super::options::rounding_options(raw_arg(args, 0));
-            let rel = super::options::relative_to(raw_arg(args, 0));
+            let (opts, rel) = super::options::duration_round_options(raw_arg(args, 0));
             wrap(ok_or_throw(d.round(opts, rel)))
         }
         "total" => {
@@ -239,19 +224,22 @@ pub fn call(recv: f64, d: &Duration, name: &str, args: &[f64]) -> f64 {
 /// replaced. Reads each provided field from the partial object; unspecified
 /// fields keep the receiver's value.
 fn with(d: &Duration, partial: f64) -> f64 {
+    // `ToTemporalPartialDurationRecord` requires an Object — a primitive
+    // (`undefined`, number, string, …) is a `TypeError`, not a RangeError. A
+    // Symbol is a NaN-boxed pointer but is also rejected.
     let jv = JSValue::from_bits(partial.to_bits());
-    if !jv.is_pointer() {
-        crate::fs::validate::throw_range_error_with_code(
-            "Temporal.Duration.prototype.with requires an object argument",
+    if !jv.is_pointer() || unsafe { crate::symbol::js_is_symbol(partial) } != 0 {
+        crate::object::throw_object_type_error(
+            b"Temporal.Duration.prototype.with requires an object argument",
         );
     }
     let obj = jv.as_pointer::<crate::object::ObjectHeader>();
     if obj.is_null() {
-        crate::fs::validate::throw_range_error_with_code(
-            "Temporal.Duration.prototype.with requires an object argument",
+        crate::object::throw_object_type_error(
+            b"Temporal.Duration.prototype.with requires an object argument",
         );
     }
-    let current: [i128; 10] = [
+    let mut next: [i128; 10] = [
         d.years() as i128,
         d.months() as i128,
         d.weeks() as i128,
@@ -263,16 +251,36 @@ fn with(d: &Duration, partial: f64) -> f64 {
         d.microseconds(),
         d.nanoseconds(),
     ];
-    let mut next = current;
-    for (i, fname) in FIELD_NAMES.iter().enumerate() {
+    // `ToTemporalPartialDurationRecord` reads the fields in *alphabetical* order
+    // (the order-of-operations tests observe this), each coerced via
+    // `ToIntegerIfIntegral` — a fractional / infinite value is a RangeError and a
+    // Symbol / BigInt a TypeError (not a silent drop). At least one recognized
+    // field must be present, else TypeError.
+    const ALPHA_FIELDS: [(&str, usize); 10] = [
+        ("days", 3),
+        ("hours", 4),
+        ("microseconds", 8),
+        ("milliseconds", 7),
+        ("minutes", 5),
+        ("months", 1),
+        ("nanoseconds", 9),
+        ("seconds", 6),
+        ("weeks", 2),
+        ("years", 0),
+    ];
+    let mut any = false;
+    for (fname, slot) in ALPHA_FIELDS {
         let key = crate::string::js_string_from_bytes(fname.as_ptr(), fname.len() as u32);
         let raw = crate::object::js_object_get_field_by_name_f64(obj, key);
         if !is_undefined(raw) {
-            let n = JSValue::from_bits(raw.to_bits()).to_number();
-            if n.is_finite() {
-                next[i] = n.trunc() as i128;
-            }
+            any = true;
+            next[slot] = to_integer_if_integral(raw);
         }
+    }
+    if !any {
+        crate::object::throw_object_type_error(
+            b"Temporal.Duration.prototype.with requires at least one duration field",
+        );
     }
     wrap(ok_or_throw(Duration::new(
         next[0] as i64,

--- a/crates/perry-runtime/src/temporal/mod.rs
+++ b/crates/perry-runtime/src/temporal/mod.rs
@@ -158,6 +158,11 @@ pub fn alloc_temporal_cell(value: TemporalValue) -> f64 {
         // `arena_alloc_gc` hands back uninitialized memory; `write` moves the
         // box pointer in without dropping the (garbage) prior contents.
         std::ptr::write(ptr, TemporalCell { value: boxed });
+        // Address reuse after a sweep must not leak a collected cell's expando
+        // properties (`Object.defineProperty` / plain assignment) onto this
+        // fresh one — clear any stale side-table slot at this address, exactly
+        // as Date/RegExp allocation does.
+        crate::object::exotic_expando::expando_clear_on_alloc(ptr as usize);
         f64::from_bits(JSValue::pointer(ptr as *const u8).bits())
     }
 }

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -79,17 +79,20 @@ pub fn plain_date_from_bag(v: f64, overflow: Option<Overflow>) -> temporal_rs::P
 }
 
 /// Build a [`temporal_rs::PlainDateTime`] from a property-bag object
-/// (`ToTemporalDateTime` for a non-Temporal Object). Mirrors
-/// [`plain_date_from_bag`] with date + time fields.
-pub fn plain_date_time_from_bag(v: f64, overflow: Option<Overflow>) -> temporal_rs::PlainDateTime {
+/// (`ToTemporalDateTime` for a non-Temporal Object). Reads, in spec order, the
+/// `calendar` slot, then the date+time fields (alphabetical), then — last — the
+/// `overflow` option from `opts` (so `from`'s observable-overflow / order tests
+/// see options processed after the fields). `opts` is `undefined` for the
+/// coercion paths (`compare`/`until`/`since`) that take no options.
+pub fn plain_date_time_from_bag(v: f64, opts: f64) -> temporal_rs::PlainDateTime {
     let obj = match as_obj(v) {
         Some(o) => o,
         None => type_error("Cannot convert value to a Temporal.PlainDateTime".to_string()),
     };
-    let partial = temporal_rs::partial::PartialDateTime {
-        fields: datetime_fields(obj),
-        calendar: calendar_slot(field(obj, "calendar")),
-    };
+    let calendar = calendar_slot(field(obj, "calendar"));
+    let fields = datetime_fields(obj);
+    let overflow = overflow(opts);
+    let partial = temporal_rs::partial::PartialDateTime { fields, calendar };
     ok_or_throw(temporal_rs::PlainDateTime::from_partial(partial, overflow))
 }
 
@@ -118,6 +121,22 @@ pub fn calendar_slot(v: f64) -> temporal_rs::Calendar {
         };
     }
     type_error("calendar must be a calendar identifier string or a Temporal object".to_string())
+}
+
+/// `ToTemporalCalendarIdentifier` for a constructor's trailing `calendar`
+/// argument — stricter than [`calendar_slot`]: a string must be a bare calendar
+/// *identifier* (`Calendar::try_from_utf8`), so an ISO date string / calendar
+/// annotation form (`"1997-12-04[u-ca=iso8601]"`, `"1111-11-11"`, `""`) is a
+/// `RangeError`, not silently accepted via `ParseTemporalCalendarString`.
+/// Non-string values defer to [`calendar_slot`] (undefined → ISO, a Temporal
+/// value → its `[[Calendar]]`, anything else → TypeError).
+pub fn calendar_identifier(v: f64) -> temporal_rs::Calendar {
+    if JSValue::from_bits(v.to_bits()).is_string() {
+        return ok_or_throw(temporal_rs::Calendar::try_from_utf8(
+            read_string(v).as_bytes(),
+        ));
+    }
+    calendar_slot(v)
 }
 
 /// `GetOptionsObject`: an options argument must be `undefined` or an Object.
@@ -150,7 +169,20 @@ fn num_field(obj: *const crate::object::ObjectHeader, name: &str) -> Option<f64>
     if is_undefined(raw) {
         return None;
     }
-    let n = JSValue::from_bits(raw.to_bits()).to_number();
+    // Spec `ToIntegerWithTruncation` / `GetOption(type: Number)` run the real
+    // abstract `ToNumber`: an object's `valueOf`/`Symbol.toPrimitive` is invoked
+    // (the order-of-operations / `*-infinity-throws-rangeerror` tests observe
+    // exactly one `valueOf` call) and a Symbol throws `TypeError`, NOT the plain
+    // bit-level `to_number()` which returns NaN for both. A non-finite result is
+    // then a `RangeError` (Temporal fields reject Infinity/NaN).
+    //
+    // A BigInt is a `TypeError` here: abstract `ToNumber(BigInt)` throws (unlike
+    // the explicit `Number(2n)` constructor, which `js_number_coerce` permits) —
+    // `roundingIncrement: 2n` and `{ year: 2n }` are wrong-type, not value 2.
+    if JSValue::from_bits(raw.to_bits()).is_bigint() {
+        type_error("Cannot convert a BigInt value to a number".to_string());
+    }
+    let n = crate::builtins::js_number_coerce(raw);
     if n.is_finite() {
         Some(n)
     } else {
@@ -195,6 +227,20 @@ fn range(msg: &str) -> ! {
     crate::fs::validate::throw_range_error_with_code(msg)
 }
 
+/// `ToPositiveIntegerWithTruncation` → `u8` slot for the `month` / `day` fields:
+/// a value `< 1` is a `RangeError` (months and days are positive, even under the
+/// `constrain` overflow — `from({ month: -1 })` throws). Out-of-range-high values
+/// saturate to `u8::MAX` so `temporal_rs`'s own bound then rejects them.
+fn positive_field_u8(n: f64, what: &str) -> u8 {
+    if n.trunc() < 1.0 {
+        range(match what {
+            "month" => "month must be a positive integer",
+            _ => "day must be a positive integer",
+        });
+    }
+    field_u8(n.trunc() as i64)
+}
+
 #[inline]
 fn type_error(msg: String) -> ! {
     crate::object::throw_object_type_error(msg.as_bytes())
@@ -237,12 +283,13 @@ fn parse_month_code(s: &str) -> MonthCode {
 
 // ---- rounding / total -----------------------------------------------------
 
-/// Marshal a `round(roundTo)` argument — a `smallestUnit` string shorthand or
-/// an options object — into [`RoundingOptions`].
-///
-/// `largest_unit` starts *unset* (not `Auto`, unlike `RoundingOptions::default`)
-/// so `Duration.round`'s "smallestUnit and largestUnit both unset" check fires
-/// correctly; the other types' `round` resolvers ignore `largest_unit`.
+/// Marshal a `round(roundTo)` argument for **PlainDateTime / ZonedDateTime**
+/// (which take no `largestUnit` / `relativeTo`) — a `smallestUnit` string
+/// shorthand or an options object — into [`RoundingOptions`]. Options are read
+/// in spec (alphabetical) order: `roundingIncrement`, `roundingMode`,
+/// `smallestUnit`. `Temporal.Duration.prototype.round` uses
+/// [`duration_round_options`] instead (it additionally reads `largestUnit` and
+/// `relativeTo`).
 pub fn rounding_options(arg: f64) -> RoundingOptions {
     let mut o = RoundingOptions::default();
     o.largest_unit = None;
@@ -256,18 +303,11 @@ pub fn rounding_options(arg: f64) -> RoundingOptions {
     }
     match as_obj(arg) {
         Some(obj) => {
-            if let Some(s) = str_field_coerce(obj, "smallestUnit") {
-                o.smallest_unit = Some(parse_unit(&s));
-            }
-            if let Some(s) = str_field_coerce(obj, "largestUnit") {
-                o.largest_unit = Some(parse_unit(&s));
-            }
-            if let Some(s) = str_field_coerce(obj, "roundingMode") {
-                o.rounding_mode = Some(parse_rounding_mode(&s));
-            }
             if let Some(n) = num_field(obj, "roundingIncrement") {
                 o.increment = Some(parse_increment(n));
             }
+            o.rounding_mode = read_rounding_mode(obj);
+            o.smallest_unit = read_smallest_unit(obj);
         }
         // GetOptionsObject: a non-string, non-object `roundTo` (number, boolean,
         // bigint, null, undefined, symbol) is a TypeError.
@@ -276,82 +316,205 @@ pub fn rounding_options(arg: f64) -> RoundingOptions {
     o
 }
 
+/// Marshal a `Temporal.Duration.prototype.round(roundTo)` argument into
+/// [`RoundingOptions`] + optional [`RelativeTo`]. Options are read in spec
+/// (alphabetical) order: `largestUnit`, `relativeTo`, `roundingIncrement`,
+/// `roundingMode`, `smallestUnit` — all read BEFORE the "both units unset"
+/// algorithmic validation (which `temporal_rs` performs in `Duration::round`).
+pub fn duration_round_options(arg: f64) -> (RoundingOptions, Option<RelativeTo>) {
+    let mut o = RoundingOptions::default();
+    o.largest_unit = None;
+    o.smallest_unit = None;
+    o.rounding_mode = None;
+    o.increment = None;
+
+    if JSValue::from_bits(arg.to_bits()).is_string() {
+        o.smallest_unit = Some(parse_unit(&read_string(arg)));
+        return (o, None);
+    }
+    let obj = match as_obj(arg) {
+        Some(obj) => obj,
+        None => type_error("round requires a unit string or an options object".to_string()),
+    };
+    if let Some(s) = str_field_coerce(obj, "largestUnit") {
+        o.largest_unit = Some(parse_unit(&s));
+    }
+    let rel = relative_to_field(obj);
+    if let Some(n) = num_field(obj, "roundingIncrement") {
+        o.increment = Some(parse_increment(n));
+    }
+    o.rounding_mode = read_rounding_mode(obj);
+    o.smallest_unit = read_smallest_unit(obj);
+    (o, rel)
+}
+
 /// Marshal a `total(totalOf)` argument — a `unit` string or a
 /// `{ unit, relativeTo }` object — into the (required) unit and optional
-/// `relativeTo`.
+/// `relativeTo`. Options are read in spec (alphabetical) order: `relativeTo`,
+/// `unit`.
 pub fn total_options(arg: f64) -> (Unit, Option<RelativeTo>) {
     if JSValue::from_bits(arg.to_bits()).is_string() {
         return (parse_unit(&read_string(arg)), None);
     }
     match as_obj(arg) {
         Some(obj) => {
+            let rel = relative_to_field(obj);
             let unit = match str_field_coerce(obj, "unit") {
                 Some(s) => parse_unit(&s),
                 None => range("total requires a unit"),
             };
-            (unit, relative_to_field(obj))
+            (unit, rel)
         }
         None => type_error("total requires a unit string or an options object".to_string()),
     }
 }
 
-/// Marshal a `toString(options)` argument into [`ToStringRoundingOptions`] —
-/// the `fractionalSecondDigits` / `smallestUnit` / `roundingMode` trio shared by
-/// every Temporal type's `toString`. A missing/`undefined` arg yields the
-/// spec-default (auto precision, no smallest-unit override).
+/// `GetTemporalFractionalSecondDigitsOption`: read `fractionalSecondDigits` into
+/// `o.precision`. A Number → floor to an integer 0..=9 (RangeError otherwise);
+/// ANY non-Number (string, null, boolean, object, bigint) → ToString must equal
+/// `"auto"`, else RangeError; a Symbol → TypeError (ToString of a Symbol throws).
+fn read_fractional_second_digits(
+    obj: *const crate::object::ObjectHeader,
+    o: &mut ToStringRoundingOptions,
+) {
+    let raw = field(obj, "fractionalSecondDigits");
+    if is_undefined(raw) {
+        return;
+    }
+    let jv = JSValue::from_bits(raw.to_bits());
+    if jv.is_number() || jv.is_int32() {
+        let n = jv.to_number();
+        if !n.is_finite() {
+            range("fractionalSecondDigits must be \"auto\" or an integer 0-9");
+        }
+        let d = n.floor();
+        if !(0.0..=9.0).contains(&d) {
+            range("fractionalSecondDigits must be between 0 and 9");
+        }
+        o.precision = Precision::Digit(d as u8);
+    } else {
+        if unsafe { crate::symbol::js_is_symbol(raw) } != 0 {
+            type_error("Cannot convert a Symbol value to a string".to_string());
+        }
+        let s = if jv.is_string() {
+            read_string(raw)
+        } else {
+            let sh = crate::value::js_jsvalue_to_string_coerce(raw);
+            read_string(crate::value::js_nanbox_string(sh as i64))
+        };
+        if s != "auto" {
+            range("fractionalSecondDigits must be \"auto\" or an integer 0-9");
+        }
+        o.precision = Precision::Auto;
+    }
+}
+
+fn read_rounding_mode(obj: *const crate::object::ObjectHeader) -> Option<RoundingMode> {
+    str_field_coerce(obj, "roundingMode").map(|s| parse_rounding_mode(&s))
+}
+
+fn read_smallest_unit(obj: *const crate::object::ObjectHeader) -> Option<Unit> {
+    str_field_coerce(obj, "smallestUnit").map(|s| parse_unit(&s))
+}
+
+fn read_display_calendar(obj: *const crate::object::ObjectHeader) -> DisplayCalendar {
+    match str_field_coerce(obj, "calendarName") {
+        Some(s) => {
+            DisplayCalendar::from_str(&s).unwrap_or_else(|_| range("Invalid calendarName option"))
+        }
+        None => DisplayCalendar::Auto,
+    }
+}
+
+/// `toString` options for the calendar-less types (Duration / Instant /
+/// PlainTime), read in spec (alphabetical) order: `fractionalSecondDigits`,
+/// `roundingMode`, `smallestUnit`.
 pub fn to_string_rounding_options(arg: f64) -> ToStringRoundingOptions {
     let mut o = ToStringRoundingOptions::default();
     let obj = match require_options_object(arg) {
         Some(o) => o,
         None => return o, // undefined → defaults; a primitive throws TypeError
     };
-    if let Some(s) = str_field_coerce(obj, "smallestUnit") {
-        o.smallest_unit = Some(parse_unit(&s));
-    }
-    if let Some(s) = str_field_coerce(obj, "roundingMode") {
-        o.rounding_mode = Some(parse_rounding_mode(&s));
-    }
-    // GetTemporalFractionalSecondDigitsOption: "auto" or an integer 0..=9.
-    let raw = field(obj, "fractionalSecondDigits");
-    if !is_undefined(raw) {
-        let jv = JSValue::from_bits(raw.to_bits());
-        if jv.is_string() {
-            if read_string(raw) != "auto" {
-                range("fractionalSecondDigits must be \"auto\" or an integer 0-9");
-            }
-            o.precision = Precision::Auto;
-        } else {
-            let n = jv.to_number();
-            if !n.is_finite() {
-                range("fractionalSecondDigits must be \"auto\" or an integer 0-9");
-            }
-            let d = n.floor();
-            if !(0.0..=9.0).contains(&d) {
-                range("fractionalSecondDigits must be between 0 and 9");
-            }
-            o.precision = Precision::Digit(d as u8);
-        }
-    }
+    read_fractional_second_digits(obj, &mut o);
+    o.rounding_mode = read_rounding_mode(obj);
+    o.smallest_unit = read_smallest_unit(obj);
     o
 }
 
-/// Marshal an `until`/`since` options argument into [`DifferenceSettings`] —
-/// the `largestUnit` / `smallestUnit` / `roundingMode` / `roundingIncrement`
-/// quartet. An `undefined` / absent arg yields the default (auto units).
+/// `Temporal.PlainDateTime.prototype.toString` options, read in spec
+/// (alphabetical) order: `calendarName`, `fractionalSecondDigits`,
+/// `roundingMode`, `smallestUnit`.
+pub fn pdt_to_string_options(arg: f64) -> (ToStringRoundingOptions, DisplayCalendar) {
+    let mut o = ToStringRoundingOptions::default();
+    let obj = match require_options_object(arg) {
+        Some(o) => o,
+        None => return (o, DisplayCalendar::Auto),
+    };
+    let cal = read_display_calendar(obj);
+    read_fractional_second_digits(obj, &mut o);
+    o.rounding_mode = read_rounding_mode(obj);
+    o.smallest_unit = read_smallest_unit(obj);
+    (o, cal)
+}
+
+/// `Temporal.ZonedDateTime.prototype.toString` options, read in spec
+/// (alphabetical) order: `calendarName`, `fractionalSecondDigits`, `offset`,
+/// `roundingMode`, `smallestUnit`, `timeZoneName`.
+pub fn zdt_to_string_options(
+    arg: f64,
+) -> (
+    ToStringRoundingOptions,
+    DisplayOffset,
+    DisplayTimeZone,
+    DisplayCalendar,
+) {
+    let mut o = ToStringRoundingOptions::default();
+    let obj = match require_options_object(arg) {
+        Some(o) => o,
+        None => {
+            return (
+                o,
+                DisplayOffset::Auto,
+                DisplayTimeZone::Auto,
+                DisplayCalendar::Auto,
+            )
+        }
+    };
+    let cal = read_display_calendar(obj);
+    read_fractional_second_digits(obj, &mut o);
+    let offset = match str_field_coerce(obj, "offset") {
+        Some(s) => DisplayOffset::from_str(&s).unwrap_or_else(|_| range("Invalid offset option")),
+        None => DisplayOffset::Auto,
+    };
+    o.rounding_mode = read_rounding_mode(obj);
+    o.smallest_unit = read_smallest_unit(obj);
+    let tz = match str_field_coerce(obj, "timeZoneName") {
+        Some(s) => {
+            DisplayTimeZone::from_str(&s).unwrap_or_else(|_| range("Invalid timeZoneName option"))
+        }
+        None => DisplayTimeZone::Auto,
+    };
+    (o, offset, tz, cal)
+}
+
+/// Marshal an `until`/`since` options argument into [`DifferenceSettings`].
+/// Options are read in spec (alphabetical) order: `largestUnit`,
+/// `roundingIncrement`, `roundingMode`, `smallestUnit`. An `undefined` / absent
+/// arg yields the default (auto units).
 pub fn difference_settings(arg: f64) -> DifferenceSettings {
     let mut s = DifferenceSettings::default();
     if let Some(obj) = require_options_object(arg) {
         if let Some(u) = str_field_coerce(obj, "largestUnit") {
             s.largest_unit = Some(parse_unit(&u));
         }
-        if let Some(u) = str_field_coerce(obj, "smallestUnit") {
-            s.smallest_unit = Some(parse_unit(&u));
+        if let Some(n) = num_field(obj, "roundingIncrement") {
+            s.increment = Some(parse_increment(n));
         }
         if let Some(m) = str_field_coerce(obj, "roundingMode") {
             s.rounding_mode = Some(parse_rounding_mode(&m));
         }
-        if let Some(n) = num_field(obj, "roundingIncrement") {
-            s.increment = Some(parse_increment(n));
+        if let Some(u) = str_field_coerce(obj, "smallestUnit") {
+            s.smallest_unit = Some(parse_unit(&u));
         }
     }
     s
@@ -365,24 +528,6 @@ pub fn display_calendar(arg: f64) -> DisplayCalendar {
             DisplayCalendar::from_str(&s).unwrap_or_else(|_| range("Invalid calendarName option"))
         }
         None => DisplayCalendar::Auto,
-    }
-}
-
-/// Parse the `offset` display option (`"auto"|"never"`) from a `toString` bag.
-pub fn display_offset(arg: f64) -> DisplayOffset {
-    match require_options_object(arg).and_then(|obj| str_field_coerce(obj, "offset")) {
-        Some(s) => DisplayOffset::from_str(&s).unwrap_or_else(|_| range("Invalid offset option")),
-        None => DisplayOffset::Auto,
-    }
-}
-
-/// Parse the `timeZoneName` display option (`"auto"|"never"|"critical"`).
-pub fn display_time_zone(arg: f64) -> DisplayTimeZone {
-    match require_options_object(arg).and_then(|obj| str_field_coerce(obj, "timeZoneName")) {
-        Some(s) => {
-            DisplayTimeZone::from_str(&s).unwrap_or_else(|_| range("Invalid timeZoneName option"))
-        }
-        None => DisplayTimeZone::Auto,
     }
 }
 
@@ -409,17 +554,50 @@ fn relative_to_field(obj: *const crate::object::ObjectHeader) -> Option<Relative
     if JSValue::from_bits(v.to_bits()).is_string() {
         return Some(ok_or_throw(RelativeTo::try_from_str(&read_string(v))));
     }
-    // A plain fields object → build a PlainDate from its calendar fields.
+    // A plain property-bag object. Per `ToRelativeTemporalObject`, the calendar
+    // and (optional) timeZone slots are resolved and validated: a bag carrying
+    // a `timeZone` becomes a `ZonedDateTime` (so an invalid timezone / offset
+    // string is a RangeError, a wrong-typed timezone a TypeError), otherwise a
+    // `PlainDate`. Previously this ignored both fields, so those validation
+    // cases never threw.
     if let Some(o) = as_obj(v) {
+        // `ToRelativeTemporalObject` reads the calendar + full datetime field set
+        // in spec (alphabetical) order: calendar, day, hour, microsecond,
+        // millisecond, minute, month, monthCode, nanosecond, offset, second,
+        // timeZone, year — with `ToNumber`/`valueOf` coercion per field (the
+        // order-of-operations tests observe this exact interleaving). `era`/
+        // `eraYear` are NOT in the ISO field set. A present `timeZone` makes it a
+        // `ZonedDateTime`, otherwise a `PlainDate`; `monthCode` is parsed at its
+        // read position so a bad month code throws before a later wrong-typed
+        // field is even read.
+        let calendar = calendar_slot(field(o, "calendar"));
+        let (cf, pt, offset, tz_raw) = read_zoned_bag_alpha(o);
+
+        if !is_undefined(tz_raw) {
+            let tz = timezone(tz_raw);
+            let mut p = PartialZonedDateTime::new();
+            p.calendar = calendar;
+            p.fields.calendar_fields = cf;
+            p.fields.time = pt;
+            p.fields.offset = offset;
+            p.timezone = Some(tz);
+            let zdt = ok_or_throw(temporal_rs::ZonedDateTime::from_partial(
+                p, None, None, None,
+            ));
+            return Some(RelativeTo::ZonedDateTime(zdt));
+        }
         let partial = temporal_rs::partial::PartialDate {
-            calendar_fields: calendar_fields(o),
-            calendar: temporal_rs::Calendar::default(),
+            calendar_fields: cf,
+            calendar,
         };
         return Some(RelativeTo::PlainDate(ok_or_throw(
             temporal_rs::PlainDate::from_partial(partial, None),
         )));
     }
-    range("relativeTo must be a PlainDate, ZonedDateTime, string, or fields object")
+    // A non-object, non-string primitive (number, boolean, bigint, null) cannot
+    // convert to a relativeTo — `ToRelativeTemporalObject` throws a TypeError
+    // before any ISO parse (the `relativeto-number` case expects TypeError).
+    type_error("relativeTo must be a Temporal object, ISO string, or property bag".to_string())
 }
 
 // ---- overflow / disambiguation (second-arg option objects) ----------------
@@ -432,14 +610,18 @@ pub fn overflow(arg: f64) -> Option<Overflow> {
     str_field_coerce(obj, "overflow").map(|s| parse_overflow(&s))
 }
 
-/// Read an optional `disambiguation` from an options arg.
+/// Read an optional `disambiguation` from an options arg. A non-object,
+/// non-undefined options value is a `TypeError` (`GetOptionsObject`) — so e.g.
+/// `toZonedDateTime(tz, "primitive")` throws even when no option is read.
 pub fn disambiguation(arg: f64) -> Option<Disambiguation> {
+    validate_options_arg(arg);
     let obj = as_obj(arg)?;
     str_field_coerce(obj, "disambiguation").map(|s| parse_disambiguation(&s))
 }
 
 /// Read an optional `offset` (offset-disambiguation) from an options arg.
 pub fn offset_option(arg: f64) -> Option<OffsetDisambiguation> {
+    validate_options_arg(arg);
     let obj = as_obj(arg)?;
     str_field_coerce(obj, "offset").map(|s| parse_offset_option(&s))
 }
@@ -467,26 +649,28 @@ pub fn require_fields_obj(
     }
 }
 
-/// Populate a [`PartialTime`] from an object's `hour…nanosecond` fields.
+/// Populate a [`PartialTime`] from an object's `hour…nanosecond` fields, read in
+/// spec (alphabetical) order: hour, microsecond, millisecond, minute,
+/// nanosecond, second — the order the order-of-operations tests observe.
 pub fn partial_time(obj: *const crate::object::ObjectHeader) -> PartialTime {
     let mut t = PartialTime::new();
     if let Some(n) = num_field(obj, "hour") {
         t.hour = Some(field_u8(n.trunc() as i64));
     }
-    if let Some(n) = num_field(obj, "minute") {
-        t.minute = Some(field_u8(n.trunc() as i64));
-    }
-    if let Some(n) = num_field(obj, "second") {
-        t.second = Some(field_u8(n.trunc() as i64));
+    if let Some(n) = num_field(obj, "microsecond") {
+        t.microsecond = Some(field_u16(n.trunc() as i64));
     }
     if let Some(n) = num_field(obj, "millisecond") {
         t.millisecond = Some(field_u16(n.trunc() as i64));
     }
-    if let Some(n) = num_field(obj, "microsecond") {
-        t.microsecond = Some(field_u16(n.trunc() as i64));
+    if let Some(n) = num_field(obj, "minute") {
+        t.minute = Some(field_u8(n.trunc() as i64));
     }
     if let Some(n) = num_field(obj, "nanosecond") {
         t.nanosecond = Some(field_u16(n.trunc() as i64));
+    }
+    if let Some(n) = num_field(obj, "second") {
+        t.second = Some(field_u8(n.trunc() as i64));
     }
     t
 }
@@ -537,58 +721,232 @@ pub fn year_month_fields(obj: *const crate::object::ObjectHeader) -> YearMonthCa
     f
 }
 
-/// Populate a [`DateTimeFields`] (calendar fields + time) for `PlainDateTime.with`.
+/// Read the ISO date+time field set in spec (alphabetical) order — day, hour,
+/// microsecond, millisecond, minute, month, monthCode, nanosecond, [offset,]
+/// second, year — with `ToNumber`/`valueOf` coercion per numeric field and
+/// `monthCode`/`offset` as required strings (parsed at their read position). The
+/// order-of-operations tests observe exactly this interleaving. `era`/`eraYear`
+/// are NOT in the ISO field set, so they are not read (reading them would record
+/// extra observable gets). `read_offset` controls whether the `offset` field
+/// (ZonedDateTime only) is read.
+fn read_iso_fields_alpha(
+    obj: *const crate::object::ObjectHeader,
+    read_offset: bool,
+) -> (CalendarFields, PartialTime, Option<UtcOffset>) {
+    let day = num_field(obj, "day");
+    let hour = num_field(obj, "hour");
+    let microsecond = num_field(obj, "microsecond");
+    let millisecond = num_field(obj, "millisecond");
+    let minute = num_field(obj, "minute");
+    let month = num_field(obj, "month");
+    let month_code = require_string_field(obj, "monthCode").map(|s| parse_month_code(&s));
+    let nanosecond = num_field(obj, "nanosecond");
+    let offset = if read_offset { offset_field(obj) } else { None };
+    let second = num_field(obj, "second");
+    let year = num_field(obj, "year");
+
+    let mut cf = CalendarFields::new();
+    if let Some(n) = year {
+        cf.year = Some(n.trunc() as i32);
+    }
+    if let Some(n) = month {
+        cf.month = Some(positive_field_u8(n, "month"));
+    }
+    cf.month_code = month_code;
+    if let Some(n) = day {
+        cf.day = Some(positive_field_u8(n, "day"));
+    }
+    let mut pt = PartialTime::new();
+    if let Some(n) = hour {
+        pt.hour = Some(field_u8(n.trunc() as i64));
+    }
+    if let Some(n) = minute {
+        pt.minute = Some(field_u8(n.trunc() as i64));
+    }
+    if let Some(n) = second {
+        pt.second = Some(field_u8(n.trunc() as i64));
+    }
+    if let Some(n) = millisecond {
+        pt.millisecond = Some(field_u16(n.trunc() as i64));
+    }
+    if let Some(n) = microsecond {
+        pt.microsecond = Some(field_u16(n.trunc() as i64));
+    }
+    if let Some(n) = nanosecond {
+        pt.nanosecond = Some(field_u16(n.trunc() as i64));
+    }
+    (cf, pt, offset)
+}
+
+/// Read a ZonedDateTime-shaped property bag's fields in spec (alphabetical)
+/// order — day, hour, microsecond, millisecond, minute, month, monthCode,
+/// nanosecond, offset, second, timeZone, year — returning the parsed
+/// `CalendarFields` + `PartialTime` + optional offset + the raw `timeZone` value
+/// (so the caller can resolve/validate it). The caller reads `calendar` FIRST.
+/// Shared by `ToTemporalZonedDateTime` (`from`) and `ToRelativeTemporalObject`.
+fn read_zoned_bag_alpha(
+    obj: *const crate::object::ObjectHeader,
+) -> (CalendarFields, PartialTime, Option<UtcOffset>, f64) {
+    let day = num_field(obj, "day");
+    let hour = num_field(obj, "hour");
+    let microsecond = num_field(obj, "microsecond");
+    let millisecond = num_field(obj, "millisecond");
+    let minute = num_field(obj, "minute");
+    let month = num_field(obj, "month");
+    let month_code = require_string_field(obj, "monthCode").map(|s| parse_month_code(&s));
+    let nanosecond = num_field(obj, "nanosecond");
+    let offset = offset_field(obj);
+    let second = num_field(obj, "second");
+    let tz_raw = field(obj, "timeZone");
+    let year = num_field(obj, "year");
+
+    let mut cf = CalendarFields::new();
+    if let Some(n) = year {
+        cf.year = Some(n.trunc() as i32);
+    }
+    if let Some(n) = month {
+        cf.month = Some(positive_field_u8(n, "month"));
+    }
+    cf.month_code = month_code;
+    if let Some(n) = day {
+        cf.day = Some(positive_field_u8(n, "day"));
+    }
+    let mut pt = PartialTime::new();
+    if let Some(n) = hour {
+        pt.hour = Some(field_u8(n.trunc() as i64));
+    }
+    if let Some(n) = minute {
+        pt.minute = Some(field_u8(n.trunc() as i64));
+    }
+    if let Some(n) = second {
+        pt.second = Some(field_u8(n.trunc() as i64));
+    }
+    if let Some(n) = millisecond {
+        pt.millisecond = Some(field_u16(n.trunc() as i64));
+    }
+    if let Some(n) = microsecond {
+        pt.microsecond = Some(field_u16(n.trunc() as i64));
+    }
+    if let Some(n) = nanosecond {
+        pt.nanosecond = Some(field_u16(n.trunc() as i64));
+    }
+    (cf, pt, offset, tz_raw)
+}
+
+/// `RejectObjectWithCalendarOrTimeZone`: a `with`-partial bag must NOT carry a
+/// `calendar` or `timeZone` property (they are read — in that order — and a
+/// present value is a TypeError). The receiver supplies the calendar/zone.
+fn reject_calendar_and_timezone(obj: *const crate::object::ObjectHeader) {
+    if !is_undefined(field(obj, "calendar")) {
+        type_error("with-fields object must not have a calendar property".to_string());
+    }
+    if !is_undefined(field(obj, "timeZone")) {
+        type_error("with-fields object must not have a timeZone property".to_string());
+    }
+}
+
+/// Populate a [`DateTimeFields`] (calendar fields + time) for `PlainDateTime.with`,
+/// reading in alphabetical order. The caller performs
+/// `RejectObjectWithCalendarOrTimeZone` first.
 pub fn datetime_fields(obj: *const crate::object::ObjectHeader) -> DateTimeFields {
+    let (cf, pt, _) = read_iso_fields_alpha(obj, false);
     let mut f = DateTimeFields::new();
-    f.calendar_fields = calendar_fields(obj);
-    f.time = partial_time(obj);
+    f.calendar_fields = cf;
+    f.time = pt;
     f
+}
+
+/// `RejectObjectWithCalendarOrTimeZone` + alphabetical-order field read for
+/// `PlainDateTime.with`.
+pub fn with_datetime_fields(obj: *const crate::object::ObjectHeader) -> DateTimeFields {
+    reject_calendar_and_timezone(obj);
+    datetime_fields(obj)
 }
 
 /// Populate a [`ZonedDateTimeFields`] (calendar fields + time + offset) for
-/// `ZonedDateTime.with`.
+/// `ZonedDateTime.with`, reading in alphabetical order after
+/// `RejectObjectWithCalendarOrTimeZone`.
 pub fn zoned_fields(obj: *const crate::object::ObjectHeader) -> ZonedDateTimeFields {
+    reject_calendar_and_timezone(obj);
+    let (cf, pt, offset) = read_iso_fields_alpha(obj, true);
     let mut f = ZonedDateTimeFields::new();
-    f.calendar_fields = calendar_fields(obj);
-    f.time = partial_time(obj);
-    f.offset = offset_field(obj);
+    f.calendar_fields = cf;
+    f.time = pt;
+    f.offset = offset;
     f
 }
 
-/// Read an optional `offset` string field → [`UtcOffset`] (a `RangeError` for a
-/// malformed string).
-fn offset_field(obj: *const crate::object::ObjectHeader) -> Option<UtcOffset> {
-    str_field(obj, "offset").map(|s| ok_or_throw(UtcOffset::from_utf8(s.as_bytes())))
+/// `ToPrimitiveAndRequireString`: read `obj.<name>` and require a String result.
+/// `undefined` → `None`; a String → that string; an Object → `ToPrimitive(string)`
+/// (its `toString`/`valueOf` runs), then the RESULT must be a String (else
+/// TypeError); any other primitive (number / boolean / bigint / null) → TypeError;
+/// a Symbol → TypeError. Used for `offset` and `monthCode` fields, which the spec
+/// reads as required strings (the property-bag observer wraps even string values
+/// in a `toString`-bearing object).
+fn require_string_field(obj: *const crate::object::ObjectHeader, name: &str) -> Option<String> {
+    let raw = field(obj, name);
+    if is_undefined(raw) {
+        return None;
+    }
+    let jv = JSValue::from_bits(raw.to_bits());
+    if jv.is_string() {
+        return Some(read_string(raw));
+    }
+    if jv.is_pointer() && unsafe { crate::symbol::js_is_symbol(raw) } == 0 {
+        // Object: `ToPrimitiveAndRequireString` — OrdinaryToPrimitive with the
+        // string hint (its `toString`/`valueOf` runs, which the order-of-operations
+        // tests observe), then the RESULT must be a String. A custom `toString`
+        // returning a non-string (`{ toString: () => 5 }`) is a TypeError, NOT a
+        // further ToString coercion. A plain object with only the default
+        // `Object.prototype.toString` (`None`) yields `"[object Object]"`, which
+        // IS a string (and then fails the month-code/offset syntax check).
+        match unsafe { crate::value::to_string::ordinary_to_primitive_string(raw) } {
+            Some(prim) => {
+                if JSValue::from_bits(prim.to_bits()).is_string() {
+                    return Some(read_string(prim));
+                }
+                // non-string primitive result → require-string fails (TypeError)
+            }
+            None => {
+                let sh = crate::value::js_jsvalue_to_string_coerce(raw);
+                return Some(read_string(crate::value::js_nanbox_string(sh as i64)));
+            }
+        }
+    }
+    type_error(format!("{name} property must be a string"))
 }
 
-/// Resolve the `timeZone` field of a property bag to a [`TimeZone`] — a
-/// tz-identifier string or another `Temporal.ZonedDateTime` (whose zone is
-/// reused). A missing `timeZone` is a `TypeError` (it is a required field of a
-/// `ZonedDateTime` property bag).
-fn timezone_field(obj: *const crate::object::ObjectHeader) -> TimeZone {
-    let raw = field(obj, "timeZone");
-    if is_undefined(raw) {
-        type_error(
-            "ZonedDateTime property bag is missing a required \"timeZone\" field".to_string(),
-        );
-    }
-    timezone(raw)
+/// Read an optional `offset` field → [`UtcOffset`]. A present `offset` is read as
+/// a required string (see [`require_string_field`]); a malformed offset string
+/// is a `RangeError` — matching the property-bag `*-invalid-offset-string` cases
+/// (`badOffsets` mixes both error kinds: non-strings → TypeError, bad strings →
+/// RangeError).
+fn offset_field(obj: *const crate::object::ObjectHeader) -> Option<UtcOffset> {
+    require_string_field(obj, "offset").map(|s| ok_or_throw(UtcOffset::from_utf8(s.as_bytes())))
 }
 
 /// Build a [`PartialZonedDateTime`] from a JS property bag for
 /// `Temporal.ZonedDateTime.from`. Returns `None` if `v` is not a plain object.
 pub fn zoned_partial(v: f64) -> Option<PartialZonedDateTime> {
     let obj = as_obj(v)?;
-    let calendar = match str_field(obj, "calendar") {
-        Some(s) => ok_or_throw(s.parse::<Calendar>()),
-        None => Calendar::default(),
-    };
+    // Spec order: `calendar` first (ToTemporalCalendarSlotValue — a null / number
+    // / wrong-typed value is a TypeError, not a silent ISO default), then the
+    // alphabetical field set (with `offset` and `timeZone` in position), then the
+    // timeZone is resolved (a missing `timeZone` is a TypeError — it is required
+    // for a ZonedDateTime bag).
+    let calendar = calendar_slot(field(obj, "calendar"));
+    let (cf, pt, offset, tz_raw) = read_zoned_bag_alpha(obj);
+    if is_undefined(tz_raw) {
+        type_error(
+            "ZonedDateTime property bag is missing a required \"timeZone\" field".to_string(),
+        );
+    }
     let mut p = PartialZonedDateTime::new();
     p.calendar = calendar;
-    p.fields.calendar_fields = calendar_fields(obj);
-    p.fields.time = partial_time(obj);
-    p.fields.offset = offset_field(obj);
-    p.timezone = Some(timezone_field(obj));
+    p.fields.calendar_fields = cf;
+    p.fields.time = pt;
+    p.fields.offset = offset;
+    p.timezone = Some(timezone(tz_raw));
     Some(p)
 }
 
@@ -616,11 +974,19 @@ pub fn optional_plain_time(v: f64) -> Option<PlainTime> {
     if let Some(o) = as_obj(v) {
         let pt = partial_time(o);
         if pt.is_empty() {
-            return Some(midnight());
+            // `ToTemporalTime` of an object with no recognized time fields is a
+            // TypeError (`plaintime-propertybag-no-time-units`), NOT midnight.
+            type_error(
+                "Temporal.PlainTime-like object must have at least one time field".to_string(),
+            );
         }
         return Some(ok_or_throw(midnight().with(pt, Some(Overflow::Constrain))));
     }
-    None
+    // `ToTemporalTime` of a number / null / boolean / bigint / symbol is a
+    // `TypeError` (only a Temporal time, ISO string, or property bag converts) —
+    // `withPlainTime`'s `argument-number` / `argument-wrong-type` cases. A
+    // missing/`undefined` arg is handled above (caller defaults to midnight).
+    type_error("Cannot convert value to a Temporal.PlainTime".to_string())
 }
 
 /// Read an optional `timeZone` from `Temporal.Instant.prototype.toString`'s

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -4,7 +4,7 @@
 //! PlainTime field sets.
 
 use super::dispatch::{
-    self, boolean, field_u16, field_u8, int_arg, num_arg, ok_or_throw, raw_arg, string, undefined,
+    self, boolean, field_u16, field_u8, ok_or_throw, raw_arg, string, undefined,
 };
 use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
 use crate::value::JSValue;
@@ -20,55 +20,81 @@ fn calendar_arg(v: f64) -> Calendar {
     super::options::calendar_slot(v)
 }
 
+/// Strict calendar-identifier parse for the constructor's trailing argument
+/// (an ISO string / annotation form is a RangeError, unlike `from`'s lenient
+/// `calendar_slot`).
+fn calendar_id_arg(v: f64) -> Calendar {
+    super::options::calendar_identifier(v)
+}
+
 /// `new Temporal.PlainDateTime(year, month, day, hour?, …, nanosecond?, calendar?)`.
 pub fn construct(args: &[f64]) -> f64 {
-    // `try_new` = overflow "reject": throw on out-of-range fields instead of
-    // constraining. Time fields saturate via `field_u8`/`field_u16` so a wrapping
-    // `as u8` cast can't slip e.g. `256` (hour) through as `0`.
+    // Each field is `ToIntegerWithTruncation`: a non-finite (`Infinity`/`NaN` /
+    // absent required field) is a RangeError, a Symbol/BigInt a TypeError — not
+    // a silently-mangled `as i32`/`0`. `try_new` = overflow "reject" (out-of-range
+    // fields throw); time fields saturate via `field_u8`/`field_u16` so a wrapping
+    // cast can't slip e.g. `256` (hour) through as `0`.
+    let year = dispatch::integer_with_truncation(raw_arg(args, 0));
+    let month = dispatch::integer_with_truncation(raw_arg(args, 1));
+    let day = dispatch::integer_with_truncation(raw_arg(args, 2));
     wrap(ok_or_throw(PlainDateTime::try_new(
-        num_arg(args, 0) as i32,     // year
-        num_arg(args, 1) as u8,      // month
-        num_arg(args, 2) as u8,      // day
-        field_u8(int_arg(args, 3)),  // hour
-        field_u8(int_arg(args, 4)),  // minute
-        field_u8(int_arg(args, 5)),  // second
-        field_u16(int_arg(args, 6)), // ms
-        field_u16(int_arg(args, 7)), // us
-        field_u16(int_arg(args, 8)), // ns
-        calendar_arg(raw_arg(args, 9)),
+        year as i32,
+        field_u8(month),
+        field_u8(day),
+        field_u8(dispatch::optional_integer_with_truncation(raw_arg(args, 3))), // hour
+        field_u8(dispatch::optional_integer_with_truncation(raw_arg(args, 4))), // minute
+        field_u8(dispatch::optional_integer_with_truncation(raw_arg(args, 5))), // second
+        field_u16(dispatch::optional_integer_with_truncation(raw_arg(args, 6))), // ms
+        field_u16(dispatch::optional_integer_with_truncation(raw_arg(args, 7))), // us
+        field_u16(dispatch::optional_integer_with_truncation(raw_arg(args, 8))), // ns
+        calendar_id_arg(raw_arg(args, 9)),
     )))
 }
 
 fn coerce_dt(v: f64) -> PlainDateTime {
-    coerce_dt_with_overflow(v, None)
+    coerce_dt_with_opts(v, undefined())
 }
 
-/// `ToTemporalDateTime(item, overflow)`. A `PlainDateTime` is cloned; a
+/// `ToTemporalDateTime(item, options)`. A `PlainDateTime` is cloned; a
 /// `PlainDate` is widened to midnight; an ISO string is parsed; a property-bag
-/// object is built via partial fields under `overflow`; anything else
-/// (number/boolean/null/symbol, or a non-date Temporal value) is a `TypeError`.
-fn coerce_dt_with_overflow(
-    v: f64,
-    overflow: Option<temporal_rs::options::Overflow>,
-) -> PlainDateTime {
+/// object is built via partial fields; anything else (number/boolean/null/symbol,
+/// or a non-date Temporal value) is a `TypeError`. The `overflow` option in
+/// `opts` is read *after* the item is processed (the spec / observable-overflow
+/// tests: a primitive throws before options are touched, an invalid string
+/// throws before options are read, and a bag reads its fields first). `opts` is
+/// `undefined` for `compare`/`until`/`since` (no options arg).
+fn coerce_dt_with_opts(v: f64, opts: f64) -> PlainDateTime {
     match temporal_value_ref(v) {
-        Some(TemporalValue::PlainDateTime(dt)) => return dt.clone(),
-        Some(TemporalValue::PlainDate(d)) => return ok_or_throw(d.to_plain_date_time(None)),
-        Some(TemporalValue::ZonedDateTime(z)) => return z.to_plain_date_time(),
+        Some(TemporalValue::PlainDateTime(dt)) => {
+            let dt = dt.clone();
+            let _ = super::options::overflow(opts);
+            return dt;
+        }
+        Some(TemporalValue::PlainDate(d)) => {
+            let dt = ok_or_throw(d.to_plain_date_time(None));
+            let _ = super::options::overflow(opts);
+            return dt;
+        }
+        Some(TemporalValue::ZonedDateTime(z)) => {
+            let dt = z.to_plain_date_time();
+            let _ = super::options::overflow(opts);
+            return dt;
+        }
         Some(_) => crate::object::throw_object_type_error(
             b"Cannot convert this Temporal value to a Temporal.PlainDateTime",
         ),
         None => {}
     }
     if JSValue::from_bits(v.to_bits()).is_string() {
-        return ok_or_throw(dispatch::read_string(v).parse::<PlainDateTime>());
+        let dt = ok_or_throw(dispatch::read_string(v).parse::<PlainDateTime>());
+        let _ = super::options::overflow(opts);
+        return dt;
     }
-    super::options::plain_date_time_from_bag(v, overflow)
+    super::options::plain_date_time_from_bag(v, opts)
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
-    let overflow = super::options::overflow(raw_arg(args, 1));
-    wrap(coerce_dt_with_overflow(raw_arg(args, 0), overflow))
+    wrap(coerce_dt_with_opts(raw_arg(args, 0), raw_arg(args, 1)))
 }
 
 pub fn compare_static(args: &[f64]) -> f64 {
@@ -124,18 +150,15 @@ pub fn get(dt: &PlainDateTime, name: &str) -> Option<f64> {
 pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
     match name {
         "add" => {
+            // Spec reads the duration argument's fields BEFORE the options bag.
+            let dur = super::duration::coerce_duration(raw_arg(args, 0));
             let overflow = super::options::overflow(raw_arg(args, 1));
-            wrap(ok_or_throw(dt.add(
-                &super::duration::coerce_duration(raw_arg(args, 0)),
-                overflow,
-            )))
+            wrap(ok_or_throw(dt.add(&dur, overflow)))
         }
         "subtract" => {
+            let dur = super::duration::coerce_duration(raw_arg(args, 0));
             let overflow = super::options::overflow(raw_arg(args, 1));
-            wrap(ok_or_throw(dt.subtract(
-                &super::duration::coerce_duration(raw_arg(args, 0)),
-                overflow,
-            )))
+            wrap(ok_or_throw(dt.subtract(&dur, overflow)))
         }
         "until" => super::duration::wrap(ok_or_throw(dt.until(
             &coerce_dt(raw_arg(args, 0)),
@@ -154,15 +177,15 @@ pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
         }
         "toPlainDate" => alloc_temporal_cell(TemporalValue::PlainDate(dt.to_plain_date())),
         "toPlainTime" => alloc_temporal_cell(TemporalValue::PlainTime(dt.to_plain_time())),
-        "toString" => string(&ok_or_throw(dt.to_ixdtf_string(
-            super::options::to_string_rounding_options(raw_arg(args, 0)),
-            super::options::display_calendar(raw_arg(args, 0)),
-        ))),
+        "toString" => {
+            let (rounding, calendar) = super::options::pdt_to_string_options(raw_arg(args, 0));
+            string(&ok_or_throw(dt.to_ixdtf_string(rounding, calendar)))
+        }
         "toJSON" | "toLocaleString" => string(&dt.to_string()),
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");
-            let fields = super::options::datetime_fields(obj);
+            let fields = super::options::with_datetime_fields(obj);
             let overflow = super::options::overflow(raw_arg(args, 1));
             wrap(ok_or_throw(dt.with(fields, overflow)))
         }
@@ -171,7 +194,16 @@ pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
             let time = super::options::optional_plain_time(raw_arg(args, 0));
             wrap(ok_or_throw(dt.to_plain_date().to_plain_date_time(time)))
         }
-        "withCalendar" => wrap(dt.with_calendar(calendar_arg(raw_arg(args, 0)))),
+        "withCalendar" => {
+            // `withCalendar` requires its argument: `ToTemporalCalendarSlotValue`
+            // of `undefined` is a TypeError (the `missing-argument` case).
+            if dispatch::is_undefined(raw_arg(args, 0)) {
+                crate::object::throw_object_type_error(
+                    b"withCalendar requires a calendar argument",
+                );
+            }
+            wrap(dt.with_calendar(calendar_arg(raw_arg(args, 0))))
+        }
         "round" => wrap(ok_or_throw(
             dt.round(super::options::rounding_options(raw_arg(args, 0))),
         )),

--- a/crates/perry-runtime/src/temporal/zoned_date_time.rs
+++ b/crates/perry-runtime/src/temporal/zoned_date_time.rs
@@ -59,22 +59,21 @@ fn timezone_arg(v: f64) -> TimeZone {
     )
 }
 
+/// `ToTemporalCalendarSlotValue`: `undefined` → ISO; a calendar string or a
+/// Temporal value → its calendar; null / number / boolean / object / symbol →
+/// `TypeError`. The previous version silently mapped any non-string to ISO, so
+/// a `null` calendar (the `calendar-wrong-type` cases) never threw.
 fn calendar_arg(v: f64) -> Calendar {
-    if dispatch::is_undefined(v) {
-        return Calendar::default();
-    }
-    let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_string() {
-        return ok_or_throw(dispatch::read_string(v).parse::<Calendar>());
-    }
-    Calendar::default()
+    super::options::calendar_slot(v)
 }
 
 /// `new Temporal.ZonedDateTime(epochNanoseconds: bigint, timeZone, calendar?)`.
 pub fn construct(args: &[f64]) -> f64 {
     let ns = require_ns(raw_arg(args, 0));
     let tz = timezone_arg(raw_arg(args, 1));
-    let cal = calendar_arg(raw_arg(args, 2));
+    // Constructor calendar arg is a strict identifier (an ISO date string is a
+    // RangeError, unlike `from`'s lenient calendar slot).
+    let cal = super::options::calendar_identifier(raw_arg(args, 2));
     wrap(ok_or_throw(ZonedDateTime::try_new(ns, tz, cal)))
 }
 
@@ -91,24 +90,36 @@ fn coerce_zdt_with_options(v: f64, opts: f64) -> ZonedDateTime {
         return z.clone();
     }
     if let Some(partial) = super::options::zoned_partial(v) {
+        // Options are read AFTER the property-bag fields, in spec order:
+        // disambiguation, offset, overflow.
+        let disambiguation = super::options::disambiguation(opts);
+        let offset = super::options::offset_option(opts);
+        let overflow = super::options::overflow(opts);
         return ok_or_throw(ZonedDateTime::from_partial(
             partial,
-            super::options::overflow(opts),
-            super::options::disambiguation(opts),
-            super::options::offset_option(opts),
+            overflow,
+            disambiguation,
+            offset,
         ));
     }
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_string() {
+        // Parse the string BEFORE reading options (spec order: an invalid string
+        // throws a RangeError before any option is touched).
+        let s = dispatch::read_string(v);
+        let disambiguation =
+            super::options::disambiguation(opts).unwrap_or(Disambiguation::Compatible);
+        let offset = super::options::offset_option(opts).unwrap_or(OffsetDisambiguation::Reject);
         return ok_or_throw(ZonedDateTime::from_utf8(
-            dispatch::read_string(v).as_bytes(),
-            super::options::disambiguation(opts).unwrap_or(Disambiguation::Compatible),
-            super::options::offset_option(opts).unwrap_or(OffsetDisambiguation::Reject),
+            s.as_bytes(),
+            disambiguation,
+            offset,
         ));
     }
-    crate::fs::validate::throw_range_error_with_code(
-        "Cannot convert value to a Temporal.ZonedDateTime",
-    )
+    // `ToTemporalZonedDateTime` accepts only an Object or a String; every other
+    // value (undefined / null / number / boolean / bigint / symbol) is a
+    // `TypeError` — "does not convert to a valid ISO string" — NOT a RangeError.
+    crate::object::throw_object_type_error(b"Cannot convert value to a Temporal.ZonedDateTime")
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
@@ -178,14 +189,17 @@ pub fn get(z: &ZonedDateTime, name: &str) -> Option<f64> {
 
 pub fn call(recv: f64, z: &ZonedDateTime, name: &str, args: &[f64]) -> f64 {
     match name {
-        "add" => wrap(ok_or_throw(z.add(
-            &super::duration::coerce_duration(raw_arg(args, 0)),
-            super::options::overflow(raw_arg(args, 1)),
-        ))),
-        "subtract" => wrap(ok_or_throw(z.subtract(
-            &super::duration::coerce_duration(raw_arg(args, 0)),
-            super::options::overflow(raw_arg(args, 1)),
-        ))),
+        "add" => {
+            // Spec reads the duration argument's fields BEFORE the options bag.
+            let dur = super::duration::coerce_duration(raw_arg(args, 0));
+            let overflow = super::options::overflow(raw_arg(args, 1));
+            wrap(ok_or_throw(z.add(&dur, overflow)))
+        }
+        "subtract" => {
+            let dur = super::duration::coerce_duration(raw_arg(args, 0));
+            let overflow = super::options::overflow(raw_arg(args, 1));
+            wrap(ok_or_throw(z.subtract(&dur, overflow)))
+        }
         "until" => super::duration::wrap(ok_or_throw(z.until(
             &coerce_zdt(raw_arg(args, 0)),
             super::options::difference_settings(raw_arg(args, 1)),
@@ -201,12 +215,13 @@ pub fn call(recv: f64, z: &ZonedDateTime, name: &str, args: &[f64]) -> f64 {
         "toPlainDateTime" => {
             alloc_temporal_cell(TemporalValue::PlainDateTime(z.to_plain_date_time()))
         }
-        "toString" => string(&ok_or_throw(z.to_ixdtf_string(
-            super::options::display_offset(raw_arg(args, 0)),
-            super::options::display_time_zone(raw_arg(args, 0)),
-            super::options::display_calendar(raw_arg(args, 0)),
-            super::options::to_string_rounding_options(raw_arg(args, 0)),
-        ))),
+        "toString" => {
+            let (rounding, offset, time_zone, calendar) =
+                super::options::zdt_to_string_options(raw_arg(args, 0));
+            string(&ok_or_throw(
+                z.to_ixdtf_string(offset, time_zone, calendar, rounding),
+            ))
+        }
         "toJSON" | "toLocaleString" => string(&z.to_string()),
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
@@ -228,7 +243,17 @@ pub fn call(recv: f64, z: &ZonedDateTime, name: &str, args: &[f64]) -> f64 {
             let tz = super::options::timezone(raw_arg(args, 0));
             wrap(ok_or_throw(z.with_timezone(tz)))
         }
-        "withCalendar" => wrap(z.with_calendar(calendar_arg(raw_arg(args, 0)))),
+        "withCalendar" => {
+            // `withCalendar` requires its argument: `ToTemporalCalendarSlotValue`
+            // of `undefined` is a TypeError (the `missing-argument` case), unlike
+            // the constructor's optional trailing calendar.
+            if dispatch::is_undefined(raw_arg(args, 0)) {
+                crate::object::throw_object_type_error(
+                    b"withCalendar requires a calendar argument",
+                );
+            }
+            wrap(z.with_calendar(calendar_arg(raw_arg(args, 0))))
+        }
         "round" => wrap(ok_or_throw(
             z.round(super::options::rounding_options(raw_arg(args, 0))),
         )),

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -42,7 +42,7 @@ mod handle;
 mod jsvalue;
 mod nanbox;
 mod tags;
-mod to_string;
+pub(crate) mod to_string;
 mod truthy;
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -32,7 +32,7 @@ thread_local! {
 /// `value` MUST be a NaN-boxed `POINTER_TAG` object whose pointer is a real
 /// heap address (`>= 0x10000`); the caller has already excluded symbols,
 /// buffers, arrays, and JSX nodes (those carry their own coercion rules).
-unsafe fn ordinary_to_primitive_string(value: f64) -> Option<f64> {
+pub(crate) unsafe fn ordinary_to_primitive_string(value: f64) -> Option<f64> {
     // Bound recursion: a `toString` that itself string-coerces `this`.
     let depth = TO_PRIMITIVE_DEPTH.with(|c| c.get());
     if depth >= 200 {


### PR DESCRIPTION
## Summary

Pushes the three biggest Temporal types' test262 tails well past the ~95% target.

**built-ins/Temporal/{ZonedDateTime, PlainDateTime, Duration}: 1976 → 2141 pass (89.3% → 96.7%)**, **zero regressions** (verified against the branch merge-base on the full `built-ins language` shard 0/12: +18 pass, 0 regressions, identical compile-fail count).

All fixes are in the `temporal_rs` binding glue (perry-runtime) — Perry writes no date/calendar math.

## Root causes (grouped, biggest first)

1. **Temporal cells crashed as `Object.defineProperty` / assignment targets.** A `Temporal.*` value is a NaN-boxed cell, not an `ObjectHeader`; the ordinary define/set path bit-cast it and corrupted the boxed payload (segfault). Added `ExoticKind::Temporal` to the exotic-expando side table (same mechanism as Date/RegExp/Error): get/set/`defineProperty`/`getOwnPropertyDescriptor` + clear-on-alloc. Fixes the `calendar-temporal-object` fast-path cluster (15 crashes).

2. **Numeric field/option reads used bit-level `to_number()`** (returns NaN for objects & Symbols) instead of abstract `ToNumber`. Now routed through `js_number_coerce` (runs `valueOf`/`Symbol.toPrimitive`; Symbol & BigInt → TypeError; non-finite → RangeError). Fixes `*-infinity-throws-rangeerror`, `roundingincrement`/`fractionalSecondDigits` wrong-type, Duration-constructor Symbol/BigInt.

3. **Options & property-bag fields were read in the wrong order.** The spec reads options/fields **alphabetically** and **before** algorithmic validation. Rewrote the `round`/`total`/`until`/`since`/`toString` option readers and the date/time/zoned/`relativeTo` field readers to read alphabetically with correct per-field coercion (`monthCode`/`offset` via `ToPrimitiveAndRequireString`). Fixes the `order-of-operations` + `options-read-before-algorithmic-validation` clusters (~35).

4. **`relativeTo` / ZonedDateTime property bags ignored `calendar`/`timeZone`/`offset`** — now resolved & validated (invalid calendar/offset/timezone strings → RangeError, wrong-typed → TypeError).

5. **`ToPrimitive` on a Temporal value** (string concat / template interpolation) derefed the cell as an object → segfault. Added a Temporal brand arm (number hint → TypeError, string/default → canonical ISO string).

6. **Misc spec conformance:** ZonedDateTime coerce/calendar/`withCalendar` TypeErrors, optional `plainTime` TypeError, PlainDateTime constructor `ToIntegerWithTruncation` (Infinity → RangeError), positive month/day, strict constructor calendar **identifier** (ISO-string calendar → RangeError), `Duration.with` TypeError + alphabetical fields.

## Files

All under `crates/perry-runtime`: `temporal/{options,dispatch,duration,plain_date_time,zoned_date_time,mod}.rs`, `object/{exotic_expando,field_get_set,field_set_by_name,object_ops,descriptors,native_call_method}.rs`, `symbol.rs`, `value/{mod,to_string}.rs`.

## Deferred (architectural / temporal_rs-internal)

- Subclassing builtins (`subclassing-ignored`, 23) — needs derived-ctor return-override for exotic cells; Perry codegen can't yet give a subclass instance a builtin's internal slots.
- Constructor requires-`new` (3) — Temporal ctors use the namespace registration path without a separate call-thunk.
- `float64-representable-integer` toString precision (7) and `exact-multiple-of-larger-unit` rounding (4) — inside `temporal_rs` 0.2.3.

No version bump / CHANGELOG / CLAUDE.md edits (maintainer folds those in at merge).