### PR TITLE
fix(http): make Agent/ClientRequest/IncomingMessage/ServerResponse constructable via new (#4904)

### DIFF
--- a/crates/perry-ext-http-server/src/handle_dispatch.rs
+++ b/crates/perry-ext-http-server/src/handle_dispatch.rs
@@ -98,6 +98,7 @@ extern "C" {
     fn js_node_http_im_complete(handle: i64) -> i32;
     fn js_node_http_im_aborted(handle: i64) -> i32;
     fn js_node_http_im_destroyed(handle: i64) -> i32;
+    fn js_node_http_im_add_header_line(handle: i64, field: f64, value: f64, dest: f64);
     fn js_node_http_im_signal(handle: i64) -> f64;
     fn js_node_http_im_remote_address(handle: i64) -> *mut StringHeader;
     fn js_node_http_im_remote_port(handle: i64) -> f64;
@@ -508,7 +509,17 @@ pub unsafe extern "C" fn js_ext_http_incoming_message_dispatch_method(
         "__get_trailersDistinct" | "trailersDistinct" => {
             json_string_value_empty_object(js_node_http_im_trailers_distinct_json(handle))
         }
-        "__get_socket" | "socket" | "__get_connection" | "connection" => self_ref,
+        "__get_socket" | "socket" | "__get_connection" | "connection" => {
+            crate::request::incoming_socket_override(handle).unwrap_or(self_ref)
+        }
+        "__set_socket" | "__set_connection" if !args.is_empty() => {
+            crate::request::incoming_socket_assign(handle, args[0]);
+            undef
+        }
+        "_addHeaderLine" if args.len() >= 3 => {
+            js_node_http_im_add_header_line(handle, args[0], args[1], args[2]);
+            undef
+        }
         "__get_signal" | "signal" => js_node_http_im_signal(handle),
         "__get_remoteAddress" | "remoteAddress" => {
             string_ptr_value(js_node_http_im_remote_address(handle))
@@ -595,13 +606,40 @@ pub unsafe extern "C" fn js_ext_http_server_response_dispatch_method(
             );
             self_ref
         }
-        "write" if !args.is_empty() => bool_value(js_node_http_res_write(handle, args[0]) != 0),
+        "write" if !args.is_empty() => {
+            // `write(chunk[, encoding][, callback])` — the callback is the
+            // last closure-valued arg (#4904).
+            let cb = args[1..]
+                .iter()
+                .rev()
+                .map(|a| closure_arg(Some(*a)))
+                .find(|c| *c != 0)
+                .unwrap_or(0);
+            bool_value(crate::response::js_node_http_res_write_with_cb(handle, args[0], cb) != 0)
+        }
         "addTrailers" if !args.is_empty() => {
             js_node_http_res_add_trailers(handle, args[0]);
             undef
         }
         "end" => {
-            js_node_http_res_end(handle, args.first().copied().unwrap_or(undef));
+            // `end([chunk][, encoding][, callback])` — `end(cb)` passes the
+            // callback first (#4904).
+            let first = args.first().copied().unwrap_or(undef);
+            let first_cb = closure_arg(Some(first));
+            let (chunk, cb) = if first_cb != 0 {
+                (undef, first_cb)
+            } else {
+                let cb = args
+                    .get(1..)
+                    .unwrap_or(&[])
+                    .iter()
+                    .rev()
+                    .map(|a| closure_arg(Some(*a)))
+                    .find(|c| *c != 0)
+                    .unwrap_or(0);
+                (first, cb)
+            };
+            crate::response::js_node_http_res_end_with_cb(handle, chunk, cb);
             self_ref
         }
         "flushHeaders" => {
@@ -641,6 +679,17 @@ pub unsafe extern "C" fn js_ext_http_server_response_dispatch_method(
             undef
         }
         "destroy" => self_ref,
+        "assignSocket" if !args.is_empty() => {
+            crate::response::js_node_http_res_assign_socket(handle, args[0]);
+            undef
+        }
+        "detachSocket" => {
+            crate::response::js_node_http_res_detach_socket(
+                handle,
+                args.first().copied().unwrap_or(undef),
+            );
+            undef
+        }
         "pipe" => undef,
         "on" | "addListener" if args.len() >= 2 => {
             let event_ptr = string_arg(args[0]);
@@ -722,7 +771,8 @@ pub unsafe extern "C" fn js_ext_http_incoming_message_dispatch_property(
         "complete" => bool_value(js_node_http_im_complete(handle) != 0),
         "aborted" => bool_value(js_node_http_im_aborted(handle) != 0),
         "destroyed" => bool_value(js_node_http_im_destroyed(handle) != 0),
-        "socket" | "connection" => handle_to_pointer_f64(handle),
+        "socket" | "connection" => crate::request::incoming_socket_override(handle)
+            .unwrap_or_else(|| handle_to_pointer_f64(handle)),
         "signal" => js_node_http_im_signal(handle),
         "remoteAddress" => string_ptr_value(js_node_http_im_remote_address(handle)),
         "remotePort" => js_node_http_im_remote_port(handle),
@@ -811,6 +861,33 @@ pub unsafe extern "C" fn js_ext_http_server_response_dispatch_property_set(
     }
 }
 
+/// Dispatch a property write on a registered server-side `IncomingMessage`
+/// (#4904). Returns 1 when the property was claimed.
+///
+/// # Safety
+/// FFI entry; pointers must be valid for their stated lengths.
+#[no_mangle]
+pub unsafe extern "C" fn js_ext_http_incoming_message_dispatch_property_set(
+    handle: i64,
+    property_ptr: *const u8,
+    property_len: usize,
+    value: f64,
+) -> i32 {
+    let property = method_name(property_ptr, property_len);
+    match property.as_str() {
+        // Node's `connection` accessor writes `this.socket`; both aliases
+        // land on the same slot.
+        "socket" | "connection" => {
+            if crate::request::incoming_socket_assign(handle, value) {
+                1
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    }
+}
+
 #[inline]
 unsafe fn method_name(ptr: *const u8, len: usize) -> String {
     if ptr.is_null() || len == 0 {
@@ -845,6 +922,18 @@ fn handle_value_or_undefined(handle: i64) -> f64 {
 
 #[inline]
 fn response_socket_value(handle: i64) -> f64 {
+    // #4904: a standalone response's socket is whatever `assignSocket`
+    // installed (undefined reads as Node's pre-assignment `null`).
+    if let Some(sr) = get_handle::<ServerResponse>(handle) {
+        if sr.standalone {
+            let v = sr.standalone_socket;
+            return if JsValue::from_bits(v.to_bits()).is_undefined() {
+                f64::from_bits(TAG_NULL)
+            } else {
+                v
+            };
+        }
+    }
     let req_handle = unsafe { js_node_http_res_req_handle(handle) };
     if req_handle == 0 {
         f64::from_bits(TAG_NULL)
@@ -933,6 +1022,9 @@ fn incoming_method_bytes(name: &str) -> Option<&'static [u8]> {
         "resume" => Some(b"resume"),
         "destroy" => Some(b"destroy"),
         "read" => Some(b"read"),
+        // #4904: internal-by-convention header-merge API, exercised
+        // directly by Node's own tests on standalone IncomingMessages.
+        "_addHeaderLine" => Some(b"_addHeaderLine"),
         _ => None,
     }
 }
@@ -951,6 +1043,9 @@ fn server_response_method_bytes(name: &str) -> Option<&'static [u8]> {
         "write" => Some(b"write"),
         "addTrailers" => Some(b"addTrailers"),
         "end" => Some(b"end"),
+        // #4904: standalone-response wiring.
+        "assignSocket" => Some(b"assignSocket"),
+        "detachSocket" => Some(b"detachSocket"),
         "flushHeaders" => Some(b"flushHeaders"),
         "cork" => Some(b"cork"),
         "uncork" => Some(b"uncork"),

--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -147,9 +147,14 @@ fn scan_http_server_roots(visitor: &mut GcRootVisitor<'_>) {
         scan_listener_roots(&mut im.listeners, visitor);
         visitor.visit_nanbox_f64_slot(&mut im.signal_controller);
         visitor.visit_nanbox_f64_slot(&mut im.signal);
+        visitor.visit_nanbox_f64_slot(&mut im.socket_value);
     });
     iter_handles_of_mut::<ServerResponse, _>(|sr| {
         scan_listener_roots(&mut sr.listeners, visitor);
+        visitor.visit_nanbox_f64_slot(&mut sr.standalone_socket);
+        for cb in sr.pending_write_callbacks.iter_mut() {
+            visitor.visit_i64_slot(cb);
+        }
     });
     iter_handles_of_mut::<Http2SessionHandle, _>(|session| {
         scan_listener_roots(&mut session.listeners, visitor);

--- a/crates/perry-ext-http-server/src/request.rs
+++ b/crates/perry-ext-http-server/src/request.rs
@@ -80,6 +80,18 @@ pub struct IncomingMessage {
     pub signal: f64,
     /// True once `'close'` has fired.
     pub close_emitted: bool,
+    /// #4904: true for `new http.IncomingMessage(socket)` instances —
+    /// standalone messages not attached to any live connection.
+    pub standalone: bool,
+    /// #4904: the socket value Node mirrors through `req.socket` /
+    /// `req.connection`. For standalone instances this holds the
+    /// constructor argument verbatim; assigning either alias
+    /// (`req.connection = v`) overwrites it (Node's `connection`
+    /// accessor writes `this.socket`).
+    pub socket_value: f64,
+    /// #4904: true once `socket`/`connection` has been assigned, so
+    /// server-attached requests also honor the override on reads.
+    pub socket_overridden: bool,
 }
 
 impl IncomingMessage {
@@ -113,6 +125,9 @@ impl IncomingMessage {
             signal_controller: f64::from_bits(crate::types::TAG_UNDEFINED),
             signal: f64::from_bits(crate::types::TAG_UNDEFINED),
             close_emitted: false,
+            standalone: false,
+            socket_value: f64::from_bits(crate::types::TAG_UNDEFINED),
+            socket_overridden: false,
         }
     }
 }
@@ -661,6 +676,203 @@ pub(crate) fn with_implicit_this<R>(this_val: f64, f: impl FnOnce() -> R) -> R {
     r
 }
 
+// ============================================================================
+// #4904: standalone `new http.IncomingMessage(socket)` support
+// ============================================================================
+
+/// `new http.IncomingMessage(socket)` — construct a standalone message not
+/// attached to any live connection. Node keeps the constructor argument
+/// verbatim on `req.socket` / `req.connection` and leaves the parse-state
+/// fields empty.
+#[no_mangle]
+pub extern "C" fn js_node_http_incoming_message_standalone_new(socket: f64) -> i64 {
+    crate::ensure_gc_scanner_registered();
+    let mut im = IncomingMessage::new(
+        String::new(),
+        String::new(),
+        HashMap::new(),
+        Vec::new(),
+        Vec::new(),
+        String::new(),
+        0,
+    );
+    im.standalone = true;
+    im.socket_value = socket;
+    register_handle(im)
+}
+
+/// `req.socket` / `req.connection` read override. `None` means the request
+/// is server-attached and untouched — dispatch falls back to the legacy
+/// self-pointer placeholder.
+pub(crate) fn incoming_socket_override(handle: i64) -> Option<f64> {
+    get_handle::<IncomingMessage>(handle).and_then(|im| {
+        if im.standalone || im.socket_overridden {
+            Some(im.socket_value)
+        } else {
+            None
+        }
+    })
+}
+
+/// `req.socket = v` / `req.connection = v`. Node's `connection` accessor
+/// writes `this.socket`, so both aliases land on the same slot.
+pub(crate) fn incoming_socket_assign(handle: i64, value: f64) -> bool {
+    if let Some(im) = get_handle_mut::<IncomingMessage>(handle) {
+        im.socket_value = value;
+        im.socket_overridden = true;
+        true
+    } else {
+        false
+    }
+}
+
+/// Header-field classification mirroring Node's `matchKnownFields`
+/// (lib/_http_incoming.js): the flag drives `_addHeaderLine` dedupe/merge.
+enum HeaderFieldKind {
+    /// Known single-value field — duplicate lines are dropped (first wins).
+    Single,
+    /// `', '`-joined list (known list fields and every unknown field).
+    List,
+    /// `Cookie` — joined with `'; '`.
+    Cookie,
+    /// `Set-Cookie` — accumulates an array.
+    SetCookie,
+}
+
+fn match_known_fields(field: &str) -> (HeaderFieldKind, String) {
+    // Node first tries an exact match against the canonical and all-lowercase
+    // spellings, then retries fully lowercased — observably identical to
+    // lowercasing up front and matching the lowercase table.
+    let lower = field.to_lowercase();
+    let kind = match lower.as_str() {
+        "age"
+        | "host"
+        | "from"
+        | "etag"
+        | "server"
+        | "referer"
+        | "expires"
+        | "location"
+        | "user-agent"
+        | "retry-after"
+        | "content-type"
+        | "max-forwards"
+        | "authorization"
+        | "last-modified"
+        | "content-length"
+        | "if-modified-since"
+        | "proxy-authorization"
+        | "if-unmodified-since" => HeaderFieldKind::Single,
+        "set-cookie" => HeaderFieldKind::SetCookie,
+        "cookie" => HeaderFieldKind::Cookie,
+        // Known list fields ("date", "vary", "origin", "expect", "accept",
+        // "upgrade", "if-match", "connection", "cache-control",
+        // "if-none-match", "accept-encoding", "accept-language",
+        // "x-forwarded-for", "content-encoding", "x-forwarded-host",
+        // "transfer-encoding", "x-forwarded-proto") and every unknown field
+        // share the same ', '-join behavior.
+        _ => HeaderFieldKind::List,
+    };
+    (kind, lower)
+}
+
+/// Stringify a JS value the way `'' + value` would inside Node's
+/// `dest[field] += ', ' + value` merge.
+fn header_value_to_string(value: f64) -> String {
+    let v = JsValue::from_bits(value.to_bits());
+    if v.is_undefined() {
+        return "undefined".to_string();
+    }
+    if v.is_null() {
+        return "null".to_string();
+    }
+    jsvalue_to_owned_string(value).unwrap_or_default()
+}
+
+/// Node's `IncomingMessage.prototype._addHeaderLine(field, value, dest)` —
+/// internal-by-convention API exercised directly by Node's own tests and by
+/// userland HTTP shims (#4904). Mutates `dest` in place per the
+/// `matchKnownFields` flag.
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_im_add_header_line(
+    _handle: i64,
+    field: f64,
+    value: f64,
+    dest: f64,
+) {
+    extern "C" {
+        fn js_object_get_field_by_name(
+            obj: *const perry_ffi::ObjectHeader,
+            key: *const StringHeader,
+        ) -> JsValue;
+        fn js_object_set_field_by_name(
+            obj: *mut perry_ffi::ObjectHeader,
+            key: *const StringHeader,
+            value: f64,
+        );
+    }
+    if !JsValue::from_bits(dest.to_bits()).is_pointer() {
+        return;
+    }
+    let dest_ptr = (dest.to_bits() & PTR_MASK) as *mut perry_ffi::ObjectHeader;
+    let field_name = jsvalue_to_owned_string(field).unwrap_or_default();
+    let (kind, name) = match_known_fields(&field_name);
+    let key = alloc_string(&name);
+    let existing = js_object_get_field_by_name(dest_ptr as *const _, key.as_raw());
+    let existing_f64 = f64::from_bits(existing.bits());
+    match kind {
+        HeaderFieldKind::List | HeaderFieldKind::Cookie => {
+            if JsValue::from_bits(existing.bits()).is_string() {
+                let sep = if matches!(kind, HeaderFieldKind::Cookie) {
+                    "; "
+                } else {
+                    ", "
+                };
+                let merged = format!(
+                    "{}{}{}",
+                    jsvalue_to_owned_string(existing_f64).unwrap_or_default(),
+                    sep,
+                    header_value_to_string(value),
+                );
+                let merged_str = alloc_string(&merged);
+                js_object_set_field_by_name(
+                    dest_ptr,
+                    key.as_raw(),
+                    f64::from_bits(STRING_TAG | (merged_str.as_raw() as u64 & PTR_MASK)),
+                );
+            } else {
+                js_object_set_field_by_name(dest_ptr, key.as_raw(), value);
+            }
+        }
+        HeaderFieldKind::SetCookie => {
+            if JsValue::from_bits(existing.bits()).is_undefined() {
+                let mut arr = perry_ffi::js_array_alloc(1);
+                arr = perry_ffi::js_array_push(arr, JsValue::from_bits(value.to_bits()));
+                js_object_set_field_by_name(
+                    dest_ptr,
+                    key.as_raw(),
+                    f64::from_bits(JsValue::from_object_ptr(arr as *mut _).bits()),
+                );
+            } else if JsValue::from_bits(existing.bits()).is_pointer() {
+                let arr = (existing.bits() & PTR_MASK) as *mut perry_ffi::ArrayHeader;
+                let new_arr = perry_ffi::js_array_push(arr, JsValue::from_bits(value.to_bits()));
+                if new_arr != arr {
+                    js_object_set_field_by_name(
+                        dest_ptr,
+                        key.as_raw(),
+                        f64::from_bits(JsValue::from_object_ptr(new_arr as *mut _).bits()),
+                    );
+                }
+            }
+        }
+        HeaderFieldKind::Single => {
+            if JsValue::from_bits(existing.bits()).is_undefined() {
+                js_object_set_field_by_name(dest_ptr, key.as_raw(), value);
+            }
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub(crate) fn _force_jsvalue_link(v: f64) -> Option<String> {
     jsvalue_to_owned_string(v)
@@ -669,4 +881,88 @@ pub(crate) fn _force_jsvalue_link(v: f64) -> Option<String> {
 #[allow(dead_code)]
 pub(crate) fn _force_jsvalue_extract(v: f64) -> bool {
     JsValue::from_bits(v.to_bits()).is_pointer()
+}
+
+#[cfg(test)]
+mod add_header_line_tests {
+    use super::*;
+
+    fn kind(field: &str) -> (u8, String) {
+        let (k, name) = match_known_fields(field);
+        let tag = match k {
+            HeaderFieldKind::Single => 0,
+            HeaderFieldKind::List => 1,
+            HeaderFieldKind::Cookie => 2,
+            HeaderFieldKind::SetCookie => 3,
+        };
+        (tag, name)
+    }
+
+    #[test]
+    fn known_single_value_fields_classify_and_lowercase() {
+        // First-wins fields from Node's matchKnownFields — including the
+        // odd-cased spellings the lowercase retry handles ('Etag' is neither
+        // the canonical 'ETag' nor all-lowercase).
+        for f in [
+            "Content-Type",
+            "content-type",
+            "Etag",
+            "User-Agent",
+            "If-Modified-Since",
+            "Proxy-Authorization",
+            "Max-Forwards",
+            "Retry-After",
+            "Last-Modified",
+            "Host",
+            "Age",
+            "Expires",
+            "Server",
+            "Location",
+            "Referer",
+            "Authorization",
+            "If-Unmodified-Since",
+        ] {
+            let (tag, name) = kind(f);
+            assert_eq!(tag, 0, "{f} should be single-valued");
+            assert_eq!(name, f.to_lowercase());
+        }
+    }
+
+    #[test]
+    fn list_fields_and_unknown_fields_join() {
+        for f in [
+            "Date",
+            "Connection",
+            "Transfer-Encoding",
+            "Cache-Control",
+            "Form",
+            "X-Totally-Custom",
+            "",
+        ] {
+            let (tag, name) = kind(f);
+            assert_eq!(tag, 1, "{f} should be ', '-joined");
+            assert_eq!(name, f.to_lowercase());
+        }
+    }
+
+    #[test]
+    fn cookie_kinds() {
+        assert_eq!(kind("Cookie"), (2, "cookie".to_string()));
+        assert_eq!(kind("Set-Cookie"), (3, "set-cookie".to_string()));
+        assert_eq!(kind("set-cookie"), (3, "set-cookie".to_string()));
+    }
+
+    #[test]
+    fn standalone_socket_assignment_aliases() {
+        // `new http.IncomingMessage()` then `req.connection = v` must read
+        // back through both `socket` and `connection` (#4904).
+        let handle = js_node_http_incoming_message_standalone_new(f64::from_bits(
+            crate::types::TAG_UNDEFINED,
+        ));
+        assert!(incoming_socket_override(handle).is_some());
+        let marker = 1234.5_f64;
+        assert!(incoming_socket_assign(handle, marker));
+        assert_eq!(incoming_socket_override(handle), Some(marker));
+        perry_ffi::drop_handle(handle);
+    }
 }

--- a/crates/perry-ext-http-server/src/response.rs
+++ b/crates/perry-ext-http-server/src/response.rs
@@ -93,6 +93,19 @@ pub struct ServerResponse {
     pub response_tx: Option<oneshot::Sender<HyperResponseShape>>,
     /// Event-name → list of registered listener closure pointers.
     pub listeners: HashMap<String, Vec<i64>>,
+    /// #4904: true for `new http.ServerResponse(req)` instances (and any
+    /// response wired through `assignSocket`) — `.end()` flushes through
+    /// `standalone_socket` instead of the hyper oneshot.
+    pub standalone: bool,
+    /// #4904: the JS Writable assigned via `res.assignSocket(socket)`.
+    /// `TAG_UNDEFINED` while unassigned.
+    pub standalone_socket: f64,
+    /// #4904: `req.method` captured from the standalone constructor's
+    /// request argument — `HEAD` suppresses the body on flush.
+    pub standalone_req_method: Option<String>,
+    /// #4904: `res.write(chunk, cb)` callbacks, invoked in order when the
+    /// buffered body flushes on `.end()`.
+    pub pending_write_callbacks: Vec<i64>,
 }
 
 /// Owned shape produced by `.end()` — the per-request oneshot channel
@@ -212,6 +225,10 @@ impl ServerResponse {
             buffered_body: Vec::new(),
             response_tx: Some(response_tx),
             listeners: HashMap::new(),
+            standalone: false,
+            standalone_socket: f64::from_bits(TAG_UNDEFINED),
+            standalone_req_method: None,
+            pending_write_callbacks: Vec::new(),
         }
     }
 
@@ -924,6 +941,211 @@ pub unsafe extern "C" fn js_node_http_res_on(
 #[no_mangle]
 pub extern "C" fn js_node_http_outgoing_message_new() -> i64 {
     register_handle(ServerResponse::outgoing_message())
+}
+
+// ============================================================================
+// #4904: standalone `new http.ServerResponse(req)` + `assignSocket` support
+// ============================================================================
+
+/// `new http.ServerResponse(req)` — a response not bound to a live hyper
+/// exchange. `req` contributes only the method (Node skips the body on
+/// flush when it was a HEAD request); writes buffer until `.end()`, which
+/// flushes through the socket assigned via `res.assignSocket(socket)`.
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_server_response_standalone_new(req: f64) -> i64 {
+    crate::ensure_gc_scanner_registered();
+    let (tx, _rx) = oneshot::channel::<HyperResponseShape>();
+    let mut sr = ServerResponse::new(tx);
+    sr.standalone = true;
+    sr.send_date = false;
+    if JsValue::from_bits(req.to_bits()).is_pointer() {
+        extern "C" {
+            fn js_object_get_field_by_name(
+                obj: *const perry_ffi::ObjectHeader,
+                key: *const StringHeader,
+            ) -> JsValue;
+        }
+        let key = alloc_string("method");
+        let m = js_object_get_field_by_name(
+            (req.to_bits() & PTR_MASK) as *const perry_ffi::ObjectHeader,
+            key.as_raw(),
+        );
+        if JsValue::from_bits(m.bits()).is_string() {
+            sr.standalone_req_method = read_string_header((m.bits() & PTR_MASK) as *mut _);
+        }
+    }
+    register_handle(sr)
+}
+
+/// `res.assignSocket(socket)` — wire a (possibly userland) Writable as the
+/// flush target. Node throws `ERR_HTTP_SOCKET_ASSIGNED` on a second call.
+#[no_mangle]
+pub extern "C" fn js_node_http_res_assign_socket(handle: i64, socket: f64) {
+    let already = get_handle::<ServerResponse>(handle)
+        .map(|sr| !JsValue::from_bits(sr.standalone_socket.to_bits()).is_undefined())
+        .unwrap_or(false);
+    if already {
+        perry_ffi::throw_with_code(
+            "Socket already assigned",
+            "ERR_HTTP_SOCKET_ASSIGNED",
+            perry_ffi::ErrorKind::Error,
+        );
+    }
+    if let Some(sr) = get_handle_mut::<ServerResponse>(handle) {
+        sr.standalone_socket = socket;
+        sr.standalone = true;
+    }
+}
+
+/// `res.detachSocket(socket)` — counterpart of `assignSocket`.
+#[no_mangle]
+pub extern "C" fn js_node_http_res_detach_socket(handle: i64, _socket: f64) {
+    if let Some(sr) = get_handle_mut::<ServerResponse>(handle) {
+        sr.standalone_socket = f64::from_bits(TAG_UNDEFINED);
+    }
+}
+
+/// `res.write(chunk[, encoding][, callback])` — callback-aware variant of
+/// `js_node_http_res_write`. The callback queues until the buffered body
+/// flushes on `.end()`, preserving call order (#4904).
+#[no_mangle]
+pub extern "C" fn js_node_http_res_write_with_cb(handle: i64, chunk: f64, callback: i64) -> i32 {
+    let bytes = jsvalue_to_body_bytes(chunk);
+    if let Some(sr) = get_handle_mut::<ServerResponse>(handle) {
+        if !sr.writable_ended {
+            sr.headers_sent = true;
+            if let Some(b) = &bytes {
+                sr.buffered_body.extend_from_slice(b);
+            }
+            if callback != 0 {
+                sr.pending_write_callbacks.push(callback);
+            }
+        }
+    }
+    1
+}
+
+/// `res.end([chunk][, callback])` — callback-aware variant. Standalone
+/// responses flush through the assigned socket; everything else takes the
+/// existing hyper-oneshot path. Queued write callbacks run first, in
+/// order, then the end callback (#4904).
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_res_end_with_cb(handle: i64, chunk: f64, callback: i64) {
+    let is_standalone = get_handle::<ServerResponse>(handle)
+        .map(|sr| sr.standalone)
+        .unwrap_or(false);
+    if is_standalone {
+        standalone_end(handle, chunk, callback);
+        return;
+    }
+    js_node_http_res_end(handle, chunk);
+    let write_cbs = get_handle_mut::<ServerResponse>(handle)
+        .map(|sr| std::mem::take(&mut sr.pending_write_callbacks))
+        .unwrap_or_default();
+    for cb in write_cbs {
+        call_closure0(cb);
+    }
+    if callback != 0 {
+        call_closure0(callback);
+    }
+}
+
+/// Flush a standalone response: serialize the head + buffered body and
+/// write them through the assigned socket's JS `write` method — one write
+/// for head+body, then the zero-length finish chunk Node's corked flush
+/// emits. The body is suppressed for HEAD requests.
+unsafe fn standalone_end(handle: i64, chunk: f64, callback: i64) {
+    let v = JsValue::from_bits(chunk.to_bits());
+    let final_chunk = if v.is_undefined() || v.is_null() {
+        None
+    } else {
+        jsvalue_to_body_bytes(chunk)
+    };
+
+    let (socket, payload, write_cbs, finish_listeners, close_listeners);
+    {
+        let sr = match get_handle_mut::<ServerResponse>(handle) {
+            Some(s) => s,
+            None => return,
+        };
+        if sr.writable_ended {
+            return;
+        }
+        if let Some(c) = final_chunk {
+            sr.buffered_body.extend_from_slice(&c);
+        }
+        sr.headers_sent = true;
+        sr.writable_ended = true;
+        sr.ensure_content_length();
+        let body = std::mem::take(&mut sr.buffered_body);
+        let reason = sr.status_message.clone().unwrap_or_else(|| {
+            StatusCode::from_u16(sr.status_code)
+                .ok()
+                .and_then(|s| s.canonical_reason())
+                .unwrap_or("")
+                .to_string()
+        });
+        let mut head = format!("HTTP/1.1 {} {}\r\n", sr.status_code, reason);
+        for (k, v) in sr.snapshot_headers() {
+            head.push_str(&k);
+            head.push_str(": ");
+            head.push_str(&v);
+            head.push_str("\r\n");
+        }
+        head.push_str("\r\n");
+        let mut bytes = head.into_bytes();
+        if sr.standalone_req_method.as_deref() != Some("HEAD") {
+            bytes.extend_from_slice(&body);
+        }
+        payload = bytes;
+        socket = sr.standalone_socket;
+        write_cbs = std::mem::take(&mut sr.pending_write_callbacks);
+        finish_listeners = sr.listeners.get("finish").cloned().unwrap_or_default();
+        close_listeners = sr.listeners.get("close").cloned().unwrap_or_default();
+        sr.writable_finished = true;
+    }
+    if !JsValue::from_bits(socket.to_bits()).is_undefined() {
+        socket_write_str(socket, &String::from_utf8_lossy(&payload));
+        socket_write_str(socket, "");
+    }
+    for cb in write_cbs {
+        call_closure0(cb);
+    }
+    if callback != 0 {
+        call_closure0(callback);
+    }
+    emit_no_arg_to_listeners(&finish_listeners);
+    emit_no_arg_to_listeners(&close_listeners);
+}
+
+/// Invoke `socket.write(chunk)` on an arbitrary JS value through the
+/// runtime's dynamic method-call path.
+unsafe fn socket_write_str(socket: f64, chunk: &str) {
+    extern "C" {
+        fn js_native_call_method_str_key(
+            object: f64,
+            name_handle: i64,
+            args_ptr: *const f64,
+            args_len: usize,
+        ) -> f64;
+    }
+    let name = alloc_string("write");
+    let chunk_val = f64::from_bits(JsValue::from_string_ptr(alloc_string(chunk).as_raw()).bits());
+    let args = [chunk_val];
+    let _ = js_native_call_method_str_key(socket, name.as_raw() as i64, args.as_ptr(), 1);
+}
+
+/// Call a closure pointer with no args, ignoring the result.
+fn call_closure0(callback: i64) {
+    if callback == 0 {
+        return;
+    }
+    unsafe {
+        let closure = JsClosure::from_raw(callback as *const RawClosureHeader);
+        if !closure.is_null() {
+            let _ = closure.call0();
+        }
+    }
 }
 
 pub(crate) fn alloc_server_response_for_request(

--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -469,8 +469,68 @@ pub unsafe extern "C" fn js_ext_http_agent_dispatch_property(
         "reuseSocket" => bind_agent_method_value(handle, b"reuseSocket"),
         "getName" => bind_agent_method_value(handle, b"getName"),
         "destroy" => bind_agent_method_value(handle, b"destroy"),
+        // #4904: data properties — Agents constructed through the dynamic
+        // value path (`const { Agent } = require('http'); new Agent(...)`)
+        // read these through handle property dispatch rather than the
+        // class-filtered native rows.
+        "maxSockets" => js_http_agent_max_sockets(handle),
+        "maxFreeSockets" => js_http_agent_max_free_sockets(handle),
+        "maxTotalSockets" => js_http_agent_max_total_sockets(handle),
+        "keepAliveMsecs" => js_http_agent_keep_alive_msecs(handle),
+        "keepAlive" => js_http_agent_keep_alive(handle),
+        "destroyed" => js_http_agent_destroyed(handle),
+        "defaultPort" => js_http_agent_default_port(handle),
+        "protocol" => {
+            let ptr = js_http_agent_protocol(handle);
+            if ptr.is_null() {
+                f64::from_bits(TAG_UNDEFINED)
+            } else {
+                f64::from_bits(JsValue::from_string_ptr(ptr).bits())
+            }
+        }
+        "sockets" => js_http_agent_sockets(handle),
+        "freeSockets" => js_http_agent_free_sockets(handle),
+        "requests" => js_http_agent_requests(handle),
         _ => f64::from_bits(TAG_UNDEFINED),
     }
+}
+
+/// #4904: property writes on a dynamically-dispatched Agent —
+/// `agent.maxSockets = 4` and the `agent.createConnection = fn`
+/// monkeypatch pattern Node's own tests use. Returns 1 when claimed.
+#[no_mangle]
+pub unsafe extern "C" fn js_ext_http_agent_dispatch_property_set(
+    handle: Handle,
+    property_ptr: *const u8,
+    property_len: usize,
+    value: f64,
+) -> i32 {
+    if property_ptr.is_null() || property_len == 0 || get_handle::<AgentHandle>(handle).is_none() {
+        return 0;
+    }
+    let property = String::from_utf8_lossy(std::slice::from_raw_parts(property_ptr, property_len));
+    match property.as_ref() {
+        "maxSockets" => js_http_agent_set_max_sockets(handle, value),
+        "maxFreeSockets" => js_http_agent_set_max_free_sockets(handle, value),
+        "maxTotalSockets" => js_http_agent_set_max_total_sockets(handle, value),
+        "keepAliveMsecs" => js_http_agent_set_keep_alive_msecs(handle, value),
+        "keepAlive" => js_http_agent_set_keep_alive(handle, value),
+        "createConnection" | "createSocket" => {
+            let bits = value.to_bits();
+            let ptr = if JsValue::from_bits(bits).is_pointer() {
+                (bits & PTR_MASK) as i64
+            } else {
+                0
+            };
+            if property.as_ref() == "createConnection" {
+                js_http_agent_set_create_connection(handle, ptr);
+            } else {
+                js_http_agent_set_create_socket(handle, ptr);
+            }
+        }
+        _ => return 0,
+    }
+    1
 }
 
 #[no_mangle]

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -937,6 +937,22 @@ pub unsafe extern "C" fn js_http_request(opts_f64: f64, callback_i64: i64) -> Ha
     request_common(opts_f64, callback_i64, "http")
 }
 
+/// `new http.ClientRequest(options)` (#4904). Perry's client model defers
+/// the actual send to `.end()`, so constructing is exactly `http.request`
+/// without a response callback. Node coerces a falsy `options.method` /
+/// `options.path` to the `GET` / `/` defaults — mirror the method side
+/// here (the empty path already reads back as `/` through the surface).
+#[no_mangle]
+pub unsafe extern "C" fn js_http_client_request_standalone_new(opts_f64: f64) -> Handle {
+    let handle = request_common(opts_f64, 0, "http");
+    with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| {
+        if req.method.is_empty() {
+            req.method = "GET".to_string();
+        }
+    });
+    handle
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_https_request(opts_f64: f64, callback_i64: i64) -> Handle {
     request_common(opts_f64, callback_i64, "https")

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -506,12 +506,23 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     args,
                 });
             }
-            if is_http_module && prop_ident.sym.as_ref() == "OutgoingMessage" {
+            // #4904: `new http.ClientRequest(opts)` / `new
+            // http.IncomingMessage(socket)` / `new http.ServerResponse(req)`
+            // join the OutgoingMessage route: NewDynamic over the module
+            // export value, which `js_new_function_construct` forwards to the
+            // stdlib http dispatcher. Instances stay dynamically dispatched
+            // (HANDLE_*_DISPATCH), matching OutgoingMessage.
+            if is_http_module
+                && matches!(
+                    prop_ident.sym.as_ref(),
+                    "OutgoingMessage" | "ClientRequest" | "IncomingMessage" | "ServerResponse"
+                )
+            {
                 let args = lower_optional_args(ctx, new_expr.args.as_deref())?;
                 return Ok(Expr::NewDynamic {
                     callee: Box::new(Expr::PropertyGet {
                         object: Box::new(Expr::NativeModuleRef("http".to_string())),
-                        property: "OutgoingMessage".to_string(),
+                        property: prop_ident.sym.to_string(),
                     }),
                     args,
                 });
@@ -974,16 +985,52 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 });
             }
 
-            if matches!(
-                ctx.lookup_native_module(&class_name),
-                Some(("http", Some("OutgoingMessage")))
-            ) {
+            // #4904: bare-ident construction of the http classes —
+            // `const { ClientRequest } = require('http'); new
+            // ClientRequest(...)` (also IncomingMessage / ServerResponse,
+            // joining the existing OutgoingMessage route).
+            let http_class_export =
+                ctx.lookup_native_module(&class_name)
+                    .and_then(|(module, export)| match (module, export) {
+                        (
+                            "http",
+                            Some(
+                                x @ ("OutgoingMessage" | "ClientRequest" | "IncomingMessage"
+                                | "ServerResponse"),
+                            ),
+                        ) => Some(x.to_string()),
+                        _ => None,
+                    });
+            if let Some(export) = http_class_export {
                 let args = lower_optional_args(ctx, new_expr.args.as_deref())?;
                 return Ok(Expr::NewDynamic {
                     callee: Box::new(Expr::PropertyGet {
                         object: Box::new(Expr::NativeModuleRef("http".to_string())),
-                        property: "OutgoingMessage".to_string(),
+                        property: export,
                     }),
+                    args,
+                });
+            }
+
+            // #4904: bare-ident `new Agent(opts)` where Agent came from
+            // `require('http')` / `require('https')` (named import,
+            // destructure, or member alias). Route to the same
+            // receiver-less NativeMethodCall as the `new http.Agent()`
+            // member form so the dispatch row runs `js_*_agent_new` and the
+            // let-stmt machinery tags the local for Agent method dispatch.
+            let http_agent_module =
+                ctx.lookup_native_module(&class_name)
+                    .and_then(|(module, export)| match (module, export) {
+                        (m @ ("http" | "https"), Some("Agent")) => Some(m.to_string()),
+                        _ => None,
+                    });
+            if let Some(agent_module) = http_agent_module {
+                let args = lower_optional_args(ctx, new_expr.args.as_deref())?;
+                return Ok(Expr::NativeMethodCall {
+                    module: agent_module,
+                    class_name: None,
+                    object: None,
+                    method: "Agent".to_string(),
                     args,
                 });
             }

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -598,6 +598,10 @@ pub(crate) fn lower_module_decl(
                                         | (
                                             "DiffieHellman" | "DiffieHellmanGroup",
                                             Some("crypto" | "node:crypto"),
+                                        )
+                                        | (
+                                            "ClientRequest" | "IncomingMessage" | "ServerResponse",
+                                            Some("http" | "node:http"),
                                         ) => None,
                                         _ => module_name,
                                     };
@@ -661,6 +665,11 @@ pub(crate) fn lower_module_decl(
                                             | (
                                                 "DiffieHellman" | "DiffieHellmanGroup",
                                                 Some("crypto" | "node:crypto"),
+                                            )
+                                            | (
+                                                "ClientRequest" | "IncomingMessage"
+                                                | "ServerResponse",
+                                                Some("http" | "node:http"),
                                             ) => None,
                                             _ => module_name,
                                         };

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -428,6 +428,15 @@ pub(crate) fn throw_bigint_serialize() -> ! {
 #[inline]
 pub(crate) unsafe fn is_closure_value(bits: u64) -> bool {
     if let Some(ptr) = extract_pointer(bits) {
+        // #2154 / #4904 — a POINTER_TAG field can be a native *handle id* (a
+        // small integer, e.g. an `http.Agent` stored in an options object),
+        // not a real heap pointer. Reading the CLOSURE_MAGIC tag at offset 12
+        // of such a value segfaults (stringifying `{ agent, lookup: () => {} }`
+        // crashed exactly here). Skip the low-memory guard range, matching
+        // the has-function probe below.
+        if crate::value::addr_class::is_handle_band(ptr as usize) {
+            return false;
+        }
         // Check for ClosureHeader magic at offset 8 (type_tag field)
         let type_tag = *((ptr as *const u8).add(12) as *const u32);
         type_tag == crate::closure::CLOSURE_MAGIC

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1642,7 +1642,24 @@ pub unsafe extern "C" fn js_new_function_construct(
                 _ => unreachable!(),
             };
         }
-        if module == "http" && method == "OutgoingMessage" {
+        // #4904: `new http.Agent(opts)` / `new http.ClientRequest(opts)` /
+        // `new http.IncomingMessage(socket)` / `new http.ServerResponse(req)`
+        // (and `new https.Agent(opts)`) through any value-aliasing path —
+        // `const { Agent } = require('http')`, `const CR =
+        // http.ClientRequest`, etc. The bound export value carries
+        // (module, method); forward construction to the stdlib http
+        // dispatcher exactly like `OutgoingMessage` below.
+        if (module == "http"
+            && matches!(
+                method.as_str(),
+                "OutgoingMessage"
+                    | "Agent"
+                    | "ClientRequest"
+                    | "IncomingMessage"
+                    | "ServerResponse"
+            ))
+            || (module == "https" && method == "Agent")
+        {
             let ptr =
                 crate::value::JS_NATIVE_HTTP_DISPATCH.load(std::sync::atomic::Ordering::SeqCst);
             if !ptr.is_null() {
@@ -1655,8 +1672,8 @@ pub unsafe extern "C" fn js_new_function_construct(
                     usize,
                 ) -> f64 = std::mem::transmute(ptr);
                 return dispatch(
-                    b"http".as_ptr(),
-                    "http".len(),
+                    module.as_ptr(),
+                    module.len(),
                     method.as_ptr(),
                     method.len(),
                     args_ptr,

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -3657,10 +3657,17 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ("http2", "connect") => Some(3),
         ("http2", "createServer" | "createSecureServer") => Some(2),
         ("http", "OutgoingMessage") => Some(1),
+        // #4904: Node `.length` — Agent(options)=1, ClientRequest(input,
+        // options, cb)=3, IncomingMessage(socket)=1, ServerResponse(req)=1.
+        ("http", "Agent" | "IncomingMessage" | "ServerResponse") => Some(1),
+        ("http", "ClientRequest") => Some(3),
         // #3697: node:https module-level exports (Node `.length`).
         ("https", "request") => Some(0),
         ("https", "get") => Some(3),
         ("https", "Agent") => Some(1),
+        // #4904: http twins of the https entries above.
+        ("http", "request") => Some(0),
+        ("http", "get") => Some(3),
         (
             "stream",
             "isDestroyed"
@@ -5608,6 +5615,21 @@ pub(crate) fn is_native_module_callable_export(module: &str, prop: &str) -> bool
             | ("http", "createServer")
             | ("http", "Server")
             | ("http", "OutgoingMessage")
+            // #4904: Node exposes these as constructable classes on the
+            // `http` module (`new http.Agent(opts)`, `new ClientRequest(...)`,
+            // `new IncomingMessage(socket)`, `new ServerResponse(req)`), and
+            // tests/userland grab them as values first (`const { Agent } =
+            // require('http')`). Construction routes through
+            // `js_new_function_construct` → the http arm in
+            // class_registry.rs → JS_NATIVE_HTTP_DISPATCH.
+            | ("http", "Agent")
+            | ("http", "ClientRequest")
+            | ("http", "IncomingMessage")
+            | ("http", "ServerResponse")
+            // #4904: `const { get, request } = require('http')` — the https
+            // twins below were already exported; the http side was missed.
+            | ("http", "request")
+            | ("http", "get")
             | ("https", "createServer")
             | ("https", "Server")
             // #3697: `https.request` / `https.get` / `https.Agent` value reads

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -1930,6 +1930,14 @@ pub(crate) unsafe fn dispatch_native_module_method(
         // dispatcher takes the module name so one callback serves all three.
         ("http", "createServer")
         | ("http", "Server")
+        // #4904: captured / aliased client entry points (`const { get } =
+        // require('http'); get(opts, cb)`) — same bound-value mechanism as
+        // the server factories; the stdlib dispatcher routes them to
+        // `js_http_get` / `js_http_request` (and https twins).
+        | ("http", "request")
+        | ("http", "get")
+        | ("https", "request")
+        | ("https", "get")
         | ("https", "createServer")
         | ("https", "Server")
         | ("http2", "createServer")

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -17,12 +17,17 @@ use crate::object::ObjectHeader;
 
 mod compile;
 mod escape;
+mod exec_array;
 mod grammar;
 mod match_all;
 mod replace_expand;
 mod replace_fn;
 pub use compile::js_regexp_compile_value;
 pub use escape::js_regexp_escape;
+use exec_array::{
+    byte_index_to_char_index, char_index_to_byte, set_exec_array_groups, set_exec_array_indices,
+    set_exec_array_indices_fancy, set_exec_array_metadata,
+};
 use grammar::{has_invalid_repeated_quantifier, js_regex_to_rust};
 pub use match_all::{
     dispatch_regexp_string_iterator_method, js_string_match_all, js_string_match_all_value,
@@ -228,7 +233,7 @@ fn string_as_str<'a>(s: *const StringHeader) -> &'a str {
 }
 
 /// Internal helper: Create a StringHeader from a Rust &str
-fn js_string_from_str(s: &str) -> *mut StringHeader {
+pub(super) fn js_string_from_str(s: &str) -> *mut StringHeader {
     crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32)
 }
 
@@ -244,189 +249,6 @@ fn throw_match_all_non_global_regex() -> ! {
     let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = crate::error::js_typeerror_new(msg);
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
-}
-
-fn set_exec_array_metadata(arr: *mut ArrayHeader, input: &str, index: f64) {
-    if arr.is_null() {
-        return;
-    }
-    let index_key = js_string_from_str("index");
-    crate::array::js_array_set_string_key(arr, index_key, index);
-
-    let input_key = js_string_from_str("input");
-    let input_str = js_string_from_str(input);
-    let input_value = js_nanbox_string(input_str as i64);
-    crate::array::js_array_set_string_key(arr, input_key, input_value);
-}
-
-/// Attach the `groups` own property to a regex match-result array.
-///
-/// Mirrors `set_exec_array_metadata` for `index`/`input`: the result of
-/// `regex.exec(s)` / `s.match(regex)` carries `groups` as a real own property
-/// so reads stay correct under aliasing and interleaved matches — a stored
-/// `m.groups` survives a later `re2.exec(...)`, instead of resolving through a
-/// single most-recent-match thread-local (`LAST_EXEC_GROUPS`). Per ECMA-262
-/// RegExpBuiltinExec, `groups` is the named-capture object when the pattern
-/// has named groups, else `undefined`.
-fn set_exec_array_groups(arr: *mut ArrayHeader, groups_obj: *mut ObjectHeader) {
-    if arr.is_null() {
-        return;
-    }
-    let groups_key = js_string_from_str("groups");
-    let value = if groups_obj.is_null() {
-        f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
-    } else {
-        crate::value::js_nanbox_pointer(groups_obj as i64)
-    };
-    crate::array::js_array_set_string_key(arr, groups_key, value);
-}
-
-/// Attach the `indices` own property to a regex match-result array when the
-/// `d` flag (hasIndices) is set. Per ECMA-262 RegExpBuiltinExec, `indices` is
-/// an array where each element is `[start, end]` for the corresponding capture
-/// group. Element 0 is the full match, elements 1..N are capture groups.
-/// Unmatched groups are `undefined`. The `indices` array also has a `.groups`
-/// property with named captures mapping to `[start, end]` pairs.
-fn set_exec_array_indices(
-    arr: *mut ArrayHeader,
-    str_data: &str,
-    search_start_byte: usize,
-    caps: &regex::Captures,
-    regex: &regex::Regex,
-) {
-    if arr.is_null() {
-        return;
-    }
-
-    let scope = crate::gc::RuntimeHandleScope::new();
-
-    // Build the indices array: [[start, end], [start, end], ...]
-    let indices_arr = crate::array::js_array_alloc(caps.len() as u32);
-    let indices_handle = scope.root_raw_mut_ptr(indices_arr);
-    unsafe {
-        (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-    }
-
-    for (i, cap) in caps.iter().enumerate() {
-        let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
-        if let Some(m) = cap {
-            // Convert byte offsets to char indices (JS spec uses UTF-16 code units,
-            // but we use char indices for simplicity — matches existing .index behavior)
-            let start_byte = m.start() + search_start_byte;
-            let end_byte = m.end() + search_start_byte;
-            let start_char = str_data[..start_byte].chars().count() as f64;
-            let end_char = str_data[..end_byte].chars().count() as f64;
-
-            // Create [start, end] pair
-            let pair = crate::array::js_array_alloc(2);
-            let pair_handle = scope.root_raw_mut_ptr(pair);
-            unsafe {
-                (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
-                crate::array::store_array_slot(
-                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    0,
-                    start_char.to_bits(),
-                );
-                crate::array::store_array_slot(
-                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    1,
-                    end_char.to_bits(),
-                );
-            }
-
-            let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
-            let nanboxed = crate::value::js_nanbox_pointer(pair_ptr as i64);
-            unsafe {
-                crate::array::store_array_slot(indices_arr_ptr, i, nanboxed.to_bits());
-            }
-        } else {
-            // Unmatched capture group -> undefined
-            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
-            unsafe {
-                crate::array::store_array_slot(indices_arr_ptr, i, undefined.to_bits());
-            }
-        }
-    }
-
-    // If there are named groups, attach .groups property to indices array
-    let has_named_groups = regex.capture_names().any(|n| n.is_some());
-    if has_named_groups {
-        let groups_obj = crate::object::js_object_alloc(0, 0);
-        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-
-        for (name, m) in regex
-            .capture_names()
-            .enumerate()
-            .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-        {
-            let val = if let Some(m) = m {
-                let start_byte = m.start() + search_start_byte;
-                let end_byte = m.end() + search_start_byte;
-                let start_char = str_data[..start_byte].chars().count() as f64;
-                let end_char = str_data[..end_byte].chars().count() as f64;
-
-                // Create [start, end] pair for named group
-                let pair = crate::array::js_array_alloc(2);
-                let pair_handle = scope.root_raw_mut_ptr(pair);
-                unsafe {
-                    (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
-                    crate::array::store_array_slot(
-                        pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                        0,
-                        start_char.to_bits(),
-                    );
-                    crate::array::store_array_slot(
-                        pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                        1,
-                        end_char.to_bits(),
-                    );
-                }
-                let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
-                crate::value::js_nanbox_pointer(pair_ptr as i64)
-            } else {
-                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
-            };
-
-            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-            let groups_obj_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-            crate::object::js_object_set_field_by_name(groups_obj_ptr, key_ptr, val);
-        }
-
-        let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-        let groups_nanboxed = crate::value::js_nanbox_pointer(groups_ptr as i64);
-        let indices_key = js_string_from_str("groups");
-        crate::array::js_array_set_string_key(
-            indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
-            indices_key,
-            f64::from_bits(groups_nanboxed.to_bits()),
-        );
-    }
-
-    // Attach indices array to the match result
-    let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
-    let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
-    let indices_key = js_string_from_str("indices");
-    crate::array::js_array_set_string_key(
-        arr,
-        indices_key,
-        f64::from_bits(indices_nanboxed.to_bits()),
-    );
-}
-
-fn char_index_to_byte(s: &str, char_index: usize) -> usize {
-    if char_index == 0 {
-        return 0;
-    }
-    for (idx, (byte, _)) in s.char_indices().enumerate() {
-        if idx == char_index {
-            return byte;
-        }
-    }
-    s.len()
-}
-
-fn byte_index_to_char_index(s: &str, byte_index: usize) -> f64 {
-    s[..byte_index.min(s.len())].chars().count() as f64
 }
 
 #[inline]
@@ -1165,121 +987,6 @@ pub(crate) unsafe fn build_fancy_groups(
         crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
     }
     groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>()
-}
-
-/// Build and attach the `indices` property for fancy-regex captures (lookbehind/backreference fallback).
-unsafe fn set_exec_array_indices_fancy(
-    arr: *mut ArrayHeader,
-    str_data: &str,
-    search_start_byte: usize,
-    fre: &fancy_regex::Regex,
-    caps: &fancy_regex::Captures,
-) {
-    if arr.is_null() {
-        return;
-    }
-
-    let scope = crate::gc::RuntimeHandleScope::new();
-
-    // Build the indices array: [[start, end], [start, end], ...]
-    let indices_arr = crate::array::js_array_alloc(caps.len() as u32);
-    let indices_handle = scope.root_raw_mut_ptr(indices_arr);
-    (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-
-    for i in 0..caps.len() {
-        let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
-        if let Some(m) = caps.get(i) {
-            let start_byte = m.start() + search_start_byte;
-            let end_byte = m.end() + search_start_byte;
-            let start_char = str_data[..start_byte].chars().count() as f64;
-            let end_char = str_data[..end_byte].chars().count() as f64;
-
-            // Create [start, end] pair
-            let pair = crate::array::js_array_alloc(2);
-            let pair_handle = scope.root_raw_mut_ptr(pair);
-            (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
-            crate::array::store_array_slot(
-                pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                0,
-                start_char.to_bits(),
-            );
-            crate::array::store_array_slot(
-                pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                1,
-                end_char.to_bits(),
-            );
-
-            let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
-            let nanboxed = crate::value::js_nanbox_pointer(pair_ptr as i64);
-            crate::array::store_array_slot(indices_arr_ptr, i, nanboxed.to_bits());
-        } else {
-            // Unmatched capture group -> undefined
-            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
-            crate::array::store_array_slot(indices_arr_ptr, i, undefined.to_bits());
-        }
-    }
-
-    // If there are named groups, attach .groups property to indices array
-    let has_named_groups = fre.capture_names().any(|n| n.is_some());
-    if has_named_groups {
-        let groups_obj = crate::object::js_object_alloc(0, 0);
-        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-
-        for (name, m) in fre
-            .capture_names()
-            .enumerate()
-            .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-        {
-            let val = if let Some(m) = m {
-                let start_byte = m.start() + search_start_byte;
-                let end_byte = m.end() + search_start_byte;
-                let start_char = str_data[..start_byte].chars().count() as f64;
-                let end_char = str_data[..end_byte].chars().count() as f64;
-
-                // Create [start, end] pair for named group
-                let pair = crate::array::js_array_alloc(2);
-                let pair_handle = scope.root_raw_mut_ptr(pair);
-                (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
-                crate::array::store_array_slot(
-                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    0,
-                    start_char.to_bits(),
-                );
-                crate::array::store_array_slot(
-                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    1,
-                    end_char.to_bits(),
-                );
-                let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
-                crate::value::js_nanbox_pointer(pair_ptr as i64)
-            } else {
-                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
-            };
-
-            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-            let groups_obj_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-            crate::object::js_object_set_field_by_name(groups_obj_ptr, key_ptr, val);
-        }
-
-        let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-        let groups_nanboxed = crate::value::js_nanbox_pointer(groups_ptr as i64);
-        let indices_key = js_string_from_str("groups");
-        crate::array::js_array_set_string_key(
-            indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
-            indices_key,
-            f64::from_bits(groups_nanboxed.to_bits()),
-        );
-    }
-
-    // Attach indices array to the match result
-    let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
-    let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
-    let indices_key = js_string_from_str("indices");
-    crate::array::js_array_set_string_key(
-        arr,
-        indices_key,
-        f64::from_bits(indices_nanboxed.to_bits()),
-    );
 }
 
 /// Fancy-regex fallback for the string-replacement (non-callback) forms of

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -406,7 +406,11 @@ fn set_exec_array_indices(
     let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
     let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
     let indices_key = js_string_from_str("indices");
-    crate::array::js_array_set_string_key(arr, indices_key, f64::from_bits(indices_nanboxed.to_bits()));
+    crate::array::js_array_set_string_key(
+        arr,
+        indices_key,
+        f64::from_bits(indices_nanboxed.to_bits()),
+    );
 }
 
 fn char_index_to_byte(s: &str, char_index: usize) -> usize {
@@ -1271,7 +1275,11 @@ unsafe fn set_exec_array_indices_fancy(
     let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
     let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
     let indices_key = js_string_from_str("indices");
-    crate::array::js_array_set_string_key(arr, indices_key, f64::from_bits(indices_nanboxed.to_bits()));
+    crate::array::js_array_set_string_key(
+        arr,
+        indices_key,
+        f64::from_bits(indices_nanboxed.to_bits()),
+    );
 }
 
 /// Fancy-regex fallback for the string-replacement (non-callback) forms of

--- a/crates/perry-runtime/src/regex/exec_array.rs
+++ b/crates/perry-runtime/src/regex/exec_array.rs
@@ -1,0 +1,311 @@
+//! Match-result array decoration — the `index` / `input` / `groups` /
+//! `indices` own properties ECMA-262 RegExpBuiltinExec attaches to the
+//! array returned by `regex.exec(s)` / `s.match(regex)`. The `indices`
+//! builders (`d` flag, hasIndices, #4930) cover both the `regex`-crate
+//! fast path and the `fancy_regex` fallback (lookbehind/backreferences).
+//!
+//! Split out of `regex.rs` under the 2000-line CI cap.
+
+use crate::array::ArrayHeader;
+use crate::object::ObjectHeader;
+use crate::value::js_nanbox_string;
+
+use super::js_string_from_str;
+
+pub(super) fn set_exec_array_metadata(arr: *mut ArrayHeader, input: &str, index: f64) {
+    if arr.is_null() {
+        return;
+    }
+    let index_key = js_string_from_str("index");
+    crate::array::js_array_set_string_key(arr, index_key, index);
+
+    let input_key = js_string_from_str("input");
+    let input_str = js_string_from_str(input);
+    let input_value = js_nanbox_string(input_str as i64);
+    crate::array::js_array_set_string_key(arr, input_key, input_value);
+}
+
+/// Attach the `groups` own property to a regex match-result array.
+///
+/// Mirrors `set_exec_array_metadata` for `index`/`input`: the result of
+/// `regex.exec(s)` / `s.match(regex)` carries `groups` as a real own property
+/// so reads stay correct under aliasing and interleaved matches — a stored
+/// `m.groups` survives a later `re2.exec(...)`, instead of resolving through a
+/// single most-recent-match thread-local (`LAST_EXEC_GROUPS`). Per ECMA-262
+/// RegExpBuiltinExec, `groups` is the named-capture object when the pattern
+/// has named groups, else `undefined`.
+pub(super) fn set_exec_array_groups(arr: *mut ArrayHeader, groups_obj: *mut ObjectHeader) {
+    if arr.is_null() {
+        return;
+    }
+    let groups_key = js_string_from_str("groups");
+    let value = if groups_obj.is_null() {
+        f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+    } else {
+        crate::value::js_nanbox_pointer(groups_obj as i64)
+    };
+    crate::array::js_array_set_string_key(arr, groups_key, value);
+}
+
+/// Attach the `indices` own property to a regex match-result array when the
+/// `d` flag (hasIndices) is set. Per ECMA-262 RegExpBuiltinExec, `indices` is
+/// an array where each element is `[start, end]` for the corresponding capture
+/// group. Element 0 is the full match, elements 1..N are capture groups.
+/// Unmatched groups are `undefined`. The `indices` array also has a `.groups`
+/// property with named captures mapping to `[start, end]` pairs.
+pub(super) fn set_exec_array_indices(
+    arr: *mut ArrayHeader,
+    str_data: &str,
+    search_start_byte: usize,
+    caps: &regex::Captures,
+    regex: &regex::Regex,
+) {
+    if arr.is_null() {
+        return;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+
+    // Build the indices array: [[start, end], [start, end], ...]
+    let indices_arr = crate::array::js_array_alloc(caps.len() as u32);
+    let indices_handle = scope.root_raw_mut_ptr(indices_arr);
+    unsafe {
+        (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
+    }
+
+    for (i, cap) in caps.iter().enumerate() {
+        let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
+        if let Some(m) = cap {
+            // Convert byte offsets to char indices (JS spec uses UTF-16 code units,
+            // but we use char indices for simplicity — matches existing .index behavior)
+            let start_byte = m.start() + search_start_byte;
+            let end_byte = m.end() + search_start_byte;
+            let start_char = str_data[..start_byte].chars().count() as f64;
+            let end_char = str_data[..end_byte].chars().count() as f64;
+
+            // Create [start, end] pair
+            let pair = crate::array::js_array_alloc(2);
+            let pair_handle = scope.root_raw_mut_ptr(pair);
+            unsafe {
+                (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+                crate::array::store_array_slot(
+                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    0,
+                    start_char.to_bits(),
+                );
+                crate::array::store_array_slot(
+                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    1,
+                    end_char.to_bits(),
+                );
+            }
+
+            let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
+            let nanboxed = crate::value::js_nanbox_pointer(pair_ptr as i64);
+            unsafe {
+                crate::array::store_array_slot(indices_arr_ptr, i, nanboxed.to_bits());
+            }
+        } else {
+            // Unmatched capture group -> undefined
+            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
+            unsafe {
+                crate::array::store_array_slot(indices_arr_ptr, i, undefined.to_bits());
+            }
+        }
+    }
+
+    // If there are named groups, attach .groups property to indices array
+    let has_named_groups = regex.capture_names().any(|n| n.is_some());
+    if has_named_groups {
+        let groups_obj = crate::object::js_object_alloc(0, 0);
+        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
+
+        for (name, m) in regex
+            .capture_names()
+            .enumerate()
+            .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
+        {
+            let val = if let Some(m) = m {
+                let start_byte = m.start() + search_start_byte;
+                let end_byte = m.end() + search_start_byte;
+                let start_char = str_data[..start_byte].chars().count() as f64;
+                let end_char = str_data[..end_byte].chars().count() as f64;
+
+                // Create [start, end] pair for named group
+                let pair = crate::array::js_array_alloc(2);
+                let pair_handle = scope.root_raw_mut_ptr(pair);
+                unsafe {
+                    (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+                    crate::array::store_array_slot(
+                        pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                        0,
+                        start_char.to_bits(),
+                    );
+                    crate::array::store_array_slot(
+                        pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                        1,
+                        end_char.to_bits(),
+                    );
+                }
+                let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
+                crate::value::js_nanbox_pointer(pair_ptr as i64)
+            } else {
+                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+            };
+
+            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            let groups_obj_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+            crate::object::js_object_set_field_by_name(groups_obj_ptr, key_ptr, val);
+        }
+
+        let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+        let groups_nanboxed = crate::value::js_nanbox_pointer(groups_ptr as i64);
+        let indices_key = js_string_from_str("groups");
+        crate::array::js_array_set_string_key(
+            indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
+            indices_key,
+            f64::from_bits(groups_nanboxed.to_bits()),
+        );
+    }
+
+    // Attach indices array to the match result
+    let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
+    let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
+    let indices_key = js_string_from_str("indices");
+    crate::array::js_array_set_string_key(
+        arr,
+        indices_key,
+        f64::from_bits(indices_nanboxed.to_bits()),
+    );
+}
+
+pub(super) fn char_index_to_byte(s: &str, char_index: usize) -> usize {
+    if char_index == 0 {
+        return 0;
+    }
+    for (idx, (byte, _)) in s.char_indices().enumerate() {
+        if idx == char_index {
+            return byte;
+        }
+    }
+    s.len()
+}
+
+pub(super) fn byte_index_to_char_index(s: &str, byte_index: usize) -> f64 {
+    s[..byte_index.min(s.len())].chars().count() as f64
+}
+
+/// Build and attach the `indices` property for fancy-regex captures (lookbehind/backreference fallback).
+pub(super) unsafe fn set_exec_array_indices_fancy(
+    arr: *mut ArrayHeader,
+    str_data: &str,
+    search_start_byte: usize,
+    fre: &fancy_regex::Regex,
+    caps: &fancy_regex::Captures,
+) {
+    if arr.is_null() {
+        return;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+
+    // Build the indices array: [[start, end], [start, end], ...]
+    let indices_arr = crate::array::js_array_alloc(caps.len() as u32);
+    let indices_handle = scope.root_raw_mut_ptr(indices_arr);
+    (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
+
+    for i in 0..caps.len() {
+        let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
+        if let Some(m) = caps.get(i) {
+            let start_byte = m.start() + search_start_byte;
+            let end_byte = m.end() + search_start_byte;
+            let start_char = str_data[..start_byte].chars().count() as f64;
+            let end_char = str_data[..end_byte].chars().count() as f64;
+
+            // Create [start, end] pair
+            let pair = crate::array::js_array_alloc(2);
+            let pair_handle = scope.root_raw_mut_ptr(pair);
+            (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+            crate::array::store_array_slot(
+                pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                0,
+                start_char.to_bits(),
+            );
+            crate::array::store_array_slot(
+                pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                1,
+                end_char.to_bits(),
+            );
+
+            let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
+            let nanboxed = crate::value::js_nanbox_pointer(pair_ptr as i64);
+            crate::array::store_array_slot(indices_arr_ptr, i, nanboxed.to_bits());
+        } else {
+            // Unmatched capture group -> undefined
+            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
+            crate::array::store_array_slot(indices_arr_ptr, i, undefined.to_bits());
+        }
+    }
+
+    // If there are named groups, attach .groups property to indices array
+    let has_named_groups = fre.capture_names().any(|n| n.is_some());
+    if has_named_groups {
+        let groups_obj = crate::object::js_object_alloc(0, 0);
+        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
+
+        for (name, m) in fre
+            .capture_names()
+            .enumerate()
+            .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
+        {
+            let val = if let Some(m) = m {
+                let start_byte = m.start() + search_start_byte;
+                let end_byte = m.end() + search_start_byte;
+                let start_char = str_data[..start_byte].chars().count() as f64;
+                let end_char = str_data[..end_byte].chars().count() as f64;
+
+                // Create [start, end] pair for named group
+                let pair = crate::array::js_array_alloc(2);
+                let pair_handle = scope.root_raw_mut_ptr(pair);
+                (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+                crate::array::store_array_slot(
+                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    0,
+                    start_char.to_bits(),
+                );
+                crate::array::store_array_slot(
+                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    1,
+                    end_char.to_bits(),
+                );
+                let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
+                crate::value::js_nanbox_pointer(pair_ptr as i64)
+            } else {
+                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+            };
+
+            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            let groups_obj_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+            crate::object::js_object_set_field_by_name(groups_obj_ptr, key_ptr, val);
+        }
+
+        let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+        let groups_nanboxed = crate::value::js_nanbox_pointer(groups_ptr as i64);
+        let indices_key = js_string_from_str("groups");
+        crate::array::js_array_set_string_key(
+            indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
+            indices_key,
+            f64::from_bits(groups_nanboxed.to_bits()),
+        );
+    }
+
+    // Attach indices array to the match result
+    let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
+    let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
+    let indices_key = js_string_from_str("indices");
+    crate::array::js_array_set_string_key(
+        arr,
+        indices_key,
+        f64::from_bits(indices_nanboxed.to_bits()),
+    );
+}

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -797,6 +797,9 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
                 | "resume"
                 | "destroy"
                 | "read"
+                | "_addHeaderLine"
+                | "__set_socket"
+                | "__set_connection"
         ) || matches!(
             method_name,
             "method"
@@ -874,6 +877,8 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
                 | "writeEarlyHints"
                 | "writeContinue"
                 | "writeProcessing"
+                | "assignSocket"
+                | "detachSocket"
         ) || matches!(
             method_name,
             "on" | "addListener" | "setStatus" | "getStatus"
@@ -1791,6 +1796,17 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
                 | "reuseSocket"
                 | "getName"
                 | "destroy"
+                | "maxSockets"
+                | "maxFreeSockets"
+                | "maxTotalSockets"
+                | "keepAliveMsecs"
+                | "keepAlive"
+                | "destroyed"
+                | "defaultPort"
+                | "protocol"
+                | "sockets"
+                | "freeSockets"
+                | "requests"
         ) && unsafe { js_ext_http_agent_is_handle(handle) } != 0
         {
             return unsafe {
@@ -2611,6 +2627,71 @@ pub unsafe extern "C" fn js_handle_property_set_dispatch(
             }
         }
     }
+
+    // #4904: Agent tunables (`agent.maxSockets = 4`) and the
+    // `agent.createConnection = fn` monkeypatch pattern Node's tests use.
+    #[cfg(feature = "http-client")]
+    if crate::http::dispatch_agent_property_set(handle, property_name, value) {
+        return;
+    }
+    #[cfg(feature = "external-http-client-pump")]
+    if matches!(
+        property_name,
+        "maxSockets"
+            | "maxFreeSockets"
+            | "maxTotalSockets"
+            | "keepAliveMsecs"
+            | "keepAlive"
+            | "createConnection"
+            | "createSocket"
+    ) {
+        extern "C" {
+            fn js_ext_http_agent_is_handle(handle: i64) -> i32;
+            fn js_ext_http_agent_dispatch_property_set(
+                handle: i64,
+                property_ptr: *const u8,
+                property_len: usize,
+                value: f64,
+            ) -> i32;
+        }
+        if unsafe { js_ext_http_agent_is_handle(handle) } != 0 {
+            unsafe {
+                js_ext_http_agent_dispatch_property_set(
+                    handle,
+                    property_name.as_ptr(),
+                    property_name.len(),
+                    value,
+                );
+            }
+            return;
+        }
+    }
+
+    // #4904: `req.connection = v` / `req.socket = v` on an IncomingMessage —
+    // Node's `connection` accessor writes `this.socket`.
+    #[cfg(feature = "external-http-server-pump")]
+    if matches!(property_name, "socket" | "connection") {
+        extern "C" {
+            fn js_ext_http_incoming_message_is_handle(handle: i64) -> i32;
+            fn js_ext_http_incoming_message_dispatch_property_set(
+                handle: i64,
+                property_ptr: *const u8,
+                property_len: usize,
+                value: f64,
+            ) -> i32;
+        }
+
+        if unsafe { js_ext_http_incoming_message_is_handle(handle) } != 0 {
+            unsafe {
+                js_ext_http_incoming_message_dispatch_property_set(
+                    handle,
+                    property_name.as_ptr(),
+                    property_name.len(),
+                    value,
+                );
+            }
+        }
+    }
 }
 
 #[no_mangle]
@@ -2688,6 +2769,93 @@ unsafe extern "C" fn js_node_http_native_dispatch(
         } else {
             perry_runtime::js_nanbox_pointer(handle)
         };
+    }
+    // #4904: Node exposes Agent / ClientRequest / IncomingMessage /
+    // ServerResponse as constructable classes. Construction through any
+    // value/aliasing path (`const { Agent } = require('http')`,
+    // `new http.IncomingMessage(socket)`, …) lands here via the
+    // class_registry http construct arm.
+    if module == "http" && method == "IncomingMessage" {
+        extern "C" {
+            fn js_node_http_incoming_message_standalone_new(socket: f64) -> i64;
+        }
+        let handle = js_node_http_incoming_message_standalone_new(arg(0));
+        return if handle == 0 {
+            undefined
+        } else {
+            perry_runtime::js_nanbox_pointer(handle)
+        };
+    }
+    if module == "http" && method == "ServerResponse" {
+        extern "C" {
+            fn js_node_http_server_response_standalone_new(req: f64) -> i64;
+        }
+        let handle = js_node_http_server_response_standalone_new(arg(0));
+        return if handle == 0 {
+            undefined
+        } else {
+            perry_runtime::js_nanbox_pointer(handle)
+        };
+    }
+    #[cfg(feature = "external-http-client-pump")]
+    {
+        extern "C" {
+            fn js_http_agent_new(options_f64: f64) -> i64;
+            fn js_https_agent_new(options_f64: f64) -> i64;
+            fn js_http_client_request_standalone_new(options_f64: f64) -> i64;
+            fn js_http_get(arg_f64: f64, callback_i64: i64) -> i64;
+            fn js_https_get(arg_f64: f64, callback_i64: i64) -> i64;
+            fn js_http_request(opts_f64: f64, callback_i64: i64) -> i64;
+            fn js_https_request(opts_f64: f64, callback_i64: i64) -> i64;
+        }
+        // #4904: captured / aliased `get` / `request` (`const { get } =
+        // require('http')`). The first non-closure arg is the options/url,
+        // the first closure-valued arg is the response callback.
+        if matches!(method, "get" | "request") && matches!(module, "http" | "https") {
+            let mut options = undefined;
+            let mut callback: i64 = 0;
+            for n in 0..args_len.min(3) {
+                let a = arg(n);
+                if callback == 0 && js_value_is_closure(a.to_bits() as i64) != 0 {
+                    callback = perry_runtime::js_nanbox_get_pointer(a);
+                } else if JSValue::from_bits(a.to_bits()).is_undefined() {
+                    continue;
+                } else if options.to_bits() == undefined.to_bits() {
+                    options = a;
+                }
+            }
+            let handle = match (module, method) {
+                ("http", "get") => js_http_get(options, callback),
+                ("http", "request") => js_http_request(options, callback),
+                ("https", "get") => js_https_get(options, callback),
+                _ => js_https_request(options, callback),
+            };
+            return if handle == 0 {
+                undefined
+            } else {
+                perry_runtime::js_nanbox_pointer(handle)
+            };
+        }
+        if method == "Agent" && (module == "http" || module == "https") {
+            let handle = if module == "https" {
+                js_https_agent_new(arg(0))
+            } else {
+                js_http_agent_new(arg(0))
+            };
+            return if handle == 0 {
+                undefined
+            } else {
+                perry_runtime::js_nanbox_pointer(handle)
+            };
+        }
+        if module == "http" && method == "ClientRequest" {
+            let handle = js_http_client_request_standalone_new(arg(0));
+            return if handle == 0 {
+                undefined
+            } else {
+                perry_runtime::js_nanbox_pointer(handle)
+            };
+        }
     }
     // Disambiguate handler (function/closure) from options (object),
     // independent of argument order.

--- a/crates/perry-stdlib/src/http.rs
+++ b/crates/perry-stdlib/src/http.rs
@@ -22,7 +22,9 @@ pub(crate) use client_request_surface::{
     dispatch_client_request_method, dispatch_client_request_property,
 };
 mod agent_dispatch;
-pub(crate) use agent_dispatch::{dispatch_agent_method, dispatch_agent_property};
+pub(crate) use agent_dispatch::{
+    dispatch_agent_method, dispatch_agent_property, dispatch_agent_property_set,
+};
 #[cfg(feature = "external-http-client-pump")]
 mod external_client_request;
 
@@ -657,6 +659,21 @@ pub unsafe extern "C" fn js_http_request(options_f64: f64, callback_i64: i64) ->
         ended: false,
         agent_handle,
     })
+}
+
+/// `new http.ClientRequest(options)` (#4904). Perry's client model defers
+/// the actual send to `.end()`, so constructing is exactly `http.request`
+/// without a response callback. Node coerces a falsy `options.method` to
+/// `GET` — mirror that here (`http.request` keeps whatever string it got).
+#[no_mangle]
+pub unsafe extern "C" fn js_http_client_request_standalone_new(options_f64: f64) -> Handle {
+    let handle = js_http_request(options_f64, 0);
+    if let Some(req) = get_handle_mut::<ClientRequestHandle>(handle) {
+        if req.method.is_empty() {
+            req.method = "GET".to_string();
+        }
+    }
+    handle
 }
 
 /// https.request(options, callback) -> ClientRequest handle

--- a/crates/perry-stdlib/src/http/agent_dispatch.rs
+++ b/crates/perry-stdlib/src/http/agent_dispatch.rs
@@ -33,8 +33,61 @@ pub(crate) fn dispatch_agent_property(handle: Handle, property: &str) -> Option<
         "destroy" => bind_agent_method_value(handle, b"destroy"),
         "keepSocketAlive" => bind_agent_method_value(handle, b"keepSocketAlive"),
         "reuseSocket" => bind_agent_method_value(handle, b"reuseSocket"),
+        // #4904: data properties — Agents constructed through the dynamic
+        // value path (`const { Agent } = require('http'); new Agent(...)`)
+        // read these through handle property dispatch rather than the
+        // class-filtered native rows.
+        "maxSockets" => super::js_http_agent_max_sockets(handle),
+        "maxFreeSockets" => super::js_http_agent_max_free_sockets(handle),
+        "maxTotalSockets" => super::js_http_agent_max_total_sockets(handle),
+        "keepAliveMsecs" => super::js_http_agent_keep_alive_msecs(handle),
+        "keepAlive" => super::js_http_agent_keep_alive(handle),
+        "destroyed" => super::js_http_agent_destroyed(handle),
+        "defaultPort" => super::js_http_agent_default_port(handle),
+        "protocol" => {
+            let ptr = super::js_http_agent_protocol(handle);
+            if ptr.is_null() {
+                f64::from_bits(JSValue::undefined().bits())
+            } else {
+                f64::from_bits(JSValue::string_ptr(ptr).bits())
+            }
+        }
+        "sockets" => js_http_agent_sockets(handle),
+        "freeSockets" => js_http_agent_free_sockets(handle),
+        "requests" => js_http_agent_requests(handle),
         _ => return None,
     })
+}
+
+/// #4904: property writes on a dynamically-dispatched Agent —
+/// `agent.maxSockets = 4` and the `agent.createConnection = fn`
+/// monkeypatch pattern Node's own tests use. Returns `true` when claimed.
+pub(crate) fn dispatch_agent_property_set(handle: Handle, property: &str, value: f64) -> bool {
+    if get_handle_mut::<AgentHandle>(handle).is_none() {
+        return false;
+    }
+    match property {
+        "maxSockets" => super::js_http_agent_set_max_sockets(handle, value),
+        "maxFreeSockets" => super::js_http_agent_set_max_free_sockets(handle, value),
+        "maxTotalSockets" => super::js_http_agent_set_max_total_sockets(handle, value),
+        "keepAliveMsecs" => super::js_http_agent_set_keep_alive_msecs(handle, value),
+        "keepAlive" => super::js_http_agent_set_keep_alive(handle, value),
+        "createConnection" | "createSocket" => {
+            let bits = value.to_bits();
+            let ptr = if JSValue::from_bits(bits).is_pointer() {
+                (bits & PTR_MASK) as i64
+            } else {
+                0
+            };
+            if property == "createConnection" {
+                super::js_http_agent_set_create_connection(handle, ptr);
+            } else {
+                super::js_http_agent_set_create_socket(handle, ptr);
+            }
+        }
+        _ => return false,
+    }
+    true
 }
 
 pub(crate) unsafe fn dispatch_agent_method(

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -159,7 +159,19 @@ pub(in crate::commands::compile) fn wrap_commonjs_for_target(
     let imports = require_specs
         .iter()
         .zip(import_local_names.iter())
-        .map(|(spec, local)| format!("import {} from '{}';", local, spec))
+        .map(|(spec, local)| {
+            // #4904: Node's underscore-prefixed internal http modules are
+            // require-only re-exports of the public `http` surface
+            // (`require('_http_agent').Agent` etc.). Bind the hoisted import
+            // to the public module; the require shim still matches on the
+            // original specifier string.
+            let import_spec = match spec.as_str() {
+                "_http_agent" | "_http_client" | "_http_incoming" | "_http_outgoing"
+                | "_http_server" => "http",
+                other => other,
+            };
+            format!("import {} from '{}';", local, import_spec)
+        })
         .collect::<Vec<_>>()
         .join("\n");
 


### PR DESCRIPTION
## Summary

Fixes #4904 — Node exposes `http.Agent`, `http.ClientRequest`, `http.IncomingMessage`, and `http.ServerResponse` as **constructable classes**; under Perry, `new`-ing them threw `TypeError: <X> is not a constructor` through every value-aliasing path (`const { Agent } = require('http')`, `require('_http_agent').Agent`, `const CR = http.ClientRequest`, `new http.IncomingMessage()`, …).

## Mechanism (mirrors the existing `OutgoingMessage` route end-to-end)

- **runtime/native_module** — export the four classes as bound callable values with Node `.length` arities, plus the previously missing `http.get` / `http.request` value exports (the `https` twins already existed; `const { Agent, get } = require('http')` destructuring needs both).
- **runtime/class_registry** — extend the http construct arm so `js_new_function_construct` forwards `(module, class, args)` through `JS_NATIVE_HTTP_DISPATCH`; the real module name is forwarded so `https.Agent` constructs with the https protocol default.
- **stdlib/dispatch** — constructor arms: `Agent` → `js_http_agent_new`, `ClientRequest` → new `js_http_client_request_standalone_new` (defers the send to `.end()`, matching Perry's client model), `IncomingMessage` / `ServerResponse` → new standalone factories in perry-ext-http-server; plus `get`/`request` value-call arms.
- **HIR** — member-form `new http.{ClientRequest,IncomingMessage,ServerResponse}()` joins the OutgoingMessage `NewDynamic` route; bare-ident forms (destructured imports) added for all four; the three handle-backed classes are skip-listed from typed native-instance registration so instances dispatch dynamically via `HANDLE_*_DISPATCH`.
- **cjs_wrap** — `require('_http_agent')` (and the other `_http_*` internal modules) binds its hoisted import to the public `http` surface.

## Instance surface

- **IncomingMessage**: standalone ctor stores the socket argument verbatim; `socket`/`connection` get/set aliasing (Node's `connection` accessor writes `this.socket`); `_addHeaderLine` with Node's `matchKnownFields` semantics (first-wins singles, `', '`/`'; '` joins, set-cookie array).
- **ServerResponse**: standalone ctor (captures `req.method`; HEAD suppresses the body), `assignSocket`/`detachSocket` with `ERR_HTTP_SOCKET_ASSIGNED` on double assignment, `write(chunk, cb)` callback queueing, `end()` flushes head+body through the assigned socket's JS `write` (one corked write + the zero-length finish chunk Node emits), write/end callbacks invoked in order.
- **Agent**: dynamic property reads (`maxSockets`, `freeSockets`, `protocol`, …) and writes (tunables + `createConnection`/`createSocket` monkeypatching) through handle dispatch in both perry-stdlib and perry-ext-http.

## Drive-by SIGSEGV fix

`json/stringify.rs`'s `is_closure_value` probed `CLOSURE_MAGIC` at offset 12 of POINTER_TAG payloads without the handle-band guard (same #2154 bug class as the sibling probe at line ~1106), so `JSON.stringify` of `{ agent, lookup: () => {} }` dereferenced unmapped low memory and crashed `http.get({ agent: new Agent({ timeout: 50 }), lookup: () => {} })`. Now routes through `addr_class::is_handle_band` first.

## Validation

- **Issue's 13 Node corpus tests** (pinned v22 `test/parallel`): **7 now pass outright** — `client-defaults`, `agent-timeout-option`, `client-timeout-option-with-agent`, `incoming-message-connection-setter`, `incoming-message-destroy`, `outgoing-message-write-callback`, `server-response-standalone` (was 0/13; all 13 previously died at construction). The other 6 construct and run to their assertions:
  - `agent-keepalive`, `agent-keepalive-delay`, `agent-error-on-idle`, `agent-abort-controller`, `client-set-timeout-after-end` need real Agent pool emulation (per-key `sockets`/`freeSockets` arrays, pool-driven `createConnection` with live socket objects) — Agent-pool follow-up territory (#4905/#4909 family).
  - `incoming-matchKnownFields` hits a **pre-existing** `assert.deepStrictEqual` divergence: `const d = {}; d.x = 'v'` never compares equal to `{ x: 'v' }` (reproduces without any http involvement). Will file separately.
- **Curated node-suite**: http 18/18, https 5/5 — 100%, 0 regressions.
- **Crate tests**: perry-ext-http-server / perry-ext-http / perry-runtime / perry-stdlib / perry-hir / perry(--lib) all green; new unit tests for `matchKnownFields` classification and the socket-alias assignment.
- **Gates**: `cargo fmt --check`, file-size gate, GC store-site inventory, addr-class inventory all pass.

Version bump + changelog left for merge time per the maintainer-folds-metadata flow.

Part of #2132.