### PR TITLE
fix(stdlib): enforce JWT exp claim in jwt.verify (GHSA-5324-c68v-8w62 / CVE-2026-53777)

### DIFF
--- a/crates/perry-stdlib/src/jsonwebtoken.rs
+++ b/crates/perry-stdlib/src/jsonwebtoken.rs
@@ -353,9 +353,16 @@ unsafe fn verify_decode(
     debug: bool,
 ) -> *mut StringHeader {
     let mut validation = Validation::new(algorithm);
-    // Don't require exp claim - tokens may not have expiry set
+    // Match Node's `jsonwebtoken`: validate the `exp` claim whenever it is
+    // present (so expired tokens are rejected), but do not *require* exp — a
+    // token that legitimately omits expiry still verifies. `required_spec_claims`
+    // stays empty for the latter; `validate_exp = true` enforces the former.
+    //
+    // This previously read `validate_exp = false`, which disabled expiry
+    // enforcement for every JWT verification path in the stdlib — expired
+    // tokens were accepted indefinitely (GHSA-5324-c68v-8w62 / CVE-2026-53777).
     validation.required_spec_claims = std::collections::HashSet::new();
-    validation.validate_exp = false;
+    validation.validate_exp = true;
 
     match decode::<Claims>(token, key, &validation) {
         Ok(token_data) => {
@@ -843,5 +850,64 @@ mod tests {
             "PERRY_DEBUG=1 must restore verbose logging; got: {:?}",
             stderr
         );
+    }
+
+    // --- GHSA-5324-c68v-8w62 / CVE-2026-53777: exp must be enforced ---
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    fn hs256_token(claims: serde_json::Value, secret: &[u8]) -> String {
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        let secret = b"supersecret";
+        let token = hs256_token(
+            serde_json::json!({ "sub": "user123", "exp": now_secs() - 3600 }),
+            secret,
+        );
+        let key = DecodingKey::from_secret(secret);
+        unsafe {
+            let r = verify_decode(&token, &key, Algorithm::HS256, false);
+            assert!(r.is_null(), "expired token must be rejected by jwt.verify");
+        }
+    }
+
+    #[test]
+    fn unexpired_token_is_accepted() {
+        let secret = b"supersecret";
+        let token = hs256_token(
+            serde_json::json!({ "sub": "user123", "exp": now_secs() + 3600 }),
+            secret,
+        );
+        let key = DecodingKey::from_secret(secret);
+        unsafe {
+            let r = verify_decode(&token, &key, Algorithm::HS256, false);
+            assert!(!r.is_null(), "valid, unexpired token must be accepted");
+        }
+    }
+
+    #[test]
+    fn token_without_exp_is_still_accepted() {
+        // Node's jsonwebtoken does not *require* exp; a token that omits it
+        // verifies. We must not regress that while enforcing exp-if-present.
+        let secret = b"supersecret";
+        let token = hs256_token(serde_json::json!({ "sub": "user123" }), secret);
+        let key = DecodingKey::from_secret(secret);
+        unsafe {
+            let r = verify_decode(&token, &key, Algorithm::HS256, false);
+            assert!(!r.is_null(), "token without exp claim must still verify");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes **GHSA-5324-c68v-8w62 / CVE-2026-53777** (Critical, CWE-613) — `jwt.verify()` accepted expired tokens.

`verify_decode` in `crates/perry-stdlib/src/jsonwebtoken.rs` is the shared helper behind **every** JWT verification path (`js_jwt_verify` HS256, `js_jwt_verify_es256`, `js_jwt_verify_rs256`, and the `_dyn` / `_dyn_opts` dispatchers). It set:

```rust
validation.validate_exp = false;
```

which tells the `jsonwebtoken` crate to ignore the `exp` claim entirely. A token whose `exp` is years in the past verified successfully as long as its signature was valid — silently disabling session expiry, logout, and revocation as authentication controls. This also inverts the default of the Node `jsonwebtoken` package perry is API-compatible with (Node enforces `exp` by default and requires `{ ignoreExpiration: true }` to suppress it).

## Fix

```rust
validation.validate_exp = true;
```

`required_spec_claims` stays empty, so the behavior now matches Node precisely:
- token with an **expired** `exp` → **rejected** ✅
- token with a **valid** `exp` → accepted
- token with **no** `exp` claim → still accepted (exp is enforced *when present*, not *required*)

Because all entry points funnel through `verify_decode`, this applies uniformly to HS256/ES256/RS256 and both dynamic dispatchers.

## Tests

Added to the existing module (`cargo test -p perry-stdlib --features bundled-jsonwebtoken jsonwebtoken::` → 7 passed):
- `expired_token_is_rejected`
- `unexpired_token_is_accepted`
- `token_without_exp_is_still_accepted`

## Notes / follow-up

- A per-call **`{ ignoreExpiration: true }`** opt-out (Node-compatible) is intentionally **not** in this PR. Supporting it end-to-end requires the codegen options-lowering (`lower_jsonwebtoken_verify`) to thread the flag — the inline-object-literal path currently drops unrecognized options like `ignoreExpiration` — plus a new FFI ABI param. That's a larger, non-security change; this PR makes the *default* safe, which is the CVE. Happy to do the opt-out as a fast-follow.
- Unrelated: `crates/perry-stdlib/src/zlib.rs` test target does not currently compile on `main` (`make_codec_state` arity mismatch at lines 1445/1495/1496) — pre-existing, blocks `cargo test -p perry-stdlib`. Flagging separately; not touched here.