### PR TITLE
fix(promise): support user-attached expando properties on Promise objects (#5142)

### DIFF
--- a/crates/perry-runtime/src/gc/tests/alloc.rs
+++ b/crates/perry-runtime/src/gc/tests/alloc.rs
@@ -421,7 +421,8 @@ fn test_gc_type_metadata_covers_all_declared_types() {
             external_byte_policy: GcExternalBytePolicy::None,
             large_object_policy: GcLargeObjectPolicy::MallocTracked,
             pointer_free: false,
-            move_hook_kind: GcMoveHookKind::None,
+            // #5142: rekey address-keyed promise expandos on GC move.
+            move_hook_kind: GcMoveHookKind::ExoticExpandoOwner,
             rewrite_hook_kind: GcRewriteHookKind::None,
             finalize_hook_kind: GcFinalizeHookKind::PromiseCleanup,
         },

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -124,6 +124,10 @@ pub(crate) enum GcMoveHookKind {
     ClosureDynamicProps,
     MapSideTables,
     SetSideTables,
+    /// Rekey a movable exotic cell's address-keyed expando side table after a
+    /// move. Used by `GC_TYPE_PROMISE`, whose `status`/`value` expandos
+    /// (#5142) live in `object::exotic_expando` keyed by the promise address.
+    ExoticExpandoOwner,
 }
 
 #[allow(dead_code)]
@@ -273,7 +277,10 @@ pub(super) static GC_TYPE_INFO_BY_ID: [Option<GcTypeInfo>; MALLOC_KIND_BUCKET_CO
         GcExternalBytePolicy::None,
         GcLargeObjectPolicy::MallocTracked,
         false,
-        GcMoveHookKind::None,
+        // #5142: a promise is movable, but user-attached expando properties
+        // (`p.status = …`) live in `object::exotic_expando` keyed by the
+        // promise address — rekey that entry when the promise relocates.
+        GcMoveHookKind::ExoticExpandoOwner,
         GcRewriteHookKind::None,
         GcFinalizeHookKind::PromiseCleanup,
     )),
@@ -566,6 +573,9 @@ pub(crate) fn gc_type_after_payload_move(obj_type: u8, old_user: usize, new_user
         GcMoveHookKind::SetSideTables => {
             crate::set::set_header_moved_for_gc(old_user, new_user);
         }
+        GcMoveHookKind::ExoticExpandoOwner => {
+            crate::object::exotic_expando::exotic_expando_owner_moved(old_user, new_user);
+        }
     }
 }
 
@@ -577,7 +587,8 @@ pub(crate) fn gc_type_clear_dead_payload_side_tables(obj_type: u8, user_ptr: usi
         GcMoveHookKind::None
         | GcMoveHookKind::ClosureDynamicProps
         | GcMoveHookKind::MapSideTables
-        | GcMoveHookKind::SetSideTables => {}
+        | GcMoveHookKind::SetSideTables
+        | GcMoveHookKind::ExoticExpandoOwner => {}
     }
 }
 

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -937,7 +937,7 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
             let mut names = match kind {
                 ExoticKind::RegExp => vec!["lastIndex".to_string()],
                 ExoticKind::Error => vec!["message".to_string(), "stack".to_string()],
-                ExoticKind::Date | ExoticKind::Temporal => Vec::new(),
+                ExoticKind::Date | ExoticKind::Temporal | ExoticKind::Promise => Vec::new(),
             };
             for key in super::exotic_expando::exotic_own_keys(kind, addr, false) {
                 if !names.contains(&key) {

--- a/crates/perry-runtime/src/object/exotic_expando.rs
+++ b/crates/perry-runtime/src/object/exotic_expando.rs
@@ -38,6 +38,19 @@ pub(crate) enum ExoticKind {
     /// the boxed payload. Built-in getters (`duration.years`, `plainDate.month`)
     /// stay in the Temporal dispatch path; only true expando keys land here.
     Temporal,
+    /// A `Promise` is a `GC_TYPE_PROMISE` cell, NOT an `ObjectHeader`, so a
+    /// plain property write (`p.status = "pending"`, `Object.assign(p, …)`)
+    /// must land in the side table rather than being bit-cast through the
+    /// `ObjectHeader` field path (which silently dropped the write — reads came
+    /// back `undefined`). Libraries attach bookkeeping to the promise object
+    /// itself: @tanstack/query-core's `pendingThenable()` stores `status` /
+    /// `value` on the promise and gates its retryer on `thenable.status`, so a
+    /// dropped expando left `isResolved()` permanently true and the fetch never
+    /// resolved (#5142). Built-in `then`/`catch`/`finally` reads stay on the
+    /// promise dispatch path; only true expando keys land here. Unlike Date /
+    /// Temporal, a promise is movable, so its expando entry is rekeyed on GC
+    /// move via `exotic_expando_owner_moved`.
+    Promise,
 }
 
 /// Classify `addr` as a Date cell, RegExp header, or Error header. Returns
@@ -52,6 +65,7 @@ pub(crate) fn exotic_expando_kind(addr: usize) -> Option<ExoticKind> {
         crate::gc::GC_TYPE_DATE_CELL => Some(ExoticKind::Date),
         crate::gc::GC_TYPE_ERROR => Some(ExoticKind::Error),
         crate::gc::GC_TYPE_TEMPORAL => Some(ExoticKind::Temporal),
+        crate::gc::GC_TYPE_PROMISE => Some(ExoticKind::Promise),
         crate::gc::GC_TYPE_OBJECT if crate::regex::is_regex_pointer(addr as *const u8) => {
             Some(ExoticKind::RegExp)
         }
@@ -188,6 +202,25 @@ pub(crate) fn expando_clear_on_alloc(addr: usize) {
     });
 }
 
+/// Rekey a movable exotic cell's expando entry after the GC relocates it from
+/// `old_addr` to `new_addr`. Date / RegExp / Temporal cells are non-movable so
+/// this never fires for them, but a `Promise` (`GC_TYPE_PROMISE`) is movable —
+/// without this, a `.then()`-chained thenable that survives a GC move would
+/// lose the `status`/`value` expandos it was gated on. Stored expando *values*
+/// are already rewritten by `scan_exotic_expando_roots_mut`; this migrates the
+/// owner *key*. Wired via `GcMoveHookKind::ExoticExpandoOwner`.
+pub(crate) fn exotic_expando_owner_moved(old_addr: usize, new_addr: usize) {
+    if !expando_in_use() || old_addr == new_addr {
+        return;
+    }
+    EXOTIC_EXPANDO.with(|m| {
+        let mut map = m.borrow_mut();
+        if let Some(entries) = map.remove(&old_addr) {
+            map.insert(new_addr, entries);
+        }
+    });
+}
+
 /// `[[Set]]` on a Date/RegExp/Error instance. Honors accessor descriptors
 /// and attribute writability from the generic side tables, plus the RegExp
 /// `lastIndex` header slot and non-extensibility for new keys. Returns
@@ -244,6 +277,10 @@ pub(crate) unsafe fn exotic_set_property(
             ExoticKind::RegExp => "RegExp",
             ExoticKind::Error => "Error",
             ExoticKind::Temporal => "",
+            // Promise.prototype's `then`/`catch`/`finally` are methods, not
+            // generic accessors in the side table, so there is no
+            // prototype-accessor setter to consult; store the own expando.
+            ExoticKind::Promise => "",
         };
         let proto = if proto_name.is_empty() {
             f64::from_bits(crate::value::TAG_UNDEFINED)

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -2291,8 +2291,9 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
             ExoticKind::RegExp => name == "lastIndex",
             ExoticKind::Error => matches!(name, "message" | "stack"),
             // Temporal built-in fields (year/month/calendar/…) are prototype
-            // getters, not own data properties (like Date).
-            ExoticKind::Date | ExoticKind::Temporal => false,
+            // getters, not own data properties (like Date). Promise's
+            // then/catch/finally are prototype methods, not own props.
+            ExoticKind::Date | ExoticKind::Temporal | ExoticKind::Promise => false,
         };
         if builtin_own {
             return nanbox_true;
@@ -3457,13 +3458,37 @@ pub extern "C" fn js_object_get_field_by_name(
             {
                 unsafe {
                     let gc_header = (raw - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-                    if (*gc_header).obj_type == crate::gc::GC_TYPE_PROMISE {
+                    // Buffers / typed arrays are `std::alloc`-backed and carry
+                    // NO GcHeader, so the byte at `raw - 8` is unrelated memory
+                    // that can read as `GC_TYPE_PROMISE` (5) by coincidence on
+                    // an IC-miss read. Exclude them before acting — otherwise a
+                    // genuine buffer metadata read would early-return undefined.
+                    if (*gc_header).obj_type == crate::gc::GC_TYPE_PROMISE
+                        && !crate::buffer::is_registered_buffer(raw)
+                        && crate::typedarray::lookup_typed_array_kind(raw).is_none()
+                    {
                         let name_ptr =
                             (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                         let name_len = (*key).byte_len as usize;
                         let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
+                        let prop = std::str::from_utf8_unchecked(name_bytes);
+                        // #5142: a user-attached own expando (`p.status = …`,
+                        // `Object.assign(p, …)`) wins over the inherited
+                        // prototype method. @tanstack/query-core's
+                        // `pendingThenable()` stores `status`/`value` on the
+                        // promise and gates its retryer on `thenable.status`;
+                        // without this the read came back `undefined`,
+                        // `isResolved()` was permanently true, and the fetch
+                        // never resolved.
+                        if let Some(v) = super::exotic_expando::exotic_get_own_property(
+                            raw,
+                            super::exotic_expando::ExoticKind::Promise,
+                            prop,
+                            f64::from_bits(obj as u64),
+                        ) {
+                            return JSValue::from_bits(v.to_bits());
+                        }
                         if matches!(name_bytes, b"then" | b"catch" | b"finally") {
-                            let prop = std::str::from_utf8_unchecked(name_bytes);
                             if let Some(v) = crate::promise::js_promise_bound_method(
                                 raw as *mut crate::promise::Promise,
                                 prop,
@@ -3471,6 +3496,10 @@ pub extern "C" fn js_object_get_field_by_name(
                                 return JSValue::from_bits(v.to_bits());
                             }
                         }
+                        // A Promise is a `GC_TYPE_PROMISE` cell, not an
+                        // `ObjectHeader`; never fall through to the field/vtable
+                        // path below (it would reinterpret the promise's bytes).
+                        return JSValue::from_bits(crate::value::TAG_UNDEFINED);
                     }
                 }
             }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1894,6 +1894,37 @@ pub unsafe extern "C" fn js_native_call_method(
         }
     }
 
+    // #5142: a promise can carry user-attached own expando methods.
+    // @tanstack/query-core's `pendingThenable()` stores `resolve`/`reject`
+    // closures on the thenable and invokes them as `thenable.resolve(value)`;
+    // an own expando function shadows the inherited prototype method, so
+    // resolve and call it here before the intrinsic then/catch/finally and the
+    // generic "<m> is not a function" fall-through. Only dispatch when the
+    // stored value is actually callable — a non-callable expando
+    // (`thenable.status()`) falls through to the normal not-a-function path.
+    if !matches!(method_name, "then" | "catch" | "finally")
+        && crate::promise::js_value_is_promise(object_handle.get_nanbox_f64()) != 0
+    {
+        let recv = object_handle.get_nanbox_f64();
+        let raw = (recv.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+        if let Some(v) = super::exotic_expando::exotic_get_own_property(
+            raw,
+            super::exotic_expando::ExoticKind::Promise,
+            method_name,
+            recv,
+        ) {
+            let cand = (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+            if (v.to_bits() & crate::value::TAG_MASK) == crate::value::POINTER_TAG
+                && crate::closure::is_closure_ptr(cand)
+            {
+                let prev_this = IMPLICIT_THIS.with(|c| c.replace(recv.to_bits()));
+                let result = crate::closure::js_native_call_value(v, args_ptr, args_len);
+                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                return result;
+            }
+        }
+    }
+
     // Issue #489 followup: Promise's `then` / `catch` / `finally` are
     // intrinsic — when the dynamic dispatch path lands a `.then(cb)` on
     // a Promise (drizzle's `mysql-proxy/session.js`:
@@ -4323,7 +4354,9 @@ pub unsafe extern "C" fn js_native_call_method(
                                         raw as *mut crate::error::ErrorHeader,
                                         key,
                                     ),
-                                    ExoticKind::Date | ExoticKind::Temporal => false,
+                                    ExoticKind::Date
+                                    | ExoticKind::Temporal
+                                    | ExoticKind::Promise => false,
                                 }
                         })
                         .unwrap_or(false);

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -841,7 +841,9 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
                                     ptr as *mut crate::error::ErrorHeader,
                                     key,
                                 ),
-                                ExoticKind::Date | ExoticKind::Temporal => false,
+                                ExoticKind::Date | ExoticKind::Temporal | ExoticKind::Promise => {
+                                    false
+                                }
                             }
                     })
                     .unwrap_or(false);

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -437,7 +437,11 @@ pub(crate) fn js_promise_new_with_parent(parent: *mut Promise) -> *mut Promise {
         promise_handle.get_raw_mut_ptr::<Promise>(),
         parent_handle.get_raw_mut_ptr::<Promise>(),
     );
-    promise_handle.get_raw_mut_ptr::<Promise>()
+    let promise = promise_handle.get_raw_mut_ptr::<Promise>();
+    // #5142: a recycled address may carry expando properties (`p.status = …`)
+    // left by a previously-collected promise; a fresh promise must start clean.
+    crate::object::exotic_expando::expando_clear_on_alloc(promise as usize);
+    promise
 }
 
 /// Free a Promise (no-op — GC handles deallocation)

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -343,15 +343,38 @@ pub unsafe extern "C" fn js_dynamic_object_get_property(
     // `undefined`.
     {
         let gc_header = (ptr as usize - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        // Typed arrays are `std::alloc`-backed with no GcHeader, so the byte at
+        // `ptr - 8` can read as `GC_TYPE_PROMISE` (5) by coincidence; exclude
+        // them before acting. (Buffers/maps/sets were already handled above.)
         if (*gc_header).obj_type == crate::gc::GC_TYPE_PROMISE
-            && matches!(property_name, "then" | "catch" | "finally")
+            && crate::typedarray::lookup_typed_array_kind(ptr as usize).is_none()
         {
-            if let Some(v) = crate::promise::js_promise_bound_method(
-                ptr as *mut crate::promise::Promise,
+            // A user-attached own expando (`p.status = "pending"`,
+            // `Object.assign(p, …)`) wins over the inherited prototype method.
+            // #5142: @tanstack/query-core's `pendingThenable()` stores `status`
+            // / `value` on the promise and gates its retryer on
+            // `thenable.status`; without this the read came back `undefined`,
+            // `isResolved()` was permanently true, and the fetch never resolved.
+            if let Some(v) = crate::object::exotic_expando::exotic_get_own_property(
+                ptr as usize,
+                crate::object::exotic_expando::ExoticKind::Promise,
                 property_name,
+                obj_value,
             ) {
                 return v;
             }
+            if matches!(property_name, "then" | "catch" | "finally") {
+                if let Some(v) = crate::promise::js_promise_bound_method(
+                    ptr as *mut crate::promise::Promise,
+                    property_name,
+                ) {
+                    return v;
+                }
+            }
+            // A Promise is a `GC_TYPE_PROMISE` cell, not an `ObjectHeader`;
+            // never fall through to the field/vtable path below (it would
+            // reinterpret the promise's bytes as object fields).
+            return f64::from_bits(TAG_UNDEFINED);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #5142 — `await queryClient.fetchQuery({ queryKey, queryFn })` with
`@tanstack/query-core` (compiled via `perry.compilePackages`) hung forever.

### Root cause

query-core's `pendingThenable()` attaches bookkeeping **directly onto the
Promise object**: `thenable.status = "pending"`, `thenable.resolve = …`, and
`Object.assign(thenable, { status, value })`. Its retryer gates on
`isResolved = () => thenable.status !== "pending"`. Perry represented a Promise
as a `GC_TYPE_PROMISE` cell with no expando storage, so:

- `p.status = "pending"` was silently dropped; the read returned `undefined`.
- `undefined !== "pending"` ⇒ `isResolved()` was permanently **true**.
- `run()` returned early, the thenable never settled, and the program hung
  (45s harness timeout).

### Fix

Route Promise property writes/reads through the existing
`object::exotic_expando` side table, exactly as `Date`/`RegExp`/`Error`/
`Temporal` already do:

- New `ExoticKind::Promise` classifies `GC_TYPE_PROMISE` cells — the generic
  set / `in` / `Object.keys` / `delete` / `defineProperty` paths pick it up.
- Compiled getter (`js_object_get_field_by_name`) and the dynamic/reflection
  getter consult the expando store first, then `then`/`catch`/`finally` bound
  methods, then return `undefined` (a Promise is not an `ObjectHeader`, so it
  must never fall through to the object-field path).
- Method-call dispatch (`js_native_call_method`) invokes an own expando closure
  — `thenable.resolve(value)` — before the intrinsic methods / not-a-function.
- Fresh promises clear any stale expando left at a recycled address.
- Promises are movable, so a new `GcMoveHookKind::ExoticExpandoOwner` rekeys the
  address-keyed expando entry when the GC relocates the promise.

Getter guards exclude buffers / typed arrays (std::alloc-backed, no GC header)
so a coincidental `GC_TYPE_PROMISE` byte at `ptr-8` on an IC-miss read can't
early-return `undefined` for genuine buffer metadata.

### Validation

- The issue repro now prints `42 42`, matching `node --experimental-strip-types`.
- Promise basics (`typeof p.then`, chaining, `catch`, `Object.keys`, `in`,
  `hasOwnProperty`) byte-match Node.
- Typed-array / Buffer / async-ordering / `Promise.all` sanity all match Node.
- Full `perry-runtime` lib test suite green (1042 passed).
- Promise expandos survive both default GC and `PERRY_GC_FORCE_EVACUATE=1`.

Per request, no version bump or CHANGELOG entry — maintainer folds in metadata
at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Promises now support user-attached expando properties and keep them correct across garbage collection moves.
  * Promise-bound custom callable expando entries are now invoked when accessed as methods.

* **Bug Fixes**
  * Fixed promise property lookup to avoid confusing TypedArray memory as Promise objects.
  * Promise expando state is now fully cleared on allocation to prevent carryover from recycled addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->