### PR TITLE
fix(hir): perry.define of process.env.* folds at lowering, not just tree-shake (#5009)

### DIFF
--- a/crates/perry-hir/src/ir/constants.rs
+++ b/crates/perry-hir/src/ir/constants.rs
@@ -77,6 +77,58 @@ pub fn clear_compile_packages_override() {
     COMPILE_PACKAGES_OVERRIDE.with(|cell| cell.borrow_mut().clear());
 }
 
+// ---- #5009 build-time `process.env` define substitution ----
+
+/// #5009: a build-time `process.env.<NAME>` substitution value, esbuild
+/// `define`-style. Mirrors the perry-crate `DefineValue` but lives here so HIR
+/// lowering can fold a defined `process.env.X` read into a literal at the
+/// single point it would otherwise emit `Expr::EnvGet`.
+#[derive(Clone, Debug)]
+pub enum EnvDefine {
+    Str(String),
+    Bool(bool),
+    Num(f64),
+    Null,
+}
+
+thread_local! {
+    /// #5009: per-thread map of `process.env.<NAME>` build-time substitutions
+    /// (`perry.define`). Keyed by the bare env var NAME (e.g. `NODE_ENV`, not
+    /// the full `process.env.NODE_ENV`). When a static `process.env.<NAME>`
+    /// read is lowered and `NAME` is present here, lowering emits the defined
+    /// literal instead of `Expr::EnvGet` — so the define is honored in every
+    /// context (branch conditions, ternaries, closures) and regardless of
+    /// whether tree-shaking is enabled.
+    ///
+    /// Before #5009 the define was only consulted by the tree-shake-gated
+    /// `env_fold` branch pruner, so a `process.env.NODE_ENV` read produced a
+    /// live runtime env lookup (`undefined` when unset) in every default
+    /// build — React/Preact/etc. then selected their development builds.
+    /// Folding at the lowering source restores esbuild-style `define`
+    /// semantics: the define wins over the runtime environment.
+    ///
+    /// The driver installs this before each `lower_module_full` and clears it
+    /// after (rayon-safe — each worker thread has its own copy).
+    static ENV_DEFINES: std::cell::RefCell<std::collections::HashMap<String, EnvDefine>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// #5009: install the per-thread `process.env.<NAME>` define map. Keys are the
+/// bare env var names (the `process.env.` prefix already stripped).
+pub fn set_env_defines(map: std::collections::HashMap<String, EnvDefine>) {
+    ENV_DEFINES.with(|cell| *cell.borrow_mut() = map);
+}
+
+/// #5009: clear the per-thread define map (symmetry with the other resets).
+pub fn clear_env_defines() {
+    ENV_DEFINES.with(|cell| cell.borrow_mut().clear());
+}
+
+/// #5009: look up a build-time `process.env.<name>` substitution, if defined.
+pub fn env_define_lookup(name: &str) -> Option<EnvDefine> {
+    ENV_DEFINES.with(|cell| cell.borrow().get(name).cloned())
+}
+
 // ---- #503 dynamic-stdlib-dispatch refusal config ----
 
 thread_local! {

--- a/crates/perry-hir/src/ir/mod.rs
+++ b/crates/perry-hir/src/ir/mod.rs
@@ -20,19 +20,19 @@ mod widget;
 // ---- constants.rs ----
 pub use constants::{
     clear_allow_dynamic_stdlib_packages, clear_compile_packages_override,
-    clear_current_module_source, clear_precompile_state, current_module_has_allow_dynamic_at,
-    current_module_line_at, current_module_source_slice, determine_module_kind,
-    dynamic_stdlib_allowed_for_package, is_native_module, is_native_module_with_externals,
-    is_node_builtin_module, package_name_for_source_path, precompile_capture_enabled,
-    precompile_result_at, refuse_dynamic_stdlib_dispatch_enabled, requires_stdlib,
-    set_allow_dynamic_stdlib_packages, set_compile_packages_override, set_current_module_source,
-    set_precompile_capture, set_precompile_results, set_refuse_dynamic_stdlib_dispatch,
-    typed_array_kind_for_name, ClassId, EnumId, InterfaceId, ModuleInitKind, ModuleKind,
-    PosixCredentialKind, TypeAliasId, NATIVE_MODULES, TYPED_ARRAY_KIND_BIGINT64,
-    TYPED_ARRAY_KIND_BIGUINT64, TYPED_ARRAY_KIND_FLOAT16, TYPED_ARRAY_KIND_FLOAT32,
-    TYPED_ARRAY_KIND_FLOAT64, TYPED_ARRAY_KIND_INT16, TYPED_ARRAY_KIND_INT32,
-    TYPED_ARRAY_KIND_INT8, TYPED_ARRAY_KIND_UINT16, TYPED_ARRAY_KIND_UINT32,
-    TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_UINT8_CLAMPED,
+    clear_current_module_source, clear_env_defines, clear_precompile_state,
+    current_module_has_allow_dynamic_at, current_module_line_at, current_module_source_slice,
+    determine_module_kind, dynamic_stdlib_allowed_for_package, env_define_lookup, is_native_module,
+    is_native_module_with_externals, is_node_builtin_module, package_name_for_source_path,
+    precompile_capture_enabled, precompile_result_at, refuse_dynamic_stdlib_dispatch_enabled,
+    requires_stdlib, set_allow_dynamic_stdlib_packages, set_compile_packages_override,
+    set_current_module_source, set_env_defines, set_precompile_capture, set_precompile_results,
+    set_refuse_dynamic_stdlib_dispatch, typed_array_kind_for_name, ClassId, EnumId, EnvDefine,
+    InterfaceId, ModuleInitKind, ModuleKind, PosixCredentialKind, TypeAliasId, NATIVE_MODULES,
+    TYPED_ARRAY_KIND_BIGINT64, TYPED_ARRAY_KIND_BIGUINT64, TYPED_ARRAY_KIND_FLOAT16,
+    TYPED_ARRAY_KIND_FLOAT32, TYPED_ARRAY_KIND_FLOAT64, TYPED_ARRAY_KIND_INT16,
+    TYPED_ARRAY_KIND_INT32, TYPED_ARRAY_KIND_INT8, TYPED_ARRAY_KIND_UINT16,
+    TYPED_ARRAY_KIND_UINT32, TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_UINT8_CLAMPED,
 };
 
 // ---- module.rs ----

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -17,6 +17,19 @@ use crate::ir::Expr;
 
 use super::{lower_expr, LoweringContext};
 
+/// #5009: resolve a build-time `perry.define` of `process.env.<name>` to the
+/// HIR literal it should fold to, if one is configured for this build. Returns
+/// `None` when there is no define for `name` (the caller then emits the normal
+/// runtime `EnvGet`).
+fn env_define_literal(name: &str) -> Option<Expr> {
+    crate::ir::env_define_lookup(name).map(|d| match d {
+        crate::ir::EnvDefine::Str(s) => Expr::String(s),
+        crate::ir::EnvDefine::Bool(b) => Expr::Bool(b),
+        crate::ir::EnvDefine::Num(n) => Expr::Number(n),
+        crate::ir::EnvDefine::Null => Expr::Null,
+    })
+}
+
 pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Result<Expr> {
     // #1723: when THIS access is the auditable `ns[dynamicKey].staticMember`
     // shape — a dynamic stdlib SUB-namespace selection (`path.win32` /
@@ -748,6 +761,16 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                             ast::MemberProp::Ident(var_ident) => {
                                 // process.env.VARNAME (static key)
                                 let var_name = var_ident.sym.to_string();
+                                // #5009: honor a build-time `perry.define` of
+                                // `process.env.<NAME>` by substituting the
+                                // literal here — before `EnvGet` (a live
+                                // runtime env lookup) is emitted. esbuild-style
+                                // define semantics: the define wins over the
+                                // runtime environment, in every context and
+                                // regardless of tree-shaking.
+                                if let Some(lit) = env_define_literal(&var_name) {
+                                    return Ok(lit);
+                                }
                                 return Ok(Expr::EnvGet(var_name));
                             }
                             ast::MemberProp::Computed(computed) => {
@@ -758,6 +781,11 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                                 // dynamic.
                                 if let ast::Expr::Lit(ast::Lit::Str(s)) = computed.expr.as_ref() {
                                     if let Some(name) = s.value.as_str() {
+                                        // #5009: same define substitution as the
+                                        // dot form above.
+                                        if let Some(lit) = env_define_literal(name) {
+                                            return Ok(lit);
+                                        }
                                         return Ok(Expr::EnvGet(name.to_string()));
                                     }
                                 }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -44,6 +44,29 @@ use parse_error::annotate_parse_error;
 
 const MAX_CROSS_MODULE_INLINE_PRIOR_MODULES: usize = 128;
 
+/// #5009: build the bare-name → literal map perry-hir lowering consults to fold
+/// `process.env.<NAME>` reads (`perry_hir::env_define_lookup`). Strips the
+/// `process.env.` prefix the `perry.define` keys carry and converts each
+/// [`super::DefineValue`] to the matching [`perry_hir::EnvDefine`]. Keys that
+/// aren't `process.env.*` are skipped (only env defines are honored today).
+fn env_defines_for_lowering(
+    define: &HashMap<String, super::DefineValue>,
+) -> HashMap<String, perry_hir::EnvDefine> {
+    define
+        .iter()
+        .filter_map(|(key, val)| {
+            let name = key.strip_prefix("process.env.")?;
+            let ev = match val {
+                super::DefineValue::Str(s) => perry_hir::EnvDefine::Str(s.clone()),
+                super::DefineValue::Bool(b) => perry_hir::EnvDefine::Bool(*b),
+                super::DefineValue::Number(n) => perry_hir::EnvDefine::Num(*n),
+                super::DefineValue::Null => perry_hir::EnvDefine::Null,
+            };
+            Some((name.to_string(), ev))
+        })
+        .collect()
+}
+
 /// Issue #818: scan a JS module's source for static ESM imports /
 /// re-exports / string-literal dynamic imports, resolve each one
 /// against the module's directory (with `resolve_with_extensions` so
@@ -595,6 +618,14 @@ fn collect_module_one(
     // immediately after the lower call so it can't leak to subsequent
     // unrelated work on the same thread.
     perry_hir::set_compile_packages_override(ctx.compile_packages.clone());
+    // #5009: install the `process.env.<NAME>` build-time defines so a static
+    // `process.env.X` read folds to its `perry.define` literal at lowering —
+    // esbuild-style, in every context and independent of tree-shaking. Keyed
+    // by the bare env var name (the `process.env.` prefix stripped). Cleared
+    // after the lower below (rayon-safe). The runtime-env default
+    // (`NODE_ENV → "production"` for node_modules) stays in the tree-shake
+    // `env_fold` pass; only explicit defines are folded here.
+    perry_hir::set_env_defines(env_defines_for_lowering(&ctx.define));
     // #503: re-install the dynamic-stdlib-dispatch config on the current
     // thread before each lower. Driver may be a rayon worker that didn't
     // inherit the thread-local set on the main thread by `compile.rs`.
@@ -651,6 +682,7 @@ fn collect_module_one(
     perry_hir::clear_compile_packages_override();
     perry_hir::clear_current_module_source();
     perry_hir::clear_precompile_state();
+    perry_hir::clear_env_defines();
     // #2309: drain refusals deferred during this lower and tag them with the
     // canonical module path so the post-collection prune can decide whether
     // they survive. Done before the `?` below so a non-deferrable error can't

--- a/crates/perry/src/commands/compile/collect_modules/tests.rs
+++ b/crates/perry/src/commands/compile/collect_modules/tests.rs
@@ -1,11 +1,48 @@
 //! Tests for the dynamic-import glob expansion + module collection driver.
 //! Split out of `collect_modules.rs` to keep that file under the file-size gate.
 
-use super::{collect_modules, expand_dynamic_import_glob};
-use crate::commands::compile::CompilationContext;
+use super::{collect_modules, env_defines_for_lowering, expand_dynamic_import_glob};
+use crate::commands::compile::{CompilationContext, DefineValue};
 use crate::commands::progress::VerboseProgress;
 use crate::OutputFormat;
 use std::collections::HashSet;
+
+#[test]
+fn env_defines_for_lowering_strips_prefix_and_maps_kinds() {
+    // #5009: only `process.env.*` define keys are honored, the prefix is
+    // stripped to the bare env var name, and each DefineValue kind maps to the
+    // matching perry_hir::EnvDefine.
+    let mut define = std::collections::HashMap::new();
+    define.insert(
+        "process.env.NODE_ENV".to_string(),
+        DefineValue::Str("production".into()),
+    );
+    define.insert("process.env.DEBUG".to_string(), DefineValue::Bool(false));
+    define.insert("process.env.LEVEL".to_string(), DefineValue::Number(3.0));
+    define.insert("process.env.MISSING".to_string(), DefineValue::Null);
+    // A non-`process.env.*` key is ignored (no other define namespace today).
+    define.insert("__DEV__".to_string(), DefineValue::Bool(true));
+
+    let mapped = env_defines_for_lowering(&define);
+    assert_eq!(mapped.len(), 4, "the non-process.env key is dropped");
+    assert!(!mapped.contains_key("__DEV__"));
+    assert!(matches!(
+        mapped.get("NODE_ENV"),
+        Some(perry_hir::EnvDefine::Str(s)) if s == "production"
+    ));
+    assert!(matches!(
+        mapped.get("DEBUG"),
+        Some(perry_hir::EnvDefine::Bool(false))
+    ));
+    assert!(matches!(
+        mapped.get("LEVEL"),
+        Some(perry_hir::EnvDefine::Num(n)) if *n == 3.0
+    ));
+    assert!(matches!(
+        mapped.get("MISSING"),
+        Some(perry_hir::EnvDefine::Null)
+    ));
+}
 
 #[test]
 fn expands_directory_files_matching_suffix() {

--- a/crates/perry/tests/issue_5009_define_process_env.rs
+++ b/crates/perry/tests/issue_5009_define_process_env.rs
@@ -1,0 +1,184 @@
+//! Regression test for #5009: `perry.define` of `process.env.<NAME>` must be
+//! applied as a build-time substitution again.
+//!
+//! When `process` became a real runtime object (#4993), the issue author
+//! suspected `process.env.NODE_ENV` had become a live property read that
+//! bypassed the define. The actual root cause is broader: the define was only
+//! ever consulted by the tree-shake-gated `env_fold` branch pruner, so a
+//! `process.env.NODE_ENV` read produced a runtime env lookup (`undefined` when
+//! unset) in every default build — and packages that branch on it (React /
+//! react-reconciler / scheduler) selected their *development* builds.
+//!
+//! The fix folds a defined `process.env.<NAME>` read into its literal at the
+//! single HIR lowering point that would otherwise emit `Expr::EnvGet`, so the
+//! define is honored in every context and independent of tree-shaking. These
+//! checks mirror the real failure: a `compilePackages` dependency selects its
+//! build via `if (process.env.NODE_ENV === 'production')`, exactly like
+//! react-reconciler's `index.js`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Build the react-reconciler-shaped fixture in `root`: a `compilePackages`
+/// dependency whose entry picks a production/development sub-module based on
+/// `process.env.NODE_ENV`, plus a user entry that prints the selected build
+/// and the raw `process.env.NODE_ENV` value. `package_json` lets each test
+/// supply its own `perry` config (with or without the define).
+fn write_fixture(root: &std::path::Path, package_json: &str) {
+    std::fs::write(root.join("package.json"), package_json).expect("write consumer package.json");
+
+    let pkg = root.join("node_modules").join("fakelib");
+    std::fs::create_dir_all(pkg.join("cjs")).expect("mkdir fakelib/cjs");
+    std::fs::write(
+        pkg.join("package.json"),
+        r#"{ "name": "fakelib", "version": "1.0.0", "main": "index.js" }"#,
+    )
+    .expect("write fakelib package.json");
+
+    // The react-reconciler `index.js` shape verbatim: a top-level `if` that
+    // selects the production or development build off `process.env.NODE_ENV`.
+    std::fs::write(
+        pkg.join("index.js"),
+        r#""use strict";
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/fakelib.production.js');
+} else {
+  module.exports = require('./cjs/fakelib.development.js');
+}
+"#,
+    )
+    .expect("write fakelib index.js");
+    std::fs::write(
+        pkg.join("cjs").join("fakelib.production.js"),
+        "\"use strict\";\nmodule.exports = { which: 'production' };\n",
+    )
+    .expect("write production build");
+    std::fs::write(
+        pkg.join("cjs").join("fakelib.development.js"),
+        "\"use strict\";\nmodule.exports = { which: 'development' };\n",
+    )
+    .expect("write development build");
+
+    std::fs::write(
+        root.join("main.ts"),
+        r#"
+import lib from 'fakelib';
+console.log("NODE_ENV=" + process.env.NODE_ENV);
+console.log("which=" + (lib as any).which);
+"#,
+    )
+    .expect("write entry");
+}
+
+fn compile(root: &std::path::Path) -> PathBuf {
+    let entry = root.join("main.ts");
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+fn run(bin: &std::path::Path, env: &[(&str, &str)]) -> String {
+    let mut cmd = Command::new(bin);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let run = cmd.output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+#[test]
+fn define_node_env_selects_production_build_and_wins_over_runtime_env() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_fixture(
+        root,
+        r#"{
+  "name": "define-process-env",
+  "type": "module",
+  "perry": {
+    "compilePackages": ["fakelib"],
+    "allow": { "compilePackages": ["fakelib"] },
+    "define": { "process.env.NODE_ENV": "production" }
+  }
+}"#,
+    );
+    let bin = compile(root);
+
+    // With the define and NO runtime env var set, the define must apply:
+    // the dependency selects its production build and the user-source read
+    // folds to the literal "production".
+    assert_eq!(
+        run(&bin, &[]),
+        "NODE_ENV=production\nwhich=production\n",
+        "perry.define of process.env.NODE_ENV must be applied (compile-time)"
+    );
+
+    // esbuild-style `define` semantics: the define is authoritative and wins
+    // over the runtime environment, so a conflicting NODE_ENV is ignored.
+    assert_eq!(
+        run(&bin, &[("NODE_ENV", "development")]),
+        "NODE_ENV=production\nwhich=production\n",
+        "the define must win over a conflicting runtime NODE_ENV"
+    );
+}
+
+#[test]
+fn no_define_still_reads_runtime_env() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_fixture(
+        root,
+        r#"{
+  "name": "no-define-process-env",
+  "type": "module",
+  "perry": {
+    "compilePackages": ["fakelib"],
+    "allow": { "compilePackages": ["fakelib"] }
+  }
+}"#,
+    );
+    let bin = compile(root);
+
+    // No define ⇒ the `process.env.NODE_ENV` reads remain live runtime
+    // lookups (no tree-shake `env_fold` here either). With the OS env var
+    // unset they read `undefined`, so the dependency's runtime `if` falls to
+    // its development branch.
+    assert_eq!(
+        run(&bin, &[]),
+        "NODE_ENV=undefined\nwhich=development\n",
+        "without a define, an unset NODE_ENV must read undefined at runtime"
+    );
+    // With the OS env var set, both the user read and the dependency's
+    // runtime `if` observe it — so production is selected, proving the read
+    // is a genuine runtime lookup (not a stale compile-time fold).
+    assert_eq!(
+        run(&bin, &[("NODE_ENV", "production")]),
+        "NODE_ENV=production\nwhich=production\n",
+        "without a define, the runtime NODE_ENV must flow through"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #5009 — `perry.define` of `process.env.NODE_ENV` (and any `process.env.*`) was **silently ignored** in every default build. As a result, compiled packages that branch on `process.env.NODE_ENV` (React, react-reconciler, scheduler, …) selected their **development** builds, and react-reconciler's dev build then threw `TypeError: value is not a function` during render — the last wall before yoga for ink (#348).

## Root cause (not #4993 as the issue guessed)

#4993 only touched runtime files; `process.env.X` still lowered to `Expr::EnvGet`. The real bug is broader: the `define` was **only** consulted by the `env_fold` branch pruner, which is **gated on `tree_shake`** — and tree-shaking is **off by default** (`PERRY_TREE_SHAKE=1` / `perry.experiments.treeShake: true` only). So in a normal build the define did nothing and `process.env.NODE_ENV` stayed a live runtime `EnvGet → js_getenv_value` lookup (`undefined` when unset).

## Fix

Fold a defined `process.env.<NAME>` read to its literal at the **single HIR lowering point** that would otherwise emit `Expr::EnvGet` — independent of tree-shaking and in every context (branch conditions, ternaries, closures). esbuild-style `define` semantics: the define wins over the runtime environment.

- **`perry-hir/ir/constants.rs`** — `EnvDefine` enum + `ENV_DEFINES` thread-local (mirrors the existing `COMPILE_PACKAGES_OVERRIDE` pattern; rayon-safe per worker) with `set_env_defines` / `clear_env_defines` / `env_define_lookup`.
- **`perry-hir/lower/expr_member.rs`** — `env_define_literal()` substitutes the literal in both the `process.env.X` and `process.env["X"]` arms before emitting `EnvGet`.
- **`perry/compile/collect_modules.rs`** — `env_defines_for_lowering()` strips the `process.env.` prefix from `ctx.define`; installed before each `lower_module_full`, cleared after.

Composes cleanly with `env_fold`: the substitution yields a string literal that `try_const` already folds, so branch-elimination still works under tree-shake; the tree-shake-only node_modules `NODE_ENV → "production"` default is unchanged. Keys *without* an explicit define still produce a runtime `EnvGet`.

## Verification

- Reproduced the bug with a react-reconciler-shaped `compilePackages` fixture; after the fix the **production** build is selected and the define **wins over** a conflicting runtime `NODE_ENV=development`.
- No regression: without a define, runtime env reads work as before; #4993's `test_gap_process_import_4987.ts` is still byte-identical to `node --experimental-strip-types`.
- New tests: `crates/perry/tests/issue_5009_define_process_env.rs` (2 integration) + a unit test for `env_defines_for_lowering`. All pass.

The secondary item in the issue (react-reconciler's **development** build hits a `value is not a function` codegen gap) is out of scope here — production is the target build and now selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)