### PR TITLE
fix(hir): obj.push/pop/shift/unshift on any-typed receivers dispatch to object methods (#5139)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -1012,32 +1012,42 @@ pub(super) fn try_array_only_methods(
                     }
                     "push" => {
                         // Generic expr.push(value) or expr.push(...spread)
-                        // GUARD: Skip if the receiver is a user-defined class instance
-                        // (e.g. Stack<T>.push()), or an object type literal (e.g.
-                        // { push: (v) => void, ... }), so its method dispatches correctly.
-                        let is_user_class_receiver = match member.obj.as_ref() {
+                        // GUARD: Skip the array fast-path if the receiver is a
+                        // user-defined class instance (e.g. Stack<T>.push()), an
+                        // object type literal (e.g. { push: (v) => void, ... }), or
+                        // an unknown/`any`-typed identifier we can't prove is an
+                        // array. The last case is the load-bearing one for #5139:
+                        // react-dom's SSR sink is `{ push(chunk){…} }` threaded
+                        // through `writeChunk(destination, c) { return destination.push(c); }`
+                        // where `destination` is an `any` param. Emitting the
+                        // `array.push_single` native call would read that plain
+                        // object as an `ArrayHeader` and silently corrupt it, so
+                        // the `push` closure never runs (markup comes back empty).
+                        // Falling through routes to the runtime method dispatch,
+                        // which handles real arrays (defensive `push` arm in
+                        // `js_native_call_method`) and object `push`
+                        // (`try_object_arraylike_mutator`) alike.
+                        let skip_array_push = match member.obj.as_ref() {
                             ast::Expr::This(_) => true,
                             ast::Expr::Ident(ident) => {
-                                ctx.lookup_local_type(ident.sym.as_ref())
-                                    .map(|ty| {
-                                        match ty {
-                                            Type::Named(name) => ctx.lookup_class(name).is_some(),
-                                            Type::Generic { base, .. } => {
-                                                let builtin =
-                                                    ["Map", "Set", "WeakMap", "WeakSet", "Promise"];
-                                                !builtin.contains(&base.as_str())
-                                                    && ctx.lookup_class(base).is_some()
-                                            }
-                                            Type::Object(_) => true, // object type literal with push property
-                                            _ => false,
-                                        }
-                                    })
-                                    .unwrap_or(false)
+                                match ctx.lookup_local_type(ident.sym.as_ref()) {
+                                    Some(Type::Named(name)) => ctx.lookup_class(name).is_some(),
+                                    Some(Type::Generic { base, .. }) => {
+                                        let builtin =
+                                            ["Map", "Set", "WeakMap", "WeakSet", "Promise"];
+                                        !builtin.contains(&base.as_str())
+                                            && ctx.lookup_class(base).is_some()
+                                    }
+                                    Some(Type::Object(_)) => true, // object type literal with push property
+                                    // Unknown/any receiver — can't prove it's an array.
+                                    None | Some(Type::Any) | Some(Type::Unknown) => true,
+                                    Some(_) => false,
+                                }
                             }
                             ast::Expr::New(_) => true, // new ClassName().push()
                             _ => false,
                         };
-                        if !is_user_class_receiver {
+                        if !skip_array_push {
                             let array_expr = lower_expr(ctx, &member.obj)?;
                             let any_spread = call.args.iter().any(|a| a.spread.is_some());
                             if !any_spread {

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -105,6 +105,18 @@ pub(super) fn try_local_array_methods(
                         | "reduceRight"
                         | "join"
                 );
+                // Stack/queue/deque mutators whose names plain objects commonly
+                // define too — react-dom's `{ push(chunk){…} }` SSR sink (#5139),
+                // a custom `Stack.push`, a Node-style stream. On an unknown (Any)
+                // receiver we can't prove it's an array, so we must route to the
+                // runtime method dispatch — which handles real arrays (the
+                // defensive arms in `js_native_call_method`'s dispatch tower) and
+                // plain-object methods (`try_object_arraylike_mutator`) alike.
+                // Emitting `Expr::ArrayPush` et al. here would read the object as
+                // an `ArrayHeader` and silently corrupt it, so the method's closure
+                // never runs and the call returns nothing.
+                let is_object_overlapping_mutator =
+                    matches!(method_name, "push" | "pop" | "shift" | "unshift");
                 let is_unknown_recv =
                     matches!(type_info, None | Some(Type::Any) | Some(Type::Unknown));
                 let is_known_not_string = type_info
@@ -153,10 +165,12 @@ pub(super) fn try_local_array_methods(
                     true // definitely not a string, enter array block
                 } else if is_ambiguous_method {
                     false // type unknown + ambiguous method, skip array block (fall through to general dispatch)
-                } else if is_unknown_recv && is_class_overlapping_method {
-                    false // type unknown + method commonly defined on user classes — fall through
+                } else if is_unknown_recv
+                    && (is_class_overlapping_method || is_object_overlapping_mutator)
+                {
+                    false // type unknown + method also common on plain objects/user classes — fall through to runtime dispatch
                 } else {
-                    true // type unknown + array-only method (push, pop, etc.), enter array block
+                    true // type unknown + unambiguously array-only method — enter array block
                 };
                 // Helper: if the callback arg is a bare Boolean/Number/String identifier,
                 // desugar to a synthetic closure: x => Boolean(x) / Number(x) / String(x).

--- a/crates/perry/tests/issue_5139_object_push_method_via_param.rs
+++ b/crates/perry/tests/issue_5139_object_push_method_via_param.rs
@@ -1,0 +1,119 @@
+//! Regression test for #5139: an object with a user-defined `push` method,
+//! invoked through an `any`-typed parameter, must dispatch to that method —
+//! not be silently read as an `ArrayHeader` by the `array.push_single`
+//! intrinsic. The HIR lowering eagerly assumed any `x.push(v)` on an unknown
+//! receiver was an array push; for react-dom's `renderToStaticMarkup` the
+//! output sink is `{ push(chunk){ result += chunk } }` threaded through
+//! `writeChunk(destination, c) { return destination.push(c); }`, so the closure
+//! never ran and SSR markup came back as the empty string.
+//!
+//! The shape below is the distilled core of that bug. We also exercise a real
+//! `any`-typed array through the same parameter-call path to prove the fix
+//! routes real arrays to the runtime dispatch correctly (no regression).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn object_push_method_dispatches_through_any_param() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+
+    std::fs::write(
+        &entry,
+        r#"
+// An object whose `push` mutates a captured local — the react-dom SSR sink shape.
+function writeChunk(d, c) { return d.push(c); }
+function render() {
+  var result = '';
+  var destination = {
+    push: function (chunk) { if (chunk !== null) { result += chunk; } return true; },
+    destroy: function (error) {}
+  };
+  writeChunk(destination, '<ul>');
+  writeChunk(destination, '<li>a</li>');
+  writeChunk(destination, '</ul>');
+  return result;
+}
+console.log(render());
+
+// The whole stack/queue/deque family must dispatch to user object methods,
+// not the array intrinsics, when reached through an any-typed parameter.
+function callPush(d, v) { return d.push(v); }
+function callPop(d) { return d.pop(); }
+function callShift(d) { return d.shift(); }
+function callUnshift(d, v) { return d.unshift(v); }
+function deque() {
+  var trace = '';
+  var obj = {
+    push: function (v) { trace += 'PU' + v; return 1; },
+    pop: function () { trace += 'PO'; return 2; },
+    shift: function () { trace += 'SH'; return 3; },
+    unshift: function (v) { trace += 'UN' + v; return 4; },
+  };
+  callPush(obj, 'a'); callPop(obj); callShift(obj); callUnshift(obj, 'b');
+  return trace;
+}
+console.log(deque());
+
+// A real array reached through the same any-typed parameter path: mutators
+// must still behave like Array.prototype.
+function pushTo(a, v) { return a.push(v); }
+function popFrom(a) { return a.pop(); }
+function shiftFrom(a) { return a.shift(); }
+function unshiftTo(a, v) { return a.unshift(v); }
+var arr: any = [1, 2, 3];
+var len = pushTo(arr, 4);
+var last = popFrom(arr);
+var first = shiftFrom(arr);
+var ulen = unshiftTo(arr, 0);
+console.log(arr.join(',') + '|' + len + '|' + last + '|' + first + '|' + ulen);
+
+// A statically-typed array keeps the dense fast path and correct semantics.
+var typed: number[] = [];
+typed.push(10);
+typed.push(20, 30);
+console.log(typed.join(',') + '|' + typed.length);
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout,
+        // 1: object `push` closure ran for every chunk (was empty before the fix).
+        // 2: object deque family (push/pop/shift/unshift) all dispatched to user methods.
+        // 3: real array mutators via any-param: [0,2,3], push len 4, pop 4, shift 1, unshift len 3.
+        // 4: typed-array fast path: [10,20,30], length 3.
+        "<ul><li>a</li></ul>\nPUaPOSHUNb\n0,2,3|4|4|1|3\n10,20,30|3\n",
+        "object push method must dispatch (not array-push); real arrays unaffected"
+    );
+}


### PR DESCRIPTION
Fixes #5139.

## Problem

`react-dom/server`'s `renderToStaticMarkup` (compiled natively via `perry.compilePackages`) returned the **empty string** instead of rendered HTML.

```ts
import { createElement } from 'react';
import { renderToStaticMarkup } from 'react-dom/server';
function Item({ n }) { return createElement('li', null, `item-${n}`); }
const list = createElement('ul', { id: 'L' }, [1, 2, 3].map((n) => createElement(Item, { key: n, n })));
console.log(renderToStaticMarkup(list));
// Node:   <ul id="L"><li>item-1</li><li>item-2</li><li>item-3</li></ul>
// Perry:  (empty string)
```

## Root cause

react-dom accumulates SSR output into a sink object and writes through it:

```js
var destination = { push: function (chunk) { result += chunk; ... }, destroy: ... };
function writeChunk(d, c) { return d.push(c); }   // d is `any`
```

HIR lowering eagerly assumed **any** `x.push(v)` on an unknown/`any`-typed receiver was an array op and emitted `Expr::ArrayPush` / the `array.push_single` native call. With a plain object receiver, that intrinsic reads the object as an `ArrayHeader` and silently corrupts it — the `push` closure never runs, so `result` stays `''` and every chunk write is lost. (Direct `destination.push(...)` worked because `destination` had a known object type; only the `any`-typed parameter dispatch hit the bad path.)

## Fix

In both lowering sites (`local_array_methods.rs` for bare-ident receivers, `array_only_methods.rs` for arbitrary-expr receivers): when the receiver type is unknown (`None`/`Any`/`Unknown`), treat the deque mutators `push`/`pop`/`shift`/`unshift` like the existing class-overlapping read methods (`find`/`map`/`filter`/…) and fall through to the runtime method dispatch.

That runtime path already handles both real arrays (the defensive `push`/`pop`/… arms in `js_native_call_method`) and plain-object methods (`try_object_arraylike_mutator`), so:
- statically-typed arrays keep their dense fast path,
- real `any`-typed arrays still behave like `Array.prototype`,
- objects with user `push`/`pop`/`shift`/`unshift` methods now dispatch correctly.

Scope is limited to the four stack/queue/deque names objects realistically define; statically array-typed receivers are untouched.

## Verification

- The exact repro from the issue now prints `<ul id="L"><li>item-1</li><li>item-2</li><li>item-3</li></ul>` (byte-for-byte Node parity), using the real `react@18.3.1` / `react-dom@18.3.1` packages via `compilePackages`.
- New regression test `crates/perry/tests/issue_5139_object_push_method_via_param.rs` covers the object-sink shape, the object deque family, real `any`-typed array mutators, and the statically-typed-array fast path.
- `perry-hir` unit tests, `issue_4950_react_render_walls`, and `issue_4915_streams_byob` pass.

Per repo convention for contributor PRs, no version/CHANGELOG bump (maintainer folds that in at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed method dispatch logic to correctly distinguish between array methods and object methods with overlapping names (`push`, `pop`, `shift`, `unshift`). Objects with user-defined methods are now properly routed instead of array intrinsics.

## Tests
* Added regression test for method dispatch behavior with dynamically-typed parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->