### PR TITLE
fix(compile): honor "exports" over legacy "module"/"main" (#5237)

### DIFF
--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -501,11 +501,25 @@ pub(super) fn resolve_package_entry(package_dir: &Path, subpath: Option<&str>) -
         // files the build didn't load, so `@swc/helpers`' `import` target
         // (`esm/*.js`) is absent while the `default` target (`cjs/*.cjs`)
         // is present — Node resolves the latter at require time.
-        for entry in resolve_exports_candidates(exports, &export_key) {
-            let entry_path = package_dir.join(&entry);
+        let candidates = resolve_exports_candidates(exports, &export_key);
+        for entry in &candidates {
+            let entry_path = package_dir.join(entry);
             if entry_path.exists() {
                 return Some(entry_path);
             }
+        }
+        // Per Node's resolution algorithm, an applicable `"exports"` entry takes
+        // precedence over the legacy `"module"`/`"main"` fields (#5237). When
+        // `exports` defines this specifier, it is authoritative: never fall
+        // back to `module`/`main` for it, even if no candidate was found on
+        // disk above. Falling through mis-resolved e.g. `y18n` (a `yargs` dep)
+        // to its `"module"` target `./build/lib/index.js` — a named-export-only
+        // file with no `default` — instead of the `exports.import` target
+        // `./index.mjs`. We only return early when `exports` actually produced
+        // a candidate; an empty list means `exports` doesn't cover this
+        // specifier, so the legacy-field fallback below still applies.
+        if let Some(first) = candidates.first() {
+            return resolve_with_extensions(&package_dir.join(first));
         }
     }
 
@@ -608,6 +622,10 @@ fn resolve_exports_with_conditions(
 ) -> Option<String> {
     match exports {
         serde_json::Value::String(s) => Some(s.clone()),
+        // Node "exports" fallback arrays: return the first element that resolves.
+        serde_json::Value::Array(items) => items
+            .iter()
+            .find_map(|item| resolve_exports_with_conditions(item, subpath, conditions)),
         serde_json::Value::Object(map) => {
             // Try the specific subpath first
             if let Some(entry) = map.get(subpath) {
@@ -706,6 +724,16 @@ pub(super) fn resolve_exports_candidates(
             serde_json::Value::String(s) => {
                 if !out.contains(s) {
                     out.push(s.clone());
+                }
+            }
+            // Node "exports" fallback arrays (e.g. y18n's
+            // `[{ "import": "./index.mjs", "require": "./build/index.cjs" }, "./build/index.cjs"]`).
+            // Each element is tried in order; we gather every resolution so the
+            // disk-existence walk in `resolve_package_entry` can pick the first
+            // that is present.
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    collect(item, subpath, out);
                 }
             }
             serde_json::Value::Object(map) => {

--- a/crates/perry/src/commands/compile/resolve/tests.rs
+++ b/crates/perry/src/commands/compile/resolve/tests.rs
@@ -1788,4 +1788,121 @@ mod exports_candidates_tests {
             vec!["./esm/foo.js".to_string(), "./cjs/foo.cjs".to_string()]
         );
     }
+
+    /// #5237 — a Node "exports" *fallback array* (an ordered list of targets,
+    /// here a conditions-object followed by a plain string) must expand to its
+    /// inner targets. Before the fix the array form produced no candidates at
+    /// all, so the resolver fell through to the legacy `"module"` field.
+    #[test]
+    fn array_form_candidates_expand() {
+        let exports: serde_json::Value = serde_json::json!({
+            ".": [
+                { "import": "./index.mjs", "require": "./build/index.cjs" },
+                "./build/index.cjs"
+            ]
+        });
+        let candidates = resolve_exports_candidates(&exports, ".");
+        assert_eq!(
+            candidates,
+            vec!["./index.mjs".to_string(), "./build/index.cjs".to_string()]
+        );
+    }
+}
+
+/// #5237 — `"exports"`, when it covers the requested specifier, takes
+/// precedence over the legacy `"module"`/`"main"` fields (matching Node's
+/// resolution algorithm). The live regression was `y18n` (a `yargs` dep):
+/// perry picked its `"module": "./build/lib/index.js"` (a named-export-only
+/// file with no `default`) instead of the `exports.import` target
+/// `./index.mjs`, breaking `import y18n from "y18n"`.
+mod exports_over_module_precedence_tests {
+    use super::super::resolve_package_entry;
+
+    /// Lay out a package mirroring the #5237 minimal repro: `module` points at
+    /// a built `build/lib/index.js`, but an array-form `exports` points its
+    /// `import` condition at `./index.mjs`.
+    fn write_y18n_like_package(root: &std::path::Path) -> std::path::PathBuf {
+        let pkg = root.join("node_modules/y18n-like");
+        std::fs::create_dir_all(pkg.join("build/lib")).unwrap();
+        std::fs::write(
+            pkg.join("package.json"),
+            r#"{
+                "name": "y18n-like",
+                "version": "1.0.0",
+                "type": "module",
+                "main": "./build/index.cjs",
+                "module": "./build/lib/index.js",
+                "exports": {
+                    ".": [
+                        { "import": "./index.mjs", "require": "./build/index.cjs" },
+                        "./build/index.cjs"
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(pkg.join("index.mjs"), "export default 1;\n").unwrap();
+        std::fs::write(pkg.join("build/lib/index.js"), "export function x(){}\n").unwrap();
+        std::fs::write(pkg.join("build/index.cjs"), "module.exports = 1;\n").unwrap();
+        pkg
+    }
+
+    #[test]
+    fn exports_import_wins_over_module_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = write_y18n_like_package(dir.path());
+
+        let resolved = resolve_package_entry(&pkg, None).expect("resolve entry");
+        assert_eq!(
+            resolved,
+            pkg.join("index.mjs"),
+            "exports.import (./index.mjs) must win over module (./build/lib/index.js)"
+        );
+    }
+
+    /// Regression: a package with `module` but NO `exports` still resolves via
+    /// the `module` field (and `main`), exactly as before.
+    #[test]
+    fn module_field_still_resolves_without_exports() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("node_modules/legacy-mod");
+        std::fs::create_dir_all(pkg.join("dist")).unwrap();
+        std::fs::write(
+            pkg.join("package.json"),
+            r#"{
+                "name": "legacy-mod",
+                "type": "module",
+                "main": "./dist/index.cjs",
+                "module": "./dist/index.mjs"
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(pkg.join("dist/index.mjs"), "export default 1;\n").unwrap();
+        std::fs::write(pkg.join("dist/index.cjs"), "module.exports = 1;\n").unwrap();
+
+        let resolved = resolve_package_entry(&pkg, None).expect("resolve entry");
+        assert_eq!(resolved, pkg.join("dist/index.mjs"));
+    }
+
+    /// Regression: a normal object-form `exports`-only package (no `module`)
+    /// resolves through `exports` unchanged.
+    #[test]
+    fn plain_object_exports_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("node_modules/modern-pkg");
+        std::fs::create_dir_all(pkg.join("dist")).unwrap();
+        std::fs::write(
+            pkg.join("package.json"),
+            r#"{
+                "name": "modern-pkg",
+                "type": "module",
+                "exports": { ".": { "import": "./dist/index.js" } }
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(pkg.join("dist/index.js"), "export default 1;\n").unwrap();
+
+        let resolved = resolve_package_entry(&pkg, None).expect("resolve entry");
+        assert_eq!(resolved, pkg.join("dist/index.js"));
+    }
 }


### PR DESCRIPTION
Fixes #5237.

## Root cause
perry honored the legacy `"module"` field with **higher** precedence than the `"exports"` map. Per Node's package resolution algorithm, an applicable `"exports"` entry takes precedence over `"main"`/`"module"`.

The concrete trigger was Node **"exports" fallback arrays** (an ordered list of targets, e.g. y18n's `[{ "import": "./index.mjs", "require": "./build/index.cjs" }, "./build/index.cjs"]`). Neither `resolve_exports_with_conditions` nor `resolve_exports_candidates` handled the JSON `Array` shape, so they returned **no candidate** — and `resolve_package_entry` then fell through to `"module"`.

For `y18n` (a `yargs` dep) this picked `"module": "./build/lib/index.js"` (a named-export-only file, no `default`) instead of the `exports.import` target `./index.mjs` (which has `export default`), producing:

```
The requested package 'y18n' does not provide an export named 'default'
```

This blocked native compilation of npm dependency trees (`perry.compilePackages: ["*"]`).

## Fix
- **Array (fallback-list) form** is now handled in both `resolve_exports_with_conditions` (first element that resolves) and `resolve_exports_candidates` (gather every element's targets in priority order).
- **Precedence**: in `resolve_package_entry`, when `"exports"` produces any candidate for the requested specifier, exports is authoritative — resolution no longer falls back to `"module"`/`"main"` for that specifier. The legacy-field fallback still applies only when there is **no** applicable `"exports"` entry (regression-guarded).

Applies to **both** resolution paths: `resolve_package_source_entry` (the compilePackages-native path) routes through `resolve_package_entry`, so it is fixed by the same change, while its intentional real-`src/*.ts` preference is preserved.

## Tests
Added in `crates/perry/src/commands/compile/resolve/tests.rs`:
- `array_form_candidates_expand` — array exports expand to inner targets.
- `exports_import_wins_over_module_field` — the #5237 minimal repro: `exports.import` (`./index.mjs`) wins over `module` (`./build/lib/index.js`).
- `module_field_still_resolves_without_exports` — regression: `module`/`main` still used when no `exports`.
- `plain_object_exports_unchanged` — regression: object-form `exports` unchanged.

`cargo test --release -p perry resolve` — all pass, no regressions.

## Evidence
**Minimal `bar` repro** (from the issue): before → `does not provide an export named 'default' … Resolved package entry: …/bar/build/lib/index.js`. After → compiles and prints `bar:x`.

**Real-world yargs** (`npm i yargs`, `compilePackages:["*"]`, `import yargs from "yargs"`): the `y18n` "does not provide an export named 'default'" error is **gone**. Compilation now proceeds through y18n into `yargs-parser` and hits a **different, unrelated** error (a linker undefined-symbol in `yargs-parser/build/lib/yargs-parser-types.js` `DefaultValuesForTypeKey`) — expected next wall, out of scope for #5237.

## Version / changelog
No version, `CHANGELOG.md`, or `**Current Version:**` edits — maintainer folds those in at merge time per CLAUDE.md.

## Risks
Low. Change is confined to the resolver. The precedence early-return only fires when `exports` yields a candidate for the requested specifier; packages without `exports` (or whose `exports` doesn't cover the specifier) keep the prior `module`/`main`/index fallback path. `Cargo.lock` untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced module and package resolution to correctly handle Node/webpack-style export configurations that include fallback arrays.
  * Improved export precedence logic to ensure exports definitions take proper priority over legacy module and main field definitions.

* **Tests**
  * Added regression tests to verify correct resolution behavior for export fallback arrays and appropriate module field precedence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->