### PR TITLE
fix: Next.js standalone walls 46+47 — inherited-capture clobber + defineProperty on handle

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1860,6 +1860,22 @@ pub(crate) fn apply_field_initializers_recursive(
         let mut init_pairs: Vec<(String, Expr)> = Vec::new();
         let mut init_pairs_computed: Vec<(Expr, Expr)> = Vec::new();
         for field in &class_fields {
+            // Wall 46: synthesized capture fields (`__perry_cap_*`) are populated
+            // EXCLUSIVELY by the constructor's capture-param assignments — for a
+            // class constructed directly, by its own ctor; for a subclass of an
+            // (inherited) dynamic parent, by super()'s parent-ctor run. They carry
+            // `init: None`, so the default `Expr::Undefined` write below would
+            // re-initialize them to `undefined` during the derived field-init
+            // phase (which runs AFTER super()), CLOBBERING the real captured value
+            // super already stored. That is the Next.js `NextNodeServer extends
+            // _baseserver.default` failure: base-server's `_iserror`/`_utils`/
+            // `_log` read `undefined` in inherited methods. Field-init must never
+            // touch these — skip them so the ctor param assignment is the sole
+            // writer (verified: captures are correct at the parent ctor end and
+            // only vanish during the derived ctor's post-super field-init).
+            if field.key_expr.is_none() && field.name.starts_with("__perry_cap_") {
+                continue;
+            }
             let init = match &field.init {
                 Some(e) => e.clone(),
                 None => Expr::Undefined,


### PR DESCRIPTION
## What

`class NextNodeServer extends _baseserver.default` (interop-ESM dynamic parent) read base-server's relative-`require` captures (`_iserror`/`_utils`/`_log` → `this.__perry_cap_*`) as `undefined` from inherited methods → `Cannot read properties of undefined (reading 'getProperError')` on every request (HTTP 500).

## Root cause

Pinned via JS read-back probes at three points on the **same instance** and **same method path**:
- parent-ctor end: captures = real objects ✓
- **post-construct (after `new NextNodeServer()` returns): `undefined`** ✗
- request: `undefined` ✗

So captures were written correctly by `super()` but **clobbered during the derived class's own construction, after `super()` returned** — the derived field-initializer phase. Synthesized capture fields (`__perry_cap_*`) are declared `init: None`, and `apply_field_initializers_recursive` emits `this.<field> = undefined` for every `init: None` field. When the field-init chain included the inherited dynamic parent's fields, that undefined-write re-initialized the captures `super()` had just populated. (ES runs derived field initializers *after* `super()`, so the clobber wins.)

## Fix

Skip `__perry_cap_*` fields in the field-initializer loop (`crates/perry-codegen/src/lower_call/new.rs`). These synthesized fields are populated **exclusively** by the constructor's capture-param assignments, so a field-init undefined-write to them is always wrong.

## Verification

Real Next.js standalone server: all captures resolve (`_iserror`/`_utils`/`_log` = object), `getProperError` TypeError gone. The request now reaches a deeper render error (separate wall). Continues the Next.js bring-up (#793; after #5152).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where certain initialization values were being incorrectly overwritten during constructor operations for inherited methods, ensuring values are properly preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->