### PR TITLE
fix(date): NaN-revive setters seed from raw +0, not LocalTime(0) (#4927)

### DIFF
--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -876,7 +876,12 @@ pub extern "C" fn js_date_apply_setter(
     if t.is_nan() && !is_full_year {
         return f64::NAN;
     }
-    let base = if t.is_nan() { 0.0 } else { t };
+    // #4927: a NaN time value is passed through to the rebuild AS NaN — its
+    // NaN branch seeds the spec's `t = +0` substitution from the RAW +0
+    // components (1970-01-01 00:00:00), per Date.prototype.setFullYear step 2,
+    // which skips LocalTime(t). Substituting 0.0 here ran the epoch through
+    // timestamp_to_local_components, so a CET process revived
+    // `new Date(NaN).setFullYear(2020)` to local 01:00 instead of 00:00.
     // The leading component is required: an omitted call (`setHours()`) coerces
     // `undefined` → NaN, so the leading slot is always `Some`.
     let lead = Some(coerced.first().copied().unwrap_or(f64::NAN));
@@ -895,9 +900,9 @@ pub extern "C" fn js_date_apply_setter(
         _ => return date_cell_store(date, f64::NAN),
     };
     if is_utc != 0 {
-        rebuild_with(date, base, year, month0, day, hour, minute, second, ms)
+        rebuild_with(date, t, year, month0, day, hour, minute, second, ms)
     } else {
-        rebuild_local_with(date, base, year, month0, day, hour, minute, second, ms)
+        rebuild_local_with(date, t, year, month0, day, hour, minute, second, ms)
     }
 }
 


### PR DESCRIPTION
Fixes #4927.

## Root cause
Narrower than the issue's suspicion: the local→UTC conversion in `rebuild_local_with` **already** computes the offset at the target instant, and DST-crossing setters on valid dates were already correct. The actual bug was the Invalid-Date revive path: ECMA-262 `Date.prototype.setFullYear` step 2 substitutes `t = +0` for a NaN time value **without** applying `LocalTime` — the seed components are raw UTC +0 (1970-01-01 00:00:00). `js_date_apply_setter` substituted `base = 0.0` before calling the rebuild, which then decoded the epoch through `timestamp_to_local_components`, picking up the 1970 epoch's local offset: CET revived `new Date(NaN).setFullYear(2020)` to local 01:00; `TZ=America/New_York` landed on 2020-12-31 19:00. `TZ=UTC` (CI) was unaffected — exactly the reported green-CI/red-laptop split.

## Fix
Pass the NaN time value through to `rebuild_with`/`rebuild_local_with` — both already implement the spec's NaN branch (seed `1970/0/1 00:00:00`, revive only when a year override is present, reassemble as local + offset-at-target). One substitution line removed.

## Validation
- `date::tests::test_full_year_setters_revive_invalid_date_only` now passes under `TZ=UTC`, `America/New_York`, `Australia/Sydney`, `Europe/Amsterdam` (previously failed everywhere but UTC); full `date::` group green under all four.
- Compiled e2e matrix vs `node --experimental-strip-types`, byte-identical in all four TZs: NaN revive (local + UTC), `setMonth` across DST boundaries both directions, `setFullYear` from a year-end timestamp, local constructors in Jan/Jul (`getTime` checked), `setHours` across the year.

Code-only PR — version bump + changelog left for merge time.