### PR TITLE
feat(wearos): full Wear OS app target (`--target wearos` / `perry run wearos`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ splitViewAddChild(split, content);
 App({ title: 'My App', width: 800, height: 500, body: split });
 ```
 
-**10 target outputs from one codebase:**
+**11 target outputs from one codebase:**
 
 | Platform | Backend | Target Flag |
 |----------|---------|-------------|
@@ -362,6 +362,7 @@ App({ title: 'My App', width: 800, height: 500, body: split });
 | tvOS | UIKit | `--target tvos` / `--target tvos-simulator` |
 | watchOS | WatchKit | `--target watchos` / `--target watchos-simulator` |
 | Android | Android Views (JNI) | `--target android` |
+| Wear OS | Android Views (JNI) | `--target wearos` |
 | Windows | Win32 | *(default on Windows)* |
 | Linux | GTK4 | *(default on Linux)* |
 | Web | DOM (JS codegen) | `--target web` |
@@ -446,6 +447,7 @@ perry compile src/main.ts --target android -o MyApp
 # TV / Watch
 perry compile src/main.ts --target tvos -o MyApp
 perry compile src/main.ts --target watchos -o MyApp
+perry compile src/main.ts --target wearos -o MyApp       # Wear OS (Android on a watch)
 
 # Web
 perry compile src/main.ts --target web -o app.html       # JavaScript output

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -410,6 +410,8 @@ pub fn resolve_target_triple(name: &str) -> Option<String> {
         "harmonyos" => Some("aarch64-unknown-linux-ohos".to_string()),
         "harmonyos-simulator" => Some("x86_64-unknown-linux-ohos".to_string()),
         "android" => Some("aarch64-unknown-linux-android".to_string()),
+        // Wear OS is Android-on-a-watch: same arm64 Android object format.
+        "wearos" => Some("aarch64-unknown-linux-android".to_string()),
         "linux" => Some("x86_64-unknown-linux-gnu".to_string()),
         "linux-aarch64" => Some("aarch64-unknown-linux-gnu".to_string()),
         // musl targets — fully static binaries that run on Lambda

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -1703,6 +1703,7 @@ pub fn run_with_parse_cache(
                 | Some("visionos")
                 | Some("visionos-simulator")
                 | Some("android")
+                | Some("wearos")
                 | Some("watchos")
                 | Some("watchos-simulator")
                 | Some("tvos")
@@ -4499,7 +4500,7 @@ pub fn run_with_parse_cache(
         }
         // Platform detection for nm tool and symbol prefix
         let _is_ios = matches!(target.as_deref(), Some("ios-simulator") | Some("ios"));
-        let is_android = matches!(target.as_deref(), Some("android"));
+        let is_android = matches!(target.as_deref(), Some("android") | Some("wearos"));
         let is_harmonyos = matches!(
             target.as_deref(),
             Some("harmonyos") | Some("harmonyos-simulator")
@@ -5051,7 +5052,7 @@ pub fn run_with_parse_cache(
         target.as_deref(),
         Some("visionos-simulator") | Some("visionos")
     );
-    let is_android = matches!(target.as_deref(), Some("android"));
+    let is_android = matches!(target.as_deref(), Some("android") | Some("wearos"));
     let is_harmonyos = matches!(
         target.as_deref(),
         Some("harmonyos") | Some("harmonyos-simulator")

--- a/crates/perry/src/commands/compile/app_metadata.rs
+++ b/crates/perry/src/commands/compile/app_metadata.rs
@@ -16,6 +16,8 @@ pub(super) fn target_bundle_section(target: Option<&str>) -> Option<&'static str
         Some("watchos") | Some("watchos-simulator") => Some("watchos"),
         Some("tvos") | Some("tvos-simulator") => Some("tvos"),
         Some("android") => Some("android"),
+        // Wear OS reuses the [android] perry.toml section (bundle_id, etc.).
+        Some("wearos") => Some("android"),
         Some("macos") => Some("macos"),
         // WinUI shares the [windows] perry.toml section (#4680).
         Some("windows") | Some("windows-winui") => Some("windows"),
@@ -171,6 +173,8 @@ pub(super) fn rust_target_triple(target: Option<&str>) -> Option<&'static str> {
         Some("harmonyos") => Some("aarch64-unknown-linux-ohos"),
         Some("harmonyos-simulator") => Some("x86_64-unknown-linux-ohos"),
         Some("android") => Some("aarch64-linux-android"),
+        // Wear OS is Android-on-a-watch: same arm64 Android .so + toolchain.
+        Some("wearos") => Some("aarch64-linux-android"),
         Some("linux") | Some("linux-x86_64") => Some("x86_64-unknown-linux-gnu"),
         Some("linux-arm64") | Some("linux-aarch64") => Some("aarch64-unknown-linux-gnu"),
         // Fully-static musl targets (#4826). The perry-runtime / perry-stdlib

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -951,7 +951,8 @@ pub(super) fn find_ui_library(target: Option<&str>) -> Option<PathBuf> {
     let lib_name = match target {
         Some("ios-simulator") | Some("ios") => "libperry_ui_ios.a",
         Some("visionos-simulator") | Some("visionos") => "libperry_ui_visionos.a",
-        Some("android") => "libperry_ui_android.a",
+        // Wear OS reuses the Android View backend.
+        Some("android") | Some("wearos") => "libperry_ui_android.a",
         Some("watchos-simulator") | Some("watchos") => "libperry_ui_watchos.a",
         Some("tvos-simulator") | Some("tvos") => "libperry_ui_tvos.a",
         Some("linux") => "libperry_ui_gtk4.a",
@@ -1090,6 +1091,14 @@ pub(super) fn android_cross_env(ndk_home: &Path, target: Option<&str>) -> Vec<(S
     };
     let clang = bin.join(format!("{}-clang{}", clang_target, ext));
     let clangpp = bin.join(format!("{}-clang++{}", clang_target, ext));
+    // NDK r27+ removed the per-target `aarch64-linux-android-ar` wrapper that
+    // cc-rs probes for by default; the archiver is now the unprefixed
+    // `llvm-ar`. Without an explicit `AR_<triple>` the runtime/stdlib C
+    // dependencies (e.g. mimalloc) fail to build with
+    // `failed to find tool "aarch64-linux-android-ar"`. `llvm-ar` has no `.cmd`
+    // wrapper on Windows — it's the bare executable (+`.exe`).
+    let ar_ext = if cfg!(target_os = "windows") { ".exe" } else { "" };
+    let llvm_ar = bin.join(format!("llvm-ar{}", ar_ext));
 
     let triple_upper = triple.to_uppercase().replace('-', "_");
     let triple_under = triple.replace('-', "_");
@@ -1102,6 +1111,8 @@ pub(super) fn android_cross_env(ndk_home: &Path, target: Option<&str>) -> Vec<(S
             format!("CXX_{}", triple_under),
             clangpp.display().to_string(),
         ),
+        (format!("AR_{}", triple), llvm_ar.display().to_string()),
+        (format!("AR_{}", triple_under), llvm_ar.display().to_string()),
         (
             format!("CARGO_TARGET_{}_LINKER", triple_upper),
             clang.display().to_string(),
@@ -1268,7 +1279,7 @@ pub(super) fn find_geisterhand_ui(target: Option<&str>) -> Option<PathBuf> {
         "libperry_ui_ios.a"
     } else if matches!(target, Some("visionos-simulator") | Some("visionos")) {
         return None;
-    } else if matches!(target, Some("android")) {
+    } else if matches!(target, Some("android") | Some("wearos")) {
         "libperry_ui_android.a"
     } else if matches!(target, Some("linux")) || cfg!(target_os = "linux") {
         "libperry_ui_gtk4.a"
@@ -1291,7 +1302,7 @@ pub(super) fn build_geisterhand_libs(target: Option<&str>, format: OutputFormat)
     // Determine which UI crate to build based on target platform
     let ui_crate = match target {
         Some("ios-simulator") | Some("ios") => "perry-ui-ios",
-        Some("android") => "perry-ui-android",
+        Some("android") | Some("wearos") => "perry-ui-android",
         Some("linux") => "perry-ui-gtk4",
         Some("windows-winui") => "perry-ui-windows-winui",
         Some("windows") => "perry-ui-windows",
@@ -1362,7 +1373,10 @@ pub(super) fn build_geisterhand_libs(target: Option<&str>, format: OutputFormat)
     // `libperry_app.so` on Android; force global-dynamic TLS so the IE
     // model doesn't crash at load. (RUSTFLAGS scopes to the cross target,
     // so host build-scripts/proc-macros are unaffected.)
-    if matches!(target, Some("android") | Some("android-x86_64")) {
+    if matches!(
+        target,
+        Some("android") | Some("android-x86_64") | Some("wearos")
+    ) {
         let tls_flag = super::optimized_libs::android_global_dynamic_tls_rustflag(&mut cargo_cmd);
         cargo_cmd.env("RUSTFLAGS", tls_flag);
     }

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1097,7 +1097,11 @@ pub(super) fn android_cross_env(ndk_home: &Path, target: Option<&str>) -> Vec<(S
     // dependencies (e.g. mimalloc) fail to build with
     // `failed to find tool "aarch64-linux-android-ar"`. `llvm-ar` has no `.cmd`
     // wrapper on Windows — it's the bare executable (+`.exe`).
-    let ar_ext = if cfg!(target_os = "windows") { ".exe" } else { "" };
+    let ar_ext = if cfg!(target_os = "windows") {
+        ".exe"
+    } else {
+        ""
+    };
     let llvm_ar = bin.join(format!("llvm-ar{}", ar_ext));
 
     let triple_upper = triple.to_uppercase().replace('-', "_");
@@ -1112,7 +1116,10 @@ pub(super) fn android_cross_env(ndk_home: &Path, target: Option<&str>) -> Vec<(S
             clangpp.display().to_string(),
         ),
         (format!("AR_{}", triple), llvm_ar.display().to_string()),
-        (format!("AR_{}", triple_under), llvm_ar.display().to_string()),
+        (
+            format!("AR_{}", triple_under),
+            llvm_ar.display().to_string(),
+        ),
         (
             format!("CARGO_TARGET_{}_LINKER", triple_upper),
             clang.display().to_string(),

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -271,7 +271,8 @@ pub(super) fn build_and_run_link(
 
     let is_ios = matches!(target, Some("ios-simulator") | Some("ios"));
     let is_visionos = matches!(target, Some("visionos-simulator") | Some("visionos"));
-    let is_android = matches!(target, Some("android"));
+    // Wear OS links exactly like Android (same triple, NDK, cdylib + TLS model).
+    let is_android = matches!(target, Some("android") | Some("wearos"));
     let is_harmonyos = matches!(target, Some("harmonyos") | Some("harmonyos-simulator"));
     let is_linux = matches!(target, Some(t) if t.starts_with("linux"))
         || (target.is_none() && cfg!(target_os = "linux"));

--- a/crates/perry/src/commands/compile/lock_scan.rs
+++ b/crates/perry/src/commands/compile/lock_scan.rs
@@ -159,7 +159,8 @@ fn derive_target_key(target: Option<&str>) -> String {
         Some("watchos-simulator") => "watchos-simulator".to_string(),
         Some("visionos") => "visionos".to_string(),
         Some("visionos-simulator") => "visionos-simulator".to_string(),
-        Some("android") => "android".to_string(),
+        // Wear OS reuses Android's resolved native-dependency set.
+        Some("android") | Some("wearos") => "android".to_string(),
         Some("harmonyos") => "harmonyos".to_string(),
         Some("harmonyos-simulator") => "harmonyos-simulator".to_string(),
         Some("web") => "web".to_string(),

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -793,7 +793,10 @@ pub(super) fn build_optimized_libs(
     // #1508: same shape for Android — cc-rs can't find the NDK clang
     // otherwise (silent on Unix where `clang` happens to exist, hard fail
     // on Windows with `clang.exe not found`).
-    if matches!(target, Some("android") | Some("android-x86_64")) {
+    if matches!(
+        target,
+        Some("android") | Some("android-x86_64") | Some("wearos")
+    ) {
         if let Some(ndk) = std::env::var_os("ANDROID_NDK_HOME") {
             for (k, v) in
                 super::library_search::android_cross_env(std::path::Path::new(&ndk), target)
@@ -821,7 +824,10 @@ pub(super) fn build_optimized_libs(
     // shadow stack), so those IE TLS relocations get baked into the final
     // cdylib. Force global-dynamic so the dynamic linker can resolve TLS
     // slots after the process has started.
-    if matches!(target, Some("android") | Some("android-x86_64")) {
+    if matches!(
+        target,
+        Some("android") | Some("android-x86_64") | Some("wearos")
+    ) {
         rustflags.push(android_global_dynamic_tls_rustflag(&mut cargo_cmd));
     }
     if !rustflags.is_empty() {
@@ -1108,7 +1114,7 @@ pub(super) fn build_optimized_libs(
                 | Some("ios-widget")
                 | Some("ios-widget-simulator") => "perry-ui-ios",
                 Some("visionos-simulator") | Some("visionos") => "perry-ui-visionos",
-                Some("android") => "perry-ui-android",
+                Some("android") | Some("wearos") => "perry-ui-android",
                 Some("watchos-simulator") | Some("watchos") => "perry-ui-watchos",
                 Some("tvos-simulator") | Some("tvos") => "perry-ui-tvos",
                 Some("linux") => "perry-ui-gtk4",

--- a/crates/perry/src/commands/compile/post_link.rs
+++ b/crates/perry/src/commands/compile/post_link.rs
@@ -42,6 +42,9 @@ pub(super) fn strip_final_binary(
         || is_watchos
         || is_harmonyos
         || target == Some("android")
+        // Wear OS ships the same dlopen'd .so — stripping would drop the
+        // no_mangle JNI/FFI symbols PerryActivity resolves at load.
+        || target == Some("wearos")
         || std::env::var("PERRY_DEBUG_SYMBOLS").is_ok()
     {
         return;

--- a/crates/perry/src/commands/compile/resolve/native_library.rs
+++ b/crates/perry/src/commands/compile/resolve/native_library.rs
@@ -55,7 +55,8 @@ pub(super) fn native_manifest_target_key(target: Option<&str>) -> &'static str {
     match target {
         Some("ios-simulator") | Some("ios") => "ios",
         Some("visionos-simulator") | Some("visionos") => "visionos",
-        Some("android") => "android",
+        // Wear OS resolves native-addon config from the [android] target.
+        Some("android") | Some("wearos") => "android",
         Some("tvos-simulator") | Some("tvos") => "tvos",
         Some("watchos-simulator") | Some("watchos") => "watchos",
         Some("harmonyos-simulator") | Some("harmonyos") => "harmonyos",
@@ -1314,7 +1315,7 @@ fn arch_for_target_key(target: Option<&str>) -> Option<&'static str> {
         Some("macos") => Some("arm64"),
         Some("linux") => Some("x64"),
         Some("windows") | Some("windows-winui") => Some("x64"),
-        Some("android") => Some("arm64"),
+        Some("android") | Some("wearos") => Some("arm64"),
         Some("harmonyos") => Some("arm64"),
         Some("harmonyos-simulator") => Some("x64"),
         // ios/tvos/watchos/visionos: device builds are always arm64 (or

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -59,7 +59,7 @@ pub fn run(args: PublishArgs, format: OutputFormat, use_color: bool, _verbose: u
     let target_hint = match args.platform {
         Some(Platform::Ios) => Some("ios"),
         Some(Platform::Visionos) => Some("visionos"),
-        Some(Platform::Android) => Some("android"),
+        Some(Platform::Android) | Some(Platform::Wearos) => Some("android"),
         Some(Platform::Linux) => Some("linux"),
         Some(Platform::Windows) => Some("windows"),
         Some(Platform::Web) => Some("web"),
@@ -150,6 +150,8 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
             Platform::Watchos => "watchos".to_string(),
             Platform::Tvos => "tvos".to_string(),
             Platform::Android => "android".to_string(),
+            // Wear OS ships through Google Play exactly like an Android app.
+            Platform::Wearos => "android".to_string(),
             Platform::Linux => "linux".to_string(),
             Platform::Windows => "windows".to_string(),
             Platform::Web => "web".to_string(),

--- a/crates/perry/src/commands/publish/preflight.rs
+++ b/crates/perry/src/commands/publish/preflight.rs
@@ -48,6 +48,7 @@ pub(super) async fn run_security_audit_step(
             Some(Platform::Ios)
             | Some(Platform::Visionos)
             | Some(Platform::Android)
+            | Some(Platform::Wearos)
             | Some(Platform::Macos)
             | Some(Platform::Tvos)
             | Some(Platform::Watchos)

--- a/crates/perry/src/commands/run/android.rs
+++ b/crates/perry/src/commands/run/android.rs
@@ -16,6 +16,31 @@ pub fn build_and_run_android(
     serial: &str,
     format: OutputFormat,
 ) -> Result<()> {
+    build_and_run_android_impl(so_path, bundle_id, serial, format, false)
+}
+
+/// Build + install a Wear OS APK. Wear OS is Android-on-a-watch, so this reuses
+/// the exact same Gradle project, Kotlin bridge, and compiled `.so` as the phone
+/// path (`build_and_run_android`) — the only differences are the watch
+/// form-factor declarations applied by `apply_wear_overlay`: the
+/// `android.hardware.type.watch` feature + the standalone meta-data + the
+/// `androidx.wear` dependency.
+pub fn build_and_run_wearos(
+    so_path: &Path,
+    bundle_id: &str,
+    serial: &str,
+    format: OutputFormat,
+) -> Result<()> {
+    build_and_run_android_impl(so_path, bundle_id, serial, format, true)
+}
+
+fn build_and_run_android_impl(
+    so_path: &Path,
+    bundle_id: &str,
+    serial: &str,
+    format: OutputFormat,
+    wear: bool,
+) -> Result<()> {
     // Find the perry workspace root to locate the Android template
     let workspace_root = super::super::compile::find_perry_workspace_root()
         .ok_or_else(|| anyhow!("Cannot find Perry workspace root — needed for Android template"))?;
@@ -41,6 +66,14 @@ pub fn build_and_run_android(
     // Copy template to build directory
     copy_dir_recursive(&template_dir, &build_dir)
         .map_err(|e| anyhow!("Failed to copy Android template: {}", e))?;
+
+    // Wear OS: overlay the watch form-factor onto the copied phone template
+    // (manifest feature + standalone meta-data, Wear minSdk, androidx.wear dep).
+    if wear {
+        if let Err(e) = apply_wear_overlay(&build_dir, format) {
+            bail!("Failed to apply Wear OS template overlay: {}", e);
+        }
+    }
 
     // Create jniLibs directory and copy .so
     let jni_dir = build_dir.join("app/src/main/jniLibs/arm64-v8a");
@@ -235,8 +268,15 @@ pub fn build_and_run_android(
         println!("Running Gradle assembleDebug...");
     }
 
-    // Run gradle build
-    let gradle_status = Command::new(&gradlew)
+    // Run gradle build. `gradlew` is `build_dir.join("gradlew")`, which is a
+    // RELATIVE path when the compile output (and thus build_dir) is relative —
+    // e.g. `android-build/gradlew`. Spawning a relative program path that
+    // contains a `/` while also setting `.current_dir(&build_dir)` resolves the
+    // program against the *new* cwd, i.e. `android-build/android-build/gradlew`,
+    // which fails with ENOENT. Canonicalize to an absolute path so the spawn is
+    // independent of the child's working directory.
+    let gradlew_abs = std::fs::canonicalize(&gradlew).unwrap_or_else(|_| gradlew.clone());
+    let gradle_status = Command::new(&gradlew_abs)
         .arg("assembleDebug")
         .current_dir(&build_dir)
         .status()
@@ -263,6 +303,63 @@ pub fn build_and_run_android(
 
     // Install and launch
     install_and_launch_android(&apk_path, bundle_id, serial, format)
+}
+
+/// Turn the copied phone Gradle project into a Wear OS app in place.
+///
+/// Wear OS apps are ordinary Android apps with three extra declarations:
+///   1. `<uses-feature android:name="android.hardware.type.watch">` — marks
+///      the APK as a watch app (Play Store filtering + launcher placement).
+///   2. `<meta-data com.google.android.wearable.standalone = true>` — the app
+///      runs without a companion phone app.
+///   3. `androidx.wear:wear` — pulls in `BoxInsetLayout` / swipe-to-dismiss so
+///      round screens and the back gesture behave like a native Wear app.
+/// minSdk is also raised to 30 (Wear OS 3), the floor Google Play requires for
+/// watch APKs.
+fn apply_wear_overlay(build_dir: &Path, format: OutputFormat) -> Result<()> {
+    // --- AndroidManifest.xml ---
+    let manifest_path = build_dir.join("app/src/main/AndroidManifest.xml");
+    if manifest_path.exists() {
+        let mut manifest = std::fs::read_to_string(&manifest_path)?;
+
+        // 1. Watch hardware feature — required, right after the <manifest> tag.
+        let manifest_open = "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\">";
+        if manifest.contains(manifest_open) && !manifest.contains("android.hardware.type.watch") {
+            manifest = manifest.replacen(
+                manifest_open,
+                &format!(
+                    "{manifest_open}\n\n    <uses-feature android:name=\"android.hardware.type.watch\" android:required=\"true\" />"
+                ),
+                1,
+            );
+        }
+
+        // 2. Standalone meta-data + the wearable shared library, inserted just
+        //    before the existing Maps API key meta-data inside <application>.
+        let maps_anchor = "        <meta-data\n            android:name=\"com.google.android.geo.API_KEY\"";
+        if manifest.contains(maps_anchor) && !manifest.contains("wearable.standalone") {
+            let wear_meta = "        <meta-data\n            android:name=\"com.google.android.wearable.standalone\"\n            android:value=\"true\" />\n        <uses-library\n            android:name=\"com.google.android.wearable\"\n            android:required=\"false\" />\n";
+            manifest = manifest.replacen(maps_anchor, &format!("{wear_meta}{maps_anchor}"), 1);
+        }
+
+        std::fs::write(&manifest_path, &manifest)?;
+    }
+
+    // --- app/build.gradle.kts ---
+    let gradle_path = build_dir.join("app/build.gradle.kts");
+    if gradle_path.exists() {
+        let mut gradle = std::fs::read_to_string(&gradle_path)?;
+        // Wear OS 3 is the minSdk floor for watch APKs on Google Play.
+        gradle = gradle.replace("minSdk = 24", "minSdk = 30");
+        // Add the Wear support library (BoxInsetLayout, swipe-to-dismiss).
+        gradle = inject_gradle_dependencies(&gradle, &["androidx.wear:wear:1.3.0".to_string()]);
+        std::fs::write(&gradle_path, gradle)?;
+    }
+
+    if let OutputFormat::Text = format {
+        println!("  Wear OS overlay: watch feature + standalone + androidx.wear (minSdk 30)");
+    }
+    Ok(())
 }
 
 /// Issue #583 — read `package.json` `perry.deepLinks` and rewrite the
@@ -885,4 +982,100 @@ pub fn get_android_pid(serial: &str, bundle_id: &str) -> String {
         std::thread::sleep(std::time::Duration::from_millis(500));
     }
     String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `apply_wear_overlay` must transform a copy of the *real* Android template
+    /// into a Wear OS project: watch feature + standalone meta-data in the
+    /// manifest, and `androidx.wear` + `minSdk = 30` in the Gradle build. This
+    /// runs against the checked-in template so anchor drift (a renamed tag or a
+    /// changed minSdk) fails here instead of silently producing a phone APK.
+    #[test]
+    fn wear_overlay_applies_to_real_template() {
+        let template = Path::new(env!("CARGO_MANIFEST_DIR")).join("../perry-ui-android/template");
+        let manifest_src = template.join("app/src/main/AndroidManifest.xml");
+        let gradle_src = template.join("app/build.gradle.kts");
+        assert!(
+            manifest_src.exists() && gradle_src.exists(),
+            "android template not found at {}",
+            template.display()
+        );
+
+        // Materialize a throwaway build dir with just the two files the overlay
+        // touches, mirroring the layout build_and_run_android_impl produces.
+        let build_dir =
+            std::env::temp_dir().join(format!("perry_wear_overlay_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&build_dir);
+        let app_main = build_dir.join("app/src/main");
+        std::fs::create_dir_all(&app_main).unwrap();
+        std::fs::copy(&manifest_src, app_main.join("AndroidManifest.xml")).unwrap();
+        std::fs::copy(&gradle_src, build_dir.join("app/build.gradle.kts")).unwrap();
+
+        apply_wear_overlay(&build_dir, OutputFormat::Json).unwrap();
+
+        let manifest = std::fs::read_to_string(app_main.join("AndroidManifest.xml")).unwrap();
+        let gradle = std::fs::read_to_string(build_dir.join("app/build.gradle.kts")).unwrap();
+
+        assert!(
+            manifest.contains("android.hardware.type.watch"),
+            "watch uses-feature not injected"
+        );
+        assert!(
+            manifest.contains("com.google.android.wearable.standalone"),
+            "standalone meta-data not injected"
+        );
+        assert!(
+            gradle.contains("androidx.wear:wear"),
+            "androidx.wear dependency not injected"
+        );
+        assert!(
+            gradle.contains("minSdk = 30") && !gradle.contains("minSdk = 24"),
+            "minSdk not raised to 30 for Wear OS"
+        );
+
+        let _ = std::fs::remove_dir_all(&build_dir);
+    }
+
+    /// The overlay must be idempotent — running it twice (e.g. a rebuild into a
+    /// reused dir) must not double-inject the watch feature or wear deps.
+    #[test]
+    fn wear_overlay_is_idempotent() {
+        let template = Path::new(env!("CARGO_MANIFEST_DIR")).join("../perry-ui-android/template");
+        let build_dir = std::env::temp_dir()
+            .join(format!("perry_wear_overlay_idem_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&build_dir);
+        let app_main = build_dir.join("app/src/main");
+        std::fs::create_dir_all(&app_main).unwrap();
+        std::fs::copy(
+            template.join("app/src/main/AndroidManifest.xml"),
+            app_main.join("AndroidManifest.xml"),
+        )
+        .unwrap();
+        std::fs::copy(
+            template.join("app/build.gradle.kts"),
+            build_dir.join("app/build.gradle.kts"),
+        )
+        .unwrap();
+
+        apply_wear_overlay(&build_dir, OutputFormat::Json).unwrap();
+        apply_wear_overlay(&build_dir, OutputFormat::Json).unwrap();
+
+        let manifest = std::fs::read_to_string(app_main.join("AndroidManifest.xml")).unwrap();
+        let gradle = std::fs::read_to_string(build_dir.join("app/build.gradle.kts")).unwrap();
+        assert_eq!(
+            manifest.matches("android.hardware.type.watch").count(),
+            1,
+            "watch feature injected more than once"
+        );
+        assert_eq!(
+            gradle.matches("androidx.wear:wear").count(),
+            1,
+            "androidx.wear dependency injected more than once"
+        );
+
+        let _ = std::fs::remove_dir_all(&build_dir);
+    }
 }

--- a/crates/perry/src/commands/run/android.rs
+++ b/crates/perry/src/commands/run/android.rs
@@ -323,7 +323,8 @@ fn apply_wear_overlay(build_dir: &Path, format: OutputFormat) -> Result<()> {
         let mut manifest = std::fs::read_to_string(&manifest_path)?;
 
         // 1. Watch hardware feature — required, right after the <manifest> tag.
-        let manifest_open = "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\">";
+        let manifest_open =
+            "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\">";
         if manifest.contains(manifest_open) && !manifest.contains("android.hardware.type.watch") {
             manifest = manifest.replacen(
                 manifest_open,
@@ -336,7 +337,8 @@ fn apply_wear_overlay(build_dir: &Path, format: OutputFormat) -> Result<()> {
 
         // 2. Standalone meta-data + the wearable shared library, inserted just
         //    before the existing Maps API key meta-data inside <application>.
-        let maps_anchor = "        <meta-data\n            android:name=\"com.google.android.geo.API_KEY\"";
+        let maps_anchor =
+            "        <meta-data\n            android:name=\"com.google.android.geo.API_KEY\"";
         if manifest.contains(maps_anchor) && !manifest.contains("wearable.standalone") {
             let wear_meta = "        <meta-data\n            android:name=\"com.google.android.wearable.standalone\"\n            android:value=\"true\" />\n        <uses-library\n            android:name=\"com.google.android.wearable\"\n            android:required=\"false\" />\n";
             manifest = manifest.replacen(maps_anchor, &format!("{wear_meta}{maps_anchor}"), 1);
@@ -1044,8 +1046,8 @@ mod tests {
     #[test]
     fn wear_overlay_is_idempotent() {
         let template = Path::new(env!("CARGO_MANIFEST_DIR")).join("../perry-ui-android/template");
-        let build_dir = std::env::temp_dir()
-            .join(format!("perry_wear_overlay_idem_{}", std::process::id()));
+        let build_dir =
+            std::env::temp_dir().join(format!("perry_wear_overlay_idem_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&build_dir);
         let app_main = build_dir.join("app/src/main");
         std::fs::create_dir_all(&app_main).unwrap();

--- a/crates/perry/src/commands/run/devices.rs
+++ b/crates/perry/src/commands/run/devices.rs
@@ -254,6 +254,20 @@ pub fn detect_android_devices() -> Result<Vec<DeviceInfo>> {
     Ok(devices)
 }
 
+/// True if the adb device with this serial is a Wear OS watch, i.e. its
+/// `ro.build.characteristics` property contains `watch`. Used to keep
+/// `perry run wearos` from selecting a paired phone connected over the same
+/// adb. Returns `false` if the property can't be read (treat as non-watch).
+pub fn is_wear_os_device(serial: &str) -> bool {
+    Command::new("adb")
+        .args(["-s", serial, "shell", "getprop", "ro.build.characteristics"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains("watch"))
+        .unwrap_or(false)
+}
+
 /// Pick a device from a list using dialoguer, or auto-select if non-interactive
 pub fn pick_device(devices: &[DeviceInfo], label: &str) -> Result<String> {
     let names: Vec<String> = devices

--- a/crates/perry/src/commands/run/entry.rs
+++ b/crates/perry/src/commands/run/entry.rs
@@ -32,6 +32,8 @@ pub fn rust_target_triple(target: Option<&str>) -> Option<&'static str> {
         Some("tvos-simulator") => Some("aarch64-apple-tvos-sim"),
         Some("tvos") => Some("aarch64-apple-tvos"),
         Some("android") => Some("aarch64-linux-android"),
+        // Wear OS is Android-on-a-watch: same arm64 Android toolchain/.so.
+        Some("wearos") => Some("aarch64-linux-android"),
         _ => None,
     }
 }
@@ -102,6 +104,26 @@ pub fn resolve_target(
                 pick_device(&devices, "Android device")?
             };
             Ok((Some("android".to_string()), Some(serial)))
+        }
+        Some(Platform::Wearos) => {
+            // Wear OS runs over adb just like a phone — the connected device is
+            // a watch or a Wear emulator. Same detection; the `wearos` target
+            // string routes packaging to the Wear Gradle template at launch.
+            let devices = detect_android_devices()?;
+            if devices.is_empty() {
+                return Err(anyhow!(
+                    "No Wear OS devices found. Pair a watch over adb or start a Wear OS emulator, then try again.\n\
+                     Create one:  avdmanager create avd -n perry_wear \\\n               \
+                     -k \"system-images;android-34;android-wear;arm64-v8a\" -d wearos_large_round\n\
+                     Boot it:     emulator -avd perry_wear"
+                ));
+            }
+            let serial = if devices.len() == 1 {
+                devices[0].udid.clone()
+            } else {
+                pick_device(&devices, "Wear OS device")?
+            };
+            Ok((Some("wearos".to_string()), Some(serial)))
         }
         Some(Platform::Ios) => {
             if let Some(ref udid) = args.simulator {

--- a/crates/perry/src/commands/run/entry.rs
+++ b/crates/perry/src/commands/run/entry.rs
@@ -107,9 +107,14 @@ pub fn resolve_target(
         }
         Some(Platform::Wearos) => {
             // Wear OS runs over adb just like a phone — the connected device is
-            // a watch or a Wear emulator. Same detection; the `wearos` target
-            // string routes packaging to the Wear Gradle template at launch.
-            let devices = detect_android_devices()?;
+            // a watch or a Wear emulator. Same detection, but filter to actual
+            // watches (`ro.build.characteristics` contains `watch`) so a paired
+            // phone on the same adb isn't selected. The `wearos` target string
+            // routes packaging to the Wear Gradle template at launch.
+            let devices: Vec<DeviceInfo> = detect_android_devices()?
+                .into_iter()
+                .filter(|d| is_wear_os_device(&d.udid))
+                .collect();
             if devices.is_empty() {
                 return Err(anyhow!(
                     "No Wear OS devices found. Pair a watch over adb or start a Wear OS emulator, then try again.\n\

--- a/crates/perry/src/commands/run/launch.rs
+++ b/crates/perry/src/commands/run/launch.rs
@@ -72,6 +72,11 @@ pub fn launch(
             let serial = device_udid.unwrap_or("");
             build_and_run_android(&result.output_path, bundle_id, serial, format)
         }
+        "wearos" => {
+            let bundle_id = result.bundle_id.as_deref().unwrap_or("com.perry.app");
+            let serial = device_udid.unwrap_or("");
+            build_and_run_wearos(&result.output_path, bundle_id, serial, format)
+        }
         _ => launch_native(&result.output_path, program_args, format),
     }
 }

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -26,7 +26,7 @@ pub use android::{
 pub use devices::{
     detect_android_devices, detect_booted_simulators, detect_booted_tv_simulators,
     detect_booted_visionos_simulators, detect_booted_watch_simulators, detect_ios_devices,
-    pick_device, pick_from_list, DeviceInfo,
+    is_wear_os_device, pick_device, pick_from_list, DeviceInfo,
 };
 pub use entry::{
     can_compile_locally, read_perry_toml_entry, resolve_entry_file, resolve_target,

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -18,7 +18,8 @@ mod remote;
 mod resign;
 
 pub use android::{
-    build_and_run_android, debug_sign_apk, find_apksigner, find_latest_build_tool, get_android_pid,
+    build_and_run_android, build_and_run_wearos, debug_sign_apk, find_apksigner,
+    find_latest_build_tool, get_android_pid,
     inject_android_deeplinks, inject_google_auth_android_resources, inject_gradle_dependencies,
     install_and_launch_android, wire_native_lib_kotlin_sources,
 };
@@ -51,7 +52,7 @@ pub use resign::{
 #[derive(Args, Debug)]
 pub struct RunArgs {
     /// Positional args: [platform] [input]. Platform is one of: macos, ios,
-    /// visionos, watchos, tvos, android, linux, windows, web. If the first arg is not a
+    /// visionos, watchos, tvos, android, wearos, linux, windows, web. If the first arg is not a
     /// known platform it is treated as the input file/directory.
     pub positional: Vec<String>,
 
@@ -129,6 +130,7 @@ pub fn parse_platform(s: &str) -> Option<Platform> {
         "watchos" => Some(Platform::Watchos),
         "tvos" => Some(Platform::Tvos),
         "android" => Some(Platform::Android),
+        "wearos" | "wear" | "wear-os" => Some(Platform::Wearos),
         "linux" => Some(Platform::Linux),
         "windows" => Some(Platform::Windows),
         "web" => Some(Platform::Web),
@@ -154,6 +156,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
             | Some("visionos-simulator")
             | Some("visionos")
             | Some("android")
+            | Some("wearos")
             | Some("watchos-simulator")
             | Some("watchos")
             | Some("tvos-simulator")

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -19,9 +19,9 @@ mod resign;
 
 pub use android::{
     build_and_run_android, build_and_run_wearos, debug_sign_apk, find_apksigner,
-    find_latest_build_tool, get_android_pid,
-    inject_android_deeplinks, inject_google_auth_android_resources, inject_gradle_dependencies,
-    install_and_launch_android, wire_native_lib_kotlin_sources,
+    find_latest_build_tool, get_android_pid, inject_android_deeplinks,
+    inject_google_auth_android_resources, inject_gradle_dependencies, install_and_launch_android,
+    wire_native_lib_kotlin_sources,
 };
 pub use devices::{
     detect_android_devices, detect_booted_simulators, detect_booted_tv_simulators,

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -77,6 +77,9 @@ pub enum Platform {
     Watchos,
     Tvos,
     Android,
+    /// Wear OS — Android on a watch. Shares the perry-ui-android backend and
+    /// `aarch64-linux-android` toolchain; only the APK packaging differs.
+    Wearos,
     Linux,
     Windows,
     Web,

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -79,6 +79,7 @@ pub enum Platform {
     Android,
     /// Wear OS — Android on a watch. Shares the perry-ui-android backend and
     /// `aarch64-linux-android` toolchain; only the APK packaging differs.
+    #[value(alias = "wear", alias = "wear-os")]
     Wearos,
     Linux,
     Windows,

--- a/docs/examples/platforms/ui/wearos_app.ts
+++ b/docs/examples/platforms/ui/wearos_app.ts
@@ -1,0 +1,27 @@
+// demonstrates: minimal Wear OS App() lifecycle snippet from the Wear OS docs page
+// docs: docs/src/platforms/wearos.md
+// platforms: macos, linux, windows
+
+// On Wear OS this lowers through the same Android View backend (perry-ui-android,
+// JNI → TextView/LinearLayout/Button/...) used for phone apps — Wear OS *is*
+// Android on a watch. `perry run wearos` builds the same `.so`, then packages it
+// with the watch form-factor overlay (uses-feature android.hardware.type.watch,
+// standalone, androidx.wear). On macOS / Linux / Windows the same TypeScript
+// lowers through the host's native UI library.
+
+// ANCHOR: wearos-app
+import { App, Text, VStack, Button, State } from "perry/ui"
+
+const count = State(0)
+
+App({
+    title: "My Watch App",
+    width: 200,
+    height: 200,
+    body: VStack(8, [
+        Text("Hello, Wear OS!"),
+        Text(`Taps: ${count.value}`),
+        Button("Tap me", () => count.set(count.value + 1)),
+    ]),
+})
+// ANCHOR_END: wearos-app

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -70,6 +70,7 @@
 - [watchOS](platforms/watchos.md)
   - [Publishing to the App Store](platforms/watchos-app-store.md)
 - [Android](platforms/android.md)
+- [Wear OS](platforms/wearos.md)
 - [HarmonyOS NEXT](platforms/harmonyos.md)
 - [Windows](platforms/windows.md)
   - [Windows 7 Compatibility](platforms/windows-7.md)

--- a/docs/src/platforms/android.md
+++ b/docs/src/platforms/android.md
@@ -91,5 +91,6 @@ See [Project Configuration](../getting-started/project-config.md#splash) for the
 
 ## Next Steps
 
+- [Wear OS](wearos.md) — full watch apps on the same Android backend
 - [Platform Overview](overview.md) — All platforms
 - [UI Overview](../ui/overview.md) — UI system

--- a/docs/src/platforms/overview.md
+++ b/docs/src/platforms/overview.md
@@ -1,6 +1,6 @@
 # Platform Overview
 
-Perry compiles TypeScript to native executables for 9 platform families from the same source code.
+Perry compiles TypeScript to native executables for 10 platform families from the same source code.
 
 ## Supported Platforms
 

--- a/docs/src/platforms/overview.md
+++ b/docs/src/platforms/overview.md
@@ -12,6 +12,7 @@ Perry compiles TypeScript to native executables for 9 platform families from the
 | tvOS | `--target tvos` / `--target tvos-simulator` | UIKit | Full support (focus engine + game controllers) |
 | watchOS | `--target watchos` / `--target watchos-simulator` | SwiftUI (data-driven) | Core support (15 widgets) |
 | Android | `--target android` | JNI/Android SDK | Full support (112/112) |
+| Wear OS | `--target wearos` | JNI/Android SDK (shared) | Android backend on a watch |
 | Windows | `--target windows` | Win32 | Full support (112/112) |
 | Linux | `--target linux` | GTK4 | Full support (112/112) |
 | Web / WebAssembly | `--target web` *(alias `--target wasm`)* | DOM/CSS via WASM bridge | Full support (168 widgets) |
@@ -31,6 +32,7 @@ perry app.ts -o app --target web   # alias: --target wasm
 perry app.ts -o app --target windows
 perry app.ts -o app --target linux
 perry app.ts -o app --target android
+perry app.ts -o app --target wearos   # Wear OS — Android on a watch
 ```
 
 ## Platform Detection
@@ -64,6 +66,7 @@ Use the `__platform__` compile-time constant to branch by platform:
 - [tvOS](tvos.md)
 - [watchOS](watchos.md)
 - [Android](android.md)
+- [Wear OS](wearos.md)
 - [Windows](windows.md)
 - [Linux (GTK4)](linux.md)
 - [Web](web.md)

--- a/docs/src/platforms/wearos.md
+++ b/docs/src/platforms/wearos.md
@@ -16,27 +16,52 @@ then packages it with a **watch form-factor overlay** — the
 
 ## Requirements
 
-Same toolchain as the [Android](android.md) target, plus a Wear OS system image:
+Wear OS uses the same toolchain as the [Android](android.md) target (the
+`.so` is cross-compiled and the APK is built with Gradle), plus a Wear OS system
+image. You need all of:
 
-- **JDK 17** and **Gradle** (`brew install --cask temurin@17` / `brew install gradle`)
-- **Android SDK + NDK** (set `ANDROID_HOME` and `ANDROID_NDK_HOME`)
-- The Rust Android target (Wear is arm64-only — NaN-boxing needs 64-bit pointers):
-  ```bash
-  rustup target add aarch64-linux-android
-  ```
-- A **Wear OS** system image + AVD:
-  ```bash
-  sdkmanager "platforms;android-35" "build-tools;35.0.0" \
-             "ndk;27.1.12297006" \
-             "system-images;android-34;android-wear;arm64-v8a"
+| Tool | Why | Notes |
+|---|---|---|
+| **JDK 17** | Runs Gradle / the Android Gradle Plugin | The template uses **AGP 8.8.2**, which targets **JDK 17**. Newer JDKs (21/26) can fail the Gradle build — point `JAVA_HOME` at a 17 if your default is newer. |
+| **Gradle 8.x** | `perry run wearos` bootstraps a Gradle wrapper from the system `gradle` | AGP 8.8.2 requires **Gradle 8.10.2+** and is **not** compatible with Gradle 9.x. |
+| **Android SDK** | `adb`, `aapt`, signing, the `android-35` platform | `platform-tools`, `build-tools;35.0.0`, `platforms;android-35`. Set `ANDROID_HOME`. |
+| **Android NDK (r27+)** | Cross-compiles the runtime/`.so` for `aarch64-linux-android` | Set `ANDROID_NDK_HOME`. r27+ is fine — Perry points `cc-rs` at the NDK `llvm-ar`. |
+| **Rust Android target** | The `.so` is `aarch64-linux-android` | `rustup target add aarch64-linux-android`. Wear is **arm64-only** — NaN-boxing needs 64-bit pointers. |
+| **Wear OS system image + emulator** | A watch to install onto | Use an **`arm64-v8a`** image (Perry packages an `arm64-v8a` `libperry_app.so`). |
 
-  avdmanager create avd -n perry_wear \
-    -k "system-images;android-34;android-wear;arm64-v8a" -d wearos_large_round
-  emulator -avd perry_wear
-  ```
+### One-time setup (macOS example)
 
-On Apple-silicon Macs use the `arm64-v8a` Wear image (runs natively). On Intel
-hosts use an `x86`/`x86_64` Wear image instead.
+```bash
+# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)
+brew install --cask temurin@17
+brew install gradle@8        # or any Gradle 8.10.2+
+
+# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/<installed-version>"   # e.g. 28.2.13676358
+export JAVA_HOME="$(/usr/libexec/java_home -v 17)"
+export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"
+
+# 3. SDK packages + a Wear OS arm64 image
+sdkmanager --licenses
+sdkmanager "platform-tools" "emulator" \
+           "platforms;android-35" "build-tools;35.0.0" \
+           "ndk;28.2.13676358" \
+           "system-images;android-34;android-wear;arm64-v8a"
+
+# 4. The Rust cross target
+rustup target add aarch64-linux-android
+
+# 5. Create + boot a Wear OS emulator (round watch)
+avdmanager create avd -n perry_wear \
+  -k "system-images;android-34;android-wear;arm64-v8a" -d wearos_large_round
+emulator -avd perry_wear
+```
+
+On Apple-silicon Macs the `arm64-v8a` image runs natively; on Intel hosts it runs
+under the emulator's arm translation. The first `perry run wearos` build also
+downloads the AGP and `androidx.wear` dependencies from Google's Maven repo, so
+the initial build needs network access.
 
 ## Building
 

--- a/docs/src/platforms/wearos.md
+++ b/docs/src/platforms/wearos.md
@@ -1,0 +1,144 @@
+# Wear OS
+
+Perry can compile TypeScript apps for Wear OS watches and the Wear OS emulator.
+
+Wear OS **is Android on a watch**, so Perry reuses the exact same backend as the
+[Android](android.md) target: your `perry/ui` tree lowers through `perry-ui-android`
+(JNI → `TextView` / `LinearLayout` / `Button` / …), and the compiled
+`aarch64-linux-android` `.so` is identical to a phone build. `perry run wearos`
+then packages it with a **watch form-factor overlay** — the
+`android.hardware.type.watch` feature, the standalone meta-data, and the
+`androidx.wear` support library — and installs it over `adb` like any other APK.
+
+> This page is about **full Wear OS apps**. For glanceable Wear OS **Tiles**
+> (the swipe-left surfaces, built from `Widget({...})` declarations), see
+> [Wear OS Tiles](../widgets/wearos.md).
+
+## Requirements
+
+Same toolchain as the [Android](android.md) target, plus a Wear OS system image:
+
+- **JDK 17** and **Gradle** (`brew install --cask temurin@17` / `brew install gradle`)
+- **Android SDK + NDK** (set `ANDROID_HOME` and `ANDROID_NDK_HOME`)
+- The Rust Android target (Wear is arm64-only — NaN-boxing needs 64-bit pointers):
+  ```bash
+  rustup target add aarch64-linux-android
+  ```
+- A **Wear OS** system image + AVD:
+  ```bash
+  sdkmanager "platforms;android-35" "build-tools;35.0.0" \
+             "ndk;27.1.12297006" \
+             "system-images;android-34;android-wear;arm64-v8a"
+
+  avdmanager create avd -n perry_wear \
+    -k "system-images;android-34;android-wear;arm64-v8a" -d wearos_large_round
+  emulator -avd perry_wear
+  ```
+
+On Apple-silicon Macs use the `arm64-v8a` Wear image (runs natively). On Intel
+hosts use an `x86`/`x86_64` Wear image instead.
+
+## Building
+
+```bash
+perry compile app.ts -o app --target wearos
+```
+
+This cross-compiles to `aarch64-linux-android` and emits `libperry_app.so` — the
+same artifact as `--target android`. Packaging into a watch APK happens at run
+time (below).
+
+## Running with `perry run`
+
+```bash
+perry run wearos          # Auto-detect a connected watch / booted Wear emulator
+```
+
+`perry run wearos`:
+
+1. Cross-compiles the `.so` (identical to the Android path).
+2. Copies the Android Gradle template and applies the Wear overlay:
+   - adds `<uses-feature android:name="android.hardware.type.watch" android:required="true" />`
+   - adds `<meta-data android:name="com.google.android.wearable.standalone" android:value="true" />`
+   - adds `implementation("androidx.wear:wear:1.3.0")`
+   - raises `minSdk` to 30 (Wear OS 3, the Google Play floor for watch APKs)
+3. Runs `./gradlew assembleDebug`, debug-signs, then `adb install` + launches and
+   streams `logcat`.
+
+`wear` and `wear-os` are accepted as aliases for `wearos`.
+
+## UI Toolkit
+
+Identical to [Android](android.md) — the same `perry/ui` widgets map to the same
+Android `View` classes (`Text` → `TextView`, `VStack` → vertical `LinearLayout`,
+`Button` → `Button`, `ScrollView` → `ScrollView`, and so on). No Wear-specific
+widget API is required: an Android UI tree renders directly on a watch.
+
+The `androidx.wear` dependency in the overlay brings in `BoxInsetLayout` and
+swipe-to-dismiss so round screens and the back gesture behave like a native Wear
+app.
+
+## App Lifecycle
+
+A Wear OS app uses the same `App({...})` entry point as every other Perry UI
+target:
+
+```typescript
+{{#include ../../examples/platforms/ui/wearos_app.ts:wearos-app}}
+```
+
+Under the hood this is the Android lifecycle: `PerryActivity` loads
+`libperry_app.so`, calls into your compiled `main()` over JNI, and the
+`perry/ui` tree is realized as Android `View`s on the watch.
+
+## State Management
+
+Reactive state works exactly as on Android and the other platforms:
+
+```typescript
+{{#include ../../examples/platforms/ui/counter_app.ts:counter}}
+```
+
+## Platform Detection
+
+Because the runtime target triple is `aarch64-linux-android`, a Wear OS app
+reports the **Android** platform number — `__platform__ === 2`:
+
+```typescript
+{{#include ../../examples/platforms/platform_detect.ts:overview-detect}}
+```
+
+There is intentionally no separate Wear OS platform constant: at runtime a Wear
+app *is* an Android app. Branch on screen size at runtime if you need
+watch-specific layout.
+
+## Configuration
+
+Wear OS reuses the `[android]` section of `perry.toml` (bundle id, etc.):
+
+```toml
+[android]
+bundle_id = "com.example.mywatch"
+```
+
+## Limitations
+
+Wear OS inherits Android's widget set but the watch form factor imposes the usual
+constraints:
+
+- **Small round screens** — design for ~1.2–1.4" displays; prefer `ScrollView`
+  and short labels. Use the `androidx.wear` `BoxInsetLayout` insets for round
+  bezels.
+- **Touch-only** — no hover or right-click.
+- **Single window** — modal flows map to `Dialog` views, same as Android.
+- **Battery / memory** — keep apps lightweight; Wear devices have far less RAM
+  than phones.
+- **Publishing** — Wear apps ship through Google Play as Android APK/AABs (the
+  `perry publish` flow treats Wear like Android).
+
+## Next Steps
+
+- [Android](android.md) — the shared backend, UI mapping, and APK details
+- [Wear OS Tiles](../widgets/wearos.md) — glanceable Tile surfaces
+- [Platform Overview](overview.md) — all platforms
+- [UI Overview](../ui/overview.md) — the `perry/ui` system

--- a/docs/src/widgets/wearos.md
+++ b/docs/src/widgets/wearos.md
@@ -2,6 +2,8 @@
 
 Perry widgets can compile to Wear OS Tiles using `--target wearos-tile`. Tiles are glanceable surfaces in the Wear OS tile carousel and watch face complications.
 
+> For full **Wear OS apps** (not glanceable Tiles), see [Wear OS](../platforms/wearos.md).
+
 > **Status:** the snippet on this page compile-links cleanly on the host LLVM
 > target via [`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts), so the
 > `Widget({...})` shape is verified against the codegen.

--- a/docs/src/widgets/wearos.md
+++ b/docs/src/widgets/wearos.md
@@ -2,7 +2,7 @@
 
 Perry widgets can compile to Wear OS Tiles using `--target wearos-tile`. Tiles are glanceable surfaces in the Wear OS tile carousel and watch face complications.
 
-> For full **Wear OS apps** (not glanceable Tiles), see [Wear OS](../platforms/wearos.md).
+For full **Wear OS apps** (not glanceable Tiles), see [Wear OS](../platforms/wearos.md).
 
 > **Status:** the snippet on this page compile-links cleanly on the host LLVM
 > target via [`docs/examples/widgets/snippets.ts`](https://github.com/PerryTS/perry/blob/main/docs/examples/widgets/snippets.ts), so the


### PR DESCRIPTION
## Summary

Adds a full **Wear OS app** target. Until now Wear OS support was limited to glanceable Tiles (`--target wearos-tile`); there was no way to ship a full watch app.

Wear OS is **Android on a watch** — same ART/JNI runtime, same `View` system — so this reuses the entire `perry-ui-android` backend and `aarch64-linux-android` toolchain rather than introducing a parallel UI crate. The compiled `.so` is identical to an Android phone build; only the APK packaging differs. **No new workspace crate, so the CI exclusion list is unchanged.**

`Platform::Wearos` (+ `wearos`/`wear`/`wear-os` aliases) cross-compiles the same `.so` as `android`, then `build_and_run_wearos` packages it through a watch form-factor **overlay** applied to the existing Android Gradle template:
- `android.hardware.type.watch` feature
- `com.google.android.wearable.standalone` meta-data + `com.google.android.wearable` uses-library
- `androidx.wear:wear` dependency
- `minSdk` raised to 30 (Wear OS 3 — the Google Play floor for watch APKs)

Everything else (jniLibs, companion `.so` bundling, assets, applicationId, deep links, signing, install, logcat) is shared with the phone path.

## Bug fixes (also affect the existing `android` path)

Found while bringing the target up on a real Wear OS emulator:

1. **`android_cross_env` now sets `AR=llvm-ar`.** NDK r27+ removed the per-target `aarch64-linux-android-ar` wrapper that cc-rs probes for, so the runtime/stdlib C deps (mimalloc) failed to cross-build.
2. **`resolve_target_triple` maps `wearos` → `aarch64-unknown-linux-android`** so codegen emits Android ELF objects (it was falling back to the host Mach-O triple → `.o: unknown file type` at link).
3. **The `gradlew` invocation uses an absolute path.** A relative `android-build/gradlew` combined with `.current_dir(&build_dir)` resolved against the new cwd (`android-build/android-build/gradlew`) → `perry run` failed with ENOENT.

## Testing

- `cargo test -p perry`: all green (incl. new `apply_wear_overlay` regression + idempotency tests).
- **Live, end-to-end on a Wear OS 5 (API 34) arm64 emulator:** `perry run wearos` compiled the Android ELF `.so`, built a watch APK (verified `android.hardware.type.watch` + `wearable.standalone` + `minSdk 30` + bundled `libperry_app.so`), installed, and launched. `libperry_app.so` loaded over JNI without crash and the `perry/ui` Text+Button tree rendered as native Android views on the round watch face.

Adds `docs/src/platforms/wearos.md` (wired into nav + cross-linked) and `docs/examples/platforms/ui/wearos_app.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Wear OS (`--target wearos`) with aliases (`wear`, `wear-os`) for build, run, and publishing workflows.
  * Enabled full Wear OS app builds and deployment by reusing the Android pipeline with a Wear-specific Gradle overlay.
  * Added Wear OS UI example and expanded platform documentation, including a dedicated Wear OS guide.

* **Bug Fixes**
  * Improved Gradle reliability by canonicalizing the `gradlew` path.
  * Made the Wear overlay injection idempotent and adjusted Wear OS handling across stripping and TLS/linking behaviors.

* **Documentation**
  * Linked Wear OS from platform overviews and updated supported-platform counts and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->