### PR TITLE
feat(runtime): Node arg-validation errors via shared validators.rs (#2013/#3146)

### DIFF
--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -47,6 +47,65 @@ use super::{
     I18nLowerCtx,
 };
 
+/// #2013/#3146: emit a setup-time `validateString` call. `value_box` is the
+/// original NaN-boxed value; `name` is the static argument name node uses in
+/// the error (`"algorithm"` for `createHash`, `"hmac"` for `createHmac`'s
+/// algorithm, `"digest"` for `pbkdf2`). The runtime throws `TypeError
+/// [ERR_INVALID_ARG_TYPE]` on a non-string value, so this is emitted BEFORE the
+/// value is unboxed to a raw pointer (a number would otherwise mask into a
+/// bogus pointer and segfault `bytes_from_ptr`).
+fn emit_validate_string_arg(ctx: &mut FnCtx<'_>, value_box: &str, name: &str) {
+    let name_label = emit_string_literal_global(ctx, name);
+    let name_len = name.len();
+    let blk = ctx.block();
+    blk.call_void(
+        "js_runtime_validate_string_arg",
+        &[
+            (DOUBLE, value_box),
+            (PTR, &name_label),
+            (I32, &name_len.to_string()),
+        ],
+    );
+}
+
+/// #2013/#3146: emit a setup-time validation for a `node:crypto` key-material
+/// argument (`createHmac` key). Accepts a string or `Buffer`/`TypedArray`/
+/// `DataView`/`ArrayBuffer`; throws `TypeError [ERR_INVALID_ARG_TYPE]`
+/// otherwise. Emitted before the value is unboxed.
+fn emit_validate_crypto_key_arg(ctx: &mut FnCtx<'_>, value_box: &str, name: &str) {
+    let name_label = emit_string_literal_global(ctx, name);
+    let name_len = name.len();
+    let blk = ctx.block();
+    blk.call_void(
+        "js_runtime_validate_crypto_key_arg",
+        &[
+            (DOUBLE, value_box),
+            (PTR, &name_label),
+            (I32, &name_len.to_string()),
+        ],
+    );
+}
+
+/// #2013/#3146: emit a setup-time `validateInteger(value, name, min, max)`
+/// call. Used for `pbkdf2*` iterations/keylen and `scryptSync` keylen, which
+/// node validates as integers in a fixed range before deriving. Emitted in
+/// node's argument order so the first bad argument reports the matching error.
+fn emit_validate_integer_arg(ctx: &mut FnCtx<'_>, value_box: &str, name: &str, min: f64, max: f64) {
+    let name_label = emit_string_literal_global(ctx, name);
+    let name_len = name.len();
+    let blk = ctx.block();
+    blk.call_void(
+        "js_runtime_validate_integer_arg",
+        &[
+            (DOUBLE, value_box),
+            (PTR, &name_label),
+            (I32, &name_len.to_string()),
+            (DOUBLE, &double_literal(min)),
+            (DOUBLE, &double_literal(max)),
+        ],
+    );
+}
+
 /// Whether a `createHash(...).update(e)` / `createHmac(alg, e)` argument is a
 /// Buffer / Uint8Array — either a direct buffer-producing expression or a
 /// local/field whose static type is `Buffer` / `Uint8Array`. Such inputs must
@@ -365,6 +424,21 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         Some(lower_expr(ctx, &digest_args[0])?)
                     };
 
+                    // #2013/#3146: validate the algorithm (and HMAC key) BEFORE
+                    // unboxing — a non-string would mask into a bogus pointer
+                    // and segfault `bytes_from_ptr`. node validates the
+                    // algorithm first, then the key.
+                    let is_hmac = create_method == "createHmac" || create_method == "Hmac";
+                    emit_validate_string_arg(
+                        ctx,
+                        &alg_box,
+                        if is_hmac { "hmac" } else { "algorithm" },
+                    );
+                    if is_hmac {
+                        if let Some(kb) = &key_box_opt {
+                            emit_validate_crypto_key_arg(ctx, kb, "key");
+                        }
+                    }
                     let blk = ctx.block();
                     let alg_handle = unbox_to_i64(blk, &alg_box);
                     // Allocate the handle. Both helpers return f64 already
@@ -494,6 +568,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else {
                 None
             };
+            // #2013/#3146: reject a non-string algorithm before unboxing.
+            emit_validate_string_arg(ctx, &alg_box, "algorithm");
             let blk = ctx.block();
             let alg_handle = unbox_to_i64(blk, &alg_box);
             // Returns an already-NaN-boxed f64 (POINTER_TAG + handle id).
@@ -816,6 +892,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             }
             let alg_box = lower_expr(ctx, &args[0])?;
             let key_box = lower_expr(ctx, &args[1])?;
+            // #2013/#3146: validate algorithm (then key) before unboxing.
+            emit_validate_string_arg(ctx, &alg_box, "hmac");
+            emit_validate_crypto_key_arg(ctx, &key_box, "key");
             let blk = ctx.block();
             let alg_handle = unbox_to_i64(blk, &alg_box);
             let key_handle = unbox_to_i64(blk, &key_box);
@@ -1701,6 +1780,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else {
                 None
             };
+            // #2013/#3146: node validates iterations (int >= 1), keylen
+            // (int >= 0), then the digest (string) before deriving — and a
+            // non-string digest would otherwise mask into a bogus pointer and
+            // segfault `bytes_from_ptr`.
+            emit_validate_integer_arg(ctx, &iter_box, "iterations", 1.0, i32::MAX as f64);
+            emit_validate_integer_arg(ctx, &keylen_box, "keylen", 0.0, i32::MAX as f64);
+            if let Some(db) = &digest_box {
+                emit_validate_string_arg(ctx, db, "digest");
+            }
             let blk = ctx.block();
             let pwd_handle = unbox_to_i64(blk, &pwd_box);
             let salt_handle = unbox_to_i64(blk, &salt_box);
@@ -1784,6 +1872,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             } else {
                 None
             };
+            // #2013/#3146: node validates keylen as an integer in [0, 2^31-1].
+            emit_validate_integer_arg(ctx, &keylen_box, "keylen", 0.0, i32::MAX as f64);
             let blk = ctx.block();
             let pwd_handle = unbox_to_i64(blk, &pwd_box);
             let salt_handle = unbox_to_i64(blk, &salt_box);

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -391,6 +391,21 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_crypto_md5", I64, &[I64]);
     module.declare_function("js_crypto_hmac_sha256", I64, &[I64, I64]);
     module.declare_function("js_crypto_hmac_sha256_bytes", I64, &[I64, I64]);
+    // #2013/#3146: shared codegen-callable argument validators. Emitted before
+    // a NaN-boxed value is unboxed to a raw pointer so a bad type throws node's
+    // `TypeError [ERR_INVALID_ARG_TYPE]` instead of dereferencing a bogus
+    // pointer (segfault). Used by `crypto.createHash`/`createHmac`/`pbkdf2*`.
+    module.declare_function("js_runtime_validate_string_arg", VOID, &[DOUBLE, PTR, I32]);
+    module.declare_function(
+        "js_runtime_validate_crypto_key_arg",
+        VOID,
+        &[DOUBLE, PTR, I32],
+    );
+    module.declare_function(
+        "js_runtime_validate_integer_arg",
+        VOID,
+        &[DOUBLE, PTR, I32, DOUBLE, DOUBLE],
+    );
     module.declare_function(
         "js_crypto_pbkdf2_bytes",
         I64,

--- a/crates/perry-runtime/src/fs/validate.rs
+++ b/crates/perry-runtime/src/fs/validate.rs
@@ -228,6 +228,13 @@ fn read_js_string(value: f64) -> String {
     string_header_to_string(ptr)
 }
 
+/// Public accessor for [`read_js_string`] so the shared `validators` module
+/// can render a string value's contents in an `ERR_INVALID_ARG_VALUE` /
+/// `validateOneOf` message.
+pub fn read_js_string_pub(value: f64) -> String {
+    read_js_string(value)
+}
+
 /// Render a string the way Node's `determineSpecificType` does for the
 /// `Received …` clause: single-quoted (switched to double quotes when the
 /// content has a single quote but no double quote), then truncated to 25

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -110,6 +110,7 @@ pub(crate) mod typedarray_props;
 pub mod typedarray_view;
 pub mod url;
 pub mod v8;
+pub mod validators;
 pub mod value;
 pub mod wasi;
 pub mod web_storage;

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -37,9 +37,41 @@ fn buffer_write_encoding_tag_or_throw(value: f64) -> i32 {
         throw_buffer_type_error_with_code("Invalid Buffer encoding", "ERR_INVALID_ARG_TYPE");
     }
     if crate::buffer::js_buffer_is_encoding(value) == 0 {
-        throw_buffer_type_error_with_code("Unknown encoding", "ERR_UNKNOWN_ENCODING");
+        throw_unknown_encoding(value);
     }
     crate::buffer::js_encoding_tag_from_value(value)
+}
+
+/// Throw `TypeError [ERR_UNKNOWN_ENCODING]: Unknown encoding: <name>` with
+/// the offending encoding name spelled out, matching node's message. `value`
+/// is the rejected encoding argument (a string).
+fn throw_unknown_encoding(value: f64) -> ! {
+    let name = crate::fs::validate::read_js_string_pub(value);
+    let message = format!("Unknown encoding: {name}");
+    crate::fs::validate::throw_type_error_with_code(&message, "ERR_UNKNOWN_ENCODING");
+}
+
+/// True when `value` is a `Buffer` or `Uint8Array` (the acceptance set of
+/// node's `Buffer.prototype.copy/compare/equals` target argument).
+fn is_buffer_or_uint8array(value: f64) -> bool {
+    let bits = value.to_bits() as i64;
+    if crate::buffer::js_buffer_is_buffer(bits) == 1 {
+        return true;
+    }
+    let raw = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+    raw >= 0x1000 && crate::typedarray::lookup_typed_array_kind(raw).is_some()
+}
+
+/// `Buffer.prototype.copy/compare/equals` reject a non-`Buffer`/`Uint8Array`
+/// target with `TypeError [ERR_INVALID_ARG_TYPE]` — and without this guard a
+/// number/boolean argument's bit pattern is masked into a bogus pointer and
+/// dereferenced (segfault). `name` is node's parameter name (`target` /
+/// `otherBuffer`).
+fn validate_buffer_target(value: f64, name: &str) {
+    if is_buffer_or_uint8array(value) {
+        return;
+    }
+    crate::validators::throw_invalid_arg_type(name, "an instance of Buffer or Uint8Array", value);
 }
 
 /// Dispatch a Buffer / Uint8Array instance method call. Receiver address
@@ -517,7 +549,11 @@ pub unsafe fn dispatch_buffer_method(
         "entries" => crate::buffer::js_buffer_entries(buf_f64),
         // `src.copy(dst, targetStart?, sourceStart?, sourceEnd?)` — mirrors
         // Node's Buffer.prototype.copy. Returns the number of bytes copied.
-        "copy" if !args.is_empty() => {
+        "copy" => {
+            if args.is_empty() {
+                validate_buffer_target(f64::from_bits(crate::value::TAG_UNDEFINED), "target");
+            }
+            validate_buffer_target(args[0], "target");
             let dst_bits = args[0].to_bits();
             let dst_addr = if (dst_bits >> 48) >= 0x7FF8 {
                 dst_bits & 0x0000_FFFF_FFFF_FFFF
@@ -539,7 +575,13 @@ pub unsafe fn dispatch_buffer_method(
         // `buf.write(string, offset?, length?, encoding?)` — writes the
         // utf8/hex/base64 encoding of `string` into `buf` at `offset`.
         // Returns the number of bytes written.
-        "write" if !args.is_empty() => {
+        "write" => {
+            if args.is_empty() || !is_buffer_dispatch_string(args[0]) {
+                throw_buffer_type_error_with_code(
+                    "argument must be a string",
+                    "ERR_INVALID_ARG_TYPE",
+                );
+            }
             let str_bits = args[0].to_bits();
             let str_addr = if (str_bits >> 48) >= 0x7FF8 {
                 str_bits & 0x0000_FFFF_FFFF_FFFF
@@ -632,9 +674,12 @@ pub unsafe fn dispatch_buffer_method(
             f64::from_bits(JSValue::pointer(result as *mut u8).bits())
         }
         "equals" => {
-            if args.is_empty() {
-                return i32_bool(0);
-            }
+            validate_buffer_target(
+                args.first()
+                    .copied()
+                    .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED)),
+                "otherBuffer",
+            );
             let other_bits = args[0].to_bits();
             let other_addr = if (other_bits >> 48) >= 0x7FF8 {
                 other_bits & 0x0000_FFFF_FFFF_FFFF
@@ -645,9 +690,12 @@ pub unsafe fn dispatch_buffer_method(
             i32_bool(crate::buffer::js_buffer_equals(buf_ptr, other))
         }
         "compare" => {
-            if args.is_empty() {
-                return 0.0;
-            }
+            validate_buffer_target(
+                args.first()
+                    .copied()
+                    .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED)),
+                "target",
+            );
             let other_bits = args[0].to_bits();
             let other_addr = if (other_bits >> 48) >= 0x7FF8 {
                 other_bits & 0x0000_FFFF_FFFF_FFFF

--- a/crates/perry-runtime/src/validators.rs
+++ b/crates/perry-runtime/src/validators.rs
@@ -1,0 +1,434 @@
+//! Shared Node-style argument validators (#2013, #3146).
+//!
+//! Mirrors node's `lib/internal/validators.js` (`validateString`,
+//! `validateNumber`, `validateInteger`, `validateInt32`, `validateUint32`,
+//! `validateBoolean`, `validateObject`, `validateFunction`, `validateBuffer`,
+//! `validateOneOf`, `validatePort`, …) so every stdlib entry point can throw
+//! the same typed error (`TypeError [ERR_INVALID_ARG_TYPE]`, `RangeError
+//! [ERR_OUT_OF_RANGE]`, `RangeError [ERR_SOCKET_BAD_PORT]`,
+//! `TypeError [ERR_INVALID_ARG_VALUE]`) with node's exact message shape.
+//!
+//! The error-object plumbing (message side table carrying `.code`, the
+//! `Received …` clause renderer) predates this module and lives in
+//! [`crate::fs::validate`]; this module is the argument-validation surface
+//! built on top of it. New stdlib validation should call these helpers
+//! rather than hand-formatting messages so the wording stays centralized.
+
+use crate::fs::validate::{
+    describe_received, format_received_number, is_numeric, throw_range_error_named,
+    throw_type_error_with_code,
+};
+use crate::value::JSValue;
+
+/// `Number.MIN_SAFE_INTEGER` / `Number.MAX_SAFE_INTEGER` — the default
+/// bounds of node's `validateInteger`.
+pub const MIN_SAFE_INTEGER: f64 = -9_007_199_254_740_991.0;
+pub const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+
+#[inline]
+fn jv(value: f64) -> JSValue {
+    JSValue::from_bits(value.to_bits())
+}
+
+/// True when `value` NaN-boxes a callable closure. Mirrors
+/// `fs::stream::extract_closure_ptr`'s probe but uses only the public
+/// `crate::closure` surface (the `fs::stream` module is private).
+fn is_closure_value(value: f64) -> bool {
+    let bits = value.to_bits();
+    let top16 = bits >> 48;
+    let raw = if (0x7FF8..=0x7FFF).contains(&top16) {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if top16 == 0 {
+        bits as usize
+    } else {
+        return false;
+    };
+    raw >= 0x1000 && crate::closure::is_closure_ptr(raw)
+}
+
+/// Numeric payload of a JS number value (plain double or INT32-tagged).
+/// Callers must have checked [`is_numeric`] first.
+pub fn number_value(value: f64) -> f64 {
+    let v = jv(value);
+    if v.is_int32() {
+        v.as_int32() as f64
+    } else {
+        v.as_number()
+    }
+}
+
+/// node `determineSpecificType` puts `argument` in the message for plain
+/// names and `property` for dotted ones (`options.level`).
+fn name_kind(name: &str) -> &'static str {
+    if name.contains('.') {
+        "property"
+    } else {
+        "argument"
+    }
+}
+
+/// Throw `TypeError [ERR_INVALID_ARG_TYPE]` with node's message shape:
+/// `The "<name>" argument must be <expected>. Received <actual>`.
+///
+/// `expected` is the already-formatted clause — `"of type string"`,
+/// `"an instance of Buffer, TypedArray, or DataView"`, `"one of type string
+/// or object"` — matching how node renders its `expected` array.
+pub fn throw_invalid_arg_type(name: &str, expected: &str, value: f64) -> ! {
+    let message = format!(
+        "The \"{}\" {} must be {}. Received {}",
+        name,
+        name_kind(name),
+        expected,
+        describe_received(value)
+    );
+    throw_type_error_with_code(&message, "ERR_INVALID_ARG_TYPE")
+}
+
+/// Render the `Received …` clause of an `ERR_OUT_OF_RANGE` message. node
+/// adds `_` numeric separators once the magnitude passes 2^32
+/// (`addNumericalSeparator` in internal/errors.js).
+pub fn format_range_received(n: f64) -> String {
+    let base = format_received_number(n);
+    if n.is_finite() && n.fract() == 0.0 && n.abs() > 4_294_967_296.0 {
+        let (sign, digits) = base
+            .strip_prefix('-')
+            .map_or(("", base.as_str()), |rest| ("-", rest));
+        let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+        let len = digits.len();
+        for (i, ch) in digits.chars().enumerate() {
+            if i > 0 && (len - i) % 3 == 0 {
+                out.push('_');
+            }
+            out.push(ch);
+        }
+        format!("{sign}{out}")
+    } else {
+        base
+    }
+}
+
+/// Throw `RangeError [ERR_OUT_OF_RANGE]`: `The value of "<name>" is out of
+/// range. It must be <range>. Received <received>`.
+pub fn throw_out_of_range(name: &str, range: &str, received: &str) -> ! {
+    let message = format!(
+        "The value of \"{}\" is out of range. It must be {}. Received {}",
+        name, range, received
+    );
+    throw_range_error_named(&message, "ERR_OUT_OF_RANGE")
+}
+
+/// Throw `TypeError [ERR_INVALID_ARG_VALUE]`: `The <argument|property>
+/// '<name>' <reason>. Received <received>`.
+pub fn throw_invalid_arg_value(name: &str, reason: &str, received: &str) -> ! {
+    let message = format!(
+        "The {} '{}' {}. Received {}",
+        name_kind(name),
+        name,
+        reason,
+        received
+    );
+    throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE")
+}
+
+/// node `validateString(value, name)`.
+pub fn validate_string(value: f64, name: &str) {
+    if !jv(value).is_any_string() {
+        throw_invalid_arg_type(name, "of type string", value);
+    }
+}
+
+/// node `validateNumber(value, name[, min[, max]])`.
+pub fn validate_number(value: f64, name: &str, min: Option<f64>, max: Option<f64>) -> f64 {
+    if !is_numeric(jv(value)) {
+        throw_invalid_arg_type(name, "of type number", value);
+    }
+    let n = number_value(value);
+    let below = min.is_some_and(|m| !(n >= m));
+    let above = max.is_some_and(|m| !(n <= m));
+    if below || above {
+        let range = match (min, max) {
+            (Some(lo), Some(hi)) => format!(
+                ">= {} && <= {}",
+                format_received_number(lo),
+                format_received_number(hi)
+            ),
+            (Some(lo), None) => format!(">= {}", format_received_number(lo)),
+            (None, Some(hi)) => format!("<= {}", format_received_number(hi)),
+            (None, None) => unreachable!(),
+        };
+        throw_out_of_range(name, &range, &format_range_received(n));
+    }
+    n
+}
+
+/// node `validateInteger(value, name[, min[, max]])` — defaults to the safe
+/// integer range. Returns the validated value.
+pub fn validate_integer(value: f64, name: &str, min: f64, max: f64) -> f64 {
+    if !is_numeric(jv(value)) {
+        throw_invalid_arg_type(name, "of type number", value);
+    }
+    let n = number_value(value);
+    if !n.is_finite() || n.fract() != 0.0 {
+        throw_out_of_range(name, "an integer", &format_range_received(n));
+    }
+    if n < min || n > max {
+        let range = format!(
+            ">= {} && <= {}",
+            format_received_number(min),
+            format_received_number(max)
+        );
+        throw_out_of_range(name, &range, &format_range_received(n));
+    }
+    n
+}
+
+/// node `validateInt32(value, name[, min[, max]])`.
+pub fn validate_int32(value: f64, name: &str, min: i32, max: i32) -> i32 {
+    validate_integer(value, name, min as f64, max as f64) as i32
+}
+
+/// node `validateUint32(value, name)`.
+pub fn validate_uint32(value: f64, name: &str) -> u32 {
+    validate_integer(value, name, 0.0, u32::MAX as f64) as u32
+}
+
+/// node `validateBoolean(value, name)`.
+pub fn validate_boolean(value: f64, name: &str) {
+    if !jv(value).is_bool() {
+        throw_invalid_arg_type(name, "of type boolean", value);
+    }
+}
+
+/// node `validateFunction(value, name)`.
+pub fn validate_function(value: f64, name: &str) {
+    if !is_closure_value(value) {
+        throw_invalid_arg_type(name, "of type function", value);
+    }
+}
+
+/// GC object-type tag for a heap pointer value, if it is one. Uses the
+/// centralized `addr_class::try_read_gc_header` (handle-band/magnitude guard +
+/// header read) rather than a hand-rolled `GcHeader` cast.
+fn gc_obj_type(value: f64) -> Option<u8> {
+    let v = jv(value);
+    if !v.is_pointer() {
+        return None;
+    }
+    let addr = v.as_pointer::<u8>() as usize;
+    let header = unsafe { crate::value::addr_class::try_read_gc_header(addr)? };
+    if header.obj_type <= crate::gc::GC_TYPE_MAX {
+        Some(header.obj_type)
+    } else {
+        None
+    }
+}
+
+/// node `validateObject(value, name)` with default options: rejects `null`,
+/// arrays, functions, and primitives.
+pub fn validate_object(value: f64, name: &str) {
+    let is_plain_object = gc_obj_type(value) == Some(crate::gc::GC_TYPE_OBJECT)
+        && !is_closure_value(value)
+        && crate::buffer::js_buffer_is_buffer(value.to_bits() as i64) != 1;
+    if !is_plain_object {
+        throw_invalid_arg_type(name, "of type object", value);
+    }
+}
+
+/// True when `value` is a `Buffer`, `TypedArray`, or `DataView` — the
+/// acceptance set of node's `validateBuffer` / `isArrayBufferView`.
+pub fn is_buffer_like(value: f64) -> bool {
+    let bits = value.to_bits() as i64;
+    if crate::buffer::js_buffer_is_buffer(bits) == 1 {
+        return true;
+    }
+    let raw = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if raw < 0x1000 {
+        return false;
+    }
+    if crate::typedarray::lookup_typed_array_kind(raw).is_some() {
+        return true;
+    }
+    crate::buffer::is_registered_buffer(raw) && crate::buffer::is_data_view(raw)
+}
+
+/// node `validateBuffer(value, name)`.
+pub fn validate_buffer(value: f64, name: &str) {
+    if !is_buffer_like(value) {
+        throw_invalid_arg_type(
+            name,
+            "an instance of Buffer, TypedArray, or DataView",
+            value,
+        );
+    }
+}
+
+/// Validate a value that may be a string OR a `Buffer`/`TypedArray`/
+/// `DataView` (the acceptance set of `hash.update`, `hmac.update`,
+/// `cipher.update`, …). `expected` is the already-formatted clause node uses
+/// for that specific API (the accepted view set varies slightly between
+/// APIs). Throws `TypeError [ERR_INVALID_ARG_TYPE]` otherwise.
+pub fn validate_string_or_buffer_view(value: f64, name: &str, expected: &str) {
+    if jv(value).is_any_string() || is_buffer_like(value) {
+        return;
+    }
+    throw_invalid_arg_type(name, expected, value);
+}
+
+/// node `validateOneOf(value, name, oneOf)` for string-valued options.
+pub fn validate_one_of_str(value: f64, name: &str, one_of: &[&str]) {
+    let v = jv(value);
+    if v.is_any_string() {
+        let content = crate::fs::validate::read_js_string_pub(value);
+        if one_of.contains(&content.as_str()) {
+            return;
+        }
+    }
+    let reason = format!(
+        "must be one of: {}",
+        one_of
+            .iter()
+            .map(|s| format!("'{s}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let received = if v.is_any_string() {
+        format!("'{}'", crate::fs::validate::read_js_string_pub(value))
+    } else {
+        describe_received(value)
+    };
+    throw_invalid_arg_value(name, &reason, &received);
+}
+
+/// node `validatePort(port, name)` — throws `RangeError
+/// [ERR_SOCKET_BAD_PORT]` with node's exact sentence (note the trailing
+/// period and the `determineSpecificType`-style `Received` clause).
+pub fn validate_port(value: f64, name: &str) -> u16 {
+    let v = jv(value);
+    let ok_number = is_numeric(v) && {
+        let n = number_value(value);
+        n.fract() == 0.0 && (0.0..65536.0).contains(&n)
+    };
+    if ok_number {
+        return number_value(value) as u16;
+    }
+    // node also accepts numeric strings ("8080").
+    if v.is_any_string() {
+        let content = crate::fs::validate::read_js_string_pub(value);
+        if let Ok(n) = content.trim().parse::<f64>() {
+            if n.fract() == 0.0 && (0.0..65536.0).contains(&n) {
+                return n as u16;
+            }
+        }
+    }
+    let message = format!(
+        "{} should be >= 0 and < 65536. Received {}.",
+        name,
+        describe_received(value)
+    );
+    throw_range_error_named(&message, "ERR_SOCKET_BAD_PORT")
+}
+
+// ============================================================================
+// Codegen-callable `#[no_mangle]` entry points.
+//
+// Some stdlib entry points (notably `crypto.createHash` / `createHmac` /
+// `pbkdf2*`) are dispatched by codegen, which NaN-*unboxes* the argument to a
+// raw pointer *before* the runtime call. A non-string argument (e.g. a number)
+// then has its bit pattern masked into a bogus pointer and dereferenced — a
+// hard segfault rather than node's catchable `TypeError`. These helpers take
+// the *original* NaN-boxed value (as `f64`) plus the argument name, so codegen
+// can emit a `call void` validation BEFORE the unbox, throwing node's typed
+// error instead of crashing. The `#[used]` anchors below keep them alive
+// through the auto-optimize whole-program rebuild (the bitcode internalizer
+// drops `#[no_mangle]` symbols only referenced from generated `.o`).
+// ============================================================================
+
+unsafe fn read_arg_name(name_ptr: *const u8, name_len: u32, fallback: &str) -> String {
+    if name_ptr.is_null() || name_len == 0 {
+        fallback.to_string()
+    } else {
+        let bytes = std::slice::from_raw_parts(name_ptr, name_len as usize);
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+}
+
+/// Codegen-callable `validateString`. Throws `TypeError
+/// [ERR_INVALID_ARG_TYPE]` (`The "<name>" argument must be of type string.
+/// Received …`) when `value` is not a string; no-op otherwise.
+///
+/// # Safety
+/// `name_ptr`/`name_len` must describe a valid UTF-8 byte range.
+#[no_mangle]
+pub unsafe extern "C" fn js_runtime_validate_string_arg(
+    value: f64,
+    name_ptr: *const u8,
+    name_len: u32,
+) {
+    if jv(value).is_any_string() {
+        return;
+    }
+    let name = read_arg_name(name_ptr, name_len, "value");
+    throw_invalid_arg_type(&name, "of type string", value);
+}
+
+/// Codegen-callable validator for a `node:crypto` key-material argument
+/// (`createHmac` key, etc.): accepts a string, `Buffer`, `TypedArray`,
+/// `DataView`, or `ArrayBuffer`. Throws node's
+/// `The "<name>" argument must be of type string or an instance of
+/// ArrayBuffer, Buffer, TypedArray, DataView, KeyObject, or CryptoKey`
+/// message otherwise.
+///
+/// # Safety
+/// `name_ptr`/`name_len` must describe a valid UTF-8 byte range.
+#[no_mangle]
+pub unsafe extern "C" fn js_runtime_validate_crypto_key_arg(
+    value: f64,
+    name_ptr: *const u8,
+    name_len: u32,
+) {
+    let v = jv(value);
+    if v.is_any_string() || is_buffer_like(value) {
+        return;
+    }
+    // A registered ArrayBuffer (without the DataView bit) is also acceptable
+    // key material.
+    let raw = (value.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+    if raw >= 0x1000 && crate::buffer::is_any_array_buffer(raw) {
+        return;
+    }
+    let name = read_arg_name(name_ptr, name_len, "key");
+    throw_invalid_arg_type(
+        &name,
+        "of type string or an instance of ArrayBuffer, Buffer, TypedArray, DataView, KeyObject, or CryptoKey",
+        value,
+    );
+}
+
+/// Codegen-callable `validateInteger(value, name, min, max)`. Throws
+/// `TypeError [ERR_INVALID_ARG_TYPE]` on a non-number, `RangeError
+/// [ERR_OUT_OF_RANGE]` on a non-integer or out-of-range value. `min`/`max`
+/// are passed as `f64` (codegen has no i64 immediate convention here).
+///
+/// # Safety
+/// `name_ptr`/`name_len` must describe a valid UTF-8 byte range.
+#[no_mangle]
+pub unsafe extern "C" fn js_runtime_validate_integer_arg(
+    value: f64,
+    name_ptr: *const u8,
+    name_len: u32,
+    min: f64,
+    max: f64,
+) {
+    let name = read_arg_name(name_ptr, name_len, "value");
+    validate_integer(value, &name, min, max);
+}
+
+#[used]
+static KEEP_VALIDATE_STRING_ARG: unsafe extern "C" fn(f64, *const u8, u32) =
+    js_runtime_validate_string_arg;
+#[used]
+static KEEP_VALIDATE_CRYPTO_KEY_ARG: unsafe extern "C" fn(f64, *const u8, u32) =
+    js_runtime_validate_crypto_key_arg;
+#[used]
+static KEEP_VALIDATE_INTEGER_ARG: unsafe extern "C" fn(f64, *const u8, u32, f64, f64) =
+    js_runtime_validate_integer_arg;

--- a/crates/perry-stdlib/src/crypto/hash_handles.rs
+++ b/crates/perry-stdlib/src/crypto/hash_handles.rs
@@ -3,6 +3,24 @@ use perry_runtime::{js_closure_call0, js_closure_call1, ClosureHeader};
 use std::collections::HashMap;
 use std::sync::{Mutex, Once};
 
+/// node validates the `data` arg of `hash.update`/`hmac.update` is a string
+/// or `Buffer`/`TypedArray`/`DataView` before touching it. Without this a
+/// number/null has its bit pattern masked into a bogus pointer and
+/// dereferenced (segfault on `createHash('sha256').update(123)`). Returns the
+/// validated value so the caller can decode it.
+fn validate_update_data(args: &[f64]) -> f64 {
+    let data = args
+        .first()
+        .copied()
+        .unwrap_or_else(|| f64::from_bits(0x7FFC_0000_0000_0001));
+    perry_runtime::validators::validate_string_or_buffer_view(
+        data,
+        "data",
+        "of type string or an instance of Buffer, TypedArray, or DataView",
+    );
+    data
+}
+
 #[derive(Default)]
 struct CryptoDigestStream {
     listeners: HashMap<String, Vec<i64>>,
@@ -426,9 +444,10 @@ pub unsafe fn dispatch_hash(handle: i64, method: &str, args: &[f64]) -> f64 {
         );
     }
     match method {
-        "update" if !args.is_empty() => {
+        "update" => {
+            let data = validate_update_data(args);
             let encoding = arg_string(args, 1);
-            let bytes = decode_hash_update_value(args[0], &encoding);
+            let bytes = decode_hash_update_value(data, &encoding);
             let mut guard = h.state.lock().unwrap();
             if let Some(state) = guard.as_mut() {
                 update_hash_state(state, &bytes);
@@ -687,9 +706,10 @@ pub unsafe fn dispatch_hmac(handle: i64, method: &str, args: &[f64]) -> f64 {
         );
     }
     match method {
-        "update" if !args.is_empty() => {
+        "update" => {
+            let data = validate_update_data(args);
             let encoding = arg_string(args, 1);
-            let bytes = decode_hash_update_value(args[0], &encoding);
+            let bytes = decode_hash_update_value(data, &encoding);
             let mut guard = h.state.lock().unwrap();
             if let Some(state) = guard.as_mut() {
                 update_hmac_state(state, &bytes);


### PR DESCRIPTION
## What this unblocks

Real-world Node code that passes a wrong-typed argument to a stdlib API now gets the **same catchable `TypeError`/`RangeError` Node throws**, instead of Perry either silently coercing or — worse — **dereferencing the argument's NaN-box bit pattern as a pointer and segfaulting**. Several of the fixed cases were hard crashes (exit 139) on bad input — a DoS-class hazard for any server that hashes/derives/copies attacker-influenced values.

Implements #2013 / #3146: a shared validators module mirroring Node's `lib/internal/validators.js`, wired into the highest-frequency `crypto` and `buffer` entry points.

## New shared module: `crates/perry-runtime/src/validators.rs`

`validateString / validateNumber / validateInteger / validateInt32 / validateUint32 / validateBoolean / validateObject / validateFunction / validateBuffer / validateOneOf / validatePort`, plus the `ERR_*` builders (`throw_invalid_arg_type`, `throw_out_of_range`, `throw_invalid_arg_value`) on top of the existing `fs::validate` error-object plumbing (message side-table `.code` + `Received …` renderer).

It also exposes three **codegen-callable** `#[no_mangle]` entry points — `js_runtime_validate_string_arg`, `js_runtime_validate_crypto_key_arg`, `js_runtime_validate_integer_arg` — emitted by codegen *before* a NaN-boxed value is unboxed to a raw pointer (the crypto dispatch path pre-extracts pointers, so a number had to be rejected at the call site to avoid the segfault). `#[used]` anchors keep them alive through the auto-optimize whole-program rebuild.

## Wired into

- **`crypto.createHash` / `createHmac`** (chain-collapse, standalone, and legacy callable arms) — algorithm/key type validation.
- **`hash.update` / `hmac.update`** — data type validation (`dispatch_hash`/`dispatch_hmac`).
- **`crypto.pbkdf2Sync` / `scryptSync`** — `iterations` / `keylen` integer-range + `digest` string validation, in Node's argument order.
- **`Buffer.prototype.copy / compare / equals / write`** — target/string type validation in `buffer_dispatch`.
- Unknown-encoding messages (`buf.write`) now spell out the encoding name (`Unknown encoding: badenc`).

## Node-differential repros (all match node v26.3.0 exactly)

Crashes fixed (were exit 139, now throw a catchable error):

| call | result (node === perry) |
|------|------|
| `crypto.createHash(123)` | `TypeError [ERR_INVALID_ARG_TYPE]` The "algorithm" argument must be of type string. Received type number (123) |
| `crypto.createHmac(123,'k')` | `TypeError [ERR_INVALID_ARG_TYPE]` The "hmac" argument must be of type string… |
| `crypto.createHmac('sha256',123)` | `TypeError [ERR_INVALID_ARG_TYPE]` The "key" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, DataView, KeyObject, or CryptoKey… |
| `createHash('sha256').update(123)` | `TypeError [ERR_INVALID_ARG_TYPE]` The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView… |
| `crypto.pbkdf2Sync('p','s',1,16,123)` | `TypeError [ERR_INVALID_ARG_TYPE]` The "digest" argument must be of type string… |
| `Buffer.alloc(2).copy(123)` | `TypeError [ERR_INVALID_ARG_TYPE]` The "target" argument must be an instance of Buffer or Uint8Array… |
| `Buffer.alloc(2).compare(123)` | same, "target" |
| `Buffer.alloc(2).equals(123)` | same, "otherBuffer" |
| `Buffer.alloc(4).write(123)` | `TypeError [ERR_INVALID_ARG_TYPE]` argument must be a string |

Silent no-throws fixed:

| call | result (node === perry) |
|------|------|
| `crypto.pbkdf2Sync('p','s','x',16,'sha256')` | `TypeError [ERR_INVALID_ARG_TYPE]` "iterations" must be of type number |
| `crypto.pbkdf2Sync('p','s',-1,16,'sha256')` | `RangeError [ERR_OUT_OF_RANGE]` "iterations" >= 1 && <= 2147483647 |
| `crypto.pbkdf2Sync('p','s',1,'x','sha256')` | `TypeError [ERR_INVALID_ARG_TYPE]` "keylen" must be of type number |
| `crypto.scryptSync('p','s','x')` / `(…,-1)` | `TypeError`/`RangeError` on "keylen" |
| `buf.write('a','badenc')` | `TypeError [ERR_UNKNOWN_ENCODING]` Unknown encoding: badenc |

Valid paths are byte-identical to node (sha256/hmac/pbkdf2/scrypt digests, `buf.copy/compare/equals/write`) — the validators are no-ops on good input.

## Files

- `crates/perry-runtime/src/validators.rs` (new), `lib.rs` (mod), `fs/validate.rs` (expose `read_js_string_pub`)
- `crates/perry-runtime/src/object/buffer_dispatch.rs` (copy/compare/equals/write + encoding-name)
- `crates/perry-stdlib/src/crypto/hash_handles.rs` (update data validation)
- `crates/perry-codegen/src/expr/calls.rs` (createHash/createHmac/pbkdf2Sync/scryptSync emit validation) + `runtime_decls/stdlib_ffi.rs` (declarations)

## Regression guard

test262 `built-ins`+`language` shard 0/16, my binary vs an origin/main baseline binary, failing-test **set** diff: **0 real regressions**. The 4 set-diff deltas were all `compile-fail` with reason "Wrote executable…" (the known concurrent-sweep contention flake) and **all 4 pass when re-run in isolation**; they're in `language/expressions/class/elements`, unrelated to crypto/buffer. Parity unchanged at 93.8%.