### PR TITLE
feat(atomics): real cross-agent Atomics.wait/notify/waitAsync over a shared SAB (#4913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,58 @@
+## v0.5.1157 — feat(atomics): real cross-agent `Atomics.wait`/`notify`/`waitAsync` over a shared SAB (#4913)
+
+Stage 2 of #4913 (Stage 1 — the honesty floor — landed in #4929). `Atomics.wait`,
+`Atomics.notify`, and `Atomics.waitAsync` were non-blocking fakes: `wait` always
+returned `"timed-out"`, `notify` always returned `0`, and `waitAsync` resolved
+`"timed-out"` immediately. They now block and wake for real across `perry/thread`
+agents.
+
+**Shared backing that actually aliases across threads.** The prerequisite was a
+`SharedArrayBuffer` whose bytes are visible from every agent. Previously every
+value crossing a `perry/thread` boundary was deep-copied (`SerializedValue`), so a
+SAB lost its sharing. Now:
+
+- `new SharedArrayBuffer(n)` allocates its `BufferHeader + data` block from the
+  global allocator (`crate::shared_sab`) — a stable, process-wide address that is
+  never freed (matching Perry's "buffers live for the life of the process" model)
+  and is therefore valid and writable from any OS thread.
+- A new `SerializedValue::SharedArrayBuffer { addr }` variant carries the SAB
+  **by reference** across the thread boundary instead of copying it; the receiving
+  agent re-registers the same address in its thread-local buffer / SAB tables, so
+  `new Int32Array(sab)` there aliases the exact same physical bytes (via the
+  existing #4103 view-meta backing path). The serializer recognises a SAB before
+  the `GcHeader` dispatch (buffers carry no `GcHeader`).
+
+**Futex park/wake (`crate::atomics_futex`).** A process-global wait table keyed by
+the **absolute physical byte address** of the atomic slot. Because a SAB aliases
+the same bytes on every agent, two agents viewing the same index compute the same
+key.
+
+- `Atomics.wait` re-checks the slot value and enqueues a waiter **atomically under
+  the table lock**, then parks the OS thread on a `Condvar` until a matching
+  `notify` or the timeout deadline — so a `notify` racing the call is never lost
+  (the agent either sees the changed value and returns `"not-equal"`, or parks and
+  is woken). Returns the real `"ok"` / `"not-equal"` / `"timed-out"`. A
+  `timeout === 0` poll still returns immediately; an `undefined`/`Infinity` timeout
+  blocks until notified.
+- `Atomics.notify` wakes up to `count` parked agents (default `undefined` →
+  `+Infinity` → all) and returns the **actual** number woken.
+- `Atomics.waitAsync` enqueues the waiter synchronously (atomic with the value
+  check, so the wake can't be missed), then resolves its promise from a background
+  thread — `"ok"` on notify, `"timed-out"` on the deadline — via the same
+  pending-result → event-loop path `spawn` uses.
+
+The `perry_stub_warn` / `PERRY_STRICT_STUBS` honesty gates added in #4929 are
+removed from these three ops — they are no longer lies.
+
+Caveat: only the `SharedArrayBuffer` itself shares across agents; a typed-array
+*view* captured directly into a thread closure still deep-copies (build the view
+per-agent from the shared SAB). The agent-coordinated test262 cases
+(`$262.agent`) remain out of scope.
+
+New: `crates/perry-runtime/src/shared_sab.rs`, `crates/perry-runtime/src/atomics_futex.rs`,
+`crates/perry/tests/issue_4913_atomics_cross_thread.rs`,
+`test-files/test_issue_4913_atomics_cross_thread.ts`.
+
 ## v0.5.1156 — fix(fetch): send dynamically-built request headers (#4932)
 
 `fetch(url, { headers })` silently dropped **every** request header whenever the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1156
+**Current Version:** 0.5.1157
 
 
 ## TypeScript Parity Status
@@ -130,7 +130,7 @@ First-resolved directory cached in `compile_package_dirs`; subsequent imports re
 ## Known Limitations
 
 - **No runtime type *validation***: declared TS types aren't enforced at runtime (a `string` param accepts a number, no throw). Annotations are mostly erased — the exception is `emitDecoratorMetadata`, which retains `design:type`/`design:paramtypes` from annotations on decorated members (see `docs/src/language/decorators.md`). Runtime type *discrimination* does exist: `typeof` via NaN-boxing tags, `instanceof` via class ID chain.
-- **`SharedArrayBuffer` + `Atomics` are single-realm only** (#4794): construction, typed-array views, and the non-blocking `Atomics` ops (`add`/`and`/`or`/`sub`/`xor`/`load`/`store`/`exchange`/`compareExchange`/`isLockFree`) match the spec on one thread. `perry/thread` deep-copies values across OS threads, so a SAB does **not** alias across threads yet, and `Atomics.wait`/`notify`/`waitAsync` are non-blocking stubs (no cross-agent wakeups). The agent-coordinated test262 cases (`$262.agent`) remain out of scope.
+- **`SharedArrayBuffer` + `Atomics` cross-thread** (#4794 single-realm; #4913 Stage 2 cross-agent): the `Atomics` ops (`add`/`and`/`or`/`sub`/`xor`/`load`/`store`/`exchange`/`compareExchange`/`isLockFree`) match the spec on one thread. A `SharedArrayBuffer` captured into a `spawn`/`parallelMap` closure now **aliases the same physical bytes** across `perry/thread` agents (its backing is a process-global, never-freed allocation — `crate::shared_sab` — passed by reference, not deep-copied), and `Atomics.wait`/`notify`/`waitAsync` are **real**: `wait` parks the OS thread on a futex table keyed by the absolute slot address (`crate::atomics_futex`), `notify` wakes parked agents and returns the count, and `waitAsync` resolves its promise on a background thread when notified or on timeout. Caveat: only the `SharedArrayBuffer` itself shares — a typed-array *view* captured directly still deep-copies (build the view per-agent from the shared SAB). The agent-coordinated test262 cases (`$262.agent`) remain out of scope.
 
 ## Common Pitfalls & Patterns
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5289,7 +5289,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "base64",
@@ -5344,14 +5344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "cc",
  "libc",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "log",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "base64",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5460,14 +5460,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "serde",
  "serde_json",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1156"
+version = "0.5.1157"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "clap",
@@ -5501,14 +5501,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "bytes",
  "h2",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "bson",
  "futures-util",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "image",
@@ -5801,14 +5801,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "brotli",
  "flate2",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "base64",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6036,14 +6036,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "itoa",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "block2",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "block2",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1156"
+version = "0.5.1157"
 
 [[package]]
 name = "perry-ui-test"
@@ -6132,11 +6132,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1156"
+version = "0.5.1157"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "block2",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "block2",
  "libc",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "libc",
@@ -6198,14 +6198,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1156"
+version = "0.5.1157"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1156"
+version = "0.5.1157"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/atomics.rs
+++ b/crates/perry-runtime/src/atomics.rs
@@ -48,6 +48,55 @@ fn supported_integer_kind(kind: u8) -> bool {
     numeric_integer_kind(kind) || bigint_integer_kind(kind)
 }
 
+/// Element size in bytes for the wait/notify-eligible kinds (Int32 / BigInt64).
+fn atomic_elem_size(kind: u8) -> usize {
+    match kind {
+        KIND_BIGINT64 | KIND_BIGUINT64 => 8,
+        _ => 4,
+    }
+}
+
+/// Translate an already-`ToNumber`'d Atomics timeout (milliseconds) into a
+/// futex deadline. Per spec: `undefined`/`NaN` and `+Infinity` mean "block
+/// forever" (`None`); a non-positive value means "poll, return immediately"
+/// (`Some(ZERO)`); otherwise the millisecond duration. Absurdly large finite
+/// timeouts that would overflow `Duration` are treated as infinite.
+fn timeout_to_deadline(timeout_ms: f64) -> Option<std::time::Duration> {
+    if timeout_ms.is_nan() || timeout_ms == f64::INFINITY {
+        return None;
+    }
+    if timeout_ms <= 0.0 {
+        return Some(std::time::Duration::ZERO);
+    }
+    let secs = timeout_ms / 1000.0;
+    if secs > 1.0e9 {
+        return None;
+    }
+    Some(std::time::Duration::from_secs_f64(secs))
+}
+
+/// `Atomics.notify` count argument → number of waiters to wake. `undefined`
+/// means `+Infinity` (wake all). Otherwise `ToIntegerOrInfinity` clamped to
+/// `[0, usize::MAX]`. `number_arg` runs the full `ToNumber` (object `valueOf`,
+/// BigInt → TypeError) before truncation.
+fn notify_count_arg(count: f64) -> usize {
+    if JSValue::from_bits(count.to_bits()).is_undefined() {
+        return usize::MAX;
+    }
+    let n = number_arg(count);
+    if n.is_nan() {
+        0
+    } else if n == f64::INFINITY {
+        usize::MAX
+    } else if n <= 0.0 {
+        0
+    } else if n >= usize::MAX as f64 {
+        usize::MAX
+    } else {
+        n.trunc() as usize
+    }
+}
+
 enum AtomicView {
     TypedArray {
         ptr: *mut TypedArrayHeader,
@@ -101,6 +150,34 @@ impl AtomicView {
             AtomicView::TypedArray { ptr, .. } => js_typed_array_set(*ptr, index, value),
             AtomicView::Uint8ArrayBuffer(ptr) => {
                 crate::buffer::js_buffer_set(*ptr, index, value as i32);
+            }
+        }
+    }
+
+    /// Absolute physical byte address of element `index`'s storage. For a
+    /// `SharedArrayBuffer`-backed view this resolves (through the view-meta
+    /// aliasing in `typed_array_bytes`) into the process-global backing store,
+    /// so the same SAB index yields the same address on every agent — the futex
+    /// table key that lets cross-thread `wait`/`notify` rendezvous (#4913).
+    /// Returns 0 if the backing pointer can't be resolved.
+    fn slot_addr(&self, index: i32) -> usize {
+        match self {
+            AtomicView::TypedArray { ptr, kind } => unsafe {
+                let base = crate::typedarray::typed_array_bytes(*ptr)
+                    .map(|b| b.as_ptr() as usize)
+                    .unwrap_or(0);
+                if base == 0 {
+                    return 0;
+                }
+                base + (index.max(0) as usize) * atomic_elem_size(*kind)
+            },
+            AtomicView::Uint8ArrayBuffer(ptr) => {
+                let base =
+                    crate::buffer::buffer_data(*ptr as *const crate::buffer::BufferHeader) as usize;
+                if base == 0 {
+                    return 0;
+                }
+                base + index.max(0) as usize
             }
         }
     }
@@ -556,12 +633,19 @@ pub extern "C" fn js_atomics_notify(
     index: f64,
     count: f64,
 ) -> f64 {
-    let (view, _idx) = wait_notify_slot(view, index);
-    let _ = numeric_arg(count);
+    let (view, idx) = wait_notify_slot(view, index);
+    // Coerce the count for its observable side effects even on a non-shared
+    // buffer (spec runs ToIntegerOrInfinity before the shared check returns 0).
+    let count = notify_count_arg(count);
     if !view.has_shared_backing() {
+        // A non-shared buffer can have no parked agents — spec returns 0.
         return 0.0;
     }
-    0.0
+    let addr = view.slot_addr(idx);
+    if addr == 0 {
+        return 0.0;
+    }
+    crate::atomics_futex::notify(addr, count) as f64
 }
 
 #[no_mangle]
@@ -580,32 +664,42 @@ pub extern "C" fn js_atomics_wait(
         throw_type_error(b"Atomics.wait requires a shared typed array");
     }
     let idx = atomics_to_index(index, view.length());
-    if view.kind() == KIND_BIGINT64 {
-        let expected = bigint_bits(expected);
-        if view.get_bigint_bits(idx) != expected {
-            return string_value(b"not-equal");
-        }
+    let kind = view.kind();
+    // Coerce expected (and timeout) before parking, observing `valueOf` once.
+    let expected_bits = if kind == KIND_BIGINT64 {
+        bigint_bits(expected)
     } else {
-        let expected = coerce_for_kind(KIND_INT32, expected);
-        if view.get_numeric(idx) != expected {
-            return string_value(b"not-equal");
-        }
+        0
+    };
+    let expected_num = if kind == KIND_BIGINT64 {
+        0.0
+    } else {
+        coerce_for_kind(KIND_INT32, expected)
+    };
+    let deadline = timeout_to_deadline(number_arg(timeout));
+    let addr = view.slot_addr(idx);
+    if addr == 0 {
+        return string_value(b"not-equal");
     }
 
-    // Value matched: a spec-compliant agent blocks here until a matching
-    // `Atomics.notify` or the timeout elapses. Perry has no cross-agent
-    // blocking yet (`perry/thread` deep-copies, so SABs don't alias), so a
-    // non-zero timeout silently degrades to an immediate "timed-out" — the
-    // #4913 lie. A `timeout === 0` poll legitimately returns "timed-out".
-    let timeout = number_arg(timeout);
-    if timeout != 0.0 {
-        crate::error::stub_warn_or_throw(
-            "Atomics.wait",
-            "does not block; returns \"timed-out\" immediately (no cross-agent wakeups)",
-            Some("#4913"),
-        );
+    // Real futex park (#4913). The value re-check runs under the wait table's
+    // lock (atomic with the enqueue), so a `notify` from another agent that
+    // races this call is never lost: the agent either sees the changed value
+    // and returns "not-equal", or parks and is woken. A `timeout === 0` poll
+    // enqueues then immediately times out → "timed-out". An `undefined`/
+    // Infinity timeout blocks until notified.
+    let still_equal = || {
+        if kind == KIND_BIGINT64 {
+            view.get_bigint_bits(idx) == expected_bits
+        } else {
+            view.get_numeric(idx) == expected_num
+        }
+    };
+    match crate::atomics_futex::wait(addr, deadline, still_equal) {
+        crate::atomics_futex::WaitOutcome::NotEqual => string_value(b"not-equal"),
+        crate::atomics_futex::WaitOutcome::Ok => string_value(b"ok"),
+        crate::atomics_futex::WaitOutcome::TimedOut => string_value(b"timed-out"),
     }
-    string_value(b"timed-out")
 }
 
 #[no_mangle]
@@ -639,23 +733,51 @@ pub extern "C" fn js_atomics_wait_async(
         view.get_numeric(idx) != expected_i32
     };
     if mismatched {
+        // Value already differs → synchronous, non-async "not-equal".
         return wait_async_result(false, string_value(b"not-equal"));
     }
     if timeout <= 0.0 {
+        // A zero/negative timeout returns synchronously (no promise).
         return wait_async_result(false, string_value(b"timed-out"));
     }
 
-    // Non-zero timeout + matching value: Node returns a promise that
-    // resolves on a matching `notify` or when the timeout elapses. Perry
-    // resolves "timed-out" immediately — the #4913 lie. Warn/throw before
-    // fabricating the already-resolved promise.
-    crate::error::stub_warn_or_throw(
-        "Atomics.waitAsync",
-        "resolves \"timed-out\" immediately; no real timer/notify wakeups",
-        Some("#4913"),
-    );
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let timed_out = scope.root_nanbox_f64(string_value(b"timed-out"));
-    let promise = crate::promise::js_promise_resolved(timed_out.get_nanbox_f64());
+    // Matching value + positive (possibly Infinity/NaN) timeout: enqueue a
+    // waiter synchronously (atomic with the value check, so a racing `notify`
+    // is not lost), then resolve the promise from a background thread when a
+    // matching `notify` arrives or the timeout elapses (#4913, Stage 2).
+    let still_equal = || {
+        if kind == KIND_BIGINT64 {
+            view.get_bigint_bits(idx) == expected_bigint_bits
+        } else {
+            view.get_numeric(idx) == expected_i32
+        }
+    };
+    let addr = view.slot_addr(idx);
+    let handle = if addr == 0 {
+        None
+    } else {
+        crate::atomics_futex::enqueue(addr, still_equal)
+    };
+    let Some(handle) = handle else {
+        // Value changed at the atomic enqueue point → synchronous "not-equal".
+        return wait_async_result(false, string_value(b"not-equal"));
+    };
+
+    let deadline = timeout_to_deadline(timeout);
+    let promise = crate::promise::js_promise_new();
+    // Pin the promise + keep the event loop alive until the async result lands.
+    unsafe {
+        crate::thread::pin_promise(promise);
+    }
+    crate::thread::thread_job_begin();
+    let promise_usize = promise as usize;
+    std::thread::spawn(move || {
+        let outcome = crate::atomics_futex::block(handle, deadline);
+        let result = match outcome {
+            crate::atomics_futex::WaitOutcome::Ok => "ok",
+            _ => "timed-out",
+        };
+        crate::thread::queue_promise_string_result(promise_usize, result);
+    });
     wait_async_result(true, crate::value::js_nanbox_pointer(promise as i64))
 }

--- a/crates/perry-runtime/src/atomics_futex.rs
+++ b/crates/perry-runtime/src/atomics_futex.rs
@@ -1,0 +1,212 @@
+//! Futex-style park/wake table backing `Atomics.wait` / `Atomics.notify` /
+//! `Atomics.waitAsync` across `perry/thread` agents (#4913 Stage 2).
+//!
+//! The table is keyed by the **absolute physical byte address** of the atomic
+//! slot. Because a `SharedArrayBuffer` aliases the same backing bytes on every
+//! thread (see [`crate::shared_sab`]), two agents viewing the same SAB index —
+//! through any combination of element kinds or byte offsets — compute the same
+//! key, so a `notify` issued on one OS thread wakes a `wait` parked on another.
+//!
+//! Correctness (no lost wakeups): the value re-check and the enqueue both
+//! happen while the global table lock is held. A writer agent stores the new
+//! value and then calls `notify`, which must acquire that same lock. So either
+//! the waiter observes the new value and never parks (`NotEqual`), or it
+//! enqueues first and the serialized `notify` finds and wakes it. The final
+//! "did I get notified or did I time out" decision is likewise settled under
+//! the table lock, so a `notify` racing a timeout resolves to exactly one
+//! outcome and the notifier's wake count stays accurate.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// One parked waiter. Shared (`Arc`) between the parking thread (which blocks
+/// on `cv`) and the table entry the notifier walks.
+struct Waiter {
+    /// Set to `true` by `notify` to mark this waiter as woken (vs. timed out).
+    notified: Mutex<bool>,
+    cv: Condvar,
+}
+
+type WaitTable = HashMap<usize, Vec<Arc<Waiter>>>;
+
+static WAIT_TABLE: OnceLock<Mutex<WaitTable>> = OnceLock::new();
+
+fn table() -> &'static Mutex<WaitTable> {
+    WAIT_TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn lock_table() -> std::sync::MutexGuard<'static, WaitTable> {
+    table().lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Outcome of a parked wait.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum WaitOutcome {
+    /// The slot value no longer matched at the atomic check — never parked.
+    NotEqual,
+    /// Woken by a matching `notify`.
+    Ok,
+    /// The timeout elapsed without a `notify`.
+    TimedOut,
+}
+
+/// Handle returned by [`enqueue`]; pass to [`block`] to park on it.
+pub struct WaitHandle {
+    addr: usize,
+    waiter: Arc<Waiter>,
+}
+
+/// Atomically (under the table lock) re-check the slot and, if it still matches,
+/// register a waiter for `addr`. Returns `None` if the value already changed
+/// (caller should report `"not-equal"`), otherwise a handle to park on.
+///
+/// `still_equal` runs while the table lock is held, so it is serialized against
+/// any concurrent `notify` (which also takes the lock after its value store).
+pub fn enqueue(addr: usize, still_equal: impl FnOnce() -> bool) -> Option<WaitHandle> {
+    let mut tbl = lock_table();
+    if !still_equal() {
+        return None;
+    }
+    let waiter = Arc::new(Waiter {
+        notified: Mutex::new(false),
+        cv: Condvar::new(),
+    });
+    tbl.entry(addr).or_default().push(waiter.clone());
+    Some(WaitHandle { addr, waiter })
+}
+
+/// Park on a previously [`enqueue`]d handle until a matching `notify` or until
+/// `timeout` elapses (`None` = block forever). Removes the waiter from the table
+/// before returning. Returns [`WaitOutcome::Ok`] or [`WaitOutcome::TimedOut`].
+pub fn block(handle: WaitHandle, timeout: Option<Duration>) -> WaitOutcome {
+    let WaitHandle { addr, waiter } = handle;
+    let deadline = timeout.map(|d| Instant::now().checked_add(d));
+
+    {
+        let mut g = waiter.notified.lock().unwrap_or_else(|e| e.into_inner());
+        while !*g {
+            match deadline {
+                // No timeout: block until notified.
+                None => {
+                    g = waiter.cv.wait(g).unwrap_or_else(|e| e.into_inner());
+                }
+                // Timeout that overflowed `Instant` (effectively infinite).
+                Some(None) => {
+                    g = waiter.cv.wait(g).unwrap_or_else(|e| e.into_inner());
+                }
+                Some(Some(dl)) => {
+                    let now = Instant::now();
+                    if now >= dl {
+                        break;
+                    }
+                    let (ng, _to) = waiter
+                        .cv
+                        .wait_timeout(g, dl - now)
+                        .unwrap_or_else(|e| e.into_inner());
+                    g = ng;
+                }
+            }
+        }
+    }
+
+    // Settle under the table lock so a `notify` racing this timeout resolves to
+    // exactly one outcome (and is counted exactly once by the notifier).
+    let mut tbl = lock_table();
+    let notified = *waiter.notified.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(list) = tbl.get_mut(&addr) {
+        list.retain(|w| !Arc::ptr_eq(w, &waiter));
+        if list.is_empty() {
+            tbl.remove(&addr);
+        }
+    }
+    if notified {
+        WaitOutcome::Ok
+    } else {
+        WaitOutcome::TimedOut
+    }
+}
+
+/// Synchronous park: [`enqueue`] then [`block`]. Returns `NotEqual` without
+/// parking if the slot value changed at the atomic check.
+pub fn wait(
+    addr: usize,
+    timeout: Option<Duration>,
+    still_equal: impl FnOnce() -> bool,
+) -> WaitOutcome {
+    match enqueue(addr, still_equal) {
+        None => WaitOutcome::NotEqual,
+        Some(handle) => block(handle, timeout),
+    }
+}
+
+/// Wake up to `count` waiters parked on `addr`. Returns the number actually
+/// woken. `count == usize::MAX` wakes all of them (`Atomics.notify` with an
+/// `undefined` / `+Infinity` count).
+pub fn notify(addr: usize, count: usize) -> usize {
+    let mut tbl = lock_table();
+    let Some(list) = tbl.get_mut(&addr) else {
+        return 0;
+    };
+    let n = count.min(list.len());
+    let mut woken = 0;
+    for waiter in list.drain(..n) {
+        {
+            let mut g = waiter.notified.lock().unwrap_or_else(|e| e.into_inner());
+            *g = true;
+        }
+        waiter.cv.notify_one();
+        woken += 1;
+    }
+    if list.is_empty() {
+        tbl.remove(&addr);
+    }
+    woken
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notify_wakes_a_parked_waiter() {
+        // A fresh isolated address (a stack slot) avoids collisions with other
+        // tests sharing the process-global table.
+        let cell = 0u64;
+        let addr = &cell as *const u64 as usize;
+
+        let handle = enqueue(addr, || true).expect("enqueued");
+        let waker = std::thread::spawn(move || {
+            // Give the parker time to block, then wake it.
+            std::thread::sleep(Duration::from_millis(20));
+            notify(addr, 1)
+        });
+        let outcome = block(handle, Some(Duration::from_secs(5)));
+        let woken = waker.join().unwrap();
+        assert_eq!(outcome, WaitOutcome::Ok);
+        assert_eq!(woken, 1);
+    }
+
+    #[test]
+    fn wait_times_out_with_no_notifier() {
+        let cell = 0u64;
+        let addr = &cell as *const u64 as usize;
+        let outcome = wait(addr, Some(Duration::from_millis(10)), || true);
+        assert_eq!(outcome, WaitOutcome::TimedOut);
+    }
+
+    #[test]
+    fn wait_returns_not_equal_without_parking() {
+        let cell = 0u64;
+        let addr = &cell as *const u64 as usize;
+        let outcome = wait(addr, None, || false);
+        assert_eq!(outcome, WaitOutcome::NotEqual);
+    }
+
+    #[test]
+    fn notify_empty_address_wakes_nobody() {
+        let cell = 0u64;
+        let addr = &cell as *const u64 as usize;
+        assert_eq!(notify(addr, usize::MAX), 0);
+    }
+}

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -693,12 +693,24 @@ pub extern "C" fn js_array_buffer_new_value(size_value: f64) -> *mut BufferHeade
     js_array_buffer_new(array_buffer_to_index(size_value))
 }
 
-/// `new SharedArrayBuffer(size)` — same BufferHeader backing store as
-/// ArrayBuffer, tracked in a distinct side registry for util.types predicates.
+/// `new SharedArrayBuffer(size)` — same `BufferHeader` shape as ArrayBuffer,
+/// tracked in a distinct side registry for util.types predicates.
+///
+/// Unlike a plain ArrayBuffer, the backing store is allocated process-globally
+/// (never freed, stable address valid from every thread — see
+/// `crate::shared_sab`) instead of from the thread-local slab. That is what
+/// lets the same SAB alias the same physical bytes across `perry/thread`
+/// agents, so cross-agent `Atomics.wait`/`notify` actually coordinate (#4913).
 #[no_mangle]
 pub extern "C" fn js_shared_array_buffer_new(size: i32) -> *mut BufferHeader {
-    let buf = zeroed_array_buffer_storage(size);
-    mark_as_shared_array_buffer(buf as usize);
+    let size = size.max(0) as u32;
+    let buf = crate::shared_sab::alloc_shared_sab(size);
+    let addr = buf as usize;
+    // Register in the creating thread's tables too so local predicates
+    // (`is_registered_buffer`, `is_shared_array_buffer`, views) work without a
+    // round-trip through the process-global registry.
+    register_buffer(buf);
+    mark_as_shared_array_buffer(addr);
     buf
 }
 

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -137,7 +137,14 @@ pub fn mark_as_shared_array_buffer(addr: usize) {
 }
 
 pub fn is_shared_array_buffer(addr: usize) -> bool {
-    SHARED_ARRAY_BUFFER_REGISTRY.with(|r| r.borrow().contains(&addr))
+    if SHARED_ARRAY_BUFFER_REGISTRY.with(|r| r.borrow().contains(&addr)) {
+        return true;
+    }
+    // #4913: a SAB backing is process-global. If this thread received it as a
+    // module-level value (not a serialized `perry/thread` capture, which would
+    // have re-registered it locally) the thread-local set misses, so fall back
+    // to the process-global registry. Slow path only — thread-local hits first.
+    crate::shared_sab::is_shared_sab(addr)
 }
 
 pub fn is_any_array_buffer(addr: usize) -> bool {
@@ -261,10 +268,17 @@ pub fn is_registered_buffer(addr: usize) -> bool {
     if BUFFER_REGISTRY.with(|r| r.borrow().contains(&addr)) {
         return true;
     }
-    external_buffers()
+    if external_buffers()
         .lock()
         .map(|r| r.contains(&addr))
         .unwrap_or(false)
+    {
+        return true;
+    }
+    // #4913: recognise a process-global SAB backing reached as a module-level
+    // value on a thread that never locally registered it (see
+    // `is_shared_array_buffer`).
+    crate::shared_sab::is_shared_sab(addr)
 }
 
 /// Mark this buffer as one that came from `new Uint8Array(...)` so it

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub mod array;
 pub mod async_context;
 pub mod async_hooks;
 pub mod atomics;
+pub mod atomics_futex;
 pub mod bigint;
 pub mod r#box;
 pub mod buffer;
@@ -94,6 +95,7 @@ pub mod readline_helpers;
 pub mod regex;
 pub mod safe_area;
 pub mod set;
+pub mod shared_sab;
 pub mod string;
 pub mod symbol;
 /// TC39 Temporal API (#4686): `Temporal.Duration`, `Temporal.Instant`,

--- a/crates/perry-runtime/src/shared_sab.rs
+++ b/crates/perry-runtime/src/shared_sab.rs
@@ -1,0 +1,78 @@
+//! Process-global `SharedArrayBuffer` backing store + registry (#4913 Stage 2).
+//!
+//! A `SharedArrayBuffer` is the one JavaScript value whose bytes must alias the
+//! same physical memory across every `perry/thread` agent. Ordinary buffers are
+//! thread-local slab / arena allocations whose addresses are only meaningful on
+//! the owning thread, and crossing a thread boundary deep-copies them — so they
+//! cannot back cross-agent `Atomics` coordination.
+//!
+//! SAB backing is therefore allocated directly from the global allocator,
+//! never freed (matching Perry's "buffers live for the life of the process"
+//! model — see `buffer::header`), and recorded in a process-global registry so
+//! any thread can:
+//!   * recognise a raw pointer as a shared backing store (during cross-thread
+//!     serialization, before the missing `GcHeader` would be misread), and
+//!   * re-register it in its own thread-local buffer / SAB tables when the
+//!     value arrives from another agent.
+//!
+//! Because the address is a stable, process-wide heap address, an `Atomics`
+//! slot inside a SAB has the same absolute byte address on every thread — which
+//! is exactly the key the futex wait/notify table ([`crate::atomics_futex`])
+//! uses to match a `notify` on one agent with a `wait` parked on another.
+
+use std::alloc::{alloc_zeroed, handle_alloc_error, Layout};
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+use crate::buffer::BufferHeader;
+
+/// Set of `BufferHeader` addresses that back a `SharedArrayBuffer`.
+static SHARED_SAB_REGISTRY: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<HashSet<usize>> {
+    SHARED_SAB_REGISTRY.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Header + data layout for a SAB of `size` data bytes. 8-byte alignment so the
+/// data region (which begins immediately after the 8-byte `BufferHeader`) is
+/// itself 8-aligned — required for `BigInt64Array` / `Float64` atomic slots.
+fn sab_layout(size: u32) -> Layout {
+    let total = std::mem::size_of::<BufferHeader>() + size as usize;
+    Layout::from_size_align(total, 8).expect("shared SAB layout")
+}
+
+/// Allocate a process-global, never-freed `BufferHeader + size` block for a
+/// `SharedArrayBuffer`. The returned address is stable for the life of the
+/// process and valid (readable / writable) from every thread, so views built
+/// over it on different agents alias the same physical bytes.
+pub fn alloc_shared_sab(size: u32) -> *mut BufferHeader {
+    let layout = sab_layout(size);
+    // SAFETY: `layout` has non-zero size (BufferHeader is 8 bytes) and 8-byte
+    // alignment. `alloc_zeroed` gives the spec-required zero-initialized bytes.
+    let raw = unsafe { alloc_zeroed(layout) };
+    if raw.is_null() {
+        handle_alloc_error(layout);
+    }
+    let buf = raw as *mut BufferHeader;
+    // SAFETY: `buf` points at a fresh `BufferHeader`-sized-and-aligned block.
+    unsafe {
+        (*buf).length = size;
+        (*buf).capacity = size;
+    }
+    registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(buf as usize);
+    buf
+}
+
+/// True if `addr` is a process-global `SharedArrayBuffer` backing store. Unlike
+/// the thread-local `buffer::is_shared_array_buffer`, this answers correctly on
+/// every thread — used by the cross-thread serializer to recognise a SAB
+/// pointer that has no `GcHeader`.
+pub fn is_shared_sab(addr: usize) -> bool {
+    registry()
+        .lock()
+        .map(|r| r.contains(&addr))
+        .unwrap_or(false)
+}

--- a/crates/perry-runtime/src/stub_diag.rs
+++ b/crates/perry-runtime/src/stub_diag.rs
@@ -111,8 +111,8 @@ pub fn deterministic_net_enabled() -> bool {
 }
 
 /// First-call diagnostic for a *runtime* API stub (dns/dgram loopback
-/// fakes, `child_process.spawn`, Atomics wait/notify, v8 heap snapshots,
-/// stdlib-adapter no-ops, …) — the manifest-flagged clusters from the
+/// fakes, v8 heap snapshots, stdlib-adapter no-ops, …) — the
+/// manifest-flagged clusters from the
 /// stub-elimination epic (#4919). Unlike [`perry_stub_warn`], whose
 /// message says "on this platform" (for the harmonyos UI stubs), this
 /// says the API itself is registered-but-fake regardless of target.

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -259,6 +259,14 @@ pub enum SerializedValue {
     /// Perry's fd registry is thread-local, so handles are not transferable;
     /// deserialize as a FileHandle-shaped object with `fd === -1`.
     DetachedFileHandle,
+
+    /// A `SharedArrayBuffer` crossing a `perry/thread` boundary (#4913).
+    /// Carries the process-global backing-store address by reference — NOT a
+    /// byte copy — so the receiving agent's views alias the same physical
+    /// memory and `Atomics.wait`/`notify` coordinate across threads. The
+    /// backing is never freed (see `crate::shared_sab`), so the raw address
+    /// stays valid for the life of the process.
+    SharedArrayBuffer { addr: usize },
 }
 
 // Safety: SerializedValue contains no raw pointers to arena memory.
@@ -322,6 +330,16 @@ pub unsafe fn serialize_nanbox_for_thread(bits: u64) -> SerializedValue {
         let raw_ptr = (bits & POINTER_MASK) as *const u8;
         if raw_ptr.is_null() || (raw_ptr as usize) < 0x1000 {
             return SerializedValue::Inline(TAG_UNDEFINED);
+        }
+
+        // SharedArrayBuffer: a process-global backing store (no GcHeader).
+        // Pass it by reference so the receiving agent aliases the same bytes
+        // (#4913). This MUST precede the GcHeader read below — a SAB header has
+        // no preceding GcHeader, so reading one would misclassify it.
+        if crate::shared_sab::is_shared_sab(raw_ptr as usize) {
+            return SerializedValue::SharedArrayBuffer {
+                addr: raw_ptr as usize,
+            };
         }
 
         // Check GcHeader to determine type
@@ -617,6 +635,16 @@ pub unsafe fn deserialize_nanbox_on_current_thread(sv: &SerializedValue) -> u64 
 
         SerializedValue::DetachedFileHandle => {
             crate::fs::build_detached_filehandle_object().to_bits()
+        }
+
+        SerializedValue::SharedArrayBuffer { addr } => {
+            // Alias the same process-global backing store (#4913) — no copy.
+            // Re-register it in THIS thread's buffer / SAB tables so local
+            // predicates (`is_registered_buffer`, `is_shared_array_buffer`) and
+            // `new Int32Array(sab)` view construction recognise it here too.
+            crate::buffer::register_buffer(*addr as *const crate::buffer::BufferHeader);
+            crate::buffer::mark_as_shared_array_buffer(*addr);
+            JSValue::pointer(*addr as *const u8).bits()
         }
     }
 }
@@ -1199,6 +1227,35 @@ fn queue_thread_result(promise_usize: usize, result: SerializedValue) {
     // resolve as soon as the OS thread finishes, not at the next
     // event-loop quantum.
     crate::event_pump::js_notify_main_thread();
+}
+
+/// Register the start of a background job that will later resolve a promise on
+/// the main thread via [`queue_promise_string_result`]. Keeps the event loop
+/// alive until the result arrives (mirrors `spawn`'s job accounting). Used by
+/// `Atomics.waitAsync` (#4913).
+pub fn thread_job_begin() {
+    ACTIVE_THREAD_JOBS.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Pin `promise` so GC keeps it alive while a background job runs; the matching
+/// unpin happens in [`js_thread_process_pending`] when the result resolves.
+///
+/// # Safety
+/// `promise` must be a live promise allocation preceded by an 8-byte GcHeader.
+pub unsafe fn pin_promise(promise: *mut crate::promise::Promise) {
+    let header = (promise as *mut u8).sub(gc::GC_HEADER_SIZE) as *mut gc::GcHeader;
+    (*header).gc_flags |= gc::GC_FLAG_PINNED;
+}
+
+/// Resolve the promise at `promise_usize` with a UTF-8 string on the main
+/// thread. Routes through the same pending-result path `spawn` uses (which
+/// unpins the promise, deserializes the value into the main arena, decrements
+/// the active-job count, and wakes the event loop). Used by `Atomics.waitAsync`.
+pub fn queue_promise_string_result(promise_usize: usize, value: &str) {
+    queue_thread_result(
+        promise_usize,
+        SerializedValue::String(value.as_bytes().to_vec()),
+    );
 }
 
 /// A pending thread result waiting to be resolved on the main thread.

--- a/crates/perry/tests/issue_4913_atomics_cross_thread.rs
+++ b/crates/perry/tests/issue_4913_atomics_cross_thread.rs
@@ -1,0 +1,144 @@
+//! Regression test for #4913 (Stage 2): `Atomics.wait`/`notify`/`waitAsync`
+//! must really block and wake across `perry/thread` agents over a shared
+//! `SharedArrayBuffer`, instead of the pre-fix non-blocking fakes (`wait`
+//! always `"timed-out"`, `notify` always `0`, `waitAsync` resolves
+//! `"timed-out"` immediately).
+//!
+//! Three things are exercised:
+//!   1. Real blocking — `wait` on a matching value with no notifier blocks for
+//!      ~the timeout (the old stub returned immediately).
+//!   2. Cross-thread shared memory + `notify` waking a parked waiter — a worker
+//!      stores into a SAB the main thread also views and wakes the parked
+//!      `wait`; the store is visible on the main thread (real aliasing).
+//!   3. `waitAsync` — its promise resolves `"ok"` on a cross-thread `notify`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// `Atomics.wait` with a matching value and no notifier must actually block
+/// for ~the timeout (then return `"timed-out"`). Pre-fix it returned instantly.
+#[test]
+fn wait_really_blocks_until_timeout() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const sab = new SharedArrayBuffer(4);
+const a = new Int32Array(sab);
+const t0 = Date.now();
+const r = Atomics.wait(a, 0, 0, 120);
+const elapsed = Date.now() - t0;
+console.log("result", r);
+console.log("blocked", elapsed >= 100);
+"#,
+    );
+    assert_eq!(
+        stdout, "result timed-out\nblocked true\n",
+        "Atomics.wait must block for the full timeout, not return immediately"
+    );
+}
+
+/// A `SharedArrayBuffer` captured into a `spawn` closure aliases the same bytes
+/// across the thread boundary: the worker's `Atomics.store` is visible on the
+/// main thread, and its `Atomics.notify` wakes the main thread's parked `wait`
+/// (the worker naps first so the main thread parks before the notify).
+#[test]
+fn shared_memory_aliases_and_notify_wakes_parked_wait() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import { spawn } from "perry/thread";
+const sab = new SharedArrayBuffer(8);
+const main = new Int32Array(sab);
+const worker = spawn(() => {
+  const view = new Int32Array(sab);
+  const nap = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(nap, 0, 0, 100); // sleep so the main thread parks first
+  Atomics.store(view, 0, 42);
+  return Atomics.notify(view, 0);
+});
+const status = Atomics.wait(main, 0, 0, 10000);
+const value = Atomics.load(main, 0);
+const woke = await worker;
+console.log("status", status);
+console.log("value", value);
+console.log("woke", woke);
+"#,
+    );
+    assert_eq!(
+        stdout, "status ok\nvalue 42\nwoke 1\n",
+        "the worker's store must be visible on the main thread and its notify \
+         must wake the parked wait (status ok, woke 1)"
+    );
+}
+
+/// `Atomics.waitAsync` returns `{ async: true, value: Promise }`; the promise
+/// resolves `"ok"` when another agent notifies. The waiter is enqueued
+/// synchronously at the call (before the worker spawns), so the notify can't
+/// be missed — a deterministic `"ok"`.
+#[test]
+fn wait_async_resolves_on_cross_thread_notify() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import { spawn } from "perry/thread";
+const sab = new SharedArrayBuffer(4);
+const a = new Int32Array(sab);
+const r = Atomics.waitAsync(a, 0, 0, 10000) as { async: boolean; value: Promise<string> };
+console.log("async", r.async);
+spawn(() => {
+  const view = new Int32Array(sab);
+  const nap = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(nap, 0, 0, 30);
+  return Atomics.notify(view, 0);
+});
+const result = await r.value;
+console.log("result", result);
+"#,
+    );
+    assert_eq!(
+        stdout, "async true\nresult ok\n",
+        "Atomics.waitAsync must return an async promise that resolves 'ok' on \
+         a cross-thread notify"
+    );
+}

--- a/test-files/test_issue_4913_atomics_cross_thread.ts
+++ b/test-files/test_issue_4913_atomics_cross_thread.ts
@@ -1,0 +1,56 @@
+// #4913 Stage 2 — real cross-agent Atomics: a SharedArrayBuffer aliases the
+// same physical bytes across a `perry/thread` boundary, and Atomics.wait /
+// notify / waitAsync block and wake for real (no more "timed-out" lie).
+import { spawn } from "perry/thread";
+
+// ── 1. Real blocking: wait on a matching value with no notifier must actually
+//      block for ~the timeout, then return "timed-out" (the old stub returned
+//      immediately). ──────────────────────────────────────────────────────────
+{
+  const sab = new SharedArrayBuffer(4);
+  const a = new Int32Array(sab);
+  const t0 = Date.now();
+  const r = Atomics.wait(a, 0, 0, 120);
+  const elapsed = Date.now() - t0;
+  console.log("1-result", r);
+  console.log("1-blocked", elapsed >= 100);
+}
+
+// ── 2. Cross-thread shared memory + notify wakes a parked waiter. The worker
+//      sleeps ~100ms (Atomics.wait timeout on its own buffer) so the main
+//      thread is parked first, then stores 42 and notifies. ───────────────────
+{
+  const sab = new SharedArrayBuffer(8);
+  const main = new Int32Array(sab);
+  const worker = spawn(() => {
+    const view = new Int32Array(sab); // captures `sab` → aliases the same bytes
+    const nap = new Int32Array(new SharedArrayBuffer(4));
+    Atomics.wait(nap, 0, 0, 100); // sleep ~100ms so main parks first
+    Atomics.store(view, 0, 42);
+    return Atomics.notify(view, 0);
+  });
+  const status = Atomics.wait(main, 0, 0, 10000);
+  const value = Atomics.load(main, 0);
+  const woke = await worker;
+  console.log("2-status", status);
+  console.log("2-value", value);
+  console.log("2-woke", woke);
+}
+
+// ── 3. Atomics.waitAsync resolves on a cross-thread notify. The async waiter is
+//      enqueued synchronously here, BEFORE the worker spawns, so the notify can
+//      never be missed → deterministic "ok". ──────────────────────────────────
+{
+  const sab = new SharedArrayBuffer(4);
+  const a = new Int32Array(sab);
+  const r = Atomics.waitAsync(a, 0, 0, 10000) as { async: boolean; value: Promise<string> };
+  console.log("3-async", r.async);
+  spawn(() => {
+    const view = new Int32Array(sab);
+    const nap = new Int32Array(new SharedArrayBuffer(4));
+    Atomics.wait(nap, 0, 0, 30); // brief nap so the main loop reaches `await`
+    return Atomics.notify(view, 0);
+  });
+  const result = await r.value;
+  console.log("3-result", result);
+}


### PR DESCRIPTION
## What

Stage 2 of #4913 (the Stage 1 honesty floor landed in #4929). `Atomics.wait`, `Atomics.notify`, and `Atomics.waitAsync` were non-blocking fakes — `wait` always returned `"timed-out"`, `notify` always returned `0`, `waitAsync` resolved `"timed-out"` immediately. They now **block and wake for real** across `perry/thread` agents over a genuinely shared `SharedArrayBuffer`.

## How

**Shared backing that aliases across threads** (the prerequisite — `perry/thread` deep-copies every crossed value, which destroyed SAB sharing):
- `new SharedArrayBuffer(n)` allocates its `BufferHeader + data` from the global allocator (`crate::shared_sab`) — a stable, process-wide, never-freed address valid and writable from any OS thread.
- New `SerializedValue::SharedArrayBuffer { addr }` carries the SAB **by reference** across a thread boundary instead of deep-copying; the receiving agent re-registers the address locally, and `is_shared_array_buffer` / `is_registered_buffer` fall back to the process-global registry so a top-level (module-global) SAB is recognised on every thread too.

**Futex park/wake** (`crate::atomics_futex`): a process-global wait table keyed by the **absolute physical byte address** of the atomic slot (same SAB index → same key on every agent).
- `wait` re-checks the value and enqueues a waiter **atomically under the table lock** (so a racing `notify` is never lost), then parks the OS thread on a `Condvar` until a matching `notify` or the timeout deadline. Returns real `"ok"` / `"not-equal"` / `"timed-out"`.
- `notify` wakes up to `count` parked agents (default `undefined` → all) and returns the **actual** count woken.
- `waitAsync` enqueues synchronously (atomic with the value check), then resolves its promise from a background thread (`"ok"` on notify, `"timed-out"` on deadline) via the same pending-result → event-loop path `spawn` uses.

The `perry_stub_warn` / `PERRY_STRICT_STUBS` gates added in #4929 are removed from these three ops — they're no longer lies.

**Caveat:** only the `SharedArrayBuffer` itself shares across agents; a typed-array *view* captured directly into a thread closure still deep-copies (build the view per-agent from the shared SAB). Agent-coordinated test262 (`$262.agent`) remains out of scope.

## Tests

- `crates/perry-runtime/src/atomics_futex.rs` unit tests (4) — notify wakes a parked waiter, timeout, not-equal-without-parking, empty-address notify. ✅
- `crates/perry/tests/issue_4913_atomics_cross_thread.rs` (3): real blocking until timeout; cross-thread shared memory + notify waking a parked `wait` (`status ok, value 42, woke 1`); `waitAsync` resolving on a cross-thread notify. ✅ `3 passed; 0 failed`
- `test-files/test_issue_4913_atomics_cross_thread.ts` repro + a top-level-SAB smoke test (exercises the module-global recognition fallback) both verified by hand.

Closes #4913.