### PR TITLE
test(gc): raise gc_write_barrier_stress timeout 120s→300s to de-flake CI

### DIFF
--- a/crates/perry/tests/gc_write_barrier_stress.rs
+++ b/crates/perry/tests/gc_write_barrier_stress.rs
@@ -36,7 +36,16 @@ const SIGTERM: i32 = 15;
 #[cfg(unix)]
 const SIGKILL: i32 = 9;
 
-const COMPILED_BINARY_TIMEOUT: Duration = Duration::from_secs(120);
+// These stress binaries run under the slowest GC configuration —
+// `PERRY_GC_FORCE_EVACUATE=1` copies every marked object on every cycle and
+// `PERRY_GC_VERIFY_EVACUATION=1` adds a full-heap pointer-verification scan
+// after each one. The churn workload takes ~1.5s normally but ~20s under
+// that config on a fast host, which scales to ~60-130s on the slower, shared,
+// heavily-parallel CI runners — right at the old 120s budget, so the job
+// flaked (timeout panic) whenever the runner was loaded. The test asserts
+// *correctness* (`BARRIER_STRESS_OK`), not speed, so give it generous
+// wall-clock headroom rather than trimming the stress coverage.
+const COMPILED_BINARY_TIMEOUT: Duration = Duration::from_secs(300);
 
 fn perry_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_perry"))


### PR DESCRIPTION
## Problem

The `cargo-test` CI job intermittently fails on `crates/perry/tests/gc_write_barrier_stress.rs` — `tenured_mutation_stress` (and `structured_clone_gc_churn_stress`) panic with `compiled binary timed out after 120s`, **regardless of the PR's changes** (it fails identically across unrelated PRs and passes on lucky/idle runs).

## Root cause — it's a timeout flake, not a correctness failure

`compile_and_run` executes the stress binaries under the **slowest GC configuration**:

```rust
run.env("PERRY_GC_FORCE_EVACUATE", "1")     // copy every marked object, every cycle
   .env("PERRY_GC_VERIFY_EVACUATION", "1"); // full-heap pointer-verification scan per cycle
```

against a heavy churn workload (`churn(5)` + `churn(4)` rounds × 30 000 allocations + explicit `gc()` each). Measured wall-clock:

| config | time |
|--------|------|
| normal | ~1.5s |
| `FORCE_EVACUATE` + `VERIFY_EVACUATION` | ~21s (fast host) |

~21s on a fast local host scales to roughly **60–130s** on the slower, shared, heavily-parallel CI runners — straddling the old **120s** deadline, so the run is killed (timeout panic) whenever the runner is loaded. (Issue #5029 fixed the underlying GC *corruption* and re-enabled these tests in #5043; this is purely the run deadline being too tight for the verify-evacuate config.)

## Fix

Raise `COMPILED_BINARY_TIMEOUT` from 120s to **300s**. The tests assert *correctness* (`BARRIER_STRESS_OK`), not speed, so widening the deadline de-flakes CI without trimming the stress coverage (still force-evacuate + full verify across all churn cycles). 300s is ~14× the measured fast-host time and ~2.5× the worst-case loaded-CI estimate.

Verified locally: both configs still print `BARRIER_STRESS_OK`; the verify-evacuate run completes in ~21s.

This de-flakes the `cargo-test` job for every open PR. No version bump / changelog per maintainer instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted garbage collection stress test timeout parameters to accommodate slower execution environments and allow adequate headroom for test completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->