### PR TITLE
fix(assert): deepStrictEqual — don't treat object-literal shape ids as prototypes (#4937)

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting/prototype_equality.rs
+++ b/crates/perry-runtime/src/builtins/formatting/prototype_equality.rs
@@ -69,7 +69,23 @@ pub(super) fn prototype_token(value: f64) -> Option<u64> {
             return Some(TAG_NULL);
         }
         let obj = addr as *const crate::object::ObjectHeader;
-        Some(CLASS_PROTO_NAMESPACE | (*obj).class_id as u64)
+        // #4937: a non-zero class_id is only a constructor marker when it is
+        // registered in CLASS_NAMES (the same test class_decl_prototype_value
+        // uses). Object literals carry an unregistered layout-shape id there,
+        // while a `{}`-born object mutated afterwards keeps class_id 0 — both
+        // have Object.prototype, so normalize unregistered ids to 0 or the
+        // two would spuriously compare as prototype-different.
+        let class_id = (*obj).class_id;
+        let proto_class_id = if class_id != 0
+            && crate::object::class_name_for_id(class_id)
+                .filter(|name| !name.is_empty())
+                .is_none()
+        {
+            0
+        } else {
+            class_id
+        };
+        Some(CLASS_PROTO_NAMESPACE | proto_class_id as u64)
     }
 }
 
@@ -81,5 +97,53 @@ pub(super) fn prototypes_differ(left: f64, right: f64) -> bool {
     match (prototype_token(left), prototype_token(right)) {
         (Some(l), Some(r)) => l != r,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// #4937: codegen gives object literals an unregistered layout-shape id in
+    /// `class_id`, while a `{}`-born object mutated afterwards keeps 0. Both
+    /// have Object.prototype — the prototype gate must not separate them.
+    /// A class_id registered in CLASS_NAMES still marks a real constructor.
+    #[test]
+    fn unregistered_shape_id_normalizes_to_plain_object_prototype() {
+        unsafe {
+            let key = crate::string::js_string_from_bytes(b"x".as_ptr(), 1);
+
+            // "literal": unregistered non-zero shape id.
+            let lit = crate::object::js_object_alloc(424_242, 1);
+            crate::object::js_object_set_field_by_name(lit, key, 1.0);
+            let lit_v = crate::value::js_nanbox_pointer(lit as i64);
+
+            // "{} then mutated": class_id 0.
+            let dyn_obj = crate::object::js_object_alloc(0, 0);
+            crate::object::js_object_set_field_by_name(dyn_obj, key, 1.0);
+            let dyn_v = crate::value::js_nanbox_pointer(dyn_obj as i64);
+
+            // registered class instance with the same body.
+            let name = b"ProtoEqTestClass4937";
+            crate::object::js_register_class_name(424_243, name.as_ptr(), name.len() as u32);
+            let inst = crate::object::js_object_alloc(424_243, 1);
+            crate::object::js_object_set_field_by_name(inst, key, 1.0);
+            let inst_v = crate::value::js_nanbox_pointer(inst as i64);
+
+            assert!(!super::prototypes_differ(lit_v, dyn_v));
+            assert!(super::prototypes_differ(inst_v, lit_v));
+            assert!(super::prototypes_differ(inst_v, dyn_v));
+
+            assert_eq!(
+                crate::value::js_is_truthy(crate::builtins::js_util_is_deep_strict_equal(
+                    lit_v, dyn_v
+                )),
+                1
+            );
+            assert_eq!(
+                crate::value::js_is_truthy(crate::builtins::js_util_is_deep_strict_equal(
+                    inst_v, dyn_v
+                )),
+                0
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #4937.

## Root cause
Not in the deep-equality body walk at all — the prototype-sensitivity gate from #2934. `prototype_token` (`builtins/formatting/prototype_equality.rs`) tokenizes a heap object's prototype as `CLASS_PROTO_NAMESPACE | class_id`. Codegen stores an **unregistered layout-shape id** in `class_id` for object literals (e.g. 4), while a `{}`-born object populated afterwards keeps `class_id` 0. Both have `Object.prototype` as their real `[[Prototype]]`, but the tokens differed (`…0000` vs `…0004`), so `prototypes_differ` short-circuited every mutated-vs-literal comparison to *not equal* before the body compare ran.

## Fix
Normalize any `class_id` with no `CLASS_NAMES` entry to 0 before building the token — the registry's own constructor test (`class_decl_prototype_value` uses exactly this predicate). Registered class instances, null-prototype objects, and recorded `setPrototypeOf` values keep their distinct tokens.

## Validation
All of these now match Node (`node --experimental-strip-types`) exactly:
```
dot / computed-lit / computed-var set then deepStrictEqual vs literal: true (was throw)
incremental multi-key build (matchKnownFields idiom): passes
class instance vs literal:        false (prototype sensitivity preserved)
Object.create(null) vs literal:   false
literal vs literal, mutated vs mutated, unequal bodies: unchanged
```
- New unit test `unregistered_shape_id_normalizes_to_plain_object_prototype` pins the token normalization + end-to-end `js_util_is_deep_strict_equal` behavior.
- `cargo test -p perry-runtime prototype`: the `test_array_exotic_descriptors_and_global_prototype_identity` flake in that group reproduces on pristine `origin/main` (parallel-run snapshot flake, passes in isolation) — pre-existing, unrelated.

Code-only PR — version bump + changelog left for merge time.