### PR TITLE
fix(hir): self-named native member base no longer OOM-loops codegen (#4908)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -253,21 +253,45 @@ pub fn lower_class_decl(
         } else if let ast::Expr::Member(member) = super_class.as_ref() {
             // Handle member expression like ethers.JsonRpcProvider or module.ClassName
             let parent_name = extract_member_class_name(member);
-            // Refs #488 drizzle-sqlite: also try resolving the parent
-            // class by name across modules. Pre-fix the Member arm set
-            // `extends = None`, so `class SQLiteIntegerBuilder extends
-            // import_mid.SQLiteColumnBuilder { ... }` lost its parent
-            // link entirely — inherited methods (drizzle's
-            // ColumnBuilder.setName etc.) were unreachable on instances.
-            // Class names are unique enough in practice that `lookup_class`
-            // resolves; if it doesn't, we fall back to the prior
-            // name-only behavior (no regression for unknown parents).
-            (
-                ctx.lookup_class(&parent_name),
-                Some(parent_name),
-                None,
-                None,
-            )
+            // Issue #4908: `extract_member_class_name` returns only the
+            // trailing property (`http.Agent` -> "Agent"). When that equals
+            // the subclass's OWN name (`class Agent extends http.Agent`), the
+            // bare-name resolution is bogus: the subclass registered its own
+            // name above (so `lookup_class` returns the class itself) and
+            // both `extends` and `extends_name` would self-reference. A
+            // self-link sends every codegen parent-chain walk into an
+            // infinite loop — the four node:http `class Agent extends
+            // http.Agent` tests OOM-crashed codegen. Leave the class
+            // parentless (all None), matching how a non-colliding native
+            // member base (`class Foo extends http.Agent`) already behaves:
+            // `extends_name` there resolves to no known class, so the class
+            // is effectively parentless and constructs cleanly. We do NOT
+            // route through the dynamic `extends_expr` path here — that
+            // turns the class derived and demands a runtime super() into the
+            // native base, which fails ("Class extends value is not a
+            // constructor" / "Must call super constructor"). Native member
+            // base inheritance (real `instanceof` / `super.method` dispatch)
+            // is unimplemented for the member-expression case generally;
+            // this keeps the colliding-name case on par with the rest.
+            if parent_name == name {
+                (None, None, None, None)
+            } else {
+                // Refs #488 drizzle-sqlite: also try resolving the parent
+                // class by name across modules. Pre-fix the Member arm set
+                // `extends = None`, so `class SQLiteIntegerBuilder extends
+                // import_mid.SQLiteColumnBuilder { ... }` lost its parent
+                // link entirely — inherited methods (drizzle's
+                // ColumnBuilder.setName etc.) were unreachable on instances.
+                // Class names are unique enough in practice that `lookup_class`
+                // resolves; if it doesn't, we fall back to the prior
+                // name-only behavior (no regression for unknown parents).
+                (
+                    ctx.lookup_class(&parent_name),
+                    Some(parent_name),
+                    None,
+                    None,
+                )
+            }
         } else {
             // Issue #711: `class X extends fn(...)` / `class X extends
             // new Foo(...)` etc. The super-class expression isn't
@@ -1183,12 +1207,22 @@ pub fn lower_class_from_ast(
             // rationale — without this, the parent link is lost and
             // inherited methods don't reach instances.
             let parent_name = extract_member_class_name(member);
-            (
-                ctx.lookup_class(&parent_name),
-                Some(parent_name),
-                None,
-                None,
-            )
+            // Issue #4908: avoid a self-referential parent edge when the
+            // member's trailing property equals the subclass's own name
+            // (`class Agent extends http.Agent`). See the matching guard in
+            // `lower_class_decl` above — a self-link loops codegen's
+            // parent-chain walk forever. Leave the class parentless, matching
+            // the non-colliding native-member-base behavior.
+            if parent_name == name {
+                (None, None, None, None)
+            } else {
+                (
+                    ctx.lookup_class(&parent_name),
+                    Some(parent_name),
+                    None,
+                    None,
+                )
+            }
         } else {
             // Issue #711: see the matching arm in `lower_class_decl` above
             // for the full rationale. Capture the lowered extends

--- a/crates/perry/tests/issue_4908_subclass_native_member_base.rs
+++ b/crates/perry/tests/issue_4908_subclass_native_member_base.rs
@@ -1,0 +1,111 @@
+//! Regression test for #4908: subclassing a native member base whose trailing
+//! property name equals the subclass's OWN name — the canonical node:http
+//! shape `class Agent extends http.Agent { ... }` — OOM-crashed codegen.
+//!
+//! Root cause: the class-heritage lowering resolves a member-expression base
+//! (`http.Agent`) by its trailing property only (`extract_member_class_name`
+//! returns "Agent"). The subclass registers its own name *before* heritage
+//! resolution, so `lookup_class("Agent")` returned the class itself and both
+//! `extends` and `extends_name` self-referenced. Every codegen parent-chain
+//! walk then looped forever, killing the process during "Generating code...".
+//!
+//! Four node:http tests (`test-http-client-abort-keep-alive-destroy-res`,
+//! `-abort-keep-alive-queued-tcp-socket`, `-abort-unix-socket`,
+//! `-read-in-error`) all share this `class Agent extends http.Agent` shape.
+//!
+//! Fix: when the member base's trailing name equals the subclass name, leave
+//! the class parentless (no self-link), matching how a non-colliding native
+//! member base already behaves. These cases must now compile AND construct
+//! without crashing.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed (pre-fix: codegen OOM-loop on self-referential \
+         extends)\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The exact failing shape: `class Agent extends http.Agent` (name collision
+/// with the `Agent` property), an overriding method that calls
+/// `super.createConnection(...)`, and a captured module-level `let` mutated via
+/// `++`. Pre-fix this OOM-looped codegen; it must now compile and construct.
+#[test]
+fn subclass_http_agent_with_super_and_captured_let_compiles_and_runs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const http = require('http');
+let socketsCreated = 0;
+
+class Agent extends http.Agent {
+  createConnection(options: any, oncreate: any) {
+    socketsCreated++;
+    return super.createConnection(options, oncreate);
+  }
+}
+
+const a = new Agent();
+console.log('ctor-ok', typeof a === 'object');
+console.log('method-ok', typeof a.createConnection === 'function');
+console.log('captured-let', socketsCreated);
+"#,
+    );
+    assert_eq!(
+        stdout, "ctor-ok true\nmethod-ok true\ncaptured-let 0\n",
+        "`class Agent extends http.Agent` must compile and construct cleanly"
+    );
+}
+
+/// The minimal trigger with no method, no super, no captured let: an *empty*
+/// `class Agent extends http.Agent {}` was already enough to OOM-crash codegen
+/// (the self-referential parent edge, not the method body, is the loop). Guards
+/// against a narrower fix that only handles the method-bearing shape.
+#[test]
+fn empty_subclass_of_self_named_member_base_compiles() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const http = require('http');
+class Agent extends http.Agent {}
+console.log('ok', typeof new Agent() === 'object');
+"#,
+    );
+    assert_eq!(stdout, "ok true\n", "empty self-named subclass must compile");
+}

--- a/crates/perry/tests/issue_4908_subclass_native_member_base.rs
+++ b/crates/perry/tests/issue_4908_subclass_native_member_base.rs
@@ -107,5 +107,8 @@ class Agent extends http.Agent {}
 console.log('ok', typeof new Agent() === 'object');
 "#,
     );
-    assert_eq!(stdout, "ok true\n", "empty self-named subclass must compile");
+    assert_eq!(
+        stdout, "ok true\n",
+        "empty self-named subclass must compile"
+    );
 }


### PR DESCRIPTION
Fixes #4908.

## Root cause

`class Agent extends http.Agent { ... }` **OOM-crashed codegen** during "Generating code...".

The class-heritage lowering resolves a member-expression base (`http.Agent`) by its trailing property only — `extract_member_class_name` returns `"Agent"`. The subclass registers its own name (`Agent`) *before* heritage resolution, so `lookup_class("Agent")` returns the class itself and both `extends` and `extends_name` end up **self-referencing**. Every codegen parent-chain walk (`extends_name` → `ctx.classes` by name → same class) then loops forever until the process is OOM-killed.

Confirmed by bisection: an *empty* `class Agent extends http.Agent {}` — no method, no `super`, no captured `let` — is already enough to crash. The `super.createConnection()` call and the captured-`let` `++` cited in the issue are **not** the trigger (both compile fine on their own; a CPU sample showed a tight recursive cycle in the parent-chain walk).

## Fix

Guard both member-heritage arms (class declaration + class expression): when the member's trailing name equals the subclass's own name, leave the class **parentless** (`extends`/`extends_name`/`native_extends`/`extends_expr` all `None`) instead of self-linking.

This matches how a *non-colliding* native member base (`class Foo extends http.Agent`) already behaves — `extends_name` there resolves to no known class, so the class is effectively parentless and constructs cleanly. Routing through the dynamic `extends_expr` path was tried and rejected: it makes the class derived and demands a runtime `super()` into the native base, which fails (`Class extends value is not a constructor` / `Must call super constructor`).

Cross-module member-extends resolution (drizzle `import_mid.SQLiteColumnBuilder`, ethers `ethers.JsonRpcProvider`) is **unchanged** — the `else` branch is byte-identical; the new guard only fires on the name-collision case.

Native member-base inheritance (real `instanceof` / `super.method` dispatch into the base) remains unimplemented for the member-expression case generally; this PR scopes to the codegen crash per the issue's acceptance ("the four tests compile").

## Validation

- The four `class Agent extends http.Agent` node:http tests now compile (`-abort-keep-alive-destroy-res`, `-abort-keep-alive-queued-tcp-socket`, `-abort-unix-socket`, `-read-in-error`).
- New regression test `crates/perry/tests/issue_4908_subclass_native_member_base.rs` (2 cases: empty subclass; method + `super.createConnection` + captured `let++`) — both compile **and** construct/run cleanly.
- `cargo test -p perry-hir` green.

Metadata (version bump + CHANGELOG) intentionally omitted for the maintainer to fold at merge.