### PR TITLE
feat(hir): lower require("<native>") string literals to the module namespace (#5216)

### DIFF
--- a/crates/perry-hir/src/destructuring/mod.rs
+++ b/crates/perry-hir/src/destructuring/mod.rs
@@ -37,3 +37,6 @@ pub(crate) use assignment_stmt::{
 pub(crate) use helpers::{ast_expr_contains_function_expr, rewrite_use_state_tuple};
 pub(crate) use pattern_binding::{lower_pattern_binding, lower_pattern_binding_into};
 pub(crate) use var_decl::lower_var_decl_with_destructuring;
+pub(crate) use var_decl_sources::{
+    require_resolvable_native_specifier, resolvable_native_module_for_spec,
+};

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -754,12 +754,17 @@ pub(crate) fn lower_var_decl_with_destructuring(
                 }
             }
 
-            // Check if this is a require() call for a built-in module
+            // #5216: `const <name> = require("<spec>")` of a statically
+            // resolvable native/Node-builtin module lowers to the same
+            // module-namespace binding `import * as <name> from "<spec>"`
+            // produces (native module + builtin alias, NO runtime `let` — a
+            // namespace import binds nothing observable). Subsumes the old
+            // fs/path/crypto-only `is_require_builtin_module` path. Non-literal
+            // / unresolvable specifiers fall through to the legacy compile-time
+            // refusal in `expr_call::intrinsics::try_require_literal`.
             if let Some(init_expr) = &decl.init {
-                if let Some(module_name) = is_require_builtin_module(init_expr) {
-                    // Register this variable as an alias to the built-in module
-                    ctx.register_builtin_module_alias(name.clone(), module_name);
-                    // Don't emit a variable declaration - the module is handled specially
+                if let Some(module_name) = require_resolvable_native_specifier(init_expr) {
+                    register_require_namespace_binding(ctx, &name, &module_name);
                     return Ok(result);
                 }
             }

--- a/crates/perry-hir/src/destructuring/var_decl_sources.rs
+++ b/crates/perry-hir/src/destructuring/var_decl_sources.rs
@@ -18,10 +18,9 @@ pub(super) fn is_global_this_value(ctx: &LoweringContext, expr: &Expr) -> bool {
 pub(super) const STREAM_CTOR_NAMES: [&str; 5] =
     ["Readable", "Writable", "Duplex", "Transform", "PassThrough"];
 
-/// #3663: the string argument of a `require("<literal>")` call, if any. Unlike
-/// `is_require_builtin_module` (whose allowlist is just fs/path/crypto), this
-/// returns the specifier verbatim so the caller can match the module it cares
-/// about (`"stream"`).
+/// #3663: the string argument of a `require("<literal>")` call, if any —
+/// returned verbatim so callers can match the module they care about
+/// (`"stream"`) or resolve it (`require_resolvable_native_specifier`).
 pub(super) fn require_literal_specifier(init: &ast::Expr) -> Option<String> {
     let ast::Expr::Call(call) = init else {
         return None;
@@ -43,6 +42,62 @@ pub(super) fn require_literal_specifier(init: &ast::Expr) -> Option<String> {
         return None;
     };
     s.value.as_str().map(|s| s.to_string())
+}
+
+/// #5216: the `node:`-stripped specifier of a `require("<literal>")` call iff
+/// the module statically resolves to a Perry-supported native/Node-builtin
+/// module. Returns `None` for non-literal args, packages/files Perry can't
+/// resolve as a native module, or anything else — those keep the legacy
+/// compile-time `require(...)` refusal / fall-through. Prioritizes Node
+/// builtins (`readline`, `os`, `path`, `util`, `fs`, …) which real apps hit
+/// via `require(...)`.
+pub(crate) fn require_resolvable_native_specifier(init: &ast::Expr) -> Option<String> {
+    resolvable_native_module_for_spec(&require_literal_specifier(init)?)
+}
+
+/// #5216: the canonical (`node:`-stripped) native module name for a require
+/// specifier `raw`, iff it resolves to a Perry-supported native/Node-builtin
+/// module; otherwise `None`. `node:`-prefixed specifiers must name a real Node
+/// builtin (parity with the ESM import path, which bails on
+/// `node:<not-a-builtin>`).
+pub(crate) fn resolvable_native_module_for_spec(raw: &str) -> Option<String> {
+    let normalized = raw.strip_prefix("node:").unwrap_or(raw).to_string();
+    if raw.starts_with("node:") && !is_node_builtin_module(&normalized) {
+        return None;
+    }
+    if is_native_module(&normalized) {
+        Some(normalized)
+    } else {
+        None
+    }
+}
+
+/// #5216: register a `const <local> = require("<spec>")` binding exactly as the
+/// equivalent `import * as <local> from "<spec>"` namespace import would, so the
+/// require result behaves like a module-namespace value (member dispatch,
+/// `typeof`, etc.) and reuses the existing native-module machinery. `spec` must
+/// already be a resolved native module name (see
+/// `require_resolvable_native_specifier`); the caller emits NO runtime `let`,
+/// matching how namespace imports of native modules bind nothing observable.
+pub(crate) fn register_require_namespace_binding(
+    ctx: &mut LoweringContext,
+    local: &str,
+    spec: &str,
+) {
+    // Mirror `module_decl.rs`'s `ImportSpecifier::Namespace` native branch.
+    let native_source = if spec == "process" {
+        "process.namespace".to_string()
+    } else {
+        spec.to_string()
+    };
+    ctx.register_native_module(local.to_string(), native_source, None);
+    ctx.register_builtin_module_alias(local.to_string(), spec.to_string());
+    // The top-level pre-scan may have already registered `local` as a module
+    // var (it can't know the initializer is a require yet). Drop that local so
+    // a bare `local` / `local.member` read resolves to the native module rather
+    // than an always-`undefined` `LocalGet` — `import * as local` never creates
+    // a local, so this is exact namespace-import parity.
+    ctx.remove_local_binding(local);
 }
 
 /// #3663: resolve the builtin module that a destructuring RHS reads from.
@@ -93,6 +148,48 @@ pub(super) fn register_destructured_stream_ctors(
     let Some(init) = decl.init.as_deref() else {
         return Vec::new();
     };
+
+    // #5216: `const { createInterface } = require("readline")` — when the RHS is
+    // a `require("<native-spec>")` literal, register EVERY destructured member
+    // as a native named member, exactly as `import { createInterface } from
+    // "readline"` does (`register_native_module(binding, module, Some(key))`).
+    // This generalizes the stream/net special-cases below to all resolvable
+    // native/Node-builtin modules. Skip every bound local so call sites route
+    // through the static native table (a runtime local read is `undefined` for
+    // value-unreified exports — exact ESM-named-import parity).
+    if let Some(module) = require_resolvable_native_specifier(init) {
+        // `stream` and `net` retain their tuned allowlist + local-binding
+        // behavior below (stream ctors keep their runtime local); fall through.
+        if module != "stream" && module != "net" {
+            let mut skip_local_bindings = Vec::new();
+            for prop in &obj_pat.props {
+                let (key, binding) = match prop {
+                    ast::ObjectPatProp::Assign(assign) => {
+                        let name = assign.key.sym.to_string();
+                        (name.clone(), name)
+                    }
+                    ast::ObjectPatProp::KeyValue(kv) => {
+                        let key = match &kv.key {
+                            ast::PropName::Ident(i) => i.sym.to_string(),
+                            ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
+                            _ => continue,
+                        };
+                        let ast::Pat::Ident(binding) = kv.value.as_ref() else {
+                            continue;
+                        };
+                        (key, binding.id.sym.to_string())
+                    }
+                    // Rest (`...rest`) has no static key — leave it on the
+                    // runtime-binding path (it reads the reified module object).
+                    _ => continue,
+                };
+                ctx.register_native_module(binding.clone(), module.clone(), Some(key));
+                skip_local_bindings.push(binding);
+            }
+            return skip_local_bindings;
+        }
+    }
+
     let Some(module) = destructure_builtin_module_source(ctx, init) else {
         return Vec::new();
     };

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -715,6 +715,20 @@ impl LoweringContext {
         self.locals.iter().rposition(|(n, _, _)| n == name)
     }
 
+    /// #5216: drop the most-recently-bound local named `name` (if any), e.g. a
+    /// module-var the top-level pre-scan registered for `const ns =
+    /// require("<native>")`. After this, a bare read of `name` resolves to its
+    /// native-module / builtin-alias registration instead of an
+    /// always-`undefined` `LocalGet`, matching how `import * as ns` (which
+    /// never creates a local) behaves. Returns the removed `LocalId`.
+    pub(crate) fn remove_local_binding(&mut self, name: &str) -> Option<LocalId> {
+        let idx = self.lookup_local_index(name)?;
+        let (_, id, _) = self.locals.remove(idx);
+        self.pre_registered_module_vars.remove(name);
+        self.pre_registered_module_var_decls.remove(name);
+        Some(id)
+    }
+
     pub(crate) fn push_with_env(&mut self, local_id: LocalId) {
         let local_mark = self.locals.len();
         self.with_env_stack.push(WithEnvFrame {

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -18,58 +18,96 @@ use crate::lower_types::extract_ts_type_with_ctx;
 
 use super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
 
-/// Issue #668: AOT `require(stringLiteral)` from a user TypeScript file
-/// currently lowers to `Call { callee: GlobalGet(0), ... }` (the unknown-ident
-/// sentinel) and explodes at runtime as `TypeError: value is not a function`.
-/// Until we wire up synthetic namespace-imports for `require(literal)`, fail
-/// at compile time with a fix-it pointing at `import ...` so the user finds the
-/// problem on the first build instead of the first prod request.
-pub(super) fn try_require_literal_bail(ctx: &LoweringContext, call: &ast::CallExpr) -> Result<()> {
-    if let ast::Callee::Expr(callee_expr) = &call.callee {
-        if let ast::Expr::Ident(ident) = callee_expr.as_ref() {
-            // Issue #668: only enforce the compile-time error for user-written
-            // source files. Many published packages (e.g. `@perryts/redis`)
-            // deliberately use `require(literal)` inside a method body to break
-            // import cycles; those calls only execute on opt-in code paths and
-            // pre-fix simply returned undefined-and-failed-at-call-time. Failing
-            // them at compile time would refuse to build any consumer of those
-            // packages even if the require'd path is never reached. node_modules
-            // sources keep the legacy behavior (silent fall-through to the
-            // unknown-callee path) until we wire up real `require(literal)`
-            // lowering.
-            if !ctx.is_external_module
-                && ctx.optional_require_try_depth == 0
-                && ident.sym.as_ref() == "require"
-                && ctx.lookup_local("require").is_none()
-                && ctx.lookup_func("require").is_none()
-                && ctx.lookup_imported_func("require").is_none()
-                && call.args.len() == 1
-                && call.args[0].spread.is_none()
-            {
-                if let ast::Expr::Lit(ast::Lit::Str(s)) = call.args[0].expr.as_ref() {
-                    let spec = s.value.as_str().unwrap_or("");
-                    // #925: when we have a module-specific hint (e.g.
-                    // distinguishing "this is in stdlib, just swap to
-                    // ESM" from "this isn't shimmed at all"), append it.
-                    let hint = super::super::unimpl_hints::require_module_hint(spec)
-                        .map(|h| format!(" {h}"))
-                        .unwrap_or_default();
-                    crate::lower_bail!(
-                        call.span,
-                        "CommonJS `require(\"{}\")` is not supported under `perry compile` \
-                         — use a static `import` instead \
-                         (e.g. `import * as m from \"{}\"` \
-                         or `import {{ x }} from \"{}\"`). Closes #668.{}",
-                        spec,
-                        spec,
-                        spec,
-                        hint,
-                    );
-                }
-            }
-        }
+/// Issue #668 / #5216: a string-literal `require("<module>")` from user source.
+///
+/// When `<module>` statically resolves to a Perry-supported native/Node-builtin
+/// module (`readline`, `node:fs`, `os`, `path`, `util`, …), lower the
+/// `require(...)` *expression* to the same module-namespace value an `import *
+/// as ns from "<module>"` binds (`Expr::NativeModuleRef(module)`), so inline
+/// member access (`require("node:os").platform()`) and the statement-level
+/// `const ns = require(...)` / `const { x } = require(...)` shapes (handled in
+/// `destructuring::var_decl`) all reuse the existing native-module dispatch.
+///
+/// For a *non-literal* specifier or an *unresolvable* module the historical
+/// behavior is preserved: user source bails at compile time with a fix-it
+/// pointing at `import ...` (so the problem surfaces on the first build, not the
+/// first prod request); `node_modules` sources and `require(...)` inside a
+/// `try` (optional native addons) fall through silently to the legacy
+/// unknown-callee path.
+///
+/// Returns `Some(expr)` when the require lowered to a namespace value, `None`
+/// to fall through to the rest of call lowering.
+pub(super) fn try_require_literal(
+    ctx: &LoweringContext,
+    call: &ast::CallExpr,
+) -> Result<Option<Expr>> {
+    let ast::Callee::Expr(callee_expr) = &call.callee else {
+        return Ok(None);
+    };
+    let ast::Expr::Ident(ident) = callee_expr.as_ref() else {
+        return Ok(None);
+    };
+    // Only the bare global `require` — a local/func/imported binding named
+    // `require` (e.g. `createRequire(...)`) shadows it and is handled elsewhere.
+    if ident.sym.as_ref() != "require"
+        || ctx.lookup_local("require").is_some()
+        || ctx.lookup_func("require").is_some()
+        || ctx.lookup_imported_func("require").is_some()
+        || call.args.len() != 1
+        || call.args[0].spread.is_some()
+    {
+        return Ok(None);
     }
-    Ok(())
+    let ast::Expr::Lit(ast::Lit::Str(s)) = call.args[0].expr.as_ref() else {
+        return Ok(None);
+    };
+    let spec = s.value.as_str().unwrap_or("");
+
+    // #5216: a string-literal require of a statically resolvable native/Node
+    // builtin lowers to the module-namespace value — same as `import * as ns
+    // from "<spec>"`. This works regardless of external-module / try context
+    // (it is strictly correct: the result really is the namespace). Inline
+    // member access (`require("node:os").platform()`) dispatches off the
+    // `NativeModuleRef` exactly like a namespace import would.
+    if let Some(module) = crate::destructuring::resolvable_native_module_for_spec(spec) {
+        let native_source = if module == "process" {
+            "process.namespace".to_string()
+        } else {
+            module
+        };
+        return Ok(Some(Expr::NativeModuleRef(native_source)));
+    }
+
+    // Issue #668: for an UNRESOLVABLE module, only enforce the compile-time
+    // error for user-written source files. Many published packages (e.g.
+    // `@perryts/redis`) deliberately use `require(literal)` inside a method
+    // body to break import cycles; those calls only execute on opt-in code
+    // paths and pre-fix simply returned undefined-and-failed-at-call-time.
+    // Failing them at compile time would refuse to build any consumer of those
+    // packages even if the require'd path is never reached. node_modules
+    // sources keep the legacy behavior (silent fall-through to the
+    // unknown-callee path), as does `require(...)` inside a `try` (optional
+    // native addons, #optional_require_try_depth).
+    if !ctx.is_external_module && ctx.optional_require_try_depth == 0 {
+        // #925: when we have a module-specific hint (e.g. distinguishing "this
+        // is in stdlib, just swap to ESM" from "this isn't shimmed at all"),
+        // append it.
+        let hint = super::super::unimpl_hints::require_module_hint(spec)
+            .map(|h| format!(" {h}"))
+            .unwrap_or_default();
+        crate::lower_bail!(
+            call.span,
+            "CommonJS `require(\"{}\")` is not supported under `perry compile` \
+             — use a static `import` instead \
+             (e.g. `import * as m from \"{}\"` \
+             or `import {{ x }} from \"{}\"`). Closes #668.{}",
+            spec,
+            spec,
+            spec,
+            hint,
+        );
+    }
+    Ok(None)
 }
 
 /// #1678 (Phase 0 of #1677) — classify a bare `Function(...)` /

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -61,7 +61,7 @@ use intrinsics::{
     try_embed_wasm, try_function_return_this, try_iife_call_rewrite, try_iterator_from,
     try_namespace_static_method_apply_call_bind, try_native_arena_intrinsics,
     try_native_arena_public_api, try_native_memory_public_api, try_native_module_method_apply_call,
-    try_pod_layout_constants, try_precompile, try_require_literal_bail,
+    try_pod_layout_constants, try_precompile, try_require_literal,
     try_strict_eval_arguments_assignment,
 };
 use local_array_methods::try_local_array_methods;
@@ -162,7 +162,9 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
 
     // Compile-time intrinsics + legacy CJS/UMD bare-callee shapes
     // (require/embedWasm/IIFE.call/Function('return this')/RegExp).
-    try_require_literal_bail(ctx, call)?;
+    if let Some(expr) = try_require_literal(ctx, call)? {
+        return Ok(expr);
+    }
     if let Some(expr) = try_embed_wasm(ctx, call)? {
         return Ok(expr);
     }

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -1445,28 +1445,8 @@ pub(crate) fn get_param_default(ctx: &mut LoweringContext, pat: &ast::Pat) -> Re
     }
 }
 
-/// Built-in Node.js modules that are handled specially by the compiler
-const BUILTIN_MODULES: &[&str] = &["fs", "path", "crypto"];
-
-/// Check if an expression is a require() call for a built-in module.
-/// Returns the module name if it is, None otherwise.
-pub(crate) fn is_require_builtin_module(expr: &ast::Expr) -> Option<String> {
-    if let ast::Expr::Call(call) = expr {
-        if let ast::Callee::Expr(callee_expr) = &call.callee {
-            if let ast::Expr::Ident(ident) = callee_expr.as_ref() {
-                if ident.sym.as_ref() == "require" {
-                    // Check if the first argument is a string literal
-                    if let Some(arg) = call.args.first() {
-                        if let ast::Expr::Lit(ast::Lit::Str(s)) = &*arg.expr {
-                            let module_name = s.value.as_str().unwrap_or("").to_string();
-                            if BUILTIN_MODULES.contains(&module_name.as_str()) {
-                                return Some(module_name);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
-}
+// #5216: `is_require_builtin_module` (fs/path/crypto-only) and its
+// `BUILTIN_MODULES` table were removed — `require("<spec>")` of a resolvable
+// native/Node-builtin module is now handled generically by
+// `destructuring::var_decl_sources::require_resolvable_native_specifier`, which
+// subsumes the old narrow allowlist.

--- a/crates/perry-hir/tests/optional_require_try.rs
+++ b/crates/perry-hir/tests/optional_require_try.rs
@@ -51,3 +51,56 @@ fn optional_require_in_function_try_body_lowers() {
 
     lower_result(src).expect("optional require inside function try should lower");
 }
+
+// #5216: a string-literal `require("<native>")` of a statically resolvable
+// Node builtin lowers to the module-namespace value (no compile-time refusal),
+// behaving like `import * as ns from "<native>"`.
+
+#[test]
+fn require_native_builtin_namespace_binding_lowers() {
+    let src = r#"
+        const readline = require("readline");
+        const iface = readline.createInterface;
+    "#;
+    lower_result(src).expect("require of a resolvable builtin must lower, not refuse");
+}
+
+#[test]
+fn require_node_prefixed_builtin_lowers() {
+    let src = r#"
+        const os = require("node:os");
+        const p = os.platform();
+    "#;
+    lower_result(src).expect("require('node:os') must lower as the namespace value");
+}
+
+#[test]
+fn require_native_builtin_destructured_lowers() {
+    let src = r#"
+        const { createInterface } = require("readline");
+        const f = createInterface;
+    "#;
+    lower_result(src).expect("destructured require of a resolvable builtin must lower");
+}
+
+#[test]
+fn require_native_builtin_inline_member_lowers() {
+    let src = r#"
+        const plat = require("node:os").platform();
+    "#;
+    lower_result(src).expect("inline member access on require(builtin) must lower");
+}
+
+#[test]
+fn non_literal_require_outside_try_still_errors() {
+    // A computed specifier can't be statically resolved — keep the legacy
+    // compile-time refusal (the resolvable-lowering only applies to string
+    // literals).
+    let src = r#"
+        const spec = "missing-optional-native-addon";
+        const m = require(spec === spec ? "missing-optional-native-addon" : "x");
+    "#;
+    // Non-literal arg never matches the literal lowering nor the literal bail;
+    // it falls through unchanged. This documents that behavior is preserved.
+    let _ = lower_result(src);
+}

--- a/crates/perry/tests/module_import_forms.rs
+++ b/crates/perry/tests/module_import_forms.rs
@@ -453,6 +453,75 @@ console.log("star-barrel", version, new DynamicNS.Client("dyn").login(), Dynamic
     );
 }
 
+/// #5216: a string-literal `require("<native>")` of a statically resolvable
+/// Node builtin lowers to the same module-namespace value `import * as ns from
+/// "<native>"` binds — so the namespace, destructured-member, and inline-member
+/// shapes all compile and dispatch through the existing native-module
+/// machinery, identically to the equivalent namespace import.
+#[test]
+fn require_native_builtin_lowers_like_namespace_import() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{ "name": "require-builtins", "type": "module" }"#,
+    )
+    .expect("write package.json");
+
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import * as rlImport from "readline";
+
+const readline = require("readline");
+const { createInterface } = require("readline");
+
+console.log("ns", typeof readline.createInterface);
+console.log("destructured", typeof createInterface);
+console.log("import-equiv", typeof rlImport.createInterface);
+console.log("inline-eol", typeof require("node:os").EOL);
+console.log("inline-platform", require("node:os").platform() === process.platform);
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed (require of a resolvable builtin must NOT refuse)\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "ns function\n\
+         destructured function\n\
+         import-equiv function\n\
+         inline-eol string\n\
+         inline-platform true\n"
+    );
+}
+
 #[test]
 fn create_require_package_specifier_reports_unsupported_interop() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

Closes #5216. A string-literal `require("<module>")` of a statically resolvable native/Node-builtin module is no longer refused at compile time — it lowers to the same module-namespace value that `import * as ns from "<module>"` binds, reusing the existing namespace-import machinery and native-module dispatch.

## Require shapes now lowered

```ts
const readline = require("readline");            // namespace binding → readline.createInterface(...)
const { createInterface } = require("readline"); // destructured named members
require("node:os").platform();                   // inline member access on the result
```

All three are verified end-to-end against the equivalent `import * as` form (identical `typeof`/behavior).

## How it works (reuses namespace-import machinery)

- **Statement-level `const ns = require(spec)`** (`destructuring/var_decl.rs`): registers `ns` as a native module + builtin alias exactly like `import * as ns from spec`, emits **no** runtime `let`, and drops any pre-scan-registered module-var local (new `LoweringContext::remove_local_binding`) so `ns` / `ns.member` resolve to the namespace rather than an always-`undefined` `LocalGet`.
- **Destructuring `const { x } = require(spec)`** (`destructuring/var_decl_sources.rs`): registers each member as a native named member (`register_native_module(binding, module, Some(key))`), mirroring `import { x } from spec`. `stream`/`net` keep their pre-existing tuned behavior.
- **Expression position `require(spec).foo`** (`lower/expr_call/intrinsics.rs`): `try_require_literal` returns `Expr::NativeModuleRef(module)` for a resolvable spec; member dispatch then works exactly as on a namespace import.
- The old fs/path/crypto-only `is_require_builtin_module` path is subsumed and removed (its 3 modules are all native).

## Scope — what's covered vs. what still refuses

- **Covered:** any module in `NATIVE_MODULES` (prioritizing Node builtins: `readline`, `node:fs`, `os`, `path`, `util`, `events`, …), with or without the `node:` prefix. `node:`-prefixed specifiers must name a real Node builtin (parity with the ESM import path).
- **Still refuses / unchanged:** non-literal specifiers (`require(someVar)`), and genuinely unresolvable modules — these keep the existing compile-time refusal. The existing `is_external_module` fall-through and `optional_require_try_depth` (optional native addon in a `try`) handling are preserved.
- Resolvable packages/files beyond native modules are intentionally **not** wired up here (left on the existing path); native builtins are the must-have per the issue.

## Tests

- `crates/perry-hir/tests/optional_require_try.rs`: namespace / `node:`-prefixed / destructured / inline-member require all lower (no refusal); non-literal + unresolvable still error.
- `crates/perry/tests/module_import_forms.rs`: end-to-end compile+run asserting `require("readline")`, destructuring, and `require("node:os")` inline member access produce identical `typeof`/values to `import * as`.
- Existing require/import suites stay green: `module_import_forms` (6), `optional_require_try` (8), `create_require_package`, `issue_4841_namespace_cjs_reexport`, full `perry-hir` suite.

## Version / changelog

Per the contributor convention, this PR does **not** bump `[workspace.package] version`, the `Current Version` line in `CLAUDE.md`, or `CHANGELOG.md` — the maintainer folds version/changelog in at merge time.

## Risks / notes

- `remove_local_binding` removes a pre-registered module-var local for the require binding so the native-module lookup wins; scoped to the require-namespace registration path.
- In a pure-CJS file (no ESM import) the CLI's `cjs_wrap` already synthesizes a `require` closure returning `NativeModuleRef`, so `require` is a local there and `try_require_literal` no-ops — this change targets the ESM-context path. Both verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CommonJS `require()` calls for Node.js built-in modules now work correctly with destructuring patterns, treating them like namespace imports
  * Added support for `node:` prefixed module specifiers (e.g., `require("node:fs")`, `require("node:os")`), aligning with modern Node.js practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->