### PR TITLE
fix(runtime): root source string across slice's destination allocation (#5062)

### DIFF
--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -1019,6 +1019,62 @@ fn test_transient_runtime_handle_string_concat_gc() {
     }
 }
 
+/// #5062: `String.prototype.slice` copies the selected range out of the source
+/// string AFTER allocating the destination, via a raw pointer derived from the
+/// source (`string_data(s) + offset`). If that destination allocation trips a
+/// moving/sweeping GC, the source is relocated/freed out from under the raw
+/// pointer and the copy reads stale memory — under sustained server GC pressure
+/// this corrupted the head of chunked slices (the new slice's own length word
+/// got stamped over its first bytes). `string_copy_range` now roots the source
+/// in a `RuntimeHandleScope`, so it survives and relocates across the
+/// allocation. This mirrors the proven concat test above.
+#[test]
+fn test_transient_runtime_handle_string_slice_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    // Distinctive ASCII payload (`b'A' + i % 26`) so a corrupted head is
+    // unmistakable; ASCII is the fast path the bug report exercises (base64).
+    // Keep the source under LARGE_OBJECT_THRESHOLD_BYTES so it lives in the
+    // movable nursery (large strings go straight to non-moving old-gen).
+    const SRC_LEN: usize = 4_000;
+    const SLICE_START: usize = 100;
+    const SLICE_LEN: usize = 3_000;
+    let src_bytes: Vec<u8> = (0..SRC_LEN as u32).map(|i| b'A' + (i % 26) as u8).collect();
+    let s = crate::string::js_string_from_bytes(src_bytes.as_ptr(), src_bytes.len() as u32);
+    assert!(crate::arena::pointer_in_nursery(s as usize));
+
+    // Force the slice's destination allocation onto the slow path with a GC
+    // trigger already due, so a copying-minor GC runs during `js_string_slice`.
+    // `s` is held only as a native-stack local and `CopyingNurseryTestGuard`
+    // disables conservative stack scanning — so without the handle root inside
+    // `string_copy_range`, the source would be swept/relocated out from under
+    // the in-flight copy pointer.
+    force_next_general_arena_alloc_slow();
+    trigger_guard.make_arena_trigger_due();
+    let before = gc_collection_count();
+    let result =
+        crate::string::js_string_slice(s, SLICE_START as i32, (SLICE_START + SLICE_LEN) as i32);
+
+    let result_scope = RuntimeHandleScope::new();
+    let result_root = result_scope.root_string_ptr(result);
+    drain_scheduled_minor_gc(before, "slice destination allocation");
+    let result = result_root.get_raw_const_ptr::<crate::StringHeader>();
+
+    unsafe {
+        assert_eq!((*result).byte_len, SLICE_LEN as u32);
+        assert_eq!((*result).utf16_len, SLICE_LEN as u32);
+        let data = (result as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        // Every byte must equal the live source range — the head especially,
+        // where the corruption manifested as a leaked length word.
+        for k in 0..SLICE_LEN {
+            let expected = b'A' + (((SLICE_START + k) as u32) % 26) as u8;
+            assert_eq!(*data.add(k), expected, "slice byte {k} corrupted");
+        }
+    }
+}
+
 #[test]
 fn test_dynamic_string_add_roots_left_string_across_rhs_coercion_gc() {
     let _guard = CopyingNurseryTestGuard::new(0);

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -2,6 +2,7 @@ use super::super::*;
 use super::support::*;
 use std::cell::Cell;
 mod callback_scanners;
+mod string_slice;
 
 fn assert_panics_with(expected: &str, f: impl FnOnce()) {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
@@ -1016,62 +1017,6 @@ fn test_transient_runtime_handle_string_concat_gc() {
         assert_eq!(*data.add(599_999), b'a');
         assert_eq!(*data.add(600_000), b'b');
         assert_eq!(*data.add(1_199_999), b'b');
-    }
-}
-
-/// #5062: `String.prototype.slice` copies the selected range out of the source
-/// string AFTER allocating the destination, via a raw pointer derived from the
-/// source (`string_data(s) + offset`). If that destination allocation trips a
-/// moving/sweeping GC, the source is relocated/freed out from under the raw
-/// pointer and the copy reads stale memory — under sustained server GC pressure
-/// this corrupted the head of chunked slices (the new slice's own length word
-/// got stamped over its first bytes). `string_copy_range` now roots the source
-/// in a `RuntimeHandleScope`, so it survives and relocates across the
-/// allocation. This mirrors the proven concat test above.
-#[test]
-fn test_transient_runtime_handle_string_slice_gc() {
-    let _guard = CopyingNurseryTestGuard::new(0);
-    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
-    register_runtime_handle_root_scanner_for_tests();
-
-    // Distinctive ASCII payload (`b'A' + i % 26`) so a corrupted head is
-    // unmistakable; ASCII is the fast path the bug report exercises (base64).
-    // Keep the source under LARGE_OBJECT_THRESHOLD_BYTES so it lives in the
-    // movable nursery (large strings go straight to non-moving old-gen).
-    const SRC_LEN: usize = 4_000;
-    const SLICE_START: usize = 100;
-    const SLICE_LEN: usize = 3_000;
-    let src_bytes: Vec<u8> = (0..SRC_LEN as u32).map(|i| b'A' + (i % 26) as u8).collect();
-    let s = crate::string::js_string_from_bytes(src_bytes.as_ptr(), src_bytes.len() as u32);
-    assert!(crate::arena::pointer_in_nursery(s as usize));
-
-    // Force the slice's destination allocation onto the slow path with a GC
-    // trigger already due, so a copying-minor GC runs during `js_string_slice`.
-    // `s` is held only as a native-stack local and `CopyingNurseryTestGuard`
-    // disables conservative stack scanning — so without the handle root inside
-    // `string_copy_range`, the source would be swept/relocated out from under
-    // the in-flight copy pointer.
-    force_next_general_arena_alloc_slow();
-    trigger_guard.make_arena_trigger_due();
-    let before = gc_collection_count();
-    let result =
-        crate::string::js_string_slice(s, SLICE_START as i32, (SLICE_START + SLICE_LEN) as i32);
-
-    let result_scope = RuntimeHandleScope::new();
-    let result_root = result_scope.root_string_ptr(result);
-    drain_scheduled_minor_gc(before, "slice destination allocation");
-    let result = result_root.get_raw_const_ptr::<crate::StringHeader>();
-
-    unsafe {
-        assert_eq!((*result).byte_len, SLICE_LEN as u32);
-        assert_eq!((*result).utf16_len, SLICE_LEN as u32);
-        let data = (result as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-        // Every byte must equal the live source range — the head especially,
-        // where the corruption manifested as a leaked length word.
-        for k in 0..SLICE_LEN {
-            let expected = b'A' + (((SLICE_START + k) as u32) % 26) as u8;
-            assert_eq!(*data.add(k), expected, "slice byte {k} corrupted");
-        }
     }
 }
 

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/string_slice.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/string_slice.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+/// #5062: `String.prototype.slice` copies the selected range out of the source
+/// string AFTER allocating the destination, via a raw pointer derived from the
+/// source (`string_data(s) + offset`). If that destination allocation trips a
+/// moving/sweeping GC, the source is relocated/freed out from under the raw
+/// pointer and the copy reads stale memory — under sustained server GC pressure
+/// this corrupted the head of chunked slices (the new slice's own length word
+/// got stamped over its first bytes). `string_copy_range` now roots the source
+/// in a `RuntimeHandleScope`, so it survives and relocates across the
+/// allocation. This mirrors the proven concat / dynamic-add tests in the parent.
+#[test]
+fn test_transient_runtime_handle_string_slice_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    // Distinctive ASCII payload (`b'A' + i % 26`) so a corrupted head is
+    // unmistakable; ASCII is the fast path the bug report exercises (base64).
+    // Keep the source under LARGE_OBJECT_THRESHOLD_BYTES so it lives in the
+    // movable nursery (large strings go straight to non-moving old-gen).
+    const SRC_LEN: usize = 4_000;
+    const SLICE_START: usize = 100;
+    const SLICE_LEN: usize = 3_000;
+    let src_bytes: Vec<u8> = (0..SRC_LEN as u32).map(|i| b'A' + (i % 26) as u8).collect();
+    let s = crate::string::js_string_from_bytes(src_bytes.as_ptr(), src_bytes.len() as u32);
+    assert!(crate::arena::pointer_in_nursery(s as usize));
+
+    // Force the slice's destination allocation onto the slow path with a GC
+    // trigger already due, so a copying-minor GC runs during `js_string_slice`.
+    // `s` is held only as a native-stack local and `CopyingNurseryTestGuard`
+    // disables conservative stack scanning — so without the handle root inside
+    // `string_copy_range`, the source would be swept/relocated out from under
+    // the in-flight copy pointer.
+    force_next_general_arena_alloc_slow();
+    trigger_guard.make_arena_trigger_due();
+    let before = gc_collection_count();
+    let result =
+        crate::string::js_string_slice(s, SLICE_START as i32, (SLICE_START + SLICE_LEN) as i32);
+
+    let result_scope = RuntimeHandleScope::new();
+    let result_root = result_scope.root_string_ptr(result);
+    drain_scheduled_minor_gc(before, "slice destination allocation");
+    let result = result_root.get_raw_const_ptr::<crate::StringHeader>();
+
+    unsafe {
+        assert_eq!((*result).byte_len, SLICE_LEN as u32);
+        assert_eq!((*result).utf16_len, SLICE_LEN as u32);
+        let data = (result as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        // Every byte must equal the live source range — the head especially,
+        // where the corruption manifested as a leaked length word.
+        for k in 0..SLICE_LEN {
+            let expected = b'A' + (((SLICE_START + k) as u32) % 26) as u8;
+            assert_eq!(*data.add(k), expected, "slice byte {k} corrupted");
+        }
+    }
+}

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -351,6 +351,45 @@ pub(crate) fn js_string_alloc_ascii_uninit(len: u32) -> (*mut StringHeader, *mut
     (ptr, data_ptr)
 }
 
+/// GC-safe copy of `byte_len` bytes starting at `byte_start` of source string
+/// `s` into a freshly allocated `StringHeader`.
+///
+/// Why this exists (issue #5062): the normal `js_string_from_bytes` family
+/// allocates the destination *before* copying, and `string_storage_alloc` can
+/// trip a moving/sweeping GC. Slice/substring fast paths hand it a raw pointer
+/// derived from a GC-managed source string (`string_data(s) + offset`), so if a
+/// collection relocates or sweeps `s` during the destination allocation, the
+/// subsequent copy reads from a dangling buffer. Under sustained server GC
+/// pressure this surfaced as a chunked `String.prototype.slice` loop stamping
+/// the new slice's own length word over the first bytes of the payload.
+///
+/// Rooting `s` in a `RuntimeHandleScope` keeps it alive across the allocation
+/// AND refreshes its address if the GC moves it, so the copy always reads from
+/// the live source. `byte_start`/`byte_len` are byte offsets into the source
+/// payload (callers translate UTF-16 indices first); `utf16_len`/`flags` become
+/// the new header's fields.
+pub(crate) fn string_copy_range(
+    s: *const StringHeader,
+    byte_start: usize,
+    byte_len: u32,
+    utf16_len: u32,
+    flags: u32,
+) -> *mut StringHeader {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let handle = scope.root_string_ptr(s);
+    let (ptr, data_ptr) = string_storage_alloc(byte_len);
+    unsafe {
+        init_string_header(ptr, utf16_len, byte_len, byte_len, 0, flags);
+        if byte_len > 0 {
+            // Re-read the (possibly relocated) source AFTER the allocation.
+            let s_now = handle.get_raw_const_ptr::<StringHeader>();
+            let src = string_data(s_now).add(byte_start);
+            ptr::copy_nonoverlapping(src, data_ptr, byte_len as usize);
+        }
+    }
+    ptr
+}
+
 /// Count UTF-16 code units for a WTF-8 byte slice without using from_utf8.
 /// Lone surrogate sequences (0xED 0xA0..0xBF 0x80..0xBF) each count as 1 unit,
 /// same as any other BMP codepoint. Astral sequences (4-byte) count as 2.

--- a/crates/perry-runtime/src/string/slice_ops.rs
+++ b/crates/perry-runtime/src/string/slice_ops.rs
@@ -33,21 +33,24 @@ pub extern "C" fn js_string_slice(
         return js_string_from_bytes(ptr::null(), 0);
     }
 
-    // ASCII fast path: byte offsets == UTF-16 offsets, skip utf16_len scan
+    // ASCII fast path: byte offsets == UTF-16 offsets, skip utf16_len scan.
+    // Copy GC-safely: the destination allocation can move/sweep `s` (#5062).
     if is_ascii_string(s) {
         let slice_len = (end - start) as u32;
-        unsafe {
-            let src = string_data(s).add(start as usize);
-            return js_string_from_ascii_bytes(src, slice_len);
-        }
+        return string_copy_range(s, start as usize, slice_len, slice_len, 0);
     }
 
     // Convert UTF-16 offsets to byte offsets
     let str_data = string_as_str(s);
     let byte_start = utf16_offset_to_byte_offset(str_data, start as usize);
     let byte_end = utf16_offset_to_byte_offset(str_data, end as usize);
-    let slice_bytes = &str_data.as_bytes()[byte_start..byte_end];
-    js_string_from_bytes(slice_bytes.as_ptr(), slice_bytes.len() as u32)
+    string_copy_range(
+        s,
+        byte_start,
+        (byte_end - byte_start) as u32,
+        (end - start) as u32,
+        0,
+    )
 }
 
 /// Get a substring (similar to slice but different behavior)
@@ -79,20 +82,23 @@ pub extern "C" fn js_string_substring(
         return js_string_from_bytes(ptr::null(), 0);
     }
 
-    // ASCII fast path: skip utf16_len scan in allocator
+    // ASCII fast path: skip utf16_len scan in allocator.
+    // Copy GC-safely: the destination allocation can move/sweep `s` (#5062).
     if is_ascii_string(s) {
         let slice_len = (end - start) as u32;
-        unsafe {
-            let src = string_data(s).add(start as usize);
-            return js_string_from_ascii_bytes(src, slice_len);
-        }
+        return string_copy_range(s, start as usize, slice_len, slice_len, 0);
     }
 
     let str_data = string_as_str(s);
     let byte_start = utf16_offset_to_byte_offset(str_data, start as usize);
     let byte_end = utf16_offset_to_byte_offset(str_data, end as usize);
-    let slice_bytes = &str_data.as_bytes()[byte_start..byte_end];
-    js_string_from_bytes(slice_bytes.as_ptr(), slice_bytes.len() as u32)
+    string_copy_range(
+        s,
+        byte_start,
+        (byte_end - byte_start) as u32,
+        (end - start) as u32,
+        0,
+    )
 }
 
 /// Legacy `String.prototype.substr(start, length)`.
@@ -143,19 +149,22 @@ pub extern "C" fn js_string_substr(
     }
 
     // ASCII fast path: byte offsets == UTF-16 offsets.
+    // Copy GC-safely: the destination allocation can move/sweep `s` (#5062).
     if is_ascii_string(s) {
         let slice_len = (end - start) as u32;
-        unsafe {
-            let src = string_data(s).add(start as usize);
-            return js_string_from_ascii_bytes(src, slice_len);
-        }
+        return string_copy_range(s, start as usize, slice_len, slice_len, 0);
     }
 
     let str_data = string_as_str(s);
     let byte_start = utf16_offset_to_byte_offset(str_data, start as usize);
     let byte_end = utf16_offset_to_byte_offset(str_data, end as usize);
-    let slice_bytes = &str_data.as_bytes()[byte_start..byte_end];
-    js_string_from_bytes(slice_bytes.as_ptr(), slice_bytes.len() as u32)
+    string_copy_range(
+        s,
+        byte_start,
+        (byte_end - byte_start) as u32,
+        (end - start) as u32,
+        0,
+    )
 }
 
 // `#[used]` keepalive: `js_string_substr` is reached only from generated `.o`,

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -882,7 +882,11 @@ pub(super) fn build_and_run_link(
             "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang{}",
             ndk_home,
             host_tag,
-            if cfg!(target_os = "windows") { ".cmd" } else { "" }
+            if cfg!(target_os = "windows") {
+                ".cmd"
+            } else {
+                ""
+            }
         );
         let stub_ok = Command::new(&ndk_clang)
             .args(["-c", "-fPIC", "-target", "aarch64-linux-android24"])

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -576,7 +576,11 @@ pub fn select_linker_command(
             "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang{}",
             ndk_home,
             host_tag,
-            if cfg!(target_os = "windows") { ".cmd" } else { "" }
+            if cfg!(target_os = "windows") {
+                ".cmd"
+            } else {
+                ""
+            }
         );
         if !PathBuf::from(&clang).exists() {
             return Err(anyhow!("Android NDK clang not found at: {}", clang));


### PR DESCRIPTION
## Summary

Fixes #5062 — large-string corruption under sustained server GC pressure, where a chunked `String.prototype.slice`/append loop wrote the 4 MB chunk-size word (`0x00400000`) over the head of the produced slices.

## Root cause

`js_string_slice` / `js_string_substring` / `js_string_substr` take this shape on every fast path:

```rust
let src = string_data(s).add(start);          // raw pointer INTO the GC-managed source string
return js_string_from_ascii_bytes(src, len);  // allocates the destination, THEN copies from src
```

The destination allocation (`string_storage_alloc` → `arena_alloc_gc`) can trip a moving/sweeping GC. The source pointer `src` is a bare interior pointer held only in a native-stack local — it is **not** a GC root. Under sustained pressure (an already-active budgeted GC cycle paying assist steps during the allocation, as on the long-running production hub) the source string can be relocated or swept out from under `src`, and the subsequent copy reads a dangling/clobbered buffer. The corrupted head matched the new slice's own length metadata leaking into the payload — a textbook use-after-relocation, the same class as the documented GC unsafe-zone bugs.

This is exactly the hazard `js_string_concat` already guards against by rooting its operands in a `RuntimeHandleScope`; the slice family was simply missing the same protection.

## Fix

Add a `string_copy_range` helper that:
1. roots the source in a `RuntimeHandleScope` (a **mutable** GC root — the slot is rewritten if the object is evacuated),
2. allocates the destination,
3. re-reads the (possibly relocated) source pointer from the handle,
4. then copies.

All three slice fast paths (ASCII and non-ASCII, for `slice`/`substring`/`substr`) route through it. This mirrors `js_string_concat` verbatim.

## Testing

- New unit test `test_transient_runtime_handle_string_slice_gc`, mirroring the existing proven `test_transient_runtime_handle_string_concat_gc` / dynamic-add GC tests (copying nursery + conservative scan disabled + GC trigger due during the slice's allocation).
- `cargo test -p perry-runtime` string + GC suites: all green.
- Functional parity vs `node --experimental-strip-types` for `slice`/`substring`/`substr` across ASCII, multibyte UTF-8, astral/surrogate, and negative-index cases: byte-for-byte identical.
- A ~24 MB chunked slice/append stress program under `PERRY_GC_FORCE_EVACUATE=1` reassembles identically.

Note: the production fault is load-dependent and (per the issue) not deterministically reproducible in isolation; the unit test follows the codebase's established pattern for this fix class rather than reproducing the exact race.

No version bump / changelog entry per request (maintainer to fold in at merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbage-collection safety for string slicing operations (`slice`, `substring`, `substr`) by using GC-safe range copying, preventing corrupted slice results during mid-operation GC.
  * Improved Android build behavior on Windows by correctly forming the NDK clang command path with the required `.cmd` suffix.
* **Tests**
  * Added a new GC regression test for `String.prototype.slice` covering slicing from transient allocations under GC pressure.
  * Expanded GC runtime-root test coverage by adding a new `string_slice` test module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->