### PR TITLE
fix(hir): dispatch Array-mutator-named methods on any-typed receivers by runtime shape (#5139)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -564,6 +564,42 @@ pub(super) fn try_array_only_methods(
                         args,
                     }));
                 }
+                // #5139: an Array-mutator name that a plain object can also own
+                // as a closure-valued property (`{ push(c) {…} }` passed as
+                // `any` — react-dom/server's SSR `destination`). When the bare-
+                // ident receiver's static type is unknown we cannot tell a real
+                // array from such an object, so committing to `Expr::ArraySort` /
+                // the `array.push_single` native arm here reads the object's
+                // header as an `ArrayHeader` and corrupts it. Defer to the
+                // runtime `js_native_call_method` dispatch, which selects by the
+                // receiver's runtime shape (real array → dense helper; plain
+                // object with an own callable of this name → that method). The
+                // GC_TYPE_ARRAY arms in `js_native_call_method` keep real arrays
+                // correct, so any-typed arrays still work (growth resolves via
+                // the #233 forwarding pointer). Mirrors the same deferral in
+                // `local_array_methods.rs` and the method set in
+                // `array::try_object_arraylike_mutator`.
+                if let ast::Expr::Ident(ident) = unwrap_transparent_expr(member.obj.as_ref()) {
+                    let unknown_recv = matches!(
+                        ctx.lookup_local_type(ident.sym.as_ref()),
+                        None | Some(Type::Any) | Some(Type::Unknown)
+                    );
+                    if unknown_recv
+                        && matches!(
+                            method_name,
+                            "push"
+                                | "pop"
+                                | "shift"
+                                | "unshift"
+                                | "reverse"
+                                | "splice"
+                                | "sort"
+                                | "concat"
+                        )
+                    {
+                        return Ok(Err(args));
+                    }
+                }
                 match method_name {
                     "reduce" if !args.is_empty() && !recv_is_class => {
                         let array_expr = lower_expr(ctx, &member.obj)?;

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -107,6 +107,18 @@ pub(super) fn try_local_array_methods(
                 );
                 let is_unknown_recv =
                     matches!(type_info, None | Some(Type::Any) | Some(Type::Unknown));
+                // #5139: Array-mutator names that a plain object can also own as a
+                // closure-valued property. The runtime's `js_native_call_method`
+                // dispatches all of these correctly on either a real array or a
+                // plain object (see `try_object_arraylike_mutator` + the generic
+                // own-field scan), so for an `any`-typed receiver we defer to it
+                // rather than committing to the array-only fast path. Mirrors the
+                // method set special-cased in
+                // `array::try_object_arraylike_mutator`.
+                let is_arraylike_mutator_method = matches!(
+                    method_name,
+                    "push" | "pop" | "shift" | "unshift" | "reverse" | "splice" | "sort" | "concat"
+                );
                 let is_known_not_string = type_info
                     .map(|ty| !matches!(ty, Type::String | Type::Any | Type::Unknown))
                     .unwrap_or(false)
@@ -155,6 +167,20 @@ pub(super) fn try_local_array_methods(
                     false // type unknown + ambiguous method, skip array block (fall through to general dispatch)
                 } else if is_unknown_recv && is_class_overlapping_method {
                     false // type unknown + method commonly defined on user classes — fall through
+                } else if is_unknown_recv && is_arraylike_mutator_method {
+                    // #5139: type unknown + an Array-mutator name that a plain
+                    // object can legitimately own (`{ push(c) {…} }` passed as
+                    // `any` — e.g. react-dom/server's SSR `destination`). Eagerly
+                    // emitting `Expr::ArrayPush`/etc. reads the object's header as
+                    // an `ArrayHeader` and corrupts it (push returns a bogus length
+                    // and never runs the user method). Fall through to the runtime
+                    // `js_native_call_method` dispatch, which inspects the actual
+                    // receiver shape: real array → dense `js_array_push_f64`; plain
+                    // object with an own callable of this name → that method (this
+                    // case routes via `try_object_arraylike_mutator`, whose
+                    // own-user-method gate returns `None`, then the generic
+                    // own-field scan invokes the closure with `this` = receiver).
+                    false
                 } else {
                     true // type unknown + array-only method (push, pop, etc.), enter array block
                 };

--- a/crates/perry/tests/issue_5139_object_arraylike_method_dispatch.rs
+++ b/crates/perry/tests/issue_5139_object_arraylike_method_dispatch.rs
@@ -1,0 +1,187 @@
+//! Regression tests for #5139 — `react-dom/server`'s `renderToStaticMarkup`
+//! returned an empty string.
+//!
+//! Root cause was in HIR lowering, not the SSR library: a method call whose
+//! name collides with an `Array.prototype` mutator (`push`/`pop`/`shift`/
+//! `unshift`/`splice`/`sort`/`reverse`/`concat`) on a receiver whose static
+//! type is `any` was eagerly lowered to the array-only fast path
+//! (`Expr::ArrayPush` / the `array.push_single` native arm). That reads the
+//! receiver's header as an `ArrayHeader`, so a *plain object* that merely owns
+//! a same-named closure property — react-dom's Fizz `destination = { push(chunk)
+//! { result += chunk } }`, passed through several `any`-typed params before
+//! `writeChunk(destination, …)` calls `destination.push` — had its bytes read
+//! as array length/capacity. `push` returned a bogus numeric length and the
+//! user closure never ran, so every chunk was dropped and the SSR result stayed
+//! empty.
+//!
+//! The fix defers these mutator names on unknown/`any` receivers to the runtime
+//! `js_native_call_method` dispatch, which selects by the receiver's *runtime*
+//! shape: a real array hits the dense `js_array_*` helpers (growth still
+//! resolves through the #233 forwarding pointer), while a plain object with an
+//! own callable of that name invokes it with `this` bound to the receiver.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> String {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+/// The reduced shape of react-dom's Fizz flush loop: a plain-object sink with a
+/// `push` closure, handed through `any`-typed params before being invoked. The
+/// closure must run (mutating its captured `result`), not be replaced by the
+/// array builtin (which would return a length and drop the write).
+#[test]
+fn object_push_method_through_any_param_runs_user_closure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+let result = "";
+const destination = { push: function (chunk: any) { if (chunk !== null) result += chunk; return true; } };
+
+function writeChunkAndReturn(d: any, chunk: any) { return d.push(chunk); }
+function writeChunk(d: any, chunk: any) { writeChunkAndReturn(d, chunk); }
+
+function flushSubtree(d: any, segment: any) {
+  const chunks = segment.chunks;
+  let chunkIdx = 0;
+  for (; chunkIdx < chunks.length - 1; chunkIdx++) {
+    writeChunk(d, chunks[chunkIdx]);
+  }
+  if (chunkIdx < chunks.length) {
+    writeChunkAndReturn(d, chunks[chunkIdx]);
+  }
+}
+
+flushSubtree(destination, { chunks: ["<ul", ">", "x", "</ul", ">"] });
+console.log("result=[" + result + "]");
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("result=[<ul>x</ul>]"),
+        "object's own push closure must run when invoked through any-typed params, \
+         not the Array.prototype.push builtin (got: {stdout})"
+    );
+}
+
+/// All the array-mutator names a plain object can legitimately own as a closure
+/// property must dispatch to the user method, with `this` bound to the receiver
+/// and captured-variable mutations visible.
+#[test]
+fn object_arraylike_mutator_names_dispatch_to_own_methods() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+let log = "";
+const o = {
+  push: function () { log += "P"; },
+  pop: function () { log += "p"; },
+  shift: function () { log += "s"; },
+  unshift: function () { log += "u"; },
+  splice: function () { log += "S"; },
+  sort: function () { log += "o"; },
+  reverse: function () { log += "r"; },
+  concat: function () { log += "c"; },
+};
+function call(x: any) {
+  x.push(); x.pop(); x.shift(); x.unshift(); x.splice(); x.sort(); x.reverse(); x.concat();
+}
+call(o);
+console.log("log=[" + log + "]");
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("log=[PpsuSorc]"),
+        "every Array-mutator-named own method must dispatch to the object's closure (got: {stdout})"
+    );
+}
+
+/// The fix must NOT regress real arrays held in `any`-typed values: mutators
+/// still behave like `Array.prototype`, including growth that reallocates
+/// across a function boundary (resolved via the #233 forwarding pointer).
+#[test]
+fn any_typed_real_arrays_keep_array_mutator_semantics() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+function pushAll(a: any, n: number) { for (let i = 0; i < n; i++) a.push(i); return a.length; }
+const arr: any = [];
+const len = pushAll(arr, 1000); // forces several reallocs across the call boundary
+let sum = 0; for (let i = 0; i < arr.length; i++) sum += arr[i];
+console.log("grow:", len, arr.length, sum);
+
+function ops(a: any) { a.unshift(0); a.push(99); a.reverse(); return a.splice(1, 1)[0]; }
+const b: any = [2, 3];
+const removed = ops(b);
+console.log("ops:", JSON.stringify(b), removed);
+
+function sortDesc(a: any) { a.sort((x: number, y: number) => y - x); return a; }
+console.log("sort:", JSON.stringify(sortDesc([3, 1, 2] as any)));
+
+const c: any = [10, 20, 30];
+console.log("popshift:", c.pop !== undefined ? "ok" : "no");
+function ps(a: any) { return [a.pop(), a.shift()]; }
+console.log("popshift2:", JSON.stringify(ps(c)), JSON.stringify(c));
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("grow: 1000 1000 499500"),
+        "any-typed array push must grow correctly across a call boundary (got: {stdout})"
+    );
+    // b = [2,3] -> unshift 0 -> [0,2,3] -> push 99 -> [0,2,3,99] -> reverse -> [99,3,2,0]
+    //   -> splice(1,1) removes the 3 -> b = [99,2,0], removed = 3
+    assert!(
+        stdout.contains("ops: [99,2,0] 3"),
+        "any-typed array unshift/push/reverse/splice must match Array semantics (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("sort: [3,2,1]"),
+        "any-typed array sort with comparator must work (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("popshift2: [30,10] [20]"),
+        "any-typed array pop/shift must mutate in place (got: {stdout})"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #5139 — `react-dom/server`'s `renderToStaticMarkup` returned an **empty string** instead of the rendered HTML when react-dom is compiled natively via `perry.compilePackages`.

## Root cause

The bug was in HIR lowering, not in react-dom. The Fizz SSR renderer accumulates output by calling `destination.push(chunk)` on a plain-object sink:

```js
const destination = { push(chunk) { result += chunk } };
// …flows through several any-typed params…
function writeChunk(d, chunk) { return d.push(chunk); } // d : any
```

HIR lowering eagerly rewrote `recv.push(x)` — where `recv` is statically `any` — into the array-only fast path (`Expr::ArrayPush` / the `array.push_single` native arm). That path reads the receiver's header as an `ArrayHeader`, so the **plain object's** bytes were interpreted as array length/capacity: `push` returned a bogus numeric length and the user closure **never ran**, dropping every chunk — SSR yielded `""`.

This affected any object owning a method whose name collides with an `Array.prototype` mutator (`push`/`pop`/`shift`/`unshift`/`splice`/`sort`/`reverse`/`concat`) when invoked through an `any`-typed receiver.

## Fix

The two lowering sites — `local_array_methods.rs` (bare-ident receivers) and `array_only_methods.rs` (the fallback for arbitrary expressions) — now **defer** those mutator names to the runtime `js_native_call_method` dispatch when the receiver's static type is unknown/`any`. That dispatcher already selects by **runtime shape**:

- **real array** → dense `js_array_*` helpers (growth still resolves via the #233 forwarding pointer, so realloc across a call boundary is preserved);
- **plain object with an own callable** of that name → invokes it with `this` bound to the receiver (via `try_object_arraylike_mutator`'s own-user-method gate + the generic own-field scan).

Positively array-typed receivers keep the inline fast path unchanged, and the read-only iteration folds (`map`/`filter`/`entries`/…) on `any` receivers are untouched.

## Verification

- Reproduced against the **real** `react-dom@18.3.1` package compiled via `perry.compilePackages`. The issue's repro now prints, matching Node:
  ```
  <ul id="L"><li>item-1</li><li>item-2</li><li>item-3</li></ul>
  ```
- New regression tests in `crates/perry/tests/issue_5139_object_arraylike_method_dispatch.rs`:
  - object `push` closure runs when invoked through `any`-typed params (the reduced Fizz flush loop);
  - all eight mutator-named own methods dispatch to the object's closures;
  - `any`-typed **real arrays** keep `Array.prototype` semantics, including 1000-push growth across a function boundary, `unshift`/`push`/`reverse`/`splice`, comparator `sort`, and in-place `pop`/`shift`.
- Full `perry` integration suite + `perry-runtime` unit tests (1035) pass, plus `perry-hir`/`perry-codegen` tests — no regressions.

No version bump or CHANGELOG entry (left to maintainer at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method dispatch for objects with unknown types to correctly invoke custom methods instead of incorrectly treating them as arrays; resolves issue `#5139` affecting `react-dom/server`'s `renderToStaticMarkup`.

* **Tests**
  * Added regression tests verifying proper method dispatch for plain objects, array mutators on objects, and real arrays with correct semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->