### PR TITLE
[codex] fix two-arg Math.min/max codegen

### DIFF
--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -448,6 +448,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // call js_math_min_array. The variadic form materializes a
         // temporary fixed-size array via js_array_alloc + push.
         Expr::MathMin(values) => {
+            if values.len() == 2 {
+                let left = lower_expr(ctx, &values[0])?;
+                let right = lower_expr(ctx, &values[1])?;
+                let blk = ctx.block();
+                return Ok(blk.call(DOUBLE, "js_math_min2", &[(DOUBLE, &left), (DOUBLE, &right)]));
+            }
             let cap = (values.len() as u32).to_string();
             let arr_handle_v = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
             // Push each value. push_f64 may realloc, so we thread the
@@ -474,6 +480,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- Math.max(...args) — same shape as Math.min --------
         Expr::MathMax(values) => {
+            if values.len() == 2 {
+                let left = lower_expr(ctx, &values[0])?;
+                let right = lower_expr(ctx, &values[1])?;
+                let blk = ctx.block();
+                return Ok(blk.call(DOUBLE, "js_math_max2", &[(DOUBLE, &left), (DOUBLE, &right)]));
+            }
             let cap = (values.len() as u32).to_string();
             let mut current = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
             for v_expr in values {

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -326,6 +326,8 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_is_undefined_or_bare_nan", I32, &[DOUBLE]);
     module.declare_function("js_math_min_array", DOUBLE, &[I64]);
     module.declare_function("js_math_max_array", DOUBLE, &[I64]);
+    module.declare_function("js_math_min2", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_math_max2", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_string_coerce", I64, &[DOUBLE]);
     module.declare_function("js_array_slice", I64, &[I64, I32, I32]);
     module.declare_function("js_array_slice_values", I64, &[I64, DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/math.rs
+++ b/crates/perry-runtime/src/math.rs
@@ -278,6 +278,21 @@ pub extern "C" fn js_math_min_array(arr_ptr: i64) -> f64 {
     }
 }
 
+/// Math.min(a, b) -> number — fast path for the common two-arg form.
+#[no_mangle]
+pub extern "C" fn js_math_min2(a: f64, b: f64) -> f64 {
+    let a = js_math_to_number(a);
+    let b = js_math_to_number(b);
+    if a.is_nan() || b.is_nan() {
+        return f64::NAN;
+    }
+    if a < b || (a == 0.0 && b == 0.0 && a.is_sign_negative()) {
+        a
+    } else {
+        b
+    }
+}
+
 /// Math.max(...array) -> number — find maximum value in an array
 #[no_mangle]
 pub extern "C" fn js_math_max_array(arr_ptr: i64) -> f64 {
@@ -308,5 +323,61 @@ pub extern "C" fn js_math_max_array(arr_ptr: i64) -> f64 {
         f64::NAN
     } else {
         result
+    }
+}
+
+/// Math.max(a, b) -> number — fast path for the common two-arg form.
+#[no_mangle]
+pub extern "C" fn js_math_max2(a: f64, b: f64) -> f64 {
+    let a = js_math_to_number(a);
+    let b = js_math_to_number(b);
+    if a.is_nan() || b.is_nan() {
+        return f64::NAN;
+    }
+    if a > b || (a == 0.0 && b == 0.0 && a.is_sign_positive()) {
+        a
+    } else {
+        b
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn js_math_min2_basic_and_signed_zero() {
+        assert_eq!(js_math_min2(4.0, -2.0), -2.0);
+        assert_eq!(js_math_min2(-2.0, 4.0), -2.0);
+
+        let neg_zero = js_math_min2(-0.0, 0.0);
+        assert_eq!(neg_zero, 0.0);
+        assert!(neg_zero.is_sign_negative());
+
+        let neg_zero_reversed = js_math_min2(0.0, -0.0);
+        assert_eq!(neg_zero_reversed, 0.0);
+        assert!(neg_zero_reversed.is_sign_negative());
+    }
+
+    #[test]
+    fn js_math_max2_basic_and_signed_zero() {
+        assert_eq!(js_math_max2(4.0, -2.0), 4.0);
+        assert_eq!(js_math_max2(-2.0, 4.0), 4.0);
+
+        let pos_zero = js_math_max2(-0.0, 0.0);
+        assert_eq!(pos_zero, 0.0);
+        assert!(pos_zero.is_sign_positive());
+
+        let pos_zero_reversed = js_math_max2(0.0, -0.0);
+        assert_eq!(pos_zero_reversed, 0.0);
+        assert!(pos_zero_reversed.is_sign_positive());
+    }
+
+    #[test]
+    fn js_math_minmax2_nan() {
+        assert!(js_math_min2(f64::NAN, 1.0).is_nan());
+        assert!(js_math_min2(1.0, f64::NAN).is_nan());
+        assert!(js_math_max2(f64::NAN, 1.0).is_nan());
+        assert!(js_math_max2(1.0, f64::NAN).is_nan());
     }
 }

--- a/tests/test_math_minmax_two_arg_codegen.sh
+++ b/tests/test_math_minmax_two_arg_codegen.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+
+if [[ ! -x "$PERRY" ]]; then
+    PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+SRC="$TMPDIR/math_minmax_two_arg_codegen.ts"
+BIN="$TMPDIR/math_minmax_two_arg_codegen"
+OBJ="$TMPDIR/math_minmax_two_arg_codegen.o"
+
+cat >"$SRC" <<'TS'
+let failures = 0;
+
+function check(label: string, actual: number, expected: number): void {
+  if (actual !== expected) {
+    console.log(label + ": expected " + String(expected) + ", got " + String(actual));
+    failures = failures + 1;
+  }
+}
+
+function checkNaN(label: string, actual: number): void {
+  if (actual === actual) {
+    console.log(label + ": expected NaN, got " + String(actual));
+    failures = failures + 1;
+  }
+}
+
+function checkReciprocal(label: string, actual: number, expected: number): void {
+  if (actual !== 0 || 1 / actual !== expected) {
+    console.log(label + ": unexpected zero sign");
+    failures = failures + 1;
+  }
+}
+
+function clip(start: number, count: number, rangeStart: number, rangeCount: number): number {
+  const drawStart = Math.max(start, rangeStart);
+  const drawEnd = Math.min(start + count, rangeStart + rangeCount);
+  return drawEnd - drawStart;
+}
+
+check("clip overlap", clip(1, 10, 3, 4), 4);
+check("min order", Math.min(4, -2), -2);
+check("max order", Math.max(4, -2), 4);
+checkNaN("min nan", Math.min(NaN, 1));
+checkNaN("max nan", Math.max(1, NaN));
+checkReciprocal("min signed zero", Math.min(0, -0), -Infinity);
+checkReciprocal("max signed zero", Math.max(-0, 0), Infinity);
+
+if (failures !== 0) {
+  throw new Error("two-arg Math.min/Math.max regression failed");
+}
+
+console.log("two-arg Math.min/Math.max ok");
+TS
+
+"$PERRY" compile --no-cache --no-auto-optimize "$SRC" -o "$BIN" >"$TMPDIR/compile.log" 2>&1 || {
+    echo "FAIL: compile failed"
+    sed 's/^/    /' "$TMPDIR/compile.log" | tail -80
+    exit 1
+}
+
+"$BIN" >"$TMPDIR/run.log" 2>&1 || {
+    echo "FAIL: program failed"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+}
+
+if ! grep -q "two-arg Math.min/Math.max ok" "$TMPDIR/run.log"; then
+    echo "FAIL: expected success marker"
+    sed 's/^/    /' "$TMPDIR/run.log" | tail -80
+    exit 1
+fi
+
+(
+    cd "$TMPDIR"
+    "$PERRY" compile --no-cache --no-auto-optimize --trace llvm --focus clip --no-link \
+        "$SRC" -o "$OBJ" >"$TMPDIR/trace-compile.log" 2>&1
+) || {
+    echo "FAIL: trace compile failed"
+    sed 's/^/    /' "$TMPDIR/trace-compile.log" | tail -80
+    exit 1
+}
+
+TRACE_DIR="$TMPDIR/.perry-trace/llvm"
+if [[ ! -d "$TRACE_DIR" ]]; then
+    echo "FAIL: LLVM trace directory not found"
+    exit 1
+fi
+
+if ! grep -R "call double @js_math_min2" "$TRACE_DIR" >/dev/null; then
+    echo "FAIL: expected js_math_min2 call in LLVM trace"
+    exit 1
+fi
+
+if ! grep -R "call double @js_math_max2" "$TRACE_DIR" >/dev/null; then
+    echo "FAIL: expected js_math_max2 call in LLVM trace"
+    exit 1
+fi
+
+if grep -R "call double @js_math_min_array" "$TRACE_DIR" >/dev/null; then
+    echo "FAIL: unexpected js_math_min_array call in two-arg LLVM trace"
+    exit 1
+fi
+
+if grep -R "call double @js_math_max_array" "$TRACE_DIR" >/dev/null; then
+    echo "FAIL: unexpected js_math_max_array call in two-arg LLVM trace"
+    exit 1
+fi
+
+if grep -R "call i64 @js_array_alloc(i32 2)" "$TRACE_DIR" >/dev/null; then
+    echo "FAIL: unexpected two-element array allocation in LLVM trace"
+    exit 1
+fi
+
+echo "PASS: two-arg Math.min/Math.max codegen"


### PR DESCRIPTION
## Summary

- add direct runtime ABI helpers for two-argument `Math.min` / `Math.max`
- lower exactly-two-argument host/native `Math.min` / `Math.max` calls to those helpers
- keep spread and 0/1/3+ argument calls on the existing array reducer path
- add a focused regression that checks JS-visible behavior and LLVM trace shape

## Verification

- `cargo fmt --check`
- `cargo test -p perry-runtime js_math`
- `cargo build -p perry`
- `cargo build -p perry-runtime`
- `tests/test_math_minmax_two_arg_codegen.sh`
- manual draw-range-shaped trace repro: emitted `call double @js_math_max2` and `call double @js_math_min2`; no `js_math_min_array` / `js_math_max_array` calls and no `js_array_alloc(i32 2)` for the two-arg path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized `Math.min()` and `Math.max()` performance for two-argument cases.

* **Tests**
  * Added test coverage for `Math.min()`/`Math.max()` edge cases, including NaN propagation and signed-zero behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->