### PR TITLE
fix(http): falsy ClientRequest method defaults to GET instead of throwing (#4970)

### DIFF
--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -605,8 +605,11 @@ fn timeout_from_options(opts: &serde_json::Value) -> Option<u64> {
 }
 
 fn method_from_options(opts: &serde_json::Value) -> String {
+    // Node defaults any falsy `options.method` (absent, `''`, `null`,
+    // `undefined`) to `'GET'` — only a truthy string is used (#4970).
     opts.get("method")
         .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
         .map(|s| s.to_uppercase())
         .unwrap_or_else(|| "GET".to_string())
 }
@@ -997,17 +1000,12 @@ pub unsafe extern "C" fn js_http_request(opts_f64: f64, callback_i64: i64) -> Ha
 /// `new http.ClientRequest(options)` (#4904). Perry's client model defers
 /// the actual send to `.end()`, so constructing is exactly `http.request`
 /// without a response callback. Node coerces a falsy `options.method` /
-/// `options.path` to the `GET` / `/` defaults — mirror the method side
-/// here (the empty path already reads back as `/` through the surface).
+/// `options.path` to the `GET` / `/` defaults — `method_from_options`
+/// handles the method side (#4970) and the empty path already reads back
+/// as `/` through the surface.
 #[no_mangle]
 pub unsafe extern "C" fn js_http_client_request_standalone_new(opts_f64: f64) -> Handle {
-    let handle = request_common(opts_f64, 0, "http");
-    with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| {
-        if req.method.is_empty() {
-            req.method = "GET".to_string();
-        }
-    });
-    handle
+    request_common(opts_f64, 0, "http")
 }
 
 #[no_mangle]

--- a/crates/perry-ext-http/src/validation.rs
+++ b/crates/perry-ext-http/src/validation.rs
@@ -88,11 +88,14 @@ pub(crate) fn validate_client_options(opts: &serde_json::Value, default_protocol
         }
     }
 
-    // `method`, when a string, must be a valid HTTP token. The error message
-    // quotes the *raw* (non-upper-cased) method, matching
-    // `validateHttpToken(method, 'Method')`.
+    // `method`, when a *non-empty* string, must be a valid HTTP token. The
+    // error message quotes the *raw* (non-upper-cased) method, matching
+    // `validateHttpToken(method, 'Method')`. Node only validates a truthy
+    // method (`if (methodIsString && method)` in lib/_http_client.js); a
+    // falsy one (`''`, `undefined`, `null`) falls through to the `'GET'`
+    // default instead of throwing (#4970).
     if let Some(method) = obj.get("method").and_then(|v| v.as_str()) {
-        if !is_valid_token(method) {
+        if !method.is_empty() && !is_valid_token(method) {
             throw_type_error_with_code(
                 &format!("Method must be a valid HTTP token [\"{method}\"]"),
                 "ERR_INVALID_HTTP_TOKEN",


### PR DESCRIPTION
Fixes #4970.

## Problem

`new ClientRequest({ method: '' })` threw `TypeError [ERR_INVALID_HTTP_TOKEN]: Method must be a valid HTTP token [""]`. Node only token-validates a **truthy** method string (`if (methodIsString && method)` in `lib/_http_client.js`); a falsy `method` (`''`, `undefined`, `null`) falls through to the `'GET'` default. The #4907 validation over-fired on the empty string, regressing `test-http-client-defaults` (which #4904 had fixed).

## Fix

- `crates/perry-ext-http/src/validation.rs` — `validate_client_options` skips the HTTP-token check for an empty `method` string. A non-empty invalid token (e.g. `'\0'`, `'B@D'`) still throws `ERR_INVALID_HTTP_TOKEN` with the same message.
- `crates/perry-ext-http/src/lib.rs` — `method_from_options` treats `''` as absent → `'GET'`, so every client path (`http.request`, `http.get`, the overload entry points, `new ClientRequest`) defaults uniformly; the now-redundant empty-method patch-up in `js_http_client_request_standalone_new` is removed.

## Verification

All compiled with the patched binary via `perry compile` from the workspace root (auto-optimize, ext-http linked), staged with the `test-compat/node-core/shim` common:

- `test-http-client-defaults.js` (Node v22 `test/parallel`) — **runtime-fail → pass** (exit 0)
- `test-http-request-invalid-method-error.js` — still **pass** (`method: '\0'` is non-empty → still throws, exact message preserved); no re-break of #4907
- Local repro (`method: ''`/`undefined`/absent → `'GET'`, `'B@D'` → `ERR_INVALID_HTTP_TOKEN`, `'post'` → `'POST'`) matches `node --experimental-strip-types` byte-for-byte
- `cargo fmt --check` and the 2000-line file-size gate are green

Code-only PR — no version bump / changelog (maintainer folds metadata at merge).