### PR TITLE
feat(runtime): real child_process spawn/exec with ChildProcess handle (#2130/#1934)

### DIFF
--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -901,12 +901,20 @@ pub(super) fn cp_signal_from_value(signal: f64) -> i32 {
     if js.is_undefined() || js.is_null() {
         return CP_SIGTERM;
     }
-    if let Some(name) = cp_value_to_string(signal) {
-        return cp_signal_number(&name).unwrap_or(CP_SIGTERM);
+    // `kill(9)` — numeric forms must be checked BEFORE the string lookup:
+    // `cp_value_to_string` routes through the unified accessor, which coerces
+    // numbers to their string form ("9"), and "9" is not a signal name. An
+    // int32 can also arrive NaN-boxed, which a raw `is_finite()` misses.
+    if js.is_int32() {
+        let n = js.as_int32();
+        return if n == 0 { CP_SIGTERM } else { n };
     }
     if signal.is_finite() {
         let n = signal as i32;
         return if n == 0 { CP_SIGTERM } else { n };
+    }
+    if let Some(name) = cp_value_to_string(signal) {
+        return cp_signal_number(&name).unwrap_or(CP_SIGTERM);
     }
     CP_SIGTERM
 }
@@ -1041,8 +1049,66 @@ extern "C" fn cp_method_remove_all_listeners(closure: *const ClosureHeader, even
 extern "C" fn cp_method_read(_closure: *const ClosureHeader, _n: f64) -> f64 {
     TAG_NULL_F64
 }
-extern "C" fn cp_method_pipe(_closure: *const ClosureHeader, dest: f64) -> f64 {
+
+/// `child.stdout.pipe(dest)` — forward every `data` chunk to `dest.write(chunk)`
+/// and call `dest.end()` at source EOF. Node skips the end-call for
+/// `process.stdout`/`process.stderr`; those stream objects expose no `end`
+/// method, so the lookup-miss skip below matches that naturally. Returns
+/// `dest` (Node returns the destination for chaining).
+extern "C" fn cp_method_pipe(closure: *const ClosureHeader, dest: f64) -> f64 {
+    let this = cp_this(closure);
+    js_register_closure_arity(cp_pipe_data_thunk as *const u8, 1);
+    js_register_closure_arity(cp_pipe_end_thunk as *const u8, 0);
+
+    let data_thunk = js_closure_alloc(cp_pipe_data_thunk as *const u8, 1);
+    js_closure_set_capture_ptr(data_thunk, 0, dest.to_bits() as i64);
+    cp_register(
+        this,
+        cp_box_string("data"),
+        cp_box_ptr(data_thunk as *const u8),
+    );
+
+    let end_thunk = js_closure_alloc(cp_pipe_end_thunk as *const u8, 1);
+    js_closure_set_capture_ptr(end_thunk, 0, dest.to_bits() as i64);
+    cp_register(
+        this,
+        cp_box_string("end"),
+        cp_box_ptr(end_thunk as *const u8),
+    );
+
     dest
+}
+
+/// Pipe `data` forwarder: slot 0 = the destination; call `dest.write(chunk)`.
+extern "C" fn cp_pipe_data_thunk(closure: *const ClosureHeader, chunk: f64) -> f64 {
+    let dest = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    let write = cp_get_field(dest, b"write");
+    if !crate::fs::extract_closure_ptr(write).is_null() {
+        let prev = js_implicit_this_set(dest);
+        let args = [chunk];
+        unsafe {
+            let _ = js_native_call_value(write, args.as_ptr(), args.len());
+        }
+        js_implicit_this_set(prev);
+    }
+    cp_undefined()
+}
+
+/// Pipe `end` forwarder: slot 0 = the destination; call `dest.end()` when the
+/// destination has one (`process.stdout`/`process.stderr` do not — matching
+/// Node's doEnd exclusion for them).
+extern "C" fn cp_pipe_end_thunk(closure: *const ClosureHeader) -> f64 {
+    let dest = f64::from_bits(js_closure_get_capture_ptr(closure, 0) as u64);
+    let end = cp_get_field(dest, b"end");
+    if !crate::fs::extract_closure_ptr(end).is_null() {
+        let prev = js_implicit_this_set(dest);
+        let args = [cp_undefined()];
+        unsafe {
+            let _ = js_native_call_value(end, args.as_ptr(), 0);
+        }
+        js_implicit_this_set(prev);
+    }
+    cp_undefined()
 }
 /// `child.stdin.write(chunk[, encoding][, callback])` — #1934. The `this` is
 /// the stdin Writable; route the bytes to the live child's stdin via the
@@ -2024,10 +2090,13 @@ fn cp_error_code_signal(run: &CpRun) -> (f64, f64, f64) {
 
 /// Build the `(err, stdout, stderr)` callback error for a failed exec/execFile
 /// run — Node attaches `code`/`signal`/`killed`/`cmd` (plus `errno`/`syscall`/
-/// `path` on spawn failure). `cmd` is the human-readable command string. #1935.
-fn cp_exec_callback_error(run: &CpRun, options: &CpRunOptions, cmd: &str) -> f64 {
+/// `path` on spawn failure). `cmd` is the human-readable command string;
+/// `file` is the program actually launched (Node's spawn-failure `syscall`/
+/// `path`/message use the file alone, while `.cmd` keeps the display string —
+/// `execFile("x", ["a"])` ENOENT reads `syscall: "spawn x"`, `cmd: "x a"`). #1935.
+fn cp_exec_callback_error(run: &CpRun, options: &CpRunOptions, cmd: &str, file: &str) -> f64 {
     if let Some((errno_code, _)) = run.spawn_error {
-        let syscall = format!("spawn {cmd}");
+        let syscall = format!("spawn {file}");
         let message = format!("{syscall} {errno_code}");
         return cp_make_error(
             &message,
@@ -2035,7 +2104,7 @@ fn cp_exec_callback_error(run: &CpRun, options: &CpRunOptions, cmd: &str) -> f64
                 ("code", cp_box_string(errno_code)),
                 ("errno", cp_errno_number(errno_code)),
                 ("syscall", cp_box_string(&syscall)),
-                ("path", cp_box_string(cmd)),
+                ("path", cp_box_string(file)),
                 ("cmd", cp_box_string(cmd)),
                 ("killed", TAG_FALSE_F64),
                 ("signal", TAG_NULL_F64),
@@ -2120,6 +2189,7 @@ pub(super) fn cp_exec_callback_args(
     run: &CpRun,
     options: &CpRunOptions,
     cmd: &str,
+    file: &str,
     mode: &CpOutput,
 ) -> (f64, f64, f64) {
     let (stdout_bytes, stderr_bytes) = cp_exec_callback_output_bytes(run, options);
@@ -2128,7 +2198,7 @@ pub(super) fn cp_exec_callback_args(
     let err_val = if run.success() {
         TAG_NULL_F64
     } else {
-        cp_exec_callback_error(run, options, cmd)
+        cp_exec_callback_error(run, options, cmd, file)
     };
     (err_val, stdout_box, stderr_box)
 }

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -139,6 +139,8 @@ pub(super) struct CpExecPending {
     mode: CpOutput,
     /// Human-readable command, for the error `.cmd` field.
     cmd: String,
+    /// Program actually launched, for the spawn-failure `syscall`/`path`.
+    file: String,
     /// Set once accumulated output passed `maxBuffer` (the child is then killed).
     exceeded: bool,
     /// Set when the `timeout` fired and the child was killed.
@@ -662,16 +664,30 @@ pub extern "C" fn js_child_process_spawn_streams(
         Err(e) => {
             // Spawn failure (e.g. ENOENT): Node emits a single `error` event and
             // never `spawn`/`exit`. Defer it so a synchronously-registered
-            // handler is present.
+            // handler is present. The error carries Node's errno shape:
+            // `code`/`errno`/`syscall`/`path`/`spawnargs`, message
+            // `spawn <cmd> <CODE>`.
             cp_set_field(cp, b"pid", cp_undefined());
-            let msg = e.to_string();
-            let mp = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-            let err = crate::error::js_error_new_with_message(mp);
-            cp_set_field(
-                cp,
-                b"__cpError",
-                crate::value::js_nanbox_pointer(err as i64),
+            let code = super::cp_io_error_code(&e);
+            let syscall = format!("spawn {cmd_str}");
+            let message = format!("{syscall} {code}");
+            // Node's error `spawnargs` excludes argv0 (internally `slice(1)`
+            // of the handle's spawnargs), unlike `child.spawnargs`.
+            let mut err_args = crate::array::js_array_alloc(arg_strs.len() as u32);
+            for a in &arg_strs {
+                err_args = crate::array::js_array_push_f64(err_args, cp_box_string(a));
+            }
+            let err = super::cp_make_error(
+                &message,
+                &[
+                    ("errno", super::cp_errno_number(code)),
+                    ("code", cp_box_string(code)),
+                    ("syscall", cp_box_string(&syscall)),
+                    ("path", cp_box_string(&cmd_str)),
+                    ("spawnargs", cp_box_ptr(err_args as *const u8)),
+                ],
             );
+            cp_set_field(cp, b"__cpError", err);
             let emit_closure =
                 crate::closure::js_closure_alloc(cp_emit_spawn_error as *const u8, 1);
             crate::closure::js_closure_set_capture_ptr(emit_closure, 0, cp.to_bits() as i64);
@@ -720,6 +736,11 @@ pub(super) fn cp_exec_async(
     cp_register_arities();
     cp_register_reactor_arities();
 
+    // The program actually launched (`sh` for exec, the file for execFile) —
+    // Node's spawn-failure error keys `syscall`/`path`/message off this, not
+    // off the display command string.
+    let file = command.get_program().to_string_lossy().into_owned();
+
     // exec/execFile capture stdout+stderr and never feed stdin.
     command.stdin(Stdio::null());
     command.stdout(Stdio::piped());
@@ -744,6 +765,7 @@ pub(super) fn cp_exec_async(
                 run_options,
                 mode,
                 cmd: cmd_str,
+                file,
                 exceeded: false,
                 timed_out: false,
             });
@@ -801,7 +823,7 @@ pub(super) fn cp_exec_async(
                 run_error: None,
             };
             let (err, out, errout) =
-                super::cp_exec_callback_args(&run, &run_options, &cmd_str, &mode);
+                super::cp_exec_callback_args(&run, &run_options, &cmd_str, &file, &mode);
             cp_defer_exec_callback(cb_val, err, out, errout);
         }
     }
@@ -861,7 +883,7 @@ fn cp_exec_fire_close(exec: Box<CpExecPending>, code: Option<i32>, signal: Optio
         run_error,
     };
     let (err, out, errout) =
-        super::cp_exec_callback_args(&run, &exec.run_options, &exec.cmd, &exec.mode);
+        super::cp_exec_callback_args(&run, &exec.run_options, &exec.cmd, &exec.file, &exec.mode);
     let cb = crate::fs::extract_closure_ptr(f64::from_bits(exec.cb_bits));
     if !cb.is_null() {
         crate::closure::js_closure_call3(cb, err, out, errout);
@@ -1250,13 +1272,21 @@ fn cp_parse_signal(signal: f64) -> i32 {
     if JSValue::from_bits(signal.to_bits()).is_undefined() {
         return SIGTERM;
     }
-    if let Some(name) = cp_value_to_string(signal) {
-        return cp_signal_number(&name).unwrap_or(SIGTERM);
+    // Numeric forms BEFORE the string lookup: the unified string accessor
+    // coerces numbers to "9"-style strings, which are not signal names; an
+    // int32 can also arrive NaN-boxed, which `is_finite()` alone misses.
+    let js = JSValue::from_bits(signal.to_bits());
+    if js.is_int32() {
+        let n = js.as_int32();
+        return if n == 0 { SIGTERM } else { n };
     }
     if signal.is_finite() {
         let n = signal as i32;
         // 0 is the "no-arg" padding sentinel — treat as the default SIGTERM.
         return if n == 0 { SIGTERM } else { n };
+    }
+    if let Some(name) = cp_value_to_string(signal) {
+        return cp_signal_number(&name).unwrap_or(SIGTERM);
     }
     SIGTERM
 }

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -208,12 +208,13 @@ fn build_stream_object_with_write(
             (0, keys, 14, Some(6))
         };
     let obj = if class_id == 0 {
-        js_object_alloc_with_shape(
-            0x7FFF_FF22,
-            field_count,
-            packed.as_ptr(),
-            packed.len() as u32,
-        )
+        // Shape ids must stay clear of NAVIGATOR_CLASS_ID (0x7FFF_FF22) — the
+        // per-shape key registry is first-registration-wins, so sharing an id
+        // with navigator made `process.stdout.write` resolve to undefined
+        // whenever navigator was built first. stdin gets its own id because
+        // its key layout diverges from stdout/stderr past field 5.
+        let shape_id = if is_stdin { 0x7FFF_FF29 } else { 0x7FFF_FF23 };
+        js_object_alloc_with_shape(shape_id, field_count, packed.as_ptr(), packed.len() as u32)
     } else {
         crate::object::js_object_alloc_class_with_keys(
             class_id,

--- a/test-files/test_issue_2130_child_process_handle.ts
+++ b/test-files/test_issue_2130_child_process_handle.ts
@@ -1,0 +1,75 @@
+// #2130/#1934 — real child_process spawn/exec option + error semantics, vs
+// `node --experimental-strip-types`:
+//   (1) spawn-failure 'error' carries Node's errno shape (code/errno/syscall/
+//       path/spawnargs) and pid stays undefined;
+//   (2) execFile spawn-failure error keys syscall/path off the FILE while
+//       `cmd` keeps the display string;
+//   (3) kill(9) — numeric signals (incl. NaN-boxed int32 forms) map to the
+//       real signal, observable through the 'close' signal name;
+//   (4) stdout.pipe(process.stdout) forwards chunks; piping into another
+//       child's stdin forwards and closes it at source EOF.
+import { spawn, execFile } from "node:child_process";
+
+function stage1() {
+  const p = spawn("definitely-not-a-cmd-xyz", ["a", "b"]);
+  console.log("1.pid", p.pid);
+  p.on("error", (e: any) => {
+    console.log(
+      "1.error",
+      e.code,
+      e.errno,
+      JSON.stringify(e.syscall),
+      JSON.stringify(e.path),
+      JSON.stringify(e.spawnargs)
+    );
+    stage2();
+  });
+}
+
+function stage2() {
+  execFile("definitely-not-a-cmd-xyz", ["a"], (err: any) => {
+    console.log(
+      "2.execFile",
+      err.code,
+      err.errno,
+      JSON.stringify(err.syscall),
+      JSON.stringify(err.path),
+      JSON.stringify(err.cmd)
+    );
+    stage3();
+  });
+}
+
+function stage3() {
+  const p = spawn("sleep", ["30"]);
+  p.on("close", (c: any, s: any) => {
+    console.log("3.close", c, s);
+    stage4();
+  });
+  setTimeout(() => p.kill(9), 50);
+}
+
+function stage4() {
+  const p = spawn("sh", ["-c", 'printf "piped-1\\n"']);
+  p.stdout.pipe(process.stdout);
+  p.on("close", (c: any) => {
+    console.log("4.close", c);
+    stage5();
+  });
+}
+
+function stage5() {
+  const src = spawn("sh", ["-c", 'printf "x\\ny\\n"']);
+  const dst = spawn("cat", ["-n"]);
+  src.stdout.pipe(dst.stdin);
+  let out = "";
+  dst.stdout.on("data", (d: any) => {
+    out += d.toString();
+  });
+  dst.on("close", (c: any) => {
+    process.stdout.write(out);
+    console.log("5.close", c);
+  });
+}
+
+stage1();


### PR DESCRIPTION
Implements the remaining real-world `child_process` spawn/exec ChildProcess-handle semantics (#2130, #1934), verified **node-differentially**: every repro below runs under `node` v26.3 and under Perry and must produce byte-identical stdout + exit code.

## What was actually broken (found by differential sweep)

1. **`process.stdout.write` inside any spawn handler threw `TypeError: write is not a function`** — the canonical `p.stdout.on('data', d => process.stdout.write(d))` pattern was dead. Root cause was outside child_process: the non-TTY `process.stdout`/`stderr` stream object shared shape id `0x7FFF_FF22` with `NAVIGATOR_CLASS_ID`, and the per-shape key registry is first-registration-wins — any `require()` build constructed navigator first, so the stream's `write` key lookup resolved through navigator's key list to undefined. Streams move to `0x7FFF_FF23`; stdin (whose key layout diverges past field 5 and was latently colliding with stdout's) gets its own `0x7FFF_FF29`.
2. **spawn launch failure (ENOENT) emitted a bare Rust `io::Error` message** with no fields. Now emits Node's errno shape: `code: 'ENOENT'`, `errno: -2`, `syscall: 'spawn <cmd>'`, `path: <cmd>`, `spawnargs: [...args]` (argv0 excluded, matching Node's internal `slice(1)`), message `spawn <cmd> ENOENT`.
3. **execFile spawn-failure error** used the joined `file args…` display string for `syscall`/`path`/message; Node keys those off the launched file alone (`.cmd` keeps the display string). The launched program is now threaded through the exec reactor.
4. **`p.kill(9)` silently sent SIGTERM** — the numeric-signal decode ran after a string lookup that coerces numbers to `"9"`-style names (and NaN-boxed int32s failed the raw `is_finite()` check). Numeric forms now decode first, in both the kill path and the `killSignal` option path.
5. **`p.stdout.pipe(dest)` was a no-op returning `dest`.** Now forwards every `data` chunk to `dest.write(chunk)` and calls `dest.end()` at source EOF when the destination has one — `process.stdout`/`stderr` expose no `end`, which naturally matches Node's doEnd exclusion for them. `p.stdout.pipe(process.stdout)` and child-to-child `p1.stdout.pipe(p2.stdin)` both work.

## Differential suite (36 cases, all matching node v26.3)

spawn: stdout/stderr `data`/`end`, `spawn`/`exit`/`close` ordering + codes, stdin `write`/`end` piping into `cat`, `kill()` / `kill('SIGKILL')` / `kill(9)` with `signalCode`, ENOENT `error` event + `pid === undefined`, `spawnfile`/`spawnargs`/`exitCode`/`killed`/`connected` props, options `cwd`/`env`/`shell`/`stdio` (`'pipe'`/`'ignore'`/`'inherit'` + array form)/`detached`/`timeout`/`signal` (AbortController), pipe-to-process-stdout, pipe chaining between children, long-lived stdin/stdout protocol child.
exec/execFile: callback `(err, stdout, stderr)` with `err.code`/`killed`/`signal`/`cmd`, ENOENT errno shapes, `maxBuffer` (RangeError + truncation), `encoding: 'buffer'`/`'hex'`, `cwd`/`env`, `util.promisify` resolve/reject shapes.
sync: `spawnSync` (`status`/`signal`/`output`/`stdout`/`stderr`, `input`, `encoding`), `execSync` (Buffer default, `encoding`, throw shape `status`/`signal`, `stdio: 'inherit'`), fork + IPC round-trip.

Committed as `test-files/test_issue_2130_child_process_handle.ts` (byte-for-byte vs `node --experimental-strip-types`); existing `test_parity_child_process.ts` and `test_issue_{1780,1934,1935_1938,4912}` files re-verified.

## Regressions

- test262 `built-ins language` shard 0/16, branch vs same-commit origin/main baseline build, jobs=12: **identical failure sets** (1843 pass / 20 diff / 114 runtime-fail / 7 compile-fail on both; 0 new, 0 fixed).
- Gap suite (`run_parity_tests.sh --filter test_gap_`): no new failures vs baseline.
- `cargo test -p perry-runtime child_process`: pass. `cargo fmt --all` clean; file-size gate OK (child_process/mod.rs already allowlisted).
- Pre-existing, **not** introduced here (identical on baseline): `test_issue_1934_spawn_reactor.ts` end-vs-exit event ordering differs from node v26-on-Linux for fast-exiting children (Node makes no ordering guarantee between `exit` and stdout `end`; output byte-identical to baseline), and `navigator.userAgent`/`hardwareConcurrency` read as `0` on Linux (broken on origin/main too — separate bug, the shape-collision fix here was a prerequisite to even seeing it).

## What this unblocks

Build-tool / CLI shellers: git wrappers, esbuild-style protocol spawners (long-lived child + stdin/stdout framing), test runners that `spawn(...).stdout.pipe(process.stdout)`, and anything keying retry/diagnostics off `err.code === 'ENOENT'` or signal-based teardown.

Files: `crates/perry-runtime/src/os_process_streams.rs`, `crates/perry-runtime/src/child_process/{mod.rs,reactor.rs}`, `test-files/test_issue_2130_child_process_handle.ts`. Code-only — no version/changelog edits (maintainer folds at merge).
