### PR TITLE
fix(json): use two-char short forms \b and \f in JSON.stringify (#5047)

### DIFF
--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -758,4 +758,19 @@ mod tests {
         let output = unsafe { js_json_stringify(outer_boxed, TYPE_UNKNOWN) };
         assert_eq!(unsafe { str_from_header(output).unwrap() }, r#"{"o":{}}"#);
     }
+
+    #[test]
+    fn stringify_uses_two_char_short_forms_for_backspace_and_formfeed() {
+        // #5047: QuoteJSONString mandates the two-character escapes for
+        // U+0008 (\b) and U+000C (\f); Perry emitted the 4-hex-digit form for both. Other
+        // control characters keep the 4-hex-digit form.
+        let input = b"a\x08b\x0cc\x0bd";
+        let s = js_string_from_bytes(input.as_ptr(), input.len() as u32);
+        let boxed = f64::from_bits(STRING_TAG | (s as u64 & POINTER_MASK));
+        let output = unsafe { js_json_stringify(boxed, TYPE_UNKNOWN) };
+        assert_eq!(
+            unsafe { str_from_header(output).unwrap() },
+            "\"a\\bb\\fc\\u000bd\""
+        );
+    }
 }

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -333,6 +333,8 @@ pub(crate) unsafe fn write_escaped_string(buf: &mut String, s: &str) {
             b'\n' => Some("\\n"),
             b'\r' => Some("\\r"),
             b'\t' => Some("\\t"),
+            0x08 => Some("\\b"),
+            0x0c => Some("\\f"),
             0..=0x1f => {
                 if start < i {
                     buf_vec.extend_from_slice(&bytes[start..i]);


### PR DESCRIPTION
Fixes #5047.

## Problem
`QuoteJSONString` (ECMA-262 §25.5.2.2) defines two-character escapes for backspace (U+0008) and formfeed (U+000C). Perry used the short forms for tab/newline/CR but fell back to the generic 4-hex-digit `\uXXXX` escape for `\b` and `\f`. Both parse back identically, but it breaks byte-for-byte parity with Node and snapshot tests.

## Fix
Add `0x08 → \\b` and `0x0c → \\f` to the escape table in `json/stringify.rs` (single escape site). Other control characters (e.g. U+000B) keep the `\uXXXX` form, per spec.

## Validation
- New unit test `stringify_uses_two_char_short_forms_for_backspace_and_formfeed` (also pins that U+000B keeps the hex form); full `json::` test module passes (14/14).
- End-to-end: compiled the issue repro — Perry output now matches Node byte-for-byte:
  ```
  "a\fb\bc"
  "x\u000by"
  ```

Code-only PR per the external-metadata convention — version bump + changelog left for merge time.