### PR TITLE
fix(parser): handle Windows verbatim path prefix in extension detection (#5228)

### DIFF
--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -155,8 +155,23 @@ fn parse_source_file_with_typescript_fallback<'a>(
     }
 }
 
+/// Strip the optional import query/hash suffix (`./mod.ts?inline`,
+/// `mod.wasm#section`) from a filename to recover the bare path for extension
+/// detection.
+///
+/// A Windows extended-length ("verbatim") path begins with the literal `\\?\`
+/// prefix — exactly what `std::fs::canonicalize` returns on Windows. The `?` in
+/// that prefix must not be mistaken for the start of a query string, or the
+/// path would be truncated to `\\` and the real `.ts`/`.tsx` extension lost,
+/// making every `.ts` file parse as plain JavaScript (issue #5228). Strip the
+/// verbatim prefix before splitting so only a genuine trailing query is removed.
+fn path_for_extension_check(filename: &str) -> &str {
+    let path = filename.strip_prefix(r"\\?\").unwrap_or(filename);
+    path.split(['?', '#']).next().unwrap_or(path)
+}
+
 fn syntax_for_filename(filename: &str) -> Syntax {
-    let path = filename.split(['?', '#']).next().unwrap_or(filename);
+    let path = path_for_extension_check(filename);
     let lower_path = path.to_ascii_lowercase();
     if lower_path.ends_with(".ts")
         || lower_path.ends_with(".tsx")
@@ -177,7 +192,7 @@ fn syntax_for_filename(filename: &str) -> Syntax {
 }
 
 fn typescript_syntax_for_filename(filename: &str) -> Syntax {
-    let path = filename.split(['?', '#']).next().unwrap_or(filename);
+    let path = path_for_extension_check(filename);
     typescript_syntax_for_path(&path.to_ascii_lowercase())
 }
 
@@ -304,7 +319,7 @@ fn parse_module_or_script(
 }
 
 fn should_parse_as_script(filename: &str, source: &str) -> bool {
-    let path = filename.split(['?', '#']).next().unwrap_or(filename);
+    let path = path_for_extension_check(filename);
     if !(path.ends_with(".js") || path.ends_with(".cjs") || path.ends_with(".jsx")) {
         return false;
     }
@@ -797,6 +812,33 @@ mod tests {
         let source = "const a = 1, b = 2;\nconst c = a / b; const s = \"x\";\nexport default c;\n";
         let module = parse_typescript(source, "math.js").unwrap();
         assert_eq!(module.body.len(), 4);
+    }
+
+    #[test]
+    fn windows_verbatim_path_parses_as_typescript() {
+        // Regression for #5228: on Windows, `std::fs::canonicalize` returns a
+        // verbatim path prefixed with `\\?\`. The `?` must not be treated as the
+        // start of an import query string, or the extension is lost and the file
+        // parses as plain JavaScript — which rejects type annotations whose exact
+        // shape the TS-recovery heuristic doesn't catch (`(x: Uint8Array)`).
+        let cases = [
+            "function f(x: Uint8Array) {}\n",
+            "const f = (x: Uint8Array) => 1;\n",
+            "function f(x: Uint8Array[]) {}\n",
+            "const f = (chunk: Uint8Array | string) => {};\n",
+        ];
+        for src in cases {
+            parse_typescript(src, r"\\?\C:\Users\x\repro.ts")
+                .unwrap_or_else(|e| panic!("verbatim .ts path failed to parse {src:?}: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn path_for_extension_check_strips_verbatim_prefix_and_query() {
+        assert_eq!(path_for_extension_check(r"\\?\C:\a\mod.ts"), r"C:\a\mod.ts");
+        assert_eq!(path_for_extension_check("./mod.ts?inline"), "./mod.ts");
+        assert_eq!(path_for_extension_check("mod.wasm#section"), "mod.wasm");
+        assert_eq!(path_for_extension_check("/home/u/mod.ts"), "/home/u/mod.ts");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #5228 — compiling a `.ts` file on Windows fails with a spurious parse error such as `Parse error: Error { error: (13..14, Expected(",", ":")) }` on a typed parameter like `function f(x: Uint8Array) {}`.

## Root cause

`std::fs::canonicalize` returns extended-length ("verbatim") paths prefixed with `\\?\` on Windows. The compiler passes that canonical path to the parser as the filename, and the parser detects the file's syntax (TS vs JS) by its extension:

```rust
let path = filename.split(['?', '#']).next().unwrap_or(filename);
```

The `?` inside the `\\?\` prefix is mistaken for the start of an import query string (e.g. `./mod.ts?inline`), truncating the path to `\\`. That doesn't end in `.ts`, so the file is parsed as **plain JavaScript**.

The parser does have a TS-recovery fallback, but it only re-parses as TypeScript when the source matches a heuristic (`source_looks_like_typescript`: contains `): `, `: number`, `: string`, `interface `, `type `, `enum `, ` as `, …). That heuristic exactly explains the issue's works/fails table:

- `function f(x: Uint8Array)` → no heuristic match → **fails**
- `function f(): Uint8Array` → contains `): ` → recovered → works
- `function f(x: number[])` → contains `: number` → recovered → works
- `interface Foo {…}; function f(x: Foo)` → contains `interface ` → recovered → works
- `(chunk: Uint8Array | string) =>` → no match → **fails**

This is Windows-only (it depends on the `\\?\` prefix), which is why it doesn't reproduce on macOS/Linux.

## Fix

Strip the leading `\\?\` verbatim prefix before splitting on the query/hash suffix, via a shared `path_for_extension_check` helper applied to all three extension-detection sites (`syntax_for_filename`, `typescript_syntax_for_filename`, `should_parse_as_script`).

## Testing

- New `windows_verbatim_path_parses_as_typescript` regression test reproduces the exact failure with a `\\?\C:\...\repro.ts` filename (the four failing forms from the issue) and asserts they now parse.
- New `path_for_extension_check_strips_verbatim_prefix_and_query` unit test covers the prefix-stripping plus genuine `?inline` / `#section` suffixes and POSIX paths.
- Full `cargo test -p perry-parser` passes (26 tests).
- The issue's repro `.ts` still compiles and runs correctly on the normal (non-verbatim) path.

No version bump / changelog entry per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed parsing of Windows verbatim paths to correctly identify file types for TypeScript and script detection.

## Tests
* Added regression tests to verify correct handling of Windows paths and path normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->