### PR TITLE
feat(diagnostics): real v8 heap snapshot from GC heap walk + inspector/repl honesty (#4916)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -712,10 +712,15 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sea", "getRawAsset", false, None),
     method("sea", "getAssetKeys", false, None),
     property("inspector", "default"),
-    method("inspector", "open", false, None),
+    method("inspector", "open", false, None).stub_note(
+        "accepts port/host but binds no real WebSocket inspector endpoint; sessions are in-process fakes (#4916)",
+    ),
     method("inspector", "close", false, None),
-    method("inspector", "url", false, None),
-    method("inspector", "waitForDebugger", false, None),
+    method("inspector", "url", false, None)
+        .stub_note("always undefined: Perry never exposes a real inspector endpoint (#4916)"),
+    method("inspector", "waitForDebugger", false, None).stub_note(
+        "returns immediately after open(); there is no debugger to wait for (#4916)",
+    ),
     property("inspector", "console"),
     property("inspector", "Network"),
     class("inspector", "Session"),
@@ -723,7 +728,9 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("inspector", "connect", true, Some("Session")),
     method("inspector", "connectToMainThread", true, Some("Session")),
     method("inspector", "disconnect", true, Some("Session")),
-    method("inspector", "post", true, Some("Session")),
+    method("inspector", "post", true, Some("Session")).stub_note(
+        "only Runtime.enable and a canned Runtime.evaluate subset respond; every other protocol method throws Inspector error -32601 (#4916)",
+    ),
     method("inspector", "on", true, Some("Session")),
     method("inspector", "once", true, Some("Session")),
     internal_method("inspector.Network", "requestWillBeSent", false, None),
@@ -4378,8 +4385,12 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("repl", "REPL_MODE_STRICT"),
     class("repl", "REPLServer"),
     class("repl", "Recoverable"),
-    method("repl", "start", false, None),
-    method("repl", "REPLServer", false, None),
+    method("repl", "start", false, None).stub_note(
+        "REPLServer shape only: never reads the input stream, and .write() evaluates just numeric literals, context lookups, and a single '+'; no real JS eval loop (#4916)",
+    ),
+    method("repl", "REPLServer", false, None).stub_note(
+        "REPLServer shape only: never reads the input stream, and .write() evaluates just numeric literals, context lookups, and a single '+'; no real JS eval loop (#4916)",
+    ),
     method("repl", "Recoverable", false, None),
     internal_method("repl", "on", true, Some("REPLServer")),
     internal_method("repl", "addListener", true, Some("REPLServer")),
@@ -4446,13 +4457,19 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // --- node:v8 (#3137/#3138/#3142) ---
     method("v8", "serialize", false, None),
     method("v8", "deserialize", false, None),
-    method("v8", "getHeapStatistics", false, None),
-    method("v8", "getHeapCodeStatistics", false, None),
-    method("v8", "getHeapSpaceStatistics", false, None),
+    method("v8", "getHeapStatistics", false, None).stub_note(
+        "Node shape, Perry numbers: total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from Perry arenas, total_physical_size=RSS, heap_size_limit fixed ~2GB (not enforced); *_executable, external_memory, global-handles and zap fields are 0 (#4916)",
+    ),
+    method("v8", "getHeapCodeStatistics", false, None)
+        .stub_note("all fields 0; Perry compiles AOT, there is no JIT code heap (#4916)"),
+    method("v8", "getHeapSpaceStatistics", false, None).stub_note(
+        "Node space names with all live usage attributed to old_space from Perry arenas; other spaces report 0 (#4916)",
+    ),
     method("v8", "cachedDataVersionTag", false, None),
     class("v8", "GCProfiler"),
     method("v8", "start", true, Some("GCProfiler")),
-    method("v8", "stop", true, Some("GCProfiler")),
+    method("v8", "stop", true, Some("GCProfiler"))
+        .stub_note("report has the Node shape but the statistics array is always empty (#4916)"),
     // #3680: class-based serialization. Serializer / Deserializer plus the
     // Default* subclasses, with their write*/read* instance methods.
     class("v8", "Serializer"),
@@ -4483,13 +4500,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // Node's ESM namespace). `getHeapSnapshot`/`writeHeapSnapshot` deeper
     // behavior is tracked by #3140; here they're added to the export surface.
     method("v8", "getCppHeapStatistics", false, None),
-    method("v8", "getHeapSnapshot", false, None)
-        .stub_note("empty-but-valid V8 heap graph, not a real snapshot (#4916)"),
+    method("v8", "getHeapSnapshot", false, None),
     method("v8", "isStringOneByteRepresentation", false, None),
     method("v8", "queryObjects", false, None),
     method("v8", "startCpuProfile", false, None),
-    method("v8", "writeHeapSnapshot", false, None)
-        .stub_note("empty-but-valid V8 heap graph, not a real snapshot (#4916)"),
+    method("v8", "writeHeapSnapshot", false, None),
     method("v8", "isBuildingSnapshot", true, Some("startupSnapshot")),
     method("v8", "addSerializeCallback", true, Some("startupSnapshot")),
     method(

--- a/crates/perry-api-manifest/tests/stub_inventory.rs
+++ b/crates/perry-api-manifest/tests/stub_inventory.rs
@@ -73,7 +73,15 @@ fn stub_inventory_matches_known_clusters() {
         // absent: read(view), controller.byobRequest respond/
         // respondWithNewView, and real byteLength desiredSize accounting
         // landed (perry-stdlib/src/streams/byob.rs).
-        ("#4916", 2),  // v8 get/writeHeapSnapshot (empty graph)
+        // #4916 (v8 get/writeHeapSnapshot) heap snapshots intentionally
+        // absent: real object graph from the GC heap walk landed
+        // (perry-runtime/src/gc/heap_snapshot.rs). The remaining #4916
+        // entries are documented approximations/fakes from the same
+        // diagnostics audit: v8 heap-stats provenance(3) +
+        // GCProfiler.stop empty statistics(1) + inspector
+        // open/url/waitForDebugger/Session.post(4) + repl
+        // start/REPLServer no-eval-loop(2).
+        ("#4916", 10),
         ("#4917", 18), // stdlib adapters: zlib(11) + http.Agent(3) + worker ref/unref(2) + mongodb(1) + backoff(1)
     ];
     let expected_map: BTreeMap<String, usize> =
@@ -99,6 +107,8 @@ fn stubs_only_appear_in_allowlisted_modules() {
         "worker_threads",
         "mongodb",
         "exponential-backoff",
+        "inspector",
+        "repl",
     ];
     for e in iter_entries().filter(|e| e.stub) {
         assert!(
@@ -115,13 +125,26 @@ fn keystone_apis_are_flagged() {
     // Spot-check the headline lies from the epic so a refactor can't
     // quietly drop the flag on the worst offenders.
     let must_be_stub: &[(&str, &str)] = &[
-        ("v8", "getHeapSnapshot"),
-        ("v8", "writeHeapSnapshot"),
+        ("repl", "start"),
+        ("inspector", "post"),
         ("zlib", "createGzip"),
         ("mongodb", "findOne"),
     ];
     for (module, name) in must_be_stub {
         let found = iter_entries().any(|e| e.module == *module && e.name == *name && e.stub);
         assert!(found, "expected {}::{} to be flagged stub", module, name);
+    }
+
+    // The inverse: APIs implemented for real must NOT stay flagged.
+    // v8 heap snapshots emit a real GC-walk object graph since #4916.
+    let must_not_be_stub: &[(&str, &str)] =
+        &[("v8", "getHeapSnapshot"), ("v8", "writeHeapSnapshot")];
+    for (module, name) in must_not_be_stub {
+        let flagged = iter_entries().any(|e| e.module == *module && e.name == *name && e.stub);
+        assert!(
+            !flagged,
+            "{}::{} is implemented for real and must not be flagged stub",
+            module, name
+        );
     }
 }

--- a/crates/perry-runtime/src/gc/heap_snapshot.rs
+++ b/crates/perry-runtime/src/gc/heap_snapshot.rs
@@ -1,0 +1,540 @@
+//! Real V8-`.heapsnapshot` builder over Perry's GC heap walk (#4916).
+//!
+//! `v8.getHeapSnapshot()` / `v8.writeHeapSnapshot()` used to emit an
+//! empty-but-valid V8 heap-snapshot document — Chrome DevTools would
+//! load it and show nothing. This module walks the same object
+//! population the collector itself sees (every arena + malloc GC
+//! allocation on the calling thread) and emits the actual object graph
+//! in V8 snapshot JSON: real node types, real `self_size` (GcHeader
+//! included), and real reference edges discovered through the same
+//! `visit_gc_rewrite_slots` enumeration the marker traces.
+//!
+//! Approximations (also stated in the public docs):
+//! - A full collection runs first, so the dump approximates the live
+//!   set. Dead objects in partially-live arena blocks that the sweep
+//!   has not reclaimed yet can still appear; free-list slots are
+//!   excluded.
+//! - Perry arenas are per-thread; the snapshot covers the calling
+//!   thread's heap only.
+//! - Object inline fields are named through the keys array and arrays
+//!   get element indices; closure captures, Map/Set side tables, and
+//!   overflow fields appear as `internal` edges with slot ordinals.
+//!
+//! IMPORTANT: nothing in this module may allocate on the JS heap while
+//! the graph is being read — a JS allocation can trigger GC, and a GC
+//! can reset or evacuate the very blocks the collected raw pointers
+//! point into. Everything below works on Rust-owned buffers.
+
+use super::*;
+use std::collections::HashMap;
+
+// Node v26 / V8 13.x layout: ["type","name","id","self_size",
+// "edge_count","detachedness"] — `trace_node_id` was dropped upstream.
+const NODE_FIELD_COUNT: u32 = 6;
+
+// Indices into the meta `node_types` table emitted below — keep both in sync.
+const NODE_TYPE_ARRAY: u32 = 1;
+const NODE_TYPE_STRING: u32 = 2;
+const NODE_TYPE_OBJECT: u32 = 3;
+const NODE_TYPE_CLOSURE: u32 = 5;
+const NODE_TYPE_NATIVE: u32 = 8;
+const NODE_TYPE_SYNTHETIC: u32 = 9;
+const NODE_TYPE_BIGINT: u32 = 13;
+
+// Indices into the meta `edge_types` table.
+const EDGE_TYPE_ELEMENT: u32 = 1;
+const EDGE_TYPE_PROPERTY: u32 = 2;
+const EDGE_TYPE_INTERNAL: u32 = 3;
+const EDGE_TYPE_SHORTCUT: u32 = 5;
+const EDGE_TYPE_WEAK: u32 = 6;
+
+/// Interned snapshot string table; index 0 is always the empty string.
+struct StringTable {
+    list: Vec<String>,
+    index: HashMap<String, u32>,
+}
+
+impl StringTable {
+    fn new() -> Self {
+        let mut t = StringTable {
+            list: Vec::new(),
+            index: HashMap::new(),
+        };
+        t.intern("");
+        t
+    }
+
+    fn intern(&mut self, s: &str) -> u32 {
+        if let Some(&i) = self.index.get(s) {
+            return i;
+        }
+        let i = self.list.len() as u32;
+        self.list.push(s.to_string());
+        self.index.insert(s.to_string(), i);
+        i
+    }
+}
+
+/// `name_or_index` of an edge: property/shortcut names are string-table
+/// indices, element/internal ordinals are plain numbers. Both serialize
+/// as integers; the edge type tells consumers which table to look in.
+#[derive(Clone, Copy)]
+struct Edge {
+    edge_type: u32,
+    name_or_index: u32,
+    to: u32,
+}
+
+struct NodeRec {
+    header: *mut GcHeader,
+    user: usize,
+    obj_type: u8,
+    self_size: u32,
+}
+
+fn json_escape_into(s: &str, out: &mut String) {
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+}
+
+/// Decode a heap slot the same way `mark_field_into_worklist` does:
+/// NaN-boxed pointer tags or a plausible raw 48-bit pointer. Returns 0
+/// for anything that cannot reference a heap object.
+fn decode_slot_target(bits: u64) -> usize {
+    use crate::value::{BIGINT_TAG, POINTER_MASK, POINTER_TAG, STRING_TAG, TAG_MASK};
+    let tag = bits & TAG_MASK;
+    if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
+        return (bits & POINTER_MASK) as usize;
+    }
+    if (0x1000..=0x0000_FFFF_FFFF_FFFF).contains(&bits) {
+        return bits as usize;
+    }
+    0
+}
+
+/// Read a heap string's content without allocating. Accepts STRING_TAG
+/// NaN-boxes and raw `StringHeader` pointers; returns `None` for short
+/// inline strings and anything that is not a registered heap string.
+unsafe fn read_heap_string(bits: u64, max_chars: usize) -> Option<String> {
+    let addr = decode_slot_target(bits);
+    if addr < GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    let header = (addr as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
+    if (*header).obj_type != GC_TYPE_STRING {
+        return None;
+    }
+    let s = addr as *const crate::StringHeader;
+    let len = (*s).byte_len as usize;
+    if len > (*header).size as usize {
+        return None;
+    }
+    let data = (addr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let raw = String::from_utf8_lossy(std::slice::from_raw_parts(data, len));
+    if raw.chars().count() > max_chars {
+        let truncated: String = raw.chars().take(max_chars).collect();
+        Some(truncated + "…")
+    } else {
+        Some(raw.into_owned())
+    }
+}
+
+/// Snapshot node type + display name for one GC object.
+unsafe fn node_label(rec: &NodeRec) -> (u32, String) {
+    match rec.obj_type {
+        GC_TYPE_ARRAY | GC_TYPE_LAZY_ARRAY => (NODE_TYPE_ARRAY, "Array".to_string()),
+        GC_TYPE_STRING => {
+            let name = read_heap_string(
+                crate::value::JSValue::string_ptr(rec.user as *mut crate::StringHeader).bits(),
+                128,
+            )
+            .unwrap_or_default();
+            (NODE_TYPE_STRING, name)
+        }
+        GC_TYPE_OBJECT => {
+            let obj = rec.user as *const crate::object::ObjectHeader;
+            let class_id = (*obj).class_id;
+            let name = if class_id != 0 {
+                crate::object::class_name_for_id(class_id).unwrap_or_else(|| "Object".to_string())
+            } else {
+                "Object".to_string()
+            };
+            (NODE_TYPE_OBJECT, name)
+        }
+        GC_TYPE_CLOSURE => {
+            let name = {
+                let bits = crate::closure::closure_get_dynamic_prop(rec.user, "name").to_bits();
+                read_heap_string(bits, 128).unwrap_or_default()
+            };
+            (
+                NODE_TYPE_CLOSURE,
+                if name.is_empty() {
+                    "()".to_string()
+                } else {
+                    name
+                },
+            )
+        }
+        GC_TYPE_PROMISE => (NODE_TYPE_OBJECT, "Promise".to_string()),
+        GC_TYPE_BIGINT => (NODE_TYPE_BIGINT, "bigint".to_string()),
+        GC_TYPE_ERROR => (NODE_TYPE_OBJECT, "Error".to_string()),
+        GC_TYPE_MAP => (NODE_TYPE_OBJECT, "Map".to_string()),
+        GC_TYPE_SET => (NODE_TYPE_OBJECT, "Set".to_string()),
+        GC_TYPE_BUFFER => (NODE_TYPE_NATIVE, "Buffer".to_string()),
+        GC_TYPE_TYPED_ARRAY => (NODE_TYPE_NATIVE, "TypedArray".to_string()),
+        GC_TYPE_DATE_CELL => (NODE_TYPE_OBJECT, "Date".to_string()),
+        GC_TYPE_TEMPORAL => (NODE_TYPE_NATIVE, "Temporal".to_string()),
+        _ => (NODE_TYPE_NATIVE, "native".to_string()),
+    }
+}
+
+/// Best-effort property name for inline object field `field_index`,
+/// resolved through the object's keys array. `None` for class
+/// instances (keys array is NULL) and non-string keys.
+unsafe fn object_field_name(
+    obj: *const crate::object::ObjectHeader,
+    field_index: usize,
+) -> Option<String> {
+    let keys_bits = (*obj).keys_array as u64;
+    let keys_addr = decode_slot_target(keys_bits);
+    if keys_addr < GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    let keys_header = (keys_addr as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
+    if (*keys_header).obj_type != GC_TYPE_ARRAY {
+        return None;
+    }
+    let keys = keys_addr as *const crate::array::ArrayHeader;
+    if field_index >= (*keys).length as usize {
+        return None;
+    }
+    let elements = (keys_addr + std::mem::size_of::<crate::array::ArrayHeader>()) as *const u64;
+    read_heap_string(*elements.add(field_index), 256)
+}
+
+/// Build the complete V8-format heap snapshot JSON document for the
+/// calling thread's heap. Public entry used by `node_v8.rs`.
+pub fn gc_build_v8_heap_snapshot_json() -> String {
+    // Approximate the live set: collect first so unreachable malloc
+    // objects are freed and fully-dead nursery blocks are reset before
+    // the walk picks the population (Node's writeHeapSnapshot also
+    // forces a full GC). Force the conservative native-stack scan for
+    // this collection: in the default `auto` mode a full collect can
+    // miss top-level locals held only on the native stack and reclaim
+    // live objects (pre-existing explicit-`gc()` bug, see #4977 —
+    // repro: `const k = {nested:{deep:"s"}}; gc();` corrupts
+    // `k.nested.deep`). A diagnostics API must never make that worse.
+    let prev = super::roots::set_conservative_stack_scan_override(Some(
+        super::roots::ConservativeStackScanMode::Full,
+    ));
+    js_gc_collect();
+    super::roots::set_conservative_stack_scan_override(prev);
+
+    // Free-list slots are dead-but-unreclaimed space inside live
+    // blocks; exclude them from the dump.
+    let free_slots: std::collections::HashSet<usize> =
+        ARENA_FREE_LIST.with(|fl| fl.borrow().iter().map(|&(ptr, _)| ptr as usize).collect());
+
+    let mut recs: Vec<NodeRec> = Vec::new();
+    let push_header = |header_ptr: *mut u8, recs: &mut Vec<NodeRec>| unsafe {
+        let header = header_ptr as *mut GcHeader;
+        let obj_type = (*header).obj_type;
+        let size = (*header).size;
+        if obj_type == 0 || obj_type > GC_TYPE_MAX || size == 0 {
+            return;
+        }
+        if (*header).gc_flags & GC_FLAG_FORWARDED != 0 {
+            return;
+        }
+        let user = header_ptr as usize + GC_HEADER_SIZE;
+        if free_slots.contains(&(header_ptr as usize)) || free_slots.contains(&user) {
+            return;
+        }
+        recs.push(NodeRec {
+            header,
+            user,
+            obj_type,
+            self_size: size,
+        });
+    };
+
+    crate::arena::arena_walk_objects(|header_ptr| push_header(header_ptr, &mut recs));
+    let malloc_headers: Vec<*mut GcHeader> = MALLOC_STATE.with(|s| s.borrow().objects.clone());
+    for header in malloc_headers {
+        push_header(header as *mut u8, &mut recs);
+    }
+
+    // Node 0 is the synthetic root; heap objects are nodes 1..=len.
+    let mut idx_of: HashMap<usize, u32> = HashMap::with_capacity(recs.len());
+    for (i, rec) in recs.iter().enumerate() {
+        idx_of.insert(rec.user, (i + 1) as u32);
+    }
+
+    let mut strings = StringTable::new();
+    let root_name = strings.intern("(GC roots)");
+
+    // Per-node labels, computed before the edge pass so the string
+    // table fills in node order.
+    let labels: Vec<(u32, u32)> = recs
+        .iter()
+        .map(|rec| {
+            let (node_type, name) = unsafe { node_label(rec) };
+            (node_type, strings.intern(&name))
+        })
+        .collect();
+
+    // Edge pass: enumerate every reference slot the GC itself would
+    // trace, keep the ones that point at walked nodes.
+    let node_count = recs.len() + 1;
+    let mut edges: Vec<Vec<Edge>> = vec![Vec::new(); node_count];
+    for (i, rec) in recs.iter().enumerate() {
+        let from = (i + 1) as usize;
+        let mut ordinal: u32 = 0;
+        let (fields_base, fields_len) = if rec.obj_type == GC_TYPE_OBJECT {
+            let obj = rec.user as *const crate::object::ObjectHeader;
+            let fc = unsafe { (*obj).field_count } as usize;
+            if fc <= 10_000 {
+                (
+                    rec.user + std::mem::size_of::<crate::object::ObjectHeader>(),
+                    fc * 8,
+                )
+            } else {
+                (0, 0)
+            }
+        } else {
+            (0, 0)
+        };
+        // Element-index naming only for regular arrays — GC_TYPE_LAZY_ARRAY
+        // has a different header layout, so its slots fall through to the
+        // `internal` label below.
+        let (elems_base, elems_len) = if rec.obj_type == GC_TYPE_ARRAY {
+            let arr = rec.user as *const crate::array::ArrayHeader;
+            (
+                rec.user + std::mem::size_of::<crate::array::ArrayHeader>(),
+                unsafe { (*arr).length } as usize * 8,
+            )
+        } else {
+            (0, 0)
+        };
+        unsafe {
+            visit_gc_rewrite_slots(rec.header, |slot| {
+                let slot_ordinal = ordinal;
+                ordinal += 1;
+                let bits = *slot.slot;
+                let target = decode_slot_target(bits);
+                if target == 0 {
+                    return;
+                }
+                let Some(&to) = idx_of.get(&target) else {
+                    return;
+                };
+                if crate::weakref::is_weak_target_trace_slot(rec.header, slot.slot) {
+                    edges[from].push(Edge {
+                        edge_type: EDGE_TYPE_WEAK,
+                        name_or_index: slot_ordinal,
+                        to,
+                    });
+                    return;
+                }
+                let slot_addr = slot.slot as usize;
+                if fields_len > 0
+                    && slot_addr >= fields_base
+                    && slot_addr < fields_base + fields_len
+                {
+                    let field_index = (slot_addr - fields_base) / 8;
+                    if let Some(name) = object_field_name(
+                        rec.user as *const crate::object::ObjectHeader,
+                        field_index,
+                    ) {
+                        edges[from].push(Edge {
+                            edge_type: EDGE_TYPE_PROPERTY,
+                            name_or_index: strings.intern(&name),
+                            to,
+                        });
+                        return;
+                    }
+                }
+                if elems_len > 0 && slot_addr >= elems_base && slot_addr < elems_base + elems_len {
+                    edges[from].push(Edge {
+                        edge_type: EDGE_TYPE_ELEMENT,
+                        name_or_index: ((slot_addr - elems_base) / 8) as u32,
+                        to,
+                    });
+                    return;
+                }
+                edges[from].push(Edge {
+                    edge_type: EDGE_TYPE_INTERNAL,
+                    name_or_index: slot_ordinal,
+                    to,
+                });
+            });
+        }
+    }
+
+    // Root edges: point the synthetic root at every node with no
+    // incoming edge, then sweep up anything still unreachable (pure
+    // cycles) so every node is reachable from the root — DevTools
+    // drops unreachable nodes.
+    let mut indegree = vec![0u32; node_count];
+    for per_node in &edges {
+        for e in per_node {
+            indegree[e.to as usize] += 1;
+        }
+    }
+    let mut reached = vec![false; node_count];
+    reached[0] = true;
+    let mut queue: Vec<u32> = Vec::new();
+    let bfs =
+        |start: u32, reached: &mut Vec<bool>, queue: &mut Vec<u32>, edges: &Vec<Vec<Edge>>| {
+            queue.push(start);
+            while let Some(n) = queue.pop() {
+                if reached[n as usize] {
+                    continue;
+                }
+                reached[n as usize] = true;
+                for e in &edges[n as usize] {
+                    if !reached[e.to as usize] {
+                        queue.push(e.to);
+                    }
+                }
+            }
+        };
+    for i in 1..node_count {
+        if indegree[i] == 0 {
+            edges[0].push(Edge {
+                edge_type: EDGE_TYPE_SHORTCUT,
+                name_or_index: root_name,
+                to: i as u32,
+            });
+            bfs(i as u32, &mut reached, &mut queue, &edges);
+        }
+    }
+    for i in 1..node_count {
+        if !reached[i] {
+            edges[0].push(Edge {
+                edge_type: EDGE_TYPE_SHORTCUT,
+                name_or_index: root_name,
+                to: i as u32,
+            });
+            bfs(i as u32, &mut reached, &mut queue, &edges);
+        }
+    }
+
+    let edge_count: usize = edges.iter().map(Vec::len).sum();
+
+    // ---- serialize ----
+    let mut out = String::with_capacity(64 * 1024 + node_count * 32 + edge_count * 16);
+    out.push_str(concat!(
+        r#"{"snapshot":{"meta":{"#,
+        r#""node_fields":["type","name","id","self_size","edge_count","detachedness"],"#,
+        r#""node_types":[["hidden","array","string","object","code","closure","regexp","number","native","synthetic","concatenated string","sliced string","symbol","bigint","object shape"],"string","number","number","number","number"],"#,
+        r#""edge_fields":["type","name_or_index","to_node"],"#,
+        r#""edge_types":[["context","element","property","internal","hidden","shortcut","weak"],"string_or_number","node"],"#,
+        r#""trace_function_info_fields":["function_id","name","script_name","script_id","line","column"],"#,
+        r#""trace_node_fields":["id","function_info_index","count","size","children"],"#,
+        r#""sample_fields":["timestamp_us","last_assigned_id"],"#,
+        r#""location_fields":["object_index","script_id","line","column"]},"#,
+    ));
+    out.push_str(&format!(
+        r#""node_count":{},"edge_count":{},"trace_function_count":0,"extra_native_bytes":0}},"#,
+        node_count, edge_count
+    ));
+
+    out.push_str(r#""nodes":["#);
+    // Synthetic root: type synthetic, name "(GC roots)", id 1, size 0.
+    out.push_str(&format!(
+        "{},{},1,0,{},0",
+        NODE_TYPE_SYNTHETIC,
+        root_name,
+        edges[0].len()
+    ));
+    for (i, rec) in recs.iter().enumerate() {
+        let (node_type, name_idx) = labels[i];
+        let id = (i + 1) * 2 + 1;
+        out.push_str(&format!(
+            ",{},{},{},{},{},0",
+            node_type,
+            name_idx,
+            id,
+            rec.self_size,
+            edges[i + 1].len()
+        ));
+    }
+    out.push_str("],");
+
+    out.push_str(r#""edges":["#);
+    let mut first = true;
+    for per_node in &edges {
+        for e in per_node {
+            if !first {
+                out.push(',');
+            }
+            first = false;
+            out.push_str(&format!(
+                "{},{},{}",
+                e.edge_type,
+                e.name_or_index,
+                e.to * NODE_FIELD_COUNT
+            ));
+        }
+    }
+    out.push_str("],");
+
+    out.push_str(
+        r#""trace_function_infos":[],"trace_tree":[],"samples":[],"locations":[],"strings":["#,
+    );
+    for (i, s) in strings.list.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        json_escape_into(s, &mut out);
+        out.push('"');
+    }
+    out.push_str("]}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn snapshot_has_real_nodes_and_edges() {
+        // Allocate a recognizable object graph, then snapshot.
+        unsafe {
+            let marker = b"__heap_snapshot_test_marker__";
+            let key = crate::string::js_string_from_bytes(marker.as_ptr(), marker.len() as u32);
+            let obj = crate::object::js_object_alloc(0, 1);
+            let arr = crate::array::js_array_alloc(2);
+            let arr_value = f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits());
+            crate::object::js_object_set_field_by_name(obj, key, arr_value);
+        }
+        let json = super::gc_build_v8_heap_snapshot_json();
+        assert!(json.starts_with(r#"{"snapshot":{"meta":"#));
+        assert!(json.contains(r#""node_count":"#));
+        // Real graph: more than just the synthetic root.
+        let node_count: usize = json
+            .split(r#""node_count":"#)
+            .nth(1)
+            .and_then(|s| s.split(',').next())
+            .and_then(|s| s.parse().ok())
+            .expect("node_count parses");
+        assert!(node_count > 1, "expected real nodes, got {node_count}");
+        assert!(
+            json.contains("__heap_snapshot_test_marker__"),
+            "string table should contain heap string content"
+        );
+        // Edges array must be non-empty (root edges at minimum).
+        assert!(!json.contains(r#""edges":[]"#));
+    }
+}

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -58,6 +58,8 @@ mod cycle;
 use cycle::*;
 mod verify;
 pub use verify::*;
+mod heap_snapshot;
+pub use heap_snapshot::gc_build_v8_heap_snapshot_json;
 
 pub fn gc_collect_minor() -> u64 {
     if defer_gc_request(DeferredGcRequest::DirectMinor) {

--- a/crates/perry-runtime/src/node_inspector.rs
+++ b/crates/perry-runtime/src/node_inspector.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 use crate::array::ArrayHeader;
@@ -14,17 +13,15 @@ const KEY_RUNTIME_ENABLED: &[u8] = b"__perryInspectorRuntimeEnabled";
 const EVENT_LISTENERS_PREFIX: &[u8] = b"__perryInspectorListeners:";
 const EVENT_ONCE_PREFIX: &[u8] = b"__perryInspectorOnce:";
 
-static NEXT_PORT: AtomicU16 = AtomicU16::new(35000);
-static NEXT_UUID: AtomicU64 = AtomicU64::new(1);
 static INSPECTOR_ENDPOINT: LazyLock<Mutex<EndpointState>> =
     LazyLock::new(|| Mutex::new(EndpointState::default()));
 
+/// `open()`/`close()` bookkeeping only. Perry never binds a real
+/// WebSocket inspector endpoint (#4916), so no host/port/uuid is
+/// retained and `inspector.url()` stays `undefined` throughout.
 #[derive(Default)]
 struct EndpointState {
     active: bool,
-    host: String,
-    port: u16,
-    uuid: String,
 }
 
 fn key(name: &str) -> *mut crate::StringHeader {
@@ -150,17 +147,6 @@ fn string_to_rust(value: f64) -> Option<String> {
         let len = (*ptr).byte_len as usize;
         let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
         Some(String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).to_string())
-    }
-}
-
-fn number_value(value: f64) -> Option<f64> {
-    let jsval = JSValue::from_bits(value.to_bits());
-    if jsval.is_int32() {
-        Some(jsval.as_int32() as f64)
-    } else if jsval.is_number() {
-        Some(value)
-    } else {
-        None
     }
 }
 
@@ -415,6 +401,16 @@ fn quoted_console_log_arg(expression: &str) -> Option<String> {
     None
 }
 
+/// The complete protocol-method subset Perry's in-process session
+/// answers (#4916). Everything else returns the spec'd JSON-RPC
+/// method-not-found error (`Inspector error -32601`):
+///
+/// - `Runtime.enable` — flips the runtime-enabled flag and emits
+///   `Runtime.executionContextCreated`.
+/// - `Runtime.evaluate` — canned responses only: the literal
+///   expressions `1 + 2` / `21 * 2` and `console.log("<string
+///   literal>")` (printed to stdout). Perry is AOT-compiled; there is
+///   no general JS evaluator behind this.
 fn run_command(session: f64, method: &str, params: f64) -> Result<f64, f64> {
     match method {
         "Runtime.enable" => {
@@ -473,20 +469,6 @@ fn promise_value(result: Result<f64, f64>) -> f64 {
     boxed_pointer(promise as *const u8)
 }
 
-fn allocate_endpoint_port(requested: f64) -> u16 {
-    let requested = number_value(requested).unwrap_or(9229.0);
-    if requested > 0.0 && requested <= u16::MAX as f64 {
-        requested as u16
-    } else {
-        NEXT_PORT.fetch_add(1, Ordering::Relaxed)
-    }
-}
-
-fn next_uuid() -> String {
-    let n = NEXT_UUID.fetch_add(1, Ordering::Relaxed);
-    format!("00000000-0000-0000-0000-{n:012x}")
-}
-
 extern "C" fn endpoint_dispose(_closure: *const ClosureHeader) -> f64 {
     js_node_inspector_close()
 }
@@ -523,12 +505,18 @@ pub extern "C" fn js_node_inspector_network_notify(_params: f64) -> f64 {
     undefined()
 }
 
+/// `inspector.open([port[, host[, wait]]])` — tracks active state for
+/// `ERR_INSPECTOR_ALREADY_ACTIVATED` / `close()` semantics, but binds
+/// no real WebSocket endpoint (#4916). It deliberately does NOT print
+/// Node's "Debugger listening on ws://..." banner: there is nothing
+/// listening, and `inspector.url()` stays `undefined`.
 #[no_mangle]
-pub extern "C" fn js_node_inspector_open(port: f64, host: f64, _wait: f64) -> f64 {
-    let host = string_to_rust(host).unwrap_or_else(|| "127.0.0.1".to_string());
-    let port = allocate_endpoint_port(port);
-    let uuid = next_uuid();
-    let url = format!("ws://{host}:{port}/{uuid}");
+pub extern "C" fn js_node_inspector_open(_port: f64, _host: f64, _wait: f64) -> f64 {
+    crate::error::stub_warn_or_throw(
+        "inspector.open",
+        "binds no real WebSocket inspector endpoint; inspector.url() stays undefined and sessions are in-process fakes",
+        Some("#4916"),
+    );
     if let Ok(mut endpoint) = INSPECTOR_ENDPOINT.lock() {
         if endpoint.active {
             throw_node_error(
@@ -537,12 +525,7 @@ pub extern "C" fn js_node_inspector_open(port: f64, host: f64, _wait: f64) -> f6
             );
         }
         endpoint.active = true;
-        endpoint.host = host;
-        endpoint.port = port;
-        endpoint.uuid = uuid;
     }
-    eprintln!("Debugger listening on {url}");
-    eprintln!("For help, see: https://nodejs.org/learn/getting-started/debugging");
     endpoint_handle()
 }
 
@@ -554,18 +537,13 @@ pub extern "C" fn js_node_inspector_close() -> f64 {
     undefined()
 }
 
+/// `inspector.url()` — always `undefined`. Node returns the ws:// URL
+/// of the live debug endpoint; Perry never has one (#4916), and a URL
+/// pointing at nothing is exactly the kind of lie this module used to
+/// tell (it previously fabricated `ws://host:port/uuid` after `open()`).
 #[no_mangle]
 pub extern "C" fn js_node_inspector_url() -> f64 {
-    let Ok(endpoint) = INSPECTOR_ENDPOINT.lock() else {
-        return undefined();
-    };
-    if !endpoint.active {
-        return undefined();
-    }
-    str_value(&format!(
-        "ws://{}:{}/{}",
-        endpoint.host, endpoint.port, endpoint.uuid
-    ))
+    undefined()
 }
 
 #[no_mangle]
@@ -577,6 +555,14 @@ pub extern "C" fn js_node_inspector_wait_for_debugger() -> f64 {
     if !active {
         throw_node_error("Inspector is not active", "ERR_INSPECTOR_NOT_ACTIVE");
     }
+    // Node blocks until a debugger client attaches. No client can ever
+    // attach to Perry (#4916), so blocking would hang forever — return
+    // immediately instead, with the first-call stub warning.
+    crate::error::stub_warn_or_throw(
+        "inspector.waitForDebugger",
+        "returns immediately; Perry has no inspector endpoint a debugger could attach to",
+        Some("#4916"),
+    );
     undefined()
 }
 
@@ -741,6 +727,11 @@ pub extern "C" fn js_node_inspector_session_post(
             crate::exception::js_throw(err)
         };
     }
+    crate::error::stub_warn_or_throw(
+        "inspector.Session.post",
+        "in-process fake session: only Runtime.enable and a canned Runtime.evaluate subset respond, all other protocol methods return Inspector error -32601",
+        Some("#4916"),
+    );
     let method = string_to_rust(method_value).unwrap_or_default();
     if promise_mode {
         promise_value(run_command(session, &method, params))

--- a/crates/perry-runtime/src/node_repl.rs
+++ b/crates/perry-runtime/src/node_repl.rs
@@ -652,8 +652,21 @@ pub extern "C" fn js_repl_start(options: f64) -> f64 {
     js_repl_repl_server_new(options)
 }
 
+/// Verified for #4916: this builds the `REPLServer` *shape* (context,
+/// listener/command storage, prompt handling) but there is no real
+/// read-eval-print loop behind it — nothing ever reads from the
+/// `input` stream, and `.write()` routes lines through
+/// `eval_simple_expression`, which only handles numeric literals,
+/// `context` lookups, and a single `+`. Perry is AOT-compiled, so a
+/// real eval loop would need an embedded interpreter; until that
+/// exists this stays flagged `stub: true` in the API manifest.
 #[no_mangle]
 pub extern "C" fn js_repl_repl_server_new(options: f64) -> f64 {
+    crate::error::stub_warn_or_throw(
+        "repl.start",
+        "REPLServer shape only: the input stream is never read and .write() evaluates just numeric literals, context lookups, and a single '+'",
+        Some("#4916"),
+    );
     let server = js_object_alloc(0, 16);
     let server_value = object_value(server);
     let context = object_value(js_object_alloc(0, 0));

--- a/crates/perry-runtime/src/node_v8.rs
+++ b/crates/perry-runtime/src/node_v8.rs
@@ -17,9 +17,10 @@
 //!   Perry's arena / RSS counters. The field *names and types* match Node so
 //!   package feature-detection works; the values reflect Perry internals.
 //! * `v8.getHeapSnapshot([options])` / `writeHeapSnapshot([filename[, options]])`
-//!   (#3140) — expose Node-shaped heap snapshot output. Perry does not embed V8,
-//!   so the snapshot is a minimal valid V8 heap-snapshot JSON document rather
-//!   than a full object graph dump.
+//!   (#3140, #4916) — a real V8-format heap snapshot built from Perry's GC heap
+//!   walk (`gc::gc_build_v8_heap_snapshot_json`): actual nodes, sizes, and
+//!   reference edges for the calling thread's heap. The `options` bag
+//!   (`exposeInternals` etc.) is validated but ignored.
 //! * `v8.GCProfiler` (#3142) — `new v8.GCProfiler()` allocates a small native
 //!   instance; `start()` returns `undefined` and `stop()` returns a
 //!   `{ version, startTime, statistics, endTime }` report object only after the
@@ -79,20 +80,6 @@ const TAG_UNDEFINED_BITS: u64 = 0x7FFC_0000_0000_0001;
 fn undefined() -> f64 {
     f64::from_bits(TAG_UNDEFINED_BITS)
 }
-
-const V8_HEAP_SNAPSHOT_JSON: &str = concat!(
-    r#"{"snapshot":{"meta":{"#,
-    r#""node_fields":["type","name","id","self_size","edge_count","trace_node_id","detachedness"],"#,
-    r#""node_types":[["hidden","array","string","object","code","closure","regexp","number","native","synthetic","concatenated string","sliced string","symbol","bigint"],"string","number","number","number","number","number"],"#,
-    r#""edge_fields":["type","name_or_index","to_node"],"#,
-    r#""edge_types":[["context","element","property","internal","hidden","shortcut","weak"],"string_or_number","node"],"#,
-    r#""trace_function_info_fields":["function_id","name","script_name","script_id","line","column"],"#,
-    r#""trace_node_fields":["id","function_info_index","count","size","children"],"#,
-    r#""sample_fields":["timestamp_us","last_assigned_id"],"#,
-    r#""location_fields":["object_index","script_id","line","column"]},"#,
-    r#""node_count":0,"edge_count":0,"trace_function_count":0},"#,
-    r#""nodes":[],"edges":[],"trace_function_infos":[],"trace_tree":[],"samples":[],"locations":[],"strings":["<dummy>"]}"#
-);
 
 /// Build a plain object from `(name, value)` numeric/any pairs.
 unsafe fn build_object(pairs: &[(&str, f64)]) -> f64 {
@@ -183,8 +170,8 @@ fn string_value(value: &str) -> f64 {
     f64::from_bits(JSValue::string_ptr(ptr).bits())
 }
 
-fn snapshot_readable_stream() -> f64 {
-    let chunk = bytes_to_buffer(V8_HEAP_SNAPSHOT_JSON.as_bytes());
+fn snapshot_readable_stream(json: &str) -> f64 {
+    let chunk = bytes_to_buffer(json.as_bytes());
     let mut chunks = crate::array::js_array_alloc(1);
     chunks = crate::array::js_array_push_f64(chunks, chunk);
     let chunks_value = f64::from_bits(JSValue::pointer(chunks as *const u8).bits());
@@ -337,15 +324,18 @@ pub extern "C" fn js_v8_cached_data_version_tag() -> f64 {
 }
 
 /// `v8.getHeapSnapshot([options])` → Readable stream of heap-snapshot JSON.
+///
+/// The document is a real object graph from Perry's GC heap walk
+/// (#4916): nodes are the calling thread's live arena/malloc GC
+/// allocations after a full collection, edges are the reference slots
+/// the collector itself traces. The JSON must be fully built BEFORE
+/// any JS-heap allocation (the stream below) happens — see the safety
+/// note in `gc/heap_snapshot.rs`.
 #[no_mangle]
 pub extern "C" fn js_v8_get_heap_snapshot(options: f64) -> f64 {
     validate_heap_snapshot_options(options);
-    crate::error::stub_warn_or_throw(
-        "v8.getHeapSnapshot",
-        "emits an empty-but-valid V8 heap graph, not a real snapshot of live objects (see PERRY_GC_DIAG=1)",
-        Some("#4916"),
-    );
-    snapshot_readable_stream()
+    let json = crate::gc::gc_build_v8_heap_snapshot_json();
+    snapshot_readable_stream(&json)
 }
 
 /// `v8.writeHeapSnapshot([filename[, options]])` → written filename.
@@ -362,12 +352,8 @@ pub extern "C" fn js_v8_write_heap_snapshot(filename: f64, options: f64) -> f64 
         }
     };
     validate_heap_snapshot_options(options);
-    crate::error::stub_warn_or_throw(
-        "v8.writeHeapSnapshot",
-        "writes an empty-but-valid V8 heap graph, not a real snapshot of live objects (see PERRY_GC_DIAG=1)",
-        Some("#4916"),
-    );
-    match std::fs::write(&path, V8_HEAP_SNAPSHOT_JSON.as_bytes()) {
+    let json = crate::gc::gc_build_v8_heap_snapshot_json();
+    match std::fs::write(&path, json.as_bytes()) {
         Ok(()) => string_value(&path),
         Err(err) => unsafe {
             crate::exception::js_throw(crate::fs::build_fs_error_value(&err, "open", &path))

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1832,11 +1832,11 @@ declare module "inspector" {
   export function Session(...args: any[]): any;
   /** stdlib */
   export function close(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub accepts port/host but binds no real WebSocket inspector endpoint; sessions are in-process fakes (#4916) */
   export function open(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub always undefined: Perry never exposes a real inspector endpoint (#4916) */
   export function url(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub returns immediately after open(); there is no debugger to wait for (#4916) */
   export function waitForDebugger(...args: any[]): any;
 }
 
@@ -3325,11 +3325,11 @@ declare module "repl" {
   /** stdlib */
   const _default: any;
   export default _default;
-  /** stdlib */
+  /** stdlib @perryStub REPLServer shape only: never reads the input stream, and .write() evaluates just numeric literals, context lookups, and a single '+'; no real JS eval loop (#4916) */
   export function REPLServer(...args: any[]): any;
   /** stdlib */
   export function Recoverable(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub REPLServer shape only: never reads the input stream, and .write() evaluates just numeric literals, context lookups, and a single '+'; no real JS eval loop (#4916) */
   export function start(...args: any[]): any;
 }
 
@@ -3975,13 +3975,13 @@ declare module "v8" {
   export function deserialize(...args: any[]): any;
   /** stdlib */
   export function getCppHeapStatistics(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub all fields 0; Perry compiles AOT, there is no JIT code heap (#4916) */
   export function getHeapCodeStatistics(...args: any[]): any;
-  /** stdlib @perryStub empty-but-valid V8 heap graph, not a real snapshot (#4916) */
+  /** stdlib */
   export function getHeapSnapshot(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub Node space names with all live usage attributed to old_space from Perry arenas; other spaces report 0 (#4916) */
   export function getHeapSpaceStatistics(...args: any[]): any;
-  /** stdlib */
+  /** stdlib @perryStub Node shape, Perry numbers: total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from Perry arenas, total_physical_size=RSS, heap_size_limit fixed ~2GB (not enforced); *_executable, external_memory, global-handles and zap fields are 0 (#4916) */
   export function getHeapStatistics(...args: any[]): any;
   /** stdlib */
   export function isStringOneByteRepresentation(...args: any[]): any;
@@ -3999,7 +3999,7 @@ declare module "v8" {
   export function stopCoverage(...args: any[]): any;
   /** stdlib */
   export function takeCoverage(...args: any[]): any;
-  /** stdlib @perryStub empty-but-valid V8 heap graph, not a real snapshot (#4916) */
+  /** stdlib */
   export function writeHeapSnapshot(...args: any[]): any;
 }
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -1697,10 +1697,10 @@ Total: 2781 entries across 114 modules.
 - `disconnect` — instance *(class: `Session`)*
 - `on` — instance *(class: `Session`)*
 - `once` — instance *(class: `Session`)*
-- `open` — module
-- `post` — instance *(class: `Session`)*
-- `url` — module
-- `waitForDebugger` — module
+- `open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket inspector endpoint; sessions are in-process fakes (#4916)
+- `post` — instance *(class: `Session`)* ⚠ **stub** — only Runtime.enable and a canned Runtime.evaluate subset respond; every other protocol method throws Inspector error -32601 (#4916)
+- `url` — module ⚠ **stub** — always undefined: Perry never exposes a real inspector endpoint (#4916)
+- `waitForDebugger` — module ⚠ **stub** — returns immediately after open(); there is no debugger to wait for (#4916)
 
 ### Properties
 
@@ -2870,7 +2870,7 @@ Total: 2781 entries across 114 modules.
 
 ### Methods
 
-- `REPLServer` — module
+- `REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the input stream, and .write() evaluates just numeric literals, context lookups, and a single '+'; no real JS eval loop (#4916)
 - `Recoverable` — module
 - `addListener` — instance *(class: `REPLServer`)*
 - `clearBufferedCommand` — instance *(class: `REPLServer`)*
@@ -2880,7 +2880,7 @@ Total: 2781 entries across 114 modules.
 - `on` — instance *(class: `REPLServer`)*
 - `once` — instance *(class: `REPLServer`)*
 - `setupHistory` — instance *(class: `REPLServer`)*
-- `start` — module
+- `start` — module ⚠ **stub** — REPLServer shape only: never reads the input stream, and .write() evaluates just numeric literals, context lookups, and a single '+'; no real JS eval loop (#4916)
 - `write` — instance *(class: `REPLServer`)*
 
 ### Properties
@@ -3514,10 +3514,10 @@ Total: 2781 entries across 114 modules.
 - `createHook` — instance *(class: `promiseHooks`)*
 - `deserialize` — module
 - `getCppHeapStatistics` — module
-- `getHeapCodeStatistics` — module
-- `getHeapSnapshot` — module ⚠ **stub** — empty-but-valid V8 heap graph, not a real snapshot (#4916)
-- `getHeapSpaceStatistics` — module
-- `getHeapStatistics` — module
+- `getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles AOT, there is no JIT code heap (#4916)
+- `getHeapSnapshot` — module
+- `getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all live usage attributed to old_space from Perry arenas; other spaces report 0 (#4916)
+- `getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from Perry arenas, total_physical_size=RSS, heap_size_limit fixed ~2GB (not enforced); *_executable, external_memory, global-handles and zap fields are 0 (#4916)
 - `isBuildingSnapshot` — instance *(class: `startupSnapshot`)*
 - `isStringOneByteRepresentation` — module
 - `onAfter` — instance *(class: `promiseHooks`)*
@@ -3538,12 +3538,12 @@ Total: 2781 entries across 114 modules.
 - `setHeapSnapshotNearHeapLimit` — module
 - `start` — instance *(class: `GCProfiler`)*
 - `startCpuProfile` — module
-- `stop` — instance *(class: `GCProfiler`)*
+- `stop` — instance *(class: `GCProfiler`)* ⚠ **stub** — report has the Node shape but the statistics array is always empty (#4916)
 - `stopCoverage` — module
 - `takeCoverage` — module
 - `writeDouble` — instance *(class: `Serializer`)*
 - `writeHeader` — instance *(class: `Serializer`)*
-- `writeHeapSnapshot` — module ⚠ **stub** — empty-but-valid V8 heap graph, not a real snapshot (#4916)
+- `writeHeapSnapshot` — module
 - `writeRawBytes` — instance *(class: `Serializer`)*
 - `writeUint32` — instance *(class: `Serializer`)*
 - `writeUint64` — instance *(class: `Serializer`)*

--- a/test-files/test_gap_v8_heap_snapshot_4916.ts
+++ b/test-files/test_gap_v8_heap_snapshot_4916.ts
@@ -1,0 +1,43 @@
+// #4916: v8.writeHeapSnapshot must emit a REAL object graph (V8
+// snapshot format), not an empty-but-valid document. Output is
+// boolean-only so it byte-matches `node --experimental-strip-types`,
+// which dumps its own (different-sized) real graph.
+import v8 from "node:v8";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// Hold a recognizable graph alive so the dump must contain it.
+const heapMarkerArray = ["__heap_marker_string_4916__", { heapMarkerKey4916: 1 }];
+
+const file = path.join(os.tmpdir(), `perry-heapsnap-${process.pid}.heapsnapshot`);
+const written = v8.writeHeapSnapshot(file);
+console.log("returns path:", written === file);
+
+const snap = JSON.parse(fs.readFileSync(file, "utf8"));
+console.log(
+  "has snapshot meta:",
+  typeof snap.snapshot === "object" && typeof snap.snapshot.meta === "object",
+);
+console.log("node_fields:", JSON.stringify(snap.snapshot.meta.node_fields));
+console.log("edge_fields:", JSON.stringify(snap.snapshot.meta.edge_fields));
+
+const nodeCount = snap.snapshot.node_count;
+const edgeCount = snap.snapshot.edge_count;
+console.log("node_count > 0:", nodeCount > 0);
+console.log("edge_count > 0:", edgeCount > 0);
+const nodeFieldCount = snap.snapshot.meta.node_fields.length;
+console.log("nodes len matches:", snap.nodes.length === nodeCount * nodeFieldCount);
+console.log("edges len matches:", snap.edges.length === edgeCount * 3);
+console.log(
+  "strings non-empty:",
+  Array.isArray(snap.strings) && snap.strings.length > 0,
+);
+console.log(
+  "marker string present:",
+  snap.strings.includes("__heap_marker_string_4916__"),
+);
+console.log("marker key present:", snap.strings.includes("heapMarkerKey4916"));
+console.log("marker alive:", heapMarkerArray.length === 2);
+
+fs.unlinkSync(file);


### PR DESCRIPTION
Closes #4916.

## What

The diagnostics audit had one SILENT-LIE (empty-but-valid heap snapshots) and two PARTIALs (inspector, repl). This PR makes the snapshot **real** and makes the rest **honest**.

### Real heap snapshot (`gc/heap_snapshot.rs`, new)

`v8.getHeapSnapshot()` / `v8.writeHeapSnapshot()` now emit an actual object graph built from Perry's GC heap walk, in Node v26 / V8 13.x snapshot format:

- **Nodes**: every arena + malloc GC allocation on the calling thread after a forced full collection — real `self_size`, type mapped from `GC_TYPE_*` (objects/arrays/strings/closures/bigints/native), class instances named via the class registry, string nodes carry their content (truncated at 128 chars).
- **Edges**: enumerated with the same `visit_gc_rewrite_slots` walk the marker traces, so the edge set is definitionally what the GC sees. Object inline fields resolve to **named property edges** through the keys array, array elements get **element** edges, weak slots get **weak** edges, everything else (captures, Map/Set side tables, overflow) is an `internal` edge.
- **Reachability**: a synthetic `(GC roots)` node points at every zero-indegree node plus any pure cycles, so DevTools (which drops unreachable nodes) shows the whole dump.
- Stub flags + first-call warnings on both APIs removed; `stub_inventory.rs` now pins them **must-not-be-stub**.

Validated by loading Perry-produced snapshots in Node and checking: 0 invalid edge targets, 100% root reachability, named property edges present, class-instance nodes present (`object:Widget ×5`), marker strings/keys in the string table. `test-files/test_gap_v8_heap_snapshot_4916.ts` byte-matches `node --experimental-strip-types` (v26.3).

### Found & sidestepped: pre-existing `gc()` liveness bug (#4977)

While validating, live top-level locals vanished from dumps and read back as garbage **with plain explicit `gc()` too** — in the default `auto` stack-scan mode a full collect skips native-stack roots and reclaims live objects (`const k={nested:{deep:"s"}}; gc();` corrupts `k.nested.deep`; fine under `PERRY_CONSERVATIVE_STACK_SCAN=full` or `PERRY_GEN_GC=0`). Filed as #4977 with the bisection. The snapshot's forced collection runs under the existing per-thread `set_conservative_stack_scan_override(Full)` so the diagnostics API cannot inherit the corruption.

### Heap stats provenance (acceptance item 2)

`getHeapStatistics` / `getHeapSpaceStatistics` / `getHeapCodeStatistics` / `GCProfiler.stop` get manifest `stub_note`s that state exactly which fields are Perry-arena numbers, which are RSS, and which are fixed/zero — rendered into `reference.md` / `perry.d.ts` (regenerated here).

### Inspector (acceptance item 3)

- `inspector.url()` → always `undefined`. It used to fabricate `ws://host:port/uuid` for an endpoint that never existed.
- `open()` no longer prints the fake `Debugger listening on ws://…` banner; first-call stub warn; keeps `ERR_INSPECTOR_ALREADY_ACTIVATED`/`close()` semantics.
- `waitForDebugger()` stub-warns (it returns immediately — blocking would hang forever since nothing can attach).
- `Session.post()`: the complete supported subset (`Runtime.enable` + canned `Runtime.evaluate`) is documented at `run_command` and in the manifest; unsupported methods keep the spec'd `-32601`.

### REPL verified (acceptance item 4)

Confirmed the suspicion: `repl.start()` builds the server object, but nothing ever reads the input stream and `.write()` routes through `eval_simple_expression` (numeric literals, context lookups, one `+`). Flagged `stub: true` with a first-call warning — a real eval loop needs an embedded interpreter, out of scope for AOT Perry.

## Tests

- `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime` — 1021/1022; the one failure (`date::tests::test_full_year_setters_revive_invalid_date_only`) fails identically on a clean origin/main tree (pre-existing, macOS-local).
- `perry-api-manifest` (incl. updated `stub_inventory` drift guard) and `perry-codegen manifest_consistency` — green.
- Gap tests `test_gap_node_v8_3137plus`, `test_gap_v8_2_3680plus`, `test_gap_v8_heap_snapshot_4916` — byte-identical to node v26.3.
- Docs regenerated via `./scripts/regen_api_docs.sh` (api-docs-drift clean).

Per contributor convention: no version bump / changelog — maintainer folds metadata at merge.