### PR TITLE
fix(http): native IncomingMessage/ServerResponse/… expose a real `.prototype` (#3527)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -2922,14 +2922,18 @@ pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Opt
     // `'prototype' in C.prototype.m === false`). (Test262 definition method/accessor
     // prop-desc.)
     //
-    // #4973 exception: bound NATIVE-MODULE *class* exports (`http.Server`,
-    // `https.Server`) are constructors in Node, and the util.inherits-era
-    // subclass pattern reads their `.prototype` as a setPrototypeOf operand
-    // (`Object.setPrototypeOf(testServer.prototype, http.Server.prototype)`).
-    // Returning None here made that read `undefined` and the setPrototypeOf
-    // threw "Object prototype may only be an Object or null". These exports
-    // are cached singleton closures (NATIVE_CALLABLE_EXPORTS), so the
-    // synthetic-class path below gives them a stable prototype object.
+    // #4973 / #3527 exception: bound NATIVE-MODULE *class* exports
+    // (`http.Server`, `http.IncomingMessage`, `http.ServerResponse`, …) are
+    // constructors in Node, and the util.inherits / `Object.create(Ctor.
+    // prototype)` subclass pattern reads their `.prototype` as a
+    // setPrototypeOf / Object.create operand. Returning None here made that
+    // read `undefined`, and `Object.create(undefined)` /
+    // `Object.setPrototypeOf(x, undefined)` then threw "Object prototype may
+    // only be an Object or null" — the exact blocker hit at Express init
+    // (`express/lib/request.js`: `Object.create(http.IncomingMessage.
+    // prototype)`). These exports are cached singleton closures
+    // (NATIVE_CALLABLE_EXPORTS), so the synthetic-class path below gives them
+    // a stable prototype object.
     {
         let jv = crate::value::JSValue::from_bits(func_value.to_bits());
         if jv.is_pointer() {
@@ -2942,7 +2946,20 @@ pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Opt
                     super::native_module::bound_native_callable_module_and_method(func_value)
                 }
                 .map(|(module, method)| {
-                    matches!(module.as_str(), "http" | "https") && method == "Server"
+                    matches!(
+                        (module.as_str(), method.as_str()),
+                        // Shared http/https constructor classes.
+                        ("http" | "https", "Server" | "Agent")
+                            // http-only request/response constructor classes
+                            // that userland subclasses (Express, util.inherits).
+                            | (
+                                "http",
+                                "IncomingMessage"
+                                    | "ServerResponse"
+                                    | "OutgoingMessage"
+                                    | "ClientRequest"
+                            )
+                    )
                 })
                 .unwrap_or(false);
                 if !is_native_class_export {

--- a/test-files/test_gap_3527_http_ctor_prototype.ts
+++ b/test-files/test_gap_3527_http_ctor_prototype.ts
@@ -1,0 +1,34 @@
+// #3527: native `node:http` constructor classes expose a real `.prototype`
+// object so userland subclassing — `Object.create(http.IncomingMessage.
+// prototype)` (Express), `util.inherits(...)` — works instead of throwing
+// "Object prototype may only be an Object or null".
+import http from "node:http";
+import https from "node:https";
+import util from "node:util";
+
+for (const name of [
+  "IncomingMessage",
+  "ServerResponse",
+  "OutgoingMessage",
+  "ClientRequest",
+  "Server",
+  "Agent",
+] as const) {
+  console.log(`http.${name}.prototype:`, typeof (http as any)[name].prototype);
+}
+console.log("https.Server.prototype:", typeof https.Server.prototype);
+console.log("https.Agent.prototype:", typeof https.Agent.prototype);
+
+// Express's request/response prototype pattern.
+const req = Object.create(http.IncomingMessage.prototype);
+const res = Object.create(http.ServerResponse.prototype);
+console.log("Object.create(IncomingMessage.prototype) is object:", typeof req === "object");
+console.log("Object.create(ServerResponse.prototype) is object:", typeof res === "object");
+
+// util.inherits over a native http class.
+function MyMessage() {}
+util.inherits(MyMessage, http.IncomingMessage);
+console.log(
+  "util.inherits links prototype chain:",
+  Object.getPrototypeOf(MyMessage.prototype) === http.IncomingMessage.prototype,
+);


### PR DESCRIPTION
## What

Compiling a standard **Express 5** app (`express@5.2.1`) crashed at init with:

```
TypeError: Object prototype may only be an Object or null: undefined
```

The throw comes from Express's prototype setup:
- `express/lib/request.js`: `var req = Object.create(http.IncomingMessage.prototype)`
- `express/lib/response.js`: `Object.create(http.ServerResponse.prototype)`

Perry exposes `http.IncomingMessage` / `http.ServerResponse` as callable constructor **values**, but their `.prototype` read returned `undefined`, so `Object.create(undefined)` threw.

## Fix

The #4973 fix already special-cased `http.Server` / `https.Server` in `ordinary_function_prototype_value_for_read` — bound native-module **class** exports get a stable synthetic prototype object instead of `undefined`. This extends that same exception to the remaining `node:http` constructor classes userland subclasses via `Object.create(Ctor.prototype)` / `util.inherits`:

- `http.IncomingMessage`, `http.ServerResponse`, `http.OutgoingMessage`, `http.ClientRequest`
- `http.Agent` / `https.Agent`

`http.Server.prototype` (the original #4973 case) is unchanged.

One-line predicate change (plus comment); no new machinery.

## Verification

- New regression test `test-files/test_gap_3527_http_ctor_prototype.ts` is **byte-for-byte identical** to `node --experimental-strip-types` (v26.3.0) — exercises the `.prototype` reads, `Object.create(...)`, and `util.inherits(...)`.
- With this change, the Express app builds and advances **past** the `Object.create` init crash (verified on the default/auto-optimize build). The next blocker in the Express tree is separate and tracked under #3527 (a context-specific `require('node:path')` returning undefined in `response.js`/`view.js` → `Cannot read properties of undefined (reading 'extname')`).
- `perry-runtime` tests: the change is regression-clean. (`object::tests::builtin_prototype_methods_reject_dynamic_new` fails under a multi-test filter both **with and without** this change — a pre-existing test-ordering artifact; it passes in isolation.)

## Note on the `intrinsic %% does not exist!` red herring

During investigation, a `SyntaxError: intrinsic %% does not exist!` (from `get-intrinsic`) appeared — but **only** under `PERRY_NO_AUTO_OPTIMIZE=1`. Root cause: the `perry-ext-*` staticlibs bundle a second `perry-runtime` compilation with its own `thread_local! REGEX_POINTERS`; regex construction registers in one copy while `.source`/`is_regex_pointer` check the other, so every regex reads back as a non-RegExp with source `"(?:)"`. The default (auto-optimize) build links a single feature-consistent runtime and is unaffected. Left as a follow-up (regex identity should be self-describing in the `RegExpHeader`, not a per-compilation side table).

Refs #3527.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP/HTTPS constructor classes (Server, Agent, IncomingMessage, ServerResponse, ClientRequest, and related exports) to properly expose their prototype objects. This resolves issues with prototype-based subclassing and inheritance patterns, enabling developers to correctly extend these core Node.js HTTP/HTTPS classes using standard prototype inheritance techniques.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->