### PR TITLE
fix(stream): node v26 read() chunk-at-a-time, no spurious EOF readable, pipe dedup

### DIFF
--- a/crates/perry-runtime/src/node_stream_readable_read.rs
+++ b/crates/perry-runtime/src/node_stream_readable_read.rs
@@ -49,7 +49,13 @@ pub(super) fn read_stream_available_default(stream: f64) -> f64 {
         return f64::from_bits(TAG_NULL);
     }
 
-    if !readable_is_flowing(stream) {
+    // Node's `howMuchToRead(NaN)` (internal/streams/readable, v26): WITHOUT a
+    // string decoder, `read()` always returns just the head chunk — one buffer
+    // at a time — even when the stream is paused. Only a *decoded* (setEncoding)
+    // paused stream concatenates the entire buffer into a single string. So we
+    // drain the whole buffer here only when paused AND a decoder is active;
+    // otherwise fall through to the head-only path below.
+    if !readable_is_flowing(stream) && readable_encoding_tag(stream).is_some() {
         return drain_whole_buffer(stream, values);
     }
 
@@ -270,7 +276,11 @@ pub(super) fn read_stream_object_mode_chunk(stream: f64) -> f64 {
     sync_pending_readable_chunks_to_buffer(stream);
     if stream_hidden_ended(stream) && remaining == 0.0 {
         clear_pending_readable_chunks(stream);
-        queue_readable_event(stream);
+        // Node never emits a final `readable` just to hand the consumer a
+        // null at EOF: once `read()` returns the last buffered item from an
+        // ended stream it transitions straight to `end` (endReadable). A
+        // re-queued `readable` here makes a fixed-count consumer observe an
+        // extra `read() === null` pair. (internal/streams/readable, v26)
         schedule_readable_end(stream);
     }
     chunk

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -461,6 +461,13 @@ pub(super) fn pipe_stream_to_destination(stream: f64, dest: f64, end_dest: bool)
     if !end_dest {
         add_pipe_no_end_destination(stream, dest);
     }
+    // A flowing destination (e.g. a piped-into PassThrough/Duplex) must consume
+    // each chunk from its own readable buffer when it emits 'data' live —
+    // otherwise the chunk lingers in the buffer and the destination's drain
+    // microtask re-emits it, duplicating every piped chunk. `pipeline()` already
+    // marks both ends; `pipe()` needs the same on the destination. (matches
+    // mark_live_pipe_consume_on_emit usage in node_stream_pipeline.rs)
+    mark_live_pipe_consume_on_emit(dest);
     install_pipe_destination_listeners(stream, dest);
     let _ = emit_stream_event(dest, string_value(b"pipe"), &[stream]);
     set_readable_flowing(stream, f64::from_bits(TAG_TRUE));

--- a/crates/perry-runtime/src/node_stream_tests_extra.rs
+++ b/crates/perry-runtime/src/node_stream_tests_extra.rs
@@ -467,8 +467,15 @@ fn readable_unshift_prepends_chunk_and_returns_hwm_signal() {
     );
     assert_eq!(js_node_stream_method_readable_length(handle), 11.0);
 
-    let joined = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
-    assert_eq!(stream_test_buffer_bytes(joined), b"hello world");
+    // Node v26 `read()` with no size and no decoder returns the head chunk only
+    // — one buffer at a time — not the whole concatenated buffer. The unshifted
+    // chunk becomes the new head, so the first read yields "hello " and "world"
+    // remains for the next read. (internal/streams/readable, howMuchToRead(NaN))
+    let head = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(stream_test_buffer_bytes(head), b"hello ");
+    assert_eq!(js_node_stream_method_readable_length(handle), 5.0);
+    let tail = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(stream_test_buffer_bytes(tail), b"world");
     assert_eq!(js_node_stream_method_readable_length(handle), 0.0);
 
     let opts = crate::object::js_object_alloc(0, 1);
@@ -493,8 +500,13 @@ fn readable_unshift_after_eof_before_end_prepends_chunk() {
         TAG_TRUE
     );
 
-    let joined = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
-    assert_eq!(stream_test_buffer_bytes(joined), b"hello world");
+    // Chunk-at-a-time (no decoder): `read()` returns the unshifted head
+    // ("hello ") and leaves "world" for the next read, even though EOF was
+    // already signalled via push(null). Matches node v26.
+    let head = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(stream_test_buffer_bytes(head), b"hello ");
+    let tail = js_node_stream_method_read(handle, f64::from_bits(TAG_UNDEFINED));
+    assert_eq!(stream_test_buffer_bytes(tail), b"world");
 }
 
 fn stream_test_buffer_bytes(value: f64) -> Vec<u8> {


### PR DESCRIPTION
## Summary

Closes the largest real-gap cluster in `test-parity/node-suite/stream` by matching node v26's `internal/streams/readable` byte-for-byte. Baseline (pristine `origin/main`, node v26.3.0): **758 pass / 10 real fail** (after excluding NODE-FAIL tests where node itself throws). This fixes **6 of the 10** via three distinct root causes; the remaining 4 are a single separate codegen gap (see below).

## Root causes & fixes

**1. `read()` with no size returns the head chunk, not the whole buffer.**
node v26 `howMuchToRead(NaN)` has a fast path: *without* a string decoder it always returns `state.buffer[bufferIndex].length` (one buffer at a time), even when paused. Only a `setEncoding` (decoded) paused stream concatenates the whole buffer into one string. Perry drained the entire buffer whenever paused.
→ fixes `readable/readable-mode-only`, `readable/read-in-readable-listener`, `readable/unshift-after-read`, `readable/iter-yields-buffer-no-encoding`

```
# readable-mode-only, before → after
- drained: aabb
+ drained: aa|bb
```

**2. objectMode `read()` of the last item no longer emits a final `readable`.**
node never emits `readable` just to deliver a `null` at EOF — after the last item of an ended stream it goes straight to `end` (endReadable). The extra emit made a fixed-count consumer observe a spurious `read()===null` pair.
→ fixes `readable/object-mode-read-returns-object`

```
  first: {"a":1}
  second: {"b":2}
- first: null
- second: null
```

**3. `pipe()` destinations now consume-on-emit.**
A flowing destination (piped-into PassThrough/Duplex) must drop each chunk from its own readable buffer when it emits `data` live; otherwise the chunk lingers and the destination's drain microtask re-emits it, duplicating every piped chunk. `pipeline()` already marks both ends via `mark_live_pipe_consume_on_emit`; `pipe()` now marks the destination too.
→ fixes `pipe/repipe-after-unpipe`

```
- joined: after-repipeafter-repipe
+ joined: after-repipe
```

Also updates two `perry-runtime` unit tests (`node_stream_tests_extra.rs`) that asserted the pre-v26 drain-whole behavior; verified against node v26, `read()` after `unshift` returns the unshifted head chunk and leaves the remainder.

## Verification (node v26.3.0, macOS)

- The 6 target tests pass.
- Focused **232-test regression** over the read/pipe/objectMode/flowing/transform/duplex/consumers surface: **226 pass, 6 node-fail, 0 compile-fail, 0 diffs — no new regressions.**
- Cross-module: pipe fan-out (one→two sinks) and chained pipes match node exactly.
- `cargo test -p perry-runtime --lib`: green (the `Date.prototype` global-state test passes in isolation — a pre-existing flake unrelated to this change).

> A full single-machine harness sweep was not feasible during this run because the shared host was at ~6× CPU load from concurrent builds; the full `stream`/`http`/etc. sweep runs in CI.

## Not addressed — separate codegen gap

`subclass/extends-{readable,writable,duplex,transform}` still throw `TypeError: Class extends value is not a constructor`. User-defined `class X extends Readable` requires native-stream subclassing support in codegen (synthesized `super()` initialising native stream state on `this`, routing `push()`/`_read` to the user object) — a much larger, independent change, not a stream-runtime bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream reading behavior for better Node.js v26 compatibility
  * Fixed duplicate chunk re-emission when piping to stream destinations
  * Refined EOF signaling to prevent extra read observations

* **Tests**
  * Updated tests to verify Node v26 stream reading behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->