### PR TITLE
fix(reflect): match Node's Reflect.construct error-message wording (#2768)

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -408,6 +408,26 @@ fn throw_type_error(msg: &str) -> f64 {
     crate::exception::js_throw(boxed)
 }
 
+/// `String(value)` rendering of a JS value, for diagnostic messages that
+/// embed the offending value (e.g. Node's `"1 is not a constructor"` and
+/// the proxy construct-trap `"… non-object ('1')"`). Returns an empty
+/// string on a null/unrenderable value. (#2768)
+pub(crate) fn value_display_string(value: f64) -> String {
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let str_ptr = crate::value::js_jsvalue_to_string(value);
+    if str_ptr.is_null() {
+        return String::new();
+    }
+    let nb = f64::from_bits(crate::value::STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    if let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(nb, &mut scratch) {
+        if !ptr.is_null() && len > 0 {
+            let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+            return String::from_utf8_lossy(bytes).into_owned();
+        }
+    }
+    String::new()
+}
+
 fn reflect_value_is_symbol(value: f64) -> bool {
     let bits = value.to_bits();
     (bits >> 48) == (POINTER_TAG >> 48)
@@ -1721,7 +1741,11 @@ pub extern "C" fn js_proxy_construct(proxy_boxed: f64, args_array: f64, new_targ
     crate::object::js_implicit_this_set(prev);
     // [[Construct]] must return an Object (spec step 9 of the construct trap).
     if !reflect_value_is_object(result) {
-        return throw_type_error("proxy [[Construct]] trap returned a non-object value");
+        // Node/V8 wording: `'construct' on proxy: trap returned non-object ('1')`.
+        return throw_type_error(&format!(
+            "'construct' on proxy: trap returned non-object ('{}')",
+            value_display_string(result)
+        ));
     }
     result
 }

--- a/crates/perry-runtime/src/proxy/reflect_misc.rs
+++ b/crates/perry-runtime/src/proxy/reflect_misc.rs
@@ -31,7 +31,10 @@ pub extern "C" fn js_reflect_construct(target: f64, args_like: f64, new_target: 
         new_target
     };
     if !is_constructor_function(nt) {
-        return throw_type_error(&format!("{} is not a constructor", value_display_string(nt)));
+        return throw_type_error(&format!(
+            "{} is not a constructor",
+            value_display_string(nt)
+        ));
     }
     let args = create_list_from_array_like(args_like);
     if lookup(target).is_some() {

--- a/crates/perry-runtime/src/proxy/reflect_misc.rs
+++ b/crates/perry-runtime/src/proxy/reflect_misc.rs
@@ -19,7 +19,11 @@ pub(super) fn array_from_args(args: &[f64]) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_reflect_construct(target: f64, args_like: f64, new_target: f64) -> f64 {
     if !is_constructor_function(target) {
-        return throw_type_error("target is not a constructor");
+        // Node reports the offending value: `1 is not a constructor`.
+        return throw_type_error(&format!(
+            "{} is not a constructor",
+            value_display_string(target)
+        ));
     }
     let nt = if new_target.to_bits() == TAG_UNDEFINED {
         target
@@ -27,7 +31,7 @@ pub extern "C" fn js_reflect_construct(target: f64, args_like: f64, new_target: 
         new_target
     };
     if !is_constructor_function(nt) {
-        return throw_type_error("newTarget is not a constructor");
+        return throw_type_error(&format!("{} is not a constructor", value_display_string(nt)));
     }
     let args = create_list_from_array_like(args_like);
     if lookup(target).is_some() {


### PR DESCRIPTION
Addresses #2768.

## Status

The substantive `Reflect.construct` semantics called for in this issue are **already implemented on current main** — I verified all of the issue's representative Node cases pass byte-for-byte against Node v26.3.0:

```
a: x
protoMatch: true          # newTarget prototype honored
kind: custom
sum: 5                     # array-like argumentsList (CreateListFromArrayLike)
proxy: {"arg":"p","isNewTarget":true}   # proxy construct trap + newTarget === proxy
badReturn threw TypeError  # proxy trap non-object result
notCtor threw TypeError
nullArgs threw TypeError
numArgs threw TypeError
badNewTarget threw TypeError
```

(`js_reflect_construct` validates target/newTarget as constructors, defaults newTarget, runs `create_list_from_array_like`, dispatches the proxy `construct` trap, and otherwise calls `js_new_function_construct_with_new_target`.)

## What this PR fixes

The only remaining gap was three **diagnostic message strings** not matching Node/V8 verbatim (test262 checks `instanceof TypeError`, not message text, so behavior already passed — this is parity polish):

| case | before | after (Node) |
|------|--------|--------------|
| non-constructor target | `target is not a constructor` | `1 is not a constructor` |
| non-constructor newTarget | `newTarget is not a constructor` | `1 is not a constructor` |
| proxy trap non-object result | `proxy [[Construct]] trap returned a non-object value` | `'construct' on proxy: trap returned non-object ('1')` |

Node reports the offending **value** (`String(value)`), not a fixed label. Adds `proxy::value_display_string` (a `String(value)` renderer) and uses it at all three sites.

## Verification

- Messages now match Node v26.3.0 exactly (see table); behavior unchanged.
- `cargo test -p perry-runtime` reflect/proxy suites pass.
- No tests pinned the old message strings.

No version bump / changelog per maintainer instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Proxy/Reflect `construct`-related `TypeError` diagnostics by including a rendered representation of the offending value in the error message.
  * This makes failures clearer when invalid `target` or computed constructor inputs are provided, replacing less informative generic messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->