### PR TITLE
fix(http): split web-fetch from bundled node:http client so Headers + node:http don't wedge the response pump (#5174)

### DIFF
--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -87,7 +87,22 @@ bundled-fastify = ["dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:byt
 # `bundled-streams` directly, and also strips `http-client` when
 # axios / node-fetch / http / https is imported through the
 # well-known table — both ends move in lockstep.
-http-client = ["dep:reqwest", "async-runtime", "bundled-streams"]
+#
+# #5174: `http-client` decomposes into `web-fetch` (the Web Fetch API —
+# `fetch()`, `Headers`, `Request`, `Response`, `Blob`/`File`, in
+# `src/fetch/` + `src/fetch_blob.rs`) plus the bundled node:http client
+# (`src/http.rs` + `src/axios.rs`). The halves share the
+# reqwest/async-runtime/streams deps but are otherwise independent.
+# Keeping them separable lets the well-known flip strip *only* the
+# bundled node:http client when `node:http` routes to perry-ext-http,
+# while preserving the Web Fetch FFIs a program needs for a bare
+# `new Headers()` / `new Response()`. Linking both the bundled client
+# and perry-ext-http previously produced duplicate
+# `js_http_process_pending` (et al.) symbols, and perry-ext-http's
+# aux-pump call bound to perry-stdlib's empty-queue copy — wedging the
+# in-process response pump (#5174).
+web-fetch = ["dep:reqwest", "async-runtime", "bundled-streams"]
+http-client = ["web-fetch"]
 
 # Web Streams API (issue #237). Per-binding gate v0.5.572 — the
 # well-known flip routes `import 'streams'` to perry-ext-streams

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -1126,7 +1126,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     // `js_native_call_method` → small-handle range check → here. Each helper
     // does its own registry-membership + property-name gate; `None` means
     // "not us, try the next dispatcher or return undefined".
-    #[cfg(feature = "http-client")]
+    #[cfg(feature = "web-fetch")]
     {
         // #1698: Request body methods (`req.json()`/`.text()`/`.arrayBuffer()`)
         // on an any-typed / computed-key receiver. Hono's `HonoRequest.#cachedBody`
@@ -2413,8 +2413,8 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
     // Each helper does its own registry-membership check; the order matches the
     // observed property-name disjointness (`url` / `method` only on Request,
     // `status` / `ok` only on Response, etc.). First match wins.
-    // Gated on `http-client` because fetch.rs itself is gated on that feature.
-    #[cfg(feature = "http-client")]
+    // Gated on `web-fetch` because fetch.rs itself is gated on that feature (#5174).
+    #[cfg(feature = "web-fetch")]
     {
         if let Some(v) = crate::fetch::dispatch_request_property(handle as usize, property_name) {
             return v;
@@ -3113,7 +3113,7 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
             f: unsafe extern "C" fn(i64) -> bool,
         );
         fn js_register_event_emitter_on(f: EventEmitterOn);
-        #[cfg(feature = "http-client")]
+        #[cfg(feature = "web-fetch")]
         fn js_register_global_fetch_with_options(
             f: unsafe extern "C" fn(
                 *const perry_runtime::StringHeader,
@@ -3122,7 +3122,7 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
                 *const perry_runtime::StringHeader,
             ) -> *mut perry_runtime::Promise,
         );
-        #[cfg(feature = "http-client")]
+        #[cfg(feature = "web-fetch")]
         fn js_register_global_fetch_constructors(
             blob_new: unsafe extern "C" fn(f64, f64) -> f64,
             file_new: unsafe extern "C" fn(f64, f64, f64, f64) -> f64,
@@ -3162,7 +3162,7 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
             ) -> f64,
             response_static_error: extern "C" fn() -> f64,
         );
-        #[cfg(feature = "http-client")]
+        #[cfg(feature = "web-fetch")]
         fn js_register_global_fetch_body_init_ptr(f: extern "C" fn(f64) -> i64);
         fn js_register_worker_threads_namespace_getters(
             worker_data: extern "C" fn() -> f64,
@@ -3182,9 +3182,9 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     js_register_handle_own_property_names_dispatch(js_handle_own_property_names_dispatch);
     js_register_handle_prototype_dispatch(js_handle_prototype_dispatch);
     crate::string_decoder::string_decoder_prototype_value();
-    #[cfg(feature = "http-client")]
+    #[cfg(feature = "web-fetch")]
     js_register_global_fetch_with_options(crate::fetch::js_fetch_with_options);
-    #[cfg(feature = "http-client")]
+    #[cfg(feature = "web-fetch")]
     js_register_global_fetch_constructors(
         crate::fetch_blob::js_blob_new,
         crate::fetch_blob::js_file_new,
@@ -3196,7 +3196,7 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
         crate::fetch::js_response_static_redirect,
         crate::fetch::js_response_static_error,
     );
-    #[cfg(feature = "http-client")]
+    #[cfg(feature = "web-fetch")]
     js_register_global_fetch_body_init_ptr(crate::fetch::js_response_body_init_ptr);
     // Probe / `on` hook / constructor all route through the shared
     // `extern "C"` events surface declared above dispatch_event_emitter_method

--- a/crates/perry-stdlib/src/lib.rs
+++ b/crates/perry-stdlib/src/lib.rs
@@ -135,18 +135,30 @@ pub mod fastify;
 #[cfg(feature = "bundled-fastify")]
 pub use fastify::*;
 
-// === HTTP Client ===
-#[cfg(feature = "http-client")]
+// === Web Fetch API (fetch / Headers / Request / Response / Blob) ===
+// #5174: gated on `web-fetch`, NOT `http-client`. The Web Fetch surface
+// (reqwest-backed `fetch()` + the WHATWG data types) is independent of
+// the bundled node:http client below, so a program that only needs
+// `new Headers()` while routing `node:http` to perry-ext-http keeps
+// these without dragging in the colliding bundled http.rs symbols.
+// `http-client = ["web-fetch"]`, so `--features http-client` still
+// compiles all of this exactly as before.
+#[cfg(feature = "web-fetch")]
 pub mod fetch;
-#[cfg(feature = "http-client")]
+#[cfg(feature = "web-fetch")]
 pub use fetch::*;
 // Issue #1211: Blob/File constructors + object-URL helpers split out
 // of fetch.rs to keep that file under the 2,000-line lint gate.
-#[cfg(feature = "http-client")]
+#[cfg(feature = "web-fetch")]
 pub mod fetch_blob;
-#[cfg(feature = "http-client")]
+#[cfg(feature = "web-fetch")]
 pub use fetch_blob::*;
 
+// === Bundled node:http client (http.request / http.get / axios) ===
+// Stays on `http-client`. The well-known flip strips `http-client`
+// (keeping `web-fetch`) when `node:http` routes to perry-ext-http, so
+// these modules — which export the same `js_http_*` symbols as
+// perry-ext-http — are absent and can't collide (#5174).
 #[cfg(feature = "http-client")]
 pub mod http;
 #[cfg(feature = "http-client")]

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -1077,32 +1077,33 @@ unsafe fn js_readable_stream_cancel_inner(
 }
 
 // Refs #915 (effect smoke fallback path): the `crate::fetch::*` helpers
-// referenced below only exist behind the `http-client` feature, so the
+// referenced below only exist behind the `web-fetch` feature, so the
 // streams-only auto-optimize build (`bundled-streams` alone, no
-// `http-client`) failed to compile. Gate the two blob/response constructors
-// on `http-client` and provide no-op stubs when it's off — anything that
-// actually needs a Blob/Response went through `http-client` anyway.
-#[cfg(feature = "http-client")]
+// `web-fetch`) failed to compile. Gate the two blob/response constructors
+// on `web-fetch` and provide no-op stubs when it's off — anything that
+// actually needs a Blob/Response went through `web-fetch` anyway. (#5174:
+// these track `fetch.rs`, which moved from `http-client` to `web-fetch`.)
+#[cfg(feature = "web-fetch")]
 #[no_mangle]
 pub unsafe extern "C" fn js_readable_stream_from_blob(blob_id: f64) -> f64 {
     let bytes = crate::fetch::blob_bytes_clone(blob_id as usize).unwrap_or_default();
     alloc_readable_from_bytes(bytes) as f64
 }
 
-#[cfg(not(feature = "http-client"))]
+#[cfg(not(feature = "web-fetch"))]
 #[no_mangle]
 pub unsafe extern "C" fn js_readable_stream_from_blob(_blob_id: f64) -> f64 {
     alloc_readable_from_bytes(Vec::new()) as f64
 }
 
-#[cfg(feature = "http-client")]
+#[cfg(feature = "web-fetch")]
 #[no_mangle]
 pub unsafe extern "C" fn js_readable_stream_from_response(resp_id: f64) -> f64 {
     let bytes = crate::fetch::response_bytes_clone(resp_id as usize).unwrap_or_default();
     alloc_readable_from_bytes(bytes) as f64
 }
 
-#[cfg(not(feature = "http-client"))]
+#[cfg(not(feature = "web-fetch"))]
 #[no_mangle]
 pub unsafe extern "C" fn js_readable_stream_from_response(_resp_id: f64) -> f64 {
     alloc_readable_from_bytes(Vec::new()) as f64

--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -364,21 +364,29 @@ pub(super) fn build_optimized_libs(
             // `compute_required_features` consulted above, so we
             // know exactly what to remove.
             for feat in crate::commands::stdlib_features::module_to_features(module_normalized) {
-                // Fix #589: `node:http` / `node:https` / `node:http2`
-                // map to `http-client`, but that feature also covers
-                // the Web Fetch FFIs (`js_headers_new`,
-                // `js_response_new`, `js_request_new`). When a
-                // compilePackages package — typically hono — uses
-                // `new Headers()` / `new Response()` while the user
-                // also imports `node:http`, stripping `http-client`
-                // breaks the link with undefined `js_headers_new` /
-                // `js_response_new` symbols. perry-ext-http only
-                // bundles the server side (perry-ext-http-server). So
-                // keep `http-client` if `uses_fetch` is set —
-                // perry-stdlib's fetch.rs stays in the build to
-                // satisfy the Web Fetch references; the well-known
-                // staticlib is still added for the server side.
+                // Fix #589 / #5174: `node:http` / `node:https` /
+                // `node:http2` map to `http-client`, but that umbrella
+                // covers BOTH the bundled node:http client
+                // (`src/http.rs` + `src/axios.rs`) AND the Web Fetch
+                // FFIs (`js_headers_new`, `js_response_new`,
+                // `js_request_new`, …). When a program uses
+                // `new Headers()` / `new Response()` (directly or via a
+                // compilePackages package like hono) while also
+                // importing `node:http`, we must keep the Web Fetch
+                // half but drop the bundled client — otherwise its
+                // `js_http_process_pending` (and the rest of the
+                // `js_http_*` surface) duplicate perry-ext-http's
+                // symbols, and perry-ext-http's aux-pump call binds to
+                // perry-stdlib's empty-queue copy, wedging the
+                // in-process response pump (#5174). Since `http-client
+                // = ["web-fetch"]`, strip the umbrella and re-assert
+                // `web-fetch`: fetch.rs/fetch_blob.rs stay,
+                // http.rs/axios.rs go. The well-known staticlib
+                // (perry-ext-http / perry-ext-http-server) is still
+                // added for the actual node:http surface.
                 if *feat == "http-client" && ctx.uses_fetch {
+                    features.remove("http-client");
+                    features.insert("web-fetch");
                     continue;
                 }
                 // Refs #643: keep `database-sqlite` enabled even when

--- a/crates/perry/src/commands/stdlib_features.rs
+++ b/crates/perry/src/commands/stdlib_features.rs
@@ -243,9 +243,16 @@ pub fn compute_required_features(
             features.insert(*feat);
         }
     }
-    // Built-in `fetch()` and `node-fetch` both bottom out in reqwest.
+    // Built-in `fetch()` / `node-fetch` and the WHATWG data types
+    // (`Headers` / `Request` / `Response` / `Blob`) bottom out in reqwest
+    // but do NOT need perry-stdlib's bundled node:http client. #5174: ask
+    // for `web-fetch` (just `src/fetch/` + `src/fetch_blob.rs`), not the
+    // `http-client` umbrella that also pulls in `src/http.rs` / `src/axios.rs`.
+    // When the program ALSO imports `node:http`, that import adds
+    // `http-client` separately and the well-known flip strips it down to
+    // `web-fetch` — so the bundled client never collides with perry-ext-http.
     if uses_fetch {
-        features.insert("http-client");
+        features.insert("web-fetch");
     }
     // Perry's bare `crypto.randomBytes` / `sha256` / etc. builtins bottom
     // out in the perry-stdlib `crypto` feature.

--- a/crates/perry/tests/issue_5174_headers_http_pump_hang.rs
+++ b/crates/perry/tests/issue_5174_headers_http_pump_hang.rs
@@ -1,0 +1,170 @@
+//! Regression test for #5174: instantiating `globalThis.Headers` inside an
+//! in-process `node:http` server handler wedged the HTTP response pump — the
+//! client's response callback never fired and the process hung (exit 124 under
+//! `timeout`).
+//!
+//! Root cause: `new Headers()` flips the compiler's `uses_fetch` flag, which
+//! used to keep the whole `http-client` perry-stdlib feature in the
+//! auto-optimize rebuild. That feature compiles BOTH the Web Fetch API
+//! (`src/fetch/`) AND the bundled node:http client (`src/http.rs` /
+//! `src/axios.rs`). With `node:http` simultaneously routed to `perry-ext-http`,
+//! both crates exported `js_http_process_pending` (et al.); perry-ext-http's
+//! aux-pump shim bound to perry-stdlib's bundled copy, which drains a different
+//! (always-empty) queue. The real response events piled up in perry-ext-http's
+//! queue forever.
+//!
+//! Fix: split `web-fetch` (the Web Fetch FFIs) out of `http-client` so the
+//! well-known flip can strip *only* the bundled node:http client while keeping
+//! the Web Fetch data types a bare `new Headers()` needs.
+//!
+//! Needs the default (auto-optimize) build — `PERRY_NO_AUTO_OPTIMIZE=1`
+//! produces a runtime-only binary where `node:http` dispatch is a no-op stub.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &std::path::Path, source: &str) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    // The bundled node:http client previously collided with perry-ext-http;
+    // the fix should leave the link clean.
+    let stderr = String::from_utf8_lossy(&compile.stderr);
+    assert!(
+        !stderr.contains("duplicate symbol '_js_http_process_pending'")
+            && !stderr.contains("duplicate symbol '_js_http_status_message'"),
+        "fix should not link both the bundled node:http client and \
+         perry-ext-http (duplicate js_http_* symbols):\n{stderr}"
+    );
+
+    output
+}
+
+/// Run `bin`, failing if it doesn't exit on its own within `secs` — the #5174
+/// signature is a hang (the in-process client callback never fires), so a
+/// wall-clock guard is the regression's real assertion. A reader thread drains
+/// stdout (so a full pipe buffer can't itself stall the child) while the main
+/// thread polls for exit against the deadline.
+fn run_with_timeout(bin: &std::path::Path, secs: u64) -> String {
+    use std::io::Read;
+
+    let mut child = Command::new(bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn compiled binary");
+
+    let mut piped = child.stdout.take().expect("piped stdout");
+    let reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = piped.read_to_string(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                let stdout = reader.join().unwrap_or_default();
+                assert!(
+                    status.success(),
+                    "binary exited non-zero: {status:?}\nstdout:\n{stdout}"
+                );
+                return stdout;
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stdout = reader.join().unwrap_or_default();
+                panic!(
+                    "#5174 regression: process hung for >{secs}s — the \
+                     in-process HTTP response pump never delivered the response \
+                     (Headers + node:http server/client wedge).\nstdout so far:\n{stdout}"
+                );
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// The issue's minimal repro: `new globalThis.Headers(...)` in the request
+/// handler must not wedge the in-process client's response callback.
+#[test]
+fn headers_in_http_handler_does_not_hang_response_pump() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = compile(
+        dir.path(),
+        r#"
+import http from "node:http";
+const server = http.createServer((req, res) => {
+  // Constructed, never used — this is the line that wedged the pump (#5174).
+  const headers = new globalThis.Headers({ foo: "1" });
+  void headers;
+  res.writeHead(200, { foo: "1", bar: "2" });
+  res.end();
+});
+server.listen(0, () => {
+  const port = (server.address() as { port: number }).port;
+  const req = http.get({ port }, (res) => {
+    console.log("STATUS", res.statusCode);
+    res.on("end", () => server.close());
+    res.resume();
+  });
+  req.on("error", (e) => console.error("client err", e.message));
+});
+"#,
+    );
+    let stdout = run_with_timeout(&bin, 30);
+    assert_eq!(stdout, "STATUS 200\n");
+}
+
+/// Web Fetch and node:http coexisting end-to-end: a built-in `fetch()` against
+/// the in-process server, with `Headers` *methods* (`append`/`get`) exercised
+/// in the handler. Confirms the Web Fetch half still works once split from the
+/// bundled node:http client.
+#[test]
+fn fetch_against_in_process_http_server_with_headers_methods() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = compile(
+        dir.path(),
+        r#"
+import http from "node:http";
+const server = http.createServer((req, res) => {
+  const h = new globalThis.Headers({ foo: "1" });
+  h.append("foo", "2");
+  res.writeHead(200, { "x-test": h.get("foo")! });
+  res.end("hello");
+});
+server.listen(0, async () => {
+  const port = (server.address() as { port: number }).port;
+  const r = await fetch(`http://127.0.0.1:${port}/`);
+  const body = await r.text();
+  console.log("FETCH", r.status, r.headers.get("x-test"), body);
+  server.close();
+});
+"#,
+    );
+    let stdout = run_with_timeout(&bin, 30);
+    assert_eq!(stdout, "FETCH 200 1, 2 hello\n");
+}


### PR DESCRIPTION
## Summary

Fixes #5174. Instantiating `new globalThis.Headers(...)` inside an in-process `node:http` server handler hung the HTTP response pump — the client's response callback never fired and the process hung (exit 124 under `timeout`). Removing that one line made it work.

## Root cause

Constructing `Headers` flips the compiler's `uses_fetch` flag, which kept the entire `http-client` perry-stdlib feature in the auto-optimize rebuild. That feature compiles **both** the Web Fetch API (`src/fetch/`) **and** the bundled node:http client (`src/http.rs` / `src/axios.rs`). With `node:http` simultaneously routed to `perry-ext-http`, both crates exported `js_http_process_pending` (and the rest of the `js_http_*` surface).

The linker deduplicated the symbol to perry-stdlib's **bundled** copy, so perry-ext-http's aux-pump shim — which calls `js_http_process_pending()` — bound to the bundled drainer, which empties a *different*, always-empty queue. The real response events pushed onto perry-ext-http's queue were never drained → client callback never fires → hang.

This was confirmed empirically: instrumented `push_event` fired 3× (response events queued in perry-ext-http) while perry-ext-http's own `js_http_process_pending` never ran — instead perry-stdlib's bundled `(BUNDLED)` copy ran every tick, draining its empty queue.

## Fix

Decompose `http-client` into:
- **`web-fetch`** — the Web Fetch FFIs (`fetch()`, `Headers`, `Request`, `Response`, `Blob`/`File`; `src/fetch/` + `src/fetch_blob.rs`)
- the bundled node:http client (`src/http.rs` / `src/axios.rs`), still on `http-client`

with `http-client = ["web-fetch"]`. The well-known flip now strips **only** the bundled client (re-asserting `web-fetch`) when `node:http` routes to perry-ext-http, so the data types a bare `new Headers()` needs stay available without the colliding `js_http_*` symbols.

`--features http-client` and `full` builds are byte-for-byte unchanged — `http-client` still pulls everything via `web-fetch`.

### Files
- `Cargo.toml`: add `web-fetch`; `http-client = ["web-fetch"]`.
- `lib.rs`: gate `fetch`/`fetch_blob` on `web-fetch`; `http`/`axios` stay on `http-client`.
- `dispatch.rs` / `streams.rs`: re-gate fetch registration + dispatch + the two blob/response stream constructors on `web-fetch`.
- `stdlib_features.rs`: `uses_fetch` ⇒ `web-fetch` (was `http-client`).
- `optimized_libs.rs`: the #589 fetch-keep path strips `http-client` and re-asserts `web-fetch`.

## Testing

New `crates/perry/tests/issue_5174_headers_http_pump_hang.rs` (2 tests, both pass):
- `headers_in_http_handler_does_not_hang_response_pump` — the issue's minimal repro, with a wall-clock hang guard and a duplicate-symbol assertion.
- `fetch_against_in_process_http_server_with_headers_methods` — built-in `fetch()` against the in-process server, exercising `Headers` `append`/`get`.

Manually verified:
- Original repro now prints `STATUS 200` and exits 0 (stable across repeated runs); **zero** duplicate-symbol warnings at link.
- Pure Web Fetch program (no `node:http`) auto-optimizes to `features=…,web-fetch` and `Headers`/`Request`/`Response` work.
- No-Headers control still works.

No regressions in existing `issue_5131_http_post_body_segfault`, `issue_4915_streams_byob`, or the `stdlib_features` unit test.

Per the issue split, this is the hang half; the #4965 `setHeaders` SIGSEGV was fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where constructing Headers inside HTTP server handlers could cause response pump hangs.

* **Refactor**
  * Reorganized HTTP and Web Fetch API feature flags to prevent linking conflicts and improve dependency clarity.

* **Tests**
  * Added regression tests for Headers handling in HTTP server handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->