### PR TITLE
fix(hir,runtime,stdlib): bare `events` specifier resolves to full EventEmitter (#4995)

### DIFF
--- a/crates/perry-ext-events/src/lib.rs
+++ b/crates/perry-ext-events/src/lib.rs
@@ -141,6 +141,13 @@ extern "C" {
     fn js_register_event_emitter_get_domain(f: unsafe extern "C" fn(i64) -> i64);
     fn js_register_event_emitter_set_domain(f: unsafe extern "C" fn(i64, i64) -> i32);
     fn js_register_event_emitter_on(f: unsafe extern "C" fn(i64, i64, i64) -> i64);
+    // #4995: serve dynamic `new` on the bound `events.EventEmitter` export
+    // value (`require('events')`, default import, namespace property read)
+    // so the runtime's `js_dynamic_new` constructs a real emitter instead of
+    // falling through to the generic empty-object path.
+    fn js_set_native_events_construct(
+        f: unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64,
+    );
     // #3072: shared listener validator. Takes the raw NaN-box bits of the
     // listener arg (codegen routes these methods through NA_JSV) and the arg
     // name; returns the closure pointer when callable, else throws
@@ -436,12 +443,35 @@ unsafe extern "C" fn event_emitter_on_hook(
     js_event_emitter_on(handle, event_bits, listener_bits)
 }
 
+/// #4995: construct `new events.EventEmitter(...)` reached through a
+/// value-aliasing path (`require('events')`, default import, namespace
+/// property read). Registered with the runtime's `js_dynamic_new` so the
+/// instance is a real emitter handle instead of an empty object.
+unsafe extern "C" fn events_native_construct(
+    class_name_ptr: *const u8,
+    class_name_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let class_name = std::slice::from_raw_parts(class_name_ptr, class_name_len);
+    if class_name != b"EventEmitter" {
+        return f64::from_bits(TAG_UNDEFINED_F64_BITS);
+    }
+    let options = if !args_ptr.is_null() && args_len > 0 {
+        *args_ptr
+    } else {
+        f64::from_bits(TAG_UNDEFINED_F64_BITS)
+    };
+    nanbox_pointer_bits(js_event_emitter_new_with_options(options))
+}
+
 fn ensure_runtime_hooks_registered() {
     EVENTS_RUNTIME_HOOKS_REGISTERED.call_once(|| unsafe {
         js_register_event_emitter_handle_probe(event_emitter_handle_probe);
         js_register_event_emitter_get_domain(js_event_emitter_get_domain);
         js_register_event_emitter_set_domain(js_event_emitter_set_domain);
         js_register_event_emitter_on(event_emitter_on_hook);
+        js_set_native_events_construct(events_native_construct);
     });
 }
 

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1205,10 +1205,15 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         property: property_name,
                     });
                 } else if module_name == "events"
+                    // Any native instance registered under module `events` is
+                    // an emitter; the class name can be an alias of the
+                    // constructor binding rather than the canonical
+                    // "EventEmitter" — `var EE = require('events'); new EE()`
+                    // registers class "EE" (#4995). Gating on the canonical
+                    // names sent alias reads down the zero-arg
+                    // NativeMethodCall path, so `typeof emitter.on` CALLED
+                    // `events.on()` and threw ERR_INVALID_ARG_TYPE.
                     && (matches!(
-                        class_name.as_str(),
-                        "EventEmitter" | "EventEmitterAsyncResource"
-                    ) && (matches!(
                         property_name.as_str(),
                         "on" | "addListener"
                             | "once"
@@ -1225,7 +1230,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                             | "setMaxListeners"
                             | "getMaxListeners"
                     ) || (class_name == "EventEmitterAsyncResource"
-                        && property_name == "emitDestroy")))
+                        && property_name == "emitDestroy"))
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -382,6 +382,33 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 args,
             });
         }
+        // #4995: `new EE()` where `EE` is the events module *value* — the
+        // default import (`import EE from 'events'`) or a CJS alias
+        // (`var EE = require('events')`). Node's `events` module exports the
+        // EventEmitter class itself, so construct it exactly like the named
+        // import (`Expr::New { class_name: "EventEmitter" }` → codegen's
+        // lower_builtin_new → `js_event_emitter_new_with_options`).
+        // Previously this fell through to `New { class_name: "EE" }`, which
+        // codegen resolved to the empty-object placeholder — instances had no
+        // `.on`/`.emit`/`.setMaxListeners`, so signal-exit's module init
+        // threw and blocked ink (#348).
+        if ctx.lookup_local(callee_ident.sym.as_ref()).is_none() {
+            let is_events_module_value = ctx
+                .lookup_native_module(callee_ident.sym.as_ref())
+                .map(|(module_name, method)| {
+                    module_name == "events"
+                        && (method.is_none() || method.as_deref() == Some("default"))
+                })
+                .unwrap_or(false)
+                || ctx.lookup_builtin_module_alias(callee_ident.sym.as_ref()) == Some("events");
+            if is_events_module_value {
+                return Ok(Expr::New {
+                    class_name: "EventEmitter".to_string(),
+                    args: lower_optional_args(ctx, new_expr.args.as_deref())?,
+                    type_args: Vec::new(),
+                });
+            }
+        }
     }
 
     // Issue #422: `new net.Socket()` over a `net` module alias. The
@@ -744,11 +771,30 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     args,
                 });
             }
+            // #4995: `new ev.EventEmitter()` over an events module alias
+            // (`import * as ev from 'events'` / `import EE from 'events'` /
+            // `const ev = require('events')`) joins the same `Expr::New`
+            // route as the named import. Aliases registered only as
+            // builtin-module aliases (not native-module bindings) are
+            // covered by the `lookup_builtin_module_alias` arm.
+            if ctx.lookup_builtin_module_alias(module_alias) == Some("events")
+                && matches!(
+                    prop_ident.sym.as_ref(),
+                    "EventEmitter" | "EventEmitterAsyncResource"
+                )
+            {
+                return Ok(Expr::New {
+                    class_name: prop_ident.sym.to_string(),
+                    args: lower_optional_args(ctx, new_expr.args.as_deref())?,
+                    type_args: Vec::new(),
+                });
+            }
             if let Some((module_name, _)) = ctx.lookup_native_module(module_alias) {
                 let class_name = prop_ident.sym.as_ref();
                 if matches!(
                     (module_name, class_name),
-                    ("events", "EventEmitterAsyncResource")
+                    ("events", "EventEmitter")
+                        | ("events", "EventEmitterAsyncResource")
                         | ("async_hooks", "AsyncLocalStorage" | "AsyncResource")
                         | ("sqlite", "DatabaseSync" | "Session" | "StatementSync")
                 ) {

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -243,10 +243,10 @@ pub use value::{
 pub use value::{
     js_set_handle_array_get, js_set_handle_array_length, js_set_handle_call_method,
     js_set_handle_object_get_property, js_set_handle_to_string, js_set_handle_typeof,
-    js_set_native_crypto_dispatch, js_set_native_domain_dispatch, js_set_native_http_dispatch,
-    js_set_native_module_js_loader, js_set_native_querystring_dispatch,
-    js_set_native_sqlite_dispatch, js_set_native_tls_dispatch, js_set_native_webcrypto_dispatch,
-    js_set_native_zlib_dispatch, js_set_new_from_handle_v8,
+    js_set_native_crypto_dispatch, js_set_native_domain_dispatch, js_set_native_events_construct,
+    js_set_native_http_dispatch, js_set_native_module_js_loader,
+    js_set_native_querystring_dispatch, js_set_native_sqlite_dispatch, js_set_native_tls_dispatch,
+    js_set_native_webcrypto_dispatch, js_set_native_zlib_dispatch, js_set_new_from_handle_v8,
 };
 
 // Extension pump registration — allows extensions to register pump functions

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -1712,6 +1712,28 @@ pub unsafe extern "C" fn js_new_function_construct(
                 );
             }
         }
+        // #4995: `new EE()` where `EE = require('events')` or came in as a
+        // default / namespace import (`import EE from 'events'`, `import * as
+        // ev from 'events'; new ev.EventEmitter()`). The callee is the bound
+        // `events.EventEmitter` export value; without this arm construction
+        // fell through to the generic empty-object path, so the instance had
+        // no `.on`/`.emit`/`.setMaxListeners` (signal-exit's init throws).
+        // Route to the linked emitter impl (perry-stdlib `bundled-events` or
+        // perry-ext-events) via the construct dispatcher registered at
+        // startup — this crate can't call the constructors directly.
+        if module == "events"
+            && matches!(
+                method.as_str(),
+                "EventEmitter" | "EventEmitterAsyncResource"
+            )
+        {
+            let ptr =
+                crate::value::JS_NATIVE_EVENTS_CONSTRUCT.load(std::sync::atomic::Ordering::SeqCst);
+            if !ptr.is_null() {
+                let dispatch: crate::value::JsNativeEventsConstructFn = std::mem::transmute(ptr);
+                return dispatch(method.as_ptr(), method.len(), args_ptr, args_len);
+            }
+        }
         if module == "zlib" && matches!(method.as_str(), "ZstdCompress" | "ZstdDecompress") {
             let ptr =
                 crate::value::JS_NATIVE_ZLIB_DISPATCH.load(std::sync::atomic::Ordering::SeqCst);

--- a/crates/perry-runtime/src/value/handle.rs
+++ b/crates/perry-runtime/src/value/handle.rs
@@ -101,6 +101,15 @@ pub extern "C" fn js_set_native_http_dispatch(func: JsNativeHttpDispatchFn) {
     JS_NATIVE_HTTP_DISPATCH.store(func as *mut (), Ordering::SeqCst);
 }
 
+/// Set the node:events class-constructor dispatcher. Registered by
+/// perry-stdlib (`bundled-events`) or perry-ext-events at startup so dynamic
+/// `new` on a bound `events.EventEmitter` export value reaches the real
+/// emitter constructor. Stays null when no events impl is linked. (#4995)
+#[no_mangle]
+pub extern "C" fn js_set_native_events_construct(func: JsNativeEventsConstructFn) {
+    JS_NATIVE_EVENTS_CONSTRUCT.store(func as *mut (), Ordering::SeqCst);
+}
+
 /// Set the native module JS property loader (called by perry-jsruntime)
 /// This callback loads a native module via V8 and gets a property from it.
 #[no_mangle]

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -60,9 +60,10 @@ pub(crate) use tags::{
 };
 pub use tags::{
     JS_HANDLE_CALL_METHOD, JS_HANDLE_TYPEOF, JS_NATIVE_CRYPTO_DISPATCH, JS_NATIVE_DOMAIN_DISPATCH,
-    JS_NATIVE_HTTP_DISPATCH, JS_NATIVE_MODULE_JS_LOADER, JS_NATIVE_QUERYSTRING_DISPATCH,
-    JS_NATIVE_SQLITE_DISPATCH, JS_NATIVE_TLS_DISPATCH, JS_NATIVE_WEBCRYPTO_DISPATCH,
-    JS_NATIVE_ZLIB_DISPATCH, JS_NEW_FROM_HANDLE_V8, SHORT_STRING_MAX_LEN,
+    JS_NATIVE_EVENTS_CONSTRUCT, JS_NATIVE_HTTP_DISPATCH, JS_NATIVE_MODULE_JS_LOADER,
+    JS_NATIVE_QUERYSTRING_DISPATCH, JS_NATIVE_SQLITE_DISPATCH, JS_NATIVE_TLS_DISPATCH,
+    JS_NATIVE_WEBCRYPTO_DISPATCH, JS_NATIVE_ZLIB_DISPATCH, JS_NEW_FROM_HANDLE_V8,
+    SHORT_STRING_MAX_LEN,
 };
 
 // Crate-internal handle dispatch atomics + callback type aliases (read by
@@ -70,10 +71,10 @@ pub use tags::{
 pub(crate) use tags::{
     JsHandleArrayGetFn, JsHandleArrayLengthFn, JsHandleCallMethodFn, JsHandleObjectGetPropertyFn,
     JsHandleToStringFn, JsHandleTypeofFn, JsNativeCryptoDispatchFn, JsNativeDomainDispatchFn,
-    JsNativeHttpDispatchFn, JsNativeModuleJsLoaderFn, JsNativeQuerystringDispatchFn,
-    JsNativeSqliteDispatchFn, JsNativeTlsDispatchFn, JsNativeWebCryptoDispatchFn,
-    JsNativeZlibDispatchFn, JsNewFromHandleV8Fn, JS_HANDLE_ARRAY_GET, JS_HANDLE_ARRAY_LENGTH,
-    JS_HANDLE_OBJECT_GET_PROPERTY, JS_HANDLE_TO_STRING,
+    JsNativeEventsConstructFn, JsNativeHttpDispatchFn, JsNativeModuleJsLoaderFn,
+    JsNativeQuerystringDispatchFn, JsNativeSqliteDispatchFn, JsNativeTlsDispatchFn,
+    JsNativeWebCryptoDispatchFn, JsNativeZlibDispatchFn, JsNewFromHandleV8Fn, JS_HANDLE_ARRAY_GET,
+    JS_HANDLE_ARRAY_LENGTH, JS_HANDLE_OBJECT_GET_PROPERTY, JS_HANDLE_TO_STRING,
 };
 
 // ----- JSValue type + impls -----
@@ -85,10 +86,10 @@ pub use handle::{
     is_js_handle, js_handle_array_get, js_handle_array_length, js_set_handle_array_get,
     js_set_handle_array_length, js_set_handle_call_method, js_set_handle_object_get_property,
     js_set_handle_to_string, js_set_handle_typeof, js_set_native_crypto_dispatch,
-    js_set_native_domain_dispatch, js_set_native_http_dispatch, js_set_native_module_js_loader,
-    js_set_native_querystring_dispatch, js_set_native_sqlite_dispatch, js_set_native_tls_dispatch,
-    js_set_native_webcrypto_dispatch, js_set_native_zlib_dispatch, js_set_new_from_handle_v8,
-    native_module_try_js_property,
+    js_set_native_domain_dispatch, js_set_native_events_construct, js_set_native_http_dispatch,
+    js_set_native_module_js_loader, js_set_native_querystring_dispatch,
+    js_set_native_sqlite_dispatch, js_set_native_tls_dispatch, js_set_native_webcrypto_dispatch,
+    js_set_native_zlib_dispatch, js_set_new_from_handle_v8, native_module_try_js_property,
 };
 
 // ----- Basic NaN-box pack / unpack FFI -----

--- a/crates/perry-runtime/src/value/tags.rs
+++ b/crates/perry-runtime/src/value/tags.rs
@@ -153,6 +153,16 @@ pub(crate) type JsNativeTlsDispatchFn =
 /// http2. Stays null when the http ext crate isn't linked. (#2533)
 pub(crate) type JsNativeHttpDispatchFn =
     unsafe extern "C" fn(*const u8, usize, *const u8, usize, *const f64, usize) -> f64;
+/// node:events class-constructor dispatcher (registered by perry-stdlib under
+/// `bundled-events`, or by perry-ext-events). Lets `new` on a bound
+/// `events.EventEmitter` / `events.EventEmitterAsyncResource` export value —
+/// reached via `require('events')`, a default import, or a namespace property
+/// read — construct a real emitter instead of falling through to the generic
+/// empty-object path. Takes (class_name_ptr, class_name_len, args_ptr,
+/// args_len) and returns the NaN-boxed instance. Stays null when no events
+/// impl is linked. (#4995)
+pub(crate) type JsNativeEventsConstructFn =
+    unsafe extern "C" fn(*const u8, usize, *const f64, usize) -> f64;
 
 // ----- JS handle dispatch atomics (shared between handle.rs and consumers) -----
 
@@ -173,3 +183,4 @@ pub static JS_NATIVE_SQLITE_DISPATCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::n
 pub static JS_NATIVE_DOMAIN_DISPATCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 pub static JS_NATIVE_TLS_DISPATCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 pub static JS_NATIVE_HTTP_DISPATCH: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+pub static JS_NATIVE_EVENTS_CONSTRUCT: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -178,6 +178,17 @@ external-http-client-pump = ["async-runtime"]
 # handlers hang. Mirrors `external-http-server-pump`.
 external-fastify-pump = ["async-runtime"]
 
+# Activated by `optimized_libs::build_optimized_libs` when the well-known
+# flip routes `node:events` to perry-ext-events. Makes
+# `js_stdlib_init_dispatch` register perry-ext-events'
+# `js_event_emitter_new_with_options` as the runtime's events construct
+# dispatcher at startup, so a dynamic `new` on the bound
+# `events.EventEmitter` export value (`require('events')`, default import,
+# aliased ctor) builds a real emitter instead of an empty object. Without
+# this, ext-events only registers its hooks lazily on the first *static*
+# emitter construction. Issue #4995.
+external-events-construct = []
+
 # TLS — direct `tls.connect()` and `socket.upgradeToTLS()` (Postgres SSLRequest flow).
 # Uses rustls (not native-tls) to avoid OpenSSL on every platform and keep Android
 # cross-compile unblocked; matches reqwest/tokio-tungstenite/mongodb feature flags.

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -83,9 +83,54 @@ unsafe fn dispatch_async_local_storage_method(
     })
 }
 
-#[cfg(feature = "bundled-events")]
+/// Shared `extern "C"` surface of the EventEmitter implementation. Both
+/// perry-stdlib (`bundled-events`) and perry-ext-events export these exact
+/// symbols, kept byte-identical per #3072. The dispatch arms below call
+/// through the linker-resolved symbol instead of `crate::events::*` so that
+/// when the well-known flip links perry-ext-events, dynamic dispatch
+/// consults the SAME handle registry the constructors used. An in-crate call
+/// always hit perry-stdlib's registry and returned `None` for ext-events
+/// handles — every dynamic `.on`/`.emit`/`.setMaxListeners` on an emitter
+/// silently no-op'd and method-value reads came back `undefined` (#4995).
+/// Mirrors the sqlite duplicate-symbol contract noted in
+/// `compile/optimized_libs.rs` (#643).
+#[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
+extern "C" {
+    fn js_event_emitter_is_handle(handle: i64) -> bool;
+    fn js_event_emitter_on(handle: i64, event_bits: i64, listener_bits: i64) -> i64;
+    fn js_event_emitter_once(handle: i64, event_bits: i64, listener_bits: i64) -> i64;
+    fn js_event_emitter_prepend_listener(handle: i64, event_bits: i64, listener_bits: i64) -> i64;
+    fn js_event_emitter_prepend_once_listener(
+        handle: i64,
+        event_bits: i64,
+        listener_bits: i64,
+    ) -> i64;
+    fn js_event_emitter_remove_listener(handle: i64, event_bits: i64, listener_bits: i64) -> i64;
+    fn js_event_emitter_remove_all_listeners(
+        handle: i64,
+        args_ptr: *const perry_runtime::ArrayHeader,
+    ) -> i64;
+    fn js_event_emitter_emit(
+        handle: i64,
+        event_bits: i64,
+        args_ptr: *mut perry_runtime::ArrayHeader,
+    ) -> f64;
+    fn js_event_emitter_listener_count(handle: i64, event_bits: i64, listener_bits: i64) -> f64;
+    fn js_event_emitter_listeners(handle: i64, event_bits: i64) -> *mut perry_runtime::ArrayHeader;
+    fn js_event_emitter_raw_listeners(
+        handle: i64,
+        event_bits: i64,
+    ) -> *mut perry_runtime::ArrayHeader;
+    fn js_event_emitter_event_names(handle: i64) -> *mut perry_runtime::ArrayHeader;
+    fn js_event_emitter_set_max_listeners(handle: i64, n: f64) -> i64;
+    fn js_event_emitter_get_max_listeners(handle: i64) -> f64;
+    fn js_event_emitter_domain_value(handle: i64) -> f64;
+    fn js_event_emitter_new_with_options(options: f64) -> i64;
+}
+
+#[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
 unsafe fn dispatch_event_emitter_method(handle: i64, method: &str, args: &[f64]) -> Option<f64> {
-    if !crate::events::is_event_emitter_handle(handle) {
+    if !js_event_emitter_is_handle(handle) {
         return None;
     }
 
@@ -99,40 +144,64 @@ unsafe fn dispatch_event_emitter_method(handle: i64, method: &str, args: &[f64])
         f64::from_bits(POINTER_TAG_BITS | (ptr as u64 & POINTER_MASK_BITS))
     };
 
+    // EventEmitterAsyncResource extras exist only in the bundled impl;
+    // perry-ext-events has no async-resource constructor, so its handles
+    // never satisfy this probe.
+    #[cfg(feature = "bundled-events")]
+    if crate::events::is_event_emitter_async_resource_handle(handle) {
+        match method {
+            "asyncId" => {
+                return Some(crate::events::js_event_emitter_async_resource_async_id(
+                    handle,
+                ));
+            }
+            "triggerAsyncId" => {
+                return Some(
+                    crate::events::js_event_emitter_async_resource_trigger_async_id(handle),
+                );
+            }
+            "asyncResource" => {
+                return Some(crate::events::js_event_emitter_async_resource_async_resource(handle));
+            }
+            "emitDestroy" => {
+                return Some(crate::events::js_event_emitter_async_resource_emit_destroy(
+                    handle,
+                ));
+            }
+            _ => {}
+        }
+    }
+
     let value = match method {
         "on" | "addListener" if args.len() >= 2 => {
-            crate::events::js_event_emitter_on(handle, event_bits(0), event_bits(1));
+            js_event_emitter_on(handle, event_bits(0), event_bits(1));
             nanbox_handle_value(handle)
         }
         "once" if args.len() >= 2 => {
-            crate::events::js_event_emitter_once(handle, event_bits(0), event_bits(1));
+            js_event_emitter_once(handle, event_bits(0), event_bits(1));
             nanbox_handle_value(handle)
         }
         "prependListener" if args.len() >= 2 => {
-            crate::events::js_event_emitter_prepend_listener(handle, event_bits(0), event_bits(1));
+            js_event_emitter_prepend_listener(handle, event_bits(0), event_bits(1));
             nanbox_handle_value(handle)
         }
         "prependOnceListener" if args.len() >= 2 => {
-            crate::events::js_event_emitter_prepend_once_listener(
-                handle,
-                event_bits(0),
-                event_bits(1),
-            );
+            js_event_emitter_prepend_once_listener(handle, event_bits(0), event_bits(1));
             nanbox_handle_value(handle)
         }
         "off" | "removeListener" if args.len() >= 2 => {
-            crate::events::js_event_emitter_remove_listener(handle, event_bits(0), event_bits(1));
+            js_event_emitter_remove_listener(handle, event_bits(0), event_bits(1));
             nanbox_handle_value(handle)
         }
         "removeAllListeners" => {
-            crate::events::js_event_emitter_remove_all_listeners(handle, pack_args_array(args));
+            js_event_emitter_remove_all_listeners(handle, pack_args_array(args));
             nanbox_handle_value(handle)
         }
         "emit" => {
             let rest = if args.len() > 1 { &args[1..] } else { &[] };
-            crate::events::js_event_emitter_emit(handle, event_bits(0), pack_args_array(rest))
+            js_event_emitter_emit(handle, event_bits(0), pack_args_array(rest))
         }
-        "listenerCount" if !args.is_empty() => crate::events::js_event_emitter_listener_count(
+        "listenerCount" if !args.is_empty() => js_event_emitter_listener_count(
             handle,
             event_bits(0),
             args.get(1)
@@ -140,40 +209,27 @@ unsafe fn dispatch_event_emitter_method(handle: i64, method: &str, args: &[f64])
                 .map(|value| value.to_bits() as i64)
                 .unwrap_or(TAG_UNDEFINED_BITS),
         ),
-        "listeners" if !args.is_empty() => nanbox_array(crate::events::js_event_emitter_listeners(
-            handle,
-            event_bits(0),
-        )),
-        "rawListeners" if !args.is_empty() => nanbox_array(
-            crate::events::js_event_emitter_raw_listeners(handle, event_bits(0)),
-        ),
-        "eventNames" => nanbox_array(crate::events::js_event_emitter_event_names(handle)),
+        "listeners" if !args.is_empty() => {
+            nanbox_array(js_event_emitter_listeners(handle, event_bits(0)))
+        }
+        "rawListeners" if !args.is_empty() => {
+            nanbox_array(js_event_emitter_raw_listeners(handle, event_bits(0)))
+        }
+        "eventNames" => nanbox_array(js_event_emitter_event_names(handle)),
         "setMaxListeners" if !args.is_empty() => {
-            crate::events::js_event_emitter_set_max_listeners(handle, args[0]);
+            js_event_emitter_set_max_listeners(handle, args[0]);
             nanbox_handle_value(handle)
         }
-        "getMaxListeners" => crate::events::js_event_emitter_get_max_listeners(handle),
-        "domain" => crate::events::js_event_emitter_domain_value(handle),
-        "asyncId" if crate::events::is_event_emitter_async_resource_handle(handle) => {
-            crate::events::js_event_emitter_async_resource_async_id(handle)
-        }
-        "triggerAsyncId" if crate::events::is_event_emitter_async_resource_handle(handle) => {
-            crate::events::js_event_emitter_async_resource_trigger_async_id(handle)
-        }
-        "asyncResource" if crate::events::is_event_emitter_async_resource_handle(handle) => {
-            crate::events::js_event_emitter_async_resource_async_resource(handle)
-        }
-        "emitDestroy" if crate::events::is_event_emitter_async_resource_handle(handle) => {
-            crate::events::js_event_emitter_async_resource_emit_destroy(handle)
-        }
+        "getMaxListeners" => js_event_emitter_get_max_listeners(handle),
+        "domain" => js_event_emitter_domain_value(handle),
         _ => return None,
     };
     Some(value)
 }
 
-#[cfg(feature = "bundled-events")]
+#[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
 unsafe fn dispatch_event_emitter_property(handle: i64, property: &str) -> Option<f64> {
-    if !crate::events::is_event_emitter_handle(handle) {
+    if !js_event_emitter_is_handle(handle) {
         return None;
     }
 
@@ -188,6 +244,7 @@ unsafe fn dispatch_event_emitter_property(handle: i64, property: &str) -> Option
         js_class_method_bind(nanbox_handle_value(handle), method.as_ptr(), method.len())
     };
 
+    #[cfg(feature = "bundled-events")]
     if crate::events::is_event_emitter_async_resource_handle(handle) {
         match property {
             "asyncId" => {
@@ -275,7 +332,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     // Dispatchers below gate on registry membership plus method vocabulary
     // because native handle id spaces are not unified (#91).
 
-    #[cfg(feature = "bundled-events")]
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
     if let Some(value) = dispatch_event_emitter_method(handle, method_name, &args) {
         return value;
     }
@@ -1713,7 +1770,7 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
         return v;
     }
 
-    #[cfg(feature = "bundled-events")]
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
     if let Some(value) = dispatch_event_emitter_property(handle, property_name) {
         return value;
     }
@@ -3056,11 +3113,20 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     );
     #[cfg(feature = "http-client")]
     js_register_global_fetch_body_init_ptr(crate::fetch::js_response_body_init_ptr);
-    #[cfg(feature = "bundled-events")]
+    // Probe / `on` hook / constructor all route through the shared
+    // `extern "C"` events surface declared above dispatch_event_emitter_method
+    // (#4995): the linker resolves them to whichever EventEmitter impl is in
+    // the binary (perry-stdlib `bundled-events` or perry-ext-events under the
+    // well-known flip), so the registry these consult is always the one the
+    // constructors used. Registered eagerly at startup — perry-ext-events
+    // alone only registers its hooks lazily on the first *static* emitter
+    // construction, which a dynamic-first program (signal-exit's
+    // `new (require('events'))()`) never performs.
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
     unsafe extern "C" fn event_emitter_probe(handle: i64) -> bool {
-        crate::events::is_event_emitter_handle(handle)
+        js_event_emitter_is_handle(handle)
     }
-    #[cfg(feature = "bundled-events")]
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
     js_register_event_emitter_handle_probe(event_emitter_probe);
     #[cfg(feature = "bundled-events")]
     unsafe extern "C" fn event_emitter_async_resource_probe(handle: i64) -> bool {
@@ -3068,8 +3134,48 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     }
     #[cfg(feature = "bundled-events")]
     js_register_event_emitter_async_resource_handle_probe(event_emitter_async_resource_probe);
-    #[cfg(feature = "bundled-events")]
-    js_register_event_emitter_on(crate::events::js_event_emitter_on);
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
+    unsafe extern "C" fn event_emitter_on_hook(
+        handle: i64,
+        event_bits: i64,
+        listener_bits: i64,
+    ) -> i64 {
+        js_event_emitter_on(handle, event_bits, listener_bits)
+    }
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
+    js_register_event_emitter_on(event_emitter_on_hook);
+    // #4995: serve dynamic `new` on the bound `events.EventEmitter` /
+    // `events.EventEmitterAsyncResource` export values (`require('events')`,
+    // default import, namespace property read) with the same constructors the
+    // named-import codegen path calls. Without this the runtime's
+    // `js_new_function_construct` fell through to the generic empty-object
+    // path and the instance had no `.on`/`.emit`/`.setMaxListeners`.
+    // EventEmitterAsyncResource exists only in the bundled impl.
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
+    unsafe extern "C" fn events_native_construct(
+        class_name_ptr: *const u8,
+        class_name_len: usize,
+        args_ptr: *const f64,
+        args_len: usize,
+    ) -> f64 {
+        let class_name = std::slice::from_raw_parts(class_name_ptr, class_name_len);
+        let options = if !args_ptr.is_null() && args_len > 0 {
+            *args_ptr
+        } else {
+            TAG_UNDEFINED_F64
+        };
+        let handle = match class_name {
+            b"EventEmitter" => js_event_emitter_new_with_options(options),
+            #[cfg(feature = "bundled-events")]
+            b"EventEmitterAsyncResource" => {
+                crate::events::js_event_emitter_async_resource_new(options)
+            }
+            _ => return TAG_UNDEFINED_F64,
+        };
+        perry_runtime::js_nanbox_pointer(handle)
+    }
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
+    perry_runtime::js_set_native_events_construct(events_native_construct);
     super::net_socket_bridge::register_net_socket_handle_probe();
     js_register_worker_threads_namespace_getters(
         crate::worker_threads::js_worker_threads_get_worker_data,

--- a/crates/perry-stdlib/src/events/domain.rs
+++ b/crates/perry-stdlib/src/events/domain.rs
@@ -13,6 +13,18 @@ pub fn is_event_emitter_handle(handle: Handle) -> bool {
     get_handle::<EventEmitterHandle>(handle).is_some()
 }
 
+/// C-ABI handle probe under the same symbol name perry-ext-events exports
+/// (#4995). The handle-dispatch arms in `common/dispatch.rs` call this via
+/// `extern "C"` instead of the in-crate `is_event_emitter_handle`, so when
+/// both implementations are linked (the well-known flip plus a full-feature
+/// stdlib) the probe resolves to whichever impl the linker picked — the same
+/// one whose `js_event_emitter_new*` constructed the handle. An in-crate call
+/// would always consult perry-stdlib's registry and miss ext-events handles.
+#[no_mangle]
+pub extern "C" fn js_event_emitter_is_handle(handle: Handle) -> bool {
+    is_event_emitter_handle(handle)
+}
+
 #[no_mangle]
 pub extern "C" fn js_event_emitter_set_domain(handle: Handle, domain: Handle) -> i32 {
     if let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) {

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -496,6 +496,17 @@ pub(super) fn build_optimized_libs(
             if matches!(module_normalized, "http" | "https") {
                 features.insert("external-http-client-pump");
             }
+            // Issue #4995 — when `node:events` routes to perry-ext-events,
+            // have js_stdlib_init_dispatch eagerly register the ext crate's
+            // EventEmitter constructor as the runtime's events construct
+            // dispatcher. Without this, a dynamic `new` on the bound
+            // `events.EventEmitter` export value (`require('events')`,
+            // default import, aliased ctor) falls through to the
+            // empty-object path until the first static construction has
+            // lazily registered the hooks.
+            if module_normalized == "events" {
+                features.insert("external-events-construct");
+            }
         }
     }
 

--- a/test-files/test_gap_events_import_4995.ts
+++ b/test-files/test_gap_events_import_4995.ts
@@ -1,0 +1,56 @@
+// #4995: bare-specifier `events` default/namespace imports must yield the
+// same working EventEmitter as the `node:events` named import. signal-exit
+// (transitive ink dep) does `var EE = require('events'); new EE()` and calls
+// `.setMaxListeners(Infinity)` on the instance during module init.
+import { EventEmitter } from 'node:events';
+import EEBare from 'events';
+import EENode from 'node:events';
+import * as evNs from 'events';
+
+// Named node: import — the previously-working reference point.
+const named = new EventEmitter();
+console.log('named ctor:', typeof EventEmitter);
+console.log('named setMaxListeners:', typeof named.setMaxListeners);
+
+// Default import, bare specifier (the signal-exit shape).
+const DefaultBare: any = EEBare;
+console.log('default bare ctor:', typeof DefaultBare);
+const db = new DefaultBare();
+console.log('default bare on:', typeof db.on);
+console.log('default bare once:', typeof db.once);
+console.log('default bare emit:', typeof db.emit);
+console.log('default bare removeListener:', typeof db.removeListener);
+console.log('default bare setMaxListeners:', typeof db.setMaxListeners);
+db.setMaxListeners(Infinity);
+console.log('default bare getMaxListeners:', db.getMaxListeners());
+let hits = 0;
+db.on('sig', (n: number) => {
+  hits += n;
+});
+db.emit('sig', 2);
+db.emit('sig', 3);
+console.log('default bare emit hits:', hits);
+
+// Default import, node: specifier.
+const DefaultNode: any = EENode;
+const dn = new DefaultNode();
+console.log('default node setMaxListeners:', typeof dn.setMaxListeners);
+dn.setMaxListeners(20);
+console.log('default node getMaxListeners:', dn.getMaxListeners());
+
+// Namespace import, bare specifier.
+const ns: any = evNs;
+console.log('ns EventEmitter:', typeof ns.EventEmitter);
+console.log('ns default:', typeof ns.default);
+const nse = new ns.EventEmitter();
+console.log('ns setMaxListeners:', typeof nse.setMaxListeners);
+nse.once('x', () => {
+  console.log('ns once fired');
+});
+nse.emit('x');
+nse.emit('x');
+console.log('ns listenerCount after once:', nse.listenerCount('x'));
+
+// captureRejections option must reach the constructor on the dynamic path.
+const opt = new DefaultBare({ captureRejections: true });
+console.log('options instance on:', typeof opt.on);


### PR DESCRIPTION
## Summary

Fixes #4995. The bare core specifier `events` (default import, namespace import, or `require('events')`) produced an `EventEmitter` whose instances had an **empty prototype** — `.on`/`.emit`/`.setMaxListeners` all `undefined` — while `node:events` worked. This blocked **signal-exit** (`cli-cursor` → `restore-cursor`), the next ink (#348) wall after #4993.

## Root cause — two layers, both real

**1. HIR lowering.** `new EE()` over an events default import / namespace import / CJS alias lowered to the empty-object placeholder instead of the real `EventEmitter`. Separately, emitter method-value reads (`typeof emitter.on`) were gated on the *canonical* class name — but `var EE = require('events')` registers the native instance under class name `"EE"`, so an aliased read fell through to a zero-arg `events.on()` native call that threw `ERR_INVALID_ARG_TYPE`.

**2. A latent, broader bug.** Even `node:events` *dynamic* dispatch (`const x: any = e; x.on(...)`) was fully broken in flip binaries. perry-stdlib's handle-dispatch arms called the in-crate `crate::events::*` registry, but the well-known flip links **perry-ext-events**, whose handles that registry never sees — so the probe returned false and every dynamic `.on`/`.emit`/`.setMaxListeners` silently no-op'd or read `undefined`.

## Fix

- **HIR** (`expr_new.rs`, `expr_member.rs`): route events default/namespace/alias `new` to `Expr::New { class_name: "EventEmitter" }`; gate emitter method-value reads on the *module* name, not the canonical class name.
- **Runtime** (`tags.rs`, `handle.rs`, `class_registry.rs`): new `js_set_native_events_construct` dispatcher so `js_new_function_construct` builds a real emitter when `new` lands on a bound `events.EventEmitter` export value.
- **stdlib** (`common/dispatch.rs`, `events/domain.rs`): handle-dispatch arms (probe / `on` / constructors) now call the linker-resolved `extern "C"` events symbols instead of in-crate `crate::events::*`, so dynamic dispatch consults the same registry the constructors used — mirroring the sqlite duplicate-symbol contract (#643). New `external-events-construct` feature registers the constructor when the well-known flip strips `bundled-events`.

## Validation

- 6-variant repro matrix (named/default/namespace × bare/`node:`) + the exact signal-exit `require('events')` pattern all pass.
- New gap test `test_gap_events_import_4995.ts` — **byte-identical** vs `node --experimental-strip-types`.
- **Zero gap-suite regressions**: my 31 failures are a strict subset of the baseline's 32 (baseline-only `test_gap_node_fs` is flaky and unrelated). Runtime tests 1022/1023 (the one failure is the pre-existing macOS `date` test).

Code-only per the maintainer-folds-metadata-at-merge convention (no version bump / changelog).