### PR TITLE
test(http): guard against POST-body-consume segfault (#5131)

### DIFF
--- a/crates/perry/tests/issue_5131_http_post_body_segfault.rs
+++ b/crates/perry/tests/issue_5131_http_post_body_segfault.rs
@@ -1,0 +1,111 @@
+//! Regression test for #5131: a `node:http` server that consumes the request
+//! body (`req.on('data')` + `req.on('end')`) on a request that actually carries
+//! a body segfaulted (SIGSEGV / exit 139).
+//!
+//! The crash was fixed on `main` by the http/stream work that landed after the
+//! issue was filed (v0.5.1167); this test guards against a regression. It needs
+//! the default (auto-optimize) build — `PERRY_NO_AUTO_OPTIMIZE=1` produces a
+//! runtime-only binary where `node:http` dispatch is a no-op stub.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: SIGSEGV / exit 139 on body consume)\n\
+         status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The issue's repro: a POST whose body is consumed via `req.on('data')` /
+/// `req.on('end')` must round-trip without crashing.
+#[test]
+fn http_server_consuming_post_body_does_not_segfault() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import http from "node:http";
+const server = http.createServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", () => { res.writeHead(200); res.end("len:" + body.length); });
+});
+server.listen(0, () => {
+  const port = (server.address() as { port: number }).port;
+  const r = http.request({ port, method: "POST" }, (res) => {
+    let d = ""; res.on("data", (c) => (d += c));
+    res.on("end", () => { console.log(d); server.close(); });
+  });
+  r.write("payload-bytes");
+  r.end();
+});
+"#,
+    );
+    assert_eq!(stdout, "len:13\n");
+}
+
+/// A larger, chunk-collected body (`Buffer.concat`) must also round-trip — this
+/// exercises the multi-chunk data path and more allocation pressure.
+#[test]
+fn http_server_consuming_large_post_body() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import http from "node:http";
+const big = "x".repeat(100000);
+const server = http.createServer((req, res) => {
+  const chunks: Buffer[] = [];
+  req.on("data", (c) => chunks.push(c as Buffer));
+  req.on("end", () => {
+    const body = Buffer.concat(chunks).toString();
+    res.writeHead(200);
+    res.end("len:" + body.length);
+  });
+});
+server.listen(0, () => {
+  const port = (server.address() as { port: number }).port;
+  const r = http.request({ port, method: "POST" }, (res) => {
+    let d = ""; res.on("data", (c) => (d += c));
+    res.on("end", () => { console.log(d); server.close(); });
+  });
+  r.write(big);
+  r.end();
+});
+"#,
+    );
+    assert_eq!(stdout, "len:100000\n");
+}


### PR DESCRIPTION
Re #5131.

## Status: already fixed on `main` — adding a regression guard
The issue was filed against v0.5.1167. On current `main` the repro no longer segfaults: a `node:http` server consuming the request body via `req.on('data')` / `req.on('end')` on a POST now round-trips cleanly (the crash was resolved by the http/stream work that landed after the issue was filed). Verified across 12 consecutive runs and under GC stress (`PERRY_GC_FORCE_EVACUATE=1`).

```
$ ./repro            # was: (no output; SIGSEGV / 139)
len:13               # now matches Node
```

## What this PR adds
Since there's no code change needed, this locks in the fixed behavior with two regression tests (`crates/perry/tests/issue_5131_http_post_body_segfault.rs`):
- the exact issue repro (small body → `len:13`);
- a larger multi-chunk `Buffer.concat` body (`len:100000`) to exercise the multi-chunk data path and allocation pressure.

Both use the default auto-optimize build (`node:http` is a no-op stub under `PERRY_NO_AUTO_OPTIMIZE=1`), matching the existing http server integration tests. Both green.

The issue can be closed once this merges.

No changelog/version bump per maintainer's release-at-merge workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved HTTP POST request handling crash when consuming request body data with both small and large payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->