### PR TITLE
fix(compile): support package createRequire interop

### DIFF
--- a/crates/perry/src/commands/compile/bootstrap.rs
+++ b/crates/perry/src/commands/compile/bootstrap.rs
@@ -310,11 +310,132 @@ pub(super) fn enforce_js_runtime_gate(ctx: &CompilationContext) -> Result<()> {
     );
 }
 
+fn is_bare_package_specifier(source: &str) -> bool {
+    !source.starts_with('.') && !source.starts_with('/')
+}
+
+fn module_provides_export(
+    ctx: &mut CompilationContext,
+    module_path: &Path,
+    export_name: &str,
+    seen: &mut HashSet<(PathBuf, String)>,
+) -> bool {
+    let key = (module_path.to_path_buf(), export_name.to_string());
+    if !seen.insert(key) {
+        return false;
+    }
+
+    let Some(module) = ctx.native_modules.get(module_path) else {
+        return false;
+    };
+    let exports = module.exports.clone();
+
+    for export in exports {
+        match export {
+            perry_hir::Export::Named { exported, .. } if exported == export_name => {
+                return true;
+            }
+            perry_hir::Export::NamespaceReExport { name, .. } if name == export_name => {
+                return true;
+            }
+            perry_hir::Export::ReExport {
+                source,
+                imported,
+                exported,
+            } if exported == export_name => {
+                if let Some((resolved, perry_hir::ModuleKind::NativeCompiled)) =
+                    super::cached_resolve_import(&source, module_path, ctx)
+                {
+                    if module_provides_export(ctx, &resolved, &imported, seen) {
+                        return true;
+                    }
+                }
+            }
+            perry_hir::Export::ExportAll { source } if export_name != "default" => {
+                if let Some((resolved, perry_hir::ModuleKind::NativeCompiled)) =
+                    super::cached_resolve_import(&source, module_path, ctx)
+                {
+                    if module_provides_export(ctx, &resolved, export_name, seen) {
+                        return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+/// Validate default imports from package entries that Perry compiles natively.
+///
+/// Perry lowers JS-module default imports to a `__default` wrapper symbol. If a
+/// package entry is ESM-shaped and exposes only named exports, that wrapper has
+/// no producer and the user sees a native linker error. Match Node's static ESM
+/// behavior for the package-import case by rejecting the import while the module
+/// graph still has source/package context.
+pub(super) fn enforce_package_default_exports(ctx: &mut CompilationContext) -> Result<()> {
+    let import_edges: Vec<(PathBuf, String, String, String)> = ctx
+        .native_modules
+        .iter()
+        .flat_map(|(importer_path, module)| {
+            module.imports.iter().filter_map(|import| {
+                if import.type_only
+                    || import.is_dynamic
+                    || import.is_native
+                    || import.module_kind != perry_hir::ModuleKind::NativeCompiled
+                    || !is_bare_package_specifier(&import.source)
+                {
+                    return None;
+                }
+                let resolved_path = import.resolved_path.as_ref()?;
+                let default_local =
+                    import
+                        .specifiers
+                        .iter()
+                        .find_map(|specifier| match specifier {
+                            perry_hir::ImportSpecifier::Default { local } => Some(local.clone()),
+                            _ => None,
+                        })?;
+                Some((
+                    importer_path.clone(),
+                    import.source.clone(),
+                    resolved_path.clone(),
+                    default_local,
+                ))
+            })
+        })
+        .collect();
+
+    for (importer_path, source, resolved_path, local) in import_edges {
+        let target_path = PathBuf::from(&resolved_path);
+        if !ctx.native_modules.contains_key(&target_path) {
+            continue;
+        }
+        if !module_provides_export(ctx, &target_path, "default", &mut HashSet::new()) {
+            anyhow::bail!(
+                "The requested package '{}' does not provide an export named 'default' \
+                 (imported as '{}' in {}). Resolved package entry: {}",
+                source,
+                local,
+                importer_path.display(),
+                target_path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod js_runtime_gate_tests {
     use std::path::PathBuf;
 
-    use super::{enforce_js_runtime_gate, CompilationContext};
+    use super::{enforce_js_runtime_gate, enforce_package_default_exports, CompilationContext};
+
+    fn empty_module(name: &str) -> perry_hir::Module {
+        perry_hir::Module::new(name)
+    }
 
     #[test]
     fn diagnostic_suggests_missing_compile_package_on_windows_paths() {
@@ -364,6 +485,44 @@ mod js_runtime_gate_tests {
         assert!(message.contains(&format!("declarations: {}", declaration.display())));
         assert!(message.contains("Declaration hint:"));
         assert!(message.contains("typed-js"));
+    }
+
+    #[test]
+    fn package_default_import_without_default_export_fails_preflight() {
+        let mut ctx = CompilationContext::new(PathBuf::from("/repo"));
+        let importer_path = PathBuf::from("/repo/main.ts");
+        let package_path = PathBuf::from("/repo/node_modules/pkg/index.ts");
+
+        let mut importer = empty_module("main");
+        importer.imports.push(perry_hir::Import {
+            source: "pkg".to_string(),
+            specifiers: vec![perry_hir::ImportSpecifier::Default {
+                local: "Pkg".to_string(),
+            }],
+            is_native: false,
+            module_kind: perry_hir::ModuleKind::NativeCompiled,
+            resolved_path: Some(package_path.to_string_lossy().to_string()),
+            type_only: false,
+            is_dynamic: false,
+            is_dynamic_target: false,
+        });
+
+        let mut package = empty_module("pkg");
+        package.exports.push(perry_hir::Export::Named {
+            local: "named".to_string(),
+            exported: "named".to_string(),
+        });
+
+        ctx.native_modules.insert(importer_path, importer);
+        ctx.native_modules.insert(package_path, package);
+
+        let message = enforce_package_default_exports(&mut ctx)
+            .expect_err("missing package default export must fail before codegen")
+            .to_string();
+
+        assert!(message.contains("pkg"));
+        assert!(message.contains("default"));
+        assert!(message.contains("Resolved package entry"));
     }
 }
 
@@ -717,6 +876,7 @@ pub(super) fn run_post_collect_preflight(
     format: OutputFormat,
 ) -> Result<()> {
     enforce_js_runtime_gate(ctx)?;
+    enforce_package_default_exports(ctx)?;
     recompute_common_project_root(ctx);
 
     let total_modules = ctx.native_modules.len() + ctx.js_modules.len();

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -30,12 +30,14 @@ use super::{
     parse_package_specifier, CompilationContext, JsModule, ParseCache,
 };
 
+mod create_require_transform;
 mod crypto_ns;
 mod dynamic_glob;
 mod parse_error;
 #[cfg(test)]
 mod tests;
 
+use create_require_transform::transform_create_require_literal_requires;
 use crypto_ns::module_uses_global_crypto_namespace;
 use dynamic_glob::expand_dynamic_import_glob;
 use parse_error::annotate_parse_error;
@@ -459,6 +461,7 @@ fn collect_module_one(
     } else {
         raw_source
     };
+    let source = transform_create_require_literal_requires(&source, &ctx.compile_packages);
 
     // Note (#686): we no longer hash source bytes here. The object cache key
     // is now keyed on a post-transform HIR fingerprint computed inside the

--- a/crates/perry/src/commands/compile/collect_modules/create_require_transform.rs
+++ b/crates/perry/src/commands/compile/collect_modules/create_require_transform.rs
@@ -1,0 +1,200 @@
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::parse_package_specifier;
+
+pub(super) fn transform_create_require_literal_requires(
+    source: &str,
+    compile_packages: &HashSet<String>,
+) -> String {
+    let create_require_aliases = collect_create_require_aliases(source);
+    if create_require_aliases.is_empty() {
+        return source.to_string();
+    }
+
+    let require_aliases = collect_require_aliases(source, &create_require_aliases);
+    if require_aliases.is_empty() {
+        return source.to_string();
+    }
+
+    let mut transformed = source.to_string();
+    let mut imports = Vec::new();
+    let mut next_id = 0usize;
+    for alias in require_aliases {
+        let call_re = require_assignment_re(&alias);
+        let mut replacements = Vec::new();
+        for cap in call_re.captures_iter(&transformed) {
+            let specifier = cap.name("spec").map(|m| m.as_str()).unwrap_or_default();
+            if should_leave_runtime_require(specifier, compile_packages) {
+                continue;
+            }
+            let Some(full) = cap.get(0) else {
+                continue;
+            };
+            let temp = unique_temp_name(&transformed, &mut next_id);
+            imports.push(format!("import * as {temp} from {:?};", specifier));
+            let indent = cap.name("indent").map(|m| m.as_str()).unwrap_or("");
+            let kind = cap.name("kind").map(|m| m.as_str()).unwrap_or("const");
+            let lhs = cap.name("lhs").map(|m| m.as_str()).unwrap_or("").trim_end();
+            let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("");
+            replacements.push((
+                full.start(),
+                full.end(),
+                format!("{indent}{kind} {lhs} = {temp};{tail}"),
+            ));
+        }
+
+        if replacements.is_empty() {
+            continue;
+        }
+        for (start, end, replacement) in replacements.into_iter().rev() {
+            transformed.replace_range(start..end, &replacement);
+        }
+    }
+
+    if imports.is_empty() {
+        return source.to_string();
+    }
+
+    let mut prefix = imports.join("\n");
+    prefix.push('\n');
+    if transformed.starts_with("#!") {
+        if let Some(line_end) = transformed.find('\n') {
+            let mut out = String::new();
+            out.push_str(&transformed[..=line_end]);
+            out.push_str(&prefix);
+            out.push_str(&transformed[line_end + 1..]);
+            out
+        } else {
+            format!("{transformed}\n{prefix}")
+        }
+    } else {
+        prefix.push_str(&transformed);
+        prefix
+    }
+}
+
+fn collect_create_require_aliases(source: &str) -> HashSet<String> {
+    static IMPORT_RE: OnceLock<Regex> = OnceLock::new();
+    let import_re = IMPORT_RE.get_or_init(|| {
+        Regex::new(
+            r#"(?m)^\s*import\s*\{(?P<specs>[^}]*)\}\s*from\s*['"](?:node:)?module['"]\s*;?"#,
+        )
+        .expect("createRequire import regex")
+    });
+
+    let mut aliases = HashSet::new();
+    for cap in import_re.captures_iter(source) {
+        let Some(specs) = cap.name("specs") else {
+            continue;
+        };
+        for part in specs.as_str().split(',') {
+            let part = part.trim();
+            if part == "createRequire" {
+                aliases.insert("createRequire".to_string());
+                continue;
+            }
+            if let Some(rest) = part.strip_prefix("createRequire as ") {
+                let alias = rest.trim();
+                if is_identifier(alias) {
+                    aliases.insert(alias.to_string());
+                }
+            }
+        }
+    }
+    aliases
+}
+
+fn collect_require_aliases(source: &str, create_require_aliases: &HashSet<String>) -> Vec<String> {
+    let mut out = Vec::new();
+    for create_alias in create_require_aliases {
+        let decl_re = create_require_decl_re(create_alias);
+        for cap in decl_re.captures_iter(source) {
+            let Some(alias) = cap.name("alias").map(|m| m.as_str()) else {
+                continue;
+            };
+            if !out.iter().any(|existing| existing == alias) {
+                out.push(alias.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn create_require_decl_re(create_alias: &str) -> Regex {
+    Regex::new(&format!(
+        r#"(?m)^\s*(?:const|let|var)\s+(?P<alias>[A-Za-z_$][A-Za-z0-9_$]*)(?:\s*:\s*[^=;]+)?\s*=\s*{}\s*\(\s*import\.meta\.url\s*\)\s*;?"#,
+        regex::escape(create_alias)
+    ))
+    .expect("createRequire declaration regex")
+}
+
+fn require_assignment_re(require_alias: &str) -> Regex {
+    Regex::new(&format!(
+        r#"(?m)^(?P<indent>[ \t]*)(?P<kind>const|let|var)\s+(?P<lhs>[^=\n;]+?)\s*=\s*{}\s*\(\s*['"](?P<spec>[^'"]+)['"]\s*\)\s*;?(?P<tail>[ \t]*(?://[^\n]*)?)$"#,
+        regex::escape(require_alias)
+    ))
+    .expect("createRequire literal call regex")
+}
+
+fn should_leave_runtime_require(specifier: &str, compile_packages: &HashSet<String>) -> bool {
+    let (package_name, _) = parse_package_specifier(specifier);
+    perry_hir::is_native_module(specifier) && !compile_packages.contains(&package_name)
+}
+
+fn unique_temp_name(source: &str, next_id: &mut usize) -> String {
+    loop {
+        let name = format!("__perry_create_require_{}", *next_id);
+        *next_id += 1;
+        if !source.contains(&name) {
+            return name;
+        }
+    }
+}
+
+fn is_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hoists_non_builtin_literal_requires_from_create_require() {
+        let source = r#"
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const Discord = require("discord.js");
+const local: any = require("./local");
+const path = require("node:path");
+"#;
+        let got = transform_create_require_literal_requires(source, &HashSet::new());
+        assert!(got.contains(r#"import * as __perry_create_require_0 from "discord.js";"#));
+        assert!(got.contains(r#"import * as __perry_create_require_1 from "./local";"#));
+        assert!(got.contains("const Discord = __perry_create_require_0;"));
+        assert!(got.contains("const local: any = __perry_create_require_1;"));
+        assert!(got.contains(r#"const path = require("node:path");"#));
+    }
+
+    #[test]
+    fn supports_renamed_create_require_and_destructuring() {
+        let source = r#"
+import { createRequire as makeRequire } from "module";
+const req = makeRequire(import.meta.url);
+const { Client } = req("mini");
+"#;
+        let got = transform_create_require_literal_requires(source, &HashSet::new());
+        assert!(got.contains(r#"import * as __perry_create_require_0 from "mini";"#));
+        assert!(got.contains("const { Client } = __perry_create_require_0;"));
+    }
+}

--- a/crates/perry/tests/create_require_package.rs
+++ b/crates/perry/tests/create_require_package.rs
@@ -1,0 +1,113 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn create_require_literal_package_and_file_resolve_to_compiled_modules() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "create-require-package-reducer",
+  "type": "module",
+  "perry": {
+    "compilePackages": ["minicord"],
+    "allow": { "compilePackages": ["minicord"] }
+  }
+}"#,
+    )
+    .expect("write consumer package.json");
+
+    let pkg = root.join("node_modules").join("minicord");
+    std::fs::create_dir_all(&pkg).expect("mkdir minicord");
+    std::fs::write(
+        pkg.join("package.json"),
+        r#"{ "name": "minicord", "version": "1.0.0", "main": "index.ts", "types": "index.ts" }"#,
+    )
+    .expect("write minicord package.json");
+    std::fs::write(
+        pkg.join("index.ts"),
+        r#"
+export class Client {
+  tag: string;
+  constructor(tag: string) {
+    this.tag = tag;
+  }
+  login(): string {
+    return "login:" + this.tag;
+  }
+}
+export const version = "mini-1";
+export function make(name: string): string {
+  return "make:" + name;
+}
+"#,
+    )
+    .expect("write minicord index");
+
+    std::fs::write(
+        root.join("local.ts"),
+        r#"
+export const localValue = "local-ok";
+export function localCall(value: string): string {
+  return "local:" + value;
+}
+"#,
+    )
+    .expect("write local module");
+
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { createRequire } from "node:module";
+
+const req = createRequire(import.meta.url);
+console.log("builtin:", typeof req("node:path").join);
+
+const require = createRequire(import.meta.url);
+const Mini = require("minicord");
+const Local = require("./local");
+
+const client = new Mini.Client("A");
+console.log("package:", Mini.version, Mini.make("B"), client.login());
+console.log("file:", Local.localValue, Local.localCall("C"));
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout,
+        "builtin: function\npackage: mini-1 make:B login:A\nfile: local-ok local:C\n"
+    );
+}


### PR DESCRIPTION
## Summary
- add a conservative createRequire(import.meta.url) literal require transform for compiled package/file specifiers
- emit namespace imports for package/file createRequire interop so named-export-only packages do not require a default export
- add package default-import preflight for compiled package entries and a focused compiled reducer

## Verification
- cargo fmt --all
- cargo test -p perry create_require_transform --bin perry
- cargo test -p perry package_default_import_without_default_export_fails_preflight --bin perry
- cargo test -p perry-runtime permission_bitwise_values_match_node
- cargo test -p perry --test create_require_package -- --nocapture
- cargo test -p perry --test module_import_forms -- --nocapture
- ./run_parity_tests.sh --suite node-suite --filter create-require-shape
- cargo build --release -p perry -p perry-runtime -p perry-stdlib

Local release artifact dir from this worktree: /Users/andrew/.codex/worktrees/75ec/perry/target/release

Note: current origin/main already contains the Discord BigInt/root-import reducer base delta via #4946; this PR keeps the remaining createRequire/default-export boundary changes scoped.