### PR TITLE
[codex] fix imported zero-arg super constructor dispatch

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -351,25 +351,30 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
                     // through to the next ancestor when `class_table`'s
                     // entry for an imported class returned a stub with
                     // `constructor: None` (stubs always have None) — even
-                    // though the source module did have a real ctor with
-                    // params. Result: `class Child extends Parent { x =
+                    // though the source module did have a real ctor/effect.
+                    // Result: `class Child extends Parent { x =
                     // "y" }` (no own ctor, parent in another module) had
                     // its synthesized ctor with ZERO params, so the user's
                     // `new Child("arg")` lost the arg before reaching
-                    // Parent_constructor. Refs #420.
-                    let imported_ctor_params = opts
+                    // Parent_constructor. Explicit zero-arg ctors and
+                    // field-initializer ctors still stop the walk even with
+                    // zero adopted params. Refs #420.
+                    let imported_ctor = opts
                         .imported_classes
                         .iter()
                         .find(|i| i.local_alias.as_deref().unwrap_or(&i.name) == pname.as_str())
-                        .map(|ic| ic.constructor_param_count)
-                        .unwrap_or(0);
+                        .filter(|ic| {
+                            ic.constructor_param_count > 0
+                                || ic.has_own_constructor
+                                || ic.has_instance_fields
+                        });
                     if let Some(pclass) = class_table.get(pname.as_str()) {
                         if let Some(pctor) = &pclass.constructor {
                             found_params = pctor.params.clone();
                             break;
                         }
-                        if imported_ctor_params > 0 {
-                            for i in 0..imported_ctor_params {
+                        if let Some(imported_ctor) = imported_ctor {
+                            for i in 0..imported_ctor.constructor_param_count {
                                 found_params.push(perry_hir::Param {
                                     id: 0xFFFF_0000 + i as u32,
                                     name: format!("__forward_arg{}", i),
@@ -385,10 +390,10 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
                         cur = pclass.extends_name.clone();
                     } else if let Some(stub) = imported_class_stubs.iter().find(|c| c.name == pname)
                     {
-                        // Imported stub — params not in HIR; use its ctor
-                        // param count as a synthetic count of unnamed args.
-                        if imported_ctor_params > 0 {
-                            for i in 0..imported_ctor_params {
+                        // Imported stub — params not in HIR; use effectful
+                        // ctor metadata as a synthetic count of unnamed args.
+                        if let Some(imported_ctor) = imported_ctor {
+                            for i in 0..imported_ctor.constructor_param_count {
                                 found_params.push(perry_hir::Param {
                                     id: 0xFFFF_0000 + i as u32,
                                     name: format!("__forward_arg{}", i),

--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -321,7 +321,11 @@ pub(super) fn compile_method(
                     break;
                 };
                 let has_local_body = pc.constructor.is_some();
-                let has_imported_ctor = ctx.imported_class_ctors.contains_key(pname);
+                let has_imported_ctor = ctx
+                    .imported_class_ctors
+                    .get(pname)
+                    .map(|ctor| ctor.stops_constructor_walk())
+                    .unwrap_or(false);
                 if has_local_body || has_imported_ctor {
                     break;
                 }
@@ -376,10 +380,10 @@ pub(super) fn compile_method(
                                 .map(|c| c.params.len())
                                 .unwrap_or(0);
                             (sym, pcount)
-                        } else if let Some((sym, n)) =
+                        } else if let Some(ctor) =
                             ctx.imported_class_ctors.get(&pname_owned).cloned()
                         {
-                            (sym, n)
+                            (ctor.symbol, ctor.param_count)
                         } else {
                             // No callable ctor symbol — bail.
                             stmt::lower_stmts(&mut ctx, &method.body).with_context(|| {
@@ -397,10 +401,8 @@ pub(super) fn compile_method(
                             let _ = std::mem::take(&mut ctx.pending_declares);
                             return Ok(());
                         }
-                    } else if let Some((sym, n)) =
-                        ctx.imported_class_ctors.get(&pname_owned).cloned()
-                    {
-                        (sym, n)
+                    } else if let Some(ctor) = ctx.imported_class_ctors.get(&pname_owned).cloned() {
+                        (ctor.symbol, ctor.param_count)
                     } else {
                         ("".to_string(), 0)
                     };

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -51,10 +51,10 @@ mod string_pool;
 
 pub use helpers::resolve_target_triple;
 pub(crate) use helpers::{default_target_triple, write_barriers_enabled};
-pub(crate) use opts::CrossModuleCtx;
 pub use opts::{
     AppMetadata, CompileOptions, FpContractMode, ImportedClass, NamespaceEntry, NamespaceEntryKind,
 };
+pub(crate) use opts::{CrossModuleCtx, ImportedCtor};
 
 use artifacts::{emit_module_artifacts, ModuleArtifactsCtx};
 use function::compile_function;
@@ -1063,7 +1063,12 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 let ctor_name = format!("{}__{}_constructor", ic.source_prefix, ic.name);
                 (
                     effective_name.to_string(),
-                    (ctor_name, ic.constructor_param_count),
+                    ImportedCtor {
+                        symbol: ctor_name,
+                        param_count: ic.constructor_param_count,
+                        has_own_constructor: ic.has_own_constructor,
+                        has_instance_fields: ic.has_instance_fields,
+                    },
                 )
             })
             .collect(),

--- a/crates/perry-codegen/src/codegen/opts.rs
+++ b/crates/perry-codegen/src/codegen/opts.rs
@@ -429,6 +429,10 @@ pub struct ImportedClass {
     pub source_prefix: String,
     /// Number of constructor parameters (needed for dispatch).
     pub constructor_param_count: usize,
+    /// Whether the source class declared its own constructor body.
+    pub has_own_constructor: bool,
+    /// Whether the source class has instance fields that require initializer replay.
+    pub has_instance_fields: bool,
     /// Method names defined on this class.
     pub method_names: Vec<String>,
     /// Per-method explicit param counts, parallel to `method_names`. Issue #235:
@@ -485,6 +489,23 @@ pub struct ImportedClass {
     /// instances by the source module's constructor. `None` falls back
     /// to a freshly-assigned id (legacy behavior).
     pub source_class_id: Option<u32>,
+}
+
+/// Constructor metadata for a class imported from another module.
+#[derive(Debug, Clone)]
+pub(crate) struct ImportedCtor {
+    pub symbol: String,
+    pub param_count: usize,
+    pub has_own_constructor: bool,
+    pub has_instance_fields: bool,
+}
+
+impl ImportedCtor {
+    /// True when constructor resolution must stop at this imported class even
+    /// when its standalone constructor takes zero user parameters.
+    pub(crate) fn stops_constructor_walk(&self) -> bool {
+        self.param_count > 0 || self.has_own_constructor || self.has_instance_fields
+    }
 }
 
 /// Cross-module import context, bundled into a single struct to avoid
@@ -603,7 +624,7 @@ pub(crate) struct CrossModuleCtx {
     /// Imported class constructor function names. Maps class_name →
     /// full constructor symbol (e.g. "Editor" → "hone_editor_...__Editor_constructor").
     /// Populated from `opts.imported_classes`.
-    pub imported_class_ctors: std::collections::HashMap<String, (String, usize)>,
+    pub imported_class_ctors: std::collections::HashMap<String, ImportedCtor>,
     /// Compile-time i18n table for resolving `Expr::I18nString` against
     /// the project's default locale. `None` when i18n is not configured.
     /// Built from `opts.i18n_table` once at the top of `compile_module`

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -334,8 +334,8 @@ pub(crate) struct FnCtx<'a> {
     /// `ctx.classes` chain (which mis-picks same-named cross-module parents).
     pub class_init_chains:
         &'a std::collections::HashMap<String, Vec<(String, Vec<perry_hir::ClassField>)>>,
-    /// Imported class constructor names: class_name → (ctor_fn_name, param_count).
-    pub imported_class_ctors: &'a std::collections::HashMap<String, (String, usize)>,
+    /// Imported class constructor metadata, keyed by effective imported class name.
+    pub imported_class_ctors: &'a std::collections::HashMap<String, crate::codegen::ImportedCtor>,
     /// Per-function param signature: `(declared_param_count,
     /// has_rest_param)`. Used by FuncRef call sites to know whether
     /// to bundle trailing arguments into a rest array.

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -625,29 +625,27 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // PgSerialBuilder → PgColumnBuilder → ColumnBuilder chain
             // where only ColumnBuilder has a ctor body).
             // Walk up the parent chain to find the first class with a
-            // local constructor body OR a cross-module ctor stub WITH
-            // declared params. JS spec requires `class Mid extends Base {}`
+            // local constructor body OR a cross-module ctor stub that must
+            // run. JS spec requires `class Mid extends Base {}`
             // followed by `class Leaf extends Mid` calling `super(...)` to
             // reach Base's ctor body (Mid has no ctor → implicit forward).
             // Refs #420 (drizzle's PgSerialBuilder → PgColumnBuilder →
             // ColumnBuilder where only ColumnBuilder has a body).
             //
-            // We must skip past imported ctors with param_count=0 too —
-            // those represent empty-bodied derived classes whose imported
-            // standalone ctor would otherwise eat the incoming args
-            // without forwarding. Walking past them and dispatching
-            // directly to the ancestor-with-real-params standalone ctor
-            // preserves the args end-to-end.
+            // Imported empty-derived classes with no fields still get walked
+            // past so their synthesized standalone ctor does not eat forwarded
+            // args. Explicit zero-arg ctors and field-initializer ctors stop
+            // the walk because their body/initializers must run.
             let mut effective_parent_name = parent_name.clone();
             let mut effective_parent_class = parent_class;
             loop {
                 let has_local_body = effective_parent_class.constructor.is_some();
-                let has_real_imported_ctor = ctx
+                let has_effectful_imported_ctor = ctx
                     .imported_class_ctors
                     .get(&effective_parent_name)
-                    .map(|(_, n)| *n > 0)
+                    .map(|ctor| ctor.stops_constructor_walk())
                     .unwrap_or(false);
-                if has_local_body || has_real_imported_ctor {
+                if has_local_body || has_effectful_imported_ctor {
                     break;
                 }
                 let Some(grandparent_name) = effective_parent_class
@@ -791,7 +789,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         ],
                     );
                 }
-            } else if let Some((ctor_name, param_count)) = ctx
+            } else if let Some(ctor) = ctx
                 .imported_class_ctors
                 .get(&effective_parent_name)
                 .cloned()
@@ -807,7 +805,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // silently drops `super(...)` for imported parents and the subclass
                 // ends up with only its own fields, breaking hono-base inheritance.
                 let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-                while lowered_args.len() < param_count {
+                while lowered_args.len() < ctor.param_count {
                     lowered_args.push(undef_lit.clone());
                 }
                 let this_slot = ctx.this_stack.last().cloned();
@@ -826,11 +824,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     ctor_args.push((DOUBLE, la.as_str()));
                 }
                 ctx.pending_declares.push((
-                    ctor_name.clone(),
+                    ctor.symbol.clone(),
                     crate::types::VOID,
                     ctor_param_types,
                 ));
-                ctx.block().call_void(&ctor_name, &ctor_args);
+                ctx.block().call_void(&ctor.symbol, &ctor_args);
             }
 
             // After the parent body has run (which may have set `this.config`

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -342,8 +342,10 @@ fn effective_constructor_param_count(ctx: &FnCtx<'_>, class: &perry_hir::Class) 
     }
     let mut parent = class.extends_name.as_deref();
     while let Some(pname) = parent {
-        if let Some((_sym, n)) = ctx.imported_class_ctors.get(pname) {
-            return *n;
+        if let Some(ctor) = ctx.imported_class_ctors.get(pname) {
+            if ctor.stops_constructor_walk() {
+                return ctor.param_count;
+            }
         }
         match ctx.classes.get(pname).copied() {
             Some(pc) => {
@@ -1352,21 +1354,20 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
         // SuperCall Error-like arm in expr.rs.
         //
         // BUT: if `class_name` is an imported stub with a cross-module
-        // ctor that has REAL params, defer to that path — the source
+        // ctor with a real body/effect, defer to that path — the source
         // module's ctor body knows the real param order
         // (e.g. `constructor(public statusCode, msg)` where args[0] is
         // statusCode, not message). Running Error-init here would
         // assign the wrong arg to `message` and corrupt the instance.
-        // When the imported ctor's param_count is 0, the source had no
-        // own ctor (codegen synthesized an empty 0-param ctor for the
-        // bare-extends-Error case), so calling it is a no-op and we
-        // still need Error-init to populate `this.message` / `this.name`.
-        let imported_ctor_has_real_params = ctx
+        // When the imported ctor is a synthesized empty 0-param ctor for the
+        // bare-extends-Error case, calling it is a no-op and we still need
+        // Error-init to populate `this.message` / `this.name`.
+        let imported_ctor_has_body_or_fields = ctx
             .imported_class_ctors
             .get(class_name)
-            .map(|(_, n)| *n > 0)
+            .map(|ctor| ctor.stops_constructor_walk())
             .unwrap_or(false);
-        if !found_inherited_ctor && !imported_ctor_has_real_params {
+        if !found_inherited_ctor && !imported_ctor_has_body_or_fields {
             // Trace the chain to find the first Error-like ancestor name.
             let mut error_kind: Option<String> = None;
             let mut cur = class.extends_name.clone();
@@ -1488,12 +1489,12 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
             let mut effective_class_name = lookup_class.clone();
             let mut effective_extends = class.extends_name.clone();
             loop {
-                let has_real_ctor = ctx
+                let has_effectful_ctor = ctx
                     .imported_class_ctors
                     .get(&effective_class_name)
-                    .map(|(_, n)| *n > 0)
+                    .map(|ctor| ctor.stops_constructor_walk())
                     .unwrap_or(false);
-                if has_real_ctor {
+                if has_effectful_ctor {
                     break;
                 }
                 // v0.5.759: stop walking ONLY for the leaf class (the user's
@@ -1527,16 +1528,16 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                 effective_class_name = parent;
                 effective_extends = parent_class.extends_name.clone();
             }
-            if let Some((ctor_name, param_count)) = ctx
+            if let Some(ctor) = ctx
                 .imported_class_ctors
                 .get(&effective_class_name)
                 .cloned()
-                .filter(|(_, _)| effective_class_name != lookup_class)
+                .filter(|_| effective_class_name != lookup_class)
             {
                 // Walked to an ancestor — call its ctor with this and forwarded args.
                 let undef_lit =
                     crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-                while lowered_args.len() < param_count {
+                while lowered_args.len() < ctor.param_count {
                     lowered_args.push(undef_lit.clone());
                 }
                 let mut ctor_args: Vec<(crate::types::LlvmType, &str)> =
@@ -1549,19 +1550,17 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                     ctor_args.push((DOUBLE, la.as_str()));
                 }
                 ctx.pending_declares.push((
-                    ctor_name.clone(),
+                    ctor.symbol.clone(),
                     crate::types::VOID,
                     ctor_param_types,
                 ));
-                ctx.block().call_void(&ctor_name, &ctor_args);
-            } else if let Some((ctor_name, param_count)) =
-                ctx.imported_class_ctors.get(class_name).cloned()
-            {
+                ctx.block().call_void(&ctor.symbol, &ctor_args);
+            } else if let Some(ctor) = ctx.imported_class_ctors.get(class_name).cloned() {
                 // Pad missing optional args with TAG_UNDEFINED so the constructor
                 // doesn't read garbage from stale registers.
                 let undef_lit =
                     crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-                while lowered_args.len() < param_count {
+                while lowered_args.len() < ctor.param_count {
                     lowered_args.push(undef_lit.clone());
                 }
                 // Pass `this` as NaN-boxed double (same as compile_method's this_arg).
@@ -1575,11 +1574,11 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
                     ctor_args.push((DOUBLE, la.as_str()));
                 }
                 ctx.pending_declares.push((
-                    ctor_name.clone(),
+                    ctor.symbol.clone(),
                     crate::types::VOID,
                     ctor_param_types,
                 ));
-                ctx.block().call_void(&ctor_name, &ctor_args);
+                ctx.block().call_void(&ctor.symbol, &ctor_args);
             }
         } // end !found_inherited_ctor
     }

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -2564,6 +2564,8 @@ pub fn run_with_parse_cache(
                                             .as_ref()
                                             .map(|c| c.params.len())
                                             .unwrap_or(0),
+                                        has_own_constructor: class.constructor.is_some(),
+                                        has_instance_fields: !class.fields.is_empty(),
                                         method_names: class
                                             .methods
                                             .iter()
@@ -2758,6 +2760,8 @@ pub fn run_with_parse_cache(
                                                 .as_ref()
                                                 .map(|c| c.params.len())
                                                 .unwrap_or(0),
+                                            has_own_constructor: class.constructor.is_some(),
+                                            has_instance_fields: !class.fields.is_empty(),
                                             method_names: class
                                                 .methods
                                                 .iter()
@@ -3004,6 +3008,8 @@ pub fn run_with_parse_cache(
                                     .as_ref()
                                     .map(|c| c.params.len())
                                     .unwrap_or(0),
+                                has_own_constructor: class.constructor.is_some(),
+                                has_instance_fields: !class.fields.is_empty(),
                                 method_names: class
                                     .methods
                                     .iter()
@@ -3068,6 +3074,8 @@ pub fn run_with_parse_cache(
                                 .as_ref()
                                 .map(|c| c.params.len())
                                 .unwrap_or(0),
+                            has_own_constructor: class.constructor.is_some(),
+                            has_instance_fields: !class.fields.is_empty(),
                             method_names: class.methods.iter().map(|m| m.name.clone()).collect(),
                             method_param_counts: class
                                 .methods
@@ -3219,6 +3227,8 @@ pub fn run_with_parse_cache(
                                 .as_ref()
                                 .map(|c| c.params.len())
                                 .unwrap_or(0),
+                            has_own_constructor: class.constructor.is_some(),
+                            has_instance_fields: !class.fields.is_empty(),
                             method_names: class.methods.iter().map(|m| m.name.clone()).collect(),
                             method_param_counts: class
                                 .methods
@@ -3677,6 +3687,8 @@ pub fn run_with_parse_cache(
                                 .as_ref()
                                 .map(|c| c.params.len())
                                 .unwrap_or(0),
+                            has_own_constructor: class.constructor.is_some(),
+                            has_instance_fields: !class.fields.is_empty(),
                             method_names: class.methods.iter().map(|m| m.name.clone()).collect(),
                             method_param_counts: class
                                 .methods
@@ -3869,6 +3881,8 @@ pub fn run_with_parse_cache(
                                 .as_ref()
                                 .map(|c| c.params.len())
                                 .unwrap_or(0),
+                            has_own_constructor: class.constructor.is_some(),
+                            has_instance_fields: !class.fields.is_empty(),
                             method_names: class.methods.iter().map(|m| m.name.clone()).collect(),
                             method_param_counts: class
                                 .methods

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -437,10 +437,12 @@ fn compute_object_cache_key_with_env(
         let mut buf = String::new();
         for c in v {
             buf.push_str(&format!(
-                "{}@{}:ctor={}:parent={}:alias={}:id={}:fields={}:methods={}:method_arities={}|",
+                "{}@{}:ctor={}:own_ctor={}:instance_fields={}:parent={}:alias={}:id={}:fields={}:methods={}:method_arities={}|",
                 c.name,
                 c.source_prefix,
                 c.constructor_param_count,
+                if c.has_own_constructor { "1" } else { "0" },
+                if c.has_instance_fields { "1" } else { "0" },
                 c.parent_name.as_deref().unwrap_or(""),
                 c.local_alias.as_deref().unwrap_or(""),
                 c.source_class_id.map(|i| i.to_string()).unwrap_or_default(),
@@ -1219,6 +1221,8 @@ mod object_cache_tests {
             local_alias: None,
             source_prefix: "feature_ts".into(),
             constructor_param_count: 0,
+            has_own_constructor: false,
+            has_instance_fields: true,
             method_names: vec![],
             method_param_counts: vec![],
             method_has_rest: vec![],
@@ -1251,6 +1255,8 @@ mod object_cache_tests {
             local_alias: None,
             source_prefix: "src".into(),
             constructor_param_count: 1,
+            has_own_constructor: true,
+            has_instance_fields: true,
             method_names: vec!["bar".into()],
             method_param_counts: vec![0],
             method_has_rest: vec![false],
@@ -1268,6 +1274,8 @@ mod object_cache_tests {
             local_alias: None,
             source_prefix: "src".into(),
             constructor_param_count: 2, // different arity
+            has_own_constructor: true,
+            has_instance_fields: true,
             method_names: vec!["bar".into()],
             method_param_counts: vec![0],
             method_has_rest: vec![false],
@@ -1293,6 +1301,8 @@ mod object_cache_tests {
             local_alias: None,
             source_prefix: "src".into(),
             constructor_param_count: 1,
+            has_own_constructor: true,
+            has_instance_fields: true,
             method_names: vec!["bar".into()],
             method_param_counts: vec![1],
             method_has_rest: vec![false],
@@ -1311,6 +1321,14 @@ mod object_cache_tests {
             compute_object_cache_key(&opts, 1, "0.5.156")
         };
         let base_key = key_for(base.clone());
+
+        let mut changed = base.clone();
+        changed.has_own_constructor = false;
+        assert_ne!(base_key, key_for(changed));
+
+        let mut changed = base.clone();
+        changed.has_instance_fields = false;
+        assert_ne!(base_key, key_for(changed));
 
         let mut changed = base.clone();
         changed.method_has_rest = vec![true];

--- a/tests/test_xmod_empty_imported_derived_arg_forward.sh
+++ b/tests/test_xmod_empty_imported_derived_arg_forward.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Regression: an imported derived class with no own constructor and no fields
+# must not stop constructor dispatch. Args should still reach the first
+# effectful imported ancestor constructor.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then
+  PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+  echo "SKIP: perry binary not found (build with cargo build -p perry)"
+  exit 0
+fi
+if [[ "$PERRY" != /* ]]; then
+  PERRY="$(cd "$(dirname "$PERRY")" && pwd)/$(basename "$PERRY")"
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat > "$TMPDIR/root.ts" <<'TS'
+export class EffectfulRoot {
+  constructor(value: any) {
+    (this as any).forwarded = value;
+  }
+}
+TS
+
+cat > "$TMPDIR/mid.ts" <<'TS'
+import { EffectfulRoot } from "./root.ts";
+
+export class EmptyMid extends EffectfulRoot {}
+TS
+
+cat > "$TMPDIR/main.ts" <<'TS'
+import { EmptyMid } from "./mid.ts";
+
+const direct: any = new EmptyMid("direct");
+console.log("direct instanceof mid", direct instanceof EmptyMid);
+console.log("direct forwarded", direct.forwarded);
+
+class ExplicitLeaf extends EmptyMid {
+  constructor(value: any) {
+    super(value);
+    (this as any).leafReady = "explicit";
+  }
+}
+
+const explicit: any = new ExplicitLeaf("explicit");
+console.log("explicit instanceof mid", explicit instanceof EmptyMid);
+console.log("explicit forwarded", explicit.forwarded);
+console.log("explicit ready", explicit.leafReady);
+
+class DefaultLeaf extends EmptyMid {}
+
+const defaultLeaf: any = new DefaultLeaf("default");
+console.log("default instanceof mid", defaultLeaf instanceof EmptyMid);
+console.log("default forwarded", defaultLeaf.forwarded);
+TS
+
+cd "$TMPDIR"
+"$PERRY" compile --no-cache --no-auto-optimize main.ts --output test_bin >/dev/null
+RUN_OUTPUT="$(./test_bin 2>&1)"
+
+EXPECTED="direct instanceof mid true
+direct forwarded direct
+explicit instanceof mid true
+explicit forwarded explicit
+explicit ready explicit
+default instanceof mid true
+default forwarded default"
+
+if [[ "$RUN_OUTPUT" == "$EXPECTED" ]]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: empty imported derived class did not forward args to effectful ancestor"
+echo "Expected:"
+echo "$EXPECTED"
+echo ""
+echo "Got:"
+echo "$RUN_OUTPUT"
+exit 1

--- a/tests/test_xmod_imported_zero_arg_super.sh
+++ b/tests/test_xmod_imported_zero_arg_super.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Regression: an explicit zero-argument constructor on an imported superclass
+# must run when a local subclass calls super().
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then
+  PERRY="$REPO_ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+  echo "SKIP: perry binary not found (build with cargo build -p perry)"
+  exit 0
+fi
+if [[ "$PERRY" != /* ]]; then
+  PERRY="$(cd "$(dirname "$PERRY")" && pwd)/$(basename "$PERRY")"
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat > "$TMPDIR/root.ts" <<'TS'
+export class CrossRoot {
+  constructor() {
+    (this as any).rootReady = "root";
+  }
+}
+TS
+
+cat > "$TMPDIR/base.ts" <<'TS'
+import { CrossRoot } from "./root.ts";
+
+export class CrossBase extends CrossRoot {
+  constructor() {
+    super();
+    (this as any).baseReady = "base";
+  }
+}
+TS
+
+cat > "$TMPDIR/main.ts" <<'TS'
+import { CrossBase } from "./base.ts";
+
+class CrossSub extends CrossBase {
+  constructor() {
+    super();
+    (this as any).subReady = "sub";
+  }
+}
+
+const value: any = new CrossSub();
+console.log("instanceof base", value instanceof CrossBase);
+console.log("root", value.rootReady);
+console.log("base", value.baseReady);
+console.log("sub", value.subReady);
+TS
+
+cd "$TMPDIR"
+"$PERRY" compile --no-cache --no-auto-optimize main.ts --output test_bin >/dev/null
+RUN_OUTPUT="$(./test_bin 2>&1)"
+
+EXPECTED="instanceof base true
+root root
+base base
+sub sub"
+
+if [[ "$RUN_OUTPUT" == "$EXPECTED" ]]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: imported zero-arg superclass constructor was not replayed"
+echo "Expected:"
+echo "$EXPECTED"
+echo ""
+echo "Got:"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Summary

Fix Perry's cross-module class constructor metadata so imported superclass dispatch can distinguish an explicit zero-argument constructor from a synthesized empty default constructor.

## Root cause

`ImportedClass` only carried `constructor_param_count`, and several constructor-walk paths treated `param_count > 0` as the proxy for a real/effectful imported constructor. That made Perry walk past explicit zero-argument imported constructors and skip their bodies while preserving the class id/`instanceof` shape.

## Changes

- Add imported class metadata for `has_own_constructor` and `has_instance_fields`.
- Thread that metadata into `ImportedCtor` and use `stops_constructor_walk()` in super/new/default-constructor dispatch paths.
- Keep empty imported derived classes with no own constructor and no fields walk-through behavior so arg forwarding still reaches an effectful ancestor.
- Include the new metadata in object-cache keys.
- Add focused cross-module regressions for explicit zero-arg imported superclass constructors and empty imported derived arg forwarding.

## Verification

- `cargo fmt --check`
- `cargo build -p perry -p perry-runtime`
- `PERRY_BIN=target/debug/perry tests/test_xmod_imported_zero_arg_super.sh`
- `PERRY_BIN=target/debug/perry tests/test_xmod_empty_imported_derived_arg_forward.sh`
- `target/debug/perry compile --no-cache --no-auto-optimize test-files/test_xmod_no_ctor_arg_forward.ts -o /tmp/xmod_arg && /tmp/xmod_arg`
- `target/debug/perry compile --no-cache --no-auto-optimize test-files/test_cross_module_no_ctor_fields.ts -o /tmp/xmod_fields && /tmp/xmod_fields`
- `PERRY_BIN=target/debug/perry tests/test_request_subclass_body.sh`
- `cargo test -p perry object_cache`

Note: `cargo test -p perry --lib object_cache` is not valid because `perry` has no library target, so the package filter above was used instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced constructor parameter forwarding in cross-module class inheritance, particularly when imported parent classes lack their own constructors.
  * Improved detection of which imported constructors should terminate the inheritance walk.

* **Tests**
  * Added regression tests validating constructor argument forwarding through empty derived imported classes.
  * Added regression test for zero-argument super() calls in cross-module inheritance chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->