### PR TITLE
fix(runtime): function-prototype expandos invisible to own-key enumeration broke Object.assign — PureComponent subclasses rendered as function components (#5024)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -458,6 +458,23 @@ pub(crate) fn ensure_function_prototype_object(
 
     class_prototype_object_root_store(class_id, proto);
 
+    // #5024: methods registered before the prototype object materialized
+    // (`F.prototype.m = v` typically runs long before any reflective
+    // `F.prototype` read) live only in CLASS_PROTOTYPE_METHODS. Backfill
+    // them as ordinary own properties so enumeration sees them; later
+    // registrations write through via class_prototype_method_root_store.
+    let registered: Vec<(String, u64)> = {
+        let guard = CLASS_PROTOTYPE_METHODS.read().unwrap();
+        guard
+            .as_ref()
+            .and_then(|map| map.get(&class_id))
+            .map(|per_class| per_class.iter().map(|(k, &v)| (k.clone(), v)).collect())
+            .unwrap_or_default()
+    };
+    for (name, value_bits) in registered {
+        unsafe { mirror_prototype_method_on_object(proto, &name, value_bits) };
+    }
+
     let func_bits = func_value.to_bits();
     if (func_bits >> 48) == 0x7FFD {
         let func_ptr = (func_bits & crate::value::POINTER_MASK) as usize;
@@ -1251,18 +1268,45 @@ fn invalidate_class_prototype_fast_guards() {
 }
 
 pub(crate) fn class_prototype_method_root_store(class_id: u32, name: String, value_bits: u64) {
-    let mut guard = CLASS_PROTOTYPE_METHODS.write().unwrap();
-    if guard.is_none() {
-        *guard = Some(HashMap::new());
+    {
+        let mut guard = CLASS_PROTOTYPE_METHODS.write().unwrap();
+        if guard.is_none() {
+            *guard = Some(HashMap::new());
+        }
+        guard
+            .as_mut()
+            .unwrap()
+            .entry(class_id)
+            .or_insert_with(HashMap::new)
+            .insert(name.clone(), value_bits);
     }
-    guard
-        .as_mut()
-        .unwrap()
-        .entry(class_id)
-        .or_insert_with(HashMap::new)
-        .insert(name, value_bits);
     invalidate_class_prototype_fast_guards();
     crate::gc::runtime_write_barrier_root_nanbox(value_bits);
+    // #5024: the side table makes the method dispatchable, but own-key
+    // enumeration on the prototype OBJECT (Object.keys / getOwnPropertyNames /
+    // `in` / hasOwnProperty / for-in / Object.assign) consults the object's
+    // keys_array, which the side table never touched — React's
+    // `Object.assign(PureComponent.prototype, Component.prototype)` copied
+    // nothing, so `isReactComponent` vanished and every `extends PureComponent`
+    // class rendered as a function component. Mirror the write onto the
+    // materialized prototype object as an ordinary enumerable own property.
+    let proto = class_prototype_object(class_id);
+    if !proto.is_null() {
+        unsafe { mirror_prototype_method_on_object(proto, &name, value_bits) };
+    }
+}
+
+/// #5024: write a side-table-registered prototype method onto the
+/// materialized prototype object so the key lands in its `keys_array`
+/// (assignment semantics: enumerable data property). Values keep their
+/// full NaN-boxed bits; dispatch paths that find the property on the
+/// object see the same value the side table holds.
+unsafe fn mirror_prototype_method_on_object(proto: *mut ObjectHeader, name: &str, value_bits: u64) {
+    if proto.is_null() || name.is_empty() {
+        return;
+    }
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(proto, key, f64::from_bits(value_bits));
 }
 
 /// Register a JS-classic prototype-method assignment on a class.
@@ -1405,7 +1449,27 @@ pub unsafe extern "C" fn js_get_function_prototype_method(
             let method = js_class_method_bind(receiver, name_ptr, name_len);
             f64::from_bits(method.to_bits())
         }
-        None => undef,
+        None => {
+            // #5024: properties can land on the prototype OBJECT without a
+            // side-table registration — `Object.assign(F.prototype, src)`
+            // (React's PureComponent setup), a replaced `F.prototype = obj`,
+            // or any generic dynamic write. Read the real prototype value
+            // (replaced object, or the materialized auto-created one) so
+            // the recognised `<func>.prototype.<name>` read shape agrees
+            // with the generic property-get path.
+            let proto_val = js_function_prototype_value_for_read(func_value);
+            let jv = crate::value::JSValue::from_bits(proto_val.to_bits());
+            if !jv.is_pointer() {
+                return undef;
+            }
+            let pptr = jv.as_pointer::<ObjectHeader>();
+            if pptr.is_null() {
+                return undef;
+            }
+            let key = crate::string::js_string_from_bytes(name_ptr, name_len as u32);
+            let v = js_object_get_field_by_name(pptr, key);
+            f64::from_bits(v.bits())
+        }
     }
 }
 

--- a/test-files/test_gap_fn_prototype_own_keys_5024.ts
+++ b/test-files/test_gap_fn_prototype_own_keys_5024.ts
@@ -1,0 +1,78 @@
+// Issue #5024: expando properties written to a function's auto-created
+// `.prototype` object must be registered in the object's own-property key
+// metadata, so Object.keys / getOwnPropertyNames / `in` / hasOwnProperty /
+// for-in / Object.assign all see them (React PureComponent setup relies on
+// Object.assign(PureComponent.prototype, Component.prototype)).
+
+// --- Part 1: minimal own-key tracking on the auto-created prototype ---
+function F(this: any) {}
+(F.prototype as any).mark = { tag: 1 };
+
+console.log("direct get:", typeof (F.prototype as any).mark);
+console.log("keys:", JSON.stringify(Object.keys(F.prototype)));
+console.log("ownNames:", JSON.stringify(Object.getOwnPropertyNames(F.prototype).sort()));
+console.log("in:", "mark" in F.prototype);
+console.log("hasOwn:", Object.prototype.hasOwnProperty.call(F.prototype, "mark"));
+
+const forInKeys: string[] = [];
+for (const k in F.prototype) forInKeys.push(k);
+console.log("forIn:", JSON.stringify(forInKeys));
+
+const t: any = {};
+Object.assign(t, F.prototype);
+console.log("assign keys:", JSON.stringify(Object.keys(t)));
+console.log("assign get:", typeof t.mark);
+
+// Read through a plain variable (generic property-get path, not the
+// recognised `<funcName>.prototype.<name>` shape).
+const FP: any = F.prototype;
+console.log("var get:", typeof FP.mark);
+
+// --- Part 2: replaced prototype (control — always worked) ---
+function G(this: any) {}
+G.prototype = { gmark: 1 };
+console.log("replaced keys:", JSON.stringify(Object.keys(G.prototype)));
+
+// --- Part 3: the React PureComponent shape (2-level chain) ---
+function Component(this: any, props: any) {
+  this.props = props;
+}
+(Component.prototype as any).isReactComponent = {};
+(Component.prototype as any).setState = function (this: any, s: any) {
+  return "setState";
+};
+
+function ComponentDummy(this: any) {}
+ComponentDummy.prototype = Component.prototype;
+
+function PureComponent(this: any, props: any) {
+  this.props = props;
+}
+const pureProto: any = new (ComponentDummy as any)();
+PureComponent.prototype = pureProto;
+pureProto.constructor = PureComponent;
+Object.assign(pureProto, Component.prototype);
+pureProto.isPureReactComponent = true;
+
+const PC: any = PureComponent;
+console.log("PC proto isReactComponent:", typeof PC.prototype.isReactComponent);
+
+class Y extends (PureComponent as any) {
+  render() {
+    return null;
+  }
+}
+console.log("Y proto isReactComponent:", typeof (Y.prototype as any).isReactComponent);
+
+// shouldConstruct, exactly as react-reconciler does it
+function shouldConstruct(type: any) {
+  const prototype = type.prototype;
+  return !!(prototype && prototype.isReactComponent);
+}
+console.log("shouldConstruct(Y):", shouldConstruct(Y));
+
+// --- Part 4: dispatch through instances still works ---
+const f: any = new (F as any)();
+console.log("inst mark:", typeof f.mark);
+const y: any = new (Y as any)();
+console.log("y setState:", y.setState ? y.setState() : "MISSING");


### PR DESCRIPTION
Fixes #5024 — the last blocker for ink end-to-end rendering (#348).

## Problem

Expando properties written to a function's auto-created `.prototype` object (`F.prototype.mark = v`) were dispatchable but invisible to own-property enumeration: `Object.keys`, `Object.getOwnPropertyNames`, `in`, `hasOwnProperty`, `for-in`, and — critically — `Object.assign` all missed them.

React 19 sets up `PureComponent` by copying `Component.prototype` with `Object.assign(PureComponent.prototype, Component.prototype)`. Because the copy saw no keys, `PureComponent.prototype.isReactComponent` ended up `undefined`, react-reconciler's `shouldConstruct` classified every `class X extends PureComponent` as a *function* component, its class `render()` never ran, and its children were dropped — ink's `<ErrorBoundary extends PureComponent>` wraps the whole app, so the entire tree rendered empty.

## Root cause

The #838 recogniser lowers `F.prototype.<name> = v` to `js_register_function_prototype_method`, which stores the value **only** in the `CLASS_PROTOTYPE_METHODS` side table (keyed by synthetic class id). Dispatch paths consult that table, so direct GET and instance-method calls worked — but the materialized prototype *object* (`ensure_function_prototype_object`) never learned the key, so its `keys_array` (the metadata every enumeration path consults) stayed empty.

A second gap on the read side: the recognised `<func>.prototype.<name>` READ shape (`js_get_function_prototype_method`) consulted *only* the side table, so properties that landed on the prototype object without a registration (`Object.assign`, generic dynamic writes, replaced `F.prototype = obj`) read back `undefined` even though the generic property-get path could see them.

## Fix (all in `crates/perry-runtime/src/object/class_registry.rs`)

1. **Write-through** — `class_prototype_method_root_store` now mirrors each side-table registration onto the materialized prototype object as an ordinary enumerable own property (when the object exists).
2. **Backfill** — `ensure_function_prototype_object` copies all already-registered side-table methods onto the freshly materialized object (covers the common `F.prototype.m = v` *before* any reflective `F.prototype` read ordering).
3. **Read fallback** — `js_get_function_prototype_method` falls back to reading the real prototype value (replaced object or materialized auto-created one) when the side table misses, so the recognised read shape agrees with the generic property-get path.

## Validation

- New gap test `test-files/test_gap_fn_prototype_own_keys_5024.ts` covers the issue's minimal repro (keys/ownNames/in/hasOwn/for-in/assign/var-read), the replaced-prototype control, the full React `Component`/`ComponentDummy`/`PureComponent`/`Object.assign` shape with a 2-level `class Y extends PureComponent` chain, `shouldConstruct` exactly as react-reconciler does it, and instance dispatch — **byte-identical to `node --experimental-strip-types`**.
- Full parity suite run (759 tests): 48 of the 50 failures fail identically on a pristine `origin/main` build of the same worktree. The remaining 2 were chased to pre-existing flakes, verified on a fully pristine tree (source stashed + `target/perry-auto-*` cleared): `test_issue_1852_net_lifecycle` hangs intermittently on pristine (4 FAIL / 2 PASS over 6 runs; byte-identical output, exit-only divergence), and `test_gap_fs_fd_2749` flips the same `fchown closed cb` line ordering on pristine (async fs callback completion-order race). A 3-way bisect (each of the three changes disabled) confirmed neither symptom tracks this fix.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1`: failure set identical to pristine `origin/main` (3 known pre-existing: `date::tests::test_full_year_setters_revive_invalid_date_only`, 2× `node_stream::tests_extra::readable_unshift_*`).

Per the workflow notes, no version bump / changelog entry — maintainer folds metadata at merge.
