### PR TITLE
fix(exception): raise try-nesting limit to 1024 to avoid process abort

### DIFF
--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -37,8 +37,13 @@ extern "C" {
     fn longjmp(env: *mut i32, val: i32) -> !;
 }
 
-// Maximum nesting depth for try blocks
-const MAX_TRY_DEPTH: usize = 128;
+// Maximum nesting depth for try blocks. Backed by fixed-size per-thread
+// arrays (see ExceptionState), so this directly sizes thread-local memory:
+// jump_buffers is MAX_TRY_DEPTH * sizeof(JmpBuf) (256 B each). 1024 covers
+// deep-but-legal recursion-through-try; genuinely unbounded recursion hits a
+// native stack overflow well before this. Raised from 128 (#5065): 128
+// aborted the process via panic on legal deeply-nested try/catch.
+const MAX_TRY_DEPTH: usize = 1024;
 
 /// Per-thread exception state. Exception handling uses setjmp/longjmp,
 /// and a jmp_buf captured by setjmp on thread A is meaningless on thread
@@ -407,5 +412,28 @@ mod tests {
 
         js_shadow_frame_pop(run_frame);
         assert_eq!(shadow_stack_depth(), base_depth);
+    }
+
+    #[test]
+    fn try_push_pop_beyond_old_limit_does_not_panic() {
+        // Regression for #5065: old fixed limit was 128 and js_try_push panicked
+        // (aborting the process) at the 129th simultaneously-active try frame.
+        // Relative to the entry depth so it's robust under shared TLS
+        // (`--test-threads=1`) alongside the other tests in this module.
+        let base = current_try_depth();
+        let pushes = (MAX_TRY_DEPTH - base) - 1;
+        assert!(
+            pushes > 128,
+            "expected room for >128 frames beyond the old limit"
+        );
+        for _ in 0..pushes {
+            let p = js_try_push();
+            assert!(!p.is_null(), "js_try_push returned null jmp_buf");
+        }
+        assert_eq!(current_try_depth(), base + pushes);
+        for _ in 0..pushes {
+            js_try_end();
+        }
+        assert_eq!(current_try_depth(), base);
     }
 }


### PR DESCRIPTION
## What
Raises `MAX_TRY_DEPTH` from 128 to 1024 in `crates/perry-runtime/src/exception.rs`.

## Why
`js_try_push` stores per-thread `try` state in fixed-size arrays of length 128 and `panic!`s (aborting the whole process) on the 129th simultaneously-active `try` frame. Legal TypeScript — e.g. a recursive function whose body is wrapped in `try`/`catch` (recursive-descent parser, tree walker) — could hit this and crash, where Node.js keeps running. Raising the cap to 1024 removes the realistic failure cases; genuinely unbounded recursion hits a native stack overflow well before 1024 nested `setjmp` frames anyway.

## Notes
- The arrays stay fixed-size (no allocation, `const fn` initializer preserved) — lowest-risk change. `JmpBuf` is 256 B, so `jump_buffers` grows to ~256 KB per OS thread; `ShadowSavepoint` is 16 B (verified). Converting the overflow into a catchable `RangeError` was considered but deliberately deferred as higher-risk.

## Test
New unit test `try_push_pop_beyond_old_limit_does_not_panic` pushes >128 frames and unwinds without panic. `cargo test -p perry-runtime exception` → green.

Closes #5065


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased maximum nesting depth for try blocks from 128 to 1024, allowing applications to use deeper exception handling structures without hitting limits.
  * Expanded documentation to clarify the new nesting depth limit and previous constraints.

* **Tests**
  * Added regression tests verifying the new limit works correctly and properly tracks nesting depth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->