### PR TITLE
fix(runtime): off-heap Buffer/typed-array GcHeader-probe segfault on await (#5226)

### DIFF
--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -326,7 +326,10 @@ fn test_array_clone_prefers_buffer_registry_before_gc_header_probe() {
     for _ in 0..4 {
         let fake_prev = crate::buffer::buffer_alloc(8);
         let buf = crate::buffer::buffer_alloc(4);
+        // Each slab slot is `GC_HEADER_SIZE` (the #5226 sentinel that precedes
+        // every buffer pointer) plus the 8-byte-aligned header+capacity.
         let expected_next = fake_prev as usize
+            + crate::gc::GC_HEADER_SIZE
             + ((std::mem::size_of::<crate::buffer::BufferHeader>() + 8 + 7) & !7);
         if buf as usize == expected_next {
             adjacent = Some((fake_prev, buf));

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -228,11 +228,20 @@ fn buffer_alloc_small(capacity: u32) -> *mut BufferHeader {
     let needed = std::mem::size_of::<BufferHeader>() + capacity as usize;
     // Round up to 8-byte boundary so every header is naturally aligned.
     let aligned = (needed + 7) & !7;
+    // #5226: reserve an extra `GC_HEADER_SIZE` per buffer for a zeroed sentinel
+    // that precedes the returned pointer (see the `write_bytes` below). Buffers
+    // are off-GC-heap with no real `GcHeader`, but the runtime is littered with
+    // `*(ptr - GC_HEADER_SIZE)` obj_type probes (Promise / Date / Array / class
+    // dispatch). Without the sentinel the back-read crosses outside the slab —
+    // into the unmapped page before a freshly mapped block for the first buffer
+    // — and segfaults. A `0` sentinel matches no `GC_TYPE_*`, so every probe
+    // cleanly classifies the buffer as "not my type".
+    let slot = crate::gc::GC_HEADER_SIZE + aligned;
 
     SMALL_BUF_SLAB.with(|slab_ref| {
         let mut slab = slab_ref.borrow_mut();
 
-        if slab.current + aligned > slab.end {
+        if slab.current + slot > slab.end {
             // Current block exhausted (or first call): allocate a fresh slab.
             let layout = Layout::from_size_align(SLAB_CAPACITY, 8).unwrap();
             let block = unsafe { alloc(layout) };
@@ -249,8 +258,15 @@ fn buffer_alloc_small(capacity: u32) -> *mut BufferHeader {
             slab.end = block_end;
         }
 
-        let ptr = slab.current as *mut BufferHeader;
-        slab.current += aligned;
+        // Zero the 8-byte sentinel, then hand out the pointer just past it. The
+        // sentinel always lands inside the slab block, so `ptr - GC_HEADER_SIZE`
+        // is a mapped read; `is_registered_buffer`'s slab-range check still
+        // covers `ptr` (it stays within `[block_start, block_end)`).
+        let ptr = unsafe {
+            std::ptr::write_bytes(slab.current as *mut u8, 0, crate::gc::GC_HEADER_SIZE);
+            (slab.current + crate::gc::GC_HEADER_SIZE) as *mut BufferHeader
+        };
+        slab.current += slot;
 
         unsafe {
             (*ptr).length = 0;
@@ -538,13 +554,21 @@ pub fn buffer_alloc(capacity: u32) -> *mut BufferHeader {
         register_buffer(ptr);
         return ptr;
     }
-    let layout = buffer_layout(capacity as usize);
+    // #5226: mid-size buffers are raw-`alloc`'d off the GC heap. Reserve a
+    // zeroed `GC_HEADER_SIZE` sentinel before the returned pointer so the
+    // runtime's `*(ptr - GC_HEADER_SIZE)` obj_type probes read a mapped `0`
+    // (matching no `GC_TYPE_*`) instead of faulting at a region boundary.
+    let inner = buffer_layout(capacity as usize);
+    let layout =
+        Layout::from_size_align(crate::gc::GC_HEADER_SIZE + inner.size(), 8).unwrap();
     unsafe {
-        let ptr = alloc(layout) as *mut BufferHeader;
-        if ptr.is_null() {
+        let raw = alloc(layout);
+        if raw.is_null() {
             // #5067 — surface a catchable `RangeError` instead of aborting.
             throw_buffer_alloc_failed();
         }
+        std::ptr::write_bytes(raw, 0, crate::gc::GC_HEADER_SIZE);
+        let ptr = raw.add(crate::gc::GC_HEADER_SIZE) as *mut BufferHeader;
         (*ptr).length = 0;
         (*ptr).capacity = capacity;
         register_buffer(ptr);

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -170,6 +170,29 @@ mod tests {
         }
     }
 
+    // #5226: every off-heap buffer (incl. `new Uint8Array(n)`, which lowers to
+    // a slab Buffer) must reserve a zeroed 8-byte sentinel before its pointer,
+    // so the runtime's many `*(ptr - GC_HEADER_SIZE)` type probes read a mapped
+    // `0` (matching no GC_TYPE) instead of crossing into the unmapped page
+    // before a freshly mapped slab/block and segfaulting. The sentinel must be
+    // `0`, never a real type tag.
+    #[test]
+    fn small_buffer_reserves_zeroed_header_sentinel() {
+        for cap in [0u32, 1, 3, 16, 255] {
+            let buf = buffer_alloc(cap);
+            assert!(is_registered_buffer(buf as usize), "cap={cap}");
+            unsafe {
+                let sentinel = *(buf as *const u8).sub(crate::gc::GC_HEADER_SIZE);
+                assert_eq!(sentinel, 0, "cap={cap}: header sentinel must be zero");
+            }
+            // The header-probing classifiers must read the sentinel and answer
+            // "not my type" without faulting.
+            let v = crate::value::js_nanbox_pointer(buf as i64);
+            assert_eq!(crate::promise::js_value_is_promise(v), 0, "cap={cap}");
+            assert!(!crate::date::is_date_cell_addr(buf as usize), "cap={cap}");
+        }
+    }
+
     #[test]
     fn test_buffer_symbol_iterator_uses_values_iterator() {
         let buf = buffer_alloc(3);

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -71,6 +71,15 @@ pub fn is_date_cell_addr(addr: usize) -> bool {
     // untyped `request.headers.get()` dispatch routed its receiver through
     // `is_date_value` here and segfaulted. `try_read_gc_header` rejects the
     // whole band before the deref, so this is an exact heap-pointer check.
+    // #5226: small typed arrays and `Buffer`s are raw-`alloc`'d off the GC
+    // heap with NO `GcHeader` prefix. `try_read_gc_header` only rejects the
+    // handle band and (on some platforms) low addresses, so on Windows these
+    // pass its magnitude check and the `addr - GC_HEADER_SIZE` back-read below
+    // faults when the block sits at the start of a freshly mapped region.
+    // Reject them via the side tables first — they are never `DateCell`s.
+    if crate::typedarray::is_offheap_sidetable_alloc(addr) {
+        return false;
+    }
     unsafe {
         let header = match crate::value::addr_class::try_read_gc_header(addr) {
             Some(header) => header,

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -4730,6 +4730,14 @@ pub fn is_class_object_ptr(ptr: *const u8) -> bool {
     if crate::value::addr_class::is_handle_band(ptr as usize) {
         return false;
     }
+    // #5226: small typed arrays and `Buffer`s (incl. `new Uint8Array(n)`, which
+    // lowers to a slab-allocated Buffer) are off-GC-heap with no GcHeader, so
+    // the `ptr - GC_HEADER_SIZE` back-read below faults when the block sits at
+    // the start of a freshly mapped region. They are never class objects —
+    // reject via the side tables first (no back-read).
+    if crate::typedarray::is_offheap_sidetable_alloc(ptr as usize) {
+        return false;
+    }
     unsafe {
         let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         (*gc_header).obj_type == crate::gc::GC_TYPE_OBJECT

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -204,6 +204,11 @@ pub extern "C" fn js_value_is_promise(value: f64) -> i32 {
     if crate::value::addr_class::is_handle_band(ptr_usize) {
         return 0;
     }
+    // Off-GC-heap header-less allocations (small typed arrays / buffers) are
+    // never Promises and must not be header-probed (#5226).
+    if crate::typedarray::is_offheap_sidetable_alloc(ptr_usize) {
+        return 0;
+    }
     unsafe {
         let gc_header =
             (ptr_usize as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
@@ -720,6 +725,11 @@ fn is_native_array_value(value: f64) -> bool {
     if crate::value::addr_class::is_handle_band(ptr) {
         return false;
     }
+    // Off-GC-heap header-less typed arrays / buffers are not Arrays and must
+    // not be header-probed (#5226).
+    if crate::typedarray::is_offheap_sidetable_alloc(ptr) {
+        return false;
+    }
     unsafe {
         let header = (ptr - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         matches!(
@@ -1222,7 +1232,11 @@ pub extern "C" fn js_assimilate_thenable(value: f64) -> f64 {
     }
 
     // Side-table-tracked heap types don't have ClassVTable entries; skip.
-    if crate::buffer::is_registered_buffer(raw_ptr)
+    // Off-GC-heap header-less allocations (small typed arrays / buffers) come
+    // first: they have no GcHeader, so they must be excluded before any probe
+    // that back-reads `raw_ptr - GC_HEADER_SIZE` — including the
+    // `is_date_cell_addr` call in this very chain (#5226).
+    if crate::typedarray::is_offheap_sidetable_alloc(raw_ptr)
         || crate::set::is_registered_set(raw_ptr)
         || crate::map::is_registered_map(raw_ptr)
         || crate::symbol::is_registered_symbol(raw_ptr)
@@ -1708,6 +1722,43 @@ mod tests {
     fn promise_probe_rejects_pointer_tagged_native_handles() {
         let fetch_family_handle = js_nanbox_pointer(0x40001);
         assert_eq!(js_value_is_promise(fetch_family_handle), 0);
+    }
+
+    // #5226: small typed arrays / buffers are system-`alloc`'d off the GC heap
+    // with NO 8-byte GcHeader prefix and are tracked only in side tables. The
+    // type-dispatch probes (`js_value_is_promise`, `is_date_cell_addr`, …) must
+    // recognize them via the side table and must NOT back-read
+    // `ptr - GC_HEADER_SIZE` — a read on a block at the start of a freshly
+    // mapped region crosses into the (unmapped) preceding page and segfaults.
+    // Reproduce that worst case with a guarded mapping: without the side-table
+    // skip these probes SIGSEGV; with it, they classify the block correctly.
+    #[cfg(unix)]
+    #[test]
+    fn type_probes_skip_offheap_typed_array_with_unmapped_preceding_page() {
+        unsafe {
+            let page = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+            let total = page * 2;
+            let base = libc::mmap(
+                std::ptr::null_mut(),
+                total,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            );
+            assert_ne!(base, libc::MAP_FAILED);
+            // Guard the first page so any `ptr - GC_HEADER_SIZE` back-read faults.
+            assert_eq!(libc::mprotect(base, page, libc::PROT_NONE), 0);
+            let ta = (base as *mut u8).add(page) as *const crate::typedarray::TypedArrayHeader;
+            crate::typedarray::register_typed_array(ta, 0);
+
+            let value = js_nanbox_pointer(ta as i64);
+            assert_eq!(js_value_is_promise(value), 0);
+            assert!(!crate::date::is_date_cell_addr(ta as usize));
+
+            crate::typedarray::unregister_typed_array(ta);
+            assert_eq!(libc::munmap(base, total), 0);
+        }
     }
 
     extern "C" fn test_thenable_resolve_twice(

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -175,6 +175,19 @@ pub fn lookup_typed_array_kind(addr: usize) -> Option<u8> {
     TYPED_ARRAY_REGISTRY.with(|r| r.borrow().get(&addr).copied())
 }
 
+/// True for off-GC-heap, header-less allocations — small typed arrays and
+/// `Buffer`s, both raw-`alloc`'d with NO 8-byte `GcHeader` prefix and tracked
+/// only in side tables. The runtime has many type probes of the form
+/// `*(ptr - GC_HEADER_SIZE)` (Promise/Date/Array obj_type checks); each MUST
+/// skip these allocations before that back-read, because reading the
+/// non-existent header crosses outside the block and segfaults when it sits at
+/// the start of a freshly mapped region (#5226). Detection is via the side
+/// tables only — never dereferences `addr`.
+#[inline]
+pub fn is_offheap_sidetable_alloc(addr: usize) -> bool {
+    lookup_typed_array_kind(addr).is_some() || crate::buffer::is_registered_buffer(addr)
+}
+
 pub(crate) fn mark_typed_array_shared_backing(ptr: *const TypedArrayHeader) {
     TYPED_ARRAY_SHARED_BACKING.with(|r| {
         r.borrow_mut().insert(ptr as usize);

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -341,7 +341,12 @@ pub unsafe extern "C" fn js_dynamic_object_get_property(
     // work). Call-form `p.then(cb)` is lowered separately by codegen; this
     // covers the value-read path the generic getter previously dropped to
     // `undefined`.
-    {
+    //
+    // #5226: skip for off-GC-heap header-less allocations (small typed arrays
+    // — buffers were already handled above): they have no `GcHeader`, so the
+    // `ptr - GC_HEADER_SIZE` back-read faults at region boundaries. They are
+    // never Promises; fall through to the normal property handling.
+    if !crate::typedarray::is_offheap_sidetable_alloc(ptr as usize) {
         let gc_header = (ptr as usize - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         // Typed arrays are `std::alloc`-backed with no GcHeader, so the byte at
         // `ptr - 8` can read as `GC_TYPE_PROMISE` (5) by coincidence; exclude


### PR DESCRIPTION
Fixes #5226.

## Symptom

Resolving an awaited Promise with an empty `Uint8Array` segfaults:

```ts
function collectBytes(): Promise<Uint8Array> {
  return new Promise((resolve) => {
    process.stdin.on('end', () => resolve(new Uint8Array(0)));
    process.stdin.resume();
  });
}
async function main() {
  const bytes = await collectBytes();
  console.log('len=' + bytes.length);
}
main();
```

```
$ printf '' | ./repro.exe
Segmentation fault
```

## Root cause

`new Uint8Array(n)` lowers to a **slab-allocated `Buffer`**, which — like small
typed arrays — lives **off the GC heap with no 8-byte `GcHeader`** preceding the
returned pointer. The runtime, however, is full of type probes shaped like
`*(ptr - GC_HEADER_SIZE)` (Promise / Date / Array / class-object dispatch) that
assume every heap pointer is header-prefixed. Many of these are on the
`resolve` → `await` path (`js_value_is_promise`, thenable assimilation, the
`typeof`/property-access classifiers, …).

When such a headerless block lands at the **start of a freshly mapped region**
(the first buffer in a fresh 256 KiB slab, or a mid-size raw `alloc`), the
`ptr - 8` back-read crosses into the **unmapped preceding page** and segfaults.
Because it depends on where the allocator places the block, the crash is
heap-layout-dependent — structurally identical programs crash in one build and
not another, which matches the "works for empty string, not for `Uint8Array`"
report.

## Fix

1. **Sentinel at the allocator (primary fix).** Reserve a zeroed
   `GC_HEADER_SIZE` byte run immediately before every off-heap buffer pointer
   (both the slab and the mid-size `alloc` path). `ptr - GC_HEADER_SIZE` is now
   always a **mapped read of `0`**, which matches no `GC_TYPE_*`, so every probe
   in the runtime classifies the block as "not my type" without faulting. The
   sentinel is deliberately `0` (never a real type tag) so type-specific *arena*
   dispatch never mistakes the off-heap block for a managed object.
   `is_registered_buffer`'s slab-range check still covers the returned pointer.

2. **Registry guards (defense-in-depth).** Guard the type-classifier
   chokepoints reached on the resolve/await path
   (`js_value_is_promise`, `is_native_array_value`, `js_assimilate_thenable`,
   `is_date_cell_addr`, `is_class_object_ptr`, `js_dynamic_object_get_property`)
   with a new `is_offheap_sidetable_alloc` helper, so they detect registered
   typed arrays/buffers via the side tables **before** any header back-read.
   This mirrors the existing pattern already used in `dyn_index` / `to_string`,
   and also covers small typed arrays (a separate allocator) at those points.

## Testing

- The issue's reproduction (and several layout-variant minimizations) now exit
  `0` and print `len=0`, deterministically across repeated runs — previously
  they segfaulted depending on layout.
- New unit tests:
  - `buffer::tests::small_buffer_reserves_zeroed_header_sentinel` — asserts the
    zeroed sentinel and that the Promise/Date probes classify a buffer without
    faulting.
  - `combinators::tests::type_probes_skip_offheap_typed_array_with_unmapped_preceding_page`
    (`#[cfg(unix)]`) — registers a typed array at the head of a guard-paged
    mapping (preceding page `PROT_NONE`); SIGSEGVs without the guard, passes
    with it.
  - Updated the slab-packing math in
    `array::tests::test_array_clone_prefers_buffer_registry_before_gc_header_probe`
    for the new per-buffer sentinel.
- `cargo test -p perry-runtime` buffer / array / gc / typedarray / promise
  suites pass.

No version bump or `CHANGELOG.md` entry per request — happy for the maintainer
to fold those in at merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory safety issues in buffer allocation by ensuring proper header management for off-heap allocations.
  * Improved type classification to safely handle typed array and buffer allocations without triggering invalid memory reads.
  * Prevented potential faults in runtime type-probing paths for promises, dates, and class objects.

* **Tests**
  * Added regression tests to verify buffer allocation safety and type classification correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->