### PR TITLE
chore(release): v0.5.1158 — roll-up changelog + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v0.5.1158 — release roll-up: stub-elimination epic tail, React render walls, http/cluster/streams parity
+
+Version-bump + changelog roll-up for the 16 commits that landed after the
+v0.5.1157 bump without per-commit metadata (maintainer-folds-at-merge PRs).
+No code changes in this commit itself.
+
+- feat(runtime): real AsyncLocalStorage + async_hooks context propagation (#788/#789) (#4967)
+- feat(runtime): real child_process spawn/exec ChildProcess handle semantics (#2130/#1934) (#4968)
+- feat(streams): BYOB readers + real ByteLengthQueuingStrategy accounting (#4915) (#4966)
+- feat(cluster): workers share a listening port — SO_REUSEPORT + IPC 'listening' round-trip (#4914) (#4963)
+- feat(diagnostics): real v8 heap snapshot from GC heap walk + inspector/repl honesty (#4916) (#4979)
+- fix(hir,codegen,runtime): clear the #4950 React render-time walls — JSX createElement mode, nested-fn branch-var hoisting, timer/AbortController values, surrogate-range regex classes (#4969)
+- fix(http): client write/end callbacks + backpressure, real client timeouts, dynamic listener registration (#4909) (#4964)
+- fix(http): wire res.write/res.end callbacks + backpressure boolean into static dispatch (#4909) (#4954)
+- fix(http): falsy ClientRequest method defaults to GET instead of throwing (#4970) (#4978)
+- fix(net,ext-http): tls.connect Node overloads + https idle-connection close path (#4971) (#4983)
+- fix(hir): lower inline `export default class` bodies — methods/fields survive (#4976) (#4981)
+- fix(hir): synthesized capture ctor on a derived class must call super() (#4972) (#4980)
+- fix(hir): self-named native member base no longer OOM-loops codegen (#4908) (#4955)
+- fix(compile): support package createRequire interop (#4960)
+- perf(runtime): optimize numeric array raw payload helpers (#4957)
+- test(codegen): unbreak typed_shape_descriptors after #4957 bulk-fill lowering (#4984)
+
 ## v0.5.1157 — feat(atomics): real cross-agent `Atomics.wait`/`notify`/`waitAsync` over a shared SAB (#4913)
 
 Stage 2 of #4913 (Stage 1 — the honesty floor — landed in #4929). `Atomics.wait`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1157
+**Current Version:** 0.5.1158
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5289,7 +5289,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "base64",
@@ -5344,14 +5344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "cc",
  "libc",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "log",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "base64",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5460,14 +5460,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "serde",
  "serde_json",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1157"
+version = "0.5.1158"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "clap",
@@ -5501,14 +5501,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "bytes",
  "h2",
@@ -5678,7 +5678,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5688,7 +5688,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "bson",
  "futures-util",
@@ -5727,7 +5727,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5768,7 +5768,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "image",
@@ -5802,14 +5802,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5826,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5836,7 +5836,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5848,7 +5848,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "brotli",
  "flate2",
@@ -5857,7 +5857,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5866,7 +5866,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5883,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "base64",
@@ -5927,7 +5927,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6019,7 +6019,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6037,14 +6037,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "itoa",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "block2",
@@ -6110,7 +6110,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "block2",
@@ -6125,7 +6125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1157"
+version = "0.5.1158"
 
 [[package]]
 name = "perry-ui-test"
@@ -6133,11 +6133,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1157"
+version = "0.5.1158"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "block2",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "block2",
@@ -6169,7 +6169,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "block2",
  "libc",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "libc",
@@ -6199,14 +6199,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1157"
+version = "0.5.1158"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1157"
+version = "0.5.1158"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
Release prep for **v0.5.1158**.

Main is 69 commits ahead of the last tag (v0.5.1151); the last 16 of those landed after the v0.5.1157 bump without version/changelog metadata (maintainer-folds-at-merge PRs). This PR:

- bumps `[workspace.package].version` 0.5.1157 → 0.5.1158 (+ `Cargo.lock`, `CLAUDE.md` version line)
- prepends a `## v0.5.1158` CHANGELOG roll-up entry listing those 16 commits

Metadata only — no code changes. After merge: tag `v0.5.1158` + publish the GitHub release (kicks Tests/parity/compile-smoke, Simulator Tests, and the Release Packages publish gate).