### PR TITLE
fix(http): TimeoutOverflowWarning on req.setTimeout overflow; reclassify pipelines test (#4910)

### DIFF
--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -1246,10 +1246,49 @@ pub unsafe extern "C" fn js_http_set_timeout(handle: Handle, ms: f64) -> Handle 
 }
 
 unsafe fn client_request_set_timeout_impl(handle: Handle, ms: f64) -> Handle {
+    // Node's `socket.setTimeout` (which backs `ClientRequest.setTimeout`)
+    // routes the delay through validateTimerDuration → enroll: an out-of-range
+    // (> 2**31-1) delay is clamped to TIMEOUT_MAX and a `TimeoutOverflowWarning`
+    // is emitted. Mirror that so `req.setTimeout(0xffffffff)` parity-matches
+    // Node instead of silently storing the raw value. (#4910)
+    const TIMEOUT_MAX: f64 = 2_147_483_647.0;
+    let effective = if ms > TIMEOUT_MAX {
+        emit_socket_timeout_overflow_warning(ms);
+        TIMEOUT_MAX
+    } else {
+        ms
+    };
     with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| {
-        req.timeout_ms = Some(ms.max(0.0) as u64);
+        req.timeout_ms = Some(effective.max(0.0) as u64);
     });
     handle
+}
+
+/// Emit Node's `TimeoutOverflowWarning` for an out-of-range socket timeout.
+/// The net/timers path warns with a message distinct from the global timer
+/// path ("Timer duration was truncated to 2147483647." rather than "Timeout
+/// duration was set to 1.") because the socket timeout clamps to TIMEOUT_MAX,
+/// not 1. (#4910)
+unsafe fn emit_socket_timeout_overflow_warning(ms: f64) {
+    let value_text = if ms.is_finite() && ms.fract() == 0.0 {
+        format!("{}", ms as i64)
+    } else {
+        format!("{ms}")
+    };
+    let message = format!(
+        "{value_text} does not fit into a 32-bit signed integer.\n\
+         Timer duration was truncated to 2147483647."
+    );
+    let msg_ptr = perry_runtime::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let label = "TimeoutOverflowWarning";
+    let label_ptr = perry_runtime::js_string_from_bytes(label.as_ptr(), label.len() as u32);
+    let msg_value = f64::from_bits(perry_runtime::JSValue::string_ptr(msg_ptr).bits());
+    let label_value = f64::from_bits(perry_runtime::JSValue::string_ptr(label_ptr).bits());
+    perry_runtime::process::js_process_emit_warning(
+        msg_value,
+        label_value,
+        f64::from_bits(TAG_UNDEFINED),
+    );
 }
 
 /// `IncomingMessage.setEncoding(encoding)` for client responses. The same

--- a/scripts/node_core_subset.py
+++ b/scripts/node_core_subset.py
@@ -100,6 +100,12 @@ _NOISE = re.compile(
     r"|^\(Use `node --trace"
 )
 
+# The `(node:<pid>)` prefix on a process warning carries a per-run pid that is
+# pure environment noise. Canonicalize it so a warning line that survives the
+# `_NOISE` filter (e.g. a `TimeoutOverflowWarning`, which is not a generic
+# `Warning`) compares by message content, not by pid. (#4910)
+_PID_PREFIX = re.compile(r"^\(node:\d+\)")
+
 
 def normalize(text: str) -> str:
     out = []
@@ -107,6 +113,7 @@ def normalize(text: str) -> str:
         line = raw.rstrip()
         if _NOISE.search(line):
             continue
+        line = _PID_PREFIX.sub("(node:PID)", line)
         out.append(line)
     while out and out[-1] == "":
         out.pop()


### PR DESCRIPTION
Closes #4910 — the final two `diff` cases of #2132's original byte-level scope.

Both were **Perry silent-exits** (`exit 0`, empty stdout) mis-tallied as `diff` because Node's reference output is non-empty *and non-deterministic*.

## `test-http-timeout-overflow.js` — fixed (diff → pass)

`req.setTimeout(0xffffffff, cb)` previously stored the raw value with no warning, so Perry emitted nothing. Node's `socket.setTimeout` (which backs `ClientRequest.setTimeout`) routes the delay through `validateTimerDuration → enroll`: an out-of-range (`> 2**31-1`) delay is **clamped to `TIMEOUT_MAX`** and a `TimeoutOverflowWarning` is emitted. Its message differs from the global-timer path:

- socket: `Timer duration was truncated to 2147483647.`
- global `setTimeout`: `Timeout duration was set to 1.`

`perry-ext-http`'s `client_request_set_timeout_impl` now mirrors both the clamp and the warning (via `perry_runtime::process::js_process_emit_warning`).

The warning's only non-deterministic byte is the `(node:<pid>)` prefix, so `scripts/node_core_subset.py::normalize` now canonicalizes that pid (`(node:<pid>)` → `(node:PID)`), letting the line compare by message content. This is a strictly-safe normalization — it can only neutralize an env-only difference, never mask a real one.

## `test-http-many-ended-pipelines.js` — reclassified into #4909

Perry exits 0 with no output; Node emits an HTTP response whose `Date:` header is non-deterministic and can never byte-match (Node-vs-Node wouldn't match across a second boundary either). This is a **silent-exit**, not a wrong-bytes case, so it folds into the #4909 silent-exit triage rather than being a fixable byte-diff.

## Verification

Isolated `node_core_subset.py --api http --auto-optimize` run over just these two tests:

```
http   pass=1  diff=1  rt-fail=0  compile-fail=0  node-skip=0  parity=50%
diff samples: [('test-http-many-ended-pipelines.js', '(no output)')]
```

i.e. timeout-overflow → pass, pipelines → confirmed `(no output)` silent-exit (#4909).

The ext-http change only triggers when `ms > 2**31-1`, so normal `setTimeout` values are byte-for-byte unchanged — no regression to other http tests.

Per maintainer convention, no version bump / changelog entry (folded at merge).