### PR TITLE
feat(runtime): implement regex `d` flag (hasIndices)

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -281,6 +281,134 @@ fn set_exec_array_groups(arr: *mut ArrayHeader, groups_obj: *mut ObjectHeader) {
     crate::array::js_array_set_string_key(arr, groups_key, value);
 }
 
+/// Attach the `indices` own property to a regex match-result array when the
+/// `d` flag (hasIndices) is set. Per ECMA-262 RegExpBuiltinExec, `indices` is
+/// an array where each element is `[start, end]` for the corresponding capture
+/// group. Element 0 is the full match, elements 1..N are capture groups.
+/// Unmatched groups are `undefined`. The `indices` array also has a `.groups`
+/// property with named captures mapping to `[start, end]` pairs.
+fn set_exec_array_indices(
+    arr: *mut ArrayHeader,
+    str_data: &str,
+    search_start_byte: usize,
+    caps: &regex::Captures,
+    regex: &regex::Regex,
+) {
+    if arr.is_null() {
+        return;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+
+    // Build the indices array: [[start, end], [start, end], ...]
+    let indices_arr = crate::array::js_array_alloc(caps.len() as u32);
+    let indices_handle = scope.root_raw_mut_ptr(indices_arr);
+    unsafe {
+        (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
+    }
+
+    for (i, cap) in caps.iter().enumerate() {
+        let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
+        if let Some(m) = cap {
+            // Convert byte offsets to char indices (JS spec uses UTF-16 code units,
+            // but we use char indices for simplicity — matches existing .index behavior)
+            let start_byte = m.start() + search_start_byte;
+            let end_byte = m.end() + search_start_byte;
+            let start_char = str_data[..start_byte].chars().count() as f64;
+            let end_char = str_data[..end_byte].chars().count() as f64;
+
+            // Create [start, end] pair
+            let pair = crate::array::js_array_alloc(2);
+            let pair_handle = scope.root_raw_mut_ptr(pair);
+            unsafe {
+                (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+                crate::array::store_array_slot(
+                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    0,
+                    start_char.to_bits(),
+                );
+                crate::array::store_array_slot(
+                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    1,
+                    end_char.to_bits(),
+                );
+            }
+
+            let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
+            let nanboxed = crate::value::js_nanbox_pointer(pair_ptr as i64);
+            unsafe {
+                crate::array::store_array_slot(indices_arr_ptr, i, nanboxed.to_bits());
+            }
+        } else {
+            // Unmatched capture group -> undefined
+            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
+            unsafe {
+                crate::array::store_array_slot(indices_arr_ptr, i, undefined.to_bits());
+            }
+        }
+    }
+
+    // If there are named groups, attach .groups property to indices array
+    let has_named_groups = regex.capture_names().any(|n| n.is_some());
+    if has_named_groups {
+        let groups_obj = crate::object::js_object_alloc(0, 0);
+        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
+
+        for (name, m) in regex
+            .capture_names()
+            .enumerate()
+            .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
+        {
+            let val = if let Some(m) = m {
+                let start_byte = m.start() + search_start_byte;
+                let end_byte = m.end() + search_start_byte;
+                let start_char = str_data[..start_byte].chars().count() as f64;
+                let end_char = str_data[..end_byte].chars().count() as f64;
+
+                // Create [start, end] pair for named group
+                let pair = crate::array::js_array_alloc(2);
+                let pair_handle = scope.root_raw_mut_ptr(pair);
+                unsafe {
+                    (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+                    crate::array::store_array_slot(
+                        pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                        0,
+                        start_char.to_bits(),
+                    );
+                    crate::array::store_array_slot(
+                        pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                        1,
+                        end_char.to_bits(),
+                    );
+                }
+                let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
+                crate::value::js_nanbox_pointer(pair_ptr as i64)
+            } else {
+                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+            };
+
+            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            let groups_obj_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+            crate::object::js_object_set_field_by_name(groups_obj_ptr, key_ptr, val);
+        }
+
+        let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+        let groups_nanboxed = crate::value::js_nanbox_pointer(groups_ptr as i64);
+        let indices_key = js_string_from_str("groups");
+        crate::array::js_array_set_string_key(
+            indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
+            indices_key,
+            f64::from_bits(groups_nanboxed.to_bits()),
+        );
+    }
+
+    // Attach indices array to the match result
+    let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
+    let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
+    let indices_key = js_string_from_str("indices");
+    crate::array::js_array_set_string_key(arr, indices_key, f64::from_bits(indices_nanboxed.to_bits()));
+}
+
 fn char_index_to_byte(s: &str, char_index: usize) -> usize {
     if char_index == 0 {
         return 0;
@@ -1010,6 +1138,117 @@ pub(crate) unsafe fn build_fancy_groups(
     groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>()
 }
 
+/// Build and attach the `indices` property for fancy-regex captures (lookbehind/backreference fallback).
+unsafe fn set_exec_array_indices_fancy(
+    arr: *mut ArrayHeader,
+    str_data: &str,
+    search_start_byte: usize,
+    fre: &fancy_regex::Regex,
+    caps: &fancy_regex::Captures,
+) {
+    if arr.is_null() {
+        return;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+
+    // Build the indices array: [[start, end], [start, end], ...]
+    let indices_arr = crate::array::js_array_alloc(caps.len() as u32);
+    let indices_handle = scope.root_raw_mut_ptr(indices_arr);
+    (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
+
+    for i in 0..caps.len() {
+        let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
+        if let Some(m) = caps.get(i) {
+            let start_byte = m.start() + search_start_byte;
+            let end_byte = m.end() + search_start_byte;
+            let start_char = str_data[..start_byte].chars().count() as f64;
+            let end_char = str_data[..end_byte].chars().count() as f64;
+
+            // Create [start, end] pair
+            let pair = crate::array::js_array_alloc(2);
+            let pair_handle = scope.root_raw_mut_ptr(pair);
+            (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+            crate::array::store_array_slot(
+                pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                0,
+                start_char.to_bits(),
+            );
+            crate::array::store_array_slot(
+                pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                1,
+                end_char.to_bits(),
+            );
+
+            let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
+            let nanboxed = crate::value::js_nanbox_pointer(pair_ptr as i64);
+            crate::array::store_array_slot(indices_arr_ptr, i, nanboxed.to_bits());
+        } else {
+            // Unmatched capture group -> undefined
+            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
+            crate::array::store_array_slot(indices_arr_ptr, i, undefined.to_bits());
+        }
+    }
+
+    // If there are named groups, attach .groups property to indices array
+    let has_named_groups = fre.capture_names().any(|n| n.is_some());
+    if has_named_groups {
+        let groups_obj = crate::object::js_object_alloc(0, 0);
+        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
+
+        for (name, m) in fre
+            .capture_names()
+            .enumerate()
+            .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
+        {
+            let val = if let Some(m) = m {
+                let start_byte = m.start() + search_start_byte;
+                let end_byte = m.end() + search_start_byte;
+                let start_char = str_data[..start_byte].chars().count() as f64;
+                let end_char = str_data[..end_byte].chars().count() as f64;
+
+                // Create [start, end] pair for named group
+                let pair = crate::array::js_array_alloc(2);
+                let pair_handle = scope.root_raw_mut_ptr(pair);
+                (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+                crate::array::store_array_slot(
+                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    0,
+                    start_char.to_bits(),
+                );
+                crate::array::store_array_slot(
+                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    1,
+                    end_char.to_bits(),
+                );
+                let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
+                crate::value::js_nanbox_pointer(pair_ptr as i64)
+            } else {
+                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+            };
+
+            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            let groups_obj_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+            crate::object::js_object_set_field_by_name(groups_obj_ptr, key_ptr, val);
+        }
+
+        let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+        let groups_nanboxed = crate::value::js_nanbox_pointer(groups_ptr as i64);
+        let indices_key = js_string_from_str("groups");
+        crate::array::js_array_set_string_key(
+            indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
+            indices_key,
+            f64::from_bits(groups_nanboxed.to_bits()),
+        );
+    }
+
+    // Attach indices array to the match result
+    let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
+    let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
+    let indices_key = js_string_from_str("indices");
+    crate::array::js_array_set_string_key(arr, indices_key, f64::from_bits(indices_nanboxed.to_bits()));
+}
+
 /// Fancy-regex fallback for the string-replacement (non-callback) forms of
 /// `String.prototype.replace`/`replaceAll`. Drives a manual non-overlapping
 /// match loop with `fancy_regex` and expands the replacement string via
@@ -1357,6 +1596,16 @@ pub extern "C" fn js_regexp_exec(
                     let groups_obj = build_fancy_groups(fre, &caps, &scope);
                     LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = groups_obj);
                     set_exec_array_groups(arr_handle.get_raw_mut_ptr::<ArrayHeader>(), groups_obj);
+                    // Build indices array if `d` flag (hasIndices) is set
+                    if (*re).has_indices {
+                        set_exec_array_indices_fancy(
+                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                            str_data,
+                            search_start_byte,
+                            fre,
+                            &caps,
+                        );
+                    }
                     return Some(arr_handle.get_raw_mut_ptr::<ArrayHeader>());
                 }
                 return Some(ptr::null_mut()); // fancy-regex tried but no match
@@ -1463,6 +1712,17 @@ pub extern "C" fn js_regexp_exec(
                     set_exec_array_groups(
                         arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
                         ptr::null_mut(),
+                    );
+                }
+
+                // Build indices array if `d` flag (hasIndices) is set
+                if (*re).has_indices {
+                    set_exec_array_indices(
+                        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                        str_data,
+                        search_start_byte,
+                        &caps,
+                        regex,
                     );
                 }
 

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -850,6 +850,18 @@ pub extern "C" fn js_string_match(
                             arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
                             groups_obj,
                         );
+                        // Build `indices` if the `d` flag (hasIndices) is set —
+                        // non-global `String.prototype.match` delegates to
+                        // RegExpExec, so it carries the same `indices` as exec().
+                        if (*re).has_indices {
+                            set_exec_array_indices_fancy(
+                                arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                                str_data,
+                                0,
+                                &fre,
+                                &caps,
+                            );
+                        }
                         return arr_handle.get_raw_mut_ptr::<ArrayHeader>();
                     }
                     _ => {
@@ -978,6 +990,19 @@ pub extern "C" fn js_string_match(
                         set_exec_array_groups(
                             arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
                             ptr::null_mut(),
+                        );
+                    }
+
+                    // Build `indices` if the `d` flag (hasIndices) is set —
+                    // non-global `String.prototype.match` delegates to
+                    // RegExpExec, so it carries the same `indices` as exec().
+                    if (*re).has_indices {
+                        set_exec_array_indices(
+                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                            str_data,
+                            0,
+                            &caps,
+                            regex,
                         );
                     }
 

--- a/test-files/test_regex_d_flag.ts
+++ b/test-files/test_regex_d_flag.ts
@@ -37,7 +37,7 @@ const re4 = /(\d+)(\.(\d+))?/d;
 const m4 = re4.exec("integer: 42");
 console.log("Test 4: Unmatched optional group");
 console.log(m4 !== null); // true
-console.log(JSON.stringify(m4!.indices)); // [[10,12],[10,12],null,null]
+console.log(JSON.stringify(m4!.indices)); // [[9,11],[9,11],null,null]
 console.log(m4!.indices[0] !== null); // true - full match
 console.log(m4!.indices[1] !== null); // true - group 1 matched
 console.log(m4!.indices[2] === undefined); // true - group 2 unmatched
@@ -113,7 +113,7 @@ const re11 = /(?=hello)/d;
 const m11 = re11.exec("say hello");
 console.log("Test 11: Zero-width assertion with d flag");
 console.log(m11 !== null); // true
-console.log(JSON.stringify(m11!.indices)); // [[0,0]]
+console.log(JSON.stringify(m11!.indices)); // [[4,4]]
 
 // Test 12: Lookbehind with d flag
 const re12 = /(?<=\$)\d+/d;
@@ -138,7 +138,7 @@ console.log(m14!.indices !== undefined); // true
 console.log(m14!.indices.groups !== undefined); // true
 console.log(JSON.stringify(m14!.indices.groups!.protocol)); // [5,10]
 console.log(JSON.stringify(m14!.indices.groups!.host)); // [13,24]
-console.log(JSON.stringify(m14!.indices.groups!.path)); // [24,43]
+console.log(JSON.stringify(m14!.indices.groups!.path)); // [24,41]
 
 // Test 15: indices property is own property
 const re15 = /test/d;
@@ -192,7 +192,7 @@ console.log(JSON.stringify(m18!.indices)); // [[0,4]]
 // [14,16]
 // Test 4: Unmatched optional group
 // true
-// [[10,12],[10,12],null,null]
+// [[9,11],[9,11],null,null]
 // true
 // true
 // true
@@ -228,7 +228,7 @@ console.log(JSON.stringify(m18!.indices)); // [[0,4]]
 // [[0,0]]
 // Test 11: Zero-width assertion with d flag
 // true
-// [[0,0]]
+// [[4,4]]
 // Test 12: Lookbehind with d flag
 // true
 // [[8,11]]
@@ -241,7 +241,7 @@ console.log(JSON.stringify(m18!.indices)); // [[0,4]]
 // true
 // [5,10]
 // [13,24]
-// [24,43]
+// [24,41]
 // Test 15: indices is own property
 // true
 // true

--- a/test-files/test_regex_d_flag.ts
+++ b/test-files/test_regex_d_flag.ts
@@ -1,0 +1,258 @@
+// Test regex `d` flag (hasIndices) implementation
+// Tests ECMA-262 RegExpBuiltinExec indices property
+
+// Test 1: Basic indices for full match
+const re1 = /hello/d;
+const m1 = re1.exec("say hello world");
+console.log("Test 1: Basic indices");
+console.log(m1 !== null); // true
+console.log(JSON.stringify(m1!.indices)); // [[4,9]]
+console.log(m1!.indices[0][0]); // 4
+console.log(m1!.indices[0][1]); // 9
+
+// Test 2: Indices with capture groups
+const re2 = /(\w+)@(\w+)/d;
+const m2 = re2.exec("email: test@example");
+console.log("Test 2: Capture groups");
+console.log(m2 !== null); // true
+console.log(JSON.stringify(m2!.indices)); // [[7,19],[7,11],[12,19]]
+console.log(m2!.indices.length); // 3
+console.log(JSON.stringify(m2!.indices[0])); // [7,19] - full match
+console.log(JSON.stringify(m2!.indices[1])); // [7,11] - group 1
+console.log(JSON.stringify(m2!.indices[2])); // [12,19] - group 2
+
+// Test 3: Indices with named groups
+const re3 = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/d;
+const m3 = re3.exec("date: 2024-03-15");
+console.log("Test 3: Named groups");
+console.log(m3 !== null); // true
+console.log(JSON.stringify(m3!.indices)); // [[6,16],[6,10],[11,13],[14,16]]
+console.log(m3!.indices.groups !== undefined); // true
+console.log(JSON.stringify(m3!.indices.groups!.year)); // [6,10]
+console.log(JSON.stringify(m3!.indices.groups!.month)); // [11,13]
+console.log(JSON.stringify(m3!.indices.groups!.day)); // [14,16]
+
+// Test 4: Unmatched optional group
+const re4 = /(\d+)(\.(\d+))?/d;
+const m4 = re4.exec("integer: 42");
+console.log("Test 4: Unmatched optional group");
+console.log(m4 !== null); // true
+console.log(JSON.stringify(m4!.indices)); // [[10,12],[10,12],null,null]
+console.log(m4!.indices[0] !== null); // true - full match
+console.log(m4!.indices[1] !== null); // true - group 1 matched
+console.log(m4!.indices[2] === undefined); // true - group 2 unmatched
+console.log(m4!.indices[3] === undefined); // true - group 3 unmatched
+
+// Test 5: hasIndices getter
+const re5 = /test/d;
+console.log("Test 5: hasIndices getter");
+console.log(re5.hasIndices); // true
+
+const re5b = /test/;
+console.log(re5b.hasIndices); // false
+
+const re5c = /test/gi;
+console.log(re5c.hasIndices); // false
+
+const re5d = /test/dgi;
+console.log(re5d.hasIndices); // true
+
+// Test 6: Without d flag, no indices
+const re6 = /test/;
+const m6 = re6.exec("test");
+console.log("Test 6: Without d flag");
+console.log(m6 !== null); // true
+console.log(m6!.indices); // undefined
+
+// Test 7: match() with d flag
+const re7 = /(\w+)@(\w+)/d;
+const m7 = "email: test@example".match(re7);
+console.log("Test 7: match() with d flag");
+console.log(m7 !== null); // true
+console.log(JSON.stringify(m7!.indices)); // [[7,19],[7,11],[12,19]]
+
+// Test 8: match() without d flag
+const re8 = /(\w+)@(\w+)/;
+const m8 = "email: test@example".match(re8);
+console.log("Test 8: match() without d flag");
+console.log(m8 !== null); // true
+console.log(m8!.indices); // undefined
+
+// Test 9: Global match with d flag
+const re9 = /\d+/dg;
+const text9 = "a1b22c333";
+const m9_1 = re9.exec(text9);
+console.log("Test 9: Global match with d flag");
+console.log(m9_1 !== null); // true
+console.log(JSON.stringify(m9_1!.indices)); // [[1,2]]
+console.log(re9.lastIndex); // 2
+
+const m9_2 = re9.exec(text9);
+console.log(m9_2 !== null); // true
+console.log(JSON.stringify(m9_2!.indices)); // [[3,5]]
+console.log(re9.lastIndex); // 5
+
+const m9_3 = re9.exec(text9);
+console.log(m9_3 !== null); // true
+console.log(JSON.stringify(m9_3!.indices)); // [[6,9]]
+console.log(re9.lastIndex); // 9
+
+const m9_4 = re9.exec(text9);
+console.log(m9_4); // null
+console.log(re9.lastIndex); // 0
+
+// Test 10: Empty match with d flag
+const re10 = /a*/d;
+const m10 = re10.exec("b");
+console.log("Test 10: Empty match with d flag");
+console.log(m10 !== null); // true
+console.log(JSON.stringify(m10!.indices)); // [[0,0]]
+
+// Test 11: Zero-width assertion with d flag
+const re11 = /(?=hello)/d;
+const m11 = re11.exec("say hello");
+console.log("Test 11: Zero-width assertion with d flag");
+console.log(m11 !== null); // true
+console.log(JSON.stringify(m11!.indices)); // [[0,0]]
+
+// Test 12: Lookbehind with d flag
+const re12 = /(?<=\$)\d+/d;
+const m12 = re12.exec("price: $100");
+console.log("Test 12: Lookbehind with d flag");
+console.log(m12 !== null); // true
+console.log(JSON.stringify(m12!.indices)); // [[8,11]]
+
+// Test 13: Backreference with d flag
+const re13 = /(\w)\1/d;
+const m13 = re13.exec("book");
+console.log("Test 13: Backreference with d flag");
+console.log(m13 !== null); // true
+console.log(JSON.stringify(m13!.indices)); // [[1,3],[1,2]]
+
+// Test 14: Complex pattern with d flag
+const re14 = /(?<protocol>https?):\/\/(?<host>[^\/]+)(?<path>\/.*)?/d;
+const m14 = re14.exec("url: https://example.com/path/to/resource");
+console.log("Test 14: Complex pattern with d flag");
+console.log(m14 !== null); // true
+console.log(m14!.indices !== undefined); // true
+console.log(m14!.indices.groups !== undefined); // true
+console.log(JSON.stringify(m14!.indices.groups!.protocol)); // [5,10]
+console.log(JSON.stringify(m14!.indices.groups!.host)); // [13,24]
+console.log(JSON.stringify(m14!.indices.groups!.path)); // [24,43]
+
+// Test 15: indices property is own property
+const re15 = /test/d;
+const m15 = re15.exec("test");
+console.log("Test 15: indices is own property");
+console.log(m15 !== null); // true
+console.log(Object.prototype.hasOwnProperty.call(m15, "indices")); // true
+
+// Test 16: indices survives aliasing
+const re16 = /(\w+)/d;
+const m16_1 = re16.exec("hello");
+const m16_2 = re16.exec("world");
+console.log("Test 16: indices survives aliasing");
+console.log(JSON.stringify(m16_1!.indices)); // [[0,5]]
+console.log(JSON.stringify(m16_2!.indices)); // [[0,5]]
+
+// Test 17: d flag with other flags
+const re17 = /hello/dgi;
+console.log("Test 17: d flag with other flags");
+console.log(re17.hasIndices); // true
+console.log(re17.global); // true
+console.log(re17.ignoreCase); // true
+
+// Test 18: RegExp constructor with d flag
+const re18 = new RegExp("test", "d");
+console.log("Test 18: RegExp constructor with d flag");
+console.log(re18.hasIndices); // true
+const m18 = re18.exec("test");
+console.log(m18 !== null); // true
+console.log(JSON.stringify(m18!.indices)); // [[0,4]]
+
+// Expected output:
+// Test 1: Basic indices
+// true
+// [[4,9]]
+// 4
+// 9
+// Test 2: Capture groups
+// true
+// [[7,19],[7,11],[12,19]]
+// 3
+// [7,19]
+// [7,11]
+// [12,19]
+// Test 3: Named groups
+// true
+// [[6,16],[6,10],[11,13],[14,16]]
+// true
+// [6,10]
+// [11,13]
+// [14,16]
+// Test 4: Unmatched optional group
+// true
+// [[10,12],[10,12],null,null]
+// true
+// true
+// true
+// true
+// Test 5: hasIndices getter
+// true
+// false
+// false
+// true
+// Test 6: Without d flag
+// true
+// undefined
+// Test 7: match() with d flag
+// true
+// [[7,19],[7,11],[12,19]]
+// Test 8: match() without d flag
+// true
+// undefined
+// Test 9: Global match with d flag
+// true
+// [[1,2]]
+// 2
+// true
+// [[3,5]]
+// 5
+// true
+// [[6,9]]
+// 9
+// null
+// 0
+// Test 10: Empty match with d flag
+// true
+// [[0,0]]
+// Test 11: Zero-width assertion with d flag
+// true
+// [[0,0]]
+// Test 12: Lookbehind with d flag
+// true
+// [[8,11]]
+// Test 13: Backreference with d flag
+// true
+// [[1,3],[1,2]]
+// Test 14: Complex pattern with d flag
+// true
+// true
+// true
+// [5,10]
+// [13,24]
+// [24,43]
+// Test 15: indices is own property
+// true
+// true
+// Test 16: indices survives aliasing
+// [[0,5]]
+// [[0,5]]
+// Test 17: d flag with other flags
+// true
+// true
+// true
+// Test 18: RegExp constructor with d flag
+// true
+// true
+// [[0,4]]

--- a/tests/test_regex_d_flag.sh
+++ b/tests/test_regex_d_flag.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test for regex `d` flag (hasIndices) implementation
+set -e
+
+PERRY="./target/release/perry"
+TEST_DIR="/tmp/perry_regex_d_test"
+mkdir -p "$TEST_DIR"
+
+# Simple test
+cat > "$TEST_DIR/test.ts" << 'EOF'
+const re = /hello/d;
+const m = re.exec("say hello world");
+console.log("indices:", JSON.stringify(m.indices));
+console.log("hasIndices:", re.hasIndices);
+EOF
+
+echo "Compiling test..."
+$PERRY "$TEST_DIR/test.ts" -o "$TEST_DIR/test" 2>&1 | tail -5
+
+echo ""
+echo "Running test..."
+"$TEST_DIR/test"
+
+echo ""
+echo "Test completed!"

--- a/tests/test_regex_d_flag_comprehensive.sh
+++ b/tests/test_regex_d_flag_comprehensive.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Comprehensive test for regex `d` flag (hasIndices) implementation
+set -e
+
+PERRY="./target/release/perry"
+TEST_DIR="/tmp/perry_regex_d_test"
+mkdir -p "$TEST_DIR"
+
+# Test 1: Basic indices
+cat > "$TEST_DIR/test1.ts" << 'EOF'
+const re = /hello/d;
+const m = re.exec("say hello world");
+console.log("Test 1: Basic indices");
+console.log("  indices:", JSON.stringify(m.indices));
+console.log("  Expected: [[4,9]]");
+console.log("  Pass:", JSON.stringify(m.indices) === "[[4,9]]");
+EOF
+
+# Test 2: Capture groups
+cat > "$TEST_DIR/test2.ts" << 'EOF'
+const re = /(\w+)@(\w+)/d;
+const m = re.exec("email: test@example");
+console.log("Test 2: Capture groups");
+console.log("  indices:", JSON.stringify(m.indices));
+console.log("  Expected: [[7,19], [7,11], [12,19]]");
+EOF
+
+# Test 3: Named groups
+cat > "$TEST_DIR/test3.ts" << 'EOF'
+const re = /(?<year>\d{4})-(?<month>\d{2})/d;
+const m = re.exec("date: 2024-03");
+console.log("Test 3: Named groups");
+console.log("  indices:", JSON.stringify(m.indices));
+console.log("  indices.groups:", JSON.stringify(m.indices.groups));
+console.log("  Expected groups: {year:[6,10], month:[11,13]}");
+EOF
+
+# Test 4: Unmatched optional group
+cat > "$TEST_DIR/test4.ts" << 'EOF'
+const re = /(\d+)(\.(\d+))?/d;
+const m = re.exec("int: 42");
+console.log("Test 4: Unmatched optional group");
+console.log("  indices:", JSON.stringify(m.indices));
+console.log("  indices[2] (unmatched):", m.indices[2]);
+console.log("  Expected: undefined");
+EOF
+
+# Test 5: Without d flag
+cat > "$TEST_DIR/test5.ts" << 'EOF'
+const re = /test/;
+const m = re.exec("test");
+console.log("Test 5: Without d flag");
+console.log("  indices:", m.indices);
+console.log("  Expected: undefined");
+console.log("  hasIndices:", re.hasIndices);
+console.log("  Expected: false");
+EOF
+
+echo "=== Test 1: Basic indices ==="
+$PERRY "$TEST_DIR/test1.ts" -o "$TEST_DIR/test1" 2>&1 | tail -2
+"$TEST_DIR/test1"
+echo ""
+
+echo "=== Test 2: Capture groups ==="
+$PERRY "$TEST_DIR/test2.ts" -o "$TEST_DIR/test2" 2>&1 | tail -2
+"$TEST_DIR/test2"
+echo ""
+
+echo "=== Test 3: Named groups ==="
+$PERRY "$TEST_DIR/test3.ts" -o "$TEST_DIR/test3" 2>&1 | tail -2
+"$TEST_DIR/test3"
+echo ""
+
+echo "=== Test 4: Unmatched optional group ==="
+$PERRY "$TEST_DIR/test4.ts" -o "$TEST_DIR/test4" 2>&1 | tail -2
+"$TEST_DIR/test4"
+echo ""
+
+echo "=== Test 5: Without d flag ==="
+$PERRY "$TEST_DIR/test5.ts" -o "$TEST_DIR/test5" 2>&1 | tail -2
+"$TEST_DIR/test5"
+echo ""
+
+echo "=== All tests completed! ==="


### PR DESCRIPTION
## Summary

Adds support for the ES2022 RegExp `d` flag (`hasIndices`), which attaches an `indices` property to match results containing start/end character positions for each capture group.

## Changes

### `crates/perry-runtime/src/regex.rs` (+260 lines)
- `set_exec_array_indices()` — attaches `indices` to match-result arrays for standard `regex::Regex` matches
- `set_exec_array_indices_fancy()` — same for `fancy_regex::Regex` captures (lookbehind/backreference patterns)
- Converts byte offsets to character indices (matching existing `.index` behavior)
- Handles unmatched capture groups as `undefined`
- Supports named capture groups via `.groups` property on the indices array

### Tests
- `test-files/test_regex_d_flag.ts` — 18 comprehensive test cases covering basic indices, capture groups, named groups, unmatched groups, `hasIndices` getter, `match()`, global match, empty matches, zero-width assertions, lookbehind, backreferences, complex URL pattern, own property check, aliasing, and `RegExp` constructor
- `tests/test_regex_d_flag.sh` — basic shell regression test
- `tests/test_regex_d_flag_comprehensive.sh` — 5 shell test scenarios

## Test Results
All 18 TypeScript test cases pass. Both shell test suites pass.