### PR TITLE
fix(hir): synthesized capture ctor on a derived class must call super() (#4972)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_captures.rs
+++ b/crates/perry-hir/src/lower_decl/class_captures.rs
@@ -25,6 +25,7 @@ pub fn synthesize_class_captures(
     ctx: &mut LoweringContext,
     name: &str,
     extends_name: Option<&str>,
+    has_heritage: bool,
     fields: &mut Vec<ClassField>,
     methods: &mut Vec<Function>,
     getters: &mut Vec<(String, Function)>,
@@ -259,13 +260,30 @@ pub fn synthesize_class_captures(
     }
 
     // 3. Constructor.
+    //
+    // Issue #4972: when the class has heritage and NO user-written ctor,
+    // the synthesized capture-stashing ctor must open with `super()` —
+    // mirroring the spec default ctor `constructor(...args) {
+    // super(...args) }`. Without it, codegen's static derived-ctor
+    // TDZ check (`new.rs`: own ctor + heritage + no `super()` call ⇒
+    // unconditional "Must call super constructor" throw) fires for a
+    // class the user never wrote a ctor for — `class FakeAgent extends
+    // http.Agent { createConnection() { new Duplex() } }` threw at
+    // `new FakeAgent()` purely because the captured `Duplex` binding
+    // forced a ctor into existence. The SuperCall also routes known
+    // user-class parents through the inline-parent-ctor arm so the
+    // parent body runs, matching the no-own-ctor `new` path.
     let mut ctor = constructor.take().unwrap_or_else(|| Function {
         id: ctx.fresh_func(),
         name: format!("{}::constructor", name),
         type_params: Vec::new(),
         params: Vec::new(),
         return_type: Type::Void,
-        body: Vec::new(),
+        body: if has_heritage {
+            vec![Stmt::Expr(Expr::SuperCall(Vec::new()))]
+        } else {
+            Vec::new()
+        },
         is_async: false,
         is_generator: false,
         is_strict: true,

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -1053,6 +1053,10 @@ pub fn lower_class_decl(
         ctx,
         &name,
         extends_name.as_deref(),
+        extends.is_some()
+            || extends_name.is_some()
+            || native_extends.is_some()
+            || extends_expr.is_some(),
         &mut fields,
         &mut methods,
         &mut getters,
@@ -1508,6 +1512,10 @@ pub fn lower_class_from_ast(
         ctx,
         name,
         extends_name.as_deref(),
+        extends.is_some()
+            || extends_name.is_some()
+            || native_extends.is_some()
+            || extends_expr.is_some(),
         &mut fields,
         &mut methods,
         &mut getters,

--- a/crates/perry/tests/issue_4972_derived_class_capture_super.rs
+++ b/crates/perry/tests/issue_4972_derived_class_capture_super.rs
@@ -1,0 +1,164 @@
+//! Regression test for #4972: a derived class with NO user-written
+//! constructor whose method bodies capture an enclosing-scope local threw
+//! "Must call super constructor in derived class before accessing 'this'"
+//! at construction time (`test-http-client-readable`).
+//!
+//! Root cause: `synthesize_class_captures` (#212/#740) materializes a
+//! capture-stashing constructor (`__perry_cap_<id>` params + `this`
+//! PropertySets) when class members reference outer locals. That synthesized
+//! ctor contained no `super()` call, so codegen's static derived-ctor TDZ
+//! check in `lower_call/new.rs` (own ctor + heritage + no `super()` ⇒
+//! unconditional ReferenceError) fired for a class the user never wrote a
+//! ctor for. The canonical shape from the node corpus:
+//!
+//! ```ts
+//! const Duplex = require('stream').Duplex;
+//! class FakeAgent extends http.Agent {
+//!   createConnection() { return new Duplex(); }   // captures `Duplex`
+//! }
+//! new FakeAgent();                                 // threw pre-fix
+//! ```
+//!
+//! Fix: when the fresh (non-user) ctor is synthesized for a class with
+//! heritage, seed its body with `super()` — mirroring the spec default ctor
+//! `constructor(...args) { super(...args) }`. This both suppresses the
+//! bogus static throw and routes known user-class parents through the
+//! inline-parent-ctor arm so the parent body actually runs.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: 'Must call super constructor' \
+         ReferenceError from the synthesized capture ctor)\nstatus: {:?}\n\
+         stdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The corpus shape (`test-http-client-readable`): a no-ctor subclass of a
+/// native member base whose method captures a module-level binding
+/// (`Duplex` via the stream-class destructure alias). Pre-fix `new
+/// FakeAgent()` threw the derived-ctor TDZ ReferenceError.
+#[test]
+fn no_ctor_subclass_of_native_member_base_with_capture_constructs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const http = require('http');
+const Duplex = require('stream').Duplex;
+
+class FakeAgent extends http.Agent {
+  createConnection() {
+    const s = new Duplex();
+    return s;
+  }
+}
+
+const a = new FakeAgent();
+console.log('ctor-ok', typeof a === 'object');
+const s = a.createConnection();
+console.log('capture-ok', typeof s === 'object');
+"#,
+    );
+    assert_eq!(
+        stdout, "ctor-ok true\ncapture-ok true\n",
+        "no-ctor subclass with captured stream alias must construct"
+    );
+}
+
+/// The minimal non-http repro the issue asks for: a function-nested derived
+/// class whose method captures an enclosing-fn local. The synthesized
+/// capture ctor must call `super()` so (a) construction doesn't throw and
+/// (b) the user parent's ctor body actually runs (`this.p = 1`).
+#[test]
+fn nested_derived_class_with_capture_runs_parent_ctor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function make() {
+  const v = 42;
+  class P {
+    p: number;
+    constructor() {
+      this.p = 1;
+    }
+  }
+  class C extends P {
+    m() {
+      return v;
+    }
+  }
+  return new C();
+}
+const c = make();
+console.log('parent-ctor', c.p);
+console.log('capture', c.m());
+"#,
+    );
+    assert_eq!(
+        stdout, "parent-ctor 1\ncapture 42\n",
+        "parent ctor must run via the synthesized super() and the capture must resolve"
+    );
+}
+
+/// Guard: a non-derived class with captures keeps its plain synthesized ctor
+/// (no super() seeded — `Expr::SuperCall` outside a heritage context is a
+/// soft no-op, but the base-class path shouldn't change at all).
+#[test]
+fn base_class_with_capture_unchanged() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function make() {
+  const tag = 'hello';
+  class Plain {
+    m() {
+      return tag;
+    }
+  }
+  return new Plain();
+}
+console.log('base', make().m());
+"#,
+    );
+    assert_eq!(
+        stdout, "base hello\n",
+        "base-class capture path must be unchanged"
+    );
+}


### PR DESCRIPTION
Fixes #4972.

## Problem

`test-http-client-readable` failed with:

```
ReferenceError: Must call super constructor in derived class before accessing 'this' or returning from derived constructor
```

As the issue predicted, this is general class codegen, not http-specific. The trigger is the combination **derived class + captured outer binding + no user-written constructor**:

```ts
const Duplex = require('stream').Duplex;
class FakeAgent extends http.Agent {
  createConnection() { return new Duplex(); }  // captures `Duplex`
}
new FakeAgent();                               // threw pre-fix
```

Pure-TS minimal repro (also threw; Node prints `1 42`):

```ts
function make() {
  const v = 42;
  class P { p: number; constructor() { this.p = 1; } }
  class C extends P { m() { return v; } }
  return new C();
}
```

## Root cause

`synthesize_class_captures` (#212/#740) materializes a capture-stashing constructor (`__perry_cap_<id>` params + `this` PropertySets) when class members reference enclosing-scope locals. That synthesized ctor contained no `super()` call. Codegen's static derived-ctor TDZ check in `lower_call/new.rs` (own ctor + heritage + no `super()` ⇒ unconditional `js_throw_reference_error_this_before_super`) then fired for a class the user never wrote a constructor for — the captured binding alone forced the ctor into existence and flipped the class from the (working) no-own-ctor `new` path onto the own-ctor path.

## Fix

When the **fresh** (non-user) ctor is synthesized for a class with any heritage (`extends` / `extends_name` / `native_extends` / `extends_expr`), seed its body with `super()` — mirroring the spec default ctor `constructor(...args) { super(...args) }`. The existing insertion logic already places capture assignments after the first `SuperCall`, so this-after-super ordering is preserved. User-written ctors are untouched; the static TDZ check still fires for genuinely missing `super()`.

Effects:
- Native/unknown member bases (`http.Agent`): `SuperCall` codegen is a safe no-op for unknown parent names, so the class stays effectively parentless — same behavior as the no-capture case (#4908).
- Known user-class parents: `super()` routes through the inline-parent-ctor arm, so the parent body now actually **runs** (`c.p === 1` above) — previously this shape threw, so nothing working could regress.

## Validation

- `test-http-client-readable` staged against the node-core shim `common`: exits 0 (was: ReferenceError at startup).
- New regression test `crates/perry/tests/issue_4972_derived_class_capture_super.rs`: corpus shape, the pure-TS nested-class repro the issue asked for, and a base-class-with-captures guard.
- `cargo test --release -p perry -p perry-hir`: 21 suites, 0 failures (includes the #4908 `issue_4908_subclass_native_member_base` neighbors).

Code-only PR — no version bump / changelog per contributor flow.