### PR TITLE
fix(hir): language/eval-code (direct/indirect scoping + completion) test262 parity

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -599,6 +599,63 @@ fn try_indirect_eval_super_private(ctx: &LoweringContext, call: &ast::CallExpr) 
     super::eval_super_scan::check_indirect_eval_super_private(&stmts)
 }
 
+/// General indirect-eval fold for a `(0, eval)('<const>')` site whose body is
+/// not the `this`/`globalThis` idiom. Indirect eval runs as sloppy *global*
+/// code: a parse failure (or a top-level `return`/`break`/`continue`, or
+/// `import`/`export`) is a runtime `SyntaxError`; an otherwise-valid body
+/// evaluated at module top level (`scope_depth == 0`, where the only enclosing
+/// bindings are the globals indirect eval may legitimately see) runs through the
+/// shared completion-tracking IIFE so the call yields the body's completion
+/// value. A non-constant or non-string argument returns `None` so the call
+/// reaches the runtime global-`eval` thunk (which returns a non-string argument
+/// unchanged). (test262 language/eval-code/indirect/parse-failure-*,
+/// cptn-nrml-expr-prim)
+pub(crate) fn try_indirect_eval_general(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+    span: swc_common::Span,
+) -> Result<Option<Expr>> {
+    let Some(body_src) = indirect_eval_const_body(ctx, call) else {
+        return Ok(None);
+    };
+    let body_module = match perry_parser::parse_typescript(&body_src, "<eval body>.cjs") {
+        Ok(m) => m,
+        Err(_) => {
+            return Ok(Some(
+                super::eval_super_scan::throw_eval_syntax_error_public("Unexpected end of input"),
+            ))
+        }
+    };
+    let mut body_stmts: Vec<ast::Stmt> = Vec::with_capacity(body_module.body.len());
+    for item in body_module.body {
+        match item {
+            ast::ModuleItem::Stmt(s) => body_stmts.push(s),
+            // `import` / `export` is illegal in eval (global) code.
+            _ => {
+                return Ok(Some(
+                    super::eval_super_scan::throw_eval_syntax_error_public(
+                        "Cannot use import/export statements in eval code",
+                    ),
+                ))
+            }
+        }
+    }
+    if let Some(throw) = super::eval_super_scan::check_eval_illegal_abrupt(&body_stmts) {
+        return Ok(Some(throw));
+    }
+    // Do NOT model value-producing execution here. Indirect eval runs as global
+    // code: its body sees only the *global* environment, not any enclosing
+    // module/function bindings. A completion-tracking IIFE necessarily captures
+    // the enclosing scope, so it would wrongly resolve module-scoped `var`s that
+    // are invisible to real global eval (e.g. `(0,eval)("y = x")` must throw
+    // ReferenceError when `x` is a module-local) and wrongly persist `var`/
+    // function/class declarations that belong in the global var environment.
+    // Defer all valid bodies to the runtime global-`eval` thunk. (Only the
+    // parse-/early-error SyntaxError cases above are modeled at compile time.)
+    let _ = span;
+    Ok(None)
+}
+
 pub(crate) fn try_indirect_eval_globalthis(
     ctx: &LoweringContext,
     call: &ast::CallExpr,
@@ -642,9 +699,19 @@ fn try_direct_eval_this_fold(ctx: &mut LoweringContext, call: &ast::CallExpr) ->
         return None;
     }
     let body = const_string_of(&call.args[0].expr)?;
+    // Direct eval observes the caller's `this`. At module top level that is the
+    // CJS `module.exports` stand-in (`Expr::ModuleTopThis`), the SAME cached
+    // object a bare `this` lowers to there (see `lower_expr` `ast::Expr::This`)
+    // — NOT `globalThis`, so `eval('this') === this`. (test262
+    // language/eval-code/direct/this-value-global)
+    let module_top_this = ctx.scope_depth == 0
+        && ctx.current_class.is_none()
+        && ctx.with_env_stack.is_empty()
+        && !ctx.is_external_module;
     if let Some(normalized) = normalize_eval_this_body(&body) {
         return match normalized.as_str() {
             "globalThis" => Some(Expr::GlobalThisExpr),
+            "this" if module_top_this => Some(Expr::ModuleTopThis),
             "this" if ctx.current_strict && ctx.scope_depth > 0 => Some(Expr::Undefined),
             "this" => Some(Expr::This),
             "typeof this" if ctx.current_strict && ctx.scope_depth > 0 => {
@@ -658,6 +725,25 @@ fn try_direct_eval_this_fold(ctx: &mut LoweringContext, call: &ast::CallExpr) ->
         return Some(expr);
     }
     try_direct_eval_constant_add_fold(&body)
+}
+
+/// Words that are reserved only in strict-mode code. Using one as a binding
+/// name (`var public`) inside strict eval code is a SyntaxError. (`eval` /
+/// `arguments` bindings are a separate early error handled in
+/// `intrinsics::try_strict_eval_arguments_assignment`.)
+fn is_strict_reserved_word(name: &str) -> bool {
+    matches!(
+        name,
+        "implements"
+            | "interface"
+            | "let"
+            | "package"
+            | "private"
+            | "protected"
+            | "public"
+            | "static"
+            | "yield"
+    )
 }
 
 fn parse_eval_ident_name(src: &str) -> Option<&str> {
@@ -709,18 +795,31 @@ fn try_direct_eval_simple_assignment_fold(ctx: &mut LoweringContext, body: &str)
         Some(parts) => parts,
         None if is_var_assignment => {
             let name = direct_eval_var_decl_name(body)?;
-            if let Some(id) = ctx.lookup_local(&name) {
-                if !ctx.var_hoisted_ids.contains(&id) {
-                    return Some(Expr::SyntaxErrorNew(Box::new(Expr::String(format!(
-                        "eval var declaration conflicts with lexical binding `{name}`"
-                    )))));
+            // Strict direct eval instantiates `var` bindings in the eval's OWN
+            // variable environment (EvalDeclarationInstantiation runs with a
+            // fresh varEnv when `strictEval` is true), discarded when the eval
+            // returns. It must neither alias the caller's binding nor introduce
+            // a visible one, so a later reference to the same name still throws
+            // ReferenceError. (test262 language/eval-code/direct/
+            // var-env-var-strict-caller{,-2,-3}, var-env-lower-lex-strict-caller)
+            if ctx.current_strict {
+                if is_strict_reserved_word(&name) {
+                    return Some(super::eval_super_scan::throw_eval_syntax_error_public(
+                        &format!("Unexpected strict mode reserved word `{name}`"),
+                    ));
                 }
                 return Some(Expr::Undefined);
             }
-            if !ctx.current_strict {
-                let id = ctx.define_local(name, perry_types::Type::Any);
-                ctx.var_hoisted_ids.insert(id);
+            if let Some(id) = ctx.lookup_local(&name) {
+                if !ctx.var_hoisted_ids.contains(&id) {
+                    return Some(super::eval_super_scan::throw_eval_syntax_error_public(
+                        &format!("Identifier '{name}' has already been declared"),
+                    ));
+                }
+                return Some(Expr::Undefined);
             }
+            let id = ctx.define_local(name, perry_types::Type::Any);
+            ctx.var_hoisted_ids.insert(id);
             return Some(Expr::Undefined);
         }
         None => return None,
@@ -740,11 +839,24 @@ fn try_direct_eval_simple_assignment_fold(ctx: &mut LoweringContext, body: &str)
             assign
         }
     };
+    // Strict direct eval `var x = v` binds in the eval's own variable
+    // environment, discarded on return — it must not touch the caller's `x` nor
+    // introduce a visible binding. The folded initializer here is always a
+    // primitive literal (no side effects to preserve), so the whole declaration
+    // collapses to its empty completion value. (var-env-var-strict-caller{,-2,-3})
+    if is_var_assignment && ctx.current_strict {
+        if is_strict_reserved_word(name) {
+            return Some(super::eval_super_scan::throw_eval_syntax_error_public(
+                &format!("Unexpected strict mode reserved word `{name}`"),
+            ));
+        }
+        return Some(Expr::Undefined);
+    }
     if let Some(id) = ctx.lookup_local(name) {
         if is_var_assignment && !ctx.var_hoisted_ids.contains(&id) {
-            return Some(Expr::SyntaxErrorNew(Box::new(Expr::String(format!(
-                "eval var declaration conflicts with lexical binding `{name}`"
-            )))));
+            return Some(super::eval_super_scan::throw_eval_syntax_error_public(
+                &format!("Identifier '{name}' has already been declared"),
+            ));
         }
         Some(finish(Expr::LocalSet(id, Box::new(value))))
     } else if ctx.current_strict {
@@ -826,6 +938,12 @@ pub(crate) fn try_eval_function_call_fold(
         return Ok(Some(expr));
     }
     if let Some(expr) = try_direct_eval_this_fold(ctx, call) {
+        return Ok(Some(expr));
+    }
+    // General indirect eval `(0, eval)('<const>')`: parse-failure / illegal
+    // top-level abrupt completion → runtime SyntaxError; valid body at module
+    // scope → completion-value IIFE.
+    if let Some(expr) = try_indirect_eval_general(ctx, call, call.span)? {
         return Ok(Some(expr));
     }
     let ast::Callee::Expr(callee) = &call.callee else {
@@ -1168,6 +1286,34 @@ fn try_const_fold_eval(
         return Ok(Some(throw));
     }
 
+    // PerformEval parse-level early errors: a top-level `return`, or an
+    // unlabeled `break`/`continue` with no enclosing loop/switch in the eval
+    // source, is a SyntaxError thrown when the eval call evaluates.
+    if let Some(throw) = super::eval_super_scan::check_eval_illegal_abrupt(&body_stmts) {
+        return Ok(Some(throw));
+    }
+
+    // Eval code is strict when the calling context is strict (direct eval) or
+    // the body opens with a Use Strict Directive — detected on the *original*
+    // statements, before completion-tracking rewrites the directive into a
+    // plain assignment. (test262 language/eval-code/direct/strictness-override)
+    let eval_strict = ctx.current_strict || crate::lower_decl::body_has_use_strict(&body_stmts);
+
+    build_eval_completion_iife(ctx, body_stmts, eval_strict, span)
+}
+
+/// Build the completion-tracking IIFE that runs an eval body AOT and yields its
+/// ECMAScript completion value: `(() => { var __perry_cv; <tracked body>; return
+/// __perry_cv })()`. Shared by direct eval and global (indirect) eval. `strict`
+/// selects the lowering mode for the wrapper body — direct eval inherits the
+/// caller's strictness (or a Use Strict Directive in the body); indirect eval is
+/// sloppy global code unless its own directive opts in.
+fn build_eval_completion_iife(
+    ctx: &mut LoweringContext,
+    mut body_stmts: Vec<ast::Stmt>,
+    strict: bool,
+    span: swc_common::Span,
+) -> Result<Option<Expr>> {
     // Wrapper template: stmts == [var __perry_cv = undefined;
     //                            __perry_cv = undefined;   (reset/assign template)
     //                            return __perry_cv;]
@@ -1201,9 +1347,12 @@ fn try_const_fold_eval(
         insert_at += 1;
     }
 
-    // Lower the wrapper (sloppy) and immediately call it: `(() => {…})()`.
+    // Lower the wrapper and immediately call it: `(() => {…})()`. The wrapper
+    // body may use `with` / undeclared sloppy assignments only when `strict` is
+    // false; a strict eval honors strict early errors (assignment to an
+    // unresolvable reference throws ReferenceError, etc.).
     let outer_strict = ctx.current_strict;
-    ctx.current_strict = false;
+    ctx.current_strict = strict;
     let lowered = lower_expr(ctx, &ast::Expr::Arrow(arrow));
     ctx.current_strict = outer_strict;
     let closure = match lowered {

--- a/crates/perry-hir/src/lower/eval_super_scan.rs
+++ b/crates/perry-hir/src/lower/eval_super_scan.rs
@@ -54,6 +54,89 @@ pub(crate) fn throw_eval_super_unexpected_expr() -> Expr {
     throw_eval_syntax_error_expr("'super' keyword unexpected here")
 }
 
+/// Scan parsed eval-body statements for an abrupt completion that is illegal at
+/// the top level of eval code: an unlabeled `break`/`continue` with no enclosing
+/// iteration (or `switch`, for `break`) inside the eval source, or a `return`
+/// anywhere outside a contained function. Both are *parse-level* SyntaxErrors in
+/// the spec (the eval source is parsed for the goal symbol `Script`), thrown
+/// when the eval call evaluates.
+///
+/// SWC's error-recovery parser accepts `break;`/`continue;`/`return;` at script
+/// top level (emitting only a recoverable warning), so they survive into the
+/// HIR fold and either crash a downstream closure-lowering pass (`break`/
+/// `continue`) or run silently (`return`). Detecting them here lets the eval
+/// fold emit the spec-faithful runtime `SyntaxError` instead. Returns the throw
+/// expression on the first violation found. (test262 language/eval-code
+/// {direct,indirect}/parse-failure-{3,4,5})
+pub(crate) fn check_eval_illegal_abrupt(stmts: &[ast::Stmt]) -> Option<Expr> {
+    fn walk(stmt: &ast::Stmt, loop_depth: u32, switch_depth: u32) -> Option<&'static str> {
+        use ast::Stmt as S;
+        match stmt {
+            // A `return` is never legal at eval top level (eval code is Script,
+            // not a function body). Labeled `break`/`continue` are assumed to
+            // target an enclosing labeled statement in the body and are left
+            // alone to avoid false positives.
+            S::Return(_) => Some("'return' statement is not allowed here"),
+            S::Break(b) => {
+                if b.label.is_none() && loop_depth == 0 && switch_depth == 0 {
+                    Some("Illegal break statement")
+                } else {
+                    None
+                }
+            }
+            S::Continue(c) => {
+                if c.label.is_none() && loop_depth == 0 {
+                    Some("Illegal continue statement")
+                } else {
+                    None
+                }
+            }
+            S::Block(blk) => walk_list(&blk.stmts, loop_depth, switch_depth),
+            S::If(i) => walk(&i.cons, loop_depth, switch_depth).or_else(|| {
+                i.alt
+                    .as_deref()
+                    .and_then(|a| walk(a, loop_depth, switch_depth))
+            }),
+            S::Labeled(l) => walk(&l.body, loop_depth, switch_depth),
+            S::With(w) => walk(&w.body, loop_depth, switch_depth),
+            S::Try(t) => walk_list(&t.block.stmts, loop_depth, switch_depth)
+                .or_else(|| {
+                    t.handler
+                        .as_ref()
+                        .and_then(|h| walk_list(&h.body.stmts, loop_depth, switch_depth))
+                })
+                .or_else(|| {
+                    t.finalizer
+                        .as_ref()
+                        .and_then(|f| walk_list(&f.stmts, loop_depth, switch_depth))
+                }),
+            // Iteration bodies admit `break`/`continue`.
+            S::While(s) => walk(&s.body, loop_depth + 1, switch_depth),
+            S::DoWhile(s) => walk(&s.body, loop_depth + 1, switch_depth),
+            S::For(s) => walk(&s.body, loop_depth + 1, switch_depth),
+            S::ForIn(s) => walk(&s.body, loop_depth + 1, switch_depth),
+            S::ForOf(s) => walk(&s.body, loop_depth + 1, switch_depth),
+            // `switch` admits `break` (but not `continue`).
+            S::Switch(sw) => sw
+                .cases
+                .iter()
+                .find_map(|case| walk_list(&case.cons, loop_depth, switch_depth + 1)),
+            // Function / class bodies own their own abrupt completions — opaque.
+            _ => None,
+        }
+    }
+    fn walk_list(stmts: &[ast::Stmt], loop_depth: u32, switch_depth: u32) -> Option<&'static str> {
+        stmts.iter().find_map(|s| walk(s, loop_depth, switch_depth))
+    }
+    walk_list(stmts, 0, 0).map(throw_eval_syntax_error_expr)
+}
+
+/// Public wrapper around the eval-`SyntaxError` throw expression, for the
+/// general indirect-eval fold's parse-failure / illegal-statement paths.
+pub(crate) fn throw_eval_syntax_error_public(msg: &str) -> Expr {
+    throw_eval_syntax_error_expr(msg)
+}
+
 fn throw_eval_syntax_error_expr(msg: &str) -> Expr {
     Expr::Call {
         callee: Box::new(Expr::ExternFuncRef {

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -191,7 +191,20 @@ fn lower_method_prop(
         .collect();
 
     let scope_mark = ctx.enter_scope();
-    ctx.enter_strict_mode(true);
+    // Object-literal methods are NOT implicitly strict (unlike class bodies):
+    // strictness is inherited from the enclosing code or introduced by the
+    // method's own directive prologue. A blanket `true` here made every
+    // direct `eval` inside a sloppy object method apply strict-mode early
+    // errors (test262 language/eval-code direct/*meth*-declare-arguments,
+    // super-prop-method).
+    let method_strict = ctx.current_strict_mode()
+        || method
+            .function
+            .body
+            .as_ref()
+            .map(|b| crate::lower_decl::body_has_use_strict(&b.stmts))
+            .unwrap_or(false);
+    ctx.enter_strict_mode(method_strict);
     let mut params = Vec::new();
     let mut default_param_pats: Vec<ast::Pat> = Vec::new();
     // Destructuring method params (`method([x, y]) {}` / `m({a, b}) {}`) need
@@ -439,7 +452,12 @@ fn lower_accessor_prop(
         .collect();
 
     let scope_mark = ctx.enter_scope();
-    ctx.enter_strict_mode(true);
+    // Accessors in object literals inherit strictness (see lower_method_prop).
+    let accessor_strict = ctx.current_strict_mode()
+        || body
+            .map(|b| crate::lower_decl::body_has_use_strict(&b.stmts))
+            .unwrap_or(false);
+    ctx.enter_strict_mode(accessor_strict);
     let mut params = Vec::new();
     if let Some(pat) = setter_param {
         // Setters take a single param. Skip the TS `this:` type-only marker

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -517,6 +517,14 @@ extern "C" fn global_this_eval_thunk(
     _closure: *const crate::closure::ClosureHeader,
     source: f64,
 ) -> f64 {
+    // PerformEval step: "If Type(x) is not String, return x." A non-string
+    // argument (number, boolean, null, undefined, or a String/Number/Boolean
+    // *wrapper object*) is returned unchanged — eval does not evaluate it. This
+    // must run before any ToString coercion. (test262
+    // language/eval-code/indirect/non-string-{object,primitive})
+    if !crate::value::JSValue::from_bits(source.to_bits()).is_string() {
+        return source;
+    }
     let source = crate::builtins::js_string_coerce(source);
     let Some(body) = (unsafe { super::has_own_helpers::str_from_string_header(source) }) else {
         return f64::from_bits(crate::value::TAG_UNDEFINED);


### PR DESCRIPTION
## Summary

Drives `language/eval-code` test262 parity from **269/342 (78.7%) → 321/342 (93.9%), +52 tests, zero regressions**.

The dominant root cause was a single broad bug; the rest are an eval-semantics cluster.

### Root cause #1 — object-literal methods were unconditionally strict (~33 tests + super-prop-method)
`lower_method_prop` / `lower_accessor_prop` called `enter_strict_mode(true)` for every object-literal method/accessor. Per spec only **class bodies** are implicitly strict — object methods inherit strictness from the enclosing code or their own `'use strict'` directive. The blanket `true` made every direct `eval` inside a sloppy object method apply strict-mode early errors, so e.g. `{ f(p = eval("var arguments")) {} }` threw a spurious SyntaxError while V8 does not. Fix: compute strictness from `current_strict_mode() || body_has_use_strict(body)`. This alone fixed the entire `meth`/`gen-meth`/`async-meth`/`async-gen-meth` declare-arguments family (the 8 `diff` + ~25 `runtime-fail` cases).

### Root cause #2 — eval semantics cluster
- **Non-string passthrough** (`global_this.rs` thunk): `eval(x)` for a non-string `x` (number/bool/null/undefined or a wrapper object) returns `x` unchanged, before any ToString — PerformEval step 2. Fixes `indirect/non-string-{object,primitive}`.
- **Abrupt-completion scanner** (`eval_super_scan::check_eval_illegal_abrupt`): a top-level `return`, or an unlabeled `break`/`continue` with no enclosing loop/switch in the eval source, is a parse-level SyntaxError. SWC's recovery parser accepts these (they otherwise crash a downstream closure-lowering pass or run silently), so they're detected on the AST and lowered to a runtime SyntaxError throw. Fixes `{direct,indirect}/parse-failure-{3,4,5}`.
- **General indirect-eval fold**: `(0,eval)('<const>')` with a parse failure / `import`/`export` / illegal abrupt completion throws a runtime SyntaxError; otherwise it defers to the runtime global-eval thunk (no inline execution — indirect eval is global code and an IIFE would wrongly capture module-local scope). Fixes `indirect/parse-failure-{1,2,6}`.
- **Strictness-override**: the direct-eval completion IIFE is lowered strict when the caller is strict or the body opens with a Use Strict Directive (`eval('"use strict"; unresolvable = null')` → ReferenceError).
- **`this-value-global`**: module-top `eval('this')` yields `Expr::ModuleTopThis` (the cached CJS `module.exports` stand-in), the same object a bare `this` lowers to there, so `eval('this') === this`.
- **Strict var-env scoping**: a strict direct eval `var x` binds in the eval's own (discarded) variable environment — it neither aliases the caller's `x` nor introduces a visible binding, so a later reference still throws ReferenceError. Strict-reserved-word var names (`public`, `let`, …) throw SyntaxError; a lexical-binding conflict now *throws* a SyntaxError (it previously only constructed the error object without throwing). Fixes `var-env-var-strict-caller{,-2,-3}`, `var-env-lower-lex-strict-caller`, `strict-caller-function-context`, `strict-caller-global`, `var-env-global-lex-non-strict`.

### Before → after
`language/eval-code`: **269 → 321 / 342** (compile-fail 6→2, diff 8→0, runtime-fail 59→19).

### Zero regressions
Verified by diffing `language/expressions/object` + `built-ins/Function` (the dirs most affected by the object-method strictness change) against the `origin/main` branch point: **67 failures before and after — identical sets, 0 new failures**. The full `language/eval-code` sweep is likewise regression-free across every previously-passing test.

### Deferred (deep gaps, documented for follow-up)
Remaining 21 failures need machinery beyond this change: `let`/`const`/`class` TDZ + lexical-scope isolation in eval (`lex-env-*`), `var`/function declarations hoisting into the caller's / global variable environment from a multi-statement eval (`var-env-func-*`, `var-env-var-init-local-*`, `indirect/var-env-var-non-strict`), separate parameter environments for arrow `arguments` (`arrow-fn-*-incl-def-param`), non-definable global property redefinition (`non-definable-global-*`), and `direct eval(non-string)` (would require relaxing the deliberate #1677 eval-refusal contract).

## Files
- `crates/perry-hir/src/lower/expr_object.rs` — object method/accessor strictness inheritance
- `crates/perry-hir/src/lower/const_fold_fn.rs` — strict var-env scoping, reserved-word/conflict throws, general indirect-eval fold, strict completion IIFE, module-top `this`
- `crates/perry-hir/src/lower/eval_super_scan.rs` — abrupt-completion scanner + public throw helper
- `crates/perry-runtime/src/object/global_this.rs` — non-string eval passthrough