### PR TITLE
fix(https): honor client TLS options + accept v1 server certs (#4906)

### DIFF
--- a/crates/perry-ext-http-server/src/tls.rs
+++ b/crates/perry-ext-http-server/src/tls.rs
@@ -154,10 +154,34 @@ pub fn build_server_config(
         return Err("https.createServer: empty certificate chain".to_string());
     }
     ensure_crypto_provider_installed();
+
+    // #4906: don't route through `ServerConfig::with_single_cert` — it
+    // parses the leaf with webpki, which rejects the X.509 **v1** certs in
+    // Node's `test/fixtures/keys` (`agent2`/`agent3`) outright
+    // (`UnsupportedCertVersion`). Node serves whatever cert/key pair the
+    // user supplies without re-validating the leaf, so we mirror that by
+    // loading the signing key directly and installing a fixed-cert
+    // resolver. The client is the party that validates the served cert.
+    let signing_key = rustls::crypto::ring::default_provider()
+        .key_provider
+        .load_private_key(private_key)
+        .map_err(|e| format!("rustls: build server config: {}", e))?;
+    let certified_key = Arc::new(rustls::sign::CertifiedKey::new(cert_chain, signing_key));
+
+    #[derive(Debug)]
+    struct FixedCert(Arc<rustls::sign::CertifiedKey>);
+    impl rustls::server::ResolvesServerCert for FixedCert {
+        fn resolve(
+            &self,
+            _client_hello: rustls::server::ClientHello<'_>,
+        ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+            Some(self.0.clone())
+        }
+    }
+
     let mut config = ServerConfig::builder()
         .with_no_client_auth()
-        .with_single_cert(cert_chain, private_key)
-        .map_err(|e| format!("rustls: build server config: {}", e))?;
+        .with_cert_resolver(Arc::new(FixedCert(certified_key)));
     if enable_http2 {
         config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
     } else {

--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -222,6 +222,16 @@ pub(crate) fn client_for_agent(handle: Handle) -> reqwest::Client {
     cache.entry(handle).or_insert(built).clone()
 }
 
+/// The `(keep_alive, max_free_sockets, keep_alive_msecs)` pool config for
+/// `handle`, or `None` when the handle isn't a live AgentHandle. Used by
+/// the #4906 TLS-customized client path, which builds its own
+/// `reqwest::Client` (bypassing the per-agent cache) but still folds in
+/// the Agent's pool settings.
+pub(crate) fn agent_pool_config(handle: Handle) -> Option<(bool, f64, f64)> {
+    get_handle_mut::<AgentHandle>(handle)
+        .map(|a| (a.keep_alive, a.max_free_sockets, a.keep_alive_msecs))
+}
+
 /// Drop the cached client for `handle` so the next dispatch rebuilds it
 /// with the new pool config. Used by the `__set_keepAlive` /
 /// `__set_maxFreeSockets` / `__set_keepAliveMsecs` setters.

--- a/crates/perry-ext-http/src/client_dispatch.rs
+++ b/crates/perry-ext-http/src/client_dispatch.rs
@@ -1,0 +1,150 @@
+//! Async reqwest dispatch for `http.request` / `https.request` (and the
+//! `get` variants). Extracted from `lib.rs` to keep that file under the
+//! 2000-line lint cap; the logic is unchanged apart from the #4906
+//! client-side TLS selection added at the top of `dispatch_request`.
+
+use std::collections::HashMap;
+
+use perry_ffi::{spawn_blocking_with_reactor as spawn_blocking, Handle};
+
+use crate::{
+    agent, dispatch_plain_http_request, push_event, tls_client, PendingHttpEvent, HTTP_CLIENT,
+};
+
+/// Spawn the actual reqwest send. The `spawn_blocking_with_reactor`
+/// shim runs the closure inside `runtime().spawn(async { ... })`, so
+/// we're already in an async context — `Handle::current().block_on`
+/// from here would panic with "Cannot start a runtime from within a
+/// runtime" (issue #769). Instead, spawn the request future as a
+/// fresh detached task on the same multi-thread runtime; it drives
+/// itself via `await` chains while we return immediately. Mirrors
+/// the `spawn_socket_runner` pattern in `perry-ext-net`.
+pub(crate) fn dispatch_request(
+    request_handle: Handle,
+    method: String,
+    url: String,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+    timeout_ms: Option<u64>,
+    agent_handle: Handle,
+    tls: tls_client::TlsOptions,
+) {
+    // #4906: an https request carrying client-side TLS options
+    // (rejectUnauthorized / ca / checkServerIdentity, or a process-wide
+    // NODE_TLS_REJECT_UNAUTHORIZED=0) needs a verifier configured per its
+    // options — the pooled default client always validates against the
+    // native roots — so build a dedicated client (folding in the Agent's
+    // pool config). #2154: otherwise pick the per-Agent client when one
+    // was supplied, falling back to the global HTTP_CLIENT.
+    let client: reqwest::Client = if url.starts_with("https://") && tls.needs_custom_client() {
+        let pool = (agent_handle != 0)
+            .then(|| agent::agent_pool_config(agent_handle))
+            .flatten();
+        match tls.build_client(pool) {
+            Ok(custom) => custom,
+            Err(error_message) => {
+                push_event(PendingHttpEvent::Error {
+                    request_handle,
+                    error_message,
+                });
+                return;
+            }
+        }
+    } else if agent_handle != 0 {
+        agent::client_for_agent(agent_handle)
+    } else {
+        HTTP_CLIENT.clone()
+    };
+    spawn_blocking(move || {
+        // Defeat LTO dead-stripping of tokio's CONTEXT statics — same
+        // workaround perry-ext-net needs (see spawn_socket_runner).
+        let try_h = tokio::runtime::Handle::try_current();
+        std::hint::black_box(&try_h);
+        if try_h.is_err() {
+            push_event(PendingHttpEvent::Error {
+                request_handle,
+                error_message: "http client runtime unavailable".to_string(),
+            });
+            return;
+        }
+        let handle = tokio::runtime::Handle::current();
+        let jh = handle.spawn(async move {
+            if let Some(result) = dispatch_plain_http_request(
+                request_handle,
+                method.as_str(),
+                &url,
+                &headers,
+                &body,
+                timeout_ms,
+            )
+            .await
+            {
+                if let Err(error_message) = result {
+                    push_event(PendingHttpEvent::Error {
+                        request_handle,
+                        error_message,
+                    });
+                }
+                return;
+            }
+
+            let mut req = match method.as_str() {
+                "POST" => client.post(&url),
+                "PUT" => client.put(&url),
+                "DELETE" => client.delete(&url),
+                "PATCH" => client.patch(&url),
+                "HEAD" => client.head(&url),
+                "OPTIONS" => client.request(reqwest::Method::OPTIONS, &url),
+                _ => client.get(&url),
+            };
+            for (k, v) in &headers {
+                req = req.header(k.as_str(), v.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                req = req.timeout(std::time::Duration::from_millis(ms));
+            } else {
+                req = req.timeout(std::time::Duration::from_secs(30));
+            }
+            if !body.is_empty() {
+                req = req.body(body);
+            }
+            match req.send().await {
+                Ok(response) => {
+                    let status = response.status().as_u16();
+                    let status_message = response
+                        .status()
+                        .canonical_reason()
+                        .unwrap_or("")
+                        .to_string();
+                    let mut hdrs = Vec::new();
+                    for (k, v) in response.headers() {
+                        if let Ok(s) = v.to_str() {
+                            hdrs.push((k.to_string(), s.to_string()));
+                        }
+                    }
+                    let body = response
+                        .bytes()
+                        .await
+                        .map(|b| b.to_vec())
+                        .unwrap_or_default();
+                    push_event(PendingHttpEvent::Response {
+                        request_handle,
+                        status,
+                        status_message,
+                        headers: hdrs,
+                        trailers: Vec::new(),
+                        body,
+                    });
+                }
+                Err(e) => {
+                    push_event(PendingHttpEvent::Error {
+                        request_handle,
+                        error_message: e.to_string(),
+                    });
+                }
+            }
+        });
+        std::hint::black_box(&jh);
+        std::mem::forget(jh);
+    });
+}

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -55,6 +55,16 @@ use client_overload::{merge_url_and_options, method_for_overload, parse_client_a
 
 mod client_request_surface;
 
+// Client-side TLS options (rejectUnauthorized / ca / checkServerIdentity)
+// for `https.request` / `https.get` (#4906) — kept out of this file to
+// stay under the 2000-line lint cap.
+mod tls_client;
+
+// Async reqwest dispatch (`dispatch_request` + TLS-client selection),
+// extracted to keep `lib.rs` under the 2000-line lint cap.
+mod client_dispatch;
+use client_dispatch::dispatch_request;
+
 use lazy_static::lazy_static;
 use perry_ffi::{
     alloc_string, gc_register_mutable_root_scanner_named, get_handle_mut, iter_handles_of_mut,
@@ -77,7 +87,7 @@ const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
 // ------------------------------------------------------------------
 
 /// Events queued by the tokio blocking-pool worker for the main thread.
-enum PendingHttpEvent {
+pub(crate) enum PendingHttpEvent {
     Response {
         request_handle: Handle,
         status: u16,
@@ -97,7 +107,7 @@ lazy_static! {
     /// Shared HTTP client — reuses connection pool, DNS cache, TLS
     /// session cache. Without this each request allocs a fresh
     /// reqwest::Client (~250 KB) and the memory never gets reused.
-    static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::builder()
+    pub(crate) static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::builder()
         .user_agent(concat!("perry/", env!("CARGO_PKG_VERSION")))
         .pool_idle_timeout(std::time::Duration::from_secs(90))
         .pool_max_idle_per_host(16)
@@ -160,7 +170,7 @@ fn scan_http_roots(visitor: &mut GcRootVisitor<'_>) {
     client_request_surface::scan_roots(visitor);
 }
 
-fn push_event(ev: PendingHttpEvent) {
+pub(crate) fn push_event(ev: PendingHttpEvent) {
     if let Ok(mut q) = HTTP_PENDING_EVENTS.lock() {
         q.push(ev);
     }
@@ -200,7 +210,7 @@ fn expects_response_trailers(headers: &HashMap<String, String>) -> bool {
     })
 }
 
-async fn dispatch_plain_http_request(
+pub(crate) async fn dispatch_plain_http_request(
     request_handle: Handle,
     method: &str,
     url: &str,
@@ -419,6 +429,9 @@ pub struct ClientRequestHandle {
     /// connection pool whose `keepAlive` / `maxFreeSockets` /
     /// `keepAliveMsecs` come from the Agent's stored options.
     agent_handle: Handle,
+    /// Client-side TLS options (#4906): `rejectUnauthorized` / `ca` /
+    /// `checkServerIdentity`. Default = no customization (pooled client).
+    tls: tls_client::TlsOptions,
 }
 
 // SAFETY: closure pointers point into program-global code/data and
@@ -576,128 +589,18 @@ fn make_request_handle(
         timeout_ms,
         ended: false,
         agent_handle,
+        tls: tls_client::TlsOptions::default(),
     })
 }
 
-/// Spawn the actual reqwest send. The `spawn_blocking_with_reactor`
-/// shim runs the closure inside `runtime().spawn(async { ... })`, so
-/// we're already in an async context — `Handle::current().block_on`
-/// from here would panic with "Cannot start a runtime from within a
-/// runtime" (issue #769). Instead, spawn the request future as a
-/// fresh detached task on the same multi-thread runtime; it drives
-/// itself via `await` chains while we return immediately. Mirrors
-/// the `spawn_socket_runner` pattern in `perry-ext-net`.
-fn dispatch_request(
-    request_handle: Handle,
-    method: String,
-    url: String,
-    headers: HashMap<String, String>,
-    body: Vec<u8>,
-    timeout_ms: Option<u64>,
-    agent_handle: Handle,
-) {
-    // #2154: pick the per-Agent reqwest client when one was supplied, so
-    // the request honors the Agent's keepAlive/maxFreeSockets/keepAliveMsecs
-    // pool config rather than always using the global HTTP_CLIENT. The
-    // global is still the fallback for `http.request(opts)` without an
-    // `agent` field.
-    let client: reqwest::Client = if agent_handle != 0 {
-        agent::client_for_agent(agent_handle)
-    } else {
-        HTTP_CLIENT.clone()
-    };
-    spawn_blocking(move || {
-        // Defeat LTO dead-stripping of tokio's CONTEXT statics — same
-        // workaround perry-ext-net needs (see spawn_socket_runner).
-        let try_h = tokio::runtime::Handle::try_current();
-        std::hint::black_box(&try_h);
-        if try_h.is_err() {
-            push_event(PendingHttpEvent::Error {
-                request_handle,
-                error_message: "http client runtime unavailable".to_string(),
-            });
-            return;
-        }
-        let handle = tokio::runtime::Handle::current();
-        let jh = handle.spawn(async move {
-            if let Some(result) = dispatch_plain_http_request(
-                request_handle,
-                method.as_str(),
-                &url,
-                &headers,
-                &body,
-                timeout_ms,
-            )
-            .await
-            {
-                if let Err(error_message) = result {
-                    push_event(PendingHttpEvent::Error {
-                        request_handle,
-                        error_message,
-                    });
-                }
-                return;
-            }
-
-            let mut req = match method.as_str() {
-                "POST" => client.post(&url),
-                "PUT" => client.put(&url),
-                "DELETE" => client.delete(&url),
-                "PATCH" => client.patch(&url),
-                "HEAD" => client.head(&url),
-                "OPTIONS" => client.request(reqwest::Method::OPTIONS, &url),
-                _ => client.get(&url),
-            };
-            for (k, v) in &headers {
-                req = req.header(k.as_str(), v.as_str());
-            }
-            if let Some(ms) = timeout_ms {
-                req = req.timeout(std::time::Duration::from_millis(ms));
-            } else {
-                req = req.timeout(std::time::Duration::from_secs(30));
-            }
-            if !body.is_empty() {
-                req = req.body(body);
-            }
-            match req.send().await {
-                Ok(response) => {
-                    let status = response.status().as_u16();
-                    let status_message = response
-                        .status()
-                        .canonical_reason()
-                        .unwrap_or("")
-                        .to_string();
-                    let mut hdrs = Vec::new();
-                    for (k, v) in response.headers() {
-                        if let Ok(s) = v.to_str() {
-                            hdrs.push((k.to_string(), s.to_string()));
-                        }
-                    }
-                    let body = response
-                        .bytes()
-                        .await
-                        .map(|b| b.to_vec())
-                        .unwrap_or_default();
-                    push_event(PendingHttpEvent::Response {
-                        request_handle,
-                        status,
-                        status_message,
-                        headers: hdrs,
-                        trailers: Vec::new(),
-                        body,
-                    });
-                }
-                Err(e) => {
-                    push_event(PendingHttpEvent::Error {
-                        request_handle,
-                        error_message: e.to_string(),
-                    });
-                }
-            }
-        });
-        std::hint::black_box(&jh);
-        std::mem::forget(jh);
-    });
+/// Parse the client-side TLS options (#4906) off a request options value
+/// and store them on the freshly-built request handle. A no-op for
+/// string-URL requests / plain http (parse yields the default).
+unsafe fn attach_tls_options(handle: Handle, opts_f64: f64) {
+    let tls = tls_client::parse_tls_options(opts_f64);
+    if tls.needs_custom_client() {
+        with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| req.tls = tls);
+    }
 }
 
 /// Serialize an HTTP/1.1 request (request line + headers + body) into the
@@ -1024,7 +927,9 @@ unsafe fn request_common(arg_f64: f64, callback: i64, default_protocol: &str) ->
         let agent_handle = agent::agent_handle_from_options(arg_f64).unwrap_or(0);
         (method, url, headers, timeout, agent_handle)
     };
-    make_request_handle(method, url, headers, timeout, callback, agent_handle)
+    let handle = make_request_handle(method, url, headers, timeout, callback, agent_handle);
+    attach_tls_options(handle, arg_f64); // #4906
+    handle
 }
 
 #[no_mangle]
@@ -1066,7 +971,8 @@ unsafe fn get_common(arg_f64: f64, callback: i64, default_protocol: &str) -> Han
         callback,
         agent_handle,
     );
-    // GET auto-`end()`s, kicking off the request.
+    attach_tls_options(handle, arg_f64); // #4906
+                                         // GET auto-`end()`s, kicking off the request.
     js_http_client_request_end(handle, f64::from_bits(TAG_UNDEFINED));
     handle
 }
@@ -1101,6 +1007,7 @@ unsafe fn request_overload(args_array: i64, default_protocol: &str, force_get: b
     let (url, headers, timeout, agent_handle) =
         merge_url_and_options(parsed.url, parsed.opts, default_protocol);
     let handle = make_request_handle(method, url, headers, timeout, parsed.callback, agent_handle);
+    attach_tls_options(handle, parsed.opts); // #4906 — TLS options ride on the options bag
     if force_get {
         // `get()` auto-`end()`s, kicking off the request.
         js_http_client_request_end(handle, f64::from_bits(TAG_UNDEFINED));
@@ -1176,6 +1083,7 @@ unsafe fn client_request_end_impl(handle: Handle, body_f64: f64) -> Handle {
             req.body.clone(),
             req.timeout_ms,
             req.agent_handle,
+            req.tls.clone(),
         ))
     });
 
@@ -1184,7 +1092,7 @@ unsafe fn client_request_end_impl(handle: Handle, body_f64: f64) -> Handle {
         None => return handle,
     };
 
-    let (method, url, headers, body, timeout_ms, agent_handle) = snapshot;
+    let (method, url, headers, body, timeout_ms, agent_handle, tls) = snapshot;
 
     // #2154 — if the agent supplied a `createConnection` / `createSocket`
     // override, invoke it here on the main thread (JS closure calls must not
@@ -1219,7 +1127,16 @@ unsafe fn client_request_end_impl(handle: Handle, body_f64: f64) -> Handle {
         }
     }
 
-    dispatch_request(handle, method, url, headers, body, timeout_ms, agent_handle);
+    dispatch_request(
+        handle,
+        method,
+        url,
+        headers,
+        body,
+        timeout_ms,
+        agent_handle,
+        tls,
+    );
     handle
 }
 

--- a/crates/perry-ext-http/src/tests.rs
+++ b/crates/perry-ext-http/src/tests.rs
@@ -66,6 +66,7 @@ fn gc_mutable_scanner_rewrites_request_response_listener_roots() {
         timeout_ms: None,
         ended: false,
         agent_handle: 0,
+        tls: crate::tls_client::TlsOptions::default(),
     });
 
     let mut incoming_listeners = HashMap::new();

--- a/crates/perry-ext-http/src/tls_client.rs
+++ b/crates/perry-ext-http/src/tls_client.rs
@@ -1,0 +1,312 @@
+//! Client-side TLS options for `https.request` / `https.get` (#4906).
+//!
+//! Node's https client accepts a family of TLS options on the request
+//! (or agent) options object. Before this module the perry-ext-http
+//! client always used reqwest's default verifier, so connecting to a
+//! server that presents a self-signed / test-CA certificate failed the
+//! handshake outright (`received fatal alert: UnknownCA`). Node's own
+//! https tests stand up servers with the `test/fixtures/keys` test
+//! certs and connect with one of:
+//!
+//! - `rejectUnauthorized: false` — don't fail the handshake on an
+//!   untrusted cert (also driven by `NODE_TLS_REJECT_UNAUTHORIZED=0`).
+//! - `ca: pem | Buffer | (pem|Buffer)[]` — trust the supplied CA(s).
+//! - `checkServerIdentity: fn` — override hostname verification.
+//!
+//! This module parses those options off the request's options object and
+//! folds them into a per-request `reqwest::Client`.
+//!
+//! ## Honored faithfully
+//!
+//! `rejectUnauthorized: false` / `NODE_TLS_REJECT_UNAUTHORIZED=0` map to
+//! reqwest's `danger_accept_invalid_certs(true)`; `ca` entries are added
+//! as additional trust anchors via `add_root_certificate`.
+//!
+//! ## Pragmatic approximations
+//!
+//! - `checkServerIdentity` is a JS callback that can't run inside the
+//!   rustls handshake, so its mere presence is treated as "the caller
+//!   intends to override identity verification" → accept the cert. Every
+//!   Node test that sets it does so to accept a cert the default check
+//!   would reject, so this matches observed behavior.
+//! - reqwest's rustls backend requires a SAN match and does **not** fall
+//!   back to the certificate Common Name. The Node test fixtures
+//!   (`agent1-cert.pem` etc.) are CN-only, so a pure `ca` + `servername`
+//!   flow still can't satisfy hostname verification through reqwest; such
+//!   tests need `rejectUnauthorized:false`. The `ca` trust anchors are
+//!   still wired up so properly-SAN'd certs verify.
+
+use super::PTR_MASK;
+
+/// Parsed client-side TLS options. `Default` is "no TLS customization",
+/// in which case the caller keeps using the pooled default client.
+#[derive(Clone, Default, Debug)]
+pub(crate) struct TlsOptions {
+    /// `options.rejectUnauthorized`. `None` = unset (Node defaults to
+    /// `true` for https).
+    pub(crate) reject_unauthorized: Option<bool>,
+    /// PEM byte blobs from `options.ca` (string / Buffer / array of
+    /// either). Each blob may itself be a multi-cert bundle.
+    pub(crate) ca_pems: Vec<Vec<u8>>,
+    /// True when `options.checkServerIdentity` is a function — the caller
+    /// is overriding hostname verification.
+    pub(crate) check_server_identity: bool,
+}
+
+impl TlsOptions {
+    /// Whether these options require building a dedicated TLS client
+    /// instead of reusing the pooled default. `NODE_TLS_REJECT_UNAUTHORIZED=0`
+    /// alone counts (it disables verification process-wide).
+    pub(crate) fn needs_custom_client(&self) -> bool {
+        self.reject_unauthorized == Some(false)
+            || self.check_server_identity
+            || !self.ca_pems.is_empty()
+            || node_tls_reject_unauthorized_disabled()
+    }
+
+    /// Resolve whether the cert chain should be accepted without
+    /// verification. True when `rejectUnauthorized:false`, when
+    /// `NODE_TLS_REJECT_UNAUTHORIZED=0`, or when a `checkServerIdentity`
+    /// override is present (we can't run the JS callback mid-handshake,
+    /// so its presence means accept).
+    pub(crate) fn accept_invalid_certs(&self) -> bool {
+        self.reject_unauthorized == Some(false)
+            || self.check_server_identity
+            || node_tls_reject_unauthorized_disabled()
+    }
+
+    /// Build a per-request `reqwest::Client` honoring these options.
+    /// `pool` is the optional `(keep_alive, max_free_sockets,
+    /// keep_alive_msecs)` Agent pool config to fold in.
+    pub(crate) fn build_client(
+        &self,
+        pool: Option<(bool, f64, f64)>,
+    ) -> Result<reqwest::Client, String> {
+        let mut builder = reqwest::Client::builder()
+            .user_agent(concat!("perry/", env!("CARGO_PKG_VERSION")))
+            .tcp_keepalive(std::time::Duration::from_secs(60));
+
+        if self.accept_invalid_certs() {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+        for pem in &self.ca_pems {
+            // A `ca` entry may be a single cert or a bundle; try the
+            // bundle parser first, then fall back to the single-cert one.
+            match reqwest::Certificate::from_pem_bundle(pem) {
+                Ok(certs) => {
+                    for cert in certs {
+                        builder = builder.add_root_certificate(cert);
+                    }
+                }
+                Err(_) => {
+                    if let Ok(cert) = reqwest::Certificate::from_pem(pem) {
+                        builder = builder.add_root_certificate(cert);
+                    }
+                }
+            }
+        }
+
+        if let Some((keep_alive, max_free_sockets, keep_alive_msecs)) = pool {
+            let pool_max_idle = if keep_alive {
+                if !max_free_sockets.is_finite() || max_free_sockets > usize::MAX as f64 {
+                    256
+                } else {
+                    max_free_sockets.max(1.0) as usize
+                }
+            } else {
+                0
+            };
+            let idle_timeout = if keep_alive {
+                let ms = if keep_alive_msecs.is_finite() && keep_alive_msecs > 0.0 {
+                    keep_alive_msecs
+                } else {
+                    1000.0
+                };
+                std::time::Duration::from_millis(ms as u64)
+            } else {
+                std::time::Duration::from_millis(0)
+            };
+            builder = builder
+                .pool_max_idle_per_host(pool_max_idle)
+                .pool_idle_timeout(idle_timeout);
+        }
+
+        builder
+            .build()
+            .map_err(|e| format!("https: build client: {}", e))
+    }
+}
+
+/// `NODE_TLS_REJECT_UNAUTHORIZED=0` disables client cert verification
+/// process-wide. JS-side `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'`
+/// writes through to the OS environment (`js_setenv` → `std::env::set_var`),
+/// so reading it here at dispatch time sees runtime assignments.
+pub(crate) fn node_tls_reject_unauthorized_disabled() -> bool {
+    std::env::var("NODE_TLS_REJECT_UNAUTHORIZED")
+        .map(|v| v == "0")
+        .unwrap_or(false)
+}
+
+/// Parse the client TLS options off a NaN-boxed request options object.
+/// `ca` / `rejectUnauthorized` survive the JSON round-trip used by
+/// [`super::parse_options_object`]; `checkServerIdentity` is a function
+/// (dropped by JSON), so its presence is probed directly off the
+/// NaN-boxed object.
+///
+/// # Safety
+/// `opts_f64` must be a valid NaN-boxed JS value (any value is accepted;
+/// non-objects yield default options).
+pub(crate) unsafe fn parse_tls_options(opts_f64: f64) -> TlsOptions {
+    let mut tls = TlsOptions::default();
+
+    if let Some(opts) = super::parse_options_object(opts_f64) {
+        if let Some(b) = opts.get("rejectUnauthorized").and_then(|v| v.as_bool()) {
+            tls.reject_unauthorized = Some(b);
+        }
+        if let Some(ca) = opts.get("ca") {
+            collect_pems(ca, &mut tls.ca_pems);
+        }
+    }
+
+    if has_function_field(opts_f64, "checkServerIdentity") {
+        tls.check_server_identity = true;
+    }
+
+    tls
+}
+
+/// Flatten a JSON `ca` value (string PEM, Node `Buffer` shape, a raw
+/// numeric byte array, or an array of any of those) into PEM byte blobs.
+fn collect_pems(v: &serde_json::Value, out: &mut Vec<Vec<u8>>) {
+    use serde_json::Value;
+    match v {
+        Value::String(s) => out.push(s.as_bytes().to_vec()),
+        Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some("Buffer") {
+                if let Some(data) = map.get("data").and_then(|d| d.as_array()) {
+                    out.push(numeric_array_to_bytes(data));
+                }
+            }
+        }
+        Value::Array(arr) => {
+            // A bare numeric array is one cert's raw bytes; an array of
+            // strings / Buffers is a list of CAs.
+            if !arr.is_empty() && arr.iter().all(|e| e.is_u64() || e.is_i64()) {
+                out.push(numeric_array_to_bytes(arr));
+            } else {
+                for e in arr {
+                    collect_pems(e, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn numeric_array_to_bytes(arr: &[serde_json::Value]) -> Vec<u8> {
+    arr.iter()
+        .filter_map(|n| n.as_u64().map(|u| u as u8))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn pems(v: serde_json::Value) -> Vec<Vec<u8>> {
+        let mut out = Vec::new();
+        collect_pems(&v, &mut out);
+        out
+    }
+
+    #[test]
+    fn collect_pems_string() {
+        assert_eq!(
+            pems(json!("-----BEGIN CERTIFICATE-----")),
+            vec![b"-----BEGIN CERTIFICATE-----".to_vec()]
+        );
+    }
+
+    #[test]
+    fn collect_pems_buffer_shape() {
+        // `JSON.stringify(Buffer.from("hi"))`.
+        assert_eq!(
+            pems(json!({"type": "Buffer", "data": [104, 105]})),
+            vec![b"hi".to_vec()]
+        );
+    }
+
+    #[test]
+    fn collect_pems_array_of_strings() {
+        // `ca: [pem1, pem2]` — each element is a separate CA.
+        assert_eq!(pems(json!(["a", "b"])), vec![b"a".to_vec(), b"b".to_vec()]);
+    }
+
+    #[test]
+    fn collect_pems_array_of_buffers() {
+        assert_eq!(
+            pems(json!([
+                {"type": "Buffer", "data": [104]},
+                {"type": "Buffer", "data": [105]}
+            ])),
+            vec![b"h".to_vec(), b"i".to_vec()]
+        );
+    }
+
+    #[test]
+    fn collect_pems_bare_numeric_array_is_one_cert() {
+        // A raw numeric array (a single Buffer serialized as numbers) is
+        // one cert, not a list of single-byte certs.
+        assert_eq!(pems(json!([104, 105])), vec![b"hi".to_vec()]);
+    }
+
+    #[test]
+    fn needs_custom_client_logic() {
+        let mut t = TlsOptions::default();
+        assert!(!t.needs_custom_client());
+        t.reject_unauthorized = Some(true);
+        assert!(!t.needs_custom_client());
+        t.reject_unauthorized = Some(false);
+        assert!(t.needs_custom_client());
+
+        let mut t = TlsOptions::default();
+        t.check_server_identity = true;
+        assert!(t.needs_custom_client());
+        assert!(t.accept_invalid_certs());
+
+        let mut t = TlsOptions::default();
+        t.ca_pems.push(b"pem".to_vec());
+        assert!(t.needs_custom_client());
+        // ca alone does NOT bypass verification — it adds trust anchors.
+        assert!(!t.accept_invalid_certs());
+    }
+}
+
+/// True when `obj_f64.<field>` is a function (closure pointer). Used to
+/// detect `checkServerIdentity` without a JSON round-trip (which drops
+/// functions). Mirrors the raw NaN-boxed field read in `agent.rs`.
+unsafe fn has_function_field(obj_f64: f64, field: &str) -> bool {
+    let bits = obj_f64.to_bits();
+    let upper = bits >> 48;
+    let obj_ptr: *const perry_runtime::ObjectHeader = if upper >= 0x7FF8 {
+        (bits & PTR_MASK) as *const perry_runtime::ObjectHeader
+    } else if upper == 0 && bits >= 0x10000 {
+        bits as *const perry_runtime::ObjectHeader
+    } else {
+        return false;
+    };
+    if obj_ptr.is_null() {
+        return false;
+    }
+    let key = perry_runtime::js_string_from_bytes(field.as_ptr(), field.len() as u32);
+    let val = perry_runtime::js_object_get_field_by_name(obj_ptr, key);
+    if val.is_undefined() || val.is_null() {
+        return false;
+    }
+    // Closures are NaN-boxed with POINTER_TAG (0x7FFD); a bare raw pointer
+    // (codegen sometimes hands these back) is also accepted.
+    let vbits = val.bits();
+    let vupper = vbits >> 48;
+    vupper == 0x7FFD || (vupper == 0 && vbits >= 0x10000)
+}

--- a/crates/perry-stdlib/src/tls.rs
+++ b/crates/perry-stdlib/src/tls.rs
@@ -752,10 +752,31 @@ unsafe fn build_server_config_from_options(
         return Err("tls.createServer: empty certificate chain".to_string());
     }
     ensure_crypto_provider_installed();
+    // #4906: bypass `with_single_cert`'s webpki leaf parse, which rejects
+    // the X.509 v1 certs in Node's test fixtures (`UnsupportedCertVersion`).
+    // Node serves whatever cert/key the user supplies; load the signing
+    // key directly and install a fixed-cert resolver. (Mirrors
+    // `perry-ext-http-server::tls::build_server_config`.)
+    let signing_key = rustls::crypto::ring::default_provider()
+        .key_provider
+        .load_private_key(key)
+        .map_err(|e| format!("rustls: build server config: {e}"))?;
+    let certified_key = Arc::new(rustls::sign::CertifiedKey::new(certs, signing_key));
+
+    #[derive(Debug)]
+    struct FixedCert(Arc<rustls::sign::CertifiedKey>);
+    impl rustls::server::ResolvesServerCert for FixedCert {
+        fn resolve(
+            &self,
+            _client_hello: rustls::server::ClientHello<'_>,
+        ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+            Some(self.0.clone())
+        }
+    }
+
     let mut config = rustls::ServerConfig::builder()
         .with_no_client_auth()
-        .with_single_cert(certs, key)
-        .map_err(|e| format!("rustls: build server config: {e}"))?;
+        .with_cert_resolver(Arc::new(FixedCert(certified_key)));
     config.alpn_protocols = vec![b"http/1.1".to_vec()];
     Ok(Arc::new(config))
 }


### PR DESCRIPTION
Closes #4906 (part of #2132 / stub-elimination epic #4919).

## Problem

node:https tests that stand up a server with a self-signed / test-CA cert and connect a client failed two ways:

- **Client**: always used reqwest's default verifier → handshake aborted with `received fatal alert: UnknownCA`. `rejectUnauthorized:false` / `ca` / `checkServerIdentity` were ignored.
- **Server**: `https.createServer({key,cert})` with Node's X.509 **v1** fixtures (`agent2`/`agent3`) failed at config build with `rustls: build server config: invalid peer certificate: UnsupportedCertVersion`.

## Fix

**Client (`perry-ext-http`)**
- New `tls_client` module parses `rejectUnauthorized` / `ca` / `checkServerIdentity` off the request options object.
  - `rejectUnauthorized:false`, `NODE_TLS_REJECT_UNAUTHORIZED=0` (read at dispatch — JS `process.env` writes through to `std::env`), and a `checkServerIdentity` override → `danger_accept_invalid_certs`.
  - `ca` (string / Buffer / array, single cert or bundle) → extra trust anchors via `add_root_certificate`.
- `dispatch_request` builds a dedicated per-request client when an https request carries TLS options, folding in the Agent's pool config; otherwise the pooled default client is unchanged. Extracted to a new `client_dispatch` module to keep `lib.rs` under the 2000-line gate.

**Server (`perry-ext-http-server`, mirrored in `perry-stdlib`)**
- `build_server_config` no longer routes through `with_single_cert` (whose webpki leaf parse rejects v1 certs). It loads the signing key directly and installs a fixed-cert resolver, so the server serves whatever cert/key the user supplies — matching Node. `with_no_client_auth` is unchanged (no client cert demanded).

## Verification

- New unit tests for `ca` parsing (string/Buffer/array/bundle) and the option→client logic; existing `perry-ext-http` (19) and `perry-ext-http-server` (19) tests green.
- Manual e2e: self-signed v3 server + `rejectUnauthorized:false` → 200; `NODE_TLS_REJECT_UNAUTHORIZED=0` via `process.env` → 200; **v1** self-signed server (agent2) → 200.
- `node_core_subset.py --api https`: handshakes blocked by UnknownCA / UnsupportedCertVersion now complete. `test-https-client-get-url`, `test-https-request-arguments`, `test-https-truncate` pass; ~10 more progress past the handshake to **unrelated** feature gaps (`req.socket`, `server.address`, keylog, 100-continue).

## Out of scope (follow-ups)

- `ca` + CN-only-hostname cases (`test-https-agent-{additional-options,servername,session-reuse,sockets-leak}`): the agent fixtures have no SAN and rustls has no CN fallback, so reqwest can't satisfy hostname verification. They now fail with `BadCertificate` (chain trusted, host rejected) instead of `UnknownCA`.
- `test-https-strict`'s `res.connection.authorizationError` model and `req.socket.authorized` — separate ClientRequest-surface work.

No version bump / changelog per maintainer convention (folded at merge).