### PR TITLE
fix(commander): keep native-shim packages off the compilePackages "*" wildcard (#5137)

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -1401,6 +1401,8 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("commander", "action", true, None),
     method("commander", "parse", true, None),
     method("commander", "opts", true, None),
+    method("commander", "argument", true, None),
+    property("commander", "args"),
     property("async_hooks", "default"),
     property("async_hooks", "asyncWrapProviders"),
     method("async_hooks", "createHook", false, None),

--- a/crates/perry-codegen/src/lower_call/native_table/node_misc.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_misc.rs
@@ -304,4 +304,26 @@ pub(super) const NODE_MISC_ROWS: &[NativeModSig] = &[
         args: &[],
         ret: NR_PTR,
     },
+    // `.argument("<file>")` declares a positional; returns the same handle so
+    // the fluent chain continues (#5137).
+    NativeModSig {
+        module: "commander",
+        has_receiver: true,
+        method: "argument",
+        class_filter: None,
+        runtime: "js_commander_argument",
+        args: &[NA_STR],
+        ret: NR_PTR,
+    },
+    // `program.args` — a bare member read lowers to this 0-arg getter, which
+    // returns a JS array of the parsed positional arguments (#5137).
+    NativeModSig {
+        module: "commander",
+        has_receiver: true,
+        method: "args",
+        class_filter: None,
+        runtime: "js_commander_args_array",
+        args: &[],
+        ret: NR_PTR,
+    },
 ];

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1058,6 +1058,8 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
 
     // ========== Commander CLI ==========
     module.declare_function("js_commander_action", I64, &[I64, I64]);
+    module.declare_function("js_commander_args_array", I64, &[I64]);
+    module.declare_function("js_commander_argument", I64, &[I64, I64]);
     module.declare_function("js_commander_command", I64, &[I64, I64]);
     module.declare_function("js_commander_description", I64, &[I64, I64]);
     module.declare_function("js_commander_get_option", I64, &[I64, I64]);

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1058,8 +1058,6 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
 
     // ========== Commander CLI ==========
     module.declare_function("js_commander_action", I64, &[I64, I64]);
-    module.declare_function("js_commander_args_array", I64, &[I64]);
-    module.declare_function("js_commander_argument", I64, &[I64, I64]);
     module.declare_function("js_commander_command", I64, &[I64, I64]);
     module.declare_function("js_commander_description", I64, &[I64, I64]);
     module.declare_function("js_commander_get_option", I64, &[I64, I64]);

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi_part2.rs
@@ -21,4 +21,10 @@ pub(crate) fn declare_stdlib_ffi_part2(module: &mut LlModule) {
     );
     module.declare_function("js_node_http_im_http_version_major", DOUBLE, &[I64]);
     module.declare_function("js_node_http_im_http_version_minor", DOUBLE, &[I64]);
+
+    // ========== Commander CLI (#5137) ==========
+    // `program.args` getter + `.argument(spec)` — kept here (not stdlib_ffi.rs)
+    // so that file stays under the 2000-line CI cap.
+    module.declare_function("js_commander_args_array", I64, &[I64]);
+    module.declare_function("js_commander_argument", I64, &[I64, I64]);
 }

--- a/crates/perry-ext-commander/src/lib.rs
+++ b/crates/perry-ext-commander/src/lib.rs
@@ -9,9 +9,10 @@
 
 use perry_ffi::{
     alloc_string, gc_register_mutable_root_scanner_named, get_handle, get_handle_mut,
-    iter_handles_of_mut, js_object_alloc_with_shape, js_object_set_field, read_string,
-    register_handle, with_handle_mut, GcRootVisitor, Handle, JsClosure, JsString, JsValue,
-    RawClosureHeader, StringHeader,
+    iter_handles_of_mut, js_array_alloc, js_array_get, js_array_length, js_array_push,
+    js_object_alloc_with_shape, js_object_set_field, read_string, register_handle, with_handle_mut,
+    ArrayHeader, GcRootVisitor, Handle, JsClosure, JsString, JsValue, RawClosureHeader,
+    StringHeader,
 };
 use std::collections::HashMap;
 
@@ -24,6 +25,10 @@ pub struct CommanderHandle {
     options: Vec<CommandOption>,
     parsed_values: HashMap<String, ParsedValue>,
     args: Vec<String>,
+    /// Declared positional argument specs from `.argument("<file>")` /
+    /// `.argument("[dir]")` — used only for the `--help` usage line. Parsing
+    /// itself collects every non-option token into `args` regardless.
+    declared_args: Vec<String>,
     /// (subcommand-name, sub-CommanderHandle) — populated by `.command(name)`.
     subcommands: Vec<(String, Handle)>,
     /// Closure pointer (raw bits) for `.action(cb)`. 0 = no action.
@@ -62,6 +67,7 @@ impl CommanderHandle {
             options: Vec::new(),
             parsed_values: HashMap::new(),
             args: Vec::new(),
+            declared_args: Vec::new(),
             subcommands: Vec::new(),
             action_callback: 0,
         }
@@ -200,6 +206,28 @@ pub unsafe extern "C" fn js_commander_required_option(
     js_commander_option(handle, flags_ptr, desc_ptr, default_ptr)
 }
 
+/// `.argument("<file>")` / `.argument("[dir]")` — declare a positional
+/// argument. Parsing always collects non-option tokens into `args`, so this
+/// only records the spec for the `--help` usage line and returns the handle so
+/// the fluent chain keeps flowing. #5137: without this entry the call fell
+/// through to generic dynamic dispatch (a silent no-op) instead of staying on
+/// the commander handle.
+///
+/// # Safety
+/// `spec_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_commander_argument(
+    handle: Handle,
+    spec_ptr: *const StringHeader,
+) -> Handle {
+    if let Some(spec) = read_str(spec_ptr) {
+        with_handle_mut::<CommanderHandle, _, _>(handle, |cmd| {
+            cmd.declared_args.push(spec);
+        });
+    }
+    handle
+}
+
 /// Register an action callback. `callback` is a raw closure pointer
 /// (NaN-box-stripped) — codegen passes it via the NA_PTR coercion which
 /// runs `unbox_to_i64` before this entry sees it. Non-zero is the
@@ -234,16 +262,46 @@ pub unsafe extern "C" fn js_commander_command(
 
 // ── Parse + dispatch ──────────────────────────────────────────────
 
-/// Top-level parse entry. The second arg is the user's `process.argv`
-/// expression — we ignore it and read `std::env::args()` directly so
-/// the program name (argv[0]) is always real and the surrounding
-/// sub-command argv-slicing logic stays consistent. Codegen still
-/// evaluates the user's argv expression for side effects via the
-/// NA_F64 dispatch coercion.
+/// Resolve the argument list `parse(argv?)` should operate on.
+///
+/// npm commander's `parse()` defaults to `from: 'node'`: when an explicit
+/// array is supplied (`program.parse(['node', 'script', ...])`) the first two
+/// entries are the executable + script path and the real args start at index
+/// 2. When called with no argument it reads `process.argv`, which on a Perry
+/// binary is `[exePath, ...realArgs]` (no separate script entry) — so we skip
+/// only the leading exe path. #5137: previously this always read
+/// `std::env::args()` and ignored the passed array, so `program.parse([...])`
+/// with a synthetic argv (the common test/REPL shape, and the issue repro)
+/// silently parsed nothing.
+fn resolve_parse_args(argv: f64) -> Vec<String> {
+    let value = JsValue::from_bits(argv.to_bits());
+    if value.is_pointer() {
+        let arr = value.as_pointer::<ArrayHeader>();
+        if !arr.is_null() {
+            let len = unsafe { js_array_length(arr) };
+            let mut out = Vec::with_capacity(len as usize);
+            for i in 0..len {
+                let elem = unsafe { js_array_get(arr, i) };
+                if let Some(s) = unsafe { read_str(elem.as_string_ptr()) } {
+                    out.push(s);
+                }
+            }
+            // `from: 'node'` default — drop argv[0] (exe) and argv[1] (script).
+            return out.into_iter().skip(2).collect();
+        }
+    }
+    std::env::args().skip(1).collect()
+}
+
+/// Top-level parse entry. The second arg is the user's `parse(argv)`
+/// expression: when it's an explicit array we honor it (commander's
+/// `from: 'node'` default), otherwise we fall back to the real
+/// `std::env::args()`. Codegen passes the NaN-boxed value through unchanged
+/// via the NA_F64 dispatch slot.
 #[no_mangle]
-pub extern "C" fn js_commander_parse(handle: Handle, _argv: f64) -> Handle {
-    let argv: Vec<String> = std::env::args().collect();
-    parse_and_dispatch(handle, &argv[1..]);
+pub extern "C" fn js_commander_parse(handle: Handle, argv: f64) -> Handle {
+    let args = resolve_parse_args(argv);
+    parse_and_dispatch(handle, &args);
     handle
 }
 
@@ -253,6 +311,7 @@ struct ParseSnapshot {
     version: String,
     options: Vec<OptionMeta>,
     subcommands: Vec<(String, Handle)>,
+    declared_args: Vec<String>,
 }
 
 struct OptionMeta {
@@ -287,6 +346,7 @@ fn snapshot_for_parse(handle: Handle) -> Option<ParseSnapshot> {
                 })
                 .collect(),
             subcommands: cmd.subcommands.clone(),
+            declared_args: cmd.declared_args.clone(),
         }
     })
 }
@@ -447,11 +507,15 @@ fn print_help(s: &ParseSnapshot) {
     } else {
         s.name.clone()
     };
-    let usage_tail = if s.subcommands.is_empty() {
+    let mut usage_tail = if s.subcommands.is_empty() {
         "[options]".to_string()
     } else {
         "[options] [command]".to_string()
     };
+    for arg in &s.declared_args {
+        usage_tail.push(' ');
+        usage_tail.push_str(arg);
+    }
     println!("Usage: {} {}", prog, usage_tail);
     println!();
     println!("Options:");
@@ -478,9 +542,37 @@ fn print_help(s: &ParseSnapshot) {
 
 // ── Read-back accessors ───────────────────────────────────────────
 
+/// `program.opts()` — return a fresh plain object of the parsed option
+/// values (matching npm commander, where `opts()` returns a data object).
+/// #5137: previously returned the raw handle, so `JSON.stringify(opts)` saw a
+/// bogus pointer and printed `null` and `opts.verbose` never resolved. The
+/// NR_PTR return ABI NaN-boxes the returned heap pointer as a JS object value.
 #[no_mangle]
 pub extern "C" fn js_commander_opts(handle: Handle) -> Handle {
-    handle
+    let parsed = get_handle_mut::<CommanderHandle>(handle)
+        .map(|cmd| cmd.parsed_values.clone())
+        .unwrap_or_default();
+    build_options_object(&parsed).as_pointer::<u8>() as Handle
+}
+
+/// `program.args` — return a fresh JS array of the parsed positional
+/// arguments (everything that wasn't an option flag or option value).
+/// #5137: a bare `program.args` member read lowers to a 0-arg
+/// NativeMethodCall through the commander table; without this getter it
+/// resolved to the zero-sentinel and `program.args[0]` read `undefined`.
+#[no_mangle]
+pub extern "C" fn js_commander_args_array(handle: Handle) -> Handle {
+    let args = get_handle_mut::<CommanderHandle>(handle)
+        .map(|cmd| cmd.args.clone())
+        .unwrap_or_default();
+    unsafe {
+        let mut arr = js_array_alloc(args.len() as u32);
+        for a in &args {
+            let val = JsValue::from_string_ptr(alloc_string(a).as_raw());
+            arr = js_array_push(arr, val);
+        }
+        arr as Handle
+    }
 }
 
 /// # Safety

--- a/crates/perry-ffi/src/jsvalue.rs
+++ b/crates/perry-ffi/src/jsvalue.rs
@@ -262,6 +262,9 @@ extern "C" {
     /// for out-of-bounds.
     pub fn js_array_get(arr: *const ArrayHeader, index: u32) -> JsValue;
 
+    /// Number of elements in the array.
+    pub fn js_array_length(arr: *const ArrayHeader) -> u32;
+
     /// Write to `index` in-place. No bounds check — caller's
     /// responsibility.
     pub fn js_array_set(arr: *mut ArrayHeader, index: u32, value: JsValue);

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -71,7 +71,7 @@ pub use handle::{
 
 mod jsvalue;
 pub use jsvalue::{
-    build_object_shape, js_array_alloc, js_array_get, js_array_push, js_array_set,
+    build_object_shape, js_array_alloc, js_array_get, js_array_length, js_array_push, js_array_set,
     js_object_alloc_with_shape, js_object_get_field, js_object_set_field, JsValue,
 };
 

--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -392,6 +392,7 @@ pub(super) fn try_static_method_and_instance(
                         | "command"
                         | "parse"
                         | "opts"
+                        | "argument"
                 );
                 // #1048 — fastify Reply chainable methods. `reply.code(201)
                 // .type("application/json").send(payload)` ships every method

--- a/crates/perry-stdlib/src/commander.rs
+++ b/crates/perry-stdlib/src/commander.rs
@@ -10,7 +10,7 @@
 //! invoked the `.action()` callback, never linked subcommands to their
 //! parent, and never printed help. The docs example silently no-op'd.
 
-use perry_runtime::array::{js_array_from_f64, js_array_length, ArrayHeader};
+use perry_runtime::array::{js_array_from_f64, js_array_get_f64, js_array_length, ArrayHeader};
 use perry_runtime::closure::js_closure_call1;
 use perry_runtime::value::js_jsvalue_to_string;
 use perry_runtime::{
@@ -302,12 +302,14 @@ unsafe fn resolve_parse_args(argv: f64) -> Vec<String> {
     if (bits & 0xFFFF_0000_0000_0000) == POINTER_TAG {
         let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize as *const ArrayHeader;
         if !ptr.is_null() {
-            let len = js_array_length(ptr) as usize;
-            let data =
-                (ptr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
-            let mut out = Vec::with_capacity(len);
+            // Read elements through the bounds-checked, layout-abstracting
+            // runtime accessor rather than indexing the ArrayHeader data
+            // region directly — mirrors the perry-ext-commander copy and
+            // stays correct if the array layout ever changes.
+            let len = js_array_length(ptr);
+            let mut out = Vec::with_capacity(len as usize);
             for i in 0..len {
-                let elem = *data.add(i);
+                let elem = js_array_get_f64(ptr, i);
                 if let Some(s) = string_from_header(js_jsvalue_to_string(elem)) {
                     out.push(s);
                 }

--- a/crates/perry-stdlib/src/commander.rs
+++ b/crates/perry-stdlib/src/commander.rs
@@ -10,7 +10,9 @@
 //! invoked the `.action()` callback, never linked subcommands to their
 //! parent, and never printed help. The docs example silently no-op'd.
 
+use perry_runtime::array::{js_array_from_f64, js_array_length, ArrayHeader};
 use perry_runtime::closure::js_closure_call1;
+use perry_runtime::value::js_jsvalue_to_string;
 use perry_runtime::{
     js_object_alloc, js_object_set_field_by_name, js_string_from_bytes, ClosureHeader, StringHeader,
 };
@@ -44,6 +46,10 @@ pub struct CommanderHandle {
     options: Vec<CommandOption>,
     parsed_values: HashMap<String, ParsedValue>,
     args: Vec<String>,
+    /// Declared positional argument specs from `.argument("<file>")` /
+    /// `.argument("[dir]")` — used only for the `--help` usage line. Parsing
+    /// itself collects every non-option token into `args` regardless.
+    declared_args: Vec<String>,
     /// (subcommand-name, sub-CommanderHandle) — populated by `.command(name)`.
     subcommands: Vec<(String, Handle)>,
     /// Closure pointer (raw bits) for `.action(cb)`. 0 = no action registered.
@@ -76,6 +82,7 @@ impl CommanderHandle {
             options: Vec::new(),
             parsed_values: HashMap::new(),
             args: Vec::new(),
+            declared_args: Vec::new(),
             subcommands: Vec::new(),
             action_callback: 0,
         }
@@ -225,6 +232,25 @@ pub unsafe extern "C" fn js_commander_required_option(
     js_commander_option(handle, flags_ptr, desc_ptr, default_ptr)
 }
 
+/// `.argument("<file>")` / `.argument("[dir]")` — declare a positional
+/// argument. Parsing always collects non-option tokens into `args`, so this
+/// only records the spec for the `--help` usage line and returns the handle so
+/// the fluent chain keeps flowing. #5137: without this entry the call fell
+/// through to generic dynamic dispatch (a silent no-op) instead of staying on
+/// the commander handle.
+#[no_mangle]
+pub unsafe extern "C" fn js_commander_argument(
+    handle: Handle,
+    spec_ptr: *const StringHeader,
+) -> Handle {
+    if let Some(spec) = string_from_header(spec_ptr) {
+        if let Some(cmd) = get_handle_mut::<CommanderHandle>(handle) {
+            cmd.declared_args.push(spec);
+        }
+    }
+    handle
+}
+
 /// Register an action callback. `callback` is a raw closure pointer
 /// (NaN-box-stripped) — codegen passes it via the NA_PTR coercion which
 /// runs `unbox_to_i64` before this entry sees it. Non-zero is the stable
@@ -257,15 +283,51 @@ pub unsafe extern "C" fn js_commander_command(
 // ---------------------------------------------------------------------------
 // Parse + dispatch
 
-/// Top-level parse entry. The second arg is the user's `process.argv`
-/// expression — we ignore it and read `std::env::args()` directly so the
-/// program name (argv[0]) is always real and the surrounding sub-command
-/// argv-slicing logic stays consistent. Codegen still evaluates the user's
-/// argv expression for side effects via the NA_F64 dispatch coercion.
+/// Resolve the argument list `parse(argv?)` should operate on.
+///
+/// npm commander's `parse()` defaults to `from: 'node'`: when an explicit
+/// array is supplied (`program.parse(['node', 'script', ...])`) the first two
+/// entries are the executable + script path and the real args start at index
+/// 2. When called with no argument it reads `process.argv`, which on a Perry
+/// binary is `[exePath, ...realArgs]` (no separate script entry) — so we skip
+/// only the leading exe path. #5137: previously this always read
+/// `std::env::args()` and ignored the passed array, so `program.parse([...])`
+/// with a synthetic argv (the common test/REPL shape, and the issue repro)
+/// silently parsed nothing.
+unsafe fn resolve_parse_args(argv: f64) -> Vec<String> {
+    let bits = argv.to_bits();
+    // A pointer-tagged value is the user's explicit argv array. Anything else
+    // (undefined when `parse()` is called with no argument, or a primitive)
+    // falls back to the real process args.
+    if (bits & 0xFFFF_0000_0000_0000) == POINTER_TAG {
+        let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as usize as *const ArrayHeader;
+        if !ptr.is_null() {
+            let len = js_array_length(ptr) as usize;
+            let data =
+                (ptr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+            let mut out = Vec::with_capacity(len);
+            for i in 0..len {
+                let elem = *data.add(i);
+                if let Some(s) = string_from_header(js_jsvalue_to_string(elem)) {
+                    out.push(s);
+                }
+            }
+            // `from: 'node'` default — drop argv[0] (exe) and argv[1] (script).
+            return out.into_iter().skip(2).collect();
+        }
+    }
+    std::env::args().skip(1).collect()
+}
+
+/// Top-level parse entry. The second arg is the user's `parse(argv)`
+/// expression: when it's an explicit array we honor it (commander's
+/// `from: 'node'` default), otherwise we fall back to the real
+/// `std::env::args()`. Codegen passes the NaN-boxed value through unchanged
+/// via the NA_F64 dispatch slot.
 #[no_mangle]
-pub extern "C" fn js_commander_parse(handle: Handle, _argv: f64) -> Handle {
-    let argv: Vec<String> = std::env::args().collect();
-    parse_and_dispatch(handle, &argv[1..]);
+pub unsafe extern "C" fn js_commander_parse(handle: Handle, argv: f64) -> Handle {
+    let args = resolve_parse_args(argv);
+    parse_and_dispatch(handle, &args);
     handle
 }
 
@@ -304,6 +366,7 @@ fn parse_and_dispatch(handle: Handle, args: &[String]) {
                     })
                     .collect(),
                 subcommands: cmd.subcommands.clone(),
+                declared_args: cmd.declared_args.clone(),
             }
         }
         None => return,
@@ -452,6 +515,7 @@ struct ParseSnapshot {
     version: String,
     options: Vec<OptionMeta>,
     subcommands: Vec<(String, Handle)>,
+    declared_args: Vec<String>,
 }
 
 struct OptionMeta {
@@ -471,11 +535,15 @@ fn print_help(s: &ParseSnapshot) {
     } else {
         s.name.clone()
     };
-    let usage_tail = if s.subcommands.is_empty() {
+    let mut usage_tail = if s.subcommands.is_empty() {
         "[options]".to_string()
     } else {
         "[options] [command]".to_string()
     };
+    for arg in &s.declared_args {
+        usage_tail.push(' ');
+        usage_tail.push_str(arg);
+    }
     println!("Usage: {} {}", prog, usage_tail);
     println!();
     println!("Options:");
@@ -503,9 +571,41 @@ fn print_help(s: &ParseSnapshot) {
 // ---------------------------------------------------------------------------
 // Read-back accessors (queryable post-parse from user TS code).
 
+/// `program.opts()` — return a fresh plain object of the parsed option
+/// values (matching npm commander, where `opts()` returns a data object).
+/// #5137: previously returned the raw handle, so `JSON.stringify(opts)` saw a
+/// bogus pointer and printed `null` and `opts.verbose` never resolved. The
+/// NR_PTR return ABI NaN-boxes this heap pointer as a JS object value.
 #[no_mangle]
 pub extern "C" fn js_commander_opts(handle: Handle) -> Handle {
-    handle
+    let parsed = match get_handle_mut::<CommanderHandle>(handle) {
+        Some(cmd) => cmd.parsed_values.clone(),
+        None => HashMap::new(),
+    };
+    unsafe { build_options_object(&parsed) as Handle }
+}
+
+/// `program.args` — return a fresh JS array of the parsed positional
+/// arguments (everything that wasn't an option flag or option value).
+/// #5137: a bare `program.args` member read lowers to a 0-arg
+/// NativeMethodCall through the commander table; without this getter it
+/// resolved to the zero-sentinel and `program.args[0]` read `undefined`.
+#[no_mangle]
+pub extern "C" fn js_commander_args_array(handle: Handle) -> Handle {
+    let args = match get_handle_mut::<CommanderHandle>(handle) {
+        Some(cmd) => cmd.args.clone(),
+        None => Vec::new(),
+    };
+    unsafe {
+        let boxed: Vec<f64> = args
+            .iter()
+            .map(|a| {
+                let s = js_string_from_bytes(a.as_ptr(), a.len() as u32);
+                f64::from_bits(nanbox_string(s as u64))
+            })
+            .collect();
+        js_array_from_f64(boxed.as_ptr(), boxed.len() as u32) as Handle
+    }
 }
 
 #[no_mangle]
@@ -618,6 +718,7 @@ mod tests {
             options: Vec::new(),
             parsed_values: HashMap::new(),
             args: Vec::new(),
+            declared_args: Vec::new(),
             subcommands: Vec::new(),
             action_callback: 0x1234_5678,
         });

--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -499,6 +499,7 @@ pub(super) fn apply_pkg_and_toml_config(
     if has_universal || !scope_wildcards.is_empty() {
         let installed = super::resolve::enumerate_installed_packages(project_root);
         let mut added = 0usize;
+        let mut skipped_native = 0usize;
         for name in installed {
             let matches = has_universal
                 || scope_wildcards.iter().any(|scope| {
@@ -506,7 +507,28 @@ pub(super) fn apply_pkg_and_toml_config(
                         .map(|rest| rest.starts_with('/'))
                         .unwrap_or(false)
                 });
-            if matches && ctx.compile_packages.insert(name) {
+            if !matches {
+                continue;
+            }
+            // #5137: don't let the `"*"` / `@scope/*` wildcard sweep in packages
+            // Perry ships a native stdlib shim for (commander, dayjs, lru-cache,
+            // …). The shim is the supported, optimized path; compiling the real
+            // npm source instead routes the import away from the native module
+            // table, so hardcoded lowerings like `new Command()` →
+            // `js_commander_new` no longer fire and the binding resolves to
+            // `undefined` ("TypeError: undefined is not a constructor"). A user
+            // who genuinely wants the real source still lists that package
+            // explicitly in `perry.compilePackages` — that exact entry is added
+            // during package.json parsing and is honored via
+            // COMPILE_PACKAGES_OVERRIDE. The wildcard only declines to add it.
+            // (`is_native_module` consults COMPILE_PACKAGES_OVERRIDE, but that
+            // thread-local is installed later, in collect_modules, so it is empty
+            // here and the check reflects the raw NATIVE_MODULES manifest.)
+            if perry_hir::is_native_module(&name) {
+                skipped_native += 1;
+                continue;
+            }
+            if ctx.compile_packages.insert(name) {
                 added += 1;
             }
         }
@@ -521,6 +543,13 @@ pub(super) fn apply_pkg_and_toml_config(
                 "  Compile package wildcard: expanded to {} installed package(s)",
                 added
             );
+            if skipped_native > 0 {
+                println!(
+                    "  Compile package wildcard: kept {} package(s) on Perry's \
+                     native shim (list explicitly to compile the real source)",
+                    skipped_native
+                );
+            }
         }
     }
 

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1939 entries across 112 modules
+// Coverage: 1940 entries across 113 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -322,6 +322,11 @@ declare module "cluster" {
   export function setupMaster(...args: any[]): any;
   /** stdlib */
   export function setupPrimary(...args: any[]): any;
+}
+
+declare module "commander" {
+  /** stdlib */
+  export const args: any;
 }
 
 declare module "console" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2802 entries across 115 modules.
+Total: 2804 entries across 115 modules.
 
 ## Modules
 
@@ -394,6 +394,7 @@ Total: 2802 entries across 115 modules.
 ### Methods
 
 - `action` — instance
+- `argument` — instance
 - `command` — instance
 - `description` — instance
 - `name` — instance
@@ -402,6 +403,10 @@ Total: 2802 entries across 115 modules.
 - `parse` — instance
 - `requiredOption` — instance
 - `version` — instance
+
+### Properties
+
+- `args`
 
 ## `console`
 

--- a/test-files/test_parity_commander.ts
+++ b/test-files/test_parity_commander.ts
@@ -38,11 +38,22 @@ if (captured) {
   console.log("action did not fire");
 }
 
+// Issue #5137: a top-level program (no subcommand) that declares a positional
+// via `.argument()`, reads `program.args`, and stringifies `program.opts()`.
+// Parsing an explicit argv array (commander's `from: 'node'` default) must be
+// honored, `opts()` must return a real object, and `args` a real array.
+const top = new Command();
+top.name("demo").option("-v, --verbose").argument("<file>");
+top.parse(["node", "x", "in.txt", "-v"]);
+console.log("positional:", top.args[0], "opts:", JSON.stringify(top.opts()));
+
 /*
 @covers
-crates/perry-stdlib/src/commander.rs:
+crates/perry-stdlib/src/commander.rs (mirrored in crates/perry-ext-commander/src/lib.rs):
   - js_commander_action
+  - js_commander_args_array
   - js_commander_args_count
+  - js_commander_argument
   - js_commander_command
   - js_commander_description
   - js_commander_get_arg


### PR DESCRIPTION
## Summary

Fixes #5137 — importing `commander` under `perry.compilePackages: ["*"]` threw `TypeError: undefined is not a constructor` on `new Command()`.

### Root cause
The `"*"` / `@scope/*` wildcard in `compilePackages` was expanded to **every** installed package, including ones Perry ships a native stdlib shim for (commander, dayjs, lru-cache, …). Once `commander` landed in `compile_packages`, the routing gate in `resolve.rs`

```rust
is_native_module(import) && !compile_packages.contains(pkg)
```

stopped routing `import { Command } from 'commander'` to the native module table. The hardcoded `new Command()` → `js_commander_new` lowering then never fired and the binding resolved to `undefined`.

### Fix
`host_config.rs` wildcard expansion now skips packages that have a native shim (and logs how many were kept on it). A user who genuinely wants the real npm source still lists that package **explicitly** in `perry.compilePackages` — that exact entry is honored via `COMPILE_PACKAGES_OVERRIDE`; only the blanket wildcard declines to add it.

### Shim correctness (so the repro matches Node)
The reported repro also exercised commander surface the shim didn't fully support. Fixed in **both** `perry-stdlib/src/commander.rs` and the well-known-flip copy `perry-ext-commander/src/lib.rs`:

- `parse(argv)` now honors an explicit array (commander's `from: 'node'` default), falling back to process args when called with none.
- `opts()` returns a real options object instead of the raw handle (so `JSON.stringify(opts)` and `opts.x` work).
- added a `program.args` array getter and `.argument(spec)` support.
- supporting changes: FFI decls + native-table entries + HIR method recognition + API-manifest entries; added `js_array_length` to `perry-ffi`; regenerated `docs/` API artifacts.

### Verification
The issue repro now prints the expected Node output both via the shim and under `compilePackages: ["*"]`:

```
in.txt {"verbose":true}
```

Under `["*"]` the compiler also reports: `Compile package wildcard: kept 1 package(s) on Perry's native shim`.

`perry-ext-commander` + `perry-ffi` unit tests pass; the commander parity test was extended with the issue-5137 surface (top-level `opts()` / `args` / `.argument()` / explicit argv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `.argument()` method for declaring positional arguments in command-line interfaces.
  * Introduced `program.args` property to retrieve parsed positional arguments as an array.
  * Enhanced argument parsing to accept explicit argument arrays from code.

* **Bug Fixes**
  * Fixed `program.opts()` to return a proper JavaScript object with parsed options.
  * Updated help/usage output to display declared positional argument specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->