### PR TITLE
fix(runtime): node:zlib 58/58 — slab-buffer fake-GcHeader SIGBUS in brand probes

### DIFF
--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -250,18 +250,28 @@ fn buffer_alloc_small(capacity: u32) -> *mut BufferHeader {
     })
 }
 
+/// True when `addr` lies inside a small-buffer slab block. Slab allocations
+/// carry NO GcHeader, so reading `addr - GC_HEADER_SIZE` there yields the
+/// previous allocation's trailing data bytes — a content-dependent fake
+/// header. `addr_class::try_read_gc_header` consults this before any deref so
+/// brand probes (Temporal/Date/Map/Set) can't misroute a small Buffer whose
+/// payload happens to spell a matching `obj_type`.
+pub(crate) fn is_small_buf_slab_addr(addr: usize) -> bool {
+    SMALL_BUF_SLAB.with(|slab_ref| {
+        slab_ref
+            .borrow()
+            .ranges
+            .iter()
+            .any(|&(start, end)| addr >= start && addr < end)
+    })
+}
+
 /// Check if a pointer is a registered buffer (for instanceof Uint8Array)
 pub fn is_registered_buffer(addr: usize) -> bool {
     // Fast path: address falls within a small-buffer slab block.  All bytes in
     // a slab block belong exclusively to BufferHeader allocations, so any match
     // is definitively a buffer pointer.
-    let in_slab = SMALL_BUF_SLAB.with(|slab_ref| {
-        let slab = slab_ref.borrow();
-        slab.ranges
-            .iter()
-            .any(|&(start, end)| addr >= start && addr < end)
-    });
-    if in_slab {
+    if is_small_buf_slab_addr(addr) {
         return true;
     }
     // Slow path: large buffers tracked in the HashSet registry.

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -30,6 +30,7 @@ mod view;
 pub use header::{BufferHeader, BUFFER_TYPE_ID, SMALL_BUF_THRESHOLD};
 
 // ---- Re-exports: allocation / registry helpers ----
+pub(crate) use header::is_small_buf_slab_addr;
 pub use header::{
     asymmetric_key_meta, buffer_ab_alias, buffer_alloc, buffer_backing_array_buffer,
     buffer_byte_offset, buffer_data, buffer_data_mut, crypto_key_meta, ensure_buffer_ab_alias,

--- a/crates/perry-runtime/src/value/addr_class.rs
+++ b/crates/perry-runtime/src/value/addr_class.rs
@@ -194,6 +194,14 @@ pub(crate) unsafe fn try_read_gc_header(addr: usize) -> Option<&'static GcHeader
     if !is_plausible_heap_addr(addr) {
         return None;
     }
+    // Small-buffer slab allocations are heap-plausible but carry NO GcHeader —
+    // `addr - GC_HEADER_SIZE` is the previous slab entry's data bytes, so a
+    // brand probe (Temporal/Date/Map/Set `obj_type` check) would read a
+    // content-dependent fake header and misroute (observed: `String(buffer)`
+    // on a zlib result took the Temporal path and deref'd buffer bytes).
+    if crate::buffer::is_small_buf_slab_addr(addr) {
+        return None;
+    }
     Some(&*((addr - GC_HEADER_SIZE) as *const GcHeader))
 }
 


### PR DESCRIPTION
## What

Raises `node:zlib` node-suite parity to **58/58 (100%)**, from 57/58 on current `main`.

> Note: the tracked 70.7% (41/58, 17 crashes) snapshot was stale — those crashes were already fixed by earlier merges (e.g. #4996 zlib one-shot arity/levels). On a fresh `origin/main` build only one test still failed, and it was a real runtime crash.

## The crash (zlib/unzip/auto-detect-deflate.ts, SIGBUS exit 138)

`unzipSync(deflateSync(Buffer.from(input)))` crashed for some inputs and not others — content-dependent.

Root cause is not in zlib at all:

- Small Buffers (<256B) are allocated from the per-thread bump slab (`buffer/header.rs`), which carries **no GcHeader**.
- `String(buffer)` / `.toString()` enters `js_to_primitive`, whose Temporal brand probe (`is_temporal_cell_addr`) runs **before** `to_string`'s buffer-registry check and reads `addr - GC_HEADER_SIZE` as a `GcHeader`.
- For a slab buffer that word is the **previous slab entry's data bytes** — i.e. whatever the previous compression produced. When those bytes happen to spell `obj_type == GC_TYPE_TEMPORAL`, the value is misrouted into the Temporal path, which dereferences the buffer's `(length, capacity)` words (`0x2f0000002f` for a 47-byte result) as a `TemporalCell` box pointer → SIGBUS.

Date/Map/Set/WeakRef brand probes share the same `try_read_gc_header` helper, so the same content-dependent misroute was latent for all of them.

## Fix

Guard at the choke point: `addr_class::try_read_gc_header` now returns `None` for addresses inside small-buffer slab ranges (new `is_small_buf_slab_addr`, also reused by `is_registered_buffer`'s existing fast path). One check covers every brand probe; large buffers are unaffected (they get real arena GcHeaders with `GC_TYPE_BUFFER`).

3 files, +26/−7. No Cargo.toml / CLAUDE.md / CHANGELOG edits (maintainer folds metadata at merge).

## Verification (local macOS, node v26.3.0 oracle, print-and-diff)

| suite | before | after |
|---|---|---|
| zlib | 57/58 (crash) | **58/58** |
| buffer | 134/134 | 134/134 |
| string_decoder | 36/36 | 36/36 |
| util / object / events | 339/348 batch | identical — all 9 fails reproduce byte-for-byte on baseline (pre-existing: util deprecate/inspect/legacy-helpers, reflect-proxy-construct, events.on async-iterator) |
| `cargo test -p perry-runtime` | — | only pre-existing flakes (date TZ flake + rotating parallel-state flakes; verified same set fails on clean baseline) |

Zero regressions: every non-zlib failure was re-run against a baseline build with the fix reverted and failed identically there.