### PR TITLE
fix(runtime): http2 server 'session' fires after client 'connect' (#812)

### DIFF
--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -441,6 +441,7 @@ fn has_active_server_session(server_handle: i64) -> bool {
     active
 }
 
+#[allow(dead_code)] // retained: server-session listener probe
 fn server_has_session_listener(server_handle: i64) -> bool {
     get_handle::<Http2SecureServer>(server_handle)
         .and_then(|server| server.base.listeners.get("session"))
@@ -448,6 +449,7 @@ fn server_has_session_listener(server_handle: i64) -> bool {
         .unwrap_or(false)
 }
 
+#[allow(dead_code)] // retained: server-session emit bookkeeping
 fn has_emitted_server_session(server_handle: i64) -> bool {
     let mut emitted = false;
     iter_handles_of::<Http2SessionHandle, _>(|session| {
@@ -466,11 +468,61 @@ fn local_client_connect_ready(session_handle: i64) -> bool {
     let Some(server_handle) = local_server_handle_for_client(session_handle) else {
         return true;
     };
-    if server_has_session_listener(server_handle) {
-        has_emitted_server_session(server_handle)
-    } else {
-        has_active_server_session(server_handle)
-    }
+    // The client `connect` only needs the server session to be ACTIVE (the
+    // handshake established), not for the server's `session` EVENT to have
+    // fired — Node emits that event after the client connect. Gating on the
+    // emitted event forced a `session`-before-`connect` order that Node never
+    // produces.
+    has_active_server_session(server_handle)
+}
+
+thread_local! {
+    /// Client sessions whose `connect` event has already been emitted, so the
+    /// server-side `session` emit can stop deferring behind them.
+    static H2_CLIENT_CONNECT_EMITTED: std::cell::RefCell<std::collections::HashSet<i64>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+fn mark_client_connect_emitted(session_handle: i64) {
+    H2_CLIENT_CONNECT_EMITTED.with(|s| {
+        s.borrow_mut().insert(session_handle);
+    });
+}
+
+/// Whether the server-side `session` event may be emitted now. Node emits it
+/// AFTER the same-process client's `connect` event, so defer while any local
+/// client targeting this server is connected but has not yet fired `connect`.
+/// (A remote client — none in-process — never blocks, so real connections emit
+/// immediately.)
+fn local_server_session_ready(server_handle: i64) -> bool {
+    let mut ready = true;
+    iter_handle_ids_of::<Http2SessionHandle, _>(|client_id| {
+        if !ready {
+            return;
+        }
+        let Some(client) = get_handle::<Http2SessionHandle>(client_id) else {
+            return;
+        };
+        if client.session_type != 1 || client.closed || client.destroyed {
+            return;
+        }
+        // Only an in-flight client (still handshaking, or connected and about to
+        // fire `connect`) blocks. A failed client — neither connecting nor
+        // connected — must NOT defer the server `session` forever.
+        if !client.connecting && !client.connected {
+            return;
+        }
+        let targets = client.server_handle == server_handle
+            || h2_listening_server_for_authority(&client.authority) == Some(server_handle);
+        if !targets {
+            return;
+        }
+        let emitted = H2_CLIENT_CONNECT_EMITTED.with(|s| s.borrow().contains(&client_id));
+        if !emitted {
+            ready = false;
+        }
+    });
+    ready
 }
 
 /// `http2.createSecureServer(opts, handler)` — opts carries `{ key, cert }`
@@ -948,9 +1000,14 @@ pub(crate) fn process_pending_h2_events() -> i32 {
         Ok(mut q) => q.drain(..).collect(),
         Err(_) => return 0,
     };
+    // Node fires the client-side `connect` before the server-side `session`
+    // event (the server's `session` emit is deferred relative to the client
+    // handshake completing). Drain `ClientConnect` first so a single-process
+    // loopback observes `connect` then `session`, matching Node's ordering.
     events.sort_by_key(|event| match event {
-        Http2PendingEvent::Session { .. } => 0,
-        _ => 1,
+        Http2PendingEvent::ClientConnect { .. } => 0,
+        Http2PendingEvent::Session { .. } => 1,
+        _ => 2,
     });
     let count = events.len() as i32;
     for event in events {
@@ -959,6 +1016,14 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                 server_handle,
                 session_handle,
             } => {
+                // Defer behind a same-process client's `connect` (Node ordering).
+                if !local_server_session_ready(server_handle) {
+                    push_h2_event(Http2PendingEvent::Session {
+                        server_handle,
+                        session_handle,
+                    });
+                    continue;
+                }
                 let listeners = get_handle::<Http2SecureServer>(server_handle)
                     .and_then(|s| s.base.listeners.get("session").cloned())
                     .unwrap_or_default();
@@ -978,6 +1043,7 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                     push_h2_event(Http2PendingEvent::ClientConnect { session_handle });
                     continue;
                 }
+                mark_client_connect_emitted(session_handle);
                 let listeners = get_handle::<Http2SessionHandle>(session_handle)
                     .and_then(|s| s.listeners.get("connect").cloned())
                     .unwrap_or_default();

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -273,6 +273,12 @@ crates/perry-runtime/src/typedarray/mod.rs
 # prologue lift (run param binding at call time) + per-yield operand Await.
 # Splitting the state builder from the closure assembly is tracked under #1435.
 crates/perry-transform/src/generator/lower.rs
+# HTTP/2 server-and-client session surface (settings/ping/goaway controls,
+# stream lifecycle, the loopback connect/session event-ordering machinery).
+# Crossed the 2000-line gate after the Node-ordering deferral that emits the
+# server `session` event after the client `connect`. Splitting the session
+# event pump from the handle/settings surface is tracked under #1435.
+crates/perry-ext-http-server/src/http2_server.rs
 EOF
 )
 


### PR DESCRIPTION
## Summary

node-suite **http/https/http2 differential: 30/32 → 32/32** vs Node v26.3.0, zero regressions (verified by running every `test-parity/node-suite/{http,https,http2}` test under Node and Perry and diffing stdout).

The two remaining failures were both http2 **event-ordering** bugs (functionality was already correct): Perry emitted the server-side `'session'` event *before* the loopback client's `'connect'`, while Node emits it *after*. Perry even gated the client `'connect'` on the server `'session'` having fired — the exact inverse of Node.

## Fix

- **client `connect` no longer waits on the server `session` event** — `local_client_connect_ready` now only needs the server session to be *active* (handshake established), not for its `'session'` event to have been emitted.
- **the pending-event drain orders `ClientConnect` before `Session`**.
- **the server `'session'` emit is deferred** (re-queued across pump cycles) while any same-process client targeting that server is still connecting, or connected but not yet `connect`-emitted — so `connect` precedes `session` even when the two events land in different drain batches. A *failed* client (neither connecting nor connected) never blocks the emit, so real remote connections (no in-process client) fire immediately.

Fixes `http2/session/controls.ts` and `http2/session/sequential-session-cleanup.ts`.

## Files
- `http2_server.rs` — connect/session ordering + deferral
- `scripts/check_file_size.sh` — allowlist (file crossed 2000 LOC; split tracked under #1435)

## Validation
`node-suite` differential, Node v26.3.0 oracle: 30→32 PASS, **0 FAIL** (was failing both http2/session cases).