### PR TITLE
fix(hir): mirror @@iterator lowering in class-expression path (#5128 review follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## v0.5.1173 — fix(hir): mirror @@iterator lowering in class-expression path (#5128 review)
+
+Follow-up to #5161 (CodeRabbit review). The #5128 fix that makes a user class
+with a generator `*[Symbol.iterator]()` iterable for runtime-dispatched consumers
+(spread, `Math.max(...)`, `Array.from`, destructuring, manual
+`obj[Symbol.iterator]()`) was only wired into the class-*declaration* lowering
+(`lower_class_decl`). The parallel class-*expression* path (`lower_class_from_ast`)
+dropped computed `[Symbol.iterator]` members unless they were `util.inspect.custom`,
+so `new (class { *[Symbol.iterator]() {…} })()` and named class-expression bindings
+stayed non-iterable.
+
+- **HIR** (`lower_decl/class_decl.rs`): extracted the generator-lift + synthetic
+  non-generator `@@iterator` wrapper into a shared `synthesize_symbol_iterator_wrapper`
+  helper and called it from both `lower_class_decl` and `lower_class_from_ast`. The
+  class-expression `PropName::Computed` arm now recognizes `[Symbol.iterator]` (mapping
+  to `@@iterator`) instead of silently dropping it, which also fixes the plain
+  non-generator case.
+- **Runtime** (`array/iterator.rs`): `array_from_spread_value` now restores
+  `IMPLICIT_THIS` on the exception path too — the iterator-factory call is wrapped in
+  the same setjmp/trap/restore pattern as `async_from_sync_call_cached_raw`, so a
+  throwing factory can no longer leak the thread-local receiver into later calls.
+- **Tests**: added `class_expression_generator_symbol_iterator_is_iterable` mirroring
+  the declaration-form regression suite (spread incl. via variable, `Math.max`,
+  `for…of`, destructuring, `Array.from`, manual iterator, anonymous-class-expression
+  spread).
+
 ## v0.5.1172 — feat(ui-windows-winui): render-backend dispatch seam + startup probe (#4680 step 3)
 
 Builds on the Windows App SDK bootstrap probe. Adds `winui::backend` — the single

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1172
+**Current Version:** 0.5.1173
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "base64",
@@ -5339,14 +5339,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "cc",
  "libc",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "log",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5396,7 +5396,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "base64",
@@ -5418,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5455,14 +5455,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "serde",
  "serde_json",
@@ -5470,7 +5470,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1172"
+version = "0.5.1173"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5481,7 +5481,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "clap",
@@ -5496,14 +5496,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5528,7 +5528,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5586,7 +5586,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5602,14 +5602,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5626,7 +5626,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5638,7 +5638,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5651,7 +5651,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "bytes",
  "h2",
@@ -5674,7 +5674,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "bson",
  "futures-util",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5781,7 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "image",
@@ -5798,14 +5798,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5814,7 +5814,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "brotli",
  "flate2",
@@ -5853,7 +5853,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "base64",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6033,14 +6033,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "itoa",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "block2",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "block2",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1172"
+version = "0.5.1173"
 
 [[package]]
 name = "perry-ui-test"
@@ -6129,11 +6129,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1172"
+version = "0.5.1173"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "block2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "block2",
@@ -6165,7 +6165,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "block2",
  "libc",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "libc",
@@ -6195,14 +6195,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1172"
+version = "0.5.1173"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1172"
+version = "0.5.1173"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -131,6 +131,91 @@ fn lower_noncomputed_class_member_registration(
     })
 }
 
+/// Lower a generator `*[Symbol.iterator]()` class method (already lowered into
+/// `func`, named `@@iterator`) into the runtime `@@iterator` vtable entry.
+///
+/// The body is lifted to a top-level `__perry_iter_<class>` generator with
+/// `this` as an explicit first parameter — the generator transform (which only
+/// visits `module.functions`) then rewrites it to the `{next, return, throw}`
+/// closure triple, and the syntactic `for…of` fast path dispatches to it
+/// directly via `iterator_func_for_class`.
+///
+/// But every *runtime*-dispatched iterator consumer (spread `[...x]`,
+/// `Math.max(...x)`, destructuring, `x[Symbol.iterator]()`, `Array.from`)
+/// resolves `@@iterator` through the class registry instead. So this also
+/// returns a synthetic NON-generator `@@iterator` wrapper method that forwards
+/// to the lifted generator (`return __perry_iter_X(this)`) for the caller to
+/// append to the instance vtable. Without it the class carries no `@@iterator`
+/// for those consumers to find and they throw "value is not iterable" (#5128).
+/// (The runtime maps the well-known `Symbol.iterator` to this `@@iterator`
+/// method name in `js_object_get_symbol_property`.)
+///
+/// Shared by `lower_class_decl` and `lower_class_from_ast` so class
+/// declarations and class expressions behave identically.
+fn synthesize_symbol_iterator_wrapper(
+    ctx: &mut LoweringContext,
+    class_name: &str,
+    func: &mut Function,
+) -> Function {
+    let this_id = ctx.fresh_local();
+    let mut new_params = Vec::with_capacity(func.params.len() + 1);
+    new_params.push(Param {
+        id: this_id,
+        name: "this".to_string(),
+        ty: Type::Named(class_name.to_string()),
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    });
+    new_params.append(&mut func.params);
+
+    let mut body = std::mem::take(&mut func.body);
+    crate::analysis::replace_this_in_stmts(&mut body, this_id);
+
+    let top_fn_id = ctx.fresh_func();
+    let top_fn = Function {
+        id: top_fn_id,
+        name: format!("__perry_iter_{}", class_name),
+        type_params: Vec::new(),
+        params: new_params,
+        return_type: Type::Any,
+        body,
+        is_async: false,
+        is_generator: true,
+        is_strict: true,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+    };
+    ctx.pending_functions.push(top_fn);
+    ctx.iterator_func_for_class
+        .insert(class_name.to_string(), top_fn_id);
+
+    Function {
+        id: ctx.fresh_func(),
+        name: "@@iterator".to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type: Type::Any,
+        body: vec![Stmt::Return(Some(Expr::Call {
+            callee: Box::new(Expr::FuncRef(top_fn_id)),
+            args: vec![Expr::This],
+            type_args: Vec::new(),
+        }))],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+    }
+}
+
 pub fn lower_class_decl(
     ctx: &mut LoweringContext,
     class_decl: &ast::ClassDecl,
@@ -707,85 +792,12 @@ pub fn lower_class_decl(
                         // removed in v0.5.319. See the v0.5.317 entry for the
                         // history and `test_issue_154_using_dispose.ts` for the
                         // regression test.
-                        // `*[Symbol.iterator]()` — lift to a top-level
-                        // generator function with `this` as an explicit
-                        // first parameter. The generator transform
-                        // (which only visits `module.functions`) then
-                        // rewrites it to return the `{next, return,
-                        // throw}` closure triple. For-of sites use
-                        // `iterator_func_for_class` to dispatch.
+                        // `*[Symbol.iterator]()` — lift to a top-level generator
+                        // and register a synthetic `@@iterator` wrapper so both
+                        // the `for…of` fast path and runtime-dispatched iterator
+                        // consumers work (#5128). See the helper for details.
                         if prop_name == "@@iterator" && func.is_generator && !method.is_static {
-                            let this_id = ctx.fresh_local();
-                            let mut new_params = Vec::with_capacity(func.params.len() + 1);
-                            new_params.push(Param {
-                                id: this_id,
-                                name: "this".to_string(),
-                                ty: Type::Named(name.clone()),
-                                default: None,
-                                decorators: Vec::new(),
-                                is_rest: false,
-                                arguments_object: None,
-                            });
-                            new_params.append(&mut func.params);
-
-                            let mut body = std::mem::take(&mut func.body);
-                            crate::analysis::replace_this_in_stmts(&mut body, this_id);
-
-                            let top_name = format!("__perry_iter_{}", name);
-                            let top_fn_id = ctx.fresh_func();
-                            let top_fn = Function {
-                                id: top_fn_id,
-                                name: top_name,
-                                type_params: Vec::new(),
-                                params: new_params,
-                                return_type: Type::Any,
-                                body,
-                                is_async: false,
-                                is_generator: true,
-                                is_strict: true,
-                                was_plain_async: false,
-                                was_unrolled: false,
-                                is_exported: false,
-                                captures: Vec::new(),
-                                decorators: Vec::new(),
-                            };
-                            ctx.pending_functions.push(top_fn);
-                            ctx.iterator_func_for_class.insert(name.clone(), top_fn_id);
-
-                            // #5128: also register a synthetic NON-generator
-                            // `@@iterator` class method that forwards to the
-                            // lifted generator (`return __perry_iter_X(this)`).
-                            // The syntactic `for…of` fast path dispatches to the
-                            // lifted function directly via `iterator_func_for_class`,
-                            // but every *runtime*-dispatched iterator consumer
-                            // (spread `[...x]`, `Math.max(...x)`, destructuring,
-                            // `x[Symbol.iterator]()`) resolves `@@iterator` through
-                            // the class registry. Without this method the class has
-                            // no `@@iterator` for them to find, so they threw
-                            // "value is not iterable". (The runtime maps the
-                            // well-known `Symbol.iterator` to this `@@iterator`
-                            // method name in `js_object_get_symbol_property`.)
-                            let wrapper_fn_id = ctx.fresh_func();
-                            let wrapper = Function {
-                                id: wrapper_fn_id,
-                                name: "@@iterator".to_string(),
-                                type_params: Vec::new(),
-                                params: Vec::new(),
-                                return_type: Type::Any,
-                                body: vec![Stmt::Return(Some(Expr::Call {
-                                    callee: Box::new(Expr::FuncRef(top_fn_id)),
-                                    args: vec![Expr::This],
-                                    type_args: Vec::new(),
-                                }))],
-                                is_async: false,
-                                is_generator: false,
-                                is_strict: true,
-                                was_plain_async: false,
-                                was_unrolled: false,
-                                is_exported: false,
-                                captures: Vec::new(),
-                                decorators: Vec::new(),
-                            };
+                            let wrapper = synthesize_symbol_iterator_wrapper(ctx, &name, &mut func);
                             methods.push(wrapper);
                             continue;
                         }
@@ -1425,6 +1437,15 @@ pub fn lower_class_from_ast(
                     // Numeric-literal member names — see the parallel arm in
                     // `lower_class_decl`. Canonical ToString of the value.
                     ast::PropName::Num(n) => (crate::lower::number_to_js_key(n.value), true),
+                    // `[Symbol.iterator]() {}` / `*[Symbol.iterator]() {}` on a
+                    // class *expression* — mirror the declaration path so
+                    // `new (class { *[Symbol.iterator]() {…} })()` is iterable
+                    // for spread, `Array.from`, destructuring, and manual
+                    // `obj[Symbol.iterator]()` calls (#5128). The generator lift
+                    // happens in the `Method` arm below.
+                    ast::PropName::Computed(computed) if is_symbol_iterator_key(&computed.expr) => {
+                        ("@@iterator".to_string(), false)
+                    }
                     ast::PropName::Computed(computed)
                         if is_inspect_custom_key(ctx, &computed.expr)
                             && !method.is_static
@@ -1467,9 +1488,17 @@ pub fn lower_class_from_ast(
                         setters.push((prop_name, func));
                     }
                     ast::MethodKind::Method => {
-                        let func = with_static_member_context(ctx, method.is_static, |ctx| {
+                        let mut func = with_static_member_context(ctx, method.is_static, |ctx| {
                             lower_class_method(ctx, method)
                         })?;
+                        // `*[Symbol.iterator]()` — lift to a top-level generator
+                        // and register a synthetic `@@iterator` wrapper (#5128),
+                        // exactly as the class-declaration path does above.
+                        if prop_name == "@@iterator" && func.is_generator && !method.is_static {
+                            let wrapper = synthesize_symbol_iterator_wrapper(ctx, name, &mut func);
+                            methods.push(wrapper);
+                            continue;
+                        }
                         if seen_generic_computed_member && can_source_order_register {
                             computed_members.push(lower_noncomputed_class_member_registration(
                                 ctx, method, &prop_name,

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -697,8 +697,23 @@ pub(crate) fn array_from_spread_value(value: f64) -> *mut ArrayHeader {
             // Without this the wrapper saw a stale `this` and the generator
             // yielded nothing (empty spread).
             let prev_this = crate::object::js_implicit_this_set(value);
-            let iter = crate::closure::js_closure_call0(fn_ptr);
+            let trap_buf = crate::exception::js_try_push();
+            let jumped =
+                unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut std::os::raw::c_int) };
+            let iter = if jumped == 0 {
+                crate::closure::js_closure_call0(fn_ptr)
+            } else {
+                // Factory threw: restore the receiver and unwind the trap frame
+                // before re-propagating, so IMPLICIT_THIS can't leak into later
+                // calls (mirrors `async_from_sync_call_cached_raw` above).
+                let exc = crate::exception::js_get_exception();
+                crate::exception::js_clear_exception();
+                crate::object::js_implicit_this_set(prev_this);
+                crate::exception::js_try_end();
+                crate::exception::js_throw(exc)
+            };
             crate::object::js_implicit_this_set(prev_this);
+            crate::exception::js_try_end();
             if crate::array::js_array_is_array(iter).to_bits() == crate::value::TAG_TRUE {
                 return js_iterator_to_array(crate::array::array_values_iter(iter));
             }

--- a/crates/perry/tests/issue_5128_user_symbol_iterator.rs
+++ b/crates/perry/tests/issue_5128_user_symbol_iterator.rs
@@ -88,6 +88,39 @@ console.log(it.next().value, it.next().value, it.next().done);
     );
 }
 
+/// The same fix must apply to class *expressions* — `lower_class_from_ast`
+/// mirrors `lower_class_decl`, so `new (class { *[Symbol.iterator]() {…} })()`
+/// and a named class-expression binding are iterable for every runtime consumer.
+#[test]
+fn class_expression_generator_symbol_iterator_is_iterable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const Range = class {
+  lo: number; hi: number;
+  constructor(lo: number, hi: number) { this.lo = lo; this.hi = hi; }
+  *[Symbol.iterator]() { for (let i = this.lo; i <= this.hi; i++) yield i; }
+};
+console.log([...new Range(1, 5)].join(","));    // spread
+console.log(Math.max(...new Range(1, 5)));       // Math.max spread
+let s = 0; for (const x of new Range(1, 5)) s += x; console.log(s); // for-of
+const r = new Range(1, 3);
+console.log([...r].join(","));                   // spread via variable
+const [a, b, c] = new Range(10, 12); console.log(a, b, c); // destructuring
+console.log(Array.from(new Range(1, 4)).join(",")); // Array.from
+const it = new Range(7, 8)[Symbol.iterator]();   // manual iterator
+console.log(it.next().value, it.next().value, it.next().done);
+// anonymous class expression spread directly
+console.log([...new (class { *[Symbol.iterator]() { yield 7; yield 8; } })()].join(","));
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "1,2,3,4,5\n5\n15\n1,2,3\n10 11 12\n1,2,3,4\n7 8 true\n7,8\n"
+    );
+}
+
 /// A non-generator `[Symbol.iterator]()` method (delegating to a backing
 /// array's iterator) must also be reachable by runtime consumers, and plain
 /// array/string spreads must keep working.


### PR DESCRIPTION
Follow-up to #5161 incorporating CodeRabbit's review feedback (the PR was merged before the comments could be addressed).

## CodeRabbit findings addressed

1. **Mirror the `@@iterator` lowering in `lower_class_from_ast`** (Major). The #5128 fix only wired the synthetic `@@iterator` wrapper into the class-*declaration* path. The class-*expression* path dropped computed `[Symbol.iterator]` members unless they were `util.inspect.custom`, so `new (class { *[Symbol.iterator]() {…} })()` and named class-expression bindings stayed non-iterable for spread, `Array.from`, destructuring, and manual `obj[Symbol.iterator]()`.

2. **Restore `IMPLICIT_THIS` on exception paths too** (Major). In `array_from_spread_value`, `IMPLICIT_THIS` was only restored on the normal return of the iterator-factory call. A throwing factory skipped the restore and leaked the thread-local receiver into later calls.

## Changes

- **HIR** (`lower_decl/class_decl.rs`): extracted the generator-lift + synthetic non-generator `@@iterator` wrapper into a shared `synthesize_symbol_iterator_wrapper` helper, called from **both** `lower_class_decl` and `lower_class_from_ast`. The class-expression `PropName::Computed` arm now recognizes `[Symbol.iterator]` (→ `@@iterator`) instead of silently dropping it — this also fixes the plain non-generator case.
- **Runtime** (`array/iterator.rs`): wrapped the iterator-factory call in the same setjmp/trap/restore pattern used by `async_from_sync_call_cached_raw`, so the receiver is always restored before re-propagating.
- **Tests**: added `class_expression_generator_symbol_iterator_is_iterable` mirroring the declaration-form regression suite.

## Verification

`cargo test -p perry --test issue_5128_user_symbol_iterator` — all 3 tests green (declaration, class-expression, plain-spread regression). Output matches Node exactly for every shape. `perry-hir` unit suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.5.1173

* **Bug Fixes**
  * Fixed Symbol.iterator behavior on class expressions to align with class declarations
  * Corrected runtime exception handling in iterator operations to prevent state leakage

* **Tests**
  * Added test coverage for class-expression generator Symbol.iterator scenarios

* **Chores**
  * Version bump to 0.5.1173

<!-- end of auto-generated comment: release notes by coderabbit.ai -->