### PR TITLE
fix: treat user class with generator [Symbol.iterator] as iterable (#5128)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -751,6 +751,42 @@ pub fn lower_class_decl(
                             };
                             ctx.pending_functions.push(top_fn);
                             ctx.iterator_func_for_class.insert(name.clone(), top_fn_id);
+
+                            // #5128: also register a synthetic NON-generator
+                            // `@@iterator` class method that forwards to the
+                            // lifted generator (`return __perry_iter_X(this)`).
+                            // The syntactic `for…of` fast path dispatches to the
+                            // lifted function directly via `iterator_func_for_class`,
+                            // but every *runtime*-dispatched iterator consumer
+                            // (spread `[...x]`, `Math.max(...x)`, destructuring,
+                            // `x[Symbol.iterator]()`) resolves `@@iterator` through
+                            // the class registry. Without this method the class has
+                            // no `@@iterator` for them to find, so they threw
+                            // "value is not iterable". (The runtime maps the
+                            // well-known `Symbol.iterator` to this `@@iterator`
+                            // method name in `js_object_get_symbol_property`.)
+                            let wrapper_fn_id = ctx.fresh_func();
+                            let wrapper = Function {
+                                id: wrapper_fn_id,
+                                name: "@@iterator".to_string(),
+                                type_params: Vec::new(),
+                                params: Vec::new(),
+                                return_type: Type::Any,
+                                body: vec![Stmt::Return(Some(Expr::Call {
+                                    callee: Box::new(Expr::FuncRef(top_fn_id)),
+                                    args: vec![Expr::This],
+                                    type_args: Vec::new(),
+                                }))],
+                                is_async: false,
+                                is_generator: false,
+                                is_strict: true,
+                                was_plain_async: false,
+                                was_unrolled: false,
+                                is_exported: false,
+                                captures: Vec::new(),
+                                decorators: Vec::new(),
+                            };
+                            methods.push(wrapper);
                             continue;
                         }
                         if seen_generic_computed_member && can_source_order_register {

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -690,7 +690,15 @@ pub(crate) fn array_from_spread_value(value: f64) -> *mut ArrayHeader {
             if fn_ptr.is_null() {
                 throw_iterator_method_not_callable();
             }
+            // Spec `GetIterator(obj)` → `Call(method, obj)`: the
+            // `[Symbol.iterator]()` factory runs with `this === obj`. A canonical
+            // bound class method (#5128's `@@iterator` wrapper) reads its receiver
+            // from IMPLICIT_THIS, so set it here too — mirroring `js_get_iterator`.
+            // Without this the wrapper saw a stale `this` and the generator
+            // yielded nothing (empty spread).
+            let prev_this = crate::object::js_implicit_this_set(value);
             let iter = crate::closure::js_closure_call0(fn_ptr);
+            crate::object::js_implicit_this_set(prev_this);
             if crate::array::js_array_is_array(iter).to_bits() == crate::value::TAG_TRUE {
                 return js_iterator_to_array(crate::array::array_values_iter(iter));
             }

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -640,7 +640,10 @@ pub(crate) unsafe fn sym_key_from_f64(sym_f64: f64) -> usize {
 /// `None` for any other symbol. Used by `js_object_get_symbol_property` to
 /// resolve a user class's iterator method off its prototype.
 fn well_known_symbol_method_name(sym_key: usize) -> Option<&'static str> {
-    for (wk, method) in [("iterator", "@@iterator"), ("asyncIterator", "@@asyncIterator")] {
+    for (wk, method) in [
+        ("iterator", "@@iterator"),
+        ("asyncIterator", "@@asyncIterator"),
+    ] {
         let s = well_known_symbol(wk);
         if !s.is_null() {
             let f = f64::from_bits(crate::value::JSValue::pointer(s as *const u8).bits());

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -634,6 +634,24 @@ pub(crate) unsafe fn sym_key_from_f64(sym_f64: f64) -> usize {
     ptr as usize
 }
 
+/// #5128: map a well-known-symbol key to the synthetic class-method name used
+/// for a symbol-keyed instance *method* (`*[Symbol.iterator]()` →
+/// `@@iterator`, `[Symbol.asyncIterator]()` → `@@asyncIterator`). Returns
+/// `None` for any other symbol. Used by `js_object_get_symbol_property` to
+/// resolve a user class's iterator method off its prototype.
+fn well_known_symbol_method_name(sym_key: usize) -> Option<&'static str> {
+    for (wk, method) in [("iterator", "@@iterator"), ("asyncIterator", "@@asyncIterator")] {
+        let s = well_known_symbol(wk);
+        if !s.is_null() {
+            let f = f64::from_bits(crate::value::JSValue::pointer(s as *const u8).bits());
+            if sym_key == unsafe { sym_key_from_f64(f) } {
+                return Some(method);
+            }
+        }
+    }
+    None
+}
+
 /// Define (or merge) a symbol-keyed accessor on an object literal, delegating
 /// to the shared symbol-accessor side table. Separate `get`/`set` definitions
 /// for the same key accumulate, matching `Object.defineProperty` semantics.
@@ -1771,6 +1789,23 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
                         crate::object::class_symbol_getter_value(class_id, sym_key, obj_f64, false)
                     {
                         return v;
+                    }
+                    // #5128: a symbol-keyed instance METHOD — `*[Symbol.iterator]()`
+                    // (and `[Symbol.asyncIterator]()`) are registered on the class
+                    // under the synthetic names `@@iterator` / `@@asyncIterator`.
+                    // Read the method off the class and return a bound method so
+                    // iteration-protocol consumers (`[...x]`, `for…of`,
+                    // `Math.max(...x)`, destructuring) can drive `.next()`. Guard
+                    // on `method_owner_class_id` first: `js_class_method_bind`
+                    // otherwise mints a bound closure for a non-existent method.
+                    if let Some(method_name) = well_known_symbol_method_name(sym_key) {
+                        if crate::object::method_owner_class_id(class_id, method_name).is_some() {
+                            return crate::object::js_class_method_bind(
+                                obj_f64,
+                                method_name.as_ptr(),
+                                method_name.len(),
+                            );
+                        }
                     }
                 }
             }

--- a/crates/perry/tests/issue_5128_user_symbol_iterator.rs
+++ b/crates/perry/tests/issue_5128_user_symbol_iterator.rs
@@ -1,0 +1,107 @@
+//! Regression test for #5128: a user-defined class with a generator
+//! `*[Symbol.iterator]()` method was not recognized as iterable — spreading it
+//! (`[...x]`), `Math.max(...x)`, `Array.from(x)`, destructuring, and a manual
+//! `x[Symbol.iterator]()` all threw `TypeError: value is not iterable`.
+//!
+//! Root cause: a generator `[Symbol.iterator]` method is lifted to a top-level
+//! `__perry_iter_<Class>` function that the syntactic `for…of` fast path calls
+//! directly. But the class itself carried no `@@iterator` method, so every
+//! *runtime*-dispatched iterator consumer (which resolves `Symbol.iterator`
+//! through the class registry) found nothing.
+//!
+//! Fix (three parts):
+//!  - HIR: also register a synthetic non-generator `@@iterator` class method
+//!    that forwards to the lifted generator (`return __perry_iter_X(this)`).
+//!  - Runtime: `js_object_get_symbol_property` maps the well-known
+//!    `Symbol.iterator` / `Symbol.asyncIterator` to the `@@iterator` /
+//!    `@@asyncIterator` class method and returns a bound method.
+//!  - Runtime: the array-spread path sets `IMPLICIT_THIS` around the iterator
+//!    call so the bound `@@iterator` wrapper sees the right receiver.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: 'TypeError: value is not iterable')\n\
+         status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn class_generator_symbol_iterator_is_iterable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class Range {
+  lo: number; hi: number;
+  constructor(lo: number, hi: number) { this.lo = lo; this.hi = hi; }
+  *[Symbol.iterator]() { for (let i = this.lo; i <= this.hi; i++) yield i; }
+}
+console.log([...new Range(1, 5)].join(","));   // spread
+console.log(Math.max(...new Range(1, 5)));      // Math.max spread
+let s = 0; for (const x of new Range(1, 5)) s += x; console.log(s); // for-of
+const r = new Range(1, 3);
+console.log([...r].join(","));                  // spread via variable
+const [a, b, c] = new Range(10, 12); console.log(a, b, c); // destructuring
+console.log(Array.from(new Range(1, 4)).join(",")); // Array.from
+const it = new Range(7, 8)[Symbol.iterator]();  // manual iterator
+console.log(it.next().value, it.next().value, it.next().done);
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "1,2,3,4,5\n5\n15\n1,2,3\n10 11 12\n1,2,3,4\n7 8 true\n"
+    );
+}
+
+/// A non-generator `[Symbol.iterator]()` method (delegating to a backing
+/// array's iterator) must also be reachable by runtime consumers, and plain
+/// array/string spreads must keep working.
+#[test]
+fn class_plain_symbol_iterator_and_spread_regression() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class Wrap { data = [9, 8, 7]; [Symbol.iterator]() { return this.data[Symbol.iterator](); } }
+console.log([...new Wrap()].join(","));
+console.log([...[1, 2, 3], ...[4, 5]].join(","));
+console.log([..."abc"].join("-"));
+"#,
+    );
+    assert_eq!(stdout, "9,8,7\n1,2,3,4,5\na-b-c\n");
+}


### PR DESCRIPTION
Fixes #5128.

## Problem
A user-defined class with a generator `*[Symbol.iterator]()` method was not recognized as iterable. Spread, `Math.max(...)`, `Array.from`, destructuring, and a manual `[Symbol.iterator]()` call all threw `TypeError: value is not iterable`; only the syntactic `for…of` fast path worked.

```ts
class Range {
  lo: number; hi: number;
  constructor(lo: number, hi: number) { this.lo = lo; this.hi = hi; }
  *[Symbol.iterator]() { for (let i = this.lo; i <= this.hi; i++) yield i; }
}
[...new Range(1, 5)]; // TypeError: value is not iterable  (Node: [1,2,3,4,5])
```

## Root cause
A generator `[Symbol.iterator]` method is lifted to a top-level `__perry_iter_<Class>` function, which `for…of` dispatches to directly via `iterator_func_for_class`. But the class itself carried **no `@@iterator` method**, so every *runtime*-dispatched iterator consumer — which resolves `Symbol.iterator` through the class registry — found nothing.

## Fix (three parts)
1. **HIR** (`lower_decl/class_decl.rs`): alongside the lift, register a synthetic non-generator `@@iterator` class method that forwards to the lifted generator (`return __perry_iter_X(this)`). The `for…of` fast path is unchanged.
2. **Runtime** (`symbol.rs`): `js_object_get_symbol_property` now maps the well-known `Symbol.iterator` / `Symbol.asyncIterator` to the `@@iterator` / `@@asyncIterator` class method and returns a bound method (guarded by `method_owner_class_id` so it never mints a bound closure for a missing method). This also fixes plain non-generator `[Symbol.iterator]()` methods.
3. **Runtime** (`array/iterator.rs`): the array-spread path now sets `IMPLICIT_THIS` around the iterator call (mirroring `js_get_iterator`), so the bound `@@iterator` wrapper sees the right receiver — without it the generator yielded nothing (empty spread).

## Verification
All match Node exactly: spread (incl. via variable), `Math.max(...)`, `for…of`, destructuring, `Array.from`, manual `[Symbol.iterator]()`, a non-generator `[Symbol.iterator]()` delegating to a backing array, and plain array/string spread (regression).

Two new integration tests in `crates/perry/tests/issue_5128_user_symbol_iterator.rs` (green). `perry-hir` suite green; `perry-runtime` isolated tests green (the full-suite shows the repo's pre-existing ~2 order-dependent flakes, which differ run-to-run and are unrelated).

No changelog/version bump per maintainer's release-at-merge workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Fixed iteration support for classes keyed by `Symbol.iterator` (and `Symbol.asyncIterator`), ensuring runtime dispatch finds the correct class method for spread, `Math.max(...x)`, destructuring, `for...of`, `Array.from()`, and direct `obj[Symbol.iterator]().next()` usage.

**Tests**
* Added a regression suite covering generator and non-generator `Symbol.iterator` class implementations to verify consistent runtime output across the above patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->