### PR TITLE
fix(cjs): reassigned require() alias stays a mutable local (#5006)

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
@@ -96,3 +96,86 @@ pub fn extract_require_aliases_with_ranges(source: &str) -> Vec<(String, String,
     }
     out
 }
+
+/// Issue #5006: does `name` appear as an *assignment target* (reassignment)
+/// anywhere in `source`, beyond its own declaration?
+///
+/// A `require()` alias is normally hoisted into an immutable module-scope ESM
+/// import binding (`import s from './m'`) and its `var s = require('./m')`
+/// declaration is blanked from the IIFE body (see `wrap.rs` adoption / hoist
+/// strip passes). That is correct only when the binding is read-only. A module
+/// that *reassigns* the alias (`s = s.filter(...)`, the canonical signal-exit
+/// shape) must keep `s` as a real mutable local, so we exclude reassigned
+/// aliases from both passes.
+///
+/// Heuristic, regex-crate-friendly (no lookaround): scan whole-word
+/// occurrences of `name`, skip member accesses (`obj.name`) and the
+/// `var`/`let`/`const name = ...` declaration itself, and flag the rest when
+/// the next non-space token is an assignment operator (`=` that is not `==`,
+/// `===`, or `=>`, or any compound `+=`/`&&=`/`>>>=`/… form). False positives
+/// only forfeit an optimization (the alias stays a mutable local, which is
+/// always correct); they never miscompile.
+pub fn identifier_is_reassigned(source: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let bytes = source.as_bytes();
+    let nlen = name.len();
+    let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b'$';
+    let mut from = 0usize;
+    while let Some(rel) = source[from..].find(name) {
+        let start = from + rel;
+        let end = start + nlen;
+        from = start + 1;
+        // Whole-word boundaries.
+        if start > 0 && is_ident(bytes[start - 1]) {
+            continue;
+        }
+        if end < bytes.len() && is_ident(bytes[end]) {
+            continue;
+        }
+        // Preceding non-space char: skip member access (`.name`).
+        let mut p = start;
+        while p > 0 && (bytes[p - 1] as char).is_whitespace() {
+            p -= 1;
+        }
+        if p > 0 && bytes[p - 1] == b'.' {
+            continue;
+        }
+        // Skip the `var`/`let`/`const name` declaration keyword.
+        let mut w = p;
+        while w > 0 && is_ident(bytes[w - 1]) {
+            w -= 1;
+        }
+        if matches!(&source[w..p], "var" | "let" | "const") {
+            continue;
+        }
+        // Following non-space char(s) must open an assignment operator.
+        let mut q = end;
+        while q < bytes.len() && (bytes[q] as char).is_whitespace() {
+            q += 1;
+        }
+        if q >= bytes.len() {
+            continue;
+        }
+        let rest = &source[q..];
+        let is_assignment =
+            if rest.starts_with("===") || rest.starts_with("==") || rest.starts_with("=>") {
+                false
+            } else if rest.starts_with('=') {
+                true
+            } else {
+                // Compound assignments: `+=`, `-=`, `*=`, `/=`, `%=`, `**=`,
+                // `<<=`, `>>=`, `>>>=`, `&=`, `|=`, `^=`, `&&=`, `||=`, `??=`.
+                const COMPOUND: &[&str] = &[
+                    ">>>=", "**=", "<<=", ">>=", "&&=", "||=", "??=", "+=", "-=", "*=", "/=", "%=",
+                    "&=", "|=", "^=",
+                ];
+                COMPOUND.iter().any(|op| rest.starts_with(op))
+            };
+        if is_assignment {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -50,6 +50,7 @@ pub(self) use extract_exports::{
 };
 pub(self) use extract_requires::{
     extract_export_star_specs, extract_require_aliases_with_ranges, extract_require_specifiers,
+    identifier_is_reassigned,
 };
 pub(self) use hoist_classes::{
     extract_top_level_class_decls, rewrite_module_exports_class_expression,
@@ -282,6 +283,62 @@ module.exports = inner;
             "expected require dispatch through aliased import, got:\n{}",
             wrapped
         );
+    }
+
+    #[test]
+    fn wrap_keeps_reassigned_require_alias_as_mutable_local() {
+        // Issue #5006: a `require()`-initialized alias that is later
+        // *reassigned* (the signal-exit `signals = signals.filter(...)` shape)
+        // must NOT be hoisted into an immutable `import s from '...'` with its
+        // declaration blanked — that makes the reassignment unresolvable
+        // (`ReferenceError: s is not defined`). It must stay a real mutable
+        // local fed by the `_req_N` import.
+        let src = "var s = require('./data.js');\ns = s.filter(function () { return true; });\nmodule.exports = s;";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/test.js"));
+        // Falls back to the placeholder import name (alias not adopted)...
+        assert!(
+            wrapped.contains("import _req_0 from './data.js';"),
+            "expected non-adopted _req_0 import, got:\n{}",
+            wrapped
+        );
+        // ...the require dispatches through it...
+        assert!(
+            wrapped.contains("if (specifier === './data.js') return _req_0;"),
+            "expected require dispatch through _req_0, got:\n{}",
+            wrapped
+        );
+        // ...and the original `var s = require('./data.js')` declaration stays
+        // in the IIFE body (not blanked) so `s` is a mutable local.
+        assert!(
+            wrapped.contains("var s = require('./data.js');"),
+            "expected the alias declaration to survive as a mutable local, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
+    fn identifier_is_reassigned_distinguishes_declaration_from_write() {
+        use super::extract_requires::identifier_is_reassigned;
+        // Pure read-only alias: declaration + member reads only.
+        assert!(!identifier_is_reassigned(
+            "var dep = require('./dep'); module.exports = dep.value;",
+            "dep"
+        ));
+        // Reassignment.
+        assert!(identifier_is_reassigned(
+            "var s = require('./d'); s = s.filter(() => true);",
+            "s"
+        ));
+        // Compound assignment.
+        assert!(identifier_is_reassigned(
+            "var n = require('./n'); n += 1;",
+            "n"
+        ));
+        // Comparisons / arrows / member writes must not count as reassignment.
+        assert!(!identifier_is_reassigned(
+            "var s = require('./d'); if (s === other) {} obj.s = 1; cb(() => s);",
+            "s"
+        ));
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -109,6 +109,13 @@ pub(in crate::commands::compile) fn wrap_commonjs_for_target(
         if hoisted_class_names.iter().any(|c| c == alias) {
             return false;
         }
+        // #5006: a reassigned alias (`s = s.filter(...)`) must stay a real
+        // mutable local — adopting it into an immutable `import s from '...'`
+        // and blanking the declaration makes the reassignment unresolvable
+        // (`ReferenceError: s is not defined`, the signal-exit → ink wall).
+        if identifier_is_reassigned(source, alias) {
+            return false;
+        }
         true
     };
     let mut import_local_names: Vec<String> = require_specs
@@ -351,6 +358,11 @@ pub(in crate::commands::compile) fn wrap_commonjs_for_target(
         let aliases = extract_require_aliases_with_ranges(source);
         let lines = aliases
             .iter()
+            // #5006: a reassigned alias must keep its mutable `var alias =
+            // require(...)` local in the IIFE body — never surface it as an
+            // immutable module-scope `const alias = _req_N;` (the const write
+            // would throw) nor strip its declaration below.
+            .filter(|(alias, _, _)| !identifier_is_reassigned(source, alias))
             .filter_map(|(alias, spec, _range)| {
                 let idx = require_specs.iter().position(|s| s == spec)?;
                 // When the alias is already the spec's import local name
@@ -369,6 +381,7 @@ pub(in crate::commands::compile) fn wrap_commonjs_for_target(
         let ranges = aliases
             .into_iter()
             .filter(|(_, spec, _)| require_specs.iter().any(|s| s == spec))
+            .filter(|(alias, _, _)| !identifier_is_reassigned(source, alias))
             .map(|(_, _, range)| range)
             .collect::<Vec<_>>();
         (lines, ranges)


### PR DESCRIPTION
Fixes #5006.

## Problem

In a `compilePackages` (CJS) module, a top-level `var s = require('./m')` that is **later reassigned** (`s = s.filter(...)`) mis-compiled: reads right after the `require` were correct, but the reassignment threw `ReferenceError: s is not defined`, corrupting `s` for the rest of the module. This is the signal-exit → ink wall (`signals = signals.filter(...)`).

## Root cause

Not codegen/boxing — it's the `cjs_wrap` **source transform**. The alias-adoption optimization (#665/#1721) hoists `var s = require('./m')` into an immutable module-scope `import s from './m'` and blanks the body declaration. So `s` becomes an ESM import binding: reads lower to `ExternFuncRef`, and the reassignment can't resolve a real local → `js_throw_reference_error_unresolvable_assignment("s")`. Correct for read-only aliases, fatal for reassigned ones.

## Fix

Add `identifier_is_reassigned(source, name)` (conservative, no-lookaround text scan: skips member accesses and the declaration keyword; flags plain `=` / compound assignments) and exclude reassigned aliases from **both** strip passes in `wrap.rs`:
- the adoption pass (`alias_is_safe`), and
- the hoisted-class `const alias = _req_N;` surfacing/strip pass.

A reassigned alias keeps its `var s = require('./m')` as a real mutable local fed by the `_req_N` import. False positives only forfeit the optimization (alias stays a mutable local — always runtime-correct); they never miscompile.

## Validation

Byte-for-byte vs `node --experimental-strip-types`:
- minimal repro (`s = s.filter(...)`) → `[ 'a', 'b', 'c' ]` ✓
- signal-exit `forEach` + `filter` reassignment, incl. a closure capture that observes the post-reassignment value ✓
- `cfg = cfg || { fallback }` ✓
- read-only class-parent alias (rate-limiter `extends Base` shape) still adopts → class identity preserved ✓

`+2` unit tests; 493 perry bin tests green. Code-only PR (no version/changelog — maintainer folds at merge).

> Next ink gate after this is yoga-layout's WASM runtime (out of scope, per the issue).