### PR TITLE
feat(cluster): workers share a listening port — SO_REUSEPORT + IPC 'listening' round-trip (#4914)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5670,6 +5670,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "serde_json",
+ "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -3643,19 +3643,18 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("querystring", "encode", false, None),
     // node:cluster — primary lifecycle surface. `setupPrimary` /
     // `setupMaster`, `fork`, and `disconnect` route through the native
-    // module bound-method path; handle sharing/listening distribution is
-    // outside this manifest entry.
+    // module bound-method path. Workers share a listening port via
+    // SO_REUSEPORT binds + a fork-IPC 'listening' round-trip (#4914);
+    // `SCHED_RR` fd-passing and the shared ephemeral port for `listen(0)`
+    // remain tracked in #4962.
     // #3687: default import (`import cluster from "node:cluster"`) is the
     // EventEmitter-shaped `cluster.default` namespace; the `import * as`
     // namespace keeps the shape-only surface.
     property("cluster", "default"),
-    method("cluster", "fork", false, None)
-        .stub_note("no socket/listening-handle distribution; workers cannot share a port (#4914)"),
+    method("cluster", "fork", false, None),
     method("cluster", "disconnect", false, None),
-    method("cluster", "setupPrimary", false, None)
-        .stub_note("no socket/listening-handle distribution; workers cannot share a port (#4914)"),
-    method("cluster", "setupMaster", false, None)
-        .stub_note("no socket/listening-handle distribution; workers cannot share a port (#4914)"),
+    method("cluster", "setupPrimary", false, None),
+    method("cluster", "setupMaster", false, None),
     class("cluster", "Worker"),
     property("cluster", "isPrimary"),
     property("cluster", "isMaster"),

--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -53,12 +53,12 @@ pub struct ApiEntry {
     /// them — the runtime first-call warning from #464 surfaces those.
     ///
     /// As of the stub-elimination epic (#4919) this is also set for the
-    /// known "registered but fake/no-op/partial" clusters — dns/dgram
-    /// loopback fakes (#4911), `child_process.spawn` (#4912), cluster
-    /// socket distribution (#4914), BYOB streams (#4915), v8 heap
-    /// snapshots (#4916), and the stdlib-adapter no-ops (#4917) — so
-    /// the manifest is the single source of truth for "this API lies".
-    /// CI drift-guards the exact set (`tests/stub_inventory.rs`).
+    /// known "registered but fake/no-op/partial" clusters — BYOB streams
+    /// (#4915), v8 heap snapshots (#4916), and the stdlib-adapter no-ops
+    /// (#4917) — so the manifest is the single source of truth for "this
+    /// API lies". (dns/dgram #4911, spawn #4912, and cluster port
+    /// sharing #4914 have since been implemented for real.) CI
+    /// drift-guards the exact set (`tests/stub_inventory.rs`).
     pub stub: bool,
     /// Short human-readable reason this entry is a stub/partial, with an
     /// issue tag — surfaced verbatim in the generated `.d.ts` and

--- a/crates/perry-api-manifest/tests/stub_inventory.rs
+++ b/crates/perry-api-manifest/tests/stub_inventory.rs
@@ -65,7 +65,10 @@ fn stub_inventory_matches_known_clusters() {
         // #4912 (child_process.spawn) intentionally absent: spawn is real
         // since #1780 (Expr::ChildProcessSpawn codegen). The audit's
         // "returns null" premise was stale; only exec() timing remains.
-        ("#4914", 3),  // cluster fork/setupPrimary/setupMaster (no handle distribution)
+        // #4914 (cluster port sharing) intentionally absent: workers share a
+        // listening port via SO_REUSEPORT binds + a fork-IPC 'listening'
+        // round-trip; SCHED_RR fd-passing + shared ephemeral `listen(0)`
+        // port are tracked in #4962 and are policy fidelity, not lies.
         ("#4915", 4),  // BYOB readers + ByteLengthQueuingStrategy (throw)
         ("#4916", 2),  // v8 get/writeHeapSnapshot (empty graph)
         ("#4917", 18), // stdlib adapters: zlib(11) + http.Agent(3) + worker ref/unref(2) + mongodb(1) + backoff(1)
@@ -84,7 +87,6 @@ fn stubs_only_appear_in_allowlisted_modules() {
     // A stub flag showing up on a module not in this list is almost
     // certainly an accident — fail loud so it gets triaged.
     let allowed = [
-        "cluster",
         "stream/web",
         "streams",
         "v8",
@@ -110,7 +112,6 @@ fn keystone_apis_are_flagged() {
     // Spot-check the headline lies from the epic so a refactor can't
     // quietly drop the flag on the worst offenders.
     let must_be_stub: &[(&str, &str)] = &[
-        ("cluster", "fork"),
         ("v8", "getHeapSnapshot"),
         ("v8", "writeHeapSnapshot"),
         ("zlib", "createGzip"),

--- a/crates/perry-ext-http-server/Cargo.toml
+++ b/crates/perry-ext-http-server/Cargo.toml
@@ -29,6 +29,10 @@ serde_json = "1"
 lazy_static = "1.5"
 tokio-tungstenite = { workspace = true }
 
+# #4914: SO_REUSEPORT binds for cluster-worker port sharing (unix-only API).
+[target.'cfg(unix)'.dependencies]
+socket2 = "0.6"
+
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
 perry-runtime = { workspace = true, features = ["external-ws-symbols"] }

--- a/crates/perry-ext-http-server/src/cluster_bind.rs
+++ b/crates/perry-ext-http-server/src/cluster_bind.rs
@@ -1,0 +1,59 @@
+//! #4914 — `node:cluster` worker port sharing for the HTTP/HTTPS/HTTP2
+//! listen sites.
+//!
+//! When this process is a `cluster.fork()`ed worker (Node's convention:
+//! non-empty `NODE_UNIQUE_ID` in the environment), every TCP bind goes
+//! through SO_REUSEPORT so N workers can share one port, and the bound
+//! address is reported to the primary over the fork IPC channel so
+//! `cluster.on('listening')` fires Node-style. Kernel SO_REUSEPORT
+//! balancing is effectively `SCHED_NONE`; round-robin fd-passing
+//! (`SCHED_RR`) and the shared ephemeral port for `listen(0)` are #4962.
+
+use std::net::{SocketAddr, TcpListener};
+
+pub(crate) fn is_cluster_worker() -> bool {
+    std::env::var("NODE_UNIQUE_ID")
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+}
+
+/// Bind `addr`, with SO_REUSEPORT (+SO_REUSEADDR) when running as a cluster
+/// worker. Non-worker binds keep the plain `TcpListener::bind` path.
+pub(crate) fn bind_listener(addr: SocketAddr) -> std::io::Result<TcpListener> {
+    #[cfg(unix)]
+    if is_cluster_worker() {
+        use socket2::{Domain, Protocol, Socket, Type};
+        let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))?;
+        socket.set_reuse_address(true)?;
+        socket.set_reuse_port(true)?;
+        socket.bind(&addr.into())?;
+        // Node's default listen backlog.
+        socket.listen(511)?;
+        return Ok(socket.into());
+    }
+    TcpListener::bind(addr)
+}
+
+extern "C" {
+    // Defined in perry-runtime's cluster.rs. This crate has no Cargo dep on
+    // perry-runtime (dev-dep only); the symbol resolves at final link, the
+    // same way perry-ffi's runtime helpers do.
+    fn perry_cluster_worker_listening(
+        addr_ptr: *const u8,
+        addr_len: u32,
+        port: i32,
+        address_type: i32,
+    );
+}
+
+/// Worker→primary `'listening'` report; no-op unless this is a cluster
+/// worker (checked again on the runtime side).
+pub(crate) fn notify_listening(host: &str, port: u16) {
+    if !is_cluster_worker() {
+        return;
+    }
+    let address_type = if host.contains(':') { 6 } else { 4 };
+    unsafe {
+        perry_cluster_worker_listening(host.as_ptr(), host.len() as u32, port as i32, address_type)
+    }
+}

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -557,7 +557,8 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
         Ok(a) => a,
         Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
     };
-    let std_listener = match std::net::TcpListener::bind(addr) {
+    // #4914 — SO_REUSEPORT in cluster workers; plain bind otherwise.
+    let std_listener = match crate::cluster_bind::bind_listener(addr) {
         Ok(l) => l,
         Err(e) => {
             eprintln!("[node:http2] bind {}:{} failed: {}", host, port, e);
@@ -569,6 +570,7 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
         eprintln!("[node:http2] set_nonblocking failed: {}", e);
         return server_handle;
     }
+    crate::cluster_bind::notify_listening(&host, actual_port);
 
     let (tls_config, plaintext) =
         if let Some(s) = get_handle_mut::<Http2SecureServer>(server_handle) {

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -159,7 +159,8 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
         Ok(a) => a,
         Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
     };
-    let std_listener = match std::net::TcpListener::bind(addr) {
+    // #4914 — SO_REUSEPORT in cluster workers; plain bind otherwise.
+    let std_listener = match crate::cluster_bind::bind_listener(addr) {
         Ok(l) => l,
         Err(e) => {
             eprintln!("[node:https] bind {}:{} failed: {}", host, port, e);
@@ -171,6 +172,7 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
         eprintln!("[node:https] set_nonblocking failed: {}", e);
         return server_handle;
     }
+    crate::cluster_bind::notify_listening(&host, actual_port);
 
     let tls_config = if let Some(s) = get_handle_mut::<HttpsServer>(server_handle) {
         s.base.bound_port = actual_port;

--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -52,6 +52,7 @@ use std::sync::Once;
 
 use perry_ffi::{gc_register_mutable_root_scanner_named, iter_handles_of_mut, GcRootVisitor};
 
+mod cluster_bind;
 mod handle_dispatch;
 mod http2_server;
 mod http2_session_settings;

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -449,7 +449,9 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
         Ok(a) => a,
         Err(_) => SocketAddr::from(([0, 0, 0, 0], port)),
     };
-    let std_listener = match std::net::TcpListener::bind(addr) {
+    // #4914 — cluster workers bind with SO_REUSEPORT so N workers share
+    // the port; `bind_listener` falls through to a plain bind otherwise.
+    let std_listener = match crate::cluster_bind::bind_listener(addr) {
         Ok(l) => l,
         Err(e) => {
             eprintln!("[node:http] bind {}:{} failed: {}", host, port, e);
@@ -461,6 +463,7 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
         eprintln!("[node:http] set_nonblocking failed: {}", e);
         return server_handle;
     }
+    crate::cluster_bind::notify_listening(&host, actual_port);
 
     if let Some(s) = get_handle_mut::<HttpServer>(server_handle) {
         s.bound_port = actual_port;

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -88,7 +88,7 @@ resolv-conf = "0.7"
 # + the common multicast/broadcast/TTL options; socket2 borrows the same fd
 # (SockRef) for the few std lacks — set_multicast_if and source-specific
 # membership — so those are real rather than silent no-ops.
-socket2 = "0.6"
+socket2 = { version = "0.6", features = ["all"] }
 # Issue #62: mimalloc replaces the system allocator for gc_malloc/arena/etc.
 # macOS `malloc` is ~25-40ns/alloc; mimalloc's per-thread free-list is ~5-10ns.
 # Set as #[global_allocator] in lib.rs, so it covers Rust heap allocations in

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -538,6 +538,9 @@ pub extern "C" fn js_array_numeric_set_f64_unboxed(
                 return 0;
             };
             let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+            // GC_STORE_AUDIT(POINTER_FREE): RawF64-layout payload slot —
+            // `number` is a plain f64, never a NaN-boxed pointer, so no
+            // write barrier is needed.
             ptr::write(elements_ptr.add(index as usize), number);
             return 1;
         }

--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -67,7 +67,17 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     let stdout_obj = cp_build_readable();
     let stderr_obj = cp_build_readable();
     let stdin_obj = cp_build_writable();
-    let stdio_kinds = cp_read_stdio(opts_val, 3);
+    let mut stdio_kinds = cp_read_stdio(opts_val, 3);
+    // Node fork semantics: `silent: false` (cluster.fork's default) inherits
+    // stdin/stdout/stderr from the parent; `silent: true` pipes them. Only an
+    // explicit `silent: false` overrides — an absent `silent` keeps Perry's
+    // historical pipe default, and an explicit `stdio` option wins (#4914).
+    let stdio_field = cp_get_field(opts_val, b"stdio");
+    if crate::value::JSValue::from_bits(stdio_field.to_bits()).is_undefined()
+        && cp_get_field(opts_val, b"silent").to_bits() == crate::value::TAG_FALSE
+    {
+        stdio_kinds.fill(CpStdio::Inherit);
+    }
     let timeout = cp_read_timeout(opts_val);
     let kill_signal = cp_read_kill_signal(opts_val);
 

--- a/crates/perry-runtime/src/cluster.rs
+++ b/crates/perry-runtime/src/cluster.rs
@@ -1,8 +1,15 @@
-//! Minimal `node:cluster` primary lifecycle support.
+//! `node:cluster` primary lifecycle + worker port sharing.
 //!
-//! This intentionally builds on the existing `child_process.fork()` IPC
-//! reactor. It tracks primary-side settings and Worker handles, but does not
-//! implement socket/listening handle distribution.
+//! Builds on the existing `child_process.fork()` IPC reactor. The primary
+//! tracks settings and Worker handles; workers share a listening port via
+//! SO_REUSEPORT (#4914): every TCP `listen()` site binds with
+//! `worker_reuseport_bind` when `NODE_UNIQUE_ID` marks the process as a
+//! cluster worker, and reports the bound address to the primary over the
+//! fork IPC channel (`{cmd:"NODE_CLUSTER", act:"listening"}`) so
+//! `cluster.on('listening')` fires Node-style. Kernel SO_REUSEPORT balancing
+//! is effectively `SCHED_NONE`; true round-robin fd-passing (`SCHED_RR`) and
+//! the primary-coordinated shared ephemeral port for `listen(0)` are tracked
+//! in #4962.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -53,13 +60,78 @@ fn empty_object_value() -> f64 {
     f64::from_bits(JSValue::object_ptr(obj as *mut u8).bits())
 }
 
+/// True when this process was `cluster.fork()`ed — Node's convention is a
+/// non-empty `NODE_UNIQUE_ID` in the worker's environment.
+pub fn is_cluster_worker() -> bool {
+    std::env::var("NODE_UNIQUE_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .is_some()
+}
+
+/// Bind a TCP listener with SO_REUSEPORT (+SO_REUSEADDR) so N cluster
+/// workers can share one port (#4914). Callers gate on
+/// [`is_cluster_worker`]; non-worker binds stay on the plain
+/// `TcpListener::bind` path.
+#[cfg(unix)]
+pub fn worker_reuseport_bind(addr: &str) -> std::io::Result<std::net::TcpListener> {
+    use std::net::ToSocketAddrs;
+    let sock_addr = addr.to_socket_addrs()?.next().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "could not resolve bind address",
+        )
+    })?;
+    let socket = socket2::Socket::new(
+        socket2::Domain::for_address(sock_addr),
+        socket2::Type::STREAM,
+        Some(socket2::Protocol::TCP),
+    )?;
+    socket.set_reuse_address(true)?;
+    socket.set_reuse_port(true)?;
+    socket.bind(&sock_addr.into())?;
+    // Node's default listen backlog.
+    socket.listen(511)?;
+    Ok(socket.into())
+}
+
+/// Worker-side: report a successful `server.listen()` bind to the primary
+/// over the fork IPC channel so it can emit `cluster.on('listening')`
+/// (#4914). No-op outside cluster workers or when the channel is gone.
+/// `#[no_mangle]` because the HTTP/HTTPS/HTTP2 listen sites live in
+/// `perry-ext-http-server`, which has no Cargo dep on perry-runtime — the
+/// symbol resolves at final link (same pattern as perry-ffi's helpers).
+#[no_mangle]
+pub extern "C" fn perry_cluster_worker_listening(
+    addr_ptr: *const u8,
+    addr_len: u32,
+    port: i32,
+    address_type: i32,
+) {
+    if !is_cluster_worker() {
+        return;
+    }
+    let address = if addr_ptr.is_null() || addr_len == 0 {
+        String::new()
+    } else {
+        unsafe {
+            String::from_utf8_lossy(std::slice::from_raw_parts(addr_ptr, addr_len as usize))
+                .into_owned()
+        }
+    };
+    let json = format!(
+        "{{\"cmd\":\"NODE_CLUSTER\",\"act\":\"listening\",\"address\":\"{}\",\"port\":{},\"addressType\":{}}}",
+        address.replace('\\', "\\\\").replace('"', "\\\""),
+        port,
+        address_type
+    );
+    crate::process::ipc::process_ipc_send_raw_json(&json);
+}
+
 pub fn cluster_property(property: &str) -> Option<f64> {
     ensure_cluster_runtime();
 
-    let is_worker = std::env::var("NODE_UNIQUE_ID")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .is_some();
+    let is_worker = is_cluster_worker();
 
     if is_worker {
         match property {
@@ -435,12 +507,13 @@ fn cluster_root_scanner(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
 }
 
 fn register_cluster_arities() {
-    let arities: [(*const u8, u32); 6] = [
+    let arities: [(*const u8, u32); 7] = [
         (worker_is_connected as *const u8, 0),
         (worker_is_dead as *const u8, 0),
         (worker_disconnect as *const u8, 0),
         (worker_destroy as *const u8, 0),
         (cluster_internal_online as *const u8, 0),
+        (cluster_internal_disconnect as *const u8, 0),
         (cluster_internal_exit as *const u8, 2),
     ];
     for (func, arity) in arities {
@@ -559,6 +632,23 @@ fn build_fork_options(settings: f64, env_arg: f64) -> *mut ObjectHeader {
     let opts = js_object_alloc(0, 10);
     let opts_val = box_ptr(opts as *const u8);
 
+    // #4914: the default `exec` is this compiled binary itself. A native
+    // executable can't be launched via `node <module>` (fork's default
+    // interpreter), so when exec is the running executable and no explicit
+    // execPath was configured, exec the binary directly. The module arg then
+    // doubles as argv[1], matching Node's worker argv convention.
+    if JSValue::from_bits(get_field(settings, b"execPath").to_bits()).is_undefined() {
+        if let Some(exec) = value_to_string(get_field(settings, b"exec")) {
+            let is_self = std::env::current_exe()
+                .ok()
+                .map(|p| p.to_string_lossy().into_owned())
+                .is_some_and(|me| me == exec);
+            if is_self {
+                set_field(opts_val, b"execPath", box_string(&exec));
+            }
+        }
+    }
+
     copy_setting_to_option(settings, opts_val, b"cwd");
     copy_setting_to_option(settings, opts_val, b"execArgv");
     copy_setting_to_option(settings, opts_val, b"execPath");
@@ -628,6 +718,11 @@ fn decorate_worker(worker: f64, id: u32) {
     );
     register_listener(
         worker,
+        "disconnect",
+        closure_value(cluster_internal_disconnect as *const u8, worker),
+    );
+    register_listener(
+        worker,
         "exit",
         closure_value(cluster_internal_exit as *const u8, worker),
     );
@@ -647,11 +742,37 @@ pub(crate) fn consume_internal_message(worker: f64, message: f64) -> bool {
     }
 
     if let Some(act) = value_to_string(get_field(message, b"act")) {
-        if act == "online" {
-            set_field(worker, b"__clusterState", box_string("online"));
+        match act.as_str() {
+            "online" => mark_worker_online(worker),
+            "listening" => {
+                // Worker reported a successful SO_REUSEPORT bind (#4914).
+                // Mirror Node: `worker.on('listening', address)` and
+                // `cluster.on('listening', (worker, address))`.
+                let address = alloc_object_value(3);
+                set_field(address, b"address", get_field(message, b"address"));
+                set_field(address, b"port", get_field(message, b"port"));
+                set_field(address, b"addressType", get_field(message, b"addressType"));
+                set_field(worker, b"__clusterState", box_string("listening"));
+                emit(worker, "listening", &[address]);
+                cluster_emit_event("listening", &[worker, address]);
+            }
+            _ => {}
         }
     }
     true
+}
+
+/// Emit `online` exactly once per worker — both the child reactor's `spawn`
+/// event and the worker's own `{act:"online"}` internal message funnel here.
+fn mark_worker_online(worker: f64) {
+    let already = get_field(worker, b"__clusterOnlineEmitted");
+    if already.to_bits() == TAG_TRUE_F64.to_bits() {
+        return;
+    }
+    set_field(worker, b"__clusterOnlineEmitted", TAG_TRUE_F64);
+    set_field(worker, b"__clusterState", box_string("online"));
+    emit(worker, "online", &[]);
+    cluster_emit_event("online", &[worker]);
 }
 
 fn register_worker(id: u32, worker: f64) {
@@ -750,20 +871,34 @@ extern "C" fn worker_destroy(closure: *const ClosureHeader) -> f64 {
 }
 
 extern "C" fn cluster_internal_online(closure: *const ClosureHeader) -> f64 {
-    let worker = closure_this(closure);
-    set_field(worker, b"__clusterState", box_string("online"));
-    emit(worker, "online", &[]);
+    mark_worker_online(closure_this(closure));
     TAG_UNDEFINED_F64
 }
 
-extern "C" fn cluster_internal_exit(
-    closure: *const ClosureHeader,
-    _code: f64,
-    _signal: f64,
-) -> f64 {
+extern "C" fn cluster_internal_disconnect(closure: *const ClosureHeader) -> f64 {
+    mark_worker_disconnected(closure_this(closure));
+    TAG_UNDEFINED_F64
+}
+
+/// Emit `disconnect` once per worker on both the worker object and the
+/// cluster — fed by the child reactor's IPC-channel-close event, with an
+/// exit-time fallback so the Node-mandated disconnect→exit order holds even
+/// if the channel close races process exit.
+fn mark_worker_disconnected(worker: f64) {
+    let already = get_field(worker, b"__clusterDisconnectEmitted");
+    if already.to_bits() == TAG_TRUE_F64.to_bits() {
+        return;
+    }
+    set_field(worker, b"__clusterDisconnectEmitted", TAG_TRUE_F64);
+    cluster_emit_event("disconnect", &[worker]);
+}
+
+extern "C" fn cluster_internal_exit(closure: *const ClosureHeader, code: f64, signal: f64) -> f64 {
     let worker = closure_this(closure);
     set_field(worker, b"__clusterState", box_string("dead"));
+    mark_worker_disconnected(worker);
     remove_worker(worker);
+    cluster_emit_event("exit", &[worker, code, signal]);
     drain_disconnect_callbacks_if_idle();
     TAG_UNDEFINED_F64
 }

--- a/crates/perry-runtime/src/net.rs
+++ b/crates/perry-runtime/src/net.rs
@@ -1,15 +1,15 @@
 //! Net module - provides TCP networking capabilities
 
-use std::net::{TcpListener, TcpStream, SocketAddr};
-use std::io::{Read, Write};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
-use crate::string::{js_string_from_bytes, StringHeader};
-use crate::object::ObjectHeader;
 use crate::buffer::BufferHeader;
 use crate::closure::ClosureHeader;
+use crate::object::ObjectHeader;
+use crate::string::{js_string_from_bytes, StringHeader};
 
 // Global handle registry for servers and sockets
 static NEXT_HANDLE: AtomicU64 = AtomicU64::new(1);
@@ -66,9 +66,28 @@ pub extern "C" fn js_net_server_listen(
     };
 
     let addr = format!("{}:{}", host, port);
-    match TcpListener::bind(&addr) {
+    // #4914 — cluster workers bind with SO_REUSEPORT so N workers share the
+    // port, then report the bound address to the primary for 'listening'.
+    #[cfg(unix)]
+    let bind_result = if crate::cluster::is_cluster_worker() {
+        crate::cluster::worker_reuseport_bind(&addr)
+    } else {
+        TcpListener::bind(&addr)
+    };
+    #[cfg(not(unix))]
+    let bind_result = TcpListener::bind(&addr);
+    match bind_result {
         Ok(listener) => {
-            let address = listener.local_addr().unwrap_or_else(|_| addr.parse().unwrap());
+            let address = listener
+                .local_addr()
+                .unwrap_or_else(|_| addr.parse().unwrap());
+            let address_type: i32 = if address.is_ipv6() { 6 } else { 4 };
+            crate::cluster::perry_cluster_worker_listening(
+                host.as_ptr(),
+                host.len() as u32,
+                address.port() as i32,
+                address_type,
+            );
             let wrapper = TcpListenerWrapper { listener, address };
 
             if let Ok(mut servers) = TCP_SERVERS.lock() {
@@ -107,29 +126,21 @@ pub extern "C" fn js_net_server_address(handle: f64) -> *mut ObjectHeader {
 
             unsafe {
                 // Set port (field 0)
-                crate::object::js_object_set_field_f64(
-                    obj,
-                    0,
-                    wrapper.address.port() as f64
-                );
+                crate::object::js_object_set_field_f64(obj, 0, wrapper.address.port() as f64);
 
                 // Set address (field 1)
                 let addr_str = wrapper.address.ip().to_string();
                 let addr_val = js_string_from_bytes(addr_str.as_ptr(), addr_str.len() as u32);
-                crate::object::js_object_set_field_f64(
-                    obj,
-                    1,
-                    (addr_val as u64) as f64
-                );
+                crate::object::js_object_set_field_f64(obj, 1, (addr_val as u64) as f64);
 
                 // Set family (field 2)
-                let family = if wrapper.address.is_ipv4() { "IPv4" } else { "IPv6" };
+                let family = if wrapper.address.is_ipv4() {
+                    "IPv4"
+                } else {
+                    "IPv6"
+                };
                 let family_val = js_string_from_bytes(family.as_ptr(), family.len() as u32);
-                crate::object::js_object_set_field_f64(
-                    obj,
-                    2,
-                    (family_val as u64) as f64
-                );
+                crate::object::js_object_set_field_f64(obj, 2, (family_val as u64) as f64);
             }
 
             return obj;
@@ -164,7 +175,10 @@ pub extern "C" fn js_net_create_connection(
         Ok(stream) => {
             let remote_address = stream.peer_addr().ok();
             let handle = NEXT_HANDLE.fetch_add(1, Ordering::SeqCst);
-            let wrapper = TcpStreamWrapper { stream, remote_address };
+            let wrapper = TcpStreamWrapper {
+                stream,
+                remote_address,
+            };
 
             if let Ok(mut sockets) = TCP_SOCKETS.lock() {
                 sockets.insert(handle, wrapper);
@@ -179,10 +193,7 @@ pub extern "C" fn js_net_create_connection(
 /// Write data to a socket
 /// Returns the number of bytes written, or -1 on error
 #[no_mangle]
-pub extern "C" fn js_net_socket_write(
-    handle: f64,
-    data_ptr: *const BufferHeader,
-) -> i32 {
+pub extern "C" fn js_net_socket_write(handle: f64, data_ptr: *const BufferHeader) -> i32 {
     let handle = handle as u64;
 
     if data_ptr.is_null() {
@@ -223,7 +234,8 @@ pub extern "C" fn js_net_socket_read(handle: f64, max_size: i32) -> *mut BufferH
                     let buf = crate::buffer::js_buffer_alloc(n as i32, 0);
                     if !buf.is_null() {
                         unsafe {
-                            let buf_data = (buf as *mut u8).add(std::mem::size_of::<BufferHeader>());
+                            let buf_data =
+                                (buf as *mut u8).add(std::mem::size_of::<BufferHeader>());
                             std::ptr::copy_nonoverlapping(buffer.as_ptr(), buf_data, n);
                             (*buf).length = n as u32;
                         }

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -9,7 +9,7 @@ use std::cell::{Cell, RefCell};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 mod credentials;
-mod ipc;
+pub(crate) mod ipc;
 pub use credentials::{
     js_process_getegid, js_process_geteuid, js_process_getgid, js_process_getgroups,
     js_process_getuid, js_process_initgroups, js_process_setegid, js_process_seteuid,

--- a/crates/perry-runtime/src/process/ipc.rs
+++ b/crates/perry-runtime/src/process/ipc.rs
@@ -339,6 +339,33 @@ fn process_ipc_send_message(message: f64) -> bool {
     }
 }
 
+/// Write an already-serialized JSON object as one newline-delimited frame on
+/// the child IPC channel. Used by `node:cluster` internal messages
+/// (`{cmd:"NODE_CLUSTER", ...}`, #4914) where the payload is built in Rust and
+/// never exists as a JS value.
+pub(crate) fn process_ipc_send_raw_json(json: &str) -> bool {
+    process_ipc_ensure_initialized();
+    #[cfg(not(unix))]
+    {
+        let _ = json;
+        false
+    }
+    #[cfg(unix)]
+    {
+        let mut frame = Vec::with_capacity(json.len() + 1);
+        frame.extend_from_slice(json.as_bytes());
+        frame.push(b'\n');
+        let mut state = ipc_lock();
+        if !state.available || !state.connected {
+            return false;
+        }
+        state
+            .send
+            .as_mut()
+            .is_some_and(|sock| sock.write_all(&frame).is_ok())
+    }
+}
+
 #[cfg(unix)]
 fn json_frame(message: f64) -> Option<Vec<u8>> {
     let sh = unsafe { crate::json::js_json_stringify(message, 0) };

--- a/crates/perry/tests/issue_4914_cluster_port_sharing.rs
+++ b/crates/perry/tests/issue_4914_cluster_port_sharing.rs
@@ -1,0 +1,158 @@
+//! End-to-end test for #4914: `node:cluster` workers actually share a
+//! listening port.
+//!
+//! The canonical cluster pattern — primary forks N workers, each worker
+//! `http.createServer().listen(port)` on the SAME port — historically
+//! "worked" silently while the second worker's bind failed (EADDRINUSE,
+//! swallowed) and no requests were served by it. Workers now bind with
+//! SO_REUSEPORT (`NODE_UNIQUE_ID` marks a worker) and report the bound
+//! address to the primary over the fork IPC channel, so:
+//!  - both workers' binds succeed (the second bind failing would mean no
+//!    second `'listening'` event, and this test times out),
+//!  - `cluster.on('listening', (worker, address))` fires per worker with
+//!    the bound port,
+//!  - requests round-trip through the shared port,
+//!  - `cluster.on('exit')` fires when the workers are killed.
+//!
+//! The primary discovers a free port by binding port 0 once and closing it
+//! (the `listen(0)` shared-ephemeral-port round-trip itself is #4962).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[cfg(unix)]
+#[test]
+fn two_workers_share_one_port() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import cluster from "node:cluster";
+import http from "node:http";
+
+if (cluster.isPrimary) {
+  // Discover a free port; both workers then SO_REUSEPORT-bind it.
+  const probe = http.createServer();
+  probe.on("listening", () => {
+    const port = (probe.address() as any).port;
+    probe.close();
+    // The probe listener (bound WITHOUT SO_REUSEPORT) is dropped
+    // asynchronously by the accept loop; give it a beat so the workers'
+    // REUSEPORT binds can't race an EADDRINUSE against it.
+    setTimeout(() => start(port), 250);
+  });
+  probe.listen(0, "127.0.0.1");
+} else {
+  const port = Number(process.env.CLUSTER_TEST_PORT);
+  http
+    .createServer((req: any, res: any) => {
+      res.end("ok");
+    })
+    .listen(port, "127.0.0.1");
+  // Orphan guard: if the primary dies without killing us, don't squat on
+  // the port forever.
+  setTimeout(() => process.exit(0), 30000);
+}
+
+function start(port: number) {
+  const workers: any[] = [];
+  let listening = 0;
+  let exited = 0;
+  let responses = 0;
+
+  // Failure watchdog: exit non-zero with the milestone counters so the
+  // harness assert shows where the lifecycle stalled.
+  setTimeout(() => {
+    console.log("TIMEOUT listening=" + listening + " responses=" + responses + " exited=" + exited);
+    process.exit(1);
+  }, 25000);
+
+  cluster.on("listening", (worker: any, address: any) => {
+    listening++;
+    if (address.port !== port) {
+      console.log("BAD-PORT got=" + address.port + " want=" + port);
+      process.exit(1);
+    }
+    if (listening === 2) {
+      console.log("both-workers-listening true");
+      probeWorkers();
+    }
+  });
+
+  cluster.on("exit", (worker: any, code: any, signal: any) => {
+    exited++;
+    if (exited === 2) {
+      console.log("both-workers-exited true");
+      process.exit(0);
+    }
+  });
+
+  function probeWorkers() {
+    for (let i = 0; i < 4; i++) {
+      http.get({ host: "127.0.0.1", port: port, path: "/" }, (res: any) => {
+        let body = "";
+        res.on("data", (c: any) => { body += c; });
+        res.on("end", () => {
+          if (body === "ok") responses++;
+          if (responses === 4) {
+            console.log("responses-ok true");
+            for (const w of workers) w.kill();
+          }
+        });
+      });
+    }
+  }
+
+  for (let i = 0; i < 2; i++) {
+    workers.push(cluster.fork({ CLUSTER_TEST_PORT: String(port) }));
+  }
+}
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "both-workers-listening true\n\
+         responses-ok true\n\
+         both-workers-exited true\n",
+        "cluster workers must both bind the shared port (SO_REUSEPORT), \
+         serve requests through it, and report listening/exit to the primary"
+    );
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -316,11 +316,11 @@ declare module "cluster" {
   export const workers: any;
   /** stdlib */
   export function disconnect(...args: any[]): any;
-  /** stdlib @perryStub no socket/listening-handle distribution; workers cannot share a port (#4914) */
+  /** stdlib */
   export function fork(...args: any[]): any;
-  /** stdlib @perryStub no socket/listening-handle distribution; workers cannot share a port (#4914) */
+  /** stdlib */
   export function setupMaster(...args: any[]): any;
-  /** stdlib @perryStub no socket/listening-handle distribution; workers cannot share a port (#4914) */
+  /** stdlib */
   export function setupPrimary(...args: any[]): any;
 }
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -372,9 +372,9 @@ Total: 2781 entries across 114 modules.
 ### Methods
 
 - `disconnect` — module
-- `fork` — module ⚠ **stub** — no socket/listening-handle distribution; workers cannot share a port (#4914)
-- `setupMaster` — module ⚠ **stub** — no socket/listening-handle distribution; workers cannot share a port (#4914)
-- `setupPrimary` — module ⚠ **stub** — no socket/listening-handle distribution; workers cannot share a port (#4914)
+- `fork` — module
+- `setupMaster` — module
+- `setupPrimary` — module
 
 ### Properties
 


### PR DESCRIPTION
Closes #4914 (stub-elimination epic #4919). The scoped-out fidelity items — shared ephemeral port for `listen(0)` and true `SCHED_RR` fd-passing — are filed as #4962.

## What

The canonical cluster pattern now actually works end-to-end in a compiled binary:

```ts
if (cluster.isPrimary) { for (...) cluster.fork(); }
else { http.createServer(...).listen(8000); }  // N workers share port 8000
```

### Port sharing (SO_REUSEPORT)
- All 4 TCP listen sites — `js_node_http_server_listen` / https / http2 (`perry-ext-http-server`, new `cluster_bind.rs`) and `js_net_server_listen` (`perry-runtime/net.rs`) — bind with `SO_REUSEPORT`+`SO_REUSEADDR` when `NODE_UNIQUE_ID` marks the process as a cluster worker. Non-worker binds keep the plain `TcpListener::bind` path, byte-for-byte.
- Kernel balancing is effectively `SCHED_NONE`; `SCHED_RR` fd-passing is #4962.

### `'listening'` round-trip + lifecycle events
- After a successful worker bind, the worker sends `{cmd:"NODE_CLUSTER", act:"listening", address, port, addressType}` over the existing fork-IPC channel (new raw-frame sender in `process/ipc.rs`; the ext-http-server sites reach the runtime via a `#[no_mangle]` symbol, same final-link pattern as perry-ffi).
- `consume_internal_message` grows a `listening` arm: emits `'listening'` on the worker **and** the cluster object with `(worker, {address, port, addressType})`, Node-style.
- Cluster-level `'online'` (deduped between the child reactor's `spawn` event and the worker's internal online message), `'disconnect'` (channel close, with an exit-time fallback preserving Node's disconnect→exit order), and `'exit' (worker, code, signal)`.

### Two fork-correctness fixes the e2e surfaced
- **Self-exec**: the default `settings.exec` is the compiled binary itself, but `fork()` launches `node <module>` — `node <native-binary>` can't work (this is why the pattern "appeared to work" while workers silently died). When `exec` resolves to `current_exe` and no explicit `execPath` is set, the binary is exec'd directly; the module arg doubles as `argv[1]`, matching Node's worker argv convention.
- **`silent: false` semantics**: `cp_read_stdio` never consulted `silent`. Node's `silent: false` (cluster's default) means *inherit* stdio. An explicit `silent: false` now inherits; absent `silent` keeps Perry's historical pipe default; an explicit `stdio` option still wins.

### Manifest / docs
- `stub: true` + notes removed from `cluster.fork` / `setupPrimary` / `setupMaster`; docs regenerated (`regen_api_docs.sh`); `stub_inventory.rs` drift guards updated (the #4914 cluster is now intentionally absent, like #4911/#4912).

## Validation

- **New e2e** `crates/perry/tests/issue_4914_cluster_port_sharing.rs`: primary discovers a free port, forks 2 workers, both SO_REUSEPORT-bind it (a failed second bind would mean no second `'listening'` and a watchdog timeout), 4 HTTP requests round-trip through the shared port, `kill()` → 2 cluster `'exit'` events. Passes.
- `test_issue_3115_3116_3117_cluster_lifecycle.ts`, `test_parity_cluster.ts`, `test_issue_1933_fork_ipc.ts`, `test_parity_child_process.ts` — all byte-identical to `node --experimental-strip-types`.
- Full `cargo test --release -p perry` green (one `late_listening_listener_fires` flake under full-parallel contention; passes 4/4 in isolation and in the full-suite re-run). `-p perry-runtime` green except `date::tests::test_full_year_setters_revive_invalid_date_only`, which fails identically on pristine `origin/main` (pre-existing, likely date-sensitive — today is 2026-06-11).
- `cargo fmt --check`, `check_file_size.sh`, `-p perry-api-manifest` / `-p perry-stdlib` / `-p perry-ext-http-server` all green.

Code-only PR — no version bump / changelog (folded at merge).