### PR TITLE
fix(http): raw 'upgrade' + tls.TLSSocket + destroy no longer hangs the event loop (#5010)

### DIFF
--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -1521,6 +1521,20 @@ pub extern "C" fn js_node_http_server_process_pending() -> i32 {
     }
     count += crate::http2_server::process_pending_h2_events();
 
+    // #5010 — drain perry-ext-net's own pending-event queue. A raw
+    // `'upgrade'` (#4973) hands the listener a real `net.Socket` adopted into
+    // perry-ext-net (`adopt_upgraded_tcp_stream`); when user code destroys it,
+    // the socket task queues a `Close` event in perry-ext-net's queue. For an
+    // http-only program perry-stdlib runs with its OWN bundled net (so its
+    // `external-net-pump` arm is OFF and never touches ext-net's queue), and
+    // the perry-ext-net aux pump proved unreliable across workspace link
+    // layouts. The http-server pump, by contrast, runs every tick
+    // (external-http-server-pump) and directly depends on perry-ext-net, so
+    // draining here — through the UNIQUE `js_ext_net_drain_pending` symbol
+    // (no stdlib twin) — reliably empties that queue so the destroyed upgrade
+    // socket stops pinning the event loop. Cheap (one mutex peek) when empty.
+    count += unsafe { perry_ext_net::js_ext_net_drain_pending() };
+
     count
 }
 

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -38,7 +38,12 @@ extern "C" {
 }
 
 extern "C" fn process_pending_aux() -> i32 {
-    unsafe { crate::js_net_process_pending() }
+    // Drain via the DISTINCT `js_ext_net_drain_pending` symbol — NOT the
+    // `js_net_process_pending` extern, whose symbol the bundled stdlib net
+    // twin shadows in a workspace build (that twin drains stdlib's queue,
+    // leaving ext-net's own adopted-socket events — e.g. the raw-`'upgrade'`
+    // `Close` — stuck and the loop pinned). #5010.
+    unsafe { crate::js_ext_net_drain_pending() }
 }
 
 pub(crate) fn ensure_runtime_dispatch_registered() {
@@ -186,7 +191,12 @@ unsafe fn socket_method(handle: i64, method: &str, args: &[f64]) -> Option<f64> 
             undefined()
         }
         "destroy" | "destroySoon" => {
-            crate::js_net_socket_destroy(handle);
+            // Drive teardown through the DISTINCT `js_ext_net_destroy_socket`
+            // symbol — NOT the `js_net_socket_destroy` extern, whose symbol the
+            // bundled stdlib net twin shadows in a workspace build (it would
+            // mark the socket destroyed in stdlib's registry, leaving the
+            // adopted raw-`'upgrade'` socket alive in ext-net's). #5010.
+            crate::js_ext_net_destroy_socket(handle);
             undefined()
         }
         "on" | "addListener" if args.len() >= 2 => {

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -1499,6 +1499,27 @@ pub unsafe extern "C" fn js_net_socket_upgrade_tls(
 /// capacity retained → zero steady-state allocation).
 #[no_mangle]
 pub unsafe extern "C" fn js_net_process_pending() -> i32 {
+    js_ext_net_drain_pending()
+}
+
+/// Drain ext-net's own pending-event queue.
+///
+/// This carries a DISTINCT `#[no_mangle]` symbol (`js_ext_net_drain_pending`),
+/// deliberately NOT the `js_net_process_pending` name that the bundled stdlib
+/// net ALSO exports. In a workspace/auto-optimize build both crates are
+/// linked, so `js_net_process_pending` is a duplicate symbol; the link binds
+/// every reference to whichever twin wins (stdlib's). The aux pump
+/// (`process_pending_aux`) and the extern wrapper above therefore call THIS
+/// uniquely-named entry point instead — a symbol with no twin and nothing to
+/// fold against — so the adopted raw-`'upgrade'` socket's `Close` event in
+/// ext-net's own queue is actually drained rather than left to pin the event
+/// loop forever. Without this the loop hung, and the behavior flipped with
+/// unrelated code-size changes (link-order roulette). (#5010)
+///
+/// # Safety
+/// Fires user JS closures (listeners); callers must hold a valid runtime.
+#[no_mangle]
+pub unsafe extern "C" fn js_ext_net_drain_pending() -> i32 {
     thread_local! {
         static SCRATCH: std::cell::RefCell<Vec<PendingNetEvent>> =
             const { std::cell::RefCell::new(Vec::new()) };

--- a/crates/perry-ext-net/src/lifecycle.rs
+++ b/crates/perry-ext-net/src/lifecycle.rs
@@ -317,6 +317,23 @@ pub unsafe extern "C" fn js_net_socket_end(handle: i64, chunk_bits: i64) {
 /// `handle` must be a registered socket id (raw, NOT NaN-boxed).
 #[no_mangle]
 pub unsafe extern "C" fn js_net_socket_destroy(handle: i64) {
+    js_ext_net_destroy_socket(handle);
+}
+
+/// Destroy an `ext-net` socket by id, operating directly on this crate's
+/// socket registry.
+///
+/// This carries a DISTINCT `#[no_mangle]` symbol (`js_ext_net_destroy_socket`),
+/// deliberately NOT the `js_net_socket_destroy` name that the bundled stdlib
+/// net ALSO exports. In a workspace/auto-optimize build both are linked, so
+/// `js_net_socket_destroy` is a duplicate symbol bound to whichever twin
+/// wins (stdlib's). The handle-dispatch `socket_method` "destroy" arm and the
+/// extern wrapper above call THIS uniquely-named entry point instead — a
+/// symbol with no twin — so an adopted raw-`'upgrade'` socket is actually
+/// marked destroyed in ext-net's own registry rather than in stdlib's empty
+/// one, which is what let the event loop drain. (#5010)
+#[no_mangle]
+pub extern "C" fn js_ext_net_destroy_socket(handle: i64) {
     let mut sockets = statics::sockets().lock().unwrap();
     if let Some(s) = sockets.get_mut(&handle) {
         s.destroyed = true;


### PR DESCRIPTION
Fixes #5010.

## Summary

`test-http-upgrade-reconsume-stream` regressed to a **hang** (exit 124 instead of 0) after #5001/#4973. The repro:

```js
const tls = require('tls'); const http = require('http');
const server = http.createServer(common.mustNotCall());
server.on('upgrade', common.mustCall((request, socket, head) => {
  new tls.TLSSocket(socket);   // re-own the raw upgrade socket
  server.close();
  socket.destroy();
}));
server.listen(0, common.mustCall(() => {
  http.get({ port: server.address().port,
             headers: { Connection: 'Upgrade', Upgrade: 'websocket' } }).on('error', () => {});
}));
```

#4973 made a raw `'upgrade'` hand the listener a **real `net.Socket`** adopted into `perry-ext-net` (`adopt_upgraded_tcp_stream`). Destroying it left a live handle pinning the loop. (The `new tls.TLSSocket(socket)` wrap named in the title is a red herring — the hang reproduces without it.)

## Root cause — perry-stdlib/perry-ext-net duplicate-symbol ("twin") hazards

Both crates export the same `#[no_mangle]` net symbols; in a workspace/auto-optimize link the bundled-stdlib twin wins, and two things broke for the adopted socket:

1. **`socket.destroy()`** dynamic-dispatched through `js_net_socket_destroy` → bound to stdlib's twin → marked the socket destroyed in stdlib's *empty* registry while it stayed `destroyed=false` (alive) in ext-net's.
2. The socket's **`Close` event** sat in ext-net's own pending-event queue, which nothing reliably drained. For an http-only program perry-stdlib runs its *own* bundled net, so its `external-net-pump` arm never touches ext-net's queue, and the ext-net aux pump proved unreliable across link layouts — the behavior even flipped with unrelated code-size changes (link-order roulette).

## Fix

- Give the destroy + queue-drain entry points **distinct, twin-free** `#[no_mangle]` symbols: `js_ext_net_destroy_socket` / `js_ext_net_drain_pending` (the original externs now delegate to them).
- Route the handle-dispatch `destroy` arm and the aux pump through those unique symbols.
- **Drain ext-net's queue from the http-server pump** (`js_node_http_server_process_pending`) — it runs every tick via `external-http-server-pump` and directly depends on perry-ext-net, so the call is a plain crate-path call to a symbol with no twin.

## Verification

- Repro: **exit 0**, 10/10 runs and 8/8 on an independent rebuild (previously 0/8 — deterministically hung).
- No regression: normal http request/response exits 0; normal `net` echo data flow is unchanged (actually *more* reliable than pristine in spot checks). The pre-existing `net`-program close-hang is unrelated and out of scope.
- `cargo test -p perry-ext-net`: 8 passed.

Code-only — version bump + changelog left for the maintainer to fold at merge.