### PR TITLE
fix(transform): don't deforest producers called inside closures (#5136)

### DIFF
--- a/crates/perry-transform/src/deforest/detect.rs
+++ b/crates/perry-transform/src/deforest/detect.rs
@@ -65,6 +65,29 @@ pub fn detect_producers(module: &Module) -> HashMap<FuncId, ProducerInfo> {
         }
     }
     candidates.retain(|id, _| !unsupported_call.contains(id));
+    if candidates.is_empty() {
+        return candidates;
+    }
+    // Fourth pass: bail on any candidate referenced inside a closure
+    // body. Neither the detection scans above nor the phase-3 call-site
+    // rewriter descend into closure bodies, so a producer called from
+    // inside a closure would have its signature rewritten while the
+    // in-closure call site kept the original arity — a mismatch that
+    // miscompiles to a SIGSEGV. Refs #5136.
+    let mut in_closure: HashSet<FuncId> = HashSet::new();
+    for func in &module.functions {
+        scan_producers_used_in_closures(&func.body, &candidates, &mut in_closure);
+    }
+    scan_producers_used_in_closures(&module.init, &candidates, &mut in_closure);
+    for class in &module.classes {
+        for m in &class.methods {
+            scan_producers_used_in_closures(&m.body, &candidates, &mut in_closure);
+        }
+        if let Some(ctor) = &class.constructor {
+            scan_producers_used_in_closures(&ctor.body, &candidates, &mut in_closure);
+        }
+    }
+    candidates.retain(|id, _| !in_closure.contains(id));
     candidates
 }
 

--- a/crates/perry-transform/src/deforest/mod.rs
+++ b/crates/perry-transform/src/deforest/mod.rs
@@ -85,7 +85,7 @@ pub use call_sites::{rewrite_call_sites_in_stmts, rewrite_call_sites_in_stmts_wi
 pub use detect::{analyze_producer, body_has_closure, detect_producers, stmt_contains_return};
 pub use out_usage::OutUsageAnalyzer;
 pub use producer_rewrite::{rewrite_producer_body, SubstituteLocal};
-pub use scan::{scan_funcref_misuses, scan_unsafe_call_sites};
+pub use scan::{scan_funcref_misuses, scan_producers_used_in_closures, scan_unsafe_call_sites};
 pub use walk::{
     max_local_id, max_local_id_for_func, stmt_references_local, walk_expr_children,
     walk_expr_children_mut,

--- a/crates/perry-transform/src/deforest/scan.rs
+++ b/crates/perry-transform/src/deforest/scan.rs
@@ -146,6 +146,294 @@ fn scan_expr_call_sites(
     walk_expr_children(e, &mut |child| scan_expr_call_sites(child, candidates, out));
 }
 
+/// Records `FuncId`s that are referenced ANYWHERE inside a closure
+/// body. Refs #5136.
+///
+/// Both the producer-detection scans above and the phase-3 call-site
+/// rewriter stop at closure boundaries: the shared `walk_expr_children`
+/// helper visits an `Expr::Closure`'s parameter defaults but never
+/// descends into its statement body. So a producer called from inside
+/// a closure is invisible to detection (it looks safe to deforest) AND
+/// to the rewriter (its call site never gets the synthetic `+1`
+/// accumulator argument). The result is a hard arity mismatch — the
+/// rewritten producer is defined with the extra out-param while the
+/// in-closure call still passes the original arity — which lowers to a
+/// garbage accumulator pointer and a SIGSEGV at runtime.
+///
+/// Rather than teach the rewriter to descend into (and correctly
+/// re-scope) closure bodies — the complete-but-risky fix, deferred as
+/// a follow-up like the other closure-walking refinements noted in
+/// `detect.rs` — conservatively bail on any producer referenced inside
+/// a closure. Both inside- and outside-closure call sites then keep the
+/// original signature. Every legitimate use of a producer is a direct
+/// call whose callee is `Expr::FuncRef(id)`, so flagging any candidate
+/// `FuncRef` seen within a closure catches all in-closure call sites.
+pub fn scan_producers_used_in_closures(
+    stmts: &[Stmt],
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    for s in stmts {
+        scan_stmt_for_closures(s, candidates, out);
+    }
+}
+
+fn scan_stmt_for_closures(
+    stmt: &Stmt,
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    match stmt {
+        Stmt::Let { init, .. } => {
+            if let Some(e) = init {
+                scan_expr_for_closures(e, candidates, out);
+            }
+        }
+        Stmt::Expr(e) | Stmt::Throw(e) => scan_expr_for_closures(e, candidates, out),
+        Stmt::Return(opt) => {
+            if let Some(e) = opt {
+                scan_expr_for_closures(e, candidates, out);
+            }
+        }
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            scan_expr_for_closures(condition, candidates, out);
+            scan_producers_used_in_closures(then_branch, candidates, out);
+            if let Some(eb) = else_branch {
+                scan_producers_used_in_closures(eb, candidates, out);
+            }
+        }
+        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+            scan_expr_for_closures(condition, candidates, out);
+            scan_producers_used_in_closures(body, candidates, out);
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            if let Some(i) = init {
+                scan_stmt_for_closures(i, candidates, out);
+            }
+            if let Some(c) = condition {
+                scan_expr_for_closures(c, candidates, out);
+            }
+            if let Some(u) = update {
+                scan_expr_for_closures(u, candidates, out);
+            }
+            scan_producers_used_in_closures(body, candidates, out);
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            scan_producers_used_in_closures(body, candidates, out);
+            if let Some(c) = catch {
+                scan_producers_used_in_closures(&c.body, candidates, out);
+            }
+            if let Some(f) = finally {
+                scan_producers_used_in_closures(f, candidates, out);
+            }
+        }
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            scan_expr_for_closures(discriminant, candidates, out);
+            for c in cases {
+                if let Some(t) = &c.test {
+                    scan_expr_for_closures(t, candidates, out);
+                }
+                scan_producers_used_in_closures(&c.body, candidates, out);
+            }
+        }
+        Stmt::Labeled { body, .. } => scan_stmt_for_closures(body, candidates, out),
+        _ => {}
+    }
+}
+
+/// Walk an expression looking for `Expr::Closure`. On finding one,
+/// flag every candidate `FuncRef` anywhere in the closure body (and in
+/// any nested closures) as unsafe. Parameter-default expressions
+/// evaluate in the OUTER scope, so they are walked normally rather than
+/// treated as inside-closure.
+fn scan_expr_for_closures(
+    e: &Expr,
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    if let Expr::Closure { params, body, .. } = e {
+        for p in params {
+            if let Some(d) = &p.default {
+                scan_expr_for_closures(d, candidates, out);
+            }
+        }
+        collect_candidate_funcrefs_in_stmts(body, candidates, out);
+        return;
+    }
+    walk_expr_children(e, &mut |child| {
+        scan_expr_for_closures(child, candidates, out)
+    });
+}
+
+/// Inside a closure body, mark every candidate `FuncRef` (in any
+/// position — callee or value) as unsafe. Recurses into nested stmts
+/// and nested closures.
+fn collect_candidate_funcrefs_in_stmts(
+    stmts: &[Stmt],
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    let mut found = false;
+    let mut collector = ClosureFuncRefCollector {
+        candidates,
+        out,
+        found: &mut found,
+    };
+    for s in stmts {
+        collector.visit_stmt(s);
+    }
+}
+
+struct ClosureFuncRefCollector<'a> {
+    candidates: &'a HashMap<FuncId, ProducerInfo>,
+    out: &'a mut HashSet<FuncId>,
+    found: &'a mut bool,
+}
+
+impl ClosureFuncRefCollector<'_> {
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        let mut walker = StmtRefAllWalker {
+            visit: &mut |e: &Expr| {
+                if let Expr::FuncRef(id) = e {
+                    if self.candidates.contains_key(id) {
+                        self.out.insert(*id);
+                        *self.found = true;
+                    }
+                }
+            },
+        };
+        walker.visit_stmt(stmt);
+    }
+}
+
+/// Generic stmt walker that invokes `visit` on every expression
+/// (including those nested in closure bodies and all control flow).
+struct StmtRefAllWalker<'a> {
+    visit: &'a mut dyn FnMut(&Expr),
+}
+
+impl StmtRefAllWalker<'_> {
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Let { init, .. } => {
+                if let Some(e) = init {
+                    self.visit_expr(e);
+                }
+            }
+            Stmt::Expr(e) | Stmt::Throw(e) => self.visit_expr(e),
+            Stmt::Return(opt) => {
+                if let Some(e) = opt {
+                    self.visit_expr(e);
+                }
+            }
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                self.visit_expr(condition);
+                for s in then_branch {
+                    self.visit_stmt(s);
+                }
+                if let Some(eb) = else_branch {
+                    for s in eb {
+                        self.visit_stmt(s);
+                    }
+                }
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                self.visit_expr(condition);
+                for s in body {
+                    self.visit_stmt(s);
+                }
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                if let Some(i) = init {
+                    self.visit_stmt(i);
+                }
+                if let Some(c) = condition {
+                    self.visit_expr(c);
+                }
+                if let Some(u) = update {
+                    self.visit_expr(u);
+                }
+                for s in body {
+                    self.visit_stmt(s);
+                }
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                for s in body {
+                    self.visit_stmt(s);
+                }
+                if let Some(c) = catch {
+                    for s in &c.body {
+                        self.visit_stmt(s);
+                    }
+                }
+                if let Some(f) = finally {
+                    for s in f {
+                        self.visit_stmt(s);
+                    }
+                }
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                self.visit_expr(discriminant);
+                for c in cases {
+                    if let Some(t) = &c.test {
+                        self.visit_expr(t);
+                    }
+                    for s in &c.body {
+                        self.visit_stmt(s);
+                    }
+                }
+            }
+            Stmt::Labeled { body, .. } => self.visit_stmt(body),
+            _ => {}
+        }
+    }
+
+    fn visit_expr(&mut self, e: &Expr) {
+        (self.visit)(e);
+        // Descend into closure bodies too — a producer call nested in a
+        // closure-within-a-closure is just as unreachable to the
+        // rewriter as one in the outer closure.
+        if let Expr::Closure { body, .. } = e {
+            for s in body {
+                self.visit_stmt(s);
+            }
+        }
+        walk_expr_children(e, &mut |child| self.visit_expr(child));
+    }
+}
+
 /// Records `FuncId`s whose `Expr::FuncRef(id)` is observed in a
 /// non-callee position (function value, callback arg, stored to a
 /// local, etc.). The set of "misused" producers is then subtracted

--- a/crates/perry-transform/src/deforest/scan.rs
+++ b/crates/perry-transform/src/deforest/scan.rs
@@ -253,7 +253,15 @@ fn scan_stmt_for_closures(
             }
         }
         Stmt::Labeled { body, .. } => scan_stmt_for_closures(body, candidates, out),
-        _ => {}
+        // Leaf statements with no nested expressions or statements —
+        // nothing to walk. Listed explicitly (no `_` catch-all) so a
+        // future `Stmt` variant that DOES carry a closure forces a
+        // compile error here instead of being silently skipped.
+        Stmt::Break
+        | Stmt::Continue
+        | Stmt::LabeledBreak(_)
+        | Stmt::LabeledContinue(_)
+        | Stmt::PreallocateBoxes(_) => {}
     }
 }
 
@@ -416,7 +424,14 @@ impl StmtRefAllWalker<'_> {
                 }
             }
             Stmt::Labeled { body, .. } => self.visit_stmt(body),
-            _ => {}
+            // Leaf statements — no nested expressions or statements.
+            // Listed explicitly (no `_` catch-all) so a future variant
+            // carrying expressions forces a revisit here.
+            Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_) => {}
         }
     }
 

--- a/crates/perry-transform/src/deforest/tests.rs
+++ b/crates/perry-transform/src/deforest/tests.rs
@@ -129,6 +129,153 @@ fn synthetic_out_params_are_assigned_by_function_id() {
     assert_eq!(func2.params.last().unwrap().id, 22);
 }
 
+#[test]
+fn rejects_producer_called_inside_closure() {
+    // Refs #5136. A producer whose ONLY call site lives inside a
+    // closure body must NOT be deforested: the call-site rewriter
+    // never descends into closures, so rewriting the producer's
+    // signature (adding the +1 accumulator param) while the in-closure
+    // call keeps the original arity miscompiles to a SIGSEGV.
+    //
+    //   function helper() { const out = []; out.push(1); return out; }
+    //   function factory() {
+    //     const generate = () => { const v = helper(); return v.length; };
+    //     return generate;
+    //   }
+    let helper = make_simple_producer(); // id=1, the producer
+
+    let closure = Expr::Closure {
+        func_id: 2,
+        params: vec![],
+        return_type: Type::Number,
+        body: vec![
+            // const v = helper();
+            Stmt::Let {
+                id: 30,
+                name: "v".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Call {
+                    callee: Box::new(Expr::FuncRef(1)),
+                    args: vec![],
+                    type_args: vec![],
+                }),
+            },
+            // return v.length;
+            Stmt::Return(Some(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(30)),
+                property: "length".to_string(),
+            })),
+        ],
+        captures: vec![],
+        mutable_captures: vec![],
+        captures_this: false,
+        captures_new_target: false,
+        enclosing_class: None,
+        is_arrow: true,
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+    };
+
+    let factory = Function {
+        id: 3,
+        name: "factory".to_string(),
+        type_params: vec![],
+        params: vec![],
+        return_type: Type::Any,
+        body: vec![
+            Stmt::Let {
+                id: 31,
+                name: "generate".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(closure),
+            },
+            Stmt::Return(Some(Expr::LocalGet(31))),
+        ],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: vec![],
+        decorators: vec![],
+        was_plain_async: false,
+        was_unrolled: false,
+    };
+
+    let mut module = Module::new("m");
+    module.functions = vec![helper, factory];
+
+    // Detection must drop the producer entirely.
+    assert!(
+        detect_producers(&module).is_empty(),
+        "producer called inside a closure must not be deforested"
+    );
+
+    // And `run` must leave the producer's signature untouched (no
+    // synthetic accumulator param added).
+    run(&mut module);
+    let helper_after = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert!(
+        helper_after.params.is_empty(),
+        "producer signature must be unchanged when only called from a closure"
+    );
+}
+
+#[test]
+fn still_deforests_when_caller_is_not_a_closure() {
+    // Control for `rejects_producer_called_inside_closure`: the SAME
+    // producer, but called from a plain statement, is still rewritten.
+    //
+    //   function helper() { const out = []; out.push(1); return out; }
+    //   function caller() { const v = helper(); /* ...used... */ }
+    let helper = make_simple_producer(); // id=1
+
+    let caller = Function {
+        id: 2,
+        name: "caller".to_string(),
+        type_params: vec![],
+        params: vec![],
+        return_type: Type::Any,
+        body: vec![Stmt::Let {
+            id: 30,
+            name: "v".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::Call {
+                callee: Box::new(Expr::FuncRef(1)),
+                args: vec![],
+                type_args: vec![],
+            }),
+        }],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: vec![],
+        decorators: vec![],
+        was_plain_async: false,
+        was_unrolled: false,
+    };
+
+    let mut module = Module::new("m");
+    module.functions = vec![helper, caller];
+
+    assert!(
+        !detect_producers(&module).is_empty(),
+        "producer with a plain (non-closure) caller should still deforest"
+    );
+
+    run(&mut module);
+    let helper_after = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert_eq!(
+        helper_after.params.len(),
+        1,
+        "producer should gain the synthetic accumulator param"
+    );
+}
+
 fn make_simple_producer() -> Function {
     Function {
         id: 1,

--- a/test-files/test_deforest_closure_caller.ts
+++ b/test-files/test_deforest_closure_caller.ts
@@ -1,0 +1,44 @@
+// Regression for #5136: the interprocedural deforestation pass
+// (crates/perry-transform/src/deforest) rewrites a "producer" function
+// — `const out = []; ...push...; return out;` — to take a trailing
+// accumulator parameter, and rewrites its call sites to pass one. The
+// call-site rewriter never descended into closure bodies, so when the
+// producer's only caller lived inside a closure returned from a
+// factory, the producer's signature gained the extra param while the
+// in-closure call still passed the original arity. That arity mismatch
+// lowered to a garbage accumulator pointer and a SIGSEGV (exit 139).
+//
+// Surfaced in the wild as `uuid`'s `v5()` crashing under
+// `perry.compilePackages`: its `stringToBytes` producer is called from
+// the `generateUUID` closure that `v35()` returns.
+//
+// This mirrors that shape with no dependencies. The fix bails on
+// deforesting any producer referenced inside a closure, so the program
+// runs correctly. Must print "ok" and exit 0.
+
+function stringToBytes(str: string): number[] {
+  const bytes: number[] = [];
+  for (let i = 0; i < str.length; ++i) {
+    bytes.push(str.charCodeAt(i));
+  }
+  return bytes;
+}
+
+function makeEncoder() {
+  function encode(value: string): number {
+    const v = stringToBytes(value);
+    let sum = 0;
+    for (let i = 0; i < v.length; ++i) sum += v[i];
+    return sum;
+  }
+  return encode;
+}
+
+const encode = makeEncoder();
+// "perry" => 112+101+114+114+121 = 562
+const sum = encode("perry");
+if (sum !== 562) {
+  console.log("FAIL: expected 562, got", sum);
+  throw new Error("deforest closure-caller regression");
+}
+console.log("ok");


### PR DESCRIPTION
## Summary

Fixes #5136 — `uuid`'s `v5()` segfaults (SIGSEGV / exit 139) under `perry.compilePackages`.

## Root cause

The interprocedural **deforestation** pass (`crates/perry-transform/src/deforest`) rewrites a "producer" function — `const out = []; …push…; return out;` — to take a trailing `__deforest_out` accumulator parameter, and rewrites its call sites to pass one.

Neither the producer-detection scans nor the phase-3 call-site rewriter descend into **closure bodies**: the shared `walk_expr_children` helper visits an `Expr::Closure`'s parameter defaults but never its statement body. So when a producer's only caller lives inside a closure (e.g. one returned from a factory), the producer's signature gains the extra param while the in-closure call site keeps the original arity:

```
define double @…__helper(double %arg1, double %arg5) …      ; +1 param after rewrite
…
%r4 = call double @…__helper(double %r3)                     ; in-closure call: still 1 arg
```

That arity mismatch makes `__deforest_out` a garbage register, the function pushes into a junk pointer, and `.length` on the bogus result dereferences null → SIGSEGV.

In `uuid` this is exactly `v5`: `v35()` returns a `generateUUID` closure that calls the module-level `stringToBytes` producer.

The bug is **general** (not compile-package specific) — it reproduces in a plain `.ts` file:

```ts
function helper(str: string) { const b: number[] = []; for (let i=0;i<str.length;++i) b.push(str.charCodeAt(i)); return b; }
function factory() { function generate(v: string) { return helper(v).length; } return generate; }
const gen = factory();
console.log(gen("perry"));   // exit 139 before this fix
```

## Fix

Add a fourth detection pass that **bails on any producer referenced inside a closure body**, so both inside- and outside-closure call sites keep the original signature. This is conservative — it only ever shrinks the candidate set (forgoes the optimization for that shape), and can never miscompile. Teaching the rewriter to descend into and correctly re-scope closure bodies is left as a follow-up, consistent with the other deferred closure-walking refinements already noted in `detect.rs`.

## Verification

- Exact issue repro (real `uuid` 9.0.1 source, compiled via `compilePackages`) now matches Node byte-for-byte: `6cb3836f-339d-52d8-acc6-8751229b61cf true 5`.
- New unit tests: `rejects_producer_called_inside_closure` (bails) and `still_deforests_when_caller_is_not_a_closure` (control — optimization still fires).
- New end-to-end self-checking regression: `test-files/test_deforest_closure_caller.ts`.
- `cargo test -p perry-transform` green (32 + 8 deforest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an arity mismatch issue (issue `#5136`) where producer functions referenced inside closure bodies could be incorrectly selected for rewriting, leading to compilation failures or incorrect transformations. Producers used within closures are now safely excluded from transformation candidates.
* **Tests**
  * Added new unit tests covering producers called only from within closures (no synthetic parameter added) and from non-closure contexts (synthetic parameter added).
  * Added a regression test for the closure-based caller scenario from `#5136`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->