### PR TITLE
fix(hir): hoist named `export default function` bindings (#5134)

### DIFF
--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -480,6 +480,33 @@ pub fn lower_module_full(
         }
     }
 
+    // #5134: a *named* `export default function foo() {}` also introduces a
+    // hoisted `foo` binding in module scope — usable for self-recursion and
+    // same-module references, exactly like a plain `function foo`. The earlier
+    // loop only handles `Stmt::Decl(Fn)` / `export function`, so without this
+    // the name went unregistered and references to it (e.g. ramda's
+    // `_curryN` calling itself inside its returned closure) lowered to an
+    // unresolved global → `ReferenceError: _curryN is not defined`. The
+    // dedicated lowering in `module_decl.rs` reuses this pre-registered id
+    // (`lower_fn_decl`: `lookup_func(name).unwrap_or_else(fresh_func)`).
+    for item in &ast_module.body {
+        if let ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDefaultDecl(export_default)) =
+            item
+        {
+            if let ast::DefaultDecl::Fn(fn_expr) = &export_default.decl {
+                if let Some(ident) = &fn_expr.ident {
+                    if fn_expr.function.body.is_some() {
+                        let func_name = ident.sym.to_string();
+                        if ctx.lookup_func(&func_name).is_none() {
+                            let func_id = ctx.fresh_func();
+                            ctx.register_func(func_name, func_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Pre-register module-level variable declarations so function bodies
     // declared before the variable can still reference them via lookup_local
     for item in &ast_module.body {


### PR DESCRIPTION
Fixes #5134.

`compilePackages: ramda` threw `ReferenceError: _curryN is not defined`.

### Root cause
ramda's `internal/_curryN.js`:
```js
export default function _curryN(length, received, fn) {
  return function () {
    ...
    return ... ? fn.apply(this, combined)
               : _arity(Math.max(0, left), _curryN(length, combined, fn)); // self-ref
  };
}
```
A **named** `export default function` that references itself by name inside its returned closure.

The module function pre-registration pass (`crates/perry-hir/src/lower/lower_module_fn.rs`) hoists `Stmt::Decl(Fn)` and `export function foo` into `register_func`, but **skipped** `ExportDefaultDecl(DefaultDecl::Fn)`. So `_curryN` was never bound in module scope; `lower_fn_decl` (which relies on the pre-pass via `lookup_func(name).unwrap_or_else(fresh_func)`) found no binding, and the self-reference lowered to an unresolved global → `ReferenceError`.

### Fix
Pre-register a named `export default function foo`'s `foo` binding exactly like a plain `function foo`. `module_decl.rs` reuses the pre-registered id (same-module references and self-recursion now resolve).

### Validation
- Local repro `export default function _selfref(){ return function(){ ... _selfref(...) } }` now runs (was `ReferenceError`).
- uuid (`export default function rng`) still produces correct output.
- ramda's `_curryN is not defined` is gone.

### Known residual (separate, pre-existing — not introduced here)
ramda's full pipeline then hits a different bug: `.apply()` on a cross-module **default**-exported variadic function (`compose`'s `pipe.apply(this, reverse(arguments))`) forwards **zero** args — the export-rename forwarder (`mod.rs` ~L2261) is emitted with fixed arity and the consumer-side value wrapper uses the empty import signature. Named exports are unaffected. Filed for follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exported default function declarations to properly support self-recursion and same-module references when defined with a name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->