### PR TITLE
fix(error): forward ES2022 `cause` through `super(message, options)` (#5127)

### DIFF
--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -600,6 +600,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     (DOUBLE, &name_val_box),
                                 ],
                             );
+                            // #5127: `super(message, options)` must forward the
+                            // ES2022 `cause` option. The instance is a generic
+                            // object, so install a non-enumerable `cause`
+                            // property from args[1] when present.
+                            if let Some(opts_val) = lowered_args.get(1) {
+                                let blk = ctx.block();
+                                blk.call_void(
+                                    "js_error_apply_cause_to_object",
+                                    &[(I64, &this_handle), (DOUBLE, opts_val)],
+                                );
+                            }
                         }
                     }
                     return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -58,6 +58,9 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         VOID,
         &[I64, I64, DOUBLE],
     );
+    // #5127: apply ES2022 `cause` from a `super(message, options)` forward to
+    // a user Error-subclass instance (a generic object). (this_handle, options)
+    module.declare_function("js_error_apply_cause_to_object", VOID, &[I64, DOUBLE]);
     module.declare_function("js_with_has_binding", I32, &[DOUBLE, I64]);
     module.declare_function("js_with_get_binding", DOUBLE, &[DOUBLE, I64]);
     module.declare_function("js_with_set_binding", DOUBLE, &[DOUBLE, I64, DOUBLE, I32]);

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -506,6 +506,28 @@ unsafe fn apply_cause_from_options(error: *mut ErrorHeader, options: f64) {
     }
 }
 
+/// #5127: apply the ES2022 `cause` option to a user `Error` *subclass*
+/// instance when its constructor forwards `super(message, options)`. Such an
+/// instance is a generic heap object (not an `ErrorHeader`) — the super-call
+/// codegen sets `message`/`name` as object properties — so the cause must be
+/// installed as a (non-enumerable) own `cause` property on the object too,
+/// matching Node's `InstallErrorCause`. Mirrors `apply_cause_from_options`:
+/// reads `options.cause` via the generic getter (works for object literals
+/// and runtime-held options alike) and is a no-op for non-object options.
+#[no_mangle]
+pub extern "C" fn js_error_apply_cause_to_object(obj: *mut crate::object::ObjectHeader, options: f64) {
+    let opts = crate::value::JSValue::from_bits(options.to_bits());
+    if !opts.is_pointer() {
+        return;
+    }
+    let key = js_string_from_bytes(b"cause".as_ptr(), 5);
+    let key_f64 = crate::value::js_nanbox_string(key as i64);
+    let cause = crate::value::js_dyn_index_get(options, key_f64);
+    if cause.to_bits() != TAG_UNDEFINED_BITS {
+        crate::object::js_object_set_field_by_name_nonenum(obj, key as *const StringHeader, cause);
+    }
+}
+
 /// #2836: allocate an Error (or native subclass) carrying a `{ cause }`
 /// option read from an arbitrary runtime options value. `kind` selects the
 /// ERROR_KIND_* discriminant so `instanceof TypeError`/etc. keep working.

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -515,7 +515,10 @@ unsafe fn apply_cause_from_options(error: *mut ErrorHeader, options: f64) {
 /// reads `options.cause` via the generic getter (works for object literals
 /// and runtime-held options alike) and is a no-op for non-object options.
 #[no_mangle]
-pub extern "C" fn js_error_apply_cause_to_object(obj: *mut crate::object::ObjectHeader, options: f64) {
+pub extern "C" fn js_error_apply_cause_to_object(
+    obj: *mut crate::object::ObjectHeader,
+    options: f64,
+) {
     let opts = crate::value::JSValue::from_bits(options.to_bits());
     if !opts.is_pointer() {
         return;

--- a/crates/perry/tests/issue_5127_error_cause_super.rs
+++ b/crates/perry/tests/issue_5127_error_cause_super.rs
@@ -1,0 +1,82 @@
+//! Regression test for #5127: an `Error` subclass that forwards options via
+//! `super(message, options)` dropped the ES2022 `cause` — `this.cause` was
+//! `undefined` afterward, even though a plain `new Error(msg, { cause })`
+//! (no subclass) worked.
+//!
+//! Root cause: the Error-like `super(...)` codegen arm only assigned
+//! `this.message = args[0]` and `this.name = <parent>`; it ignored `args[1]`
+//! (the options object). Fix: when a second arg is present, call
+//! `js_error_apply_cause_to_object`, which installs a non-enumerable own
+//! `cause` property on the subclass instance from `options.cause` (matching
+//! Node's `InstallErrorCause`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn error_subclass_forwards_cause_through_super() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class AppError extends Error {
+  constructor(msg: string, opts?: ErrorOptions) { super(msg, opts); this.name = "AppError"; }
+}
+const e = new AppError("high-level", { cause: new TypeError("low-level") });
+console.log(e.message, (e.cause as Error)?.message);
+console.log(e.name, e instanceof Error);
+// `cause` is a non-enumerable own property (Node semantics).
+console.log(Object.keys(e).includes("cause"), Object.prototype.hasOwnProperty.call(e, "cause"));
+
+// Plain (non-subclass) Error with cause still works.
+const p = new Error("m", { cause: 42 });
+console.log(p.cause);
+
+// No options forwarded => no cause.
+class B extends Error { constructor(m: string){ super(m); } }
+console.log(new B("x").cause);
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "high-level low-level\nAppError true\nfalse true\n42\nundefined\n"
+    );
+}


### PR DESCRIPTION
Fixes #5127.

## Problem
An `Error` subclass that forwards options via `super(message, options)` lost the ES2022 `cause`:

```ts
class AppError extends Error {
  constructor(msg: string, opts?: ErrorOptions) { super(msg, opts); this.name = "AppError"; }
}
const e = new AppError("high-level", { cause: new TypeError("low-level") });
console.log(e.cause); // undefined  (Node: the TypeError)
```

A plain `new Error(msg, { cause })` (no subclass) already worked, so the option was dropped specifically when passed up through `super(...)`.

## Root cause
The Error-like `super(...)` codegen arm (`this_super_call.rs`) only assigned `this.message = args[0]` and `this.name = <parent>`. It ignored `args[1]` (the options object), so `cause` never reached the subclass instance (which is a generic heap object, not an `ErrorHeader`).

## Fix
- New runtime helper `js_error_apply_cause_to_object(this, options)` (`error.rs`) — mirrors the existing `apply_cause_from_options` but installs a **non-enumerable own** `cause` property on the instance object, matching Node's `InstallErrorCause`. No-op for non-object options.
- The Error-like `super(...)` arm now calls it whenever a second argument is forwarded.

## Verification
Output matches Node exactly, including `cause` being a non-enumerable own property, plain-`Error` cause still working, and no-options ⇒ no cause:

```
high-level low-level
AppError true
false true        # Object.keys excludes cause; hasOwnProperty true
42
undefined
```

New regression test: `crates/perry/tests/issue_5127_error_cause_super.rs` (green).

No changelog/version bump per maintainer's release-at-merge workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error subclasses now forward ES2022 `{ cause }` from `super(message, options)` into the created error instance, supporting standard error-chaining patterns.

* **Bug Fixes**
  * Ensures `cause` is applied correctly when using `super(message, options)` (including the expected non-enumerable behavior on instances).

* **Tests**
  * Added a regression test covering `super(message, options)` propagation for custom `Error` subclasses, plus coverage for plain `Error` and missing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->