### PR TITLE
fix(resolve): treat bare `.` / `..` as relative directory imports (#5141)

### DIFF
--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -847,10 +847,7 @@ pub(super) fn declaration_sidecar_for_resolved_import(
         return canonical_existing_declaration(resolved_path.to_path_buf());
     }
 
-    if !(import_source.starts_with("./")
-        || import_source.starts_with("../")
-        || import_source.starts_with('/'))
-    {
+    if !(is_relative_specifier(import_source) || import_source.starts_with('/')) {
         let (package_name, subpath) = parse_package_specifier(import_source);
         if let Some(package_dir) = package_dir_for_resolved_path(resolved_path, &package_name) {
             if let Some(sidecar) = resolve_package_declaration_entry(
@@ -897,13 +894,28 @@ pub(super) fn resolve_relative_import_path(
     import_source: &str,
     importer_path: &Path,
 ) -> Option<PathBuf> {
-    if !import_source.starts_with("./") && !import_source.starts_with("../") {
+    if !is_relative_specifier(import_source) {
         return None;
     }
     let parent = importer_path.parent()?;
     let resolved = parent.join(import_source);
     let path = resolve_with_extensions(&resolved)?;
     path.canonicalize().ok()
+}
+
+/// True for ECMAScript relative-import specifiers. Besides the obvious `./x`
+/// and `../x`, the bare `"."` and `".."` are also relative — they resolve to
+/// the current / parent **directory**'s `index` file. `@tanstack/table-core`'s
+/// source uses `import { _getVisibleLeafColumns } from '..'` (the package
+/// barrel); without matching `".."` here it fell through to bare-package
+/// resolution, `import.resolved_path` never matched the index module, and every
+/// name imported through it lowered to an unresolved raw extern symbol → link
+/// failure (`__getVisibleLeafColumns`). Refs #5141.
+pub(super) fn is_relative_specifier(import_source: &str) -> bool {
+    import_source.starts_with("./")
+        || import_source.starts_with("../")
+        || import_source == "."
+        || import_source == ".."
 }
 
 /// Resolve an import specifier to a file path
@@ -938,11 +950,8 @@ pub(super) fn resolve_import(
         None
     };
 
-    // Handle relative imports (./ or ../)
-    if import_source.starts_with("./")
-        || import_source.starts_with("../")
-        || subpath_import_target.is_some()
-    {
+    // Handle relative imports (./ or ../, plus bare "." / ".." directory imports)
+    if is_relative_specifier(import_source) || subpath_import_target.is_some() {
         if let Some(canonical) = subpath_import_target
             .or_else(|| resolve_relative_import_path(import_source, importer_path))
         {


### PR DESCRIPTION
Fixes #5141 (`compilePackages: @tanstack/table-core` link failure).

### Symptom
```
Undefined symbols for architecture arm64:
  "__getVisibleLeafColumns", referenced from: ...
```

### Root cause
`@tanstack/table-core`'s source uses the package-barrel idiom — `features/ColumnSizing.ts` does:
```ts
import { _getVisibleLeafColumns } from '..'   // '..' => the package index.ts
```
and `index.ts` does `export * from './features/ColumnVisibility'`.

The import resolver (`crates/perry/src/commands/compile/resolve.rs`) detected relative imports with `starts_with("./") || starts_with("../")`. The bare specifiers `"."` and `".."` (current/parent **directory** imports — valid ECMAScript, resolving to that directory's `index`) match **neither**, so `import { X } from '..'` fell through to bare-package resolution. `import.resolved_path` was then never matched to the index module in `native_modules`, so **every** name imported through it lowered to an unresolved **raw extern symbol** (`_getVisibleLeafColumns`, not `perry_fn_...`) → link failure.

`from '../index'` worked only because it carries the `"../"` prefix. The leading underscore was a red herring — a directly-defined `index` export imported via `from '..'` failed identically.

### Fix
A shared `is_relative_specifier()` helper that also matches exact `"."` / `".."`, used by `resolve_relative_import_path`, `resolve_import`, and the declaration-sidecar resolver.

### Validation
- Minimal repro (`import { x } from '..'` through an `export *` barrel) — was link-fail, now runs.
- **Real @tanstack/table-core**: links and runs; `createTable({...}).getRowModel().rows.length` → `3`, `getAllLeafColumns().length` → `1`, matching Node byte-for-byte.
- No regression: `./` and `../foo` imports (uuid, dayjs, re-export repros) still resolve; `-p perry` resolve tests pass.

This is general — any `import … from '.'`/`'..'` (directory→index) was affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced module resolution to properly handle bare relative import specifiers (`.` and `..`) consistently with explicit relative paths (`./` and `../`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->