### PR TITLE
fix(http,net,hir): #4905 — server/timer/socket lifecycle methods (closeAllConnections, req.setTimeout timeout event, CJS net destructure)

### DIFF
--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -185,6 +185,14 @@ lazy_static! {
 
 static NEXT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Server handles whose accept loop saw a new connection since the last
+/// pump tick. Drained by `js_node_http_server_process_pending` to fire
+/// `'connection'` listeners on the main thread (#4905). Node passes the
+/// socket as the listener argument; we don't model a net.Socket for
+/// hyper connections yet, so listeners fire with no args — enough for
+/// the canonical connection-counting idiom.
+static PENDING_CONNECTION_EVENTS: Mutex<Vec<i64>> = Mutex::new(Vec::new());
+
 /// Signal tracked connections of `server_handle` to close. With
 /// `only_idle`, connections currently processing a request are left
 /// alone (Node's `closeIdleConnections` semantics; `server.close()`
@@ -514,6 +522,9 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                                         busy: busy.clone(),
                                     },
                                 );
+                                if let Ok(mut q) = PENDING_CONNECTION_EVENTS.lock() {
+                                    q.push(server_handle);
+                                }
                                 tokio::spawn(async move {
                                     let service = service_fn(move |req: Request<Incoming>| {
                                         let request_tx = request_tx.clone();
@@ -1043,15 +1054,24 @@ fn reap_in_flight_requests() {
         let now = Instant::now();
         guard.retain(|e| {
             let ended = response_writable_ended(e.response_handle);
+            // #4905: the per-request oneshot receiver died with its
+            // connection task (client disconnected / closeAllConnections)
+            // — the response can never be flushed, so don't pin the event
+            // loop for the rest of the grace window.
+            let peer_gone = get_handle::<ServerResponse>(e.response_handle)
+                .and_then(|sr| sr.response_tx.as_ref())
+                .map(|tx| tx.is_closed())
+                .unwrap_or(false);
             let expired = now >= e.deadline;
-            if ended || expired {
+            if ended || expired || peer_gone {
                 to_finalize.push((
                     e.request_handle,
                     e.response_handle,
                     // Only synthesize when we're giving up on a handler
                     // that never ended the response — not when it ended
-                    // it itself, and never for skip-default paths.
-                    !ended && !e.skip_default_response,
+                    // it itself, never for skip-default paths, and never
+                    // when the peer is gone (nothing to deliver to).
+                    !ended && !e.skip_default_response && !peer_gone,
                 ));
                 false
             } else {
@@ -1208,6 +1228,25 @@ pub extern "C" fn js_node_http_server_process_pending() -> i32 {
     // #4728 — finalize any async-handler requests that have flushed their
     // response since the last tick (or timed out) before draining new ones.
     reap_in_flight_requests();
+
+    // #4905 — fire `'connection'` listeners for connections accepted since
+    // the last tick, before their requests are dispatched (Node fires
+    // `'connection'` ahead of `'request'`).
+    let connection_events: Vec<i64> = PENDING_CONNECTION_EVENTS
+        .lock()
+        .map(|mut q| q.drain(..).collect())
+        .unwrap_or_default();
+    for server_handle in connection_events {
+        let listeners = get_handle::<HttpServer>(server_handle)
+            .and_then(|s| s.listeners.get("connection").cloned())
+            .unwrap_or_default();
+        if listeners.is_empty() {
+            continue;
+        }
+        let this_val = handle_to_pointer_f64(server_handle);
+        with_implicit_this(this_val, || emit_no_arg_to_listeners(&listeners));
+        count += 1;
+    }
 
     // Snapshot handle ids first so we can mutate handle state
     // (drain channels, free per-request handles) without the

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -6,8 +6,11 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use lazy_static::lazy_static;
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
@@ -159,6 +162,42 @@ pub struct HttpPendingUpgrade {
     pub server_handle: i64,
     pub request_handle: i64,
     pub ws_id: i64,
+}
+
+// ============================================================================
+// #4905 — per-connection tracking for closeAllConnections/closeIdleConnections
+// ============================================================================
+
+/// Live HTTP/1.1 connection tracked so `server.closeAllConnections()` /
+/// `server.closeIdleConnections()` can reach into the per-connection
+/// tokio task. `busy` counts in-flight requests on the connection (0
+/// between keep-alive requests); `close` wakes the connection task's
+/// `select!`, which drops the hyper connection and closes the socket.
+struct TrackedConnection {
+    server_handle: i64,
+    close: Arc<tokio::sync::Notify>,
+    busy: Arc<AtomicUsize>,
+}
+
+lazy_static! {
+    static ref CONNECTIONS: Mutex<HashMap<u64, TrackedConnection>> = Mutex::new(HashMap::new());
+}
+
+static NEXT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Signal tracked connections of `server_handle` to close. With
+/// `only_idle`, connections currently processing a request are left
+/// alone (Node's `closeIdleConnections` semantics; `server.close()`
+/// also closes idle keep-alive sockets since Node 19).
+fn signal_connections_close(server_handle: i64, only_idle: bool) {
+    let conns = CONNECTIONS.lock().unwrap();
+    for entry in conns.values() {
+        if entry.server_handle == server_handle
+            && (!only_idle || entry.busy.load(Ordering::SeqCst) == 0)
+        {
+            entry.close.notify_one();
+        }
+    }
 }
 
 // ============================================================================
@@ -461,22 +500,49 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                                 let request_tx = request_tx_for_spawn.clone();
                                 let upgrade_tx = upgrade_tx_for_spawn.clone();
                                 let server_handle = server_handle;
+                                // #4905 — register the connection so
+                                // closeAllConnections/closeIdleConnections can
+                                // reach this task from the main thread.
+                                let conn_id = NEXT_CONNECTION_ID.fetch_add(1, Ordering::SeqCst);
+                                let busy = Arc::new(AtomicUsize::new(0));
+                                let close = Arc::new(tokio::sync::Notify::new());
+                                CONNECTIONS.lock().unwrap().insert(
+                                    conn_id,
+                                    TrackedConnection {
+                                        server_handle,
+                                        close: close.clone(),
+                                        busy: busy.clone(),
+                                    },
+                                );
                                 tokio::spawn(async move {
                                     let service = service_fn(move |req: Request<Incoming>| {
                                         let request_tx = request_tx.clone();
                                         let upgrade_tx = upgrade_tx.clone();
+                                        let busy = busy.clone();
                                         async move {
-                                            handle_request(server_handle, peer, req, request_tx, upgrade_tx).await
+                                            busy.fetch_add(1, Ordering::SeqCst);
+                                            let res = handle_request(server_handle, peer, req, request_tx, upgrade_tx).await;
+                                            busy.fetch_sub(1, Ordering::SeqCst);
+                                            res
                                         }
                                     });
-                                    if let Err(e) = http1::Builder::new()
+                                    let conn = http1::Builder::new()
                                         .serve_connection(io, service)
-                                        .with_upgrades()
-                                        .await
-                                    {
-                                        // Common when client closes mid-request — silenced.
-                                        let _ = e;
+                                        .with_upgrades();
+                                    tokio::pin!(conn);
+                                    tokio::select! {
+                                        result = &mut conn => {
+                                            // Common when client closes mid-request — silenced.
+                                            let _ = result;
+                                        }
+                                        _ = close.notified() => {
+                                            // closeAllConnections / closeIdleConnections:
+                                            // dropping the pinned connection closes the
+                                            // socket immediately (in-flight request gets
+                                            // a reset, matching Node's socket.destroy()).
+                                        }
                                     }
+                                    CONNECTIONS.lock().unwrap().remove(&conn_id);
                                 });
                             }
                             Err(e) => eprintln!("[node:http] accept error: {}", e),
@@ -526,6 +592,9 @@ pub unsafe extern "C" fn js_node_http_server_close(server_handle: i64, callback:
     } else {
         close_listeners = Vec::new();
     }
+    // Node 19+: `server.close()` destroys idle keep-alive connections
+    // (active requests are allowed to finish) (#4905).
+    signal_connections_close(server_handle, true);
     emit_no_arg_to_listeners(&close_listeners);
     if callback != 0 {
         let raw = callback as *const RawClosureHeader;
@@ -536,15 +605,37 @@ pub unsafe extern "C" fn js_node_http_server_close(server_handle: i64, callback:
     }
 }
 
-/// `server.closeAllConnections()` — placeholder. Active hyper
-/// connections live in their own tokio tasks; we'd need to thread an
-/// abort handle through every task. For Phase 1 this is a no-op
-/// (matches `closeIdleConnections` too).
+/// `server.closeAllConnections()` — destroy every tracked connection
+/// of this server, including ones with an in-flight request (#4905).
 #[no_mangle]
-pub extern "C" fn js_node_http_server_close_all_connections(_handle: i64) {}
+pub extern "C" fn js_node_http_server_close_all_connections(handle: i64) {
+    signal_connections_close(handle, false);
+    // Parked async requests on the destroyed connections can never flush
+    // a response (the per-request oneshot receiver died with the
+    // connection task) — drop them now so `has_in_flight_requests()`
+    // doesn't pin the event loop for the 300s grace window.
+    let mut to_finalize: Vec<(i64, i64)> = Vec::new();
+    if let Ok(mut guard) = IN_FLIGHT.lock() {
+        guard.retain(|e| {
+            if e.server_handle == handle {
+                to_finalize.push((e.request_handle, e.response_handle));
+                false
+            } else {
+                true
+            }
+        });
+    }
+    for (req, res) in to_finalize {
+        finalize_request_handles(req, res);
+    }
+}
 
+/// `server.closeIdleConnections()` — destroy connections with no
+/// in-flight request (idle keep-alive sockets) (#4905).
 #[no_mangle]
-pub extern "C" fn js_node_http_server_close_idle_connections(_handle: i64) {}
+pub extern "C" fn js_node_http_server_close_idle_connections(handle: i64) {
+    signal_connections_close(handle, true);
+}
 
 /// `server.address()` — returns `{ port, address, family }` as a
 /// JSON-stringified object. TS-side wrapper parses with `JSON.parse`.
@@ -894,6 +985,9 @@ pub extern "C" fn js_node_http_server_has_active() -> i32 {
 
 /// A request whose handler returned before finishing the response.
 struct InFlightRequest {
+    /// Owning server — lets `closeAllConnections()` drop parked requests
+    /// whose connection it just destroyed (#4905).
+    server_handle: i64,
     request_handle: i64,
     response_handle: i64,
     /// Mirrors `HttpPendingRequest::skip_default_response`: when true the
@@ -994,6 +1088,7 @@ pub(crate) fn finalize_or_park_request(pending: &HttpPendingRequest) {
     let deadline = Instant::now() + Duration::from_millis(grace_ms as u64);
     if let Ok(mut guard) = IN_FLIGHT.lock() {
         guard.push(InFlightRequest {
+            server_handle: pending.server_handle,
             request_handle: pending.request_handle,
             response_handle: pending.response_handle,
             skip_default_response: pending.skip_default_response,

--- a/crates/perry-ext-http/src/client_dispatch.rs
+++ b/crates/perry-ext-http/src/client_dispatch.rs
@@ -137,10 +137,16 @@ pub(crate) fn dispatch_request(
                     });
                 }
                 Err(e) => {
-                    push_event(PendingHttpEvent::Error {
-                        request_handle,
-                        error_message: e.to_string(),
-                    });
+                    // #4905: surface transport deadlines as the 'timeout'
+                    // event instead of a generic error.
+                    if e.is_timeout() {
+                        push_event(PendingHttpEvent::Timeout { request_handle });
+                    } else {
+                        push_event(PendingHttpEvent::Error {
+                            request_handle,
+                            error_message: e.to_string(),
+                        });
+                    }
                 }
             }
         });

--- a/crates/perry-ext-http/src/client_events.rs
+++ b/crates/perry-ext-http/src/client_events.rs
@@ -1,0 +1,112 @@
+//! #4905 — client-request event helpers for the pending-event drain
+//! loop: no-arg/error listener firing, transport-error → Node-coded
+//! Error mapping, and the `'timeout'` event flow.
+
+use super::*;
+
+/// Fire a client request's `event` listeners with no arguments.
+///
+/// # Safety
+///
+/// Listener entries are raw closure headers registered via `.on()`; they
+/// stay live for the program's lifetime (GC scanner pins them).
+pub(crate) unsafe fn fire_request_event_listeners(request_handle: Handle, event: &str) {
+    let listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
+        .and_then(|r| r.listeners.get(event).cloned())
+        .unwrap_or_default();
+    for cb in listeners {
+        if cb != 0 {
+            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
+            let _ = closure.call0();
+        }
+    }
+}
+
+/// Fire a client request's `'error'` listeners with `arg`.
+///
+/// # Safety
+///
+/// Same listener-liveness contract as [`fire_request_event_listeners`].
+pub(crate) unsafe fn fire_request_error_listeners(request_handle: Handle, arg: f64) {
+    let listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
+        .and_then(|r| r.listeners.get("error").cloned())
+        .unwrap_or_default();
+    for cb in listeners {
+        if cb != 0 {
+            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
+            let _ = closure.call1(arg);
+        }
+    }
+}
+
+/// #4905 — map a transport error message to the value handed to
+/// `'error'` listeners. Recognized shapes become real Error objects
+/// carrying the Node `.code` (corpus tests assert
+/// `err.code === 'ECONNRESET'`); unrecognized messages keep the legacy
+/// string argument so existing consumers are unaffected.
+pub(crate) fn error_event_arg(error_message: &str) -> f64 {
+    let lower = error_message.to_lowercase();
+    let coded = if lower.contains("connection reset")
+        || lower.contains("incompletemessage")
+        || lower.contains("connection closed before")
+    {
+        Some(("socket hang up".to_string(), "ECONNRESET"))
+    } else if lower.contains("connection refused") {
+        Some((error_message.to_string(), "ECONNREFUSED"))
+    } else {
+        None
+    };
+    match coded {
+        Some((msg, code)) => f64::from_bits(
+            perry_ffi::error_value_with_code(&msg, code, perry_ffi::ErrorKind::Error).bits(),
+        ),
+        None => {
+            let s = alloc_string(error_message);
+            f64::from_bits(STRING_TAG | (s.as_raw() as u64 & PTR_MASK))
+        }
+    }
+}
+
+/// #4905 — drain handler for `PendingHttpEvent::Timeout`: fire
+/// `'timeout'` listeners (falling back to the legacy error surface when
+/// none are registered), honor an in-handler `req.destroy()` with the
+/// coded ECONNRESET "socket hang up" error, then fire `'close'`.
+///
+/// # Safety
+///
+/// Same listener-liveness contract as [`fire_request_event_listeners`].
+pub(crate) unsafe fn handle_timeout_event(request_handle: Handle) {
+    let timeout_listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
+        .and_then(|r| r.listeners.get("timeout").cloned())
+        .unwrap_or_default();
+    if timeout_listeners.is_empty() {
+        // No `'timeout'` listener — keep the legacy error surface.
+        fire_request_error_listeners(request_handle, error_event_arg("request timed out"));
+    } else {
+        for cb in timeout_listeners {
+            if cb != 0 {
+                let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
+                let _ = closure.call0();
+            }
+        }
+        // Node's `'timeout'` doesn't tear the request down by itself, but
+        // our transport deadline already aborted the exchange. The
+        // canonical pattern destroys the request in the handler and
+        // expects ECONNRESET "socket hang up"; honor that destroy with
+        // the coded error.
+        if client_request_surface::request_destroyed(request_handle) {
+            fire_request_error_listeners(
+                request_handle,
+                f64::from_bits(
+                    perry_ffi::error_value_with_code(
+                        "socket hang up",
+                        "ECONNRESET",
+                        perry_ffi::ErrorKind::Error,
+                    )
+                    .bits(),
+                ),
+            );
+        }
+    }
+    fire_request_event_listeners(request_handle, "close");
+}

--- a/crates/perry-ext-http/src/client_request_surface.rs
+++ b/crates/perry-ext-http/src/client_request_surface.rs
@@ -58,6 +58,12 @@ fn with_state_mut<T>(handle: Handle, f: impl FnOnce(&mut ClientRequestSurfaceSta
     f(states.entry(handle).or_default())
 }
 
+/// Whether `req.destroy()` has been called on this request (#4905 —
+/// the timeout drain path checks this to emit the coded ECONNRESET).
+pub(crate) fn request_destroyed(handle: Handle) -> bool {
+    with_state_mut(handle, |state| state.destroyed)
+}
+
 fn find_header_key(req: &ClientRequestHandle, name: &str) -> Option<String> {
     req.headers
         .keys()

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -100,6 +100,13 @@ pub(crate) enum PendingHttpEvent {
         request_handle: Handle,
         error_message: String,
     },
+    /// #4905 — the transport deadline from `req.setTimeout(ms)` /
+    /// `options.timeout` fired. Drains to the request's `'timeout'`
+    /// listeners when any exist; falls back to the Error surface
+    /// otherwise.
+    Timeout {
+        request_handle: Handle,
+    },
 }
 
 lazy_static! {
@@ -731,10 +738,7 @@ fn dispatch_request_over_socket(
                 } else {
                     if start.elapsed() >= deadline {
                         (vtable.close)(socket_id);
-                        push_event(PendingHttpEvent::Error {
-                            request_handle,
-                            error_message: "request timed out".to_string(),
-                        });
+                        push_event(PendingHttpEvent::Timeout { request_handle });
                         return;
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(1)).await;
@@ -1482,6 +1486,69 @@ pub extern "C" fn js_http_has_pending() -> i32 {
         .unwrap_or(0)
 }
 
+/// Fire a client request's `event` listeners with no arguments.
+///
+/// # Safety
+///
+/// Listener entries are raw closure headers registered via `.on()`; they
+/// stay live for the program's lifetime (GC scanner pins them).
+unsafe fn fire_request_event_listeners(request_handle: Handle, event: &str) {
+    let listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
+        .and_then(|r| r.listeners.get(event).cloned())
+        .unwrap_or_default();
+    for cb in listeners {
+        if cb != 0 {
+            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
+            let _ = closure.call0();
+        }
+    }
+}
+
+/// Fire a client request's `'error'` listeners with `arg`.
+///
+/// # Safety
+///
+/// Same listener-liveness contract as [`fire_request_event_listeners`].
+unsafe fn fire_request_error_listeners(request_handle: Handle, arg: f64) {
+    let listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
+        .and_then(|r| r.listeners.get("error").cloned())
+        .unwrap_or_default();
+    for cb in listeners {
+        if cb != 0 {
+            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
+            let _ = closure.call1(arg);
+        }
+    }
+}
+
+/// #4905 — map a transport error message to the value handed to
+/// `'error'` listeners. Recognized shapes become real Error objects
+/// carrying the Node `.code` (corpus tests assert
+/// `err.code === 'ECONNRESET'`); unrecognized messages keep the legacy
+/// string argument so existing consumers are unaffected.
+fn error_event_arg(error_message: &str) -> f64 {
+    let lower = error_message.to_lowercase();
+    let coded = if lower.contains("connection reset")
+        || lower.contains("incompletemessage")
+        || lower.contains("connection closed before")
+    {
+        Some(("socket hang up".to_string(), "ECONNRESET"))
+    } else if lower.contains("connection refused") {
+        Some((error_message.to_string(), "ECONNREFUSED"))
+    } else {
+        None
+    };
+    match coded {
+        Some((msg, code)) => f64::from_bits(
+            perry_ffi::error_value_with_code(&msg, code, perry_ffi::ErrorKind::Error).bits(),
+        ),
+        None => {
+            let s = alloc_string(error_message);
+            f64::from_bits(STRING_TAG | (s.as_raw() as u64 & PTR_MASK))
+        }
+    }
+}
+
 /// Drain the pending HTTP-event queue and fire user callbacks. Called
 /// from codegen's event-loop tick. Returns count of events drained.
 #[no_mangle]
@@ -1588,24 +1655,56 @@ pub unsafe extern "C" fn js_http_process_pending() -> i32 {
                         let _ = closure.call0();
                     }
                 }
+
+                // Node emits `'close'` on the request once the response has
+                // fully ended (#4905).
+                fire_request_event_listeners(request_handle, "close");
             }
             PendingHttpEvent::Error {
                 request_handle,
                 error_message,
             } => {
-                let error_listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
-                    .and_then(|r| r.listeners.get("error").cloned())
+                fire_request_error_listeners(request_handle, error_event_arg(&error_message));
+                // Node emits `'close'` on the request after `'error'` (#4905).
+                fire_request_event_listeners(request_handle, "close");
+            }
+            PendingHttpEvent::Timeout { request_handle } => {
+                let timeout_listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
+                    .and_then(|r| r.listeners.get("timeout").cloned())
                     .unwrap_or_default();
-                if !error_listeners.is_empty() {
-                    let s = alloc_string(&error_message);
-                    let arg = f64::from_bits(STRING_TAG | (s.as_raw() as u64 & PTR_MASK));
-                    for cb in error_listeners {
+                if timeout_listeners.is_empty() {
+                    // No `'timeout'` listener — keep the legacy error surface.
+                    fire_request_error_listeners(
+                        request_handle,
+                        error_event_arg("request timed out"),
+                    );
+                } else {
+                    for cb in timeout_listeners {
                         if cb != 0 {
                             let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
-                            let _ = closure.call1(arg);
+                            let _ = closure.call0();
                         }
                     }
+                    // Node's `'timeout'` doesn't tear the request down by
+                    // itself, but our transport deadline already aborted the
+                    // exchange. The canonical pattern destroys the request in
+                    // the handler and expects ECONNRESET "socket hang up";
+                    // honor that destroy with the coded error.
+                    if client_request_surface::request_destroyed(request_handle) {
+                        fire_request_error_listeners(
+                            request_handle,
+                            f64::from_bits(
+                                perry_ffi::error_value_with_code(
+                                    "socket hang up",
+                                    "ECONNRESET",
+                                    perry_ffi::ErrorKind::Error,
+                                )
+                                .bits(),
+                            ),
+                        );
+                    }
                 }
+                fire_request_event_listeners(request_handle, "close");
             }
         }
     }

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -65,6 +65,11 @@ mod tls_client;
 mod client_dispatch;
 use client_dispatch::dispatch_request;
 
+// Client-request event drain helpers (#4905) — extracted from this file
+// to stay under the 2000-line lint cap.
+mod client_events;
+use client_events::{error_event_arg, fire_request_error_listeners, fire_request_event_listeners};
+
 use lazy_static::lazy_static;
 use perry_ffi::{
     alloc_string, gc_register_mutable_root_scanner_named, get_handle_mut, iter_handles_of_mut,
@@ -104,9 +109,7 @@ pub(crate) enum PendingHttpEvent {
     /// `options.timeout` fired. Drains to the request's `'timeout'`
     /// listeners when any exist; falls back to the Error surface
     /// otherwise.
-    Timeout {
-        request_handle: Handle,
-    },
+    Timeout { request_handle: Handle },
 }
 
 lazy_static! {
@@ -1486,69 +1489,6 @@ pub extern "C" fn js_http_has_pending() -> i32 {
         .unwrap_or(0)
 }
 
-/// Fire a client request's `event` listeners with no arguments.
-///
-/// # Safety
-///
-/// Listener entries are raw closure headers registered via `.on()`; they
-/// stay live for the program's lifetime (GC scanner pins them).
-unsafe fn fire_request_event_listeners(request_handle: Handle, event: &str) {
-    let listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
-        .and_then(|r| r.listeners.get(event).cloned())
-        .unwrap_or_default();
-    for cb in listeners {
-        if cb != 0 {
-            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
-            let _ = closure.call0();
-        }
-    }
-}
-
-/// Fire a client request's `'error'` listeners with `arg`.
-///
-/// # Safety
-///
-/// Same listener-liveness contract as [`fire_request_event_listeners`].
-unsafe fn fire_request_error_listeners(request_handle: Handle, arg: f64) {
-    let listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
-        .and_then(|r| r.listeners.get("error").cloned())
-        .unwrap_or_default();
-    for cb in listeners {
-        if cb != 0 {
-            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
-            let _ = closure.call1(arg);
-        }
-    }
-}
-
-/// #4905 — map a transport error message to the value handed to
-/// `'error'` listeners. Recognized shapes become real Error objects
-/// carrying the Node `.code` (corpus tests assert
-/// `err.code === 'ECONNRESET'`); unrecognized messages keep the legacy
-/// string argument so existing consumers are unaffected.
-fn error_event_arg(error_message: &str) -> f64 {
-    let lower = error_message.to_lowercase();
-    let coded = if lower.contains("connection reset")
-        || lower.contains("incompletemessage")
-        || lower.contains("connection closed before")
-    {
-        Some(("socket hang up".to_string(), "ECONNRESET"))
-    } else if lower.contains("connection refused") {
-        Some((error_message.to_string(), "ECONNREFUSED"))
-    } else {
-        None
-    };
-    match coded {
-        Some((msg, code)) => f64::from_bits(
-            perry_ffi::error_value_with_code(&msg, code, perry_ffi::ErrorKind::Error).bits(),
-        ),
-        None => {
-            let s = alloc_string(error_message);
-            f64::from_bits(STRING_TAG | (s.as_raw() as u64 & PTR_MASK))
-        }
-    }
-}
-
 /// Drain the pending HTTP-event queue and fire user callbacks. Called
 /// from codegen's event-loop tick. Returns count of events drained.
 #[no_mangle]
@@ -1669,42 +1609,7 @@ pub unsafe extern "C" fn js_http_process_pending() -> i32 {
                 fire_request_event_listeners(request_handle, "close");
             }
             PendingHttpEvent::Timeout { request_handle } => {
-                let timeout_listeners = get_handle_mut::<ClientRequestHandle>(request_handle)
-                    .and_then(|r| r.listeners.get("timeout").cloned())
-                    .unwrap_or_default();
-                if timeout_listeners.is_empty() {
-                    // No `'timeout'` listener — keep the legacy error surface.
-                    fire_request_error_listeners(
-                        request_handle,
-                        error_event_arg("request timed out"),
-                    );
-                } else {
-                    for cb in timeout_listeners {
-                        if cb != 0 {
-                            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
-                            let _ = closure.call0();
-                        }
-                    }
-                    // Node's `'timeout'` doesn't tear the request down by
-                    // itself, but our transport deadline already aborted the
-                    // exchange. The canonical pattern destroys the request in
-                    // the handler and expects ECONNRESET "socket hang up";
-                    // honor that destroy with the coded error.
-                    if client_request_surface::request_destroyed(request_handle) {
-                        fire_request_error_listeners(
-                            request_handle,
-                            f64::from_bits(
-                                perry_ffi::error_value_with_code(
-                                    "socket hang up",
-                                    "ECONNRESET",
-                                    perry_ffi::ErrorKind::Error,
-                                )
-                                .bits(),
-                            ),
-                        );
-                    }
-                }
-                fire_request_event_listeners(request_handle, "close");
+                client_events::handle_timeout_event(request_handle);
             }
         }
     }

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -669,15 +669,20 @@ pub unsafe extern "C" fn js_net_socket_connect(arg1_f64: f64, arg2_f64: f64, arg
         fn js_get_string_pointer_unified(value: f64) -> i64;
     }
     let host_ptr = js_get_string_pointer_unified(arg2_f64);
-    let host = match string_from_header_i64(host_ptr) {
-        Some(h) => h,
-        None => return 0,
+    let (host, listener_f64) = match string_from_header_i64(host_ptr) {
+        Some(h) => (h, arg3_f64),
+        // #4905: `connect(port)` / `connect(port, connectListener)` —
+        // Node defaults the host to localhost when arg2 isn't a string
+        // (it may carry the connectListener instead). Pre-fix this
+        // returned handle 0, so the socket never connected and no
+        // 'connect'/'error' event ever fired.
+        None => ("127.0.0.1".to_string(), arg2_f64),
     };
     // #2013: positional `port` must be a valid integer in [0, 65536).
     js_net_validate_connect_port(arg1_f64);
     let port = arg1_f64 as u16;
     let handle = spawn_socket_task(host, port, /* direct_tls: */ None);
-    register_connect_cb(handle, arg3_f64);
+    register_connect_cb(handle, listener_f64);
     handle
 }
 

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -1837,10 +1837,42 @@ pub(crate) fn lower_var_decl_with_destructuring(
             });
         }
         ast::Pat::Array(_) | ast::Pat::Object(_) => {
-            // #3663: tag destructured `node:stream` constructors as native-module
-            // aliases so subsequent `new Readable(...)` bindings register as
-            // stream instances and their methods route to the real pump.
-            register_destructured_stream_ctors(ctx, decl);
+            // #3663 / #4905: tag destructured builtin-module members
+            // (stream ctors, net factories) as native-module aliases so
+            // call sites route through the static native table. Bindings
+            // returned in `skip_local_bindings` must not also bind a
+            // runtime local — the local (undefined for `net.connect`)
+            // would shadow the alias at call sites; ESM named imports
+            // never create one (exact parity).
+            let skip_local_bindings = register_destructured_stream_ctors(ctx, decl);
+            let filtered_pat;
+            let pattern: &ast::Pat = if skip_local_bindings.is_empty() {
+                &decl.name
+            } else if let ast::Pat::Object(obj) = &decl.name {
+                let mut obj = obj.clone();
+                obj.props.retain(|prop| match prop {
+                    ast::ObjectPatProp::Assign(a) => {
+                        !skip_local_bindings.contains(&a.key.sym.to_string())
+                    }
+                    ast::ObjectPatProp::KeyValue(kv) => match kv.value.as_ref() {
+                        ast::Pat::Ident(b) => {
+                            !skip_local_bindings.contains(&b.id.sym.to_string())
+                        }
+                        _ => true,
+                    },
+                    _ => true,
+                });
+                if obj.props.is_empty() {
+                    // Every binding became a native alias; nothing left to
+                    // bind at runtime (require of a builtin module has no
+                    // observable side effects).
+                    return Ok(result);
+                }
+                filtered_pat = ast::Pat::Object(obj);
+                &filtered_pat
+            } else {
+                &decl.name
+            };
 
             // Delegate to the recursive pattern binding helper so that all
             // destructuring features (nested patterns, defaults, rest, computed
@@ -1865,7 +1897,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         .transpose()?
                         .ok_or_else(|| anyhow!("Destructuring requires an initializer"))?
                 };
-            let stmts = lower_pattern_binding(ctx, &decl.name, init_expr, mutable)?;
+            let stmts = lower_pattern_binding(ctx, pattern, init_expr, mutable)?;
             result.extend(stmts);
         }
         _ => {

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -1855,9 +1855,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         !skip_local_bindings.contains(&a.key.sym.to_string())
                     }
                     ast::ObjectPatProp::KeyValue(kv) => match kv.value.as_ref() {
-                        ast::Pat::Ident(b) => {
-                            !skip_local_bindings.contains(&b.id.sym.to_string())
-                        }
+                        ast::Pat::Ident(b) => !skip_local_bindings.contains(&b.id.sym.to_string()),
                         _ => true,
                     },
                     _ => true,

--- a/crates/perry-hir/src/destructuring/var_decl_sources.rs
+++ b/crates/perry-hir/src/destructuring/var_decl_sources.rs
@@ -68,23 +68,43 @@ pub(super) fn destructure_builtin_module_source(
     None
 }
 
-/// #3663: register destructured stream constructors as native-module aliases.
+/// #3663 / #4905: register destructured builtin-module members as
+/// native-module aliases, mirroring what ESM named imports get
+/// generically in `module_decl.rs` (`import { connect } from 'net'`).
+/// Without the alias, the binding only holds the runtime property read
+/// off the reified module object — which is `undefined` for exports
+/// whose value-read path isn't reified (`net.connect`), so the
+/// canonical CJS corpus idiom `const { connect } = require('net')`
+/// threw `value is not a function` at the call site.
+///
+/// Returns the binding names that must NOT also bind a runtime local:
+/// a local would shadow the alias at call sites (the call lowers as a
+/// closure call of the undefined local instead of the native-table
+/// row). ESM named imports never create a local, so skipping the
+/// binding is exact parity. Stream ctors keep their local (their
+/// runtime member read works, and #3663 shipped with it).
 pub(super) fn register_destructured_stream_ctors(
     ctx: &mut LoweringContext,
     decl: &ast::VarDeclarator,
-) {
+) -> Vec<String> {
     let ast::Pat::Object(obj_pat) = &decl.name else {
-        return;
+        return Vec::new();
     };
     let Some(init) = decl.init.as_deref() else {
-        return;
+        return Vec::new();
     };
     let Some(module) = destructure_builtin_module_source(ctx, init) else {
-        return;
+        return Vec::new();
     };
-    if module != "stream" {
-        return;
-    }
+    let allowed: &[&str] = match module.as_str() {
+        "stream" => &STREAM_CTOR_NAMES,
+        // #4905: net's factory exports — call sites lower through the
+        // static native table rows, so the alias works even though the
+        // runtime member read is undefined.
+        "net" => &["connect", "createConnection"],
+        _ => return Vec::new(),
+    };
+    let mut skip_local_bindings = Vec::new();
     for prop in &obj_pat.props {
         let (key, binding) = match prop {
             ast::ObjectPatProp::Assign(assign) => {
@@ -104,8 +124,12 @@ pub(super) fn register_destructured_stream_ctors(
             }
             _ => continue,
         };
-        if STREAM_CTOR_NAMES.contains(&key.as_str()) {
-            ctx.register_native_module(binding, "stream".to_string(), Some(key));
+        if allowed.contains(&key.as_str()) {
+            ctx.register_native_module(binding.clone(), module.clone(), Some(key));
+            if module == "net" {
+                skip_local_bindings.push(binding);
+            }
         }
     }
+    skip_local_bindings
 }


### PR DESCRIPTION
Fixes #4905 (the acceptance items; remaining corpus failures re-bucket to other walls, see below).

## What landed

**Server lifecycle (perry-ext-http-server)**
- `server.closeAllConnections()` / `server.closeIdleConnections()` were no-op stubs — now real. Each accepted HTTP/1.1 connection registers in a tracked-connection table (`Arc<Notify>` close signal + in-flight request counter); `closeAllConnections` drops every connection of that server, `closeIdleConnections` only those with no request in flight. `server.close()` now also closes idle keep-alive sockets (Node 19+ semantics).
- `closeAllConnections()` also reaps requests parked in the `IN_FLIGHT` table (#4728) whose connection it just destroyed — previously they pinned the event loop for the full 300 s grace window.
- The reaper now detects a dead peer generally: a parked request whose per-request oneshot receiver died with its connection task (client disconnect, timeout abort) is finalized immediately instead of holding the process open.
- `'connection'` server event: accepted connections queue their server handle; the pump fires `'connection'` listeners on the main thread (no socket arg yet — enough for the canonical connection-counting idiom).

**Client request (perry-ext-http)**
- `req.setTimeout(ms)` timeouts now emit the `'timeout'` event (new `PendingHttpEvent::Timeout`, pushed when reqwest reports `is_timeout()` and from the agent-socket deadline path). If the handler destroys the request — the canonical pattern — the `'error'` listeners get a real coded Error (`ECONNRESET` / "socket hang up"). With no `'timeout'` listener the legacy error surface is kept.
- `'error'` events for recognized transport failures (connection reset / refused / closed-before-response) now carry real Error objects with `.code` instead of bare strings; unrecognized messages keep the legacy string (no blast radius).
- `'close'` now fires on the request after `'error'` and after the response fully ends, per Node.

**CJS destructure of net factories (perry-hir) — the cluster's dominant thrower**
- `const { connect, createConnection } = require('net')` produced `undefined` bindings (the reified module object has the keys but no callable value), so ~28 of the 37 corpus tests died at `value is not a function` before reaching any lifecycle method. The #3663 stream-ctor destructure hook is generalized: net's factory exports register as native-module aliases (exact ESM `import { connect } from 'net'` parity), and the runtime local that would shadow the alias is skipped.

**net positional connect (perry-ext-net)**
- `connect(port)` / `connect(port, connectListener)` returned handle 0 (no host string → bail), so no `'connect'`/`'error'` event ever fired. Host now defaults to `127.0.0.1` and a closure in the host slot is treated as the connect listener, per Node.

**Verified already working (no change needed)**
- `setTimeout(fn, ms).unref()` / `.ref()` / `.hasRef()` match node byte-for-byte (chained, variable, dynamic forms; unref'd timers don't keep the loop alive).

## Validation

- Repros match node:
  - close-all repro: client connection killed by `closeAllConnections`, `'close'` fires, clean exit (was: no-op + 300 s hang).
  - set-timeout repro: `'timeout'` → `req.destroy()` → `error.code === 'ECONNRESET'` → `'close'` → clean exit (was: no event, generic string error, hang).
  - the close-all corpus shape (`createServer(handler, opts)` + `net.connect(port)` + `server.on('connection')` + `closeAllConnections` + `close`) runs end-to-end.
- 37-test corpus sweep (vs pinned Node v22, same shim as `scripts/node_core_subset.py`): before = 37/37 dead, ~28 at `connect is not a function`. After: every test progresses past the missing-method stage; remaining failures re-bucket to other open walls:
  - headers/request-timeout **enforcement** (server must actually time out slow requests) → #2210 Phase 2
  - raw-net client `'data'` from keep-alive responses, `mustCall` this/socket args
  - `(number).listen/.on/.compare` handle-band cases (the re-bucket the issue called for; #4903's listen-callback fix has merged, these survivors look like a distinct handle-band path — #4909 triage)
  - `agent.addRequest` legacy API, `PerformanceObserver({type:'http'})` → separate items from the #4905 list, not lifecycle methods
- 0-regress: `cargo test` green for perry-hir / perry-ext-http / perry-ext-http-server / perry-ext-net; node-suite `net` module — only mismatch (`connection-state-limits`) reproduces identically on the base commit (pre-existing); node-suite `http` 100% (two compile-fails were concurrency artifacts; both PASS isolated); node-suite `stream` imports group 100% (the only stream tests exercising the changed destructure path — the suite is otherwise pure ESM, untouched).

No version bump / changelog — maintainer folds metadata at merge per CLAUDE.md.

> Note: the `lint` job currently fails on `crates/perry-runtime/src/regex.rs` (rustfmt diff + 2252 LOC over the 2000-line gate) — inherited from #4930 on `main`, untouched by this branch.
