### PR TITLE
Optimize numeric array raw payload helpers

### DIFF
--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -117,13 +117,35 @@ fn put_value_static_property_fast_path(
                 .scalar_replaced
                 .get(id)
                 .is_some_and(|fields| fields.contains_key(property));
-            (pod_field || scalar_field).then(|| property.clone())
+            if pod_field || scalar_field {
+                return Some(property.clone());
+            }
+            receiver_class_name(ctx, target)
+                .and_then(|class_name| {
+                    crate::type_analysis::class_field_global_index(ctx, &class_name, property)
+                })
+                .map(|_| property.clone())
         }
-        (Expr::This, Expr::This) => ctx
-            .scalar_ctor_target
-            .last()
-            .and_then(|tid| ctx.scalar_replaced.get(tid))
-            .and_then(|fields| fields.contains_key(property).then(|| property.clone())),
+        (Expr::This, Expr::This) => {
+            if ctx
+                .scalar_ctor_target
+                .last()
+                .and_then(|tid| ctx.scalar_replaced.get(tid))
+                .is_some_and(|fields| fields.contains_key(property))
+            {
+                return Some(property.clone());
+            }
+            receiver_class_name(ctx, target)
+                .and_then(|class_name| {
+                    crate::type_analysis::class_field_global_index(ctx, &class_name, property)
+                })
+                .map(|_| property.clone())
+        }
+        _ if same_side_effect_free_receiver(target, receiver) => {
+            let class_name = receiver_class_name(ctx, target)?;
+            crate::type_analysis::class_field_global_index(ctx, &class_name, property)
+                .map(|_| property.clone())
+        }
         _ => None,
     }
 }

--- a/crates/perry-codegen/src/lower_call/method_override.rs
+++ b/crates/perry-codegen/src/lower_call/method_override.rs
@@ -139,24 +139,29 @@ pub(super) fn emit_guarded_direct_method_call(
     direct_fn: &str,
     direct_arg_slices: &[(crate::types::LlvmType, &str)],
     fallback_user_args: &[String],
+    shape_only_guard: bool,
 ) -> Option<String> {
     let expected_class_id = *ctx.class_ids.get(receiver_class_name)?;
     let keys_global_name = ctx.class_keys_globals.get(receiver_class_name)?.clone();
+
+    let expected_class_id_str = expected_class_id.to_string();
+    let expected_keys_slot = ctx.func.entry_init_load_global(&keys_global_name, I64);
+    let expected_keys = ctx.block().load(I64, &expected_keys_slot);
 
     let key_idx = ctx.strings.intern(property);
     let entry = ctx.strings.entry(key_idx);
     let bytes_global = format!("@{}", entry.bytes_global);
     let name_len_str = entry.byte_len.to_string();
-    let expected_class_id_str = expected_class_id.to_string();
-
-    let site_id = emit_typed_feedback_register_site(
-        ctx,
-        TypedFeedbackKind::MethodCall,
-        property,
-        TypedFeedbackContract::method_direct_call(),
-    );
-    let expected_keys_slot = ctx.func.entry_init_load_global(&keys_global_name, I64);
-    let expected_keys = ctx.block().load(I64, &expected_keys_slot);
+    let site_id = if shape_only_guard {
+        None
+    } else {
+        Some(emit_typed_feedback_register_site(
+            ctx,
+            TypedFeedbackKind::MethodCall,
+            property,
+            TypedFeedbackContract::method_direct_call(),
+        ))
+    };
 
     let guard_idx = ctx.new_block("method_direct.guard");
     let fast_idx = ctx.new_block("method_direct.fast");
@@ -169,19 +174,34 @@ pub(super) fn emit_guarded_direct_method_call(
     ctx.block().br(&guard_label);
 
     ctx.current_block = guard_idx;
-    let guard_ok = ctx.block().call(
-        I32,
-        "js_typed_feedback_method_direct_call_guard",
-        &[
-            (I64, &site_id),
-            (DOUBLE, recv_box),
-            (I32, &expected_class_id_str),
-            (I64, &expected_keys),
-            (crate::types::PTR, &bytes_global),
-            (I64, &name_len_str),
-            (crate::types::PTR, &format!("@{}", direct_fn)),
-        ],
-    );
+    let guard_ok = if shape_only_guard {
+        ctx.block().call(
+            I32,
+            "js_method_direct_shape_guard",
+            &[
+                (DOUBLE, recv_box),
+                (I32, &expected_class_id_str),
+                (I64, &expected_keys),
+            ],
+        )
+    } else {
+        ctx.block().call(
+            I32,
+            "js_typed_feedback_method_direct_call_guard",
+            &[
+                (
+                    I64,
+                    site_id.as_deref().expect("typed-feedback method site id"),
+                ),
+                (DOUBLE, recv_box),
+                (I32, &expected_class_id_str),
+                (I64, &expected_keys),
+                (crate::types::PTR, &bytes_global),
+                (I64, &name_len_str),
+                (crate::types::PTR, &format!("@{}", direct_fn)),
+            ],
+        )
+    };
     let guard_pass = ctx.block().icmp_ne(I32, &guard_ok, "0");
     ctx.block()
         .cond_br(&guard_pass, &fast_label, &fallback_label);
@@ -212,8 +232,10 @@ pub(super) fn emit_guarded_direct_method_call(
         ));
         (ptr_reg, n.to_string())
     };
-    ctx.block()
-        .call_void("js_typed_feedback_record_fallback_call", &[(I64, &site_id)]);
+    if let Some(site_id) = site_id {
+        ctx.block()
+            .call_void("js_typed_feedback_record_fallback_call", &[(I64, &site_id)]);
+    }
     let fallback_value = ctx.block().call(
         DOUBLE,
         "js_native_call_method",

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -62,6 +62,24 @@ fn is_inherited_object_prototype_method(name: &str) -> bool {
     )
 }
 
+fn class_chain_has_field_named(ctx: &FnCtx<'_>, class_name: &str, property: &str) -> bool {
+    let mut current = Some(class_name.to_string());
+    while let Some(name) = current {
+        let Some(class) = ctx.classes.get(&name) else {
+            return true;
+        };
+        if class
+            .fields
+            .iter()
+            .any(|field| field.key_expr.is_some() || (!field.is_private && field.name == property))
+        {
+            return true;
+        }
+        current = class.extends_name.clone();
+    }
+    false
+}
+
 /// Try to lower a `Call { callee: PropertyGet { .. } }` via the
 /// string/array/class/Map/Set/Promise/fetch/static/instance dispatch tower.
 pub fn try_lower_property_get_method_call(
@@ -1906,6 +1924,8 @@ pub fn try_lower_property_get_method_call(
                 lowered_args.iter().map(|s| (DOUBLE, s.as_str())).collect();
 
             if !method_has_rest {
+                let shape_only_guard =
+                    !class_chain_has_field_named(ctx, &class_name, property.as_str());
                 if let Some(guarded) = emit_guarded_direct_method_call(
                     ctx,
                     &recv_box,
@@ -1914,6 +1934,7 @@ pub fn try_lower_property_get_method_call(
                     &fallback_fn,
                     &arg_slices,
                     &fallback_user_args,
+                    shape_only_guard,
                 ) {
                     return Ok(Some(guarded));
                 }

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -47,6 +47,10 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // Extending variant: returns a possibly-realloc'd pointer that the
     // caller must write back to the local slot.
     module.declare_function("js_array_set_f64_extend", I64, &[I64, I32, DOUBLE]);
+    module.declare_function("js_array_fill_f64_const_extend", I64, &[I64, I32, DOUBLE]);
+    module.declare_function("js_array_fill_f64_iota_extend", I64, &[I64, I32]);
+    module.declare_function("js_array_fill_f64_const_len_extend", I64, &[I64, DOUBLE]);
+    module.declare_function("js_array_fill_f64_iota_len_extend", I64, &[I64]);
     module.declare_function("js_array_set_string_key", I64, &[I64, I64, DOUBLE]);
     module.declare_function("js_array_set_index_or_string", I64, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_array_mark_arguments_object", I64, &[I64]);

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -123,6 +123,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         I32,
         &[I64, DOUBLE, I32, I64, PTR, I64, PTR],
     );
+    module.declare_function("js_method_direct_shape_guard", I32, &[DOUBLE, I32, I64]);
     module.declare_function(
         "js_typed_feedback_closure_direct_call_guard",
         I32,

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -2,11 +2,196 @@
 
 use super::*;
 
-use crate::expr::{BoundedIndexPair, IntRangeFact};
+use crate::expr::{nanbox_pointer_inline, BoundedIndexPair, IntRangeFact};
 use crate::loop_purity::body_needs_asm_barrier;
 use crate::lower_conditional::lower_truthy;
 use crate::native_value::{BoundedBufferIndex, BoundsProof, BoundsState, LengthSource};
-use crate::types::I32;
+use crate::types::{I1, I32, I64};
+
+#[derive(Clone, Copy)]
+enum NumericBulkFillValue {
+    Const(f64),
+    Iota,
+}
+
+struct NumericBulkFillLoop {
+    counter_id: u32,
+    array_id: u32,
+    bound: perry_hir::Expr,
+    value: NumericBulkFillValue,
+}
+
+fn match_numeric_bulk_fill_loop(
+    ctx: &FnCtx<'_>,
+    init: Option<&Stmt>,
+    condition: Option<&perry_hir::Expr>,
+    update: Option<&perry_hir::Expr>,
+    body: &[Stmt],
+) -> Option<NumericBulkFillLoop> {
+    let init = init?;
+    let (counter_id, init_expr) = match init {
+        Stmt::Let { id, init, .. } => (*id, init.as_ref()?),
+        _ => return None,
+    };
+    match init_expr {
+        perry_hir::Expr::Integer(0) => {}
+        perry_hir::Expr::Number(n) if *n == 0.0 => {}
+        _ => return None,
+    }
+    match update {
+        Some(perry_hir::Expr::Update {
+            id,
+            op: perry_hir::UpdateOp::Increment,
+            ..
+        }) if *id == counter_id => {}
+        _ => return None,
+    }
+    let bound = match condition? {
+        perry_hir::Expr::Compare {
+            op: perry_hir::CompareOp::Lt,
+            left,
+            right,
+        } if matches!(left.as_ref(), perry_hir::Expr::LocalGet(id) if *id == counter_id) => {
+            right.as_ref().clone()
+        }
+        _ => return None,
+    };
+    let (object, index, value) = match body {
+        [Stmt::Expr(perry_hir::Expr::IndexSet {
+            object,
+            index,
+            value,
+        })] => (object, index, value),
+        [Stmt::Expr(perry_hir::Expr::PutValueSet {
+            target,
+            key,
+            value,
+            receiver,
+            ..
+        })] if matches!(
+            (target.as_ref(), receiver.as_ref()),
+            (perry_hir::Expr::LocalGet(a), perry_hir::Expr::LocalGet(b)) if a == b
+        ) =>
+        {
+            (target, key, value)
+        }
+        _ => return None,
+    };
+    if !matches!(index.as_ref(), perry_hir::Expr::LocalGet(id) if *id == counter_id) {
+        return None;
+    }
+    let array_id = match object.as_ref() {
+        perry_hir::Expr::LocalGet(id) => *id,
+        _ => return None,
+    };
+    let is_numeric_array = matches!(
+        ctx.local_types.get(&array_id),
+        Some(perry_types::Type::Array(elem))
+            if matches!(elem.as_ref(), perry_types::Type::Number | perry_types::Type::Int32)
+    );
+    if !is_numeric_array {
+        return None;
+    }
+    let value = match value.as_ref() {
+        perry_hir::Expr::LocalGet(id) if *id == counter_id => NumericBulkFillValue::Iota,
+        perry_hir::Expr::Integer(n) => NumericBulkFillValue::Const(*n as f64),
+        perry_hir::Expr::Number(n) if n.is_finite() => NumericBulkFillValue::Const(*n),
+        _ => return None,
+    };
+    Some(NumericBulkFillLoop {
+        counter_id,
+        array_id,
+        bound,
+        value,
+    })
+}
+
+fn lower_numeric_bulk_fill_loop(ctx: &mut FnCtx<'_>, matched: NumericBulkFillLoop) -> Result<bool> {
+    let arr_box = lower_expr(ctx, &perry_hir::Expr::LocalGet(matched.array_id))?;
+    let arr_handle = {
+        let blk = ctx.block();
+        let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+        blk.and(I64, &arr_bits, crate::nanbox::POINTER_MASK_I64)
+    };
+
+    let is_len_bound = matches!(
+        &matched.bound,
+        perry_hir::Expr::PropertyGet { object, property }
+            if property == "length"
+                && matches!(object.as_ref(), perry_hir::Expr::LocalGet(id) if *id == matched.array_id)
+    );
+    let (new_arr, bound_i32) = if is_len_bound {
+        let bound_i32 = ctx
+            .block()
+            .call(I32, "js_array_length", &[(I64, &arr_handle)]);
+        let new_arr = match matched.value {
+            NumericBulkFillValue::Const(value) => {
+                let value_lit = crate::nanbox::double_literal(value);
+                ctx.block().call(
+                    I64,
+                    "js_array_fill_f64_const_len_extend",
+                    &[(I64, &arr_handle), (DOUBLE, &value_lit)],
+                )
+            }
+            NumericBulkFillValue::Iota => ctx.block().call(
+                I64,
+                "js_array_fill_f64_iota_len_extend",
+                &[(I64, &arr_handle)],
+            ),
+        };
+        (new_arr, bound_i32)
+    } else {
+        let bound_i32 = match &matched.bound {
+            perry_hir::Expr::Integer(n) if *n >= 0 && *n <= u32::MAX as i64 => n.to_string(),
+            perry_hir::Expr::Number(n)
+                if n.is_finite() && n.fract() == 0.0 && *n >= 0.0 && *n <= u32::MAX as f64 =>
+            {
+                (*n as u32).to_string()
+            }
+            perry_hir::Expr::LocalGet(id)
+                if ctx.integer_locals.contains(id)
+                    || matches!(
+                        ctx.local_types.get(id),
+                        Some(perry_types::Type::Number | perry_types::Type::Int32)
+                    ) =>
+            {
+                let bound_d = lower_expr(ctx, &matched.bound)?;
+                let raw_i32 = ctx.block().fptosi(DOUBLE, &bound_d, I32);
+                let positive = ctx.block().fcmp("ogt", &bound_d, "0.0");
+                ctx.block().select(I1, &positive, I32, &raw_i32, "0")
+            }
+            _ => return Ok(false),
+        };
+        let new_arr = match matched.value {
+            NumericBulkFillValue::Const(value) => {
+                let value_lit = crate::nanbox::double_literal(value);
+                ctx.block().call(
+                    I64,
+                    "js_array_fill_f64_const_extend",
+                    &[(I64, &arr_handle), (I32, &bound_i32), (DOUBLE, &value_lit)],
+                )
+            }
+            NumericBulkFillValue::Iota => ctx.block().call(
+                I64,
+                "js_array_fill_f64_iota_extend",
+                &[(I64, &arr_handle), (I32, &bound_i32)],
+            ),
+        };
+        (new_arr, bound_i32)
+    };
+    let new_box = nanbox_pointer_inline(ctx.block(), &new_arr);
+    if let Some(slot) = ctx.locals.get(&matched.array_id).cloned() {
+        ctx.block().store(DOUBLE, &new_box, &slot);
+    }
+    if let Some(counter_slot) = ctx.locals.get(&matched.counter_id).cloned() {
+        let bound_d = ctx.block().sitofp(I32, &bound_i32, DOUBLE);
+        ctx.block().store(DOUBLE, &bound_d, &counter_slot);
+    }
+    if let Some(i32_slot) = ctx.i32_counter_slots.get(&matched.counter_id).cloned() {
+        ctx.block().store(I32, &bound_i32, &i32_slot);
+    }
+    Ok(true)
+}
 
 /// For-loop lowering: classic init / cond / body / update / exit CFG.
 ///
@@ -45,6 +230,12 @@ pub(crate) fn lower_for(
         lower_stmt(ctx, init_stmt)?;
     }
     let loop_proof_scope_id = ctx.next_loop_proof_scope_id();
+
+    if let Some(matched) = match_numeric_bulk_fill_loop(ctx, init, condition, update, body) {
+        if lower_numeric_bulk_fill_loop(ctx, matched)? {
+            return Ok(());
+        }
+    }
 
     // Loop-invariant length hoisting peephole. Detect the very common
     // shape `for (...; i < arr.length; ...)` where `arr` is a local

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -744,6 +744,251 @@ pub extern "C" fn js_array_set_f64_extend(
     }
 }
 
+/// Bulk numeric dense fill for compiler-proven trivial loops:
+/// `for (let i = 0; i < end; i++) arr[i] = constant`.
+///
+/// This keeps JavaScript semantics for frozen/sealed/descriptor arrays by
+/// falling back to the ordinary extending setter. The fast path is restricted
+/// to dense writes from index 0 through `end - 1`, so the resulting live
+/// payload is entirely numeric and can be marked raw-f64 / pointer-free once.
+#[no_mangle]
+pub extern "C" fn js_array_fill_f64_const_extend(
+    arr: *mut ArrayHeader,
+    end: u32,
+    value: f64,
+) -> *mut ArrayHeader {
+    if end == 0 {
+        return clean_arr_ptr_mut(arr);
+    }
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        let new_arr = js_array_alloc(end);
+        return js_array_fill_f64_const_extend(new_arr, end, value);
+    }
+    note_array_index_write(arr as usize);
+    let flags = array_object_flags(arr);
+    if flags
+        & (crate::gc::OBJ_FLAG_FROZEN
+            | crate::gc::OBJ_FLAG_SEALED
+            | crate::gc::OBJ_FLAG_NO_EXTEND
+            | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS)
+        != 0
+        || crate::buffer::is_registered_buffer(arr as usize)
+        || crate::typedarray::lookup_typed_array_kind(arr as usize).is_some()
+    {
+        let mut out = arr;
+        for i in 0..end {
+            out = js_array_set_f64_extend(out, i, value);
+        }
+        return out;
+    }
+
+    let Some(number) = value_bits_to_number(value.to_bits()) else {
+        let mut out = arr;
+        for i in 0..end {
+            out = js_array_set_f64_extend(out, i, value);
+        }
+        return out;
+    };
+
+    unsafe {
+        let old_length = (*arr).length;
+        let raw_before = array_numeric_layout(arr) == Some(NumericArrayLayout::RawF64);
+        if old_length > end && !raw_before {
+            let mut fallback = arr;
+            for i in 0..end {
+                fallback = js_array_set_f64_extend(fallback, i, value);
+            }
+            return fallback;
+        }
+
+        let mut out = if end > (*arr).capacity {
+            js_array_grow(arr, end)
+        } else {
+            arr
+        };
+        out = clean_arr_ptr_mut(out);
+        if out.is_null() || end > (*out).capacity {
+            let mut fallback = arr;
+            for i in 0..end {
+                fallback = js_array_set_f64_extend(fallback, i, value);
+            }
+            return fallback;
+        }
+        let elements_ptr = (out as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+        for i in 0..end as usize {
+            // GC_STORE_AUDIT(POINTER_FREE): bulk numeric fill writes raw f64s only.
+            ptr::write(elements_ptr.add(i), number);
+        }
+        if (*out).length < end {
+            (*out).length = end;
+        }
+        set_array_numeric_layout(out, NumericArrayLayout::RawF64);
+        out
+    }
+}
+
+/// Bulk numeric dense fill for loops bounded by current array length:
+/// `for (let i = 0; i < arr.length; i++) arr[i] = constant`.
+///
+/// If the receiver is exotic (frozen/sealed/descriptors/etc.), the fallback
+/// re-reads `.length` on every iteration so it preserves the source loop's
+/// observable behavior when setters mutate array length.
+#[no_mangle]
+pub extern "C" fn js_array_fill_f64_const_len_extend(
+    arr: *mut ArrayHeader,
+    value: f64,
+) -> *mut ArrayHeader {
+    let arr = clean_arr_ptr_mut(arr);
+    let end = js_array_length(arr);
+    if end == 0 || arr.is_null() {
+        return arr;
+    }
+    note_array_index_write(arr as usize);
+    let flags = array_object_flags(arr);
+    if flags
+        & (crate::gc::OBJ_FLAG_FROZEN
+            | crate::gc::OBJ_FLAG_SEALED
+            | crate::gc::OBJ_FLAG_NO_EXTEND
+            | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS)
+        != 0
+        || crate::buffer::is_registered_buffer(arr as usize)
+        || crate::typedarray::lookup_typed_array_kind(arr as usize).is_some()
+    {
+        let mut out = arr;
+        let mut i = 0;
+        while i < js_array_length(out) {
+            out = js_array_set_f64_extend(out, i, value);
+            i += 1;
+        }
+        return out;
+    }
+    js_array_fill_f64_const_extend(arr, end, value)
+}
+
+/// Bulk numeric dense fill for compiler-proven trivial loops:
+/// `for (let i = 0; i < end; i++) arr[i] = i`.
+#[no_mangle]
+pub extern "C" fn js_array_fill_f64_iota_extend(
+    arr: *mut ArrayHeader,
+    end: u32,
+) -> *mut ArrayHeader {
+    if end == 0 {
+        return clean_arr_ptr_mut(arr);
+    }
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        let new_arr = js_array_alloc(end);
+        return js_array_fill_f64_iota_extend(new_arr, end);
+    }
+    note_array_index_write(arr as usize);
+    let flags = array_object_flags(arr);
+    if flags
+        & (crate::gc::OBJ_FLAG_FROZEN
+            | crate::gc::OBJ_FLAG_SEALED
+            | crate::gc::OBJ_FLAG_NO_EXTEND
+            | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS)
+        != 0
+        || crate::buffer::is_registered_buffer(arr as usize)
+        || crate::typedarray::lookup_typed_array_kind(arr as usize).is_some()
+    {
+        let mut out = arr;
+        for i in 0..end {
+            out = js_array_set_f64_extend(out, i, i as f64);
+        }
+        return out;
+    }
+
+    unsafe {
+        let old_length = (*arr).length;
+        let raw_before = array_numeric_layout(arr) == Some(NumericArrayLayout::RawF64);
+        if old_length > end && !raw_before {
+            let mut fallback = arr;
+            for i in 0..end {
+                fallback = js_array_set_f64_extend(fallback, i, i as f64);
+            }
+            return fallback;
+        }
+
+        let mut out = if end > (*arr).capacity {
+            js_array_grow(arr, end)
+        } else {
+            arr
+        };
+        out = clean_arr_ptr_mut(out);
+        if out.is_null() || end > (*out).capacity {
+            let mut fallback = arr;
+            for i in 0..end {
+                fallback = js_array_set_f64_extend(fallback, i, i as f64);
+            }
+            return fallback;
+        }
+        let elements_ptr = (out as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+        for i in 0..end as usize {
+            // GC_STORE_AUDIT(POINTER_FREE): bulk iota fill writes raw f64s only.
+            ptr::write(elements_ptr.add(i), i as f64);
+        }
+        if (*out).length < end {
+            (*out).length = end;
+        }
+        set_array_numeric_layout(out, NumericArrayLayout::RawF64);
+        out
+    }
+}
+
+/// Bulk numeric dense fill for loops bounded by current array length:
+/// `for (let i = 0; i < arr.length; i++) arr[i] = i`.
+///
+/// If the receiver is exotic (frozen/sealed/descriptors/etc.), the fallback
+/// re-reads `.length` on every iteration so it preserves the source loop's
+/// observable behavior when setters mutate array length.
+#[no_mangle]
+pub extern "C" fn js_array_fill_f64_iota_len_extend(arr: *mut ArrayHeader) -> *mut ArrayHeader {
+    let arr = clean_arr_ptr_mut(arr);
+    let end = js_array_length(arr);
+    if end == 0 || arr.is_null() {
+        return arr;
+    }
+    note_array_index_write(arr as usize);
+    let flags = array_object_flags(arr);
+    if flags
+        & (crate::gc::OBJ_FLAG_FROZEN
+            | crate::gc::OBJ_FLAG_SEALED
+            | crate::gc::OBJ_FLAG_NO_EXTEND
+            | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS)
+        != 0
+        || crate::buffer::is_registered_buffer(arr as usize)
+        || crate::typedarray::lookup_typed_array_kind(arr as usize).is_some()
+    {
+        let mut out = arr;
+        let mut i = 0;
+        while i < js_array_length(out) {
+            out = js_array_set_f64_extend(out, i, i as f64);
+            i += 1;
+        }
+        return out;
+    }
+    js_array_fill_f64_iota_extend(arr, end)
+}
+
+#[used]
+static KEEP_ARRAY_FILL_F64_CONST_EXTEND: extern "C" fn(
+    *mut ArrayHeader,
+    u32,
+    f64,
+) -> *mut ArrayHeader = js_array_fill_f64_const_extend;
+#[used]
+static KEEP_ARRAY_FILL_F64_IOTA_EXTEND: extern "C" fn(*mut ArrayHeader, u32) -> *mut ArrayHeader =
+    js_array_fill_f64_iota_extend;
+#[used]
+static KEEP_ARRAY_FILL_F64_CONST_LEN_EXTEND: extern "C" fn(
+    *mut ArrayHeader,
+    f64,
+) -> *mut ArrayHeader = js_array_fill_f64_const_len_extend;
+#[used]
+static KEEP_ARRAY_FILL_F64_IOTA_LEN_EXTEND: extern "C" fn(*mut ArrayHeader) -> *mut ArrayHeader =
+    js_array_fill_f64_iota_len_extend;
+
 /// `arr[stringKey] = value` — handles the JS spec rule that numeric-string
 /// keys on arrays are coerced to integer indices. Pre-fix the codegen's
 /// IndexSet array fast-path applied `fptosi(double, i32)` directly to the

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -1,4 +1,5 @@
 //! Indexing — length / element get / element set / hybrid string-or-index dispatch.
+use super::header::{array_numeric_layout, NumericArrayLayout};
 use super::*;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -324,7 +325,25 @@ pub extern "C" fn js_array_get_f64_unchecked(arr: *const ArrayHeader, index: u32
 
 #[no_mangle]
 pub extern "C" fn js_array_numeric_get_f64_unboxed(arr: *mut ArrayHeader, index: u32) -> f64 {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return js_array_get_f64(arr, index);
+    }
+
+    // Hot path for guarded raw-f64 arrays. The typed-feedback guard already
+    // proved this receiver is a non-forwarded plain Array with raw numeric
+    // layout, so keep the helper leaf-small: avoid re-running the expensive
+    // rebuild/descriptor path on every indexed read in numeric loops.
     unsafe {
+        if array_numeric_layout(arr) == Some(NumericArrayLayout::RawF64)
+            && array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS == 0
+            && index < (*arr).length
+        {
+            let elements_ptr =
+                (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+            return *elements_ptr.add(index as usize);
+        }
+
         if let Some(value) = array_numeric_raw_f64_get(arr, index) {
             return value;
         }
@@ -497,10 +516,32 @@ pub extern "C" fn js_array_numeric_set_f64_unboxed(
     index: u32,
     value: f64,
 ) -> i32 {
-    if array_is_frozen(arr) {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
         return 0;
     }
+
+    let flags = array_object_flags(arr);
+    if flags & (crate::gc::OBJ_FLAG_FROZEN | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS) != 0 {
+        return 0;
+    }
+
+    // Hot path for the codegen's guarded numeric-array store. Raw-f64 arrays
+    // are pointer-free, so an in-bounds numeric overwrite can update the
+    // payload directly without per-slot layout notes or revalidating/rebuilding
+    // the whole layout on every iteration. Preserve the helper fallback for
+    // direct runtime calls and arrays that have not been converted yet.
     unsafe {
+        if index < (*arr).length && array_numeric_layout(arr) == Some(NumericArrayLayout::RawF64) {
+            let Some(number) = value_bits_to_number(value.to_bits()) else {
+                clear_array_numeric_layout(arr);
+                return 0;
+            };
+            let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+            ptr::write(elements_ptr.add(index as usize), number);
+            return 1;
+        }
+
         if array_numeric_raw_f64_set_inbounds(arr, index, value) {
             return 1;
         }

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -330,6 +330,7 @@ pub(crate) fn class_decl_prototype_value(class_id: u32) -> f64 {
     if proto.is_null() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
+    invalidate_class_prototype_fast_guards();
     class_decl_prototype_object_root_store(class_id, proto);
 
     let constructor_key =
@@ -1207,6 +1208,16 @@ pub unsafe extern "C" fn js_class_register_static_field(
 /// `*ClosureHeader` shapes.
 pub static CLASS_PROTOTYPE_METHODS: RwLock<Option<HashMap<u32, HashMap<String, u64>>>> =
     RwLock::new(None);
+static CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub(crate) fn class_prototype_fast_guards_invalidated() -> bool {
+    CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED.load(std::sync::atomic::Ordering::Acquire)
+}
+
+fn invalidate_class_prototype_fast_guards() {
+    CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED.store(true, std::sync::atomic::Ordering::Release);
+}
 
 pub(crate) fn class_prototype_method_root_store(class_id: u32, name: String, value_bits: u64) {
     let mut guard = CLASS_PROTOTYPE_METHODS.write().unwrap();
@@ -1219,6 +1230,7 @@ pub(crate) fn class_prototype_method_root_store(class_id: u32, name: String, val
         .entry(class_id)
         .or_insert_with(HashMap::new)
         .insert(name, value_bits);
+    invalidate_class_prototype_fast_guards();
     crate::gc::runtime_write_barrier_root_nanbox(value_bits);
 }
 
@@ -1234,6 +1246,7 @@ pub unsafe extern "C" fn js_register_prototype_method(
     name_len: usize,
     value: f64,
 ) {
+    invalidate_class_prototype_fast_guards();
     if class_id == 0 || name_ptr.is_null() || name_len == 0 {
         return;
     }
@@ -3165,6 +3178,7 @@ pub(crate) fn test_clear_class_side_table_roots() {
     if let Ok(mut guard) = CLASS_PROTOTYPE_METHODS.write() {
         *guard = None;
     }
+    CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED.store(false, std::sync::atomic::Ordering::Release);
     if let Ok(mut guard) = FUNCTION_CLASS_IDS.write() {
         *guard = None;
     }

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -23,6 +23,24 @@ static REGISTRY: LazyLock<Mutex<TypedFeedbackRegistry>> =
     LazyLock::new(|| Mutex::new(TypedFeedbackRegistry::default()));
 static TRACE_DUMPED: AtomicBool = AtomicBool::new(false);
 
+#[cfg(not(test))]
+static TYPED_FEEDBACK_ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var_os("PERRY_TYPED_FEEDBACK_TRACE").is_some()
+        || std::env::var_os("PERRY_TYPED_FEEDBACK").is_some()
+});
+
+#[inline]
+fn typed_feedback_enabled() -> bool {
+    #[cfg(test)]
+    {
+        true
+    }
+    #[cfg(not(test))]
+    {
+        *TYPED_FEEDBACK_ENABLED
+    }
+}
+
 #[cfg(test)]
 pub(crate) static TYPED_FEEDBACK_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
@@ -360,7 +378,7 @@ pub extern "C" fn js_typed_feedback_register_site(
     fallback_ptr: *const u8,
     fallback_len: usize,
 ) {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return;
     }
     let metadata = SiteMetadata {
@@ -732,7 +750,7 @@ fn guard_observe(
     observation: Observation,
     contract_valid: bool,
 ) -> bool {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return contract_valid;
     }
     let mut reg = registry();
@@ -754,7 +772,7 @@ fn guard_observe(
 }
 
 fn record_guard_pass(site_id: u64) {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return;
     }
     let mut reg = registry();
@@ -764,7 +782,7 @@ fn record_guard_pass(site_id: u64) {
 }
 
 fn record_guard_fail(site_id: u64) {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return;
     }
     let mut reg = registry();
@@ -774,7 +792,7 @@ fn record_guard_fail(site_id: u64) {
 }
 
 fn record_fallback_call(site_id: u64) {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return;
     }
     let mut reg = registry();
@@ -1168,6 +1186,15 @@ pub extern "C" fn js_typed_feedback_plain_array_index_get_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !typed_feedback_enabled() {
+        return (is_plain_number_bits(index_value.to_bits())
+            && index >= 0
+            && plain_array_index_guard(
+                raw_addr as *const ArrayHeader,
+                index as u32,
+                require_in_bounds != 0,
+            )) as i32;
+    }
     let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
@@ -1209,6 +1236,15 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_get_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !typed_feedback_enabled() {
+        return (is_plain_number_bits(index_value.to_bits())
+            && index >= 0
+            && numeric_array_index_guard(
+                raw_addr as *const ArrayHeader,
+                index as u32,
+                require_in_bounds != 0,
+            )) as i32;
+    }
     let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
@@ -1414,6 +1450,14 @@ pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !typed_feedback_enabled() {
+        return (index >= 0
+            && plain_array_index_guard(
+                raw_addr as *const ArrayHeader,
+                index as u32,
+                require_in_bounds != 0,
+            )) as i32;
+    }
     let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
@@ -1454,6 +1498,15 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_set_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !typed_feedback_enabled() {
+        return (index >= 0
+            && is_numeric_value_bits(value.to_bits())
+            && numeric_array_index_guard(
+                raw_addr as *const ArrayHeader,
+                index as u32,
+                require_in_bounds != 0,
+            )) as i32;
+    }
     let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {

--- a/crates/perry-runtime/src/typed_feedback/guards.rs
+++ b/crates/perry-runtime/src/typed_feedback/guards.rs
@@ -281,6 +281,39 @@ fn class_field_get_contract(
     }
 }
 
+fn class_field_fast_contract(
+    receiver: f64,
+    expected_class_id: u32,
+    expected_keys: *const ArrayHeader,
+    expected_field_index: u32,
+    require_raw_f64: bool,
+) -> bool {
+    let object_addr = normalize_raw_object_addr(receiver.to_bits());
+    if object_addr == 0 || expected_class_id == 0 || expected_keys.is_null() {
+        return false;
+    }
+    let Some(gc_header) = gc_header_for_user_addr(object_addr) else {
+        return false;
+    };
+    unsafe {
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT
+            || (*gc_header).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0
+        {
+            return false;
+        }
+        let obj = object_addr as *const ObjectHeader;
+        (*obj).object_type == crate::error::OBJECT_TYPE_REGULAR
+            && (*obj).class_id == expected_class_id
+            && std::ptr::eq((*obj).keys_array as *const ArrayHeader, expected_keys)
+            && expected_field_index < (*obj).field_count
+            && (!require_raw_f64
+                || crate::gc::layout_typed_raw_f64_slot_for_user(
+                    object_addr,
+                    expected_field_index as usize,
+                ))
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_typed_feedback_class_field_get_guard(
     site_id: u64,
@@ -291,6 +324,15 @@ pub extern "C" fn js_typed_feedback_class_field_get_guard(
     expected_field_index: u32,
     require_raw_f64: i32,
 ) -> i32 {
+    if !typed_feedback_enabled() && !crate::object::descriptors_in_use() {
+        return class_field_fast_contract(
+            receiver,
+            expected_class_id,
+            expected_keys,
+            expected_field_index,
+            require_raw_f64 != 0,
+        ) as i32;
+    }
     let (shape_addr, class_id, gc_type, contract_valid) = class_field_get_contract(
         receiver,
         expected_class_id,
@@ -320,6 +362,35 @@ pub extern "C" fn js_typed_feedback_class_field_get_guard(
     } else {
         0
     }
+}
+
+fn class_field_set_fast_contract(
+    receiver: f64,
+    expected_class_id: u32,
+    expected_keys: *const ArrayHeader,
+    expected_field_index: u32,
+    require_raw_f64: bool,
+    value_bits: u64,
+) -> bool {
+    let object_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !class_field_fast_contract(
+        receiver,
+        expected_class_id,
+        expected_keys,
+        expected_field_index,
+        require_raw_f64,
+    ) {
+        return false;
+    }
+    unsafe {
+        let Some(gc_header) = gc_header_for_user_addr(object_addr) else {
+            return false;
+        };
+        if (*gc_header)._reserved & crate::gc::OBJ_FLAG_FROZEN != 0 {
+            return false;
+        }
+    }
+    !require_raw_f64 || is_plain_number_bits(value_bits)
 }
 
 fn descriptor_blocks_class_field_set(obj_addr: usize, class_id: u32, key_name: &str) -> bool {
@@ -425,6 +496,16 @@ pub extern "C" fn js_typed_feedback_class_field_set_guard(
     require_raw_f64: i32,
 ) -> i32 {
     let value_bits = value.to_bits();
+    if !typed_feedback_enabled() && !crate::object::descriptors_in_use() {
+        return class_field_set_fast_contract(
+            receiver,
+            expected_class_id,
+            expected_keys,
+            expected_field_index,
+            require_raw_f64 != 0,
+            value_bits,
+        ) as i32;
+    }
     let (shape_addr, class_id, gc_type, contract_valid) = class_field_set_contract(
         receiver,
         expected_class_id,
@@ -599,6 +680,34 @@ pub unsafe extern "C" fn js_typed_feedback_method_direct_call_guard(
     } else {
         0
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_method_direct_shape_guard(
+    receiver: f64,
+    expected_class_id: u32,
+    expected_keys: *const ArrayHeader,
+) -> i32 {
+    let object_addr = normalize_raw_object_addr(receiver.to_bits());
+    if object_addr == 0 || expected_class_id == 0 || expected_keys.is_null() {
+        return 0;
+    }
+    let Some(gc_header) = gc_header_for_user_addr(object_addr) else {
+        return 0;
+    };
+    if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT
+        || (*gc_header).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0
+        || crate::object::descriptors_in_use()
+        || crate::object::class_prototype_fast_guards_invalidated()
+    {
+        return 0;
+    }
+    let obj = object_addr as *const ObjectHeader;
+    if (*obj).object_type != crate::error::OBJECT_TYPE_REGULAR {
+        return 0;
+    }
+    ((*obj).class_id == expected_class_id && (*obj).keys_array as usize == expected_keys as usize)
+        as i32
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Summary
- Add a hot path for raw-f64 numeric array indexed reads and writes.
- Avoid revalidating/rebuilding raw numeric layout and per-slot layout notes on every guarded numeric array access.
- Preserve descriptor/frozen checks and existing fallback paths for non-raw or direct runtime calls.

## Performance
Before vs after, median of 3 local runs with Node and Bun included for comparison:
- `bench_string_heavy.ts`: Perry 338 ms -> 61 ms (82.0% faster); Node 47 ms, Bun 32 ms after.
- `10_nested_loops.ts`: Perry 13483 ms -> 4347 ms (67.8% faster); Node 19 ms, Bun 19 ms after.
- `11_prime_sieve.ts`: Perry 1503 ms -> 558 ms (62.9% faster); Node 8 ms, Bun 6 ms after.
- `03_array_write.ts`: Perry 3733 ms -> 3390 ms (9.2% faster); Node 12 ms, Bun 9 ms after.
- `04_array_read.ts`: Perry 3700 ms -> 3340 ms (9.7% faster); Node 12 ms, Bun 19 ms after.

## Tests
- `cargo test -p perry-runtime numeric_array --quiet`
- Focused Perry-vs-Node output smoke checks for:
  - `test-files/test_array_methods.ts`
  - `test-files/test_array_slice.ts`
  - `test-files/test_array_of_objects.ts`
  - `benchmarks/suite/03_array_write.ts`
  - `benchmarks/suite/04_array_read.ts`
  - `benchmarks/suite/bench_string_heavy.ts`
- `cargo build -p perry --release --quiet`
