### PR TITLE
fix(runtime): Object.getPrototypeOf returns installed [[Prototype]] by identity (#3986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+## v0.5.1174 — fix(runtime): Object.getPrototypeOf returns the installed [[Prototype]] by identity (#3986)
+
+`Object.getPrototypeOf` now returns the exact prototype object that was
+installed, by identity, for two synthetic-class receiver shapes that
+previously fell through to a self-prototype fallback:
+
+- `Object.create(proto)` results — `Object.getPrototypeOf(Object.create(p)) === p`.
+- Plain function-constructor instances — `Object.getPrototypeOf(new F()) === F.prototype`.
+
+Both of these record the real `[[Prototype]]` object pointer in the runtime's
+`CLASS_PROTOTYPE_OBJECTS` side-table keyed by the instance's synthetic class id
+(Object.create allocates a synthetic id and maps it to `proto`; `new F()`
+instances carry the function-prototype synthetic id). `js_object_get_prototype_of`
+walked the iterator-prototype and declared-class-prototype tables but never
+consulted `CLASS_PROTOTYPE_OBJECTS`, so these instances hit the trailing
+`return obj_value` fallback and reported *themselves* as their prototype — the
+`=== proto` identity checks were false even though the chain walk
+(`isPrototypeOf`, inherited property/method dispatch) still worked.
+
+The fix adds a `class_prototype_object(class_id)` lookup in both pointer-shape
+branches of `js_object_get_prototype_of`, just after the existing iterator /
+declared-class checks and before the self-prototype fallback. Declared ES
+classes use the separate `CLASS_DECL_PROTOTYPE_OBJECTS` table (handled just
+above) and object literals resolve through `default_object_prototype_for_owner`,
+so neither is perturbed — the load-bearing
+`getPrototypeOf(classInstance) === classInstance` model that `.constructor`
+resolution relies on is preserved.
+
+Test262 `built-ins/Object --max 180` differential: 168 → 170 pass (93.3% →
+94.4%), 0 regressions; the newly-passing cases are
+`built-ins/Object/create/15.2.3.5-3-1.js` and
+`built-ins/Object/create/15.2.3.5-4-1.js`. Added node-suite parity fixture
+`test-parity/node-suite/object/create/getprototypeof-identity.ts` covering
+Object.create (literal / function-object / with-props prototypes), `new F()`
+prototype identity, and the unaffected declared-class / object-literal /
+`Object.create(null)` controls.
+
+Part of the #3986 object-model epic (ToObject / wrapper / prototype identity);
+follows the earlier #4161 / #4239 / #4269 cuts.
+
 ## v0.5.1173 — fix(hir): mirror @@iterator lowering in class-expression path (#5128 review)
 
 Follow-up to #5161 (CodeRabbit review). The #5128 fix that makes a user class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1173
+**Current Version:** 0.5.1174
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1173"
+version = "0.5.1174"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -2714,6 +2714,27 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                     {
                         return proto;
                     }
+                    // #3986: `Object.create(proto)` and `new F()` (a plain
+                    // function ctor, whose instances carry a synthetic
+                    // function-prototype class id) record the actual
+                    // [[Prototype]] object pointer in CLASS_PROTOTYPE_OBJECTS
+                    // keyed by that synthetic class id. Return the exact stored
+                    // pointer so `Object.getPrototypeOf(o) === proto` holds by
+                    // identity (test262 built-ins/Object/create/15.2.3.5-*,
+                    // S9.9 ToObject identity). Declared ES classes use the
+                    // separate CLASS_DECL_PROTOTYPE_OBJECTS table handled just
+                    // above, so this does not perturb the
+                    // `getPrototypeOf(instance) === instance` model their
+                    // `.constructor` resolution relies on. Without this the
+                    // synthetic-class instance fell through to the
+                    // `return obj_value` self-prototype fallback below.
+                    let synth_proto =
+                        super::class_registry::class_prototype_object((*obj).class_id);
+                    if !synth_proto.is_null() {
+                        return f64::from_bits(
+                            crate::value::js_nanbox_pointer(synth_proto as i64).to_bits(),
+                        );
+                    }
                 }
             }
             return obj_value;
@@ -2800,6 +2821,27 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                         )
                     {
                         return proto;
+                    }
+                    // #3986: `Object.create(proto)` and `new F()` (a plain
+                    // function ctor, whose instances carry a synthetic
+                    // function-prototype class id) record the actual
+                    // [[Prototype]] object pointer in CLASS_PROTOTYPE_OBJECTS
+                    // keyed by that synthetic class id. Return the exact stored
+                    // pointer so `Object.getPrototypeOf(o) === proto` holds by
+                    // identity (test262 built-ins/Object/create/15.2.3.5-*,
+                    // S9.9 ToObject identity). Declared ES classes use the
+                    // separate CLASS_DECL_PROTOTYPE_OBJECTS table handled just
+                    // above, so this does not perturb the
+                    // `getPrototypeOf(instance) === instance` model their
+                    // `.constructor` resolution relies on. Without this the
+                    // synthetic-class instance fell through to the
+                    // `return obj_value` self-prototype fallback below.
+                    let synth_proto =
+                        super::class_registry::class_prototype_object((*obj).class_id);
+                    if !synth_proto.is_null() {
+                        return f64::from_bits(
+                            crate::value::js_nanbox_pointer(synth_proto as i64).to_bits(),
+                        );
                     }
                 }
             }

--- a/test-parity/node-suite/object/create/getprototypeof-identity.ts
+++ b/test-parity/node-suite/object/create/getprototypeof-identity.ts
@@ -1,0 +1,44 @@
+// #3986: Object.getPrototypeOf must return the SAME object identity that was
+// installed as the [[Prototype]] — for Object.create(proto) and for instances
+// of a plain function constructor (whose [[Prototype]] is `F.prototype`).
+// Previously these synthetic-class instances fell through to a self-prototype
+// fallback (getPrototypeOf returned the instance itself), so the `=== proto`
+// identity checks were false even though the prototype chain still worked.
+
+// Object.create with an object-literal prototype.
+const lit = { a: 1 };
+const d = Object.create(lit);
+console.log("create lit: proto identity", Object.getPrototypeOf(d) === lit);
+console.log("create lit: isPrototypeOf", lit.isPrototypeOf(d));
+console.log("create lit: inherited a", (d as any).a);
+
+// Object.create with a function-constructed prototype (test262 15.2.3.5-3-1).
+function Base(this: any) {}
+const baseInst: any = new (Base as any)();
+const created = Object.create(baseInst);
+console.log("create fnobj: proto identity", Object.getPrototypeOf(created) === baseInst);
+console.log("create fnobj: isPrototypeOf", baseInst.isPrototypeOf(created));
+
+// Object.create with added own properties (test262 15.2.3.5-4-1).
+const withProps = Object.create(baseInst, {
+  x: { value: true, writable: false },
+  y: { value: "str", writable: false },
+});
+console.log("create props: proto identity", Object.getPrototypeOf(withProps) === baseInst);
+console.log("create props: x", (withProps as any).x, "y", (withProps as any).y);
+console.log("create props: base untouched", (baseInst as any).x);
+
+// Plain function constructor instance: [[Prototype]] is F.prototype.
+function F(this: any, v: number) {
+  this.value = v;
+}
+const inst: any = new (F as any)(7);
+console.log("new F: proto is F.prototype", Object.getPrototypeOf(inst) === (F as any).prototype);
+console.log("new F: proto.constructor", Object.getPrototypeOf(inst).constructor === F);
+
+// Declared ES classes and object literals must be unaffected.
+class C {}
+const c = new C();
+console.log("class: proto is C.prototype", Object.getPrototypeOf(c) === (C as any).prototype);
+console.log("literal: proto is Object.prototype", Object.getPrototypeOf({}) === Object.prototype);
+console.log("create(null): proto null", Object.getPrototypeOf(Object.create(null)) === null);


### PR DESCRIPTION
## Summary

Part of the #3986 object-model epic (ToObject / wrapper / **prototype identity**), following the earlier #4161 / #4239 / #4269 cuts. This cut fixes `Object.getPrototypeOf` so it returns the **same prototype object that was installed, by identity** — not a self-prototype fallback.

Two synthetic-class receiver shapes were broken:

- `Object.create(proto)` results → now `Object.getPrototypeOf(Object.create(p)) === p`.
- Plain function-constructor instances → now `Object.getPrototypeOf(new F()) === F.prototype`.

Both record their real `[[Prototype]]` object pointer in the runtime's `CLASS_PROTOTYPE_OBJECTS` side-table keyed by the instance's synthetic class id. `js_object_get_prototype_of` walked the iterator-prototype and declared-class-prototype tables but **never consulted `CLASS_PROTOTYPE_OBJECTS`**, so these instances hit the trailing `return obj_value` fallback and reported *themselves* as their prototype. The `=== proto` identity checks were false even though `isPrototypeOf` and inherited property/method dispatch still worked.

## Fix

Add a `class_prototype_object(class_id)` lookup in **both** pointer-shape branches of `js_object_get_prototype_of` (NaN-boxed `0x7FFD` and module-level raw-pointer `0x0000` shapes), just after the existing iterator / declared-class checks and before the self-prototype fallback.

Declared ES classes use the separate `CLASS_DECL_PROTOTYPE_OBJECTS` table (handled just above), and object literals resolve through `default_object_prototype_for_owner` — neither is perturbed, so the load-bearing `getPrototypeOf(classInstance) === classInstance` model that `.constructor` resolution relies on is preserved.

## Validation

- **Test262** `built-ins/Object --max 180` differential (test262 `4249661…`, Node v26.3.0): **168 → 170 pass (93.3% → 94.4%), 0 regressions**. Newly passing: `built-ins/Object/create/15.2.3.5-3-1.js`, `built-ins/Object/create/15.2.3.5-4-1.js`.
- New node-suite parity fixture `test-parity/node-suite/object/create/getprototypeof-identity.ts` — byte-for-byte match vs Node — covering Object.create (literal / function-object / with-props prototypes), `new F()` prototype identity, plus unaffected declared-class / object-literal / `Object.create(null)` controls.
- All existing `test-parity/node-suite/object/*` fixtures still match Node.
- `cargo test -p perry-runtime object:: -- --test-threads=1` (29 passed). `cargo fmt --all -- --check`, `./scripts/check_file_size.sh`, `git diff --check` clean.

> Note: `object::tests::builtin_prototype_methods_reject_dynamic_new` flakes under the default parallel test runner due to shared global prototype-registry state — it fails identically on unmodified `main` and passes in isolation, so it is pre-existing and unrelated to this change (this PR only adds a read).

## Out of scope (remaining #3986 test262 tail)

The other `built-ins/Object` runtime-fails are distinct concerns, not prototype identity: Proxy-trap internals (`source-own-prop-*`, `strings-and-symbol-order-proxy`), array `push`-realloc identity aliasing (`S15.2.1.1_A2_T10`, `S15.2.2.1_A2_T3` — a separate broad array bug), `valueOf` own-property dispatch on function-constructor instances (`S9.9_A6`), Object.assign array/string-target semantics (`target-Array`, `assignment-to-readonly…`), and the Arguments-object brand (`15.2.3.5-4-15`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `Object.getPrototypeOf` behavior to correctly return the exact prototype object for instances created with `Object.create()` and constructor functions, improving standards compliance.

* **Chores**
  * Version bumped to v0.5.1174.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->