### PR TITLE
fix(compile): define exported binding for uninitialized `export var` (#5239)

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -1211,6 +1211,64 @@ pub(crate) fn lower_module_decl(
                                     module.exported_objects.push(name.clone());
                                 }
                             }
+                        } else {
+                            // `export var X;` / `export let X;` with NO
+                            // initializer. The canonical TypeScript-emitted
+                            // enum/namespace IIFE pattern relies on this:
+                            //
+                            //   export var Color;
+                            //   (function (Color) { Color["RED"]="red"; … })
+                            //       (Color || (Color = {}));
+                            //
+                            // declares the binding uninitialized, then a
+                            // following module-scope statement assigns it
+                            // (`Color = {}` plus member writes). Pre-fix this
+                            // arm did nothing: no `Stmt::Let` (so no backing
+                            // module global / value-getter), no `Export` entry,
+                            // and no `exported_objects` entry. The binding then
+                            // wasn't in any consumer's `imported_vars`, so a
+                            // consumer reading `Color` as a value fell through
+                            // to the closure-wrapper path and referenced an
+                            // undefined `__perry_wrap_perry_fn_<src>__Color`
+                            // symbol → "Undefined symbols … Linking failed"
+                            // (#5239). This pattern appears in nearly every
+                            // TypeScript-compiled JS package, so it broadly
+                            // gated native compilation of real npm trees.
+                            //
+                            // Fix: treat it like a hoisted `var` declared
+                            // `undefined` — emit a `Stmt::Let { init: None }`
+                            // backed by the (already pre-registered) local id,
+                            // and register the export. The later module-scope
+                            // assignments (`Color = {}`, `Color["RED"]="red"`)
+                            // already lower to `LocalSet`/`PutValueSet` on the
+                            // same id, so they flow into the exported binding
+                            // and importers observe the populated object.
+                            let id = if ctx.pre_registered_module_vars.remove(&name) {
+                                ctx.pre_registered_module_var_decls.remove(&name);
+                                let id = ctx.lookup_local(&name).unwrap();
+                                if let Some((_, _, existing_ty)) =
+                                    ctx.locals.iter_mut().rev().find(|(n, _, _)| n == &name)
+                                {
+                                    *existing_ty = ty.clone();
+                                }
+                                id
+                            } else if let Some(id) = ctx.lookup_local(&name) {
+                                id
+                            } else {
+                                ctx.define_local(name.clone(), ty.clone())
+                            };
+                            module.init.push(Stmt::Let {
+                                id,
+                                name: name.clone(),
+                                ty,
+                                mutable: true,
+                                init: None,
+                            });
+                            module.exports.push(Export::Named {
+                                local: name.clone(),
+                                exported: name.clone(),
+                            });
+                            module.exported_objects.push(name.clone());
                         }
                     }
                 }

--- a/crates/perry-hir/tests/export_var_uninitialized_lowering.rs
+++ b/crates/perry-hir/tests/export_var_uninitialized_lowering.rs
@@ -1,0 +1,108 @@
+// Regression test for #5239: an uninitialized exported `var` (the canonical
+// TypeScript-emitted enum/namespace IIFE pattern) must register an exported
+// binding so consumers route through its value-getter instead of an undefined
+// closure-wrapper symbol (`__perry_wrap_perry_fn_<src>__<Name>`).
+
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Export, Module, Stmt};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_result(src: &str) -> Module {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = parse_typescript_with_cache(&src, "export_var_uninit.ts", &mut cache)
+                .expect("parse should succeed");
+            lower_module(&parsed.module, "test", "export_var_uninit.ts")
+                .expect("lowering should succeed")
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+fn is_named_export(module: &Module, name: &str) -> bool {
+    module.exports.iter().any(|export| {
+        matches!(export, Export::Named { local, exported }
+            if local == name && exported == name)
+    })
+}
+
+#[test]
+fn uninitialized_export_var_registers_exported_binding() {
+    // The exact TypeScript enum IIFE shape from #5239.
+    let module = lower_result(
+        r#"
+        export var Color;
+        (function (Color) {
+            Color["RED"] = "red";
+            Color["BLUE"] = "blue";
+        })(Color || (Color = {}));
+        "#,
+    );
+
+    assert!(
+        is_named_export(&module, "Color"),
+        "uninitialized `export var Color;` must be a named export: {:?}",
+        module.exports
+    );
+    assert!(
+        module.exported_objects.contains(&"Color".to_string()),
+        "uninitialized `export var Color;` must get an export global so the \
+         value-getter is emitted (otherwise the consumer references an \
+         undefined wrapper symbol): {:?}",
+        module.exported_objects
+    );
+
+    // A backing `Stmt::Let` (declared `undefined`) must precede the IIFE
+    // assignment in module init — without it codegen never emits the global
+    // that backs the value-getter.
+    let let_idx = module.init.iter().position(|s| {
+        matches!(s, Stmt::Let { name, init, .. } if name == "Color" && init.is_none())
+    });
+    assert!(
+        let_idx.is_some(),
+        "expected a hoisted `Stmt::Let {{ name: \"Color\", init: None }}` in module init: {:?}",
+        module.init
+    );
+}
+
+#[test]
+fn uninitialized_export_var_assigned_later_still_exports() {
+    // General case (no IIFE): declare uninitialized, assign at module scope.
+    let module = lower_result(
+        r#"
+        export var x;
+        x = 41;
+        x = x + 1;
+        export let z;
+        z = 5;
+        "#,
+    );
+
+    for name in ["x", "z"] {
+        assert!(
+            is_named_export(&module, name),
+            "`export var/let {name};` (assigned later) must be a named export: {:?}",
+            module.exports
+        );
+        assert!(
+            module.exported_objects.contains(&name.to_string()),
+            "`export var/let {name};` must get an export global: {:?}",
+            module.exported_objects
+        );
+    }
+}
+
+#[test]
+fn initialized_export_var_still_exports() {
+    // Regression: the initialized form must keep working (it hits the
+    // `Some(init)` branch, not the new `else`).
+    let module = lower_result("export var initialized = 1;");
+    assert!(is_named_export(&module, "initialized"));
+    assert!(module
+        .exported_objects
+        .contains(&"initialized".to_string()));
+}


### PR DESCRIPTION
Fixes #5239.

## Root cause
When perry natively compiles a JS module (via `perry.compilePackages`) using the standard TypeScript-emitted enum/namespace IIFE pattern:

```js
export var DefaultValuesForTypeKey;
(function (DefaultValuesForTypeKey) { DefaultValuesForTypeKey["BOOLEAN"] = "boolean"; /*...*/ })(DefaultValuesForTypeKey || (DefaultValuesForTypeKey = {}));
```

the link failed with `Undefined symbols: "___perry_wrap_perry_fn_<src>__<Name>" … Linking failed`.

The exported `Decl::Var` arm in HIR lowering (`crates/perry-hir/src/lower/module_decl.rs`) only handled the `if let Some(init)` case. An **uninitialized** exported `var`/`let` (declared, then assigned later at module scope — here via the IIFE) fell through with no `else`:

- no `Stmt::Let` in `module.init` → no backing module global → no value-getter `perry_fn_<src>__<Name>`,
- no `Export::Named` entry,
- no `exported_objects` entry.

So the binding was absent from every consumer's `imported_vars`. A consumer reading the binding **as a value** (`ExternFuncRef` value-form in `expr/dyn_extern_i18n.rs`) then took the closure-wrapper branch instead of the var-getter branch and referenced `__perry_wrap_perry_fn_<src>__<Name>`, which the producer never defines for a var. This pattern is in nearly every TypeScript-compiled JS package, so it broadly gated native compilation of real npm dependency trees.

## Fix
Add the missing `else` branch: treat an uninitialized exported var like a hoisted `var` declared `undefined`. Emit `Stmt::Let { init: None }` backed by the already-pre-registered local id, and register the export (`Export::Named` + `exported_objects`). The subsequent module-scope assignments (`X = {}`, `X["RED"]="red"`) already lower to `LocalSet`/`PutValueSet` on the **same** local id, so they flow into the exported binding and importers observe the populated object. Not a syntactic special-case of the enum pattern — it handles the general "exported module `var` declared uninitialized, assigned later" case.

## Test evidence
New `crates/perry-hir/tests/export_var_uninitialized_lowering.rs` (3 tests, all green): enum IIFE shape, general declare-then-assign (`export var x; x=41; x=x+1; export const y=()=>x`), and the still-working initialized form.

End-to-end (matching Node):
- `baz` repro (`export var Color; (function(Color){Color["RED"]="red";Color["BLUE"]="blue";})(Color||(Color={})); export function name(c){...}`), consumer `import { Color, name } from "baz"; console.log(name(Color.RED), Color.BLUE)` → **before:** `Undefined symbols … __Color … Linking failed`; **after:** prints `color:red blue`.
- general case: importer of `export var x; x=41; x=x+1; export const y=()=>x; export let z; z=5;` → prints `42 42 5`.
- regressions: `export var x = 1;` / `export const` / `export function` still work; a TS `enum` in TypeScript source still compiles (`red blue 1 2`).

`cargo test -p perry-hir` and `-p perry-codegen` fully green. (`perry` crate: the only reds were `issue_4903_listen_callback_deferred` — a known parallel port-binding race; both pass with `--test-threads=1` and the change is HIR-only, unrelated to http listen timing.)

## yargs real-world check
`yargs@18` (whose `yargs-parser` ships `export var DefaultValuesForTypeKey; (function(...){...})(...)`), compiled with `perry.compilePackages:["*"]`:
- **Before:** `Undefined symbols: "___perry_wrap_perry_fn_…__DefaultValuesForTypeKey" … Linking failed`.
- **After:** that undefined-symbol error is **gone**. The next (unrelated) error is a CJS/ESM default-export interop gap: `The requested package 'y18n' does not provide an export named 'default' (imported as 'y18n' in yargs/lib/platform-shims/esm.mjs)`. Out of scope for this PR.

## Notes / risks
- Per the contributor-PR convention, this branch does **not** touch `Cargo.toml` version, the `CLAUDE.md` Current Version line, or `CHANGELOG.md` — the maintainer folds in the version bump + changelog entry at merge.
- Risk is low and contained: the change only adds an `else` arm to a previously-no-op branch (uninitialized exported var), reusing the exact id-reuse logic the initialized arm already uses. The initialized `Some(init)` path is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation of exported variables declared without initializers in modules

* **Tests**
  * Added regression tests to verify proper handling of uninitialized exported variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->