### PR TITLE
fix(runtime): restore js_node_system_error_value dropped by #5112 (unbreaks ALL auto-opt http/https/http2 compilation)

### DIFF
--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -352,6 +352,51 @@ static KEEP_JS_THROW_ERROR_WITH_CODE: unsafe extern "C" fn(
     i32,
 ) -> ! = js_throw_error_with_code;
 
+/// Build a Node-style system `Error`: `.message` + `.code` (the message→code
+/// side table the `.code` getter reads) plus `.syscall` (string) and `.errno`
+/// (number) own properties. `perry-ext-http` calls this to surface client
+/// transport failures (`ECONNREFUSED`, `ENOTFOUND`, `ECONNRESET`, …) as the
+/// real coded `Error` objects Node hands to `request.on('error')`.
+///
+/// # Safety
+/// `msg_ptr`/`code_ptr`/`syscall_ptr` must each point to their stated number of
+/// valid bytes, or be null with the matching length `0`.
+#[no_mangle]
+pub unsafe extern "C" fn js_node_system_error_value(
+    msg_ptr: *const u8,
+    msg_len: usize,
+    code_ptr: *const u8,
+    code_len: usize,
+    syscall_ptr: *const u8,
+    syscall_len: usize,
+    errno: f64,
+) -> f64 {
+    let err_val = js_error_value_with_code(msg_ptr, msg_len, code_ptr, code_len, 0);
+    let obj = err_val.to_bits() as *mut crate::object::ObjectHeader;
+    if !syscall_ptr.is_null() && syscall_len > 0 {
+        let key = js_string_from_bytes(b"syscall".as_ptr(), 7) as *const StringHeader;
+        let sval_str = js_string_from_bytes(syscall_ptr, syscall_len as u32);
+        let sval = crate::value::js_nanbox_string(sval_str as i64);
+        crate::object::js_object_set_field_by_name(obj, key, sval);
+    }
+    {
+        let key = js_string_from_bytes(b"errno".as_ptr(), 5) as *const StringHeader;
+        crate::object::js_object_set_field_by_name(obj, key, errno);
+    }
+    err_val
+}
+
+#[used]
+static KEEP_JS_NODE_SYSTEM_ERROR_VALUE: unsafe extern "C" fn(
+    *const u8,
+    usize,
+    *const u8,
+    usize,
+    *const u8,
+    usize,
+    f64,
+) -> f64 = js_node_system_error_value;
+
 /// Throw `ERR_PERRY_UNIMPLEMENTED` for a registered-but-stub API. Used
 /// by the stub-elimination epic's strict mode (#4918/#4919): a runtime
 /// stub calls [`crate::stub_diag::perry_runtime_stub`] to warn, then —


### PR DESCRIPTION
## Severity: HIGH — breaks ALL auto-optimize http/https/http2 compilation at HEAD

PR #5112 ("Next.js standalone walls 31-35") refactored \`crates/perry-runtime/src/error.rs\` and **deleted** the \`#[no_mangle] pub unsafe extern \"C\" fn js_node_system_error_value\` (originally added by #5078) along with its \`#[used]\` symbol-retention static. But \`crates/perry-ffi/src/error.rs\` still declares it \`extern\` and calls it from \`system_error_value()\`. So any build that links perry-ffi's \`system_error_value\` (which lives in \`libperry_ext_http.a\`) fails to link:

\`\`\`
"_js_node_system_error_value", referenced from:
    perry_ffi::error::system_error_value ... in libperry_ext_http.a
Error: Linking failed
\`\`\`

Since auto-optimize is the **default**, this breaks compiling **every** http / https / http2 program from a cold cache. It merged green because CI never links that path and warm auto-opt caches masked it locally; a fresh \`--no-cache\` http compile reproduces it immediately.

This does **not** revert #5112 (a large, legitimate Next.js fix) — it only restores the one symbol #5112 dropped.

## Fix

Re-added the deleted function **verbatim** (no #5112 replacement for system-error construction exists) next to the sibling \`#[used]\` keepalive anchors (\`KEEP_JS_ERROR_VALUE_WITH_CODE\` / \`KEEP_JS_THROW_ERROR_WITH_CODE\`), plus its own \`KEEP_JS_NODE_SYSTEM_ERROR_VALUE\` retention static. All helper signatures it calls are unchanged post-#5112:

- \`js_error_value_with_code(msg, len, code, len, kind: i32) -> f64\`
- \`js_string_from_bytes(data, len: u32) -> *mut StringHeader\`
- \`crate::value::js_nanbox_string\`
- \`crate::object::js_object_set_field_by_name\`

The extern contract perry-ffi imports — \`js_node_system_error_value(msg,len,code,len,syscall,len,errno)->f64\` — is restored as a \`#[no_mangle]\` symbol with \`#[used]\` retention.

## Verification

**Regression confirmed on pristine origin/main** (built clean):
\`\`\`
"_js_node_system_error_value", referenced from:
Error: Linking failed
\`\`\`

**Fixed tree — fresh \`--no-cache\` auto-opt http link now succeeds:**
\`\`\`
Wrote executable: /tmp/v
Binary size: 14.6MB
\`\`\`
and the binary runs (status-codes.ts prints expected output).

**http/https/http2 sweep (all \`.ts\`, \`--no-cache\`, diffed vs node v26):**
- COMPILE_FAIL: **0**  ← the link is fixed
- DIFF: 4, all behavioral/timing, none compile failures:
  - \`http/server/aliased-create-server.ts\` (segfaults — pre-existing, independent of this change; only newly observable now that http compiles again; does not touch the transport-error path)
  - \`http2/{plaintext/loopback-streams, session/sequential-session-cleanup, session/controls}.ts\` (known http2 session-timing tests)

**cargo test** \`-p perry-runtime -p perry-ffi -p perry-stdlib\`: 1032 passed; the 3 perry-runtime failures (\`dynamic_props\` GC-scanner isolation flakes + \`builtin_prototype_methods_reject_dynamic_new\`) are **pre-existing** — verified identical on pristine origin/main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced system error handling with more detailed error information, including error codes and system call context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->