### PR TITLE
fix(proxy): Reflect.set(t,k,v,receiver) with proxy receiver segfaults (#5129)

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1119,7 +1119,10 @@ unsafe fn build_create_data_descriptor(value: f64) -> f64 {
             field,
         );
     }
-    f64::from_bits(POINTER_TAG | ((desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>() as u64) & POINTER_MASK))
+    f64::from_bits(
+        POINTER_TAG
+            | ((desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>() as u64) & POINTER_MASK),
+    )
 }
 
 fn create_or_update_receiver_property(receiver: f64, key: f64, value: f64) -> bool {

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1097,9 +1097,46 @@ fn call_setter_with_receiver(setter_bits: u64, receiver: f64, value: f64) -> boo
     true
 }
 
+/// #5129: build a fresh data property descriptor
+/// `{ value, writable: true, enumerable: true, configurable: true }`
+/// (the CreateDataProperty shape) for defining a property on a Proxy receiver
+/// via its `[[DefineOwnProperty]]`.
+unsafe fn build_create_data_descriptor(value: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_root = scope.root_nanbox_f64(value);
+    let desc = crate::object::js_object_alloc(0, 4);
+    let desc_handle = scope.root_raw_mut_ptr(desc);
+    for (name, field) in [
+        (b"value".as_slice(), value_root.get_nanbox_f64()),
+        (b"writable".as_slice(), f64::from_bits(TAG_TRUE)),
+        (b"enumerable".as_slice(), f64::from_bits(TAG_TRUE)),
+        (b"configurable".as_slice(), f64::from_bits(TAG_TRUE)),
+    ] {
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        crate::object::js_object_set_field_by_name(
+            desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>(),
+            key,
+            field,
+        );
+    }
+    f64::from_bits(POINTER_TAG | ((desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>() as u64) & POINTER_MASK))
+}
+
 fn create_or_update_receiver_property(receiver: f64, key: f64, value: f64) -> bool {
     if !reflect_value_is_object(receiver) {
         return false;
+    }
+    // #5129: a Proxy receiver — e.g. a `set` trap forwarding
+    // `Reflect.set(target, key, value, proxy)` (the 4-arg form) — must route
+    // through the proxy's `[[DefineOwnProperty]]` (its `defineProperty` trap,
+    // or, absent a trap, a define on the proxy's target), NOT an ordinary data
+    // store. This is OrdinarySetWithOwnDescriptor's tail
+    // `CreateDataProperty(Receiver, P, V)`. Treating the proxy id as a heap
+    // object (the `target_set` fall-through below) segfaulted; re-invoking the
+    // `set` trap would have recursed infinitely.
+    if lookup(receiver).is_some() {
+        let desc = unsafe { build_create_data_descriptor(value) };
+        return crate::value::js_is_truthy(js_reflect_define_property(receiver, key, desc)) != 0;
     }
     if let Some(desc) = own_set_descriptor(receiver, key) {
         match desc {

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1125,6 +1125,27 @@ unsafe fn build_create_data_descriptor(value: f64) -> f64 {
     )
 }
 
+/// #5129: build a `{ value }`-only property descriptor — the `valueDesc` of
+/// OrdinarySetWithOwnDescriptor step 2.d.iii, used to update an existing
+/// writable data property on a Proxy receiver without disturbing its other
+/// attributes (`writable`/`enumerable`/`configurable`).
+unsafe fn build_value_only_descriptor(value: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_root = scope.root_nanbox_f64(value);
+    let desc = crate::object::js_object_alloc(0, 1);
+    let desc_handle = scope.root_raw_mut_ptr(desc);
+    let key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
+    crate::object::js_object_set_field_by_name(
+        desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>(),
+        key,
+        value_root.get_nanbox_f64(),
+    );
+    f64::from_bits(
+        POINTER_TAG
+            | ((desc_handle.get_raw_mut_ptr::<crate::ObjectHeader>() as u64) & POINTER_MASK),
+    )
+}
+
 fn create_or_update_receiver_property(receiver: f64, key: f64, value: f64) -> bool {
     if !reflect_value_is_object(receiver) {
         return false;
@@ -1138,7 +1159,37 @@ fn create_or_update_receiver_property(receiver: f64, key: f64, value: f64) -> bo
     // object (the `target_set` fall-through below) segfaulted; re-invoking the
     // `set` trap would have recursed infinitely.
     if lookup(receiver).is_some() {
-        let desc = unsafe { build_create_data_descriptor(value) };
+        // OrdinarySetWithOwnDescriptor steps 2.c–2.e for a Proxy receiver. We
+        // must mirror the ordinary algorithm's receiver-own-descriptor checks,
+        // not jump straight to CreateDataProperty:
+        //
+        //   2.c existingDescriptor = Receiver.[[GetOwnProperty]](P)
+        //   2.d if it exists:
+        //       i.   accessor descriptor      → return false
+        //       ii.  non-writable data        → return false
+        //       iii. else redefine `{ value }` only (preserve other attrs)
+        //   2.e else CreateDataProperty(Receiver, P, V)
+        //
+        // `[[GetOwnProperty]]` fires the proxy's getOwnPropertyDescriptor trap
+        // (trap-less: reads its target) and returns a completed plain
+        // descriptor object, or `undefined` when absent. A throwing/invariant-
+        // violating trap unwinds via `js_throw` and never returns here.
+        let existing = js_reflect_get_own_property_descriptor(receiver, key);
+        let desc = if reflect_value_is_object(existing) {
+            let is_accessor = unsafe {
+                reflect::descriptor_field_present(existing, b"get")
+                    || reflect::descriptor_field_present(existing, b"set")
+            };
+            // A completed data descriptor always carries `writable`; treat a
+            // missing flag as non-writable (reject) to stay on the safe side.
+            let writable = unsafe { reflect::descriptor_bool_field(existing, b"writable") };
+            if is_accessor || writable != Some(true) {
+                return false;
+            }
+            unsafe { build_value_only_descriptor(value) }
+        } else {
+            unsafe { build_create_data_descriptor(value) }
+        };
         return crate::value::js_is_truthy(js_reflect_define_property(receiver, key, desc)) != 0;
     }
     if let Some(desc) = own_set_descriptor(receiver, key) {

--- a/crates/perry-runtime/src/proxy/reflect.rs
+++ b/crates/perry-runtime/src/proxy/reflect.rs
@@ -220,7 +220,7 @@ fn descriptor_key(name: &[u8]) -> (*const crate::StringHeader, f64) {
     (key, key_value)
 }
 
-unsafe fn descriptor_field_present(desc: f64, name: &[u8]) -> bool {
+pub(super) unsafe fn descriptor_field_present(desc: f64, name: &[u8]) -> bool {
     let (key, key_value) = descriptor_key(name);
     if lookup(desc).is_some() {
         let scope = crate::gc::RuntimeHandleScope::new();
@@ -250,7 +250,7 @@ unsafe fn descriptor_field(desc: f64, name: &[u8]) -> f64 {
     f64::from_bits(crate::object::js_object_get_field_by_name(ptr, key).bits())
 }
 
-unsafe fn descriptor_bool_field(desc: f64, name: &[u8]) -> Option<bool> {
+pub(super) unsafe fn descriptor_bool_field(desc: f64, name: &[u8]) -> Option<bool> {
     if !descriptor_field_present(desc, name) {
         return None;
     }

--- a/crates/perry/tests/issue_5129_proxy_reflect_set_receiver.rs
+++ b/crates/perry/tests/issue_5129_proxy_reflect_set_receiver.rs
@@ -1,0 +1,89 @@
+//! Regression test for #5129: a `Proxy` whose `set` trap calls the 4-arg
+//! `Reflect.set(target, key, value, receiver)` (forwarding the proxy itself as
+//! the receiver) segfaulted (SIGSEGV / exit 139).
+//!
+//! Root cause: `Reflect.set` → `OrdinarySetWithOwnDescriptor` ends in
+//! `CreateDataProperty(Receiver, P, V)` = `Receiver.[[DefineOwnProperty]]`.
+//! Perry's `create_or_update_receiver_property` instead did an ordinary data
+//! store (`target_set`) on the receiver — but the receiver was a Proxy (a small
+//! registered id, not a heap object), so it dereferenced a fake pointer.
+//!
+//! Fix: when the receiver is a Proxy, route through its `[[DefineOwnProperty]]`
+//! (`js_reflect_define_property` with a CreateDataProperty descriptor), which
+//! invokes the `defineProperty` trap or, absent one, defines on the target.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: SIGSEGV / exit 139)\nstatus: {:?}\n\
+         stdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn proxy_set_trap_reflect_set_with_receiver_does_not_segfault() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const p = new Proxy({ a: 1 } as Record<string, unknown>, {
+  set(t, k, v, r) { return Reflect.set(t, k, v, r); },
+});
+p.b = 2;
+console.log("set ok");
+console.log(p.a, p.b);
+
+// The trap body runs once per write, then the define lands on the target.
+const log: string[] = [];
+const p2 = new Proxy({ x: 0 } as Record<string, unknown>, {
+  set(t, k, v, r) { log.push("trap:" + String(k)); return Reflect.set(t, k, v, r); },
+});
+p2.x = 9; p2.y = 7;
+console.log(log.join(","), p2.x, p2.y);
+
+// A defineProperty trap on the same proxy must be invoked by the receiver define.
+const dlog: string[] = [];
+const p3 = new Proxy({} as Record<string, unknown>, {
+  set(t, k, v, r) { return Reflect.set(t, k, v, r); },
+  defineProperty(t, k, d) { dlog.push("def:" + String(k)); return Reflect.defineProperty(t, k, d); },
+});
+p3.z = 5;
+console.log(dlog.join(","), p3.z);
+"#,
+    );
+    assert_eq!(stdout, "set ok\n1 2\ntrap:x,trap:y 9 7\ndef:z 5\n");
+}

--- a/crates/perry/tests/issue_5129_proxy_reflect_set_receiver.rs
+++ b/crates/perry/tests/issue_5129_proxy_reflect_set_receiver.rs
@@ -30,6 +30,9 @@ fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
         .arg(&entry)
         .arg("-o")
         .arg(&output)
+        // Bypass the compile cache so the test always exercises the current
+        // proxy-receiver codegen/runtime path rather than a stale artifact.
+        .arg("--no-cache")
         .output()
         .expect("run perry compile");
     assert!(


### PR DESCRIPTION
Fixes #5129.

## Problem
A `Proxy` whose `set` trap calls the 4-arg `Reflect.set(target, key, value, receiver)` (forwarding the proxy itself as the receiver) segfaulted (SIGSEGV / exit 139):

```ts
const p = new Proxy({ a: 1 }, {
  set(t, k, v, r) { return Reflect.set(t, k, v, r); },
});
p.b = 2;            // crash (Node: works, p.b === 2)
```

## Root cause
`Reflect.set` → `OrdinarySetWithOwnDescriptor` ends in `CreateDataProperty(Receiver, P, V)` = `Receiver.[[DefineOwnProperty]]`. Perry's `create_or_update_receiver_property` instead did an ordinary data store (`target_set`) on the receiver. But the receiver was a **Proxy** — a small registered id, not a heap object — so `target_set` dereferenced a fake pointer and crashed. (Routing it back through the `set` trap would instead have recursed infinitely.)

## Fix
When the receiver is a Proxy, route through its `[[DefineOwnProperty]]` via `js_reflect_define_property` with a CreateDataProperty descriptor (`{ value, writable: true, enumerable: true, configurable: true }`). That invokes the proxy's `defineProperty` trap when present, or — absent a trap — defines on the proxy's target, matching Node.

## Verification
Matches Node exactly: the repro (`set ok` / `1 2`), the trap firing once per write then the value landing on the target, a `defineProperty` trap being invoked by the receiver define, plus regressions for direct-assignment traps, 3-arg `Reflect.set`, a different plain-object receiver, and a prototype setter with a receiver.

New integration test: `crates/perry/tests/issue_5129_proxy_reflect_set_receiver.rs` (green). proxy/reflect runtime unit tests green.

No changelog/version bump per maintainer's release-at-merge workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed Proxy receiver handling for `set` operations so property writes correctly route through `Reflect.defineProperty` when the receiver is itself a Proxy, ensuring consistent receiver-side dispatch.

## Tests
* Added a regression test for issue `#5129` covering `Proxy` `set` traps that call `Reflect.set` with the receiver set to the proxy, including cases with `defineProperty` traps.

## Internal
* Adjusted Proxy descriptor-processing helpers to allow shared use within the parent module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->