### PR TITLE
fix(hir): non-class expression-semantics remnant test262 parity

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -366,6 +366,20 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                                 args,
                             });
                         }
+                        // `super['getThis']()` in a CLASS method with a string-
+                        // literal key is a super METHOD CALL — route it through
+                        // SuperMethodCall (the ident-form path) so it binds the
+                        // current `this` as receiver. Without this it fell through
+                        // to a generic property-get-then-call that lost the
+                        // receiver binding (test262 super/prop-expr-cls-ref-this).
+                        if let ast::Expr::Lit(ast::Lit::Str(s)) = computed.expr.as_ref() {
+                            if let Some(method) = s.value.as_str() {
+                                return Ok(Expr::SuperMethodCall {
+                                    method: method.to_string(),
+                                    args,
+                                });
+                            }
+                        }
                     }
                 }
             }

--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -82,14 +82,27 @@ pub(super) fn lower_super_prop(
             }
         }
         ast::SuperProp::Computed(computed) => {
-            let index = Box::new(lower_expr(ctx, &computed.expr)?);
             if let Some(home_id) = ctx.object_super_home_stack.last().copied() {
+                let index = Box::new(lower_expr(ctx, &computed.expr)?);
                 Ok(Expr::ObjectSuperPropertyGet {
                     home: Box::new(Expr::LocalGet(home_id)),
                     key: index,
                     receiver: Box::new(Expr::This),
                 })
+            } else if let Some(key) = match computed.expr.as_ref() {
+                ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str().map(|s| s.to_string()),
+                _ => None,
+            } {
+                // `super['fromA']` in a CLASS method with a string-literal key:
+                // route through the same parent-prototype-chain lookup as the
+                // ident form `super.fromA` (Expr::SuperPropertyGet). The previous
+                // `this[index]` fallback read the property off the CHILD instance,
+                // shadowing the parent value (test262
+                // super/prop-expr-cls-val{,-from-arrow}). A truly dynamic computed
+                // key (not a literal) still falls back below.
+                Ok(Expr::SuperPropertyGet { property: key })
             } else {
+                let index = Box::new(lower_expr(ctx, &computed.expr)?);
                 Ok(Expr::IndexGet {
                     object: Box::new(Expr::This),
                     index,

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -672,6 +672,16 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
                 let ty_expr = match bin.right.as_ref() {
                     ast::Expr::Ident(ident) => {
                         let name = ident.sym.as_ref();
+                        // `x instanceof undefined`: `undefined` is the primitive
+                        // value, never a class name. Codegen would resolve `ty =
+                        // "undefined"` to class_id 0 and silently return `false`;
+                        // ECMAScript requires evaluating the RHS and throwing a
+                        // TypeError because it is not an object (test262
+                        // instanceof/S11.8.6_A3 #4). Lower it to the undefined
+                        // value so it routes through `js_instanceof_dynamic`.
+                        if name == "undefined" {
+                            Some(Box::new(Expr::Undefined))
+                        } else
                         // A local holding a class ref (drizzle's `is(value, type)`),
                         // OR a top-level ES5 function constructor (`function Foo(){…}`
                         // used as `x instanceof Foo`). The latter has no class entry,

--- a/crates/perry-runtime/src/collection_iter.rs
+++ b/crates/perry-runtime/src/collection_iter.rs
@@ -115,6 +115,24 @@ pub(crate) fn is_iterable(value: f64) -> bool {
     if crate::map::is_registered_map(addr) || crate::set::is_registered_set(addr) {
         return true;
     }
+    // A built-in iterator object — an array/map/set/string/buffer/iterator-
+    // helper iterator — IS already an iterator and is therefore iterable
+    // (`[Symbol.iterator]()` returns itself). Mirrors the equivalent
+    // `is_builtin_iterator_class_id` arm in `js_get_iterator`.
+    if crate::array::is_builtin_iterator_class_id(addr) {
+        return true;
+    }
+    // A generator object (`g()` from `function* g(){}`) is lowered by Perry to a
+    // plain object with own closure-valued `next`/`return`/`throw` methods and
+    // NO `[Symbol.iterator]` symbol property, so the generic check below misses
+    // it. Generators ARE iterable (`[Symbol.iterator]()` returns themselves), so
+    // without this `js_array_like_to_array` — call / `new` / super spread of a
+    // generator (`f(...g())`, `new C(...g())`) and `new Map/Set(g())` — fell
+    // through to the array-reinterpret garbage path. `js_get_iterator` returns
+    // the generator unchanged (its own `.next()` drives the state machine).
+    if crate::object::js_util_types_is_generator_object(value).to_bits() == crate::value::TAG_TRUE {
+        return true;
+    }
     // Generic object: iterable iff it exposes a callable `[Symbol.iterator]`.
     if !crate::object::is_valid_obj_ptr(raw as *const u8) {
         return false;

--- a/crates/perry-runtime/src/object/property_key.rs
+++ b/crates/perry-runtime/src/object/property_key.rs
@@ -189,7 +189,17 @@ pub unsafe extern "C" fn js_super_accessor_get(
             }
         }
     }
-    let proto = crate::object::class_prototype_object(parent_class_id);
+    // Prefer the *declared* prototype object (stable heap identity). A dynamic
+    // write `Parent.prototype.foo = v` lands on that object, whereas the older
+    // overloaded `CLASS_PROTOTYPE_OBJECTS` table may hold a distinct synthetic
+    // prototype that never sees such writes — so reading through it returned
+    // `undefined` for data properties added to a parent prototype after the
+    // class declaration (test262 super/prop-{dot,expr}-cls-val). Falls back to
+    // the older table for synthetic-prototype sources that lack a decl entry.
+    let mut proto = crate::object::class_decl_prototype_object(parent_class_id);
+    if proto.is_null() {
+        proto = crate::object::class_prototype_object(parent_class_id);
+    }
     if !proto.is_null() {
         let target = crate::value::js_nanbox_pointer(proto as i64);
         return js_object_get_property_key(target, key);


### PR DESCRIPTION
## Summary

Five surgical fixes to non-class expression semantics in `language/expressions/*`. **+9 test262 cases, 0 regressions**, verified same-mode (`PERRY_NO_AUTO_OPTIMIZE=1`) against a binary built at this branch's parent commit across all 11 target directories (`super object yield generators async-generator call delete new property-accessors instanceof compound-assignment`): pass 2001 → 2010, parity 88.6% → 89.0%.

Also separately verified **0 regressions** on iterable-heavy directories (`built-ins/Map`, `built-ins/Set`, `built-ins/Array/from`, `language/statements/for-of`, `built-ins/GeneratorPrototype`) to bound the global `is_iterable` change.

## Root causes & fixes

### 1. `super.<prop>` / `super['<lit>']` data-property reads miss dynamic parent-prototype writes
`super.fromA` in a class method routed `js_super_accessor_get` through the older overloaded `CLASS_PROTOTYPE_OBJECTS` table, which can hold a *distinct* synthetic prototype from the stable declared-class prototype that `Parent.prototype.foo = v` actually writes to — so the read returned `undefined`. Now prefers the declared prototype object (`class_decl_prototype_object`), falling back to the old table.
→ `super/prop-dot-cls-val`, `prop-dot-cls-val-from-arrow`

### 2. Computed `super['<string-literal>']` read/call in a class method
The computed super arm only handled object-literal methods (home stack); class methods fell back to `this[index]`, reading the **child** instance and shadowing the parent. String-literal computed keys now route to the ident-form `SuperPropertyGet` (reads) and `SuperMethodCall` (calls — `super['m']()` binds the current `this` as receiver).
→ `super/prop-expr-cls-val`, `prop-expr-cls-val-from-arrow` (and guards `prop-expr-cls-ref-this` from regressing)

### 3. `x instanceof undefined` folded to `false`
The `undefined` identifier on the RHS resolved to no class and codegen silently produced `false`. It now lowers to the undefined value and routes through `js_instanceof_dynamic`, which throws `TypeError` (RHS not an object).
→ `instanceof/S11.8.6_A3`

### 4. Generator spread into call / `new` not iterated
A Perry generator object is a plain object with own closure-valued `next`/`return`/`throw` and **no** `[Symbol.iterator]` symbol property, so `is_iterable` missed it and `js_array_like_to_array` (call / `new` / super spread) fell through to the array-reinterpret garbage path — `f(...g())` silently passed a malformed arg and generator-body throws never propagated. `is_iterable` now recognizes generator objects (and built-in iterator objects), so spread drives the iterator protocol. Also fixes `new Map/Set(g())`.
→ `call/spread-err-{mult,sngl}-err-expr-throws`, `new/spread-err-{mult,sngl}-err-expr-throws`

## Files
- `crates/perry-hir/src/lower/expr_misc.rs` — computed super string-literal read
- `crates/perry-hir/src/lower/expr_call/mod.rs` — computed super string-literal method call
- `crates/perry-hir/src/lower/lower_expr.rs` — `instanceof undefined` dynamic routing
- `crates/perry-runtime/src/object/property_key.rs` — super read via declared prototype
- `crates/perry-runtime/src/collection_iter.rs` — `is_iterable` recognizes generators / built-in iterators

## Out of scope (deferred, high-risk / architectural)
- `super(...spread)` — conflicts with Perry's positional inline-constructor model (runtime-dynamic spread length).
- `yield*` full abrupt-completion (return/throw) delegation — large state-machine change.
- compound-assignment A7 single-eval / RequireObjectCoercible-before-ToPropertyKey — core member-access evaluation order, broad risk.
- `new <non-ctor object/number>` TypeError — blocked by NaN-box pointer/number ambiguity.