### PR TITLE
fix(runtime): small built-ins tails (Date setters/parse, BigInt ++/--)

### DIFF
--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -664,28 +664,41 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // module globals.
         Expr::Update { id, op, prefix } => {
             super::invalidate_local_write_facts(ctx, *id);
-            // Spec ToNumber: `x++`/`++x` coerce the operand to a number
-            // (ToNumber on bool/null/string/object-with-valueOf) before the
-            // add/sub, and the *returned* value (postfix) is the coerced
-            // number, not the original boxed operand. Statically-integer loop
-            // counters already hold a real f64 and skip the call to keep the
-            // hot path a single `fadd`. (BigInt operands convert to Number here
-            // — full BigInt-preserving `++`/`--` additionally needs the Update
-            // result's static type to be inferred as BigInt so `===` uses the
-            // value path, not `fcmp`; deferred.)
+            // Spec ToNumeric: `x++`/`++x` coerce the operand (ToNumber on
+            // bool/null/string/object-with-valueOf, or BigInt passthrough)
+            // before the add/sub, and the *returned* value (postfix) is the
+            // coerced numeric, not the original boxed operand. Statically-
+            // integer loop counters already hold a real f64 and skip the call
+            // to keep the hot path a single `fadd`. The slow path routes
+            // through `js_to_numeric`/`js_numeric_step` so a BigInt operand
+            // stays a BigInt (`let i = 10n; i++` → `11n`, not the Number `11`
+            // which would make a later `i + 87n` throw a mixed-type
+            // TypeError; test262 BigInt/prototype/toString/a-z).
             let needs_numeric_coerce =
                 !ctx.integer_locals.contains(id) && !ctx.unsigned_i32_locals.contains(id);
+            let is_increment_arg = match op {
+                UpdateOp::Increment => "1",
+                UpdateOp::Decrement => "0",
+            };
             let coerce_old = |blk: &mut crate::block::LlBlock, raw: &str| -> String {
                 if needs_numeric_coerce {
-                    blk.call(DOUBLE, "js_number_coerce", &[(DOUBLE, raw)])
+                    blk.call(DOUBLE, "js_to_numeric", &[(DOUBLE, raw)])
                 } else {
                     raw.to_string()
                 }
             };
             let step_new = |blk: &mut crate::block::LlBlock, old_num: &str| -> String {
-                match op {
-                    UpdateOp::Increment => blk.fadd(old_num, "1.0"),
-                    UpdateOp::Decrement => blk.fsub(old_num, "1.0"),
+                if needs_numeric_coerce {
+                    blk.call(
+                        DOUBLE,
+                        "js_numeric_step",
+                        &[(DOUBLE, old_num), (I32, is_increment_arg)],
+                    )
+                } else {
+                    match op {
+                        UpdateOp::Increment => blk.fadd(old_num, "1.0"),
+                        UpdateOp::Decrement => blk.fsub(old_num, "1.0"),
+                    }
                 }
             };
             // Closure capture path: runtime get + add/sub + runtime set.

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1049,6 +1049,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // the raw `js_bigint_<op>`, and re-box with BIGINT_TAG. Also
     // tolerate mixed bigint/int32 operands.
     module.declare_function("js_dynamic_add", DOUBLE, &[DOUBLE, DOUBLE]);
+    // `++`/`--` slow path: ToNumeric read (BigInt passthrough, else ToNumber)
+    // and a type-preserving step by 1n/1.0. Keeps `let i = 10n; i++` a BigInt.
+    module.declare_function("js_to_numeric", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_numeric_step", DOUBLE, &[DOUBLE, I32]);
     // Refs #486: dispatch path for `+` when neither operand has a static
     // type (string|number|bigint). Per JS spec, string concat takes
     // priority; otherwise BigInt or numeric add. Hono's

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -433,22 +433,40 @@ fn parse_tz_offset(rest: &str) -> Option<i64> {
 /// ISO 8601 / MySQL branch. Returns `Some(ms)` on success.
 fn parse_iso8601(s: &str) -> Option<f64> {
     let b = s.as_bytes();
-    // Year-only "YYYY" or "+YYYYYY" not handled here (rare); require a 4-digit
-    // year prefix.
-    if b.len() < 4 || !b[0..4].iter().all(|c| c.is_ascii_digit()) {
-        return None;
-    }
-    let year: i64 = s[0..4].parse().ok()?;
+    // Year: either a 4-digit "YYYY" or an expanded "±YYYYYY" (mandatory sign,
+    // exactly 6 digits) per the ECMAScript Date Time String Format. "-000000"
+    // is explicitly NOT a valid representation (negative-zero year), so it is
+    // rejected. (test262 Date/{parse,prototype/toString}/...-year, where
+    // `new Date('-000001-07-01T00:00Z')` must parse, not yield Invalid Date.)
+    let (year, year_end): (i64, usize) = if b.first() == Some(&b'+') || b.first() == Some(&b'-') {
+        if b.len() < 7 || !b[1..7].iter().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        let mag: i64 = s[1..7].parse().ok()?;
+        if b[0] == b'-' {
+            if mag == 0 {
+                return None;
+            }
+            (-mag, 7)
+        } else {
+            (mag, 7)
+        }
+    } else {
+        if b.len() < 4 || !b[0..4].iter().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        (s[0..4].parse().ok()?, 4)
+    };
     let mut month1: u32 = 1;
     let mut day: i64 = 1;
     let mut hour: i64 = 0;
     let mut minute: i64 = 0;
     let mut second: i64 = 0;
     let mut millis: i64 = 0;
-    let mut idx = 4;
+    let mut idx = year_end;
 
-    // "YYYY" only.
-    if s.len() == 4 {
+    // Year only ("YYYY" / "±YYYYYY").
+    if s.len() == year_end {
         return Some(make_utc_ms(
             year,
             month1 as i64 - 1,
@@ -460,27 +478,27 @@ fn parse_iso8601(s: &str) -> Option<f64> {
         ));
     }
     // Require a '-' for month.
-    if b.get(4) != Some(&b'-') {
+    if b.get(year_end) != Some(&b'-') {
         return None;
     }
-    if b.len() < 7 {
+    if b.len() < year_end + 3 {
         return None;
     }
-    month1 = s[5..7].parse().ok()?;
+    month1 = s[year_end + 1..year_end + 3].parse().ok()?;
     if !(1..=12).contains(&month1) {
         return None;
     }
-    idx = 7;
+    idx = year_end + 3;
     let mut has_day = false;
-    if b.get(7) == Some(&b'-') {
-        if b.len() < 10 {
+    if b.get(idx) == Some(&b'-') {
+        if b.len() < idx + 3 {
             return None;
         }
-        day = s[8..10].parse().ok()?;
+        day = s[idx + 1..idx + 3].parse().ok()?;
         if !(1..=31).contains(&day) {
             return None;
         }
-        idx = 10;
+        idx += 3;
         has_day = true;
     }
 
@@ -1133,45 +1151,34 @@ pub extern "C" fn js_date_apply_setter(
             None,
         );
     }
-    // V8/Node observable order for the date/time setters (fields 0..=6): the
-    // LEADING argument is ToNumber-coerced first, THEN `thisTimeValue` is read
-    // — not before. A `valueOf` on the leading argument that re-enters and
-    // mutates this very Date is therefore visible to the rest of the
-    // algorithm. (test262 `date-value-read-before-tonumber-when-date-is-*`
-    // pin V8's read-AFTER order despite their spec-derived names, and so does
-    // `arg-coercion-order` for the short-circuit below.) The earlier `captured`
-    // read drives only setTime/setYear (fields 7/8), which already returned.
-    let _ = captured;
-    let leading = if argc >= 1 {
-        jsvalue_to_number(args[0])
-    } else {
-        f64::NAN
-    };
-    // Re-read the time value AFTER the leading arg's side effects.
-    let t = date_cell_timestamp(date);
+    // Spec / V8 / node v26 observable order for the date/time setters (fields
+    // 0..=6): `thisTimeValue` is read FIRST (the `captured` read above, before
+    // any ToNumber). THEN every PRESENT argument is ToNumber-coerced
+    // left-to-right — all of them, even when the time value is NaN (test262
+    // `set*/arg-coercion-order`). ONLY after all coercions does a NaN time
+    // value short-circuit to NaN. A `valueOf` on an argument that re-enters
+    // and mutates this very Date is therefore NOT visible to the rebuild — the
+    // `captured` timestamp is the one used (test262
+    // `date-value-read-before-tonumber-when-date-is-{valid,invalid}`).
+    let t = captured;
     let is_full_year = field == 0;
-    // For every setter except setFullYear/setUTCFullYear, a NaN time value at
-    // this point short-circuits to NaN: the remaining arguments are NOT
-    // coerced and the cell is NOT written (so a `valueOf`-installed value
-    // persists). setFullYear substitutes +0 for a NaN time value and coerces
-    // all of its arguments.
+    // Coerce every present argument in source order, capturing all `valueOf`
+    // side effects, BEFORE the NaN short-circuit below. An ABSENT trailing
+    // argument stays `None` ("keep the current field"); a PRESENT argument —
+    // even explicit `undefined` — is coerced (so `setMinutes(0, 0, undefined)`
+    // yields NaN, not the retained millisecond; test262 set*/arg-*-to-number).
+    let coerced: Vec<f64> = args.iter().map(|&a| jsvalue_to_number(a)).collect();
+    // For every setter except setFullYear/setUTCFullYear, a NaN time value
+    // short-circuits to NaN: the cell is NOT written (so a `valueOf`-installed
+    // value persists). setFullYear substitutes +0 for a NaN time value.
     if t.is_nan() && !is_full_year {
         return f64::NAN;
     }
     let base = if t.is_nan() { 0.0 } else { t };
-    // Trailing optional components: an ABSENT trailing argument is `None`
-    // ("keep the current field"); a PRESENT argument — even an explicit
-    // `undefined` — is ToNumber-coerced (so `setMinutes(0, 0, undefined)`
-    // yields NaN, not the retained millisecond; test262 set*/arg-*-to-number).
-    // The leading component is already coerced.
-    let lead = Some(leading);
-    let opt = |i: usize| -> Option<f64> {
-        if i < argc {
-            Some(jsvalue_to_number(args[i]))
-        } else {
-            None
-        }
-    };
+    // The leading component is required: an omitted call (`setHours()`) coerces
+    // `undefined` → NaN, so the leading slot is always `Some`.
+    let lead = Some(coerced.first().copied().unwrap_or(f64::NAN));
+    let opt = |i: usize| -> Option<f64> { coerced.get(i).copied() };
     // Map (field, positional index) → the seven rebuild slots.
     // Slots: year, month0, day, hour, minute, second, ms. The first slot of
     // each setter is the required leading component.

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -362,10 +362,19 @@ pub(crate) fn time_clip(t: f64) -> f64 {
 /// when (and only when) it falls in that range.
 #[inline]
 fn rebase_two_digit_year(year: f64) -> f64 {
-    if year.fract() == 0.0 && (0.0..100.0).contains(&year) {
-        year + 1900.0
+    // ECMAScript MakeFullYear: y = ToInteger(year) (truncate toward zero);
+    // if 0 ≤ y ≤ 99 then the full year is 1900 + y. The truncation happens
+    // BEFORE the range test, so `Date.UTC(-0.999999, 0)` rebases to 1900
+    // (ToInteger(-0.999999) = 0), not the literal year 0 (test262
+    // Date/UTC/year-offset). Non-finite years pass through unchanged.
+    if !year.is_finite() {
+        return year;
+    }
+    let yi = year.trunc();
+    if (0.0..=99.0).contains(&yi) {
+        1900.0 + yi
     } else {
-        year
+        yi
     }
 }
 
@@ -388,11 +397,14 @@ fn parse_date_string(s: &str) -> f64 {
         return f64::NAN;
     }
 
+    // Date.parse always TimeClips: a parsed instant outside ±8.64e15 ms (the
+    // supported Date range) is Invalid (`Date.parse("-271821-04-19T23:59:59.999Z")`
+    // → NaN, one ms below the minimum; test262 Date/parse/time-value-maximum-range).
     if let Some(ts) = parse_iso8601(s) {
-        return ts;
+        return time_clip(ts);
     }
     if let Some(ts) = parse_rfc_or_named(s) {
-        return ts;
+        return time_clip(ts);
     }
     f64::NAN
 }
@@ -735,6 +747,20 @@ fn components_to_timestamp(
     days * 86400 + hour as i64 * 3600 + minute as i64 * 60 + second as i64
 }
 
+/// Format a calendar year for ISO 8601 (`toISOString` / `toJSON`): `0..=9999`
+/// is 4 zero-padded digits ("2024"), every other year uses the expanded sign +
+/// 6-digit form ("+275760" / "-271821" / "-000001"). Unlike [`format_year`],
+/// which omits the `+` for the human `toString`/`toUTCString` forms.
+fn iso_year(year: i64) -> String {
+    if (0..=9999).contains(&year) {
+        format!("{:04}", year)
+    } else if year < 0 {
+        format!("-{:06}", -year)
+    } else {
+        format!("+{:06}", year)
+    }
+}
+
 /// Get timestamp from Date (date.getTime())
 /// Since we store dates as timestamps, this is an identity function
 #[no_mangle]
@@ -762,10 +788,18 @@ pub extern "C" fn js_date_to_iso_string(timestamp: f64) -> *mut crate::StringHea
     // This is a simplified implementation - proper implementation would use chrono crate
     let (year, month, day, hour, minute, second) = timestamp_to_components(secs);
 
-    // Format as ISO 8601: YYYY-MM-DDTHH:mm:ss.sssZ
+    // ISO 8601 "YYYY-MM-DDTHH:mm:ss.sssZ"; years outside 0..=9999 use the
+    // expanded "±YYYYYY" form (see `iso_year`) — test262
+    // Date/parse/time-value-maximum-range.
     let iso_string = format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
-        year, month, day, hour, minute, second, millis
+        "{}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        iso_year(year as i64),
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        millis
     );
 
     crate::string::js_string_from_bytes(iso_string.as_ptr(), iso_string.len() as u32)

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -170,6 +170,46 @@ pub unsafe extern "C" fn js_dynamic_add(a: f64, b: f64) -> f64 {
     a + b
 }
 
+/// `ToNumeric(value)` for the `++`/`--` slow path: a BigInt passes through
+/// unchanged, every other value is coerced via `ToNumber`. The codegen's
+/// update path uses this for the *operand read* so that the postfix return
+/// value and the stepping base keep their BigInt type instead of collapsing
+/// to a Number (`let i = 10n; i++` must stay a BigInt — otherwise a later
+/// `i + 87n` throws a mixed-type TypeError; test262
+/// BigInt/prototype/toString/a-z).
+#[no_mangle]
+pub unsafe extern "C" fn js_to_numeric(value: f64) -> f64 {
+    if JSValue::from_bits(value.to_bits()).is_bigint() {
+        value
+    } else {
+        crate::builtins::js_number_coerce(value)
+    }
+}
+
+/// Step a ToNumeric operand by `1` of its own numeric type for `++`/`--`.
+/// `numeric` is already the result of [`js_to_numeric`]: a BigInt steps by
+/// `1n` (staying a BigInt), any Number steps by `1.0`. `is_increment` is
+/// nonzero for `++`, zero for `--`.
+#[no_mangle]
+pub unsafe extern "C" fn js_numeric_step(numeric: f64, is_increment: i32) -> f64 {
+    if JSValue::from_bits(numeric.to_bits()).is_bigint() {
+        let one_ptr = crate::bigint::js_bigint_from_i64(1);
+        // `js_nanbox_bigint` is pure and `dynamic_bigint_binary_op` roots both
+        // operands before any further allocation, so `one_ptr` survives.
+        let one_val = js_nanbox_bigint(one_ptr as i64);
+        let op = if is_increment != 0 {
+            crate::bigint::js_bigint_add
+        } else {
+            crate::bigint::js_bigint_sub
+        };
+        dynamic_bigint_binary_op(numeric, one_val, op)
+    } else if is_increment != 0 {
+        numeric + 1.0
+    } else {
+        numeric - 1.0
+    }
+}
+
 /// Dynamic `a + b` for type-uncertain operands. Per JS spec, when either
 /// operand is a string after ToPrimitive, the result is string concatenation;
 /// otherwise both operands are coerced to numbers and summed (or BigInt-
@@ -394,3 +434,7 @@ pub unsafe extern "C" fn js_dynamic_ushr(a: f64, b: f64) -> f64 {
 static KEEP_DYNAMIC_POW: unsafe extern "C" fn(f64, f64) -> f64 = js_dynamic_pow;
 #[used]
 static KEEP_DYNAMIC_USHR: unsafe extern "C" fn(f64, f64) -> f64 = js_dynamic_ushr;
+#[used]
+static KEEP_TO_NUMERIC: unsafe extern "C" fn(f64) -> f64 = js_to_numeric;
+#[used]
+static KEEP_NUMERIC_STEP: unsafe extern "C" fn(f64, i32) -> f64 = js_numeric_step;


### PR DESCRIPTION
## Summary

Mops several small high-% built-in tails (Date + BigInt) from the test262 sweep over `built-ins/{Number,Boolean,Symbol,Error,Map,Set,Weak*,Reflect,BigInt,Math,Date,ArrayBuffer,URI,parse*,global}`.

**Parity 93.4% → 95.0%** over 2314 judged tests: **+38 fixed, 0 regressed** (Date 37, BigInt 1), verified by diffing failure sets against a from-scratch build of the merge base (`aee4e82c5`).

## Root causes & fixes

1. **Date `set*` coercion order** (`date.rs::js_date_apply_setter`) — `thisTimeValue` must be read *before* coercing any argument, then *all* present arguments coerced left-to-right *before* the NaN-time short-circuit. The code did the opposite (read-AFTER the leading arg, short-circuited before coercing the rest). node v26 confirms read-before / coerce-all. Fixes `set{Date,Hours,Minutes,Seconds,Milliseconds,Month,FullYear,UTC*}/{date-value-read-before-tonumber-*,arg-coercion-order}` (~22).

2. **Date expanded-year ISO parse** (`date.rs::parse_iso8601`) — accept the `±YYYYYY` extended-year form (mandatory sign, 6 digits; `-000000` rejected) in addition to 4-digit `YYYY`. `new Date('-000001-07-01T00:00Z')` no longer yields Invalid Date, fixing the `{toString,toDateString,toUTCString}/negative-year` set.

3. **Date `toISOString` expanded-year** (`iso_year`) — years outside `0..=9999` serialize as `±YYYYYY` (`new Date(8.64e15).toISOString()` → `+275760-09-13T00:00:00.000Z`).

4. **`Date.UTC` / constructor year rebasing** (`rebase_two_digit_year`) — apply `ToInteger` (truncate-toward-zero) *before* the `0..=99` two-digit-year test, so `Date.UTC(-0.999999, 0)` rebases to 1900, not literal year 0.

5. **`Date.parse` TimeClip** — a parsed instant outside ±8.64e15 ms is now Invalid (`Date.parse("-271821-04-19T23:59:59.999Z")` → NaN).

6. **BigInt-preserving `++`/`--`** (`dynamic_arith.rs` + codegen `literals_vars.rs`) — the update slow path coerced the operand with `js_number_coerce` + `fadd 1.0`, collapsing a BigInt to a Number (`let i = 10n; i++` produced the Number `11`, so a later `i + 87n` threw a mixed-type `TypeError`). New `js_to_numeric` (ToNumeric: BigInt passthrough, else ToNumber) + `js_numeric_step` (steps by `1n`/`1.0` of the operand's own type). Non-BigInt behavior is byte-identical; integer-local fast path (`fadd`) unchanged. Fixes `BigInt/prototype/toString/a-z`.

## Files
- `crates/perry-runtime/src/date.rs`
- `crates/perry-runtime/src/value/dynamic_arith.rs`
- `crates/perry-codegen/src/expr/literals_vars.rs`
- `crates/perry-codegen/src/runtime_decls/strings.rs`

## Validation
- Built + tested on a 48-core box against test262 (node v26 oracle), `--jobs 40`.
- Zero-regression proof: failure-set diff vs a clean build of merge base `aee4e82c5` → 38 fixed, 0 regressed.
- No `Cargo.toml`/`CLAUDE.md`/`CHANGELOG.md` edits (maintainer folds version/changelog at merge).