### PR TITLE
fix(fetch): send dynamically-built request headers (#4932)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## v0.5.1156 — fix(fetch): send dynamically-built request headers (#4932)
+
+`fetch(url, { headers })` silently dropped **every** request header whenever the
+`headers` value was anything other than a plain object *literal* — a variable
+(`const h = {}; h["Authorization"] = ...; fetch(url, { headers: h })`), a spread
+literal (`{ ...h }`), or a call such as `Object.assign({}, h)` / `new Headers(h)`
+/ `JSON.parse(JSON.stringify(h))`. The literal form worked, so any library that
+builds its headers dynamically lost its auth header. Most visibly this broke the
+Stripe Node SDK's fetch HTTP client: it constructs headers via property
+assignment, so the `Authorization` header vanished and every call 401'd.
+
+**Root cause.** HIR lowering of `fetch(url, { ... })`
+(`crates/perry-hir/src/lower/expr_call/globals.rs`) only extracted the `headers`
+field when it was an object literal whose props were all plain (non-computed)
+string/ident keys, walking the AST into a `Vec<(String, Expr)>`. Any other shape
+fell through with an **empty** headers vector — codegen then built an empty
+object, stringified it to `{}`, and sent no headers. Spread props and computed
+keys inside an otherwise-literal `headers` object hit the same hole.
+
+**Fix.** `FetchWithOptions` gains a `headers_dynamic: Option<Box<Expr>>` field.
+Lowering now classifies the `headers` value: a literal with only plain
+string/ident keys keeps the existing static-extraction fast path; anything else
+(variable, spread literal, call, computed/getter prop) is captured whole in
+`headers_dynamic`. Codegen lowers that expression to a JSValue and
+`js_json_stringify`s it at runtime — exactly the path object literals already
+took — so a property-assigned object enumerates its own properties identically
+to a literal. The JS and WASM backends were updated to match.
+
+Verified against a local echo server: dynamic / literal / spread /
+`Object.assign` / copy-loop / `JSON.parse(JSON.stringify(...))` headers all send
+the `Authorization` header now; an empty `{}` and no-options `fetch` are
+unchanged. New regression test
+`crates/perry-hir/tests/fetch_dynamic_headers_lowering.rs`. Note: passing the
+*entire* options object as a variable (`fetch(url, opts)`) is a separate,
+pre-existing gap (it still falls back to a bare GET) and is out of scope here.
+
 ## v0.5.1155 — chore(runtime): split date.rs under the 2,000-line CI cap
 
 `crates/perry-runtime/src/date.rs` had grown to 2008 lines (pushed over by the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1155
+**Current Version:** 0.5.1156
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5289,7 +5289,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "base64",
@@ -5344,14 +5344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "cc",
  "libc",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "log",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "base64",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5460,14 +5460,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "serde",
  "serde_json",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1155"
+version = "0.5.1156"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "clap",
@@ -5501,14 +5501,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "bytes",
  "h2",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "bson",
  "futures-util",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "image",
@@ -5801,14 +5801,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "brotli",
  "flate2",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "base64",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6033,14 +6033,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "itoa",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "block2",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "block2",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1155"
+version = "0.5.1156"
 
 [[package]]
 name = "perry-ui-test"
@@ -6129,11 +6129,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1155"
+version = "0.5.1156"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "block2",
@@ -6165,7 +6165,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "block2",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "libc",
@@ -6195,14 +6195,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1155"
+version = "0.5.1156"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1155"
+version = "0.5.1156"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -38,6 +38,7 @@ impl JsEmitter {
                 method,
                 body,
                 headers,
+                headers_dynamic,
             } => {
                 self.output.push_str("fetch(");
                 self.emit_expr(url);
@@ -45,16 +46,24 @@ impl JsEmitter {
                 self.emit_expr(method);
                 self.output.push_str(", body: ");
                 self.emit_expr(body);
-                self.output.push_str(", headers: {");
-                for (i, (key, val)) in headers.iter().enumerate() {
-                    if i > 0 {
-                        self.output.push_str(", ");
+                self.output.push_str(", headers: ");
+                if let Some(hexpr) = headers_dynamic {
+                    // Dynamically-built headers (variable / spread / call): emit
+                    // the expression verbatim so the JS engine enumerates it.
+                    self.emit_expr(hexpr);
+                } else {
+                    self.output.push('{');
+                    for (i, (key, val)) in headers.iter().enumerate() {
+                        if i > 0 {
+                            self.output.push_str(", ");
+                        }
+                        self.output.push_str(&self.quote_string(key));
+                        self.output.push_str(": ");
+                        self.emit_expr(val);
                     }
-                    self.output.push_str(&self.quote_string(key));
-                    self.output.push_str(": ");
-                    self.emit_expr(val);
+                    self.output.push('}');
                 }
-                self.output.push_str("}})");
+                self.output.push_str("})");
             }
             Expr::FetchGetWithAuth { url, auth_header } => {
                 self.output.push_str("fetch(");

--- a/crates/perry-codegen-wasm/src/emit/expr/net_fetch_crypto.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/net_fetch_crypto.rs
@@ -28,12 +28,17 @@ impl<'a> FuncEmitCtx<'a> {
                 method,
                 body,
                 headers,
+                headers_dynamic,
             } => {
                 self.emit_expr(func, url);
                 self.emit_expr(func, method);
                 self.emit_expr(func, body);
                 // Build headers object
-                if headers.is_empty() {
+                if let Some(hexpr) = headers_dynamic {
+                    // Dynamically-built headers: leave the object value on the
+                    // stack so the runtime enumerates its own properties (#4932).
+                    self.emit_expr(func, hexpr);
+                } else if headers.is_empty() {
                     func.instruction(&Instruction::I64Const(TAG_UNDEFINED as i64));
                 } else {
                     self.emit_frame_begin(func, 0);

--- a/crates/perry-codegen-wasm/src/emit/js_fallback.rs
+++ b/crates/perry-codegen-wasm/src/emit/js_fallback.rs
@@ -353,6 +353,7 @@ impl WasmModuleEmitter {
                 method,
                 body,
                 headers,
+                headers_dynamic,
             } => {
                 let url_js = self.emit_js_expr(url, locals);
                 let method_js = self.emit_js_expr(method, locals);
@@ -362,7 +363,12 @@ impl WasmModuleEmitter {
                 if !matches!(body.as_ref(), Expr::Undefined) {
                     opts.push_str(&format!(", body: getString({})", body_js));
                 }
-                if !headers.is_empty() {
+                if let Some(hexpr) = headers_dynamic {
+                    // Dynamically-built headers: pass the JS object through so
+                    // fetch enumerates every property (#4932).
+                    let h = self.emit_js_expr(hexpr, locals);
+                    opts.push_str(&format!(", headers: toJsValue({})", h));
+                } else if !headers.is_empty() {
                     opts.push_str(", headers: {");
                     for (i, (key, val)) in headers.iter().enumerate() {
                         if i > 0 {

--- a/crates/perry-codegen-wasm/src/emit/string_collection.rs
+++ b/crates/perry-codegen-wasm/src/emit/string_collection.rs
@@ -954,6 +954,7 @@ impl WasmModuleEmitter {
                 method,
                 body,
                 headers,
+                headers_dynamic,
             } => {
                 self.collect_strings_in_expr(url);
                 self.collect_strings_in_expr(method);
@@ -961,6 +962,9 @@ impl WasmModuleEmitter {
                 for (key, val) in headers {
                     self.intern_string(key);
                     self.collect_strings_in_expr(val);
+                }
+                if let Some(hd) = headers_dynamic {
+                    self.collect_strings_in_expr(hd);
                 }
             }
             Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -668,12 +668,16 @@ pub fn check_escapes_in_expr(
             method,
             body,
             headers,
+            headers_dynamic,
         } => {
             check_escapes_in_expr(url, candidates, classes, escaped);
             check_escapes_in_expr(method, candidates, classes, escaped);
             check_escapes_in_expr(body, candidates, classes, escaped);
             for (_, v) in headers {
                 check_escapes_in_expr(v, candidates, classes, escaped);
+            }
+            if let Some(hd) = headers_dynamic {
+                check_escapes_in_expr(hd, candidates, classes, escaped);
             }
         }
         Expr::SuperCall(args)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -751,12 +751,16 @@ fn collect_used_new_fields_in_expr(
             method,
             body,
             headers,
+            headers_dynamic,
         } => {
             collect_used_new_fields_in_expr(url, non_escaping_news, used);
             collect_used_new_fields_in_expr(method, non_escaping_news, used);
             collect_used_new_fields_in_expr(body, non_escaping_news, used);
             for (_, value) in headers {
                 collect_used_new_fields_in_expr(value, non_escaping_news, used);
+            }
+            if let Some(hd) = headers_dynamic {
+                collect_used_new_fields_in_expr(hd, non_escaping_news, used);
             }
         }
         Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -79,34 +79,51 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             method,
             body,
             headers,
+            headers_dynamic,
         } => {
             let url_box = lower_expr(ctx, url)?;
             let method_box = lower_expr(ctx, method)?;
             let body_box = lower_expr(ctx, body)?;
 
-            // Build the headers object: js_object_alloc(0, N) followed by
-            // js_object_set_field_by_name for each (interned key, value).
-            let n_str = (headers.len() as u32).to_string();
-            let zero_str = "0".to_string();
-            let headers_handle =
-                ctx.block()
-                    .call(I64, "js_object_alloc", &[(I32, &zero_str), (I32, &n_str)]);
-            for (key, val_expr) in headers {
-                let key_idx = ctx.strings.intern(key);
-                let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
-                let v_box = lower_expr(ctx, val_expr)?;
-                let blk = ctx.block();
-                let key_box = blk.load(DOUBLE, &key_handle_global);
-                let key_bits = blk.bitcast_double_to_i64(&key_box);
-                let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
-                blk.call_void(
-                    "js_object_set_field_by_name",
-                    &[(I64, &headers_handle), (I64, &key_raw), (DOUBLE, &v_box)],
+            // Obtain the headers as a NaN-boxed object value, then JSON-stringify
+            // it below. Two cases:
+            //   * `headers_dynamic` — the headers value was a variable, a spread
+            //     literal, or a call (`Object.assign`/`new Headers`/`JSON.parse`).
+            //     Lower it directly; `js_json_stringify` enumerates its own
+            //     properties at runtime (#4932).
+            //   * otherwise — statically-extracted `{ "k": v, ... }` pairs, which
+            //     we build into a fresh object field-by-field.
+            let headers_obj_box = if let Some(hexpr) = headers_dynamic {
+                lower_expr(ctx, hexpr)?
+            } else {
+                // Build the headers object: js_object_alloc(0, N) followed by
+                // js_object_set_field_by_name for each (interned key, value).
+                let n_str = (headers.len() as u32).to_string();
+                let zero_str = "0".to_string();
+                let headers_handle = ctx.block().call(
+                    I64,
+                    "js_object_alloc",
+                    &[(I32, &zero_str), (I32, &n_str)],
                 );
-            }
+                for (key, val_expr) in headers {
+                    let key_idx = ctx.strings.intern(key);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let v_box = lower_expr(ctx, val_expr)?;
+                    let blk = ctx.block();
+                    let key_box = blk.load(DOUBLE, &key_handle_global);
+                    let key_bits = blk.bitcast_double_to_i64(&key_box);
+                    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                    blk.call_void(
+                        "js_object_set_field_by_name",
+                        &[(I64, &headers_handle), (I64, &key_raw), (DOUBLE, &v_box)],
+                    );
+                }
+                let blk = ctx.block();
+                nanbox_pointer_inline(blk, &headers_handle)
+            };
 
             let blk = ctx.block();
-            let headers_obj_box = nanbox_pointer_inline(blk, &headers_handle);
             // js_json_stringify(value: f64, indent: i32) -> i64 string handle.
             let zero_i = "0".to_string();
             let headers_str = blk.call(

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -1408,12 +1408,16 @@ pub(crate) fn collect_assigned_locals_expr(expr: &Expr, assigned: &mut Vec<Local
             method,
             body,
             headers,
+            headers_dynamic,
         } => {
             collect_assigned_locals_expr(url, assigned);
             collect_assigned_locals_expr(method, assigned);
             collect_assigned_locals_expr(body, assigned);
             for (_, v) in headers {
                 collect_assigned_locals_expr(v, assigned);
+            }
+            if let Some(hd) = headers_dynamic {
+                collect_assigned_locals_expr(hd, assigned);
             }
         }
         Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-hir/src/capability.rs
+++ b/crates/perry-hir/src/capability.rs
@@ -514,6 +514,7 @@ mod tests {
             method: Box::new(Expr::String("GET".into())),
             body: Box::new(Expr::Undefined),
             headers: vec![],
+            headers_dynamic: None,
         }));
         let v = audit_module_capabilities(
             &m,

--- a/crates/perry-hir/src/egress.rs
+++ b/crates/perry-hir/src/egress.rs
@@ -480,6 +480,7 @@ mod tests {
             method: Box::new(Expr::String("GET".into())),
             body: Box::new(Expr::Undefined),
             headers: vec![],
+            headers_dynamic: None,
         }));
         let v = audit_module_egress(&m, "/repo/main.ts", &pats(&["api.example.com"]), false);
         assert_eq!(v.len(), 1);
@@ -496,6 +497,7 @@ mod tests {
             method: Box::new(Expr::String("GET".into())),
             body: Box::new(Expr::Undefined),
             headers: vec![],
+            headers_dynamic: None,
         }));
         let v = audit_module_egress(&m, "/repo/main.ts", &pats(&["api.example.com"]), false);
         assert!(v.is_empty());
@@ -509,6 +511,7 @@ mod tests {
             method: Box::new(Expr::String("GET".into())),
             body: Box::new(Expr::Undefined),
             headers: vec![],
+            headers_dynamic: None,
         }));
         let v = audit_module_egress(&m, "/repo/main.ts", &pats(&["api.example.com"]), false);
         assert_eq!(v.len(), 1);
@@ -527,6 +530,7 @@ mod tests {
             method: Box::new(Expr::String("GET".into())),
             body: Box::new(Expr::Undefined),
             headers: vec![],
+            headers_dynamic: None,
         }));
         let v = audit_module_egress(
             &m,

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1373,7 +1373,14 @@ pub enum Expr {
         url: Box<Expr>,
         method: Box<Expr>,
         body: Box<Expr>,
+        // Statically-extracted headers from an object *literal* whose keys are
+        // all plain (non-computed) string/ident keys: `{ "k": v, ... }`.
         headers: Vec<(String, Expr)>,
+        // A dynamically-built headers value (a variable, a spread literal, a
+        // call like `Object.assign`/`new Headers`, etc.) that can only be
+        // serialized at runtime. When `Some`, it takes precedence over the
+        // static `headers` pairs above. See #4932.
+        headers_dynamic: Option<Box<Expr>>,
     },
     FetchGetWithAuth {
         // fetchWithAuth(url, authHeader) -> Promise<Response>

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -289,6 +289,7 @@ pub(super) fn try_global_builtins(
                             let mut method = Expr::String("GET".to_string());
                             let mut body = Expr::Undefined;
                             let mut headers_obj: Vec<(String, Expr)> = Vec::new();
+                            let mut headers_dynamic: Option<Box<Expr>> = None;
 
                             for prop in &obj.props {
                                 if let ast::PropOrSpread::Prop(prop) = prop {
@@ -311,35 +312,73 @@ pub(super) fn try_global_builtins(
                                                     body = lower_expr(ctx, &kv.value)?;
                                                 }
                                                 "headers" => {
-                                                    // Extract headers object
-                                                    if let ast::Expr::Object(headers_ast) =
-                                                        &*kv.value
-                                                    {
-                                                        for hprop in &headers_ast.props {
-                                                            if let ast::PropOrSpread::Prop(hprop) =
-                                                                hprop
-                                                            {
-                                                                if let ast::Prop::KeyValue(hkv) =
-                                                                    hprop.as_ref()
+                                                    // The headers value can be serialized statically
+                                                    // only if it is an object *literal* whose props
+                                                    // are all plain (non-computed) string/ident keys.
+                                                    // Anything else — a variable (`headers: h`), a
+                                                    // spread literal (`{...h}`), a call such as
+                                                    // `Object.assign({}, h)` / `new Headers(h)` /
+                                                    // `JSON.parse(...)`, or a computed/getter prop —
+                                                    // must be serialized at runtime, so capture the
+                                                    // whole expression in `headers_dynamic`. Without
+                                                    // this, dynamically-built header objects silently
+                                                    // dropped every header (#4932).
+                                                    let static_literal = match &*kv.value {
+                                                        ast::Expr::Object(headers_ast) => {
+                                                            headers_ast.props.iter().all(|p| {
+                                                                match p {
+                                                                    ast::PropOrSpread::Prop(prop) => {
+                                                                        matches!(
+                                                                            prop.as_ref(),
+                                                                            ast::Prop::KeyValue(hkv)
+                                                                                if matches!(
+                                                                                    &hkv.key,
+                                                                                    ast::PropName::Ident(_)
+                                                                                        | ast::PropName::Str(_)
+                                                                                )
+                                                                        )
+                                                                    }
+                                                                    ast::PropOrSpread::Spread(_) => false,
+                                                                }
+                                                            })
+                                                        }
+                                                        _ => false,
+                                                    };
+                                                    if static_literal {
+                                                        if let ast::Expr::Object(headers_ast) =
+                                                            &*kv.value
+                                                        {
+                                                            for hprop in &headers_ast.props {
+                                                                if let ast::PropOrSpread::Prop(hprop) =
+                                                                    hprop
                                                                 {
-                                                                    let hkey = match &hkv.key {
-                                                                        ast::PropName::Ident(
-                                                                            ident,
-                                                                        ) => ident.sym.to_string(),
-                                                                        ast::PropName::Str(s) => s
-                                                                            .value
-                                                                            .as_str()
-                                                                            .unwrap_or("")
-                                                                            .to_string(),
-                                                                        _ => continue,
-                                                                    };
-                                                                    let hval = lower_expr(
-                                                                        ctx, &hkv.value,
-                                                                    )?;
-                                                                    headers_obj.push((hkey, hval));
+                                                                    if let ast::Prop::KeyValue(hkv) =
+                                                                        hprop.as_ref()
+                                                                    {
+                                                                        let hkey = match &hkv.key {
+                                                                            ast::PropName::Ident(
+                                                                                ident,
+                                                                            ) => ident.sym.to_string(),
+                                                                            ast::PropName::Str(s) => s
+                                                                                .value
+                                                                                .as_str()
+                                                                                .unwrap_or("")
+                                                                                .to_string(),
+                                                                            _ => continue,
+                                                                        };
+                                                                        let hval = lower_expr(
+                                                                            ctx, &hkv.value,
+                                                                        )?;
+                                                                        headers_obj
+                                                                            .push((hkey, hval));
+                                                                    }
                                                                 }
                                                             }
                                                         }
+                                                    } else {
+                                                        headers_dynamic = Some(Box::new(
+                                                            lower_expr(ctx, &kv.value)?,
+                                                        ));
                                                     }
                                                 }
                                                 _ => {}
@@ -372,6 +411,7 @@ pub(super) fn try_global_builtins(
                                 method: Box::new(method),
                                 body: Box::new(body),
                                 headers: headers_obj,
+                                headers_dynamic,
                             }));
                         }
                     }
@@ -384,6 +424,7 @@ pub(super) fn try_global_builtins(
                     method: Box::new(Expr::String("GET".to_string())),
                     body: Box::new(Expr::Undefined),
                     headers: Vec::new(),
+                    headers_dynamic: None,
                 }));
             }
             _ => {} // Fall through to generic handling

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -358,7 +358,7 @@ impl SH for Expr {
             Expr::ChildProcessSpawnBackground { command, args, log_file, env_json, } => { tag(h, 240); command.as_ref().hash(h); args.hash(h); log_file.as_ref().hash(h); env_json.hash(h); }
             Expr::ChildProcessGetProcessStatus(e) => { tag(h, 241); e.as_ref().hash(h); }
             Expr::ChildProcessKillProcess(e) => { tag(h, 242); e.as_ref().hash(h); }
-            Expr::FetchWithOptions { url, method, body, headers, } => { tag(h, 243); url.as_ref().hash(h); method.as_ref().hash(h); body.as_ref().hash(h); headers.hash(h); }
+            Expr::FetchWithOptions { url, method, body, headers, headers_dynamic, } => { tag(h, 243); url.as_ref().hash(h); method.as_ref().hash(h); body.as_ref().hash(h); headers.hash(h); if let Some(hd) = headers_dynamic { tag(h, 1); hd.as_ref().hash(h); } else { tag(h, 0); } }
             Expr::FetchGetWithAuth { url, auth_header } => { tag(h, 244); url.as_ref().hash(h); auth_header.as_ref().hash(h); }
             Expr::FetchPostWithAuth { url, auth_header, body, } => { tag(h, 245); url.as_ref().hash(h); auth_header.as_ref().hash(h); body.as_ref().hash(h); }
             Expr::NetCreateServer { options, connection_listener, } => { tag(h, 246); options.hash(h); connection_listener.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1440,12 +1440,16 @@ where
             method,
             body,
             headers,
+            headers_dynamic,
         } => {
             f(url);
             f(method);
             f(body);
             for (_, v) in headers {
                 f(v);
+            }
+            if let Some(hd) = headers_dynamic {
+                f(hd);
             }
         }
         Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1417,12 +1417,16 @@ where
             method,
             body,
             headers,
+            headers_dynamic,
         } => {
             f(url);
             f(method);
             f(body);
             for (_, v) in headers {
                 f(v);
+            }
+            if let Some(hd) = headers_dynamic {
+                f(hd);
             }
         }
         Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-hir/tests/fetch_dynamic_headers_lowering.rs
+++ b/crates/perry-hir/tests/fetch_dynamic_headers_lowering.rs
@@ -1,0 +1,119 @@
+//! Regression test for #4932: `fetch()` dropped request headers when the
+//! `headers` option was a dynamically-built object (a variable, a spread
+//! literal, or a call such as `Object.assign`/`new Headers`/`JSON.parse`).
+//!
+//! Only an object *literal* with plain string/ident keys gets statically
+//! extracted into `FetchWithOptions::headers`. Everything else must be
+//! captured in `FetchWithOptions::headers_dynamic` and serialized at runtime,
+//! otherwise the headers silently vanish.
+
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Expr};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_src(src: &str) -> anyhow::Result<perry_hir::Module> {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "fetch_dynamic_headers.ts", &mut cache)?;
+    lower_module(&parsed.module, "test", "fetch_dynamic_headers.ts")
+}
+
+/// Locate the single top-level `FetchWithOptions` node and report
+/// `(static_header_pairs, headers_dynamic.is_some())`.
+fn find_fetch(module: &perry_hir::Module) -> (usize, bool) {
+    fn walk(e: &Expr, out: &mut Option<(usize, bool)>) {
+        if let Expr::FetchWithOptions {
+            headers,
+            headers_dynamic,
+            ..
+        } = e
+        {
+            *out = Some((headers.len(), headers_dynamic.is_some()));
+        }
+        perry_hir::walker::walk_expr_children(e, &mut |c| walk(c, out));
+    }
+    let mut result = None;
+    for stmt in &module.init {
+        if let perry_hir::Stmt::Expr(e) = stmt {
+            walk(e, &mut result);
+        }
+    }
+    result.unwrap_or_else(|| panic!("no FetchWithOptions found in module: {module:#?}"))
+}
+
+#[test]
+fn literal_headers_are_extracted_statically() {
+    let module = lower_src(
+        r#"fetch("http://x/", { method: "POST", headers: { "Authorization": "Bearer x" }, body: "b" });"#,
+    )
+    .expect("fetch with literal headers should lower");
+
+    let (static_pairs, has_dynamic) = find_fetch(&module);
+    assert_eq!(
+        static_pairs, 1,
+        "literal headers should be extracted statically"
+    );
+    assert!(
+        !has_dynamic,
+        "literal headers must not route through the dynamic path"
+    );
+}
+
+#[test]
+fn variable_headers_are_captured_as_dynamic() {
+    let module = lower_src(
+        r#"
+        const h: Record<string, string> = {};
+        h["Authorization"] = "Bearer x";
+        fetch("http://x/", { method: "POST", headers: h, body: "b" });
+        "#,
+    )
+    .expect("fetch with variable headers should lower");
+
+    let (static_pairs, has_dynamic) = find_fetch(&module);
+    assert_eq!(static_pairs, 0, "a variable headers value has no static pairs");
+    assert!(
+        has_dynamic,
+        "a property-assigned headers object must be captured in headers_dynamic (#4932)"
+    );
+}
+
+#[test]
+fn spread_literal_headers_are_captured_as_dynamic() {
+    // `{ ...h }` is an object literal, but its spread prop cannot be enumerated
+    // statically, so it must fall back to the runtime path.
+    let module = lower_src(
+        r#"
+        const h: Record<string, string> = {};
+        h["Authorization"] = "Bearer x";
+        fetch("http://x/", { headers: { ...h } });
+        "#,
+    )
+    .expect("fetch with spread headers should lower");
+
+    let (static_pairs, has_dynamic) = find_fetch(&module);
+    assert_eq!(static_pairs, 0);
+    assert!(
+        has_dynamic,
+        "spread-literal headers must be captured in headers_dynamic (#4932)"
+    );
+}
+
+#[test]
+fn call_headers_are_captured_as_dynamic() {
+    // `Object.assign({}, h)` / `JSON.parse(...)` / `new Headers(h)` etc.
+    let module = lower_src(
+        r#"
+        const h: Record<string, string> = {};
+        h["Authorization"] = "Bearer x";
+        fetch("http://x/", { headers: Object.assign({}, h) });
+        "#,
+    )
+    .expect("fetch with computed headers should lower");
+
+    let (static_pairs, has_dynamic) = find_fetch(&module);
+    assert_eq!(static_pairs, 0);
+    assert!(
+        has_dynamic,
+        "call-produced headers must be captured in headers_dynamic (#4932)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #4932. `fetch(url, { headers })` silently dropped **every** request header unless `headers` was a plain object **literal**. A property-assigned object (`const h = {}; h["Authorization"] = ...; fetch(url, { headers: h })`), a spread literal (`{ ...h }`), or a call (`Object.assign({}, h)` / `new Headers(h)` / `JSON.parse(JSON.stringify(h))`) all sent no headers — so the Stripe Node SDK (which builds headers dynamically) lost its `Authorization` header and 401'd on every call.

## Root cause

HIR lowering of `fetch(url, { ... })` (`crates/perry-hir/src/lower/expr_call/globals.rs`) only extracted the `headers` field when it was an `ast::Expr::Object` whose props were all plain (non-computed) string/ident keys, walking them into `FetchWithOptions::headers: Vec<(String, Expr)>`. Any other shape fell through with an **empty** vector; codegen then built an empty object, stringified it to `{}`, and sent nothing. Spread props / computed keys inside an otherwise-literal `headers` hit the same hole.

## Fix

- Add `FetchWithOptions::headers_dynamic: Option<Box<Expr>>`.
- Lowering classifies the `headers` value: a literal with only plain string/ident keys keeps the existing static-extraction fast path; everything else (variable, spread literal, call, computed/getter prop) is captured whole in `headers_dynamic`.
- Codegen lowers that expression to a JSValue and `js_json_stringify`s it at runtime — exactly the path object literals already took — so a dynamically-built object enumerates its own properties identically to a literal. JS and WASM backends updated to match.

## Testing

- New `crates/perry-hir/tests/fetch_dynamic_headers_lowering.rs` (4 cases): literal stays static; variable / spread / call route through `headers_dynamic`. All pass.
- Manual e2e against a local echo server: dynamic / literal / spread / `Object.assign` / copy-loop / `JSON.parse(JSON.stringify(...))` headers all send `Authorization` now; empty `{}` and no-options `fetch` unchanged.
- Full `perry-runtime + perry-stdlib + perry` release build is clean.

## Out of scope

Passing the **entire** options object as a variable (`fetch(url, opts)`) is a separate, pre-existing gap (it still falls back to a bare GET). Not addressed here.