### PR TITLE
fix(runtime): built-ins/Array callback-iteration methods test262 parity (v4)

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -99,6 +99,101 @@ unsafe fn array_sparse_index_property_set(arr: *mut ArrayHeader, index: u32, val
     }
 }
 
+/// Whether iterating `arr` with the raw dense-store loop would diverge from the
+/// spec `[[HasProperty]]`/`[[Get]]` protocol. True ("exotic") when the array has
+/// index accessors / custom-attr descriptors, lives in (partly) sparse storage,
+/// or the prototype chain carries indexed properties. When false the fast loop
+/// is byte-identical to the spec, so callers keep their hot path.
+#[inline]
+pub(crate) fn array_iteration_is_exotic(arr: *const ArrayHeader) -> bool {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return false;
+    }
+    if array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
+        return true;
+    }
+    if ARRAY_PROTO_HAS_INDEX.load(Ordering::Relaxed) {
+        return true;
+    }
+    // Live indices beyond the dense backing store are stored in the sparse
+    // named-property map, which the raw element loop never reads.
+    unsafe { (*arr).length > (*arr).capacity }
+}
+
+/// Spec `OrdinaryGetOwnProperty(O, ToString(index)) != undefined` for an Array:
+/// is `index` present as an *own* property (dense non-hole slot, sparse named
+/// data property, or an accessor descriptor)?
+unsafe fn array_has_own_index(arr: *const ArrayHeader, index: u32) -> bool {
+    if crate::object::descriptors_in_use() {
+        let key = index.to_string();
+        if crate::object::get_accessor_descriptor(arr as usize, &key).is_some() {
+            return true;
+        }
+    }
+    let key = index.to_string();
+    if array_named_property_get_by_name(arr, &key).is_some() {
+        return true;
+    }
+    if index < (*arr).length && index < (*arr).capacity {
+        let elements = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const u64;
+        if ptr::read(elements.add(index as usize)) != crate::value::TAG_HOLE {
+            return true;
+        }
+    }
+    false
+}
+
+/// Spec `[[HasProperty]]`(O, ToString(index)) for an ordinary Array receiver:
+/// own property OR inherited indexed property from `Array.prototype`.
+pub(crate) fn array_spec_has_index(arr: *const ArrayHeader, index: u32) -> bool {
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return false;
+    }
+    unsafe {
+        if array_has_own_index(arr, index) {
+            return true;
+        }
+        if ARRAY_PROTO_HAS_INDEX.load(Ordering::Relaxed) {
+            let proto = array_prototype_addr();
+            if proto != 0 && proto != arr as usize {
+                let proto_arr = proto as *const ArrayHeader;
+                if index < (*proto_arr).length && array_has_own_index(proto_arr, index) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+/// Spec `[[Get]]`(O, ToString(index)) for an ordinary Array receiver: own value
+/// (firing index accessors via `js_array_get_f64`) or, for an absent own index,
+/// the inherited `Array.prototype[index]`. Returns `undefined` when absent.
+pub(crate) fn array_spec_get(arr: *const ArrayHeader, index: u32) -> f64 {
+    const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
+    let arr = clean_arr_ptr(arr);
+    if arr.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    unsafe {
+        if array_has_own_index(arr, index) {
+            return js_array_get_f64(arr, index);
+        }
+        if ARRAY_PROTO_HAS_INDEX.load(Ordering::Relaxed) {
+            let proto = array_prototype_addr();
+            if proto != 0 && proto != arr as usize {
+                let proto_arr = proto as *const ArrayHeader;
+                if index < (*proto_arr).length && array_has_own_index(proto_arr, index) {
+                    return js_array_get_f64(proto_arr, index);
+                }
+            }
+        }
+        TAG_UNDEFINED_F64
+    }
+}
+
 fn array_get_property_by_key(arr: *const ArrayHeader, key: *const crate::StringHeader) -> f64 {
     let value =
         crate::object::js_object_get_field_by_name(arr as *const crate::object::ObjectHeader, key);

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -55,9 +55,18 @@ pub extern "C" fn js_array_forEach(arr: *const ArrayHeader, callback: *const Clo
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
-
         let arr_value = array_receiver_value(arr);
+        if crate::array::array_iteration_is_exotic(arr) {
+            for i in 0..length as usize {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    continue;
+                }
+                let element = crate::array::array_spec_get(arr, i as u32);
+                js_closure_call3(callback, element, i as f64, arr_value);
+            }
+            return;
+        }
+        let elements_ptr = array_elements_ptr(arr);
         for i in 0..length as usize {
             let Some(element) = present_array_element(elements_ptr, i) else {
                 continue;
@@ -111,9 +120,18 @@ pub extern "C" fn js_array_map(
             ptr::null_mut()
         };
 
+        let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in 0..length as usize {
-            let Some(element) = present_array_element(elements_ptr, i) else {
-                continue;
+            let element = if exotic {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    continue;
+                }
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                match present_array_element(elements_ptr, i) {
+                    Some(e) => e,
+                    None => continue,
+                }
             };
             // JS .map() callback receives (element, index, array).
             let mapped = js_closure_call3(callback, element, i as f64, arr_value);
@@ -146,9 +164,18 @@ pub extern "C" fn js_array_map_discard(arr: *const ArrayHeader, callback: *const
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
-
+        if crate::array::array_iteration_is_exotic(arr) {
+            for i in 0..length as usize {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    continue;
+                }
+                let element = crate::array::array_spec_get(arr, i as u32);
+                let _ = js_closure_call3(callback, element, i as f64, arr_value);
+            }
+            return;
+        }
+        let elements_ptr = array_elements_ptr(arr);
         for i in 0..length as usize {
             let Some(element) = present_array_element(elements_ptr, i) else {
                 continue;
@@ -189,9 +216,18 @@ pub extern "C" fn js_array_filter(
         // #854: `js_array_push_f64` already maintains `(*result).length`.
         let mut to = 0usize;
 
+        let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in 0..length as usize {
-            let Some(element) = present_array_element(elements_ptr, i) else {
-                continue;
+            let element = if exotic {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    continue;
+                }
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                match present_array_element(elements_ptr, i) {
+                    Some(e) => e,
+                    None => continue,
+                }
             };
             let keep = js_closure_call3(callback, element, i as f64, arr_value);
             // Proper truthy check: handles NaN-boxed booleans (TAG_FALSE != 0.0 but is falsy)
@@ -227,9 +263,14 @@ pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const Closur
         let length = (*arr).length;
         let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
+        let exotic = crate::array::array_iteration_is_exotic(arr);
 
         for i in 0..length as usize {
-            let element = array_element_get_value(elements_ptr, i);
+            let element = if exotic {
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                array_element_get_value(elements_ptr, i)
+            };
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             // Proper truthy check: handles NaN-boxed booleans
             if crate::value::js_is_truthy(result) != 0 {
@@ -263,9 +304,14 @@ pub extern "C" fn js_array_findIndex(
         let length = (*arr).length;
         let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
+        let exotic = crate::array::array_iteration_is_exotic(arr);
 
         for i in 0..length as usize {
-            let element = array_element_get_value(elements_ptr, i);
+            let element = if exotic {
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                array_element_get_value(elements_ptr, i)
+            };
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             // Proper truthy check: handles NaN-boxed booleans
             if crate::value::js_is_truthy(result) != 0 {
@@ -298,8 +344,13 @@ pub extern "C" fn js_array_find_last(
         let length = (*arr).length as usize;
         let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
+        let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in (0..length).rev() {
-            let element = array_element_get_value(elements_ptr, i);
+            let element = if exotic {
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                array_element_get_value(elements_ptr, i)
+            };
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             if crate::value::js_is_truthy(result) != 0 {
                 return element;
@@ -330,8 +381,13 @@ pub extern "C" fn js_array_find_last_index(
         let length = (*arr).length as usize;
         let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
+        let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in (0..length).rev() {
-            let element = array_element_get_value(elements_ptr, i);
+            let element = if exotic {
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                array_element_get_value(elements_ptr, i)
+            };
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             if crate::value::js_is_truthy(result) != 0 {
                 return i as i32;
@@ -407,10 +463,19 @@ pub extern "C" fn js_array_some(arr: *const ArrayHeader, callback: *const Closur
         let length = (*arr).length;
         let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
+        let exotic = crate::array::array_iteration_is_exotic(arr);
 
         for i in 0..length as usize {
-            let Some(element) = present_array_element(elements_ptr, i) else {
-                continue;
+            let element = if exotic {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    continue;
+                }
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                match present_array_element(elements_ptr, i) {
+                    Some(e) => e,
+                    None => continue,
+                }
             };
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             if crate::value::js_is_truthy(result) != 0 {
@@ -442,10 +507,19 @@ pub extern "C" fn js_array_every(arr: *const ArrayHeader, callback: *const Closu
         let length = (*arr).length;
         let elements_ptr = array_elements_ptr(arr);
         let arr_value = array_receiver_value(arr);
+        let exotic = crate::array::array_iteration_is_exotic(arr);
 
         for i in 0..length as usize {
-            let Some(element) = present_array_element(elements_ptr, i) else {
-                continue;
+            let element = if exotic {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    continue;
+                }
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                match present_array_element(elements_ptr, i) {
+                    Some(e) => e,
+                    None => continue,
+                }
             };
             let result = js_closure_call3(callback, element, i as f64, arr_value);
             if crate::value::js_is_truthy(result) == 0 {
@@ -549,12 +623,22 @@ pub extern "C" fn js_array_reduce(
             throw_reduce_of_empty();
         }
 
+        let exotic = crate::array::array_iteration_is_exotic(arr);
+        let present = |i: usize| -> Option<f64> {
+            if exotic {
+                crate::array::array_spec_has_index(arr, i as u32)
+                    .then(|| crate::array::array_spec_get(arr, i as u32))
+            } else {
+                present_array_element(elements_ptr, i)
+            }
+        };
+
         let (mut accumulator, start_idx) = if has_initial != 0 {
             (initial, 0)
         } else {
             let mut seed = None;
             for i in 0..length {
-                if let Some(element) = present_array_element(elements_ptr, i) {
+                if let Some(element) = present(i) {
                     seed = Some((element, i + 1));
                     break;
                 }
@@ -567,7 +651,7 @@ pub extern "C" fn js_array_reduce(
 
         let arr_value = array_receiver_value(arr);
         for i in start_idx..length {
-            let Some(element) = present_array_element(elements_ptr, i) else {
+            let Some(element) = present(i) else {
                 continue;
             };
             // Spec callback is `(accumulator, currentValue, currentIndex, array)`.

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -63,6 +63,7 @@ pub use self::immutable::{
     js_array_to_sorted_default, js_array_to_sorted_with_comparator, js_array_to_spliced,
     js_array_with,
 };
+pub(crate) use self::indexing::{array_iteration_is_exotic, array_spec_get, array_spec_has_index};
 pub use self::indexing::{
     js_array_get_element, js_array_get_element_f64, js_array_get_f64, js_array_get_f64_unchecked,
     js_array_get_index_or_string, js_array_get_length, js_array_length,

--- a/crates/perry-runtime/src/array/reduce_right.rs
+++ b/crates/perry-runtime/src/array/reduce_right.rs
@@ -51,12 +51,22 @@ pub extern "C" fn js_array_reduce_right(
             throw_reduce_of_empty();
         }
 
+        let exotic = crate::array::array_iteration_is_exotic(arr);
+        let present = |i: usize| -> Option<f64> {
+            if exotic {
+                crate::array::array_spec_has_index(arr, i as u32)
+                    .then(|| crate::array::array_spec_get(arr, i as u32))
+            } else {
+                present_array_element(elements_ptr, i)
+            }
+        };
+
         let (mut accumulator, start_idx) = if has_initial != 0 {
             (initial, length)
         } else {
             let mut seed = None;
             for i in (0..length).rev() {
-                if let Some(element) = present_array_element(elements_ptr, i) {
+                if let Some(element) = present(i) {
                     seed = Some((element, i));
                     break;
                 }
@@ -70,7 +80,7 @@ pub extern "C" fn js_array_reduce_right(
         let arr_value = f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits());
         if start_idx > 0 {
             for i in (0..start_idx).rev() {
-                let Some(element) = present_array_element(elements_ptr, i) else {
+                let Some(element) = present(i) else {
                     continue;
                 };
                 // Spec callback `(accumulator, currentValue, currentIndex, array)`.

--- a/crates/perry-runtime/src/array/search.rs
+++ b/crates/perry-runtime/src/array/search.rs
@@ -134,14 +134,29 @@ pub extern "C" fn js_array_indexOf_jsvalue(
     }
     unsafe {
         let length = (*arr).length as i64;
+        // ECMA-262 §23.1.3.13 step 3: `len == 0 → -1` is checked BEFORE
+        // ToIntegerOrInfinity(fromIndex), so a throwing/observable `fromIndex`
+        // coercion never runs on an empty array.
+        if length == 0 {
+            return -1;
+        }
         let start = match forward_start_index(length, from_index, has_from) {
             Some(s) => s,
             None => return -1,
         };
         let elements_ptr = array_elements_ptr(arr);
+        let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in start..length {
-            let Some(element) = present_array_element(elements_ptr, i as usize) else {
-                continue;
+            let element = if exotic {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    continue;
+                }
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                match present_array_element(elements_ptr, i as usize) {
+                    Some(e) => e,
+                    None => continue,
+                }
             };
             if crate::value::js_jsvalue_equals(element, value) == 1 {
                 return i as i32;
@@ -223,11 +238,23 @@ pub extern "C" fn js_array_last_index_of_jsvalue(
             }
         };
 
+        let exotic = crate::array::array_iteration_is_exotic(arr);
         let mut i = start;
         while i >= 0 {
-            let Some(element) = present_array_element(elements_ptr, i as usize) else {
-                i -= 1;
-                continue;
+            let element = if exotic {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    i -= 1;
+                    continue;
+                }
+                crate::array::array_spec_get(arr, i as u32)
+            } else {
+                match present_array_element(elements_ptr, i as usize) {
+                    Some(e) => e,
+                    None => {
+                        i -= 1;
+                        continue;
+                    }
+                }
             };
             if crate::value::js_jsvalue_equals(element, value) == 1 {
                 return i as i32;

--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -343,15 +343,32 @@ pub(crate) unsafe fn define_array_property(
             // Materialize BEFORE storing the accessor — the extend helper
             // dispatches accessor setters, so installing the accessor first
             // would turn this internal materialization into a setter call.
+            //
+            // Extending `length` past the dense capacity reallocates the array
+            // (header + inline elements are one allocation), leaving a
+            // forwarding pointer at the old address. The side tables
+            // (ACCESSOR_DESCRIPTORS / property attrs / OBJ_FLAG) are keyed by
+            // address, and every later read resolves through `clean_arr_ptr` to
+            // the NEW home — so they must be keyed to that canonical address,
+            // not the stale `obj`. Without this, a length-extending accessor
+            // (`Object.defineProperty(arr, "20", {get})` on a short array) was
+            // silently dropped: `arr[20]` / `indexOf` never fired the getter.
+            let mut side_addr = obj as usize;
             if !exists {
-                crate::array::js_array_set_f64_extend(
+                let new_arr = crate::array::js_array_set_f64_extend(
                     arr,
                     index,
                     f64::from_bits(crate::value::TAG_UNDEFINED),
                 );
+                let canonical = crate::array::clean_arr_ptr(new_arr);
+                if !canonical.is_null() && canonical as usize != side_addr {
+                    let gc = gc_header_for(canonical as *const ObjectHeader);
+                    (*gc)._reserved |= crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS;
+                    side_addr = canonical as usize;
+                }
             }
             set_accessor_descriptor(
-                obj as usize,
+                side_addr,
                 key_name.to_string(),
                 AccessorDescriptor {
                     get: get_bits,
@@ -364,7 +381,7 @@ pub(crate) unsafe fn define_array_property(
             // all-true attributes (so data→accessor keeps enumerable:true).
             let cur = if exists {
                 Some(
-                    super::get_property_attrs(obj as usize, key_name)
+                    super::get_property_attrs(side_addr, key_name)
                         .unwrap_or_else(|| PropertyAttrs::new(true, true, true)),
                 )
             } else {
@@ -375,7 +392,7 @@ pub(crate) unsafe fn define_array_property(
             let configurable = read_bool(b"configurable")
                 .unwrap_or_else(|| cur.map(|a| a.configurable()).unwrap_or(false));
             set_property_attrs(
-                obj as usize,
+                side_addr,
                 key_name.to_string(),
                 PropertyAttrs::new(false, enumerable, configurable),
             );


### PR DESCRIPTION
## Root cause

The higher-order `Array.prototype` methods — `map`/`filter`/`some`/`every`/`forEach`/`find`/`findIndex`/`findLast`/`findLastIndex`/`reduce`/`reduceRight` — plus `indexOf`/`lastIndexOf` iterated by reading the **dense backing store directly** (`present_array_element`), bypassing the ECMA-262 `[[HasProperty]]`/`[[Get]]` property protocol. This is the callback-iteration cluster that the array-v3 pass missed (it touched concat/reverse/push/pop). One shared cause produced ~5 visible buckets:

- **index getters** (`Object.defineProperty(arr, "0", {get})`) were skipped instead of fired (144 tests)
- **inherited indexed properties** (`Array.prototype[1] = 13`) were never consulted (21 tests)
- **getters mutating the array mid-iteration** (delete/shrink) diverged
- **sparse slots** beyond the dense store were invisible
- **`indexOf` `len == 0`** was checked *after* `ToIntegerOrInfinity(fromIndex)` instead of before

## Fix

Gate each method: keep the existing fast raw-store loop for **ordinary dense arrays** (byte-identical → zero perf/behavior change on the hot path), and fall to a generic spec loop when the array is **exotic** — index accessors/custom-attr descriptors (`OBJ_FLAG_ARRAY_DESCRIPTORS`), a polluted `Array.prototype` (indexed props), or sparse storage. Two new co-located helpers, `array_spec_has_index` / `array_spec_get`, implement `[[HasProperty]]`/`[[Get]]` with own (dense / sparse / accessor) + `Array.prototype` chain consultation, firing index getters via the existing `js_array_get_f64`.

Also fixes a **latent bug** surfaced by proto-consultation: a length-extending accessor define (`Object.defineProperty(arr, "20", {get})` on a short array) reallocates the array (header + inline elements are one allocation) and forwards it, but `define_array_property` keyed the accessor side-table to the **stale pre-grow address** — so `arr[20]` / `indexOf` never fired the getter. Re-key the side-table to the post-grow canonical address.

`indexOf`: return `-1` for an empty array before coercing `fromIndex` (spec step 3 ordering).

## Results (test262, 12 callback-iteration dirs)

| | before | after |
|---|---|---|
| fails | 280 | **105** |
| parity | 86.1% | **94.8%** |

**+175 fixed, zero regressions** (verified by failure-set diff). Array runtime unit tests 113/0. Adjacent Array dirs (includes/slice/flat/flatMap/fill/concat) unaffected.

Remaining 105 are separate root causes out of scope for this iteration: `sort` comparator/holes-to-end (26), `Array.prototype.M.call(exoticReceiver)` generic-object dispatch + Date/String `al_has` (36 protocall), and prototype-chain method resolution when an intermediate prototype is an Array instance (28 `every is not a function`).

## Files
- `array/indexing.rs` — `array_iteration_is_exotic`, `array_spec_has_index`, `array_spec_get`
- `array/iter_methods.rs`, `array/reduce_right.rs`, `array/search.rs` — exotic-gated loops
- `array/mod.rs` — re-exports
- `object/array_object_ops.rs` — accessor side-table re-key after grow