### PR TITLE
fix(codegen): bind call-site `this` for super-method value invocations (#5138)

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -899,9 +899,18 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
     // materialize them via `js_closure_alloc_singleton(@__perry_wrap_<method>)`.
     // Methods have signature `perry_method_<...>(this_box, args...)`;
     // the closure-call ABI is `(i64 closure, double a0, ...)` and
-    // doesn't carry a separate `this`. Strict JS for `const fn =
-    // super.greet; fn(x)` calls the method with `this=undefined`,
-    // which is what we forward here.
+    // doesn't carry a separate `this`. The receiver therefore comes from
+    // IMPLICIT_THIS, set by the dispatcher right before the call:
+    //   * A method-style invocation of a stored super-method value
+    //     (`this._complete = super._complete; obj._complete()` — rxjs's
+    //     `OperatorSubscriber` forwarding `complete`/`error`/`next` to the
+    //     base `Subscriber` when no override callback was supplied) sets
+    //     IMPLICIT_THIS to the receiver, so the base method runs with the
+    //     right `this`. Pre-fix this hardcoded `this=undefined`, so the
+    //     forwarded `complete` never reached `this.destination.complete()`
+    //     and the pipeline stalled (top-level await never settled, #5138).
+    //   * A bare call (`const fn = super.greet; fn(x)`) leaves
+    //     IMPLICIT_THIS undefined, matching strict-mode `this`.
     let mut emitted_wrappers: std::collections::HashSet<String> = std::collections::HashSet::new();
     for class in &hir.classes {
         for method in &class.methods {
@@ -923,11 +932,11 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             let wf = llmod.define_function(&wrap_name, DOUBLE, wrap_params);
             let _ = wf.create_block("entry");
             let blk = wf.block_mut(0).unwrap();
-            // Forward `this=undefined` then the args.
-            let undef_lit = crate::nanbox::i64_literal(crate::nanbox::TAG_UNDEFINED);
-            let undef_double = blk.bitcast_i64_to_double(&undef_lit);
+            // Forward the call-site receiver (IMPLICIT_THIS) as `this`,
+            // then the args. See the block comment above (#5138).
+            let this_box = blk.call(DOUBLE, "js_implicit_this_get", &[]);
             let mut call_args: Vec<(LlvmType, String)> = Vec::with_capacity(arity + 1);
-            call_args.push((DOUBLE, undef_double));
+            call_args.push((DOUBLE, this_box));
             for i in 0..arity {
                 call_args.push((DOUBLE, format!("%a{}", i)));
             }

--- a/crates/perry/tests/issue_5138_super_method_value_this.rs
+++ b/crates/perry/tests/issue_5138_super_method_value_this.rs
@@ -1,0 +1,107 @@
+//! Regression test for #5138: a `super.<method>` value stored on an instance
+//! and later invoked method-style ran the base method with `this=undefined`.
+//!
+//! The canonical real-world shape is rxjs's `OperatorSubscriber`, which does
+//! `this._complete = onComplete ? wrapper : super._complete` in its
+//! constructor. With no override callback the operator forwards completion to
+//! the base `Subscriber`, so `map(...)` relies on `super._complete`. A
+//! synchronous `of(...).pipe(filter, map, reduce)` then never drove its
+//! subscriber to completion: `reduce` only emits on `complete`, `firstValueFrom`
+//! never resolved, and the program exited 13 ("Detected unsettled top-level
+//! await").
+//!
+//! Root cause: the class-method closure wrapper emitted for value-form
+//! `super.<method>` (`__perry_wrap_<method>`) hardcoded `this=undefined` when
+//! forwarding to the underlying method. That is correct for a *bare* call
+//! (`const fn = super.greet; fn()` → strict `this`), but wrong for a
+//! *method-style* call where the dispatcher has already set IMPLICIT_THIS to the
+//! receiver. Fix: the wrapper now reads IMPLICIT_THIS and forwards it as `this`,
+//! so both call shapes match Node.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// `this._x = super._x; obj._x()` must run the base method with `this === obj`.
+/// Pre-fix the base method saw `this=undefined` and threw on `this.tag`.
+#[test]
+fn super_method_value_invoked_method_style_binds_receiver() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class Base {
+  _complete() { console.log('base complete', this.tag); }
+}
+class Child extends Base {
+  tag = 'child';
+  _complete: () => void;
+  constructor(onComplete?: () => void) {
+    super();
+    this._complete = onComplete ? onComplete : super._complete;
+  }
+}
+const c = new Child();
+c._complete();
+"#,
+    );
+    assert_eq!(stdout, "base complete child\n");
+}
+
+/// The other side of the contract: a *bare* call of a `super.<method>` value
+/// must still see strict-mode `this === undefined` (Node parity), not leak a
+/// stale receiver.
+#[test]
+fn super_method_value_invoked_bare_keeps_undefined_this() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class Base {
+  greet() { console.log('this is', this === undefined ? 'undefined' : 'defined'); }
+}
+class Child extends Base {
+  run() { const fn = super.greet; fn(); }
+}
+new Child().run();
+"#,
+    );
+    assert_eq!(stdout, "this is undefined\n");
+}


### PR DESCRIPTION
## Summary

Fixes #5138 — `await firstValueFrom(of(...).pipe(filter, map, reduce))` against rxjs never settled and the process exited 13 with `Warning: Detected unsettled top-level await`.

## Root cause

The closure-call wrapper emitted for value-form `super.<method>` (`__perry_wrap_<method>`, in `codegen/artifacts.rs`) hardcoded `this=undefined` when forwarding to the underlying method. That's correct for a *bare* call (`const fn = super.greet; fn()` → strict-mode `this`), but wrong when the value is stored and later invoked *method-style*: the dispatcher has already set `IMPLICIT_THIS` to the receiver, yet the wrapper discarded it.

rxjs's `OperatorSubscriber` constructor does `this._complete = onComplete ? wrapper : super._complete`. With no override callback, `map(...)` forwards completion to the base `Subscriber` through `super._complete`. Running that with `this=undefined` meant `this.destination.complete()` never fired, so a synchronous `of(...).pipe(filter, map, reduce)` never drove its subscriber to completion. `reduce` only emits on `complete`, so `firstValueFrom` never resolved and top-level await hung.

## Fix

The method-value wrapper now reads `IMPLICIT_THIS` and forwards it as `this`:
- method-style call (`obj._complete()`) → sees the receiver
- bare call (`const fn = super.greet; fn()`) → still sees strict-mode `undefined`

Both match Node.

## Validation

- Repro from the issue now prints `90` (matches `node --experimental-strip-types`).
- New end-to-end regression test `crates/perry/tests/issue_5138_super_method_value_this.rs` covers both the method-style (binds receiver) and bare-call (keeps `undefined`) shapes — both pass.
- `cargo test -p perry-codegen -p perry-hir -p perry-runtime` green (the `native_proof_regressions` poison-errors seen in a parallel run are a pre-existing env-lock contention artifact; the binary passes 45/45 single-threaded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method invocation through `super` references to correctly bind the receiver context, resolving issues with callback forwarding in subclass inheritance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->