### PR TITLE
fix(codegen): gate closure-local-call implicit-this reset on callee reading dynamic this

### DIFF
--- a/crates/perry-codegen/src/lower_call/early_branches.rs
+++ b/crates/perry-codegen/src/lower_call/early_branches.rs
@@ -258,13 +258,19 @@ pub fn try_lower_closure_typed_local_call(
             // Receiverless call of a closure-typed local: bind `this` to
             // undefined for the duration of the call (OrdinaryCallBindThis,
             // #3576) so an enclosing method dispatch's IMPLICIT_THIS does
-            // not leak into the callee body.
+            // not leak into the callee body. Like the FuncRef path, the
+            // reset is gated on the statically-known callee actually reading
+            // dynamic `this`, so a hot-loop call of a plain helper closure
+            // pays nothing (#5030). When the typed-feedback guard falls back
+            // (the receiver is NOT the statically-mapped closure), the
+            // fallback block does its own reset — that callee is unknown.
             let undef_this =
                 crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-            let prev_this =
-                ctx.block()
-                    .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, &undef_this)]);
-            if let Some(func_id) = ctx.local_closure_func_ids.get(id).copied() {
+            let known_func_id = ctx.local_closure_func_ids.get(id).copied();
+            let callee_reads_this = known_func_id
+                .map(|fid| ctx.funcs_reading_dynamic_this.contains(&fid))
+                .unwrap_or(true);
+            if let Some(func_id) = known_func_id {
                 let declared_count = ctx
                     .local_closure_param_counts
                     .get(id)
@@ -280,6 +286,15 @@ pub fn try_lower_closure_typed_local_call(
                         &format!("closure:{}", func_id),
                         TypedFeedbackContract::closure_direct_call(),
                     );
+                    let prev_this = if callee_reads_this {
+                        Some(ctx.block().call(
+                            DOUBLE,
+                            "js_implicit_this_set",
+                            &[(DOUBLE, &undef_this)],
+                        ))
+                    } else {
+                        None
+                    };
                     let expected_arity = declared_count.to_string();
                     let call_arity = lowered_args.len().to_string();
                     let guard_ok = ctx.block().call(
@@ -318,6 +333,18 @@ pub fn try_lower_closure_typed_local_call(
                     ctx.current_block = fallback_idx;
                     ctx.block()
                         .call_void("js_typed_feedback_record_fallback_call", &[(I64, &site_id)]);
+                    // Guard failed: the receiver is some OTHER closure whose
+                    // body codegen never saw — reset `this` here (and only
+                    // here) when the static gating skipped the outer reset.
+                    let fallback_prev_this = if prev_this.is_none() {
+                        Some(ctx.block().call(
+                            DOUBLE,
+                            "js_implicit_this_set",
+                            &[(DOUBLE, &undef_this)],
+                        ))
+                    } else {
+                        None
+                    };
                     let runtime_fn = format!("js_closure_call{}", lowered_args.len());
                     let mut fallback_args: Vec<(crate::types::LlvmType, &str)> =
                         vec![(I64, &closure_handle)];
@@ -325,6 +352,11 @@ pub fn try_lower_closure_typed_local_call(
                         fallback_args.push((DOUBLE, v.as_str()));
                     }
                     let fallback_value = ctx.block().call(DOUBLE, &runtime_fn, &fallback_args);
+                    if let Some(prev) = &fallback_prev_this {
+                        let _ = ctx
+                            .block()
+                            .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, prev)]);
+                    }
                     let after_fallback = ctx.block().label.clone();
                     if !ctx.block().is_terminated() {
                         ctx.block().br(&merge_label);
@@ -338,12 +370,20 @@ pub fn try_lower_closure_typed_local_call(
                             (fallback_value.as_str(), after_fallback.as_str()),
                         ],
                     );
-                    let _ =
-                        ctx.block()
-                            .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, &prev_this)]);
+                    if let Some(prev) = &prev_this {
+                        let _ = ctx
+                            .block()
+                            .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, prev)]);
+                    }
                     return Ok(Some(merged));
                 }
             }
+            // Generic js_closure_callN dispatch (unknown func id, rest
+            // params, or arity mismatch): the runtime-resolved callee may
+            // read `this`, so the reset is unconditional here.
+            let prev_this =
+                ctx.block()
+                    .call(DOUBLE, "js_implicit_this_set", &[(DOUBLE, &undef_this)]);
             let runtime_fn = format!("js_closure_call{}", lowered_args.len());
             let mut call_args: Vec<(crate::types::LlvmType, &str)> = vec![(I64, &closure_handle)];
             for v in &lowered_args {


### PR DESCRIPTION
## Summary

Fixes #5030 — unbreaks the required `compiler-output-regression` check, red on `main` since #5004 (verified by adjacent-commit runs: gate green at 50c1a6469 / #5003, red at f991e2ead / #5004 with the exact failure signature from CI).

## Root cause

#5004 added an OrdinaryCallBindThis reset (`js_implicit_this_set(undefined)` + restore) around receiverless calls. The `FuncRef` path correctly gates it on `funcs_reading_dynamic_this` ("ordinary helper calls pay nothing"), but `try_lower_closure_typed_local_call` (early_branches.rs) emits the pair **unconditionally**. In the `h1_buffer_alias_negative` fixture, `closureCapture()`'s hot loop calls a this-free arrow (`read(i)`) — the per-iteration `js_implicit_this_set` pair trips `hot_loops_no_runtime_calls` (it is the only call in the failing report that is not on the workload's allowlist).

## Fix

Mirror the FuncRef gating in the closure-typed-local path:

- **Direct/guarded path, statically-known callee:** emit the reset only when the mapped closure's body reads dynamic `this` (`funcs_reading_dynamic_this`, which conservatively includes arrows capturing lexical `this`).
- **Typed-feedback guard fallback:** the runtime receiver is some *other* closure codegen never saw — when the static gate skipped the outer reset, the fallback block now does its own reset/restore around `js_closure_callN`. (Fallback blocks are not hot-loop blocks, so the gate stays green while #3576 semantics are preserved even for reassigned closure locals.)
- **Generic `js_closure_callN` tail** (unknown func id / rest params / arity mismatch): unconditional reset, as before.

## Validation

- `compiler_output_regression.py suite --suite native-region-proof` → **all workloads pass** (`failed_workloads: []`), previously `h1_buffer_alias_negative` failed.
- `capture --gate` for `vectorized_buffer_transform` and `hir_fact_rewrite` → pass.
- `python3 -m unittest tests.test_compiler_output_regression` → 40/40.
- `test-files/test_object_model_semantics_3986.ts` (the #5004 semantics test) still prints `object-model-semantics: ok` under Perry.
- New targeted behavioral check (compiled + ran): (1) closure local statically mapped to a this-free arrow but **reassigned at runtime** to a `this`-reading function — guard fallback binds `this` to undefined/globalThis, no receiver leak; (2) this-reading closure local on the fast path — reset still applied; (3) the #5030 hot-loop helper shape computes correctly.
- `cargo test --release -p perry-codegen` → green except `manifest_param_counts_match_dispatch_table` (zlib::deflateRawSync arity drift), which is pre-existing macOS-local and unrelated (my diff touches neither manifest nor dispatch; the test passes in Linux CI on current main).

Related: #5031 fixes the cargo-test red (stream unshift); #5029 (gc_write_barrier_stress) is being bisected separately.

No version bump / changelog per external-PR convention.