### PR TITLE
fix(util): quote top-level strings in util.format %o/%O (Node parity)

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting/util_format.rs
+++ b/crates/perry-runtime/src/builtins/formatting/util_format.rs
@@ -112,6 +112,22 @@ unsafe fn util_format_json_object_has_cycle(ptr: *const u8, stack: &mut Vec<usiz
     found
 }
 
+/// Render a `%o`/`%O` argument the way `util.inspect` does at the top
+/// level: a primitive string is **quoted** (`'hello'`), matching
+/// `js_util_inspect`. `format_jsvalue` alone leaves a top-level string
+/// unquoted (the `console.log(str)` bare-string behavior), so calling it
+/// directly for `%o`/`%O` diverged from Node, which routes the value
+/// through `util.inspect` (strings quoted at every depth).
+fn inspect_format_arg(val: f64) -> String {
+    let jv = crate::value::JSValue::from_bits(val.to_bits());
+    if jv.is_any_string() {
+        let s = jsvalue_string_content(val).unwrap_or_default();
+        format!("'{}'", escape_string(&s))
+    } else {
+        format_jsvalue(val, 0)
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f64 {
     use crate::value::JSValue;
@@ -324,12 +340,12 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
                     let _depth_guard = InspectDepthLimitGuard::new(4);
                     let _hidden_guard = InspectShowHiddenGuard::new(true);
                     let _proxy_guard = InspectShowProxyGuard::new(true);
-                    out.push_str(&format_jsvalue(val, 0));
+                    out.push_str(&inspect_format_arg(val));
                 }
                 b'O' => {
                     // `%O` keeps the default depth cap (2) — matching
                     // Node's `util.inspect` default options.
-                    out.push_str(&format_jsvalue(val, 0));
+                    out.push_str(&inspect_format_arg(val));
                 }
                 b'c' => {
                     // Browser/Node console style marker. Consume the CSS


### PR DESCRIPTION
## Problem

`util.format("%o", "hello")` and `console.log("%o", str)` printed the string **unquoted** (`hello`), but Node renders `%o`/`%O` arguments through `util.inspect`, which quotes strings: `'hello'`.

```
# node v26.3.0           # perry (before)
util.format("%o","hi") → 'hi'        util.format("%o","hi") → hi
util.format("%O","hi") → 'hi'        util.format("%O","hi") → hi
```

## Root cause

The `%o`/`%O` arms called `format_jsvalue(val, 0)`, which mirrors the bare `console.log(str)` behavior of leaving a **top-level** string unquoted. But `%o`/`%O` should inspect the value, and `util.inspect` quotes strings at every depth (nested strings already came out right — `%o` of `{a:"x"}` → `{ a: 'x' }`). `js_util_inspect` already special-cases top-level strings (`format!("'{}'", escape_string(&s))`); the `%o`/`%O` path just didn't.

## Fix

Route the `%o`/`%O` argument through a new `inspect_format_arg` helper that mirrors `js_util_inspect`'s top-level handling: a primitive string becomes `'<escaped>'`, everything else goes through `format_jsvalue`.

## Verification (vs Node v26.3.0)

```
%o "hello" → 'hello'      %O "hello" → 'hello'     %o 42 → 42
%o {a:"x"} → { a: 'x' }   %o null → null           %o true → true
%s "hello" → hello   (unchanged — %s coerces, no quotes)
```

Existing `perry-runtime` formatting + inspect unit tests pass (12). Found via a `util.format`/`util.inspect` differential sweep against Node; relates to the console/util-formatting parity gap noted in `CLAUDE.md` and the parity roadmap (#4315).

**Out of scope:** Node's `%o` also sets `showHidden`, so an array prints `[ 1, 'two', [length]: 2 ]`; matching that internal-slot rendering is a separate showHidden-array feature, left as-is.

No version bump / changelog per maintainer instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for `%o` and `%O` so string arguments are now rendered with quotes and proper escaping, matching `util.inspect`-style output.
  * Non-string values keep the same formatting behavior as before to ensure consistency across all other types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->