### PR TITLE
docs: refresh Node.js compatibility status + document .js compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ perry compile src/main.ts -o myapp
 
 Perry uses [SWC](https://swc.rs/) for TypeScript parsing and [LLVM](https://llvm.org/) for native code generation. The output is a single binary with no runtime dependencies.
 
+### Node.js compatibility
+
+Perry targets close behavioral parity with Node.js. Against Node's own test suite
+(node v26.3.0, 53 `node:*` modules), Perry's native runtime passes **~97%**
+(2792 / 2863 cases), and overall Node/TypeScript compatibility sits around **95%**.
+Real implementations — not stubs — cover `fs`, `http`/`https`/`http2`, `net`/`tls`,
+`dns`/`dgram`, `crypto`, `stream` (+ `stream/web`), `events`, `child_process`,
+`cluster`, `worker_threads`, `zlib`, `process`, `async_hooks` /
+`AsyncLocalStorage`, `Atomics` / `SharedArrayBuffer` (cross-thread), the WHATWG
+web globals (`fetch`, `URL`, streams, `structuredClone`, WebCrypto, …), and ~50
+popular npm packages. The remaining gap is a long tail of edge-case options and a
+few categorical items (lookbehind regex, some `console` formatting). See
+[`docs/runtime-parity-gaps.md`](docs/runtime-parity-gaps.md).
+
+**Perry also compiles `.js` / `.cjs` / `.mjs` / `.jsx` source directly** (parsed as
+JavaScript, lowered through the same native pipeline as TypeScript) — no
+TypeScript annotations required. There are no guarantees for every dynamic JS
+pattern, but plain JavaScript projects compile and run in most cases.
+
 ---
 
 ## Built with Perry
@@ -491,7 +510,7 @@ perry publish macos   # or: ios / android / linux
 | Spread operator in calls and literals | ✅ |
 | RegExp (test, match, replace) | ✅ |
 | BigInt (256-bit) | ✅ |
-| Decorators | ❌ ([not supported](docs/src/language/limitations.md#no-decorators)) |
+| Decorators | ⚠️ Legacy TS decorators + `emitDecoratorMetadata` ([details](docs/src/language/limitations.md#decorators)) |
 
 ### Standard Library
 

--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -2,6 +2,16 @@
 
 This document is a structured gap analysis comparing the public Node.js + Bun runtime API surface (catalogued in `runtime-parity.md`) against the APIs Perry can dispatch at compile time. Coverage sources are: the unimplemented-API gate manifest (`crates/perry-api-manifest/src/entries.rs`, ~590 (module, method) entries), `Expr::*` HIR variants in `crates/perry-hir/src/ir.rs` that lower stdlib APIs directly to dedicated codegen arms (~301 stdlib-shaped variants), and `js_*` FFI exports across `perry-runtime` (~984), `perry-stdlib` (~633), and 35 `perry-ext-*` crates (~553). Output is intended for prioritizing which APIs to implement next.
 
+> **Behavioral status (v0.5.x).** This list counts individual API *surface* gaps,
+> not behavioral pass rate. Measured against Node's own test suite
+> (`scripts/node_suite_run.py` vs `test-parity/node_suite_baseline.json`, node
+> v26.3.0, 53 `node:*` modules), Perry's runtime passes **~97%** (2792 / 2863
+> cases); overall Node.js/TypeScript compatibility is around **95%**. The heavily
+> used modules (`fs`, `http`/`https`/`http2`, `net`/`tls`, `crypto`, `stream`,
+> `events`, `child_process`, `worker_threads`, `process`, `zlib`) are real, not
+> stubs — the gaps below are concentrated in less-common modules and edge-case
+> option surfaces.
+
 ## Summary
 
 | Category | Modules | Gap APIs | Verified-covered |

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -21,7 +21,8 @@ Hello from Perry!
 - **Terminal UI** — Build interactive CLIs with [ink-shape React hooks](tui/overview.md) (`useState`, `useEffect`, `useApp`) on a native cell-grid renderer. No Node, no reconciler — just a single static binary.
 - **7 targets** — macOS, iOS, Android, Windows, Linux, Web, and WebAssembly from the same source code.
 - **Familiar ecosystem** — Use npm packages like `fastify`, `mysql2`, `redis`, `bcrypt`, `lodash`, and more — compiled natively.
-- **Zero config** — Point Perry at a `.ts` file and get a binary. No `tsconfig.json` required.
+- **Node.js compatibility** — ~95% behavioral parity with Node, including real (non-stub) implementations of `fs`, `http`/`https`/`http2`, `net`/`tls`, `crypto`, `stream`, `events`, `child_process`, `worker_threads`, `process`, and the WHATWG web globals. Against Node's own test suite (node v26), Perry passes ~97% of cases.
+- **Zero config** — Point Perry at a `.ts` (or `.js`) file and get a binary. No `tsconfig.json` required.
 
 ## What Perry Compiles
 
@@ -34,6 +35,11 @@ Perry supports a practical subset of TypeScript:
 - Regular expressions, JSON, Promises
 - Module imports/exports
 - Generic type erasure
+
+Perry also compiles **plain JavaScript** — `.js`, `.cjs`, `.mjs`, and `.jsx`
+source files are parsed as JavaScript and lowered through the same native
+pipeline, so no TypeScript annotations are required. Dynamic JS patterns aren't
+all guaranteed, but most JavaScript projects compile and run.
 
 See [Supported Features](language/supported-features.md) for the complete list.
 

--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -86,6 +86,13 @@ const mod = await import("./module");
 Perry has internal CommonJS compatibility paths for some npm package wrappers,
 but user-written modules should use static `import` declarations.
 
+> **JavaScript source compiles too.** Perry accepts `.js`, `.cjs`, `.mjs`, and
+> `.jsx` files as compiler input — they are parsed as JavaScript and lowered
+> through the same native pipeline as TypeScript, so no type annotations are
+> required. The limitations on this page still apply (no `eval`, no general
+> dynamic `require()`, etc.), but plain JavaScript projects compile and run in
+> most cases.
+
 ## Limited Prototype Manipulation
 
 Perry compiles classes to fixed structures. Dynamic prototype modification is not supported:
@@ -137,7 +144,16 @@ needs Perry's supported Proxy surface.
 
 Perry supports real multi-threading via `parallelMap` and `spawn` from `perry/thread`. See [Multi-Threading](../threading/overview.md).
 
-Threads do not share mutable state — closures passed to thread primitives cannot capture mutable variables (enforced at compile time). Values are deep-copied across thread boundaries. There is no `SharedArrayBuffer` or `Atomics`.
+Threads do not share mutable state by default — closures passed to thread
+primitives cannot capture mutable variables (enforced at compile time), and
+values are deep-copied across thread boundaries. The exception is
+`SharedArrayBuffer`: a SAB captured into a `spawn` / `parallelMap` closure now
+**aliases the same physical bytes** across agents, and `Atomics`
+(`add`/`load`/`store`/`compareExchange`/… plus a real blocking
+`wait`/`notify`/`waitAsync`) operate on it for genuine cross-thread coordination.
+Caveat: only the `SharedArrayBuffer` itself shares — a typed-array *view*
+captured directly still deep-copies, so build the view per-agent from the shared
+SAB.
 
 ## npm Package Compatibility
 

--- a/docs/src/language/supported-features.md
+++ b/docs/src/language/supported-features.md
@@ -230,6 +230,34 @@ Caveat: this is Perry's TSX runtime, not React DOM or full React reconciler
 semantics. For `perry/ui`, or for `perry/tui` intrinsics whose JSX rewrite has
 not landed yet, the function-call form remains the canonical native API.
 
+## JavaScript (`.js`) Input
+
+Perry is a TypeScript compiler, but TypeScript is a superset of JavaScript — so
+Perry also compiles plain JavaScript. `.js`, `.cjs`, `.mjs`, and `.jsx` files are
+parsed as JavaScript (decorators, JSX, and import attributes enabled) and lowered
+through the exact same native pipeline as `.ts`. No type annotations are required.
+
+```bash
+perry compile src/main.js -o myapp
+./myapp
+```
+
+There are no guarantees for every dynamic JavaScript pattern (the
+[Limitations](limitations.md) still apply — no `eval`, no general dynamic
+`require()`), but most plain JavaScript projects compile and run.
+
+## Node.js Compatibility
+
+Perry implements a large, real (non-stub) slice of the Node.js standard library —
+`fs`, `http`/`https`/`http2`, `net`/`tls`, `dns`/`dgram`, `crypto`, `stream`
+(+ `stream/web`), `events`, `child_process`, `cluster`, `worker_threads`, `zlib`,
+`process`, `async_hooks` / `AsyncLocalStorage`, `Atomics` / `SharedArrayBuffer`,
+and the WHATWG web globals (`fetch`, `URL`, streams, `structuredClone`,
+WebCrypto, …). Against Node's own test suite (node v26, 53 `node:*` modules)
+Perry passes ~97% of cases, with overall Node/TypeScript compatibility around
+95%. The per-module surface and remaining gaps are tracked in
+`docs/runtime-parity-gaps.md`.
+
 ## Next Steps
 
 - [Type System](type-system.md) — Type inference and checking

--- a/docs/src/threading/overview.md
+++ b/docs/src/threading/overview.md
@@ -125,6 +125,13 @@ This eliminates data races by design. If you need to aggregate results, use the 
 {{#include ../../examples/runtime/thread_snippets.ts:overview-reduce-instead}}
 ```
 
+The one explicit shared-state escape hatch is `SharedArrayBuffer`: a SAB captured
+into a `spawn` / `parallelMap` closure aliases the same physical bytes across
+agents, and the `Atomics` API (including a real blocking `Atomics.wait` /
+`Atomics.notify` / `Atomics.waitAsync`) operates on it for cross-thread
+coordination. Only the `SharedArrayBuffer` itself is shared — build any typed-array
+view over it per-agent rather than capturing the view directly.
+
 ### Independent Thread Arenas
 
 Each worker thread has its own memory arena. Objects created on one thread can never be accessed from another thread. Values cross thread boundaries only through deep-copy serialization, which Perry handles automatically and invisibly.

--- a/docs/typescript-compatibility-tests.md
+++ b/docs/typescript-compatibility-tests.md
@@ -2,6 +2,15 @@
 
 A comprehensive edge-case test suite for the Perry TypeScript compiler, designed to surface bugs and compatibility gaps by comparing Perry's native output against Node.js running the same TypeScript source.
 
+> **⚠️ The status figure below is historical (v0.4.50).** Perry's compatibility
+> has moved far past this snapshot: as of v0.5.x it sits at roughly **95%
+> Node.js/TypeScript parity** and passes **~97%** of Node's own test suite
+> (node v26). Day-to-day parity is now tracked by the gap test suite
+> (`test-files/test_gap_*.ts`, byte-for-byte vs `node --experimental-strip-types`)
+> and the Node module suite (`scripts/node_suite_run.py` against
+> `test-parity/node_suite_baseline.json`). See
+> [`runtime-parity-gaps.md`](runtime-parity-gaps.md) for the maintained gap list.
+
 **Status (v0.4.50):** 7 of 26 tests pass with full parity against Node.js. Several others are within 1–6 output-line diffs of passing.
 
 ---

--- a/docs/typescript-parity-gaps.md
+++ b/docs/typescript-parity-gaps.md
@@ -1,5 +1,17 @@
 # TypeScript/Node.js Parity Gaps
 
+> **⚠️ This document is historical (captured at v0.4.56) and is no longer
+> accurate.** Most items listed below as "Missing" or "Partial" — generators and
+> the full iterator protocol, `Symbol` / well-known symbols, `Proxy`, `Reflect`,
+> async generators, `for await...of`, and more — have since landed. As of
+> v0.5.x Perry sits at roughly **95% Node.js/TypeScript compatibility** and
+> passes **~97%** of Node's own test suite (node v26, 53 `node:*` modules).
+> For the current, maintained gap analysis see
+> [`runtime-parity-gaps.md`](runtime-parity-gaps.md); for the language-feature
+> status see [`src/language/supported-features.md`](src/language/supported-features.md)
+> and [`src/language/limitations.md`](src/language/limitations.md). The rows below
+> are kept only for historical reference.
+
 Everything the Perry compiler is missing for absolute parity with Node.js running TypeScript, as of v0.4.56.
 
 **Current status:** 100% pass rate on 87 parity tests (27 edge-case + 60 existing). The gaps below are features NOT covered by those tests — they either aren't tested or aren't implemented.


### PR DESCRIPTION
## What

Documentation-only refresh after the recent Node.js parity sprint (PRs ~#4900–#5040+). Brings the public docs in line with current behavior and corrects several stale claims.

## Why

The docs hadn't kept pace with the runtime work. Perry now sits at ~95% Node.js/TypeScript compatibility and passes ~97% of Node's own test suite (2792/2863 cases, node v26.3.0, 53 `node:*` modules — `test-parity/node_suite_baseline.json`), and it compiles plain JavaScript (`.js`/`.cjs`/`.mjs`/`.jsx`) source directly. Several docs still described pre-v0.5 limitations (no SharedArrayBuffer/Atomics, decorators unsupported, generators/Symbols/Proxy missing).

## Changes

- **README**: new "Node.js compatibility" section (~97% Node test suite / ~95% overall) + note that Perry compiles `.js`/`.cjs`/`.mjs`/`.jsx` directly; fix the stale `Decorators: ❌ not supported` row → legacy TS decorators + `emitDecoratorMetadata`.
- **docs/src/introduction.md**: add Node.js compatibility bullet + plain-JavaScript compilation note.
- **docs/src/language/supported-features.md**: new "JavaScript (`.js`) Input" and "Node.js Compatibility" sections.
- **docs/src/language/limitations.md**: correct the stale "no SharedArrayBuffer or Atomics" claim (real cross-thread Atomics + SAB landed via #4913); note `.js` compilation.
- **docs/src/threading/overview.md**: document the SharedArrayBuffer/Atomics shared-state escape hatch.
- **docs/runtime-parity-gaps.md**: add a behavioral-status header (the list counts API surface, not pass rate).
- **docs/typescript-parity-gaps.md** (v0.4.56) & **docs/typescript-compatibility-tests.md** (v0.4.50): add prominent "historical/outdated" banners pointing at the maintained source of truth — these predate generators/Symbols/Proxy/etc. landing.

`docs/runtime-parity.md` is intentionally left untouched: it's a deliberately Perry-agnostic Node/Bun API inventory, not a status doc.

## Notes

- Docs-only; no version bump or CHANGELOG entry included (left for the maintainer to fold in per the repo workflow). Happy to add one if preferred.
- The ~95% figure is anchored to the measurable ~97% Node-test-suite pass rate so the claims have a defensible source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Node.js compatibility documentation with ~95% behavioral parity metrics and ~97% test-suite pass rate details.
  * Clarified support for JavaScript file inputs (`.js`, `.cjs`, `.mjs`, `.jsx`) compiled through the same pipeline as TypeScript.
  * Documented `SharedArrayBuffer` and `Atomics` for cross-thread memory sharing and coordination.
  * Updated parity tracking references and limitation clarifications for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->