### PR TITLE
fix(codegen,runtime): entry-initialize boxed slots — eliminate undef box-pointer operands (#4926)

### DIFF
--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -774,6 +774,19 @@ pub(crate) fn lower_let(
         // branches may capture this id later, and an alloca placed
         // here would not dominate those branches' loads.
         let slot = ctx.func.alloca_entry(DOUBLE);
+        // perry#4926 (source bug behind the #4898 SIGBUS): the alloca
+        // dominates every use, but the store of the box pointer below
+        // only runs when this `Let` executes. A boxed read/write on a
+        // path that skips the Let (sibling-branch closure capture,
+        // switch fallthrough, hoisted-`var` use in a minified function)
+        // loads an uninitialized slot — LLVM folds that load to `undef`
+        // and regalloc substitutes whatever register happens to be live,
+        // handing `js_box_set`/`js_box_get` an arbitrary "plausible"
+        // pointer. Initialize the slot to TAG_UNDEFINED in the entry
+        // block (mirroring the non-boxed path) so skipped-init paths
+        // read a defined non-pointer sentinel that the runtime rejects
+        // deterministically.
+        ctx.func.entry_allocas_push_store(DOUBLE, &undef, &slot);
         let box_as_double = ctx.block().bitcast_i64_to_double(&box_ptr);
         ctx.block().store(DOUBLE, &box_as_double, &slot);
         // Step 2: register BEFORE lowering init.

--- a/crates/perry-codegen/src/stmt/mod.rs
+++ b/crates/perry-codegen/src/stmt/mod.rs
@@ -534,6 +534,14 @@ pub(crate) fn lower_stmt(ctx: &mut FnCtx<'_>, stmt: &Stmt) -> Result<()> {
                 let blk = ctx.block();
                 let box_ptr = blk.call(crate::types::I64, "js_box_alloc", &[(DOUBLE, &undef)]);
                 let slot = ctx.func.alloca_entry(DOUBLE);
+                // perry#4926: PreallocateBoxes can sit nested inside an
+                // If/Try/Labeled body (e.g. the async state-machine
+                // wrapper), so this block's box-pointer store doesn't
+                // necessarily dominate every load of the slot. Entry-init
+                // the slot to TAG_UNDEFINED so paths that bypass this
+                // statement read a defined sentinel instead of `undef`
+                // (see the boxed `Stmt::Let` arm in let_stmt.rs).
+                ctx.func.entry_allocas_push_store(DOUBLE, &undef, &slot);
                 let box_as_double = ctx.block().bitcast_i64_to_double(&box_ptr);
                 ctx.block().store(DOUBLE, &box_as_double, &slot);
                 ctx.locals.insert(*id, slot);

--- a/crates/perry-runtime/src/box.rs
+++ b/crates/perry-runtime/src/box.rs
@@ -98,7 +98,7 @@ pub fn scan_box_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
 
 /// Get the value from a box
 ///
-/// Same robustness as `js_box_set`: invalid pointers return NaN
+/// Same robustness as `js_box_set`: invalid pointers return `undefined`
 /// rather than dereferencing. See perry#393 for the failure mode.
 #[no_mangle]
 pub extern "C" fn js_box_get(ptr: *mut Box) -> f64 {
@@ -107,8 +107,9 @@ pub extern "C" fn js_box_get(ptr: *mut Box) -> f64 {
             // perry#924: production services see these in tight bursts of
             // 3 synced with normal request handling and the operator can't
             // tell whether anything is wrong. The path is correctness-safe
-            // (we already return NaN to the caller); gate the diagnostic
-            // behind `PERRY_DEBUG=1` so it only surfaces during bisection.
+            // (we already return a defined value to the caller); gate the
+            // diagnostic behind `PERRY_DEBUG=1` so it only surfaces during
+            // bisection.
             if std::env::var_os("PERRY_DEBUG").is_some() {
                 let count = BOX_GET_NULL_COUNT.fetch_add(1, Ordering::Relaxed);
                 if count < 3 {
@@ -118,7 +119,14 @@ pub extern "C" fn js_box_get(ptr: *mut Box) -> f64 {
                     );
                 }
             }
-            return f64::NAN;
+            // perry#4926: with codegen entry-initializing boxed slots to
+            // TAG_UNDEFINED, this arm is the read-before-initialization
+            // path for a boxed variable — in JS that reads as `undefined`
+            // (Perry has no TDZ), not as the number NaN. TAG_UNDEFINED is
+            // itself a quiet-NaN bit pattern, so numeric consumers behave
+            // exactly as before; JS-level checks (`typeof`, `== null`)
+            // now see `undefined`.
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
         (*ptr).value
     }
@@ -241,8 +249,15 @@ mod tests {
         // Must be a silent no-op, not a write/crash.
         js_box_set(fake, 1.0);
         assert_eq!(RODATA[0], 0xDEAD_BEEF, "rodata must be untouched");
-        // Reads from an unregistered pointer return NaN, never deref.
-        assert!(js_box_get(fake).is_nan());
+        // Reads from an unregistered pointer return `undefined` (perry#4926:
+        // the read-before-initialization value of a boxed variable), never
+        // deref. TAG_UNDEFINED is a NaN bit pattern, so this also preserves
+        // the older "returns NaN" numeric behavior.
+        assert_eq!(
+            js_box_get(fake).to_bits(),
+            crate::value::TAG_UNDEFINED,
+            "unregistered box read must yield undefined"
+        );
     }
 
     /// A real `js_box_alloc` box still round-trips through set/get after the

--- a/crates/perry/tests/issue_4926_boxed_slot_skipped_init.rs
+++ b/crates/perry/tests/issue_4926_boxed_slot_skipped_init.rs
@@ -1,0 +1,105 @@
+//! Regression test for #4926 (source bug behind the #4898 SIGBUS): a boxed
+//! (closure-captured + mutated) variable read or written on a control-flow
+//! path where its `let` initializer never executed must be DEFINED behavior.
+//!
+//! Before the fix, the boxed slot's alloca lived in the entry block but the
+//! box-pointer store only ran when the `Stmt::Let` executed — a skipped-init
+//! path loaded an uninitialized slot, LLVM folded it to `undef`, and regalloc
+//! substituted whatever register was live. Under typed-feedback density
+//! (react-reconciler) that was a read-only guard-string constant, and
+//! `js_box_set` wrote into `__TEXT.__cstring` → SIGBUS. The fix entry-
+//! initializes every boxed slot with TAG_UNDEFINED, so skipped-init reads see
+//! `undefined` (Perry has no TDZ) and skipped-init writes are deterministic
+//! no-ops.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn boxed_var_skipped_init_is_defined_behavior() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+
+    // A switch-case `let` is in scope for the whole switch block, but its
+    // initializer only runs when its case is taken — entering at case 2
+    // reaches boxed reads/writes with no dominating box allocation.
+    std::fs::write(
+        &entry,
+        r#"
+function readSkipped(c: number): any {
+  switch (c) {
+    case 1:
+      let x: any = 5;
+      const inc = () => {
+        x = x + 1;
+      };
+      inc();
+      return x;
+    case 2:
+      return typeof x;
+  }
+  return "none";
+}
+console.log(readSkipped(2));
+console.log(readSkipped(1));
+console.log(readSkipped(3));
+
+function writeSkipped(c: number): any {
+  switch (c) {
+    case 1:
+      let y: any = 5;
+      const incY = () => {
+        y = y + 1;
+      };
+      incY();
+      return y;
+    case 2:
+      y = 99;
+      return typeof y;
+  }
+  return "none";
+}
+console.log(writeSkipped(2));
+console.log(writeSkipped(1));
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (signal = #4926/#4898 regression)\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    // Skipped-init read = "undefined" (pre-fix: undef garbage, typically
+    // "number" via a rejected-pointer NaN). Taken paths unchanged.
+    // Skipped-init write is a deterministic no-op, so the follow-up read is
+    // still "undefined".
+    assert_eq!(
+        stdout, "undefined\n6\nnone\nundefined\n6\n",
+        "boxed skipped-init paths must be deterministic undefined"
+    );
+}


### PR DESCRIPTION
Fixes #4926 — the deferred source bug behind the #4898 react-reconciler SIGBUS (runtime gate shipped in #4902).

## Root cause

The boxed-var `Stmt::Let` path hoisted the slot **alloca** to the entry block (so it dominates all uses), but the store of the box pointer into that slot only runs where the `Let` executes. Any boxed read/write on a control-flow path that skips the Let — switch fallthrough into a later case, sibling-branch closure capture — loaded an **uninitialized** slot. LLVM folds that load to `undef`, and regalloc substitutes whatever register happens to be live. Under typed-feedback (#854) density (react-reconciler emits ~2500 `register_site` calls in one minified function), that live value was the read-only `"object_get_by_name_guard"` cstring pointer → `js_box_set` wrote into `__TEXT.__cstring` → SIGBUS. `PreallocateBoxes` (#569) had the same non-dominating-store shape when nested inside `If`/`Try`/`Labeled` bodies.

## Fix

- **codegen** (`stmt/let_stmt.rs`, `stmt/mod.rs`): entry-initialize every boxed slot with `TAG_UNDEFINED` via `entry_allocas_push_store` — exactly what the non-boxed Let path already did. Skipped-init paths now read a *defined* sentinel that even the structural checks alone reject deterministically; no more undef, no more regalloc roulette.
- **runtime** (`box.rs`): `js_box_get` on an unregistered pointer returns `undefined` instead of bare `NaN` — the JS value of a read-before-initialization variable (Perry has no TDZ). `TAG_UNDEFINED` is a quiet-NaN bit pattern, so numeric consumers behave exactly as before; `typeof`/null-checks now see `undefined`.
- **e2e test** (`crates/perry/tests/issue_4926_boxed_slot_skipped_init.rs`): switch-case skipped-init boxed read/write must be deterministic `undefined`, taken paths unchanged.

## Verification

- **Mechanism repro** (switch-case `let` captured+mutated by a closure, entered at the later case): pre-fix `PERRY_DEBUG=1` showed `js_box_get: invalid box pointer 0x1` (undef materialized as garbage) and `typeof x` printed `number`; post-fix the pointer is exactly the sentinel `0x7ffc000000000001` and `typeof x` prints `undefined`.
- **react-reconciler** (`rr_min.tsx` from #4898): the stray `js_box_set` operand collapses from arbitrary `__TEXT` garbage (`0x1016e9360`) to the deterministic sentinel — proving the rr stray call was this exact mechanism and is now defined behavior end to end. `createReconciler({...full hostconfig})` still builds a working reconciler.
- **Zero regressions**: 225-file `test_gap_*` sweep vs `node --experimental-strip-types` — failure sets byte-identical between baseline (clean main) and fixed builds (190 pass / 35 pre-existing, the only output diffs being ASLR addresses and thread IDs in panic backtraces). Full `perry-runtime` suite green single-threaded (1013 passed; the 1 failure, `date::tests::test_full_year_setters_revive_invalid_date_only`, fails on main too). `cargo fmt` clean; all touched files under the 2000-line gate.

No version bump / CHANGELOG entry per maintainer convention (folded in at merge).
