### PR TITLE
ci(test): add sccache + bound cargo-test timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,11 +110,19 @@ jobs:
   api-docs-drift:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_SIZE: "2G"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Start sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -167,11 +175,35 @@ jobs:
     # don't exercise any platform behavior; they're pure logic +
     # codegen.
     runs-on: ubuntu-latest
+    # Was unbounded (the workflow default of 360 min). This gate legitimately
+    # runs ~45-50 min (per-package serial build+prune loop below, plus the big
+    # stdlib links), and a cold sccache run can be a bit slower — so the bound
+    # is set well ABOVE the real runtime: it exists only to cut a true hang
+    # (e.g. a flaky link SIGBUS retry storm) at ~2 h instead of 6 h, never to
+    # fail a normal slow run.
+    timeout-minutes: 120
+    # sccache (compiler-level cache, shared across ALL branches/jobs via the
+    # GitHub Actions cache backend) on top of Swatinem/rust-cache (target/ +
+    # registry). rust-cache only writes on main (save-if below), so PRs can't
+    # warm it — and any change to the constantly-churning perry-runtime
+    # invalidates the whole downstream target/, whereas sccache still reuses
+    # the unchanged compilation units. CARGO_INCREMENTAL=0 is required: sccache
+    # cannot cache incremental builds. SCCACHE_CACHE_SIZE bounds the on-runner
+    # cache so it doesn't compound this job's known disk pressure (the prune
+    # loop below).
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_SIZE: "2G"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Start sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -314,11 +346,19 @@ jobs:
   compiler-output-regression:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_SIZE: "2G"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Start sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## What

Adds `sccache` (GitHub Actions cache backend) to the three PR-lane jobs that compile Rust — `cargo-test`, `compiler-output-regression`, `api-docs-drift` — and bounds `cargo-test` with a 120-min timeout.

## Why

A normal PR can't warm `Swatinem/rust-cache` (it has `save-if: main`, so only `main` writes new entries), and because the constantly-churning `perry-runtime` is a dependency of 22 crates, any change to it invalidates the whole downstream `target/`. `sccache` caches per compilation unit, so unchanged units still hit across branches and jobs. `cargo-test` was also unbounded (the 360-min workflow default).

## Scope / risk

- Workflow-only; no source changes, no behavior change, no new required checks.
- `CARGO_INCREMENTAL=0` (required by sccache) + `SCCACHE_CACHE_SIZE=2G` to avoid compounding `cargo-test`'s known disk pressure (the per-package serial build + prune loop).
- The 120-min `cargo-test` timeout sits well above the real ~45–50 min runtime — it only fires on a true hang (e.g. a link-retry storm), never on a normal slow run, and cuts such a hang at ~2 h instead of the 6 h default.
- **Validation is the first CI run on this PR:** confirm the sccache hit-rate in the step logs and that `cargo-test` disk stays healthy. Rollback = revert (jobs fall back to direct rustc).
- Note: the GHA cache is capped at ~10 GB/repo and LRU-evicted; if hit-rate degrades we move the sccache backend to S3/R2 in a follow-up.

## Expected impact

`sccache` caches compilation, not linking or test execution, so `cargo-test` (serial build + large stdlib links + test run) improves modestly on warm runs; the larger wins are the other compiling jobs and an upcoming build-once job. This is the first step of a tiered-CI cost-reduction effort (compiler-cache foundation → build-once + fast curated PR gate → merge queue for the heavy sweeps).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to optimize build performance and reliability.
  * Added build caching mechanisms to testing jobs.
  * Set timeout limits for CI jobs to prevent hanging processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->