### PR TITLE
fix(fastify): forward dynamic request/reply property reads in external-fastify variant builds (#5037)

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -2282,6 +2282,75 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
         };
     }
 
+    // #5037 — external-fastify variant of the request/reply property
+    // dispatch above. When the well-known flip routes `fastify` to
+    // perry-ext-fastify (auto-optimize / `--no-default-features`),
+    // `bundled-fastify`/`http-server` are stripped and the bundled
+    // arm above is compiled out. A `request`/`reply` handle that
+    // escaped into a user helper — its static type erased, so codegen
+    // emitted a generic dynamic property read here rather than a
+    // `NativeMethodCall` — then had no dispatch path and read
+    // `undefined` (inline reads in the handler still worked because
+    // codegen recognised the receiver and called `js_fastify_req_*`
+    // directly). The handle lives in perry-ext-fastify's perry-ffi
+    // registry, not perry-stdlib's, so probe membership via the
+    // external `js_ext_fastify_is_context_handle` symbol (resolved at
+    // link time) and forward to the same `js_fastify_req_*` exports
+    // the bundled arm uses. Mirrors the `external-fastify-pump` pump
+    // wiring in `async_bridge.rs`.
+    #[cfg(all(feature = "external-fastify-pump", not(feature = "http-server")))]
+    {
+        extern "C" {
+            fn js_ext_fastify_is_context_handle(handle: i64) -> i32;
+            fn js_fastify_req_query_object(handle: i64) -> f64;
+            fn js_fastify_req_params_object(handle: i64) -> f64;
+            fn js_fastify_req_json(handle: i64) -> f64;
+            fn js_fastify_req_body(handle: i64) -> *mut perry_runtime::StringHeader;
+            fn js_fastify_req_headers(handle: i64) -> i64;
+            fn js_fastify_req_method(handle: i64) -> *mut perry_runtime::StringHeader;
+            fn js_fastify_req_url(handle: i64) -> *mut perry_runtime::StringHeader;
+            fn js_fastify_req_get_user_data(handle: i64) -> f64;
+        }
+        if js_ext_fastify_is_context_handle(handle) != 0 {
+            return match property_name {
+                "query" => js_fastify_req_query_object(handle),
+                "params" => js_fastify_req_params_object(handle),
+                "body" => js_fastify_req_json(handle),
+                "rawBody" | "text" => {
+                    let ptr = js_fastify_req_body(handle);
+                    if ptr.is_null() {
+                        f64::from_bits(0x7FFC_0000_0000_0001)
+                    } else {
+                        f64::from_bits(perry_runtime::JSValue::string_ptr(ptr).bits())
+                    }
+                }
+                "headers" => {
+                    // Returns NaN-boxed JS object bits — use directly.
+                    let bits = js_fastify_req_headers(handle);
+                    f64::from_bits(bits as u64)
+                }
+                "method" => {
+                    let ptr = js_fastify_req_method(handle);
+                    if ptr.is_null() {
+                        f64::from_bits(0x7FFC_0000_0000_0001)
+                    } else {
+                        f64::from_bits(perry_runtime::JSValue::string_ptr(ptr).bits())
+                    }
+                }
+                "url" => {
+                    let ptr = js_fastify_req_url(handle);
+                    if ptr.is_null() {
+                        f64::from_bits(0x7FFC_0000_0000_0001)
+                    } else {
+                        f64::from_bits(perry_runtime::JSValue::string_ptr(ptr).bits())
+                    }
+                }
+                "user" => js_fastify_req_get_user_data(handle),
+                _ => f64::from_bits(0x7FFC_0000_0000_0001), // undefined
+            };
+        }
+    }
+
     // Issue #340: axios response — dispatch `r.status` / `r.data` /
     // `r.statusText` / `r.headers` to the AxiosResponseHandle accessor
     // shims. The handle id is registered in the common HANDLES

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -882,7 +882,11 @@ pub(super) fn build_and_run_link(
             "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang{}",
             ndk_home,
             host_tag,
-            if cfg!(target_os = "windows") { ".cmd" } else { "" }
+            if cfg!(target_os = "windows") {
+                ".cmd"
+            } else {
+                ""
+            }
         );
         let stub_ok = Command::new(&ndk_clang)
             .args(["-c", "-fPIC", "-target", "aarch64-linux-android24"])

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -576,7 +576,11 @@ pub fn select_linker_command(
             "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang{}",
             ndk_home,
             host_tag,
-            if cfg!(target_os = "windows") { ".cmd" } else { "" }
+            if cfg!(target_os = "windows") {
+                ".cmd"
+            } else {
+                ""
+            }
         );
         if !PathBuf::from(&clang).exists() {
             return Err(anyhow!("Android NDK clang not found at: {}", clang));


### PR DESCRIPTION
## Summary

Fixes #5037 — a fastify `request` object passed into a plain helper function reads `request.headers === undefined` (→ fastify 500), **but only in auto-optimize variant builds**. The same source against the prebuilt release libs works.

## Root cause

The compiler binary is identical between prebuilt and auto-optimize modes — only the linked runtime/ext static libs differ by cargo feature flags. For a program importing `fastify`, auto-optimize triggers the well-known-bindings flip: `import 'fastify'` is routed to **perry-ext-fastify**, `bundled-fastify`/`http-server` are stripped, and `external-fastify-pump` is activated (see `optimized_libs.rs` and `well_known_bindings.toml`).

The bundled `FastifyContext` property-dispatch arm in `js_handle_property_dispatch` (`crates/perry-stdlib/src/common/dispatch.rs`) is gated on `#[cfg(feature = "http-server")]`, so in the flipped build it is **compiled out**. When a `request`/`reply` handle escapes into a user helper, its static type is erased and codegen emits a generic dynamic property read here rather than a `NativeMethodCall` — and there was **no external-fastify dispatch arm** to handle it, so the read fell through to `undefined`. Inline reads in the handler still worked because codegen recognised the receiver and called `js_fastify_req_*` directly.

perry-ext-fastify already exports the membership probe `js_ext_fastify_is_context_handle` precisely for this path (its doc comment claims "perry-stdlib's `js_handle_property_dispatch` arms call this") — but the stdlib arm was never wired up, unlike the equivalent external-zlib and external-net arms.

## Fix

Add the missing external-fastify property-dispatch arm, gated on `all(feature = "external-fastify-pump", not(feature = "http-server"))` (the same gate the `external-fastify-pump` pump uses in `async_bridge.rs`). It probes `js_ext_fastify_is_context_handle` and forwards `query`/`params`/`body`/`rawBody`/`text`/`headers`/`method`/`url`/`user` to the same `js_fastify_req_*` exports the bundled arm uses. The extern symbols resolve at link time from perry-ext-fastify, mirroring the established `external-zlib-pump` / `external-net-pump` probe-and-forward arms.

## Validation

- `cargo check -p perry-stdlib` (default config — new arm compiled out under `http-server`): clean.
- `cargo check -p perry-stdlib --no-default-features --features external-fastify-pump` (the flipped/auto-optimize config — new arm compiled in): clean. This config is **not** exercised by CI, so it was verified locally.

Note: macOS host builds don't reproduce the original bug because their auto-optimize variant set keeps the bundled fastify path (no flip); the linux worker pipeline does flip. No version bump / changelog per maintainer (folded in at squash-merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Fastify request/reply property dispatch for the external-fastify integration, including better support for common fields like query, params, body/raw body, headers, method, URL, and user data.
* **Chores / Refactor**
  * Reformatted Android linker and NDK clang executable name construction for the Windows host case, preserving the same output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->