### PR TITLE
fix(perry-ffi): unbreak `cargo test -p perry-ffi` (undefined js_register_ffi_handle_exists_probe)

### DIFF
--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -105,11 +105,37 @@ extern "C" {
         scanner_id: usize,
         scanner: PerryFfiNamedMutableRootScanner,
     );
-    /// perry-runtime hook: register a probe the runtime's generic method
-    /// dispatcher consults to tell a `register_handle` id apart from a Node
-    /// timer id (both occupy the pointer-tagged small-integer band). Resolved
-    /// at final link (perry-runtime is always linked into the binary).
+}
+
+// perry-runtime hook: register a probe the runtime's generic method dispatcher
+// consults to tell a `register_handle` id apart from a Node timer id (both
+// occupy the pointer-tagged small-integer band). Defined in perry-runtime and
+// resolved at the final link of any real Perry binary.
+//
+// The declaration is gated OUT of perry-ffi's own unit-test binary when
+// `runtime-link` is off, where a no-op stub stands in instead (see below) —
+// otherwise the always-present `extern` item and the stub would clash (E0428).
+#[cfg(not(all(test, not(feature = "runtime-link"))))]
+extern "C" {
     fn js_register_ffi_handle_exists_probe(probe: extern "C" fn(handle: i64) -> bool);
+}
+
+// perry-ffi's own unit-test binary does not link perry-runtime: `runtime-link`
+// is off by default and CI runs `cargo test -p perry-ffi` per-package in
+// isolation (no `--workspace` feature unification, see `.github/workflows/
+// test.yml`). The handle-registry tests below exercise `register_handle`,
+// which calls `js_register_ffi_handle_exists_probe` to wire up the runtime's
+// handle-vs-timer disambiguation probe (#5083). Give that test binary a no-op
+// definition so it links and the registry tests keep running. Gated on
+// `not(feature = "runtime-link")` so it never collides with perry-runtime's
+// real definition — which is present whenever runtime-link is on, or at a
+// wrapper's final link against libperry_runtime.a, neither of which is a
+// perry-ffi `test` build.
+#[cfg(all(test, not(feature = "runtime-link")))]
+#[no_mangle]
+unsafe extern "C" fn js_register_ffi_handle_exists_probe(
+    _probe: extern "C" fn(handle: i64) -> bool,
+) {
 }
 
 /// Probe handed to perry-runtime: is `handle` a live entry in this registry?


### PR DESCRIPTION
## Problem

The `cargo-test` CI gate is **red on `main`** (e.g. #5083's own run, and every PR branched off it — including #5086). The failure is a link error, not a test failure — every `test result` line shows `0 failed`, then the job dies at `cc`:

```
perry_ffi ... undefined reference to `js_register_ffi_handle_exists_probe'
collect2: error: ld returned 1 exit status
error: could not compile `perry-ffi` (lib test) due to 1 previous error
```

## Root cause

#5083 added a `js_register_ffi_handle_exists_probe(...)` call inside `register_handle` (`crates/perry-ffi/src/handle.rs`) to wire up the runtime's handle-vs-timer disambiguation probe. That symbol is defined in **`perry-runtime`**, which `perry-ffi` only pulls in behind its **`runtime-link`** feature (off by default).

`perry-ffi`'s handle-registry tests live in a **bare `#[cfg(test)]`** module (unlike every other `perry-ffi` test module, which gates on `#[cfg(all(test, feature = "runtime-link"))]`). They call `register_handle`, so once #5083 made `register_handle` reference the runtime symbol, the default test binary retained an undefined reference. It only surfaces in isolation because CI runs `cargo test -p $package` **per-package in a loop** (see `.github/workflows/test.yml`) — there's no `cargo test --workspace`, so feature unification from the `perry-ext-*` dev-deps never pulls `runtime-link` in.

## Fix

Gating the handle tests on `runtime-link` like the other modules would drop them from CI **entirely** (the per-package loop never enables the feature). Instead, add a **test-only no-op stub** for the symbol, gated `#[cfg(all(test, not(feature = "runtime-link")))]`, so the registry tests keep running and the binary links. The real `extern` declaration is gated out of that exact configuration to avoid an `E0428` name clash.

The stub can never collide with `perry-runtime`'s real definition — it exists only in `perry-ffi`'s own `test` binary with `runtime-link` off:
- `runtime-link` **on** → stub excluded, real `perry-runtime` symbol used.
- non-`test` lib builds (npm wrappers) → stub excluded; final binary links `libperry_runtime.a`.

## Verification

- `cargo test -p perry-ffi` (default, the failing config) → **links + passes, 13 tests**.
- `cargo test -p perry-ffi --features runtime-link` → uses the real perry-runtime symbol, **passes, 35 tests**, no `E0428`, no duplicate-symbol.

Touches only `crates/perry-ffi/src/handle.rs` (+ version/changelog).

---

This unblocks the `cargo-test` gate for the whole repo. Recommended to merge **before** #5086 (the loop-guard perf PR), which currently inherits this same red `cargo-test`; after this lands I'll rebase #5086 and its CI will go green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Resolved test infrastructure conflicts by updating conditional declarations, allowing unit tests to run successfully in specific build configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->