### PR TITLE
fix(events): errorMonitor in the linked EventEmitter twin + handle-band guards (#4633)

### DIFF
--- a/crates/perry-ext-events/src/error_monitor.rs
+++ b/crates/perry-ext-events/src/error_monitor.rs
@@ -1,0 +1,41 @@
+//! `events.errorMonitor` dispatch for the ext-events EventEmitter twin
+//! (#4633). Split out of `lib.rs` to keep it under the 2000-line cap.
+
+use super::*;
+
+/// String key under which a listener registered via the `events.errorMonitor`
+/// symbol lands: `event_name_from_bits` stringifies symbol event names, and
+/// `Symbol.for("events.errorMonitor")` renders as this. Mirrors the stdlib
+/// twin's constant so the two implementations stay behaviorally identical.
+pub(super) const ERROR_MONITOR_EVENT_NAME: &str = "Symbol(events.errorMonitor)";
+
+/// Node's `events.errorMonitor` semantics (#4633): listeners installed under
+/// the monitor symbol observe every `'error'` emit BEFORE the regular
+/// `'error'` listeners run, without counting as error handling - an
+/// unhandled `'error'` still throws after the monitor fires. Mirrors
+/// `dispatch_error_monitor` in perry-stdlib's events twin.
+pub(super) unsafe fn dispatch_error_monitor(
+    emitter: &mut EventEmitterHandle,
+    handle: Handle,
+    arg: Option<f64>,
+) {
+    let snapshot: Vec<Listener> = match emitter.events.get(ERROR_MONITOR_EVENT_NAME) {
+        Some(v) if !v.is_empty() => v.clone(),
+        _ => return,
+    };
+    if snapshot.iter().any(|l| l.once) {
+        if let Some(v) = emitter.events.get_mut(ERROR_MONITOR_EVENT_NAME) {
+            v.retain(|l| !l.once);
+        }
+        emitter.prune_event_if_empty(ERROR_MONITOR_EVENT_NAME);
+    }
+    for l in snapshot {
+        if l.callback != 0 {
+            let args: &[f64] = match arg.as_ref() {
+                Some(a) => std::slice::from_ref(a),
+                None => &[],
+            };
+            let _ = call_emitter_listener(handle, l.callback, args);
+        }
+    }
+}

--- a/crates/perry-ext-events/src/lib.rs
+++ b/crates/perry-ext-events/src/lib.rs
@@ -1013,6 +1013,43 @@ unsafe fn collect_emit_args(args_ptr: *const ArrayHeader) -> Vec<f64> {
     args
 }
 
+/// String key under which a listener registered via the `events.errorMonitor`
+/// symbol lands: `event_name_from_bits` stringifies symbol event names, and
+/// `Symbol.for("events.errorMonitor")` renders as this. Mirrors the stdlib
+/// twin's constant so the two implementations stay behaviorally identical.
+const ERROR_MONITOR_EVENT_NAME: &str = "Symbol(events.errorMonitor)";
+
+/// Node's `events.errorMonitor` semantics (#4633): listeners installed under
+/// the monitor symbol observe every `'error'` emit BEFORE the regular
+/// `'error'` listeners run, without counting as error handling - an
+/// unhandled `'error'` still throws after the monitor fires. Mirrors
+/// `dispatch_error_monitor` in perry-stdlib's events twin.
+unsafe fn dispatch_error_monitor(
+    emitter: &mut EventEmitterHandle,
+    handle: Handle,
+    arg: Option<f64>,
+) {
+    let snapshot: Vec<Listener> = match emitter.events.get(ERROR_MONITOR_EVENT_NAME) {
+        Some(v) if !v.is_empty() => v.clone(),
+        _ => return,
+    };
+    if snapshot.iter().any(|l| l.once) {
+        if let Some(v) = emitter.events.get_mut(ERROR_MONITOR_EVENT_NAME) {
+            v.retain(|l| !l.once);
+        }
+        emitter.prune_event_if_empty(ERROR_MONITOR_EVENT_NAME);
+    }
+    for l in snapshot {
+        if l.callback != 0 {
+            let args: &[f64] = match arg.as_ref() {
+                Some(a) => std::slice::from_ref(a),
+                None => &[],
+            };
+            let _ = call_emitter_listener(handle, l.callback, args);
+        }
+    }
+}
+
 unsafe fn call_emitter_listener(handle: Handle, callback: i64, args: &[f64]) -> f64 {
     let receiver = nanbox_pointer_bits(handle);
     let callback_value = nanbox_pointer_bits(callback);
@@ -1169,6 +1206,7 @@ pub unsafe extern "C" fn js_event_emitter_emit(
         let first_arg = first_arg_or_undefined(args_ptr);
         let emitted_args = collect_emit_args(args_ptr);
         if event_name == "error" {
+            dispatch_error_monitor(emitter, handle, Some(first_arg));
             let has_error_once = emitter
                 .pending_once_promises
                 .get("error")
@@ -1249,6 +1287,7 @@ pub unsafe extern "C" fn js_event_emitter_emit0(handle: Handle, event_bits: i64)
         let empty_args = js_array_alloc(0);
         if event_name == "error" {
             let error_value = undefined_value();
+            dispatch_error_monitor(emitter, handle, None);
             let has_error_once = emitter
                 .pending_once_promises
                 .get("error")

--- a/crates/perry-ext-events/src/lib.rs
+++ b/crates/perry-ext-events/src/lib.rs
@@ -28,6 +28,8 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::sync::{Mutex, MutexGuard, Once, OnceLock};
 
+mod error_monitor;
+use error_monitor::dispatch_error_monitor;
 mod max_listeners;
 mod messages;
 mod target_helpers;
@@ -1011,43 +1013,6 @@ unsafe fn collect_emit_args(args_ptr: *const ArrayHeader) -> Vec<f64> {
         args.push(f64::from_bits(js_array_get(args_ptr, index as u32).bits()));
     }
     args
-}
-
-/// String key under which a listener registered via the `events.errorMonitor`
-/// symbol lands: `event_name_from_bits` stringifies symbol event names, and
-/// `Symbol.for("events.errorMonitor")` renders as this. Mirrors the stdlib
-/// twin's constant so the two implementations stay behaviorally identical.
-const ERROR_MONITOR_EVENT_NAME: &str = "Symbol(events.errorMonitor)";
-
-/// Node's `events.errorMonitor` semantics (#4633): listeners installed under
-/// the monitor symbol observe every `'error'` emit BEFORE the regular
-/// `'error'` listeners run, without counting as error handling - an
-/// unhandled `'error'` still throws after the monitor fires. Mirrors
-/// `dispatch_error_monitor` in perry-stdlib's events twin.
-unsafe fn dispatch_error_monitor(
-    emitter: &mut EventEmitterHandle,
-    handle: Handle,
-    arg: Option<f64>,
-) {
-    let snapshot: Vec<Listener> = match emitter.events.get(ERROR_MONITOR_EVENT_NAME) {
-        Some(v) if !v.is_empty() => v.clone(),
-        _ => return,
-    };
-    if snapshot.iter().any(|l| l.once) {
-        if let Some(v) = emitter.events.get_mut(ERROR_MONITOR_EVENT_NAME) {
-            v.retain(|l| !l.once);
-        }
-        emitter.prune_event_if_empty(ERROR_MONITOR_EVENT_NAME);
-    }
-    for l in snapshot {
-        if l.callback != 0 {
-            let args: &[f64] = match arg.as_ref() {
-                Some(a) => std::slice::from_ref(a),
-                None => &[],
-            };
-            let _ = call_emitter_listener(handle, l.callback, args);
-        }
-    }
 }
 
 unsafe fn call_emitter_listener(handle: Handle, callback: i64, args: &[f64]) -> f64 {

--- a/crates/perry-runtime/src/event_target.rs
+++ b/crates/perry-runtime/src/event_target.rs
@@ -389,11 +389,10 @@ unsafe fn is_event_target(target: *const ObjectHeader) -> bool {
         return false;
     }
     // Handle-based receivers (EventEmitter ids live at 0x38000..0x40000,
-    // widget/stream handles lower) are small integers, not heap pointers —
-    // the runtime-wide convention is "below 0x100000 = handle". Probing the
-    // GcHeader at handle-8 read unmapped memory and SIGSEGV'd when
-    // events.on(emitter, ...) validated its target (#4633).
-    if (target as usize) < crate::gc::GC_HEADER_SIZE + 0x100000 {
+    // widget/stream handles lower) are small integers, not heap pointers.
+    // Probing the GcHeader at handle-8 read unmapped memory and SIGSEGV'd
+    // when events.on(emitter, ...) validated its target (#4633).
+    if crate::value::addr_class::is_handle_band(target as usize) {
         return false;
     }
     let gc_header =

--- a/crates/perry-runtime/src/event_target.rs
+++ b/crates/perry-runtime/src/event_target.rs
@@ -388,7 +388,12 @@ unsafe fn is_event_target(target: *const ObjectHeader) -> bool {
     if target.is_null() {
         return false;
     }
-    if (target as usize) < crate::gc::GC_HEADER_SIZE + 0x10000 {
+    // Handle-based receivers (EventEmitter ids live at 0x38000..0x40000,
+    // widget/stream handles lower) are small integers, not heap pointers —
+    // the runtime-wide convention is "below 0x100000 = handle". Probing the
+    // GcHeader at handle-8 read unmapped memory and SIGSEGV'd when
+    // events.on(emitter, ...) validated its target (#4633).
+    if (target as usize) < crate::gc::GC_HEADER_SIZE + 0x100000 {
         return false;
     }
     let gc_header =

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -76,7 +76,12 @@ pub(super) fn string_value_eq(value: f64, expected: &[u8]) -> bool {
 
 pub(super) fn object_ptr_from_value(value: f64) -> Option<*mut ObjectHeader> {
     let raw = raw_ptr_from_value(value);
-    if raw < 0x10000 || crate::buffer::is_registered_buffer(raw) {
+    // Below 0x100000 is the handle band (EventEmitter ids sit at
+    // 0x38000..0x40000, widget/stream handles lower) — never a heap object.
+    // The old 0x10000 floor let an EventEmitter handle through to the
+    // GcHeader probe at raw-8, which is unmapped memory (#4633 SIGSEGV in
+    // events.on(emitter, name, { signal }) target validation).
+    if raw < 0x100000 || crate::buffer::is_registered_buffer(raw) {
         return None;
     }
     unsafe {

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -76,12 +76,12 @@ pub(super) fn string_value_eq(value: f64, expected: &[u8]) -> bool {
 
 pub(super) fn object_ptr_from_value(value: f64) -> Option<*mut ObjectHeader> {
     let raw = raw_ptr_from_value(value);
-    // Below 0x100000 is the handle band (EventEmitter ids sit at
-    // 0x38000..0x40000, widget/stream handles lower) — never a heap object.
-    // The old 0x10000 floor let an EventEmitter handle through to the
-    // GcHeader probe at raw-8, which is unmapped memory (#4633 SIGSEGV in
+    // The handle band (EventEmitter ids sit at 0x38000..0x40000,
+    // widget/stream handles lower) is never a heap object. The old 0x10000
+    // floor let an EventEmitter handle through to the GcHeader probe at
+    // raw-8, which is unmapped memory (#4633 SIGSEGV in
     // events.on(emitter, name, { signal }) target validation).
-    if raw < 0x100000 || crate::buffer::is_registered_buffer(raw) {
+    if crate::value::addr_class::is_handle_band(raw) || crate::buffer::is_registered_buffer(raw) {
         return None;
     }
     unsafe {


### PR DESCRIPTION
Fixes #4633.

## Status of the issue's 12 failures
Most had been fixed by intervening work — on current `main` the events module was already at 67/69 (`newListener`/`removeListener`, `rawListeners` once-wrappers, `listenerCount(event, listener)`, `setMaxListeners` validation, module-helper target validation: all passing). Two real failures remained; this PR fixes both → **69/69 (100%)**.

## Fix 1 — `errors/error-monitor`
Three EventEmitter implementations exist (perry-stdlib `events.rs`, perry-runtime stream-emitter, perry-ext-events). The stdlib twin implements `events.errorMonitor`; instrumentation proved the twin that actually links into compiled binaries (even under `PERRY_NO_AUTO_OPTIMIZE=1`) is **perry-ext-events** — which had no monitor support. Ported `dispatch_error_monitor` into ext-events' `emit`/`emit0`: monitor listeners observe every `'error'` emit before the regular listeners, once-wrappers prune, and the monitor never counts as handling (unhandled `'error'` still throws).

## Fix 2 — `on/async-iterator-abort` (SIGSEGV)
`events.on(emitter, name, { signal })` validates its target by probing predicates with the raw EventEmitter **handle** (an id in the 0x38000..0x40000 band). `is_event_target` (event_target.rs) and `object_ptr_from_value` (node_stream_readwrite.rs) used 0x10000 floors, so the handle flowed through to a `GcHeader` read at `handle-8` → unmapped memory. Raised both floors to the runtime-wide `< 0x100000` handle convention (lldb-verified at both faults: `EXC_BAD_ACCESS addr=0x37ff8`).

## Validation
- `./run_parity_tests.sh --suite node-suite --module events`: 67/69 → **69/69**, no compile fails.
- Blast-radius check on the floor change: full `--module stream` sweep — all 10 failures it reports reproduce identically on a pristine-main binary (4 known `subclass/extends-*` + 6 readable/pipe cases), i.e. **0 regressions**.
- `cargo test -p perry-ext-events` (8/8), runtime `event` tests (15/15).
- Residual: the process-exit hang after a signal abort is pre-existing across the events abort family (the long-passing `once/abort-cleans-pending-error` hangs identically) — filed as #5056.

Code-only PR — version bump + changelog left for merge time.