### PR TITLE
fix(hir): run static field initializers + static blocks for in-function classes

### DIFF
--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -302,6 +302,47 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         }));
                     }
                 }
+                // Static field initializers + static blocks for a
+                // function-nested class. The module-level path
+                // (`lower/stmt.rs`) emits these into `module.init`; here they
+                // belong in the function body so they run when the class
+                // declaration is evaluated. Without this, an in-function
+                // class's `static x = …` fields and `static { … }` blocks
+                // silently stayed at their zero default — only top-level
+                // classes initialized. Mirrors the top-level emission order
+                // (fields then blocks, per ClassDefinitionEvaluation), with
+                // lexical `this` in field initializers bound to the class ref.
+                for sf in &class.static_fields {
+                    if let Some(init) = &sf.init {
+                        let mut init_value = init.clone();
+                        crate::analysis::substitute_lexical_this_in_expr(
+                            &mut init_value,
+                            &Expr::ClassRef(class.name.clone()),
+                        );
+                        if let Some(key) = sf.key_expr.as_ref() {
+                            result.push(Stmt::Expr(Expr::ClassStaticSymbolSet {
+                                class_name: class.name.clone(),
+                                key: Box::new(key.clone()),
+                                value: Box::new(init_value),
+                            }));
+                        } else {
+                            result.push(Stmt::Expr(Expr::StaticFieldSet {
+                                class_name: class.name.clone(),
+                                field_name: sf.name.clone(),
+                                value: Box::new(init_value),
+                            }));
+                        }
+                    }
+                }
+                for sm in &class.static_methods {
+                    if sm.name.starts_with("__perry_static_init_") {
+                        result.push(Stmt::Expr(Expr::StaticMethodCall {
+                            class_name: class.name.clone(),
+                            method_name: sm.name.clone(),
+                            args: Vec::new(),
+                        }));
+                    }
+                }
                 ctx.pending_classes.push(class);
             } else {
                 // Duplicate same-named class: still evaluate its computed

--- a/test-files/test_class_static_in_function.ts
+++ b/test-files/test_class_static_in_function.ts
@@ -1,0 +1,42 @@
+// Static field initializers and static blocks must run for a class
+// declared INSIDE a function body, not only for top-level classes.
+// Regression test: previously the in-function lowering path emitted the
+// class but not its static-field-init / static-block-call statements, so
+// `D.a`/`D.b`/`D.c` silently stayed at their zero default.
+
+function build(): string {
+  class D {
+    static a = 7;
+    static b = 3 * 4;
+    static c: number;
+    static {
+      D.c = D.a + D.b;
+    }
+  }
+  return `${D.a},${D.b},${D.c}`;
+}
+
+// Same shape inside an arrow IIFE.
+const arrow = (() => {
+  class E {
+    static v = 0;
+    static {
+      E.v = 99;
+    }
+  }
+  return E.v;
+})();
+
+// Top-level class (already worked) — guards against regressing it.
+class T {
+  static a = 7;
+  static b = 3 * 4;
+  static c: number;
+  static {
+    T.c = T.a + T.b;
+  }
+}
+
+console.log("in-func:", build()); // 7,12,19
+console.log("arrow:", arrow); // 99
+console.log("top-level:", `${T.a},${T.b},${T.c}`); // 7,12,19


### PR DESCRIPTION
## Problem

A class declared **inside a function body** lost all static initialization — `static x = …` fields and `static { … }` blocks silently stayed at their zero default. Only top-level classes initialized.

```ts
function build() {
  class D { static a = 7; static b = 3*4; static c: number; static { D.c = D.a + D.b; } }
  return `${D.a},${D.b},${D.c}`;
}
build();   // node: "7,12,19"   perry (before): "0,0,0"
```

(Reproduces for both `function` bodies and arrow IIFEs.)

## Root cause

The in-function class-decl lowering path (`lower_decl/body_stmt.rs`) emitted the class plus its parent / computed-member / capture registrations, but — unlike the module-level path in `lower/stmt.rs` — never emitted the static-field-init (`StaticFieldSet` / `ClassStaticSymbolSet`) or static-block-call (`StaticMethodCall __perry_static_init_N`) statements. So the synthetic static-init methods were never invoked and field initializers never ran.

## Fix

Mirror the top-level emission in `body_stmt.rs`: after the class is set up, push the static-field initializers (with lexical `this` in the initializer bound to the class ref) then the static-block calls into the function body, in source order per ClassDefinitionEvaluation.

## Verification (vs Node v26.3.0)

- in-function class: `7,12,19` (was `0,0,0`); arrow-IIFE static block: `99` (was `0`); top-level unchanged (`7,12,19`).
- New `test-files/test_class_static_in_function.ts` matches Node byte-for-byte.
- `cargo test -p perry-hir` passes; existing class test-files (`test_class_static_iife`, `test_class_static_symbol`, `test_edge_class_advanced`, `test_gap_*_static_helpers`) all compile + run clean.

Found via a `node --experimental-strip-types` differential sweep. No version bump / changelog per maintainer instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed classes declared inside functions so their static field initializers and `static` blocks run correctly during declaration evaluation, including computed and symbol-keyed fields.
* **Tests**
  * Added a regression test covering in-function class declarations (including inside an arrow IIFE) to verify static initialization behavior end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->