### PR TITLE
feat(ui-windows-winui): real Windows App SDK bootstrap probe (#4680 step 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+## v0.5.1154 — feat(ui-windows-winui): real Windows App SDK bootstrap probe (#4680 step 2)
+
+**WinUI 3 backend, step 2 of 6.** `--target windows-winui` already builds, links,
+and runs (the `perry-ui-windows-winui` crate re-exports the Win32 backend and
+shares its Fluent DWM chrome — Mica, rounded corners, theme-aware title bar). The
+one piece that was still a no-op lie was the Windows App SDK bootstrap:
+`winui::bootstrap::initialize()` unconditionally returned `Ready` whether or not
+the runtime existed. This turns it into a real runtime probe.
+
+`crates/perry-ui-windows-winui/src/winui.rs` now resolves the bootstrapper at
+**runtime via dynamic loading** — `LoadLibraryW("Microsoft.WindowsAppRuntime.Bootstrap.dll")`
++ `GetProcAddress` — and calls `MddBootstrapInitialize2` (falling back to
+`MddBootstrapInitialize` on older SDKs). `S_OK` → `InitStatus::Ready`; a missing
+DLL, missing entry points, or any failure HRESULT → `InitStatus::RuntimeMissing`,
+so the caller falls back to Win32 instead of crashing.
+
+Dynamic loading (not a link-time import of `Microsoft.WindowsAppRuntime.Bootstrap.lib`)
+is deliberate: it preserves Perry's single self-contained `.exe` model. A
+`windows-winui` binary starts on a host *without* the Windows App SDK and degrades
+to the Win32 path, rather than failing to load against an unresolved import. No new
+cargo dependency is added — the bootstrapper is bound with raw `extern "system"`
+declarations against `kernel32`, mirroring the existing `dwm.rs`/`crash_handler`
+FFI style.
+
+Details:
+- Result is memoized in an `AtomicU8` (the runtime is process-wide and initialized
+  at most once); repeated `initialize()` calls are cheap and stable.
+- Target SDK release defaults to 1.6, overridable at runtime with
+  `PERRY_WINAPPSDK_VERSION="major.minor"` so a host with a different SDK can be
+  targeted without a rebuild.
+- `PACKAGE_VERSION` is passed as a by-value `u64` (ABI-identical to the single-`UINT64`
+  union on x64); `versionTag` empty (stable channel); `minVersion` 0 (any installed
+  framework at/above the requested major.minor).
+- Off Windows the probe is a compile-time `RuntimeMissing` (the crate still builds
+  everywhere for host tooling).
+- Tests: `initialize()` is total (never panics) and idempotent on any host; off
+  Windows it must report `RuntimeMissing`. The `RuntimeMissing` path is fully
+  covered on a host without the SDK; the success path runs only where the runtime
+  is installed.
+
+Step 3 (the XAML widget mapping) consults this probe before constructing any
+`Microsoft.UI.Xaml` object; that work is still ahead. Win32 (`--target windows`)
+remains the default and is unaffected.
+
 ## v0.5.1153 — fix: keep `js_promise_report_unhandled_rejections` alive through auto-optimize LTO (#4876)
 
 **Regression fix (v0.5.1151 → all native links broken).** Codegen emits an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1153
+**Current Version:** 0.5.1154
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5289,7 +5289,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "base64",
@@ -5344,14 +5344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "cc",
  "libc",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "log",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "base64",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5460,14 +5460,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "serde",
  "serde_json",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1153"
+version = "0.5.1154"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "clap",
@@ -5501,14 +5501,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "bytes",
  "h2",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "bson",
  "futures-util",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "image",
@@ -5801,14 +5801,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "brotli",
  "flate2",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "base64",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6033,14 +6033,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "itoa",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "block2",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "block2",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1153"
+version = "0.5.1154"
 
 [[package]]
 name = "perry-ui-test"
@@ -6129,11 +6129,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1153"
+version = "0.5.1154"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "block2",
@@ -6165,7 +6165,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "block2",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "libc",
@@ -6195,14 +6195,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1153"
+version = "0.5.1154"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1153"
+version = "0.5.1154"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ui-windows-winui/Cargo.toml
+++ b/crates/perry-ui-windows-winui/Cargo.toml
@@ -22,15 +22,18 @@ crate-type = ["rlib", "staticlib"]
 # The entire current Windows backend. Re-exported wholesale (see src/lib.rs).
 perry-ui-windows = { path = "../perry-ui-windows" }
 
-# Future (XAML widget mapping, #4680 steps 1-6): driving WinAppSDK +
-# Microsoft.UI.Xaml through the windows-rs WinRT projections. Intentionally
-# NOT added yet — the WinAppSDK runtime + bootstrapper
-# (Microsoft.WindowsAppRuntime.Bootstrap) is acquired out-of-band (NuGet /
-# redistributable), not as a cargo dependency, so wiring it is its own step.
-# When that lands, add:
+# Step 2 (#4680) — Windows App SDK bootstrap — is implemented in
+# `src/winui.rs` via *runtime* dynamic loading (LoadLibraryW + GetProcAddress
+# on Microsoft.WindowsAppRuntime.Bootstrap.dll), NOT a link dependency. That
+# deliberately keeps the single self-contained .exe model: a windows-winui
+# binary starts fine on a host without the SDK and falls back to Win32 instead
+# of failing to load. So no bootstrap .lib / cargo crate is needed for it.
+#
+# Future (XAML widget mapping, #4680 step 3+): driving Microsoft.UI.Xaml
+# controls through the windows-rs WinRT projections. When that lands, add:
 #   windows = { version = "0.58", features = [
 #       "UI_Xaml", "UI_Xaml_Controls", "UI_Xaml_Hosting", ... ] }
-# and the bootstrap link to Microsoft.WindowsAppRuntime.Bootstrap.lib.
+# gated so it is constructed only after bootstrap::initialize() reports Ready.
 
 [features]
 geisterhand = ["perry-ui-windows/geisterhand"]

--- a/crates/perry-ui-windows-winui/src/lib.rs
+++ b/crates/perry-ui-windows-winui/src/lib.rs
@@ -30,7 +30,10 @@
 //! projections, until the whole ~40-widget set is Fluent. Steps, in order:
 //!
 //! 1. WinAppSDK + `Microsoft.UI.Xaml` projections wired in (`Cargo.toml`).
-//! 2. Bootstrapper / runtime acquisition ([`winui::bootstrap`]).
+//! 2. Bootstrapper / runtime acquisition ([`winui::bootstrap`]) — **done**:
+//!    [`winui::bootstrap::initialize`] dynamically loads the Windows App SDK
+//!    bootstrapper and reports whether the WinUI path is usable, falling back
+//!    to Win32 (this re-export) when the runtime is absent.
 //! 3. Widget mapping layer (perry-ui widget set → XAML controls).
 //! 4. Window chrome: Mica/Acrylic backdrop, Fluent title bar, light/dark/system.
 //! 5. Packaging: MSIX or unpackaged WinAppSDK bootstrap; document the runtime.

--- a/crates/perry-ui-windows-winui/src/winui.rs
+++ b/crates/perry-ui-windows-winui/src/winui.rs
@@ -9,33 +9,193 @@
 /// Windows App SDK bootstrap (#4680 step 2).
 ///
 /// A WinUI 3 / unpackaged app must initialize the Windows App SDK runtime
-/// before any `Microsoft.UI.Xaml` type is constructed — normally via the
-/// bootstrapper API (`MddBootstrapInitialize2` from
-/// `Microsoft.WindowsAppRuntime.Bootstrap`, acquired as a redistributable, not
-/// a cargo crate).
+/// before any `Microsoft.UI.Xaml` type is constructed. The runtime ships the
+/// bootstrapper entry points (`MddBootstrapInitialize2` /
+/// `MddBootstrapInitialize`) in `Microsoft.WindowsAppRuntime.Bootstrap.dll`.
 ///
-/// This is a **stub**: it links nothing and is a no-op, so the scaffold builds
-/// and runs anywhere (the Win32 re-export path needs no runtime). When the
-/// XAML mapping lands, this becomes the real `MddBootstrapInitialize2` call,
-/// gated behind the WinAppSDK link dependency, and is invoked from app startup
-/// before the first XAML object is created.
+/// # Why dynamic loading (not a link dependency)
+///
+/// Perry's defining constraint is the single self-contained `.exe`. Linking
+/// `Microsoft.WindowsAppRuntime.Bootstrap.lib` would make *every*
+/// `windows-winui` binary hard-require the Windows App SDK at load time — the
+/// process would fail to start on a machine that doesn't have it, even though
+/// the scaffold can fall back to the Win32 backend and run fine. So instead of
+/// a link-time import we resolve the bootstrapper at runtime with
+/// `LoadLibraryW` + `GetProcAddress`. If the DLL isn't present (no Windows App
+/// SDK installed), [`initialize`] reports [`InitStatus::RuntimeMissing`] and
+/// the caller falls back to Win32 rather than crashing. This keeps the binary
+/// dependency-free; the SDK is consumed only when the host actually has it.
+///
+/// The result is cached after the first call: the runtime is process-wide and
+/// initialized at most once, so repeated [`initialize`] calls are cheap and
+/// return a stable answer.
 pub mod bootstrap {
+    use std::sync::atomic::{AtomicU8, Ordering};
+
     /// Outcome of attempting to initialize the Windows App SDK runtime.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum InitStatus {
-        /// Runtime is ready (or not yet required — current scaffold state).
+        /// The Windows App SDK runtime is present and initialized — the WinUI
+        /// (XAML) rendering path is usable.
         Ready,
-        /// The Windows App SDK runtime is not installed; the caller should
-        /// fall back to the Win32 backend rather than crash.
+        /// The Windows App SDK runtime is not installed (or failed to
+        /// initialize); the caller should fall back to the Win32 backend
+        /// rather than crash.
         RuntimeMissing,
     }
 
-    /// Initialize the Windows App SDK runtime. Currently a no-op returning
-    /// [`InitStatus::Ready`] because the scaffold renders through Win32 and
-    /// needs no WinAppSDK runtime. Replaced by the real bootstrapper call in
-    /// #4680 step 2.
+    // Cached outcome of the one-time initialize() probe. The runtime is
+    // process-wide, so we resolve + bootstrap it at most once and memoize the
+    // verdict. 0 = not yet attempted, 1 = Ready, 2 = RuntimeMissing.
+    const CACHE_UNINIT: u8 = 0;
+    const CACHE_READY: u8 = 1;
+    const CACHE_MISSING: u8 = 2;
+    static CACHED: AtomicU8 = AtomicU8::new(CACHE_UNINIT);
+
+    /// Initialize the Windows App SDK runtime, returning whether the WinUI
+    /// (XAML) path is usable. On Windows this dynamically loads the
+    /// bootstrapper and calls `MddBootstrapInitialize2` (falling back to
+    /// `MddBootstrapInitialize`); if the runtime is absent or initialization
+    /// fails it returns [`InitStatus::RuntimeMissing`] so the caller can fall
+    /// back to Win32. Off Windows it is always [`InitStatus::RuntimeMissing`].
+    ///
+    /// The result is cached: subsequent calls return the first verdict without
+    /// re-loading the DLL. This is the #4680 step-2 deliverable; the XAML
+    /// widget mapping (step 3) consults this before constructing any
+    /// `Microsoft.UI.Xaml` object.
     pub fn initialize() -> InitStatus {
-        InitStatus::Ready
+        match CACHED.load(Ordering::Acquire) {
+            CACHE_READY => return InitStatus::Ready,
+            CACHE_MISSING => return InitStatus::RuntimeMissing,
+            _ => {}
+        }
+        let status = init_uncached();
+        CACHED.store(
+            match status {
+                InitStatus::Ready => CACHE_READY,
+                InitStatus::RuntimeMissing => CACHE_MISSING,
+            },
+            Ordering::Release,
+        );
+        status
+    }
+
+    #[cfg(target_os = "windows")]
+    fn init_uncached() -> InitStatus {
+        windows_impl::bootstrap_initialize()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn init_uncached() -> InitStatus {
+        // There is no Windows App SDK off Windows. The crate still compiles for
+        // host tooling (the workspace builds it on every platform); callers get
+        // RuntimeMissing and fall back to the Win32 path.
+        InitStatus::RuntimeMissing
+    }
+
+    #[cfg(target_os = "windows")]
+    mod windows_impl {
+        use super::InitStatus;
+
+        type HModule = *mut core::ffi::c_void;
+        type FarProc = *const core::ffi::c_void;
+
+        extern "system" {
+            fn LoadLibraryW(name: *const u16) -> HModule;
+            fn GetProcAddress(module: HModule, name: *const u8) -> FarProc;
+            fn FreeLibrary(module: HModule) -> i32;
+        }
+
+        // Bootstrapper entry points (`MddBootstrap.h`). `PACKAGE_VERSION` is a
+        // union over a single `UINT64`, so on x64 it is ABI-identical to a
+        // by-value `u64`; `versionTag` is a `PCWSTR`; `options` is an `enum`
+        // (`int`). The `2`-suffixed variant (Windows App SDK 1.2+) takes the
+        // extra `options` argument; the original is the fallback for older
+        // bootstrappers.
+        type PfnInitialize2 = unsafe extern "system" fn(u32, *const u16, u64, i32) -> i32;
+        type PfnInitialize = unsafe extern "system" fn(u32, *const u16, u64) -> i32;
+
+        /// `MddBootstrapInitializeOptions_None`.
+        const MDD_BOOTSTRAP_OPTIONS_NONE: i32 = 0;
+
+        /// Packed `major << 16 | minor` Windows App SDK release the binary was
+        /// built against. Defaults to 1.6 (the current servicing baseline) and
+        /// is overridable at runtime with `PERRY_WINAPPSDK_VERSION="major.minor"`
+        /// so a host with a different SDK can be targeted without a rebuild.
+        fn target_major_minor() -> u32 {
+            const DEFAULT_MAJOR: u32 = 1;
+            const DEFAULT_MINOR: u32 = 6;
+            if let Ok(raw) = std::env::var("PERRY_WINAPPSDK_VERSION") {
+                if let Some((maj, min)) = raw.split_once('.') {
+                    if let (Ok(maj), Ok(min)) =
+                        (maj.trim().parse::<u16>(), min.trim().parse::<u16>())
+                    {
+                        return ((maj as u32) << 16) | (min as u32);
+                    }
+                }
+            }
+            (DEFAULT_MAJOR << 16) | DEFAULT_MINOR
+        }
+
+        fn wide_nul(s: &str) -> Vec<u16> {
+            s.encode_utf16().chain(std::iter::once(0)).collect()
+        }
+
+        pub fn bootstrap_initialize() -> InitStatus {
+            let dll = wide_nul("Microsoft.WindowsAppRuntime.Bootstrap.dll");
+            // SAFETY: `dll` is a NUL-terminated UTF-16 buffer that outlives the
+            // call. A missing DLL returns NULL (no Windows App SDK) — we never
+            // dereference the handle in that case.
+            let module = unsafe { LoadLibraryW(dll.as_ptr()) };
+            if module.is_null() {
+                return InitStatus::RuntimeMissing;
+            }
+
+            let major_minor = target_major_minor();
+            // Stable release channel uses an empty version tag; minimum package
+            // version 0 accepts any installed framework at/above major_minor.
+            let version_tag = wide_nul("");
+            let min_version: u64 = 0;
+
+            // SAFETY: the function pointers come from this freshly-loaded module
+            // and are transmuted to the documented `MddBootstrap.h` signatures.
+            // Both pointer arguments outlive the synchronous call. If neither
+            // entry point resolves the DLL is not a usable bootstrapper, so we
+            // free it and report the runtime missing.
+            let hr = unsafe {
+                let init2 = GetProcAddress(module, b"MddBootstrapInitialize2\0".as_ptr());
+                if !init2.is_null() {
+                    let f: PfnInitialize2 = core::mem::transmute(init2);
+                    f(
+                        major_minor,
+                        version_tag.as_ptr(),
+                        min_version,
+                        MDD_BOOTSTRAP_OPTIONS_NONE,
+                    )
+                } else {
+                    let init1 = GetProcAddress(module, b"MddBootstrapInitialize\0".as_ptr());
+                    if init1.is_null() {
+                        FreeLibrary(module);
+                        return InitStatus::RuntimeMissing;
+                    }
+                    let f: PfnInitialize = core::mem::transmute(init1);
+                    f(major_minor, version_tag.as_ptr(), min_version)
+                }
+            };
+
+            if hr == 0 {
+                // Success: the runtime must stay mapped for the process
+                // lifetime, so we deliberately do NOT FreeLibrary here.
+                InitStatus::Ready
+            } else {
+                // S_OK is the only success; any failure HRESULT (e.g. the
+                // framework not being present at the requested version) means
+                // we fall back to Win32. Release the handle we won't use.
+                // SAFETY: `module` is the handle we just loaded.
+                unsafe { FreeLibrary(module) };
+                InitStatus::RuntimeMissing
+            }
+        }
     }
 }
 
@@ -44,9 +204,27 @@ mod tests {
     use super::bootstrap::{initialize, InitStatus};
 
     #[test]
-    fn bootstrap_scaffold_is_ready() {
-        // The scaffold must never report a missing runtime — it renders via
-        // the re-exported Win32 backend, which has no WinAppSDK dependency.
-        assert_eq!(initialize(), InitStatus::Ready);
+    fn initialize_is_total_and_idempotent() {
+        // initialize() must never panic and must return a stable, cached
+        // verdict regardless of whether the Windows App SDK is installed on the
+        // test host. (On CI without the SDK, that verdict is RuntimeMissing.)
+        let first = initialize();
+        let second = initialize();
+        assert_eq!(
+            first, second,
+            "cached bootstrap verdict must be stable across calls"
+        );
+        assert!(matches!(
+            first,
+            InitStatus::Ready | InitStatus::RuntimeMissing
+        ));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn missing_off_windows() {
+        // There is no Windows App SDK off Windows, so the verdict is always
+        // RuntimeMissing — the caller falls back to Win32.
+        assert_eq!(initialize(), InitStatus::RuntimeMissing);
     }
 }


### PR DESCRIPTION
## What

Implements **step 2 of #4680** (opt-in WinUI 3 / Fluent Windows target): a real **Windows App SDK bootstrap probe**.

`--target windows-winui` already builds, links, and runs today — the `perry-ui-windows-winui` crate re-exports the Win32 backend and shares its Fluent DWM chrome (Mica, rounded corners, theme-aware title bar). The one piece still stubbed was the Windows App SDK bootstrap: `winui::bootstrap::initialize()` unconditionally returned `Ready` whether or not the runtime existed. This turns it into an honest runtime probe — the gate every future XAML control (step 3) checks before constructing a `Microsoft.UI.Xaml` object.

## How

`crates/perry-ui-windows-winui/src/winui.rs` now resolves the bootstrapper at **runtime via dynamic loading**:

- `LoadLibraryW("Microsoft.WindowsAppRuntime.Bootstrap.dll")` + `GetProcAddress`
- calls `MddBootstrapInitialize2` (falls back to `MddBootstrapInitialize` on older SDKs)
- `S_OK` → `InitStatus::Ready`; missing DLL / missing entry points / failure HRESULT → `InitStatus::RuntimeMissing`, so the caller falls back to Win32 instead of crashing.

**Why dynamic loading, not a link dependency:** importing `Microsoft.WindowsAppRuntime.Bootstrap.lib` would make every `windows-winui` binary hard-require the SDK at load time and fail to start without it. Dynamic loading preserves Perry's single self-contained `.exe` model — the binary runs on a host *without* the SDK and degrades to Win32. No new cargo dependency is added; the entry points are bound with raw `extern "system"` against `kernel32`, mirroring the existing `dwm.rs` / `crash_handler` FFI style.

Other details:
- Result memoized in an `AtomicU8` (runtime is process-wide, initialized at most once).
- Target SDK release defaults to 1.6, overridable at runtime via `PERRY_WINAPPSDK_VERSION="major.minor"`.
- `PACKAGE_VERSION` passed by value as `u64` (ABI-identical to the single-`UINT64` union on x64); empty `versionTag` (stable channel); `minVersion` 0.
- Off Windows the probe is a compile-time `RuntimeMissing` (the crate still builds everywhere for host tooling).

## Testing

- `cargo test -p perry-ui-windows-winui` → green. `initialize()` is total (never panics) and idempotent on any host; off Windows it must report `RuntimeMissing`.
- **`RuntimeMissing` path verified on this Windows host** (no Windows App SDK installed → `LoadLibraryW` returns null). The `Ready` path runs only where the runtime is installed, so it is exercised on SDK-equipped hosts rather than CI.

## Scope / not in this PR

Win32 (`--target windows`) remains the default and is untouched. Step 3 (the actual XAML widget mapping that consults this probe) is still ahead — this PR lands the foundational gate it needs.
