### PR TITLE
fix(publish): sanitize server-controlled artifact path (GHSA-x55v-q459-68ch)

### DIFF
--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -13,6 +13,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use tokio_tungstenite::tungstenite::Message;
+use url::Url;
 use walkdir::WalkDir;
 
 use crate::{OutputFormat, Platform};
@@ -1789,10 +1790,25 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
                 }
 
                 fs::create_dir_all(&args.output)?;
-                let dest = args.output.join(&name);
+                // `name` is supplied verbatim by the build server over the
+                // WebSocket. Reduce it to a bare, traversal-free file name so a
+                // malicious hub cannot write outside the output directory
+                // (GHSA-x55v-q459-68ch).
+                let safe_name = sanitize_artifact_name(&name)?;
+                let dest = args.output.join(&safe_name);
 
                 if let Some(ref src_path) = download_path {
-                    // Local path available (self-hosted hub) - copy directly
+                    // `download_path` is also server-controlled. A filesystem
+                    // path is only meaningful when the hub shares this machine's
+                    // filesystem; honoring it for a remote hub would let a
+                    // malicious server copy out any file the user can read
+                    // (GHSA-x55v-q459-68ch, Path B). Fall back to HTTP otherwise.
+                    if !server_is_local(&server_url) {
+                        bail!(
+                            "Hub at {server_url} reported a local artifact path ({src_path}) but is not a local hub; refusing to read from an arbitrary local path"
+                        );
+                    }
+                    // Local path available (self-hosted hub on this machine) - copy directly
                     fs::copy(src_path, &dest)
                         .with_context(|| format!("Failed to copy artifact from {src_path}"))?;
                 } else {
@@ -1873,6 +1889,42 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
     }
 
     Ok(())
+}
+
+/// Reduce a server-supplied artifact name to a single, traversal-free file
+/// name. The build server controls this value over the WebSocket, so it must
+/// never be able to escape the chosen output directory: absolute paths, `..`,
+/// `.`, and embedded path separators are all rejected (GHSA-x55v-q459-68ch).
+fn sanitize_artifact_name(name: &str) -> Result<String> {
+    let trimmed = name.trim();
+    let is_unsafe = trimmed.is_empty()
+        || trimmed == "."
+        || trimmed == ".."
+        || trimmed.contains('/')
+        || trimmed.contains('\\')
+        // Anything whose final path component is not exactly the input (drive
+        // prefixes, embedded NULs, platform-specific separators, ...).
+        || Path::new(trimmed).file_name().and_then(|s| s.to_str()) != Some(trimmed);
+
+    if is_unsafe {
+        bail!("Server sent an unsafe artifact name {name:?}; refusing to write outside the output directory");
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Whether the resolved hub URL points at the local machine. Used to gate the
+/// `download_path` local-copy shortcut, which trusts a server-controlled local
+/// filesystem path (GHSA-x55v-q459-68ch, Path B).
+fn server_is_local(server_url: &str) -> bool {
+    match Url::parse(server_url) {
+        Ok(u) => match u.host() {
+            Some(url::Host::Domain(d)) => d.eq_ignore_ascii_case("localhost"),
+            Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+            Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+            None => false,
+        },
+        Err(_) => false,
+    }
 }
 
 pub(crate) async fn auto_register_license(server_url: &str) -> Result<String> {

--- a/crates/perry/src/commands/publish/tests.rs
+++ b/crates/perry/src/commands/publish/tests.rs
@@ -439,3 +439,50 @@ fn test_validate_passes_when_all_present() {
     );
     assert!(result.is_ok());
 }
+
+// --- GHSA-x55v-q459-68ch: server-controlled artifact path handling ---
+
+#[test]
+fn test_sanitize_artifact_name_accepts_plain_names() {
+    assert_eq!(sanitize_artifact_name("app.zip").unwrap(), "app.zip");
+    assert_eq!(sanitize_artifact_name("MyGame-1.2.3.dmg").unwrap(), "MyGame-1.2.3.dmg");
+    // Surrounding whitespace is trimmed, not treated as part of the name.
+    assert_eq!(sanitize_artifact_name("  app.ipa  ").unwrap(), "app.ipa");
+}
+
+#[test]
+fn test_sanitize_artifact_name_rejects_traversal() {
+    for evil in [
+        "../../.ssh/authorized_keys",
+        "../x",
+        "a/b",
+        "a/../b",
+        "/etc/cron.d/x",
+        "/etc/passwd",
+        "..",
+        ".",
+        "",
+        "   ",
+        "foo/bar.zip",
+        "..\\windows\\system32",
+        "C:\\Users\\victim\\evil.exe",
+    ] {
+        assert!(
+            sanitize_artifact_name(evil).is_err(),
+            "expected {evil:?} to be rejected as unsafe"
+        );
+    }
+}
+
+#[test]
+fn test_server_is_local() {
+    assert!(server_is_local("http://localhost:3000"));
+    assert!(server_is_local("https://LOCALHOST"));
+    assert!(server_is_local("http://127.0.0.1:8080"));
+    assert!(server_is_local("http://[::1]:9000"));
+
+    assert!(!server_is_local("https://hub.perryts.com"));
+    assert!(!server_is_local("https://attacker.example.com"));
+    assert!(!server_is_local("http://10.0.0.5:3000"));
+    assert!(!server_is_local("not a url"));
+}

--- a/crates/perry/src/commands/publish/tests.rs
+++ b/crates/perry/src/commands/publish/tests.rs
@@ -445,7 +445,10 @@ fn test_validate_passes_when_all_present() {
 #[test]
 fn test_sanitize_artifact_name_accepts_plain_names() {
     assert_eq!(sanitize_artifact_name("app.zip").unwrap(), "app.zip");
-    assert_eq!(sanitize_artifact_name("MyGame-1.2.3.dmg").unwrap(), "MyGame-1.2.3.dmg");
+    assert_eq!(
+        sanitize_artifact_name("MyGame-1.2.3.dmg").unwrap(),
+        "MyGame-1.2.3.dmg"
+    );
     // Surrounding whitespace is trimmed, not treated as part of the name.
     assert_eq!(sanitize_artifact_name("  app.ipa  ").unwrap(), "app.ipa");
 }


### PR DESCRIPTION
## Summary

Fixes the path-traversal / arbitrary-file-write reported in **GHSA-x55v-q459-68ch**.

`perry publish` processes `ArtifactReady` WebSocket messages from the build server and used the server-supplied `artifact_name` (and `download_path`) **verbatim** when building the local destination path. Since `PathBuf::join` does not normalize `..` or reject absolute paths, a malicious/compromised hub could:

- **Arbitrary write (Path A & B destination):** deliver `artifact_name = "../../.ssh/authorized_keys"` (or an absolute path) and have downloaded content written anywhere the process can write.
- **Arbitrary local read (Path B):** in the self-hosted-hub local-copy path, set `download_path` to any local file (e.g. `~/.aws/credentials`) and have it copied into the output directory.

The primary multi-victim vector is a malicious PR setting `[publish] server = "https://attacker…"` in a repo's `perry.toml`; CI runs (`--no-interactive` / non-TTY) get no confirmation prompt.

## Fix

- **`sanitize_artifact_name()`** reduces the server-supplied name to a single, traversal-free file name (rejects empty, `.`, `..`, embedded `/` or `\`, absolute/drive-prefixed paths) before it's joined onto the output dir. This closes the arbitrary-write vector for both paths.
- **`server_is_local()`** gates the `download_path` local-copy shortcut to loopback hubs only (`localhost`, `127.0.0.0/8`, `::1`). A remote hub's local filesystem path is meaningless and is no longer honored — remote hubs fall back to the existing HTTP download. This closes the arbitrary local-file-read vector.

## Tests

Added unit tests in `commands/publish/tests.rs`:
- accepted plain names (incl. whitespace trimming)
- a battery of traversal/absolute/separator payloads, all rejected
- the loopback gate (`localhost`/`127.0.0.1`/`[::1]` allowed; public hosts, private LAN IPs, and unparseable URLs rejected)

`cargo test -p perry --bins publish::tests` → 27 passed, 0 failed.

## Notes

- No behavioral change for legitimate runs: artifact names are normally bare filenames, and the local-copy shortcut only applied to same-machine self-hosted hubs (still allowed via loopback). Remote self-hosted hubs that previously relied on a shared-filesystem `download_path` will transparently fall back to HTTP download.
- Heads-up: this PR references an advisory that is still in triage. If you'd prefer to land it privately first, it can instead go through the advisory's temporary private fork before publishing.