### PR TITLE
fix(runtime): Temporal PlainDate/YearMonth/MonthDay/Time/Instant/Now tail -> ~98%

### DIFF
--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -234,6 +234,13 @@ unsafe fn rel_to_primitive(value: f64) -> f64 {
         // which is itself a Number (a plain `f64` is its own NaN-box).
         return crate::date::js_date_coerce_number(value);
     }
+    // ToPrimitive(temporal, NUMBER) → the type's `valueOf`, which is a hard
+    // `TypeError` for every `Temporal.*` value (the spec bans relational ordering
+    // of Temporal values: `plainDate < plainDate` throws). Without this the cell
+    // fell through to the `DefaultString` arm and compared ISO strings silently.
+    if crate::temporal::is_temporal_value(value) {
+        return crate::temporal::dispatch::call_method(value, "valueOf", &[]);
+    }
     match crate::value::to_primitive_number(value) {
         crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => p,
         crate::value::OrdinaryToPrimitiveOutcome::DefaultString => {

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -1339,6 +1339,15 @@ pub extern "C" fn js_date_get_utc_milliseconds(timestamp: f64) -> f64 {
 /// date.valueOf() — same as getTime(), returns ms timestamp.
 #[no_mangle]
 pub extern "C" fn js_date_value_of(timestamp: f64) -> f64 {
+    // A static `.valueOf()` call is lowered to `DateValueOf` even when the
+    // receiver is typed `any` and is actually a Temporal value (e.g. from
+    // `Temporal.PlainDate.from(...)`). Every `Temporal.*` type's `valueOf` is a
+    // hard `TypeError` (the spec bans implicit numeric coercion / ordering), so
+    // route a Temporal receiver to its brand dispatch, which throws — rather
+    // than returning the opaque cell as a pseudo-Date timestamp.
+    if crate::temporal::is_temporal_value(timestamp) {
+        return crate::temporal::dispatch::call_method(timestamp, "valueOf", &[]);
+    }
     if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(timestamp) {
         return payload;
     }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -3896,12 +3896,11 @@ fn install_temporal_namespace(ns_obj: *mut ObjectHeader) {
     populate_prototype(
         instant,
         "Temporal.Instant",
-        &[
-            "epochMilliseconds",
-            "epochNanoseconds",
-            "epochSeconds",
-            "epochMicroseconds",
-        ],
+        // Per the current Temporal spec, `Temporal.Instant.prototype` exposes
+        // only `epochMilliseconds` and `epochNanoseconds`; the older
+        // `epochSeconds` / `epochMicroseconds` accessors were removed (Node v26
+        // ships neither, and `get()` never implemented them).
+        &["epochMilliseconds", "epochNanoseconds"],
         &[
             ("add", 1),
             ("subtract", 1),

--- a/crates/perry-runtime/src/temporal/dispatch.rs
+++ b/crates/perry-runtime/src/temporal/dispatch.rs
@@ -234,6 +234,19 @@ pub(crate) fn ok_or_throw<T>(r: temporal_rs::TemporalResult<T>) -> T {
     }
 }
 
+/// Every `Temporal.*` constructor is `[[Construct]]`-only: calling it without
+/// `new` is a `TypeError` (`Temporal.PlainDate(…)` vs `new Temporal.PlainDate(…)`).
+/// `new` routes through `js_new_function_construct`, which sets `new.target` to
+/// the constructor before invoking the thunk; a plain `[[Call]]` leaves it
+/// `undefined`, so an undefined `new.target` is the bare-call signal.
+pub(crate) fn require_construct(type_name: &str) {
+    if crate::object::js_new_target_get().to_bits() == crate::value::TAG_UNDEFINED {
+        crate::object::throw_object_type_error(
+            format!("Constructor {type_name} requires 'new'").as_bytes(),
+        );
+    }
+}
+
 /// `valueOf` throws on every Temporal type (the spec bans implicit ordering /
 /// arithmetic coercion). Used by every type's method router.
 pub(crate) fn throw_value_of(type_name: &str) -> ! {

--- a/crates/perry-runtime/src/temporal/instant.rs
+++ b/crates/perry-runtime/src/temporal/instant.rs
@@ -41,17 +41,52 @@ fn require_ns(v: f64) -> i128 {
         if t.is_empty() {
             return 0;
         }
-        return t.parse::<i128>().unwrap_or_else(|_| {
-            crate::fs::validate::throw_range_error_with_code("Cannot convert string to a BigInt")
-        });
+        // `StringToBigInt` failure is a **SyntaxError** (`new Temporal.Instant("abc123")`),
+        // not a RangeError — invalid BigInt *syntax* is a parse error. A
+        // syntactically-valid but out-of-i128-range string still rejects below
+        // (and `Instant::try_new` then range-checks the value itself).
+        return t.parse::<i128>().unwrap_or_else(|_| throw_bigint_syntax());
     }
     crate::object::throw_object_type_error(
         b"Cannot convert value to a BigInt for Temporal.Instant epoch-nanoseconds",
     )
 }
 
+/// Throw a JS `SyntaxError` for a string that is not valid BigInt syntax
+/// (`StringToBigInt` failure), matching Node's `new Temporal.Instant("abc123")`.
+fn throw_bigint_syntax() -> ! {
+    let msg = b"Cannot convert string to a BigInt";
+    let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err_ptr = crate::error::js_syntaxerror_new(msg_str);
+    crate::exception::js_throw(f64::from_bits(
+        JSValue::pointer(err_ptr as *const u8).bits(),
+    ))
+}
+
+/// `ToNumber(epochMilliseconds)` then `NumberToBigInt`: a BigInt or Symbol is a
+/// `TypeError` (abstract `ToNumber` rejects them), and a non-integral Number
+/// (`Infinity`/`NaN`/`1.3`/`undefined`→NaN) is a `RangeError` (`NumberToBigInt`
+/// requires an integral Number). `valueOf` is observed for objects.
+fn epoch_number_to_integer(raw: f64) -> i64 {
+    let jv = JSValue::from_bits(raw.to_bits());
+    if jv.is_bigint() {
+        crate::object::throw_object_type_error(b"Cannot convert a BigInt value to a number");
+    }
+    if unsafe { crate::symbol::js_is_symbol(raw) } != 0 {
+        crate::object::throw_object_type_error(b"Cannot convert a Symbol value to a number");
+    }
+    let n = crate::builtins::js_number_coerce(raw);
+    if !n.is_finite() || n.fract() != 0.0 {
+        crate::fs::validate::throw_range_error_with_code(
+            "epochMilliseconds must be an integral Number",
+        );
+    }
+    n as i64
+}
+
 /// `new Temporal.Instant(epochNanoseconds: bigint)`.
 pub fn construct(args: &[f64]) -> f64 {
+    dispatch::require_construct(TYPE_NAME);
     wrap(ok_or_throw(Instant::try_new(require_ns(raw_arg(args, 0)))))
 }
 
@@ -91,8 +126,8 @@ pub fn from_static(args: &[f64]) -> f64 {
 }
 
 pub fn from_epoch_milliseconds_static(args: &[f64]) -> f64 {
-    let ms = JSValue::from_bits(raw_arg(args, 0).to_bits()).to_number();
-    wrap(ok_or_throw(Instant::from_epoch_milliseconds(ms as i64)))
+    let ms = epoch_number_to_integer(raw_arg(args, 0));
+    wrap(ok_or_throw(Instant::from_epoch_milliseconds(ms)))
 }
 
 pub fn from_epoch_nanoseconds_static(args: &[f64]) -> f64 {

--- a/crates/perry-runtime/src/temporal/now.rs
+++ b/crates/perry-runtime/src/temporal/now.rs
@@ -6,21 +6,20 @@
 
 use super::dispatch::{self, ok_or_throw, raw_arg, string};
 use super::{alloc_temporal_cell, TemporalValue};
-use crate::value::JSValue;
 use temporal_rs::{Temporal, TimeZone};
 
-/// Resolve an optional time-zone argument (an IANA id string) to a `TimeZone`,
-/// or `None` to use the host's current zone.
+/// Resolve an optional time-zone argument (an IANA id string or a
+/// `Temporal.ZonedDateTime`) to a `TimeZone`, or `None` (absent / `undefined`)
+/// to use the host's current zone. A present-but-wrong-typed value is rejected
+/// exactly like `ToTemporalTimeZoneIdentifier`: an invalid string → `RangeError`,
+/// any non-string / non-ZonedDateTime primitive or object → `TypeError`. (The
+/// old version silently dropped wrong types to `None`, so the host zone was used
+/// instead of throwing — the `timezone-wrong-type` cases never rejected.)
 fn tz_arg(v: f64) -> Option<TimeZone> {
     if dispatch::is_undefined(v) {
         return None;
     }
-    let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_string() {
-        let s = dispatch::read_string(v);
-        return Some(ok_or_throw(TimeZone::try_from_str(&s)));
-    }
-    None
+    Some(super::options::timezone(v))
 }
 
 pub fn instant(_args: &[f64]) -> f64 {

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -60,22 +60,238 @@ pub fn require_options_object(arg: f64) -> Option<*const crate::object::ObjectHe
     }
 }
 
+/// Read the `era` / `eraYear` calendar fields, but ONLY for a non-ISO calendar.
+/// The ISO-8601 calendar has no eras, so `ToTemporalDate` / `ToTemporalYearMonth`
+/// never read `era`/`eraYear` for it — and the order-of-operations tests assert
+/// exactly that (an ISO bag observes no `era`/`eraYear` gets). Reading them
+/// unconditionally would record extra observable property accesses.
+fn read_era_fields(
+    obj: *const crate::object::ObjectHeader,
+    calendar: &Calendar,
+) -> (Option<TinyAsciiStr<19>>, Option<i32>) {
+    if calendar.is_iso() {
+        return (None, None);
+    }
+    let era =
+        str_field(obj, "era").and_then(|s| TinyAsciiStr::<19>::try_from_utf8(s.as_bytes()).ok());
+    let era_year = num_field(obj, "eraYear").map(|n| n.trunc() as i32);
+    (era, era_year)
+}
+
+/// Read a date property bag's calendar fields in `ToTemporalDate` /
+/// `ToTemporalMonthDay` spec order — the calendar's date field keys read
+/// **alphabetically**: `day`, [`era`, `eraYear` for non-ISO calendars], `month`,
+/// `monthCode`, `year`. Numeric fields go through the real `ToNumber`
+/// (`valueOf`) coercion; `monthCode` is `ToPrimitiveAndRequireString` (so a
+/// `toString`-bearing wrapper is observed); `month`/`day` are
+/// `ToPositiveIntegerWithTruncation` (a value `< 1` is a `RangeError`, even
+/// under `constrain`). The caller resolves the `calendar` slot FIRST and reads
+/// `overflow` LAST. Replaces the old non-alphabetical [`calendar_fields`] read
+/// (which used `str_field` for `monthCode` — dropping a wrapped value — and
+/// `field_u8` for `month`/`day` — silently saturating a negative to 255).
+fn read_date_fields_alpha(
+    obj: *const crate::object::ObjectHeader,
+    calendar: &Calendar,
+) -> CalendarFields {
+    let day = num_field(obj, "day");
+    let (era, era_year) = read_era_fields(obj, calendar);
+    let month = num_field(obj, "month");
+    let month_code = require_string_field(obj, "monthCode").map(|s| parse_month_code(&s));
+    let year = num_field(obj, "year");
+
+    let mut f = CalendarFields::new();
+    if let Some(n) = year {
+        f.year = Some(n.trunc() as i32);
+    }
+    if let Some(n) = month {
+        f.month = Some(positive_field_u8(n, "month"));
+    }
+    f.month_code = month_code;
+    if let Some(n) = day {
+        f.day = Some(positive_field_u8(n, "day"));
+    }
+    f.era = era;
+    if let Some(y) = era_year {
+        f.era_year = Some(y);
+    }
+    f
+}
+
+/// `ToTemporalYearMonth` field read in spec (alphabetical) order — [`era`,
+/// `eraYear` for non-ISO], `month`, `monthCode`, `year` (no `day`). Same coercion
+/// rules as [`read_date_fields_alpha`].
+fn read_year_month_fields_alpha(
+    obj: *const crate::object::ObjectHeader,
+    calendar: &Calendar,
+) -> YearMonthCalendarFields {
+    let (era, era_year) = read_era_fields(obj, calendar);
+    let month = num_field(obj, "month");
+    let month_code = require_string_field(obj, "monthCode").map(|s| parse_month_code(&s));
+    let year = num_field(obj, "year");
+
+    let mut f = YearMonthCalendarFields::new();
+    if let Some(n) = year {
+        f.year = Some(n.trunc() as i32);
+    }
+    if let Some(n) = month {
+        f.month = Some(positive_field_u8(n, "month"));
+    }
+    f.month_code = month_code;
+    f.era = era;
+    if let Some(y) = era_year {
+        f.era_year = Some(y);
+    }
+    f
+}
+
 /// Build a [`temporal_rs::PlainDate`] from a property-bag object
 /// (`ToTemporalDate` step for an Object that isn't already a Temporal value):
-/// read its calendar fields + `calendar` slot into a `PartialDate` and let
-/// `temporal_rs` validate/construct under the given `overflow`. A non-object
+/// resolve the `calendar` slot FIRST, then read the date fields in alphabetical
+/// order, and construct under the given `overflow`. A non-object
 /// (number/boolean/null/symbol) is a `TypeError`, matching the spec's
-/// "Numbers cannot be used in place of an ISO string" wrong-type cases.
+/// "Numbers cannot be used in place of an ISO string" wrong-type cases. Used by
+/// the `compare`/`until`/`since`/`equals` coercion paths (which take no options,
+/// so `overflow` is precomputed / `None`); `from` uses [`plain_date_from_bag_opts`].
 pub fn plain_date_from_bag(v: f64, overflow: Option<Overflow>) -> temporal_rs::PlainDate {
     let obj = match as_obj(v) {
         Some(o) => o,
         None => type_error("Cannot convert value to a Temporal.PlainDate".to_string()),
     };
+    let calendar = calendar_slot(field(obj, "calendar"));
+    let calendar_fields = read_date_fields_alpha(obj, &calendar);
     let partial = temporal_rs::partial::PartialDate {
-        calendar_fields: calendar_fields(obj),
-        calendar: calendar_slot(field(obj, "calendar")),
+        calendar_fields,
+        calendar,
     };
     ok_or_throw(temporal_rs::PlainDate::from_partial(partial, overflow))
+}
+
+/// `ToTemporalDate` for `Temporal.PlainDate.from(bag, options)`: read the bag's
+/// calendar + fields in spec order, then `GetTemporalOverflowOption(options)`
+/// **last** (so a failing field read happens before `overflow` is observed, and
+/// a primitive `options` argument throws `TypeError` only after the fields are
+/// read — the `observable-get-overflow` / `options-wrong-type` order tests).
+pub fn plain_date_from_bag_opts(v: f64, opts: f64) -> temporal_rs::PlainDate {
+    let obj = match as_obj(v) {
+        Some(o) => o,
+        None => type_error("Cannot convert value to a Temporal.PlainDate".to_string()),
+    };
+    let calendar = calendar_slot(field(obj, "calendar"));
+    let calendar_fields = read_date_fields_alpha(obj, &calendar);
+    let overflow = overflow(opts);
+    let partial = temporal_rs::partial::PartialDate {
+        calendar_fields,
+        calendar,
+    };
+    ok_or_throw(temporal_rs::PlainDate::from_partial(partial, overflow))
+}
+
+/// `ToTemporalYearMonth` for `Temporal.PlainYearMonth.from(bag, options)`:
+/// resolve calendar, read year-month fields alphabetically, then read `overflow`
+/// from `options` last.
+pub fn plain_year_month_from_bag_opts(v: f64, opts: f64) -> temporal_rs::PlainYearMonth {
+    let obj = match as_obj(v) {
+        Some(o) => o,
+        None => type_error("Cannot convert value to a Temporal.PlainYearMonth".to_string()),
+    };
+    let calendar = calendar_slot(field(obj, "calendar"));
+    let calendar_fields = read_year_month_fields_alpha(obj, &calendar);
+    require_year_month_field(&calendar_fields);
+    let overflow = overflow(opts);
+    let partial = temporal_rs::partial::PartialYearMonth {
+        calendar_fields,
+        calendar,
+    };
+    ok_or_throw(temporal_rs::PlainYearMonth::from_partial(partial, overflow))
+}
+
+/// `ToTemporalYearMonth` for the no-options coercion paths
+/// (`compare`/`until`/`since`/`equals`): calendar + fields, `constrain` overflow.
+pub fn plain_year_month_from_bag(v: f64) -> temporal_rs::PlainYearMonth {
+    let obj = match as_obj(v) {
+        Some(o) => o,
+        None => type_error("Cannot convert value to a Temporal.PlainYearMonth".to_string()),
+    };
+    let calendar = calendar_slot(field(obj, "calendar"));
+    let calendar_fields = read_year_month_fields_alpha(obj, &calendar);
+    require_year_month_field(&calendar_fields);
+    let partial = temporal_rs::partial::PartialYearMonth {
+        calendar_fields,
+        calendar,
+    };
+    ok_or_throw(temporal_rs::PlainYearMonth::from_partial(
+        partial,
+        Some(Overflow::Constrain),
+    ))
+}
+
+/// `ToTemporalMonthDay` for `Temporal.PlainMonthDay.from(bag, options)`: resolve
+/// calendar, read the date fields alphabetically (a `PlainMonthDay` bag reads the
+/// same `day`/`month`/`monthCode`/`year` set as a date), then `overflow` last.
+pub fn plain_month_day_from_bag_opts(v: f64, opts: f64) -> temporal_rs::PlainMonthDay {
+    let obj = match as_obj(v) {
+        Some(o) => o,
+        None => type_error("Cannot convert value to a Temporal.PlainMonthDay".to_string()),
+    };
+    let calendar = calendar_slot(field(obj, "calendar"));
+    let calendar_fields = read_date_fields_alpha(obj, &calendar);
+    require_month_day_field(&calendar_fields);
+    let overflow = overflow(opts);
+    let partial = temporal_rs::partial::PartialDate {
+        calendar_fields,
+        calendar,
+    };
+    ok_or_throw(temporal_rs::PlainMonthDay::from_partial(partial, overflow))
+}
+
+/// `ToTemporalMonthDay` for the no-options `equals` coercion path.
+pub fn plain_month_day_from_bag(v: f64) -> temporal_rs::PlainMonthDay {
+    let obj = match as_obj(v) {
+        Some(o) => o,
+        None => type_error("Cannot convert value to a Temporal.PlainMonthDay".to_string()),
+    };
+    let calendar = calendar_slot(field(obj, "calendar"));
+    let calendar_fields = read_date_fields_alpha(obj, &calendar);
+    require_month_day_field(&calendar_fields);
+    let partial = temporal_rs::partial::PartialDate {
+        calendar_fields,
+        calendar,
+    };
+    ok_or_throw(temporal_rs::PlainMonthDay::from_partial(
+        partial,
+        Some(Overflow::Constrain),
+    ))
+}
+
+/// A `PlainYearMonth` property bag must carry at least one recognized year-month
+/// field (`year`/`month`/`monthCode`/`era`/`eraYear`); otherwise
+/// `ToTemporalYearMonth` / `PrepareTemporalFields` throws a `TypeError`. Checked
+/// on the ALREADY-READ fields (not by pre-scanning the object) so `calendar` is
+/// still observed first — the order-of-operations tests assert that exact order.
+fn require_year_month_field(f: &YearMonthCalendarFields) {
+    if f.year.is_none()
+        && f.month.is_none()
+        && f.month_code.is_none()
+        && f.era.is_none()
+        && f.era_year.is_none()
+    {
+        type_error("object is not a valid Temporal.PlainYearMonth property bag".to_string());
+    }
+}
+
+/// A `PlainMonthDay` property bag must carry at least one recognized field
+/// (`month`/`monthCode`/`day`/`year`/`era`/`eraYear`). Checked on the already-read
+/// fields so `calendar` is observed first.
+fn require_month_day_field(f: &CalendarFields) {
+    if f.year.is_none()
+        && f.month.is_none()
+        && f.month_code.is_none()
+        && f.day.is_none()
+        && f.era.is_none()
+        && f.era_year.is_none()
+    {
+        type_error("object is not a valid Temporal.PlainMonthDay property bag".to_string());
+    }
 }
 
 /// Build a [`temporal_rs::PlainDateTime`] from a property-bag object
@@ -700,23 +916,25 @@ pub fn calendar_fields(obj: *const crate::object::ObjectHeader) -> CalendarField
     f
 }
 
-/// Populate a [`YearMonthCalendarFields`] from an object's year/month fields.
-pub fn year_month_fields(obj: *const crate::object::ObjectHeader) -> YearMonthCalendarFields {
-    let mut f = YearMonthCalendarFields::new();
+/// `Temporal.PlainYearMonth.prototype.toPlainDate(item)` reads ONLY `day` from
+/// `item` — the year/month come from the receiver — so the observable order is
+/// just `get day` / `valueOf`. (The old `calendar_fields` read year/month/
+/// monthCode/day/era/eraYear, recording extra gets.) `day` is
+/// `ToPositiveIntegerWithTruncation`.
+pub fn to_plain_date_day_field(obj: *const crate::object::ObjectHeader) -> CalendarFields {
+    let mut f = CalendarFields::new();
+    if let Some(n) = num_field(obj, "day") {
+        f.day = Some(positive_field_u8(n, "day"));
+    }
+    f
+}
+
+/// `Temporal.PlainMonthDay.prototype.toPlainDate(item)` reads ONLY `year` from
+/// `item` (the month/day come from the receiver).
+pub fn to_plain_date_year_field(obj: *const crate::object::ObjectHeader) -> CalendarFields {
+    let mut f = CalendarFields::new();
     if let Some(n) = num_field(obj, "year") {
         f.year = Some(n.trunc() as i32);
-    }
-    if let Some(n) = num_field(obj, "month") {
-        f.month = Some(field_u8(n.trunc() as i64));
-    }
-    if let Some(s) = str_field(obj, "monthCode") {
-        f.month_code = Some(parse_month_code(&s));
-    }
-    if let Some(s) = str_field(obj, "era") {
-        f.era = TinyAsciiStr::<19>::try_from_utf8(s.as_bytes()).ok();
-    }
-    if let Some(n) = num_field(obj, "eraYear") {
-        f.era_year = Some(n.trunc() as i32);
     }
     f
 }
@@ -861,6 +1079,39 @@ pub fn datetime_fields(obj: *const crate::object::ObjectHeader) -> DateTimeField
 pub fn with_datetime_fields(obj: *const crate::object::ObjectHeader) -> DateTimeFields {
     reject_calendar_and_timezone(obj);
     datetime_fields(obj)
+}
+
+/// `Temporal.PlainDate.prototype.with` / `PlainMonthDay.prototype.with`
+/// partial-fields read: `RejectObjectWithCalendarOrTimeZone` (reads `calendar`
+/// then `timeZone`, throwing `TypeError` if present), then the calendar's date
+/// fields alphabetically — exactly mirroring `PlainDateTime.with`. The receiver
+/// supplies `calendar` (so era fields are read only for a non-ISO calendar) and
+/// the caller reads `overflow` LAST. Replaces the old `calendar_fields` read
+/// (non-alphabetical, `str_field` monthCode, `field_u8` negatives, no reject).
+pub fn with_calendar_fields(
+    obj: *const crate::object::ObjectHeader,
+    calendar: &Calendar,
+) -> CalendarFields {
+    reject_calendar_and_timezone(obj);
+    read_date_fields_alpha(obj, calendar)
+}
+
+/// `Temporal.PlainYearMonth.prototype.with` partial-fields read:
+/// `RejectObjectWithCalendarOrTimeZone` then the year-month fields alphabetically.
+pub fn with_year_month_fields(
+    obj: *const crate::object::ObjectHeader,
+    calendar: &Calendar,
+) -> YearMonthCalendarFields {
+    reject_calendar_and_timezone(obj);
+    read_year_month_fields_alpha(obj, calendar)
+}
+
+/// `Temporal.PlainTime.prototype.with` partial-fields read:
+/// `RejectObjectWithCalendarOrTimeZone` (a `PlainTime` bag still rejects a
+/// `calendar`/`timeZone` property per spec), then the time fields alphabetically.
+pub fn with_partial_time(obj: *const crate::object::ObjectHeader) -> PartialTime {
+    reject_calendar_and_timezone(obj);
+    partial_time(obj)
 }
 
 /// Populate a [`ZonedDateTimeFields`] (calendar fields + time + offset) for

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -24,16 +24,24 @@ fn calendar_arg(v: f64) -> Calendar {
 
 /// `new Temporal.PlainDate(year, month, day, calendar?)`.
 pub fn construct(args: &[f64]) -> f64 {
-    let year = dispatch::num_arg(args, 0);
-    let month = dispatch::num_arg(args, 1);
-    let day = dispatch::num_arg(args, 2);
-    let cal = calendar_arg(raw_arg(args, 3));
+    dispatch::require_construct(TYPE_NAME);
+    // Each field is `ToIntegerWithTruncation` (real `ToNumber`, observing
+    // `valueOf`; `Infinity`/`NaN` → `RangeError`), read in order — so the
+    // order-of-operations / `infinity-throws-rangeerror` tests see exactly one
+    // `valueOf` per field and a non-finite field rejects at its read position.
+    let year = dispatch::integer_with_truncation(raw_arg(args, 0));
+    let month = dispatch::integer_with_truncation(raw_arg(args, 1));
+    let day = dispatch::integer_with_truncation(raw_arg(args, 2));
+    // The constructor's `calendar` is `ToTemporalCalendarIdentifier` — a bare
+    // identifier string, NOT a parseable ISO/annotation string (so
+    // `"1997-12-04[u-ca=iso8601]"` is a `RangeError`, not silently accepted).
+    let cal = super::options::calendar_identifier(raw_arg(args, 3));
     // `try_new` = overflow "reject": the constructor throws on out-of-range
     // fields (e.g. month 13) rather than silently constraining to 2021-12-01.
     wrap(ok_or_throw(PlainDate::try_new(
-        year as i32,
-        month as u8,
-        day as u8,
+        year.clamp(i32::MIN as i64, i32::MAX as i64) as i32,
+        dispatch::field_u8(month),
+        dispatch::field_u8(day),
         cal,
     )))
 }
@@ -66,11 +74,43 @@ fn coerce_date_with_overflow(
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
-    // `from(item, options)`: a wrong-typed options arg is a TypeError, thrown
-    // before the item is converted (GetOptionsObject). `overflow` also drives
-    // constrain/reject for a property-bag / string item.
-    let overflow = super::options::overflow(raw_arg(args, 1));
-    wrap(coerce_date_with_overflow(raw_arg(args, 0), overflow))
+    // `ToTemporalDate(item, options)`. The point at which `options` is processed
+    // is observable and differs by item kind:
+    //   * A **string** is parsed FIRST (an invalid ISO string → `RangeError`)
+    //     and only then is `overflow` read from `options` — so a bad string
+    //     throws before a wrong-typed `options` would (`options-wrong-type`'s
+    //     `"1976-11-18Z"` case expects `RangeError`, not `TypeError`).
+    //   * A `PlainDate` / `PlainDateTime` / `ZonedDateTime` reads `overflow`
+    //     (validating `options` → `TypeError` on a primitive) then takes/derives
+    //     its date.
+    //   * A **property bag** reads its calendar + fields first, then `overflow`
+    //     LAST (`observable-get-overflow` / `order-of-operations`).
+    let item = raw_arg(args, 0);
+    let opts = raw_arg(args, 1);
+    if JSValue::from_bits(item.to_bits()).is_string() {
+        let d = ok_or_throw(dispatch::read_string(item).parse::<PlainDate>());
+        let _ = super::options::overflow(opts);
+        return wrap(d);
+    }
+    match temporal_value_ref(item) {
+        Some(TemporalValue::PlainDate(d)) => {
+            let _ = super::options::overflow(opts);
+            return wrap(d.clone());
+        }
+        Some(TemporalValue::PlainDateTime(dt)) => {
+            let _ = super::options::overflow(opts);
+            return wrap(dt.to_plain_date());
+        }
+        Some(TemporalValue::ZonedDateTime(z)) => {
+            let _ = super::options::overflow(opts);
+            return wrap(z.to_plain_date());
+        }
+        Some(_) => crate::object::throw_object_type_error(
+            b"Cannot convert this Temporal value to a Temporal.PlainDate",
+        ),
+        None => {}
+    }
+    wrap(super::options::plain_date_from_bag_opts(item, opts))
 }
 
 pub fn compare_static(args: &[f64]) -> f64 {
@@ -124,7 +164,13 @@ fn to_zoned_args(v: f64) -> (TimeZone, Option<PlainTime>) {
         return (super::options::timezone(v), None);
     }
     let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_pointer() {
+    // A `Temporal.ZonedDateTime` tz-like reuses its own zone.
+    if let Some(TemporalValue::ZonedDateTime(_)) = temporal_value_ref(v) {
+        return (super::options::timezone(v), None);
+    }
+    // A plain object is the `{ timeZone, plainTime }` options form (a Symbol is
+    // POINTER-tagged but is a primitive, never an options object).
+    if jv.is_pointer() && unsafe { crate::symbol::js_is_symbol(v) } == 0 {
         let obj = jv.as_pointer::<crate::object::ObjectHeader>();
         if !obj.is_null() {
             let tz_key = crate::string::js_string_from_bytes(b"timeZone".as_ptr(), 8);
@@ -135,8 +181,11 @@ fn to_zoned_args(v: f64) -> (TimeZone, Option<PlainTime>) {
             return (tz, super::options::optional_plain_time(pt_raw));
         }
     }
-    crate::fs::validate::throw_range_error_with_code(
-        "Temporal.PlainDate.prototype.toZonedDateTime requires a time zone",
+    // A non-string, non-object primitive (null / boolean / number / bigint /
+    // symbol) is never a valid time-zone — `ToTemporalTimeZoneIdentifier` throws
+    // a `TypeError` (not a RangeError, which is reserved for bad *strings*).
+    crate::object::throw_object_type_error(
+        b"Temporal.PlainDate.prototype.toZonedDateTime requires a time-zone string or object",
     )
 }
 
@@ -178,11 +227,20 @@ pub fn call(recv: f64, d: &PlainDate, name: &str, args: &[f64]) -> f64 {
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");
-            let fields = super::options::calendar_fields(obj);
+            let fields = super::options::with_calendar_fields(obj, d.calendar());
             let overflow = super::options::overflow(raw_arg(args, 1));
             wrap(ok_or_throw(d.with(fields, overflow)))
         }
-        "withCalendar" => wrap(d.with_calendar(calendar_arg(raw_arg(args, 0)))),
+        "withCalendar" => {
+            // `withCalendar` requires a calendar argument — a missing / `undefined`
+            // one is a `TypeError` (not the ISO default that `calendar_slot` returns).
+            if dispatch::is_undefined(raw_arg(args, 0)) {
+                crate::object::throw_object_type_error(
+                    b"Temporal.PlainDate.prototype.withCalendar requires a calendar argument",
+                );
+            }
+            wrap(d.with_calendar(calendar_arg(raw_arg(args, 0))))
+        }
         "toPlainDateTime" => {
             let time = super::options::optional_plain_time(raw_arg(args, 0));
             alloc_temporal_cell(TemporalValue::PlainDateTime(ok_or_throw(

--- a/crates/perry-runtime/src/temporal/plain_month_day.rs
+++ b/crates/perry-runtime/src/temporal/plain_month_day.rs
@@ -2,11 +2,11 @@
 //!
 //! A calendar month + day with no year (e.g. a recurring birthday/holiday).
 
-use super::dispatch::{self, num_arg, ok_or_throw, raw_arg, string};
+use super::dispatch::{self, ok_or_throw, raw_arg, string};
 use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
 use crate::value::JSValue;
 use temporal_rs::options::Overflow;
-use temporal_rs::{Calendar, PlainMonthDay};
+use temporal_rs::PlainMonthDay;
 
 const TYPE_NAME: &str = "Temporal.PlainMonthDay";
 
@@ -14,39 +14,42 @@ fn wrap(md: PlainMonthDay) -> f64 {
     alloc_temporal_cell(TemporalValue::PlainMonthDay(md))
 }
 
-fn calendar_arg(v: f64) -> Calendar {
-    if dispatch::is_undefined(v) {
-        return Calendar::default();
-    }
-    let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_string() {
-        return ok_or_throw(dispatch::read_string(v).parse::<Calendar>());
-    }
-    crate::object::throw_object_type_error(b"calendar must be a calendar identifier string")
-}
-
 /// `new Temporal.PlainMonthDay(month, day, calendar?, referenceYear?)`.
 pub fn construct(args: &[f64]) -> f64 {
+    dispatch::require_construct(TYPE_NAME);
+    // Spec order: `ToIntegerWithTruncation(month)`, `…(day)`,
+    // `ToTemporalCalendarIdentifier(calendar)`, then the reference ISO year
+    // (defaults to 1972). Real `ToNumber` observes `valueOf` and rejects
+    // `Infinity`/`NaN` at the field's read position.
+    let month = dispatch::integer_with_truncation(raw_arg(args, 0));
+    let day = dispatch::integer_with_truncation(raw_arg(args, 1));
+    let cal = super::options::calendar_identifier(raw_arg(args, 2));
     let ref_year = {
-        let y = num_arg(args, 3);
-        if y.is_finite() {
-            Some(y as i32)
-        } else {
+        let raw = raw_arg(args, 3);
+        if dispatch::is_undefined(raw) {
             None
+        } else {
+            Some(
+                dispatch::integer_with_truncation(raw).clamp(i32::MIN as i64, i32::MAX as i64)
+                    as i32,
+            )
         }
     };
     // Overflow "reject": the constructor throws on an invalid month/day (e.g.
     // Feb 30) instead of constraining it to Feb 29. The `.from()` fields path
     // (`coerce_md`) keeps the spec's "constrain" default.
     wrap(ok_or_throw(PlainMonthDay::new_with_overflow(
-        num_arg(args, 0) as u8,
-        num_arg(args, 1) as u8,
-        calendar_arg(raw_arg(args, 2)),
+        dispatch::field_u8(month),
+        dispatch::field_u8(day),
+        cal,
         Overflow::Reject,
         ref_year,
     )))
 }
 
+/// `ToTemporalMonthDay(item)` for the no-options `equals` coercion path: a
+/// `Temporal.PlainMonthDay` (clone), an ISO string, or a property bag (read in
+/// spec order with `constrain` overflow).
 fn coerce_md(v: f64) -> PlainMonthDay {
     if let Some(TemporalValue::PlainMonthDay(md)) = temporal_value_ref(v) {
         return md.clone();
@@ -61,34 +64,8 @@ fn coerce_md(v: f64) -> PlainMonthDay {
                 b"Cannot convert a Symbol to a Temporal.PlainMonthDay",
             );
         }
-        let obj = jv.as_pointer::<crate::object::ObjectHeader>();
-        if !obj.is_null() {
-            let has_field = |name: &str| -> bool {
-                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-                crate::object::js_object_get_field_by_name_f64(obj, key).to_bits()
-                    != crate::value::TAG_UNDEFINED
-            };
-            if !["month", "monthCode", "day", "year", "era", "eraYear"]
-                .iter()
-                .any(|n| has_field(n))
-            {
-                crate::object::throw_object_type_error(
-                    b"object is not a valid Temporal.PlainMonthDay property bag",
-                );
-            }
-            // Build via the calendar's `month_day_from_fields` so `monthCode`,
-            // `year`/`era` disambiguation, and overflow handling all work
-            // (the old `month`/`day`-only path dropped monthCode entirely).
-            let cal_key = crate::string::js_string_from_bytes(b"calendar".as_ptr(), 8);
-            let cal_raw = crate::object::js_object_get_field_by_name_f64(obj, cal_key);
-            let partial = temporal_rs::partial::PartialDate {
-                calendar_fields: super::options::calendar_fields(obj),
-                calendar: calendar_arg(cal_raw),
-            };
-            return ok_or_throw(PlainMonthDay::from_partial(
-                partial,
-                Some(Overflow::Constrain),
-            ));
+        if !jv.as_pointer::<crate::object::ObjectHeader>().is_null() {
+            return super::options::plain_month_day_from_bag(v);
         }
     }
     // Non-string, non-object primitive → TypeError per ToTemporalMonthDay.
@@ -96,7 +73,31 @@ fn coerce_md(v: f64) -> PlainMonthDay {
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
-    wrap(coerce_md(raw_arg(args, 0)))
+    // `ToTemporalMonthDay(item, options)`: a string is parsed FIRST (invalid →
+    // `RangeError`), a `PlainMonthDay` is cloned after `overflow` is read
+    // (validating `options`), and a property bag reads its calendar + fields,
+    // then `overflow` LAST. (Previously this dropped `options` entirely, so a
+    // wrong-typed `options`, `overflow: "reject"`, or a bad overflow string
+    // never threw.)
+    let item = raw_arg(args, 0);
+    let opts = raw_arg(args, 1);
+    if JSValue::from_bits(item.to_bits()).is_string() {
+        let md = ok_or_throw(dispatch::read_string(item).parse::<PlainMonthDay>());
+        let _ = super::options::overflow(opts);
+        return wrap(md);
+    }
+    if let Some(TemporalValue::PlainMonthDay(md)) = temporal_value_ref(item) {
+        let _ = super::options::overflow(opts);
+        return wrap(md.clone());
+    }
+    // Any other object — including a non-PlainMonthDay Temporal value such as a
+    // `PlainDate` — is read as a property bag (`ToTemporalMonthDay` reads its
+    // `month`/`monthCode`/`day` getters), NOT a TypeError.
+    let jv = JSValue::from_bits(item.to_bits());
+    if jv.is_pointer() && !crate::symbol::is_registered_symbol(jv.as_pointer::<u8>() as usize) {
+        return wrap(super::options::plain_month_day_from_bag_opts(item, opts));
+    }
+    crate::object::throw_object_type_error(b"Cannot convert value to a Temporal.PlainMonthDay")
 }
 
 pub fn get(md: &PlainMonthDay, name: &str) -> Option<f64> {
@@ -112,9 +113,14 @@ pub fn call(recv: f64, md: &PlainMonthDay, name: &str, args: &[f64]) -> f64 {
     match name {
         "equals" => {
             let other = coerce_md(raw_arg(args, 0));
+            // Two `PlainMonthDay`s are equal iff their full ISO date —
+            // `[[ISOYear]]` (the reference year), `[[ISOMonth]]`/`[[ISODay]]`, and
+            // calendar — all match. The reference year IS observable here: two
+            // month-days that differ only in reference year are NOT equal.
             dispatch::boolean(
                 md.day() == other.day()
                     && md.month_code() == other.month_code()
+                    && md.reference_year() == other.reference_year()
                     && md.calendar_id() == other.calendar_id(),
             )
         }
@@ -127,14 +133,14 @@ pub fn call(recv: f64, md: &PlainMonthDay, name: &str, args: &[f64]) -> f64 {
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");
-            let fields = super::options::calendar_fields(obj);
+            let fields = super::options::with_calendar_fields(obj, md.calendar());
             let overflow = super::options::overflow(raw_arg(args, 1));
             wrap(ok_or_throw(md.with(fields, overflow)))
         }
         "toPlainDate" => {
             let obj =
                 super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "toPlainDate");
-            let year = super::options::calendar_fields(obj);
+            let year = super::options::to_plain_date_year_field(obj);
             alloc_temporal_cell(TemporalValue::PlainDate(ok_or_throw(
                 md.to_plain_date(Some(year)),
             )))

--- a/crates/perry-runtime/src/temporal/plain_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_time.rs
@@ -3,7 +3,7 @@
 //! Wall-clock time with no date or timezone. No calendar, so the plainest of
 //! the plain types.
 
-use super::dispatch::{self, field_u16, field_u8, int_arg, ok_or_throw, raw_arg, string};
+use super::dispatch::{self, field_u16, field_u8, ok_or_throw, raw_arg, string};
 use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
 use crate::value::JSValue;
 use temporal_rs::options::ToStringRoundingOptions;
@@ -15,17 +15,25 @@ fn wrap(t: PlainTime) -> f64 {
     alloc_temporal_cell(TemporalValue::PlainTime(t))
 }
 
+/// `ToIntegerWithTruncation` for an optional `PlainTime` constructor field
+/// (absent / `undefined` → 0), as an `i64`. Real `ToNumber` observes `valueOf`
+/// and rejects `Infinity`/`NaN` with a `RangeError` at the field's read position.
+fn time_field(args: &[f64], i: usize) -> i64 {
+    dispatch::optional_integer_with_truncation(raw_arg(args, i))
+}
+
 /// `new Temporal.PlainTime(hour?, minute?, second?, ms?, µs?, ns?)`. Out-of-range
 /// fields saturate via `field_u8`/`field_u16` so `try_new` rejects them (an `as
 /// u8` cast on the raw i64 would *wrap* `256` back to `0` and accept it).
 pub fn construct(args: &[f64]) -> f64 {
+    dispatch::require_construct(TYPE_NAME);
     wrap(ok_or_throw(PlainTime::try_new(
-        field_u8(int_arg(args, 0)),
-        field_u8(int_arg(args, 1)),
-        field_u8(int_arg(args, 2)),
-        field_u16(int_arg(args, 3)),
-        field_u16(int_arg(args, 4)),
-        field_u16(int_arg(args, 5)),
+        field_u8(time_field(args, 0)),
+        field_u8(time_field(args, 1)),
+        field_u8(time_field(args, 2)),
+        field_u16(time_field(args, 3)),
+        field_u16(time_field(args, 4)),
+        field_u16(time_field(args, 5)),
     )))
 }
 
@@ -40,8 +48,15 @@ fn coerce_time(v: f64) -> PlainTime {
 /// no recognized time field, or any non-string primitive (number / bigint /
 /// boolean / null / symbol), throws TypeError; a malformed string → RangeError.
 fn coerce_time_overflow(v: f64, overflow: temporal_rs::options::Overflow) -> PlainTime {
-    if let Some(TemporalValue::PlainTime(t)) = temporal_value_ref(v) {
-        return *t;
+    // A `PlainTime` / `PlainDateTime` / `ZonedDateTime` supplies its time via
+    // its internal slot — NO observable property getter calls
+    // (`argument-plaindatetime`'s fast-path assertion). Reading `hour`…`second`
+    // off such a value as a bag (the old fallthrough) called the getters.
+    match temporal_value_ref(v) {
+        Some(TemporalValue::PlainTime(t)) => return *t,
+        Some(TemporalValue::PlainDateTime(dt)) => return dt.to_plain_time(),
+        Some(TemporalValue::ZonedDateTime(z)) => return z.to_plain_time(),
+        _ => {}
     }
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_string() {
@@ -79,30 +94,56 @@ fn coerce_time_overflow(v: f64, overflow: temporal_rs::options::Overflow) -> Pla
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
-    // `from(item, options)` — `GetTemporalOverflowOption` is consulted only on
-    // the property-bag path; a string item is parsed first (so an invalid string
-    // throws RangeError before the `overflow` getter is observed). The options
-    // bag is still type-checked for every item kind.
+    // `ToTemporalTime(item, options)`. A string is parsed FIRST (invalid →
+    // `RangeError`) and only then is `overflow` read (so a bad string throws
+    // before a wrong-typed `options` would); a `PlainTime` / `PlainDateTime` /
+    // `ZonedDateTime` takes its time slot directly (after reading `overflow`,
+    // which validates `options`); a property bag reads its time fields, then
+    // `overflow` LAST.
     let item = raw_arg(args, 0);
     let opts = raw_arg(args, 1);
-    let overflow = if is_time_property_bag(item) {
-        super::options::overflow(opts).unwrap_or_default()
-    } else {
-        let _ = super::options::require_options_object(opts);
-        temporal_rs::options::Overflow::Constrain
-    };
-    wrap(coerce_time_overflow(item, overflow))
-}
-
-/// True if `v` is a plain object (not a Temporal value, not a Symbol) — i.e. a
-/// property bag that ToTemporalTime would read fields from (and thus read the
-/// `overflow` option for).
-fn is_time_property_bag(v: f64) -> bool {
-    let jv = JSValue::from_bits(v.to_bits());
-    if !jv.is_pointer() || temporal_value_ref(v).is_some() {
-        return false;
+    if JSValue::from_bits(item.to_bits()).is_string() {
+        let t = ok_or_throw(dispatch::read_string(item).parse::<PlainTime>());
+        let _ = super::options::overflow(opts);
+        return wrap(t);
     }
-    !crate::symbol::is_registered_symbol(jv.as_pointer::<u8>() as usize)
+    match temporal_value_ref(item) {
+        Some(TemporalValue::PlainTime(t)) => {
+            let _ = super::options::overflow(opts);
+            return wrap(*t);
+        }
+        Some(TemporalValue::PlainDateTime(dt)) => {
+            let _ = super::options::overflow(opts);
+            return wrap(dt.to_plain_time());
+        }
+        Some(TemporalValue::ZonedDateTime(z)) => {
+            let _ = super::options::overflow(opts);
+            return wrap(z.to_plain_time());
+        }
+        Some(_) => crate::object::throw_object_type_error(
+            b"Cannot convert this Temporal value to a Temporal.PlainTime",
+        ),
+        None => {}
+    }
+    let jv = JSValue::from_bits(item.to_bits());
+    if jv.is_pointer() && !crate::symbol::is_registered_symbol(jv.as_pointer::<u8>() as usize) {
+        let obj = jv.as_pointer::<crate::object::ObjectHeader>();
+        if !obj.is_null() {
+            let partial = super::options::partial_time(obj);
+            // `ToTemporalTime` of a bag with NO recognized time field → TypeError
+            // (`PrepareTemporalFields` requires ≥1 field), BEFORE `overflow`.
+            if partial.is_empty() {
+                crate::object::throw_object_type_error(
+                    b"object is not a valid Temporal.PlainTime property bag (no time fields)",
+                );
+            }
+            let overflow =
+                super::options::overflow(opts).unwrap_or(temporal_rs::options::Overflow::Constrain);
+            let base = ok_or_throw(PlainTime::try_new(0, 0, 0, 0, 0, 0));
+            return wrap(ok_or_throw(base.with(partial, Some(overflow))));
+        }
+    }
+    crate::object::throw_object_type_error(b"Cannot convert value to a Temporal.PlainTime")
 }
 
 pub fn compare_static(args: &[f64]) -> f64 {
@@ -156,7 +197,7 @@ pub fn call(recv: f64, t: &PlainTime, name: &str, args: &[f64]) -> f64 {
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");
-            let partial = super::options::partial_time(obj);
+            let partial = super::options::with_partial_time(obj);
             let overflow = super::options::overflow(raw_arg(args, 1));
             wrap(ok_or_throw(t.with(partial, overflow)))
         }

--- a/crates/perry-runtime/src/temporal/plain_year_month.rs
+++ b/crates/perry-runtime/src/temporal/plain_year_month.rs
@@ -2,11 +2,10 @@
 //!
 //! A calendar year + month (e.g. a billing period), no day/time/timezone.
 
-use super::dispatch::{self, boolean, num_arg, ok_or_throw, raw_arg, string, undefined};
+use super::dispatch::{self, boolean, ok_or_throw, raw_arg, string, undefined};
 use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
 use crate::value::JSValue;
-use temporal_rs::options::Overflow;
-use temporal_rs::{Calendar, PlainYearMonth};
+use temporal_rs::PlainYearMonth;
 
 const TYPE_NAME: &str = "Temporal.PlainYearMonth";
 
@@ -14,49 +13,40 @@ fn wrap(ym: PlainYearMonth) -> f64 {
     alloc_temporal_cell(TemporalValue::PlainYearMonth(ym))
 }
 
-fn calendar_arg(v: f64) -> Calendar {
-    if dispatch::is_undefined(v) {
-        return Calendar::default();
-    }
-    let jv = JSValue::from_bits(v.to_bits());
-    if jv.is_string() {
-        return ok_or_throw(dispatch::read_string(v).parse::<Calendar>());
-    }
-    // A calendar must be `undefined` or a calendar-id string; null / number /
-    // boolean / bigint / symbol / plain object → TypeError (ToTemporalCalendar).
-    crate::object::throw_object_type_error(b"calendar must be a calendar identifier string")
-}
-
 /// `new Temporal.PlainYearMonth(year, month, calendar?, referenceDay?)`.
 pub fn construct(args: &[f64]) -> f64 {
+    dispatch::require_construct(TYPE_NAME);
+    // Spec order: `ToIntegerWithTruncation(year)`, `…(month)`,
+    // `ToTemporalCalendarIdentifier(calendar)`, then the reference ISO day
+    // (defaults to 1). Real `ToNumber` observes `valueOf` and rejects
+    // `Infinity`/`NaN` at the field's read position.
+    let year = dispatch::integer_with_truncation(raw_arg(args, 0));
+    let month = dispatch::integer_with_truncation(raw_arg(args, 1));
+    let cal = super::options::calendar_identifier(raw_arg(args, 2));
     let ref_day = {
-        let d = num_arg(args, 3);
-        if d.is_finite() {
-            Some(d as u8)
-        } else {
+        let raw = raw_arg(args, 3);
+        if dispatch::is_undefined(raw) {
             None
+        } else {
+            Some(dispatch::field_u8(dispatch::integer_with_truncation(raw)))
         }
     };
     // `try_new` = overflow "reject": throw on an out-of-range month (e.g. 13)
     // rather than constraining it to December.
     wrap(ok_or_throw(PlainYearMonth::try_new(
-        num_arg(args, 0) as i32,
-        num_arg(args, 1) as u8,
+        year.clamp(i32::MIN as i64, i32::MAX as i64) as i32,
+        dispatch::field_u8(month),
         ref_day,
-        calendar_arg(raw_arg(args, 2)),
+        cal,
     )))
 }
 
+/// `ToTemporalYearMonth(item)` for the no-options coercion paths
+/// (`compare`/`until`/`since`/`equals`): a `Temporal.PlainYearMonth` (clone), an
+/// ISO string, or a `{ year, month | monthCode, calendar, … }` property bag
+/// (read in spec order with `constrain` overflow). No recognized field, a
+/// Symbol, or any non-string primitive → TypeError.
 fn coerce_ym(v: f64) -> PlainYearMonth {
-    coerce_ym_overflow(v, Overflow::Constrain)
-}
-
-/// `ToTemporalYearMonth(item, overflow)` — from a `Temporal.PlainYearMonth`
-/// (clone), an ISO string, or a `{ year, month | monthCode, calendar, … }`
-/// property bag (via the calendar's `year_month_from_fields`, so `monthCode`
-/// and out-of-range/overflow handling work). No recognized field, a Symbol, or
-/// any non-string primitive → TypeError.
-fn coerce_ym_overflow(v: f64, overflow: Overflow) -> PlainYearMonth {
     if let Some(TemporalValue::PlainYearMonth(ym)) = temporal_value_ref(v) {
         return ym.clone();
     }
@@ -70,30 +60,8 @@ fn coerce_ym_overflow(v: f64, overflow: Overflow) -> PlainYearMonth {
                 b"Cannot convert a Symbol to a Temporal.PlainYearMonth",
             );
         }
-        let obj = jv.as_pointer::<crate::object::ObjectHeader>();
-        if !obj.is_null() {
-            // A property bag with NONE of the recognized year-month calendar
-            // fields → TypeError (ToTemporalYearMonth / PrepareTemporalFields).
-            let has_field = |name: &str| -> bool {
-                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-                crate::object::js_object_get_field_by_name_f64(obj, key).to_bits()
-                    != crate::value::TAG_UNDEFINED
-            };
-            if !["year", "month", "monthCode", "era", "eraYear"]
-                .iter()
-                .any(|n| has_field(n))
-            {
-                crate::object::throw_object_type_error(
-                    b"object is not a valid Temporal.PlainYearMonth property bag",
-                );
-            }
-            let cal_key = crate::string::js_string_from_bytes(b"calendar".as_ptr(), 8);
-            let cal_raw = crate::object::js_object_get_field_by_name_f64(obj, cal_key);
-            let partial = temporal_rs::partial::PartialYearMonth {
-                calendar_fields: super::options::year_month_fields(obj),
-                calendar: calendar_arg(cal_raw),
-            };
-            return ok_or_throw(PlainYearMonth::from_partial(partial, Some(overflow)));
+        if !jv.as_pointer::<crate::object::ObjectHeader>().is_null() {
+            return super::options::plain_year_month_from_bag(v);
         }
     }
     // Non-string, non-object primitive → TypeError per ToTemporalYearMonth.
@@ -101,24 +69,30 @@ fn coerce_ym_overflow(v: f64, overflow: Overflow) -> PlainYearMonth {
 }
 
 pub fn from_static(args: &[f64]) -> f64 {
-    // Overflow is consulted only on the property-bag path; a string item is
-    // parsed first (an invalid string throws before the `overflow` getter is
-    // observed). The options bag is type-checked for every item kind.
+    // `ToTemporalYearMonth(item, options)`. As with `PlainDate.from`, the point
+    // `options` is processed is observable: a string is parsed FIRST (invalid →
+    // `RangeError`), a `PlainYearMonth` is cloned after `overflow` is read
+    // (validating `options`), and a property bag reads its calendar + fields,
+    // then `overflow` LAST.
     let item = raw_arg(args, 0);
     let opts = raw_arg(args, 1);
-    let is_bag = {
-        let jv = JSValue::from_bits(item.to_bits());
-        jv.is_pointer()
-            && temporal_value_ref(item).is_none()
-            && !crate::symbol::is_registered_symbol(jv.as_pointer::<u8>() as usize)
-    };
-    let overflow = if is_bag {
-        super::options::overflow(opts).unwrap_or_default()
-    } else {
-        let _ = super::options::require_options_object(opts);
-        Overflow::Constrain
-    };
-    wrap(coerce_ym_overflow(item, overflow))
+    if JSValue::from_bits(item.to_bits()).is_string() {
+        let ym = ok_or_throw(dispatch::read_string(item).parse::<PlainYearMonth>());
+        let _ = super::options::overflow(opts);
+        return wrap(ym);
+    }
+    if let Some(TemporalValue::PlainYearMonth(ym)) = temporal_value_ref(item) {
+        let _ = super::options::overflow(opts);
+        return wrap(ym.clone());
+    }
+    // Any other object — including a non-PlainYearMonth Temporal value such as a
+    // `PlainDate` — is read as a property bag (`ToTemporalYearMonth` treats it as
+    // an object and reads its `year`/`month`/`monthCode` getters), NOT a TypeError.
+    let jv = JSValue::from_bits(item.to_bits());
+    if jv.is_pointer() && !crate::symbol::is_registered_symbol(jv.as_pointer::<u8>() as usize) {
+        return wrap(super::options::plain_year_month_from_bag_opts(item, opts));
+    }
+    crate::object::throw_object_type_error(b"Cannot convert value to a Temporal.PlainYearMonth")
 }
 
 pub fn compare_static(args: &[f64]) -> f64 {
@@ -185,14 +159,14 @@ pub fn call(recv: f64, ym: &PlainYearMonth, name: &str, args: &[f64]) -> f64 {
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");
-            let fields = super::options::year_month_fields(obj);
+            let fields = super::options::with_year_month_fields(obj, ym.calendar());
             let overflow = super::options::overflow(raw_arg(args, 1));
             wrap(ok_or_throw(ym.with(fields, overflow)))
         }
         "toPlainDate" => {
             let obj =
                 super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "toPlainDate");
-            let day = super::options::calendar_fields(obj);
+            let day = super::options::to_plain_date_day_field(obj);
             alloc_temporal_cell(TemporalValue::PlainDate(ok_or_throw(
                 ym.to_plain_date(Some(day)),
             )))


### PR DESCRIPTION
## Summary

Pushes the remaining `Temporal.Plain*` / `Instant` / `Now` test262 tails to ~98%, grouped by root cause, **zero regressions**.

Measured on the 48-core box vs `node v26` (self-validating Temporal cases), `built-ins/Temporal/{PlainDate,PlainYearMonth,PlainMonthDay,PlainTime,Instant,Now}`, `PERRY_NO_AUTO_OPTIMIZE=1 --jobs 12` (the contended default run mislabels ~66 cache/auto-opt races as `compile-fail`; the clean run shows the real picture):

| | pass | runtime-fail | parity |
|---|---|---|---|
| before | 2241 | 143 | **94.0%** |
| after  | 2343 | 41  | **98.3%** |

**+102 tests, 0 regressions.**

Broad regression check — `built-ins language` shard `0/12` (2645 cases) diffed vs the branch base:
- **Regressions (pass to fail): 0**
- Fixed (fail to pass): 12 (all Temporal)

## Root causes fixed (grouped)

**1. `from()` / ToTemporalX bag reading (~40 tests).** Rewrote the property-bag path for `PlainDate`/`PlainYearMonth`/`PlainMonthDay`/`PlainTime`:
- `calendar` slot read **first**, then the calendar's date fields **alphabetically** (`day,[era,eraYear],month,monthCode,year`; era/eraYear only for non-ISO calendars), then `overflow` **last** — matching the observable order-of-operations.
- `monthCode` now `ToPrimitiveAndRequireString` (was `str_field`, which dropped a `toString`-wrapped value); `month`/`day` now `ToPositiveIntegerWithTruncation` (a value < 1 is a `RangeError` even under `constrain`, was silently saturated to 255).
- A **string** item is parsed first (invalid -> `RangeError`) before `options` is validated; a wrong-typed `options` is a `TypeError` only after the fields are read. `PlainMonthDay.from` previously ignored `options`/`overflow` entirely.
- Non-target Temporal values (e.g. a `PlainDate` passed to `PlainYearMonth.from`) are read as property bags, not rejected.

**2. Constructors (~10).** `PlainDate`/`PlainYearMonth`/`PlainMonthDay`/`PlainTime` now coerce each numeric field via real `ToNumber` (`ToIntegerWithTruncation` — observes `valueOf`, rejects `Infinity`/`NaN` with a `RangeError` at the field's read position) and resolve `calendar` via the strict `ToTemporalCalendarIdentifier`. All five are now `[[Construct]]`-only — calling without `new` is a `TypeError`.

**3. `with()` (~16).** `PlainDate`/`PlainYearMonth`/`PlainMonthDay`/`PlainTime` `with` now run `RejectObjectWithCalendarOrTimeZone` (reads `calendar`+`timeZone` first, `TypeError` if present), read fields alphabetically with positive validation, and read `overflow` last. `withCalendar()` with a missing argument is a `TypeError`.

**4. `valueOf` / relational (5).** A statically-lowered `temporal.valueOf()` (lowered to `DateValueOf` for an `any` receiver) and `temporal < temporal` (relational `ToPrimitive(number)`) now route to the Temporal brand dispatch, which throws `TypeError` per spec.

**5. Instant / Now / misc.**
- `Now.plainDate*ISO(tz)` / `PlainDate.toZonedDateTime(tz)`: a wrong-typed time-zone is now `TypeError` (was silently dropped / `RangeError`).
- `new Temporal.Instant("abc123")` -> `SyntaxError`; `Instant.fromEpochMilliseconds` -> real `ToNumber` (BigInt/Symbol `TypeError`) + `NumberToBigInt` integral check (`RangeError`).
- `Instant.prototype` no longer advertises the removed `epochSeconds`/`epochMicroseconds` accessors.
- `PlainMonthDay.prototype.equals` compares the reference (ISO) year.
- `toPlainDate` reads only `day` (YearMonth) / `year` (MonthDay) from its argument.

## Deferred (out of scope / other workers)
- **Subclassing** (~31): Temporal cells have no `[[Prototype]]` link; full subclass support is an architectural change (also deferred by the big-3 worker).
- `PlainDate.add/subtract` duration-bag order-of-operations (2): lives in `duration.rs` (big-3 worker's domain).
- `exact-multiple-of-larger-unit` / `float64-representable-integer` (6): `temporal_rs` 0.2.3 rounding-precision internals.
- `Instant/large-bigint` (1): pre-existing BigInt unary-negation bug, outside Temporal.

## Files
`crates/perry-runtime/src/temporal/{options,plain_date,plain_year_month,plain_month_day,plain_time,instant,now,dispatch}.rs`, `object/global_this.rs`, `date.rs`, `builtins/arithmetic.rs`.