### PR TITLE
feat(compile): text-asset imports — default export = file contents as string (#5223)

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -91,8 +91,8 @@ pub(crate) use resolve::validate_native_library_manifest_value;
 use resolve::{
     cached_resolve_import, compute_module_prefix, declaration_sidecar_for_resolved_import,
     extract_compile_package_dir, has_perry_native_library, is_declaration_file,
-    is_in_compile_package, is_in_perry_native_package, is_js_file, parse_native_library_manifest,
-    parse_package_specifier, resolve_import,
+    is_in_compile_package, is_in_perry_native_package, is_js_file, is_recognized_text_asset,
+    parse_native_library_manifest, parse_package_specifier, resolve_import,
 };
 use strip_dedup::{
     dedup_native_lib_for_tier3, dedup_runtime_for_tier3, dedup_stdlib_for_tier3,

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -26,7 +26,8 @@ use crate::OutputFormat;
 use super::{
     cached_resolve_import, declaration_sidecar_for_resolved_import, extract_compile_package_dir,
     has_perry_native_library, is_declaration_file, is_in_compile_package,
-    is_in_perry_native_package, is_js_file, parse_cached, parse_native_library_manifest,
+    is_in_perry_native_package, is_js_file, is_recognized_text_asset, parse_cached,
+    parse_native_library_manifest,
     parse_package_specifier, CompilationContext, JsModule, ParseCache,
 };
 
@@ -377,6 +378,11 @@ fn collect_module_one(
     // Check if this file should be handled by JS runtime instead of native compilation
     // This includes: JS files, declaration files (.d.ts), JSON files, or any file in node_modules when JS runtime is enabled
     let is_json = canonical.extension().and_then(|e| e.to_str()) == Some("json");
+    // #5223: text-asset imports (`import s from "./x.txt"`). A recognized text
+    // extension is read verbatim and synthesized into a native module whose
+    // default export is the file contents as a JS string (see the text branch
+    // below, mirroring the JSON-module path). `.wasm` is out of scope.
+    let is_text_asset = is_recognized_text_asset(&canonical);
     let is_in_node_modules = canonical.to_string_lossy().contains("node_modules");
     let is_perry_native = is_in_node_modules && is_in_perry_native_package(&canonical);
     let is_in_compiled_pkg = (is_in_node_modules && is_in_compile_package(&canonical, &ctx.compile_packages))
@@ -528,6 +534,21 @@ fn collect_module_one(
             ));
         }
         format!("export default {};\n", raw_source.trim())
+    } else if is_text_asset {
+        // #5223: text-asset import. The file's contents are exposed verbatim as
+        // the module's default export (a JS string). We never TS-parse the raw
+        // text — instead we synthesize `export default "<escaped-contents>";`.
+        // `serde_json::to_string` of a string produces a valid double-quoted JS
+        // string literal with all required escaping (newlines, quotes, control
+        // chars, unicode), so the contents round-trip byte-for-byte.
+        let literal = serde_json::to_string(&raw_source).map_err(|e| {
+            anyhow!(
+                "Failed to encode text asset {} as a string literal: {}",
+                canonical.display(),
+                e
+            )
+        })?;
+        format!("export default {};\n", literal)
     } else {
         raw_source
     };

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -27,8 +27,8 @@ use super::{
     cached_resolve_import, declaration_sidecar_for_resolved_import, extract_compile_package_dir,
     has_perry_native_library, is_declaration_file, is_in_compile_package,
     is_in_perry_native_package, is_js_file, is_recognized_text_asset, parse_cached,
-    parse_native_library_manifest,
-    parse_package_specifier, CompilationContext, JsModule, ParseCache,
+    parse_native_library_manifest, parse_package_specifier, CompilationContext, JsModule,
+    ParseCache,
 };
 
 mod create_require_transform;

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -880,7 +880,8 @@ pub(super) fn is_recognized_text_asset(path: &Path) -> bool {
     if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
         matches!(
             ext.to_ascii_lowercase().as_str(),
-            "txt" | "sql"
+            "txt"
+                | "sql"
                 | "md"
                 | "html"
                 | "htm"

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -873,6 +873,29 @@ pub(super) fn is_js_file(path: &Path) -> bool {
     }
 }
 
+/// #5223: Recognized text-asset extensions. An import resolving to one of these
+/// is loaded as a string (its raw contents become the module's default export)
+/// rather than TS-parsed. `.wasm` is intentionally excluded (out of scope).
+pub(super) fn is_recognized_text_asset(path: &Path) -> bool {
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        matches!(
+            ext.to_ascii_lowercase().as_str(),
+            "txt" | "sql"
+                | "md"
+                | "html"
+                | "htm"
+                | "css"
+                | "graphql"
+                | "gql"
+                | "glsl"
+                | "vert"
+                | "frag"
+        )
+    } else {
+        false
+    }
+}
+
 /// Determine if a file is a TypeScript declaration file (.d.ts)
 pub(super) fn is_declaration_file(path: &Path) -> bool {
     let path = path.to_string_lossy();

--- a/crates/perry/tests/issue_5223_text_asset_imports.rs
+++ b/crates/perry/tests/issue_5223_text_asset_imports.rs
@@ -11,9 +11,53 @@
 
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::Once;
 
 fn perry_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+        .join("debug")
+}
+
+/// Build `libperry_runtime.a` once so the compiled binaries can link. The CI
+/// `cargo-test` job doesn't pre-build the runtime staticlib, and these tests
+/// link real executables, so they'd otherwise fail with "Could not find
+/// libperry_runtime.a" (mirrors module_import_forms.rs).
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let build = Command::new(cargo)
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime")
+            .output()
+            .expect("run cargo build -p perry-runtime");
+        assert!(
+            build.status.success(),
+            "cargo build -p perry-runtime failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn runtime_dir() -> PathBuf {
+    ensure_runtime_archive();
+    target_debug_dir()
 }
 
 /// Compile `main.ts` in `dir` and return its stdout. Asset files must already
@@ -26,6 +70,7 @@ fn compile_and_run(dir: &std::path::Path) -> String {
     compile
         .current_dir(dir)
         .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
         .arg("compile")
         .arg(&entry)
         .arg("-o")

--- a/crates/perry/tests/issue_5223_text_asset_imports.rs
+++ b/crates/perry/tests/issue_5223_text_asset_imports.rs
@@ -1,0 +1,124 @@
+//! Regression test for #5223: `import X from "./file.txt"` used to make perry
+//! TS-parse the asset and fail (`Failed to parse ...txt: Parse error`).
+//!
+//! Fix: a recognized text-asset extension (`.txt`, `.sql`, `.md`, `.html`,
+//! `.htm`, `.css`, `.graphql`, `.gql`, `.glsl`, `.vert`, `.frag`) is read
+//! verbatim and synthesized into a native module whose default export is the
+//! file contents as a JS string — mirroring the existing JSON-module path. The
+//! trigger is the extension; an explicit `with { type: "text" }` attribute is
+//! parsed and tolerated but is not (yet) itself the trigger. `.wasm` is out of
+//! scope.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `main.ts` in `dir` and return its stdout. Asset files must already
+/// be written into `dir`.
+fn compile_and_run(dir: &std::path::Path) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+
+    let mut compile = Command::new(perry_bin());
+    compile
+        .current_dir(dir)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output);
+    let compile = compile.output().expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed (pre-fix: TS-parse error on .txt)\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn text_and_sql_default_exports_are_exact_string_contents() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let greeting = "Hello, Perry!\nLine two.\n  indented \"quoted\" third\n";
+    let query = "SELECT *\nFROM users\nWHERE id = 1;\n";
+    std::fs::write(dir.path().join("greeting.txt"), greeting).expect("write txt");
+    std::fs::write(dir.path().join("query.sql"), query).expect("write sql");
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+import greeting from "./greeting.txt";
+import query from "./query.sql";
+// JSON.stringify makes the byte-exact contents (newlines, quotes) visible.
+process.stdout.write(JSON.stringify(greeting));
+process.stdout.write("\n");
+process.stdout.write(JSON.stringify(query));
+process.stdout.write("\n");
+"#,
+    )
+    .expect("write main");
+
+    let stdout = compile_and_run(dir.path());
+    let expected = format!(
+        "{}\n{}\n",
+        serde_json::to_string(greeting).unwrap(),
+        serde_json::to_string(query).unwrap()
+    );
+    assert_eq!(stdout, expected, "text asset contents did not round-trip");
+}
+
+#[test]
+fn text_import_with_type_text_attribute_compiles() {
+    // The `with { type: "text" }` attribute is parsed and tolerated; the `.txt`
+    // extension is what drives the text loader.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("note.txt"), "attribute-form works\n").expect("write txt");
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+import note from "./note.txt" with { type: "text" };
+process.stdout.write(note.trim());
+"#,
+    )
+    .expect("write main");
+
+    let stdout = compile_and_run(dir.path());
+    assert_eq!(stdout, "attribute-form works");
+}
+
+#[test]
+fn json_import_still_works() {
+    // No-regression: JSON-module imports continue to parse to a value.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("data.json"),
+        r#"{"name":"perry","count":3}"#,
+    )
+    .expect("write json");
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+import data from "./data.json";
+process.stdout.write(data.name + ":" + data.count);
+"#,
+    )
+    .expect("write main");
+
+    let stdout = compile_and_run(dir.path());
+    assert_eq!(stdout, "perry:3");
+}


### PR DESCRIPTION
Closes #5223.

## Problem
`import X from "./file.txt"` made perry parse the `.txt` as TypeScript and fail (`Failed to parse ...txt: Parse error`). opencode uses this pervasively (36 `.txt`, 44 `.sql`, 1 `.md`).

## Fix
When an import resolves to a recognized **text asset**, the file is read verbatim and synthesized into a native ESM module whose **default export is the file contents as a JS string** — so `import s from "./x.txt"` binds `s` to that string. This mirrors the existing JSON-module path in `collect_modules.rs` (which synthesizes `export default <json>;`); the text path synthesizes `export default "<escaped-contents>";`, using `serde_json::to_string` of the raw string to produce a correctly-escaped JS string literal (newlines, quotes, control chars, unicode) so contents round-trip byte-for-byte.

The text branch short-circuits before the TS parse that previously failed.

## Trigger set
**Extension-based** (the trigger): `.txt`, `.sql`, `.md`, `.html`, `.htm`, `.css`, `.graphql`, `.gql`, `.glsl`, `.vert`, `.frag` (case-insensitive). See `is_recognized_text_asset` in `resolve.rs`.

**`with { type: "text" }`**: parsed and tolerated, but **not** the trigger in v1 — the import attribute lives on the `ImportDecl` and is not accessible at the resolved-path module-processing layer (`collect_module_one` only receives the resolved `canonical` path). The extension drives the loader. A `.txt` import written with `with { type: "text" }` works (test included); a non-text-extension file with only the attribute would not be treated as text. Extension-based alone is acceptable for v1 per the issue.

**`.wasm` is out of scope** (explicitly excluded from the recognized set).

No resolver changes were needed: an explicit `./greeting.txt` that exists resolves as a literal path already.

## Files changed
- `crates/perry/src/commands/compile/resolve.rs` — new `is_recognized_text_asset(path)`.
- `crates/perry/src/commands/compile/collect_modules.rs` — `is_text_asset` detection + text-synthesis branch alongside the JSON branch.
- `crates/perry/src/commands/compile.rs` — re-export `is_recognized_text_asset`.
- `crates/perry/tests/issue_5223_text_asset_imports.rs` — new integration tests.

## Test evidence
New tests (`cargo test --release -p perry --test issue_5223_text_asset_imports`): 3 passed.
- `text_and_sql_default_exports_are_exact_string_contents` — `.txt` + `.sql` with multi-line content + embedded quotes round-trip byte-exact (verified via `JSON.stringify`).
- `text_import_with_type_text_attribute_compiles` — `with { type: "text" }` form compiles and runs.
- `json_import_still_works` — no-regression for JSON imports.

`module_import_forms` (no-regression): 5 passed.

Manual end-to-end: a fixture importing a multi-line `.txt` and a `.sql` printed exact contents (incl. trailing newline) at runtime; `.json` import still works.

## Version / CHANGELOG
Per the contributor convention, this PR does **not** bump `[workspace.package] version`, the `Current Version` line in `CLAUDE.md`, or `CHANGELOG.md` — left for the maintainer to fold in at merge time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for text asset imports in the TypeScript/JavaScript compile flow: `.txt`, `.sql`, `.md`, `.html`, `.css`, `.graphql`, and shader-related extensions can now be imported as string literals (via default export or `with { type: "text" }`).
* **Tests**
  * Added regression coverage for text asset imports, validating correct round-trip string contents at runtime and ensuring existing `.json` imports continue to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->