### PR TITLE
fix(runtime,codegen): built-ins tails v2 (TypedArray/String/JSON/Proxy)

### DIFF
--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -110,17 +110,24 @@ pub(crate) fn lower_string_method(
 
     match property {
         "indexOf" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
-                    "perry-codegen: String.indexOf expects 1 or 2 args, got {}",
+                    "perry-codegen: String.indexOf expects 0, 1 or 2 args, got {}",
                     args.len()
                 );
             }
-            let needle_box = lower_expr(ctx, &args[0])?;
+            // No `searchString` → `undefined`, which `js_string_coerce`
+            // stringifies to "undefined" (`"".indexOf()` === -1).
+            let needle_box = if args.is_empty() {
+                ctx.block()
+                    .bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64)
+            } else {
+                lower_expr(ctx, &args[0])?
+            };
             // An object `searchString` must be `ToString`-coerced (running its
             // user `toString`/`valueOf`) BEFORE `ToNumber(position)`, per
             // ECMA-262 §22.1.3.8. A statically string-typed arg skips this.
-            let needle_is_str = is_string_expr(ctx, &args[0]);
+            let needle_is_str = !args.is_empty() && is_string_expr(ctx, &args[0]);
             // Optional fromIndex.
             let from_idx_double = if args.len() == 2 {
                 Some(lower_expr(ctx, &args[1])?)
@@ -213,9 +220,11 @@ pub(crate) fn lower_string_method(
         }
         "split" => {
             // Issue #567: accept the optional 2nd `limit: number` arg.
-            if args.is_empty() || args.len() > 2 {
+            // `str.split()` with no args is valid: an `undefined` separator
+            // yields `[str]` (handled by `js_string_split_value`).
+            if args.len() > 2 {
                 bail!(
-                    "perry-codegen: String.split expects 1 or 2 args (delimiter[, limit]), got {}",
+                    "perry-codegen: String.split expects 0, 1, or 2 args (delimiter[, limit]), got {}",
                     args.len()
                 );
             }
@@ -227,7 +236,11 @@ pub(crate) fn lower_string_method(
             // `unbox_str_handle` of an object/undefined separator would
             // bit-cast garbage; a raw `fptosi` of a boxed limit skips its
             // `valueOf`.
-            let delim_box = lower_expr(ctx, &args[0])?;
+            let delim_box = if args.is_empty() {
+                None
+            } else {
+                Some(lower_expr(ctx, &args[0])?)
+            };
             let limit_box = if args.len() == 2 {
                 Some(lower_expr(ctx, &args[1])?)
             } else {
@@ -235,6 +248,12 @@ pub(crate) fn lower_string_method(
             };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
+            // No separator → pass `undefined`, which `js_string_split_value`
+            // resolves to `[S]`.
+            let delim_box = match delim_box {
+                Some(v) => v,
+                None => blk.bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64),
+            };
             let limit_box = match limit_box {
                 Some(v) => v,
                 None => blk.bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64),
@@ -564,17 +583,24 @@ pub(crate) fn lower_string_method(
             ))
         }
         "lastIndexOf" => {
-            if args.is_empty() || args.len() > 2 {
+            if args.len() > 2 {
                 bail!(
-                    "perry-codegen: String.lastIndexOf expects 1 or 2 args, got {}",
+                    "perry-codegen: String.lastIndexOf expects 0, 1 or 2 args, got {}",
                     args.len()
                 );
             }
-            let needle_box = lower_expr(ctx, &args[0])?;
+            // No `searchString` → `undefined` → "undefined"
+            // (`"".lastIndexOf()` === -1).
+            let needle_box = if args.is_empty() {
+                ctx.block()
+                    .bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64)
+            } else {
+                lower_expr(ctx, &args[0])?
+            };
             // `ToString(searchString)` runs the arg's user `toString`/`valueOf`
             // (ECMA-262 §22.1.3.9) before `ToNumber(position)`; static strings
             // skip the coercion.
-            let needle_is_str = is_string_expr(ctx, &args[0]);
+            let needle_is_str = !args.is_empty() && is_string_expr(ctx, &args[0]);
             // Optional `position` (2nd arg). Without it, use the plain
             // last-index-of (search to the end); with it, the position-aware
             // variant. Mirrors the `indexOf` arm.
@@ -685,13 +711,23 @@ pub(crate) fn lower_string_method(
             Ok(nanbox_string_inline(blk, &result))
         }
         "localeCompare" => {
-            if args.is_empty() || args.len() > 3 {
+            if args.len() > 3 {
                 bail!(
-                    "perry-codegen: String.localeCompare expects 1-3 args, got {}",
+                    "perry-codegen: String.localeCompare expects 0-3 args, got {}",
                     args.len()
                 );
             }
-            let other_box = lower_expr(ctx, &args[0])?;
+            // A missing/undefined `that` argument coerces to the string
+            // "undefined" (ECMA-262 §22.1.3.10: `ToString(that)`), so
+            // `s.localeCompare()` === `s.localeCompare(undefined)` ===
+            // `s.localeCompare("undefined")`.
+            let other_is_str = !args.is_empty() && is_string_expr(ctx, &args[0]);
+            let other_box = if args.is_empty() {
+                ctx.block()
+                    .bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64)
+            } else {
+                lower_expr(ctx, &args[0])?
+            };
             // `options` is the 3rd arg; `locales` (2nd) is validated for its
             // RangeError side effect (#2781) but collation ordering stays
             // locale-neutral (full ICU deferred). With an options object
@@ -712,7 +748,13 @@ pub(crate) fn lower_string_method(
             }
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let other_handle = unbox_str_handle(blk, &other_box);
+            // A non-string `that` (undefined/number/object) must be
+            // `ToString`-coerced, not bit-cast as a string pointer.
+            let other_handle = if other_is_str {
+                unbox_str_handle(blk, &other_box)
+            } else {
+                blk.call(I64, "js_string_coerce", &[(DOUBLE, &other_box)])
+            };
             // Returns a plain f64 (-1/0/1) — NOT NaN-tagged.
             if let Some(opts) = options_box {
                 Ok(blk.call(

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -1587,6 +1587,24 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
         buf.push_str("[]");
         return;
     }
+    // Circular-reference detection (ECMA-262 25.5.2 SerializeJSONArray step
+    // 1-2). Unlike objects, the compact array path does NOT bump `depth`, so
+    // an all-array cycle (`a=[]; a.push(a)`) would otherwise recurse until the
+    // native stack overflows (crash, no output). Track the open-array pointers
+    // in `STRINGIFY_STACK` and throw a `TypeError` on revisit. The stack is
+    // cleared at the outermost `js_json_stringify` entry, so a `longjmp` out of
+    // this throw (which skips the pops below) cannot leak across top-level
+    // calls. A sibling array reused in two positions is NOT a cycle: each
+    // position pushes-then-pops, so the second visit sees an empty-of-it stack.
+    if STRINGIFY_STACK.with(|s| s.borrow().contains(&(arr as usize))) {
+        let msg = "Converting circular structure to JSON";
+        let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+        let err_ptr = crate::error::js_typeerror_new(msg_ptr);
+        crate::exception::js_throw(f64::from_bits(
+            POINTER_TAG | (err_ptr as u64 & POINTER_MASK),
+        ));
+    }
+    STRINGIFY_STACK.with(|s| s.borrow_mut().push(arr as usize));
     let len = (*arr).length;
     let elements = (arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
 
@@ -1639,6 +1657,7 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
             }
         }
         buf.push(']');
+        STRINGIFY_STACK.with(|s| s.borrow_mut().pop());
         return;
     }
 
@@ -1754,6 +1773,7 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
         }
     }
     buf.push(']');
+    STRINGIFY_STACK.with(|s| s.borrow_mut().pop());
 }
 
 #[inline]

--- a/crates/perry-runtime/src/json/stringify_api.rs
+++ b/crates/perry-runtime/src/json/stringify_api.rs
@@ -156,6 +156,12 @@ pub unsafe extern "C" fn js_json_stringify(value: f64, type_hint: u32) -> *mut S
     // it can't leak across top-level calls.
     if prior_depth == 0 {
         super::SUPPRESS_NEXT_TO_JSON.with(|c| c.set(false));
+        // A circular-ref `TypeError` longjmps past the `STRINGIFY_STACK`
+        // pops (js_throw doesn't unwind Rust), so a caught throw can leave
+        // stale ancestor pointers behind. Clear at the outermost entry so they
+        // can't trigger a spurious "circular structure" on the next top-level
+        // call (or, worse, mask a real cycle by colliding with a reused addr).
+        super::STRINGIFY_STACK.with(|s| s.borrow_mut().clear());
     }
     let saved_cache = if prior_depth > 0 {
         Some(take_shape_cache())

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -153,7 +153,16 @@ fn proxy_arg_is_object(value: f64) -> bool {
     // POINTER_TAG heap value (object / function / array).
     if top == 0x7FFD {
         let ptr = (bits & POINTER_MASK) as usize;
-        return ptr >= 0x1000;
+        if ptr < 0x1000 {
+            return false;
+        }
+        // A Symbol is a POINTER_TAG value too (registered side-table), but it
+        // is a primitive, not an object — `new Proxy(Symbol(), {})` and
+        // `new Proxy({}, Symbol())` must throw TypeError.
+        if crate::symbol::is_registered_symbol(ptr) {
+            return false;
+        }
+        return true;
     }
     // Module-level raw-I64 object/array pointers (top16 == 0).
     if top == 0 && bits > 0x10000 {

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -276,6 +276,26 @@ pub(crate) unsafe fn ordinary_to_primitive_number_for_add(
     let scope = crate::gc::RuntimeHandleScope::new();
     let value_handle = scope.root_nanbox_f64(value);
 
+    // A TypedArray is an exotic object whose header is NOT an ObjectHeader;
+    // the `valueOf`/`toString` field lookups below would bit-cast garbage
+    // (heap-dependent: sometimes a fake "method" → spurious TypeError, e.g.
+    // `"" + new Float64Array([1])`). Its ToPrimitive resolves to
+    // %TypedArray%.prototype.toString (= `join(",")`); detect via the
+    // registry (no deref) and join. `Symbol.toPrimitive` was already
+    // consulted by the caller (`js_to_primitive`).
+    if (value.to_bits() & 0xFFFF_0000_0000_0000) == POINTER_TAG {
+        let addr = (value.to_bits() & POINTER_MASK) as usize;
+        if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+            let joined = crate::typedarray::js_typed_array_join(
+                addr as *const crate::typedarray::TypedArrayHeader,
+                std::ptr::null(),
+            );
+            return OrdinaryToPrimitiveOutcome::Primitive(crate::value::js_nanbox_string(
+                joined as i64,
+            ));
+        }
+    }
+
     match call_method_for_primitive(&scope, &value_handle, b"valueOf") {
         MethodOutcome::Primitive(p) => return OrdinaryToPrimitiveOutcome::Primitive(p),
         MethodOutcome::NonPrimitive => {}
@@ -614,6 +634,20 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
                 return crate::buffer::js_buffer_to_string(
                     ptr as *const crate::buffer::BufferHeader,
                     0,
+                );
+            }
+            // A TypedArray stringifies via %TypedArray%.prototype.toString
+            // (= `Array.prototype.join(",")`), not "[object Object]". Detected
+            // via the registry (a by-value lookup, no deref) before any
+            // GC-header probe — a TypedArrayHeader is NOT an ObjectHeader, so
+            // the ordinary toString/valueOf field path below would bit-cast
+            // garbage. Covers `String(ta)`, `` `${ta}` ``, and the `+` add
+            // fallback. (`Symbol.toPrimitive` overrides were already consulted
+            // above via `js_to_primitive`.)
+            if crate::typedarray::lookup_typed_array_kind(ptr as usize).is_some() {
+                return crate::typedarray::js_typed_array_join(
+                    ptr as *const crate::typedarray::TypedArrayHeader,
+                    std::ptr::null(),
                 );
             }
             // #2089: a Date is a NaN-boxed `DateCell` pointer. `String(date)`,


### PR DESCRIPTION
## Summary

Mops several independent built-ins test262 tails. Differential vs `node v26.3.0`, 8 target dirs (Promise/String/JSON/Proxy/TypedArray/DataView + eval-code/function-code).

**Parity: 87.6% → 89.0%** over the 8 dirs (judged=3540). **+50 tests fixed, 0 regressions** (verified by diffing the full failure sets, not just the aggregate).

| dir | pass before → after | compile-fail |
|-----|------|------|
| TypedArray | 739 → 770 (+31) | — |
| String | 857 → 873 (+16) | 16 → 1 |
| Proxy | 205 → 207 (+2) | — |
| JSON | 108 → 109 (+1) | — |

## Root causes & fixes

**1. TypedArray stringification (+~29).** `String(ta)`, `` `${ta}` ``, `"" + ta`, and `ta.toString()` produced `"[object Object]"` — or, heap-layout-dependently, threw `TypeError: Cannot convert object to primitive value`. A `TypedArrayHeader` is **not** an `ObjectHeader`, but `ordinary_to_primitive_number_for_add` (and `js_jsvalue_to_string`) bit-cast it as one and read garbage for the `valueOf`/`toString` field lookups — so a second TA in the program could throw where the first only mis-rendered. Detect TypedArrays via the registry (`lookup_typed_array_kind`, a by-value lookup, no deref) and stringify via `js_typed_array_join(",")`, matching `%TypedArray%.prototype.toString`. `Symbol.toPrimitive` overrides are still honored. Files: `value/to_string.rs`.

**2. String methods with 0 args (+15 compile-fails).** `"x".split()`, `"".indexOf()`, `"".lastIndexOf()`, and `s.localeCompare()` all hard-errored at codegen (`expects 1 or 2 args, got 0`). These are valid: a missing separator/search/`that` argument coerces to `undefined` → `[S]` / `"undefined"`. Allow 0 args and default the missing operand to `undefined`; `localeCompare` now `ToString`-coerces a non-string `that` instead of bit-casting it as a string pointer. Files: `lower_string_method.rs`.

**3. JSON.stringify circular arrays (+1, prevents crash).** `a=[]; a.push(a); JSON.stringify(a)` infinitely recursed → native stack overflow (crash, no output). Object cycles were already detected past `MAX_FAST_DEPTH`, but the compact **array** path never bumps `depth`, so an all-array cycle never reached the guard. Track open-array pointers in `STRINGIFY_STACK` (push/check/pop, so a sibling array reused in two positions is not a false cycle) and throw `TypeError: Converting circular structure to JSON`. Cleared at the outermost `js_json_stringify` entry so a `longjmp`-out throw can't leak ancestors across top-level calls. Files: `json/stringify.rs`, `json/stringify_api.rs`.

**4. Proxy with a Symbol target/handler (+2).** `new Proxy(Symbol(), {})` / `new Proxy({}, Symbol())` must throw `TypeError`, but `proxy_arg_is_object` accepted any `POINTER_TAG` value — and a Symbol is a registered `POINTER_TAG` value. Exclude registered symbols. Files: `proxy.rs`.

## Validation
- `cargo fmt --all` clean; `scripts/check_file_size.sh` OK.
- Affected `perry-runtime` unit tests (json/stringify/typed_array/to_string/proxy) green.
- Full 8-dir differential: 50 fixed / 0 new failures.

## Deferred (out of scope here)
- Buffer-backed TA `includes`/`indexOf` and `reduce` (no-initial-value) are **codegen-sensitive Heisenbugs** (adding an unrelated alias of the receiver makes them pass) — a receiver-lowering/escape issue, risky to fix blind.
- `JSON.stringify` object cycles routed through a `toJSON` that returns an ancestor (still crashes; pre-existing — hot-path object tracking deferred).
- eval-in-parameter-scope lexical-conflict negatives (~24, AOT-hard).