### PR TITLE
iOS: emit aps-environment entitlement for push notifications (#5074)

### DIFF
--- a/crates/perry/src/commands/compile/apple_info_plist.rs
+++ b/crates/perry/src/commands/compile/apple_info_plist.rs
@@ -254,6 +254,113 @@ pub(super) fn inject_ios_app_group_entitlement(
     Some(())
 }
 
+/// #5074 — write (or augment) `app.entitlements` with the `aps-environment`
+/// entitlement when `[ios] push_notifications = true` is set in perry.toml.
+/// Without this entitlement `[UIApplication registerForRemoteNotifications]`
+/// (`notificationRegisterRemote` in `perry/system`) always fails and no APNs
+/// token is ever produced.
+///
+/// The value defaults to `development` (matching the dev-signed bundles
+/// `perry compile --target ios` produces); an explicit
+/// `[ios] push_environment = "production"` overrides it for distribution
+/// builds. Any value other than `production` (including a typo) resolves to
+/// `development`, the safe default for on-device debugging.
+///
+/// Idempotent with `inject_ios_deeplinks` / `inject_ios_app_group_entitlement`:
+/// if an entitlements file already exists we splice our `<key>...</key>` before
+/// the closing `</dict>` (and leave any hand-written `aps-environment` alone);
+/// otherwise we emit the full plist wrapper. Either way the user's signing
+/// pipeline picks up a single `app.entitlements` at codesign time, and the
+/// dev-resign path (`build_dev_entitlements_xml`) layers its development keys
+/// on top without dropping this one.
+pub(super) fn inject_ios_push_entitlement(
+    input: &std::path::Path,
+    app_dir: &std::path::Path,
+    format: OutputFormat,
+) -> Option<()> {
+    let (enabled, environment) = read_ios_push_config(input)?;
+    if !enabled {
+        return None;
+    }
+
+    let entitlements_path = app_dir.join("app.entitlements");
+    let key_block = format!(
+        "    <key>aps-environment</key>\n    <string>{}</string>\n",
+        environment
+    );
+
+    let new_contents = match fs::read_to_string(&entitlements_path) {
+        Ok(existing) => {
+            // Already declared (hand-written or a previous run)? leave it alone.
+            if existing.contains("aps-environment") {
+                return Some(());
+            }
+            existing.replace(
+                "</dict>\n</plist>",
+                &format!("{}</dict>\n</plist>", key_block),
+            )
+        }
+        Err(_) => format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n{}</dict>\n</plist>\n",
+            key_block
+        ),
+    };
+
+    fs::write(&entitlements_path, new_contents).ok()?;
+
+    if let OutputFormat::Text = format {
+        println!(
+            "  Push notifications: aps-environment={} → {} (#5074)",
+            environment,
+            entitlements_path.display()
+        );
+        println!(
+            "  Sign with: codesign --entitlements {} ...",
+            entitlements_path.display()
+        );
+    }
+    Some(())
+}
+
+/// Resolve `[ios] push_notifications` (bool) and `[ios] push_environment`
+/// (string) from the nearest `perry.toml` walking up from `input`. Returns
+/// `(enabled, environment)` where `environment` is normalized to
+/// `"development"` unless explicitly set to `"production"`. `None` on any
+/// missing-file / parse failure (caller skips injection — matches the
+/// config-helper convention in this file).
+fn read_ios_push_config(input: &std::path::Path) -> Option<(bool, String)> {
+    let mut dir = input.canonicalize().ok()?;
+    let mut data: Option<String> = None;
+    for _ in 0..5 {
+        dir = dir.parent()?.to_path_buf();
+        let toml_path = dir.join("perry.toml");
+        if toml_path.exists() {
+            data = fs::read_to_string(&toml_path).ok();
+            break;
+        }
+    }
+    let doc: toml::Table = data?.parse().ok()?;
+    Some(parse_ios_push_config(&doc))
+}
+
+/// Pure resolver shared by `read_ios_push_config` and the unit tests.
+/// `[ios] push_notifications` opts in; `[ios] push_environment` selects the
+/// APNs environment (`production`, else `development`).
+fn parse_ios_push_config(doc: &toml::Table) -> (bool, String) {
+    let ios = doc.get("ios").and_then(|v| v.as_table());
+    let enabled = ios
+        .and_then(|t| t.get("push_notifications"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let environment = ios
+        .and_then(|t| t.get("push_environment"))
+        .and_then(|v| v.as_str())
+        .filter(|s| *s == "production")
+        .unwrap_or("development")
+        .to_string();
+    (enabled, environment)
+}
+
 /// Cheap CFBundleIdentifier extraction from an in-memory Info.plist string.
 /// We need it for the CFBundleURLName field (Apple's convention is
 /// `<bundle-id>.<scheme>`). Falls back to `perry.deeplink` when the
@@ -265,4 +372,142 @@ fn lookup_bundle_id_from_info_plist(info_plist: &str) -> Option<String> {
     let start = rest.find("<string>")? + "<string>".len();
     let end = rest[start..].find("</string>")?;
     Some(rest[start..start + end].trim().to_string())
+}
+
+#[cfg(test)]
+mod push_entitlement_tests {
+    use super::{inject_ios_push_entitlement, parse_ios_push_config};
+    use crate::OutputFormat;
+
+    fn parse(src: &str) -> toml::Table {
+        src.parse::<toml::Table>().unwrap()
+    }
+
+    #[test]
+    fn push_config_defaults_to_development_when_opted_in() {
+        // #5074 — `push_notifications = true` opts in; environment defaults to
+        // `development` (the dev-signed bundles `perry compile --target ios`
+        // produces).
+        let (enabled, env) = parse_ios_push_config(&parse("[ios]\npush_notifications = true\n"));
+        assert!(enabled);
+        assert_eq!(env, "development");
+    }
+
+    #[test]
+    fn push_config_honors_production_environment() {
+        let (enabled, env) = parse_ios_push_config(&parse(
+            "[ios]\npush_notifications = true\npush_environment = \"production\"\n",
+        ));
+        assert!(enabled);
+        assert_eq!(env, "production");
+    }
+
+    #[test]
+    fn push_config_clamps_unknown_environment_to_development() {
+        let (enabled, env) = parse_ios_push_config(&parse(
+            "[ios]\npush_notifications = true\npush_environment = \"sandbox\"\n",
+        ));
+        assert!(enabled);
+        assert_eq!(env, "development");
+    }
+
+    #[test]
+    fn push_config_off_when_absent_or_false() {
+        assert!(!parse_ios_push_config(&parse("[ios]\nbundle_id = \"a\"\n")).0);
+        assert!(!parse_ios_push_config(&parse("[ios]\npush_notifications = false\n")).0);
+        assert!(!parse_ios_push_config(&parse("")).0);
+    }
+
+    #[test]
+    fn injects_full_plist_when_no_entitlements_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("src").join("main.ts");
+        std::fs::create_dir_all(input.parent().unwrap()).unwrap();
+        std::fs::write(&input, "console.log('x')").unwrap();
+        std::fs::write(
+            dir.path().join("perry.toml"),
+            "[ios]\npush_notifications = true\n",
+        )
+        .unwrap();
+        let app_dir = dir.path().join("out.app");
+        std::fs::create_dir_all(&app_dir).unwrap();
+
+        assert!(inject_ios_push_entitlement(&input, &app_dir, OutputFormat::Json).is_some());
+
+        let ent = std::fs::read_to_string(app_dir.join("app.entitlements")).unwrap();
+        assert!(ent.starts_with("<?xml"));
+        assert!(ent.contains("<key>aps-environment</key>"));
+        assert!(ent.contains("<string>development</string>"));
+        assert_eq!(ent.matches("</dict>").count(), 1);
+        assert_eq!(ent.matches("</plist>").count(), 1);
+    }
+
+    #[test]
+    fn splices_into_existing_app_group_entitlements_without_clobbering() {
+        // Idempotent with #1178: an existing app.entitlements (e.g. App Group)
+        // gets the aps-environment key spliced in, both keys survive, and the
+        // wrapper stays single.
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("main.ts");
+        std::fs::write(&input, "console.log('x')").unwrap();
+        std::fs::write(
+            dir.path().join("perry.toml"),
+            "[ios]\npush_notifications = true\npush_environment = \"production\"\n",
+        )
+        .unwrap();
+        let app_dir = dir.path().join("out.app");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(
+            app_dir.join("app.entitlements"),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<plist version=\"1.0\">\n<dict>\n    \
+             <key>com.apple.security.application-groups</key>\n    <array>\n        \
+             <string>group.com.example.shared</string>\n    </array>\n</dict>\n</plist>\n",
+        )
+        .unwrap();
+
+        assert!(inject_ios_push_entitlement(&input, &app_dir, OutputFormat::Json).is_some());
+
+        let ent = std::fs::read_to_string(app_dir.join("app.entitlements")).unwrap();
+        assert!(ent.contains("com.apple.security.application-groups"));
+        assert!(ent.contains("group.com.example.shared"));
+        assert!(ent.contains("<key>aps-environment</key>"));
+        assert!(ent.contains("<string>production</string>"));
+        assert_eq!(ent.matches("</dict>").count(), 1);
+        assert_eq!(ent.matches("</plist>").count(), 1);
+    }
+
+    #[test]
+    fn idempotent_when_aps_environment_already_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("main.ts");
+        std::fs::write(&input, "console.log('x')").unwrap();
+        std::fs::write(
+            dir.path().join("perry.toml"),
+            "[ios]\npush_notifications = true\n",
+        )
+        .unwrap();
+        let app_dir = dir.path().join("out.app");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        let hand_written = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<plist version=\"1.0\">\n<dict>\n    <key>aps-environment</key>\n    <string>production</string>\n</dict>\n</plist>\n";
+        std::fs::write(app_dir.join("app.entitlements"), hand_written).unwrap();
+
+        assert!(inject_ios_push_entitlement(&input, &app_dir, OutputFormat::Json).is_some());
+
+        // Hand-written value preserved (not downgraded to development).
+        let ent = std::fs::read_to_string(app_dir.join("app.entitlements")).unwrap();
+        assert_eq!(ent, hand_written);
+    }
+
+    #[test]
+    fn skips_when_not_opted_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("main.ts");
+        std::fs::write(&input, "console.log('x')").unwrap();
+        std::fs::write(dir.path().join("perry.toml"), "[ios]\nbundle_id = \"a\"\n").unwrap();
+        let app_dir = dir.path().join("out.app");
+        std::fs::create_dir_all(&app_dir).unwrap();
+
+        assert!(inject_ios_push_entitlement(&input, &app_dir, OutputFormat::Json).is_none());
+        assert!(!app_dir.join("app.entitlements").exists());
+    }
 }

--- a/crates/perry/src/commands/compile/bundle_ios.rs
+++ b/crates/perry/src/commands/compile/bundle_ios.rs
@@ -18,6 +18,7 @@ use crate::OutputFormat;
 
 use super::apple_info_plist::{
     inject_google_auth_info_plist, inject_ios_app_group_entitlement, inject_ios_deeplinks,
+    inject_ios_push_entitlement,
 };
 use super::resources::stage_native_library_artifacts;
 use super::targets::compile_metallib_for_bundle;
@@ -445,6 +446,12 @@ pub(super) fn build_ios_app_bundle(
     // existing entitlements (associated-domains, hand-written
     // entries) intact.
     inject_ios_app_group_entitlement(&app_dir, ctx.app_metadata.app_group.as_deref(), format);
+
+    // #5074 — emit the `aps-environment` entitlement when
+    // `[ios] push_notifications = true` is set in perry.toml. Without it
+    // `registerForRemoteNotifications` always fails and no APNs token is
+    // produced. Idempotent with the deeplinks / app-group passes above.
+    inject_ios_push_entitlement(&input, &app_dir, format);
 
     // #1138 — `[google_auth]` block in perry.toml feeds the
     // GoogleSignIn SDK via Info.plist keys the Swift bridge in

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -44,7 +44,8 @@ pub use remote::{
 pub use resign::{
     create_dev_profile_via_api, embed_profile_and_sign, find_dev_identity_for_team,
     find_identity_for_team, find_system_dev_profile, generate_asc_jwt, read_bundle_id_from_app,
-    read_ios_app_group_from_toml, resign_for_development, try_sign_existing_dev_profile,
+    read_ios_app_group_from_toml, read_ios_push_notifications_from_toml, resign_for_development,
+    try_sign_existing_dev_profile,
 };
 
 #[derive(Args, Debug)]

--- a/crates/perry/src/commands/run/resign.rs
+++ b/crates/perry/src/commands/run/resign.rs
@@ -54,12 +54,14 @@ pub async fn resign_for_development(
             println!("  Creating development provisioning profile via App Store Connect...");
         }
         let app_group = read_ios_app_group_from_toml();
+        let push = read_ios_push_notifications_from_toml().unwrap_or(false);
         create_dev_profile_via_api(
             config,
             &bundle_id,
             &team_id,
             device_udid,
             app_group.as_deref(),
+            push,
             format,
         )
         .await
@@ -320,6 +322,7 @@ pub async fn create_dev_profile_via_api(
     _team_id: &str,
     device_udid: &str,
     app_group: Option<&str>,
+    push_notifications: bool,
     format: OutputFormat,
 ) -> Result<Vec<u8>> {
     let apple = config.apple.as_ref().ok_or_else(|| {
@@ -470,6 +473,41 @@ pub async fn create_dev_profile_via_api(
             );
             println!("    Then re-run so the profile picks up the binding.");
             println!();
+        }
+    }
+
+    // 2c. Best-effort Push Notifications capability enablement (#5074).
+    //
+    // Unlike App Groups, PUSH_NOTIFICATIONS has no identifier to register — the
+    // capability toggle on the App ID is all that's needed for the minted
+    // profile to validate the `aps-environment` entitlement that
+    // `inject_ios_push_entitlement` writes at compile time. An already-enabled
+    // capability comes back as a 409 conflict; treat that as success and never
+    // fail profile creation over the toggle.
+    if push_notifications {
+        if let OutputFormat::Text = format {
+            print!("    Enabling Push Notifications capability...");
+            std::io::Write::flush(&mut std::io::stdout()).ok();
+        }
+        let resp = client
+            .post(format!("{base}/bundleIdCapabilities"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "data": {
+                    "type": "bundleIdCapabilities",
+                    "attributes": { "capabilityType": "PUSH_NOTIFICATIONS" },
+                    "relationships": {
+                        "bundleId": {
+                            "data": { "type": "bundleIds", "id": bundle_id_resource_id }
+                        }
+                    }
+                }
+            }))
+            .send()
+            .await;
+        let enabled = matches!(&resp, Ok(r) if r.status().is_success());
+        if let OutputFormat::Text = format {
+            println!(" {}", if enabled { "done" } else { "already enabled" });
         }
     }
 
@@ -667,6 +705,28 @@ fn parse_ios_app_group(content: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Read `[ios] push_notifications` from `./perry.toml` (#5074). Best-effort —
+/// any missing file / key / parse error yields `false`, since the capability
+/// toggle never gates provisioning. The matching `aps-environment` entitlement
+/// is written separately by `inject_ios_push_entitlement` at compile time.
+pub fn read_ios_push_notifications_from_toml() -> Option<bool> {
+    let path = std::env::current_dir().ok()?.join("perry.toml");
+    let content = std::fs::read_to_string(path).ok()?;
+    Some(parse_ios_push_notifications(&content))
+}
+
+fn parse_ios_push_notifications(content: &str) -> bool {
+    toml::from_str::<toml::Value>(content)
+        .ok()
+        .and_then(|parsed| {
+            parsed
+                .get("ios")
+                .and_then(|i| i.get("push_notifications"))
+                .and_then(|v| v.as_bool())
+        })
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -747,5 +807,48 @@ mod tests {
         assert_eq!(parse_ios_app_group("[ios]\nbundle_id = \"a\"\n"), None);
         assert_eq!(parse_ios_app_group("[ios]\napp_group = \"\"\n"), None);
         assert_eq!(parse_ios_app_group("not = valid = toml"), None);
+    }
+
+    /// #5074: re-signing must not drop the `aps-environment` entitlement that
+    /// `perry compile --target ios` writes to `app.entitlements` — otherwise
+    /// `registerForRemoteNotifications` fails on the dev-signed bundle.
+    #[test]
+    fn dev_entitlements_preserve_compile_emitted_push() {
+        let dir = std::env::temp_dir().join(format!("perry_resign_push_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("app.entitlements"),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <plist version=\"1.0\">\n<dict>\n    \
+             <key>aps-environment</key>\n    <string>development</string>\n</dict>\n</plist>\n",
+        )
+        .unwrap();
+
+        let xml = build_dev_entitlements_xml(&dir, "ABCDE12345", "com.example.app");
+
+        // Push entitlement survives, development keys are layered in.
+        assert!(xml.contains("<key>aps-environment</key>"));
+        assert!(xml.contains("<string>development</string>"));
+        assert!(xml.contains("<key>application-identifier</key>"));
+        assert!(xml.contains("ABCDE12345.com.example.app"));
+        assert_eq!(xml.matches("</dict>").count(), 1);
+        assert_eq!(xml.matches("</plist>").count(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #5074: `[ios] push_notifications` drives the best-effort
+    /// PUSH_NOTIFICATIONS capability toggle during dev provisioning.
+    #[test]
+    fn parse_ios_push_notifications_opt_in() {
+        assert!(parse_ios_push_notifications(
+            "[ios]\npush_notifications = true\n"
+        ));
+        assert!(!parse_ios_push_notifications(
+            "[ios]\npush_notifications = false\n"
+        ));
+        assert!(!parse_ios_push_notifications("[ios]\nbundle_id = \"a\"\n"));
+        assert!(!parse_ios_push_notifications("not = valid = toml"));
     }
 }

--- a/crates/perry/src/commands/setup/ios.rs
+++ b/crates/perry/src/commands/setup/ios.rs
@@ -893,6 +893,7 @@ pub fn ios_development_setup(saved: &PerryConfig) -> Result<()> {
     // A declared `[ios] app_group` is enabled (best-effort) on the bundle ID and
     // the remaining manual portal step is surfaced inside the API call (#1301).
     let app_group = crate::commands::run::read_ios_app_group_from_toml();
+    let push = crate::commands::run::read_ios_push_notifications_from_toml().unwrap_or(false);
     let rt = tokio::runtime::Runtime::new()?;
     let profile_data = rt.block_on(crate::commands::run::create_dev_profile_via_api(
         saved,
@@ -900,6 +901,7 @@ pub fn ios_development_setup(saved: &PerryConfig) -> Result<()> {
         &team_id,
         &udid,
         app_group.as_deref(),
+        push,
         crate::OutputFormat::Text,
     ))?;
 

--- a/docs/src/system/notifications.md
+++ b/docs/src/system/notifications.md
@@ -47,6 +47,25 @@ Firebase Messaging on Android — wired via JNI through
 No-op on platforms without a push pipeline (tvOS, visionOS, watchOS, GTK4,
 Windows, Web).
 
+### Enabling APNs on iOS
+
+`registerForRemoteNotifications` only succeeds when the signed `.app` carries
+the `aps-environment` entitlement. Opt in from `perry.toml`
+([#5074](https://github.com/PerryTS/perry/issues/5074)):
+
+```toml
+[ios]
+push_notifications = true          # emit the aps-environment entitlement
+# push_environment = "production"  # default "development"; set for distribution
+```
+
+With this set, `perry compile --target ios` writes `aps-environment` into the
+bundle's `app.entitlements` (defaulting to `development`, which matches
+dev-signed builds), and `perry setup ios` / `perry run --target ios` enable the
+Push Notifications capability on the App ID when minting the development
+provisioning profile. For App Store / Ad Hoc distribution set
+`push_environment = "production"`.
+
 ## Platform Implementation
 
 | Platform | Backend |


### PR DESCRIPTION
Fixes #5074.

## Problem

`registerForRemoteNotifications` (`notificationRegisterRemote` in `perry/system`) always failed on Perry-built iOS apps. The runtime side was already complete — the registration call plus the `didRegister…DeviceToken` delegate wiring in `perry-ui-ios` — but the signed `.app` never carried the `aps-environment` entitlement, so iOS responded with `didFailToRegisterForRemoteNotificationsWithError` and no APNs device token was ever produced. There was no `perry.toml` key to request it.

## Fix

New opt-in switch in `perry.toml`:

```toml
[ios]
push_notifications = true          # emit the aps-environment entitlement
# push_environment = "production"  # default "development"; set for distribution
```

- **Compile** — `inject_ios_push_entitlement` (`apple_info_plist.rs`) writes `aps-environment` into the bundle's `app.entitlements` during `perry compile --target ios`. Defaults to `development` (matching the dev-signed bundles compile produces); `push_environment = "production"` overrides it for App Store / Ad Hoc distribution, and any other value clamps back to `development`. Idempotent with the deeplinks (#583) and App Group (#1178) entitlement passes — splices the key into an existing `app.entitlements` rather than clobbering it, and leaves a hand-written `aps-environment` alone.
- **Dev resign** — `build_dev_entitlements_xml` already layers the development signing keys on top of the compile-emitted `app.entitlements`, so the push entitlement survives `perry run --target ios` re-signing (new regression test).
- **Provisioning** — `create_dev_profile_via_api` now enables the `PUSH_NOTIFICATIONS` capability on the App ID (best-effort, mirroring the App Groups toggle) when `[ios] push_notifications = true`. Wired through both `perry setup ios` and `perry run --target ios`.

## Docs / tests

- `docs/src/system/notifications.md` gains an "Enabling APNs on iOS" section.
- 8 new unit tests across `apple_info_plist.rs` and `resign.rs`; full `perry` suite green (543 passed), release build succeeds.

> Note: no version bump / CHANGELOG entry in this branch — left for the maintainer to fold in at merge time.

https://claude.ai/code/session_017TRpeWZrkdbBwpmGQb7eXE

---
_Generated by [Claude Code](https://claude.ai/code/session_017TRpeWZrkdbBwpmGQb7eXE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iOS push notifications support: configure `push_notifications = true` in project configuration to enable APNs.
  * Automatic injection of push notification entitlements during app compilation.
  * Automatic App Store Connect capability enablement during development setup.

* **Documentation**
  * Added guide for configuring and enabling iOS push notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->