### PR TITLE
feat(eval): defer runtime-unknown eval/new Function to a throw-on-reach error by default (#5206)

### DIFF
--- a/crates/perry-hir/src/eval_classifier.rs
+++ b/crates/perry-hir/src/eval_classifier.rs
@@ -29,9 +29,31 @@
 //!
 //! `PERRY_EVAL_DIAG=1` logs every classified site (package + `file:line` +
 //! bucket) to stderr, so a single compile reveals which dependencies hit
-//! each bucket. `PERRY_ALLOW_EVAL=1` downgrades the bucket-3 refusal back
-//! to the legacy (non-functional) fall-through for a one-off build — an
-//! escape hatch mirroring `#503`'s `PERRY_ALLOW_DYNAMIC_STDLIB`.
+//! each bucket.
+//!
+//! ## #5206 — deferred-runtime-error default vs. strict refusal
+//!
+//! As of #5206 the runtime-unknown bucket no longer blocks the build by
+//! default. Two compile modes select what happens to a bucket-3 site:
+//!
+//! - **defer** (the default, non-strict): the site is compiled to a value
+//!   that throws a descriptive [`Error`] *only when it is actually
+//!   invoked* (an `eval(...)` call throws when evaluated; a `new
+//!   Function(...)` returns a function that throws when called). Each such
+//!   site is recorded in a thread-local sink so the compile driver can
+//!   print a single visible end-of-build notice listing the degraded
+//!   sites (count + kind + `file:line`).
+//! - **error** (strict, opt-in): restores the historical hard compile-time
+//!   refusal — every bucket-3 site fails the build with [`EvalClassification::refusal_message`].
+//!
+//! The mode is a thread-local set at compile entry from the CLI flag
+//! (`--strict-eval`) and project config (`perry.eval` / `perry.strict`).
+//! `PERRY_ALLOW_EVAL=1` is kept for back-compat: it forces non-strict
+//! (defer) mode and so overrides a strict config/flag for a one-off build,
+//! mirroring `#503`'s `PERRY_ALLOW_DYNAMIC_STDLIB`.
+
+use std::cell::RefCell;
+use std::sync::Mutex;
 
 use swc_ecma_ast as ast;
 
@@ -148,11 +170,27 @@ impl EvalClassification {
              - If this comes from a code-generating library, only \
                `fast-json-stringify`, `ajv`, and `find-my-way` are recognized so far \
                (#1680/#1681/#1682) — file an issue against #1677 naming the package.\n\
-             - Set `PERRY_ALLOW_EVAL=1` to restore the legacy (non-functional) \
-               behavior for a one-off build.",
+             - This refusal is strict-eval mode. The default (`perry.eval = \"defer\"`) \
+               instead compiles the site to a runtime error that throws only if reached, \
+               and prints a compile-time notice. Drop `--strict-eval` / `perry.eval = \
+               \"error\"` (or set `PERRY_ALLOW_EVAL=1`) to use it.",
             surface = self.surface.label(),
             loc = self.location(),
             prov = self.provenance(),
+        )
+    }
+
+    /// The descriptive message a *deferred* bucket-3 site throws at runtime
+    /// when it is actually reached (#5206). Names the surface and the
+    /// `file:line` so a crash points straight back at the offending source.
+    pub fn deferred_runtime_error_message(&self) -> String {
+        let what = match self.surface {
+            EvalSurface::Eval => "eval()",
+            EvalSurface::FunctionCall | EvalSurface::NewFunction => "new Function()",
+        };
+        format!(
+            "{what} cannot run in an ahead-of-time compiled binary ({loc})",
+            loc = self.location(),
         )
     }
 
@@ -262,10 +300,85 @@ pub fn eval_diag_enabled() -> bool {
     env_flag("PERRY_EVAL_DIAG")
 }
 
-/// Whether `PERRY_ALLOW_EVAL` is set — downgrades the bucket-3 refusal to
-/// the legacy fall-through for a one-off build.
+/// Whether `PERRY_ALLOW_EVAL` is set — forces non-strict (defer) mode for a
+/// one-off build, overriding any strict flag/config (back-compat with the
+/// pre-#5206 escape hatch).
 pub fn eval_override_enabled() -> bool {
     env_flag("PERRY_ALLOW_EVAL")
+}
+
+thread_local! {
+    /// `true` when strict-eval mode is active for the current compile: a
+    /// runtime-unknown (`bucket-3`) site is a hard compile-time refusal.
+    /// `false` (the default) defers it to a throw-on-reach runtime error.
+    /// Set once at compile entry (and re-applied per rayon worker) via
+    /// [`set_eval_strict_mode`].
+    static EVAL_STRICT_MODE: RefCell<bool> = const { RefCell::new(false) };
+}
+
+/// Sites that were deferred to a runtime error during this compile (#5206).
+/// Process-global (not thread-local) because modules lower on rayon worker
+/// threads while the driver drains this at the end of the build to print the
+/// visible "degraded sites" notice. De-duplicated by `(kind, location)` so a
+/// module lowered more than once isn't counted twice.
+static EVAL_DEFERRED_SITES: Mutex<Vec<DeferredEvalSite>> = Mutex::new(Vec::new());
+
+/// A bucket-3 site that was compiled to a deferred runtime error. Reported in
+/// the end-of-compile notice (#5206).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeferredEvalSite {
+    /// Display label of the call shape, e.g. `new Function(...)`.
+    pub kind: String,
+    /// `file:line` of the site.
+    pub location: String,
+}
+
+/// Set strict-eval mode for the current compile thread. `true` restores the
+/// historical hard compile-time refusal of runtime-unknown sites; `false`
+/// (the default) defers them to throw-on-reach runtime errors. Called once
+/// at compile entry. `PERRY_ALLOW_EVAL` always wins (forces `false`).
+pub fn set_eval_strict_mode(strict: bool) {
+    EVAL_STRICT_MODE.with(|s| *s.borrow_mut() = strict && !eval_override_enabled());
+}
+
+/// Whether strict-eval mode is active for the current compile.
+pub fn eval_strict_mode() -> bool {
+    EVAL_STRICT_MODE.with(|s| *s.borrow())
+}
+
+/// Record a deferred bucket-3 site for the end-of-compile notice. Idempotent
+/// per `(kind, location)`.
+fn record_deferred_site(classification: &EvalClassification) {
+    let site = DeferredEvalSite {
+        kind: classification.surface.label().to_string(),
+        location: classification.location(),
+    };
+    if let Ok(mut v) = EVAL_DEFERRED_SITES.lock() {
+        if !v.contains(&site) {
+            v.push(site);
+        }
+    }
+}
+
+/// Drain and return every deferred bucket-3 site recorded so far this
+/// compile. Called by the driver to render the end-of-compile notice.
+pub fn take_deferred_eval_sites() -> Vec<DeferredEvalSite> {
+    EVAL_DEFERRED_SITES
+        .lock()
+        .map(|mut v| std::mem::take(&mut *v))
+        .unwrap_or_default()
+}
+
+/// What the lowering site should do with a classified call (#5206).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvalDecision {
+    /// Const-foldable / known-library site: proceed with the existing
+    /// (placeholder / native-fold) lowering unchanged.
+    Proceed,
+    /// Runtime-unknown site under the default (defer) mode, or a tree-shake
+    /// deferral: compile it to a value that throws this descriptive [`Error`]
+    /// message only when reached.
+    DeferToRuntimeError(String),
 }
 
 fn env_flag(name: &str) -> bool {
@@ -288,35 +401,60 @@ pub fn report(classification: &EvalClassification) {
 /// The single decision point both lowering sites (`new Function` in
 /// `expr_new`, `Function(...)`/`eval(...)` in `expr_call`) funnel through.
 ///
-/// Classifies the site, logs it under `PERRY_EVAL_DIAG`, and returns
-/// `Err` (a span-tagged [`crate::error::LowerError`]) only for the
-/// runtime-unknown bucket — unless `PERRY_ALLOW_EVAL` is set, which
-/// downgrades the refusal to the legacy fall-through. `Ok(())` means the
-/// caller should proceed with its existing lowering (const-foldable /
-/// known-library sites keep their placeholder behaviour for Phase 0).
+/// Classifies the site, logs it under `PERRY_EVAL_DIAG`, and decides what the
+/// caller does with it (#5206):
+///
+/// - const-foldable / known-library buckets → [`EvalDecision::Proceed`]
+///   (existing lowering unchanged).
+/// - runtime-unknown bucket in **strict** mode → `Err` (a span-tagged
+///   [`crate::error::LowerError`]) — the historical hard refusal.
+/// - runtime-unknown bucket in the **default** (defer) mode → records the
+///   site for the end-of-compile notice and returns
+///   [`EvalDecision::DeferToRuntimeError`] with the message the caller should
+///   compile to a throw-on-reach value.
+///
+/// The tree-shake deferral sink (#2309) still short-circuits in either mode:
+/// when armed for a `node_modules` module under tree-shaking, the refusal is
+/// recorded and deferred (the module may be pruned), and the call lowers to
+/// the throw-on-reach value so a *surviving* module still behaves correctly
+/// while the driver re-raises (strict) or notices (defer) it.
 pub fn check_site(
     surface: EvalSurface,
     body_arg: Option<&ast::Expr>,
     source_file_path: &str,
     span: swc_common::Span,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<EvalDecision> {
     let classification = classify(surface, body_arg, source_file_path, span.lo.0);
     report(&classification);
-    if classification.is_refused() && !eval_override_enabled() {
-        // #2309: when the tree-shake deferral sink is armed (a node_modules
-        // module being lowered under tree-shaking), record the refusal and
-        // fall through instead of erroring — the module may be pruned as
-        // unreachable, in which case this refusal never matters. The driver
-        // re-raises any deferred refusal that survives the prune.
-        if crate::deferral::try_defer_refusal(classification.refusal_message(), span.lo.0) {
-            return Ok(());
-        }
+    if !classification.is_refused() {
+        return Ok(EvalDecision::Proceed);
+    }
+
+    let strict = eval_strict_mode();
+
+    // #2309: tree-shake deferral. When the sink is armed (a node_modules
+    // module lowered under tree-shaking), record the refusal and compile to
+    // the throw-on-reach value instead of erroring — the module may be pruned
+    // as unreachable. The driver re-raises any deferred refusal that survives
+    // the prune (strict), or surfaces it in the notice (defer).
+    if crate::deferral::try_defer_refusal(classification.refusal_message(), span.lo.0) {
+        return Ok(EvalDecision::DeferToRuntimeError(
+            classification.deferred_runtime_error_message(),
+        ));
+    }
+
+    if strict {
         return Err(anyhow::Error::new(crate::error::LowerError::new(
             classification.refusal_message(),
             span,
         )));
     }
-    Ok(())
+
+    // Default (defer) mode: throw-on-reach + visible end-of-compile notice.
+    record_deferred_site(&classification);
+    Ok(EvalDecision::DeferToRuntimeError(
+        classification.deferred_runtime_error_message(),
+    ))
 }
 
 #[cfg(test)]
@@ -446,5 +584,93 @@ mod tests {
         let p = c.body_preview.unwrap();
         assert!(p.ends_with('…'));
         assert_eq!(p.chars().count(), 49); // 48 chars + ellipsis
+    }
+
+    #[test]
+    fn deferred_runtime_error_message_names_surface_and_location() {
+        let body = non_const();
+        let c = classify(EvalSurface::NewFunction, Some(&body), "/app/x.ts", 0);
+        let msg = c.deferred_runtime_error_message();
+        assert!(msg.contains("new Function()"));
+        assert!(msg.contains("ahead-of-time compiled binary"));
+        assert!(msg.contains("/app/x.ts"));
+
+        let body = non_const();
+        let c = classify(EvalSurface::Eval, Some(&body), "/app/x.ts", 0);
+        assert!(c.deferred_runtime_error_message().contains("eval()"));
+    }
+
+    /// Default (non-strict) mode: a runtime-unknown site defers to a
+    /// throw-on-reach value AND is recorded for the end-of-compile notice.
+    #[test]
+    fn default_mode_defers_runtime_unknown_and_records_site() {
+        set_eval_strict_mode(false);
+        // Use a unique path so this test's recorded site is identifiable even
+        // if other tests push to the process-global sink concurrently.
+        let path = "/app/default_mode_defers_fixture.ts";
+        let span = Span::new(BytePos(0), BytePos(0));
+        let body = non_const();
+        let decision = check_site(EvalSurface::Eval, Some(&body), path, span).expect("no error");
+        match decision {
+            EvalDecision::DeferToRuntimeError(msg) => {
+                assert!(msg.contains("eval()"));
+                assert!(msg.contains(path));
+            }
+            other => panic!("expected defer, got {other:?}"),
+        }
+        let sites = take_deferred_eval_sites();
+        let mine: Vec<_> = sites.iter().filter(|s| s.location.contains(path)).collect();
+        assert_eq!(mine.len(), 1, "exactly one recorded site for {path}");
+        assert_eq!(mine[0].kind, "eval(...)");
+    }
+
+    /// Strict-eval mode: a runtime-unknown site is a hard compile-time error.
+    #[test]
+    fn strict_mode_refuses_runtime_unknown() {
+        // PERRY_ALLOW_EVAL would force non-strict; only assert when unset.
+        if eval_override_enabled() {
+            return;
+        }
+        set_eval_strict_mode(true);
+        let span = Span::new(BytePos(0), BytePos(0));
+        let body = non_const();
+        let path = "/app/strict_refuses_fixture.ts";
+        let res = check_site(EvalSurface::Eval, Some(&body), path, span);
+        assert!(res.is_err(), "strict mode must refuse runtime-unknown");
+        // No notice site recorded for this path in strict mode.
+        assert!(
+            !take_deferred_eval_sites()
+                .iter()
+                .any(|s| s.location.contains(path)),
+            "strict mode must not record a notice site"
+        );
+        set_eval_strict_mode(false); // restore for sibling tests on this thread
+    }
+
+    /// Const-foldable sites always proceed regardless of mode.
+    #[test]
+    fn const_foldable_always_proceeds() {
+        set_eval_strict_mode(true);
+        let span = Span::new(BytePos(0), BytePos(0));
+        let body = str_lit("return 1");
+        let decision = check_site(EvalSurface::NewFunction, Some(&body), "/app/main.ts", span)
+            .expect("const-foldable never errors");
+        assert_eq!(decision, EvalDecision::Proceed);
+        set_eval_strict_mode(false);
+    }
+
+    /// `PERRY_ALLOW_EVAL` forces non-strict even when strict is requested.
+    #[test]
+    fn allow_eval_env_forces_non_strict() {
+        // Only meaningful when the env var is actually set; otherwise the
+        // back-compat alias has nothing to override and we skip.
+        if !eval_override_enabled() {
+            return;
+        }
+        set_eval_strict_mode(true);
+        assert!(
+            !eval_strict_mode(),
+            "PERRY_ALLOW_EVAL must force non-strict"
+        );
     }
 }

--- a/crates/perry-hir/src/lib.rs
+++ b/crates/perry-hir/src/lib.rs
@@ -40,7 +40,8 @@ pub use dynamic_import::{
 pub use egress::{audit_module_egress, EgressRefusalReason, EgressViolation};
 pub use enums::fix_imported_enums;
 pub use eval_classifier::{
-    classify as classify_eval_surface, EvalBucket, EvalClassification, EvalSurface,
+    classify as classify_eval_surface, set_eval_strict_mode, take_deferred_eval_sites,
+    DeferredEvalSite, EvalBucket, EvalClassification, EvalDecision, EvalSurface,
 };
 pub use ir::*;
 pub use js_transform::{

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -85,6 +85,75 @@ fn synth_throwing_iife(
     lowered
 }
 
+/// #5206: synthesize the throw-on-reach value for a runtime-unknown `eval`
+/// / `Function` / `new Function` site under the default (defer) mode. The
+/// `message` is the descriptive
+/// [`crate::eval_classifier::EvalClassification::deferred_runtime_error_message`].
+///
+/// - For `eval(...)` the value is a throwing IIFE — the throw happens when
+///   the `eval(...)` call evaluates (it is "reached" the moment control
+///   reaches the eval).
+/// - For `Function(...)` / `new Function(...)` the value is a *function* that
+///   throws when called — constructing it is fine; invoking the result is
+///   what's "reached". The site replaces the whole `new Function(...)` /
+///   `Function(...)` expression, so it must evaluate to that function value.
+pub(crate) fn synth_deferred_eval_value(
+    ctx: &mut LoweringContext,
+    surface: EvalSurface,
+    message: &str,
+    span: swc_common::Span,
+) -> Result<Expr> {
+    // JSON-encode the message so embedded quotes / newlines are safe inside
+    // the synthesized source string literal.
+    let lit = json_string_literal(message);
+    let throw_stmt = format!("throw new Error({lit});");
+    match surface {
+        EvalSurface::Eval => synth_throwing_iife(ctx, &throw_stmt, span),
+        EvalSurface::FunctionCall | EvalSurface::NewFunction => {
+            // A function value that throws on invocation.
+            let src = format!("(function () {{ {throw_stmt} }});\n");
+            let module = perry_parser::parse_typescript(&src, "<deferred eval value>.cjs")
+                .map_err(|e| anyhow::Error::new(LowerError::new(format!("internal: {e}"), span)))?;
+            let ast::ModuleItem::Stmt(ast::Stmt::Expr(expr_stmt)) =
+                module.body.into_iter().next().ok_or_else(|| {
+                    anyhow::Error::new(LowerError::new("internal: empty synth".to_string(), span))
+                })?
+            else {
+                return Err(anyhow::Error::new(LowerError::new(
+                    "internal: synth shape".to_string(),
+                    span,
+                )));
+            };
+            let outer_strict = ctx.current_strict;
+            ctx.current_strict = false;
+            let lowered = lower_expr(ctx, &expr_stmt.expr);
+            ctx.current_strict = outer_strict;
+            lowered
+        }
+    }
+}
+
+/// Minimal JSON string-literal encoder for embedding a message into
+/// synthesized source. Escapes the characters that would break a double-
+/// quoted JS string literal.
+fn json_string_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// Render an `f64` the way JavaScript's `Number::toString` (radix 10) would,
 /// for the small primitive subset Test262 hands to `new Function`. Exactness
 /// only matters when the number lands in a *parameter* slot (where it is an

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -115,27 +115,32 @@ pub(super) fn try_require_literal(
 /// before this (in `lower_call_inner`) and short-circuits, so its inner
 /// `Function('return this')` never reaches here.
 ///
-/// Returns `Err` (span-tagged) only for the runtime-unknown bucket —
-/// const-foldable (string-literal body) and known-codegen-library sites
-/// log under `PERRY_EVAL_DIAG` and fall through to the existing lowering
-/// (a bare `Function`/`eval` ident → `GlobalGet(0)` sentinel) unchanged,
-/// to be picked up by later phases. `Ok(())` means proceed.
-pub(super) fn check_eval_function_call(ctx: &LoweringContext, call: &ast::CallExpr) -> Result<()> {
+/// In strict-eval mode returns `Err` (span-tagged) for the runtime-unknown
+/// bucket — const-foldable (string-literal body) and known-codegen-library
+/// sites log under `PERRY_EVAL_DIAG` and fall through (`Ok(None)`) to the
+/// existing lowering, to be picked up by later phases. Under the default
+/// (defer) mode a runtime-unknown site returns `Ok(Some(throw_value))`
+/// (#5206): the caller uses that expression in place of the call so it
+/// throws a descriptive `Error` only if reached. `Ok(None)` means proceed.
+pub(super) fn check_eval_function_call(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+) -> Result<Option<Expr>> {
     let ast::Callee::Expr(callee_expr) = &call.callee else {
-        return Ok(());
+        return Ok(None);
     };
     let mut callee = callee_expr.as_ref();
     while let ast::Expr::Paren(p) = callee {
         callee = p.expr.as_ref();
     }
     let ast::Expr::Ident(ident) = callee else {
-        return Ok(());
+        return Ok(None);
     };
     let name = ident.sym.as_ref();
     let surface = match name {
         "eval" => crate::eval_classifier::EvalSurface::Eval,
         "Function" => crate::eval_classifier::EvalSurface::FunctionCall,
-        _ => return Ok(()),
+        _ => return Ok(None),
     };
     // A local/func/imported binding named `eval`/`Function` shadows the
     // builtin — leave those alone.
@@ -143,7 +148,7 @@ pub(super) fn check_eval_function_call(ctx: &LoweringContext, call: &ast::CallEx
         || ctx.lookup_func(name).is_some()
         || ctx.lookup_imported_func(name).is_some()
     {
-        return Ok(());
+        return Ok(None);
     }
     // Body argument: the only arg for `eval(code)`, the last arg for
     // `Function(p1, p2, body)`. A spread in the body position yields a
@@ -153,7 +158,14 @@ pub(super) fn check_eval_function_call(ctx: &LoweringContext, call: &ast::CallEx
         _ => call.args.last(),
     }
     .map(|a| a.expr.as_ref());
-    crate::eval_classifier::check_site(surface, body_arg, &ctx.source_file_path, call.span)
+    match crate::eval_classifier::check_site(surface, body_arg, &ctx.source_file_path, call.span)? {
+        crate::eval_classifier::EvalDecision::Proceed => Ok(None),
+        crate::eval_classifier::EvalDecision::DeferToRuntimeError(message) => Ok(Some(
+            super::super::const_fold_fn::synth_deferred_eval_value(
+                ctx, surface, &message, call.span,
+            )?,
+        )),
+    }
 }
 
 pub(super) fn try_strict_eval_arguments_assignment(

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -228,9 +228,13 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
     if let Some(expr) = super::const_fold_fn::try_eval_function_call_fold(ctx, call)? {
         return Ok(expr);
     }
-    // #1678: classify `Function(...)` / `eval(...)`. Bails on the
-    // runtime-unknown bucket; otherwise logs + falls through.
-    check_eval_function_call(ctx, call)?;
+    // #1678/#5206: classify `Function(...)` / `eval(...)`. In strict-eval
+    // mode bails on the runtime-unknown bucket; by default compiles that
+    // bucket to a throw-on-reach value (returned here); otherwise falls
+    // through.
+    if let Some(expr) = check_eval_function_call(ctx, call)? {
+        return Ok(expr);
+    }
     if let Some(expr) = try_bare_regexp_call(ctx, call, has_spread)? {
         return Ok(expr);
     }

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -1190,12 +1190,24 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 // Not fully const-foldable — body is the last argument
                 // (`new Function(p1, p2, body)`); earlier args are param names.
                 let body_arg = args_slice.last().map(|a| a.expr.as_ref());
-                crate::eval_classifier::check_site(
+                match crate::eval_classifier::check_site(
                     crate::eval_classifier::EvalSurface::NewFunction,
                     body_arg,
                     &ctx.source_file_path,
                     new_expr.span,
-                )?;
+                )? {
+                    crate::eval_classifier::EvalDecision::Proceed => {}
+                    // #5206: default (defer) mode — compile to a function value
+                    // that throws a descriptive Error only when invoked.
+                    crate::eval_classifier::EvalDecision::DeferToRuntimeError(message) => {
+                        return super::const_fold_fn::synth_deferred_eval_value(
+                            ctx,
+                            crate::eval_classifier::EvalSurface::NewFunction,
+                            &message,
+                            new_expr.span,
+                        );
+                    }
+                }
             }
 
             // #1691: an inline `new Request(...)` / `new Response(...)` / etc.

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -5761,6 +5761,14 @@ pub fn run_with_parse_cache(
 
     cleanup_intermediates(args.keep_intermediates, &obj_cleanup_paths);
 
+    // #5206: visible end-of-compile notice listing every runtime-eval site
+    // (`eval(...)` / `new Function(<dynamic body>)`) that was compiled to a
+    // deferred runtime error instead of blocking the build. Strict-eval mode
+    // (`--strict-eval` / `perry.eval = "error"`) never reaches here for such
+    // a site — it fails the build earlier. Text format only (JSON consumers
+    // get a clean machine-readable result on stdout).
+    print_deferred_eval_notice(format);
+
     let final_output_path = result_app_dir.unwrap_or(exe_path);
     let codegen_cache_stats = summarize_codegen_cache_stats(&object_cache);
 
@@ -5773,6 +5781,48 @@ pub fn run_with_parse_cache(
         link_cache_stats: Some(link_cache_status.stats()),
         build_cache_stats: Some(build_cache_stats),
     })
+}
+
+/// #5206: print the end-of-compile notice for runtime-eval sites that were
+/// compiled to deferred runtime errors. Drains the process-global sink (so
+/// re-running a compile in the same process starts fresh) and prints a single
+/// stand-out block. No-op when there are no such sites or for JSON output.
+fn print_deferred_eval_notice(format: OutputFormat) {
+    let sites = perry_hir::take_deferred_eval_sites();
+    if sites.is_empty() || !matches!(format, OutputFormat::Text) {
+        return;
+    }
+    // Sort for deterministic output (kind then location).
+    let mut sites = sites;
+    sites.sort_by(|a, b| (&a.kind, &a.location).cmp(&(&b.kind, &b.location)));
+    let n = sites.len();
+    let plural = if n == 1 { "site" } else { "sites" };
+    // ANSI yellow + bold so the notice stands out from the surrounding build
+    // log; degrade to plain text when stderr isn't a TTY.
+    let tty = std::io::IsTerminal::is_terminal(&std::io::stderr());
+    let (y, b, r) = if tty {
+        ("\x1b[33m", "\x1b[1m", "\x1b[0m")
+    } else {
+        ("", "", "")
+    };
+    eprintln!();
+    eprintln!(
+        "{y}{b}notice:{r}{y} {n} runtime-eval {plural} compiled to a deferred runtime error (throws only if reached):{r}"
+    );
+    // Align the locations into a column for readability.
+    let kind_width = sites.iter().map(|s| s.kind.len()).max().unwrap_or(0);
+    for s in &sites {
+        eprintln!(
+            "  - {:<width$}   {}",
+            s.kind,
+            s.location,
+            width = kind_width
+        );
+    }
+    eprintln!(
+        "  Pass {b}--strict-eval{r} (or set {b}perry.eval = \"error\"{r}) to make these a compile-time error instead."
+    );
+    eprintln!();
 }
 
 #[cfg(test)]

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -702,6 +702,9 @@ fn collect_module_one(
     // inherit the thread-local set on the main thread by `compile.rs`.
     perry_hir::set_refuse_dynamic_stdlib_dispatch(ctx.refuse_dynamic_stdlib_dispatch);
     perry_hir::set_allow_dynamic_stdlib_packages(ctx.allow_dynamic_stdlib_packages.clone());
+    // #5206: re-install strict-eval mode on this (possibly rayon-worker)
+    // thread before each lower, mirroring the dynamic-stdlib knob above.
+    perry_hir::set_eval_strict_mode(ctx.strict_eval);
     // #503: stash the module source text so the dynamic-dispatch check
     // can look up `// @perry-allow-dynamic` line annotations adjacent to
     // any violation site without re-reading the file. Cleared right

--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -346,6 +346,28 @@ pub(super) fn apply_pkg_and_toml_config(
                 {
                     ctx.lockdown = ld;
                 }
+                // #5206: `perry.eval = "defer" | "error"` and/or
+                // `perry.strict = true` select strict-eval mode. `perry.eval`
+                // wins if both are present (most specific). Unknown
+                // `perry.eval` strings are ignored (default keeps "defer").
+                if let Some(strict) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("strict"))
+                    .and_then(|v| v.as_bool())
+                {
+                    ctx.strict_eval = strict;
+                }
+                if let Some(mode) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("eval"))
+                    .and_then(|v| v.as_str())
+                {
+                    match mode {
+                        "error" | "strict" => ctx.strict_eval = true,
+                        "defer" => ctx.strict_eval = false,
+                        _ => {}
+                    }
+                }
                 // #502: perry.allowedHosts — compile-time URL/host
                 // egress allowlist. Patterns: exact host, "*.foo.com"
                 // subdomain wildcard, "https://host/prefix*" URL
@@ -476,6 +498,55 @@ pub(super) fn apply_pkg_and_toml_config(
     if args.lockdown {
         ctx.lockdown = true;
     }
+
+    // #5206 — strict-eval precedence (last wins): package.json
+    // `perry.eval`/`perry.strict` (read above) → perry.toml `[perry] eval` /
+    // `[perry] strict` → env `PERRY_ALLOW_EVAL=1` (forces OFF, back-compat) →
+    // CLI `--strict-eval`. The toml read is folded into the i18n/app-metadata
+    // perry.toml parse below; here we apply the env + CLI layers.
+    if let Some(dir) = {
+        let mut d = Some(project_root.to_path_buf());
+        let mut found = None;
+        while let Some(dir) = d {
+            if dir.join("perry.toml").exists() {
+                found = Some(dir);
+                break;
+            }
+            d = dir.parent().map(Path::to_path_buf);
+        }
+        found
+    } {
+        if let Some(table) = fs::read_to_string(dir.join("perry.toml"))
+            .ok()
+            .and_then(|s| s.parse::<toml::Table>().ok())
+        {
+            if let Some(perry_tbl) = table.get("perry").and_then(|v| v.as_table()) {
+                if let Some(strict) = perry_tbl.get("strict").and_then(|v| v.as_bool()) {
+                    ctx.strict_eval = strict;
+                }
+                if let Some(mode) = perry_tbl.get("eval").and_then(|v| v.as_str()) {
+                    match mode {
+                        "error" | "strict" => ctx.strict_eval = true,
+                        "defer" => ctx.strict_eval = false,
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    // CLI flag opts in.
+    if args.strict_eval {
+        ctx.strict_eval = true;
+    }
+    // Back-compat: `PERRY_ALLOW_EVAL` forces non-strict for a one-off build,
+    // overriding any strict flag/config.
+    if perry_hir::eval_classifier::eval_override_enabled() {
+        ctx.strict_eval = false;
+    }
+    // Install into the HIR thread-local before any lowering begins (re-applied
+    // per rayon worker in collect_modules.rs, mirroring the dynamic-stdlib
+    // dispatch knob above).
+    perry_hir::set_eval_strict_mode(ctx.strict_eval);
 
     // #3527 (blocker #4): materialize `"*"` / `"@scope/*"` wildcard entries
     // in `perry.compilePackages` into concrete installed package names.

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -281,6 +281,17 @@ pub struct CompileArgs {
     #[arg(long)]
     pub lockdown: bool,
 
+    /// #5206 — strict-eval mode. Fail the build at compile time if any
+    /// `eval(...)` or `new Function(<dynamic body>)` site has a runtime-
+    /// unknown body (the historical behavior). By default such a site is
+    /// instead compiled to a value that throws a descriptive `Error` only if
+    /// reached, and a notice listing the degraded sites is printed at the end
+    /// of the build. Also settable via `"perry": { "eval": "error" }` /
+    /// `"perry": { "strict": true }` in package.json or perry.toml.
+    /// `PERRY_ALLOW_EVAL=1` forces this off.
+    #[arg(long)]
+    pub strict_eval: bool,
+
     /// Minimum Windows version the compiled executable must run on.
     /// Accepted values: `7`, `8`, `10` (default `10`). Ignored on every
     /// non-Windows target.
@@ -652,6 +663,15 @@ pub struct CompilationContext {
     /// allows the listed packages — captured in
     /// `allow_dynamic_stdlib_packages`.
     pub refuse_dynamic_stdlib_dispatch: bool,
+    /// #5206: strict-eval mode. When true, a runtime-unknown `eval(...)` /
+    /// `new Function(<dynamic body>)` site is a hard compile-time refusal
+    /// (the historical behavior). When false (the default), such a site is
+    /// compiled to a value that throws a descriptive `Error` only if reached,
+    /// and a visible end-of-compile notice lists every degraded site. Sources,
+    /// last wins: `perry.eval = "defer" | "error"` / `perry.strict = true` in
+    /// package.json or perry.toml → CLI `--strict-eval`. `PERRY_ALLOW_EVAL=1`
+    /// always forces this off (back-compat escape hatch).
+    pub strict_eval: bool,
     /// #503: package names whose modules may legitimately use dynamic
     /// stdlib dispatch (`perry.allowDynamicStdlibDispatch: [...]`).
     /// Consulted per-module during HIR lowering; ignored when
@@ -852,6 +872,7 @@ impl CompilationContext {
             entry_canonical: None,
             extra_stdlib_features: BTreeSet::new(),
             refuse_dynamic_stdlib_dispatch: true,
+            strict_eval: false,
             allow_dynamic_stdlib_packages: HashSet::new(),
             js_runtime_importers: Vec::new(),
             permissions: std::collections::BTreeMap::new(),

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -305,6 +305,7 @@ fn build_once(
         emit_attest: false,
         emit_sandbox: false,
         lockdown: false,
+        strict_eval: false,
         min_windows_version: "10".to_string(),
         windows_subsystem: "auto".to_string(),
         // Phase 2 v7: harmonyos signing flags. `perry dev` is the watch

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -236,6 +236,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         emit_attest: false,
         emit_sandbox: false,
         lockdown: false,
+        strict_eval: false,
         min_windows_version: "10".to_string(),
         windows_subsystem: "auto".to_string(),
         // Phase 2 v7: harmonyos signing flags. `perry run` is for local

--- a/crates/perry/tests/issue_5206_deferred_eval_runtime_error.rs
+++ b/crates/perry/tests/issue_5206_deferred_eval_runtime_error.rs
@@ -1,0 +1,194 @@
+//! Regression test for #5206: a runtime-unknown `eval(...)` / `new
+//! Function(<dynamic body>)` site no longer blocks the build by default.
+//!
+//! The default (non-strict) behavior:
+//!   1. compilation SUCCEEDS even with such a site in a cold (never-taken)
+//!      branch,
+//!   2. a visible end-of-compile NOTICE lists the degraded site(s)
+//!      (count + kind + `file:line`),
+//!   3. the binary runs fine when the eval path is never reached, and
+//!   4. if the eval path IS reached at runtime it throws a descriptive,
+//!      catchable `Error` (not a crash, not a silent no-op).
+//!
+//! Strict-eval mode (CLI `--strict-eval` or `perry.eval = "error"` /
+//! `perry.strict = true` config) restores the historical hard compile-time
+//! refusal.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// The cold-path fixture: `new Function` is only reached in the JSON-parse
+/// `catch`. The default `console.log` exercises the JSON path, so the deferred
+/// site is never invoked unless the caller forces it.
+const COLD_FIXTURE: &str = r#"
+function parseParams(s: string): any {
+  try { return JSON.parse(s); } catch { return new Function(`return (${s})`)(); }
+}
+// JSON path — never hits new Function.
+console.log(parseParams('{"a":1}').a);
+
+// Force the deferred path only when asked, and prove it throws a catchable
+// Error rather than crashing.
+if (process.argv.indexOf("--force-eval") !== -1) {
+  try {
+    parseParams("not json");
+    console.log("NO_THROW");
+  } catch (e: any) {
+    console.log("CAUGHT:" + (e && e.message));
+  }
+}
+"#;
+
+fn compile(root: &std::path::Path, extra_args: &[&str]) -> std::process::Output {
+    let entry = root.join("main.ts");
+    let output = root.join("main_bin");
+    let mut cmd = Command::new(perry_bin());
+    cmd.current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    // Pure-language program — skip auto-optimize to avoid runtime rebuilds.
+    cmd.env("PERRY_NO_AUTO_OPTIMIZE", "1");
+    cmd.output().expect("run perry compile")
+}
+
+#[test]
+fn default_defer_compiles_prints_notice_and_runs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(root.join("main.ts"), COLD_FIXTURE).expect("write entry");
+
+    let out = compile(root, &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "default compile must succeed; stderr:\n{stderr}"
+    );
+
+    // The visible end-of-compile notice: count + kind + file:line.
+    assert!(
+        stderr.contains("runtime-eval site"),
+        "expected the deferred-eval notice; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("new Function(...)"),
+        "notice must name the site kind; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("main.ts:3"),
+        "notice must name the site location; stderr:\n{stderr}"
+    );
+
+    // The JSON path runs fine (the deferred site is never invoked).
+    let bin = root.join("main_bin");
+    let run = Command::new(&bin).output().expect("run compiled binary");
+    assert!(run.status.success(), "binary must run on the JSON path");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(stdout.trim(), "1", "JSON path must print 1; got:\n{stdout}");
+
+    // Forcing the deferred path throws a descriptive, catchable Error.
+    let run2 = Command::new(&bin)
+        .arg("--force-eval")
+        .output()
+        .expect("run compiled binary --force-eval");
+    let stdout2 = String::from_utf8_lossy(&run2.stdout);
+    assert!(
+        stdout2.contains("CAUGHT:"),
+        "the invoked deferred site must throw a catchable Error; got:\n{stdout2}"
+    );
+    assert!(
+        stdout2.contains("ahead-of-time compiled binary"),
+        "the thrown Error must be descriptive; got:\n{stdout2}"
+    );
+    assert!(
+        !stdout2.contains("NO_THROW"),
+        "the invoked deferred site must NOT silently no-op; got:\n{stdout2}"
+    );
+}
+
+#[test]
+fn strict_eval_flag_refuses_at_compile_time() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(root.join("main.ts"), COLD_FIXTURE).expect("write entry");
+
+    let out = compile(root, &["--strict-eval"]);
+    assert!(
+        !out.status.success(),
+        "strict-eval mode must fail the build for a runtime-unknown site"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("is refused at compile time"),
+        "strict-eval must print the refusal message; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn perry_eval_error_config_refuses_at_compile_time() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(root.join("main.ts"), COLD_FIXTURE).expect("write entry");
+    // Config-driven strict mode via package.json `perry.eval = "error"`.
+    std::fs::write(
+        root.join("package.json"),
+        r#"{ "name": "strict-eval-cfg", "perry": { "eval": "error" } }"#,
+    )
+    .expect("write package.json");
+
+    let out = compile(root, &[]);
+    assert!(
+        !out.status.success(),
+        "perry.eval = \"error\" must fail the build for a runtime-unknown site"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("is refused at compile time"),
+        "config strict mode must print the refusal message; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn allow_eval_env_overrides_strict_config() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(root.join("main.ts"), COLD_FIXTURE).expect("write entry");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{ "name": "allow-eval-override", "perry": { "eval": "error" } }"#,
+    )
+    .expect("write package.json");
+
+    // PERRY_ALLOW_EVAL=1 forces non-strict even though config asked for error.
+    let entry = root.join("main.ts");
+    let output = root.join("main_bin");
+    let out = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_ALLOW_EVAL", "1")
+        .output()
+        .expect("run perry compile");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "PERRY_ALLOW_EVAL=1 must override a strict config and build; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("runtime-eval site"),
+        "back-compat override must still print the deferred notice; stderr:\n{stderr}"
+    );
+}

--- a/crates/perry/tests/issue_5206_deferred_eval_runtime_error.rs
+++ b/crates/perry/tests/issue_5206_deferred_eval_runtime_error.rs
@@ -16,9 +16,53 @@
 
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::Once;
 
 fn perry_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+        .join("debug")
+}
+
+/// Build `libperry_runtime.a` once so the compiled binaries can link. The CI
+/// `cargo-test` job doesn't pre-build the runtime staticlib, and these tests
+/// link real executables, so they'd otherwise fail with "Could not find
+/// libperry_runtime.a" (mirrors module_import_forms.rs).
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let build = Command::new(cargo)
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime")
+            .output()
+            .expect("run cargo build -p perry-runtime");
+        assert!(
+            build.status.success(),
+            "cargo build -p perry-runtime failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn runtime_dir() -> PathBuf {
+    ensure_runtime_archive();
+    target_debug_dir()
 }
 
 /// The cold-path fixture: `new Function` is only reached in the JSON-parse
@@ -58,6 +102,7 @@ fn compile(root: &std::path::Path, extra_args: &[&str]) -> std::process::Output 
     }
     // Pure-language program — skip auto-optimize to avoid runtime rebuilds.
     cmd.env("PERRY_NO_AUTO_OPTIMIZE", "1");
+    cmd.env("PERRY_RUNTIME_DIR", runtime_dir());
     cmd.output().expect("run perry compile")
 }
 
@@ -180,6 +225,7 @@ fn allow_eval_env_overrides_strict_config() {
         .arg("--no-cache")
         .env("PERRY_NO_AUTO_OPTIMIZE", "1")
         .env("PERRY_ALLOW_EVAL", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
         .output()
         .expect("run perry compile");
     let stderr = String::from_utf8_lossy(&out.stderr);

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -86,6 +86,7 @@ Minification strips comments, collapses whitespace, and mangles local variable/p
 | `--enable-js-runtime` | Enable V8 JavaScript runtime for unsupported npm packages |
 | `--enable-wasm-runtime` | Force-link the wasmi WebAssembly host runtime (auto-detected when `WebAssembly.*` is referenced; needed only when loading via dlopen / FFI without a static reference) |
 | `--type-check` | Enable type checking via tsgo IPC |
+| `--strict-eval` | Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic body>)` site is reachable. By default such a site is compiled to a deferred runtime error (throws only if reached) and a compile-time notice is printed. Also settable via `perry.eval = "error"` / `perry.strict = true` (package.json or perry.toml). `PERRY_ALLOW_EVAL=1` forces it off. See [Limitations](../language/limitations.md#no-eval-or-dynamic-code). |
 
 ## Environment Variables
 

--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -20,14 +20,52 @@ explicit `typeof` checks and `instanceof`.
 
 ## No eval() or Dynamic Code
 
-Perry compiles to native code ahead of time. Dynamic code execution is not possible:
+Perry compiles to native code ahead of time. It cannot evaluate a code string
+that is only known at runtime. A *constant* code string is the exception —
+`eval("1 + 1")` and `new Function("a", "b", "return a + b")` are compiled to
+real native functions (#1679). Only a body built from runtime data hits this
+limit:
 
-<!-- intentionally-rejects: this snippet documents code Perry refuses to compile -->
-```text
-// Not supported
-eval("console.log('hi')");
-new Function("return 42");
+```ts
+// Constant body → compiled natively (works)
+const add = new Function("a", "b", "return a + b");
+
+// Runtime-built body → cannot be compiled ahead of time
+function run(src: string) { return new Function(`return (${src})`)(); }
 ```
+
+### Default: deferred runtime error + compile-time notice (#5206)
+
+By default a runtime-unknown `eval(...)` / `new Function(<dynamic body>)` site
+does **not** block the build. Perry compiles it to a value that throws a
+descriptive `Error` *only if it is actually reached* (an `eval(...)` throws when
+evaluated; a `new Function(...)` returns a function that throws when called),
+and prints a single end-of-compile notice listing every degraded site:
+
+```text
+notice: 2 runtime-eval site(s) compiled to a deferred runtime error (throws only if reached):
+  - new Function(...)   src/cli/cmd/debug/agent.handler.ts:41
+  - eval(...)           src/foo.ts:12
+  Pass --strict-eval (or set perry.eval = "error") to make these a compile-time error instead.
+```
+
+This lets a single such call in a cold path ship without aborting the whole
+build, while still failing loudly (and catchably) if that path runs.
+
+### Strict mode: refuse at compile time
+
+To make every runtime-unknown site a hard compile-time error instead, opt into
+strict-eval mode by any of:
+
+- the `--strict-eval` flag on `perry compile`,
+- `"perry": { "eval": "error" }` (or `"perry": { "strict": true }`) in
+  `package.json`, or
+- `[perry]` `eval = "error"` (or `strict = true`) in `perry.toml`.
+
+`perry.eval` accepts `"defer"` (the default) or `"error"`. Precedence is
+package.json/perry.toml config → `--strict-eval` (opts in). The legacy
+`PERRY_ALLOW_EVAL=1` environment variable still works: it forces non-strict
+(defer) mode for a one-off build, overriding any strict flag/config.
 
 Test262 rows that only observe parsing or executing a code string remain
 intentional AOT exclusions, not runtime dynamic-code work. This includes the


### PR DESCRIPTION
Closes #5206.

## Problem
Perry refuses `eval(...)` and `new Function(<dynamic body>)` at **compile time**, aborting the whole build — so a single such call in a cold path blocks an entire program.

## New default behavior (non-strict / "defer")
A runtime-unknown `eval`/`new Function` site no longer blocks the build. Instead:

- It is compiled to a binding that **throws a descriptive `Error` at runtime, and only if actually invoked**:
  - `eval(...)` → a throwing IIFE: throws when the eval call evaluates.
  - `new Function(<dynamic body>)` → a function value that throws **when called** (constructing is fine).
  - Message: `eval() cannot run in an ahead-of-time compiled binary (<file>:<line>)` / `new Function() cannot run in an ahead-of-time compiled binary (<file>:<line>)`. It is a real, catchable `Error` (not a silent non-functional placeholder).
- A **visible end-of-compile notice** lists every degraded site (count + kind + `file:line`):

```
notice: 2 runtime-eval site(s) compiled to a deferred runtime error (throws only if reached):
  - eval(...)           src/foo.ts:12
  - new Function(...)   src/cli/cmd/debug/agent.handler.ts:41
  Pass --strict-eval (or set perry.eval = "error") to make these a compile-time error instead.
```

(Yellow/bold on a TTY, plain otherwise; text format only — JSON output stays clean.)

## Strict mode (opt-in) — restores today's hard block
Refuses every such site at compile time → build fails. Available via:
- CLI flag: **`--strict-eval`** on `perry compile`.
- Config: **`perry.eval = "error"`** (default `"defer"`) and/or **`perry.strict = true`** in **package.json** or **perry.toml** (`[perry] eval = "error"` / `strict = true`). `perry.eval` wins over `perry.strict` when both are set.
- **`PERRY_ALLOW_EVAL=1`** kept for back-compat: now a harmless alias for "force non-strict (defer)", overriding any strict flag/config.

Precedence: package.json/perry.toml config → `--strict-eval` (opts in) → `PERRY_ALLOW_EVAL=1` (forces off).

## Implementation
- `crates/perry-hir/src/eval_classifier.rs` — `check_site` now returns `EvalDecision` (`Proceed` | `DeferToRuntimeError(msg)`). Strict mode is a thread-local (`set_eval_strict_mode`); deferred sites collect in a process-global sink (`take_deferred_eval_sites`) so rayon-worker lowering is visible to the driver. The tree-shake deferral sink (#2309) is preserved.
- `crates/perry-hir/src/lower/const_fold_fn.rs` — `synth_deferred_eval_value` builds the throw-on-reach value (IIFE for eval, throwing function for new Function).
- `expr_call/intrinsics.rs`, `expr_call/mod.rs`, `expr_new.rs` — route the defer decision into the synthesized value. Known-template (depd) and const-foldable native-fold paths unchanged.
- `commands/compile/host_config.rs` — reads config + flag + env and calls `set_eval_strict_mode`; `collect_modules.rs` re-applies per worker; `compile.rs` prints the notice near the end of a successful build (`print_deferred_eval_notice`).
- `commands/compile/types.rs` (`strict_eval` field + `--strict-eval` arg), `dev.rs`/`run/mod.rs` (literal `CompileArgs`).

## Tests
- `crates/perry-hir` unit tests (eval_classifier): +5 — deferred message, default-mode defer + site recording, strict refusal, const-foldable always proceeds, PERRY_ALLOW_EVAL forces non-strict. **14/14 pass.**
- `crates/perry/tests/issue_5206_deferred_eval_runtime_error.rs` (new): default-defer compiles + prints notice + runs the JSON path (prints `1`) + forcing the deferred path throws a catchable descriptive Error (no crash, no silent no-op); `--strict-eval` refuses; `perry.eval = "error"` config refuses; `PERRY_ALLOW_EVAL=1` overrides strict config and still prints the notice. **4/4 pass.**
- Verified end-to-end manually with the issue's `parseParams`/`JSON.parse` fixture (default builds + runs `1`; forced eval path throws the descriptive Error; `--strict-eval` and `perry.toml`/`package.json` config fail the build with the refusal). Existing eval fixtures (`test_new_function_const_fold`, `test_gap_eval_as_value`, indirect-eval) still compile with no spurious notices.

Build: `cargo build --release -p perry -p perry-runtime -p perry-stdlib` green.

## Notes for the maintainer
- Per CLAUDE.md external-contributor flow, this PR intentionally does **not** bump `[workspace.package].version`, the `**Current Version:**` line, or `CHANGELOG.md` — please fold those in at merge time. (`Cargo.lock` was left untouched too; a build regenerates it.)
- Docs updated: `docs/src/language/limitations.md` (defer-by-default + strict scheme) and `docs/src/cli/flags.md` (`--strict-eval`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added default “defer” handling for runtime-unknown `eval(...)` and `new Function(...)`, producing a single end-of-compile notice and a runtime throw only if reached.
  * Added `--strict-eval` (and config support) to switch to compile-time refusal; `PERRY_ALLOW_EVAL=1` restores the non-strict defer behavior.
* **Documentation**
  * Expanded CLI flags and limitations docs with the defer vs strict-eval model and precedence.
* **Tests**
  * Added regression coverage for default, strict, and environment override behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->