### PR TITLE
feat(compile): defer recognized-but-unimplemented APIs to throw-on-reach by default (#5245)

### DIFF
--- a/crates/perry-hir/src/eval_classifier.rs
+++ b/crates/perry-hir/src/eval_classifier.rs
@@ -307,6 +307,16 @@ pub fn eval_override_enabled() -> bool {
     env_flag("PERRY_ALLOW_EVAL")
 }
 
+/// Whether `PERRY_ALLOW_UNIMPLEMENTED` is set — forces non-strict (defer) mode
+/// for recognized-but-unimplemented node/stdlib APIs (#5245), overriding any
+/// strict flag/config for a one-off build. This is the back-compat alias of the
+/// pre-#5245 `#463` escape hatch: it used to skip the gate entirely (silent
+/// fall-through); it now force-defers the site to a throw-on-reach runtime error
+/// AND records it in the end-of-compile notice, like the default path.
+pub fn unimplemented_override_enabled() -> bool {
+    std::env::var_os("PERRY_ALLOW_UNIMPLEMENTED").is_some()
+}
+
 thread_local! {
     /// `true` when strict-eval mode is active for the current compile: a
     /// runtime-unknown (`bucket-3`) site is a hard compile-time refusal.
@@ -314,6 +324,14 @@ thread_local! {
     /// Set once at compile entry (and re-applied per rayon worker) via
     /// [`set_eval_strict_mode`].
     static EVAL_STRICT_MODE: RefCell<bool> = const { RefCell::new(false) };
+
+    /// `true` when strict-unimplemented mode is active for the current compile
+    /// (#5245): a reference to a recognized-but-unimplemented node/stdlib API is
+    /// a hard compile-time refusal (the historical `#463` behavior). `false`
+    /// (the default) defers it to a throw-on-reach runtime error and records the
+    /// site for the end-of-compile notice. Set once at compile entry (and
+    /// re-applied per rayon worker) via [`set_unimplemented_strict_mode`].
+    static UNIMPL_STRICT_MODE: RefCell<bool> = const { RefCell::new(false) };
 }
 
 /// Sites that were deferred to a runtime error during this compile (#5206).
@@ -350,6 +368,95 @@ pub fn set_eval_strict_mode(strict: bool) {
 /// Whether strict-eval mode is active for the current compile.
 pub fn eval_strict_mode() -> bool {
     EVAL_STRICT_MODE.with(|s| *s.borrow())
+}
+
+/// Set strict-unimplemented mode for the current compile thread (#5245).
+/// `true` restores the historical hard `#463` compile-time refusal of a
+/// recognized-but-unimplemented node/stdlib API; `false` (the default) defers
+/// it to a throw-on-reach runtime error. Called once at compile entry.
+/// `PERRY_ALLOW_UNIMPLEMENTED` always wins (forces `false`).
+pub fn set_unimplemented_strict_mode(strict: bool) {
+    UNIMPL_STRICT_MODE.with(|s| *s.borrow_mut() = strict && !unimplemented_override_enabled());
+}
+
+/// Whether strict-unimplemented mode is active for the current compile.
+pub fn unimplemented_strict_mode() -> bool {
+    UNIMPL_STRICT_MODE.with(|s| *s.borrow())
+}
+
+/// `kind` tag used for unimplemented-API sites in the shared end-of-compile
+/// notice (#5245). Kept as a constant so the notice and any tests agree.
+pub const UNIMPLEMENTED_API_KIND: &str = "unimplemented API";
+
+/// What a lowering site should do with a recognized-but-unimplemented
+/// node/stdlib API reference (#5245). Mirrors [`EvalDecision`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnimplementedDecision {
+    /// Strict-unimplemented mode: fail the build with the `#463` refusal.
+    Refuse,
+    /// Default (defer) mode, the `PERRY_ALLOW_UNIMPLEMENTED` override, or a
+    /// tree-shake deferral: compile the reference to a value that throws this
+    /// descriptive message only if it is actually reached.
+    DeferToRuntimeError(String),
+}
+
+/// Resolve a `file:line` location from a source path + byte offset, the same
+/// way [`EvalClassification::location`] does (line omitted when unknown). Used
+/// by the unimplemented-API gate sites (#5245), which don't build a full
+/// [`EvalClassification`].
+pub fn location_string(source_file_path: &str, byte_offset: u32) -> String {
+    match crate::ir::current_module_line_at(byte_offset) {
+        Some(line) if line != 0 => format!("{source_file_path}:{line}"),
+        _ => source_file_path.to_string(),
+    }
+}
+
+/// Build the descriptive message a *deferred* unimplemented-API site throws at
+/// runtime when it is actually reached (#5245). `api` is the dotted display
+/// label (e.g. `process.binding`); `location` is `file:line`.
+pub fn unimplemented_runtime_error_message(api: &str, location: &str) -> String {
+    format!("{api} is not implemented in Perry (ahead-of-time) ({location})")
+}
+
+/// The single decision point every unimplemented-API gate (#463 sites in
+/// `expr_member` / `expr_call`) funnels through (#5245).
+///
+/// - **strict-unimplemented** mode → [`UnimplementedDecision::Refuse`]: the
+///   caller raises the historical `#463` compile-time error.
+/// - **default** (defer) mode, the `PERRY_ALLOW_UNIMPLEMENTED` override, or an
+///   armed tree-shake deferral sink → records the site for the end-of-compile
+///   notice (except the tree-shake path, which records its own deferral) and
+///   returns [`UnimplementedDecision::DeferToRuntimeError`] with the message the
+///   caller should compile to a throw-on-reach value.
+///
+/// `refusal_message` is the full `#463` message (used for the strict error and
+/// the tree-shake deferral sink). `api` is the dotted API label and `location`
+/// is `file:line` — both feed the deferred runtime message and the notice.
+/// `byte_offset` is the site's `span.lo.0` (for the tree-shake sink).
+pub fn check_unimplemented_api(
+    refusal_message: &str,
+    api: &str,
+    location: &str,
+    byte_offset: u32,
+) -> UnimplementedDecision {
+    let runtime_msg = unimplemented_runtime_error_message(api, location);
+
+    // Tree-shake deferral (mirrors `check_site`): when the sink is armed for a
+    // node_modules module lowered under tree-shaking, record the refusal and
+    // compile to the throw-on-reach value — the module may be pruned. The
+    // driver re-raises a surviving deferral (strict) or surfaces it (defer).
+    if crate::deferral::try_defer_refusal(refusal_message.to_string(), byte_offset) {
+        return UnimplementedDecision::DeferToRuntimeError(runtime_msg);
+    }
+
+    if unimplemented_strict_mode() {
+        return UnimplementedDecision::Refuse;
+    }
+
+    // Default (defer) mode or the `PERRY_ALLOW_UNIMPLEMENTED` override: record
+    // the site for the visible end-of-compile notice and defer.
+    record_deferred_aot_site(UNIMPLEMENTED_API_KIND, location);
+    UnimplementedDecision::DeferToRuntimeError(runtime_msg)
 }
 
 /// Record a deferred ahead-of-time-unsupported site for the end-of-compile
@@ -690,6 +797,67 @@ mod tests {
         assert!(
             !eval_strict_mode(),
             "PERRY_ALLOW_EVAL must force non-strict"
+        );
+    }
+
+    // ---- #5245: unimplemented-API gate decision ----
+
+    /// Default (non-strict) mode: an unimplemented-API site defers to a
+    /// throw-on-reach value AND is recorded for the end-of-compile notice with
+    /// the `"unimplemented API"` kind.
+    #[test]
+    fn unimplemented_defers_by_default_and_records_site() {
+        // PERRY_ALLOW_UNIMPLEMENTED forces defer regardless — fine for this
+        // (defer) assertion either way, so no skip needed.
+        set_unimplemented_strict_mode(false);
+        // Unique location so this test's recorded site is identifiable even if
+        // sibling tests push to the process-global sink concurrently.
+        let loc = "/app/unimpl_defers_fixture.ts:42";
+        let decision =
+            check_unimplemented_api("`process.binding` is not implemented (#463)", "process.binding", loc, 0);
+        match decision {
+            UnimplementedDecision::DeferToRuntimeError(msg) => {
+                assert!(msg.contains("process.binding"), "msg: {msg}");
+                assert!(msg.contains("ahead-of-time"), "msg: {msg}");
+                assert!(msg.contains(loc), "msg: {msg}");
+            }
+            other => panic!("expected defer, got {other:?}"),
+        }
+        let sites = take_deferred_eval_sites();
+        let mine: Vec<_> = sites.iter().filter(|s| s.location == loc).collect();
+        assert_eq!(mine.len(), 1, "exactly one recorded site for {loc}");
+        assert_eq!(mine[0].kind, UNIMPLEMENTED_API_KIND);
+    }
+
+    /// Strict-unimplemented mode: an unimplemented-API site is refused (the
+    /// caller raises the hard `#463` error) and records no notice site.
+    #[test]
+    fn unimplemented_refuses_in_strict_mode() {
+        // PERRY_ALLOW_UNIMPLEMENTED would force defer; only assert when unset.
+        if unimplemented_override_enabled() {
+            return;
+        }
+        set_unimplemented_strict_mode(true);
+        let loc = "/app/unimpl_strict_fixture.ts:7";
+        let decision = check_unimplemented_api("refusal", "fs.bogus", loc, 0);
+        assert_eq!(decision, UnimplementedDecision::Refuse);
+        assert!(
+            !take_deferred_eval_sites().iter().any(|s| s.location == loc),
+            "strict mode must not record a notice site"
+        );
+        set_unimplemented_strict_mode(false); // restore for sibling tests
+    }
+
+    /// `PERRY_ALLOW_UNIMPLEMENTED` forces non-strict even when strict is set.
+    #[test]
+    fn allow_unimplemented_env_forces_non_strict() {
+        if !unimplemented_override_enabled() {
+            return;
+        }
+        set_unimplemented_strict_mode(true);
+        assert!(
+            !unimplemented_strict_mode(),
+            "PERRY_ALLOW_UNIMPLEMENTED must force non-strict"
         );
     }
 }

--- a/crates/perry-hir/src/lib.rs
+++ b/crates/perry-hir/src/lib.rs
@@ -40,9 +40,10 @@ pub use dynamic_import::{
 pub use egress::{audit_module_egress, EgressRefusalReason, EgressViolation};
 pub use enums::fix_imported_enums;
 pub use eval_classifier::{
-    classify as classify_eval_surface, record_deferred_aot_site, set_eval_strict_mode,
+    check_unimplemented_api, classify as classify_eval_surface, location_string,
+    record_deferred_aot_site, set_eval_strict_mode, set_unimplemented_strict_mode,
     take_deferred_eval_sites, DeferredEvalSite, EvalBucket, EvalClassification, EvalDecision,
-    EvalSurface,
+    EvalSurface, UnimplementedDecision, UNIMPLEMENTED_API_KIND,
 };
 pub use ir::*;
 pub use js_transform::{

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -85,6 +85,23 @@ fn synth_throwing_iife(
     lowered
 }
 
+/// #5245: synthesize a throw-on-reach value for a recognized-but-unimplemented
+/// node/stdlib API reference under the default (defer) mode. The whole gated
+/// expression (the member read `process.binding`, or the call callee) is
+/// replaced by a throwing IIFE: the descriptive `Error` is thrown the moment
+/// control reaches the reference — which a guarding `try/catch` then swallows,
+/// exactly as a real package (e.g. `safer-buffer`) expects. `message` is
+/// [`crate::eval_classifier::unimplemented_runtime_error_message`].
+pub(crate) fn synth_deferred_throw_value(
+    ctx: &mut LoweringContext,
+    message: &str,
+    span: swc_common::Span,
+) -> Result<Expr> {
+    let lit = json_string_literal(message);
+    let throw_stmt = format!("throw new Error({lit});");
+    synth_throwing_iife(ctx, &throw_stmt, span)
+}
+
 /// #5206: synthesize the throw-on-reach value for a runtime-unknown `eval`
 /// / `Function` / `new Function` site under the default (defer) mode. The
 /// `message` is the descriptive

--- a/crates/perry-hir/src/lower/expr_call/module_class_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_class_static.rs
@@ -89,10 +89,7 @@ pub(super) fn try_module_class_static(
                         // `NativeMethodCall` without recursing through
                         // lower_member. Without this, `crypto.subtle.encrypt(...)`
                         // built cleanly and silently returned undefined.
-                        let allow_unimplemented =
-                            std::env::var_os("PERRY_ALLOW_UNIMPLEMENTED").is_some();
                         if !is_sub_namespace
-                            && !allow_unimplemented
                             && perry_api_manifest::module_has_any_entries(module_name)
                             && perry_api_manifest::module_has_symbol(module_name, &class_name)
                                 .is_none()
@@ -110,10 +107,24 @@ pub(super) fn try_module_class_static(
                                  or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
                                 module_name, class_name, hint,
                             );
-                            // #2309: defer under tree-shaking; re-raised only
-                            // if the module survives pruning.
-                            if !crate::try_defer_refusal(msg.clone(), outer_member.span.lo.0) {
-                                crate::lower_bail!(outer_member.span, "{}", msg);
+                            // #5245: default → throw-on-reach + notice; strict →
+                            // hard #463 refusal. #2309 tree-shake handled inside.
+                            let api = format!("{module_name}.{class_name}");
+                            let location = crate::eval_classifier::location_string(
+                                &ctx.source_file_path,
+                                outer_member.span.lo.0,
+                            );
+                            match crate::check_unimplemented_api(&msg, &api, &location, outer_member.span.lo.0) {
+                                crate::UnimplementedDecision::Refuse => {
+                                    crate::lower_bail!(outer_member.span, "{}", msg);
+                                }
+                                crate::UnimplementedDecision::DeferToRuntimeError(runtime_msg) => {
+                                    return Ok(Ok(super::super::const_fold_fn::synth_deferred_throw_value(
+                                        ctx,
+                                        &runtime_msg,
+                                        outer_member.span,
+                                    )?));
+                                }
                             }
                         }
                         if !is_sub_namespace {

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -443,19 +443,32 @@ pub(super) fn try_native_module_methods(
                             return Ok(Ok(Expr::ProcessHrtime(prior)));
                         }
                         _ => {
-                            let allow_unimplemented =
-                                std::env::var_os("PERRY_ALLOW_UNIMPLEMENTED").is_some();
-                            if !allow_unimplemented {
-                                let hint = unimpl_hints::module_member_hint("process", method_name)
-                                    .map(|h| format!(" {h}"))
-                                    .unwrap_or_default();
-                                let msg = format!(
-                                    "`process.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
-                                     or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
-                                    method_name, hint,
-                                );
-                                if !crate::try_defer_refusal(msg.clone(), member.span.lo.0) {
+                            let hint = unimpl_hints::module_member_hint("process", method_name)
+                                .map(|h| format!(" {h}"))
+                                .unwrap_or_default();
+                            let msg = format!(
+                                "`process.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
+                                 or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
+                                method_name, hint,
+                            );
+                            // #5245: default → throw-on-reach + notice; strict
+                            // (`perry.strict` / `--strict-unimplemented`) → hard
+                            // #463 refusal. Tree-shake deferral handled inside.
+                            let api = format!("process.{method_name}");
+                            let location = crate::eval_classifier::location_string(
+                                &ctx.source_file_path,
+                                member.span.lo.0,
+                            );
+                            match crate::check_unimplemented_api(&msg, &api, &location, member.span.lo.0) {
+                                crate::UnimplementedDecision::Refuse => {
                                     crate::lower_bail!(member.span, "{}", msg);
+                                }
+                                crate::UnimplementedDecision::DeferToRuntimeError(runtime_msg) => {
+                                    return Ok(Ok(super::super::const_fold_fn::synth_deferred_throw_value(
+                                        ctx,
+                                        &runtime_msg,
+                                        member.span,
+                                    )?));
                                 }
                             }
                         }
@@ -1508,12 +1521,9 @@ pub(super) fn try_native_module_methods(
                         // wording, different escape hatch, harder for users to
                         // recognize as the same class of mistake. Mirrors the
                         // 3-deep gate above for `mod.X.Y()`.
-                        let allow_unimplemented =
-                            std::env::var_os("PERRY_ALLOW_UNIMPLEMENTED").is_some();
                         let manifest_entry =
                             perry_api_manifest::module_has_symbol(module_name, &method_name);
-                        if !allow_unimplemented
-                            && perry_api_manifest::module_has_any_entries(module_name)
+                        if perry_api_manifest::module_has_any_entries(module_name)
                             && manifest_entry.is_none()
                         {
                             // #925: this is the gate that fires
@@ -1529,10 +1539,24 @@ pub(super) fn try_native_module_methods(
                                  or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
                                 module_name, method_name, hint,
                             );
-                            // #2309: defer under tree-shaking; re-raised only
-                            // if the module survives pruning.
-                            if !crate::try_defer_refusal(msg.clone(), member.span.lo.0) {
-                                crate::lower_bail!(member.span, "{}", msg);
+                            // #5245: default → throw-on-reach + notice; strict →
+                            // hard #463 refusal. #2309 tree-shake handled inside.
+                            let api = format!("{module_name}.{method_name}");
+                            let location = crate::eval_classifier::location_string(
+                                &ctx.source_file_path,
+                                member.span.lo.0,
+                            );
+                            match crate::check_unimplemented_api(&msg, &api, &location, member.span.lo.0) {
+                                crate::UnimplementedDecision::Refuse => {
+                                    crate::lower_bail!(member.span, "{}", msg);
+                                }
+                                crate::UnimplementedDecision::DeferToRuntimeError(runtime_msg) => {
+                                    return Ok(Ok(super::super::const_fold_fn::synth_deferred_throw_value(
+                                        ctx,
+                                        &runtime_msg,
+                                        member.span,
+                                    )?));
+                                }
                             }
                         }
                         if let Some(entry) = manifest_entry {

--- a/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
+++ b/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
@@ -84,7 +84,7 @@ pub(super) fn try_process_memory_usage_rss(
 /// generic mod.X.Y() arm so the strict-API gate (#463) doesn't
 /// reject `subtle` (which is a sub-namespace, not a class).
 pub(super) fn try_web_crypto_subtle(
-    ctx: &LoweringContext,
+    ctx: &mut LoweringContext,
     expr: &ast::Expr,
     args: Vec<Expr>,
 ) -> Result<Result<Expr, Vec<Expr>>> {
@@ -262,20 +262,37 @@ pub(super) fn try_web_crypto_subtle(
                                         // (RSA-PSS / ECDSA / RSA-OAEP),
                                         // deriveKey are still out of
                                         // scope per the issue.
-                                        let allow_unimplemented =
-                                            std::env::var_os("PERRY_ALLOW_UNIMPLEMENTED").is_some();
-                                        if !allow_unimplemented {
-                                            let msg = format!(
-                                                "`crypto.subtle.{}` is not implemented in Perry — supported subtle methods are digest, importKey, sign, verify, encrypt, decrypt, generateKey, wrapKey, unwrapKey (HMAC + SHA-1/256/384/512; encrypt/decrypt/generateKey/wrapKey currently AES-GCM/AES-KW only). \
-                                                 See `perry --print-api-manifest` and #561, or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore.",
-                                                method,
-                                            );
-                                            // #2309: defer under tree-shaking.
-                                            if !crate::try_defer_refusal(
-                                                msg.clone(),
-                                                outer_member.span.lo.0,
-                                            ) {
+                                        let msg = format!(
+                                            "`crypto.subtle.{}` is not implemented in Perry — supported subtle methods are digest, importKey, sign, verify, encrypt, decrypt, generateKey, wrapKey, unwrapKey (HMAC + SHA-1/256/384/512; encrypt/decrypt/generateKey/wrapKey currently AES-GCM/AES-KW only). \
+                                             See `perry --print-api-manifest` and #561, or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore.",
+                                            method,
+                                        );
+                                        // #5245: default → throw-on-reach + notice;
+                                        // strict → hard refusal. #2309 inside.
+                                        let api = format!("crypto.subtle.{method}");
+                                        let location = crate::eval_classifier::location_string(
+                                            &ctx.source_file_path,
+                                            outer_member.span.lo.0,
+                                        );
+                                        match crate::check_unimplemented_api(
+                                            &msg,
+                                            &api,
+                                            &location,
+                                            outer_member.span.lo.0,
+                                        ) {
+                                            crate::UnimplementedDecision::Refuse => {
                                                 crate::lower_bail!(outer_member.span, "{}", msg);
+                                            }
+                                            crate::UnimplementedDecision::DeferToRuntimeError(
+                                                runtime_msg,
+                                            ) => {
+                                                return Ok(Ok(
+                                                    super::super::const_fold_fn::synth_deferred_throw_value(
+                                                        ctx,
+                                                        &runtime_msg,
+                                                        outer_member.span,
+                                                    )?,
+                                                ));
                                             }
                                         }
                                     }
@@ -297,7 +314,7 @@ pub(super) fn try_web_crypto_subtle(
 /// only need the canonical module name; `util.types` remains a runtime object
 /// property, not a second API-manifest module.
 pub(super) fn try_util_types_namespace(
-    ctx: &LoweringContext,
+    ctx: &mut LoweringContext,
     expr: &ast::Expr,
     args: Vec<Expr>,
 ) -> Result<Result<Expr, Vec<Expr>>> {
@@ -317,20 +334,39 @@ pub(super) fn try_util_types_namespace(
                     {
                         if namespace.sym.as_ref() == "types" {
                             let method_name = method.sym.as_ref();
-                            let allow_unimplemented =
-                                std::env::var_os("PERRY_ALLOW_UNIMPLEMENTED").is_some();
-                            if !allow_unimplemented
-                                && perry_api_manifest::module_has_symbol("util/types", method_name)
-                                    .is_none()
+                            if perry_api_manifest::module_has_symbol("util/types", method_name)
+                                .is_none()
                             {
                                 let msg = format!(
                                     "`util.types.{}` is not implemented in Perry — see `perry --print-api-manifest` for the supported surface, \
                                      or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463)",
                                     method_name,
                                 );
-                                // #2309: defer under tree-shaking.
-                                if !crate::try_defer_refusal(msg.clone(), outer_member.span.lo.0) {
-                                    crate::lower_bail!(outer_member.span, "{}", msg);
+                                // #5245: default → throw-on-reach + notice; strict
+                                // → hard #463 refusal. #2309 tree-shake inside.
+                                let api = format!("util.types.{method_name}");
+                                let location = crate::eval_classifier::location_string(
+                                    &ctx.source_file_path,
+                                    outer_member.span.lo.0,
+                                );
+                                match crate::check_unimplemented_api(
+                                    &msg,
+                                    &api,
+                                    &location,
+                                    outer_member.span.lo.0,
+                                ) {
+                                    crate::UnimplementedDecision::Refuse => {
+                                        crate::lower_bail!(outer_member.span, "{}", msg);
+                                    }
+                                    crate::UnimplementedDecision::DeferToRuntimeError(runtime_msg) => {
+                                        return Ok(Ok(
+                                            super::super::const_fold_fn::synth_deferred_throw_value(
+                                                ctx,
+                                                &runtime_msg,
+                                                outer_member.span,
+                                            )?,
+                                        ));
+                                    }
                                 }
                             }
                             return Ok(Ok(Expr::NativeMethodCall {

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -2236,7 +2236,6 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         (&*object, &member.prop)
     {
         let prop = prop_ident.sym.as_ref();
-        let allow_unimplemented = std::env::var_os("PERRY_ALLOW_UNIMPLEMENTED").is_some();
         // Skip the gate when `member.obj` is an Ident that was a
         // *named* import binding from the module (e.g. `import {
         // EventEmitter } from "node:events"; EventEmitter.prototype`).
@@ -2301,11 +2300,22 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
             },
             _ => false,
         };
-        if !allow_unimplemented
-            && !obj_is_named_import
+        if !obj_is_named_import
             && perry_api_manifest::module_has_any_entries(module)
             && perry_api_manifest::module_has_symbol(module, prop).is_none()
         {
+            // #3896: a bare *value read* of an absent member on a Node
+            // builtin module namespace/default object is an ordinary
+            // property miss → `undefined` (e.g. `dns/promises.ADDRCONFIG`,
+            // which Node also doesn't export but reads as undefined). Calls
+            // (`ns.foo()`) keep going through the gate — `lower_call` set the
+            // callee marker, so `member_is_call_callee` is true there. Only
+            // Node core modules relax; unenumerated npm packages keep the gate.
+            // This is independent of #463/#5245 strict-unimplemented mode (it's
+            // a real Node semantic, not a degraded surface).
+            if !member_is_call_callee && perry_api_manifest::is_node_core_module(module) {
+                return Ok(Expr::Undefined);
+            }
             // #925: when there's a known supported equivalent for this
             // shape, append it to the error so the user doesn't have to
             // grep through the manifest to find the replacement.
@@ -2317,21 +2327,22 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                  or set `PERRY_ALLOW_UNIMPLEMENTED=1` to ignore. (#463){}",
                 module, prop, hint,
             );
-            // #2309: defer when tree-shaking (sink armed for this node_modules
-            // module); re-raised only if the module survives pruning.
-            if !crate::try_defer_refusal(msg.clone(), member.span.lo.0) {
-                // #3896: a bare *value read* of an absent member on a Node
-                // builtin module namespace/default object is an ordinary
-                // property miss → `undefined` (e.g. `dns/promises.ADDRCONFIG`,
-                // which Node also doesn't export but reads as undefined). Calls
-                // (`ns.foo()`) keep rejecting — `lower_call` set the callee
-                // marker, so `member_is_call_callee` is true there. Only Node
-                // core modules relax; unenumerated npm packages keep the strict
-                // gate (and the tree-shaking defer above).
-                if !member_is_call_callee && perry_api_manifest::is_node_core_module(module) {
-                    return Ok(Expr::Undefined);
+            // #5245: defer to a throw-on-reach runtime error by default (record
+            // for the end-of-compile notice); strict-unimplemented mode restores
+            // the hard #463 refusal. #2309 tree-shake deferral is handled inside.
+            let api = format!("{module}.{prop}");
+            let location = crate::eval_classifier::location_string(&ctx.source_file_path, member.span.lo.0);
+            match crate::check_unimplemented_api(&msg, &api, &location, member.span.lo.0) {
+                crate::UnimplementedDecision::Refuse => {
+                    crate::lower_bail!(member.span, "{}", msg);
                 }
-                crate::lower_bail!(member.span, "{}", msg);
+                crate::UnimplementedDecision::DeferToRuntimeError(runtime_msg) => {
+                    return super::const_fold_fn::synth_deferred_throw_value(
+                        ctx,
+                        &runtime_msg,
+                        member.span,
+                    );
+                }
             }
         }
     }

--- a/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
+++ b/crates/perry-hir/tests/dynamic_stdlib_dispatch.rs
@@ -176,7 +176,11 @@ fn still_refuses_global_process_pipe_call() {
     let src = r#"
         process.pipe("ok");
     "#;
+    // #5245: the unimplemented-API gate only refuses at compile time in strict
+    // mode; the default now defers `process.pipe` to a throw-on-reach value.
+    perry_hir::set_unimplemented_strict_mode(true);
     let err = try_lower(src, "/tmp/host.ts").expect_err("global process.pipe must stay gated");
+    perry_hir::set_unimplemented_strict_mode(false);
     assert!(
         err.contains("`process.pipe` is not implemented in Perry"),
         "unexpected error: {err}"

--- a/crates/perry-hir/tests/unimplemented_api_check.rs
+++ b/crates/perry-hir/tests/unimplemented_api_check.rs
@@ -9,14 +9,34 @@ use perry_hir::lower_module;
 use perry_parser::parse_typescript_with_cache;
 
 fn lower_result(src: &str) -> Result<perry_hir::Module, String> {
+    lower_result_mode(src, false)
+}
+
+/// As of #5245 the default (non-strict) mode *defers* a recognized-but-
+/// unimplemented API to a throw-on-reach runtime error rather than failing the
+/// build — so the historical "must error" assertions run in strict mode, which
+/// restores the hard `#463` refusal.
+fn lower_result_strict(src: &str) -> Result<perry_hir::Module, String> {
+    lower_result_mode(src, true)
+}
+
+fn lower_result_mode(src: &str, strict_unimplemented: bool) -> Result<perry_hir::Module, String> {
     let src = src.to_string();
     std::thread::Builder::new()
         .stack_size(32 * 1024 * 1024)
         .spawn(move || {
+            // Thread-local: set on this lower thread so it doesn't race the
+            // other tests' (default-mode) lowers in the same binary.
+            perry_hir::set_unimplemented_strict_mode(strict_unimplemented);
             let mut cache = SourceCache::new();
             let parsed = parse_typescript_with_cache(&src, "test.ts", &mut cache)
                 .expect("parse should succeed");
-            lower_module(&parsed.module, "test", "test.ts").map_err(|e| e.to_string())
+            let result =
+                lower_module(&parsed.module, "test", "test.ts").map_err(|e| e.to_string());
+            // Drain any notice sites this lower recorded so they don't leak
+            // into the process-global sink another test might inspect.
+            let _ = perry_hir::take_deferred_eval_sites();
+            result
         })
         .expect("spawn lower thread")
         .join()
@@ -181,7 +201,7 @@ fn crypto_unknown_method_is_rejected() {
         read.is_ok(),
         "crypto.foobar value read should resolve to undefined (#3896), got {read:?}"
     );
-    let call = lower_result(
+    let call = lower_result_strict(
         r#"
         import * as crypto from "crypto";
         crypto.foobar();
@@ -189,7 +209,50 @@ fn crypto_unknown_method_is_rejected() {
     );
     assert!(
         call.is_err(),
-        "crypto.foobar() call should still error as unimplemented"
+        "crypto.foobar() call should still error as unimplemented (strict)"
+    );
+}
+
+/// #5245: the default (non-strict) mode defers a recognized-but-unimplemented
+/// API call to a throw-on-reach runtime error instead of failing the build,
+/// rather than the historical hard `#463` refusal. `process.binding('buffer')`
+/// (the `safer-buffer` probe) is the motivating case. (The notice-recording
+/// side is covered by the deterministic `check_unimplemented_api` unit test in
+/// `crates/perry-hir/src/eval_classifier.rs`, which avoids the process-global
+/// sink races inherent to a parallel integration-test binary.)
+#[test]
+fn unimplemented_api_defers_by_default() {
+    let result = lower_result(
+        r#"
+        let max: any;
+        try { max = (process as any).binding("buffer").kStringMaxLength; } catch {}
+        console.log("ok", typeof max);
+    "#,
+    );
+    assert!(
+        result.is_ok(),
+        "process.binding(...) must compile by default (#5245): {result:?}"
+    );
+}
+
+/// #5245: strict-unimplemented mode restores the hard `#463` refusal for the
+/// same `process.binding` probe.
+#[test]
+fn unimplemented_api_refuses_in_strict_mode() {
+    // PERRY_ALLOW_UNIMPLEMENTED would force defer; only assert when unset.
+    if perry_hir::eval_classifier::unimplemented_override_enabled() {
+        return;
+    }
+    let result = lower_result_strict(
+        r#"
+        let max: any;
+        try { max = (process as any).binding("buffer"); } catch {}
+    "#,
+    );
+    let err = result.expect_err("strict mode must refuse process.binding (#463)");
+    assert!(
+        err.contains("process.binding") && err.contains("#463"),
+        "expected the #463 refusal naming process.binding, got: {err}"
     );
 }
 
@@ -246,7 +309,7 @@ fn os_eol_and_path_sep_compile() {
 /// entries fails CI before the PR ships.
 #[test]
 fn supported_module_with_unknown_member_is_rejected() {
-    let result = lower_result(
+    let result = lower_result_strict(
         r#"
         import axios from "axios";
         const x = axios.foo;
@@ -304,7 +367,8 @@ fn every_supported_module_rejects_bogus_member() {
         "#
         );
         let is_core = perry_api_manifest::is_node_core_module(module);
-        match lower_result(&src) {
+        // #5245: the gate only refuses at compile time in strict mode.
+        match lower_result_strict(&src) {
             Ok(_) => {
                 // #3896: a bogus member *value read* on a Node-core module
                 // namespace is an ordinary property miss → undefined (matching
@@ -372,7 +436,8 @@ fn every_supported_module_rejects_bogus_call() {
             m.__perry_known_bogus_member_525__();
         "#
         );
-        match lower_result(&src) {
+        // #5245: the gate only refuses at compile time in strict mode.
+        match lower_result_strict(&src) {
             Ok(_) => {
                 failures.push(format!(
                     "{module}: bogus call did not error (strict mode not engaged)"

--- a/crates/perry-hir/tests/util_types_lowering.rs
+++ b/crates/perry-hir/tests/util_types_lowering.rs
@@ -22,12 +22,17 @@ fn lower_err(src: &str) -> String {
     std::thread::Builder::new()
         .stack_size(32 * 1024 * 1024)
         .spawn(move || {
+            // #5245: the unimplemented-API gate only refuses at compile time in
+            // strict mode; the default now defers to a throw-on-reach value.
+            perry_hir::set_unimplemented_strict_mode(true);
             let mut cache = SourceCache::new();
             let parsed = parse_typescript_with_cache(&src, "test.ts", &mut cache)
                 .expect("parse should succeed");
-            lower_module(&parsed.module, "test", "test.ts")
+            let err = lower_module(&parsed.module, "test", "test.ts")
                 .expect_err("lowering should reject unsupported API")
-                .to_string()
+                .to_string();
+            perry_hir::set_unimplemented_strict_mode(false);
+            err
         })
         .expect("spawn lower thread")
         .join()

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -768,6 +768,8 @@ fn collect_module_one(
     // #5206: re-install strict-eval mode on this (possibly rayon-worker)
     // thread before each lower, mirroring the dynamic-stdlib knob above.
     perry_hir::set_eval_strict_mode(ctx.strict_eval);
+    // #5245: likewise re-install strict-unimplemented mode per worker thread.
+    perry_hir::set_unimplemented_strict_mode(ctx.strict_unimplemented);
     // #503: stash the module source text so the dynamic-dispatch check
     // can look up `// @perry-allow-dynamic` line annotations adjacent to
     // any violation site without re-reading the file. Cleared right

--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -358,6 +358,8 @@ pub(super) fn apply_pkg_and_toml_config(
                     ctx.strict_eval = strict;
                     // #5230: the broad `perry.strict` covers dynamic imports too.
                     ctx.strict_dynamic_import = strict;
+                    // #5245: …and recognized-but-unimplemented APIs.
+                    ctx.strict_unimplemented = strict;
                 }
                 if let Some(mode) = pkg
                     .get("perry")
@@ -540,6 +542,8 @@ pub(super) fn apply_pkg_and_toml_config(
                     ctx.strict_eval = strict;
                     // #5230: broad `perry.strict` covers dynamic imports too.
                     ctx.strict_dynamic_import = strict;
+                    // #5245: …and recognized-but-unimplemented APIs.
+                    ctx.strict_unimplemented = strict;
                 }
                 if let Some(mode) = perry_tbl.get("eval").and_then(|v| v.as_str()) {
                     match mode {
@@ -566,6 +570,11 @@ pub(super) fn apply_pkg_and_toml_config(
     if args.strict_dynamic_import {
         ctx.strict_dynamic_import = true;
     }
+    // #5245: `--strict-unimplemented` opts the recognized-but-unimplemented-API
+    // gate back into the historical hard `#463` refusal.
+    if args.strict_unimplemented {
+        ctx.strict_unimplemented = true;
+    }
     // Back-compat: `PERRY_ALLOW_EVAL` forces non-strict for a one-off build,
     // overriding any strict flag/config — for both eval and dynamic import
     // (shared AOT escape hatch, #5230).
@@ -573,10 +582,16 @@ pub(super) fn apply_pkg_and_toml_config(
         ctx.strict_eval = false;
         ctx.strict_dynamic_import = false;
     }
+    // #5245: `PERRY_ALLOW_UNIMPLEMENTED` is the back-compat escape hatch for the
+    // unimplemented-API gate — forces non-strict (defer) for a one-off build.
+    if perry_hir::eval_classifier::unimplemented_override_enabled() {
+        ctx.strict_unimplemented = false;
+    }
     // Install into the HIR thread-local before any lowering begins (re-applied
     // per rayon worker in collect_modules.rs, mirroring the dynamic-stdlib
     // dispatch knob above).
     perry_hir::set_eval_strict_mode(ctx.strict_eval);
+    perry_hir::set_unimplemented_strict_mode(ctx.strict_unimplemented);
 
     // #3527 (blocker #4): materialize `"*"` / `"@scope/*"` wildcard entries
     // in `perry.compilePackages` into concrete installed package names.

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -303,6 +303,18 @@ pub struct CompileArgs {
     #[arg(long)]
     pub strict_dynamic_import: bool,
 
+    /// #5245 — strict-unimplemented mode. Fail the build at compile time if any
+    /// recognized-but-unimplemented node/stdlib API is referenced (the
+    /// historical `#463` behavior). By default such a reference is instead
+    /// compiled to a value that throws a descriptive `Error` only if reached
+    /// (so a `try/catch`-guarded probe — e.g. `safer-buffer`'s
+    /// `process.binding('buffer')` — no longer blocks the build), and is listed
+    /// in the same end-of-build notice as deferred eval / dynamic-import sites.
+    /// Also settable via the broad `"perry": { "strict": true }` in
+    /// package.json or perry.toml. `PERRY_ALLOW_UNIMPLEMENTED=1` forces this off.
+    #[arg(long)]
+    pub strict_unimplemented: bool,
+
     /// Minimum Windows version the compiled executable must run on.
     /// Accepted values: `7`, `8`, `10` (default `10`). Ignored on every
     /// non-Windows target.
@@ -693,6 +705,16 @@ pub struct CompilationContext {
     /// `--strict-dynamic-import` CLI flag. `PERRY_ALLOW_EVAL=1` forces it off
     /// (shared AOT escape hatch).
     pub strict_dynamic_import: bool,
+    /// #5245: strict mode for recognized-but-unimplemented node/stdlib APIs.
+    /// When true, a reference to such an API is a hard compile-time `#463`
+    /// refusal (the historical behavior). When false (the default), it is
+    /// compiled to a value that throws a descriptive `Error` only if reached
+    /// (so a `try/catch`-guarded probe doesn't block the build) and is recorded
+    /// in the shared end-of-compile notice. Defaults to `strict_eval` so the
+    /// broad `perry.strict = true` covers it; the `--strict-unimplemented` CLI
+    /// flag forces it on. `PERRY_ALLOW_UNIMPLEMENTED=1` forces it off (back-compat
+    /// escape hatch).
+    pub strict_unimplemented: bool,
     /// #503: package names whose modules may legitimately use dynamic
     /// stdlib dispatch (`perry.allowDynamicStdlibDispatch: [...]`).
     /// Consulted per-module during HIR lowering; ignored when
@@ -895,6 +917,7 @@ impl CompilationContext {
             refuse_dynamic_stdlib_dispatch: true,
             strict_eval: false,
             strict_dynamic_import: false,
+            strict_unimplemented: false,
             allow_dynamic_stdlib_packages: HashSet::new(),
             js_runtime_importers: Vec::new(),
             permissions: std::collections::BTreeMap::new(),

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -307,6 +307,7 @@ fn build_once(
         lockdown: false,
         strict_eval: false,
         strict_dynamic_import: false,
+        strict_unimplemented: false,
         min_windows_version: "10".to_string(),
         windows_subsystem: "auto".to_string(),
         // Phase 2 v7: harmonyos signing flags. `perry dev` is the watch

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -238,6 +238,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         lockdown: false,
         strict_eval: false,
         strict_dynamic_import: false,
+        strict_unimplemented: false,
         min_windows_version: "10".to_string(),
         windows_subsystem: "auto".to_string(),
         // Phase 2 v7: harmonyos signing flags. `perry run` is for local


### PR DESCRIPTION
## What

Closes #5245. A reference to a recognized-but-unimplemented node/stdlib API (e.g. `process.binding`) was a hard compile error (the #463 gate), even when guarded by `try/catch`. Real packages probe for optional capabilities exactly that way — `safer-buffer` does `try { process.binding('buffer').kStringMaxLength } catch {}`; express/router probe `http.map` etc. — so the refusal needlessly blocked the whole build.

This makes **deferral the default**, extending the existing AOT-deferral policy from eval / `new Function` (#5206) and dynamic `import()` (#5230) to the unimplemented-API surface.

## Behavior

- **Default (non-strict):** the unimplemented-API reference compiles to a throwing IIFE that raises `<api> is not implemented in Perry (ahead-of-time) (file:line)` only **if reached**, instead of failing the build. Each site is recorded via the shared `record_deferred_aot_site("unimplemented API", location)` sink and listed in the same end-of-compile notice as deferred eval / dynamic-import sites.
- **Strict** (`perry.strict = true` or `--strict-unimplemented`): restores the historical hard #463 compile-time refusal.
- **`PERRY_ALLOW_UNIMPLEMENTED=1`** keeps working as a force-defer alias (now also records the notice site), overriding any strict flag/config for a one-off build.

## How (reuses #5206/#5230 infra)

All five #463 gate sites funnel through a new `eval_classifier::check_unimplemented_api(...)` decision point that reuses the deferred-AOT-site sink, the shared notice printer (`print_deferred_eval_notice`), the strict thread-local plumbing, and the #2309 tree-shake deferral. The #3896 Node-core value-read→`undefined` exemption is preserved. Strict mode is plumbed from `perry.strict` (package.json + perry.toml) and a new `--strict-unimplemented` flag, mirroring `strict_eval` / `strict_dynamic_import`.

Gate sites updated: `expr_member` (member read), `process.*()` and `mod.method()` in `native_module`, `mod.X.Y()` in `module_class_static`, `crypto.subtle.*` and `util.types.*` in `nested_namespace`.

## Test evidence

Repro:
```ts
let max: any;
try { max = process.binding("buffer").kStringMaxLength; } catch {}
console.log("ok", typeof max);
```
- **Default:** compiles (exit 0), prints `notice: 1 ahead-of-time-unsupported site … unimplemented API  <file>:2`, runs `ok undefined`.
- **`--strict-unimplemented`:** `Error: \`process.binding\` is not implemented in Perry … (#463)` (exit 1).
- **`PERRY_ALLOW_UNIMPLEMENTED=1`** (even with `--strict-unimplemented`): compiles + runs `ok undefined`.
- Implemented APIs (`crypto.randomUUID()`, `process.cwd()`) still compile with no notice.

Express (`compilePackages:["*"]`, `allow.compilePackages:["*"]`):
- **Before (== `--strict-unimplemented`):** `Error: \`http.map\` is not implemented in Perry … (#463)` — build fails.
- **After (default):** builds; notice lists 3 deferred unimplemented-API sites in express/router. Next wall is the predicted `get-intrinsic` `SyntaxError: intrinsic %% does not exist!` runtime error (out of scope here).

Suites: `cargo test -p perry-hir` (full) and `cargo test -p perry` green; new unit tests for `check_unimplemented_api` (defer/strict/env-override + notice recording) and integration tests for the repro; existing #463 error-asserting tests (`unimplemented_api_check`, `util_types_lowering`, `dynamic_stdlib_dispatch`) updated to run in strict mode.

## Version / CHANGELOG

Intentionally omitted — to be folded in by the maintainer at merge (per CLAUDE.md). No `Cargo.lock` / version / `Current Version` / CHANGELOG edits.

## Risks

- `crates/perry-hir/src/lower/expr_member.rs` is already over the 2000-line cap (3426 lines) pre-existing; this PR adds ~10 net lines there rather than splitting it (out of scope / risky).
- The end-of-compile notice sink is process-global; the notice-recording assertion lives in a deterministic `eval_classifier` unit test (the integration test only asserts compile-success) to avoid parallel-test sink races.