### PR TITLE
fix(stream): node:stream classic subclassing (class X extends Writable/Readable/Duplex/Transform)

### DIFF
--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -289,6 +289,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         }
                     }
                     let node_stream_kind = match parent_name.as_str() {
+                        "Readable" => Some("readable"),
                         "Writable" => Some("writable"),
                         "Duplex" => Some("duplex"),
                         "Transform" => Some("transform"),
@@ -336,6 +337,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     }
                     let node_stream_kind = match parent_name.as_str() {
                         "Readable" => Some("readable"),
+                        "Writable" => Some("writable"),
                         "Duplex" => Some("duplex"),
                         "Transform" => Some("transform"),
                         _ => None,

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -215,6 +215,21 @@ pub fn lower_class_decl(
                     "transform_stream".to_string(),
                     "TransformStream".to_string(),
                 )),
+                // #1545: classic node:stream base classes. Recognising them
+                // as native parents (rather than letting the unknown-Ident
+                // arm capture `extends_expr`) avoids the dynamic
+                // parent-registration throw ("Class extends value is not a
+                // constructor") — a node:stream export is a callable but not
+                // a registered class constructor. The `super(opts)` codegen
+                // arm (`lower_node_stream_super_init`) and the runtime
+                // `js_node_stream_*_subclass_init` helpers, which install the
+                // native stream methods directly onto `this`, were already
+                // built; this is the missing HIR wiring. Keep in lockstep
+                // with the parallel arm in `lower_class_from_ast` below.
+                "Readable" => Some(("node_stream".to_string(), "Readable".to_string())),
+                "Writable" => Some(("node_stream".to_string(), "Writable".to_string())),
+                "Duplex" => Some(("node_stream".to_string(), "Duplex".to_string())),
+                "Transform" => Some(("node_stream".to_string(), "Transform".to_string())),
                 _ => None,
             };
             if native_parent.is_some() {
@@ -1215,6 +1230,12 @@ pub fn lower_class_from_ast(
                     "transform_stream".to_string(),
                     "TransformStream".to_string(),
                 )),
+                // #1545: classic node:stream base classes — keep in lockstep
+                // with the parallel arm in `lower_class_decl` above.
+                "Readable" => Some(("node_stream".to_string(), "Readable".to_string())),
+                "Writable" => Some(("node_stream".to_string(), "Writable".to_string())),
+                "Duplex" => Some(("node_stream".to_string(), "Duplex".to_string())),
+                "Transform" => Some(("node_stream".to_string(), "Transform".to_string())),
                 _ => None,
             };
             if native_parent.is_some() {


### PR DESCRIPTION
## Summary

Originally chartered to close the **node-suite `console/` formatting gap** (11 diffs / 119). Investigation found the console *formatter itself has zero bugs* — of the 11 diffs:

- **9** are `time/` tests — byte-identical format, only the measured `X.XXXms` duration varies → **timing-variant** (verified: diff is empty after normalizing the ms value).
- **1** is `output/error-cause.ts` — the only differences are V8 **stack-trace frames** (real file paths + node-internal frames; Perry renders `at <anonymous>`). The surrounding inspect structure (`Error: outer { code: 'E_OUTER', [cause]: TypeError: inner }`) matches byte-for-byte → **environment-variant**.
- **1** is `console-class/stream-errors.ts` — a genuine bug, but **not** a formatter bug: `class Boom extends Writable` threw `TypeError: Class extends value is not a constructor`, so the test couldn't even run.

This PR fixes that last one — the real, deterministic gap.

## Root cause

User classes extending the **classic** `node:stream` base classes (`Writable`/`Readable`/`Duplex`/`Transform`) threw at `new`. The full machinery already existed:

- codegen: `lower_node_stream_super_init` (this_super_call.rs)
- runtime: `js_node_stream_{writable,readable,duplex,transform}_subclass_init`, which install the native stream methods directly onto `this` and pick up the subclass `_write`/`_read` override.

But the HIR `class_decl` lowering never tagged these bare names as native parents (only the *Web Streams* `WritableStream`/`ReadableStream`/`TransformStream` were). So they fell to the unknown-Ident `extends_expr` path, which emits `js_register_class_parent_dynamic` — and that rejects the callable-but-non-constructor node:stream export.

## Fix

Pure wiring of the already-built path:

1. `crates/perry-hir/src/lower_decl/class_decl.rs` — add `Readable`/`Writable`/`Duplex`/`Transform` to **both** `native_parent` match arms (module tag `node_stream`, which is inert in the sole `lookup_class_native_extends` consumer — it gates on the Web Streams tags).
2. `crates/perry-codegen/src/expr/this_super_call.rs` — complete **both** `node_stream_kind` super-call arms (one was missing `Readable`, the other `Writable`) so all four bases reach `lower_node_stream_super_init` regardless of which parent-resolution branch fires.

No new dispatch entry / FFI ⇒ no `API_MANIFEST` row.

## Before / after — `console/console-class/stream-errors.ts`

```
# before (Perry)
TypeError: Class extends value is not a constructor
    at <anonymous>

# after (Perry == node v26, byte-for-byte)
ignore start
stdout error: boom
stderr error: boom
ignore end
invalid stream: TypeError ERR_CONSOLE_WRITABLE_STREAM
```

## Validation

- **console suite:** `stream-errors` now passes. Remaining 10 diffs are all documented environment-variant (9 timing-value, 1 stack-trace) — none are formatter bugs.
- **net improvement to stream suite:** the 6 dedicated `stream/extends-*` + `passthrough-*` + `transform-constructor` subclass tests (which previously threw) now pass.
- **no regression:** all 12 remaining `node-suite/stream` diffs are pre-existing (none subclass a stream base; my change is codegen-isolated to subclassing paths). The 9 `console/time` + `error-cause` diffs are unchanged.
- `cargo test -p perry-hir -p perry-codegen` green. `perry-runtime` has 2 pre-existing `url::node_compat::path_to_file_url_posix_*` failures (CWD-sensitive, in the untouched `url` crate).

Refs #1545.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced support for Node.js stream base classes (`Readable`, `Writable`, `Duplex`, `Transform`) when used in class inheritance, ensuring proper initialization and routing through stream-specific handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->