### PR TITLE
feat(stubs): stub-elimination keystone — honest manifest + first-call warnings + PERRY_STRICT_STUBS (#4918/#4919)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Tracked via the gap test suite (`test-files/test_gap_*.ts`, 28 tests). Compared 
 **Last full sweep:** run `./run_parity_tests.sh` for the current snapshot. The umbrella tracker is #793 (Node.js + TypeScript compatibility roadmap); the previously-cited #447–#452 batch closed on 2026-05-04. Currently-open trackers worth knowing about:
 
 - **Effect framework end-to-end (#321)** — `#684` (Schema.ts ~310th-init `(number).slice` regression) and `#809` (object-literal computed-keys + cross-module spread) are the live HashRing/Schema blockers.
-- **Async context** — `#788` (real `AsyncLocalStorage` tracking across `await`/microtasks/timers) and `#789` (real `async_hooks.createHook` lifecycle + asyncId). Today these are name-only stubs.
+- **Async context** — `AsyncLocalStorage` (real tracking across `await`/microtasks/timers, `#788`) and `async_hooks.createHook` (real lifecycle + asyncId, `#789`) both landed (closed 2026-05-16); these are no longer stubs.
 - **Compile-as-package** — `#348` (ink TUI end-to-end), `#488/#489` (Drizzle + MySQL), `#678` (linker emits native callsites for V8-fallback modules).
 - **Test/CI mechanics** — `#794` (per-category parity thresholds), `#796` (gap-suite output truncation + O(n²) `normalize_output`), `#812` (42-module behavioral matrix), `#806/#807/#808` (test harnesses for mixins / async context / ≥300-init scale).
 - **Skip-list audit** — `#797` covers `test-parity/known_failures.json` provenance (issue # + date per entry).

--- a/crates/perry-api-manifest/src/emit.rs
+++ b/crates/perry-api-manifest/src/emit.rs
@@ -173,16 +173,7 @@ pub fn emit_dts(_perry_version: &str) -> String {
             .iter()
             .filter(|e| matches!(e.kind, ApiKind::Class) && entry_is_public_named_export(e))
         {
-            let _ = writeln!(
-                out,
-                "  /** {}{} */",
-                source_dts_tag(e),
-                if e.stub {
-                    " — stub (no-op at runtime)"
-                } else {
-                    ""
-                }
-            );
+            let _ = writeln!(out, "  /** {}{} */", source_dts_tag(e), stub_dts_suffix(e));
             let _ = writeln!(
                 out,
                 "  export class {} {{ [key: string]: any; }}",
@@ -195,12 +186,7 @@ pub fn emit_dts(_perry_version: &str) -> String {
             .iter()
             .filter(|e| matches!(e.kind, ApiKind::Property) && entry_is_public_named_export(e))
         {
-            let _ = writeln!(
-                out,
-                "  /** {}{} */",
-                source_dts_tag(e),
-                if e.stub { " — stub" } else { "" }
-            );
+            let _ = writeln!(out, "  /** {}{} */", source_dts_tag(e), stub_dts_suffix(e));
             if e.name == "default" {
                 let _ = writeln!(out, "  const _default: any;");
                 let _ = writeln!(out, "  export default _default;");
@@ -232,12 +218,7 @@ pub fn emit_dts(_perry_version: &str) -> String {
             if !emitted_fn_names.insert(e.name) {
                 continue;
             }
-            let _ = writeln!(
-                out,
-                "  /** {}{} */",
-                source_dts_tag(e),
-                if e.stub { " — stub" } else { "" }
-            );
+            let _ = writeln!(out, "  /** {}{} */", source_dts_tag(e), stub_dts_suffix(e));
             // `default` is the npm convention for "the module is
             // callable" (e.g. `import sharp from 'sharp'`). TypeScript
             // expresses that as `export default function (...)`, with
@@ -448,9 +429,27 @@ fn source_marker(entry: &ApiEntry) -> String {
         ApiSource::Intrinsic => " *(intrinsic)*".to_string(),
     };
     if entry.stub {
-        tag.push_str(" ⚠ stub");
+        match entry.stub_note {
+            Some(note) => {
+                let _ = write!(tag, " ⚠ **stub** — {}", note);
+            }
+            None => tag.push_str(" ⚠ **stub** (no-op at runtime)"),
+        }
     }
     tag
+}
+
+/// `.d.ts` doc-comment suffix for a stub entry: an `@perryStub` JSDoc
+/// tag (editors surface it on hover, mirroring `@deprecated`) plus the
+/// per-entry note when present. Empty string for real APIs. (#4918)
+fn stub_dts_suffix(entry: &ApiEntry) -> String {
+    if !entry.stub {
+        return String::new();
+    }
+    match entry.stub_note {
+        Some(note) => format!(" @perryStub {}", note),
+        None => " @perryStub stub — no-op at runtime".to_string(),
+    }
 }
 
 fn source_dts_tag(entry: &ApiEntry) -> &'static str {

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -255,6 +255,7 @@ const fn method_entry(
         },
         source: ApiSource::Stdlib,
         stub: false,
+        stub_note: None,
         module_export: module_export && !has_receiver && class_filter.is_none(),
         abi_version: None,
         params: &[],
@@ -321,6 +322,7 @@ const fn method_sig_entry(
         },
         source: ApiSource::Stdlib,
         stub: false,
+        stub_note: None,
         module_export: module_export && !has_receiver && class_filter.is_none(),
         abi_version: None,
         params,
@@ -335,6 +337,7 @@ const fn property(module: &'static str, name: &'static str) -> ApiEntry {
         kind: ApiKind::Property,
         source: ApiSource::Stdlib,
         stub: false,
+        stub_note: None,
         module_export: true,
         abi_version: None,
         params: &[],
@@ -349,6 +352,7 @@ const fn internal_property(module: &'static str, name: &'static str) -> ApiEntry
         kind: ApiKind::Property,
         source: ApiSource::Stdlib,
         stub: false,
+        stub_note: None,
         module_export: false,
         abi_version: None,
         params: &[],
@@ -363,6 +367,7 @@ const fn class(module: &'static str, name: &'static str) -> ApiEntry {
         kind: ApiKind::Class,
         source: ApiSource::Stdlib,
         stub: false,
+        stub_note: None,
         module_export: true,
         abi_version: None,
         params: &[],
@@ -377,6 +382,7 @@ const fn internal_class(module: &'static str, name: &'static str) -> ApiEntry {
         kind: ApiKind::Class,
         source: ApiSource::Stdlib,
         stub: false,
+        stub_note: None,
         module_export: false,
         abi_version: None,
         params: &[],
@@ -422,6 +428,7 @@ const ZLIB_OPTIONS_PARAM: ParamSpec = ParamSpec::Named {
 };
 const fn zlib_stream_factory(name: &'static str) -> ApiEntry {
     method_sig("zlib", name, false, None, ZLIB_STREAM_OPTS, TypeSpec::Any)
+        .stub_note("options (level/chunkSize/dictionary/...) accepted but ignored (#4917)")
 }
 
 /// Source-of-truth manifest. See module-level docs for what feeds it.
@@ -583,7 +590,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("mongodb", "insertOne", true, None),
     method("mongodb", "insertMany", true, None),
     method("mongodb", "find", true, None),
-    method("mongodb", "findOne", true, None),
+    method("mongodb", "findOne", true, None)
+        .stub_note("resolves a JSON string, not a document object (#4917)"),
     method("mongodb", "updateOne", true, None),
     method("mongodb", "updateMany", true, None),
     method("mongodb", "deleteOne", true, None),
@@ -793,44 +801,76 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // node:dns is currently runtime-only and deterministic: inventory
     // helpers, constants, Resolver method shapes, and lookup/lookupService
     // for localhost/loopback. It does not perform external DNS IO.
-    method("dns", "lookup", false, None),
-    method("dns", "lookupService", false, None),
-    method("dns", "resolve", false, None),
-    method("dns", "resolve4", false, None),
-    method("dns", "resolve6", false, None),
-    method("dns", "resolveAny", false, None),
-    method("dns", "resolveCaa", false, None),
-    method("dns", "resolveCname", false, None),
-    method("dns", "resolveMx", false, None),
-    method("dns", "resolveNaptr", false, None),
-    method("dns", "resolveNs", false, None),
-    method("dns", "resolvePtr", false, None),
-    method("dns", "resolveSoa", false, None),
-    method("dns", "resolveSrv", false, None),
-    method("dns", "resolveTlsa", false, None),
-    method("dns", "resolveTxt", false, None),
-    method("dns", "reverse", false, None),
+    method("dns", "lookup", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "lookupService", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolve", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolve4", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolve6", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveAny", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveCaa", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveCname", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveMx", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveNaptr", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveNs", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolvePtr", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveSoa", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveSrv", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveTlsa", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveTxt", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "reverse", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
     method("dns", "getServers", false, None),
     method("dns", "setServers", false, None),
     method("dns", "setDefaultResultOrder", false, None),
     method("dns", "getDefaultResultOrder", false, None),
     class("dns", "Resolver"),
     method("dns", "Resolver", false, None),
-    method("dns", "resolve", true, Some("Resolver")),
-    method("dns", "resolve4", true, Some("Resolver")),
-    method("dns", "resolve6", true, Some("Resolver")),
-    method("dns", "resolveAny", true, Some("Resolver")),
-    method("dns", "resolveCaa", true, Some("Resolver")),
-    method("dns", "resolveCname", true, Some("Resolver")),
-    method("dns", "resolveMx", true, Some("Resolver")),
-    method("dns", "resolveNaptr", true, Some("Resolver")),
-    method("dns", "resolveNs", true, Some("Resolver")),
-    method("dns", "resolvePtr", true, Some("Resolver")),
-    method("dns", "resolveSoa", true, Some("Resolver")),
-    method("dns", "resolveSrv", true, Some("Resolver")),
-    method("dns", "resolveTlsa", true, Some("Resolver")),
-    method("dns", "resolveTxt", true, Some("Resolver")),
-    method("dns", "reverse", true, Some("Resolver")),
+    method("dns", "resolve", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolve4", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolve6", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveAny", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveCaa", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveCname", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveMx", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveNaptr", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveNs", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolvePtr", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveSoa", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveSrv", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveTlsa", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "resolveTxt", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns", "reverse", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
     method("dns", "cancel", true, Some("Resolver")),
     method("dns", "getServers", true, Some("Resolver")),
     method("dns", "setServers", true, Some("Resolver")),
@@ -862,44 +902,76 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("dns", "LOADIPHLPAPI"),
     property("dns", "ADDRGETNETWORKPARAMS"),
     property("dns", "CANCELLED"),
-    method("dns/promises", "lookup", false, None),
-    method("dns/promises", "lookupService", false, None),
-    method("dns/promises", "resolve", false, None),
-    method("dns/promises", "resolve4", false, None),
-    method("dns/promises", "resolve6", false, None),
-    method("dns/promises", "resolveAny", false, None),
-    method("dns/promises", "resolveCaa", false, None),
-    method("dns/promises", "resolveCname", false, None),
-    method("dns/promises", "resolveMx", false, None),
-    method("dns/promises", "resolveNaptr", false, None),
-    method("dns/promises", "resolveNs", false, None),
-    method("dns/promises", "resolvePtr", false, None),
-    method("dns/promises", "resolveSoa", false, None),
-    method("dns/promises", "resolveSrv", false, None),
-    method("dns/promises", "resolveTlsa", false, None),
-    method("dns/promises", "resolveTxt", false, None),
-    method("dns/promises", "reverse", false, None),
+    method("dns/promises", "lookup", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "lookupService", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolve", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolve4", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolve6", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveAny", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveCaa", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveCname", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveMx", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveNaptr", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveNs", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolvePtr", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveSoa", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveSrv", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveTlsa", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveTxt", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "reverse", false, None)
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
     method("dns/promises", "getServers", false, None),
     method("dns/promises", "setServers", false, None),
     method("dns/promises", "setDefaultResultOrder", false, None),
     method("dns/promises", "getDefaultResultOrder", false, None),
     class("dns/promises", "Resolver"),
     method("dns/promises", "Resolver", false, None),
-    method("dns/promises", "resolve", true, Some("Resolver")),
-    method("dns/promises", "resolve4", true, Some("Resolver")),
-    method("dns/promises", "resolve6", true, Some("Resolver")),
-    method("dns/promises", "resolveAny", true, Some("Resolver")),
-    method("dns/promises", "resolveCaa", true, Some("Resolver")),
-    method("dns/promises", "resolveCname", true, Some("Resolver")),
-    method("dns/promises", "resolveMx", true, Some("Resolver")),
-    method("dns/promises", "resolveNaptr", true, Some("Resolver")),
-    method("dns/promises", "resolveNs", true, Some("Resolver")),
-    method("dns/promises", "resolvePtr", true, Some("Resolver")),
-    method("dns/promises", "resolveSoa", true, Some("Resolver")),
-    method("dns/promises", "resolveSrv", true, Some("Resolver")),
-    method("dns/promises", "resolveTlsa", true, Some("Resolver")),
-    method("dns/promises", "resolveTxt", true, Some("Resolver")),
-    method("dns/promises", "reverse", true, Some("Resolver")),
+    method("dns/promises", "resolve", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolve4", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolve6", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveAny", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveCaa", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveCname", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveMx", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveNaptr", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveNs", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolvePtr", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveSoa", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveSrv", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveTlsa", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "resolveTxt", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
+    method("dns/promises", "reverse", true, Some("Resolver"))
+        .stub_note("loopback-only deterministic fake; no real DNS resolution (#4911)"),
     method("dns/promises", "cancel", true, Some("Resolver")),
     method("dns/promises", "getServers", true, Some("Resolver")),
     method("dns/promises", "setServers", true, Some("Resolver")),
@@ -912,7 +984,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("dgram", "createSocket", false, None),
     class("dgram", "Socket"),
     method("dgram", "Socket", false, None),
-    method("dgram", "send", true, Some("Socket")),
+    method("dgram", "send", true, Some("Socket"))
+        .stub_note("in-process loopback only; no real UDP socket I/O (#4911)"),
     method("dgram", "bind", true, Some("Socket")),
     method("dgram", "close", true, Some("Socket")),
     method("dgram", "address", true, Some("Socket")),
@@ -927,19 +1000,27 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("dgram", "emit", true, Some("Socket")),
     method("dgram", "listenerCount", true, Some("Socket")),
     method("dgram", "eventNames", true, Some("Socket")),
-    method("dgram", "addMembership", true, Some("Socket")),
-    method("dgram", "dropMembership", true, Some("Socket")),
-    method("dgram", "addSourceSpecificMembership", true, Some("Socket")),
+    method("dgram", "addMembership", true, Some("Socket"))
+        .stub_note("accepted but no OS multicast/broadcast side effect (#4911)"),
+    method("dgram", "dropMembership", true, Some("Socket"))
+        .stub_note("accepted but no OS multicast/broadcast side effect (#4911)"),
+    method("dgram", "addSourceSpecificMembership", true, Some("Socket"))
+        .stub_note("accepted but no OS multicast/broadcast side effect (#4911)"),
     method(
         "dgram",
         "dropSourceSpecificMembership",
         true,
         Some("Socket"),
-    ),
-    method("dgram", "setBroadcast", true, Some("Socket")),
-    method("dgram", "setMulticastTTL", true, Some("Socket")),
-    method("dgram", "setMulticastLoopback", true, Some("Socket")),
-    method("dgram", "setMulticastInterface", true, Some("Socket")),
+    )
+    .stub_note("accepted but no OS multicast/broadcast side effect (#4911)"),
+    method("dgram", "setBroadcast", true, Some("Socket"))
+        .stub_note("accepted but no OS multicast/broadcast side effect (#4911)"),
+    method("dgram", "setMulticastTTL", true, Some("Socket"))
+        .stub_note("accepted but no OS multicast/broadcast side effect (#4911)"),
+    method("dgram", "setMulticastLoopback", true, Some("Socket"))
+        .stub_note("accepted but no OS multicast/broadcast side effect (#4911)"),
+    method("dgram", "setMulticastInterface", true, Some("Socket"))
+        .stub_note("accepted but no OS multicast/broadcast side effect (#4911)"),
     method("dgram", "setTTL", true, Some("Socket")),
     method("dgram", "setRecvBufferSize", true, Some("Socket")),
     method("dgram", "setSendBufferSize", true, Some("Socket")),
@@ -1619,7 +1700,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
         None,
         &[p_any("p0"), p_any("p1")],
         TypeSpec::Any,
-    ),
+    )
+    .stub_note("retry options ignored; hardcoded 3 attempts / 100ms / x2 (#4917)"),
     method_sig(
         "argon2",
         "hash",
@@ -2776,8 +2858,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("worker_threads", "once", true, Some("Worker")),
     method("worker_threads", "off", true, Some("Worker")),
     method("worker_threads", "terminate", true, Some("Worker")),
-    method("worker_threads", "ref", true, Some("Worker")),
-    method("worker_threads", "unref", true, Some("Worker")),
+    method("worker_threads", "ref", true, Some("Worker"))
+        .stub_note("no-op; does not affect process event-loop ref-count (#4917)"),
+    method("worker_threads", "unref", true, Some("Worker"))
+        .stub_note("no-op; does not affect process event-loop ref-count (#4917)"),
     method("worker_threads", "getHeapStatistics", true, Some("Worker")),
     method("worker_threads", "cpuUsage", true, Some("Worker")),
     method("worker_threads", "getHeapSnapshot", true, Some("Worker")),
@@ -3638,10 +3722,13 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // EventEmitter-shaped `cluster.default` namespace; the `import * as`
     // namespace keeps the shape-only surface.
     property("cluster", "default"),
-    method("cluster", "fork", false, None),
+    method("cluster", "fork", false, None)
+        .stub_note("no socket/listening-handle distribution; workers cannot share a port (#4914)"),
     method("cluster", "disconnect", false, None),
-    method("cluster", "setupPrimary", false, None),
-    method("cluster", "setupMaster", false, None),
+    method("cluster", "setupPrimary", false, None)
+        .stub_note("no socket/listening-handle distribution; workers cannot share a port (#4914)"),
+    method("cluster", "setupMaster", false, None)
+        .stub_note("no socket/listening-handle distribution; workers cannot share a port (#4914)"),
     class("cluster", "Worker"),
     property("cluster", "isPrimary"),
     property("cluster", "isMaster"),
@@ -4157,8 +4244,10 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("stream/web", "default"),
     class("stream/web", "ReadableStream"),
     class("stream/web", "ReadableStreamDefaultReader"),
-    class("stream/web", "ReadableStreamBYOBReader"),
-    class("stream/web", "ReadableStreamBYOBRequest"),
+    class("stream/web", "ReadableStreamBYOBReader")
+        .stub_note("constructor/use throws: not yet implemented (#4915)"),
+    class("stream/web", "ReadableStreamBYOBRequest")
+        .stub_note("constructor/use throws: not yet implemented (#4915)"),
     class("stream/web", "ReadableByteStreamController"),
     class("stream/web", "ReadableStreamDefaultController"),
     class("stream/web", "TransformStream"),
@@ -4166,7 +4255,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("stream/web", "WritableStream"),
     class("stream/web", "WritableStreamDefaultWriter"),
     class("stream/web", "WritableStreamDefaultController"),
-    class("stream/web", "ByteLengthQueuingStrategy"),
+    class("stream/web", "ByteLengthQueuingStrategy")
+        .stub_note("constructor/use throws: not yet implemented (#4915)"),
     class("stream/web", "CountQueuingStrategy"),
     class("stream/web", "TextEncoderStream"),
     class("stream/web", "TextDecoderStream"),
@@ -4464,11 +4554,13 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Node's ESM namespace). `getHeapSnapshot`/`writeHeapSnapshot` deeper
     // behavior is tracked by #3140; here they're added to the export surface.
     method("v8", "getCppHeapStatistics", false, None),
-    method("v8", "getHeapSnapshot", false, None),
+    method("v8", "getHeapSnapshot", false, None)
+        .stub_note("empty-but-valid V8 heap graph, not a real snapshot (#4916)"),
     method("v8", "isStringOneByteRepresentation", false, None),
     method("v8", "queryObjects", false, None),
     method("v8", "startCpuProfile", false, None),
-    method("v8", "writeHeapSnapshot", false, None),
+    method("v8", "writeHeapSnapshot", false, None)
+        .stub_note("empty-but-valid V8 heap graph, not a real snapshot (#4916)"),
     method("v8", "isBuildingSnapshot", true, Some("startupSnapshot")),
     method("v8", "addSerializeCallback", true, Some("startupSnapshot")),
     method(
@@ -4624,10 +4716,13 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("http", "Agent"),
     method("http", "Agent", false, None),
     method("http", "getName", true, Some("Agent")),
-    method("http", "destroy", true, Some("Agent")),
+    method("http", "destroy", true, Some("Agent"))
+        .stub_note("real Agent object, but Perry does not pool sockets; this is a no-op (#4917)"),
     method("http", "close", true, Some("Agent")),
-    method("http", "keepSocketAlive", true, Some("Agent")),
-    method("http", "reuseSocket", true, Some("Agent")),
+    method("http", "keepSocketAlive", true, Some("Agent"))
+        .stub_note("real Agent object, but Perry does not pool sockets; this is a no-op (#4917)"),
+    method("http", "reuseSocket", true, Some("Agent"))
+        .stub_note("real Agent object, but Perry does not pool sockets; this is a no-op (#4917)"),
     // Synthetic `__get_<name>` / `__set_<name>` accessor methods (HIR
     // rewrites bare `agent.maxSockets` reads to `__get_maxSockets()`
     // when the receiver is class-tagged) + their bare-name twins for
@@ -5105,7 +5200,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     class("streams", "TextDecoder"),
     class("streams", "DecompressionStream"),
     // node:stream/web QueuingStrategy classes (#1545).
-    class("streams", "ByteLengthQueuingStrategy"),
+    class("streams", "ByteLengthQueuingStrategy")
+        .stub_note("constructor/use throws: not yet implemented (#4915)"),
     class("streams", "CountQueuingStrategy"),
     // --- node:http server (issue #577) ---
     method("http", "createServer", false, None),

--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -51,7 +51,22 @@ pub struct ApiEntry {
     /// Intentional no-op stubs (platform-gated UI symbols, etc.) are
     /// flagged so the unimplemented-API check (#463) does NOT error on
     /// them — the runtime first-call warning from #464 surfaces those.
+    ///
+    /// As of the stub-elimination epic (#4919) this is also set for the
+    /// known "registered but fake/no-op/partial" clusters — dns/dgram
+    /// loopback fakes (#4911), `child_process.spawn` (#4912), cluster
+    /// socket distribution (#4914), BYOB streams (#4915), v8 heap
+    /// snapshots (#4916), and the stdlib-adapter no-ops (#4917) — so
+    /// the manifest is the single source of truth for "this API lies".
+    /// CI drift-guards the exact set (`tests/stub_inventory.rs`).
     pub stub: bool,
+    /// Short human-readable reason this entry is a stub/partial, with an
+    /// issue tag — surfaced verbatim in the generated `.d.ts` and
+    /// `reference.md` so the docs say *how* it's limited, not just that
+    /// it is. `None` falls back to the generic "no-op at runtime" text.
+    /// Used to distinguish a pure no-op (dns loopback fake) from a
+    /// real-but-partial API (`http.Agent` doesn't pool). (#4918)
+    pub stub_note: Option<&'static str>,
     /// True when this row is a real top-level export of the module.
     ///
     /// Some rows exist only so the runtime dispatch table and strict
@@ -78,6 +93,31 @@ pub struct ApiEntry {
     /// loose `any` rendering"; concrete values let the .d.ts emitter
     /// produce a typed signature. (#512)
     pub returns: TypeSpec,
+}
+
+impl ApiEntry {
+    /// Mark this entry as a stub: registered and callable, but a no-op,
+    /// fake, or silently-wrong/partial implementation. Chains in the
+    /// `const` manifest table: `method("dns", "resolve4", false, None).stub()`.
+    /// Surfaced in `.d.ts`, `reference.md`, and `--print-api-manifest`;
+    /// the runtime dispatch path is expected to emit a first-call
+    /// `perry_stub_warn` and throw `ERR_PERRY_UNIMPLEMENTED` under
+    /// `PERRY_STRICT_STUBS=1`. (#4918)
+    pub const fn stub(mut self) -> Self {
+        self.stub = true;
+        self
+    }
+
+    /// Like [`ApiEntry::stub`], but attaches a short human-readable
+    /// reason (with an issue tag) rendered verbatim in the generated
+    /// docs — e.g. `"loopback-only fake, no real DNS (#4911)"` for a
+    /// pure no-op or `"real, but does not pool sockets (#4917)"` for a
+    /// partial implementation. (#4918)
+    pub const fn stub_note(mut self, note: &'static str) -> Self {
+        self.stub = true;
+        self.stub_note = Some(note);
+        self
+    }
 }
 
 /// One parameter slot on a method entry. Mirrors the param-type

--- a/crates/perry-api-manifest/tests/stub_inventory.rs
+++ b/crates/perry-api-manifest/tests/stub_inventory.rs
@@ -1,0 +1,127 @@
+//! Drift guard for the stub-elimination epic (#4919 / keystone #4918).
+//!
+//! The manifest's `ApiEntry.stub` flag is the single source of truth for
+//! "this API is registered and callable, but no-op / fake / silently
+//! wrong / partial". Before #4918 the flag existed but was never set, so
+//! every doc surface (`.d.ts`, `reference.md`, `--print-api-manifest`)
+//! presented stubs as fully supported.
+//!
+//! These tests pin the exact stub inventory so a new lie cannot ship
+//! silently: adding or removing a `.stub()`/`.stub_note()` annotation
+//! moves a number here, forcing a reviewed, deliberate change — the same
+//! discipline `manifest_consistency.rs` applies to dispatch-table arity.
+
+use perry_api_manifest::iter_entries;
+
+/// Parse the trailing `(#1234)` issue tag from a stub note.
+fn issue_tag(note: &str) -> Option<String> {
+    let start = note.rfind("(#")?;
+    let end = note[start..].find(')')? + start;
+    Some(note[start + 1..end].to_string())
+}
+
+#[test]
+fn every_stub_has_a_documented_reason() {
+    // Policy: a stub may exist, but it must be *visible* — a human note
+    // explaining how it lies, tagged with the tracking issue. No bare
+    // `.stub()` without a reason is allowed in the table.
+    for e in iter_entries().filter(|e| e.stub) {
+        let note = e.stub_note.unwrap_or_else(|| {
+            panic!(
+                "stub entry {}::{} has no stub_note — use .stub_note(\"reason (#issue)\")",
+                e.module, e.name
+            )
+        });
+        assert!(
+            issue_tag(note).is_some(),
+            "stub note for {}::{} must carry a tracking issue tag like (#4911): {:?}",
+            e.module,
+            e.name,
+            note
+        );
+    }
+}
+
+#[test]
+fn stub_inventory_matches_known_clusters() {
+    use std::collections::BTreeMap;
+    let mut by_issue: BTreeMap<String, usize> = BTreeMap::new();
+    for e in iter_entries().filter(|e| e.stub) {
+        if let Some(note) = e.stub_note {
+            if let Some(tag) = issue_tag(note) {
+                *by_issue.entry(tag).or_default() += 1;
+            }
+        }
+    }
+
+    // Expected per-issue stub counts. Update these (and the changelog)
+    // when a stub is implemented for real (count goes down) or a newly
+    // discovered lie is annotated (count goes up). A surprise diff here
+    // means an API silently changed honesty state.
+    let expected: &[(&str, usize)] = &[
+        ("#4911", 73), // dns + dns/promises loopback fakes, dgram send + multicast
+        // #4912 (child_process.spawn) intentionally absent: spawn is real
+        // since #1780 (Expr::ChildProcessSpawn codegen). The audit's
+        // "returns null" premise was stale; only exec() timing remains.
+        ("#4914", 3),  // cluster fork/setupPrimary/setupMaster (no handle distribution)
+        ("#4915", 4),  // BYOB readers + ByteLengthQueuingStrategy (throw)
+        ("#4916", 2),  // v8 get/writeHeapSnapshot (empty graph)
+        ("#4917", 18), // stdlib adapters: zlib(11) + http.Agent(3) + worker ref/unref(2) + mongodb(1) + backoff(1)
+    ];
+    let expected_map: BTreeMap<String, usize> =
+        expected.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+
+    assert_eq!(
+        by_issue, expected_map,
+        "stub inventory drifted — a stub was added/removed without updating tests/stub_inventory.rs"
+    );
+}
+
+#[test]
+fn stubs_only_appear_in_allowlisted_modules() {
+    // A stub flag showing up on a module not in this list is almost
+    // certainly an accident — fail loud so it gets triaged.
+    let allowed = [
+        "dns",
+        "dns/promises",
+        "dgram",
+        "cluster",
+        "stream/web",
+        "streams",
+        "v8",
+        "zlib",
+        "http",
+        "https",
+        "worker_threads",
+        "mongodb",
+        "exponential-backoff",
+    ];
+    for e in iter_entries().filter(|e| e.stub) {
+        assert!(
+            allowed.contains(&e.module),
+            "unexpected stub on module {:?} ({}). If intentional, add it to the allowlist.",
+            e.module,
+            e.name
+        );
+    }
+}
+
+#[test]
+fn keystone_apis_are_flagged() {
+    // Spot-check the headline lies from the epic so a refactor can't
+    // quietly drop the flag on the worst offenders.
+    let must_be_stub: &[(&str, &str)] = &[
+        ("dns", "resolve4"),
+        ("dns", "lookup"),
+        ("dns/promises", "resolve"),
+        ("cluster", "fork"),
+        ("v8", "getHeapSnapshot"),
+        ("v8", "writeHeapSnapshot"),
+        ("zlib", "createGzip"),
+        ("mongodb", "findOne"),
+    ];
+    for (module, name) in must_be_stub {
+        let found = iter_entries().any(|e| e.module == *module && e.name == *name && e.stub);
+        assert!(found, "expected {}::{} to be flagged stub", module, name);
+    }
+}

--- a/crates/perry-runtime/src/atomics.rs
+++ b/crates/perry-runtime/src/atomics.rs
@@ -592,7 +592,19 @@ pub extern "C" fn js_atomics_wait(
         }
     }
 
-    let _ = number_arg(timeout);
+    // Value matched: a spec-compliant agent blocks here until a matching
+    // `Atomics.notify` or the timeout elapses. Perry has no cross-agent
+    // blocking yet (`perry/thread` deep-copies, so SABs don't alias), so a
+    // non-zero timeout silently degrades to an immediate "timed-out" — the
+    // #4913 lie. A `timeout === 0` poll legitimately returns "timed-out".
+    let timeout = number_arg(timeout);
+    if timeout != 0.0 {
+        crate::error::stub_warn_or_throw(
+            "Atomics.wait",
+            "does not block; returns \"timed-out\" immediately (no cross-agent wakeups)",
+            Some("#4913"),
+        );
+    }
     string_value(b"timed-out")
 }
 
@@ -633,6 +645,15 @@ pub extern "C" fn js_atomics_wait_async(
         return wait_async_result(false, string_value(b"timed-out"));
     }
 
+    // Non-zero timeout + matching value: Node returns a promise that
+    // resolves on a matching `notify` or when the timeout elapses. Perry
+    // resolves "timed-out" immediately — the #4913 lie. Warn/throw before
+    // fabricating the already-resolved promise.
+    crate::error::stub_warn_or_throw(
+        "Atomics.waitAsync",
+        "resolves \"timed-out\" immediately; no real timer/notify wakeups",
+        Some("#4913"),
+    );
     let scope = crate::gc::RuntimeHandleScope::new();
     let timed_out = scope.root_nanbox_f64(string_value(b"timed-out"));
     let promise = crate::promise::js_promise_resolved(timed_out.get_nanbox_f64());

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -526,8 +526,16 @@ pub extern "C" fn js_child_process_spawn(
     _args_ptr: *const crate::array::ArrayHeader,
     _options_ptr: *const ObjectHeader,
 ) -> *mut ObjectHeader {
-    // TODO: Implement async spawn with proper ChildProcess handle
-    // For now, return null - async child processes need event loop integration
+    // DEAD/LEGACY path: user-level `child_process.spawn(...)` no longer
+    // routes here. It lowers to `Expr::ChildProcessSpawn`
+    // (crates/perry-codegen/src/expr/child_proc.rs), which builds a real
+    // streaming ChildProcess (stdin/stdout/stderr Readable streams, pid,
+    // kill(), spawn/exit/close/error events) — issue #1780. This FFI
+    // symbol predates that and is retained only so the dispatch table
+    // stays link-complete; it is not reachable from emitted code. (The
+    // stub-elimination audit's #4912 "spawn returns null" premise was
+    // stale against current main — spawn is real; only `exec` timing
+    // remains, tracked in #4912.)
     std::ptr::null_mut()
 }
 

--- a/crates/perry-runtime/src/dgram.rs
+++ b/crates/perry-runtime/src/dgram.rs
@@ -1186,6 +1186,11 @@ fn send_impl(socket: f64, args: &[f64]) -> f64 {
 }
 
 fn membership_impl(_socket: f64, args: &[f64], syscall: &'static str) -> f64 {
+    crate::error::stub_warn_or_throw(
+        "dgram multicast membership",
+        "accepted but no OS multicast side effect",
+        Some("#4911"),
+    );
     let multicast_address = args.first().copied().unwrap_or_else(undefined_value);
     if is_missing_membership_arg(multicast_address) {
         throw_missing_arg("multicastAddress");
@@ -1200,6 +1205,11 @@ fn membership_impl(_socket: f64, args: &[f64], syscall: &'static str) -> f64 {
 }
 
 fn source_membership_impl(_socket: f64, args: &[f64], syscall: &'static str) -> f64 {
+    crate::error::stub_warn_or_throw(
+        "dgram multicast membership",
+        "accepted but no OS multicast side effect",
+        Some("#4911"),
+    );
     let source_address = validate_string_arg(
         args.first().copied().unwrap_or_else(undefined_value),
         "sourceAddress",

--- a/crates/perry-runtime/src/dns.rs
+++ b/crates/perry-runtime/src/dns.rs
@@ -709,6 +709,11 @@ fn localhost_name(name: &str) -> bool {
 }
 
 fn resolve_records(kind: RecordKind, name: &str) -> f64 {
+    crate::error::stub_warn_or_throw(
+        "dns",
+        "loopback-only deterministic answers; no real DNS resolution",
+        Some("#4911"),
+    );
     if !localhost_name(name) {
         return empty_array_value();
     }
@@ -734,6 +739,11 @@ fn resolve_records(kind: RecordKind, name: &str) -> f64 {
 }
 
 fn reverse_records(name: &str) -> f64 {
+    crate::error::stub_warn_or_throw(
+        "dns",
+        "loopback-only deterministic answers; no real DNS resolution",
+        Some("#4911"),
+    );
     match name.parse::<IpAddr>() {
         Ok(IpAddr::V4(ip)) if ip.is_loopback() => string_array_value(&["localhost"]),
         Ok(IpAddr::V6(ip)) if ip.is_loopback() => string_array_value(&["localhost"]),
@@ -863,6 +873,11 @@ fn lookup_value(hostname: &str, options: LookupOptions) -> Result<f64, f64> {
 }
 
 fn lookup_callback_values(hostname: &str, options: LookupOptions) -> Result<Vec<f64>, f64> {
+    crate::error::stub_warn_or_throw(
+        "dns",
+        "loopback-only deterministic answers; no real DNS resolution",
+        Some("#4911"),
+    );
     let addresses = lookup_addresses(hostname, options.family)?;
     if options.all {
         Ok(vec![null_value(), lookup_all_result(&addresses)])
@@ -904,6 +919,11 @@ fn service_for_port(port: u16) -> String {
 }
 
 fn lookup_service_result(address: &str, port: u16) -> Result<(String, String), f64> {
+    crate::error::stub_warn_or_throw(
+        "dns",
+        "loopback-only deterministic answers; no real DNS resolution",
+        Some("#4911"),
+    );
     match address.parse::<IpAddr>() {
         Ok(addr) if addr.is_loopback() => Ok(("localhost".to_string(), service_for_port(port))),
         Ok(_) => Ok((address.to_string(), service_for_port(port))),

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -340,6 +340,41 @@ static KEEP_JS_THROW_ERROR_WITH_CODE: unsafe extern "C" fn(
     i32,
 ) -> ! = js_throw_error_with_code;
 
+/// Throw `ERR_PERRY_UNIMPLEMENTED` for a registered-but-stub API. Used
+/// by the stub-elimination epic's strict mode (#4918/#4919): a runtime
+/// stub calls [`crate::stub_diag::perry_runtime_stub`] to warn, then —
+/// if `PERRY_STRICT_STUBS=1` — diverges here instead of returning a
+/// fake value. `api` is the JS-facing name; `issue` an optional tag.
+pub fn throw_unimplemented_stub(api: &str, issue: Option<&str>) -> ! {
+    let msg = match issue {
+        Some(tag) => format!(
+            "{} is not implemented in Perry (stub); set PERRY_STRICT_STUBS=0 to allow the fake result — tracking {}",
+            api, tag
+        ),
+        None => format!(
+            "{} is not implemented in Perry (stub); set PERRY_STRICT_STUBS=0 to allow the fake result",
+            api
+        ),
+    };
+    let code = b"ERR_PERRY_UNIMPLEMENTED";
+    // SAFETY: both slices are valid UTF-8 byte ranges living for the
+    // duration of the call; kind 0 = generic Error.
+    unsafe {
+        js_throw_error_with_code(msg.as_ptr(), msg.len(), code.as_ptr(), code.len(), 0);
+    }
+}
+
+/// Convenience for runtime stub sites: warn (first-call) and, under
+/// `PERRY_STRICT_STUBS`, throw `ERR_PERRY_UNIMPLEMENTED`. Returns
+/// normally in non-strict mode so the caller proceeds with its
+/// deterministic/fake fallback. (#4918/#4919)
+pub fn stub_warn_or_throw(api: &'static str, reason: &'static str, issue: Option<&'static str>) {
+    crate::stub_diag::perry_runtime_stub(api, reason, issue);
+    if crate::stub_diag::strict_stubs_enabled() {
+        throw_unimplemented_stub(api, issue);
+    }
+}
+
 /// Create a new SyntaxError with a message
 #[no_mangle]
 pub extern "C" fn js_syntaxerror_new(message: *mut StringHeader) -> *mut ErrorHeader {

--- a/crates/perry-runtime/src/node_v8.rs
+++ b/crates/perry-runtime/src/node_v8.rs
@@ -340,6 +340,11 @@ pub extern "C" fn js_v8_cached_data_version_tag() -> f64 {
 #[no_mangle]
 pub extern "C" fn js_v8_get_heap_snapshot(options: f64) -> f64 {
     validate_heap_snapshot_options(options);
+    crate::error::stub_warn_or_throw(
+        "v8.getHeapSnapshot",
+        "emits an empty-but-valid V8 heap graph, not a real snapshot of live objects (see PERRY_GC_DIAG=1)",
+        Some("#4916"),
+    );
     snapshot_readable_stream()
 }
 
@@ -357,6 +362,11 @@ pub extern "C" fn js_v8_write_heap_snapshot(filename: f64, options: f64) -> f64 
         }
     };
     validate_heap_snapshot_options(options);
+    crate::error::stub_warn_or_throw(
+        "v8.writeHeapSnapshot",
+        "writes an empty-but-valid V8 heap graph, not a real snapshot of live objects (see PERRY_GC_DIAG=1)",
+        Some("#4916"),
+    );
     match std::fs::write(&path, V8_HEAP_SNAPSHOT_JSON.as_bytes()) {
         Ok(()) => string_value(&path),
         Err(err) => unsafe {

--- a/crates/perry-runtime/src/stub_diag.rs
+++ b/crates/perry-runtime/src/stub_diag.rs
@@ -78,6 +78,57 @@ pub fn perry_stub_warn(name: &'static str, reason: &'static str, issue: Option<&
     }
 }
 
+/// Whether `PERRY_STRICT_STUBS=1` (or `on`/`true`) is set — the opt-in
+/// strictness mode from the stub-elimination epic (#4918/#4919). When
+/// on, a runtime stub that would otherwise return a fake/no-op result
+/// instead throws `ERR_PERRY_UNIMPLEMENTED`, turning silent lies into
+/// measurable failures for package-compat work. Read once and cached.
+pub fn strict_stubs_enabled() -> bool {
+    static STRICT: OnceLock<bool> = OnceLock::new();
+    *STRICT.get_or_init(|| {
+        matches!(
+            std::env::var("PERRY_STRICT_STUBS").as_deref(),
+            Ok("1") | Ok("on") | Ok("true") | Ok("yes")
+        )
+    })
+}
+
+/// First-call diagnostic for a *runtime* API stub (dns/dgram loopback
+/// fakes, `child_process.spawn`, Atomics wait/notify, v8 heap snapshots,
+/// stdlib-adapter no-ops, …) — the manifest-flagged clusters from the
+/// stub-elimination epic (#4919). Unlike [`perry_stub_warn`], whose
+/// message says "on this platform" (for the harmonyos UI stubs), this
+/// says the API itself is registered-but-fake regardless of target.
+///
+/// `name` is the JS-facing API (e.g. `"dns.resolve4"`), `reason` a
+/// one-liner, `issue` the tracking tag. Honors the same `PERRY_STUB_DIAG`
+/// modes (first-call / off / verbose) as [`perry_stub_warn`].
+pub fn perry_runtime_stub(name: &'static str, reason: &'static str, issue: Option<&'static str>) {
+    let m = mode();
+    if m == DiagMode::Off {
+        return;
+    }
+    if m == DiagMode::FirstCall {
+        let mut s = match seen().lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if !s.insert(name) {
+            return;
+        }
+    }
+    match issue {
+        Some(tag) => eprintln!(
+            "[perry] warning: `{}` is a stub (registered but not real) — {} (tracking: {})",
+            name, reason, tag
+        ),
+        None => eprintln!(
+            "[perry] warning: `{}` is a stub (registered but not real) — {}",
+            name, reason
+        ),
+    }
+}
+
 /// C-ABI shim around [`perry_stub_warn`] for FFI crates that link
 /// perry-runtime as a Cargo dependency but must reach it through a
 /// stable, feature-set-independent symbol rather than the hash-mangled

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -316,11 +316,11 @@ declare module "cluster" {
   export const workers: any;
   /** stdlib */
   export function disconnect(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub no socket/listening-handle distribution; workers cannot share a port (#4914) */
   export function fork(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub no socket/listening-handle distribution; workers cannot share a port (#4914) */
   export function setupMaster(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub no socket/listening-handle distribution; workers cannot share a port (#4914) */
   export function setupPrimary(...args: any[]): any;
 }
 
@@ -1193,39 +1193,39 @@ declare module "dns" {
   export function getDefaultResultOrder(...args: any[]): any;
   /** stdlib */
   export function getServers(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function lookup(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function lookupService(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolve(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolve4(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolve6(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveAny(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveCaa(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveCname(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveMx(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveNaptr(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveNs(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolvePtr(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveSoa(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveSrv(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveTlsa(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveTxt(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function reverse(...args: any[]): any;
   /** stdlib */
   export function setDefaultResultOrder(...args: any[]): any;
@@ -1293,39 +1293,39 @@ declare module "dns/promises" {
   export function getDefaultResultOrder(...args: any[]): any;
   /** stdlib */
   export function getServers(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function lookup(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function lookupService(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolve(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolve4(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolve6(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveAny(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveCaa(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveCname(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveMx(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveNaptr(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveNs(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolvePtr(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveSoa(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveSrv(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveTlsa(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function resolveTxt(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub loopback-only deterministic fake; no real DNS resolution (#4911) */
   export function reverse(...args: any[]): any;
   /** stdlib */
   export function setDefaultResultOrder(...args: any[]): any;
@@ -1409,7 +1409,7 @@ declare module "events" {
 }
 
 declare module "exponential-backoff" {
-  /** stdlib */
+  /** stdlib @perryStub retry options ignored; hardcoded 3 attempts / 100ms / x2 (#4917) */
   export function backOff(p0: any, p1: any): any;
 }
 
@@ -3461,7 +3461,7 @@ declare module "stream/promises" {
 }
 
 declare module "stream/web" {
-  /** stdlib */
+  /** stdlib @perryStub constructor/use throws: not yet implemented (#4915) */
   export class ByteLengthQueuingStrategy { [key: string]: any; }
   /** stdlib */
   export class CompressionStream { [key: string]: any; }
@@ -3473,9 +3473,9 @@ declare module "stream/web" {
   export class ReadableByteStreamController { [key: string]: any; }
   /** stdlib */
   export class ReadableStream { [key: string]: any; }
-  /** stdlib */
+  /** stdlib @perryStub constructor/use throws: not yet implemented (#4915) */
   export class ReadableStreamBYOBReader { [key: string]: any; }
-  /** stdlib */
+  /** stdlib @perryStub constructor/use throws: not yet implemented (#4915) */
   export class ReadableStreamBYOBRequest { [key: string]: any; }
   /** stdlib */
   export class ReadableStreamDefaultController { [key: string]: any; }
@@ -3501,7 +3501,7 @@ declare module "stream/web" {
 }
 
 declare module "streams" {
-  /** stdlib */
+  /** stdlib @perryStub constructor/use throws: not yet implemented (#4915) */
   export class ByteLengthQueuingStrategy { [key: string]: any; }
   /** stdlib */
   export class CountQueuingStrategy { [key: string]: any; }
@@ -3977,7 +3977,7 @@ declare module "v8" {
   export function getCppHeapStatistics(...args: any[]): any;
   /** stdlib */
   export function getHeapCodeStatistics(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub empty-but-valid V8 heap graph, not a real snapshot (#4916) */
   export function getHeapSnapshot(...args: any[]): any;
   /** stdlib */
   export function getHeapSpaceStatistics(...args: any[]): any;
@@ -3999,7 +3999,7 @@ declare module "v8" {
   export function stopCoverage(...args: any[]): any;
   /** stdlib */
   export function takeCoverage(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub empty-but-valid V8 heap graph, not a real snapshot (#4916) */
   export function writeHeapSnapshot(...args: any[]): any;
 }
 
@@ -4180,27 +4180,27 @@ declare module "zlib" {
   export function brotliDecompressSync(p0: string): Buffer;
   /** stdlib */
   export function crc32(p0: string, seed?: number): number;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createBrotliCompress(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createBrotliDecompress(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createDeflate(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createDeflateRaw(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createGunzip(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createGzip(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createInflate(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createInflateRaw(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createUnzip(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createZstdCompress(options?: any): any;
-  /** stdlib */
+  /** stdlib @perryStub options (level/chunkSize/dictionary/...) accepted but ignored (#4917) */
   export function createZstdDecompress(options?: any): any;
   /** stdlib */
   export function deflate(buffer: any, callback: any): void;

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -372,9 +372,9 @@ Total: 2781 entries across 114 modules.
 ### Methods
 
 - `disconnect` — module
-- `fork` — module
-- `setupMaster` — module
-- `setupPrimary` — module
+- `fork` — module ⚠ **stub** — no socket/listening-handle distribution; workers cannot share a port (#4914)
+- `setupMaster` — module ⚠ **stub** — no socket/listening-handle distribution; workers cannot share a port (#4914)
+- `setupPrimary` — module ⚠ **stub** — no socket/listening-handle distribution; workers cannot share a port (#4914)
 
 ### Properties
 
@@ -858,16 +858,16 @@ Total: 2781 entries across 114 modules.
 
 - `Socket` — module
 - `addListener` — instance *(class: `Socket`)*
-- `addMembership` — instance *(class: `Socket`)*
-- `addSourceSpecificMembership` — instance *(class: `Socket`)*
+- `addMembership` — instance *(class: `Socket`)* ⚠ **stub** — accepted but no OS multicast/broadcast side effect (#4911)
+- `addSourceSpecificMembership` — instance *(class: `Socket`)* ⚠ **stub** — accepted but no OS multicast/broadcast side effect (#4911)
 - `address` — instance *(class: `Socket`)*
 - `bind` — instance *(class: `Socket`)*
 - `close` — instance *(class: `Socket`)*
 - `connect` — instance *(class: `Socket`)*
 - `createSocket` — module
 - `disconnect` — instance *(class: `Socket`)*
-- `dropMembership` — instance *(class: `Socket`)*
-- `dropSourceSpecificMembership` — instance *(class: `Socket`)*
+- `dropMembership` — instance *(class: `Socket`)* ⚠ **stub** — accepted but no OS multicast/broadcast side effect (#4911)
+- `dropSourceSpecificMembership` — instance *(class: `Socket`)* ⚠ **stub** — accepted but no OS multicast/broadcast side effect (#4911)
 - `emit` — instance *(class: `Socket`)*
 - `eventNames` — instance *(class: `Socket`)*
 - `getRecvBufferSize` — instance *(class: `Socket`)*
@@ -881,11 +881,11 @@ Total: 2781 entries across 114 modules.
 - `ref` — instance *(class: `Socket`)*
 - `remoteAddress` — instance *(class: `Socket`)*
 - `removeListener` — instance *(class: `Socket`)*
-- `send` — instance *(class: `Socket`)*
-- `setBroadcast` — instance *(class: `Socket`)*
-- `setMulticastInterface` — instance *(class: `Socket`)*
-- `setMulticastLoopback` — instance *(class: `Socket`)*
-- `setMulticastTTL` — instance *(class: `Socket`)*
+- `send` — instance *(class: `Socket`)* ⚠ **stub** — in-process loopback only; no real UDP socket I/O (#4911)
+- `setBroadcast` — instance *(class: `Socket`)* ⚠ **stub** — accepted but no OS multicast/broadcast side effect (#4911)
+- `setMulticastInterface` — instance *(class: `Socket`)* ⚠ **stub** — accepted but no OS multicast/broadcast side effect (#4911)
+- `setMulticastLoopback` — instance *(class: `Socket`)* ⚠ **stub** — accepted but no OS multicast/broadcast side effect (#4911)
+- `setMulticastTTL` — instance *(class: `Socket`)* ⚠ **stub** — accepted but no OS multicast/broadcast side effect (#4911)
 - `setRecvBufferSize` — instance *(class: `Socket`)*
 - `setSendBufferSize` — instance *(class: `Socket`)*
 - `setTTL` — instance *(class: `Socket`)*
@@ -928,38 +928,38 @@ Total: 2781 entries across 114 modules.
 - `getDefaultResultOrder` — module
 - `getServers` — module
 - `getServers` — instance *(class: `Resolver`)*
-- `lookup` — module
-- `lookupService` — module
-- `resolve` — module
-- `resolve` — instance *(class: `Resolver`)*
-- `resolve4` — module
-- `resolve4` — instance *(class: `Resolver`)*
-- `resolve6` — module
-- `resolve6` — instance *(class: `Resolver`)*
-- `resolveAny` — module
-- `resolveAny` — instance *(class: `Resolver`)*
-- `resolveCaa` — module
-- `resolveCaa` — instance *(class: `Resolver`)*
-- `resolveCname` — module
-- `resolveCname` — instance *(class: `Resolver`)*
-- `resolveMx` — module
-- `resolveMx` — instance *(class: `Resolver`)*
-- `resolveNaptr` — module
-- `resolveNaptr` — instance *(class: `Resolver`)*
-- `resolveNs` — module
-- `resolveNs` — instance *(class: `Resolver`)*
-- `resolvePtr` — module
-- `resolvePtr` — instance *(class: `Resolver`)*
-- `resolveSoa` — module
-- `resolveSoa` — instance *(class: `Resolver`)*
-- `resolveSrv` — module
-- `resolveSrv` — instance *(class: `Resolver`)*
-- `resolveTlsa` — module
-- `resolveTlsa` — instance *(class: `Resolver`)*
-- `resolveTxt` — module
-- `resolveTxt` — instance *(class: `Resolver`)*
-- `reverse` — module
-- `reverse` — instance *(class: `Resolver`)*
+- `lookup` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `lookupService` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve4` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve4` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve6` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve6` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveAny` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveAny` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveCaa` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveCaa` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveCname` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveCname` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveMx` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveMx` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveNaptr` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveNaptr` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveNs` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveNs` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolvePtr` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolvePtr` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveSoa` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveSoa` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveSrv` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveSrv` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveTlsa` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveTlsa` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveTxt` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveTxt` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `reverse` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `reverse` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
 - `setDefaultResultOrder` — module
 - `setLocalAddress` — instance *(class: `Resolver`)*
 - `setServers` — module
@@ -1037,38 +1037,38 @@ Total: 2781 entries across 114 modules.
 - `getDefaultResultOrder` — module
 - `getServers` — module
 - `getServers` — instance *(class: `Resolver`)*
-- `lookup` — module
-- `lookupService` — module
-- `resolve` — module
-- `resolve` — instance *(class: `Resolver`)*
-- `resolve4` — module
-- `resolve4` — instance *(class: `Resolver`)*
-- `resolve6` — module
-- `resolve6` — instance *(class: `Resolver`)*
-- `resolveAny` — module
-- `resolveAny` — instance *(class: `Resolver`)*
-- `resolveCaa` — module
-- `resolveCaa` — instance *(class: `Resolver`)*
-- `resolveCname` — module
-- `resolveCname` — instance *(class: `Resolver`)*
-- `resolveMx` — module
-- `resolveMx` — instance *(class: `Resolver`)*
-- `resolveNaptr` — module
-- `resolveNaptr` — instance *(class: `Resolver`)*
-- `resolveNs` — module
-- `resolveNs` — instance *(class: `Resolver`)*
-- `resolvePtr` — module
-- `resolvePtr` — instance *(class: `Resolver`)*
-- `resolveSoa` — module
-- `resolveSoa` — instance *(class: `Resolver`)*
-- `resolveSrv` — module
-- `resolveSrv` — instance *(class: `Resolver`)*
-- `resolveTlsa` — module
-- `resolveTlsa` — instance *(class: `Resolver`)*
-- `resolveTxt` — module
-- `resolveTxt` — instance *(class: `Resolver`)*
-- `reverse` — module
-- `reverse` — instance *(class: `Resolver`)*
+- `lookup` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `lookupService` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve4` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve4` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve6` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolve6` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveAny` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveAny` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveCaa` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveCaa` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveCname` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveCname` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveMx` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveMx` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveNaptr` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveNaptr` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveNs` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveNs` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolvePtr` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolvePtr` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveSoa` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveSoa` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveSrv` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveSrv` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveTlsa` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveTlsa` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveTxt` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `resolveTxt` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `reverse` — module ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
+- `reverse` — instance *(class: `Resolver`)* ⚠ **stub** — loopback-only deterministic fake; no real DNS resolution (#4911)
 - `setDefaultResultOrder` — module
 - `setLocalAddress` — instance *(class: `Resolver`)*
 - `setServers` — module
@@ -1200,7 +1200,7 @@ Total: 2781 entries across 114 modules.
 
 ### Methods
 
-- `backOff` — module
+- `backOff` — module ⚠ **stub** — retry options ignored; hardcoded 3 attempts / 100ms / x2 (#4917)
 
 ## `fastify`
 
@@ -1521,7 +1521,7 @@ Total: 2781 entries across 114 modules.
 - `createServer` — module
 - `createServer` — module
 - `defaultPort` — instance *(class: `Agent`)*
-- `destroy` — instance *(class: `Agent`)*
+- `destroy` — instance *(class: `Agent`)* ⚠ **stub** — real Agent object, but Perry does not pool sockets; this is a no-op (#4917)
 - `destroy` — instance *(class: `IncomingMessage`)*
 - `destroy` — instance *(class: `ClientRequest`)*
 - `destroyed` — instance *(class: `Agent`)*
@@ -1548,7 +1548,7 @@ Total: 2781 entries across 114 modules.
 - `keepAliveMsecs` — instance *(class: `Agent`)*
 - `keepAliveTimeout` — instance *(class: `HttpServer`)*
 - `keepAliveTimeoutBuffer` — instance *(class: `HttpServer`)*
-- `keepSocketAlive` — instance *(class: `Agent`)*
+- `keepSocketAlive` — instance *(class: `Agent`)* ⚠ **stub** — real Agent object, but Perry does not pool sockets; this is a no-op (#4917)
 - `listen` — instance *(class: `HttpServer`)*
 - `listenerCount` — instance *(class: `ClientRequest`)*
 - `listening` — instance *(class: `HttpServer`)*
@@ -1570,7 +1570,7 @@ Total: 2781 entries across 114 modules.
 - `requestTimeout` — instance *(class: `HttpServer`)*
 - `requests` — instance *(class: `Agent`)*
 - `resume` — instance *(class: `IncomingMessage`)*
-- `reuseSocket` — instance *(class: `Agent`)*
+- `reuseSocket` — instance *(class: `Agent`)* ⚠ **stub** — real Agent object, but Perry does not pool sockets; this is a no-op (#4917)
 - `setEncoding` — instance *(class: `IncomingMessage`)*
 - `setGlobalProxyFromEnv` — module
 - `setHeader` — instance *(class: `ClientRequest`)*
@@ -1882,7 +1882,7 @@ Total: 2781 entries across 114 modules.
 - `deleteMany` — instance
 - `deleteOne` — instance
 - `find` — instance
-- `findOne` — instance
+- `findOne` — instance ⚠ **stub** — resolves a JSON string, not a document object (#4917)
 - `insertMany` — instance
 - `insertOne` — instance
 - `updateMany` — instance
@@ -3105,14 +3105,14 @@ Total: 2781 entries across 114 modules.
 
 ### Classes
 
-- `ByteLengthQueuingStrategy`
+- `ByteLengthQueuingStrategy` ⚠ **stub** — constructor/use throws: not yet implemented (#4915)
 - `CompressionStream`
 - `CountQueuingStrategy`
 - `DecompressionStream`
 - `ReadableByteStreamController`
 - `ReadableStream`
-- `ReadableStreamBYOBReader`
-- `ReadableStreamBYOBRequest`
+- `ReadableStreamBYOBReader` ⚠ **stub** — constructor/use throws: not yet implemented (#4915)
+- `ReadableStreamBYOBRequest` ⚠ **stub** — constructor/use throws: not yet implemented (#4915)
 - `ReadableStreamDefaultController`
 - `ReadableStreamDefaultReader`
 - `TextDecoderStream`
@@ -3131,7 +3131,7 @@ Total: 2781 entries across 114 modules.
 
 ### Classes
 
-- `ByteLengthQueuingStrategy`
+- `ByteLengthQueuingStrategy` ⚠ **stub** — constructor/use throws: not yet implemented (#4915)
 - `CountQueuingStrategy`
 - `DecompressionStream`
 - `ReadableStream`
@@ -3515,7 +3515,7 @@ Total: 2781 entries across 114 modules.
 - `deserialize` — module
 - `getCppHeapStatistics` — module
 - `getHeapCodeStatistics` — module
-- `getHeapSnapshot` — module
+- `getHeapSnapshot` — module ⚠ **stub** — empty-but-valid V8 heap graph, not a real snapshot (#4916)
 - `getHeapSpaceStatistics` — module
 - `getHeapStatistics` — module
 - `isBuildingSnapshot` — instance *(class: `startupSnapshot`)*
@@ -3543,7 +3543,7 @@ Total: 2781 entries across 114 modules.
 - `takeCoverage` — module
 - `writeDouble` — instance *(class: `Serializer`)*
 - `writeHeader` — instance *(class: `Serializer`)*
-- `writeHeapSnapshot` — module
+- `writeHeapSnapshot` — module ⚠ **stub** — empty-but-valid V8 heap graph, not a real snapshot (#4916)
 - `writeRawBytes` — instance *(class: `Serializer`)*
 - `writeUint32` — instance *(class: `Serializer`)*
 - `writeUint64` — instance *(class: `Serializer`)*
@@ -3644,12 +3644,12 @@ Total: 2781 entries across 114 modules.
 - `once` — instance *(class: `Worker`)*
 - `postMessageToThread` — module
 - `receiveMessageOnPort` — module
-- `ref` — instance *(class: `Worker`)*
+- `ref` — instance *(class: `Worker`)* ⚠ **stub** — no-op; does not affect process event-loop ref-count (#4917)
 - `setEnvironmentData` — module
 - `startCpuProfile` — instance *(class: `Worker`)*
 - `startHeapProfile` — instance *(class: `Worker`)*
 - `terminate` — instance *(class: `Worker`)*
-- `unref` — instance *(class: `Worker`)*
+- `unref` — instance *(class: `Worker`)* ⚠ **stub** — no-op; does not affect process event-loop ref-count (#4917)
 
 ### Properties
 
@@ -3725,17 +3725,17 @@ Total: 2781 entries across 114 modules.
 - `brotliDecompress` — module
 - `brotliDecompressSync` — module
 - `crc32` — module
-- `createBrotliCompress` — module
-- `createBrotliDecompress` — module
-- `createDeflate` — module
-- `createDeflateRaw` — module
-- `createGunzip` — module
-- `createGzip` — module
-- `createInflate` — module
-- `createInflateRaw` — module
-- `createUnzip` — module
-- `createZstdCompress` — module
-- `createZstdDecompress` — module
+- `createBrotliCompress` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createBrotliDecompress` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createDeflate` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createDeflateRaw` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createGunzip` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createGzip` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createInflate` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createInflateRaw` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createUnzip` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createZstdCompress` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
+- `createZstdDecompress` — module ⚠ **stub** — options (level/chunkSize/dictionary/...) accepted but ignored (#4917)
 - `deflate` — module
 - `deflateRaw` — module
 - `deflateRawSync` — module

--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -673,8 +673,13 @@ for test_file in "${TEST_FILES[@]}"; do
     fi
 
     # Run Perry binary — same cap-via-tempfile protocol as Node above (#796).
+    # Silence the stub-elimination first-call diagnostics (#4919): parity
+    # measures *behavioral* byte-parity against Node, and Node never emits
+    # Perry's `[perry] warning: ... is a stub` lines. They'd otherwise show
+    # up on the 2>&1-captured stream for any test that exercises a flagged
+    # API (dns/dgram loopback, v8 heap snapshot, …) and diff against Node.
     perry_tmp=$(mktemp)
-    run_with_timeout 10 env "${parity_env[@]}" "$perry_binary" "${test_argv[@]}" > "$perry_tmp" 2>&1
+    run_with_timeout 10 env PERRY_STUB_DIAG=off "${parity_env[@]}" "$perry_binary" "${test_argv[@]}" > "$perry_tmp" 2>&1
     perry_exit=$?
     perry_output=$(cap_output < "$perry_tmp")
     rm -f "$perry_tmp"


### PR DESCRIPTION
## What

Implements the **keystone (#4918)** of the stub-elimination epic (**#4919**) — *"every registered API is real, or it fails loud"* — and brings the runtime/stdlib stub clusters to the epic's **honest floor**: visible in docs, warns on first call, throws under strict mode.

The real-implementation halves of the network/concurrency clusters (real DNS/UDP I/O, cross-thread shared SAB + futex wakeups, cluster fd-passing, BYOB streams, GC heap-graph snapshots) are multi-stage work tracked on their own issues. This PR makes them **honest rather than silently fake** — which is precisely the recurrence-prevention gate the epic's "Done when" defines.

## Sub-issue coverage

| Issue | Status in this PR |
|---|---|
| **#4918** keystone | ✅ Implemented — manifest flag populated, docs surface it, CI drift guard, strict mode |
| #4911 dns/dgram | Flagged + first-call warn + strict-throw (real network I/O = follow-up) |
| #4912 spawn/exec | **Re-triaged**: `spawn` is *real* since #1780 (verified) — premise stale, left unflagged. `exec` timing remains. |
| #4913 Atomics | Warn/throw on the genuinely-lying blocking path (not in manifest — global intrinsic) |
| #4914 cluster | Flagged (fd-passing = follow-up) |
| #4915 BYOB streams | Flagged (already throws; now visible) |
| #4916 v8/inspector/repl | Heap snapshots flagged + warn + strict-throw |
| #4917 stdlib adapters | zlib/http.Agent/worker/mongodb/backoff flagged |

## Keystone (#4918) details

- `ApiEntry.stub` existed but **0 of ~2,500 entries set it**. Added const `ApiEntry::stub()` / `stub_note(reason)` builders + a `stub_note` field so docs say *how* an API is limited (distinguishes a pure no-op from a real-but-partial like `http.Agent`).
- **101 entries flagged** across 7 clusters. `.d.ts` gets `@perryStub <note>`, `reference.md` gets `⚠ **stub** — <note>`. Docs regenerated.
- **CI drift guard** (`tests/stub_inventory.rs`): pins the per-issue inventory, requires every stub to carry an issue-tagged reason, allowlists which modules may have stubs.
- *Design note:* the build-generated `STUB_MANIFEST` (harmonyos UI platform stubs) is build-target-conditional and can't be literally cross-checked against the host-independent `API_MANIFEST`; the inventory drift-guard achieves #4918's "one source of truth, drift-guarded" intent instead.

## Runtime honesty + strict mode

- `stub_diag::perry_runtime_stub` / `strict_stubs_enabled`; `error::{throw_unimplemented_stub, stub_warn_or_throw}`. A flagged path warns once (honoring `PERRY_STUB_DIAG`) and, under **`PERRY_STRICT_STUBS=1`**, throws `ERR_PERRY_UNIMPLEMENTED`.
- `run_parity_tests.sh` runs Perry with `PERRY_STUB_DIAG=off` so the new stderr diagnostics don't diff against Node in the byte-for-byte suite.

## Verification

```
$ ./perry dns_test.ts && ./dns_test
[perry] warning: `dns` is a stub (registered but not real) — loopback-only … (tracking: #4911)
resolve4: null [ '127.0.0.1' ]

$ PERRY_STRICT_STUBS=1 ./dns_test
Error: dns is not implemented in Perry (stub); … — tracking #4911   [code: ERR_PERRY_UNIMPLEMENTED]
```

- `cargo test -p perry-api-manifest` (incl. new `stub_inventory`) ✅
- `cargo test -p perry-codegen --test manifest_consistency` ✅
- `cargo test -p perry-hir --test unimplemented_api_check` ✅
- `spawn` verified real via `test_issue_1780_spawn_streams.ts` ✅
- docs regenerated (`api-docs-drift` clean), fmt + clippy clean for touched code.