### PR TITLE
fix(hir,codegen,runtime): clear the #4950 React render-time walls (JSX createElement mode + 4 companion fixes)

### DIFF
--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -531,6 +531,25 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     .block()
                     .call(DOUBLE, "js_unresolved_namespace_stub", &[]));
             }
+            // #4950: built-in globals that HIR lowers to `ExternFuncRef` even
+            // in VALUE position (the `is_builtin_function` timer set —
+            // `setTimeout`, `setImmediate`, …) used to fall through to the
+            // TAG_TRUE sentinel, so `var localSetImmediate = setImmediate`
+            // read a boolean and calling through it threw `value is not a
+            // function` (scheduler's host-callback setup, → react-reconciler
+            // → every React renderer). Resolve them to the same
+            // `populate_global_this_builtins` closure `globalThis.<name>`
+            // reads, which is callable through the dynamic dispatch path.
+            if is_global_this_builtin_name(name) {
+                let name_idx = ctx.strings.intern(name);
+                let name_bytes_global = format!("@{}", ctx.strings.entry(name_idx).bytes_global);
+                let name_len = name.len().to_string();
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_get_global_this_builtin_value",
+                    &[(PTR, &name_bytes_global), (I64, &name_len)],
+                ));
+            }
             Ok(double_literal(f64::from_bits(crate::nanbox::TAG_TRUE)))
         }
 

--- a/crates/perry-hir/src/jsx.rs
+++ b/crates/perry-hir/src/jsx.rs
@@ -67,6 +67,20 @@ pub(crate) fn lower_jsx_element(ctx: &mut LoweringContext, jsx: &ast::JSXElement
         Expr::Object(props_fields)
     };
 
+    // #4950: a module that default-imports the npm `react` package gets
+    // REACT element semantics — `React.createElement(type, props)` returns
+    // an element OBJECT and the reconciler calls the component later, with
+    // the hooks dispatcher installed. Perry's native `jsx` adapter calls
+    // function components eagerly (SSR-to-HTML, the hono path), which under
+    // ink/react-reconciler ran `<Text>`'s `useContext` outside any render
+    // and died on React's "Invalid hook call" null-dispatcher TypeError.
+    // (`createElement` reads `props.children` the same way the jsx-runtime
+    // does, so folding children into props is shared between both paths.)
+    if let Some(react_element_call) = react_create_element_call(ctx, type_expr.clone(), &props_expr)
+    {
+        return Ok(react_element_call);
+    }
+
     Ok(Expr::Call {
         callee: Box::new(Expr::ExternFuncRef {
             name: func_name.to_string(),
@@ -74,6 +88,38 @@ pub(crate) fn lower_jsx_element(ctx: &mut LoweringContext, jsx: &ast::JSXElement
             return_type: Type::Any,
         }),
         args: vec![type_expr, props_expr],
+        type_args: Vec::new(),
+    })
+}
+
+/// #4950: build `<ReactLocal>.createElement(type, props)` when the module
+/// default-imports the npm `react` package. Returns `None` when no react
+/// binding is in scope (Perry's native `js_jsx` semantics apply).
+fn react_create_element_call(
+    ctx: &mut LoweringContext,
+    type_expr: Expr,
+    props_expr: &Expr,
+) -> Option<Expr> {
+    let react_local = ctx.react_default_import_local.clone()?;
+    // Resolve the react binding the same way ordinary ident lowering would:
+    // a shadowing local wins, otherwise the imported-function registration.
+    let object = if let Some(id) = ctx.lookup_local(&react_local) {
+        Expr::LocalGet(id)
+    } else if let Some(orig) = ctx.lookup_imported_func(&react_local) {
+        Expr::ExternFuncRef {
+            name: orig.to_string(),
+            param_types: Vec::new(),
+            return_type: Type::Any,
+        }
+    } else {
+        return None;
+    };
+    Some(Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(object),
+            property: "createElement".to_string(),
+        }),
+        args: vec![type_expr, props_expr.clone()],
         type_args: Vec::new(),
     })
 }
@@ -109,6 +155,29 @@ pub(crate) fn lower_jsx_fragment(
     } else {
         Expr::Object(props_fields)
     };
+
+    // #4950: react-mode fragments are `React.createElement(React.Fragment,
+    // props)` — see `react_create_element_call`.
+    if let Some(react_local) = ctx.react_default_import_local.clone() {
+        let fragment_type = Expr::PropertyGet {
+            object: Box::new(if let Some(id) = ctx.lookup_local(&react_local) {
+                Expr::LocalGet(id)
+            } else {
+                Expr::ExternFuncRef {
+                    name: ctx
+                        .lookup_imported_func(&react_local)
+                        .unwrap_or(&react_local)
+                        .to_string(),
+                    param_types: Vec::new(),
+                    return_type: Type::Any,
+                }
+            }),
+            property: "Fragment".to_string(),
+        };
+        if let Some(call) = react_create_element_call(ctx, fragment_type, &props_expr) {
+            return Ok(call);
+        }
+    }
 
     Ok(Expr::Call {
         callee: Box::new(Expr::ExternFuncRef {
@@ -303,4 +372,42 @@ pub(crate) fn normalize_jsx_text(text: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jsx_uses_react_create_element_when_react_default_import_present() {
+        // #4950: with `import React from 'react'` in scope, JSX must build
+        // elements via `React.createElement` (reconciler-controlled component
+        // invocation), never Perry's eager `js_jsx` adapter.
+        let mut ctx = LoweringContext::new("test.tsx");
+        ctx.react_default_import_local = Some("React".to_string());
+        ctx.register_imported_func("React".to_string(), "React".to_string());
+        let call =
+            react_create_element_call(&mut ctx, Expr::String("div".to_string()), &Expr::Null)
+                .expect("react mode must produce a createElement call");
+        match call {
+            Expr::Call { callee, args, .. } => {
+                match *callee {
+                    Expr::PropertyGet { property, .. } => assert_eq!(property, "createElement"),
+                    other => panic!("expected PropertyGet callee, got {other:?}"),
+                }
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected Call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn jsx_keeps_native_adapter_without_react_import() {
+        let mut ctx = LoweringContext::new("test.tsx");
+        assert!(
+            react_create_element_call(&mut ctx, Expr::String("div".to_string()), &Expr::Null)
+                .is_none(),
+            "without a react import the native js_jsx adapter must stay in effect"
+        );
+    }
 }

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -105,6 +105,7 @@ impl LoweringContext {
             module_native_instances: Vec::new(),
             uses_fetch: false,
             uses_webassembly: false,
+            react_default_import_local: None,
             suppress_stdlib_dispatch_guard_once: false,
             lowering_call_callee: false,
             unresolved_ident_as_global: false,

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -600,6 +600,9 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
     // with that index or higher was defined in the current scope.
     let outer_locals_len = scope_mark.0;
     let mut hoisted_id_set: std::collections::HashSet<LocalId> = std::collections::HashSet::new();
+    // #4950: undefined-initialised `Stmt::Let`s for `var`s found nested in
+    // compound statements — prepended to the lowered body below.
+    let mut nested_var_prologue: Vec<Stmt> = Vec::new();
     if let Some(ref block) = fn_expr.function.body {
         // Issue #838 followup (b): pre-register top-level `var` decls in
         // this function body BEFORE lowering any statement. dayjs's
@@ -683,6 +686,57 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
                 }
             }
         }
+        // #4950: pre-register `var` bindings nested inside compound
+        // statements (if/else arms, loops, try/catch, switch) of this
+        // function body. `var` is function-scoped, so react's
+        //   if (cond) { var getCurrentTime = function () {…}; }
+        //   else { getCurrentTime = function () {…}; }
+        // (react-reconciler's time source, factory shape) must resolve the
+        // else-arm write AND sibling-closure reads to ONE hoisted local.
+        // The top-level pre-pass above only saw direct `Stmt::Decl(Var)`
+        // children, so the if-arm declaration never registered, the
+        // else-arm assignment fell through to an implicit-global write,
+        // and `getCurrentTime()` inside prepareFreshStack threw
+        // `getCurrentTime is not defined` — silently swallowed by the
+        // scheduler pump, killing every React render. Mirrors the
+        // module-level nested-var hoisting in lower_module_fn.rs.
+        for stmt in &block.stmts {
+            // Direct top-level var decls are handled by the pre-pass above;
+            // only walk into compound statements for nested `var`s here.
+            if matches!(stmt, ast::Stmt::Decl(_)) {
+                continue;
+            }
+            let mut names = Vec::new();
+            crate::lower_decl::collect_var_binding_names_from_stmt(stmt, &mut names);
+            names.sort();
+            names.dedup();
+            for name in names {
+                let already_in_scope = ctx
+                    .locals
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .any(|(idx, (n, _, _))| n == &name && idx >= outer_locals_len);
+                if !already_in_scope {
+                    let id = ctx.define_local(name.clone(), Type::Any);
+                    ctx.var_hoisted_ids.insert(id);
+                    hoisted_id_set.insert(id);
+                    // Emit an explicit undefined-initialised slot at body
+                    // entry (same rationale as the module-level pass: a
+                    // read or LocalSet compiled before the nested decl
+                    // needs storage to exist; the nested `Stmt::Let`
+                    // later reuses the slot via the var-redeclaration
+                    // path).
+                    nested_var_prologue.push(Stmt::Let {
+                        id,
+                        name,
+                        ty: Type::Any,
+                        mutable: true,
+                        init: Some(Expr::Undefined),
+                    });
+                }
+            }
+        }
     }
 
     // Lower body with JS hoisting: only function declarations are fully
@@ -729,7 +783,12 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
                     _ => exec_stmts.extend(lowered),
                 }
             }
-            let mut combined: Vec<Stmt> = Vec::with_capacity(func_decls.len() + exec_stmts.len());
+            let mut combined: Vec<Stmt> =
+                Vec::with_capacity(nested_var_prologue.len() + func_decls.len() + exec_stmts.len());
+            // Nested-var undefined slots first so every later read/write —
+            // including from hoisted function-declaration closures — sees
+            // initialised storage (#4950).
+            combined.extend(std::mem::take(&mut nested_var_prologue));
             combined.extend(func_decls);
             combined.extend(exec_stmts);
             // Issue #633: prealloc-box for sibling/forward captures.

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -313,6 +313,16 @@ pub struct LoweringContext {
     pub(crate) uses_fetch: bool,
     /// Issue #76 — set when any `WebAssembly.*` HIR variant is lowered.
     pub(crate) uses_webassembly: bool,
+    /// #4950: local binding name of a default import from the npm `react`
+    /// package (`import React from 'react'`). When set, JSX lowers to
+    /// `<local>.createElement(type, props)` so REACT controls when function
+    /// components run (the reconciler installs the hooks dispatcher first).
+    /// Perry's native `js_jsx` adapter calls function components EAGERLY
+    /// (SSR-to-HTML semantics, hono-style) — under a real React renderer
+    /// (ink, react-three-fiber, …) that ran `<Text>`'s `useContext` outside
+    /// any render and threw React's "Invalid hook call" / null-dispatcher
+    /// TypeError.
+    pub(crate) react_default_import_local: Option<String>,
     /// #1723 — one-shot flag set by an enclosing `ns[dynamicKey].staticMember`
     /// access to tell the *immediately-nested* computed-member lowering to skip
     /// the #503 dynamic-stdlib-dispatch refusal. The dynamic index there only

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -394,6 +394,13 @@ pub(crate) fn lower_module_decl(
                             // `perry_fn_<src>__default` — matching what the origin module
                             // actually emits. Closes #901.
                             ctx.register_imported_func(local.clone(), local.clone());
+                            // #4950: remember the react default-import binding
+                            // so JSX in this module lowers to
+                            // `<local>.createElement(...)` instead of Perry's
+                            // eager `js_jsx` adapter (see jsx.rs).
+                            if source == "react" {
+                                ctx.react_default_import_local = Some(local.clone());
+                            }
                         }
                         specifiers.push(ImportSpecifier::Default { local });
                     }

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -2053,6 +2053,15 @@ pub unsafe extern "C" fn js_new_function_construct(
                     CLASS_ID_DECOMPRESSION_STREAM,
                 );
             }
+            // #4950 (secondary note): react-reconciler captures the global
+            // `AbortController` into a local (`AbortControllerLocal = typeof
+            // AbortController !== "undefined" ? AbortController : <shim>`) and
+            // constructs through the variable. Without this arm the dynamic
+            // `new` fell through and threw "AbortController is not a function".
+            "AbortController" => {
+                let controller = crate::url::js_abort_controller_new();
+                return crate::value::js_nanbox_pointer(controller as i64);
+            }
             "MessageChannel" => {
                 return crate::messaging::js_message_channel_new();
             }

--- a/crates/perry-runtime/src/regex/grammar.rs
+++ b/crates/perry-runtime/src/regex/grammar.rs
@@ -323,6 +323,83 @@ fn emit_astral_class(out: &mut String, ranges: &[(u32, u32)]) {
     out.push(']');
 }
 
+/// Parse a character-class member at `chars[i]` that is a lone-surrogate
+/// `\uXXXX` escape or a `\uXXXX-\uYYYY` range of them. Returns the astral
+/// scalar ranges the member matches (see `surrogate_units_to_astral`) and the
+/// index just past the member. `None` leaves the escape untouched.
+fn parse_class_surrogate_member(chars: &[char], i: usize) -> Option<(Vec<(u32, u32)>, usize)> {
+    let (lo, j) = parse_u4_escape(chars, i)?;
+    if !is_surrogate(lo) {
+        return None;
+    }
+    if chars.get(j) == Some(&'-') && chars.get(j + 1) != Some(&']') {
+        // Range form: only rewrite when the upper bound is also a surrogate
+        // escape; a mixed `\ud800-z` range passes through unchanged (and fails
+        // downstream exactly as before) rather than mis-translating.
+        let (hi, k) = parse_u4_escape(chars, j + 1)?;
+        if !is_surrogate(hi) || lo > hi {
+            return None;
+        }
+        return Some((surrogate_units_to_astral(lo, hi), k));
+    }
+    Some((surrogate_units_to_astral(lo, lo), j))
+}
+
+/// Map a UTF-16 surrogate code-unit range `[a, b]` to the Unicode scalar
+/// values whose UTF-16 encoding contains a unit in that range — the set a
+/// non-`u` JS class member like `[\ud800-\udfff]` matches when run over a
+/// well-formed string. A unit in the high half (`D800-DBFF`) selects the
+/// contiguous astral block it leads; a unit in the low half (`DC00-DFFF`)
+/// selects one offset out of every 0x400-wide astral block (a striped set,
+/// emitted exactly; the full low half collapses to "all astral"). Lone
+/// surrogates in the *subject* string remain unmatchable — the Rust `regex`
+/// crate only matches scalar values (the WTF-8 categorical gap).
+fn surrogate_units_to_astral(a: u32, b: u32) -> Vec<(u32, u32)> {
+    let mut out: Vec<(u32, u32)> = Vec::new();
+    let (h1, h2) = (a.max(0xD800), b.min(0xDBFF));
+    if h1 <= h2 {
+        out.push((
+            0x10000 + (h1 - 0xD800) * 0x400,
+            0x10000 + (h2 - 0xD800) * 0x400 + 0x3FF,
+        ));
+    }
+    let (l1, l2) = (a.max(0xDC00), b.min(0xDFFF));
+    if l1 <= l2 {
+        if (l1, l2) == (0xDC00, 0xDFFF) {
+            out.push((0x10000, 0x10FFFF));
+        } else {
+            for block in 0..0x400u32 {
+                let base = 0x10000 + block * 0x400;
+                out.push((base + (l1 - 0xDC00), base + (l2 - 0xDC00)));
+            }
+        }
+    }
+    out.sort_unstable();
+    let mut merged: Vec<(u32, u32)> = Vec::new();
+    for (x, y) in out {
+        match merged.last_mut() {
+            Some(last) if x <= last.1.saturating_add(1) => {
+                if y > last.1 {
+                    last.1 = y;
+                }
+            }
+            _ => merged.push((x, y)),
+        }
+    }
+    merged
+}
+
+/// Emit astral ranges as members of an already-open character class.
+fn emit_astral_class_members(out: &mut String, ranges: &[(u32, u32)]) {
+    for &(x, y) in ranges {
+        if x == y {
+            out.push_str(&format!("\\x{{{x:x}}}"));
+        } else {
+            out.push_str(&format!("\\x{{{x:x}}}-\\x{{{y:x}}}"));
+        }
+    }
+}
+
 /// Rewrite UTF-16 surrogate-pair escape sequences into the astral scalar values
 /// they encode, so the Rust `regex` crate (which works on Unicode scalars and
 /// rejects lone-surrogate code points) can compile them.
@@ -566,6 +643,24 @@ pub(super) fn js_regex_to_rust(pattern: &str) -> String {
                         }
                     }
                 }
+                // A lone-surrogate `\uXXXX` (or `\uXXXX-\uYYYY` range) inside a
+                // character class: the crate rejects surrogate code points, so
+                // rewrite to the astral scalars whose UTF-16 encoding contains
+                // such a unit. es-toolkit's `truncate.js` builds
+                // `[‍\ud800-\udfff̀-...]` at module init (→ ink/#348);
+                // before this rewrite importing it threw `SyntaxError: invalid
+                // pattern`. Pairs (`💍`) were already folded by
+                // `fold_surrogate_pairs` and never reach this arm.
+                'u' if in_class => {
+                    if let Some((ranges, end)) = parse_class_surrogate_member(&chars, i) {
+                        emit_astral_class_members(&mut result, &ranges);
+                        i = end;
+                    } else {
+                        result.push('\\');
+                        result.push('u');
+                        i += 2;
+                    }
+                }
                 ch if is_regex_identity_escape(ch) => {
                     // Inside a character class an escaped hyphen `\-` is always a
                     // literal hyphen, but the Rust `regex` crate reads a bare `-`
@@ -688,6 +783,46 @@ mod tests {
                 "string-width pattern failed to compile: {pat} -> {translated}"
             );
         }
+    }
+
+    #[test]
+    fn class_lone_surrogate_range_rewrites_to_astral() {
+        // es-toolkit `truncate.js` (→ ink, #348/#4950 verification): a class
+        // mixing BMP members with the full surrogate range must compile and
+        // detect astral characters like Node does (over well-formed strings).
+        let pat =
+            "[\\u200d\\ud800-\\udfff\\u0300-\\u036f\\ufe20-\\ufe2f\\u20d0-\\u20ff\\ufe0e\\ufe0f]";
+        let translated = js_regex_to_rust(pat);
+        let re = regex::Regex::new(&translated)
+            .unwrap_or_else(|e| panic!("es-toolkit class failed to compile: {translated}: {e}"));
+        assert!(re.is_match("a\u{1F48D}b"), "astral char must match");
+        assert!(re.is_match("a\u{200D}b"), "ZWJ member must still match");
+        assert!(!re.is_match("plain ascii"), "ASCII must not match");
+
+        // Full surrogate range alone → all astral scalars.
+        assert_eq!(
+            js_regex_to_rust("[\\ud800-\\udfff]"),
+            "[\\x{10000}-\\x{10ffff}]"
+        );
+        // High-only subrange → the contiguous astral block(s) it leads.
+        assert_eq!(
+            js_regex_to_rust("[\\ud800-\\ud801]"),
+            "[\\x{10000}-\\x{107ff}]"
+        );
+        // A high singleton matches the astral block led by that unit:
+        // `/[\ud83d]/.test("💍")` is true in JS.
+        let high_single = js_regex_to_rust("[\\ud83d]");
+        let re = regex::Regex::new(&high_single).unwrap();
+        assert!(re.is_match("\u{1F48D}"));
+        assert!(!re.is_match("\u{10000}"));
+        // Low-only subranges are striped sets, emitted exactly:
+        // `/[\udc8d]/.test("💍")` is true in JS (matches the low unit).
+        let low_single = js_regex_to_rust("[\\udc8d]");
+        let re = regex::Regex::new(&low_single).unwrap();
+        assert!(re.is_match("\u{1F48D}"));
+        assert!(!re.is_match("\u{1F48E}"));
+        // Surrogate-to-nonsurrogate ranges stay untouched (still invalid).
+        assert_eq!(js_regex_to_rust("[\\ud800-z]"), "[\\ud800-z]");
     }
 
     #[test]

--- a/crates/perry/tests/issue_4950_react_render_walls.rs
+++ b/crates/perry/tests/issue_4950_react_render_walls.rs
@@ -1,0 +1,165 @@
+//! Regression tests for #4950 — the "null hooks dispatcher / Invalid hook
+//! call" wall that blocked every React renderer (ink, react-three-fiber, …).
+//!
+//! Debugging disproved the issue's cross-module-identity hypothesis (the
+//! shared `ReactSharedInternals` object IS the same instance on both sides);
+//! the real wall was a chain of independent bugs, each covered here:
+//!
+//! 1. Branch-local `var` hoisting inside FUNCTION EXPRESSIONS: react's dev
+//!    reconciler does `if (cond) { var getCurrentTime = … } else {
+//!    getCurrentTime = … }` inside its 17k-line factory; the binding never
+//!    hoisted, the else-arm write went to an implicit global, and the render
+//!    loop died on a silently-swallowed `getCurrentTime is not defined`.
+//! 2. Timer builtins captured as VALUES: scheduler's `localSetImmediate =
+//!    typeof setImmediate !== "undefined" ? setImmediate : null` read the
+//!    TAG_TRUE sentinel (typeof "boolean") and host callbacks never ran.
+//! 3. `new` through a variable holding the global `AbortController`
+//!    (react-reconciler's `AbortControllerLocal`).
+//! 4. JSX in react-importing modules must build ELEMENTS via
+//!    `React.createElement`, not eagerly call function components via
+//!    Perry's SSR `js_jsx` adapter — the eager call ran `useContext`
+//!    outside any render, which is the literal "Invalid hook call" +
+//!    `null.useContext` from the issue.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> String {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+#[test]
+fn branch_local_var_hoists_in_nested_function_expression() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+const outer = (function () {
+  return function factory(flag: boolean) {
+    function reader() { return getCurrentTime(); }
+    if (flag) {
+      var getCurrentTime = function () { return 1; };
+    } else {
+      getCurrentTime = function () { return 2; };
+    }
+    return reader;
+  };
+})();
+console.log("flag=false:", outer(false)());
+console.log("flag=true:", outer(true)());
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("flag=false: 2"),
+        "else-arm assignment must reach the hoisted var (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("flag=true: 1"),
+        "if-arm declaration must reach the hoisted var (got: {stdout})"
+    );
+}
+
+#[test]
+fn timer_builtins_work_as_captured_values() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+const si: any = (typeof setImmediate !== "undefined") ? setImmediate : null;
+console.log("typeof si:", typeof si);
+const st: any = setTimeout;
+console.log("typeof st:", typeof st);
+si(() => console.log("si ran"));
+st(() => console.log("st ran"), 0);
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("typeof si: function") && stdout.contains("typeof st: function"),
+        "timer builtins as values must be functions, not the TAG_TRUE sentinel (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("si ran") && stdout.contains("st ran"),
+        "callbacks scheduled through captured timer values must fire (got: {stdout})"
+    );
+}
+
+#[test]
+fn abort_controller_constructs_through_variable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+const AbortControllerLocal: any =
+  typeof AbortController !== "undefined" ? AbortController : null;
+const c = new AbortControllerLocal();
+console.log("controller:", typeof c, "signal:", typeof c.signal, "aborted:", c.signal.aborted);
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("controller: object signal: object aborted: false"),
+        "new through a captured AbortController must construct (got: {stdout})"
+    );
+}
+
+#[test]
+fn lone_surrogate_range_class_regex_compiles_and_matches() {
+    // es-toolkit's `truncate.js` module-init regex (in ink's dependency
+    // graph); pre-fix this threw `SyntaxError: invalid pattern` at startup.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        "const re = /[\\u200d\\ud800-\\udfff\\u0300-\\u036f\\ufe20-\\ufe2f\\u20d0-\\u20ff\\ufe0e\\ufe0f]/;\n\
+         console.log(\"ascii:\", re.test(\"plain ascii\"));\n\
+         console.log(\"astral:\", re.test(\"a\\u{1F48D}b\"));\n\
+         console.log(\"zwj:\", re.test(\"a\\u{200D}b\"));\n",
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("ascii: false")
+            && stdout.contains("astral: true")
+            && stdout.contains("zwj: true"),
+        "surrogate-range class must match astral chars like Node (got: {stdout})"
+    );
+}


### PR DESCRIPTION
Fixes #4950.

## TL;DR

The issue's hypothesized mechanism — cross-module identity loss for the mutable `ReactSharedInternals` singleton — **does not exist**. Sentinel probes on the real ink graph show `react-reconciler`'s captured object `===` react's own instance, on every leg (reconciler capture, main's view, post-write readback). The observed `Invalid hook call` / `Cannot read properties of null (reading 'useContext')` was produced by a chain of independent bugs, all fixed here. A real `react@19` + `react-reconciler@0.33` harness now renders a hook-using function component end-to-end under Perry, byte-matching node.

## Root causes (in dependency order)

1. **JSX eagerly invoked function components** (`perry-hir/src/jsx.rs`). Perry's `js_jsx` adapter calls a function-component closure immediately (SSR-to-HTML semantics — the hono path). Under a React renderer, `render(<App/>)` evaluated `<Text>…</Text>` by **calling `Text(props)` on the spot** — lldb backtrace showed `main → Text_js__Text → react useContext → throw`, with no reconciler frame anywhere. `useContext` ran outside any render, dispatcher null, exactly the reported error. Fix: a module that default-imports the npm `react` package now lowers JSX to `React.createElement(type, props)` (fragments: `React.Fragment`), so the reconciler controls when components run. Modules without a react import keep the native adapter unchanged.

2. **Branch-local `var` in function expressions never hoisted** (`perry-hir/src/lower/expr_function.rs`). react-reconciler's 17k-line factory has `if (cond) { var getCurrentTime = … } else { getCurrentTime = … }`. The fn-expr pre-pass only scanned direct top-level `Stmt::Decl(Var)` children, so the if-arm declaration never registered, the else-arm write became an implicit global, and `prepareFreshStack`'s `getCurrentTime()` threw `getCurrentTime is not defined` — swallowed by the scheduler pump, killing every render silently. Fix mirrors the module-level nested-var hoisting pass (deep-walk via `collect_var_binding_names_from_stmt`, undefined-initialised slots at body entry).

3. **Timer builtins as values were TAG_TRUE booleans** (`perry-codegen/src/expr/dyn_extern_i18n.rs`). `scheduler` does `localSetImmediate = typeof setImmediate !== "undefined" ? setImmediate : null`; the value read fell to the ExternFuncRef catch-all's TAG_TRUE sentinel (`typeof` = "boolean", uncallable), so host callbacks never ran. Fix: builtin globals in that catch-all resolve via `js_get_global_this_builtin_value` to the real populated closures.

4. **`new` through a captured `AbortController` threw** (`perry-runtime/src/object/class_registry.rs`). react-reconciler's `AbortControllerLocal = typeof AbortController !== "undefined" ? AbortController : <shim>` selected the real binding but dynamic construct had no arm for it. (This was the issue's "secondary note".)

5. **Lone-surrogate ranges in regex classes** (`perry-runtime/src/regex/grammar.rs`). es-toolkit's `truncate.js` builds `[‍\ud800-\udfff…]` at module init (in ink's graph since #4960 widened the compiled set); the Rust regex crate rejects surrogate code points, so startup threw `SyntaxError: invalid pattern` before render. Class members that are surrogate escapes/ranges now rewrite to the astral scalars whose UTF-16 encoding contains such a unit (exact, including striped low-half sets; full range → `\x{10000}-\x{10FFFF}`).

## Verification

- Synthetic harness (real react + react-reconciler, ink-style host config): `updateContainer OK` → **`App rendered with n = 7`** → `commit callback` — matches node. Pre-fix it died at `AbortController is not a function`, then silently.
- ink `hello.tsx`: previously threw the issue's exact error at `render(<App/>)`; now builds real elements, enters ink's `render()` → `Ink` instantiation. Next walls are intra-ink package-import gaps unrelated to the dispatcher: a default-exported `new Map()` const (`instances.js`) reaches importers as a stub object, and `new Ink()` (default-exported class) skips the constructor — I'll file these separately (they're the gate before the yoga-layout WASM wall the issue already anticipated).
- New regression tests: `crates/perry/tests/issue_4950_react_render_walls.rs` (4 e2e tests), JSX-mode unit tests in `perry-hir`, surrogate-class unit tests in `perry-runtime` grammar tests.
- Suites: perry-hir all green (145), perry-codegen green except `typed_shape_descriptors::bounded_integer_array_store_omits_layout_note_and_barrier` (**fails on pristine origin/main too** — pre-existing, likely from #4957), perry-runtime 1021/1022 with `date::tests::test_full_year_setters_revive_invalid_date_only` (**also fails on pristine origin/main** — pre-existing).

No version bump / changelog — maintainer folds metadata at merge.