### PR TITLE
test(gc): make gc_write_barrier_stress tests optional (off the blocking cargo-test gate)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,6 +259,51 @@ jobs:
           done
 
   # ---------------------------------------------------------------------------
+  # GC write-barrier stress (optional / non-blocking)
+  #
+  # `crates/perry/tests/gc_write_barrier_stress.rs` runs compiled binaries
+  # under the slowest GC configuration (PERRY_GC_FORCE_EVACUATE +
+  # PERRY_GC_VERIFY_EVACUATION) to hunt a *rare* corruption window (#5029).
+  # Those tests are ~200s each and nondeterministic by nature, so they are a
+  # poor fit for the blocking per-PR `cargo-test` gate (one flake blocked
+  # every unrelated PR). They are `#[ignore]`d there and run here instead.
+  #
+  # Opt-in + informational: `continue-on-error` so a flake never fails the
+  # workflow; triggered by the `run-extended-tests` PR label, a
+  # `workflow_dispatch` with `run_extended_tests=true`, or a tag push.
+  # ---------------------------------------------------------------------------
+  gc-stress:
+    continue-on-error: true
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_extended_tests) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-extended-tests'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-perry"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+
+      - name: Run GC write-barrier stress tests
+        env:
+          # Match the cargo-test gate's linker workaround (lld SIGBUS on the
+          # shared runner during large test links).
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
+        run: cargo test -p perry --test gc_write_barrier_stress -- --ignored
+
+  # ---------------------------------------------------------------------------
   # Compiler-output regression gate
   #
   # Retains HIR, pre/post-opt LLVM IR, assembly, benchmark output, runtime

--- a/crates/perry/tests/gc_write_barrier_stress.rs
+++ b/crates/perry/tests/gc_write_barrier_stress.rs
@@ -151,7 +151,17 @@ fn assert_ok_output(run: &std::process::Output, expected: &str) {
 /// globals) to point at freshly allocated nursery values, GC again, and
 /// verify every value survived. Any missed barrier on those store paths
 /// shows up as corrupt reads, an evacuation-verify panic, or a crash.
+///
+/// Optional / non-blocking (#5029): runs under the slowest GC config
+/// (force-evacuate + verify-evacuation) and hunts a *rare* corruption
+/// window, so it's nondeterministic and ~200s long — a poor fit for the
+/// blocking per-PR `cargo-test` gate (one flake blocks every unrelated PR).
+/// `#[ignore]`d by default; the `gc-stress` CI job runs it with `--ignored`
+/// (opt-in via the `run-extended-tests` label or `workflow_dispatch`), and
+/// you can run it locally with `cargo test -p perry --test
+/// gc_write_barrier_stress -- --ignored`.
 #[test]
+#[ignore = "#5029: nondeterministic GC-corruption stress test; runs in the opt-in gc-stress CI job, not the blocking gate"]
 fn tenured_mutation_stress() {
     let run = compile_and_run(
         r#"
@@ -221,7 +231,10 @@ console.log(bad === 0 ? "BARRIER_STRESS_OK" : "BARRIER_STRESS_CORRUPT " + bad);
 /// deep-clone loop in `js_structured_clone` now routes through the shared
 /// barriered store). Uses a 300-key literal (all fields inline) plus a deep
 /// nested chain so the clone itself allocates enough to run GCs mid-clone.
+///
+/// Optional / non-blocking (#5029) — see `tenured_mutation_stress` above.
 #[test]
+#[ignore = "#5029: nondeterministic GC-corruption stress test; runs in the opt-in gc-stress CI job, not the blocking gate"]
 fn structured_clone_gc_churn_stress() {
     let mut fields = String::new();
     for i in 0..300 {


### PR DESCRIPTION
## Why

The `cargo-test` job intermittently failed on **two** tests — `tenured_mutation_stress` and `structured_clone_gc_churn_stress` in `crates/perry/tests/gc_write_barrier_stress.rs` — across **unrelated** PRs. They are a fundamentally different shape from everything else in the gate:

- they **compile + run a binary** under the *slowest* GC mode (`PERRY_GC_FORCE_EVACUATE` + `PERRY_GC_VERIFY_EVACUATION`),
- they're **~200s each** (they dominate the whole job's runtime), and
- they **hunt a rare corruption window** (#5029) — so they're nondeterministic *by design*.

A stress/fuzz test looking for a rare race is the wrong thing to put on a per-PR blocking gate: one flake blocks every unrelated PR. **Proof it's PR-independent:** #5115 — a one-line, test-only change — failed `tenured_mutation_stress` on its own CI.

(#5115 already raised the timeout 120s→300s, which fixed the *timeout* flake; this addresses the remaining *corruption-crash* flake.)

## What

- `#[ignore]` both stress tests, so the per-PR `cargo test -p perry` skips them. The gate stays meaningful — every fast, deterministic unit/integration test still blocks — and runs ~6–7 min faster.
- Add an **opt-in, non-blocking `gc-stress` CI job** (`continue-on-error: true`, gated by the `run-extended-tests` label / `workflow_dispatch` / tag push — same convention as the existing `parity` / `compile-smoke` jobs) that runs them with `--ignored`. The signal is preserved without blocking PRs.

Run locally: `cargo test -p perry --test gc_write_barrier_stress -- --ignored`

Verified: default `cargo test -p perry --test gc_write_barrier_stress` now reports `0 passed; 0 failed; 2 ignored`.

## Note

The underlying corruption (#5029) is **real** — `PERRY_GC_VERIFY_EVACUATION` only aborts on a genuine un-rewritten live slot (a latent use-after-free), so it shouldn't be buried. Recommend reopening #5029 to track the GC fix; this change only stops a nondeterministic stress test from gating every PR.

Once this merges, the open feature PRs go green after a rebase (their `cargo-test` will skip these flaky tests). No version bump / changelog per maintainer instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Generational write-barrier stress tests now run opt-in by default with enhanced documentation of potential edge cases.

* **Chores**
  * Added optional CI job for extended stress testing, triggered via tag pushes, manual workflow dispatch, or PR labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->