### PR TITLE
feat(watchos): target arm64 (aarch64-apple-watchos) for device builds

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -379,7 +379,7 @@ pub(crate) fn default_target_triple() -> String {
 /// Supported:
 ///  * `ios`, `ios-simulator`           → aarch64-apple-ios
 ///  * `visionos`, `visionos-simulator` → arm64-apple-xros1.0{,-simulator}
-///  * `watchos`                        → arm64_32-apple-watchos (ILP32)
+///  * `watchos`                        → aarch64-apple-watchos (arm64, S9+ / watchOS 26)
 ///  * `watchos-simulator`              → arm64-apple-watchos10.0-simulator
 ///  * `tvos`, `tvos-simulator`         → aarch64-apple-tvos
 ///  * `android`                        → aarch64-unknown-linux-android
@@ -397,7 +397,7 @@ pub fn resolve_target_triple(name: &str) -> Option<String> {
         "ios-simulator" => Some("arm64-apple-ios17.0-simulator".to_string()),
         "visionos" => Some("arm64-apple-xros1.0".to_string()),
         "visionos-simulator" => Some("arm64-apple-xros1.0-simulator".to_string()),
-        "watchos" => Some("arm64_32-apple-watchos".to_string()),
+        "watchos" => Some("aarch64-apple-watchos".to_string()),
         "watchos-simulator" => Some("arm64-apple-watchos10.0-simulator".to_string()),
         "tvos" => Some("aarch64-apple-tvos".to_string()),
         "tvos-simulator" => Some("arm64-apple-tvos17.0-simulator".to_string()),

--- a/crates/perry/src/commands/compile/app_metadata.rs
+++ b/crates/perry/src/commands/compile/app_metadata.rs
@@ -158,7 +158,7 @@ pub(super) fn rust_target_triple(target: Option<&str>) -> Option<&'static str> {
         Some("visionos-simulator") => Some("aarch64-apple-visionos-sim"),
         Some("visionos") => Some("aarch64-apple-visionos"),
         Some("watchos-simulator") => Some("aarch64-apple-watchos-sim"),
-        Some("watchos") => Some("arm64_32-apple-watchos"),
+        Some("watchos") => Some("aarch64-apple-watchos"),
         Some("tvos-simulator") => Some("aarch64-apple-tvos-sim"),
         Some("tvos") => Some("aarch64-apple-tvos"),
         Some("harmonyos") => Some("aarch64-unknown-linux-ohos"),

--- a/crates/perry/src/commands/compile/bundle_apple.rs
+++ b/crates/perry/src/commands/compile/bundle_apple.rs
@@ -173,6 +173,14 @@ pub(super) fn bundle_for_watchos(
     // #4849: read version/build_number from perry.toml (was hardcoded "1.0").
     let (app_version, app_build_number) = read_apple_app_version(input);
 
+    // Device builds are arm64-only, which requires watchOS 26 (S9+); the
+    // simulator target keeps the lower floor.
+    let min_os = if target == Some("watchos-simulator") {
+        "10.0"
+    } else {
+        "26.0"
+    };
+
     let info_plist = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -189,7 +197,7 @@ pub(super) fn bundle_for_watchos(
     <key>CFBundleShortVersionString</key>
     <string>{app_version}</string>
     <key>MinimumOSVersion</key>
-    <string>10.0</string>
+    <string>{min_os}</string>
     <key>UIDeviceFamily</key>
     <array>
         <integer>4</integer>

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -1247,7 +1247,7 @@ pub(super) fn build_and_run_link(
             let (lib_name, build_cmd) = if is_watchos {
                 (
                     "libperry_ui_watchos.a",
-                    "cargo build --release -p perry-ui-watchos --target arm64_32-apple-watchos",
+                    "cargo +nightly build -Z build-std=std,panic_abort --release -p perry-ui-watchos --target aarch64-apple-watchos (or --target aarch64-apple-watchos-sim for the simulator)",
                 )
             } else if is_tvos {
                 (
@@ -1755,7 +1755,9 @@ pub(super) fn build_and_run_link(
                 let swift_triple = if target == Some("watchos-simulator") {
                     "arm64-apple-watchos10.0-simulator"
                 } else {
-                    "arm64_32-apple-watchos10.0"
+                    // Device builds are arm64-only (S9+ / watchOS 26): Perry's
+                    // NaN-boxed values need 64-bit pointers, which arm64_32 lacks.
+                    "arm64-apple-watchos26.0"
                 };
                 let swift_sysroot = String::from_utf8(
                     Command::new("xcrun")

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -56,7 +56,9 @@ pub fn select_linker_command(
         let triple = if target == Some("watchos-simulator") {
             "arm64-apple-watchos10.0-simulator"
         } else {
-            "arm64_32-apple-watchos10.0"
+            // Device builds are arm64-only (S9+ / watchOS 26): Perry's
+            // NaN-boxed values need 64-bit pointers, which arm64_32 lacks.
+            "arm64-apple-watchos26.0"
         };
 
         // Find the entry object whose stem matches the user's input file stem

--- a/crates/perry/src/commands/compile/targets.rs
+++ b/crates/perry/src/commands/compile/targets.rs
@@ -554,7 +554,9 @@ pub(super) fn compile_for_watchos_widget(
     let target_triple = if is_simulator {
         "arm64-apple-watchos10.0-simulator"
     } else {
-        "arm64_32-apple-watchos10.0"
+        // Device builds are arm64-only (S9+ / watchOS 26), matching the app
+        // target: Perry's NaN-boxed values need 64-bit pointers.
+        "arm64-apple-watchos26.0"
     };
     let mut frameworks = vec!["WidgetKit", "SwiftUI"];
     if uses_app_intents {


### PR DESCRIPTION
## Why

Real-watch builds (`--target watchos`) have never linked: the device triple was `arm64_32-apple-watchos`, and Perry's NaN-boxed value representation (48-bit pointer masks, tags in the high 16 bits of a 64-bit word) fundamentally requires 64-bit `usize` — `perry-runtime` doesn't even compile for arm64_32 ("literal out of range for usize" in value.rs).

watchOS 26 moved S9-and-later watches to full arm64, so a 64-bit device target now exists. Apple also requires arm64 for all new watchOS App Store submissions since July 2025.

## What

- Device triple: `arm64_32-apple-watchos` → `aarch64-apple-watchos` (codegen helpers + native-lib target mapping)
- Swift/linker triples: `arm64_32-apple-watchos10.0` → `arm64-apple-watchos26.0` (link, platform_cmd, watchos-widget)
- Watch bundle `MinimumOSVersion`: 26.0 for device builds (simulator keeps 10.0)
- Updated the missing-lib hint to the nightly `-Z build-std` invocation the tier-3 target needs

## Validation

Built a real game (Bloom Jump) end to end: `perry-runtime` + `perry-ui-watchos` via nightly build-std for `aarch64-apple-watchos`, game compiled/linked with `--features watchos-swift-app`, produced a Mach-O `platform WATCHOS minos 26.0` arm64 executable, signed and **accepted by App Store Connect** (uploaded as a watch-only app, processing).

## Notes

- `aarch64-apple-watchos` is a tier-3 Rust target: runtime libs need `cargo +nightly build -Z build-std=std,panic_abort`. Worth wiring into release-packages.yml so PERRY_RUNTIME_DIR users get prebuilt .a files.
- App Store validation additionally demands `MinimumOSVersion >= 27.0` for arm64-only watch apps (below that an arm64_32 slice is mandatory). 26.0 is kept here because it allows Xcode dev-installs on S9+ watches running watchOS 26; store packaging can re-stamp with `vtool -set-build-version watchos 27.0`. Could alternatively make this a perry.toml knob — happy to follow up.
- Watch-only App Store packaging needs an iOS stub wrapper (separate concern from this PR; `perry publish watchos` support could build on this).