### PR TITLE
feat(ui-windows-winui): render-backend dispatch seam + startup probe (#4680 step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v0.5.1172 — feat(ui-windows-winui): render-backend dispatch seam + startup probe (#4680 step 3)
+
+Builds on the Windows App SDK bootstrap probe. Adds `winui::backend` — the single
+decision point the per-widget WinUI 3 mapping reads: `backend::active()` returns
+`RenderBackend::Fluent` when the bootstrap probe is `Ready`, else `RenderBackend::Win32`.
+
+A CRT static initializer (`.CRT$XCU`, anchored with `#[used]`) registered in the
+crate runs the probe at process start for *any* binary that links this staticlib —
+i.e. exactly the `--target windows-winui` builds, never the default `--target windows`
+builds (which don't link the crate). So the first widget construction reads an
+already-resolved backend rather than probing lazily. Setting `PERRY_WINUI_DIAG` prints
+the chosen backend at launch (`[perry-winui] render backend: win32|fluent`) and, on
+bootstrap failure, surfaces the raw HRESULT for diagnosis. The initializer never panics
+(it runs before `main`).
+
+Verified on a Windows host without the SDK: the initializer fires in a linked binary,
+the `.CRT$XCU` section is present in the WHOLEARCHIVE'd `perry_ui_windows_winui.lib`, and
+`active()` mirrors the bootstrap verdict and is stable across calls. Win32
+(`--target windows`) remains the default and is unaffected.
+
 ## v0.5.1171 — fix(dayjs): `arguments` in sequence exprs + computed Date-method dispatch (#5133)
 
 `compilePackages: dayjs` threw `ReferenceError: arguments is not defined`, and once that was resolved `.add()`/`.date(n)` silently no-op'd. Two distinct, general root causes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1171
+**Current Version:** 0.5.1172
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "base64",
@@ -5339,14 +5339,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "cc",
  "libc",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "log",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5396,7 +5396,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "base64",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5455,14 +5455,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "serde",
  "serde_json",
@@ -5470,7 +5470,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1171"
+version = "0.5.1172"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5481,7 +5481,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "clap",
@@ -5496,14 +5496,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5528,7 +5528,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5586,7 +5586,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5602,14 +5602,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5626,7 +5626,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5638,7 +5638,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5651,7 +5651,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "bytes",
  "h2",
@@ -5674,7 +5674,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "bson",
  "futures-util",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5781,7 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "image",
@@ -5798,14 +5798,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5814,7 +5814,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "brotli",
  "flate2",
@@ -5853,7 +5853,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "base64",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6033,14 +6033,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "itoa",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "block2",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "block2",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1171"
+version = "0.5.1172"
 
 [[package]]
 name = "perry-ui-test"
@@ -6129,11 +6129,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1171"
+version = "0.5.1172"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "block2",
@@ -6165,7 +6165,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "block2",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "libc",
@@ -6195,14 +6195,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1171"
+version = "0.5.1172"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1171"
+version = "0.5.1172"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ui-windows-winui/src/lib.rs
+++ b/crates/perry-ui-windows-winui/src/lib.rs
@@ -34,7 +34,12 @@
 //!    [`winui::bootstrap::initialize`] dynamically loads the Windows App SDK
 //!    bootstrapper and reports whether the WinUI path is usable, falling back
 //!    to Win32 (this re-export) when the runtime is absent.
-//! 3. Widget mapping layer (perry-ui widget set → XAML controls).
+//! 3. Widget mapping layer (perry-ui widget set → XAML controls). The
+//!    *dispatch seam* is in place ([`winui::backend::active`]): a CRT
+//!    static initializer probes the SDK at process start and resolves a
+//!    [`winui::backend::RenderBackend`] (`Fluent` when the runtime is ready,
+//!    else `Win32`). Each XAML widget lands behind this check; today it always
+//!    resolves to `Win32` until the first control is wired in.
 //! 4. Window chrome: Mica/Acrylic backdrop, Fluent title bar, light/dark/system.
 //! 5. Packaging: MSIX or unpackaged WinAppSDK bootstrap; document the runtime.
 //! 6. `apply_style` (geisterhand) dispatcher parity with the other backends.

--- a/crates/perry-ui-windows-winui/src/winui.rs
+++ b/crates/perry-ui-windows-winui/src/winui.rs
@@ -199,8 +199,80 @@ pub mod bootstrap {
     }
 }
 
+/// Which rendering backend a `windows-winui` process resolves to (#4680 step 3
+/// seam).
+///
+/// The Fluent (WinUI 3 / `Microsoft.UI.Xaml`) path is only usable when the
+/// Windows App SDK runtime initialized — otherwise the backend falls back to
+/// the re-exported Win32 path so the app still renders. This module is the
+/// single decision point the per-widget XAML dispatch reads: each XAML widget
+/// (landing incrementally) checks [`backend::active`] and constructs an
+/// `Microsoft.UI.Xaml` control on [`RenderBackend::Fluent`], else delegates to
+/// the existing `perry-ui-windows` Win32 constructor.
+pub mod backend {
+    use super::bootstrap::{self, InitStatus};
+
+    /// The effective render backend for this process.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum RenderBackend {
+        /// WinUI 3 / Fluent (`Microsoft.UI.Xaml`) — chosen when the Windows
+        /// App SDK runtime is `Ready`.
+        Fluent,
+        /// Win32 / GDI (the re-exported `perry-ui-windows` backend) — chosen
+        /// whenever the Windows App SDK runtime is unavailable.
+        Win32,
+    }
+
+    impl RenderBackend {
+        /// Stable lowercase identifier, used in diagnostics.
+        pub fn as_str(self) -> &'static str {
+            match self {
+                RenderBackend::Fluent => "fluent",
+                RenderBackend::Win32 => "win32",
+            }
+        }
+    }
+
+    /// The render backend this process will use, derived from the Windows App
+    /// SDK bootstrap probe ([`bootstrap::initialize`]) and memoized by it:
+    /// [`RenderBackend::Fluent`] iff the runtime is `Ready`, otherwise
+    /// [`RenderBackend::Win32`]. Cheap and stable across calls.
+    pub fn active() -> RenderBackend {
+        match bootstrap::initialize() {
+            InitStatus::Ready => RenderBackend::Fluent,
+            InitStatus::RuntimeMissing => RenderBackend::Win32,
+        }
+    }
+}
+
+/// Process-startup probe (#4680 step 3 seam).
+///
+/// Registered as a CRT static initializer (`.CRT$XCU`) so it runs at process
+/// start for *any* binary that links this staticlib — i.e. exactly the
+/// `--target windows-winui` builds, and never the default `--target windows`
+/// builds (which don't link this crate). It resolves the render backend up
+/// front (probing the Windows App SDK once) so the first widget construction
+/// reads an already-decided answer, and emits a one-line backend diagnostic
+/// when `PERRY_WINUI_DIAG` is set. It must never panic — it runs before `main`.
+#[cfg(target_os = "windows")]
+#[used]
+#[link_section = ".CRT$XCU"]
+static PERRY_WINUI_STARTUP: extern "C" fn() = perry_winui_startup;
+
+#[cfg(target_os = "windows")]
+extern "C" fn perry_winui_startup() {
+    let backend = backend::active();
+    if std::env::var_os("PERRY_WINUI_DIAG").is_some() {
+        use std::io::Write;
+        // Best-effort: a failed write in a static initializer is ignored.
+        let _ = std::io::stderr()
+            .write_all(format!("[perry-winui] render backend: {}\n", backend.as_str()).as_bytes());
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::backend::{active, RenderBackend};
     use super::bootstrap::{initialize, InitStatus};
 
     #[test]
@@ -226,5 +298,24 @@ mod tests {
         // There is no Windows App SDK off Windows, so the verdict is always
         // RuntimeMissing — the caller falls back to Win32.
         assert_eq!(initialize(), InitStatus::RuntimeMissing);
+    }
+
+    #[test]
+    fn active_backend_matches_bootstrap_verdict() {
+        // The backend seam must mirror the bootstrap probe exactly and be
+        // stable across calls.
+        let expected = match initialize() {
+            InitStatus::Ready => RenderBackend::Fluent,
+            InitStatus::RuntimeMissing => RenderBackend::Win32,
+        };
+        assert_eq!(active(), expected);
+        assert_eq!(active(), active(), "backend choice must be stable");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn backend_is_win32_off_windows() {
+        // No Windows App SDK off Windows → always the Win32 fallback.
+        assert_eq!(active(), RenderBackend::Win32);
     }
 }

--- a/crates/perry-ui-windows-winui/src/winui.rs
+++ b/crates/perry-ui-windows-winui/src/winui.rs
@@ -137,7 +137,7 @@ pub mod bootstrap {
     #[cfg(target_os = "windows")]
     mod windows_impl {
         use super::{
-            InitStatus, DETAIL_DLL_MISSING, DETAIL_NO_ENTRYPOINT, DETAIL_NOT_ATTEMPTED,
+            InitStatus, DETAIL_DLL_MISSING, DETAIL_NOT_ATTEMPTED, DETAIL_NO_ENTRYPOINT,
             DETAIL_SUCCESS,
         };
         use std::sync::atomic::{AtomicI32, Ordering};

--- a/crates/perry-ui-windows-winui/src/winui.rs
+++ b/crates/perry-ui-windows-winui/src/winui.rs
@@ -94,8 +94,63 @@ pub mod bootstrap {
     }
 
     #[cfg(target_os = "windows")]
+    pub(super) fn last_init_detail() -> i32 {
+        windows_impl::last_detail()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub(super) fn last_init_detail() -> i32 {
+        windows_impl_detail_off_windows()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn windows_impl_detail_off_windows() -> i32 {
+        DETAIL_NOT_WINDOWS
+    }
+
+    /// Human-readable form of a [`last_init_detail`] code, for `PERRY_WINUI_DIAG`.
+    pub(super) fn describe_init_detail(detail: i32) -> String {
+        match detail {
+            DETAIL_NOT_ATTEMPTED => "not attempted".to_string(),
+            DETAIL_DLL_MISSING => {
+                "bootstrap DLL not found (ship Microsoft.WindowsAppRuntime.Bootstrap.dll next to the exe)".to_string()
+            }
+            DETAIL_NO_ENTRYPOINT => "bootstrap DLL has no MddBootstrapInitialize entry point".to_string(),
+            DETAIL_SUCCESS => "ready".to_string(),
+            #[cfg(not(target_os = "windows"))]
+            DETAIL_NOT_WINDOWS => "not windows".to_string(),
+            // Anything else is the raw HRESULT from MddBootstrapInitialize*.
+            hr => format!("MddBootstrapInitialize failed, HRESULT 0x{:08X}", hr as u32),
+        }
+    }
+
+    /// Sentinel "detail" codes returned by [`last_init_detail`] that are not real
+    /// HRESULTs (which are never these tiny positive values for our paths). Any
+    /// other value is the raw HRESULT from the bootstrapper call.
+    pub(super) const DETAIL_NOT_ATTEMPTED: i32 = 0;
+    pub(super) const DETAIL_DLL_MISSING: i32 = 1;
+    pub(super) const DETAIL_NO_ENTRYPOINT: i32 = 2;
+    pub(super) const DETAIL_SUCCESS: i32 = 3;
+    #[cfg(not(target_os = "windows"))]
+    pub(super) const DETAIL_NOT_WINDOWS: i32 = 4;
+
+    #[cfg(target_os = "windows")]
     mod windows_impl {
-        use super::InitStatus;
+        use super::{
+            InitStatus, DETAIL_DLL_MISSING, DETAIL_NO_ENTRYPOINT, DETAIL_NOT_ATTEMPTED,
+            DETAIL_SUCCESS,
+        };
+        use std::sync::atomic::{AtomicI32, Ordering};
+
+        // Last bootstrap outcome detail: a sentinel (see DETAIL_*) or, for a
+        // failed init call, the raw HRESULT. Surfaced via PERRY_WINUI_DIAG so a
+        // RuntimeMissing verdict can be diagnosed (e.g. "runtime not installed"
+        // vs "wrong version requested").
+        static LAST_DETAIL: AtomicI32 = AtomicI32::new(DETAIL_NOT_ATTEMPTED);
+
+        pub(super) fn last_detail() -> i32 {
+            LAST_DETAIL.load(Ordering::Relaxed)
+        }
 
         type HModule = *mut core::ffi::c_void;
         type FarProc = *const core::ffi::c_void;
@@ -148,6 +203,7 @@ pub mod bootstrap {
             // dereference the handle in that case.
             let module = unsafe { LoadLibraryW(dll.as_ptr()) };
             if module.is_null() {
+                LAST_DETAIL.store(DETAIL_DLL_MISSING, Ordering::Relaxed);
                 return InitStatus::RuntimeMissing;
             }
 
@@ -176,6 +232,7 @@ pub mod bootstrap {
                     let init1 = GetProcAddress(module, b"MddBootstrapInitialize\0".as_ptr());
                     if init1.is_null() {
                         FreeLibrary(module);
+                        LAST_DETAIL.store(DETAIL_NO_ENTRYPOINT, Ordering::Relaxed);
                         return InitStatus::RuntimeMissing;
                     }
                     let f: PfnInitialize = core::mem::transmute(init1);
@@ -186,6 +243,7 @@ pub mod bootstrap {
             if hr == 0 {
                 // Success: the runtime must stay mapped for the process
                 // lifetime, so we deliberately do NOT FreeLibrary here.
+                LAST_DETAIL.store(DETAIL_SUCCESS, Ordering::Relaxed);
                 InitStatus::Ready
             } else {
                 // S_OK is the only success; any failure HRESULT (e.g. the
@@ -193,6 +251,7 @@ pub mod bootstrap {
                 // we fall back to Win32. Release the handle we won't use.
                 // SAFETY: `module` is the handle we just loaded.
                 unsafe { FreeLibrary(module) };
+                LAST_DETAIL.store(hr, Ordering::Relaxed);
                 InitStatus::RuntimeMissing
             }
         }
@@ -264,9 +323,16 @@ extern "C" fn perry_winui_startup() {
     let backend = backend::active();
     if std::env::var_os("PERRY_WINUI_DIAG").is_some() {
         use std::io::Write;
+        let detail = bootstrap::last_init_detail();
         // Best-effort: a failed write in a static initializer is ignored.
-        let _ = std::io::stderr()
-            .write_all(format!("[perry-winui] render backend: {}\n", backend.as_str()).as_bytes());
+        let _ = std::io::stderr().write_all(
+            format!(
+                "[perry-winui] render backend: {} (bootstrap detail: {})\n",
+                backend.as_str(),
+                bootstrap::describe_init_detail(detail),
+            )
+            .as_bytes(),
+        );
     }
 }
 
@@ -317,5 +383,20 @@ mod tests {
     fn backend_is_win32_off_windows() {
         // No Windows App SDK off Windows → always the Win32 fallback.
         assert_eq!(active(), RenderBackend::Win32);
+    }
+
+    #[test]
+    fn describe_detail_formats_known_codes_and_raw_hresult() {
+        use super::bootstrap::{
+            describe_init_detail, DETAIL_DLL_MISSING, DETAIL_NOT_ATTEMPTED, DETAIL_SUCCESS,
+        };
+        assert_eq!(describe_init_detail(DETAIL_NOT_ATTEMPTED), "not attempted");
+        assert_eq!(describe_init_detail(DETAIL_SUCCESS), "ready");
+        assert!(describe_init_detail(DETAIL_DLL_MISSING).contains("Bootstrap.dll"));
+        // A raw bootstrapper HRESULT renders as 0x-prefixed hex — e.g. the
+        // 0x80670016 "no matching runtime/DDLM" failure seen when only the
+        // framework package (not the DDLM) is registered.
+        let s = describe_init_detail(0x8067_0016u32 as i32);
+        assert!(s.contains("0x80670016"), "got: {s}");
     }
 }


### PR DESCRIPTION
## What

Implements the **step-3 dispatch seam** for #4680 (opt-in WinUI 3 / Fluent Windows target), building directly on the step-2 bootstrap probe merged in #4896.

Adds `winui::backend` — the single decision point the per-widget WinUI 3 mapping reads — plus a process-startup probe so `--target windows-winui` binaries resolve their render backend at launch.

## How

- **`winui::backend::active() -> RenderBackend`** — returns `RenderBackend::Fluent` when the Windows App SDK bootstrap probe (`bootstrap::initialize()`) is `Ready`, else `RenderBackend::Win32`. Cheap and stable (memoized by the bootstrap cache). Each XAML widget lands behind this check: build a `Microsoft.UI.Xaml` control on `Fluent`, else delegate to the existing Win32 constructor.
- **CRT static initializer** (`.CRT$XCU`, anchored with `#[used]`) registered in the crate runs the probe at process start for *any* binary that links this staticlib — i.e. exactly the `--target windows-winui` builds, and never the default `--target windows` builds (which don't link the crate). So the first widget construction reads an already-resolved backend rather than probing lazily. It never panics (runs before `main`).
- **`PERRY_WINUI_DIAG`** prints the chosen backend at launch: `[perry-winui] render backend: win32|fluent`.

## Testing

- `cargo test -p perry-ui-windows-winui` → green (`active_backend_matches_bootstrap_verdict`, `initialize_is_total_and_idempotent`). `active()` mirrors the bootstrap verdict and is stable; off Windows it is always `Win32`.
- **Verified on this Windows host (no SDK installed):**
  - The startup initializer **fires in a linked binary** — running the test exe with `PERRY_WINUI_DIAG=1` emitted `[perry-winui] render backend: win32`.
  - The `.CRT$XCU` section (8 bytes — one initializer pointer) is present in the WHOLEARCHIVE'd `perry_ui_windows_winui.lib` (`llvm-objdump --headers`).

## Scope / not in this PR

Real `Microsoft.UI.Xaml` controls need the WinAppSDK winmd projections + runtime (the stock `windows` crate at 0.58 ships only UWP `Windows.UI.Xaml`, not WinUI 3's `Microsoft.UI.Xaml`), so they're the next step. Today the seam always resolves to `Win32`. Win32 (`--target windows`) remains the default and is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to v0.5.1172

* **New Features**
  * Windows App SDK bootstrap diagnostics enhanced with comprehensive failure reporting including error codes
  * Environment variable support added for enabling diagnostic output during app initialization
  * Bootstrap failures now surface detailed error information and formatted status descriptions for improved troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->