### PR TITLE
fix(hir): destructuring declarators in C-style for-init (#5248)

### DIFF
--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1326,12 +1326,38 @@ pub(crate) fn lower_stmt(
                         let is_var = var_decl.kind == ast::VarDeclKind::Var;
                         if is_var {
                             for decl in var_decl.decls.iter() {
-                                let name = get_binding_name(&decl.name)?;
                                 if let Some(init_ast) = decl.init.as_ref() {
                                     module.init.extend(predeclare_implicit_assignment_targets(
                                         ctx, init_ast,
                                     ));
                                 }
+                                // A destructuring declarator (`for (var {a} = o; …)`)
+                                // routes through the shared pattern-binding helper
+                                // rather than `get_binding_name`, which only handles
+                                // plain idents. The bound ids are var-hoisted so they
+                                // escape the for's block scope, matching plain
+                                // `var`-decl destructuring.
+                                if is_destructuring_pattern(&decl.name) {
+                                    let init_expr = decl
+                                        .init
+                                        .as_ref()
+                                        .map(|e| lower_expr(ctx, e))
+                                        .transpose()?
+                                        .ok_or_else(|| {
+                                            anyhow!("Destructuring requires an initializer")
+                                        })?;
+                                    let stmts = crate::destructuring::lower_pattern_binding(
+                                        ctx, &decl.name, init_expr, true,
+                                    )?;
+                                    for stmt in &stmts {
+                                        if let Stmt::Let { id, .. } = stmt {
+                                            ctx.var_hoisted_ids.insert(*id);
+                                        }
+                                    }
+                                    module.init.extend(stmts);
+                                    continue;
+                                }
+                                let name = get_binding_name(&decl.name)?;
                                 let init_expr =
                                     decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
                                 let id = ctx.define_local(name.clone(), Type::Any);
@@ -1347,12 +1373,30 @@ pub(crate) fn lower_stmt(
                             None
                         } else {
                             for decl in var_decl.decls.iter().skip(1) {
-                                let name = get_binding_name(&decl.name)?;
                                 if let Some(init_ast) = decl.init.as_ref() {
                                     module.init.extend(predeclare_implicit_assignment_targets(
                                         ctx, init_ast,
                                     ));
                                 }
+                                // `for (let {a} = o, i = 0; …)` — a destructuring
+                                // declarator binds via the shared helper into the
+                                // pre-loop init block.
+                                if is_destructuring_pattern(&decl.name) {
+                                    let init_expr = decl
+                                        .init
+                                        .as_ref()
+                                        .map(|e| lower_expr(ctx, e))
+                                        .transpose()?
+                                        .ok_or_else(|| {
+                                            anyhow!("Destructuring requires an initializer")
+                                        })?;
+                                    let stmts = crate::destructuring::lower_pattern_binding(
+                                        ctx, &decl.name, init_expr, true,
+                                    )?;
+                                    module.init.extend(stmts);
+                                    continue;
+                                }
+                                let name = get_binding_name(&decl.name)?;
                                 let init_expr =
                                     decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
                                 let id = ctx.define_local(name.clone(), Type::Any);
@@ -1365,22 +1409,46 @@ pub(crate) fn lower_stmt(
                                 });
                             }
                             if let Some(decl) = var_decl.decls.first() {
-                                let name = get_binding_name(&decl.name)?;
                                 if let Some(init_ast) = decl.init.as_ref() {
                                     module.init.extend(predeclare_implicit_assignment_targets(
                                         ctx, init_ast,
                                     ));
                                 }
-                                let init_expr =
-                                    decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
-                                let id = ctx.define_local(name.clone(), Type::Any);
-                                Some(Box::new(Stmt::Let {
-                                    id,
-                                    name,
-                                    ty: Type::Any,
-                                    mutable: true,
-                                    init: init_expr,
-                                }))
+                                // A destructuring first-declarator can't be a single
+                                // `Stmt::Let` (it lowers to several binds), so emit it
+                                // into the pre-loop init block and leave the for's own
+                                // init empty. It still runs exactly once before the
+                                // first test, preserving for-init semantics.
+                                if is_destructuring_pattern(&decl.name) {
+                                    let init_expr = decl
+                                        .init
+                                        .as_ref()
+                                        .map(|e| lower_expr(ctx, e))
+                                        .transpose()?
+                                        .ok_or_else(|| {
+                                            anyhow!("Destructuring requires an initializer")
+                                        })?;
+                                    let stmts = crate::destructuring::lower_pattern_binding(
+                                        ctx, &decl.name, init_expr, true,
+                                    )?;
+                                    module.init.extend(stmts);
+                                    None
+                                } else {
+                                    let name = get_binding_name(&decl.name)?;
+                                    let init_expr = decl
+                                        .init
+                                        .as_ref()
+                                        .map(|e| lower_expr(ctx, e))
+                                        .transpose()?;
+                                    let id = ctx.define_local(name.clone(), Type::Any);
+                                    Some(Box::new(Stmt::Let {
+                                        id,
+                                        name,
+                                        ty: Type::Any,
+                                        mutable: true,
+                                        init: init_expr,
+                                    }))
+                                }
                             } else {
                                 None
                             }

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -515,12 +515,38 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         let is_var = var_decl.kind == ast::VarDeclKind::Var;
                         if is_var {
                             for decl in var_decl.decls.iter() {
-                                let name = get_binding_name(&decl.name)?;
                                 if let Some(init_ast) = decl.init.as_ref() {
                                     result.extend(predeclare_implicit_assignment_targets(
                                         ctx, init_ast,
                                     ));
                                 }
+                                // A destructuring declarator (`for (var {a} = o; …)`)
+                                // routes through the shared pattern-binding helper
+                                // rather than `get_binding_name`, which only handles
+                                // plain idents. The bound ids are var-hoisted so they
+                                // escape the for's block scope, matching plain
+                                // `var`-decl destructuring.
+                                if is_destructuring_pattern(&decl.name) {
+                                    let init_expr = decl
+                                        .init
+                                        .as_ref()
+                                        .map(|e| lower_expr(ctx, e))
+                                        .transpose()?
+                                        .ok_or_else(|| {
+                                            anyhow!("Destructuring requires an initializer")
+                                        })?;
+                                    let stmts = crate::destructuring::lower_pattern_binding(
+                                        ctx, &decl.name, init_expr, true,
+                                    )?;
+                                    for stmt in &stmts {
+                                        if let Stmt::Let { id, .. } = stmt {
+                                            ctx.var_hoisted_ids.insert(*id);
+                                        }
+                                    }
+                                    result.extend(stmts);
+                                    continue;
+                                }
+                                let name = get_binding_name(&decl.name)?;
                                 let init_expr =
                                     decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
                                 let id = ctx.define_local(name.clone(), Type::Any);
@@ -536,12 +562,30 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                             None
                         } else {
                             for decl in var_decl.decls.iter().skip(1) {
-                                let name = get_binding_name(&decl.name)?;
                                 if let Some(init_ast) = decl.init.as_ref() {
                                     result.extend(predeclare_implicit_assignment_targets(
                                         ctx, init_ast,
                                     ));
                                 }
+                                // `for (let {a} = o, i = 0; …)` — a destructuring
+                                // declarator binds via the shared helper into the
+                                // pre-loop init block.
+                                if is_destructuring_pattern(&decl.name) {
+                                    let init_expr = decl
+                                        .init
+                                        .as_ref()
+                                        .map(|e| lower_expr(ctx, e))
+                                        .transpose()?
+                                        .ok_or_else(|| {
+                                            anyhow!("Destructuring requires an initializer")
+                                        })?;
+                                    let stmts = crate::destructuring::lower_pattern_binding(
+                                        ctx, &decl.name, init_expr, true,
+                                    )?;
+                                    result.extend(stmts);
+                                    continue;
+                                }
+                                let name = get_binding_name(&decl.name)?;
                                 let init_expr =
                                     decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
                                 let id = ctx.define_local(name.clone(), Type::Any);
@@ -554,22 +598,46 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                                 });
                             }
                             if let Some(decl) = var_decl.decls.first() {
-                                let name = get_binding_name(&decl.name)?;
                                 if let Some(init_ast) = decl.init.as_ref() {
                                     result.extend(predeclare_implicit_assignment_targets(
                                         ctx, init_ast,
                                     ));
                                 }
-                                let init_expr =
-                                    decl.init.as_ref().map(|e| lower_expr(ctx, e)).transpose()?;
-                                let id = ctx.define_local(name.clone(), Type::Any);
-                                Some(Box::new(Stmt::Let {
-                                    id,
-                                    name,
-                                    ty: Type::Any,
-                                    mutable: true,
-                                    init: init_expr,
-                                }))
+                                // A destructuring first-declarator can't be a single
+                                // `Stmt::Let` (it lowers to several binds), so emit it
+                                // into the pre-loop init block and leave the for's own
+                                // init empty. It still runs exactly once before the
+                                // first test, preserving for-init semantics.
+                                if is_destructuring_pattern(&decl.name) {
+                                    let init_expr = decl
+                                        .init
+                                        .as_ref()
+                                        .map(|e| lower_expr(ctx, e))
+                                        .transpose()?
+                                        .ok_or_else(|| {
+                                            anyhow!("Destructuring requires an initializer")
+                                        })?;
+                                    let stmts = crate::destructuring::lower_pattern_binding(
+                                        ctx, &decl.name, init_expr, true,
+                                    )?;
+                                    result.extend(stmts);
+                                    None
+                                } else {
+                                    let name = get_binding_name(&decl.name)?;
+                                    let init_expr = decl
+                                        .init
+                                        .as_ref()
+                                        .map(|e| lower_expr(ctx, e))
+                                        .transpose()?;
+                                    let id = ctx.define_local(name.clone(), Type::Any);
+                                    Some(Box::new(Stmt::Let {
+                                        id,
+                                        name,
+                                        ty: Type::Any,
+                                        mutable: true,
+                                        init: init_expr,
+                                    }))
+                                }
                             } else {
                                 None
                             }

--- a/crates/perry-hir/tests/for_init_destructuring_lowering.rs
+++ b/crates/perry-hir/tests/for_init_destructuring_lowering.rs
@@ -1,0 +1,63 @@
+//! Regression test for #5248: a destructuring declarator inside a C-style
+//! `for` init clause (`for (var {a} = o; …)`) used to bail with
+//! `error[U006]: Unsupported binding pattern` because the for-init lowering
+//! called `get_binding_name` (idents only) on every declarator. The fix routes
+//! `Pat::Object` / `Pat::Array` declarators through the shared
+//! `lower_pattern_binding` helper. These cases lower at module top level and
+//! inside a function body (two separate for-init lowering paths).
+
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Module};
+
+fn lower_result(src: &str) -> Result<Module, String> {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = perry_parser::parse_typescript_with_cache(
+                &src,
+                "for_init_destructuring.ts",
+                &mut cache,
+            )
+            .expect("parse should succeed");
+            lower_module(&parsed.module, "test", "for_init_destructuring.ts")
+                .map_err(|e| e.to_string())
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+/// Every form listed in the issue's "Scope" table, both at module scope and
+/// nested in a function body, must lower without the U006 bail.
+#[test]
+fn for_init_destructuring_declarators_lower() {
+    let forms = [
+        // (object, multi-declarator)
+        "for (var { a, b } = { a: 1, b: 2 }, i = 0; i < 1; i++) console.log(a, b, i);",
+        // (object, single declarator)
+        "for (var { a, b } = { a: 1, b: 2 }; a < 5; a++) console.log(a, b);",
+        // let
+        "for (let { a } = { a: 1 }, i = 0; i < 1; i++) console.log(a, i);",
+        // const
+        "for (const { a } = { a: 1 }; ;) { console.log(a); break; }",
+        // array pattern
+        "for (var [a, b] = [1, 2], i = 0; i < 1; i++) console.log(a, b, i);",
+        // renamed object keys (the bundler-emitted shape from the issue)
+        "for (var { a: x, b: y } = { a: 1, b: 2 }, i = 0; i < 1; i++) console.log(x, y, i);",
+    ];
+
+    for form in forms {
+        // Module top level (lower/stmt.rs path).
+        lower_result(form).unwrap_or_else(|e| {
+            panic!("module-scope for-init destructuring should lower: {form}\n{e}")
+        });
+
+        // Inside a function body (lower_decl/body_stmt.rs path).
+        let in_fn = format!("function f() {{ {form} }}\nf();");
+        lower_result(&in_fn).unwrap_or_else(|e| {
+            panic!("function-body for-init destructuring should lower: {form}\n{e}")
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5248. A `var`/`let`/`const` declarator that uses a **destructuring pattern** inside a **C-style `for` init clause** — e.g. `for (var { a, b } = o, i = 0; …; …)` — failed to lower with `error[U006]: Unsupported binding pattern`. The identical destructuring works fine in a plain declaration and in `for…of`, so this was a context-specific gap in the for-init path. Bundlers routinely emit this shape, so it was an early wall when compiling generated bundles.

## Root cause

The C-style `for` init lowering called `get_binding_name(&decl.name)?` for every declarator. That helper only handles `Pat::Ident` and bails on everything else, so a `Pat::Object` / `Pat::Array` declarator hit the catch-all `U006`.

## Fix

Route destructuring declarators through the shared `destructuring::lower_pattern_binding` helper — the same machinery used by plain `var`-decls and `for…of` — binding the pattern leaves into the pre-loop init block. For `var`, the bound ids are marked var-hoisted so they escape the for's block scope. Plain-ident declarators keep the existing `get_binding_name` fast path.

This is applied to **both** for-init lowering paths:
- `crates/perry-hir/src/lower/stmt.rs` — module top level
- `crates/perry-hir/src/lower_decl/body_stmt.rs` — function bodies

A destructuring first-declarator can't be expressed as the for's single `Stmt::Let` init (it lowers to several binds), so it is emitted into the pre-loop init block and the for's own init is left empty — it still runs exactly once before the first test, preserving for-init semantics.

## Validation

- New regression test `crates/perry-hir/tests/for_init_destructuring_lowering.rs` covers every form in the issue's scope table, at both module scope and inside a function body.
- Output verified **byte-for-byte identical** to `node --experimental-strip-types` for all forms:
  ```
  for (var { a, b } = { a: 1, b: 2 }, i = 0; i < 1; i++) console.log(a, b, i);
  for (var { a: x, b: y } = { a: 1, b: 2 }; x < 5; x++) console.log(x, y);
  for (let { a } = { a: 10 }, i = 0; i < 1; i++) console.log(a, i);
  for (const { a } = { a: 20 }; ;) { console.log(a); break; }
  for (var [p, q] = [3, 4], i = 0; i < 1; i++) console.log(p, q, i);
  ```
- `cargo test -p perry-hir` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of destructuring patterns in `for` loop initialization clauses for `var`, `let`, and `const` declarations.
  * Improved error messaging for destructuring declarations without initializers.

* **Tests**
  * Added regression tests for destructuring declarators in `for` loop initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->