### PR TITLE
fix(hir): synthesize captures for static computed class methods (#5199)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_captures.rs
+++ b/crates/perry-hir/src/lower_decl/class_captures.rs
@@ -53,7 +53,13 @@ pub fn synthesize_class_captures(
             union_captures.insert(id);
         }
     }
-    for member in computed_members.iter().filter(|member| !member.is_static) {
+    // Both instance AND static computed members (`static [k]() {}` and the
+    // static methods next emits as computed members, e.g. `NextResponse.json`)
+    // can reference enclosing-fn locals — and even when they don't, a
+    // `new <Self>(…)` inside them still needs the constructor's capture args
+    // appended at the call site. Collect from all of them so the union (and
+    // thus the decl-site snapshot) is complete. Refs #5199.
+    for member in computed_members.iter() {
         for id in collect_method_captures(&member.function, &outer_scope_ids, &module_level_ids) {
             union_captures.insert(id);
         }
@@ -345,6 +351,47 @@ pub fn synthesize_class_captures(
         prologue.append(&mut sm.body);
         sm.body = prologue;
         append_self_sites(&mut sm.body, &id_map);
+    }
+
+    // 2c. STATIC computed methods (`static [k]() {}`, and the static methods
+    // bundlers emit as computed members — e.g. next's `NextResponse.json` /
+    // `redirect` / `rewrite` / `next`). These get the SAME decl-site snapshot
+    // rebind as the plain static methods in 2b. Previously they were skipped
+    // entirely: a `new <Self>(…)` inside such a method (`return new
+    // NextResponse(response.body, response)`) never had the constructor's
+    // trailing `__perry_cap_*` args appended, so `inline_constructor_param_values`
+    // mis-split the user args into the capture slots and the constructor read
+    // its captures (here the `INTERNALS` symbol) as the uninitialized/garbage
+    // tail — segfaulting when that garbage was a fetch handle keyed into a
+    // property set. Refs #5199 (next/server NextResponse.json SIGSEGV).
+    for member in computed_members
+        .iter_mut()
+        .filter(|member| member.is_static)
+    {
+        let mut id_map: std::collections::HashMap<LocalId, LocalId> =
+            std::collections::HashMap::new();
+        let mut prologue: Vec<Stmt> = Vec::new();
+        for (index, &outer_id) in captures_vec.iter().enumerate() {
+            let new_id = ctx.fresh_local();
+            id_map.insert(outer_id, new_id);
+            prologue.push(Stmt::Let {
+                id: new_id,
+                name: format!("__perry_cap_{}", outer_id),
+                ty: captured_outer_types
+                    .get(&outer_id)
+                    .cloned()
+                    .unwrap_or(Type::Any),
+                mutable: true,
+                init: Some(Expr::ClassCaptureValue {
+                    class_name: name.to_string(),
+                    index: index as u32,
+                }),
+            });
+        }
+        crate::analysis::remap_local_ids_in_stmts(&mut member.function.body, &id_map);
+        prologue.append(&mut member.function.body);
+        member.function.body = prologue;
+        append_self_sites(&mut member.function.body, &id_map);
     }
 
     // 3. Constructor.


### PR DESCRIPTION
## Summary

Fixes #5199 — `next/server`'s `NextResponse.json(...)` segfaulted (SIGSEGV / exit 139) when `next` is compiled via `perry.compilePackages`.

## Root cause

When a class is nested in a function scope — which is exactly how a CommonJS module body is lowered (Perry wraps it in an IIFE-style closure) — its methods capture enclosing-scope locals through the synthesized `__perry_cap_*` mechanism in `synthesize_class_captures`.

That pass handled instance methods, getters/setters, instance computed members, plain static methods, and the constructor — but **silently skipped static computed members**. Bundler output (and next) emits `static json()` / `redirect` / `rewrite` / `next` as `ClassComputedMember { is_static: true }`, not as entries in `static_methods`.

Because those static methods were skipped:
- their `new <Self>(…)` call sites never had the constructor's trailing `__perry_cap_*` capture arguments appended, and
- they received no decl-site (`ClassCaptureValue`) rebind prologue.

So next's `static json(body, init) { return new NextResponse(Response.json(body, init).body, response) }` constructed `NextResponse` passing only the 2 user args. `inline_constructor_param_values` then mis-split them — `n_caps = caps.min(lowered_args.len())` classified both *user* args as the trailing captures — leaving `body`/`init` undefined and binding the captured `INTERNALS` symbol to `response` (a Web-Fetch handle in the `0x40000` band). The constructor's `this[INTERNALS] = {…}` keyed a property set on that handle-band value; `js_to_property_key` → `js_jsvalue_to_string` dereferenced it as a heap pointer → **SIGSEGV**. (The crash was intermittent because the mis-bound capture slot read whatever uninitialized value happened to be live.)

## Fix

In `synthesize_class_captures`:
1. Collect captures from **all** computed members (static included), so the decl-site snapshot is complete.
2. Add step **2c**: give static computed members the same `ClassCaptureValue` rebind prologue + self-`new` capture-append as plain static methods (step 2b).

## Testing

- The issue repro (`NextResponse.json({ ok: true, n: 42 }, { status: 201 })`) no longer crashes — verified deterministic across 10 runs in both the default auto-optimize and `--no-auto-optimize` builds (previously crashed ~every run / nondeterministically).
- Added local functional checks: a captured `Symbol` used in the constructor of a `Response` subclass built from a static method; a captured string used directly in a static method; a zod-style `static create()` reading a captured enum; multiple static methods each constructing self with distinct captures — all correct and deterministic.
- `cargo test -p perry-hir` and `cargo test -p perry-codegen` pass. (One unrelated pre-existing failure, `every_dispatch_entry_has_manifest_counterpart` / `commander::args` manifest drift, reproduces on the base commit without this change.)

## Notes / out of scope

A separate, pre-existing limitation remains: `Response.json(body, init)` (and `new Response(body, init)`) only honors `init.status` when `init` is a compile-time object literal, so next's repro now prints `created 200` rather than `201`. That dynamic-init status propagation is unrelated to the segfault and is left for a follow-up.

No version bump / changelog entry per request — maintainer to fold in at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class capture computation for computed members: both instance and static computed members now consistently include the relevant outer-scope locals, ensuring captured values are correctly propagated.
  * Static computed members are now lowered with the same capture-handling behavior as other static members, preventing missing or incorrect captures in class decl-site snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->