### PR TITLE
fix(hir): lower inline `export default class` bodies — methods/fields survive (#4976)

### DIFF
--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -580,18 +580,31 @@ pub fn lower_module_full(
     // fails if FullMath is declared after SqrtPriceMath.
     for item in &ast_module.body {
         let class_decl = match item {
-            ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::Class(cd))) => Some(cd),
+            ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::Class(cd))) => {
+                Some((cd.ident.sym.to_string(), &cd.class))
+            }
             ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(export_decl)) => {
                 if let ast::Decl::Class(cd) = &export_decl.decl {
-                    Some(cd)
+                    Some((cd.ident.sym.to_string(), &cd.class))
                 } else {
                     None
                 }
             }
+            // #4976: named inline `export default class Name { … }` is a
+            // real class declaration too — pre-register it so same-file
+            // static cross-references resolve regardless of order.
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDefaultDecl(
+                ast::ExportDefaultDecl {
+                    decl: ast::DefaultDecl::Class(class_expr),
+                    ..
+                },
+            )) => class_expr
+                .ident
+                .as_ref()
+                .map(|ident| (ident.sym.to_string(), &class_expr.class)),
             _ => None,
         };
-        if let Some(cd) = class_decl {
-            let name = cd.ident.sym.to_string();
+        if let Some((name, cd)) = class_decl {
             if ctx.lookup_class(&name).is_none() {
                 let id = ctx.fresh_class();
                 ctx.register_class(name.clone(), id);
@@ -599,7 +612,7 @@ pub fn lower_module_full(
             // Collect static field/method names
             let mut static_field_names = Vec::new();
             let mut static_method_names = Vec::new();
-            for member in &cd.class.body {
+            for member in &cd.body {
                 match member {
                     // Only true static *methods* register as callable statics.
                     // Static accessors (`static get foo()`) are NOT methods —

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -1756,13 +1756,85 @@ pub(crate) fn lower_module_decl(
                     }
                 }
                 ast::DefaultDecl::Class(class_expr) => {
-                    if let Some(ref ident) = class_expr.ident {
-                        let class_name = ident.sym.to_string();
-                        module.exports.push(Export::Named {
-                            local: class_name,
-                            exported: "default".to_string(),
-                        });
+                    // Issue #4976: pre-fix this arm only recorded the export
+                    // name and dropped the class body — the class never
+                    // entered `module.classes`, so the importer's
+                    // `exported_classes` lookup missed and `import Widget
+                    // from 'pkg'; new Widget()` fell through to the
+                    // synthetic-default / empty-object placeholder: an
+                    // instance whose prototype holds only `constructor`,
+                    // with every method and field initializer gone (ink's
+                    // `export default class Ink { render() {…} }`).
+                    //
+                    // Synthesize a `ClassDecl` (ident `default` for the
+                    // anonymous `export default class { … }` form, mirroring
+                    // the anonymous-default-function branch above) and run
+                    // it through the same flow as `ExportDecl::Class` so
+                    // methods, field initializers, statics, computed
+                    // members, and decorators are all installed normally.
+                    let synth_ident = class_expr.ident.clone().unwrap_or_else(|| {
+                        ast::Ident::new(
+                            "default".to_string().into(),
+                            swc_common::DUMMY_SP,
+                            Default::default(),
+                        )
+                    });
+                    let synth_class_decl = ast::ClassDecl {
+                        ident: synth_ident,
+                        declare: false,
+                        class: class_expr.class.clone(),
+                    };
+                    let class = lower_class_decl(ctx, &synth_class_decl, true)?;
+                    let class_name = class.name.clone();
+                    // Issue #711: dynamic parent-class registration at the
+                    // source position (see non-export class arm for
+                    // rationale).
+                    if let Some(extends_expr) = &class.extends_expr {
+                        module
+                            .init
+                            .push(Stmt::Expr(Expr::RegisterClassParentDynamic {
+                                class_name: class_name.clone(),
+                                parent_expr: extends_expr.clone(),
+                            }));
                     }
+                    for member in &class.computed_members {
+                        module
+                            .init
+                            .push(Stmt::Expr(class_computed_member_registration_expr(
+                                &class_name,
+                                member,
+                            )));
+                    }
+                    // Inject static-field-init statements in source order
+                    // (see non-export class arm for rationale).
+                    for sf in &class.static_fields {
+                        if let Some(init) = &sf.init {
+                            if let Some(key) = sf.key_expr.as_ref() {
+                                module.init.push(Stmt::Expr(Expr::ClassStaticSymbolSet {
+                                    class_name: class_name.clone(),
+                                    key: Box::new(key.clone()),
+                                    value: Box::new(init.clone()),
+                                }));
+                            } else {
+                                module.init.push(Stmt::Expr(Expr::StaticFieldSet {
+                                    class_name: class_name.clone(),
+                                    field_name: sf.name.clone(),
+                                    value: Box::new(init.clone()),
+                                }));
+                            }
+                        }
+                    }
+                    append_legacy_decorator_init_for_class(ctx, &mut module.init, &class);
+                    push_class_dedup(module, class);
+                    // The `local != exported` shape lets the #485 alias loop
+                    // in compile.rs register the class under `(path,
+                    // "default")` so default-importers resolve full class
+                    // metadata (same machinery the working `class X {};
+                    // export default X` form uses via #665).
+                    module.exports.push(Export::Named {
+                        local: class_name,
+                        exported: "default".to_string(),
+                    });
                 }
                 _ => {}
             }

--- a/crates/perry-hir/tests/export_default_class_lowering.rs
+++ b/crates/perry-hir/tests/export_default_class_lowering.rs
@@ -1,0 +1,117 @@
+//! Issue #4976: inline `export default class Name { … }` must lower the
+//! class body, not just record the export name. Pre-fix, the
+//! `DefaultDecl::Class` arm dropped the class entirely — the importer's
+//! `exported_classes` lookup missed and `new Widget()` fell through to the
+//! empty-object placeholder with every prototype method and field
+//! initializer gone (ink's `export default class Ink { render() {…} }`).
+
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Export, Module};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_result(src: &str) -> Result<Module, String> {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = parse_typescript_with_cache(&src, "export_default_class.ts", &mut cache)
+                .expect("parse should succeed");
+            lower_module(&parsed.module, "test", "export_default_class.ts")
+                .map_err(|e| e.to_string())
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+fn has_named_export(module: &Module, local: &str, exported: &str) -> bool {
+    module.exports.iter().any(
+        |e| matches!(e, Export::Named { local: l, exported: x } if l == local && x == exported),
+    )
+}
+
+#[test]
+fn named_inline_export_default_class_lowers_full_body() {
+    let module = lower_result(
+        r#"
+        export default class Widget {
+            field1;
+            arrow = () => 'arrow';
+            greet() { return 'hello'; }
+        }
+        "#,
+    )
+    .expect("export default class should lower");
+
+    let class = module
+        .classes
+        .iter()
+        .find(|c| c.name == "Widget")
+        .expect("class Widget should be in module.classes");
+    assert!(class.is_exported, "class must be flagged exported");
+    assert!(
+        class.methods.iter().any(|m| m.name == "greet"),
+        "prototype method greet should survive: {:?}",
+        class.methods.iter().map(|m| &m.name).collect::<Vec<_>>()
+    );
+    let field_names: Vec<&str> = class.fields.iter().map(|f| f.name.as_str()).collect();
+    assert!(
+        field_names.contains(&"field1") && field_names.contains(&"arrow"),
+        "field initializers should survive: {field_names:?}"
+    );
+    assert!(
+        has_named_export(&module, "Widget", "default"),
+        "class must be registered as the default export: {:?}",
+        module.exports
+    );
+}
+
+#[test]
+fn anonymous_export_default_class_lowers_full_body() {
+    let module = lower_result(
+        r#"
+        export default class {
+            greet() { return 'anon'; }
+        }
+        "#,
+    )
+    .expect("anonymous export default class should lower");
+
+    let class = module
+        .classes
+        .iter()
+        .find(|c| c.name == "default")
+        .expect("anonymous default class should lower under synthetic name `default`");
+    assert!(class.is_exported);
+    assert!(
+        class.methods.iter().any(|m| m.name == "greet"),
+        "prototype method greet should survive"
+    );
+    assert!(
+        has_named_export(&module, "default", "default"),
+        "default export entry must exist: {:?}",
+        module.exports
+    );
+}
+
+#[test]
+fn named_then_default_export_shape_still_works() {
+    // The previously-working form (#665) — guard against regression.
+    let module = lower_result(
+        r#"
+        class Widget2 { greet() { return 'hi2'; } }
+        export default Widget2;
+        "#,
+    )
+    .expect("named class + export default ident should lower");
+
+    let class = module
+        .classes
+        .iter()
+        .find(|c| c.name == "Widget2")
+        .expect("class Widget2 should be in module.classes");
+    assert!(class.is_exported);
+    assert!(class.methods.iter().any(|m| m.name == "greet"));
+    assert!(has_named_export(&module, "Widget2", "default"));
+}


### PR DESCRIPTION
Fixes #4976 — the ESM sibling of #4933/#4947.

## Root cause

`ExportDefaultDecl(DefaultDecl::Class)` in `crates/perry-hir/src/lower/module_decl.rs` only recorded the export name and **dropped the class body entirely**. The class never entered `module.classes`, so the importer's `exported_classes` lookup missed and `import Widget from 'pkg'; new Widget()` fell through to the synthetic-default / empty-object placeholder — an instance whose prototype holds only `constructor`, with every prototype method and field initializer gone. This is why ink's `export default class Ink { render() {…} }` died with `render is not a function`.

(The CJS form never hit this because `cjs_wrap` rewrites `module.exports = class` to the named-then-`export default Name` shape, which goes through the working #665 path — exactly the shape the issue confirmed works.)

## Fix

- Synthesize a `ClassDecl` and run it through the same flow as `ExportDecl::Class`: full body lowering (methods, field initializers, statics, computed members, decorators), dynamic-parent registration (#711), static-field init statements, then `Export::Named { local: Name, exported: "default" }` so the existing #485/#665 alias machinery gives importers full class metadata.
- Anonymous `export default class { … }` gets the synthetic ident `default`, mirroring the anonymous-default-function branch above it.
- Pre-register named inline default classes in `lower_module_fn.rs`'s declaration-order pass so same-file static cross-references resolve regardless of order.

## Verification

- Issue's minimal repro (edcpkg/edcpkg2 in `compilePackages`): output now **byte-identical to Node** (`constructor,greet function` / `function hello function arrow` for the inline form; named-then-export form unchanged).
- Additional shapes vs Node: static fields (`Base.count`), anonymous default class, `class Sub extends Base` over a default-imported class with `super.greet()` + `instanceof` — all match.
- **ink (#348)**: `hello.tsx` clears the `instance.render is not a function` wall — `render()` now executes and stops later at a different, pre-existing gap (`undefined.COLUMNS` terminal-size handling, then yoga WASM).
- New integration test `crates/perry-hir/tests/export_default_class_lowering.rs`: named / anonymous / named-then-default regression guard.
- `cargo test -p perry-hir` (300+ tests) and `cargo test -p perry` (488 unit + all integration tests) green; `scripts/check_file_size.sh` passes (`module_decl.rs` already allowlisted).

Code-only PR — no version bump / changelog per the maintainer-folds-at-merge convention.