### PR TITLE
perf(object): O(1) dynamic property set + wide-object read index (#5054)

### DIFF
--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -812,6 +812,12 @@ pub const OBJ_FLAG_NULL_PROTO: u16 = 0x40;
 // and `GC_ARRAY_ARGUMENTS_OBJECT` (0x200). Only meaningful for
 // `GC_TYPE_ARRAY`.
 pub const OBJ_FLAG_ARRAY_DESCRIPTORS: u16 = 0x400;
+// #5054: a property/accessor descriptor (or builtin attrs) has been installed
+// on this specific object — the dynamic-write fast path must take the full
+// descriptor-aware OrdinarySet walk. Bit 11; only meaningful for
+// `GC_TYPE_OBJECT`. Set-only (clearing a descriptor leaves it set; the slow
+// path is always correct).
+pub const OBJ_FLAG_HAS_DESCRIPTORS: u16 = 0x800;
 // #2145: this object is a per-kind `<TypedArrayCtor>.prototype` whose
 // `[[Prototype]]` is the shared `%TypedArray%.prototype` intrinsic.
 // `Object.getPrototypeOf(Int8Array.prototype)` returns the cached

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2713,6 +2713,122 @@ pub(super) unsafe fn native_module_own_field_by_key(
     None
 }
 
+// ─── #5054: wide-object key index ─────────────────────────────────────────────
+// A `{}`-born object grown to thousands of dynamic properties pays a linear
+// keys_array scan per `obj[key]` read once the 1024-entry FIELD_CACHE can't
+// hold its key set — O(N) per read, quadratic for read-everything loops. For
+// keys arrays past this threshold, build a key→index map once and validate
+// every hit against the actual slot (same trust model as FIELD_CACHE: a
+// reused keys-array address or a mutated slot fails validation and drops the
+// index). Misses still fall through to the linear scan — the index is an
+// accelerator, never authoritative — and a scan hit back-fills the map so
+// interleaved appends stay amortized O(1).
+const WIDE_KEY_INDEX_MIN_KEYS: usize = 257;
+const WIDE_KEY_INDEX_CAPACITY: usize = 4;
+
+struct WideKeyIndexEntry {
+    keys_id: usize,
+    indexed_len: u32,
+    map: std::collections::HashMap<Vec<u8>, u32>,
+}
+
+thread_local! {
+    static WIDE_KEY_INDEX: std::cell::RefCell<Vec<WideKeyIndexEntry>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Probe the wide-object index for `key_bytes` in the keys array identified by
+/// `keys_id`. Returns a slot index whose stored key has been re-validated
+/// against `key` — `None` means "not found via the index" (caller falls back
+/// to the linear scan).
+unsafe fn wide_key_index_lookup(
+    keys_id: usize,
+    key_bytes: &[u8],
+    key: *const crate::StringHeader,
+    keys: *const crate::array::ArrayHeader,
+    key_count: usize,
+) -> Option<u32> {
+    WIDE_KEY_INDEX.with(|cell| {
+        let mut table = cell.borrow_mut();
+        let pos = table.iter().position(|e| e.keys_id == keys_id);
+        let pos = match pos {
+            Some(p) => p,
+            None => {
+                // Build the full map once (first occurrence wins, matching
+                // linear-scan order).
+                let mut map = std::collections::HashMap::with_capacity(key_count);
+                let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+                for i in 0..key_count {
+                    let stored = crate::array::js_array_get(keys, i as u32);
+                    if let Some(b) = crate::string::js_string_key_bytes(stored, &mut sso) {
+                        map.entry(b.to_vec()).or_insert(i as u32);
+                    }
+                }
+                if table.len() >= WIDE_KEY_INDEX_CAPACITY {
+                    table.pop();
+                }
+                table.insert(
+                    0,
+                    WideKeyIndexEntry {
+                        keys_id,
+                        indexed_len: key_count as u32,
+                        map,
+                    },
+                );
+                0
+            }
+        };
+        let entry = &mut table[pos];
+        if (key_count as u32) < entry.indexed_len {
+            // The keys array shrank (a delete compacted it) — slot indices
+            // are no longer trustworthy. Drop and let the next read rebuild.
+            table.remove(pos);
+            return None;
+        }
+        if (key_count as u32) > entry.indexed_len {
+            // Catch up on appended keys.
+            let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+            for i in entry.indexed_len as usize..key_count {
+                let stored = crate::array::js_array_get(keys, i as u32);
+                if let Some(b) = crate::string::js_string_key_bytes(stored, &mut sso) {
+                    entry.map.entry(b.to_vec()).or_insert(i as u32);
+                }
+            }
+            entry.indexed_len = key_count as u32;
+        }
+        let idx = entry.map.get(key_bytes).copied();
+        match idx {
+            Some(i) if (i as usize) < key_count => {
+                let stored = crate::array::js_array_get(keys, i);
+                if crate::string::js_string_key_matches(stored, key) {
+                    if pos != 0 {
+                        let e = table.remove(pos);
+                        table.insert(0, e);
+                    }
+                    Some(i)
+                } else {
+                    // Stale (address reuse or in-place mutation): drop the
+                    // whole entry rather than chase it.
+                    table.remove(pos);
+                    None
+                }
+            }
+            _ => None,
+        }
+    })
+}
+
+/// Back-fill a linear-scan hit into the wide-object index (no-op when the
+/// keys array has no entry — the next lookup builds it wholesale).
+fn wide_key_index_note_hit(keys_id: usize, key_bytes: &[u8], index: u32) {
+    WIDE_KEY_INDEX.with(|cell| {
+        let mut table = cell.borrow_mut();
+        if let Some(e) = table.iter_mut().find(|e| e.keys_id == keys_id) {
+            e.map.entry(key_bytes.to_vec()).or_insert(index);
+        }
+    });
+}
+
 #[no_mangle]
 pub extern "C" fn js_object_get_field_by_name(
     obj: *const ObjectHeader,
@@ -5010,11 +5126,38 @@ pub extern "C" fn js_object_get_field_by_name(
         // Slow path: linear scan through keys array
         let _field_count = (*obj).field_count as usize;
 
+        let alloc_limit = std::cmp::max((*obj).field_count, 8) as usize;
+
+        // #5054: wide objects get a validated key→index map so per-key reads
+        // stay O(1) instead of O(key_count). A `None` falls through to the
+        // linear scan below (the index is an accelerator, not authoritative).
+        if key_count >= WIDE_KEY_INDEX_MIN_KEYS {
+            if let Some(i) = wide_key_index_lookup(keys_id, key_bytes, key, keys, key_count) {
+                if ACCESSORS_IN_USE.with(|c| c.get()) {
+                    if let Ok(name) = std::str::from_utf8(key_bytes) {
+                        if let Some(acc) = get_accessor_descriptor(obj as usize, name) {
+                            if acc.get != 0 {
+                                let receiver = crate::value::js_nanbox_pointer(obj as i64);
+                                return invoke_accessor_getter(acc.get, receiver);
+                            }
+                            return JSValue::undefined();
+                        }
+                    }
+                }
+                return if (i as usize) < alloc_limit {
+                    js_object_get_field(obj, i)
+                } else {
+                    match overflow_get(obj as usize, i as usize) {
+                        Some(bits) => JSValue::from_bits(bits),
+                        None => JSValue::undefined(),
+                    }
+                };
+            }
+        }
+
         if key_count > 65536 {
             return JSValue::undefined();
         }
-
-        let alloc_limit = std::cmp::max((*obj).field_count, 8) as usize;
 
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(keys, i as u32);
@@ -5027,6 +5170,9 @@ pub extern "C" fn js_object_get_field_by_name(
                     let cache = &mut *c.get();
                     cache[cache_idx] = (keys_id, key_hash, i as u32);
                 });
+                if key_count >= WIDE_KEY_INDEX_MIN_KEYS {
+                    wide_key_index_note_hit(keys_id, key_bytes, i as u32);
+                }
                 // Accessor short-circuit (see fast path above).
                 if ACCESSORS_IN_USE.with(|c| c.get()) {
                     if let Ok(name) = std::str::from_utf8(key_bytes) {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -678,6 +678,39 @@ pub(crate) fn descriptors_in_use() -> bool {
     GLOBAL_DESCRIPTORS_IN_USE.load(Ordering::Relaxed)
 }
 
+/// #5054: a descriptor (any kind) has been installed on the canonical
+/// `Object.prototype` — inherited setters / non-writable data props there
+/// must intercept writes of keys missing on the receiver, so the dynamic
+/// plain-object write fast path is disabled process-wide once this flips.
+static OBJECT_PROTO_DESCRIPTORS: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn object_proto_descriptors_in_use() -> bool {
+    OBJECT_PROTO_DESCRIPTORS.load(Ordering::Relaxed)
+}
+
+/// #5054: record descriptor installation on the target object itself —
+/// `OBJ_FLAG_HAS_DESCRIPTORS` in its GcHeader (travels with the object on
+/// evacuation), plus the `Object.prototype` process-global above. Unlike
+/// `GLOBAL_DESCRIPTORS_IN_USE`, neither is poisoned by the runtime
+/// installing attrs on unrelated builtins (RegExp prototype etc.), so the
+/// dynamic-write fast path stays precise.
+pub(crate) fn note_descriptor_target(obj: usize) {
+    if crate::array::object_prototype_addr_matches(obj) {
+        OBJECT_PROTO_DESCRIPTORS.store(true, Ordering::Relaxed);
+    }
+    if crate::typedarray::lookup_typed_array_kind(obj).is_some() {
+        return;
+    }
+    unsafe {
+        if let Some(header) = crate::value::addr_class::try_read_gc_header(obj) {
+            if header.obj_type == crate::gc::GC_TYPE_OBJECT {
+                let header = header as *const crate::gc::GcHeader as *mut crate::gc::GcHeader;
+                (*header)._reserved |= crate::gc::OBJ_FLAG_HAS_DESCRIPTORS;
+            }
+        }
+    }
+}
+
 /// Look up the property descriptor for (obj, key). Returns None if no entry exists,
 /// in which case the JS default `{ writable: true, enumerable: true, configurable: true }` applies.
 pub(crate) fn get_property_attrs(obj: usize, key: &str) -> Option<PropertyAttrs> {
@@ -686,6 +719,7 @@ pub(crate) fn get_property_attrs(obj: usize, key: &str) -> Option<PropertyAttrs>
 
 /// Store a property descriptor for (obj, key).
 pub(crate) fn set_property_attrs(obj: usize, key: String, attrs: PropertyAttrs) {
+    note_descriptor_target(obj);
     PROPERTY_ATTRS_IN_USE.with(|c| c.set(true));
     GLOBAL_DESCRIPTORS_IN_USE.store(true, Ordering::Relaxed);
     PROPERTY_DESCRIPTORS.with(|m| {
@@ -790,6 +824,7 @@ pub(crate) unsafe fn json_object_getter_value(
 
 /// Store an accessor descriptor for (obj, key).
 pub(crate) fn set_accessor_descriptor(obj: usize, key: String, acc: AccessorDescriptor) {
+    note_descriptor_target(obj);
     ACCESSORS_IN_USE.with(|c| c.set(true));
     GLOBAL_DESCRIPTORS_IN_USE.store(true, Ordering::Relaxed);
     ACCESSOR_DESCRIPTORS.with(|m| {
@@ -849,6 +884,7 @@ pub(crate) fn set_builtin_accessor_descriptor(
 /// `PROPERTY_DESCRIPTORS` per-object and unconditionally. The gate stays
 /// down, so the object get/set hot path is unaffected for every program.
 pub(crate) fn set_builtin_property_attrs(obj: usize, key: String, attrs: PropertyAttrs) {
+    note_descriptor_target(obj);
     PROPERTY_DESCRIPTORS.with(|m| {
         m.borrow_mut().insert((obj, key), attrs);
     });

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -688,3 +688,73 @@ fn entries_and_values_skip_non_enumerable_descriptor_slots() {
         assert_eq!(crate::array::js_array_get(pair, 1).bits(), 2.0f64.to_bits());
     }
 }
+
+/// #5054: wide objects (≥257 keys) read through the validated key→index map;
+/// the dynamic-write fast path must still respect descriptors installed later.
+#[test]
+fn wide_object_index_reads_and_descriptor_writes() {
+    unsafe {
+        let obj = js_object_alloc(0, 0);
+        let n = 600u32;
+        for i in 0..n {
+            let name = format!("w{}", i);
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            js_object_set_field_by_name(obj, key, i as f64);
+        }
+        for i in 0..n {
+            let name = format!("w{}", i);
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            let v = js_object_get_field_by_name(obj as *const ObjectHeader, key);
+            assert_eq!(f64::from_bits(v.bits()), i as f64, "read-back of {}", name);
+        }
+        // Missing key stays undefined (index miss → scan → not found).
+        let missing = crate::string::js_string_from_bytes(b"nope".as_ptr(), 4);
+        assert!(crate::value::JSValue::from_bits(
+            js_object_get_field_by_name(obj as *const ObjectHeader, missing).bits()
+        )
+        .is_undefined());
+
+        // Install a non-writable descriptor on one key; the put_value_set
+        // fast path must bail to the descriptor-aware walk and reject the
+        // write (sloppy mode: value unchanged, no throw).
+        let obj_value = crate::value::js_nanbox_pointer(obj as i64);
+        let target_name = b"w42";
+        let target_key = crate::string::js_string_from_bytes(target_name.as_ptr(), 3);
+        let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+        let writable_key = crate::string::js_string_from_bytes(b"writable".as_ptr(), 8);
+        let descriptor = js_object_alloc(0, 0);
+        js_object_set_field_by_name(descriptor, value_key, 42.0);
+        js_object_set_field_by_name(
+            descriptor,
+            writable_key,
+            f64::from_bits(crate::value::TAG_FALSE),
+        );
+        crate::object::object_ops::js_object_define_property(
+            obj_value,
+            f64::from_bits(JSValue::string_ptr(target_key).bits()),
+            crate::value::js_nanbox_pointer(descriptor as i64),
+        );
+        crate::proxy::js_put_value_set(
+            obj_value,
+            f64::from_bits(JSValue::string_ptr(target_key).bits()),
+            777.0,
+            obj_value,
+            0,
+        );
+        let after = js_object_get_field_by_name(obj as *const ObjectHeader, target_key);
+        assert_eq!(f64::from_bits(after.bits()), 42.0);
+
+        // Writes to other keys still go through (fast path off for this
+        // object now — but correctness preserved either way).
+        let other_key = crate::string::js_string_from_bytes(b"w43".as_ptr(), 3);
+        crate::proxy::js_put_value_set(
+            obj_value,
+            f64::from_bits(JSValue::string_ptr(other_key).bits()),
+            4343.0,
+            obj_value,
+            0,
+        );
+        let v43 = js_object_get_field_by_name(obj as *const ObjectHeader, other_key);
+        assert_eq!(f64::from_bits(v43.bits()), 4343.0);
+    }
+}

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1107,6 +1107,60 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
         return ok;
     }
 
+    // #5054 fast path: the spec walk below probes own_set_descriptor on the
+    // target, which ends in a LINEAR keys_array scan — so every dynamic
+    // `obj[key] = v` was O(own-key-count) and building a wide dynamic object
+    // quadratic (10k props ~ 12s). When nothing the walk models can apply —
+    // plain GC_TYPE_OBJECT receiver written as itself, no property/accessor
+    // descriptor ever installed in the process (monotonic global), no class
+    // machinery (class_id 0), no recorded setPrototypeOf target, extensible,
+    // string key — the write reduces to the ordinary data-property store.
+    // #5054 fast path: the spec walk below probes own_set_descriptor on the
+    // target, which ends in a LINEAR keys_array scan — so every dynamic
+    // `obj[key] = v` was O(own-key-count) and building a wide dynamic object
+    // quadratic (10k props ~ 12s). When nothing the walk models can apply,
+    // the write reduces to the ordinary data-property store:
+    //   - target written as itself (receiver bits identical),
+    //   - plain GC_TYPE_OBJECT with class_id 0 (no class setter machinery),
+    //   - no descriptor ever installed on THIS object
+    //     (OBJ_FLAG_HAS_DESCRIPTORS) and not frozen/sealed/non-extensible,
+    //   - no recorded setPrototypeOf target (prototype chain is exactly
+    //     Object.prototype) and no descriptor on Object.prototype,
+    //   - string key.
+    let target_top16 = target.to_bits() >> 48;
+    if target.to_bits() == receiver.to_bits()
+        // POINTER_TAG'd heap object, or a module-level slot's raw I64 pointer
+        // (top 16 bits zero).
+        && (target_top16 == 0x7FFD || target_top16 == 0)
+        && !crate::object::object_proto_descriptors_in_use()
+        && unsafe { crate::symbol::js_is_symbol(key) } == 0
+    {
+        let addr = extract_pointer(target.to_bits()) as usize;
+        // Typed arrays must be excluded before the header probe: small TAs
+        // are plain-alloc'd without a GcHeader.
+        if crate::typedarray::lookup_typed_array_kind(addr).is_none()
+            && crate::object::exotic_expando::exotic_expando_kind_of_value(target).is_none()
+            && !crate::closure::is_closure_ptr(addr)
+        {
+            unsafe {
+                if let Some(header) = crate::value::addr_class::try_read_gc_header(addr) {
+                    const SLOW_FLAGS: u16 = crate::gc::OBJ_FLAG_FROZEN
+                        | crate::gc::OBJ_FLAG_SEALED
+                        | crate::gc::OBJ_FLAG_NO_EXTEND
+                        | crate::gc::OBJ_FLAG_HAS_DESCRIPTORS;
+                    if header.obj_type == crate::gc::GC_TYPE_OBJECT
+                        && header._reserved & SLOW_FLAGS == 0
+                        && (*(addr as *const crate::ObjectHeader)).class_id == 0
+                        && crate::object::prototype_chain::object_static_prototype(addr).is_none()
+                    {
+                        target_set(target, key, value);
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
     let mut current = target;
     for _ in 0..64 {
         // Integer-Indexed exotic [[Set]] (§10.4.5.5): a typed array in the


### PR DESCRIPTION
Fixes #5054.

## Problem
Building a wide dynamic object — `obj[key] = v` thousands of times — was quadratic. 10k props took ~12s; 100k never finished. *Both* the write and every subsequent read did a linear `keys_array` scan per key.

## Fix — two halves

### Write path (`proxy.rs::ordinary_set_with_receiver`)
Every `obj[key] = v` probed `own_set_descriptor` on the target, which ends in a linear keys scan. Added a fast path that reduces the write to the ordinary data-property store when nothing the spec walk models can apply: plain `GC_TYPE_OBJECT` written as its own receiver, no descriptor on *this* object (new `OBJ_FLAG_HAS_DESCRIPTORS` GcHeader bit, travels with the object on evacuation), `class_id == 0`, prototype exactly `Object.prototype` (no `setPrototypeOf`, no descriptor on `Object.prototype`), extensible, string key.

`GLOBAL_DESCRIPTORS_IN_USE` was unusable as the gate — it's poisoned at startup when the runtime installs attrs on builtin prototypes (RegExp etc.), so the very first dynamic write already saw it true. The per-object header flag plus a dedicated `OBJECT_PROTO_DESCRIPTORS` global are precise.

### Read path (`field_get_set.rs::js_object_get_field_by_name`)
The 1024-entry inline field cache thrashes once an object has thousands of distinct keys. For keys arrays past 257 entries, build a validated key→index `HashMap` (keyed on `keys_array` id, LRU of 4), re-validated against the live slot on every hit — exactly the trust model the inline cache already uses. Misses fall through to the linear scan (the index is an accelerator, never authoritative); scan hits back-fill it. Side effect: indexed hits lift the old `>65536-key → return undefined` cliff.

## Results
- 10k props: **12s → 0.05s**. 100k build + read-all: **never → 0.14s**.
- 12-case edge battery byte-identical to `node --experimental-strip-types`: delete+rebuild, `defineProperty` non-writable/setter installed *after* a wide build, `freeze`, `preventExtensions`, symbol keys, `Object.prototype` setter intercepting missing-key writes, `setPrototypeOf` to a proto with a setter, spread/`entries`/JSON round-trip, shape sharing, `hasOwnProperty`/`in`.
- New unit test `wide_object_index_reads_and_descriptor_writes`.
- Gap suite: 207 pass / 27 fail, **set-identical to a pristine-main baseline binary** (0 regressions); the 27 are pre-existing/environmental.

Code-only PR — version bump + changelog left for merge time.