### PR TITLE
Optimize dense numeric array fill loops

### DIFF
--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -47,6 +47,10 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // Extending variant: returns a possibly-realloc'd pointer that the
     // caller must write back to the local slot.
     module.declare_function("js_array_set_f64_extend", I64, &[I64, I32, DOUBLE]);
+    module.declare_function("js_array_fill_f64_const_extend", I64, &[I64, I32, DOUBLE]);
+    module.declare_function("js_array_fill_f64_iota_extend", I64, &[I64, I32]);
+    module.declare_function("js_array_fill_f64_const_len_extend", I64, &[I64, DOUBLE]);
+    module.declare_function("js_array_fill_f64_iota_len_extend", I64, &[I64]);
     module.declare_function("js_array_set_string_key", I64, &[I64, I64, DOUBLE]);
     module.declare_function("js_array_set_index_or_string", I64, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_array_mark_arguments_object", I64, &[I64]);

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -2,11 +2,196 @@
 
 use super::*;
 
-use crate::expr::{BoundedIndexPair, IntRangeFact};
+use crate::expr::{nanbox_pointer_inline, BoundedIndexPair, IntRangeFact};
 use crate::loop_purity::body_needs_asm_barrier;
 use crate::lower_conditional::lower_truthy;
 use crate::native_value::{BoundedBufferIndex, BoundsProof, BoundsState, LengthSource};
-use crate::types::I32;
+use crate::types::{I1, I32, I64};
+
+#[derive(Clone, Copy)]
+enum NumericBulkFillValue {
+    Const(f64),
+    Iota,
+}
+
+struct NumericBulkFillLoop {
+    counter_id: u32,
+    array_id: u32,
+    bound: perry_hir::Expr,
+    value: NumericBulkFillValue,
+}
+
+fn match_numeric_bulk_fill_loop(
+    ctx: &FnCtx<'_>,
+    init: Option<&Stmt>,
+    condition: Option<&perry_hir::Expr>,
+    update: Option<&perry_hir::Expr>,
+    body: &[Stmt],
+) -> Option<NumericBulkFillLoop> {
+    let init = init?;
+    let (counter_id, init_expr) = match init {
+        Stmt::Let { id, init, .. } => (*id, init.as_ref()?),
+        _ => return None,
+    };
+    match init_expr {
+        perry_hir::Expr::Integer(0) => {}
+        perry_hir::Expr::Number(n) if *n == 0.0 => {}
+        _ => return None,
+    }
+    match update {
+        Some(perry_hir::Expr::Update {
+            id,
+            op: perry_hir::UpdateOp::Increment,
+            ..
+        }) if *id == counter_id => {}
+        _ => return None,
+    }
+    let bound = match condition? {
+        perry_hir::Expr::Compare {
+            op: perry_hir::CompareOp::Lt,
+            left,
+            right,
+        } if matches!(left.as_ref(), perry_hir::Expr::LocalGet(id) if *id == counter_id) => {
+            right.as_ref().clone()
+        }
+        _ => return None,
+    };
+    let (object, index, value) = match body {
+        [Stmt::Expr(perry_hir::Expr::IndexSet {
+            object,
+            index,
+            value,
+        })] => (object, index, value),
+        [Stmt::Expr(perry_hir::Expr::PutValueSet {
+            target,
+            key,
+            value,
+            receiver,
+            ..
+        })] if matches!(
+            (target.as_ref(), receiver.as_ref()),
+            (perry_hir::Expr::LocalGet(a), perry_hir::Expr::LocalGet(b)) if a == b
+        ) =>
+        {
+            (target, key, value)
+        }
+        _ => return None,
+    };
+    if !matches!(index.as_ref(), perry_hir::Expr::LocalGet(id) if *id == counter_id) {
+        return None;
+    }
+    let array_id = match object.as_ref() {
+        perry_hir::Expr::LocalGet(id) => *id,
+        _ => return None,
+    };
+    let is_numeric_array = matches!(
+        ctx.local_types.get(&array_id),
+        Some(perry_types::Type::Array(elem))
+            if matches!(elem.as_ref(), perry_types::Type::Number | perry_types::Type::Int32)
+    );
+    if !is_numeric_array {
+        return None;
+    }
+    let value = match value.as_ref() {
+        perry_hir::Expr::LocalGet(id) if *id == counter_id => NumericBulkFillValue::Iota,
+        perry_hir::Expr::Integer(n) => NumericBulkFillValue::Const(*n as f64),
+        perry_hir::Expr::Number(n) if n.is_finite() => NumericBulkFillValue::Const(*n),
+        _ => return None,
+    };
+    Some(NumericBulkFillLoop {
+        counter_id,
+        array_id,
+        bound,
+        value,
+    })
+}
+
+fn lower_numeric_bulk_fill_loop(ctx: &mut FnCtx<'_>, matched: NumericBulkFillLoop) -> Result<bool> {
+    let arr_box = lower_expr(ctx, &perry_hir::Expr::LocalGet(matched.array_id))?;
+    let arr_handle = {
+        let blk = ctx.block();
+        let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+        blk.and(I64, &arr_bits, crate::nanbox::POINTER_MASK_I64)
+    };
+
+    let is_len_bound = matches!(
+        &matched.bound,
+        perry_hir::Expr::PropertyGet { object, property }
+            if property == "length"
+                && matches!(object.as_ref(), perry_hir::Expr::LocalGet(id) if *id == matched.array_id)
+    );
+    let (new_arr, bound_i32) = if is_len_bound {
+        let bound_i32 = ctx
+            .block()
+            .call(I32, "js_array_length", &[(I64, &arr_handle)]);
+        let new_arr = match matched.value {
+            NumericBulkFillValue::Const(value) => {
+                let value_lit = crate::nanbox::double_literal(value);
+                ctx.block().call(
+                    I64,
+                    "js_array_fill_f64_const_len_extend",
+                    &[(I64, &arr_handle), (DOUBLE, &value_lit)],
+                )
+            }
+            NumericBulkFillValue::Iota => ctx.block().call(
+                I64,
+                "js_array_fill_f64_iota_len_extend",
+                &[(I64, &arr_handle)],
+            ),
+        };
+        (new_arr, bound_i32)
+    } else {
+        let bound_i32 = match &matched.bound {
+            perry_hir::Expr::Integer(n) if *n >= 0 && *n <= u32::MAX as i64 => n.to_string(),
+            perry_hir::Expr::Number(n)
+                if n.is_finite() && n.fract() == 0.0 && *n >= 0.0 && *n <= u32::MAX as f64 =>
+            {
+                (*n as u32).to_string()
+            }
+            perry_hir::Expr::LocalGet(id)
+                if ctx.integer_locals.contains(id)
+                    || matches!(
+                        ctx.local_types.get(id),
+                        Some(perry_types::Type::Number | perry_types::Type::Int32)
+                    ) =>
+            {
+                let bound_d = lower_expr(ctx, &matched.bound)?;
+                let raw_i32 = ctx.block().fptosi(DOUBLE, &bound_d, I32);
+                let positive = ctx.block().fcmp("ogt", &bound_d, "0.0");
+                ctx.block().select(I1, &positive, I32, &raw_i32, "0")
+            }
+            _ => return Ok(false),
+        };
+        let new_arr = match matched.value {
+            NumericBulkFillValue::Const(value) => {
+                let value_lit = crate::nanbox::double_literal(value);
+                ctx.block().call(
+                    I64,
+                    "js_array_fill_f64_const_extend",
+                    &[(I64, &arr_handle), (I32, &bound_i32), (DOUBLE, &value_lit)],
+                )
+            }
+            NumericBulkFillValue::Iota => ctx.block().call(
+                I64,
+                "js_array_fill_f64_iota_extend",
+                &[(I64, &arr_handle), (I32, &bound_i32)],
+            ),
+        };
+        (new_arr, bound_i32)
+    };
+    let new_box = nanbox_pointer_inline(ctx.block(), &new_arr);
+    if let Some(slot) = ctx.locals.get(&matched.array_id).cloned() {
+        ctx.block().store(DOUBLE, &new_box, &slot);
+    }
+    if let Some(counter_slot) = ctx.locals.get(&matched.counter_id).cloned() {
+        let bound_d = ctx.block().sitofp(I32, &bound_i32, DOUBLE);
+        ctx.block().store(DOUBLE, &bound_d, &counter_slot);
+    }
+    if let Some(i32_slot) = ctx.i32_counter_slots.get(&matched.counter_id).cloned() {
+        ctx.block().store(I32, &bound_i32, &i32_slot);
+    }
+    Ok(true)
+}
 
 /// For-loop lowering: classic init / cond / body / update / exit CFG.
 ///
@@ -45,6 +230,12 @@ pub(crate) fn lower_for(
         lower_stmt(ctx, init_stmt)?;
     }
     let loop_proof_scope_id = ctx.next_loop_proof_scope_id();
+
+    if let Some(matched) = match_numeric_bulk_fill_loop(ctx, init, condition, update, body) {
+        if lower_numeric_bulk_fill_loop(ctx, matched)? {
+            return Ok(());
+        }
+    }
 
     // Loop-invariant length hoisting peephole. Detect the very common
     // shape `for (...; i < arr.length; ...)` where `arr` is a local

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -744,6 +744,251 @@ pub extern "C" fn js_array_set_f64_extend(
     }
 }
 
+/// Bulk numeric dense fill for compiler-proven trivial loops:
+/// `for (let i = 0; i < end; i++) arr[i] = constant`.
+///
+/// This keeps JavaScript semantics for frozen/sealed/descriptor arrays by
+/// falling back to the ordinary extending setter. The fast path is restricted
+/// to dense writes from index 0 through `end - 1`, so the resulting live
+/// payload is entirely numeric and can be marked raw-f64 / pointer-free once.
+#[no_mangle]
+pub extern "C" fn js_array_fill_f64_const_extend(
+    arr: *mut ArrayHeader,
+    end: u32,
+    value: f64,
+) -> *mut ArrayHeader {
+    if end == 0 {
+        return clean_arr_ptr_mut(arr);
+    }
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        let new_arr = js_array_alloc(end);
+        return js_array_fill_f64_const_extend(new_arr, end, value);
+    }
+    note_array_index_write(arr as usize);
+    let flags = array_object_flags(arr);
+    if flags
+        & (crate::gc::OBJ_FLAG_FROZEN
+            | crate::gc::OBJ_FLAG_SEALED
+            | crate::gc::OBJ_FLAG_NO_EXTEND
+            | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS)
+        != 0
+        || crate::buffer::is_registered_buffer(arr as usize)
+        || crate::typedarray::lookup_typed_array_kind(arr as usize).is_some()
+    {
+        let mut out = arr;
+        for i in 0..end {
+            out = js_array_set_f64_extend(out, i, value);
+        }
+        return out;
+    }
+
+    let Some(number) = value_bits_to_number(value.to_bits()) else {
+        let mut out = arr;
+        for i in 0..end {
+            out = js_array_set_f64_extend(out, i, value);
+        }
+        return out;
+    };
+
+    unsafe {
+        let old_length = (*arr).length;
+        let raw_before = array_numeric_layout(arr) == Some(NumericArrayLayout::RawF64);
+        if old_length > end && !raw_before {
+            let mut fallback = arr;
+            for i in 0..end {
+                fallback = js_array_set_f64_extend(fallback, i, value);
+            }
+            return fallback;
+        }
+
+        let mut out = if end > (*arr).capacity {
+            js_array_grow(arr, end)
+        } else {
+            arr
+        };
+        out = clean_arr_ptr_mut(out);
+        if out.is_null() || end > (*out).capacity {
+            let mut fallback = arr;
+            for i in 0..end {
+                fallback = js_array_set_f64_extend(fallback, i, value);
+            }
+            return fallback;
+        }
+        let elements_ptr = (out as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+        for i in 0..end as usize {
+            // GC_STORE_AUDIT(POINTER_FREE): bulk numeric fill writes raw f64s only.
+            ptr::write(elements_ptr.add(i), number);
+        }
+        if (*out).length < end {
+            (*out).length = end;
+        }
+        set_array_numeric_layout(out, NumericArrayLayout::RawF64);
+        out
+    }
+}
+
+/// Bulk numeric dense fill for loops bounded by current array length:
+/// `for (let i = 0; i < arr.length; i++) arr[i] = constant`.
+///
+/// If the receiver is exotic (frozen/sealed/descriptors/etc.), the fallback
+/// re-reads `.length` on every iteration so it preserves the source loop's
+/// observable behavior when setters mutate array length.
+#[no_mangle]
+pub extern "C" fn js_array_fill_f64_const_len_extend(
+    arr: *mut ArrayHeader,
+    value: f64,
+) -> *mut ArrayHeader {
+    let arr = clean_arr_ptr_mut(arr);
+    let end = js_array_length(arr);
+    if end == 0 || arr.is_null() {
+        return arr;
+    }
+    note_array_index_write(arr as usize);
+    let flags = array_object_flags(arr);
+    if flags
+        & (crate::gc::OBJ_FLAG_FROZEN
+            | crate::gc::OBJ_FLAG_SEALED
+            | crate::gc::OBJ_FLAG_NO_EXTEND
+            | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS)
+        != 0
+        || crate::buffer::is_registered_buffer(arr as usize)
+        || crate::typedarray::lookup_typed_array_kind(arr as usize).is_some()
+    {
+        let mut out = arr;
+        let mut i = 0;
+        while i < js_array_length(out) {
+            out = js_array_set_f64_extend(out, i, value);
+            i += 1;
+        }
+        return out;
+    }
+    js_array_fill_f64_const_extend(arr, end, value)
+}
+
+/// Bulk numeric dense fill for compiler-proven trivial loops:
+/// `for (let i = 0; i < end; i++) arr[i] = i`.
+#[no_mangle]
+pub extern "C" fn js_array_fill_f64_iota_extend(
+    arr: *mut ArrayHeader,
+    end: u32,
+) -> *mut ArrayHeader {
+    if end == 0 {
+        return clean_arr_ptr_mut(arr);
+    }
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        let new_arr = js_array_alloc(end);
+        return js_array_fill_f64_iota_extend(new_arr, end);
+    }
+    note_array_index_write(arr as usize);
+    let flags = array_object_flags(arr);
+    if flags
+        & (crate::gc::OBJ_FLAG_FROZEN
+            | crate::gc::OBJ_FLAG_SEALED
+            | crate::gc::OBJ_FLAG_NO_EXTEND
+            | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS)
+        != 0
+        || crate::buffer::is_registered_buffer(arr as usize)
+        || crate::typedarray::lookup_typed_array_kind(arr as usize).is_some()
+    {
+        let mut out = arr;
+        for i in 0..end {
+            out = js_array_set_f64_extend(out, i, i as f64);
+        }
+        return out;
+    }
+
+    unsafe {
+        let old_length = (*arr).length;
+        let raw_before = array_numeric_layout(arr) == Some(NumericArrayLayout::RawF64);
+        if old_length > end && !raw_before {
+            let mut fallback = arr;
+            for i in 0..end {
+                fallback = js_array_set_f64_extend(fallback, i, i as f64);
+            }
+            return fallback;
+        }
+
+        let mut out = if end > (*arr).capacity {
+            js_array_grow(arr, end)
+        } else {
+            arr
+        };
+        out = clean_arr_ptr_mut(out);
+        if out.is_null() || end > (*out).capacity {
+            let mut fallback = arr;
+            for i in 0..end {
+                fallback = js_array_set_f64_extend(fallback, i, i as f64);
+            }
+            return fallback;
+        }
+        let elements_ptr = (out as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+        for i in 0..end as usize {
+            // GC_STORE_AUDIT(POINTER_FREE): bulk iota fill writes raw f64s only.
+            ptr::write(elements_ptr.add(i), i as f64);
+        }
+        if (*out).length < end {
+            (*out).length = end;
+        }
+        set_array_numeric_layout(out, NumericArrayLayout::RawF64);
+        out
+    }
+}
+
+/// Bulk numeric dense fill for loops bounded by current array length:
+/// `for (let i = 0; i < arr.length; i++) arr[i] = i`.
+///
+/// If the receiver is exotic (frozen/sealed/descriptors/etc.), the fallback
+/// re-reads `.length` on every iteration so it preserves the source loop's
+/// observable behavior when setters mutate array length.
+#[no_mangle]
+pub extern "C" fn js_array_fill_f64_iota_len_extend(arr: *mut ArrayHeader) -> *mut ArrayHeader {
+    let arr = clean_arr_ptr_mut(arr);
+    let end = js_array_length(arr);
+    if end == 0 || arr.is_null() {
+        return arr;
+    }
+    note_array_index_write(arr as usize);
+    let flags = array_object_flags(arr);
+    if flags
+        & (crate::gc::OBJ_FLAG_FROZEN
+            | crate::gc::OBJ_FLAG_SEALED
+            | crate::gc::OBJ_FLAG_NO_EXTEND
+            | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS)
+        != 0
+        || crate::buffer::is_registered_buffer(arr as usize)
+        || crate::typedarray::lookup_typed_array_kind(arr as usize).is_some()
+    {
+        let mut out = arr;
+        let mut i = 0;
+        while i < js_array_length(out) {
+            out = js_array_set_f64_extend(out, i, i as f64);
+            i += 1;
+        }
+        return out;
+    }
+    js_array_fill_f64_iota_extend(arr, end)
+}
+
+#[used]
+static KEEP_ARRAY_FILL_F64_CONST_EXTEND: extern "C" fn(
+    *mut ArrayHeader,
+    u32,
+    f64,
+) -> *mut ArrayHeader = js_array_fill_f64_const_extend;
+#[used]
+static KEEP_ARRAY_FILL_F64_IOTA_EXTEND: extern "C" fn(*mut ArrayHeader, u32) -> *mut ArrayHeader =
+    js_array_fill_f64_iota_extend;
+#[used]
+static KEEP_ARRAY_FILL_F64_CONST_LEN_EXTEND: extern "C" fn(
+    *mut ArrayHeader,
+    f64,
+) -> *mut ArrayHeader = js_array_fill_f64_const_len_extend;
+#[used]
+static KEEP_ARRAY_FILL_F64_IOTA_LEN_EXTEND: extern "C" fn(*mut ArrayHeader) -> *mut ArrayHeader =
+    js_array_fill_f64_iota_len_extend;
+
 /// `arr[stringKey] = value` — handles the JS spec rule that numeric-string
 /// keys on arrays are coerced to integer indices. Pre-fix the codegen's
 /// IndexSet array fast-path applied `fptosi(double, i32)` directly to the

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -23,6 +23,24 @@ static REGISTRY: LazyLock<Mutex<TypedFeedbackRegistry>> =
     LazyLock::new(|| Mutex::new(TypedFeedbackRegistry::default()));
 static TRACE_DUMPED: AtomicBool = AtomicBool::new(false);
 
+#[cfg(not(test))]
+static TYPED_FEEDBACK_ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var_os("PERRY_TYPED_FEEDBACK_TRACE").is_some()
+        || std::env::var_os("PERRY_TYPED_FEEDBACK").is_some()
+});
+
+#[inline]
+fn typed_feedback_enabled() -> bool {
+    #[cfg(test)]
+    {
+        true
+    }
+    #[cfg(not(test))]
+    {
+        *TYPED_FEEDBACK_ENABLED
+    }
+}
+
 #[cfg(test)]
 pub(crate) static TYPED_FEEDBACK_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
@@ -360,7 +378,7 @@ pub extern "C" fn js_typed_feedback_register_site(
     fallback_ptr: *const u8,
     fallback_len: usize,
 ) {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return;
     }
     let metadata = SiteMetadata {
@@ -732,7 +750,7 @@ fn guard_observe(
     observation: Observation,
     contract_valid: bool,
 ) -> bool {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return contract_valid;
     }
     let mut reg = registry();
@@ -754,7 +772,7 @@ fn guard_observe(
 }
 
 fn record_guard_pass(site_id: u64) {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return;
     }
     let mut reg = registry();
@@ -764,7 +782,7 @@ fn record_guard_pass(site_id: u64) {
 }
 
 fn record_guard_fail(site_id: u64) {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return;
     }
     let mut reg = registry();
@@ -774,7 +792,7 @@ fn record_guard_fail(site_id: u64) {
 }
 
 fn record_fallback_call(site_id: u64) {
-    if site_id == 0 {
+    if site_id == 0 || !typed_feedback_enabled() {
         return;
     }
     let mut reg = registry();
@@ -1168,6 +1186,15 @@ pub extern "C" fn js_typed_feedback_plain_array_index_get_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !typed_feedback_enabled() {
+        return (is_plain_number_bits(index_value.to_bits())
+            && index >= 0
+            && plain_array_index_guard(
+                raw_addr as *const ArrayHeader,
+                index as u32,
+                require_in_bounds != 0,
+            )) as i32;
+    }
     let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
@@ -1209,6 +1236,15 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_get_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !typed_feedback_enabled() {
+        return (is_plain_number_bits(index_value.to_bits())
+            && index >= 0
+            && numeric_array_index_guard(
+                raw_addr as *const ArrayHeader,
+                index as u32,
+                require_in_bounds != 0,
+            )) as i32;
+    }
     let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
@@ -1414,6 +1450,14 @@ pub extern "C" fn js_typed_feedback_plain_array_index_set_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !typed_feedback_enabled() {
+        return (index >= 0
+            && plain_array_index_guard(
+                raw_addr as *const ArrayHeader,
+                index as u32,
+                require_in_bounds != 0,
+            )) as i32;
+    }
     let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {
@@ -1454,6 +1498,15 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_set_guard(
     require_in_bounds: i32,
 ) -> i32 {
     let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !typed_feedback_enabled() {
+        return (index >= 0
+            && is_numeric_value_bits(value.to_bits())
+            && numeric_array_index_guard(
+                raw_addr as *const ArrayHeader,
+                index as u32,
+                require_in_bounds != 0,
+            )) as i32;
+    }
     let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
     let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(observed_index));
     let observation = Observation {


### PR DESCRIPTION
## Summary
- lower compiler-proven dense numeric array fill loops into bulk runtime helpers
- add raw-f64 bulk fill helpers for constant and iota writes, including arr.length-bounded variants
- gate typed feedback collection in normal runtime unless feedback tracing is enabled

## Benchmarks
Median of 3 runs with --no-auto-optimize, compared to the prior typed-feedback baseline:
- 03_array_write.ts: 3270 ms -> 4 ms (817.5x faster; faster than Node 9 ms and Bun 6 ms locally)
- 04_array_read.ts: 3388 ms -> 174 ms (19.5x faster)
- 10_nested_loops.ts: 4300 ms -> 307 ms (14.0x faster)
- 11_prime_sieve.ts: 549 ms -> 47 ms (11.7x faster)
- 16_matrix_multiply.ts: 8854 ms -> 581 ms (15.2x faster)
- bench_numeric_array_numeric.ts: 3651 ms -> 243 ms (15.0x faster)
- bench_array_grow.ts: 523 ms -> 125 ms (4.2x faster)

Current local comparison after this change (Perry / Node / Bun, median ms):
- 03_array_write.ts: 4 / 9 / 6
- 06_math_intensive.ts: 51 / 51 / 52
- 05_fibonacci.ts: 318 / 1029 / 553
- 15_mandelbrot.ts: 23 / 25 / 29

Remaining gaps to target next:
- 09_method_calls.ts: Perry 7338 ms vs Node 11 ms vs Bun 19 ms
- 16_matrix_multiply.ts: Perry 581 ms vs Node/Bun 35 ms
- bench_numeric_array_numeric.ts: Perry 243 ms vs Node/Bun 5 ms
- 04_array_read.ts: Perry 174 ms vs Node 12 ms vs Bun 19 ms

## Validation
- cargo check -p perry-codegen --quiet
- cargo test -p perry-runtime numeric_array --quiet
- cargo test -p perry-runtime typed_feedback --quiet
- cargo build -p perry --release --quiet
- cargo build -p perry-runtime --release --quiet
- rustfmt --check on the four touched source files
- git diff --check
- Perry vs Node smoke comparisons for array write/read, numeric arrays, grow, array methods/slice/object arrays, guarded raw numeric arrays, and bulk-fill length semantics

Note: cargo fmt -- --check currently reports unrelated pre-existing formatting diffs in perry-codegen/perry-hir files. cargo test --workspace cannot complete on this machine because pkg-config cannot find the system gtk4 and graphene-gobject-1.0 libraries required by gdk4-sys/graphene-sys.
