### PR TITLE
fix(http): node:http 'upgrade' inherits-pattern + raw-socket upgrades (#4973)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5664,6 +5664,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "lazy_static",
+ "perry-ext-net",
  "perry-ext-ws",
  "perry-ffi",
  "perry-runtime",

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -376,8 +376,9 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         has_receiver: true,
         method: "setEncoding",
         class_filter: Some("Socket"),
-        runtime: "js_net_socket_noop_self",
-        args: &[],
+        // #4973: real setEncoding — switches 'data' delivery to strings.
+        runtime: "js_net_socket_set_encoding",
+        args: &[NA_STR],
         ret: NR_PTR,
     },
     NativeModSig {

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -319,5 +319,23 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         &[DOUBLE, DOUBLE, DOUBLE],
     );
 
+    // #4973: util.inherits-era `http(s).Server.call(this, handler)` + real
+    // `socket.setEncoding(enc)`. Declared here (rather than in stdlib_ffi.rs)
+    // to keep that file under the 2000-line CI gate. The server-ctor pair
+    // lives in perry-runtime (routes through JS_NATIVE_HTTP_DISPATCH) so it
+    // links for every program; args are NaN-boxed JSValues.
+    let server_ctor_args = &[DOUBLE, DOUBLE, DOUBLE];
+    module.declare_function(
+        "js_http_server_construct_with_this",
+        DOUBLE,
+        server_ctor_args,
+    );
+    module.declare_function(
+        "js_https_server_construct_with_this",
+        DOUBLE,
+        server_ctor_args,
+    );
+    module.declare_function("js_net_socket_set_encoding", I64, &[I64, I64]);
+
     declare_stdlib_ffi(module);
 }

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -194,19 +194,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_http_server_listening", I32, &[I64]);
     module.declare_function("js_node_http_server_listening_value", DOUBLE, &[I64]);
     module.declare_function("js_node_http_server_on", DOUBLE, &[I64, I64, I64]);
-    // #4973: util.inherits-era `http(s).Server.call(this, handler)` — lives
-    // in perry-runtime (JS_NATIVE_HTTP_DISPATCH); args are NaN-boxed JSValues.
-    let server_ctor_args = &[DOUBLE, DOUBLE, DOUBLE];
-    module.declare_function(
-        "js_http_server_construct_with_this",
-        DOUBLE,
-        server_ctor_args,
-    );
-    module.declare_function(
-        "js_https_server_construct_with_this",
-        DOUBLE,
-        server_ctor_args,
-    );
+    // #4973 http(s).Server.call(this,…) + net socket.setEncoding decls live in
+    // objects.rs's declare chain to keep this file under the 2000-line gate.
     // IncomingMessage:
     module.declare_function("js_node_http_im_method", I64, &[I64]);
     module.declare_function("js_node_http_im_url", I64, &[I64]);
@@ -1712,8 +1701,6 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // setTimeout takes (socket handle, msecs:DOUBLE, callback:I64).
     module.declare_function("js_net_validate_create_server_options", VOID, &[DOUBLE]);
     module.declare_function("js_net_socket_set_timeout", I64, &[I64, DOUBLE, I64]);
-    // #4973: real `socket.setEncoding(enc)` — string-delivery for 'data'.
-    module.declare_function("js_net_socket_set_encoding", I64, &[I64, I64]);
     // Issue #1123 followup — `net.Server` instance method FFIs. The
     // NA_PTR slot for callbacks is `I64` here (closures arrive as raw
     // pointer-bits after the codegen's `unbox_to_i64` lowering); ports

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -194,6 +194,19 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_node_http_server_listening", I32, &[I64]);
     module.declare_function("js_node_http_server_listening_value", DOUBLE, &[I64]);
     module.declare_function("js_node_http_server_on", DOUBLE, &[I64, I64, I64]);
+    // #4973: util.inherits-era `http(s).Server.call(this, handler)` — lives
+    // in perry-runtime (JS_NATIVE_HTTP_DISPATCH); args are NaN-boxed JSValues.
+    let server_ctor_args = &[DOUBLE, DOUBLE, DOUBLE];
+    module.declare_function(
+        "js_http_server_construct_with_this",
+        DOUBLE,
+        server_ctor_args,
+    );
+    module.declare_function(
+        "js_https_server_construct_with_this",
+        DOUBLE,
+        server_ctor_args,
+    );
     // IncomingMessage:
     module.declare_function("js_node_http_im_method", I64, &[I64]);
     module.declare_function("js_node_http_im_url", I64, &[I64]);
@@ -1699,6 +1712,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     // setTimeout takes (socket handle, msecs:DOUBLE, callback:I64).
     module.declare_function("js_net_validate_create_server_options", VOID, &[DOUBLE]);
     module.declare_function("js_net_socket_set_timeout", I64, &[I64, DOUBLE, I64]);
+    // #4973: real `socket.setEncoding(enc)` — string-delivery for 'data'.
+    module.declare_function("js_net_socket_set_encoding", I64, &[I64, I64]);
     // Issue #1123 followup — `net.Server` instance method FFIs. The
     // NA_PTR slot for callbacks is `I64` here (closures arrive as raw
     // pointer-bits after the codegen's `unbox_to_i64` lowering); ports

--- a/crates/perry-ext-http-server/Cargo.toml
+++ b/crates/perry-ext-http-server/Cargo.toml
@@ -16,6 +16,11 @@ perry-ffi.workspace = true
 # listeners receive a ws_id usable through the rest of the
 # perry-ext-ws FFI surface (`js_ws_send` / `js_ws_close` / `js_ws_on`).
 perry-ext-ws = { path = "../perry-ext-ws" }
+# #4973: raw-socket `'upgrade'` handoff. perry-ext-net exposes
+# `adopt_upgraded_tcp_stream(TcpStream) -> i64` so keyless Upgrade requests
+# reach JS as a standard net.Socket with nothing written to the wire
+# (Node semantics) — see raw_upgrade.rs.
+perry-ext-net = { path = "../perry-ext-net" }
 hyper = { version = "1.4", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["server", "server-auto", "tokio"] }
 h2 = "0.4"

--- a/crates/perry-ext-http-server/src/handle_dispatch.rs
+++ b/crates/perry-ext-http-server/src/handle_dispatch.rs
@@ -47,6 +47,15 @@ extern "C" {
         event_name_ptr: *const StringHeader,
         callback: i64,
     ) -> f64;
+    fn js_node_http_server_remove_all_listeners(
+        handle: i64,
+        event_name_ptr: *const StringHeader,
+    ) -> f64;
+    fn js_node_http_server_remove_listener(
+        handle: i64,
+        event_name_ptr: *const StringHeader,
+        callback: i64,
+    ) -> f64;
     fn js_node_http_server_set_timeout_method(handle: i64, msecs: f64, callback: i64) -> i64;
     fn js_node_https_server_listen(server_handle: i64, args_array: i64) -> i64;
     fn js_node_https_server_close(server_handle: i64, callback: i64);
@@ -198,6 +207,9 @@ pub const HTTP_SERVER_METHODS: &[&str] = &[
     "address",
     "on",
     "addListener",
+    "removeAllListeners",
+    "removeListener",
+    "off",
     "setTimeout",
     "@@__perry_wk_asyncDispose",
 ];
@@ -211,6 +223,9 @@ fn http_server_method_bytes(name: &str) -> Option<&'static [u8]> {
         "address" => Some(b"address"),
         "on" => Some(b"on"),
         "addListener" => Some(b"addListener"),
+        "removeAllListeners" => Some(b"removeAllListeners"),
+        "removeListener" => Some(b"removeListener"),
+        "off" => Some(b"off"),
         "setTimeout" => Some(b"setTimeout"),
         "@@__perry_wk_asyncDispose" => Some(b"@@__perry_wk_asyncDispose"),
         _ => None,
@@ -345,6 +360,30 @@ pub unsafe extern "C" fn js_ext_http_server_dispatch_method(
                 js_node_https_server_on(handle, event_ptr, cb);
             } else {
                 js_node_http_server_on(handle, event_ptr, cb);
+            }
+            self_ref
+        }
+        // #4973: `server.removeAllListeners([event])` — http/1 only for now
+        // (https/h2 listener registries wrap an HttpServer base; the http
+        // entry covers the plain `node:http` surface the upgrade tests use).
+        "removeAllListeners" => {
+            let event_ptr = args
+                .first()
+                .map(|&a| string_arg(a))
+                .unwrap_or(std::ptr::null());
+            if !is_h2 && !is_https {
+                js_node_http_server_remove_all_listeners(handle, event_ptr);
+            }
+            self_ref
+        }
+        "removeListener" | "off" if args.len() >= 2 => {
+            let event_ptr = string_arg(args[0]);
+            if event_ptr.is_null() {
+                return self_ref;
+            }
+            let cb = closure_arg(Some(args[1]));
+            if !is_h2 && !is_https {
+                js_node_http_server_remove_listener(handle, event_ptr, cb);
             }
             self_ref
         }

--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -59,6 +59,7 @@ mod http2_session_settings;
 mod http2_settings;
 mod http2_stream_props;
 mod https_server;
+mod raw_upgrade;
 mod request;
 mod response;
 mod server;

--- a/crates/perry-ext-http-server/src/raw_upgrade.rs
+++ b/crates/perry-ext-http-server/src/raw_upgrade.rs
@@ -1,0 +1,223 @@
+//! #4973 — Node-semantics raw-socket `'upgrade'` dispatch.
+//!
+//! Node's `http.Server` emits `'upgrade'` with `(req, socket, head)` where
+//! `socket` is the **raw net.Socket** and *nothing* has been written to the
+//! connection — the listener composes its own `101` response bytes. The
+//! pre-existing Phase-4 path (upgrade.rs) instead let hyper write a 101 and
+//! wrapped the stream in a tungstenite WebSocket — fine for the
+//! `WebSocketServer({ server })` integration, but wrong for the classic
+//! handshake-by-hand servers (`test-http-upgrade-server`): hyper's 101 plus
+//! the listener's handwritten 101 would both reach the client, and the
+//! unconsumed body bytes (`head`) were lost.
+//!
+//! This module adds the Node-exact path for *keyless* Upgrade requests
+//! (no `Sec-WebSocket-Key` — i.e. not a real WebSocket client handshake):
+//!
+//! 1. When the server has `'upgrade'` listeners, the accept task peeks the
+//!    request head off the TCP stream *before* handing anything to hyper.
+//! 2. If the head carries `Connection: …upgrade…` + an `Upgrade:` header and
+//!    no `Sec-WebSocket-Key`, the stream is handed to perry-ext-net
+//!    (`adopt_upgraded_tcp_stream`) so JS sees a standard `net.Socket`
+//!    surface, and the `'upgrade'` listeners fire with the unconsumed bytes
+//!    after the head as `head`.
+//! 3. Anything else (no Upgrade header, real WS handshakes, oversized or
+//!    truncated heads) is replayed to hyper byte-for-byte through
+//!    `PrefixedStream`, preserving today's behavior.
+//!
+//! Real WebSocket handshakes (key present) deliberately keep the
+//! tungstenite path so `new WebSocketServer({ server })` keeps working.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+
+use crate::request::alloc_incoming_message;
+use crate::request::IncomingMessage;
+use crate::server::HttpPendingUpgrade;
+
+/// Replays an already-read prefix before the live stream. Write side passes
+/// straight through.
+pub(crate) struct PrefixedStream<S> {
+    prefix: Vec<u8>,
+    pos: usize,
+    inner: S,
+}
+
+impl<S> PrefixedStream<S> {
+    pub(crate) fn new(prefix: Vec<u8>, inner: S) -> Self {
+        Self {
+            prefix,
+            pos: 0,
+            inner,
+        }
+    }
+
+    pub(crate) fn empty(inner: S) -> Self {
+        Self::new(Vec::new(), inner)
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for PrefixedStream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        if this.pos < this.prefix.len() {
+            let remaining = &this.prefix[this.pos..];
+            let n = remaining.len().min(buf.remaining());
+            buf.put_slice(&remaining[..n]);
+            this.pos += n;
+            if this.pos >= this.prefix.len() {
+                this.prefix = Vec::new();
+                this.pos = 0;
+            }
+            return Poll::Ready(Ok(()));
+        }
+        Pin::new(&mut this.inner).poll_read(cx, buf)
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for PrefixedStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
+pub(crate) enum PeekResult {
+    /// Raw upgrade dispatched; the stream now lives in perry-ext-net.
+    Handled,
+    /// Not a raw upgrade — continue to hyper, replaying the peeked bytes.
+    Passthrough(PrefixedStream<TcpStream>),
+}
+
+/// Cap on the peeked head. Node's llhttp default max header size is 16 KiB;
+/// we allow 64 KiB before giving up and replaying to hyper (which enforces
+/// its own limits).
+const MAX_HEAD: usize = 64 * 1024;
+
+fn find_head_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|p| p + 4)
+}
+
+/// Peek the request head and dispatch a raw `'upgrade'` if it qualifies.
+/// Only called when the server has `'upgrade'` listeners.
+pub(crate) async fn peek_and_maybe_dispatch_raw_upgrade(
+    server_handle: i64,
+    peer: SocketAddr,
+    mut stream: TcpStream,
+    upgrade_tx: &mpsc::Sender<HttpPendingUpgrade>,
+) -> PeekResult {
+    let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    let mut tmp = [0u8; 8 * 1024];
+    let head_end = loop {
+        if let Some(pos) = find_head_end(&buf) {
+            break Some(pos);
+        }
+        if buf.len() >= MAX_HEAD {
+            break None;
+        }
+        match stream.read(&mut tmp).await {
+            Ok(0) => break None,
+            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+            Err(_) => break None,
+        }
+    };
+    let Some(head_end) = head_end else {
+        return PeekResult::Passthrough(PrefixedStream::new(buf, stream));
+    };
+
+    let Some((method, url, headers_lower, raw_headers)) = parse_head(&buf[..head_end]) else {
+        return PeekResult::Passthrough(PrefixedStream::new(buf, stream));
+    };
+
+    let connection_upgrade = headers_lower
+        .get("connection")
+        .map(|v| v.to_ascii_lowercase().contains("upgrade"))
+        .unwrap_or(false);
+    let has_upgrade = headers_lower.contains_key("upgrade");
+    let has_ws_key = headers_lower.contains_key("sec-websocket-key");
+    if !connection_upgrade || !has_upgrade || has_ws_key {
+        return PeekResult::Passthrough(PrefixedStream::new(buf, stream));
+    }
+
+    // Raw upgrade: unconsumed bytes after the head become `head` (Node's
+    // `upgradeHead`), the stream becomes a net.Socket.
+    let head_rest = buf[head_end..].to_vec();
+    let mut im = IncomingMessage::new(
+        method,
+        url,
+        headers_lower,
+        raw_headers,
+        Vec::new(),
+        peer.ip().to_string(),
+        peer.port(),
+    );
+    im.complete = true;
+    let im_handle = alloc_incoming_message(im);
+    let socket_id = perry_ext_net::adopt_upgraded_tcp_stream(stream);
+
+    let pending = HttpPendingUpgrade {
+        server_handle,
+        request_handle: im_handle,
+        ws_id: 0,
+        raw_socket_id: socket_id,
+        head: head_rest,
+    };
+    let _ = upgrade_tx.send(pending).await;
+    perry_ffi::notify_main_thread();
+    PeekResult::Handled
+}
+
+/// Minimal HTTP/1.x head parse: request line + headers. Returns
+/// `(method, url, lowercased-name header map, raw (name, value) pairs)`.
+/// `None` on anything that doesn't look like an HTTP request — the caller
+/// replays the bytes to hyper, which produces the proper error response.
+#[allow(clippy::type_complexity)]
+fn parse_head(
+    head: &[u8],
+) -> Option<(
+    String,
+    String,
+    HashMap<String, String>,
+    Vec<(String, String)>,
+)> {
+    let text = std::str::from_utf8(head).ok()?;
+    let mut lines = text.split("\r\n");
+    let request_line = lines.next()?;
+    let mut parts = request_line.split(' ');
+    let method = parts.next()?.to_string();
+    let url = parts.next()?.to_string();
+    let version = parts.next()?;
+    if method.is_empty() || !version.starts_with("HTTP/") {
+        return None;
+    }
+    let mut headers_lower = HashMap::new();
+    let mut raw_headers = Vec::new();
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        let (name, value) = line.split_once(':')?;
+        let value = value.trim_start();
+        headers_lower.insert(name.to_ascii_lowercase(), value.to_string());
+        raw_headers.push((name.to_string(), value.to_string()));
+    }
+    Some((method, url, headers_lower, raw_headers))
+}

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -164,7 +164,15 @@ pub struct HttpPendingRequest {
 pub struct HttpPendingUpgrade {
     pub server_handle: i64,
     pub request_handle: i64,
+    /// WebSocket path (real handshakes with a `Sec-WebSocket-Key`): the
+    /// perry-ext-ws connection id. 0 on the raw path.
     pub ws_id: i64,
+    /// #4973 raw path (keyless Upgrade requests): the perry-ext-net socket
+    /// id adopted from the connection. 0 on the WebSocket path.
+    pub raw_socket_id: i64,
+    /// #4973 raw path: unconsumed bytes that followed the request head —
+    /// Node's `upgradeHead` argument.
+    pub head: Vec<u8>,
 }
 
 // ============================================================================
@@ -587,7 +595,8 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                                 let busy = Arc::new(AtomicUsize::new(0));
                                 let read_active = Arc::new(AtomicBool::new(false));
                                 let close = Arc::new(tokio::sync::Notify::new());
-                                let io = TokioIo::new(ReadActivity::new(stream, read_active.clone()));
+                                let read_active_for_io = read_active.clone();
+                                let upgrade_tx_peek = upgrade_tx_for_spawn.clone();
                                 CONNECTIONS.lock().unwrap().insert(
                                     conn_id,
                                     TrackedConnection {
@@ -601,6 +610,40 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                                     q.push(server_handle);
                                 }
                                 tokio::spawn(async move {
+                                    // #4973 — when `'upgrade'` listeners exist, peek the
+                                    // request head before hyper writes anything: a keyless
+                                    // Upgrade request must reach JS as a raw net.Socket
+                                    // with NO response on the wire (Node semantics). Other
+                                    // connections replay the peeked bytes to hyper.
+                                    let has_upgrade_listeners =
+                                        get_handle::<HttpServer>(server_handle)
+                                            .map(|s| {
+                                                s.listeners
+                                                    .get("upgrade")
+                                                    .map(|v| !v.is_empty())
+                                                    .unwrap_or(false)
+                                            })
+                                            .unwrap_or(false);
+                                    let stream = if has_upgrade_listeners {
+                                        match crate::raw_upgrade::peek_and_maybe_dispatch_raw_upgrade(
+                                            server_handle,
+                                            peer,
+                                            stream,
+                                            &upgrade_tx_peek,
+                                        )
+                                        .await
+                                        {
+                                            crate::raw_upgrade::PeekResult::Handled => {
+                                                CONNECTIONS.lock().unwrap().remove(&conn_id);
+                                                return;
+                                            }
+                                            crate::raw_upgrade::PeekResult::Passthrough(s) => s,
+                                        }
+                                    } else {
+                                        crate::raw_upgrade::PrefixedStream::empty(stream)
+                                    };
+                                    let io =
+                                        TokioIo::new(ReadActivity::new(stream, read_active_for_io));
                                     let service = service_fn(move |req: Request<Incoming>| {
                                         let request_tx = request_tx.clone();
                                         let upgrade_tx = upgrade_tx.clone();
@@ -791,6 +834,50 @@ pub unsafe extern "C" fn js_node_http_server_on(
     handle_to_pointer_f64(handle)
 }
 
+/// `server.removeAllListeners([event])` — drop every listener for `event`,
+/// or every listener for every event when `event_name_ptr` is null (#4973:
+/// test-http-upgrade-server clears its `'upgrade'` listeners between
+/// phases so the next Upgrade request falls through to `'request'`).
+///
+/// # Safety
+/// FFI entry; `event_name_ptr` is either null or a valid StringHeader.
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_server_remove_all_listeners(
+    handle: i64,
+    event_name_ptr: *const StringHeader,
+) -> f64 {
+    if let Some(s) = get_handle_mut::<HttpServer>(handle) {
+        if event_name_ptr.is_null() {
+            s.listeners.clear();
+        } else if let Some(event) = read_string_header(event_name_ptr as *mut _) {
+            s.listeners.remove(&event);
+        }
+    }
+    handle_to_pointer_f64(handle)
+}
+
+/// `server.removeListener(event, cb)` / `server.off(event, cb)` — remove one
+/// registration of `cb` for `event` (last-registered first, matching Node).
+///
+/// # Safety
+/// FFI entry; pointers must be valid.
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_server_remove_listener(
+    handle: i64,
+    event_name_ptr: *const StringHeader,
+    callback: i64,
+) -> f64 {
+    let event = read_string_header(event_name_ptr as *mut _).unwrap_or_default();
+    if let Some(s) = get_handle_mut::<HttpServer>(handle) {
+        if let Some(cbs) = s.listeners.get_mut(&event) {
+            if let Some(pos) = cbs.iter().rposition(|&c| c == callback) {
+                cbs.remove(pos);
+            }
+        }
+    }
+    handle_to_pointer_f64(handle)
+}
+
 // ============================================================================
 // Request dispatch — hyper service fn + main-thread event loop
 // ============================================================================
@@ -829,18 +916,36 @@ async fn handle_request(
     // task that awaits hyper's upgraded stream + completes the
     // tungstenite server handshake + registers the resulting
     // WebSocketStream with perry-ext-ws.
+    //
+    // #4973 gates: (a) Node dispatches an Upgrade request as a normal
+    // `'request'` when the server has no `'upgrade'` listeners — the
+    // unconditional branch used to hijack it into a bogus 101; (b) only a
+    // real WebSocket handshake (`Sec-WebSocket-Key` present) belongs on the
+    // tungstenite path — keyless Upgrade requests are served Node-style by
+    // the raw peek path in raw_upgrade.rs and only reach hyper when no
+    // listener was attached at accept time.
     if crate::upgrade::is_websocket_upgrade(&req) {
-        return handle_websocket_upgrade(
-            server_handle,
-            peer,
-            req,
-            method,
-            url,
-            headers_lower,
-            raw_headers,
-            upgrade_tx,
-        )
-        .await;
+        let has_upgrade_listeners = get_handle::<HttpServer>(server_handle)
+            .map(|s| {
+                s.listeners
+                    .get("upgrade")
+                    .map(|v| !v.is_empty())
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false);
+        if has_upgrade_listeners && req.headers().contains_key("sec-websocket-key") {
+            return handle_websocket_upgrade(
+                server_handle,
+                peer,
+                req,
+                method,
+                url,
+                headers_lower,
+                raw_headers,
+                upgrade_tx,
+            )
+            .await;
+        }
     }
 
     let body_bytes = match req.collect().await {
@@ -971,6 +1076,8 @@ async fn handle_websocket_upgrade(
             server_handle,
             request_handle: im_handle,
             ws_id,
+            raw_socket_id: 0,
+            head: Vec::new(),
         };
         let _ = upgrade_tx.send(pending).await;
         perry_ffi::notify_main_thread();
@@ -1347,12 +1454,25 @@ pub extern "C" fn js_node_http_server_process_pending() -> i32 {
         // Drain upgrades first so they don't get starved by a busy
         // request stream.
         while let Some(up) = try_recv_upgrade(h) {
-            crate::upgrade::fire_upgrade_listeners(
-                up.server_handle,
-                up.request_handle,
-                up.ws_id,
-                Vec::new(),
-            );
+            if up.raw_socket_id != 0 {
+                // #4973 raw path: make sure the adopted net.Socket's
+                // dispatch extensions + GC scanner are registered on the
+                // main thread before user code touches the socket.
+                perry_ext_net::ensure_adopted_socket_dispatch();
+                crate::upgrade::fire_upgrade_listeners(
+                    up.server_handle,
+                    up.request_handle,
+                    up.raw_socket_id,
+                    up.head,
+                );
+            } else {
+                crate::upgrade::fire_upgrade_listeners(
+                    up.server_handle,
+                    up.request_handle,
+                    up.ws_id,
+                    Vec::new(),
+                );
+            }
             count += 1;
         }
         while let Some(p) = try_recv_pending_nonblocking(h) {

--- a/crates/perry-ext-net/src/adopt.rs
+++ b/crates/perry-ext-net/src/adopt.rs
@@ -1,0 +1,96 @@
+//! #4973 — adopt an already-connected TCP stream as a `net.Socket`
+//! (the HTTP raw-`'upgrade'` handoff), plus the base64 helper the
+//! string-encoding data delivery uses. Split out of `lib.rs` to keep it
+//! under the 2000-line CI gate.
+
+use crate::{
+    dispatch, ensure_gc_scanner_registered, next_id, run_socket_task, statics, SocketCommand,
+    SocketState, Transport,
+};
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+
+/// Adopt an already-connected TCP stream as a `net.Socket` handle.
+///
+/// perry-ext-http-server's raw `'upgrade'` path (#4973) calls this: Node
+/// hands the `'upgrade'` listener the raw connection socket with nothing
+/// written to it, so the HTTP accept task peels the request head off the
+/// stream and passes the live stream here. The returned id drives the
+/// standard socket surface (`write` / `end` / `on('data')` / …) through the
+/// existing `run_socket_task` + main-thread pump machinery, exactly like a
+/// socket accepted by `net.createServer`.
+///
+/// Must be called from within a tokio runtime context (the HTTP accept task
+/// qualifies); the per-socket IO loop is spawned on that runtime. Does NOT
+/// register the GC scanner or the runtime dispatch extensions — those are
+/// main-thread-affine; call `ensure_adopted_socket_dispatch()` from the
+/// main thread (the upgrade-event drain does) before user code touches the
+/// socket.
+pub fn adopt_upgraded_tcp_stream(stream: tokio::net::TcpStream) -> i64 {
+    let id = next_id();
+    let (tx, rx) = mpsc::unbounded_channel::<SocketCommand>();
+    let local = stream.local_addr().ok();
+    statics::sockets().lock().unwrap().insert(
+        id,
+        SocketState {
+            cmd_tx: tx,
+            pending_rx: None,
+            is_open: true,
+            local_addr: local,
+            raw: None,
+            destroyed: false,
+            bytes_read: 0,
+            bytes_written: 0,
+            timeout: None,
+            type_of_service: 0,
+            server_id: None,
+        },
+    );
+    statics::listeners()
+        .lock()
+        .unwrap()
+        .insert(id, HashMap::new());
+    tokio::spawn(async move {
+        let mut rx = rx;
+        run_socket_task(id, Transport::Plain(stream), &mut rx).await;
+    });
+    id
+}
+
+/// Main-thread companion to `adopt_upgraded_tcp_stream`: registers the GC
+/// root scanner and the runtime handle-dispatch/pump extensions so an
+/// adopted socket's methods, events, and liveness work even when no other
+/// `js_net_*` entry point has run yet (an http-only program receiving a raw
+/// upgrade).
+pub fn ensure_adopted_socket_dispatch() {
+    ensure_gc_scanner_registered();
+    dispatch::ensure_runtime_dispatch_registered();
+}
+
+/// Minimal standard-alphabet base64 (with padding) for `setEncoding('base64')`
+/// data delivery — avoids pulling a base64 crate into perry-ext-net.
+pub(crate) fn base64_encode(bytes: &[u8]) -> String {
+    const ALPHA: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b = [
+            chunk[0],
+            chunk.get(1).copied().unwrap_or(0),
+            chunk.get(2).copied().unwrap_or(0),
+        ];
+        let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
+        out.push(ALPHA[(n >> 18) as usize & 63] as char);
+        out.push(ALPHA[(n >> 12) as usize & 63] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHA[(n >> 6) as usize & 63] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHA[n as usize & 63] as char
+        } else {
+            '='
+        });
+    }
+    out
+}

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -251,8 +251,24 @@ unsafe fn socket_method(handle: i64, method: &str, args: &[f64]) -> Option<f64> 
             crate::js_net_socket_set_timeout(handle, msecs, callback);
             nanbox_handle(handle)
         }
-        "setNoDelay" | "setKeepAlive" | "setEncoding" | "pause" | "resume" | "ref" | "unref"
-        | "cork" | "uncork" | "setDefaultEncoding" => nanbox_handle(handle),
+        // #4973: real setEncoding — switches 'data' delivery to strings.
+        "setEncoding" => {
+            let enc_ptr = args
+                .first()
+                .map(|a| {
+                    let bits = a.to_bits();
+                    if (bits >> 48) == 0x7FFF {
+                        (bits & 0x0000_FFFF_FFFF_FFFF) as i64
+                    } else {
+                        0
+                    }
+                })
+                .unwrap_or(0);
+            crate::js_net_socket_set_encoding(handle, enc_ptr);
+            nanbox_handle(handle)
+        }
+        "setNoDelay" | "setKeepAlive" | "pause" | "resume" | "ref" | "unref" | "cork"
+        | "uncork" | "setDefaultEncoding" => nanbox_handle(handle),
         _ => undefined(),
     };
     Some(result)

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -72,10 +72,12 @@ use raw_bridge::RawReadState;
 // perry-runtime (split out to keep lib.rs under the 2000-line gate). The
 // `#[no_mangle]` setter/setTimeout symbols re-export at the crate root; the
 // validator `extern` declarations are imported for the listen/connect sites.
+mod adopt;
+pub use adopt::{adopt_upgraded_tcp_stream, ensure_adopted_socket_dispatch};
 mod option_setters;
 pub use option_setters::{
     js_net_server_noop_self, js_net_socket_get_type_of_service, js_net_socket_noop_self,
-    js_net_socket_set_timeout, js_net_socket_set_type_of_service,
+    js_net_socket_set_encoding, js_net_socket_set_timeout, js_net_socket_set_type_of_service,
 };
 use option_setters::{js_net_validate_connect_port, js_net_validate_listen_port};
 
@@ -88,7 +90,7 @@ use crate::tls::do_tls_handshake;
 
 // ─── Transport enum (plain or TLS, swappable at runtime) ─────────────────────
 
-enum Transport {
+pub(crate) enum Transport {
     Plain(TcpStream),
     Tls(Box<TlsStream<TcpStream>>),
 }
@@ -187,6 +189,16 @@ pub(crate) mod statics {
     pub fn servers() -> &'static Mutex<HashMap<i64, ServerState>> {
         static S: OnceLock<Mutex<HashMap<i64, ServerState>>> = OnceLock::new();
         S.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// #4973 — per-socket read encoding set via `socket.setEncoding(enc)`.
+    /// When present, the main-thread pump delivers `'data'` as a decoded
+    /// string instead of a Buffer (Node readable-stream semantics). Side
+    /// table (not a SocketState field) so the many SocketState literal
+    /// constructions stay untouched.
+    pub fn encodings() -> &'static Mutex<HashMap<i64, String>> {
+        static E: OnceLock<Mutex<HashMap<i64, String>>> = OnceLock::new();
+        E.get_or_init(|| Mutex::new(HashMap::new()))
     }
 }
 
@@ -1268,7 +1280,7 @@ pub(crate) fn spawn_socket_task(
 }
 
 /// The read/write/command loop. Shared by plain-TCP and direct-TLS paths.
-async fn run_socket_task(
+pub(crate) async fn run_socket_task(
     id: i64,
     initial_transport: Transport,
     rx: &mut mpsc::UnboundedReceiver<SocketCommand>,
@@ -1524,16 +1536,33 @@ pub unsafe extern "C" fn js_net_process_pending() -> i32 {
                 if cbs.is_empty() {
                     continue;
                 }
-                let buf = alloc_buffer(&bytes);
-                if buf.is_null() {
-                    continue;
-                }
-                // POINTER_TAG over the buffer pointer.
-                let buf_f64 =
-                    f64::from_bits(0x7FFD_0000_0000_0000 | (buf as u64 & 0x0000_FFFF_FFFF_FFFF));
+                // #4973: `socket.setEncoding(enc)` switches 'data' delivery
+                // from Buffers to decoded strings (Node readable-stream
+                // semantics). 'hex'/'base64' render their text forms; the
+                // remaining text encodings decode as UTF-8 (lossy).
+                let encoding = statics::encodings().lock().unwrap().get(&id).cloned();
+                let payload_f64 = if let Some(enc) = encoding {
+                    let s = match enc.as_str() {
+                        "hex" => bytes.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+                        "base64" => adopt::base64_encode(&bytes),
+                        _ => String::from_utf8_lossy(&bytes).into_owned(),
+                    };
+                    let hdr = alloc_string(&s);
+                    f64::from_bits(
+                        0x7FFF_0000_0000_0000 | (hdr.as_raw() as u64 & 0x0000_FFFF_FFFF_FFFF),
+                    )
+                } else {
+                    let buf = alloc_buffer(&bytes);
+                    if buf.is_null() {
+                        continue;
+                    }
+                    // POINTER_TAG over the buffer pointer.
+                    f64::from_bits(0x7FFD_0000_0000_0000 | (buf as u64 & 0x0000_FFFF_FFFF_FFFF))
+                };
                 for cb in cbs {
                     if cb != 0 {
-                        let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call1(buf_f64);
+                        let _ =
+                            JsClosure::from_raw(cb as *const RawClosureHeader).call1(payload_f64);
                     }
                 }
                 lifecycle::drain_once_listeners(id, "data");
@@ -1577,6 +1606,7 @@ pub unsafe extern "C" fn js_net_process_pending() -> i32 {
                 statics::listeners().lock().unwrap().remove(&id);
                 statics::sockets().lock().unwrap().remove(&id);
                 statics::once_flags().lock().unwrap().remove(&id);
+                statics::encodings().lock().unwrap().remove(&id);
             }
             // Issue #1123 followup — server-side events. The
             // accept loop pushes `ServerConnection`/`ServerListening`/

--- a/crates/perry-ext-net/src/option_setters.rs
+++ b/crates/perry-ext-net/src/option_setters.rs
@@ -94,3 +94,27 @@ pub extern "C" fn js_net_socket_set_type_of_service(handle: i64, tos: f64) -> i6
     }
     handle
 }
+
+/// #4973: `socket.setEncoding(enc?)` — record the read encoding so the
+/// main-thread pump delivers `'data'` events as decoded strings (Node
+/// readable-stream semantics). Calling with no/nullish arg clears it
+/// (back to Buffers). Recognized text encodings decode as UTF-8 (lossy);
+/// 'hex'/'base64' render their respective text forms in the pump.
+///
+/// # Safety
+/// `enc_ptr` is either 0 or a StringHeader pointer (codegen NA_STR slot).
+#[no_mangle]
+pub unsafe extern "C" fn js_net_socket_set_encoding(handle: i64, enc_ptr: i64) -> i64 {
+    match crate::string_from_header_i64(enc_ptr) {
+        Some(enc) if !enc.is_empty() => {
+            crate::statics::encodings()
+                .lock()
+                .unwrap()
+                .insert(handle, enc.to_ascii_lowercase());
+        }
+        _ => {
+            crate::statics::encodings().lock().unwrap().remove(&handle);
+        }
+    }
+    handle
+}

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -1492,6 +1492,21 @@ pub(crate) fn lower_var_decl_with_destructuring(
                     *existing_ty = ty.clone();
                 }
                 id
+            } else if let Some(fid) = match &decl.name {
+                // #4973: the function-body hoist pass pre-registered this
+                // exact `let`/`const` declarator (span-keyed) so hoisted
+                // sibling functions could forward-reference it. Reuse the
+                // pre-registered id here so the init lands in the slot/box
+                // those references captured.
+                ast::Pat::Ident(ident) => ctx.lexical_forward_decls.remove(&ident.id.span.lo.0),
+                _ => None,
+            } {
+                if let Some((_, _, existing_ty)) =
+                    ctx.locals.iter_mut().rev().find(|(_, lid, _)| *lid == fid)
+                {
+                    *existing_ty = ty.clone();
+                }
+                fid
             } else if let Some(id) = is_var_decl
                 .then(|| {
                     // Issue #838 followup (b): when the closure-body hoist

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -111,6 +111,7 @@ impl LoweringContext {
             unresolved_ident_as_global: false,
             with_env_stack: Vec::new(),
             var_hoisted_ids: HashSet::new(),
+            lexical_forward_decls: HashMap::new(),
             functions_index: HashMap::new(),
             classes_index: HashMap::new(),
             imported_functions_index: HashMap::new(),

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -1338,6 +1338,47 @@ pub(super) fn try_native_module_method_apply_call(
         return Ok(None);
     }
 
+    // #4973: `http.Server.call(this, handler)` — the util.inherits-era
+    // subclass pattern. For native CLASS exports the thisArg is NOT
+    // irrelevant: Node initializes `this` as the server. Route to the
+    // construct-with-this extern (which constructs the server AND aliases
+    // `this` → handle) instead of dropping the receiver below.
+    if !is_apply && !call.args.is_empty() {
+        let module = ctx
+            .lookup_builtin_module_alias(ns_name)
+            .map(str::to_string)
+            .or_else(|| {
+                ctx.lookup_native_module(ns_name)
+                    .map(|(m, _)| m.to_string())
+            });
+        if let (Some(module), ast::MemberProp::Ident(method_ident)) = (module, &inner.prop) {
+            let normalized = module.strip_prefix("node:").unwrap_or(&module);
+            if matches!(normalized, "http" | "https") && method_ident.sym.as_ref() == "Server" {
+                let mut lowered: Vec<Expr> = call
+                    .args
+                    .iter()
+                    .map(|a| lower_expr(ctx, &a.expr))
+                    .collect::<Result<Vec<_>>>()?;
+                // (this, options?, listener?) — fixed 3-arg extern ABI.
+                lowered.resize(3, Expr::Undefined);
+                let extern_name = if normalized == "https" {
+                    "js_https_server_construct_with_this"
+                } else {
+                    "js_http_server_construct_with_this"
+                };
+                return Ok(Some(Expr::Call {
+                    callee: Box::new(Expr::ExternFuncRef {
+                        name: extern_name.to_string(),
+                        param_types: Vec::new(),
+                        return_type: Type::Any,
+                    }),
+                    args: lowered,
+                    type_args: Vec::new(),
+                }));
+            }
+        }
+    }
+
     // Build the synthesized direct-call argument list at the AST level.
     let synth_args: Vec<ast::ExprOrSpread> = if is_apply {
         match call.args.get(1) {

--- a/crates/perry-hir/src/lower/expr_call/module_class_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_class_static.rs
@@ -119,6 +119,43 @@ pub(super) fn try_module_class_static(
                         if !is_sub_namespace {
                             if let ast::MemberProp::Ident(method_ident) = &outer_member.prop {
                                 let method_name = method_ident.sym.to_string();
+                                // #4973: util.inherits-era subclassing —
+                                // `http.Server.call(this, handler)` inside a
+                                // function constructor. The generic
+                                // NativeMethodCall arm below loses `this`
+                                // (the dispatcher just constructs a server
+                                // from the args), so the instance never
+                                // becomes server-backed. Route to a dedicated
+                                // runtime extern that constructs the server
+                                // AND aliases `this` to the handle.
+                                let normalized =
+                                    module_name.strip_prefix("node:").unwrap_or(module_name);
+                                if matches!(normalized, "http" | "https")
+                                    && class_name == "Server"
+                                    && method_name == "call"
+                                    && !args.is_empty()
+                                {
+                                    let mut it = args.into_iter();
+                                    let this_arg = it.next().unwrap();
+                                    let mut rest: Vec<Expr> = it.collect();
+                                    rest.resize(2, Expr::Undefined);
+                                    let mut call_args = vec![this_arg];
+                                    call_args.extend(rest);
+                                    let extern_name = if normalized == "https" {
+                                        "js_https_server_construct_with_this"
+                                    } else {
+                                        "js_http_server_construct_with_this"
+                                    };
+                                    return Ok(Ok(Expr::Call {
+                                        callee: Box::new(Expr::ExternFuncRef {
+                                            name: extern_name.to_string(),
+                                            param_types: Vec::new(),
+                                            return_type: Type::Any,
+                                        }),
+                                        args: call_args,
+                                        type_args: Vec::new(),
+                                    }));
+                                }
                                 return Ok(Ok(Expr::NativeMethodCall {
                                     module: module_name.to_string(),
                                     class_name: Some(class_name),

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1464,6 +1464,36 @@ pub(super) fn try_native_module_methods(
                             {
                                 return Ok(Ok(event_emitter_constructor_call(args)));
                             }
+                            // #4973: named-import form of the inherits
+                            // pattern — `const { Server } = require('http');
+                            // Server.call(this, handler)`. Same extern as
+                            // the dotted `http.Server.call(...)` form in
+                            // module_class_static.rs.
+                            if matches!(normalized_module, "http" | "https")
+                                && matches!(imported_method, Some("Server"))
+                                && !args.is_empty()
+                            {
+                                let mut it = args.into_iter();
+                                let this_arg = it.next().unwrap();
+                                let mut rest: Vec<Expr> = it.collect();
+                                rest.resize(2, Expr::Undefined);
+                                let mut call_args = vec![this_arg];
+                                call_args.extend(rest);
+                                let extern_name = if normalized_module == "https" {
+                                    "js_https_server_construct_with_this"
+                                } else {
+                                    "js_http_server_construct_with_this"
+                                };
+                                return Ok(Ok(Expr::Call {
+                                    callee: Box::new(Expr::ExternFuncRef {
+                                        name: extern_name.to_string(),
+                                        param_types: Vec::new(),
+                                        return_type: Type::Any,
+                                    }),
+                                    args: call_args,
+                                    type_args: Vec::new(),
+                                }));
+                            }
                         }
                         // Unimplemented-API gate (#463 / #525) for the 2-deep
                         // `mod.method()` call form. Without this, perry/* and

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -686,6 +686,57 @@ pub(crate) fn lower_fn_expr(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) ->
                 }
             }
         }
+        // #4973: pre-register top-level `let`/`const` Ident bindings of this
+        // function body so a hoisted sibling FUNCTION that references them
+        // before their lexical position binds the (boxed) function-scope
+        // local instead of falling through to a global read. The classic
+        // Node test shape (test-http-upgrade-server):
+        //   function t() { … server.close(); }
+        //   const server = createTestServer();
+        //   server.listen(0, () => t());
+        // JS hoists the *binding* (with a TDZ Perry is lax about); pre-fix,
+        // `server` inside `t` lowered to a globalThis read → undefined.
+        // Gated on the body containing at least one hoisted function
+        // declaration — the only consumers that can legally observe the
+        // binding before its source position — to bound the blast radius.
+        // Keyed by declarator-ident span: the Let site in var_decl.rs reuses
+        // the id only for the *exact* declarator (`lexical_forward_decls`),
+        // so a shadowing `const` in an inner block still gets a fresh
+        // binding.
+        let body_has_fn_decl = block
+            .stmts
+            .iter()
+            .any(|s| matches!(s, ast::Stmt::Decl(ast::Decl::Fn(_))));
+        if body_has_fn_decl {
+            for stmt in &block.stmts {
+                if let ast::Stmt::Decl(ast::Decl::Var(var_decl)) = stmt {
+                    if matches!(
+                        var_decl.kind,
+                        ast::VarDeclKind::Let | ast::VarDeclKind::Const
+                    ) {
+                        for decl in &var_decl.decls {
+                            if let ast::Pat::Ident(ident) = &decl.name {
+                                let name = ident.id.sym.to_string();
+                                let already_in_scope =
+                                    ctx.locals.iter().enumerate().rev().any(|(idx, (n, _, _))| {
+                                        n == &name && idx >= outer_locals_len
+                                    });
+                                if !already_in_scope {
+                                    let id = ctx.define_local(name, Type::Any);
+                                    // Boxed-capture semantics: a closure
+                                    // created before the init must see the
+                                    // post-init value through the box, not a
+                                    // snapshot of the empty slot.
+                                    ctx.var_hoisted_ids.insert(id);
+                                    hoisted_id_set.insert(id);
+                                    ctx.lexical_forward_decls.insert(ident.id.span.lo.0, id);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
         // #4950: pre-register `var` bindings nested inside compound
         // statements (if/else arms, loops, try/catch, switch) of this
         // function body. `var` is function-scoped, so react's

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -349,6 +349,15 @@ pub struct LoweringContext {
     /// continue to lexically shadow the object environment.
     pub(crate) with_env_stack: Vec<WithEnvFrame>,
     pub(crate) var_hoisted_ids: HashSet<LocalId>,
+    /// #4973: top-of-function-body `let`/`const` Ident bindings pre-registered
+    /// by the function-body hoist pass so hoisted sibling FUNCTIONS that
+    /// reference them before their lexical position bind the (boxed) local
+    /// instead of falling through to a global read (the classic Node test
+    /// shape: `function t() { server.close(); }` … `const server = …`).
+    /// Keyed by the declarator-ident span (`span.lo.0`) so ONLY the exact
+    /// declarator reuses the id at its Let site — a shadowing `const` in an
+    /// inner block still lowers a fresh binding.
+    pub(crate) lexical_forward_decls: HashMap<u32, LocalId>,
     /// Shadow index: function name -> index in `functions` Vec (last entry for shadowing)
     pub(crate) functions_index: HashMap<String, usize>,
     /// Shadow index: class name -> index in `classes` Vec

--- a/crates/perry-runtime/src/object/class_handles.rs
+++ b/crates/perry-runtime/src/object/class_handles.rs
@@ -282,6 +282,34 @@ pub fn handle_property_dispatch() -> Option<HandlePropertyDispatchFn> {
     }
 }
 
+/// #4973: the PRIMARY (stdlib) handle method dispatcher only, skipping the
+/// extension dispatchers. The inherits-alias forwarding uses this because it
+/// KNOWS its handle is an http(s) server handle — going through the
+/// composite would let an id-colliding extension registry (an ext-net
+/// socket with the same small id) claim shared method names like
+/// `address`/`on` first and answer for the wrong object.
+#[inline]
+pub(crate) fn handle_method_dispatch_primary() -> Option<HandleMethodDispatchFn> {
+    let p = HANDLE_METHOD_DISPATCH_PTR.load(Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute::<*mut (), HandleMethodDispatchFn>(p) })
+    }
+}
+
+/// Primary-only sibling of `handle_property_dispatch` — see
+/// `handle_method_dispatch_primary`.
+#[inline]
+pub(crate) fn handle_property_dispatch_primary() -> Option<HandlePropertyDispatchFn> {
+    let p = HANDLE_PROPERTY_DISPATCH_PTR.load(Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute::<*mut (), HandlePropertyDispatchFn>(p) })
+    }
+}
+
 #[inline]
 pub fn handle_property_set_dispatch() -> Option<HandlePropertySetDispatchFn> {
     if has_extension(&HANDLE_PROPERTY_SET_EXTENSION_DISPATCH_PTRS) {

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -2679,6 +2679,15 @@ pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Opt
     // and have NO `prototype` own property (`C.prototype.m.prototype === undefined`,
     // `'prototype' in C.prototype.m === false`). (Test262 definition method/accessor
     // prop-desc.)
+    //
+    // #4973 exception: bound NATIVE-MODULE *class* exports (`http.Server`,
+    // `https.Server`) are constructors in Node, and the util.inherits-era
+    // subclass pattern reads their `.prototype` as a setPrototypeOf operand
+    // (`Object.setPrototypeOf(testServer.prototype, http.Server.prototype)`).
+    // Returning None here made that read `undefined` and the setPrototypeOf
+    // threw "Object prototype may only be an Object or null". These exports
+    // are cached singleton closures (NATIVE_CALLABLE_EXPORTS), so the
+    // synthetic-class path below gives them a stable prototype object.
     {
         let jv = crate::value::JSValue::from_bits(func_value.to_bits());
         if jv.is_pointer() {
@@ -2687,7 +2696,16 @@ pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Opt
                 && is_valid_obj_ptr(cptr as *const u8)
                 && crate::closure::closure_is_bound_method(cptr)
             {
-                return None;
+                let is_native_class_export = unsafe {
+                    super::native_module::bound_native_callable_module_and_method(func_value)
+                }
+                .map(|(module, method)| {
+                    matches!(module.as_str(), "http" | "https") && method == "Server"
+                })
+                .unwrap_or(false);
+                if !is_native_class_export {
+                    return None;
+                }
             }
         }
     }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -5172,6 +5172,22 @@ pub extern "C" fn js_object_get_field_by_name_f64(
     // routes `.constructor` to the global Date constructor closure and every
     // other key to `undefined` without derefing the small cell as an object.
     let value = js_object_get_field_by_name(obj, key);
+    // #4973: inherits-pattern instances (`http.Server.call(this, …)`) —
+    // a read that missed every layer forwards to the aliased native handle
+    // so `server.listen` / `server.address` resolve to bound callables on
+    // the codegen static-typed read-then-call path.
+    if value.bits() == crate::value::TAG_UNDEFINED
+        && super::native_this_alias::alias_active()
+        && !key.is_null()
+    {
+        if let Some(name) = unsafe { super::has_own_helpers::str_from_string_header(key) } {
+            if let Some(fwd) =
+                super::native_this_alias::alias_forward_property_read(obj as usize, name)
+            {
+                return fwd;
+            }
+        }
+    }
     f64::from_bits(value.bits())
 }
 

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -53,6 +53,7 @@ mod native_module_crypto_random;
 mod native_module_dispatch;
 mod native_module_dispatch_crypto;
 mod native_module_stream;
+mod native_this_alias;
 mod object_literal_ops;
 mod object_ops;
 mod object_ops_frozen;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -4341,6 +4341,12 @@ pub unsafe extern "C" fn js_native_call_method(
                 let prev_this = IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits()));
                 let result = crate::closure::js_native_call_value(object, rest_ptr, rest_len);
                 IMPLICIT_THIS.with(|c| c.set(prev_this));
+                // #4973: `http.Server.call(this, handler)` — the inherits
+                // pattern. Alias the explicit `this` object to the handle the
+                // native class export constructed.
+                super::native_this_alias::maybe_alias_explicit_this_construction(
+                    object, this_arg, result,
+                );
                 return result;
             }
             // #3662: `Function.prototype.call.call(x, …)` on a non-callable
@@ -4434,6 +4440,11 @@ pub unsafe extern "C" fn js_native_call_method(
                 let result =
                     crate::closure::js_native_call_value(object, call_args_ptr, call_args_len);
                 IMPLICIT_THIS.with(|c| c.set(prev_this));
+                // #4973: `http.Server.apply(this, args)` — same inherits
+                // pattern as the `call` arm above.
+                super::native_this_alias::maybe_alias_explicit_this_construction(
+                    object, this_arg, result,
+                );
                 return result;
             }
             // #3662: `Function.prototype.apply.call(x, …)` on a non-callable
@@ -4962,6 +4973,32 @@ pub unsafe extern "C" fn js_native_call_method(
                     id,
                     method_name.as_ptr(),
                     method_name.len(),
+                    args.as_ptr(),
+                    args.len(),
+                );
+            }
+        }
+    }
+
+    // #4973: inherits-pattern instances (`http.Server.call(this, …)`) forward
+    // method calls that missed every user-defined dispatch layer (own fields,
+    // vtable, prototype walk) to their aliased native handle, so
+    // `server.listen(...)` / `server.on(...)` on the plain-object `this`
+    // behave as calls on the underlying server. See native_this_alias.rs.
+    if super::native_this_alias::alias_active() {
+        if let Some(handle_val) = super::native_this_alias::alias_handle_for_object(object) {
+            // Dispatch through the PRIMARY handle dispatcher only: the alias
+            // handle is known to be an http(s) server handle, and the
+            // composite's extension dispatchers (ext-net) may own an
+            // id-colliding socket that would claim shared names like
+            // `address`/`on` first.
+            if let Some(dispatch) = super::class_handles::handle_method_dispatch_primary() {
+                let handle = (handle_val.to_bits() & crate::value::POINTER_MASK) as i64;
+                let args = refreshed_args();
+                return dispatch(
+                    handle,
+                    method_name_ptr as *const u8,
+                    method_name_len,
                     args.as_ptr(),
                     args.len(),
                 );

--- a/crates/perry-runtime/src/object/native_this_alias.rs
+++ b/crates/perry-runtime/src/object/native_this_alias.rs
@@ -1,0 +1,298 @@
+//! #4973: util.inherits-era construction over native-module classes.
+//!
+//! The classic pre-class Node subclass pattern constructs through an
+//! explicit-`this` parent call:
+//!
+//! ```js
+//! function testServer() {
+//!   http.Server.call(this, () => {});
+//!   this.on('connection', ...);
+//! }
+//! Object.setPrototypeOf(testServer.prototype, http.Server.prototype);
+//! const server = new testServer();
+//! server.listen(0, cb);
+//! ```
+//!
+//! Perry's `http.Server` is a bound native-module export whose invocation
+//! creates a *handle* (a small integer id dispatched through
+//! `HANDLE_METHOD_DISPATCH`), not an initialization of `this`. The `.call`
+//! return value is discarded by the pattern, so `this` stayed a plain object
+//! and every subsequent `server.on(...)` / `server.listen(...)` failed.
+//!
+//! Fix: when a bound native *class* export is invoked through
+//! `Function.prototype.call` / `.apply` with an explicit plain-object `this`,
+//! record an alias `this → handle`. `js_native_call_method` consults the
+//! alias for object receivers with no own method of that name and forwards
+//! the call to the handle, so the instance behaves as the native object.
+//!
+//! Storage is a small Vec (alias count is tiny — one per inherits-style
+//! server) with a GC root scanner that keeps both the object and the handle
+//! value alive and rewrites the object pointer if the GC moves it.
+
+use crate::value::JSValue;
+use std::cell::{Cell, RefCell};
+
+struct AliasEntry {
+    /// Raw heap address of the user object (`this`). Rewritten by the GC
+    /// scanner when the object is evacuated. Keyed by address (not NaN-box
+    /// bits) because `this` reaches the runtime both NaN-boxed
+    /// (POINTER_TAG) and as a raw i64 pointer bit-cast to f64, depending on
+    /// the codegen path.
+    obj_addr: usize,
+    /// NaN-boxed handle value the object forwards to.
+    handle_bits: u64,
+}
+
+/// Extract a plausible ObjectHeader address from a value that may be
+/// NaN-boxed (POINTER_TAG) or a raw i64 pointer bit-cast to f64 (top 16
+/// bits zero — the codegen's I64 object convention). 0 = not an object.
+fn object_addr_of(value: f64) -> usize {
+    let bits = value.to_bits();
+    let top = bits >> 48;
+    let addr = if top == 0x7FFD {
+        (bits & crate::value::POINTER_MASK) as usize
+    } else if top == 0 {
+        bits as usize
+    } else {
+        return 0;
+    };
+    if crate::value::addr_class::is_above_handle_band(addr) {
+        addr
+    } else {
+        0
+    }
+}
+
+thread_local! {
+    static ALIAS_ACTIVE: Cell<bool> = const { Cell::new(false) };
+    static ALIASES: RefCell<Vec<AliasEntry>> = const { RefCell::new(Vec::new()) };
+}
+
+static SCANNER_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+fn scan_alias_roots(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    ALIASES.with(|a| {
+        for entry in a.borrow_mut().iter_mut() {
+            visitor.visit_usize_slot(&mut entry.obj_addr);
+            visitor.visit_nanbox_u64_slot(&mut entry.handle_bits);
+        }
+    });
+}
+
+/// Cheap per-call gate for `js_native_call_method`: true only after at least
+/// one alias has been registered on this thread.
+#[inline]
+pub(crate) fn alias_active() -> bool {
+    ALIAS_ACTIVE.with(|c| c.get())
+}
+
+/// Look up the forwarding handle for an object receiver (NaN-boxed or raw
+/// pointer value).
+pub(crate) fn alias_handle_for_object(receiver: f64) -> Option<f64> {
+    let addr = object_addr_of(receiver);
+    if addr == 0 {
+        return None;
+    }
+    ALIASES.with(|a| {
+        a.borrow()
+            .iter()
+            .find(|e| e.obj_addr == addr)
+            .map(|e| f64::from_bits(e.handle_bits))
+    })
+}
+
+/// True when `(module, method)` names a native-module class export whose
+/// explicit-`this` invocation should alias the receiver to the constructed
+/// handle. Kept narrow: the inherits pattern in the wild targets the server
+/// classes; widen deliberately, with tests, if more show up.
+fn is_aliasable_native_class(module: &str, method: &str) -> bool {
+    matches!(module, "http" | "https") && matches!(method, "Server" | "createServer")
+}
+
+/// Called from the `Function.prototype.call` / `.apply` arms after the callee
+/// returned. Registers `this_arg → result` when the callee is a bound native
+/// class export, `this_arg` is a plain heap object, and `result` is a native
+/// handle.
+pub(crate) fn maybe_alias_explicit_this_construction(callee: f64, this_arg: f64, result: f64) {
+    // Callee must be a bound native-module class export.
+    let Some((module, method)) =
+        (unsafe { super::native_module::bound_native_callable_module_and_method(callee) })
+    else {
+        return;
+    };
+    if !is_aliasable_native_class(&module, &method) {
+        return;
+    }
+    // Result must be a NaN-boxed small handle.
+    let result_jv = JSValue::from_bits(result.to_bits());
+    if !result_jv.is_pointer() {
+        return;
+    }
+    let handle_addr = (result.to_bits() & crate::value::POINTER_MASK) as usize;
+    if !crate::value::addr_class::is_small_handle(handle_addr) {
+        return;
+    }
+    // `this` must be a real heap object (not a closure, not another handle).
+    // Accept both the NaN-boxed and the raw-i64-pointer object shapes.
+    let obj_addr = object_addr_of(this_arg);
+    if obj_addr == 0
+        || !super::is_valid_obj_ptr(obj_addr as *const u8)
+        || crate::closure::is_closure_ptr(obj_addr)
+    {
+        return;
+    }
+
+    SCANNER_REGISTERED.call_once(|| {
+        crate::gc::gc_register_mutable_root_scanner_named(
+            "runtime:native-this-alias",
+            scan_alias_roots,
+        );
+    });
+    ALIASES.with(|a| {
+        let mut aliases = a.borrow_mut();
+        if let Some(existing) = aliases.iter_mut().find(|e| e.obj_addr == obj_addr) {
+            existing.handle_bits = result.to_bits();
+        } else {
+            aliases.push(AliasEntry {
+                obj_addr,
+                handle_bits: result.to_bits(),
+            });
+        }
+    });
+    ALIAS_ACTIVE.with(|c| c.set(true));
+}
+
+/// Property-read forwarding companion to `alias_handle_for_object`: when a
+/// by-name read on an aliased object missed every layer (returned
+/// undefined), re-dispatch the read against the aliased native handle so
+/// `server.address` / `server.listen` read as bound callables — codegen's
+/// static `Named("<fn>")` paths read the method as a property value first,
+/// then call it. Returns None when the receiver has no alias or the handle
+/// dispatcher yields undefined.
+pub(crate) fn alias_forward_property_read(obj_addr: usize, key: &str) -> Option<f64> {
+    if !alias_active() || obj_addr == 0 {
+        return None;
+    }
+    let handle_bits = ALIASES.with(|a| {
+        a.borrow()
+            .iter()
+            .find(|e| e.obj_addr == obj_addr)
+            .map(|e| e.handle_bits)
+    })?;
+    let handle = (handle_bits & crate::value::POINTER_MASK) as i64;
+    // Primary dispatcher only — see handle_method_dispatch_primary (an
+    // id-colliding ext-net socket must not answer for the server).
+    let dispatch = super::class_handles::handle_property_dispatch_primary()?;
+    let value = unsafe { dispatch(handle, key.as_ptr(), key.len()) };
+    if value.to_bits() == crate::value::TAG_UNDEFINED {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+/// Shared implementation for the `js_http(s)_server_construct_with_this`
+/// externs: dispatch `(module, "Server")` through the registered native
+/// http dispatcher with the (up to 2) constructor args, then alias
+/// `this_val` to the resulting handle.
+unsafe fn construct_native_server_with_this(module: &str, this_val: f64, a0: f64, a1: f64) -> f64 {
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let ptr = crate::value::JS_NATIVE_HTTP_DISPATCH.load(std::sync::atomic::Ordering::SeqCst);
+    if ptr.is_null() {
+        return undefined;
+    }
+    let dispatch: unsafe extern "C" fn(
+        *const u8,
+        usize,
+        *const u8,
+        usize,
+        *const f64,
+        usize,
+    ) -> f64 = std::mem::transmute(ptr);
+    // Trim trailing undefined padding so the dispatcher's arg
+    // classification sees the same arity the source call had.
+    let args = [a0, a1];
+    let mut len = args.len();
+    while len > 0 && args[len - 1].to_bits() == crate::value::TAG_UNDEFINED {
+        len -= 1;
+    }
+    let method = "Server";
+    let result = dispatch(
+        module.as_ptr(),
+        module.len(),
+        method.as_ptr(),
+        method.len(),
+        args.as_ptr(),
+        len,
+    );
+
+    // Alias `this` → handle (same gates as the .call/.apply arm path).
+    let result_jv = JSValue::from_bits(result.to_bits());
+    let handle_addr = (result.to_bits() & crate::value::POINTER_MASK) as usize;
+    let obj_addr = object_addr_of(this_val);
+    if result_jv.is_pointer()
+        && crate::value::addr_class::is_small_handle(handle_addr)
+        && obj_addr != 0
+        && super::is_valid_obj_ptr(obj_addr as *const u8)
+        && !crate::closure::is_closure_ptr(obj_addr)
+    {
+        SCANNER_REGISTERED.call_once(|| {
+            crate::gc::gc_register_mutable_root_scanner_named(
+                "runtime:native-this-alias",
+                scan_alias_roots,
+            );
+        });
+        ALIASES.with(|a| {
+            let mut aliases = a.borrow_mut();
+            if let Some(existing) = aliases.iter_mut().find(|e| e.obj_addr == obj_addr) {
+                existing.handle_bits = result.to_bits();
+            } else {
+                aliases.push(AliasEntry {
+                    obj_addr,
+                    handle_bits: result.to_bits(),
+                });
+            }
+        });
+        ALIAS_ACTIVE.with(|c| c.set(true));
+    }
+    result
+}
+
+/// #4973: `http.Server.call(this, handler)` — HIR-lowered entry. Constructs
+/// the server through the stdlib dispatcher and aliases `this` to the
+/// handle so subsequent `this.on(...)` / `server.listen(...)` calls on the
+/// plain-object instance forward to the server.
+///
+/// # Safety
+/// FFI entry from generated code; args are NaN-boxed JS values.
+#[no_mangle]
+pub unsafe extern "C" fn js_http_server_construct_with_this(
+    this_val: f64,
+    a0: f64,
+    a1: f64,
+) -> f64 {
+    construct_native_server_with_this("http", this_val, a0, a1)
+}
+
+/// #4973: `https.Server.call(this, ...)` twin of the above.
+///
+/// # Safety
+/// FFI entry from generated code; args are NaN-boxed JS values.
+#[no_mangle]
+pub unsafe extern "C" fn js_https_server_construct_with_this(
+    this_val: f64,
+    a0: f64,
+    a1: f64,
+) -> f64 {
+    construct_native_server_with_this("https", this_val, a0, a1)
+}
+
+/// Keepalive anchors: the auto-optimize whole-program LLVM rebuild
+/// dead-strips `#[no_mangle]` fns referenced only from generated `.o`
+/// files. See the `KEEP_JS_FUNCTION_BIND` precedent in closure/dispatch.rs.
+#[used]
+static KEEP_HTTP_SERVER_CONSTRUCT_WITH_THIS: unsafe extern "C" fn(f64, f64, f64) -> f64 =
+    js_http_server_construct_with_this;
+#[used]
+static KEEP_HTTPS_SERVER_CONSTRUCT_WITH_THIS: unsafe extern "C" fn(f64, f64, f64) -> f64 =
+    js_https_server_construct_with_this;

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -830,7 +830,12 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
             "listen" | "close" | "address" | "on" | "addListener" | "setTimeout"
         ) || matches!(
             method_name,
-            "closeAllConnections" | "closeIdleConnections" | "@@__perry_wk_asyncDispose"
+            "closeAllConnections"
+                | "closeIdleConnections"
+                | "removeAllListeners"
+                | "removeListener"
+                | "off"
+                | "@@__perry_wk_asyncDispose"
         );
         if is_http_server_method && unsafe { js_ext_http_server_is_handle(handle) } != 0 {
             return unsafe {


### PR DESCRIPTION
Fixes #4973.

## Summary

`test-http-upgrade-server` threw `TypeError: Object prototype may only be an Object or null`, and once that cleared a cascade of follow-on failures surfaced. The shared root is the classic util.inherits-era subclass pattern applied to a native class export:

```js
function testServer() {
  http.Server.call(this, () => {});
  this.on('upgrade', (req, socket, head) => { socket.write('HTTP/1.1 101 …'); … });
}
Object.setPrototypeOf(testServer.prototype, http.Server.prototype);
Object.setPrototypeOf(testServer, http.Server);
const server = new testServer();
server.listen(0, cb);
```

Perry's `http.Server` is a *bound native export* that, when called, constructs a server **handle** (a small integer dispatched through `HANDLE_METHOD_DISPATCH`) rather than initializing `this`. Every layer of that pattern needed work.

## Fixes (in dependency order)

1. **`http.Server.prototype` is an object** — bound native class exports (http/https `Server`) now expose a singleton `.prototype` via `ordinary_function_prototype_value_for_read`, so the `setPrototypeOf` operand is an object instead of `undefined`.

2. **`this`-aliasing for `Server.call(this, …)`** — new `perry-runtime/object/native_this_alias.rs`. The HIR lowers `http(s).Server.call/apply(this, …)` (dotted, named-import, and `ns.method.call` forms) to `js_http(s)_server_construct_with_this`, which constructs the server through the stdlib dispatcher and records a `this → handle` alias. Method calls and property reads on the aliased plain object forward to the native handle — through the **primary** dispatcher only, so an id-colliding ext-net socket can't answer for shared names like `address`/`on`.

3. **Lexical forward-declaration hoisting** — a hoisted sibling function that references a later top-level `let`/`const` (`function t(){ server.close() } … const server = …`) now binds the boxed function-scope local instead of reading `globalThis` → `undefined`. Gated on the body containing a function declaration; span-keyed so an inner-block shadow still gets a fresh binding.

4. **Raw-socket `'upgrade'`** — keyless Upgrade requests (no `Sec-WebSocket-Key`) are peeked off the TCP stream before hyper, adopted into perry-ext-net as a real `net.Socket` (`adopt_upgraded_tcp_stream`), and dispatched to `'upgrade'` listeners as `(req, socket, head)` with nothing written to the wire — Node semantics. Real WebSocket handshakes keep the tungstenite path. An Upgrade request with **no** `'upgrade'` listener now falls through to `'request'`.

5. **`server.removeAllListeners` / `removeListener` / `off`** in the ext-http-server handle dispatcher.

6. **Real `socket.setEncoding(enc)`** — `'data'` is delivered as a decoded string (hex/base64/utf-8) instead of a Buffer; cleared on socket close.

`perry-ext-net/adopt.rs` was split out to keep `lib.rs` under the 2000-line CI gate.

## Acceptance

`test-http-upgrade-server` no longer throws and runs to completion (all three phases: upgrade-with-listener, upgrade-no-listener → request, standard HTTP).

## Testing

- Target test passes end-to-end under Perry; byte-compared against `node --experimental-strip-types`.
- `net` and `http` parity suites: 100%.
- Gap suite: 0-regression vs `origin/main` baseline (the lone `test_gap_node_fs` delta is a known flake under sweep load — passes in isolation).
- `perry-hir` + `perry-codegen` unit tests green; `perry-runtime` green except the pre-existing `date::test_full_year_setters_revive_invalid_date_only` macOS failure (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)