### PR TITLE
fix(runtime): node:http2 — fix session/stream hang from timer-id ↔ handle-id collision

### DIFF
--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -105,6 +105,32 @@ extern "C" {
         scanner_id: usize,
         scanner: PerryFfiNamedMutableRootScanner,
     );
+    /// perry-runtime hook: register a probe the runtime's generic method
+    /// dispatcher consults to tell a `register_handle` id apart from a Node
+    /// timer id (both occupy the pointer-tagged small-integer band). Resolved
+    /// at final link (perry-runtime is always linked into the binary).
+    fn js_register_ffi_handle_exists_probe(probe: extern "C" fn(handle: i64) -> bool);
+}
+
+/// Probe handed to perry-runtime: is `handle` a live entry in this registry?
+/// Used to disambiguate a `POINTER_TAG | id` value that names both a live
+/// handle and a live timer (e.g. HTTP/2 server handle 1 vs `setTimeout` id 1),
+/// so the runtime routes `server.close()` to the handle rather than swallowing
+/// it as `clearTimeout`. See `class_handles::ffi_handle_exists`.
+extern "C" fn ffi_handle_exists_probe(handle: Handle) -> bool {
+    HANDLES.contains_key(&handle)
+}
+
+/// Register [`ffi_handle_exists_probe`] with perry-runtime exactly once, the
+/// first time any handle is created. Done lazily (rather than at an init entry
+/// point perry-ffi doesn't own) so it is wired up before any handle value can
+/// reach the runtime's generic dispatcher.
+fn ensure_handle_exists_probe_registered() {
+    use std::sync::Once;
+    static REGISTER: Once = Once::new();
+    REGISTER.call_once(|| unsafe {
+        js_register_ffi_handle_exists_probe(ffi_handle_exists_probe);
+    });
 }
 
 /// Function pointer type for native wrappers that expose mutable GC root slots.
@@ -193,6 +219,7 @@ impl<'a> GcRootVisitor<'a> {
 /// across threads (tokio workers may resolve promises that touch
 /// handle data while the main thread is also touching it).
 pub fn register_handle<T: 'static + Send + Sync>(value: T) -> Handle {
+    ensure_handle_exists_probe_registered();
     let handle = next_handle_id();
     HANDLES.insert(handle, Box::new(value));
     handle

--- a/crates/perry-runtime/src/object/class_handles.rs
+++ b/crates/perry-runtime/src/object/class_handles.rs
@@ -101,6 +101,15 @@ pub type EventEmitterSetDomainFn = unsafe extern "C" fn(handle: i64, domain: i64
 /// pointer-tagged small integer handles, not heap objects with class ids.
 pub type NetSocketHandleProbeFn = unsafe extern "C" fn(handle: i64) -> bool;
 
+/// Probe for live `perry-ffi` registry handles. `register_handle`-issued ids
+/// and Node timer ids both occupy the pointer-tagged small-integer band and
+/// both count from 1, so a bare id is ambiguous between (say) an HTTP/2 server
+/// handle and a `setTimeout` id. The timer-method dispatch arm consults this
+/// probe to yield to an authoritative registered handle when the id is one,
+/// so `server.close()` (handle 1) is not swallowed by `clearTimeout(1)` when a
+/// timer with the colliding id also happens to be alive.
+pub type FfiHandleExistsProbeFn = unsafe extern "C" fn(handle: i64) -> bool;
+
 /// Narrow registration hook for runtime code that needs to attach an
 /// EventEmitter listener without routing through the generic handle dispatcher.
 pub type EventEmitterOnFn =
@@ -143,6 +152,7 @@ static EVENT_EMITTER_ASYNC_RESOURCE_HANDLE_PROBE_PTR: AtomicPtr<()> =
 static EVENT_EMITTER_GET_DOMAIN_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static EVENT_EMITTER_SET_DOMAIN_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static NET_SOCKET_HANDLE_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
+static FFI_HANDLE_EXISTS_PROBE_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static EVENT_EMITTER_ON_PTR: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
@@ -485,6 +495,32 @@ pub fn net_socket_handle_probe() -> Option<NetSocketHandleProbeFn> {
 #[no_mangle]
 pub unsafe extern "C" fn js_register_net_socket_handle_probe(f: NetSocketHandleProbeFn) {
     NET_SOCKET_HANDLE_PROBE_PTR.store(f as *mut (), Ordering::Release);
+}
+
+#[inline]
+pub fn ffi_handle_exists_probe() -> Option<FfiHandleExistsProbeFn> {
+    let p = FFI_HANDLE_EXISTS_PROBE_PTR.load(Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { std::mem::transmute::<*mut (), FfiHandleExistsProbeFn>(p) })
+    }
+}
+
+/// Returns `true` only when a probe is registered AND it confirms `id` is a
+/// live `perry-ffi` registry handle. Absent a probe (no native wrapper linked)
+/// this is `false`, preserving the prior behavior.
+#[inline]
+pub fn ffi_handle_exists(id: i64) -> bool {
+    match ffi_handle_exists_probe() {
+        Some(probe) => unsafe { probe(id) },
+        None => false,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn js_register_ffi_handle_exists_probe(f: FfiHandleExistsProbeFn) {
+    FFI_HANDLE_EXISTS_PROBE_PTR.store(f as *mut (), Ordering::Release);
 }
 
 #[inline]

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -2009,7 +2009,16 @@ pub unsafe extern "C" fn js_native_call_method(
         let top16 = bits >> 48;
         if top16 == 0x7FFD {
             let id = (bits & 0x0000_FFFF_FFFF_FFFF) as i64;
-            if crate::timer::is_known_timer_id(id) {
+            // Timer ids and `perry-ffi` registry handles share the pointer-tagged
+            // small-integer band and both count from 1, so a bare id can be
+            // ambiguous (e.g. an HTTP/2 server handle 1 vs a `setTimeout` id 1
+            // alive at the same time). A live registered handle is the
+            // authoritative interpretation — it owns a real Rust object and its
+            // method surface (`close`/`ref`/`unref`/…) — so yield to the handle
+            // dispatch below rather than swallow `server.close()` as
+            // `clearTimeout`. A genuine timer whose id does not also name a live
+            // handle still resolves here.
+            if crate::timer::is_known_timer_id(id) && !super::class_handles::ffi_handle_exists(id) {
                 match method_name {
                     "ref" => {
                         crate::timer::js_timer_ref(id);


### PR DESCRIPTION
## Summary

\`node:http2\` was at 8/9 in the in-repo node-suite (the mandate's "44%" was stale; the suite already passed 8 cases). The one failure — \`session/controls.ts\` — produced **byte-identical output but hung** (exit 124), which also hung the print-and-diff harness on that case.

## Root cause

Perry's Node **timer ids** (\`NEXT_TIMER_ID\`, counting from 1) and the **perry-ffi handle registry** ids (\`NEXT_HANDLE\`, counting from 1) share the pointer-tagged small-integer value space, and both start at 1. So a JS value like \`POINTER_TAG | 1\` is **bit-ambiguous** between an HTTP/2 server handle (handle 1) and a \`setTimeout\` id (timer 1).

\`js_native_call_method\`'s timer-method dispatch arm fires on \`is_known_timer_id(id)\` alone. When \`controls.ts\` had both an HTTP/2 server (handle 1) and a \`setTimeout\` guard (timer 1) alive, \`server.close()\` (\`0x7ffd…0001\`) was swallowed by the timer arm → \`clearTimeout(1)\` instead of \`js_node_http2_server_close\`. The server never closed, \`base.listening\` stayed \`true\`, \`js_node_http_server_has_active\` kept returning 1, and the main event loop parked on the pump condvar forever.

The handle-registry docs already anticipate this class of bug ("handle families that participate in generic property/method dispatch reserve disjoint visible id ranges") — timers and the FFI registry simply both used \`[1, 0x40000)\`.

## Fix

An authoritative **FFI-handle-existence probe**:
- perry-runtime exposes \`js_register_ffi_handle_exists_probe\` + \`ffi_handle_exists(id)\` (mirrors the existing net-socket/stream probe pattern).
- perry-ffi registers \`ffi_handle_exists_probe\` (\`HANDLES.contains_key\`) on first \`register_handle\`.
- The timer arm now gates on \`is_known_timer_id(id) && !ffi_handle_exists(id)\`, so a live registered handle wins over the ambiguous timer-id heuristic. A genuine timer whose id is not also a live handle still resolves as a timer.

**Provably inert for pure-JS / test262**: with no \`register_handle\` the probe is never registered and \`ffi_handle_exists\` returns \`false\`, leaving the timer dispatch arm byte-identical to before.

## Results (local, node v26 print-and-diff)

- **http2**: the suite no longer hangs; \`controls.ts\` now exits 0.
- **Collateral fixes** (same root cause — server handles + timers): \`http/client-request/header-state-controls\`, \`http/incoming-message/client-set-encoding\`, \`http/incoming-message/server-headers-body\` now pass (verified 3/3 stable). net/http/https went 29→32 pass.
- **0 regressions**: \`timers\` (identical 7 pre-existing flaky delay-warning fails on baseline and fix), \`net\`/\`http\`/\`https\` (no fix-only fails). perry-ffi + perry-runtime unit tests pass.

## Known limitation: \`controls.ts\` is Node-side flaky

After the hang fix, \`controls.ts\` still diffs intermittently because the server \`'session'\` vs client \`'connect'\` event ordering is a **genuine loopback race in node v26** (measured server-first 12 : client-first 8 over 20 node runs). \`sequential-session-cleanup.ts\` deterministically requires the *opposite* order (client-first), so **no single deterministic Perry ordering can match both**. Perry keeps client-first, which keeps the other 8 http2 cases deterministically green; \`controls\` passes whenever Node's coin-flip lands client-first. This is Node nondeterminism, not a Perry correctness gap.

## Files
- \`crates/perry-runtime/src/object/class_handles.rs\` — probe registration + \`ffi_handle_exists\`
- \`crates/perry-runtime/src/object/native_call_method.rs\` — gate the timer dispatch arm
- \`crates/perry-ffi/src/handle.rs\` — probe impl + lazy registration in \`register_handle\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method dispatch on FFI-based objects to prevent incorrect routing to timer methods, ensuring proper method execution (e.g., `.close()` calls work as expected).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->