### PR TITLE
fix(compile): add .cmd extension for Android NDK clang on Windows

### DIFF
--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -879,8 +879,10 @@ pub(super) fn build_and_run_link(
             "linux-x86_64"
         };
         let ndk_clang = format!(
-            "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang",
-            ndk_home, host_tag
+            "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang{}",
+            ndk_home,
+            host_tag,
+            if cfg!(target_os = "windows") { ".cmd" } else { "" }
         );
         let stub_ok = Command::new(&ndk_clang)
             .args(["-c", "-fPIC", "-target", "aarch64-linux-android24"])

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -573,8 +573,10 @@ pub fn select_linker_command(
             "linux-x86_64"
         };
         let clang = format!(
-            "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang",
-            ndk_home, host_tag
+            "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang{}",
+            ndk_home,
+            host_tag,
+            if cfg!(target_os = "windows") { ".cmd" } else { "" }
         );
         if !PathBuf::from(&clang).exists() {
             return Err(anyhow!("Android NDK clang not found at: {}", clang));


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

<!-- One or two sentences on what this PR changes and why. -->

This PR fixes a bug where Android cross-compilation fails on Windows hosts because Perry attempts to invoke the NDK compiler toolchain (`aarch64-linux-android24-clang`) without the mandatory `.cmd` extension.

On Windows, attempting to execute a `.cmd` or `.bat` file via Rust's `Command::new` without specifying the extension results in `os error 193` ("%1 is not a valid Win32 application"). This PR ensures the correct extension is appended when the host OS is Windows.

## Changes

<!--
- Bullet list of concrete changes, one per logical item.
- File paths optional but appreciated for non-trivial PRs.
-->

- Modified `crates/perry/src/commands/compile/link/platform_cmd.rs` and `mod.rs` to conditionally append `.cmd` to the Android NDK clang path when `cfg!(target_os = "windows")` is true.

## Related issue

<!-- Fixes #123 / Closes #123 / Refs #123 — or "n/a" if standalone. -->

Refs #1508 (Specifically fixes the remaining `os error 193` on Windows hosts during the linking stage which was not fully covered by previous fixes).

## Test plan

<!--
How did you verify this works? A paste of the commands you ran is perfect.
-->

```powershell
# 1. Build perry from source
cargo build --release

# 2. Set Android NDK path
$env:ANDROID_NDK_HOME = "C:\Users\***\AppData\Local\Android\Sdk\ndk\30.0.14904198"

# 3. Verify Android compilation on Windows host
./target/release/perry compile ../sample-android-app/src/main.ts --target android -o sample.apk
```

- [x] `cargo build --release` clean
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [ ] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/`
- [x] (if touching a platform UI backend) Built `-p perry-ui-android` locally on that platform

<!-- ## Screenshots / output -->

<!-- Optional. If the change is visible (UI, CLI output, error messages), paste before/after. -->

**Before fix (Windows host):**
```
Linking (runtime-only)...
Error: %1 は有効な Win32 アプリケーションではありません。 (os error 193)
```

**After fix (Windows host):**
```
Linking (runtime-only)...
Linking perry/ui (native UI) from target/aarch64-linux-android/release/libperry_ui_android.a
Wrote executable: ../sample-android-app/sample.apk
Binary size: 24.8MB
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android NDK compilation on Windows hosts by properly handling toolchain executable path resolution for JNI stub builds and linker operations. This ensures native code compilation works correctly when targeting Android platforms on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->