### PR TITLE
test(stdlib): fix zlib test build — make_codec_state arity (unblocks cargo-test)

### DIFF
--- a/crates/perry-stdlib/src/zlib.rs
+++ b/crates/perry-stdlib/src/zlib.rs
@@ -1442,7 +1442,7 @@ mod stream_tests {
     /// Drive the streaming codec like the FFI ops do: write + drain, flush +
     /// drain between chunks, then finish — reassembling the full stream.
     fn stream_compress(codec: Codec, chunks: &[&[u8]]) -> Vec<u8> {
-        let mut cs = make_codec_state(codec).expect("streaming codec");
+        let mut cs = make_codec_state(codec, Compression::default()).expect("streaming codec");
         let mut out = Vec::new();
         for c in chunks {
             cs.write_chunk(c).unwrap();
@@ -1492,8 +1492,8 @@ mod stream_tests {
 
     #[test]
     fn zstd_buffer_until_end_stream_roundtrips() {
-        assert!(make_codec_state(Codec::ZstdCompress).is_none());
-        assert!(make_codec_state(Codec::ZstdDecompress).is_none());
+        assert!(make_codec_state(Codec::ZstdCompress, Compression::default()).is_none());
+        assert!(make_codec_state(Codec::ZstdDecompress, Compression::default()).is_none());
 
         let c = run_codec(Codec::ZstdCompress, b"zstd stream test").unwrap();
         assert!(!c.is_empty());


### PR DESCRIPTION
## Summary

`crates/perry-stdlib/src/zlib.rs` does not compile as a test target on `main`: `make_codec_state` gained a `level: Compression` parameter, but three test call sites still pass a single argument:

```
error[E0061]: this function takes 2 arguments but 1 argument was supplied
  zlib.rs:1445  make_codec_state(codec)
  zlib.rs:1495  make_codec_state(Codec::ZstdCompress)
  zlib.rs:1496  make_codec_state(Codec::ZstdDecompress)
```

This fails `cargo test -p perry-stdlib`, which **breaks the `cargo-test` CI gate for the entire crate** — masking real test signal. (It's why the JWT regression tests in #5008 couldn't run in CI, and why I had to patch this locally to validate that fix.)

## Fix

Pass `Compression::default()` at all three call sites:
- streaming cases (`Gzip`/`Deflate`) use the level for the encoder — `default()` is the standard round-trip level;
- the `Zstd*` cases assert `None` (buffer-until-end), so the level is irrelevant there;
- decoders ignore the level entirely.

## Validation

`cargo test -p perry-stdlib zlib::` → **6 passed**. `cargo fmt --all -- --check` clean.

## Context

Pre-existing breakage on `main`, unrelated to but surfaced by the security work (GHSA-5324 / #5008). Separate, deeper issue still open: `compiler-output-regression` fails on `h1_buffer_alias_negative` (a `js_implicit_this_set` call in a typed-array hot loop), which traces to the recent this-binding / TypedArray codegen commits — **not addressed here**, flagging for that area's owner.