### PR TITLE
fix(codegen): register rest/arguments metadata for renamed-export value wrappers (#5134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## v0.5.1170 — fix(codegen): register rest/`arguments` metadata for renamed-export value wrappers (#5134)
+
+`.apply()`/`.call()` on a cross-module **default**-exported (or otherwise
+renamed) *variadic* function forwarded **zero** arguments. ramda's `compose`
+is `export default function compose() { … return pipe.apply(this,
+reverse(arguments)); }`, and `pipe` is `export default function pipe()` with a
+synthesized `arguments` param — so `union.js`'s init (`_curry2(compose(uniq,
+_concat))`) threw `Error: pipe requires at least one argument`.
+
+Root cause: a renamed export gets a forwarding value wrapper
+`__perry_wrap_perry_fn_<src>__<exported>`, but the rest/synthetic-`arguments`
+registration loops (`string_pool.rs`, consumed by `lookup_closure_rest_full` in
+`js_native_call_value`) keyed only on the function's **local** name
+(`__perry_wrap_..._<local>`). When a consumer referenced the renamed export as a
+value and invoked it via `.apply`, the runtime found no rest entry for the
+wrapper's `func_ptr` and dispatched positionally instead of bundling all args
+into the rest/`arguments` slot — so the variadic callee saw
+`arguments.length === 0`. Named exports (local == exported) were unaffected.
+
+Fix (`artifacts.rs`): for each `Export::Named { local, exported }` rename whose
+local function has a rest / synthetic-`arguments` param, also register the
+`__perry_wrap_perry_fn_<src>__<exported>` alias wrapper with the matching
+metadata. Together with #5134's `export default function` hoisting (PR #5149),
+the full ramda repro (`R.pipe(R.filter(...), R.map(...), R.sum)([...])`) now
+returns `120`, matching Node byte-for-byte. Validated no regression on named /
+non-variadic-default `.apply`.
+
 ## v0.5.1168 — Next.js standalone bring-up: walls 36–44 (rebased on main)
 
 Dynamic-parent classes, forward-capture, super.method, cjs export-hint, self-new in capturing closure. (Same content as PR #5125, re-applied cleanly onto current main.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1168
+**Current Version:** 0.5.1170
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ codegen-units = 16
 opt-level = "s"       # Optimize for size in stdlib
 
 [workspace.package]
-version = "0.5.1168"
+version = "0.5.1170"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1308,7 +1308,7 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             }
         })
         .collect();
-    let user_fn_wrapper_rest_and_arguments: std::collections::HashSet<String> = hir
+    let mut user_fn_wrapper_rest_and_arguments: std::collections::HashSet<String> = hir
         .functions
         .iter()
         .filter_map(|f| {
@@ -1326,6 +1326,65 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             }
         })
         .collect();
+    let mut user_fn_wrapper_rest = user_fn_wrapper_rest;
+    let mut user_fn_wrapper_synthetic_arguments = user_fn_wrapper_synthetic_arguments;
+
+    // #5134-followup: a renamed export (`export { local as exported }`, which
+    // includes `export default function local`) gets a forwarding value wrapper
+    // `__perry_wrap_perry_fn_<src>__<exported>` (emitted above), but the
+    // rest/synthetic-`arguments` *metadata* loops below key only on the local
+    // function name (`__perry_wrap_..._<local>`). So a consumer that referenced
+    // the renamed export as a VALUE and called it via `.apply`/`.call`
+    // (`compose`'s `pipe.apply(this, reverse(arguments))` in ramda — `pipe` is
+    // `export default function pipe()` with a synthetic `arguments`) reached
+    // `js_native_call_value` with an unregistered wrapper func_ptr, so
+    // `lookup_closure_rest_full` missed and the args were dispatched positionally
+    // instead of bundled — the variadic function saw `arguments.length === 0`.
+    // Register the exported-alias wrapper symbol with the same metadata as the
+    // local one so the runtime bundles correctly through the rename.
+    {
+        let func_by_local_name: HashMap<&str, &perry_hir::Function> =
+            hir.functions.iter().map(|f| (f.name.as_str(), f)).collect();
+        for export in &hir.exports {
+            let perry_hir::Export::Named { local, exported } = export else {
+                continue;
+            };
+            if local == exported {
+                continue;
+            }
+            let Some(f) = func_by_local_name.get(local.as_str()) else {
+                continue;
+            };
+            let alias_wrap = format!(
+                "__perry_wrap_perry_fn_{}__{}",
+                module_prefix,
+                sanitize(exported)
+            );
+            // The registration loop (`string_pool.rs`) iterates
+            // `user_fn_wrapper_rest`; the synthetic/rest_and_arguments sets only
+            // *refine* which runtime fn each entry uses. So the alias must be
+            // added to `user_fn_wrapper_rest` (keyed on the rest param index) in
+            // EVERY case, plus the matching refinement set.
+            let Some(rest_idx) = f.params.iter().position(|p| p.is_rest) else {
+                continue;
+            };
+            let last_is_synth_args = f
+                .params
+                .last()
+                .map(|p| p.arguments_object.is_some())
+                .unwrap_or(false);
+            let has_user_rest = f
+                .params
+                .iter()
+                .any(|p| p.is_rest && p.arguments_object.is_none());
+            user_fn_wrapper_rest.push((alias_wrap.clone(), rest_idx));
+            if last_is_synth_args && has_user_rest {
+                user_fn_wrapper_rest_and_arguments.insert(alias_wrap);
+            } else if last_is_synth_args {
+                user_fn_wrapper_synthetic_arguments.insert(alias_wrap);
+            }
+        }
+    }
 
     // Wrapper arities — ABI param count per top-level user-function wrapper.
     // Used by dynamic closure dispatch to pad omitted trailing parameters


### PR DESCRIPTION
Follow-up to #5149 — together these fully fix `compilePackages: ramda` (#5134).

### Symptom
After the `_curryN` hoisting fix (#5149), ramda's full pipeline threw `Error: pipe requires at least one argument` at module init.

### Root cause
`.apply()`/`.call()` on a cross-module **default**-exported (or otherwise renamed) **variadic** function forwarded **zero** arguments.

- ramda's `compose` is `export default function compose() { … return pipe.apply(this, reverse(arguments)); }`
- `pipe` is `export default function pipe()` with a synthesized `arguments` param
- `union.js` init runs `_curry2(compose(uniq, _concat))` → `compose` → `pipe.apply(this, [_concat, uniq])` → **pipe sees 0 args**

A renamed export gets a forwarding value wrapper `__perry_wrap_perry_fn_<src>__<exported>` (emitted in `artifacts.rs`), but the rest/synthetic-`arguments` **registration** loops (`string_pool.rs`, consumed by `lookup_closure_rest_full` inside `js_native_call_value`) keyed only on the **local** function name (`__perry_wrap_..._<local>`). So when a consumer referenced the renamed export as a value and called it via `.apply`, the runtime found no rest entry for the wrapper's `func_ptr` and dispatched positionally instead of bundling args into the rest/`arguments` slot. Named exports (local == exported) were unaffected — which is why `variadicNamed.apply(...)` worked but `defaultExport.apply(...)` didn't.

### Fix
`crates/perry-codegen/src/codegen/artifacts.rs`: for each `Export::Named { local, exported }` rename whose local function has a rest / synthetic-`arguments` param, also register the `__perry_wrap_perry_fn_<src>__<exported>` alias wrapper with the matching metadata (`user_fn_wrapper_rest` + the `synthetic_arguments` / `rest_and_arguments` refinement sets).

### Validation
- Local repro: `v.apply(null, [4,5,6])` on `export default function variadic(){return arguments.length}` → was `0:`, now `3:4,5,6`.
- **Full ramda repro** (with #5149 stacked): `R.pipe(R.filter(x=>x%2===0), R.map(x=>x*10), R.sum)([1..6])` → `120`, matching Node.
- No regression: named-variadic `.apply` (`3`), non-variadic-default `.apply` (`7`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a codegen issue affecting variadic functions exported and renamed across modules. These functions would previously fail to properly bundle arguments into the rest parameter when called via `.apply()`, `.call()`, or similar methods. The fix ensures correct argument handling for all invocation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->