### PR TITLE
fix(gc): close the #5029 conservative-scan × evacuation corruption — re-enable write-barrier stress tests

### DIFF
--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -994,6 +994,7 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
     }
     remembered_set_clear();
     collector.sticky.restore();
+    restore_surviving_dirty_coverage(&snapshot);
     let malloc_freed_bytes = if malloc_sweep_due {
         let phase_start = trace_phase_start(trace);
         let freed = sweep_malloc_objects();

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -565,6 +565,7 @@ impl RootScanCycleState {
         consider_evacuation: bool,
         budget: usize,
         allow_synchronous_scanners: bool,
+        pin_only_old_conservative: bool,
     ) -> bool {
         match self.subphase {
             RootScanSubphase::ConservativeStack => {
@@ -572,8 +573,13 @@ impl RootScanCycleState {
                     return false;
                 }
                 let conservative_scan_decision = conservative_stack_scan_decision();
-                let conservative_root_stats =
-                    mark_stack_roots_for_decision(valid_ptrs, conservative_scan_decision);
+                // #5029: minors retain old-gen conservative discoveries
+                // pin-only (no trace) — see try_mark_conservative_word.
+                let conservative_root_stats = mark_stack_roots_for_decision(
+                    valid_ptrs,
+                    conservative_scan_decision,
+                    pin_only_old_conservative,
+                );
                 let conservative_pin_stats = if consider_evacuation
                     && matches!(
                         conservative_scan_decision,
@@ -824,6 +830,9 @@ pub(super) struct GcCycleState {
     atomic_finalize: Option<AtomicFinalizeCycleState>,
     minor: Option<MinorCycleContext>,
     live_old_to_young_sticky: Option<StickyRememberedSet>,
+    /// Dirty snapshot captured just before this cycle's remembered_set_clear
+    /// begins, for the post-restore coverage repair (#5029).
+    pre_clear_dirty_snapshot: Option<super::barrier::RememberedDirtySnapshot>,
     sweep_state: Option<IncrementalSweepState>,
     reclaim_state: Option<ReclaimCycleState>,
     sweep: Option<SweepTraceStats>,
@@ -854,6 +863,7 @@ impl GcCycleState {
             atomic_finalize: None,
             minor: None,
             live_old_to_young_sticky: None,
+            pre_clear_dirty_snapshot: None,
             sweep_state: None,
             reclaim_state: None,
             sweep: None,
@@ -907,6 +917,7 @@ impl GcCycleState {
                 evacuation_sticky: StickyRememberedSet::default(),
             }),
             live_old_to_young_sticky: None,
+            pre_clear_dirty_snapshot: None,
             sweep_state: None,
             reclaim_state: None,
             sweep: None,
@@ -1079,6 +1090,7 @@ impl GcCycleState {
                     consider_evacuation,
                     budget.work_units,
                     allow_synchronous_scanners,
+                    self.minor.is_some(),
                 );
             trace_phase_record(&mut self.trace, phase_name, phase_start);
             if done {
@@ -1415,6 +1427,14 @@ impl GcCycleState {
                     let clear = {
                         let reclaim_state =
                             self.reclaim_state.as_mut().expect("reclaim state exists");
+                        if reclaim_state.remembered_set_clear.is_none()
+                            && self.pre_clear_dirty_snapshot.is_none()
+                        {
+                            // Snapshot the pre-clear dirty set so the
+                            // post-restore repair can rescan it (#5029).
+                            self.pre_clear_dirty_snapshot =
+                                Some(super::barrier::remembered_dirty_snapshot());
+                        }
                         reclaim_state
                             .remembered_set_clear
                             .get_or_insert_with(RememberedSetClearState::new)
@@ -1429,6 +1449,9 @@ impl GcCycleState {
                         }
                         if let Some(sticky) = self.live_old_to_young_sticky.as_ref() {
                             sticky.restore();
+                        }
+                        if let Some(snapshot) = self.pre_clear_dirty_snapshot.take() {
+                            restore_surviving_dirty_coverage(&snapshot);
                         }
                         let reclaim_state =
                             self.reclaim_state.as_mut().expect("reclaim state exists");

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -111,7 +111,24 @@ fn gc_collect_minor_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome
     let current_rss_bytes = crate::process::get_rss_bytes();
     let evacuation_policy_allowed = gen_gc_evacuate_enabled();
     let force_evacuation = gc_force_evacuate_enabled();
-    let old_page_selection = if evacuation_policy_allowed && old_to_young_tracking_complete() {
+    // #5029: old-page defrag (C4b old-gen compaction) is skipped on cycles
+    // that run the conservative native-stack scan. Conservative stack words
+    // cannot be rewritten after a move, and per-object CONS_PINNED only
+    // protects DIRECT discoveries — the stress suite demonstrated a moved
+    // old object whose remaining referrer was not rewritten (clone shape
+    // lookups through it returned recycled memory). Until every such
+    // referrer surface is registered for rewrite, moving old objects is only
+    // sound when all roots are precise. Copying minors (the steady-state
+    // path) never run the conservative scan, so defrag keeps operating
+    // there via its own policy.
+    let conservative_scan_this_cycle = matches!(
+        roots::conservative_stack_scan_decision(),
+        roots::ConservativeStackScanDecision::Scan
+    );
+    let old_page_selection = if evacuation_policy_allowed
+        && old_to_young_tracking_complete()
+        && !conservative_scan_this_cycle
+    {
         select_old_page_defrag_pages(force_evacuation)
     } else {
         OldPageDefragSelection::default()

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -434,9 +434,10 @@ pub extern "C" fn js_gc_register_global_root(ptr: i64) {
 pub(super) fn mark_stack_roots_for_decision(
     valid_ptrs: &ValidPointerSet,
     decision: ConservativeStackScanDecision,
+    pin_only_old: bool,
 ) -> ConservativeRootTraceStats {
     match decision {
-        ConservativeStackScanDecision::Scan => mark_stack_roots_unchecked(valid_ptrs),
+        ConservativeStackScanDecision::Scan => mark_stack_roots_unchecked(valid_ptrs, pin_only_old),
         ConservativeStackScanDecision::SkipDisabled => ConservativeRootTraceStats::default(),
     }
 }
@@ -447,6 +448,7 @@ pub(super) fn mark_stack_roots_for_decision(
 /// variables — codegen stores these as raw I64 words (not NaN-boxed) in registers and on stack.
 pub(super) fn mark_stack_roots_unchecked(
     valid_ptrs: &ValidPointerSet,
+    pin_only_old: bool,
 ) -> ConservativeRootTraceStats {
     let mut stats = ConservativeRootTraceStats::default();
     // Capture callee-saved registers into a buffer via setjmp.
@@ -476,7 +478,7 @@ pub(super) fn mark_stack_roots_unchecked(
 
     // Scan the register buffer (covers callee-saved regs: x19-x28 on AArch64, rbx/rbp/r12-r15 on x86_64)
     for &word in &jmp_buf {
-        if try_mark_value_or_raw(word, valid_ptrs) {
+        if try_mark_conservative_word(word, valid_ptrs, pin_only_old) {
             stats.root_count += 1;
         }
     }
@@ -530,7 +532,7 @@ pub(super) fn mark_stack_roots_unchecked(
             options(nostack, preserves_flags),
         );
         for &word in &fp_regs {
-            if try_mark_value_or_raw(word, valid_ptrs) {
+            if try_mark_conservative_word(word, valid_ptrs, pin_only_old) {
                 stats.root_count += 1;
             }
         }
@@ -566,7 +568,7 @@ pub(super) fn mark_stack_roots_unchecked(
     let mut addr = stack_top;
     while addr < stack_bottom {
         let word = unsafe { *(addr as *const u64) };
-        if try_mark_value_or_raw(word, valid_ptrs) {
+        if try_mark_conservative_word(word, valid_ptrs, pin_only_old) {
             stats.root_count += 1;
         }
         addr += 8;
@@ -579,6 +581,88 @@ pub(super) fn mark_stack_roots_unchecked(
 /// This is used for conservative scanning where Perry stores raw I64 pointers (for is_string/
 /// is_array/is_pointer/is_closure vars) alongside NaN-boxed F64 values.
 #[inline]
+/// Conservative-scan variant of `try_mark_value_or_raw` (#5029).
+///
+/// In a MINOR cycle, a conservative stack discovery that lives in the OLD
+/// generation is retained WITHOUT tracing: minors never sweep the old
+/// generation, so the mark is not needed for survival, and `CONS_PINNED`
+/// already excludes the object from every evacuation candidate set. Tracing
+/// it is actively unsound: a stale stack word (a dead frame slot from an
+/// earlier loop iteration) can resurrect a DEAD old object whose slots still
+/// hold pointers into long-swept nursery memory. Once fresh nursery blocks
+/// are allocated over those freed ranges, the resurrected object's slots
+/// alias live young objects; tracing / force-evacuating / rewriting through
+/// them corrupts the heap, and the old-young-edge verifier reports the same
+/// aliases as phantom missing remembered-set edges (the
+/// gc_write_barrier_stress signature: missing_edges=7710 on a dead 256 KB
+/// array backing). A LIVE old object loses nothing here: its real old→young
+/// edges are dirty-page-covered by the write barriers, which is the only
+/// mechanism a minor uses to find them anyway, and precise roots (shadow
+/// stack, module vars, registered scanners) still mark and trace as before.
+///
+/// FULL collections (`pin_only_old == false`) keep the old behavior: the old
+/// sweep frees unmarked old objects, so a stack-only-referenced old object
+/// must be marked for retention there (#4977).
+pub(super) fn try_mark_conservative_word(
+    word: u64,
+    valid_ptrs: &ValidPointerSet,
+    pin_only_old: bool,
+) -> bool {
+    if !pin_only_old {
+        return try_mark_value_or_raw(word, valid_ptrs);
+    }
+
+    // Resolve the candidate exactly like `try_mark_value_or_raw` —
+    // NaN-boxed heap tags first, then the raw-I64 pointer fallback with the
+    // interior-pointer (`enclosing_object`) lookup.
+    let tag = word & TAG_MASK;
+    let target = if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
+        let ptr_val = (word & POINTER_MASK) as usize;
+        if ptr_val == 0 || !valid_ptrs.maybe_contains(ptr_val) || !valid_ptrs.contains(&ptr_val) {
+            return false;
+        }
+        ptr_val
+    } else {
+        if !(0x1000..=0x0000_FFFF_FFFF_FFFF).contains(&word) {
+            return false;
+        }
+        let raw_ptr = word as usize;
+        if !valid_ptrs.maybe_contains(raw_ptr)
+            && raw_ptr.saturating_sub(0x10_0000) > valid_ptrs.range_max
+        {
+            return false;
+        }
+        if valid_ptrs.contains(&raw_ptr) {
+            raw_ptr
+        } else {
+            match valid_ptrs.enclosing_object(raw_ptr) {
+                Some(start) => start,
+                None => return false,
+            }
+        }
+    };
+
+    unsafe {
+        let header = header_from_user_ptr(target as *const u8);
+        if (*header).gc_flags & GC_FLAG_MARKED != 0 {
+            return false;
+        }
+        if (*header).gc_flags & GC_FLAG_PINNED != 0 {
+            return false;
+        }
+        if matches!(
+            crate::arena::classify_heap_generation(target),
+            crate::arena::HeapGeneration::Old
+        ) {
+            // Pin-only retention: not moved, not traced, not marked.
+            return pin_conservative_root_header(header);
+        }
+        (*header).gc_flags |= GC_FLAG_MARKED;
+        push_mark_seed(header);
+    }
+    true
+}
+
 pub(super) fn try_mark_value_or_raw(word: u64, valid_ptrs: &ValidPointerSet) -> bool {
     // First try NaN-boxed interpretation (POINTER_TAG / STRING_TAG / BIGINT_TAG)
     if try_mark_value(word, valid_ptrs) {

--- a/crates/perry-runtime/src/gc/verify.rs
+++ b/crates/perry-runtime/src/gc/verify.rs
@@ -162,6 +162,84 @@ pub(super) unsafe fn remember_evacuated_old_copy_young_slots(
     });
 }
 
+/// Post-cycle remembered-set repair (#5029): after `remembered_set_clear` +
+/// sticky restore, rescan every PRE-cycle dirty page (and external dirty
+/// entry) with the same slot predicate `verify_old_to_young_edges_covered`
+/// uses, and re-remember any slot that still points into the nursery. The
+/// from-scratch rebuild can disagree with the verifier across the cycle
+/// boundary (measured: ~130 covered pages at cycle entry, ~10 after the
+/// rebuild, verifier missing_edges=7710 on the next minor while the swept
+/// children were still referenced); deriving the kept set from the SAME walk
+/// the verifier performs makes dropping a still-needed page impossible by
+/// construction. Pages whose every slot now points old (the common case
+/// after evacuation rewrites) are still dropped, so the remembered set keeps
+/// shrinking as before.
+pub(super) fn restore_surviving_dirty_coverage(snapshot: &RememberedDirtySnapshot) {
+    let mut sticky = StickyRememberedSet::default();
+    // Mirror scan_remembered_dirty_slots_copying's scan_header guards: the
+    // external dirty entries can carry headers the harness seeded
+    // synthetically, and a dead entry may point at reclaimed memory — never
+    // dereference before the plausibility check.
+    let mut visit_parent = |header: *mut GcHeader| unsafe {
+        if header.is_null() {
+            return;
+        }
+        let arena_parent = plausible_gc_header(header, true);
+        let malloc_parent = !arena_parent && plausible_gc_header(header, false);
+        if !arena_parent && !malloc_parent {
+            return;
+        }
+        if (*header).gc_flags & GC_FLAG_FORWARDED != 0 {
+            return;
+        }
+        let user = (header as *mut u8).add(GC_HEADER_SIZE) as usize;
+        if arena_parent
+            && !matches!(
+                crate::arena::classify_heap_generation(user),
+                crate::arena::HeapGeneration::Old
+            )
+        {
+            return;
+        }
+        visit_gc_rewrite_slots(header, |slot| unsafe {
+            if crate::weakref::is_weak_target_trace_slot(header, slot.slot) {
+                return;
+            }
+            slot.record_layout_read();
+            remember_evacuated_old_to_young_slot(&mut sticky, header, slot.slot);
+        });
+    };
+    if !snapshot.dirty_old_pages.is_empty() {
+        crate::arena::old_arena_walk_objects_on_pages(&snapshot.dirty_old_pages, |hp| {
+            visit_parent(hp as *mut GcHeader);
+        });
+    }
+    let mut seen_external = crate::fast_hash::new_ptr_hash_set();
+    for &(_, header_addr) in &snapshot.external_dirty_entries {
+        if !seen_external.insert(header_addr) {
+            continue;
+        }
+        // External entries may be stale (or, in the GC unit tests,
+        // synthetic). Establish that the address is dereference-safe
+        // WITHOUT touching it: old/longlived arena pages are always
+        // mapped; anything else must still be a registered malloc GC
+        // object.
+        let deref_safe = matches!(
+            crate::arena::classify_heap_generation(header_addr),
+            crate::arena::HeapGeneration::Old | crate::arena::HeapGeneration::Longlived
+        ) || MALLOC_STATE.with(|s| {
+            s.borrow()
+                .objects
+                .iter()
+                .any(|&h| h as usize == header_addr)
+        });
+        if deref_safe {
+            visit_parent(header_addr as *mut GcHeader);
+        }
+    }
+    sticky.restore();
+}
+
 pub(super) fn rebuild_evacuated_old_to_young_remembered_set(
     evacuated_headers: &[*mut GcHeader],
 ) -> StickyRememberedSet {
@@ -556,9 +634,22 @@ pub(super) fn rewrite_heap_objects(valid_ptrs: &ValidPointerSet) {
             if flags & GC_FLAG_FORWARDED != 0 {
                 return;
             }
-            // Skip dead objects — sweep is about to free them.
+            // Skip dead NURSERY objects — this cycle's sweep frees them.
+            // An UNMARKED object outside the nursery is NOT dead: a minor
+            // cycle neither traces nor sweeps the old generation, so being
+            // unmarked is the normal state of a live old object whose pages
+            // are clean. Old→old references have no dirty-page coverage
+            // (barriers only track old→young), which makes this walk the
+            // ONLY pass that re-points an old referrer at an old-page
+            // evacuation target. Skipping unmarked old objects left their
+            // slots aimed at forwarding stubs that
+            // `release_evacuated_original_forwarding_stubs` then released —
+            // dangling pointers into reused memory (#5029).
             if flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) == 0 {
-                return;
+                let user = (header as *mut u8).add(GC_HEADER_SIZE) as usize;
+                if crate::arena::pointer_in_nursery(user) {
+                    return;
+                }
             }
             rewrite_heap_object_fields(header, valid_ptrs);
         }
@@ -751,8 +842,16 @@ pub(super) fn verify_heap_objects(valid_ptrs: &ValidPointerSet) {
         if flags & GC_FLAG_FORWARDED != 0 {
             return;
         }
+        // Mirror rewrite_heap_objects: only unmarked NURSERY objects are
+        // dead this cycle. Unmarked old/longlived/malloc objects survive a
+        // minor and must hold no stale forwarded references either — this
+        // gate previously hid exactly the #5029 dangling old→old slots from
+        // PERRY_GC_VERIFY_EVACUATION.
         if flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) == 0 {
-            return;
+            let user = (header as *mut u8).add(GC_HEADER_SIZE) as usize;
+            if crate::arena::pointer_in_nursery(user) {
+                return;
+            }
         }
         verify_heap_object_fields(header, valid_ptrs, "heap fields");
     };

--- a/crates/perry/tests/gc_write_barrier_stress.rs
+++ b/crates/perry/tests/gc_write_barrier_stress.rs
@@ -142,16 +142,7 @@ fn assert_ok_output(run: &std::process::Output, expected: &str) {
 /// globals) to point at freshly allocated nursery values, GC again, and
 /// verify every value survived. Any missed barrier on those store paths
 /// shows up as corrupt reads, an evacuation-verify panic, or a crash.
-// TEMPORARILY IGNORED — #5029. The Full conservative stack scan (default for
-// explicit gc() since #4998) exposes a PRE-EXISTING remembered-set bug: minor
-// cycles drop legitimate old→young dirty-page coverage (measured ~130 pages at
-// cycle entry → ~10 after clear+rebuild), live nursery children of old-gen
-// large objects get swept while still referenced, and forced evacuation then
-// corrupts through the dangling slots. Root-cause trail, repro matrix, and
-// bisect proof are in the #5029 issue comments. Re-enable both tests when the
-// remembered-set coverage fix lands; do NOT revert #4998 (it fixes #4977).
 #[test]
-#[ignore = "#5029: pre-existing remembered-set coverage drop under Full conservative scan + forced evacuation"]
 fn tenured_mutation_stress() {
     let run = compile_and_run(
         r#"
@@ -221,9 +212,7 @@ console.log(bad === 0 ? "BARRIER_STRESS_OK" : "BARRIER_STRESS_CORRUPT " + bad);
 /// deep-clone loop in `js_structured_clone` now routes through the shared
 /// barriered store). Uses a 300-key literal (all fields inline) plus a deep
 /// nested chain so the clone itself allocates enough to run GCs mid-clone.
-// TEMPORARILY IGNORED — #5029; see tenured_mutation_stress above.
 #[test]
-#[ignore = "#5029: pre-existing remembered-set coverage drop under Full conservative scan + forced evacuation"]
 fn structured_clone_gc_churn_stress() {
     let mut fields = String::new();
     for i in 0..300 {


### PR DESCRIPTION
Fixes #5029.

## The bug chain (all empirically measured — full trail in the #5029 comments)

The stress suite has been red since #4998 made explicit `gc()` run the Full conservative native-stack scan. The corruption is real (clone fields read recycled memory), and the root cause is an interaction chain, not a single defect:

1. **A stale stack word resurrects a dead old object.** The churn loop leaves dead frame slots pointing at a previous round's 256 KB array backing (born directly in old-gen as a large allocation). The conservative Full scan marks it as a trace seed every manual `gc()`.
2. **Its slots dangle into recycled nursery memory.** The dead array's children were legitimately swept cycles ago; when fresh nursery blocks are later allocated over those freed ranges, the dead object's slots suddenly alias *live young objects* (`pointer_in_nursery` flips false→true for unchanged slot bits — measured at panic time: 7710 aliased slots, page-pattern all-clean, manual barrier replay covers instantly).
3. **Tracing/evacuating/rewriting through the aliases corrupts the heap**, and the old-young-edge verifier reports them as the deterministic `missing_edges=7710` signature.
4. Independently, **old-page defrag moved objects whose unmarked-old referrers were skipped by the rewrite pass** (753 skipped stale referrers measured per evacuating cycle), and one un-rewritable referrer surface remains (codegen raw-pointer globals — #5042).

## The four fixes

| # | Change | Failure mode it closes |
|---|---|---|
| 1 | Conservative discoveries classified **Old** are **pin-only in minors** (`CONS_PINNED`, no mark/trace seed); full collections keep mark+trace for #4977 | resurrection-tracing through dangling slots; the phantom verifier signature |
| 2 | `rewrite_heap_objects` / `verify_heap_objects` no longer skip **unmarked non-nursery** objects (unmarked ≠ dead outside the nursery in a minor) | un-rewritten old→old referrers of evacuated targets |
| 3 | `restore_surviving_dirty_coverage()`: post-clear remembered-set repair using the **same walk the verifier uses** (address-validated before any header deref — the reclaim unit tests seed synthetic entries) | coverage drops the from-scratch rebuild could disagree on; the copying-path to-survivor re-remember gap (`ptrs.decode_bits` → None for to-space children) |
| 4 | **Old-page defrag skipped on conservative-scan cycles** (copying minors never scan conservatively, so steady-state defrag is unaffected) | moved old objects with un-rewritable referrers — containment until #5042 lands |

The two stress tests are **re-enabled** (they were `#[ignore]`d in #5033 to unblock CI).

## Why a live old object loses nothing from fix 1

Its real old→young edges are barrier-covered: measured ~60k `mark_dirty_old_page` calls per inter-cycle window, all landing on the right pages — minors only ever find old→young edges through the remembered set anyway. Retention doesn't need the mark (minors don't sweep old-gen), and `CONS_PINNED` already blocks every evacuation path.

## Validation

- `gc_write_barrier_stress`: **2/2, repeated ×4 runs** (re-enabled)
- Standalone repro matrix: **23/23 clean** across `FORCE_EVACUATE+VERIFY_EVACUATION`, `PERRY_CONSERVATIVE_STACK_SCAN=full`, default knobs, `PERRY_GEN_GC=0`, `PERRY_GEN_GC_EVACUATE=0`
- GC unit suite: 377/377; full perry-runtime lib green (single known macOS-local date/timezone flake, green in Linux CI)
- perry bin + integration suites green (one auto-optimize archive cache race under concurrent cargo, passes serially)
- Behavioral smokes: #5024 gap test byte-identical to Node; clone/probe programs clean through all rounds under stress knobs

## Follow-up

#5042 — register codegen raw-pointer globals (`perry_class_keys_*` et al.) as mutable roots, then lift the fix-4 defrag gate and extend `PERRY_GC_VERIFY_EVACUATION` to walk those tables.

No version bump / changelog — maintainer folds metadata at merge.