### PR TITLE
perf(codegen): integer-specialize `i < n` loop guards for any/untyped bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,46 @@
+## v0.5.1164 — perf(codegen): integer-specialize `i < n` loop guards when the bound is `any`/untyped
+
+Tight integer loops whose bound is **not statically typed `number`** — most
+commonly an `any`-typed or un-annotated value (e.g. a count out of
+`JSON.parse`) — compiled their `i < n` / `i <= n` guard to a generic
+per-iteration comparison: `sitofp` the i32 counter back to a double, keep `n`
+as a NaN-boxed f64 on the stack, and `call @js_rel_lt` every iteration. On the
+hot path of a compute kernel this is ~50× slower than an integer induction
+variable + `icmp`, and it blocks SCEV / the loop vectorizer.
+
+It presented as an x86_64-vs-arm64 divergence, but the emitted LLVM IR is
+**identical** across both targets (only the `target triple` header differs).
+The difference was downstream, in the link pipeline: `js_rel_lt` is a
+`#[no_mangle] extern "C"` runtime function in a separate compilation unit. The
+macOS default **auto-optimize** build rebuilds + inlines the runtime so LLVM
+folds the call away (making it *look* optimized), whereas the `--target linux`
+build links a **prebuilt `libperry_runtime.a`** with no cross-module inlining,
+so the per-iteration `callq` survives — the entire cause of poor compute
+throughput on Lambda.
+
+**Fix** (`crates/perry-codegen`): a runtime-guarded i32 specialization that
+extends the existing `i < arr.length` / `i < n` (number-typed) peepholes to
+`any`/untyped bounds. New `classify_for_local_bound_dynamic` matches the shape;
+the loop head hoists, **once**, an `is-number` check (NaN-box tag test
+mirroring `JSValue::is_number`) plus `fptosi(n)`; the cond block branches on
+that loop-invariant flag into `for.cond.fast` (`icmp slt i32`, no per-iteration
+`sitofp`/`call`) and `for.cond.slow` (the generic `js_rel_lt` path, preserving
+full JS coercion semantics for non-number values). LLVM's LoopUnswitch peels
+the invariant branch into two loops at -O2+; even unswitched, the hot
+(is-number) path runs pure integer compares. When the bound *is* a primitive
+number, hoisting `fptosi(n)` once carries the same documented trust-types
+trade-off as the static `number`-typed path (a non-integer float bound shifts
+the trip count by at most one). Added the `SHORT_STRING_TAG` ABI-mirror
+constant to codegen's `nanbox.rs`.
+
+Verified: `any`-bound loop guards now lower to `icmp slt i32` with no
+per-iteration call; numeric `any` bounds compute the correct result via the
+fast path, while string/`<=` cases keep correct coercion semantics via the slow
+path. `perry-codegen` (16/16), `perry-hir` + `perry` (522/0 + integration
+suites) green; the residual `perry-runtime` date/url failures and the
+`issue_4909` HTTP-timeout test are pre-existing load/timezone flakes
+(unchanged with this patch stashed; pass in isolation).
+
 ## v0.5.1163 — fix: chalk boolean style modifiers — `<Text dimColor>` no longer renders `[object Object]` (#5039)
 
 Fixes #5039 — ink's `<Text dimColor>` (and `bold`/`italic`/`underline`/…)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1163
+**Current Version:** 0.5.1164
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "base64",
@@ -5338,14 +5338,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "cc",
  "libc",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "log",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5377,7 +5377,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "base64",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5454,14 +5454,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "serde",
  "serde_json",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1163"
+version = "0.5.1164"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5480,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "clap",
@@ -5495,14 +5495,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5569,7 +5569,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5577,7 +5577,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5601,14 +5601,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5650,7 +5650,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "bytes",
  "h2",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5694,7 +5694,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "bson",
  "futures-util",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5763,7 +5763,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "image",
@@ -5797,14 +5797,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5843,7 +5843,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "brotli",
  "flate2",
@@ -5852,7 +5852,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5861,7 +5861,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "base64",
@@ -5922,7 +5922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6032,14 +6032,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "itoa",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "block2",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "block2",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1163"
+version = "0.5.1164"
 
 [[package]]
 name = "perry-ui-test"
@@ -6128,11 +6128,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1163"
+version = "0.5.1164"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "block2",
@@ -6148,7 +6148,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "block2",
@@ -6164,7 +6164,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "block2",
  "libc",
@@ -6177,7 +6177,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "libc",
@@ -6194,14 +6194,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6215,7 +6215,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1163"
+version = "0.5.1164"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1163"
+version = "0.5.1164"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/nanbox.rs
+++ b/crates/perry-codegen/src/nanbox.rs
@@ -25,6 +25,11 @@ pub const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
 pub const INT32_MASK: u64 = 0x0000_0000_FFFF_FFFF;
 pub const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
 pub const BIGINT_TAG: u64 = 0x7FFA_0000_0000_0000;
+/// Low end of the Perry-owned qNaN tag band. A NaN-boxed value is a primitive
+/// number iff its `TAG_MASK` bits are NOT in `[SHORT_STRING_TAG, STRING_TAG]`.
+/// Must match `perry-runtime::value::tags::SHORT_STRING_TAG` (used by the
+/// inline `is-number` guard in `stmt::loops`).
+pub const SHORT_STRING_TAG: u64 = 0x7FF9_0000_0000_0000;
 pub const TAG_MASK: u64 = 0xFFFF_0000_0000_0000;
 
 pub const TAG_UNDEFINED_I64: &str = "9222246136947933185";

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -21,6 +21,22 @@ struct NumericBulkFillLoop {
     value: NumericBulkFillValue,
 }
 
+/// Runtime-guarded i32 specialization for `i < n` loops whose bound `n` is an
+/// `any`/untyped (non-`number`) local. The `is-number` flag and `fptosi(n)`
+/// value are both hoisted to stack slots once before the loop; the cond block
+/// branches on the (loop-invariant) flag to choose the `icmp slt i32` fast loop
+/// or the generic per-iteration comparison. See `classify_for_local_bound_dynamic`.
+struct DynamicI32Bound {
+    counter_id: u32,
+    op: perry_hir::CompareOp,
+    /// `i1` slot: true when `n` was a primitive number at loop entry.
+    flag_slot: String,
+    /// `i32` slot holding `fptosi(n)` (valid only when `flag_slot` is true).
+    bound_i32_slot: String,
+    /// Whether we allocated the counter's i32 slot (so we remove it at exit).
+    counter_i32_was_fresh: bool,
+}
+
 fn match_numeric_bulk_fill_loop(
     ctx: &FnCtx<'_>,
     init: Option<&Stmt>,
@@ -409,6 +425,73 @@ pub(crate) fn lower_for(
             local_bound_counter_i32_was_fresh = false;
             None
         };
+    // Issue #168 follow-up: when neither the `arr.length` hoist nor the static
+    // `i < n` (number-typed bound) peephole fired, try the runtime-guarded path
+    // for an `any`/untyped numeric bound. We hoist the `is-number` check and
+    // `fptosi(n)` once here, in the pre-loop block, so the cond block can pick
+    // an `icmp slt i32` fast loop (no per-iteration `sitofp` / `js_rel_*` call)
+    // when `n` was a primitive number at entry, and fall back to the generic
+    // comparison (full coercion semantics) otherwise.
+    let dynamic_i32_bound: Option<DynamicI32Bound> = if hoist_classification.is_none()
+        && local_bound_classification.is_none()
+    {
+        condition
+            .and_then(|cond| classify_for_local_bound_dynamic(cond, ctx))
+            .and_then(|(counter_id, bound_id, op)| {
+                let bound_slot = ctx.locals.get(&bound_id).cloned()?;
+                // Ensure an i32 counter slot exists (the Let site allocates
+                // one for `integer_locals`, but allocate here if absent so
+                // the fast path and Update stay in sync).
+                let counter_i32_was_fresh = if !ctx.i32_counter_slots.contains_key(&counter_id) {
+                    let counter_slot = ctx.locals.get(&counter_id).cloned()?;
+                    let i32_slot = ctx.func.alloca_entry(I32);
+                    let cur_dbl = ctx.block().load(DOUBLE, &counter_slot);
+                    let cur_i32 = ctx.block().fptosi(DOUBLE, &cur_dbl, I32);
+                    ctx.block().store(I32, &cur_i32, &i32_slot);
+                    ctx.i32_counter_slots.insert(counter_id, i32_slot);
+                    true
+                } else {
+                    false
+                };
+                // One-time `is-number` test, mirroring runtime
+                // `JSValue::is_number`: a value is a number unless its tag
+                // bits fall in the Perry-owned band [SHORT_STRING_TAG,
+                // STRING_TAG].
+                let n_dbl = ctx.block().load(DOUBLE, &bound_slot);
+                let n_bits = ctx.block().bitcast_double_to_i64(&n_dbl);
+                let tag = ctx.block().and(
+                    I64,
+                    &n_bits,
+                    &crate::nanbox::i64_literal(crate::nanbox::TAG_MASK),
+                );
+                let below = ctx.block().icmp_ult(
+                    I64,
+                    &tag,
+                    &crate::nanbox::i64_literal(crate::nanbox::SHORT_STRING_TAG),
+                );
+                let above = ctx.block().icmp_ugt(
+                    I64,
+                    &tag,
+                    &crate::nanbox::i64_literal(crate::nanbox::STRING_TAG),
+                );
+                let is_number = ctx.block().or(I1, &below, &above);
+                let flag_slot = ctx.func.alloca_entry(I1);
+                ctx.block().store(I1, &is_number, &flag_slot);
+                // `fptosi(n)` is valid only on the fast (is-number) path.
+                let bound_i32 = ctx.block().fptosi(DOUBLE, &n_dbl, I32);
+                let bound_i32_slot = ctx.func.alloca_entry(I32);
+                ctx.block().store(I32, &bound_i32, &bound_i32_slot);
+                Some(DynamicI32Bound {
+                    counter_id,
+                    op,
+                    flag_slot,
+                    bound_i32_slot,
+                    counter_i32_was_fresh,
+                })
+            })
+    } else {
+        None
+    };
     let local_bound_index_bounds_are_safe =
         local_bound_classification.is_some_and(|(counter_id, _, op)| {
             matches!(op, perry_hir::CompareOp::Lt)
@@ -509,6 +592,44 @@ pub(crate) fn lower_for(
         } else {
             false
         }
+    } else if let Some(ref dyn_bound) = dynamic_i32_bound {
+        // Issue #168 follow-up: `i < n` / `i <= n` where `n` is an `any`/untyped
+        // local. Branch on the one-time `is-number` flag hoisted above: the
+        // fast loop uses `icmp slt i32`; the slow loop keeps full JS comparison
+        // semantics. The branch is loop-invariant, so LLVM's LoopUnswitch peels
+        // it into two loops at -O2+; even unswitched, the hot (is-number) path
+        // executes pure integer compares with no per-iteration `sitofp` / call.
+        if let Some(ctr_i32_slot) = ctx.i32_counter_slots.get(&dyn_bound.counter_id).cloned() {
+            let fast_idx = ctx.new_block("for.cond.fast");
+            let slow_idx = ctx.new_block("for.cond.slow");
+            let fast_label = ctx.block_label(fast_idx);
+            let slow_label = ctx.block_label(slow_idx);
+            let flag = ctx.block().load(I1, &dyn_bound.flag_slot);
+            ctx.block().cond_br(&flag, &fast_label, &slow_label);
+
+            // Fast path: integer induction variable + `icmp`.
+            ctx.current_block = fast_idx;
+            let ctr = ctx.block().load(I32, &ctr_i32_slot);
+            let bound = ctx.block().load(I32, &dyn_bound.bound_i32_slot);
+            let cmp = match dyn_bound.op {
+                perry_hir::CompareOp::Le => ctx.block().icmp_sle(I32, &ctr, &bound),
+                _ => ctx.block().icmp_slt(I32, &ctr, &bound),
+            };
+            ctx.block().cond_br(&cmp, &body_label, &exit_label);
+
+            // Slow path: generic per-iteration comparison (full coercion).
+            ctx.current_block = slow_idx;
+            if let Some(cond_expr) = condition {
+                let cv = lower_expr(ctx, cond_expr)?;
+                let i1 = lower_truthy(ctx, &cv, cond_expr);
+                ctx.block().cond_br(&i1, &body_label, &exit_label);
+            } else {
+                ctx.block().br(&body_label);
+            }
+            true
+        } else {
+            false
+        }
     } else {
         false
     };
@@ -596,6 +717,12 @@ pub(crate) fn lower_for(
         }
     }
     let _ = i32_local_bound_slot;
+    // Same cleanup for the runtime-guarded `any`-bound path.
+    if let Some(dyn_bound) = dynamic_i32_bound {
+        if dyn_bound.counter_i32_was_fresh {
+            ctx.i32_counter_slots.remove(&dyn_bound.counter_id);
+        }
+    }
     ctx.bounded_index_pairs
         .retain(|fact| fact.scope_id != loop_proof_scope_id);
     ctx.bounded_buffer_index_pairs
@@ -721,6 +848,68 @@ pub(crate) fn classify_for_local_bound(
                 Some(perry_types::Type::Number | perry_types::Type::Int32)
             ));
     if !bound_is_integer_safe {
+        return None;
+    }
+    Some((counter_id, bound_id, op))
+}
+
+/// Like [`classify_for_local_bound`], but for the case the static classifier
+/// deliberately rejects: an `i < n` / `i <= n` loop whose bound `n` is an
+/// accessible (unboxed, non-module-global) local whose *static* type is **not**
+/// `number`/`int32` — most commonly an `any`-typed value or an un-annotated
+/// parameter (e.g. a count pulled out of `JSON.parse`).
+///
+/// We can't `fptosi` such a bound unconditionally: at runtime it may hold a
+/// non-number, and JS `<` would coerce it (`ToNumber`/`ToPrimitive`).  So this
+/// only reports the shape; the caller emits a **one-time** `is-number` guard at
+/// the loop head and runs the `icmp slt i32` fast loop when it holds, falling
+/// back to the generic per-iteration `js_rel_*` comparison otherwise.  This
+/// removes the per-iteration `sitofp` + runtime `callq` from the hot path for
+/// the extremely common untyped-count loop (issue #168 follow-up).
+///
+/// When the bound *is* a primitive number at runtime, hoisting `fptosi(n)` once
+/// is subject to the same documented trust-types trade-off as the static path
+/// (a non-integer float bound shifts the trip count by at most one).
+pub(crate) fn classify_for_local_bound_dynamic(
+    cond: &perry_hir::Expr,
+    ctx: &crate::expr::FnCtx<'_>,
+) -> Option<(u32, u32, perry_hir::CompareOp)> {
+    use perry_hir::{CompareOp, Expr};
+    let (op, left, right) = match cond {
+        Expr::Compare { op, left, right } => (*op, left.as_ref(), right.as_ref()),
+        _ => return None,
+    };
+    if !matches!(op, CompareOp::Lt | CompareOp::Le) {
+        return None;
+    }
+    let counter_id = match left {
+        Expr::LocalGet(id) => *id,
+        _ => return None,
+    };
+    let bound_id = match right {
+        Expr::LocalGet(id) => *id,
+        _ => return None,
+    };
+    if !ctx.integer_locals.contains(&counter_id) {
+        return None;
+    }
+    // Bound must be a directly-accessible slot — same load-path constraints as
+    // the static classifier (skip module globals and boxed/closure-captured
+    // variables, which load differently).
+    if !ctx.locals.contains_key(&bound_id)
+        || ctx.boxed_vars.contains(&bound_id)
+        || ctx.module_globals.contains_key(&bound_id)
+    {
+        return None;
+    }
+    // Defer to the static classifier for integer- and `number`-typed bounds;
+    // this path only handles the residual non-`number` (e.g. `any`) case.
+    if ctx.integer_locals.contains(&bound_id)
+        || matches!(
+            ctx.local_types.get(&bound_id),
+            Some(perry_types::Type::Number | perry_types::Type::Int32)
+        )
+    {
         return None;
     }
     Some((counter_id, bound_id, op))


### PR DESCRIPTION
## Problem

A tight `for (let i = 0; i < n; i++)` integer loop whose bound `n` is **not statically typed `number`** — most commonly an `any`-typed or un-annotated value (e.g. a count from `JSON.parse`/untyped request data) — lowered its `i < n` / `i <= n` guard to a **generic per-iteration comparison**:

```llvm
for.cond:
  %i  = load i32, ptr %ctr
  %id = sitofp i32 %i to double          ; vcvtsi2sd — every iteration
  %nd = load double, ptr %n              ; n kept as a NaN-boxed f64 on the stack
  %r  = call double @js_rel_lt(%id, %nd) ; callq — every iteration
  %b  = icmp eq i64 bitcast(%r), <TAG_TRUE>
  br i1 %b, label %body, label %exit
```

On the hot path of a compute kernel this is ~50× slower than an integer induction variable + `icmp`, and the call blocks SCEV / the loop vectorizer.

## Why it looked arch-specific (it isn't)

The reporter observed this only on x86_64-linux, with arm64 "optimizing it correctly." But the **emitted LLVM IR is byte-identical across both targets** — only the `target triple` header line differs. `js_rel_lt` is a `#[no_mangle] extern "C"` runtime function in a separate compilation unit:

- **macOS** uses the default **auto-optimize** build, which rebuilds + inlines the runtime so LLVM folds `js_rel_lt` into the loop and the call vanishes → *looks* optimized.
- **`--target linux` / Lambda** links a **prebuilt `libperry_runtime.a`** with no cross-module inlining → the per-iteration `callq` survives → the ~50× hit.

The suboptimal IR was present on *both* arches; arm64 just masked it at link time. (A complementary follow-up — marking `js_rel_*` inlinable / enabling cross-module inlining on the prebuilt-archive path — would help every un-specialized hot comparison on Lambda, not just loop guards.)

## Fix

A **runtime-guarded i32 specialization** extending the existing `i < arr.length` and `i < n` (number-typed) peepholes to `any`/untyped bounds:

- New `classify_for_local_bound_dynamic` matches `i < n` / `i <= n` where `n` is an accessible (unboxed, non-module-global) local whose static type is **not** `number`/`int32`.
- The loop head hoists, **once**, an `is-number` check (NaN-box tag test mirroring `JSValue::is_number`) plus `fptosi(n)`.
- The cond block branches on that loop-invariant flag:
  - `for.cond.fast` → `icmp slt i32` (no per-iteration `sitofp`, no call)
  - `for.cond.slow` → the generic `js_rel_lt` path, preserving full JS coercion semantics for non-number values.
- LLVM's LoopUnswitch peels the invariant branch into two loops at -O2+; even unswitched, the hot (is-number) path runs pure integer compares.
- Added the `SHORT_STRING_TAG` ABI-mirror constant to codegen's `nanbox.rs`.

When the bound *is* a primitive number, hoisting `fptosi(n)` once carries the same documented trust-types trade-off as the static `number`-typed path (a non-integer float bound shifts the trip count by at most one).

## Verification

- The `any`-bound guard now lowers to `for.cond.fast: icmp slt i32` with **no per-iteration `sitofp`/`call`**; the entry block computes the `is-number` flag + `fptosi(n)` once.
- Runtime correctness: numeric `any` bound → fast path, correct sum (`499999500000`); `"3"` string bound → slow path, coerces to `3`; `<=` bound → `15`.
- Tests: `perry-codegen` 16/16; `perry-hir` + `perry` lib 522/0 plus integration suites green. The residual `perry-runtime` date/url failures and the `issue_4909` HTTP-timeout test are pre-existing load/timezone flakes — unchanged with this patch stashed, and pass in isolation.

Touches only `crates/perry-codegen` (`stmt/loops.rs`, `nanbox.rs`); +version bump/changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loop performance when loop bounds come from dynamic/untyped values, reducing per-iteration overhead and speeding execution.

* **Documentation**
  * Added changelog entry for v0.5.1164 describing the performance improvement and verification status.

* **Chores**
  * Version bumped to v0.5.1164.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->