### PR TITLE
fix(https): certless createServer() listens; _http_server.kConnectionsCheckingInterval (#4974)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -4649,6 +4649,11 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     // helpers validate header tokens/values or are deterministic no-ops.
     property("http", "maxHeaderSize"),
     property("http", "globalAgent"),
+    // #4974 — `require('_http_server').kConnectionsCheckingInterval`
+    // (Perry aliases `_http_server` to `http`). Node exports a Symbol
+    // tests use as `server[k]._destroyed`; Perry resolves it to the
+    // sentinel key the server handle dispatch recognizes.
+    property("http", "kConnectionsCheckingInterval"),
     method("http", "validateHeaderName", false, None),
     method("http", "validateHeaderValue", false, None),
     method("http", "setMaxIdleHTTPParsers", false, None),

--- a/crates/perry-ext-http-server/src/handle_dispatch.rs
+++ b/crates/perry-ext-http-server/src/handle_dispatch.rs
@@ -401,6 +401,29 @@ pub unsafe extern "C" fn js_ext_http_server_dispatch_property(
     let is_h2 = get_handle::<Http2SecureServer>(handle).is_some();
     match property.as_str() {
         "listening" => bool_value(server_is_listening(handle, is_https, is_h2)),
+        // #4974: `server[kConnectionsCheckingInterval]` — the
+        // `_http_server` introspection key resolves to Node's
+        // connections-checking interval timer; tests assert on its
+        // `_destroyed` flag after `close()`. Perry has no such timer,
+        // so synthesize the minimal Timeout shape from the tracked flag.
+        "@@kConnectionsCheckingInterval" => {
+            let destroyed = if is_h2 {
+                get_handle::<Http2SecureServer>(handle)
+                    .map(|s| s.base.connections_checking_interval_destroyed)
+            } else if is_https {
+                get_handle::<HttpsServer>(handle)
+                    .map(|s| s.base.connections_checking_interval_destroyed)
+            } else {
+                get_handle::<HttpServer>(handle).map(|s| s.connections_checking_interval_destroyed)
+            };
+            match destroyed {
+                Some(d) => {
+                    let json = format!("{{\"_destroyed\":{}}}", d);
+                    json_string_value(alloc_string(&json).as_raw())
+                }
+                None => undef,
+            }
+        }
         "headersTimeout" => {
             server_base_property(handle, is_https, is_h2, |s| s.headers_timeout).unwrap_or(undef)
         }

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -1960,6 +1960,7 @@ pub unsafe extern "C" fn js_node_http2_server_close(handle: i64, callback: i64) 
     let close_listeners;
     if let Some(s) = get_handle_mut::<Http2SecureServer>(handle) {
         s.base.listening = false;
+        s.base.connections_checking_interval_destroyed = true;
         s.base.shutdown_tx.take();
         close_listeners = s.base.listeners.get("close").cloned().unwrap_or_default();
     } else {

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -34,8 +34,8 @@ use crate::server::{
     CONNECTIONS, NEXT_CONNECTION_ID, PENDING_CONNECTION_EVENTS,
 };
 use crate::tls::{
-    build_server_config, has_pem_material, json_value_to_pem_bytes, parse_cert_chain,
-    parse_private_key,
+    build_certless_server_config, build_server_config, has_pem_material, json_value_to_pem_bytes,
+    parse_cert_chain, parse_private_key,
 };
 
 /// Decode `{ key, cert, alpnProtocols? }` from a NaN-boxed JsValue
@@ -97,12 +97,22 @@ pub unsafe extern "C" fn js_node_https_create_server(opts_f64: f64, handler: i64
 
     let cert_chain = parse_cert_chain(&cert_pem);
     let has_tls_material = has_pem_material(&key_pem, &cert_pem);
+    if !has_tls_material {
+        // `https.createServer()` with no key/cert — Node constructs and
+        // listens fine; the handshake fails per-connection instead. A
+        // `None` config here used to make `listen()` refuse outright
+        // ("tls config unavailable"), so the 'listening' callback never
+        // fired (#4974).
+        return register_handle(HttpsServer {
+            handler,
+            tls_config: Some(build_certless_server_config(enable_http2_alpn)),
+            base,
+        });
+    }
     let private_key = match parse_private_key(&key_pem) {
         Some(k) => k,
         None => {
-            if has_tls_material {
-                eprintln!("[node:https] no recognized PEM private key");
-            }
+            eprintln!("[node:https] no recognized PEM private key");
             // Still register the handle so the user gets a `.listen`
             // call that fails with a clear bind error rather than a
             // silent zero-handle.
@@ -483,6 +493,7 @@ pub unsafe extern "C" fn js_node_https_server_close(handle: i64, callback: i64) 
     let close_listeners;
     if let Some(s) = get_handle_mut::<HttpsServer>(handle) {
         s.base.listening = false;
+        s.base.connections_checking_interval_destroyed = true;
         s.base.shutdown_tx.take();
         close_listeners = s.base.listeners.get("close").cloned().unwrap_or_default();
     } else {

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -110,6 +110,14 @@ pub struct HttpServer {
     pub no_delay: bool,
     pub keep_alive: bool,
     pub keep_alive_initial_delay: f64,
+    /// #4974 — mirrors Node's `server[kConnectionsCheckingInterval]`
+    /// timer state: Node creates the interval in the `Server`
+    /// constructor and `clearInterval`s it in `close()`, so the timer's
+    /// `_destroyed` flips to `true` once the server closes. Perry has
+    /// no such timer (the hyper accept loop owns connection lifecycle),
+    /// so we track just the flag the `_http_server` introspection key
+    /// exposes.
+    pub connections_checking_interval_destroyed: bool,
 }
 
 impl HttpServer {
@@ -139,6 +147,7 @@ impl HttpServer {
             no_delay: true,
             keep_alive: false,
             keep_alive_initial_delay: 0.0,
+            connections_checking_interval_destroyed: false,
         }
     }
 }
@@ -678,6 +687,7 @@ pub unsafe extern "C" fn js_node_http_server_close(server_handle: i64, callback:
     let close_listeners;
     if let Some(s) = get_handle_mut::<HttpServer>(server_handle) {
         s.listening = false;
+        s.connections_checking_interval_destroyed = true;
         s.shutdown_tx.take();
         close_listeners = s.listeners.get("close").cloned().unwrap_or_default();
     } else {

--- a/crates/perry-ext-http-server/src/tls.rs
+++ b/crates/perry-ext-http-server/src/tls.rs
@@ -79,6 +79,38 @@ pub fn parse_private_key(pem_bytes: &[u8]) -> Option<PrivateKeyDer<'static>> {
     None
 }
 
+/// Build a `ServerConfig` for an `https.Server` constructed without
+/// key/cert material — `https.createServer()` with empty (or omitted)
+/// options. Node constructs and `listen()`s such a server fine; the
+/// missing credentials only surface per-connection, as a TLS alert
+/// during the handshake. The always-`None` cert resolver reproduces
+/// that: rustls accepts the TCP connection, then aborts the handshake
+/// with a fatal alert when no certificate resolves (#4974).
+pub fn build_certless_server_config(enable_http2: bool) -> Arc<ServerConfig> {
+    ensure_crypto_provider_installed();
+
+    #[derive(Debug)]
+    struct NoCert;
+    impl rustls::server::ResolvesServerCert for NoCert {
+        fn resolve(
+            &self,
+            _client_hello: rustls::server::ClientHello<'_>,
+        ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+            None
+        }
+    }
+
+    let mut config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_cert_resolver(Arc::new(NoCert));
+    if enable_http2 {
+        config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    } else {
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    }
+    Arc::new(config)
+}
+
 /// rustls 0.23 requires explicit selection of a CryptoProvider when
 /// multiple providers are linked into the binary (perry transitively
 /// pulls in both `ring` via our direct dep and `aws-lc-rs` via

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -7529,6 +7529,15 @@ pub(crate) unsafe fn get_native_module_constant(
                 b"WebSocket".as_ptr(),
                 "WebSocket".len(),
             )),
+            // #4974: `require('_http_server').kConnectionsCheckingInterval`
+            // (the module aliases to "http" in cjs_wrap). Node exports a
+            // Symbol used as `server[k]` to reach the connections-checking
+            // interval timer; Perry represents it as a sentinel string key
+            // the ext-http server handle dispatch recognizes, mirroring the
+            // `@@__perry_wk_*` well-known-symbol encoding.
+            "kConnectionsCheckingInterval" => {
+                Some(native_string_value("@@kConnectionsCheckingInterval"))
+            }
             _ => None,
         },
         "https" => match property {

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -1954,6 +1954,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
                 | "addListener"
                 | "setTimeout"
                 | "@@__perry_wk_asyncDispose"
+                | "@@kConnectionsCheckingInterval"
                 | "listening"
                 | "headersTimeout"
                 | "keepAliveTimeout"

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1924 entries across 111 modules
+// Coverage: 1925 entries across 111 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -1745,6 +1745,8 @@ declare module "http" {
   export const STATUS_CODES: any;
   /** stdlib */
   export const globalAgent: any;
+  /** stdlib */
+  export const kConnectionsCheckingInterval: any;
   /** stdlib */
   export const maxHeaderSize: any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2781 entries across 114 modules.
+Total: 2782 entries across 114 modules.
 
 ## Modules
 
@@ -1605,6 +1605,7 @@ Total: 2781 entries across 114 modules.
 - `METHODS`
 - `STATUS_CODES`
 - `globalAgent`
+- `kConnectionsCheckingInterval`
 - `maxHeaderSize`
 
 ## `http2`


### PR DESCRIPTION
Fixes #4974.

## Root cause

`test-https-server-async-dispose` calls **`https.createServer()` with no options at all** — no key, no cert. Node constructs such a server and `listen()` succeeds (the missing credentials only surface per-connection, as a TLS alert during the handshake). Perry stored `tls_config: None` and `listen()` bailed with `[node:https] tls config unavailable; refusing to listen` **before** queueing the deferred `'listening'` emit — so the listen callback never fired and the test hung. Async-dispose was a red herring; the options were never "torn down", they were never there.

The test additionally asserts `server[kConnectionsCheckingInterval]._destroyed` via `require('_http_server')`, which Perry didn't export.

## Fix

- **`tls.rs`**: new `build_certless_server_config()` — a rustls `ServerConfig` with an always-`None` cert resolver. The server binds, listens, and accepts TCP; each TLS handshake aborts with a fatal alert (Node-equivalent failure mode).
- **`https_server.rs`**: the no-PEM-material path (`has_pem_material() == false`) now registers the certless config instead of `tls_config: None`. Supplied-but-unparseable key/cert keeps the existing refuse-to-listen behavior.
- **`kConnectionsCheckingInterval`**: exported from the `http` module arm (`_http_server` aliases to `http` in cjs_wrap) as a sentinel string key, plus an api-manifest entry so the static property read isn't compile-time-lowered to `undefined`. `server[k]` resolves through the ext-http server handle dispatch to a minimal `{ _destroyed }` Timeout shape; the flag lives on `HttpServer` and is set by all three close paths (http / https / http2).
- Docs (`perry.d.ts`, `reference.md`) regenerated via `scripts/regen_api_docs.sh`.

## Verification

All compiled with this branch's `perry` + auto-optimized ext crates, against the Node v22 corpus tests staged with the `test-compat/node-core/shim` common:

| test | before | after |
|---|---|---|
| `test-https-server-async-dispose` | hang (timeout), "tls config unavailable" | exit 0, all `mustCall`s fire |
| `test-http-server-async-dispose` | — | exit 0 |
| `test-http2-server-async-dispose` | — | exit 0 |
| with-key/cert https server + `https.get` round-trip (regression) | — | `body: ok`, exit 0 |

Behavior cross-checked against `node` v26 (certless server listens, disposes, `_destroyed === true`).

`cargo test -p perry-ext-http-server -p perry-api-manifest` green (23 + 36), `cargo fmt --check` clean, file-size gate OK.

No version bump / changelog — maintainer folds metadata at merge.