### PR TITLE
fix(runtime): node:dns — correct resolve/reverse error shape (syscall + hostname); 6/6 node-suite

### DIFF
--- a/crates/perry-runtime/src/dns.rs
+++ b/crates/perry-runtime/src/dns.rs
@@ -825,14 +825,39 @@ fn dns_error_code(err: DnsError) -> &'static str {
     }
 }
 
+/// Build a c-ares-style DNS error carrying Node's `.code`, `.syscall`, and
+/// `.hostname` own properties. Node's `dns.resolve*`/`dns.reverse` rejections
+/// always set all three (with `errno` left `undefined`); registering them on
+/// the message StringHeader mirrors the `.code` path so caught errors expose
+/// the full shape, not just `.code`.
+fn dns_query_error_value(
+    message: &str,
+    code: &'static str,
+    syscall: &'static str,
+    hostname: &str,
+) -> f64 {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg, code);
+    crate::node_submodules::register_error_syscall(msg, syscall);
+    crate::node_submodules::register_error_hostname(msg, hostname.to_string());
+    let err = crate::error::js_error_new_with_message(msg);
+    boxed_pointer(err as *const u8)
+}
+
 fn resolve_error_value(kind: RecordKind, host: &str, err: DnsError) -> f64 {
     let code = dns_error_code(err);
-    plain_error_value(&format!("{} {code} {host}", resolve_syscall(kind)), code)
+    let syscall = resolve_syscall(kind);
+    dns_query_error_value(&format!("{syscall} {code} {host}"), code, syscall, host)
 }
 
 fn reverse_error_value(host: &str, err: DnsError) -> f64 {
     let code = dns_error_code(err);
-    plain_error_value(&format!("getHostByAddr {code} {host}"), code)
+    dns_query_error_value(
+        &format!("getHostByAddr {code} {host}"),
+        code,
+        "getHostByAddr",
+        host,
+    )
 }
 
 /// Deterministic-mode (`PERRY_DETERMINISTIC_NET=1`) loopback answers — the

--- a/crates/perry-runtime/src/node_submodules/diagnostics.rs
+++ b/crates/perry-runtime/src/node_submodules/diagnostics.rs
@@ -477,6 +477,31 @@ pub fn error_path_for_message(message_ptr: *const StringHeader) -> Option<String
     ERROR_MESSAGE_PATHS.with(|m| m.borrow().get(&(message_ptr as usize)).cloned())
 }
 
+thread_local! {
+    pub(crate) static ERROR_MESSAGE_HOSTNAMES: RefCell<HashMap<usize, String>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Attach a Node-style `hostname` string to an Error keyed by its message
+/// StringHeader. Node's c-ares `dns.resolve*`/`dns.reverse` failures carry the
+/// queried hostname (or address) on `err.hostname`. Read back from the
+/// `.hostname` getter in `field_get_set` (mirrors `.path`).
+pub fn register_error_hostname(message_ptr: *const StringHeader, hostname: String) {
+    if message_ptr.is_null() {
+        return;
+    }
+    ERROR_MESSAGE_HOSTNAMES.with(|m| {
+        m.borrow_mut().insert(message_ptr as usize, hostname);
+    });
+}
+
+pub fn error_hostname_for_message(message_ptr: *const StringHeader) -> Option<String> {
+    if message_ptr.is_null() {
+        return None;
+    }
+    ERROR_MESSAGE_HOSTNAMES.with(|m| m.borrow().get(&(message_ptr as usize)).cloned())
+}
+
 /// Attach a Node-style `dest` string to an Error keyed by its message
 /// StringHeader. Node sets `dest` on two-path fs errors (rename/copyFile/
 /// link/symlink) alongside `path`. Read back from the `.dest` getter.

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -4205,6 +4205,21 @@ pub extern "C" fn js_object_get_field_by_name(
                         }
                         return JSValue::undefined();
                     }
+                    b"hostname" => {
+                        // Node attaches `hostname` to c-ares dns errors
+                        // (`dns.resolve*`/`dns.reverse`). Mirrors `.path`.
+                        let msg = crate::error::js_error_get_message(err_ptr);
+                        if let Some(hostname) =
+                            crate::node_submodules::error_hostname_for_message(msg)
+                        {
+                            let s = crate::string::js_string_from_bytes(
+                                hostname.as_ptr(),
+                                hostname.len() as u32,
+                            );
+                            return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+                        }
+                        return JSValue::undefined();
+                    }
                     b"dest" => {
                         // Node attaches `dest` to two-path fs errors
                         // (rename/copyFile/link/symlink). Mirrors `.path`.

--- a/test-parity/node-suite/dns/imports/default-export.ts
+++ b/test-parity/node-suite/dns/imports/default-export.ts
@@ -28,5 +28,17 @@ console.log(
 );
 
 const resolver = new dnsPromisesDefault.Resolver();
-const resolver4 = await resolver.resolve4("localhost");
-console.log("promises default resolve4:", Array.isArray(resolver4), JSON.stringify(resolver4));
+// resolve4 queries the configured nameserver directly (it does not read
+// /etc/hosts), so "localhost" yields an A record on some resolvers and
+// ESERVFAIL/ENOTFOUND on others — node itself rejects (and aborts on the
+// unhandled rejection) when the resolver has no answer for it. Print
+// array-or-error-code so node and Perry agree regardless of the machine's
+// resolver, the same record-or-error approach the dns/resolve suite uses.
+let resolver4Summary: string;
+try {
+  const resolver4 = await resolver.resolve4("localhost");
+  resolver4Summary = Array.isArray(resolver4) ? "array" : typeof resolver4;
+} catch (e: any) {
+  resolver4Summary = "err:" + e.code;
+}
+console.log("promises default resolve4:", resolver4Summary);


### PR DESCRIPTION
## Summary

Investigated the report that node:dns was crashing on all 6 node-suite tests. **The "0/6 crash" premise was stale for this environment** — on a pristine `origin/main` worktree the dns node-suite already measured **5/6 with no panics or segfaults** (the #5040 hosts-file reverse logic is correct here — this machine's `/etc/hosts` produces exactly node's `["proxyman.dev","enceladus.local","local","kubernetes.docker.internal"]`).

Root-causing the single real failure surfaced **one genuine product bug** (error shape) and **one non-portable test**. Both fixed. **node-suite dns: 5/6 → 6/6**, zero regressions.

## Root causes fixed

### 1. `dns.resolve*` / `dns.reverse` rejections missing `.syscall` and `.hostname` (real bug)
A caught `dns.resolve4` error exposed only `.code` (`"ESERVFAIL"`). Node's c-ares errors also carry `e.syscall === "queryA"` and `e.hostname === "localhost"` (with `errno` left `undefined`); `dns.reverse` errors carry `syscall === "getHostByAddr"`.

Before / after (this machine SERVFAILs `localhost` A-queries):
```
node : resolve4 threw: Error ESERVFAIL queryA localhost
perry: resolve4 threw: Error ESERVFAIL undefined undefined   ← before
perry: resolve4 threw: Error ESERVFAIL queryA localhost      ← after
```

- `dns.rs`: new `dns_query_error_value` registers code + syscall + hostname on the message StringHeader (mirrors the existing `.code` side-table path); `resolve_error_value`/`reverse_error_value` route through it.
- `node_submodules/diagnostics.rs`: new `ERROR_MESSAGE_HOSTNAMES` table + `register_error_hostname`/`error_hostname_for_message`, paralleling the syscall/path/dest tables.
- `object/field_get_set.rs`: new `.hostname` Error getter arm (mirrors `.path`/`.syscall`). The user-assigned-prop path is consulted **before** this arm, so a user-set `err.hostname` still wins (verified against node).

### 2. `imports/default-export.ts` asserted an unportable result (test bug)
The test did `const r = await resolver.resolve4("localhost")` and asserted an array. `resolve4` queries the configured nameserver directly — it does **not** consult `/etc/hosts` — so `localhost` yields an A record on some resolvers and `ESERVFAIL`/`ENOTFOUND` on others. On a SERVFAIL machine **node itself aborts** on the unhandled rejection, so the assertion can't pass regardless of Perry. Rewrote it to print array-or-error-code — the identical environment-robust record-or-error approach #5040 already applied to the sibling `dns/resolve/localhost.ts`. No product behavior was papered over: Perry already threw the correct `ESERVFAIL`; the fix above just completes that error's shape.

## node-suite dns: before → after
```
before (origin/main):  5/6   (imports/default-export.ts FAIL — unhandled ESERVFAIL rejection)
after:                 6/6
```
All six: constants/error-aliases, imports/default-export, lookup/loopback, resolve/localhost, settings/default-result-order, settings/servers — PASS.

## Regression check (zero regressions)
- error-shape modules **assert/net/dgram**: clean. (Two net cases initially showed FAIL under heavy concurrent-worktree CPU load — one literally `Killed: 9` — re-running `net/socket/type-of-service` cleanly gives byte-identical node/perry output. Both read only `err.code`/`.name`/`.message`, never `.hostname`/`.syscall`, so they're untouched by this change.)
- regression probe: user-set `err.hostname`/`err.path` and a plain error's `.hostname`/`.syscall` all match node exactly.
- `perry-runtime` `dns_resolver` unit tests: 3/3 pass.

## Files
- `crates/perry-runtime/src/dns.rs`
- `crates/perry-runtime/src/node_submodules/diagnostics.rs`
- `crates/perry-runtime/src/object/field_get_set.rs`
- `test-parity/node-suite/dns/imports/default-export.ts`

Per repo policy, no `Cargo.toml`/`CLAUDE.md`/`CHANGELOG.md` edits (maintainer folds version + changelog at merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* DNS lookup errors now include detailed error information (error code, system call details, and hostname) for improved error diagnostics.

## Tests
* Enhanced DNS test reliability across different resolver configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->