### PR TITLE
fix(http2): emit server 'session' event promptly (before client 'connect')

### DIFF
--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -476,55 +476,6 @@ fn local_client_connect_ready(session_handle: i64) -> bool {
     has_active_server_session(server_handle)
 }
 
-thread_local! {
-    /// Client sessions whose `connect` event has already been emitted, so the
-    /// server-side `session` emit can stop deferring behind them.
-    static H2_CLIENT_CONNECT_EMITTED: std::cell::RefCell<std::collections::HashSet<i64>> =
-        std::cell::RefCell::new(std::collections::HashSet::new());
-}
-
-fn mark_client_connect_emitted(session_handle: i64) {
-    H2_CLIENT_CONNECT_EMITTED.with(|s| {
-        s.borrow_mut().insert(session_handle);
-    });
-}
-
-/// Whether the server-side `session` event may be emitted now. Node emits it
-/// AFTER the same-process client's `connect` event, so defer while any local
-/// client targeting this server is connected but has not yet fired `connect`.
-/// (A remote client — none in-process — never blocks, so real connections emit
-/// immediately.)
-fn local_server_session_ready(server_handle: i64) -> bool {
-    let mut ready = true;
-    iter_handle_ids_of::<Http2SessionHandle, _>(|client_id| {
-        if !ready {
-            return;
-        }
-        let Some(client) = get_handle::<Http2SessionHandle>(client_id) else {
-            return;
-        };
-        if client.session_type != 1 || client.closed || client.destroyed {
-            return;
-        }
-        // Only an in-flight client (still handshaking, or connected and about to
-        // fire `connect`) blocks. A failed client — neither connecting nor
-        // connected — must NOT defer the server `session` forever.
-        if !client.connecting && !client.connected {
-            return;
-        }
-        let targets = client.server_handle == server_handle
-            || h2_listening_server_for_authority(&client.authority) == Some(server_handle);
-        if !targets {
-            return;
-        }
-        let emitted = H2_CLIENT_CONNECT_EMITTED.with(|s| s.borrow().contains(&client_id));
-        if !emitted {
-            ready = false;
-        }
-    });
-    ready
-}
-
 /// `http2.createSecureServer(opts, handler)` — opts carries `{ key, cert }`
 /// PEM strings + the usual handler closure. ALPN advertises both
 /// `h2` and `http/1.1` so non-HTTP/2 clients are still served (matches
@@ -1000,13 +951,14 @@ pub(crate) fn process_pending_h2_events() -> i32 {
         Ok(mut q) => q.drain(..).collect(),
         Err(_) => return 0,
     };
-    // Node fires the client-side `connect` before the server-side `session`
-    // event (the server's `session` emit is deferred relative to the client
-    // handshake completing). Drain `ClientConnect` first so a single-process
-    // loopback observes `connect` then `session`, matching Node's ordering.
+    // Causally, the server creates its session and sends its SETTINGS frame
+    // before a client can complete its connect handshake, so the server-side
+    // `session` event fires BEFORE the client-side `connect` (Node on Linux:
+    // `server>client`). Drain `Session` first so a single-process loopback
+    // observes `session` then `connect`, matching the causal/Linux ordering.
     events.sort_by_key(|event| match event {
-        Http2PendingEvent::ClientConnect { .. } => 0,
-        Http2PendingEvent::Session { .. } => 1,
+        Http2PendingEvent::Session { .. } => 0,
+        Http2PendingEvent::ClientConnect { .. } => 1,
         _ => 2,
     });
     let count = events.len() as i32;
@@ -1016,14 +968,6 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                 server_handle,
                 session_handle,
             } => {
-                // Defer behind a same-process client's `connect` (Node ordering).
-                if !local_server_session_ready(server_handle) {
-                    push_h2_event(Http2PendingEvent::Session {
-                        server_handle,
-                        session_handle,
-                    });
-                    continue;
-                }
                 let listeners = get_handle::<Http2SecureServer>(server_handle)
                     .and_then(|s| s.base.listeners.get("session").cloned())
                     .unwrap_or_default();
@@ -1043,7 +987,6 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                     push_h2_event(Http2PendingEvent::ClientConnect { session_handle });
                     continue;
                 }
-                mark_client_connect_emitted(session_handle);
                 let listeners = get_handle::<Http2SessionHandle>(session_handle)
                     .and_then(|s| s.listeners.get("connect").cloned())
                     .unwrap_or_default();


### PR DESCRIPTION
## Problem

Perry deferred the http2 server `'session'` event until **after** the in-process client's `'connect'` event. This is causally wrong: an http2 server creates its session and sends its SETTINGS frame *before* a client can complete its connect handshake, so the server `'session'` event must fire **before** the client `'connect'`. Node on Linux does exactly this (`server>client`).

macOS node happens to defer it, and a prior Perry change was tuned to that macOS quirk, adding an explicit deferral mechanism that is incorrect for the canonical Linux sweep environment.

## Fix

In `crates/perry-ext-http-server/src/http2_server.rs` `process_pending_h2_events()`:

- Flip the drain order so `Session` events are processed **before** `ClientConnect` (was the reverse).
- Remove the `local_server_session_ready()` gate that re-queued the `Session` event behind the client's `connect`.
- Delete the supporting machinery that existed only for that deferral: the `H2_CLIENT_CONNECT_EMITTED` thread-local, `mark_client_connect_emitted()`, and its call site.

Net: +7 / -64 lines, runtime emit-scheduling only — no new dispatch entries.

## Verification

Target tests (run 3x, deterministic):
- `http2/session/sequential-session-cleanup.ts` → `probe order: server>client` / `probe settings cb: true 65535`
- `http2/session/controls.ts` → `server controls:` and `server settings shape:` now appear early (before `ping return: true`)

> Note: these 2 tests will *diff* against local **macOS** node — that is the macOS-node quirk being corrected, not a regression. Judge by the causally-correct Linux `server>client` order.

No-regression: all other http/http2/https/net tests still match local node (43/44; the 1 fail, `net/server/connection-state-limits.ts`, is **pre-existing** — reproduced identically on pristine origin/main, unrelated `getConnections` timing in the untouched net path).

`cargo test` for perry-runtime/perry-stdlib/perry-codegen green (single-threaded; the parallel-run reds are unrelated global-state flakes — Date prototype / handle counters).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized HTTP/2 event processing logic by streamlining event ordering and removing unnecessary internal bookkeeping, resulting in improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->