### PR TITLE
fix(net,ext-http): tls.connect Node overloads + https idle-connection close path (#4971)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1224,12 +1224,17 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     property("tls", "rootCertificates"),
     property("tls", "CLIENT_RENEG_LIMIT"),
     property("tls", "CLIENT_RENEG_WINDOW"),
+    // #4971 — all-any params: the runtime resolves Node's overloads
+    // (`connect(options[, cb])`, `connect(port[, host][, options][, cb])`)
+    // plus the legacy positional `(host, port, servername?, verify?)` from
+    // the raw NaN-boxed args; the old `(string, any, string, any)` shape
+    // string-coerced an options-object first arg.
     method_sig(
         "tls",
         "connect",
         false,
         None,
-        &[p_str("p0"), p_any("p1"), p_str("p2"), p_any("p3")],
+        &[p_any("p0"), p_any("p1"), p_any("p2"), p_any("p3")],
         TypeSpec::Any,
     ),
     class("tls", "SecureContext"),

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -721,17 +721,22 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[NA_STR, NA_F64],
         ret: NR_PROMISE,
     },
-    // Factory: `tls.connect(host, port, servername, verify)` opens plain TCP
-    // then runs a full TLS handshake before firing 'connect'. Returns a Socket
-    // handle that behaves identically to one produced by net.createConnection
-    // (same write/end/destroy/on surface).
+    // Factory: `tls.connect(...)` opens plain TCP then runs a full TLS
+    // handshake before firing 'connect'. Returns a Socket handle that behaves
+    // identically to one produced by net.createConnection (same
+    // write/end/destroy/on surface). All four args pass through as raw
+    // NaN-boxed values so the runtime can resolve Node's overloads —
+    // `connect(options[, cb])`, `connect(port[, host][, options][, cb])` —
+    // plus Perry's legacy positional `connect(host, port, servername, verify)`
+    // (#4971: the old NA_STR first arg string-coerced the options object, so
+    // `tls.connect({ port })` returned a null handle).
     NativeModSig {
         module: "tls",
         has_receiver: false,
         method: "connect",
         class_filter: None,
         runtime: "js_tls_connect",
-        args: &[NA_STR, NA_F64, NA_STR, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64, NA_F64],
         ret: NR_PTR,
     },
     // ========== net.Server (issue #1123 followup) ==========

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -28,7 +29,10 @@ use crate::request::{
     IncomingMessage,
 };
 use crate::response::{alloc_server_response_for_request, HyperResponseShape, ResponseBody};
-use crate::server::{HttpPendingRequest, HttpServer};
+use crate::server::{
+    signal_connections_close, HttpPendingRequest, HttpServer, ReadActivity, TrackedConnection,
+    CONNECTIONS, NEXT_CONNECTION_ID, PENDING_CONNECTION_EVENTS,
+};
 use crate::tls::{
     build_server_config, has_pem_material, json_value_to_pem_bytes, parse_cert_chain,
     parse_private_key,
@@ -216,28 +220,74 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
                             Ok((stream, peer)) => {
                                 let acceptor = acceptor.clone();
                                 let request_tx = request_tx_for_spawn.clone();
+                                // #4905/#4971 — register the connection so
+                                // close()/closeAllConnections/
+                                // closeIdleConnections can reach this task
+                                // from the main thread, and queue the
+                                // 'connection' emit (Node fires it on the raw
+                                // TCP connection, before the TLS handshake).
+                                let conn_id = NEXT_CONNECTION_ID.fetch_add(1, Ordering::SeqCst);
+                                let busy = Arc::new(AtomicUsize::new(0));
+                                let read_active = Arc::new(AtomicBool::new(false));
+                                let close = Arc::new(tokio::sync::Notify::new());
+                                CONNECTIONS.lock().unwrap().insert(
+                                    conn_id,
+                                    TrackedConnection {
+                                        server_handle,
+                                        close: close.clone(),
+                                        busy: busy.clone(),
+                                        read_active: read_active.clone(),
+                                    },
+                                );
+                                if let Ok(mut q) = PENDING_CONNECTION_EVENTS.lock() {
+                                    q.push(server_handle);
+                                }
                                 tokio::spawn(async move {
                                     let tls_stream = match acceptor.accept(stream).await {
                                         Ok(s) => s,
                                         Err(e) => {
                                             eprintln!("[node:https] tls handshake: {}", e);
+                                            CONNECTIONS.lock().unwrap().remove(&conn_id);
                                             return;
                                         }
                                     };
-                                    let io = TokioIo::new(tls_stream);
+                                    // Track read activity on the DECRYPTED
+                                    // stream — handshake bytes must not mark
+                                    // a request-less socket non-idle (#4971).
+                                    let io = TokioIo::new(ReadActivity::new(
+                                        tls_stream,
+                                        read_active.clone(),
+                                    ));
                                     let service = service_fn(move |req: Request<Incoming>| {
                                         let request_tx = request_tx.clone();
+                                        let busy = busy.clone();
+                                        let read_active = read_active.clone();
                                         async move {
-                                            handle_https_request(server_handle, peer, req, request_tx).await
+                                            busy.fetch_add(1, Ordering::SeqCst);
+                                            read_active.store(false, Ordering::SeqCst);
+                                            let res = handle_https_request(server_handle, peer, req, request_tx).await;
+                                            busy.fetch_sub(1, Ordering::SeqCst);
+                                            res
                                         }
                                     });
-                                    if let Err(e) = http1::Builder::new()
+                                    let conn = http1::Builder::new()
                                         .serve_connection(io, service)
-                                        .with_upgrades()
-                                        .await
-                                    {
-                                        let _ = e;
+                                        .with_upgrades();
+                                    tokio::pin!(conn);
+                                    tokio::select! {
+                                        result = &mut conn => {
+                                            // Common when the client closes
+                                            // mid-request — silenced.
+                                            let _ = result;
+                                        }
+                                        _ = close.notified() => {
+                                            // close()/closeAllConnections/
+                                            // closeIdleConnections: dropping
+                                            // the pinned connection closes the
+                                            // socket immediately.
+                                        }
                                     }
+                                    CONNECTIONS.lock().unwrap().remove(&conn_id);
                                 });
                             }
                             Err(e) => eprintln!("[node:https] accept error: {}", e),
@@ -438,6 +488,9 @@ pub unsafe extern "C" fn js_node_https_server_close(handle: i64, callback: i64) 
     } else {
         close_listeners = Vec::new();
     }
+    // Node 19+: `server.close()` destroys idle keep-alive connections
+    // (active requests are allowed to finish) (#4905/#4971).
+    signal_connections_close(handle, true);
     emit_no_arg_to_listeners(&close_listeners);
     if callback != 0 {
         let raw = callback as *const RawClosureHeader;
@@ -462,11 +515,25 @@ pub unsafe extern "C" fn js_node_https_server_on(
     f64::from_bits(POINTER_TAG | (handle as u64 & PTR_MASK))
 }
 
+/// `httpsServer.closeAllConnections()` — destroy every tracked
+/// connection of this server, including ones with an in-flight request.
+/// Was a no-op stub pre-#4971; the HTTPS accept loop now registers each
+/// connection in the shared `CONNECTIONS` registry (#4905 machinery).
 #[no_mangle]
-pub extern "C" fn js_node_https_server_close_all_connections(_handle: i64) {}
+pub extern "C" fn js_node_https_server_close_all_connections(handle: i64) {
+    // Delegate to the HTTP variant: the CONNECTIONS and IN_FLIGHT
+    // registries are shared and keyed by server handle, and the HTTP
+    // path also finalizes parked async requests whose connection task
+    // just died.
+    crate::server::js_node_http_server_close_all_connections(handle);
+}
 
+/// `httpsServer.closeIdleConnections()` — destroy connections with no
+/// in-flight request and no half-received one (#4971).
 #[no_mangle]
-pub extern "C" fn js_node_https_server_close_idle_connections(_handle: i64) {}
+pub extern "C" fn js_node_https_server_close_idle_connections(handle: i64) {
+    signal_connections_close(handle, true);
+}
 
 macro_rules! https_server_getter {
     ($name:ident, $field:ident) => {

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -6,8 +6,10 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::task::Poll;
 use std::time::{Duration, Instant};
 
 use lazy_static::lazy_static;
@@ -18,6 +20,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{body::Incoming, Request, Response};
 use hyper_util::rt::TokioIo;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 
@@ -171,19 +174,83 @@ pub struct HttpPendingUpgrade {
 /// Live HTTP/1.1 connection tracked so `server.closeAllConnections()` /
 /// `server.closeIdleConnections()` can reach into the per-connection
 /// tokio task. `busy` counts in-flight requests on the connection (0
-/// between keep-alive requests); `close` wakes the connection task's
-/// `select!`, which drops the hyper connection and closes the socket.
-struct TrackedConnection {
-    server_handle: i64,
-    close: Arc<tokio::sync::Notify>,
-    busy: Arc<AtomicUsize>,
+/// between keep-alive requests); `read_active` flags request bytes
+/// received since the last dispatched request (a half-sent request head
+/// is "currently sending a request" in Node's idleness terms even
+/// though nothing has reached the service yet — #4971); `close` wakes
+/// the connection task's `select!`, which drops the hyper connection
+/// and closes the socket. Shared with the HTTPS accept loop in
+/// `https_server.rs`.
+pub(crate) struct TrackedConnection {
+    pub(crate) server_handle: i64,
+    pub(crate) close: Arc<tokio::sync::Notify>,
+    pub(crate) busy: Arc<AtomicUsize>,
+    pub(crate) read_active: Arc<AtomicBool>,
 }
 
 lazy_static! {
-    static ref CONNECTIONS: Mutex<HashMap<u64, TrackedConnection>> = Mutex::new(HashMap::new());
+    pub(crate) static ref CONNECTIONS: Mutex<HashMap<u64, TrackedConnection>> =
+        Mutex::new(HashMap::new());
 }
 
-static NEXT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
+pub(crate) static NEXT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
+
+/// AsyncRead/AsyncWrite passthrough that flips `saw_bytes` on every
+/// read that produces data. Wrapped around the server-side stream (the
+/// decrypted one, for HTTPS — handshake traffic must not count) so
+/// idleness can see "client started sending a request whose head hasn't
+/// parsed yet": hyper only invokes the service (and bumps `busy`) once
+/// a complete head arrives. The flag resets at service entry; while a
+/// request is in flight `busy > 0` covers activity, and a quiet
+/// keep-alive socket after the response reads as idle again. #4971.
+pub(crate) struct ReadActivity<S> {
+    inner: S,
+    saw_bytes: Arc<AtomicBool>,
+}
+
+impl<S> ReadActivity<S> {
+    pub(crate) fn new(inner: S, saw_bytes: Arc<AtomicBool>) -> Self {
+        Self { inner, saw_bytes }
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for ReadActivity<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        let before = buf.filled().len();
+        let poll = Pin::new(&mut this.inner).poll_read(cx, buf);
+        if matches!(poll, Poll::Ready(Ok(()))) && buf.filled().len() > before {
+            this.saw_bytes.store(true, Ordering::SeqCst);
+        }
+        poll
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for ReadActivity<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
 
 /// Server handles whose accept loop saw a new connection since the last
 /// pump tick. Drained by `js_node_http_server_process_pending` to fire
@@ -191,17 +258,20 @@ static NEXT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
 /// socket as the listener argument; we don't model a net.Socket for
 /// hyper connections yet, so listeners fire with no args — enough for
 /// the canonical connection-counting idiom.
-static PENDING_CONNECTION_EVENTS: Mutex<Vec<i64>> = Mutex::new(Vec::new());
+pub(crate) static PENDING_CONNECTION_EVENTS: Mutex<Vec<i64>> = Mutex::new(Vec::new());
 
 /// Signal tracked connections of `server_handle` to close. With
-/// `only_idle`, connections currently processing a request are left
-/// alone (Node's `closeIdleConnections` semantics; `server.close()`
-/// also closes idle keep-alive sockets since Node 19).
-fn signal_connections_close(server_handle: i64, only_idle: bool) {
+/// `only_idle`, connections currently processing a request — or mid-way
+/// through sending one (`read_active`, #4971) — are left alone (Node's
+/// `closeIdleConnections` semantics; `server.close()` also closes idle
+/// keep-alive sockets since Node 19).
+pub(crate) fn signal_connections_close(server_handle: i64, only_idle: bool) {
     let conns = CONNECTIONS.lock().unwrap();
     for entry in conns.values() {
         if entry.server_handle == server_handle
-            && (!only_idle || entry.busy.load(Ordering::SeqCst) == 0)
+            && (!only_idle
+                || (entry.busy.load(Ordering::SeqCst) == 0
+                    && !entry.read_active.load(Ordering::SeqCst)))
         {
             entry.close.notify_one();
         }
@@ -507,7 +577,6 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                     accepted = listener.accept() => {
                         match accepted {
                             Ok((stream, peer)) => {
-                                let io = TokioIo::new(stream);
                                 let request_tx = request_tx_for_spawn.clone();
                                 let upgrade_tx = upgrade_tx_for_spawn.clone();
                                 let server_handle = server_handle;
@@ -516,13 +585,16 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                                 // reach this task from the main thread.
                                 let conn_id = NEXT_CONNECTION_ID.fetch_add(1, Ordering::SeqCst);
                                 let busy = Arc::new(AtomicUsize::new(0));
+                                let read_active = Arc::new(AtomicBool::new(false));
                                 let close = Arc::new(tokio::sync::Notify::new());
+                                let io = TokioIo::new(ReadActivity::new(stream, read_active.clone()));
                                 CONNECTIONS.lock().unwrap().insert(
                                     conn_id,
                                     TrackedConnection {
                                         server_handle,
                                         close: close.clone(),
                                         busy: busy.clone(),
+                                        read_active: read_active.clone(),
                                     },
                                 );
                                 if let Ok(mut q) = PENDING_CONNECTION_EVENTS.lock() {
@@ -533,8 +605,13 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                                         let request_tx = request_tx.clone();
                                         let upgrade_tx = upgrade_tx.clone();
                                         let busy = busy.clone();
+                                        let read_active = read_active.clone();
                                         async move {
                                             busy.fetch_add(1, Ordering::SeqCst);
+                                            // The pending head is now an in-flight
+                                            // request; `busy` covers activity until
+                                            // the response ships (#4971).
+                                            read_active.store(false, Ordering::SeqCst);
                                             let res = handle_request(server_handle, peer, req, request_tx, upgrade_tx).await;
                                             busy.fetch_sub(1, Ordering::SeqCst);
                                             res
@@ -1240,8 +1317,14 @@ pub extern "C" fn js_node_http_server_process_pending() -> i32 {
         .map(|mut q| q.drain(..).collect())
         .unwrap_or_default();
     for server_handle in connection_events {
+        // The handle may back an HttpServer or an HttpsServer (whose
+        // accept loop pushes here too since #4971) — probe both.
         let listeners = get_handle::<HttpServer>(server_handle)
             .and_then(|s| s.listeners.get("connection").cloned())
+            .or_else(|| {
+                get_handle::<crate::https_server::HttpsServer>(server_handle)
+                    .and_then(|s| s.base.listeners.get("connection").cloned())
+            })
             .unwrap_or_default();
         if listeners.is_empty() {
             continue;

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -441,13 +441,13 @@ pub(crate) unsafe fn jsvalue_to_socket_bytes(value: f64) -> Option<Vec<u8>> {
 /// missing user args with `TAG_UNDEFINED` (`0x7FFC` band), so this
 /// check has to reject `undefined` cleanly to keep "user passed only
 /// 2 args" from misfiring as "user passed a callback". Issue #770.
-fn is_nanboxed_pointer(val_f64: f64) -> bool {
+pub(crate) fn is_nanboxed_pointer(val_f64: f64) -> bool {
     (val_f64.to_bits() >> 48) == 0x7FFD
 }
 
 /// Unbox a NaN-boxed value to the raw 48-bit pointer payload, regardless
 /// of which `0x7FFx` tag it carries.
-unsafe fn unbox_pointer(val_f64: f64) -> *mut u8 {
+pub(crate) unsafe fn unbox_pointer(val_f64: f64) -> *mut u8 {
     let bits = val_f64.to_bits();
     (bits & 0x0000_FFFF_FFFF_FFFF) as *mut u8
 }
@@ -502,6 +502,31 @@ pub(crate) unsafe fn get_object_number_field(obj_f64: f64, field_name: &str) -> 
                 return Some(n);
             }
         }
+    }
+    None
+}
+
+/// Read a boolean option off a NaN-boxed JS object. Accepts real
+/// booleans plus numbers (`rejectUnauthorized: 0` shows up in npm
+/// code). `None` when the field is absent/undefined/null. #4971.
+pub(crate) unsafe fn get_object_bool_field(obj_f64: f64, field_name: &str) -> Option<bool> {
+    if !is_nanboxed_pointer(obj_f64) {
+        return None;
+    }
+    let obj_ptr = unbox_pointer(obj_f64) as *const ObjectHeader;
+    if obj_ptr.is_null() {
+        return None;
+    }
+    let key = js_string_from_bytes(field_name.as_ptr(), field_name.len() as u32);
+    let val = JsValue::from_bits(js_object_get_field_by_name_f64(obj_ptr, key).to_bits());
+    if val.is_undefined() || val.is_null() {
+        return None;
+    }
+    if val.is_bool() {
+        return Some(val.to_bool());
+    }
+    if val.is_number() {
+        return Some(val.to_number() != 0.0);
     }
     None
 }
@@ -1153,40 +1178,18 @@ pub unsafe extern "C" fn js_net_socket_method_connect(handle: i64, port: f64, ho
     });
 }
 
-// ─── FFI: tls.connect(host, port, servername) ────────────────────────────────
-
-/// `tls.connect(host, port, servername, verify)` — opens a plain TCP socket
-/// and runs the TLS handshake before firing `'connect'`. Use this for
-/// HTTPS-style protocols that start TLS from byte 0.
-///
-/// # Safety
-///
-/// `host_ptr` and `servername_ptr` must be null or Perry-runtime
-/// `StringHeader` pointers cast to `i64`.
-#[no_mangle]
-pub unsafe extern "C" fn js_tls_connect(
-    host_ptr: i64,
-    port: f64,
-    servername_ptr: i64,
-    verify: f64,
-) -> i64 {
-    let host = match string_from_header_i64(host_ptr) {
-        Some(h) => h,
-        None => return 0,
-    };
-    let servername = match string_from_header_i64(servername_ptr) {
-        Some(s) => s,
-        None => host.clone(),
-    };
-    let port = port as u16;
-    let verify = verify != 0.0;
-    spawn_socket_task(host, port, Some((servername, verify)))
-}
+// ─── FFI: tls.connect ────────────────────────────────────────────────────────
+// `js_tls_connect` lives in tls.rs (this file is at the 2000-line gate);
+// it resolves Node's connect overloads and reuses `spawn_socket_task`.
 
 /// Internal: allocate the handle, spawn the tokio task.
 /// `direct_tls = Some((servername, verify))` runs a TLS handshake before
 /// firing 'connect'; None keeps the socket in plain TCP mode.
-fn spawn_socket_task(host: String, port: u16, direct_tls: Option<(String, bool)>) -> i64 {
+pub(crate) fn spawn_socket_task(
+    host: String,
+    port: u16,
+    direct_tls: Option<(String, bool)>,
+) -> i64 {
     ensure_gc_scanner_registered();
     dispatch::ensure_runtime_dispatch_registered();
     let id = next_id();
@@ -1505,6 +1508,16 @@ pub unsafe extern "C" fn js_net_process_pending() -> i32 {
                     }
                 }
                 lifecycle::drain_once_listeners(id, "connect");
+                // TLS sockets additionally fire 'secureConnect' once the
+                // handshake completes — the direct-TLS connect path only
+                // signals Connect after the handshake, so this is the right
+                // tick. Plain sockets simply have no listeners here. #4971.
+                for cb in listeners_for(id, "secureConnect") {
+                    if cb != 0 {
+                        let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call0();
+                    }
+                }
+                lifecycle::drain_once_listeners(id, "secureConnect");
             }
             PendingNetEvent::Data(id, bytes) => {
                 let cbs = listeners_for(id, "data");

--- a/crates/perry-ext-net/src/tls.rs
+++ b/crates/perry-ext-net/src/tls.rs
@@ -8,6 +8,13 @@ use tokio::net::TcpStream;
 use tokio_rustls::{client::TlsStream, rustls, TlsConnector};
 
 fn build_tls_connector(verify: bool) -> Result<TlsConnector, String> {
+    // rustls panics resolving the process-level CryptoProvider when both
+    // `ring` and `aws-lc-rs` end up in the dep graph. Server paths install
+    // one before their first handshake; a client-only program (no tls/https
+    // server) reached `ClientConfig::builder()` with none installed once
+    // #4971 made `tls.connect` actually resolve its host. Idempotent —
+    // `install_default` errors (ignored) if a provider is already set.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     if !verify {
         return build_tls_connector_insecure();
     }
@@ -91,4 +98,146 @@ pub(crate) async fn do_tls_handshake(
         .connect(server_name, tcp)
         .await
         .map_err(|e| format!("tls handshake: {}", e))
+}
+
+// ─── FFI: tls.connect ────────────────────────────────────────────────────────
+
+/// `tls.connect(...)` — opens a plain TCP socket and runs the TLS handshake
+/// before firing `'connect'`/`'secureConnect'`. Use this for HTTPS-style
+/// protocols that start TLS from byte 0.
+///
+/// Resolves Node's overloads plus Perry's legacy positional form (#4971 —
+/// pre-fix only the legacy form existed; `tls.connect({ port })` had its
+/// options object string-coerced by the NA_STR table row, returned handle 0,
+/// and every method call on the "socket" hit the runtime's null-pointer
+/// guard):
+///
+/// - `tls.connect(options[, callback])` — `port` required; `host`/`hostname`
+///   default `"localhost"`; `servername` defaults to the host;
+///   `rejectUnauthorized: false` disables cert verification.
+/// - `tls.connect(port[, host][, options][, callback])`
+/// - Legacy Perry positional: `tls.connect(host, port, servername?, verify?)`.
+///
+/// The `callback` (whichever slot it lands in) registers as a
+/// `'secureConnect'` listener, matching the Node spec.
+///
+/// # Safety
+///
+/// All four args must be raw NaN-boxed Perry-runtime values per the codegen
+/// ABI — see `NA_F64` lowering in perry-codegen.
+#[no_mangle]
+pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f64) -> i64 {
+    use crate::option_setters::js_net_validate_connect_port;
+    use crate::{
+        get_object_bool_field, get_object_number_field, get_object_string_field,
+        is_nanboxed_pointer, spawn_socket_task, statics, string_from_header_i64, unbox_pointer,
+    };
+    use perry_ffi::JsValue;
+
+    extern "C" {
+        fn js_value_is_closure(value_bits: i64) -> i32;
+        fn js_get_string_pointer_unified(value: f64) -> i64;
+    }
+    let is_closure =
+        |v: f64| is_nanboxed_pointer(v) && js_value_is_closure(v.to_bits() as i64) != 0;
+    let as_string = |v: f64| -> Option<String> {
+        if !JsValue::from_bits(v.to_bits()).is_string() {
+            return None;
+        }
+        string_from_header_i64(js_get_string_pointer_unified(v))
+    };
+    // Cert verification only goes off when the caller says so explicitly —
+    // a missing/undefined flag keeps it on.
+    let explicitly_off = |v: f64| -> bool {
+        let j = JsValue::from_bits(v.to_bits());
+        (j.is_bool() && !j.to_bool()) || (j.is_number() && j.to_number() == 0.0)
+    };
+
+    let (host, port, servername, verify, cb_f64);
+    if let Some(h) = as_string(arg1) {
+        // Legacy Perry positional: (host, port, servername?, verify?).
+        let p = JsValue::from_bits(arg2.to_bits());
+        if !p.is_number() {
+            return 0;
+        }
+        port = p.to_number() as u16;
+        servername = as_string(arg3).unwrap_or_else(|| h.clone());
+        host = h;
+        verify = !explicitly_off(arg4);
+        cb_f64 = None;
+    } else if is_nanboxed_pointer(arg1) && !is_closure(arg1) {
+        // Node options form: tls.connect(options[, callback]).
+        port = match get_object_number_field(arg1, "port") {
+            Some(p) => {
+                js_net_validate_connect_port(p);
+                p as u16
+            }
+            None => return 0,
+        };
+        host = match get_object_string_field(arg1, "host")
+            .or_else(|| get_object_string_field(arg1, "hostname"))
+        {
+            Some(h) if !h.is_empty() => h,
+            _ => "localhost".to_string(),
+        };
+        servername = get_object_string_field(arg1, "servername").unwrap_or_else(|| host.clone());
+        verify = get_object_bool_field(arg1, "rejectUnauthorized").unwrap_or(true);
+        cb_f64 = is_closure(arg2).then_some(arg2);
+    } else if JsValue::from_bits(arg1.to_bits()).is_number() {
+        // Node positional form: tls.connect(port[, host][, options][, cb]).
+        js_net_validate_connect_port(arg1);
+        port = arg1 as u16;
+        let mut opt_host: Option<String> = None;
+        let mut opts: Option<f64> = None;
+        let mut cb: Option<f64> = None;
+        for v in [arg2, arg3, arg4] {
+            if opt_host.is_none() {
+                if let Some(h) = as_string(v) {
+                    opt_host = Some(h);
+                    continue;
+                }
+            }
+            if is_closure(v) {
+                cb = cb.or(Some(v));
+            } else if is_nanboxed_pointer(v) {
+                opts = opts.or(Some(v));
+            }
+        }
+        host = opt_host
+            .or_else(|| {
+                opts.and_then(|o| {
+                    get_object_string_field(o, "host")
+                        .or_else(|| get_object_string_field(o, "hostname"))
+                })
+            })
+            .filter(|h| !h.is_empty())
+            .unwrap_or_else(|| "localhost".to_string());
+        servername = opts
+            .and_then(|o| get_object_string_field(o, "servername"))
+            .unwrap_or_else(|| host.clone());
+        verify = opts
+            .and_then(|o| get_object_bool_field(o, "rejectUnauthorized"))
+            .unwrap_or(true);
+        cb_f64 = cb;
+    } else {
+        return 0;
+    }
+
+    let handle = spawn_socket_task(host, port, Some((servername, verify)));
+    if let Some(cb) = cb_f64 {
+        if handle != 0 {
+            let cb_ptr = unbox_pointer(cb) as i64;
+            if cb_ptr != 0 {
+                statics::listeners()
+                    .lock()
+                    .unwrap()
+                    .entry(handle)
+                    .or_default()
+                    .entry("secureConnect".to_string())
+                    .or_default()
+                    .push(cb_ptr);
+            }
+        }
+    }
+    handle
 }

--- a/crates/perry-stdlib/src/net/mod.rs
+++ b/crates/perry-stdlib/src/net/mod.rs
@@ -305,6 +305,31 @@ unsafe fn get_object_number_field(obj_f64: f64, field_name: &str) -> Option<f64>
     None
 }
 
+/// Read a boolean option off a NaN-boxed JS object. Accepts real
+/// booleans plus numbers (`rejectUnauthorized: 0` shows up in npm
+/// code). `None` when the field is absent/undefined/null. #4971.
+unsafe fn get_object_bool_field(obj_f64: f64, field_name: &str) -> Option<bool> {
+    if !is_nanboxed_pointer(obj_f64) {
+        return None;
+    }
+    let obj_ptr = unbox_pointer(obj_f64) as *const perry_runtime::ObjectHeader;
+    if obj_ptr.is_null() {
+        return None;
+    }
+    let key = perry_runtime::js_string_from_bytes(field_name.as_ptr(), field_name.len() as u32);
+    let val = perry_runtime::js_object_get_field_by_name(obj_ptr, key);
+    if val.is_undefined() || val.is_null() {
+        return None;
+    }
+    if val.is_bool() {
+        return Some(val.to_bool());
+    }
+    if val.is_number() {
+        return Some(val.as_number() != 0.0);
+    }
+    None
+}
+
 /// Issue #770 — build an `Error`-shaped object `{ message: msg }` so
 /// `socket.on('error', err => err.message)` works. Returns a NaN-boxed
 /// f64 pointing at the object, falling back to a bare string on alloc
@@ -358,6 +383,13 @@ fn mark_closed(id: i64) {
 
 #[cfg(feature = "tls")]
 fn build_tls_connector(verify: bool) -> Result<TlsConnector, String> {
+    // rustls panics resolving the process-level CryptoProvider when both
+    // `ring` and `aws-lc-rs` end up in the dep graph. Server paths install
+    // one before their first handshake; a client-only program (no tls/https
+    // server) reached `ClientConfig::builder()` with none installed once
+    // #4971 made `tls.connect` actually resolve its host. Idempotent —
+    // `install_default` errors (ignored) if a provider is already set.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     if !verify {
         return build_tls_connector_insecure();
     }
@@ -613,38 +645,136 @@ pub unsafe extern "C" fn js_net_socket_method_connect(handle: i64, port: f64, ho
     });
 }
 
-// ─── FFI: tls.connect(host, port, servername) ────────────────────────────────
+// ─── FFI: tls.connect ────────────────────────────────────────────────────────
 
-/// `tls.connect(host, port, servername)` — opens a plain TCP socket and
-/// immediately runs the TLS handshake before firing `'connect'`. Use this
-/// for protocols that start TLS from byte 0 (HTTPS, SMTP with SMTPS, etc.).
+/// `tls.connect(...)` — opens a plain TCP socket and immediately runs the
+/// TLS handshake before firing `'connect'`/`'secureConnect'`. Use this for
+/// protocols that start TLS from byte 0 (HTTPS, SMTP with SMTPS, etc.).
 ///
 /// For protocols that negotiate TLS mid-stream (Postgres' `SSLRequest`,
 /// SMTP STARTTLS), use `net.createConnection` then `socket.upgradeToTLS`
 /// instead.
 ///
+/// Resolves Node's overloads plus Perry's legacy positional form — kept in
+/// sync with the perry-ext-net copy, which is the live path after the
+/// well-known flip (#4971):
+///
+/// - `tls.connect(options[, callback])` — `port` required; `host`/`hostname`
+///   default `"localhost"`; `servername` defaults to the host;
+///   `rejectUnauthorized: false` disables cert verification.
+/// - `tls.connect(port[, host][, options][, callback])`
+/// - Legacy Perry positional: `tls.connect(host, port, servername?, verify?)`.
+///
 /// Signature matches `{ module: "tls", method: "connect",
-/// args: &[NA_STR, NA_F64, NA_STR], ret: NR_PTR }`.
+/// args: &[NA_F64, NA_F64, NA_F64, NA_F64], ret: NR_PTR }`.
 #[cfg(feature = "tls")]
 #[no_mangle]
-pub unsafe extern "C" fn js_tls_connect(
-    host_ptr: i64,
-    port: f64,
-    servername_ptr: i64,
-    verify: f64,
-) -> i64 {
-    let host = match string_from_header_i64(host_ptr) {
-        Some(h) => h,
-        None => return 0,
+pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f64) -> i64 {
+    extern "C" {
+        fn js_value_is_closure(value_bits: i64) -> i32;
+    }
+    let is_closure =
+        |v: f64| is_nanboxed_pointer(v) && js_value_is_closure(v.to_bits() as i64) != 0;
+    let as_string = |v: f64| -> Option<String> {
+        if !JSValue::from_bits(v.to_bits()).is_string() {
+            return None;
+        }
+        string_from_header_i64(perry_runtime::js_get_string_pointer_unified(v))
     };
-    let servername = match string_from_header_i64(servername_ptr) {
-        Some(s) => s,
-        None => host.clone(),
+    // Cert verification only goes off when the caller says so explicitly —
+    // a missing/undefined flag keeps it on.
+    let explicitly_off = |v: f64| -> bool {
+        let j = JSValue::from_bits(v.to_bits());
+        (j.is_bool() && !j.to_bool()) || (j.is_number() && j.as_number() == 0.0)
     };
-    let port = port as u16;
-    let verify = verify != 0.0;
+
+    let (host, port, servername, verify, cb_f64);
+    if let Some(h) = as_string(arg1) {
+        // Legacy Perry positional: (host, port, servername?, verify?).
+        let p = JSValue::from_bits(arg2.to_bits());
+        if !p.is_number() {
+            return 0;
+        }
+        port = p.as_number() as u16;
+        servername = as_string(arg3).unwrap_or_else(|| h.clone());
+        host = h;
+        verify = !explicitly_off(arg4);
+        cb_f64 = None;
+    } else if is_nanboxed_pointer(arg1) && !is_closure(arg1) {
+        // Node options form: tls.connect(options[, callback]).
+        port = match get_object_number_field(arg1, "port") {
+            Some(p) => {
+                perry_runtime::net_validate::js_net_validate_connect_port(p);
+                p as u16
+            }
+            None => return 0,
+        };
+        host = match get_object_string_field(arg1, "host")
+            .or_else(|| get_object_string_field(arg1, "hostname"))
+        {
+            Some(h) if !h.is_empty() => h,
+            _ => "localhost".to_string(),
+        };
+        servername = get_object_string_field(arg1, "servername").unwrap_or_else(|| host.clone());
+        verify = get_object_bool_field(arg1, "rejectUnauthorized").unwrap_or(true);
+        cb_f64 = if is_closure(arg2) { Some(arg2) } else { None };
+    } else if JSValue::from_bits(arg1.to_bits()).is_number() {
+        // Node positional form: tls.connect(port[, host][, options][, cb]).
+        perry_runtime::net_validate::js_net_validate_connect_port(arg1);
+        port = arg1 as u16;
+        let mut opt_host: Option<String> = None;
+        let mut opts: Option<f64> = None;
+        let mut cb: Option<f64> = None;
+        for v in [arg2, arg3, arg4] {
+            if opt_host.is_none() {
+                if let Some(h) = as_string(v) {
+                    opt_host = Some(h);
+                    continue;
+                }
+            }
+            if is_closure(v) {
+                cb = cb.or(Some(v));
+            } else if is_nanboxed_pointer(v) {
+                opts = opts.or(Some(v));
+            }
+        }
+        host = opt_host
+            .or_else(|| {
+                opts.and_then(|o| {
+                    get_object_string_field(o, "host")
+                        .or_else(|| get_object_string_field(o, "hostname"))
+                })
+            })
+            .filter(|h| !h.is_empty())
+            .unwrap_or_else(|| "localhost".to_string());
+        servername = opts
+            .and_then(|o| get_object_string_field(o, "servername"))
+            .unwrap_or_else(|| host.clone());
+        verify = opts
+            .and_then(|o| get_object_bool_field(o, "rejectUnauthorized"))
+            .unwrap_or(true);
+        cb_f64 = cb;
+    } else {
+        return 0;
+    }
+
     let handle = spawn_socket_task(host, port, Some((servername, verify)));
     crate::tls::record_tls_client_handle(handle);
+    if let Some(cb) = cb_f64 {
+        if handle != 0 {
+            let cb_ptr = unbox_pointer(cb) as i64;
+            if cb_ptr != 0 {
+                NET_LISTENERS
+                    .lock()
+                    .unwrap()
+                    .entry(handle)
+                    .or_default()
+                    .entry("secureConnect".to_string())
+                    .or_default()
+                    .push(cb_ptr);
+            }
+        }
+    }
     handle
 }
 

--- a/crates/perry-stdlib/src/tls.rs
+++ b/crates/perry-stdlib/src/tls.rs
@@ -1909,9 +1909,16 @@ pub unsafe extern "C" fn js_tls_native_dispatch(
             js_tls_check_server_identity(arg(0).to_bits() as i64, arg(1).to_bits() as i64)
         }
         "connect" => {
-            let host = js_get_string_pointer_unified(arg(0));
-            let servername = js_get_string_pointer_unified(arg(2));
-            let handle = crate::net::js_tls_connect(host, arg(1), servername, arg(3));
+            // Pass the args through raw — js_tls_connect resolves Node's
+            // `connect(options[, cb])` / `connect(port[, host][, options][,
+            // cb])` overloads plus the legacy positional form itself (#4971).
+            let handle = crate::net::js_tls_connect(arg(0), arg(1), arg(2), arg(3));
+            if handle == 0 {
+                // Unresolvable args (e.g. no port) — undefined beats a
+                // NaN-boxed null pointer that every later method call
+                // trips over (#4971).
+                return undefined();
+            }
             record_tls_client_handle(handle);
             nanbox_handle(handle)
         }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -3709,7 +3709,7 @@ declare module "tls" {
   /** stdlib */
   export function checkServerIdentity(hostname: any, cert: any): any;
   /** stdlib */
-  export function connect(p0: string, p1: any, p2: string, p3: any): any;
+  export function connect(p0: any, p1: any, p2: any, p3: any): any;
   /** stdlib */
   export function createSecureContext(options: any): any;
   /** stdlib */

--- a/test-files/test_issue_4971_tls_connect_options.ts
+++ b/test-files/test_issue_4971_tls_connect_options.ts
@@ -1,0 +1,130 @@
+// #4971 — tls.connect(options) overload + https idle-connection close path.
+//
+// Mirrors Node's test-https-server-close-idle: an https server gets two raw
+// TLS clients. client1 sends only a partial request line (it is "currently
+// sending a request" — NOT idle); client2 completes a keep-alive request and
+// then sits idle. `server.close()` must destroy only the idle client2 socket;
+// `server.closeAllConnections()` then takes client1 down too.
+//
+// Pre-fix, `tls.connect({ port, rejectUnauthorized: false })` string-coerced
+// the options object (NA_STR table row), returned a NaN-boxed NULL handle,
+// and every `client.on(...)`/`client.write(...)` tripped the runtime's
+// [NULL_PTR_METHOD_CALL] guard while the test hung forever. The https server
+// additionally had no connection tracking at all: no 'connection' events and
+// closeAllConnections/closeIdleConnections as silent no-ops.
+
+import { createServer } from "node:https";
+import { connect } from "node:tls";
+
+const key = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCZdknk+UU6sHsu
+dx2QKZbcNO4sH1GZ/xyXhzSerQuHJ3MufBDqq7SgI7W3AanlomfGy/f4qnPkM1MQ
+JNzhtsJ9w/CRHlzBFrKik1rSegss6DvSxBYVijv8lYipPJaOmvgZ0n3aRKBSO7ZV
+DmESLRxq4eBr8hpL6bm58XpHP4EO3ZONGPjcCpOBlQ47xm7FEhqh7wDYtHbMaMl9
+ItjfbUkPxpeINOxROpcxZEsi/w1zzh6JZrDyxTZUS0aM2oyx0pE1b/9c7IUrCLIg
+VKYP+zuzcLh476DBZyjV3rZ/wrytEfF7qy1/emCN4JNrsfdcLimgMiHI2xrcvRSE
+Qbdw71gVAgMBAAECggEAHnkeec0k2d9fCo5FLNIRXqdVDyZl8BA4R3+l64ddtWgY
+R2gD/PF9M9p7dDxslgiellt84WBJlIw7h4ZmZRzDOLGOpOZ0UTRWYxGjNI3fB7sS
+3Aqrfvn86O5xnXeGRwmPUCNb8dp0QngQgAnTrUYPcUrqo0zHO4FNK9b/asP5tu9q
+rFSYdoYYZRAUEdjhHsAnbqsL0NXbPQhaAPLlXJfyY74s/3fhxz3IM/NVI62D2nAY
+RY4jNb2Hq8Vse8vhskJ30v7Jx/fm/FIWidBODGETM598ATTQWy8ZJ2jlEjAwit9G
+RxTq+HQXMLVFn6GBntIiz8a6w6dcugxouI3LDIKY6QKBgQDGNWVaoMz+TcYDjNLt
+XoSsUZalo3CAhRPP0P2zvsvX+juFWxvnJ2fobZe3MMyRBmKgXDzxVivB/MkgbLM6
+9UpC+/i03BHgTDiVArnC0L2tWISAAV2W8TdeYL5fS/mFrxpk3IsSKndZaZ/JSOQk
+jprUgxmcB2ouhRoTG0eJUcCACQKBgQDGNPEUsh1CXNHHRAXYSXzCuQwQywk2LcRd
+TDqUsxLv0akYRYCqGgBAt8d2KIbgTPF57Kb1EQaBUvKZ2UUd6LsnnW3uiffcrc9O
+GD4iZNNJ/ih6DtVHen+e+TgxVUB+S4zRkW9kSA1RdGVBCEyMF6D2VAhWQtZ3BfP8
+3yECesLCrQKBgQCOqbIo+CJ0TABhX8QWC/kMmrEGycvZBXAMHY3uCT9pVffvdXNw
+/mEA35jaxyoGnITyjVFkF7TpLIyLZRHgNttbuUb6zoejXNlBD7Qq79oGYfcEt3bo
+hPhoWtPLfcC8oxspS8Bhs+Uxmx/iXi+vzGDO4wnUz1Vy5GSvKexkf05CGQKBgC9A
+n9jXPbJ8fmaLCPmvS1cA1qeKP//ymUXEzpJ0vqb9zNpEd5AV8sl7BspcjwsaTNdM
+W+FA1dQu+jdDXP7sZPHkzjh4G+c4aJutm+KHNvgE55Fxx9bqlVJJB+R69o0lZcTw
+byXxJ3urzBfc6qLbXzxafEJUXNyzRp+acjwtGBFhAoGBAIZMg+6vO9lrT8cWYm8L
+o6x16raQ5j6pD1TJOR5pZ7r5RJ5qV7l1xr6kPAbZVrYtB5v2Zadr2L+5Pg2DnGfI
+Qf1AWmqoqZzUqMRTl9ccGZ+VRCxs6RfqCLJ+uoTnL9ofvb66HBl9mbmCrv89/w5z
+ARi9DXMIk3COw3E7osC7sMFc
+-----END PRIVATE KEY-----`;
+
+const cert = `-----BEGIN CERTIFICATE-----
+MIIDJzCCAg+gAwIBAgIUDJiFqrHvxns50S82U2/TF+Pmyd0wDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDYxMTA3MTQ1OVoYDzIxMjYw
+NTE4MDcxNDU5WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCZdknk+UU6sHsudx2QKZbcNO4sH1GZ/xyXhzSerQuH
+J3MufBDqq7SgI7W3AanlomfGy/f4qnPkM1MQJNzhtsJ9w/CRHlzBFrKik1rSegss
+6DvSxBYVijv8lYipPJaOmvgZ0n3aRKBSO7ZVDmESLRxq4eBr8hpL6bm58XpHP4EO
+3ZONGPjcCpOBlQ47xm7FEhqh7wDYtHbMaMl9ItjfbUkPxpeINOxROpcxZEsi/w1z
+zh6JZrDyxTZUS0aM2oyx0pE1b/9c7IUrCLIgVKYP+zuzcLh476DBZyjV3rZ/wryt
+EfF7qy1/emCN4JNrsfdcLimgMiHI2xrcvRSEQbdw71gVAgMBAAGjbzBtMB0GA1Ud
+DgQWBBS0hSQZgeoLIYQud2S7NhU1Me0aBzAfBgNVHSMEGDAWgBS0hSQZgeoLIYQu
+d2S7NhU1Me0aBzAPBgNVHRMBAf8EBTADAQH/MBoGA1UdEQQTMBGCCWxvY2FsaG9z
+dIcEfwAAATANBgkqhkiG9w0BAQsFAAOCAQEAM+QXKOl6u8jFMrIzODBXKDQlAjro
+ROH9WmaFw4QzLsobWniQOOOrzfRZJohVlbMxBmcF4gtQB7i2tcCYKwDZe9phiAKX
+eqsZiRjWLvY0U5mvfY29CAiKRCKBpXNjnJamz7Epk19peza2e1jx7ZP+dswcIgy3
+QjEFEQQ6k1QkL4jPYnRc9joH/pu8FUr4iBBYzy7oeU8AgjIm34RDwPpMNHoz73VI
+pnKoYubWNYsbPJCGZx1JracfY5XlaLkWUZoq/vGM0EfScUKnBlP5tSai+8R9dIEd
+pSmi20rjXYZDwqE2tjZyGHvl2L5r62A8rpUL/ocBeY23MkxrJKvqT248+A==
+-----END CERTIFICATE-----`;
+
+let connections = 0;
+let client1Closed = false;
+let client2Closed = false;
+
+const server = createServer({ key, cert }, (req: any, res: any) => {
+  res.writeHead(200, { Connection: "keep-alive" });
+  res.end();
+});
+
+server.on("connection", () => {
+  connections++;
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+
+  // client1: starts a request but never finishes the head — NOT idle.
+  const client1 = connect({ port, rejectUnauthorized: false });
+  console.log("client1 typeof:", typeof client1);
+
+  client1.on("connect", () => {
+    console.log("client1 connected");
+    client1.write("GET / HTTP/1.1");
+
+    // client2: completes a keep-alive request, then sits idle.
+    const client2 = connect({ port, rejectUnauthorized: false });
+    let response = "";
+
+    client2.on("data", (chunk: any) => {
+      response += chunk.toString("utf8");
+      if (response.endsWith("0\r\n\r\n") || response.indexOf("200") >= 0) {
+        console.log("client2 got response:", response.indexOf("200 OK") >= 0);
+        console.log("connections:", connections);
+
+        // Node 19+: close() destroys idle keep-alive sockets only.
+        server.close();
+
+        setTimeout(() => {
+          console.log("after close: client1Closed =", client1Closed);
+          console.log("after close: client2Closed =", client2Closed);
+          server.closeAllConnections();
+          setTimeout(() => {
+            console.log("after closeAll: client1Closed =", client1Closed);
+            process.exit(0);
+          }, 500);
+        }, 500);
+      }
+    });
+
+    client2.on("close", () => {
+      client2Closed = true;
+    });
+
+    client2.on("connect", () => {
+      client2.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    });
+  });
+
+  client1.on("close", () => {
+    client1Closed = true;
+  });
+  client1.on("error", () => {});
+});


### PR DESCRIPTION
Fixes #4971.

## Root cause

The `[NULL_PTR_METHOD_CALL]` crashes in `test-https-server-close-idle` were not coming from the idle sweep — they were the **tls client sockets**. The test calls `tls.connect({ port, rejectUnauthorized: false })` (Node's options-object form), but Perry only implemented the legacy positional `connect(host, port, servername, verify)`: the `NA_STR` native-table row string-coerced the options object, `js_tls_connect` got no usable host, returned handle `0`, and the NaN-boxed null handle made every `client.on(...)`/`client.write(...)` trip the runtime's null-pointer guard while the test hung forever.

Two more gaps sat behind it, both exercised by the same test:

1. **The https server had none of the #4905 connection machinery** — no `'connection'` events, and `closeAllConnections`/`closeIdleConnections` were silent no-op stubs; `server.close()` never closed idle keep-alive sockets.
2. **Idleness ignored half-received requests** — `busy` only increments when hyper dispatches a complete request head, so a connection mid-way through *sending* a request (client1 in the test) counted as idle and would be destroyed by `server.close()`; Node keeps it.

## Changes

- **`tls.connect` overloads** (`perry-ext-net/src/tls.rs` + bundled copy in `perry-stdlib/src/net/mod.rs`, kept in sync): resolves `connect(options[, cb])`, `connect(port[, host][, options][, cb])`, and the legacy positional form from raw NaN-boxed args. Honors `host`/`hostname`/`servername`/`rejectUnauthorized`; the callback registers as a `'secureConnect'` listener (ext-net's pump now fires `'secureConnect'` alongside `'connect'`). Native-table row switched to `NA_F64 ×4`; the dynamic `js_tls_native_dispatch` arm passes args through raw and returns `undefined` (not a null handle) when the args are unresolvable.
- **https connection tracking** (`perry-ext-http-server`): the https accept loop now registers each connection in the shared #4905 `CONNECTIONS` registry, queues `'connection'` events (the pump drain now probes `HttpsServer` handles too), and selects on the close `Notify`. `closeAllConnections`/`closeIdleConnections` are real (the former delegates to the http variant for the shared `IN_FLIGHT` finalization), and `https server.close()` destroys idle keep-alive sockets (Node 19+).
- **`ReadActivity` idleness tracking** (http + https accept loops): a passthrough stream wrapper flags request bytes received since the last dispatched request, so "currently sending a request" connections survive idle sweeps. For https it wraps the *decrypted* stream so handshake traffic doesn't count. The flag resets at service entry (`busy` covers in-flight from there).
- **Latent `CryptoProvider` panic**: with no tls/https *server* in the process (servers install the provider), the first real client handshake panicked in rustls ("could not automatically determine the process-level CryptoProvider"). Both client connector builders now install the default provider idempotently. Pre-fix this was masked on the static-table path because the host never resolved — `test-files/test_tls_connect.ts` (legacy positional form against github.com) goes **FAIL → OK** with this PR.
- Manifest row for `tls.connect` updated to all-`any` params + `docs/api/perry.d.ts` regenerated (`./scripts/regen_api_docs.sh`, drift-clean).
- New e2e test `test-files/test_issue_4971_tls_connect_options.ts` (self-contained embedded cert): options-form connect, `'connection'` counting, idle-only `close()` (mid-request client survives), then `closeAllConnections()`.

## Acceptance vs. the corpus test

`test-https-server-close-idle` **no longer crashes** — zero `[NULL_PTR_METHOD_CALL]`, real sockets, and the close-idle semantics verified end-to-end by the new test (client1 mid-request survives `close()`, idle client2 is destroyed, `closeAllConnections()` takes client1 down). The corpus test itself still times out, but on a *pre-existing, unrelated* byte-framing diff: its success condition waits for the chunked terminator (`response.endsWith('0\r\n\r\n')`) and asserts `Connection:` header casing, while Perry/hyper responds with `content-length: 0` and lowercase header names. That's the #2132/#4909/#4910 response-framing tail, out of scope here.

## Validation

- Repro before/after: baseline binary printed `[NULL_PTR_METHOD_CALL] ... 'on'` ×3 + `'write'` and hung; fixed binary has zero null-pointer hits.
- New e2e test passes; `test_tls_connect.ts` FAIL → OK; `test_issue_3199_3200_tls_server_tlssocket.ts` now runs its intended happy path (baseline silently ignored the no-verify flag and failed the handshake on the test's expired cert).
- `test_net_socket.ts`, `test_net_upgrade_tls.ts`, `test_issue_3196_3198_tls_helpers.ts`: byte-identical output vs baseline.
- `cargo test` green for `perry-ext-net`, `perry-ext-http-server`, `perry-api-manifest`; `check_file_size.sh` clean (`js_tls_connect` lives in ext-net's `tls.rs` to stay under the 2000-line gate).
- Corpus SET-diff (https + net APIs, fixed vs baseline binary): **identical buckets, zero flips** — per-API counts and sampled test sets byte-equal between the two reports (https: 7 pass / 38 runtime-fail, net: 14 pass / 2 diff / 84 runtime-fail / 1 compile-fail; 146 judged). Baseline ran in a pristine `origin/main` worktree so auto-optimize linked unmodified ext crates.

Code-only PR — version bump + changelog folded at merge per repo convention.
