### PR TITLE
feat(apple): CFBundleDisplayName from [project]/[platform] display_name

### DIFF
--- a/crates/perry/src/commands/compile/bundle_apple.rs
+++ b/crates/perry/src/commands/compile/bundle_apple.rs
@@ -78,6 +78,46 @@ pub(super) fn read_apple_app_version(input: &Path) -> (String, String) {
     read.unwrap_or_else(|| ("1.0.0".to_string(), "1".to_string()))
 }
 
+/// Read the human-facing app display name from `perry.toml`, used for the
+/// `CFBundleDisplayName` Info.plist key — the name shown under the icon on the
+/// Home Screen. Prefers the platform's own `[<platform>].display_name` (e.g.
+/// `[ios]`, `[tvos]`), falling back to `[project].display_name`. Returns `None`
+/// when neither is set, in which case the bundler omits CFBundleDisplayName and
+/// the Home Screen falls back to CFBundleName — i.e. the sanitized executable
+/// stem, e.g. `bloom-jump` instead of the intended `Bloom Jump`.
+pub(super) fn read_app_display_name(input: &Path, platform: &str) -> Option<String> {
+    let mut dir = input.canonicalize().ok()?;
+    for _ in 0..5 {
+        dir = dir.parent()?.to_path_buf();
+        let toml_path = dir.join("perry.toml");
+        if !toml_path.exists() {
+            continue;
+        }
+        let doc: toml::Table = fs::read_to_string(&toml_path).ok()?.parse().ok()?;
+        let from_table = |name: &str| {
+            doc.get(name)
+                .and_then(|v| v.as_table())
+                .and_then(|t| t.get("display_name"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        };
+        // First perry.toml on the walk is the project manifest; stop here
+        // whether or not it carries the key (mirrors read_apple_app_version).
+        return from_table(platform).or_else(|| from_table("project"));
+    }
+    None
+}
+
+/// Minimal XML escape for text interpolated into an Info.plist `<string>`.
+/// Display names are user-controlled (perry.toml), so an `&` or `<` would
+/// otherwise produce a malformed plist that the bundle tooling rejects.
+pub(super) fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 /// Read the SDK marketing version (e.g. `26.2`) from the cross sysroot's
 /// `SDKSettings.json` so the plist DT* version matches the SDK that actually
 /// links the binary (its Mach-O `LC_BUILD_VERSION` sdk field). Returns `None`
@@ -313,6 +353,18 @@ pub(super) fn bundle_for_tvos(
     };
     let dt_block = apple_dt_plist_block(dt_platform_name, dt_sysroot_env, dt_default_sysroot);
 
+    // CFBundleDisplayName — name shown under the icon on the tvOS Home Screen.
+    // Prefers [tvos]/[project] display_name; without it tvOS falls back to
+    // CFBundleName (the executable stem, e.g. "bloom-jump").
+    let display_name_block = read_app_display_name(input, "tvos")
+        .map(|name| {
+            format!(
+                "    <key>CFBundleDisplayName</key>\n    <string>{}</string>\n",
+                xml_escape(&name)
+            )
+        })
+        .unwrap_or_default();
+
     let info_plist = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -324,7 +376,7 @@ pub(super) fn bundle_for_tvos(
     <string>{bundle_id}</string>
     <key>CFBundleName</key>
     <string>{exe_stem}</string>
-    <key>CFBundleVersion</key>
+{display_name_block}    <key>CFBundleVersion</key>
     <string>{app_build_number}</string>
     <key>CFBundleShortVersionString</key>
     <string>{app_version}</string>

--- a/crates/perry/src/commands/compile/bundle_ios.rs
+++ b/crates/perry/src/commands/compile/bundle_ios.rs
@@ -129,6 +129,19 @@ pub(super) fn build_ios_app_bundle(
     // (#4849: same logic the watchOS/tvOS/visionOS bundlers use).
     let (app_version, app_build_number) = super::bundle_apple::read_apple_app_version(input);
 
+    // CFBundleDisplayName — the name shown under the icon on the Home Screen.
+    // Without it iOS falls back to CFBundleName (the executable stem), so a
+    // project named `bloom-jump` shows up as "bloom-jump". When perry.toml sets
+    // [ios]/[project] display_name, emit it so the Home Screen reads "Bloom Jump".
+    let display_name_block = super::bundle_apple::read_app_display_name(input, "ios")
+        .map(|name| {
+            format!(
+                "<key>CFBundleDisplayName</key>\n<string>{}</string>\n",
+                super::bundle_apple::xml_escape(&name)
+            )
+        })
+        .unwrap_or_default();
+
     let encryption_exempt_plist = (|| -> Option<String> {
         let mut dir = input.canonicalize().ok()?;
         for _ in 0..5 {
@@ -224,7 +237,7 @@ pub(super) fn build_ios_app_bundle(
 <string>{bundle_id}</string>
 <key>CFBundleName</key>
 <string>{exe_stem}</string>
-<key>CFBundleVersion</key>
+{display_name_block}<key>CFBundleVersion</key>
 <string>{app_build_number}</string>
 <key>CFBundleShortVersionString</key>
 <string>{app_version}</string>

--- a/crates/perry/src/commands/publish/config_types.rs
+++ b/crates/perry/src/commands/publish/config_types.rs
@@ -41,6 +41,9 @@ pub(super) struct GoogleAuthConfig {
 #[derive(Debug, Deserialize)]
 pub(super) struct ProjectConfig {
     pub(super) name: Option<String>,
+    /// Home Screen / Finder display name (CFBundleDisplayName). Platform tables
+    /// ([ios]/[macos]/[tvos]) may override per-platform; falls back here.
+    pub(super) display_name: Option<String>,
     pub(super) version: Option<String>,
     pub(super) build_number: Option<u64>,
     pub(super) bundle_id: Option<String>,
@@ -73,6 +76,7 @@ pub(super) struct IconsConfig {
 #[derive(Debug, Deserialize)]
 pub(super) struct MacosConfig {
     pub(super) bundle_id: Option<String>,
+    pub(super) display_name: Option<String>,
     pub(super) category: Option<String>,
     pub(super) minimum_os: Option<String>,
     pub(super) entitlements: Option<Vec<String>>,
@@ -99,6 +103,7 @@ pub(super) struct MacosConfig {
 #[derive(Debug, Deserialize)]
 pub(super) struct IosConfig {
     pub(super) bundle_id: Option<String>,
+    pub(super) display_name: Option<String>,
     pub(super) deployment_target: Option<String>,
     /// Alias for deployment_target (perry.toml uses minimum_version)
     pub(super) minimum_version: Option<String>,
@@ -184,6 +189,7 @@ pub(super) struct WatchosConfig {
 #[derive(Debug, Deserialize)]
 pub(super) struct TvosConfig {
     pub(super) bundle_id: Option<String>,
+    pub(super) display_name: Option<String>,
     pub(super) entry: Option<String>,
     pub(super) deployment_target: Option<String>,
     pub(super) encryption_exempt: Option<bool>,

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -1199,8 +1199,24 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
         } else {
             (version.clone(), None)
         };
+    // Home Screen display name (CFBundleDisplayName): prefer the target's own
+    // [platform].display_name, else [project].display_name. None → the build
+    // service omits the key and the icon label falls back to the app name.
+    let platform_display_name = if is_ios {
+        config.ios.as_ref().and_then(|c| c.display_name.clone())
+    } else if is_macos {
+        config.macos.as_ref().and_then(|c| c.display_name.clone())
+    } else if is_tvos {
+        config.tvos.as_ref().and_then(|c| c.display_name.clone())
+    } else {
+        None
+    };
+    let display_name = platform_display_name
+        .or_else(|| config.project.as_ref().and_then(|p| p.display_name.clone()));
+
     let manifest = BuildManifest {
         app_name: app_name.clone(),
+        display_name,
         bundle_id,
         version: manifest_version,
         short_version: manifest_short_version,

--- a/crates/perry/src/commands/publish/server_api.rs
+++ b/crates/perry/src/commands/publish/server_api.rs
@@ -82,6 +82,9 @@ pub(super) enum ServerMessage {
 #[derive(Debug, Serialize)]
 pub(super) struct BuildManifest {
     pub(super) app_name: String,
+    /// Home Screen display name (CFBundleDisplayName). `None` → the build
+    /// service omits the key and the icon label falls back to CFBundleName.
+    pub(super) display_name: Option<String>,
     pub(super) bundle_id: String,
     pub(super) version: String,
     pub(super) short_version: Option<String>,


### PR DESCRIPTION
## What
Apple bundlers emit only `CFBundleName` (= the executable stem), so a project named `bloom-jump` shows **bloom-jump** under its Home Screen icon instead of a human-readable name. `CFBundleDisplayName` overrides that label when present.

## Change
- **config_types**: optional `display_name` on `[project]`, `[ios]`, `[macos]`, `[tvos]`.
- **publish** (`server_api.rs`, `mod.rs`): forward `display_name` into the build manifest, preferring the target platform's table then `[project]`. The macOS build service (builder-macos) emits the plist key from this field (companion PR PerryTS/builder-macos#5).
- **compile/bundle**: for locally-built `.app`s, emit `CFBundleDisplayName` in the iOS (`bundle_ios.rs`) and tvOS (`bundle_apple::bundle_for_tvos`) Info.plist via a shared `read_app_display_name` + `xml_escape` helper. tvOS isn't packaged by builder-macos, so this is also the tvOS publish path.

Omitted when unset → existing `CFBundleName` fallback unchanged.

## Notes
- Branched off `main` (not the unrelated `feat/size-optimize-npm` WIP); contains only these 5 files.
- `cargo check -p perry` green on `main`.
- Consumer: Bloom Jump sets `[project] display_name = "Bloom Jump"` (Bloom-Engine/jump#2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apps can now display custom names on iOS, macOS, and tvOS devices. Configure platform-specific display names in `perry.toml` that control how your app appears on user home screens and the App Store, with fallback to project-level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->