### PR TITLE
fix(link): route emitted js_event_emitter_* symbols to perry-ext-events (#5140)

### DIFF
--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -462,6 +462,47 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_url_create_object_url",                    OwnerKind::Stdlib { feature: Some("http-client") }),
     ("js_url_revoke_object_url",                    OwnerKind::Stdlib { feature: Some("http-client") }),
     ("js_buffer_resolve_object_url",                OwnerKind::Stdlib { feature: Some("http-client") }),
+
+    // ── #5140: EventEmitter without a source-level `import "events"` ──
+    // `new EventEmitter()` / `.on` / `.emit` / … lower to these
+    // `js_event_emitter_*` helpers purely off the class NAME being
+    // `EventEmitter` (`lower_call/builtin.rs` + the events native-table
+    // rows), regardless of which package the binding came from. The
+    // canonical implementations live in `perry-ext-events` (the
+    // `[bindings.events]` well-known crate); `import "events"` flips that
+    // wrapper onto the link line via `ctx.native_module_imports`. But a
+    // program that gets `EventEmitter` from a *different* package — e.g.
+    // `import EventEmitter from "eventemitter3"` under
+    // `perry.compilePackages` — never inserts `"events"` into the import
+    // set, so the wrapper stays off the link line and the build fails with
+    // `Undefined symbols: _js_event_emitter_new_with_options` (and the
+    // `_on` / `_emit` / `_remove_all_listeners` companions). Tagging the
+    // emitted symbols here makes the well-known flip fire off codegen
+    // provenance instead of imports — same mechanism as the #846 / #3954
+    // http/net rows above. Flipping `"events"` also activates perry-stdlib's
+    // `external-events-construct` feature (see optimized_libs.rs), which the
+    // default-import dynamic-`new` path relies on (#4995).
+    //
+    // Only the core surface defined by perry-ext-events is listed; the
+    // `js_event_emitter_async_resource_*` helpers live in perry-stdlib and
+    // are out of scope here (`EventEmitterAsyncResource` is node:events-only).
+    ("js_event_emitter_new",                        OwnerKind::WellKnown("events")),
+    ("js_event_emitter_new_with_options",           OwnerKind::WellKnown("events")),
+    ("js_event_emitter_on",                         OwnerKind::WellKnown("events")),
+    ("js_event_emitter_once",                       OwnerKind::WellKnown("events")),
+    ("js_event_emitter_prepend_listener",           OwnerKind::WellKnown("events")),
+    ("js_event_emitter_prepend_once_listener",      OwnerKind::WellKnown("events")),
+    ("js_event_emitter_emit",                       OwnerKind::WellKnown("events")),
+    ("js_event_emitter_emit0",                      OwnerKind::WellKnown("events")),
+    ("js_event_emitter_remove_listener",            OwnerKind::WellKnown("events")),
+    ("js_event_emitter_remove_all_listeners",       OwnerKind::WellKnown("events")),
+    ("js_event_emitter_listener_count",             OwnerKind::WellKnown("events")),
+    ("js_event_emitter_listeners",                  OwnerKind::WellKnown("events")),
+    ("js_event_emitter_raw_listeners",              OwnerKind::WellKnown("events")),
+    ("js_event_emitter_event_names",                OwnerKind::WellKnown("events")),
+    ("js_event_emitter_set_max_listeners",          OwnerKind::WellKnown("events")),
+    ("js_event_emitter_get_max_listeners",          OwnerKind::WellKnown("events")),
+    ("js_event_emitter_domain_value",               OwnerKind::WellKnown("events")),
 ];
 
 /// Process-wide collector of provider keys observed during codegen.
@@ -629,6 +670,42 @@ mod tests {
                 _ => OwnerKind::WellKnown("http"),
             };
             assert_symbol_routes_to(symbol, owner);
+        }
+    }
+
+    /// #5140 regression: `new EventEmitter()` / `.on` / `.emit` /
+    /// `.removeAllListeners` lower to `js_event_emitter_*` helpers off the
+    /// class name alone, so a program that imports `EventEmitter` from a
+    /// non-`events` package (`import EventEmitter from "eventemitter3"`)
+    /// emits these symbols without ever inserting `"events"` into the import
+    /// set. Each must route to `WellKnown("events")` so the well-known flip
+    /// pulls `perry-ext-events` onto the link line; before the fix the build
+    /// failed with `Undefined symbols: _js_event_emitter_new_with_options`.
+    #[test]
+    fn emitted_event_emitter_symbols_route_to_events() {
+        let _guard = PROVIDER_TEST_LOCK
+            .lock()
+            .expect("provider test lock poisoned");
+        for symbol in [
+            "js_event_emitter_new",
+            "js_event_emitter_new_with_options",
+            "js_event_emitter_on",
+            "js_event_emitter_once",
+            "js_event_emitter_prepend_listener",
+            "js_event_emitter_prepend_once_listener",
+            "js_event_emitter_emit",
+            "js_event_emitter_emit0",
+            "js_event_emitter_remove_listener",
+            "js_event_emitter_remove_all_listeners",
+            "js_event_emitter_listener_count",
+            "js_event_emitter_listeners",
+            "js_event_emitter_raw_listeners",
+            "js_event_emitter_event_names",
+            "js_event_emitter_set_max_listeners",
+            "js_event_emitter_get_max_listeners",
+            "js_event_emitter_domain_value",
+        ] {
+            assert_symbol_routes_to(symbol, OwnerKind::WellKnown("events"));
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #5140 — compiling a program that imports `eventemitter3` (or any package whose default/named export is an `EventEmitter` class) fails at link time with `Undefined symbols: _js_event_emitter_*`.

## Root cause

`new EventEmitter()` / `.on` / `.emit` / `.removeAllListeners` lower to the native `js_event_emitter_*` helpers purely off the class **name** being `EventEmitter` (`lower_call/builtin.rs` + the events native-table rows) — regardless of which package the binding was imported from. The canonical implementations live in `perry-ext-events`, the `[bindings.events]` well-known crate. `import "events"` flips that wrapper onto the link line by inserting `"events"` into `ctx.native_module_imports`.

A program that gets `EventEmitter` from a *different* package — e.g. `import EventEmitter from "eventemitter3"` under `perry.compilePackages` — never inserts `"events"` into the import set, so `perry-ext-events` stays off the link line even though codegen emitted calls into it. The link then fails:

```
Undefined symbols for architecture arm64:
  "_js_event_emitter_emit"
  "_js_event_emitter_new_with_options"
  "_js_event_emitter_on"
  "_js_event_emitter_remove_all_listeners"
```

## Fix

Tag the codegen-emitted core `js_event_emitter_*` symbols in the FFI provenance registry (`ext_registry.rs`) as `WellKnown("events")`. This makes the well-known flip fire off **codegen provenance** instead of imports — the exact same mechanism the existing `#846` / `#3954` http/net rows already use for symbols emitted without a matching source-level import.

Flipping `"events"` does three things, all already wired:
- links `perry-ext-events` onto the link line,
- strips the duplicate `bundled-events` perry-stdlib feature (so there's no duplicate-symbol conflict — `optimized_libs.rs` line ~366), and
- activates `external-events-construct`, which the default-import dynamic-`new` path relies on (`#4995`).

Only the core surface defined by `perry-ext-events` is listed; the `js_event_emitter_async_resource_*` helpers live in perry-stdlib and are out of scope (`EventEmitterAsyncResource` is `node:events`-only).

## Testing

- New unit test `emitted_event_emitter_symbols_route_to_events` (all 5 `ext_registry` tests pass).
- Repro from the issue (`import EventEmitter from "eventemitter3"`) now links and prints `5` (matching Node).
- `import { EventEmitter } from "events"` still links and prints `5` (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EventEmitter symbol resolution to ensure proper routing and binding resolution in all scenarios.

* **Tests**
  * Added regression test to verify EventEmitter symbols are correctly identified and routed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->