### PR TITLE
perf(transform): O(1) class-chain lookups in inliner shadowing analysis

### DIFF
--- a/crates/perry-transform/src/inline/analysis.rs
+++ b/crates/perry-transform/src/inline/analysis.rs
@@ -247,10 +247,20 @@ pub fn method_lookup_is_unshadowed(classes: &[Class], class_name: &str, method_n
         return false;
     };
 
+    // Index classes by name for O(1) chain-walk lookups instead of an
+    // O(classes) linear scan per level. `entry().or_insert` keeps the FIRST
+    // class for a duplicate name, matching the prior `iter().find()` semantics
+    // (duplicate class names occur cross-module, e.g. Effect's same-named
+    // `Type` in SchemaAST and ParseResult).
+    let mut by_name: HashMap<&str, &Class> = HashMap::with_capacity(classes.len());
+    for c in classes {
+        by_name.entry(c.name.as_str()).or_insert(c);
+    }
+
     let mut cur = Some(class_name);
     let mut depth = 0usize;
     while let Some(name) = cur {
-        let Some(class) = classes.iter().find(|c| c.name == name) else {
+        let Some(class) = by_name.get(name).copied() else {
             return false;
         };
         if class.extends_expr.is_some() || class.native_extends.is_some() {
@@ -308,10 +318,16 @@ pub fn class_chain_property_sets(
     let mut fields = HashSet::new();
     let mut getters = HashSet::new();
     let mut setters = HashSet::new();
+    // Index by name for O(1) chain-walk lookups; `entry().or_insert` keeps the
+    // first class for a duplicate name, matching the prior `iter().find()`.
+    let mut by_name: HashMap<&str, &Class> = HashMap::with_capacity(classes.len());
+    for c in classes {
+        by_name.entry(c.name.as_str()).or_insert(c);
+    }
     let mut cur = Some(class_name);
     let mut depth = 0usize;
     while let Some(name) = cur {
-        let class = classes.iter().find(|c| c.name == name)?;
+        let class = by_name.get(name).copied()?;
         if class.extends_expr.is_some() || class.native_extends.is_some() {
             return None;
         }


### PR DESCRIPTION
Replaces the O(classes) linear scan per inheritance level in the inliner's method-shadowing analysis with O(1) hash lookups.

## What

`method_lookup_is_unshadowed` and `class_chain_property_sets` (`crates/perry-transform/src/inline/analysis.rs`) walk the class inheritance chain (depth capped at 32) and at **every level** did `classes.iter().find(|c| c.name == name)` — an O(number-of-classes) scan. Both functions are called once per inlinable-method candidate (from `inline/mod.rs` and `inline/cross_module.rs`), so candidate evaluation was effectively `O(candidates × depth × classes)`. On modules with many classes and deep hierarchies (e.g. Effect-style codebases) this is wasted compile time.

This indexes the class slice by name into a `HashMap<&str, &Class>` once per call and does O(1) lookups during the walk.

## Correctness

`HashMap::entry(...).or_insert(c)` keeps the **first** class for a duplicate name, exactly matching the prior `iter().find()` first-match semantics. This matters: duplicate class names occur across modules (e.g. Effect's same-named `Type` in `SchemaAST` and `ParseResult`). Compiler output is unchanged — only lookup complexity drops.

## Verification

- `cargo test --release -p perry-transform` — all pass (30 tests).
- Built the full driver and compiled/ran a 3-level inheritance program with method overriding and inlining; output is correct (overrides resolve to the right method, inherited methods reach the base implementation).

Pure compile-speed change; no runtime or codegen-output behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized class name resolution in method-lookup and property-set validation checks for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->