### PR TITLE
fix(url): String/template/concat of URL & URLSearchParams give href/query (Node parity)

### DIFF
--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -102,6 +102,26 @@ unsafe fn to_primitive_default_for_add(value: f64) -> f64 {
         return crate::value::js_nanbox_string(s as i64);
     }
 
+    // WHATWG `URL` / `URLSearchParams` have native `toString`s (`href` / the
+    // query string) that OrdinaryToPrimitive can't see — it would resolve the
+    // inherited `Object.prototype.toString` and yield "[object Object]". Like
+    // the Date special-case above, pre-empt with the real string so
+    // `"" + url` / `` `${url}` `` match explicit `url.toString()` (#URL coercion).
+    {
+        let boxed =
+            f64::from_bits(crate::value::POINTER_TAG | ((ptr as u64) & crate::value::POINTER_MASK));
+        let href = crate::url::url_class::js_url_href_if_url(boxed);
+        if href.to_bits() != crate::value::TAG_UNDEFINED {
+            let s = js_jsvalue_to_string(href);
+            return crate::value::js_nanbox_string(s as i64);
+        }
+        let obj = ptr as *mut crate::object::ObjectHeader;
+        if crate::url::try_read_as_search_params(obj).is_some() {
+            let s = crate::url::search_params::js_url_search_params_to_string(obj);
+            return crate::value::js_nanbox_string(s as i64);
+        }
+    }
+
     match crate::value::ordinary_to_primitive_number_for_add(value) {
         crate::value::OrdinaryToPrimitiveOutcome::Primitive(p) => p,
         crate::value::OrdinaryToPrimitiveOutcome::DefaultString => {

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -107,10 +107,10 @@ unsafe fn to_primitive_default_for_add(value: f64) -> f64 {
     // inherited `Object.prototype.toString` and yield "[object Object]". Like
     // the Date special-case above, pre-empt with the real string so
     // `"" + url` / `` `${url}` `` match explicit `url.toString()` (#URL coercion).
-    // Skip small-handle values (`< 0x100000` — sockets / timers / widget
-    // handles): they are registry ids, not heap `ObjectHeader`s, so the shape
-    // probe would dereference unmapped memory.
-    if ptr >= 0x100000 {
+    // Skip small-handle values (sockets / timers / widget handles): they are
+    // registry ids, not heap `ObjectHeader`s, so the shape probe would
+    // dereference unmapped memory.
+    if !crate::value::addr_class::is_handle_band(ptr) {
         let boxed =
             f64::from_bits(crate::value::POINTER_TAG | ((ptr as u64) & crate::value::POINTER_MASK));
         let href = crate::url::url_class::js_url_href_if_url(boxed);

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -107,7 +107,10 @@ unsafe fn to_primitive_default_for_add(value: f64) -> f64 {
     // inherited `Object.prototype.toString` and yield "[object Object]". Like
     // the Date special-case above, pre-empt with the real string so
     // `"" + url` / `` `${url}` `` match explicit `url.toString()` (#URL coercion).
-    {
+    // Skip small-handle values (`< 0x100000` — sockets / timers / widget
+    // handles): they are registry ids, not heap `ObjectHeader`s, so the shape
+    // probe would dereference unmapped memory.
+    if ptr >= 0x100000 {
         let boxed =
             f64::from_bits(crate::value::POINTER_TAG | ((ptr as u64) & crate::value::POINTER_MASK));
         let href = crate::url::url_class::js_url_href_if_url(boxed);

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -704,10 +704,10 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
             // pointer (upper-16 == 0), and `js_url_href_if_url`'s
             // `object_from_f64` only recognizes `POINTER_TAG`. `String(url)`
             // already arrives tagged. Skip the probe for small-handle values
-            // (`< 0x100000` — sockets / timers / widget handles): those are
-            // registry ids, not heap `ObjectHeader`s, so the shape check would
-            // dereference unmapped memory.
-            if (ptr as usize) >= 0x100000 {
+            // (sockets / timers / widget handles): those are registry ids, not
+            // heap `ObjectHeader`s, so the shape check would dereference
+            // unmapped memory.
+            if !crate::value::addr_class::is_handle_band(ptr as usize) {
                 let boxed = f64::from_bits(POINTER_TAG | ((ptr as u64) & POINTER_MASK));
                 let url_href = crate::url::url_class::js_url_href_if_url(boxed);
                 if url_href.to_bits() != crate::value::TAG_UNDEFINED {

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -703,18 +703,23 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
             // the `+`/template concat path delivers the operand as a raw
             // pointer (upper-16 == 0), and `js_url_href_if_url`'s
             // `object_from_f64` only recognizes `POINTER_TAG`. `String(url)`
-            // already arrives tagged.
-            let boxed = f64::from_bits(POINTER_TAG | ((ptr as u64) & POINTER_MASK));
-            let url_href = crate::url::url_class::js_url_href_if_url(boxed);
-            if url_href.to_bits() != crate::value::TAG_UNDEFINED {
-                return js_jsvalue_to_string(url_href);
-            }
-            if crate::url::try_read_as_search_params(ptr as *mut crate::object::ObjectHeader)
-                .is_some()
-            {
-                return crate::url::search_params::js_url_search_params_to_string(
-                    ptr as *mut crate::object::ObjectHeader,
-                );
+            // already arrives tagged. Skip the probe for small-handle values
+            // (`< 0x100000` — sockets / timers / widget handles): those are
+            // registry ids, not heap `ObjectHeader`s, so the shape check would
+            // dereference unmapped memory.
+            if (ptr as usize) >= 0x100000 {
+                let boxed = f64::from_bits(POINTER_TAG | ((ptr as u64) & POINTER_MASK));
+                let url_href = crate::url::url_class::js_url_href_if_url(boxed);
+                if url_href.to_bits() != crate::value::TAG_UNDEFINED {
+                    return js_jsvalue_to_string(url_href);
+                }
+                if crate::url::try_read_as_search_params(ptr as *mut crate::object::ObjectHeader)
+                    .is_some()
+                {
+                    return crate::url::search_params::js_url_search_params_to_string(
+                        ptr as *mut crate::object::ObjectHeader,
+                    );
+                }
             }
             // OrdinaryToPrimitive(obj, "string"): the object has no
             // `[Symbol.toPrimitive]` (checked above) and is not an

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -691,6 +691,31 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
                     return js_jsvalue_to_string(f64::from_bits(html.bits()));
                 }
             }
+            // WHATWG `URL` / `URLSearchParams` have native `toString`s
+            // (`href` / the query string) that aren't discoverable as object
+            // fields. They must be checked BEFORE OrdinaryToPrimitive, which
+            // would otherwise find the inherited `Object.prototype.toString`
+            // and return "[object Object]" — so `String(url)`, `` `${url}` ``
+            // and `"" + url` diverged from explicit `url.toString()`. Detected
+            // before the GC-header object dispatch like the other native types.
+            //
+            // Normalize the raw heap pointer to a `POINTER_TAG` value first:
+            // the `+`/template concat path delivers the operand as a raw
+            // pointer (upper-16 == 0), and `js_url_href_if_url`'s
+            // `object_from_f64` only recognizes `POINTER_TAG`. `String(url)`
+            // already arrives tagged.
+            let boxed = f64::from_bits(POINTER_TAG | ((ptr as u64) & POINTER_MASK));
+            let url_href = crate::url::url_class::js_url_href_if_url(boxed);
+            if url_href.to_bits() != crate::value::TAG_UNDEFINED {
+                return js_jsvalue_to_string(url_href);
+            }
+            if crate::url::try_read_as_search_params(ptr as *mut crate::object::ObjectHeader)
+                .is_some()
+            {
+                return crate::url::search_params::js_url_search_params_to_string(
+                    ptr as *mut crate::object::ObjectHeader,
+                );
+            }
             // OrdinaryToPrimitive(obj, "string"): the object has no
             // `[Symbol.toPrimitive]` (checked above) and is not an
             // array/buffer/JSX/symbol with its own coercion. Per spec, call


### PR DESCRIPTION
## Problem

ToString **coercion** of a WHATWG `URL` / `URLSearchParams` returned `[object Object]`, diverging from explicit `url.toString()` (which already works):

```
                    # node v26.3.0          # perry (before)
url.toString()    → https://e.com/p?x=1   https://e.com/p?x=1   ✓
String(url)       → https://e.com/p?x=1   [object Object]       ✗
`${url}`          → https://e.com/p?x=1   [object Object]       ✗
"" + url          → https://e.com/p?x=1   [object Object]       ✗
String(usp)       → a=1&b=2               [object Object]       ✗
`${usp}`          → a=1&b=2               [object Object]       ✗
```

`URL`/`URLSearchParams` carry native `toString`s (the href / the query string) that aren't discoverable as object fields, so the generic OrdinaryToPrimitive resolves the inherited `Object.prototype.toString` → `[object Object]`.

## Fix

Two coercion entry points needed a URL/URLSearchParams arm, mirroring the existing `Date` special-cases:

- **`js_jsvalue_to_string`** (backs `String(x)` / explicit coercion): detect URL/USP *before* OrdinaryToPrimitive and return the href / query string. The pointer is normalized to `POINTER_TAG` first since the operand can arrive as a raw heap pointer (upper-16 == 0).
- **`to_primitive_default_for_add`** (backs `+` and template literals via `js_dynamic_string_or_number_add`): same arm before `ordinary_to_primitive_number_for_add`, which would otherwise return the inherited `Object.prototype.toString`'s `[object Object]`.

Reuses existing `js_url_href_if_url` / `try_read_as_search_params` detectors and `js_url_search_params_to_string`.

## Verification (vs Node v26.3.0)

- explicit / `String()` / template / concat of a `URL` → href; of a `URLSearchParams` → query string. ✓
- No regression: custom `toString`/`valueOf`/plain-object/class coercion unchanged (`CUSTOM`/`T`/`C`/`pt`, and `[object Object]` for `valueOf`-only & plain). ✓
- The full URL differential probe (href/origin/host/searchParams/relative resolution/sort/encode/etc.) is byte-identical to Node.
- `perry-runtime` to_string + dynamic + concat unit tests pass. (`builtin_prototype_methods_reject_dynamic_new` passes in isolation; its failure under the parallel `dynamic` filter is pre-existing test-interference, not this change.)

Found via a `node --experimental-strip-types` differential sweep; relates to the parity roadmap (#4315). No version bump / changelog per maintainer instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coercion behavior so `String(url)` now stringifies `URL` objects to their `href` value.
  * Improved coercion behavior so `URLSearchParams` objects now stringify to their serialized query-string form.
  * Enhanced numeric/arithmetic conversions for `URL`/`URLSearchParams` to better match native `URL`/`URLSearchParams` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->