### PR TITLE
fix(util): render [Object: null prototype] prefix in util.inspect (Node parity)

### DIFF
--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -1283,7 +1283,8 @@ unsafe fn format_object_as_json(
     // (e.g. `Object.create(null)`), since it has no constructor to name.
     // The flag is set at allocation by `js_object_alloc_null_proto`.
     let is_null_proto = {
-        let gc = (obj_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        let gc =
+            (obj_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0
     };
     // The display prefix before the `{ … }` body: a real class/constructor

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -1279,11 +1279,30 @@ unsafe fn format_object_as_json(
     } else {
         class_name.as_deref()
     };
+    // Node prefixes a null-prototype object with `[Object: null prototype]`
+    // (e.g. `Object.create(null)`), since it has no constructor to name.
+    // The flag is set at allocation by `js_object_alloc_null_proto`.
+    let is_null_proto = {
+        let gc = (obj_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        (*gc)._reserved & crate::gc::OBJ_FLAG_NULL_PROTO != 0
+    };
+    // The display prefix before the `{ … }` body: a real class/constructor
+    // name when present, otherwise `[Object: null prototype]` for a
+    // null-proto plain object, otherwise nothing. (Distinct from
+    // `class_name_ref`/`has_class_name`, which drive the private-field skip
+    // and must reflect only a genuine class.)
+    let name_prefix: Option<String> = match class_name_ref {
+        Some(name) => Some(name.to_string()),
+        None if boxed_base.is_none() && is_null_proto => {
+            Some("[Object: null prototype]".to_string())
+        }
+        None => None,
+    };
     let empty_object = || {
         if let Some(base) = boxed_base.as_deref() {
             return base.to_string();
         }
-        match class_name_ref {
+        match name_prefix.as_deref() {
             Some(name) => format!("{name} {{}}"),
             None => "{}".to_string(),
         }
@@ -1398,7 +1417,7 @@ unsafe fn format_object_as_json(
     if parts.is_empty() {
         return empty_object();
     }
-    let single_line = match (boxed_base.as_deref(), class_name_ref) {
+    let single_line = match (boxed_base.as_deref(), name_prefix.as_deref()) {
         (Some(base), _) => format!("{} {{ {} }}", base, parts.join(", ")),
         (None, Some(name)) => format!("{} {{ {} }}", name, parts.join(", ")),
         (None, None) => format!("{{ {} }}", parts.join(", ")),
@@ -1425,7 +1444,7 @@ unsafe fn format_object_as_json(
         .map(|p| format!("{}{}", indent, p.replace('\n', "\n  ")))
         .collect::<Vec<_>>()
         .join(",\n");
-    match (boxed_base.as_deref(), class_name_ref) {
+    match (boxed_base.as_deref(), name_prefix.as_deref()) {
         (Some(base), _) => format!("{} {{\n{}\n}}", base, body),
         (None, Some(name)) => format!("{} {{\n{}\n}}", name, body),
         (None, None) => format!("{{\n{}\n}}", body),


### PR DESCRIPTION
## Problem

`util.inspect` / `console.log` of a null-prototype object printed it as a bare `{}`, where Node prefixes it with `[Object: null prototype]`:

```
                            # node v26.3.0                  # perry (before)
util.inspect(Object.create(null)) → [Object: null prototype] {}   →  {}
```

These objects are common as option bags / lookup maps, so the missing prefix is a visible parity gap.

## Fix

Detect the existing `OBJ_FLAG_NULL_PROTO` GC-header flag (set by `js_object_alloc_null_proto`) in the object formatter and introduce a `name_prefix` that resolves to:
- the constructor/class name when present,
- else `[Object: null prototype]` for a null-proto plain object,
- else nothing.

`name_prefix` replaces `class_name_ref` **only** at the three render sites (empty / single-line / multi-line). `has_class_name` (which drives the `#private`-field skip) still reflects a genuine class, so behavior for normal and class objects is unchanged.

## Verification (vs Node v26.3.0)

- `Object.create(null)` → `[Object: null prototype] {}` ✓
- All 17 other inspect-probe cases unchanged (classes `Foo { x: 1 }`, `Map(1) { … }`, `Set`, circular `<ref *1>`, `Error`, `Date`, `RegExp`, `[Getter]`, bigint, NaN/Infinity, …).
- `perry-runtime` formatting + inspect unit tests pass (12).

Found via a `util.inspect` differential sweep vs Node; relates to the console/util-formatting parity gap in `CLAUDE.md` and the parity roadmap (#4315). (Known remaining inspect nits, left out of scope: sparse-array holes render as `NaN` not `<1 empty item>`, and Node's quote-style heuristic / `showHidden` array `[length]`.)

No version bump / changelog per maintainer instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for null-prototype plain objects so they consistently display as `[Object: null prototype]` across both compact and expanded output views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->