### PR TITLE
feat(runtime): real AsyncLocalStorage + async_hooks context propagation (#788/#789)

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -384,6 +384,14 @@ pub(super) fn compile_module_entry(
         // fallback both validate against the known-heap-pointer set and
         // discard non-matching bits.
         register_module_globals_as_gc_roots(&mut ctx, module_globals);
+        // ESM entry (import/export syntax or top-level await — Node's module
+        // detection): mark the pending module-evaluation checkpoint so the
+        // first microtask drain finishes promise/queueMicrotask jobs before
+        // the nextTick queue, matching Node's job-within-checkpoint ordering
+        // for ESM evaluation (#788). CJS-style entries keep ticks-first.
+        if !hir.imports.is_empty() || !hir.exports.is_empty() || hir.has_top_level_await {
+            ctx.block().call_void("js_mark_entry_module_esm", &[]);
+        }
         // Initialize static class fields with their declared init
         // expressions. Runs once at the top of main, before user code.
         //

--- a/crates/perry-codegen/src/expr/fs_await.rs
+++ b/crates/perry-codegen/src/expr/fs_await.rs
@@ -157,13 +157,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 .cond_br(&is_promise_bool, &drain_once_label, &merge_label);
 
             // === drain_once ===
-            // Flush queueMicrotask callbacks before the first state check.
-            // When the promise is already settled (e.g. `await Promise.resolve()`)
-            // the wait loop below is never entered, so microtasks queued before
-            // this await would never fire. One drain here covers that path;
-            // the wait loop covers all subsequent ticks for pending promises.
+            // Run pending promise/queueMicrotask jobs before the first state
+            // check. When the promise is already settled (e.g.
+            // `await Promise.resolve()`) the wait loop below is never
+            // entered, so jobs queued before this await would never fire
+            // before execution continues. Promise jobs ONLY — nextTick
+            // callbacks queued in the same synchronous stretch wait for the
+            // next real tick boundary, matching Node's checkpoint ordering
+            // (#788; previously this drained the tick queue instead, so a
+            // nextTick callback overtook earlier-queued microtasks). The
+            // wait loop covers ticks/timers for pending promises.
             ctx.current_block = drain_once_idx;
-            ctx.block().call_void("js_drain_queued_microtasks", &[]);
+            let _ = ctx.block().call(I32, "js_promise_run_promise_jobs", &[]);
             ctx.block().br(&check_label);
 
             // === check ===

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -631,6 +631,12 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     // branch so `await thenable` enters the polling path.
     module.declare_function("js_assimilate_thenable", DOUBLE, &[DOUBLE]);
     module.declare_function("js_promise_run_microtasks", I32, &[]);
+    // ESM entry marker: first microtask drain finishes promise jobs before
+    // the nextTick queue (Node module-evaluation checkpoint ordering, #788).
+    module.declare_function("js_mark_entry_module_esm", VOID, &[]);
+    // Promise/queueMicrotask jobs only — no nextTick drain, no timers.
+    // Used by the await lowering's drain_once block (#788).
+    module.declare_function("js_promise_run_promise_jobs", I32, &[]);
     // Drain stdlib's tokio async queue (fetch, DB, etc.). Lives in
     // perry-runtime as a thin function-pointer trampoline so it's
     // safe to call even when perry-stdlib is not linked (no-op).

--- a/crates/perry-runtime/src/async_context.rs
+++ b/crates/perry-runtime/src/async_context.rs
@@ -85,8 +85,125 @@ pub fn get_store(handle: i64) -> Option<f64> {
     })
 }
 
+/// Replace the current store for `handle` (top of its stack) without growing
+/// the stack, pushing only when the handle has no active store. This is
+/// `AsyncLocalStorage#enterWith` semantics: Node's AsyncContextFrame `set`
+/// swaps the storage's value in the current frame, so a surrounding `run()`
+/// (which saves/restores exactly one slot for its own handle) still restores
+/// the pre-`run` value on exit (#788, differential case 21).
+pub fn set_store(handle: i64, store: f64) {
+    ACTIVE_CONTEXT.with(|ctx| {
+        let mut ctx = ctx.borrow_mut();
+        if let Some(entry) = ctx.entries.iter_mut().find(|entry| entry.handle == handle) {
+            if let Some(slot) = entry.stores.last_mut() {
+                *slot = store;
+            } else {
+                entry.stores.push(store);
+            }
+        } else {
+            ctx.entries.push(AsyncContextEntry {
+                handle,
+                stores: vec![store],
+            });
+        }
+    });
+}
+
 pub fn enter_with(handle: i64, store: f64) {
-    push_store(handle, store);
+    set_store(handle, store);
+}
+
+/// Deferred context-restore action for a scope (`AsyncLocalStorage#run`/
+/// `#exit`, `AsyncResource#runInAsyncScope`) whose callback may throw.
+/// `js_throw` longjmps past the normal restore code, so each scope records
+/// its restore action here (tagged with the `try` depth at entry) and
+/// `js_throw` applies every action belonging to frames it is about to
+/// unwind past (#788, differential cases 10/25).
+pub enum ContextGuardAction {
+    /// `run()`: pop the one store slot the scope pushed for its handle.
+    PopStore(i64),
+    /// `exit()`: restore the handle's store stack removed at entry.
+    RestoreStores(i64, Option<Vec<f64>>),
+    /// `runInAsyncScope()` / snapshot trampoline: restore the full snapshot.
+    RestoreSnapshot(AsyncContextSnapshot),
+    /// Silently pop one async_hooks execution-id frame (no `after` hook
+    /// callbacks: arbitrary JS must not run mid-`js_throw`).
+    RestoreExecutionIds,
+}
+
+struct ContextGuard {
+    try_depth: usize,
+    action: ContextGuardAction,
+}
+
+thread_local! {
+    static CONTEXT_GUARDS: RefCell<Vec<ContextGuard>> = const { RefCell::new(Vec::new()) };
+}
+
+pub fn push_context_guard(action: ContextGuardAction) {
+    let try_depth = crate::exception::current_try_depth();
+    CONTEXT_GUARDS.with(|guards| {
+        guards.borrow_mut().push(ContextGuard { try_depth, action });
+    });
+}
+
+/// Pop the most recent guard without applying it. The caller either applies
+/// it (normal scope exit) or discards it (the restore already happened by
+/// other means).
+pub fn pop_context_guard() -> Option<ContextGuardAction> {
+    CONTEXT_GUARDS.with(|guards| guards.borrow_mut().pop().map(|guard| guard.action))
+}
+
+pub fn apply_context_guard(action: ContextGuardAction) {
+    match action {
+        ContextGuardAction::PopStore(handle) => pop_store(handle),
+        ContextGuardAction::RestoreStores(handle, stores) => restore_store(handle, stores),
+        ContextGuardAction::RestoreSnapshot(snapshot) => restore_context(snapshot),
+        ContextGuardAction::RestoreExecutionIds => crate::async_hooks::unwind_execution_scope(),
+    }
+}
+
+/// Called from `js_throw` just before the longjmp: apply (newest-first) every
+/// guard registered at a `try` depth greater than the depth of the handler
+/// being jumped to — those scopes' normal restore code is being unwound past.
+/// Guards registered at or below the handler's depth belong to still-live
+/// scopes and stay.
+pub(crate) fn unwind_context_guards(target_try_depth: usize) {
+    loop {
+        let action = CONTEXT_GUARDS.with(|guards| {
+            let mut guards = guards.borrow_mut();
+            match guards.last() {
+                Some(guard) if guard.try_depth > target_try_depth => {
+                    guards.pop().map(|guard| guard.action)
+                }
+                _ => None,
+            }
+        });
+        match action {
+            Some(action) => apply_context_guard(action),
+            None => break,
+        }
+    }
+}
+
+fn scan_context_guard_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    CONTEXT_GUARDS.with(|guards| {
+        for guard in guards.borrow_mut().iter_mut() {
+            match &mut guard.action {
+                ContextGuardAction::PopStore(_) | ContextGuardAction::RestoreExecutionIds => {}
+                ContextGuardAction::RestoreStores(_, stores) => {
+                    if let Some(stores) = stores {
+                        for store in stores.iter_mut() {
+                            visitor.visit_nanbox_f64_slot(store);
+                        }
+                    }
+                }
+                ContextGuardAction::RestoreSnapshot(snapshot) => {
+                    scan_snapshot_roots_mut(snapshot, visitor);
+                }
+            }
+        }
+    });
 }
 
 pub fn clear_store(handle: i64) {
@@ -168,16 +285,18 @@ pub(crate) fn scan_snapshot_roots_mut_step(
 }
 
 pub fn scan_active_context_roots(mark: &mut dyn FnMut(f64)) {
+    let mut visitor = crate::gc::RuntimeRootVisitor::for_copy(mark);
     ACTIVE_CONTEXT.with(|ctx| {
-        let mut visitor = crate::gc::RuntimeRootVisitor::for_copy(mark);
         scan_snapshot_roots_mut(&mut ctx.borrow_mut(), &mut visitor);
     });
+    scan_context_guard_roots_mut(&mut visitor);
 }
 
 pub fn scan_active_context_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     ACTIVE_CONTEXT.with(|ctx| {
         scan_snapshot_roots_mut(&mut ctx.borrow_mut(), visitor);
     });
+    scan_context_guard_roots_mut(visitor);
 }
 
 pub struct AsyncContextSnapshotRoots<'scope> {

--- a/crates/perry-runtime/src/async_hooks.rs
+++ b/crates/perry-runtime/src/async_hooks.rs
@@ -4,7 +4,7 @@
 //! thread-local execution/trigger id stack used by the compiled runtime.
 
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ptr;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex};
@@ -24,7 +24,11 @@ const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
 const TAG_MASK: u64 = 0xFFFF_0000_0000_0000;
 const TAG_UNDEFINED_F64: f64 = f64::from_bits(crate::value::TAG_UNDEFINED);
 
-static NEXT_ASYNC_ID: AtomicU64 = AtomicU64::new(1);
+// Async ids start at 2: Node reserves id 1 for the bootstrap/root execution
+// context, so the first user-visible resource (e.g. the first `setTimeout`)
+// gets an id > 1 — observable through `executionAsyncId()` inside its
+// callback (#789).
+static NEXT_ASYNC_ID: AtomicU64 = AtomicU64::new(2);
 pub static HOOKS_ACTIVE: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Clone, Copy)]
@@ -93,6 +97,15 @@ static CONTEXT_SNAPSHOTS: LazyLock<
     Mutex<HashMap<usize, crate::async_context::AsyncContextSnapshot>>,
 > = LazyLock::new(|| Mutex::new(HashMap::new()));
 static ASYNC_WRAP_PROVIDERS: AtomicU64 = AtomicU64::new(0);
+
+/// Live `AsyncResource` handles. Handles are raw `Box::into_raw` pointers
+/// (never freed → membership is monotonic), NaN-boxed with POINTER_TAG like
+/// heap objects — so the dynamic method path needs this registry to recognize
+/// one BEFORE dereferencing it as an ObjectHeader (#789, mirrors the
+/// BOX_REGISTRY pattern from #4898).
+static ASYNC_RESOURCE_HANDLES: LazyLock<Mutex<HashSet<i64>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+static ASYNC_RESOURCE_HANDLE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 thread_local! {
     static EXECUTION_STACK: RefCell<Vec<(u64, u64)>> = const { RefCell::new(Vec::new()) };
@@ -514,6 +527,18 @@ pub fn after(async_id: u64) {
     CURRENT_TRIGGER_ID.with(|c| c.set(prev.1));
 }
 
+/// Throw-unwind counterpart of [`after`]: restore the execution/trigger ids
+/// of the enclosing scope WITHOUT firing `after` hook callbacks — this runs
+/// inside `js_throw` (via a context guard), where re-entering user JS is not
+/// safe (#788).
+pub(crate) fn unwind_execution_scope() {
+    let prev = EXECUTION_STACK
+        .with(|stack| stack.borrow_mut().pop())
+        .unwrap_or((0, 0));
+    CURRENT_EXECUTION_ID.with(|c| c.set(prev.0));
+    CURRENT_TRIGGER_ID.with(|c| c.set(prev.1));
+}
+
 pub fn promise_resolve(async_id: u64) {
     if async_id == 0 {
         return;
@@ -836,11 +861,92 @@ pub extern "C" fn js_async_resource_new(type_value: f64, options: f64) -> i64 {
     let trigger_async_id = trigger_id_from_options(options_handle.get_nanbox_f64());
     let ids = init_resource_with_trigger(&type_name, TAG_UNDEFINED_F64, true, trigger_async_id);
     let handle = Box::into_raw(Box::new(AsyncResourceHandle { ids })) as i64;
+    ASYNC_RESOURCE_HANDLES.lock().unwrap().insert(handle);
+    ASYNC_RESOURCE_HANDLE_COUNT.fetch_add(1, Ordering::Relaxed);
     let resource_value = crate::value::js_nanbox_pointer(handle);
     if let Some(meta) = RESOURCES.lock().unwrap().get_mut(&ids.async_id) {
         meta.resource = resource_value;
     }
     handle
+}
+
+/// Dynamic method dispatch for `AsyncResource` receivers whose static type
+/// the codegen lost (closure-captured / `any`-typed bindings). Registry
+/// membership is checked before any dereference, so a genuine heap object
+/// can never be claimed. Returns `None` when the receiver is not a live
+/// AsyncResource handle or the method name is not part of its vocabulary.
+pub fn try_async_resource_method_dispatch(
+    handle: i64,
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    if ASYNC_RESOURCE_HANDLE_COUNT.load(Ordering::Relaxed) == 0 {
+        return None;
+    }
+    if !matches!(
+        method_name,
+        "runInAsyncScope" | "asyncId" | "triggerAsyncId" | "emitDestroy" | "bind"
+    ) {
+        return None;
+    }
+    if !ASYNC_RESOURCE_HANDLES.lock().unwrap().contains(&handle) {
+        return None;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let raw_args: Vec<f64> = if args_ptr.is_null() || args_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(args_ptr, args_len).to_vec() }
+    };
+    let arg_handles = scope.root_nanbox_f64_slice(&raw_args);
+    let args = crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(&arg_handles);
+    Some(match method_name {
+        "asyncId" => js_async_resource_async_id(handle),
+        "triggerAsyncId" => js_async_resource_trigger_async_id(handle),
+        "emitDestroy" => {
+            js_async_resource_emit_destroy(handle);
+            crate::value::js_nanbox_pointer(handle)
+        }
+        "runInAsyncScope" => {
+            // runInAsyncScope(fn[, thisArg, ...args])
+            let callback = args.first().copied().unwrap_or(TAG_UNDEFINED_F64);
+            let this_arg = args.get(1).copied().unwrap_or(TAG_UNDEFINED_F64);
+            let rest = if args.len() > 2 { &args[2..] } else { &[] };
+            let args_array = pack_rest_args_array(rest);
+            js_async_resource_run_in_async_scope(handle, callback, this_arg, args_array)
+        }
+        "bind" => {
+            // bind(fn[, thisArg])
+            let callback = args.first().copied().unwrap_or(TAG_UNDEFINED_F64);
+            let this_arg = args.get(1).copied().unwrap_or(TAG_UNDEFINED_F64);
+            let bound = js_async_resource_bind(handle, callback, this_arg);
+            if bound == 0 {
+                TAG_UNDEFINED_F64
+            } else {
+                crate::value::js_nanbox_pointer(bound)
+            }
+        }
+        _ => unreachable!("gated by the matches! above"),
+    })
+}
+
+/// Pack trailing call args into a fresh array for the `args_array: i64`
+/// FFI convention (`0` = no forwarded args).
+fn pack_rest_args_array(rest: &[f64]) -> i64 {
+    if rest.is_empty() {
+        return 0;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let rest_handles = scope.root_nanbox_f64_slice(rest);
+    let arr = crate::array::js_array_alloc(0);
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+    for handle in &rest_handles {
+        let grown =
+            crate::array::js_array_push_f64(arr_handle.get_raw_mut_ptr(), handle.get_nanbox_f64());
+        arr_handle.set_raw_mut_ptr(grown);
+    }
+    arr_handle.get_raw_mut_ptr::<ArrayHeader>() as i64
 }
 
 #[no_mangle]
@@ -906,9 +1012,15 @@ pub extern "C" fn js_async_resource_run_in_async_scope(
     let mut resource_context = resource_context;
     let resource_context_roots = crate::async_context::root_snapshot(&scope, &resource_context);
     let previous = crate::async_context::enter_context(&resource_context);
-    let mut previous = previous;
-    let previous_roots = crate::async_context::root_snapshot(&scope, &previous);
+    // The guard owns the previous snapshot: it is GC-scanned while held, and
+    // if the callback throws, `js_throw` restores it during unwind (#788).
+    crate::async_context::push_context_guard(
+        crate::async_context::ContextGuardAction::RestoreSnapshot(previous),
+    );
     before(resource.ids.async_id, resource.ids.trigger_async_id);
+    crate::async_context::push_context_guard(
+        crate::async_context::ContextGuardAction::RestoreExecutionIds,
+    );
     let prev_this = crate::object::js_implicit_this_set(this_arg_handle.get_nanbox_f64());
     let result = if args_array == 0 {
         unsafe { js_closure_call_array(callback as i64, ptr::null(), 0) }
@@ -924,13 +1036,17 @@ pub extern "C" fn js_async_resource_run_in_async_scope(
     };
     crate::object::js_implicit_this_set(prev_this);
     let result_handle = scope.root_nanbox_f64(result);
+    // Normal exit: `after` fires hooks and pops the execution scope itself,
+    // so discard the silent-unwind guard rather than applying it.
+    let _ = crate::async_context::pop_context_guard();
     after(resource.ids.async_id);
     crate::async_context::refresh_snapshot_from_roots(
         &mut resource_context,
         &resource_context_roots,
     );
-    crate::async_context::refresh_snapshot_from_roots(&mut previous, &previous_roots);
-    crate::async_context::restore_context(previous);
+    if let Some(action) = crate::async_context::pop_context_guard() {
+        crate::async_context::apply_context_guard(action);
+    }
     result_handle.get_nanbox_f64()
 }
 
@@ -1118,13 +1234,16 @@ fn run_with_context_snapshot(snapshot_id: usize, f: impl FnOnce() -> f64) -> f64
     let mut snapshot = snapshot;
     let snapshot_roots = crate::async_context::root_snapshot(&scope, &snapshot);
     let previous = crate::async_context::enter_context(&snapshot);
-    let mut previous = previous;
-    let previous_roots = crate::async_context::root_snapshot(&scope, &previous);
+    // Guard-held (GC-scanned, throw-safe) — see runInAsyncScope (#788).
+    crate::async_context::push_context_guard(
+        crate::async_context::ContextGuardAction::RestoreSnapshot(previous),
+    );
     let result = f();
     let result_handle = scope.root_nanbox_f64(result);
     crate::async_context::refresh_snapshot_from_roots(&mut snapshot, &snapshot_roots);
-    crate::async_context::refresh_snapshot_from_roots(&mut previous, &previous_roots);
-    crate::async_context::restore_context(previous);
+    if let Some(action) = crate::async_context::pop_context_guard() {
+        crate::async_context::apply_context_guard(action);
+    }
     result_handle.get_nanbox_f64()
 }
 
@@ -1255,7 +1374,7 @@ pub fn reset_for_tests() {
     CONTEXT_SNAPSHOTS.lock().unwrap().clear();
     ASYNC_WRAP_PROVIDERS.store(0, Ordering::Relaxed);
     HOOKS_ACTIVE.store(0, Ordering::Relaxed);
-    NEXT_ASYNC_ID.store(1, Ordering::Relaxed);
+    NEXT_ASYNC_ID.store(2, Ordering::Relaxed);
     NEXT_CONTEXT_SNAPSHOT_ID.store(1, Ordering::Relaxed);
     CURRENT_EXECUTION_ID.with(|c| c.set(0));
     CURRENT_TRIGGER_ID.with(|c| c.set(0));
@@ -1319,8 +1438,10 @@ mod tests {
         reset_for_tests();
         let a = init_resource("A", TAG_UNDEFINED_F64, true);
         let b = init_resource("B", TAG_UNDEFINED_F64, true);
-        assert_eq!(a.async_id, 1);
-        assert_eq!(b.async_id, 2);
+        // Ids start above 1 (Node reserves 1 for the root context) and are
+        // monotonic.
+        assert!(a.async_id > 1);
+        assert_eq!(b.async_id, a.async_id + 1);
     }
 
     #[test]

--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -110,6 +110,13 @@ pub extern "C" fn js_try_end() {
     });
 }
 
+/// Current `try` nesting depth on this thread. Async-context scopes
+/// (`AsyncLocalStorage#run` etc.) record this at entry so the unwind path
+/// can tell which scopes a throw is about to longjmp past (#788).
+pub(crate) fn current_try_depth() -> usize {
+    with_exception_state(|s| unsafe { (*s).try_depth })
+}
+
 /// Throw an exception with the given value
 #[no_mangle]
 pub extern "C" fn js_throw(value: f64) -> ! {
@@ -145,6 +152,11 @@ pub extern "C" fn js_throw(value: f64) -> ! {
         crate::closure::reset_throw_not_callable_counter();
 
         let depth = (*s).try_depth - 1;
+        // Apply the deferred context restores of async-context scopes
+        // (`AsyncLocalStorage#run`/`#exit`, `runInAsyncScope`) whose normal
+        // restore code this longjmp skips (#788). Pure thread-local state
+        // swaps — no JS runs and nothing allocates.
+        crate::async_context::unwind_context_guards(depth);
         // Drop the shadow-stack frames of the functions we are about to
         // unwind past. `longjmp` skips their epilogues (and therefore their
         // `js_shadow_frame_pop` calls), so without this the next GC would

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -4579,6 +4579,21 @@ pub unsafe extern "C" fn js_native_call_method(
         if (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
             return 0.0;
         }
+
+        // AsyncResource handles are raw Box pointers under POINTER_TAG, not
+        // GC heap objects — recognize them by registry membership BEFORE the
+        // gc_header read below (which would read foreign allocator memory).
+        // Covers receivers whose static type the codegen lost, e.g. a
+        // closure-captured `let resource: AsyncResource` (#789).
+        if let Some(r) = crate::async_hooks::try_async_resource_method_dispatch(
+            obj as i64,
+            method_name,
+            args_ptr,
+            args_len,
+        ) {
+            return r;
+        }
+
         let gc_header =
             (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         let gc_type = (*gc_header).obj_type;

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -30,6 +30,24 @@ thread_local! {
     /// macrotasks, and running them from a nested microtask checkpoint can
     /// build an unbounded stack of exception traps.
     static MICROTASK_RUN_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+
+    /// One-shot: the entry module is ESM and its evaluation checkpoint has
+    /// not happened yet. Consumed by the first `run_microtasks` drain, which
+    /// then finishes promise/queueMicrotask jobs before the nextTick queue
+    /// (Node runs ESM evaluation as a job inside a microtask checkpoint, so
+    /// ticks queued at top level wait for the checkpoint to finish; #788).
+    static ESM_EVAL_CHECKPOINT_PENDING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Called once from the compiled entry (before top-level statements) when the
+/// entry module uses import/export syntax — i.e. Node would load it as ESM.
+#[no_mangle]
+pub extern "C" fn js_mark_entry_module_esm() {
+    ESM_EVAL_CHECKPOINT_PENDING.with(|c| c.set(true));
+}
+
+fn consume_esm_eval_checkpoint() -> bool {
+    ESM_EVAL_CHECKPOINT_PENDING.with(|c| c.replace(false))
 }
 
 #[no_mangle]
@@ -41,10 +59,23 @@ pub(crate) fn js_promise_run_microtasks_checkpoint() -> i32 {
     run_microtasks(MicrotaskDrainMode::MicrotasksOnly)
 }
 
+/// Drain pending promise/queueMicrotask jobs WITHOUT giving the nextTick
+/// queue a turn. Used by the await lowering's `drain_once` block: an `await`
+/// of an already-settled promise must let earlier-queued microtasks run
+/// before execution continues, but ticks queued in the same synchronous
+/// stretch wait for the next real tick boundary (event-loop / entry flush) —
+/// Node runs them only after the microtask checkpoint completes (#788).
+#[no_mangle]
+pub extern "C" fn js_promise_run_promise_jobs() -> i32 {
+    run_microtasks(MicrotaskDrainMode::PromiseJobsOnly)
+}
+
 #[derive(Copy, Clone)]
 enum MicrotaskDrainMode {
     AllowTimers,
     MicrotasksOnly,
+    /// Promise/queueMicrotask jobs only — no nextTick drain, no timers.
+    PromiseJobsOnly,
 }
 
 fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
@@ -155,12 +186,38 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
     // Reading the env var directly here was ~30 ns per microtask drain;
     // the atomic load is ~1 ns.
     let prof = mt_profile_enabled();
+    // Node gives the nextTick queue its turn only at "tick boundaries":
+    // after a macrotask callback (timer/immediate — ticks first there, see
+    // the timer pump) or once the V8 microtask queue is exhausted. Two cases
+    // where this drain is entered MID-checkpoint and must therefore finish
+    // promise/queueMicrotask jobs before the first tick drain (#788):
+    //
+    //  1. ESM module evaluation — it runs as a job inside a checkpoint, so
+    //     ticks queued at top level wait for the queue to finish. One-shot
+    //     flag set by the compiled entry when the module uses import/export.
+    //  2. Re-entrant drains from inside a running promise job (the `await`
+    //     pump): ticks queued by the job must not overtake microtasks queued
+    //     by the same job. `CURRENT_MICROTASK_CALLBACK` is non-null exactly
+    //     while a promise/queueMicrotask/async-step callback is executing;
+    //     timer and nextTick callbacks don't set it, so their re-entries
+    //     keep the macrotask-boundary ticks-first ordering.
+    let ticks_allowed = !matches!(mode, MicrotaskDrainMode::PromiseJobsOnly);
+    let mid_promise_job = CURRENT_MICROTASK_CALLBACK.with(|c| !c.get().is_null());
+    let mut esm_defer_tick_drain = if ticks_allowed {
+        consume_esm_eval_checkpoint() || (reentrant && mid_promise_job)
+    } else {
+        // PromiseJobsOnly never drains ticks; leave the one-shot ESM flag
+        // for the first real checkpoint to consume.
+        false
+    };
     loop {
         let ran_before_checkpoint = ran;
 
         // Node runs process.nextTick jobs before regular microtasks, while
         // queueMicrotask jobs share FIFO order with Promise reactions.
-        ran += crate::builtins::drain_queued_microtasks_count();
+        if ticks_allowed && !esm_defer_tick_drain {
+            ran += crate::builtins::drain_queued_microtasks_count();
+        }
 
         loop {
             let t0 = if prof {
@@ -660,6 +717,15 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                     ran += 1;
                 }
             }
+        }
+
+        // ESM first checkpoint: the promise/queueMicrotask queue has fully
+        // drained (inner loop above); NOW the nextTick queue gets its first
+        // turn, still ahead of any timer. Subsequent iterations use the
+        // normal ticks-first ordering.
+        if esm_defer_tick_drain {
+            esm_defer_tick_drain = false;
+            ran += crate::builtins::drain_queued_microtasks_count();
         }
 
         if ran == ran_before_checkpoint {

--- a/crates/perry-stdlib/src/async_local_storage.rs
+++ b/crates/perry-stdlib/src/async_local_storage.rs
@@ -93,9 +93,15 @@ pub unsafe extern "C" fn js_async_local_storage_run(
     // without leaving a pushed store behind (#3092).
     let cb = validate_callback(callback);
 
+    // A context guard mirrors the pop below: if the callback throws,
+    // `js_throw` applies the guard while unwinding so the catch site still
+    // observes the pre-`run` store (#788, Node restores via try/finally).
     async_context::push_store(handle, store);
+    async_context::push_context_guard(async_context::ContextGuardAction::PopStore(handle));
     let result = call_with_forwarded_args(cb, args_array);
-    async_context::pop_store(handle);
+    if let Some(action) = async_context::pop_context_guard() {
+        async_context::apply_context_guard(action);
+    }
 
     result
 }
@@ -141,10 +147,21 @@ pub unsafe extern "C" fn js_async_local_storage_exit(
         None
     };
 
+    // Guarded like run(): a throwing callback must still restore the saved
+    // store stack at the catch site (#788).
+    let guarded = saved.is_some();
+    if let Some(saved) = saved {
+        async_context::push_context_guard(async_context::ContextGuardAction::RestoreStores(
+            handle, saved,
+        ));
+    }
+
     let result = call_with_forwarded_args(cb, args_array);
 
-    if let Some(saved) = saved {
-        async_context::restore_store(handle, saved);
+    if guarded {
+        if let Some(action) = async_context::pop_context_guard() {
+            async_context::apply_context_guard(action);
+        }
     }
 
     result

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -31,6 +31,58 @@ unsafe fn pack_args_array(args: &[f64]) -> *mut perry_runtime::ArrayHeader {
     arr_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>()
 }
 
+/// Dynamic dispatch for `AsyncLocalStorage` receivers whose static type the
+/// codegen lost (`any`-typed bindings, closure captures). Gated on registry
+/// type membership so no other subsystem's handle is claimed (#788).
+unsafe fn dispatch_async_local_storage_method(
+    handle: i64,
+    method: &str,
+    args: &[f64],
+) -> Option<f64> {
+    if !matches!(
+        method,
+        "run" | "getStore" | "enterWith" | "exit" | "disable"
+    ) {
+        return None;
+    }
+    if get_handle_mut::<crate::async_local_storage::AsyncLocalStorageHandle>(handle).is_none() {
+        return None;
+    }
+    Some(match method {
+        "getStore" => crate::async_local_storage::js_async_local_storage_get_store(handle),
+        "run" if args.len() >= 2 => {
+            let rest = if args.len() > 2 { &args[2..] } else { &[] };
+            let rest_array = if rest.is_empty() {
+                0
+            } else {
+                pack_args_array(rest) as i64
+            };
+            crate::async_local_storage::js_async_local_storage_run(
+                handle, args[0], args[1], rest_array,
+            )
+        }
+        "enterWith" => {
+            let store = args.first().copied().unwrap_or(TAG_UNDEFINED_F64);
+            crate::async_local_storage::js_async_local_storage_enter_with(handle, store);
+            TAG_UNDEFINED_F64
+        }
+        "exit" if !args.is_empty() => {
+            let rest = if args.len() > 1 { &args[1..] } else { &[] };
+            let rest_array = if rest.is_empty() {
+                0
+            } else {
+                pack_args_array(rest) as i64
+            };
+            crate::async_local_storage::js_async_local_storage_exit(handle, args[0], rest_array)
+        }
+        "disable" => {
+            crate::async_local_storage::js_async_local_storage_disable(handle);
+            TAG_UNDEFINED_F64
+        }
+        _ => return None,
+    })
+}
+
 #[cfg(feature = "bundled-events")]
 unsafe fn dispatch_event_emitter_method(handle: i64, method: &str, args: &[f64]) -> Option<f64> {
     if !crate::events::is_event_emitter_handle(handle) {
@@ -225,6 +277,10 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
 
     #[cfg(feature = "bundled-events")]
     if let Some(value) = dispatch_event_emitter_method(handle, method_name, &args) {
+        return value;
+    }
+
+    if let Some(value) = dispatch_async_local_storage_method(handle, method_name, &args) {
         return value;
     }
 

--- a/test-files/test_parity_async_context.ts
+++ b/test-files/test_parity_async_context.ts
@@ -1,0 +1,188 @@
+// Node-differential parity test for AsyncLocalStorage / async_hooks context
+// propagation (#788/#789). Byte-compared against `node` (v26+); every case is
+// deterministic (no wall-clock-dependent cross-timer ordering).
+import { AsyncLocalStorage, AsyncResource } from 'node:async_hooks';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function caseBasicAwait() {
+  console.log('== basic-await ==');
+  const als = new AsyncLocalStorage<{ id: number }>();
+  await als.run({ id: 1 }, async () => {
+    await Promise.resolve();
+    console.log('after-await', als.getStore()?.id);
+    await sleep(1);
+    console.log('after-timer-await', als.getStore()?.id);
+  });
+  console.log('outside', als.getStore());
+}
+
+async function caseNestedRun() {
+  console.log('== nested-run ==');
+  const als = new AsyncLocalStorage<string>();
+  als.run('outer', () => {
+    console.log('a', als.getStore());
+    als.run('inner', () => console.log('b', als.getStore()));
+    console.log('c', als.getStore());
+  });
+  console.log('d', als.getStore());
+}
+
+async function caseEnterWithInRun() {
+  console.log('== enterwith-in-run ==');
+  const als = new AsyncLocalStorage<string>();
+  als.run('r', () => {
+    console.log('1', als.getStore());
+    als.enterWith('e');
+    console.log('2', als.getStore());
+  });
+  // run() restores its own storage's pre-run value even after enterWith.
+  console.log('3', als.getStore());
+}
+
+async function caseCrossStorage() {
+  console.log('== cross-storage ==');
+  const a = new AsyncLocalStorage<string>();
+  const b = new AsyncLocalStorage<string>();
+  a.run('A', () => {
+    b.enterWith('B');
+    console.log('1', a.getStore(), b.getStore());
+  });
+  // a.run restores only its own storage; b's enterWith survives.
+  console.log('2', a.getStore(), b.getStore());
+  b.run('B2', () => {
+    a.exit(() => {
+      b.enterWith('B3');
+      console.log('3', a.getStore(), b.getStore());
+    });
+    console.log('4', a.getStore(), b.getStore());
+  });
+  console.log('5', a.getStore(), b.getStore());
+}
+
+async function caseThrowRestores() {
+  console.log('== throw-restores ==');
+  const als = new AsyncLocalStorage<string>();
+  als.run('outer', () => {
+    try {
+      als.run('inner', () => {
+        throw new Error('boom');
+      });
+    } catch (e: any) {
+      console.log('caught', e.message, 'store', als.getStore());
+    }
+  });
+  console.log('end', als.getStore());
+}
+
+async function caseResourceThrow() {
+  console.log('== resource-throw ==');
+  const als = new AsyncLocalStorage<string>();
+  const res = new AsyncResource('T');
+  als.run('outer', () => {
+    try {
+      res.runInAsyncScope(() => {
+        throw new Error('rs');
+      });
+    } catch (e: any) {
+      console.log('caught', e.message, als.getStore());
+    }
+  });
+  console.log('end', als.getStore());
+}
+
+async function caseMicrotaskOrdering() {
+  console.log('== microtask-ordering ==');
+  const als = new AsyncLocalStorage<string>();
+  await new Promise<void>((done) => {
+    als.run('m', () => {
+      queueMicrotask(() => console.log('qm', als.getStore()));
+      process.nextTick(() => {
+        console.log('nt', als.getStore());
+        done();
+      });
+      Promise.resolve().then(() => console.log('then', als.getStore()));
+    });
+  });
+}
+
+async function caseRunReturnAndArgs() {
+  console.log('== run-return ==');
+  const als = new AsyncLocalStorage<string>();
+  console.log('sync-ret', als.run('x', () => 42));
+  console.log('args-ret', als.run('y', (a: number, b: number) => a + b, 10, 20));
+  console.log('async-ret', await als.run('z', async () => {
+    await Promise.resolve();
+    return als.getStore();
+  }));
+  console.log('exit-ret', als.run('w', () => als.exit((s: string) => s + ':' + als.getStore(), 'e')));
+}
+
+async function caseConcurrentStores() {
+  console.log('== concurrent ==');
+  const als = new AsyncLocalStorage<number>();
+  const seen: string[] = [];
+  async function task(id: number, ms: number) {
+    await sleep(ms);
+    seen.push('task ' + id + ' sees ' + als.getStore());
+    await sleep(ms);
+    seen.push('task ' + id + ' still sees ' + als.getStore());
+  }
+  const p1 = als.run(1, () => task(1, 8));
+  const p2 = als.run(2, () => task(2, 3));
+  await Promise.all([p1, p2]);
+  console.log(seen.sort().join('\n'));
+}
+
+async function caseDynamicReceiver() {
+  console.log('== dynamic-receiver ==');
+  const als: any = new AsyncLocalStorage();
+  const r = als.run({ x: 1 }, (a: number, b: number) => {
+    console.log('dyn-run', als.getStore().x, a + b);
+    return 'ok';
+  }, 3, 4);
+  console.log('ret', r, als.getStore());
+
+  let resource: AsyncResource | undefined;
+  const captured = new AsyncLocalStorage<string>();
+  captured.run('captured', () => {
+    resource = new AsyncResource('TEST');
+  });
+  captured.run('current', () => {
+    resource!.runInAsyncScope(() => console.log('inScope', captured.getStore()));
+    console.log('after', captured.getStore());
+  });
+}
+
+async function caseSnapshotBind() {
+  console.log('== snapshot-bind ==');
+  const als = new AsyncLocalStorage<string>();
+  let bound: () => string | undefined;
+  let snap: any;
+  als.run('bind-ctx', () => {
+    bound = AsyncLocalStorage.bind(() => als.getStore());
+    snap = AsyncLocalStorage.snapshot();
+  });
+  als.run('other', () => {
+    console.log('bound', bound());
+    console.log('snap', snap(() => als.getStore()));
+    console.log('direct', als.getStore());
+  });
+}
+
+async function main() {
+  await caseBasicAwait();
+  await caseNestedRun();
+  await caseEnterWithInRun();
+  await caseCrossStorage();
+  await caseThrowRestores();
+  await caseResourceThrow();
+  await caseMicrotaskOrdering();
+  await caseRunReturnAndArgs();
+  await caseConcurrentStores();
+  await caseDynamicReceiver();
+  await caseSnapshotBind();
+  console.log('done');
+}
+
+main();


### PR DESCRIPTION
Closes the remaining semantic gaps in AsyncLocalStorage / async_hooks context propagation (#788, #789). All fixes are node-differential: each repro below now produces byte-identical output under Perry and `node` v26.3.0 (verified on Linux x86-64).

## What now works (was broken on main)

1. **`run()` restore semantics match Node's AsyncContextFrame** — `enterWith()` now *replaces* the current store slot instead of pushing a second one, so `als.run(s, cb)` restores its own storage's pre-run value on exit even when `cb` called `enterWith`. Cross-storage behavior matches Node exactly: `b.enterWith(...)` inside `a.run(...)` *survives* `a.run`'s exit (Node restores only its own key).

2. **Throw-safety** — a callback that throws out of `als.run()` / `als.exit()` / `resource.runInAsyncScope()` now restores the caller's context at the catch site. Perry's `js_throw` is a longjmp, which skipped the normal restore code; a new try-depth-tagged, GC-scanned *context-guard stack* in `perry-runtime/src/async_context.rs` is applied by `js_throw` for exactly the scopes being unwound past (pure TLS swaps, no JS runs mid-unwind). Previously `catch` observed the *inner* store and the leak persisted after `run()` returned.

3. **nextTick vs microtask checkpoint ordering (ESM)** — Node evaluates an ESM module as a job inside a microtask checkpoint, so ticks queued at top level (or from inside any promise job) wait until the promise/queueMicrotask queue exhausts. Perry drained ticks first everywhere. Now: compiled ESM entries (import/export syntax or TLA) mark a one-shot checkpoint flag; re-entrant drains from inside a promise job defer ticks; and the await lowering's `drain_once` runs *promise jobs only* (new `js_promise_run_promise_jobs`) instead of draining the tick queue ahead of earlier-queued microtasks. CJS-style entries and timer-callback boundaries keep Node's ticks-first ordering (verified: 10 ordering probes match node in both module modes).

4. **Dynamic dispatch** — `AsyncResource` methods (`runInAsyncScope`/`asyncId`/`triggerAsyncId`/`emitDestroy`/`bind`) now work on receivers whose static type codegen lost (closure-captured `let r: AsyncResource`, `any`). AsyncResource handles are raw `Box` pointers under POINTER_TAG; a monotonic handle registry (the #4898 BOX_REGISTRY pattern) recognizes them *before* the generic object path dereferences them. `AsyncLocalStorage` methods likewise dispatch through `any`-typed bindings via the stdlib handle dispatcher (previously `als.run` on an `any` receiver threw "not a function").

5. **`executionAsyncId()` lifecycle** — async ids now start at 2 (Node reserves 1 for the root/bootstrap context), so `executionAsyncId() > 1` inside the first timer callback, matching Node's observable invariants (init/before/after/destroy + trigger ids already fired correctly).

## Differential evidence

28-case suite (run/getStore/enterWith/exit/disable across `await`, `.then`, `queueMicrotask`, `process.nextTick`, `setTimeout`/`setImmediate`/`setInterval`, nested + concurrent `run()`, fs callbacks, **http server request tracing incl. two concurrent requests with separate stores**, `createHook` lifecycle, `AsyncResource`, `AsyncLocalStorage.bind`/`snapshot`, dynamic receivers, throw paths): **28/28 byte-match node v26** (was 17/23 on the original failing subset before the fixes; the http cases additionally needed `perry-ext-http`/-server built, which is a box-setup matter, not a code change).

New repo parity test: `test-files/test_parity_async_context.ts` (11 deterministic cases, auto-discovered by `run_parity_tests.sh`, byte-matched vs node). Existing `test_parity_async_local_storage.ts`, `test_parity_async_hooks.ts`, `test_async_local_storage_context.ts` still MATCH.

This unblocks context-aware middleware (request tracing, auth context, ORM transaction scoping) in Express/Fastify/NestJS-style servers: a store set in `als.run()` inside a request handler now survives awaits, timers, nested calls, and emitted events, stays isolated between concurrent requests, and is correctly restored when handlers throw.

## Files

- `perry-runtime/src/async_context.rs` — `set_store` (enterWith replace semantics); context-guard stack (`push/pop/apply/unwind_context_guards`) + GC scanning
- `perry-runtime/src/exception.rs` — `js_throw` applies pending context guards before the longjmp; exposes `current_try_depth`
- `perry-runtime/src/async_hooks.rs` — guards in `runInAsyncScope`/snapshot trampoline; silent execution-scope unwind; AsyncResource handle registry + `try_async_resource_method_dispatch`; ids start at 2
- `perry-runtime/src/promise/microtasks.rs` — ESM checkpoint flag (`js_mark_entry_module_esm`), mid-promise-job tick deferral, `js_promise_run_promise_jobs` (no-ticks drain mode)
- `perry-runtime/src/object/native_call_method.rs` — AsyncResource registry probe before the gc-header deref in the dynamic method path
- `perry-stdlib/src/async_local_storage.rs` — guard-protected `run()`/`exit()`
- `perry-stdlib/src/common/dispatch.rs` — `dispatch_async_local_storage_method`
- `perry-codegen/src/codegen/entry.rs`, `expr/fs_await.rs`, `runtime_decls/strings_part2.rs` — ESM marker emission; `drain_once` → promise-jobs-only; FFI decls
- `test-files/test_parity_async_context.ts` — new parity test

## Regressions

- test262 `built-ins` + `language` shard 0/16 (1,984 cases), patched vs pristine origin/main on the same box, jobs=12: parity 92.9% both, **identical 140-test failure sets** (20 diff / 113 runtime-fail / 7 compile-fail — name-by-name set diff, not just totals).
- Gap suite (all 227 `test-files/test_gap_*.ts`, node-differential, both builds run with the same crude no-normalization runner): **identical result sets** (193 MATCH / 33 DIFF / 1 env-gated SKIP; the 33 DIFFs and a handful of segfaults are pre-existing, byte-identical between baseline and patched).
- `cargo test` for perry-runtime (1022 pass), perry-stdlib, perry-codegen, perry-hir, perry-transform, perry-api-manifest: green. (`bounded_integer_array_store_omits_layout_note_and_barrier` fails identically on pristine origin/main on this box — pre-existing/environmental, not introduced here.)
- `cargo fmt --all` clean; file-size gate passes.

No version bump / CHANGELOG edits per external-contributor flow (maintainer folds metadata at merge).
