### PR TITLE
fix(compile): version-key the auto-optimize runtime cache (#4876)

### DIFF
--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -607,11 +607,25 @@ pub(super) fn build_optimized_libs(
     // separately so a wasm program's build doesn't get served from a
     // cached non-wasm dir (which would lack `js_webassembly_*` symbols)
     // and vice versa (would carry unresolved `perry_wasm_host_*` refs).
+    //
+    // The compiler version is part of the key too. Codegen emits calls to
+    // runtime entrypoints (e.g. `js_promise_run_promise_jobs`,
+    // `js_mark_entry_module_esm`) that grow with each release; the object
+    // cache is already version-invalidated (see build_cache.rs — it misses on
+    // `perry_version != CARGO_PKG_VERSION`), so on a persistent build host a
+    // newer compiler emits the new calls while this version-blind dir would
+    // hand back a stale `libperry_runtime.a` lacking those symbols — an
+    // "undefined symbol" link failure for exactly the newly-added entrypoints.
+    // Keying on the version forces a matching rebuild whenever perry upgrades.
     // Cheap djb2 — no need for the SipHash overhead.
     let target_str = target.unwrap_or("host");
     let key_input = format!(
-        "{}|{}|{}|wasm={}",
-        feature_arg, panic_abort_safe, target_str, ctx.needs_wasm_runtime
+        "{}|{}|{}|wasm={}|v={}",
+        feature_arg,
+        panic_abort_safe,
+        target_str,
+        ctx.needs_wasm_runtime,
+        env!("CARGO_PKG_VERSION"),
     );
     let mut hash: u64 = 5381;
     for b in key_input.as_bytes() {


### PR DESCRIPTION
## Problem

Fixes #4876. Native builds (iOS/tvOS/macOS/Linux) fail to link with `undefined symbol` for a handful of runtime entrypoints:

```
undefined symbol: js_promise_run_promise_jobs
undefined symbol: js_register_closure_strict_function
undefined symbol: js_iterator_result_validate
undefined symbol: js_promise_report_unhandled_rejections
undefined symbol: js_mark_entry_module_esm
```

The earlier fix (#4883) added a `#[used]` anchor for `js_promise_report_unhandled_rejections`, but it's **still** undefined — so the symbol isn't being dead-stripped from a fresh runtime; it's **absent from a stale cached runtime**.

## Root cause

Two caches with inconsistent version policy:

- **Object cache** (`build_cache.rs`) *is* version-invalidated — it misses on `manifest.perry_version != env!("CARGO_PKG_VERSION")`. So after a compiler upgrade, program objects are rebuilt with the **new** codegen, which emits calls to the newly-added runtime entrypoints.
- **Auto-optimize runtime cache** (`optimized_libs.rs`) keys `target/perry-auto-{hash}` only on `(features, panic_mode, target, wasm-host)` — **not** the compiler version. On a persistent build host it hands back the **previous** compiler's `libperry_runtime.a`, which predates those symbols.

New codegen calls + stale runtime = link failure for **exactly** the entrypoints added since the cached runtime was built — and only those; every older entrypoint in the same compiled `_main` (`js_gc_init`, `js_promise_run_microtasks`, `js_timer_tick`, …) resolves fine. That asymmetry is the tell: it's not a strip, it's a stale archive.

## Fix

Add `CARGO_PKG_VERSION` to the auto-optimize cache key, mirroring the object cache. A compiler upgrade now lands in a fresh `perry-auto-*` dir and forces a matching runtime rebuild, so the runtime ABI can never lag the codegen that calls into it.

One-line change to the key tuple (+ comment). No behavior change within a single compiler version; the only effect is a one-time runtime rebuild after an upgrade — which is the correct, intended behavior.

## Note on testing

I could not run the suite locally (current `main` needs the edition-2024 `unsafe(no_mangle)` toolchain; my local cargo is older). The change is a pure cache-key addition validated against the #4876 CI symptom. Please run native CI to confirm the link.
