### PR TITLE
fix(runtime): spec-compliant String.prototype.split with a RegExp separator (test262 tail)

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -1148,28 +1148,34 @@ pub extern "C" fn js_string_split_regex_n(
         return arr_handle.get_raw_mut_ptr::<ArrayHeader>();
     }
 
+    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
     unsafe {
-        // Fancy-regex fallback (lookbehind/backreferences): `fancy_regex` has no
-        // `split`, so walk non-overlapping matches and slice between them. This
-        // mirrors the `regex` crate's `split` (delimiter text dropped, captured
-        // groups NOT spliced into the result — same as the standard path here).
-        let mut parts: Vec<&str> = if let Some(fre) = lookup_fancy_regex(re) {
-            let mut v: Vec<&str> = Vec::new();
+        // Each element is either a substring (`Some`) or `undefined` (`None`,
+        // for an unmatched capture group spliced into the result).
+        let parts: Vec<Option<String>> = if let Some(fre) = lookup_fancy_regex(re) {
+            // Fancy-regex fallback (lookbehind/backreferences): `fancy_regex` has
+            // no `split`, so walk non-overlapping matches and slice between them.
+            // (Captured-group splicing is not reproduced for this engine.)
+            let mut v: Vec<Option<String>> = Vec::new();
             let mut last = 0usize;
             let mut iter = fre.find_iter(&str_data);
             while let Some(Ok(m)) = iter.next() {
-                v.push(&str_data[last..m.start()]);
+                v.push(Some(str_data[last..m.start()].to_string()));
                 last = m.end();
             }
-            v.push(&str_data[last..]);
+            v.push(Some(str_data[last..].to_string()));
+            if limit > 0 && (v.len() as i64) > (limit as i64) {
+                v.truncate(limit as usize);
+            }
             v
         } else {
-            let regex = &*(*re).regex_ptr;
-            regex.split(&str_data).collect()
+            // Standard engine: the JS `RegExp.prototype[Symbol.split]` algorithm
+            // (21.2.5.11). The `regex` crate's own `split` diverges from JS for
+            // zero-width matches (it emits leading/trailing/consecutive empty
+            // strings the spec's `e == p` skip suppresses) and never splices
+            // captured groups, so walk the string the spec's way instead.
+            crate::string::spec_regex_split(&*(*re).regex_ptr, &str_data, limit)
         };
-        if limit > 0 && (parts.len() as i64) > (limit as i64) {
-            parts.truncate(limit as usize);
-        }
 
         let arr = crate::array::js_array_alloc(parts.len() as u32);
         let scope = crate::gc::RuntimeHandleScope::new();
@@ -1177,9 +1183,14 @@ pub extern "C" fn js_string_split_regex_n(
         (*arr_handle.get_raw_mut_ptr::<ArrayHeader>()).length = parts.len() as u32;
 
         for (i, part) in parts.iter().enumerate() {
-            let str_ptr = js_string_from_str(part) as u64;
+            let nanboxed = match part {
+                Some(text) => {
+                    let str_ptr = js_string_from_str(text) as u64;
+                    STRING_TAG | (str_ptr & POINTER_MASK)
+                }
+                None => TAG_UNDEFINED,
+            };
             let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
-            let nanboxed = STRING_TAG | (str_ptr & POINTER_MASK);
             // GC_STORE_AUDIT(BARRIERED): regex split result slot uses the shared array slot-store helper.
             crate::array::store_array_slot(arr, i, nanboxed);
         }

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -34,6 +34,7 @@ mod pad;
 mod raw;
 mod slice_ops;
 mod split;
+pub(crate) use split::spec_regex_split;
 
 #[cfg(test)]
 mod tests;

--- a/crates/perry-runtime/src/string/split.rs
+++ b/crates/perry-runtime/src/string/split.rs
@@ -3,6 +3,76 @@
 use super::*;
 use crate::array::ArrayHeader;
 
+/// Advance to the next UTF-8 character boundary strictly after `i`.
+fn next_char_boundary(s: &str, i: usize) -> usize {
+    let mut j = i + 1;
+    while j < s.len() && !s.is_char_boundary(j) {
+        j += 1;
+    }
+    j
+}
+
+/// JS-spec `RegExp.prototype[Symbol.split]` (21.2.5.11) for the standard
+/// `regex` engine. Walks the subject with a *sticky* match at each position,
+/// applies the `e == p` empty-match skip (so a zero-width match at the current
+/// segment start does not emit an empty string), and splices captured groups
+/// (unmatched groups → `undefined`/`None`) after each segment. Honors `limit`
+/// (`< 0` ⇒ unbounded) by stopping once `limit` elements have been produced.
+/// Each element is `Some(substring)` or `None` for a spliced unmatched group.
+pub(crate) fn spec_regex_split(regex: &regex::Regex, s: &str, limit: i32) -> Vec<Option<String>> {
+    let mut out: Vec<Option<String>> = Vec::new();
+    let unbounded = limit < 0;
+    // Returns true once the limit is reached (caller must stop).
+    let mut push = |out: &mut Vec<Option<String>>, v: Option<String>| -> bool {
+        out.push(v);
+        !unbounded && out.len() as i32 >= limit
+    };
+    let size = s.len();
+    if size == 0 {
+        // Empty subject: `[""]` unless the pattern matches the empty string.
+        if regex.find(s).is_none() {
+            out.push(Some(String::new()));
+        }
+        return out;
+    }
+    let mut p = 0usize; // start of the pending segment
+    let mut q = 0usize; // scan cursor
+    while q < size {
+        match regex.find_at(s, q) {
+            // Sticky: a match must begin exactly at `q`.
+            Some(m) if m.start() == q => {
+                let e = m.end().min(size);
+                if e == p {
+                    // Zero-width match at the segment start: skip it.
+                    q = next_char_boundary(s, q);
+                } else {
+                    if push(&mut out, Some(s[p..q].to_string())) {
+                        return out;
+                    }
+                    if let Some(caps) = regex.captures_at(s, q) {
+                        for i in 1..caps.len() {
+                            let g = caps.get(i).map(|gm| gm.as_str().to_string());
+                            if push(&mut out, g) {
+                                return out;
+                            }
+                        }
+                    }
+                    p = e;
+                    q = p;
+                }
+            }
+            // Leftmost match lies to the right of `q`; no match (and thus no
+            // zero-width match) exists in between, so jump straight to it.
+            Some(m) => q = m.start(),
+            None => break,
+        }
+    }
+    if unbounded || (out.len() as i32) < limit {
+        out.push(Some(s[p..size].to_string()));
+    }
+    out
+}
+
 /// Split a string by a delimiter
 /// Returns an array of string pointers (stored as f64 bit patterns)
 #[no_mangle]


### PR DESCRIPTION
## Summary

`built-ins/String` + `built-ins/RegExp` test262: **+8, zero regressions** (verified by diffing the per-test failure set; String+RegExp fails 97 → 89).

## Root cause

Perry delegated `String.prototype.split(regexp, limit)` to the Rust `regex` crate's `Regex::split`, which diverges from JS `RegExp.prototype[Symbol.split]` (21.2.5.11):

- **zero-width matches** — `regex::split` emits the leading/trailing/consecutive empty strings that the spec's `e == p` skip suppresses. `"one-1 two".split(new RegExp)` (empty pattern) returned `["","o",…,"o",""]` (length 11) instead of the spec's `["o",…,"o"]` (length 9, one element per char); and
- **captured groups** were never spliced into the result (`"a1b".split(/(\d)/)` dropped the `"1"`).

## Fix

Replaced the standard-engine branch of `js_string_split_regex_n` with the spec algorithm: a *sticky* match at each position, the empty-match-at-segment-start (`e == p`) skip, and capture-group splicing where an unmatched group becomes `undefined`. `limit` is honoured per-element. The fancy-regex (lookbehind) fallback is unchanged. Helpers (`spec_regex_split`, `next_char_boundary`) live in `string/split.rs` so `regex.rs` stays under the 2000-line cap.

## Files
- `regex.rs` — standard split branch + undefined-aware array build
- `string/split.rs` — `spec_regex_split` + `next_char_boundary`
- `string/mod.rs` — re-export

## Validation
`test262_subset.py --dir built-ins/String built-ins/RegExp` vs tc39/test262 @ `4249661`, Node v26.3.0: 8 newly-passing (split/call-split-new-reg-exp, the new-reg-exp-and-N family, separator-regexp), **0 newly-broken**.