### PR TITLE
fix(compile): keep CJS classes reading `exports` inside the IIFE (#5251)

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
@@ -233,7 +233,21 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
     // `Undefined variable in update expression`. The conservative rule
     // is to leave the class inside the IIFE when *any* of its referenced
     // identifiers would lose their binding to the IIFE-local state.
-    let iife_locals = collect_top_level_let_const_var_names(source);
+    let mut iife_locals = collect_top_level_let_const_var_names(source);
+    // Issue #5251 — the cjs_wrap preamble injects `var exports`, `var module`,
+    // and a `require` function as IIFE-local bindings (see `wrap.rs`'s
+    // `cjs_preamble`). They are NOT declared in the original source, so the
+    // textual top-level scan above never sees them. A class whose body reads
+    // `exports.X` / `module.exports` / `require(...)` must therefore ALSO stay
+    // inside the IIFE — hoisting it out severs the closure over the injected
+    // `var exports`, and `exports` then resolves as an unknown global
+    // (`exports.X` lowers to the numeric `0` sentinel → `(number).test is not a
+    // function` inside class methods/constructors of CJS packages like ajv).
+    for injected in ["exports", "module", "require"] {
+        if !iife_locals.iter().any(|n| n == injected) {
+            iife_locals.push(injected.to_string());
+        }
+    }
 
     let mut i = 0usize;
     while i < bytes.len() {

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -649,6 +649,55 @@ module.exports = SafeBuffer;"#;
     }
 
     #[test]
+    fn issue_5251_class_reading_exports_stays_in_iife() {
+        // #5251: a top-level class whose body reads the cjs_wrap-injected
+        // `exports` binding (`exports.X` inside a method/ctor) must NOT be
+        // hoisted out of the IIFE — hoisting severs its closure over the
+        // injected `var exports`, so `exports.X` resolves as an unknown
+        // global and lowers to the numeric `0` sentinel inside class methods.
+        let src = "\"use strict\";\nexports.TAG = \"hi\";\nclass C { greet() { return exports.TAG + \"!\"; } }\nexports.mk = function () { return new C(); };\n";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/app/node_modules/re/index.js"));
+        let iife_start = wrapped
+            .find("const _cjs = (function() {")
+            .expect("expected an IIFE wrap (no flat default class), got:\n");
+        let class_pos = wrapped
+            .find("class C ")
+            .expect("class C must survive in the wrapped output");
+        assert!(
+            class_pos > iife_start,
+            "class reading `exports` must stay INSIDE the IIFE (after its \
+             opener), not hoisted above it, got:\n{}",
+            wrapped
+        );
+        assert!(
+            perry_parser::parse_typescript(&wrapped, "re/index.js").is_ok(),
+            "wrapped module must parse, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
+    fn issue_5251_class_without_exports_still_hoists() {
+        // Regression guard: a top-level class that does NOT touch the injected
+        // `exports`/`module`/`require` bindings must still hoist above the
+        // IIFE (so `import { D } from "pkg"` resolves to the real class).
+        let src = "\"use strict\";\nclass D { val() { return 42; } }\nexports.mkD = function () { return new D(); };\n";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/app/node_modules/re/index.js"));
+        let iife_start = wrapped
+            .find("const _cjs = (function() {")
+            .expect("expected an IIFE wrap, got:\n");
+        let class_pos = wrapped
+            .find("class D ")
+            .expect("class D must survive in the wrapped output");
+        assert!(
+            class_pos < iife_start,
+            "a class not referencing exports/module/require must still hoist \
+             above the IIFE, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
     fn issue_1721_blanks_adopted_alias_require_in_body() {
         // #1721: `const c = require('./common')` adopts `c` as the import
         // local name (so `import c from './common'`). The original body line


### PR DESCRIPTION
## Summary
Fixes #5251. Inside a **class method/constructor** of a natively-compiled CJS package (`compilePackages`), reading a module-level `exports.X` yielded perry's numeric **`0` sentinel** instead of the value — the dominant root of the native-compile "sentinel-`0`" class (e.g. ajv's `exports.IDENTIFIER.test(s)` inside a class constructor → `(number).test is not a function`).

## Root cause
The cjs_wrap preamble injects `var exports`, `var module`, and a `require` function as **IIFE-local** bindings. `extract_top_level_class_decls` (the #652 class-hoist pass) hoists top-level classes *out* of the IIFE so consumers can `import { X }` and resolve to the real class. The #2310 guard already refuses to hoist a class whose body references a top-level `let`/`const`/`var` — but its textual scan only sees declarations in the **original** source, and `exports`/`module`/`require` are never declared there (they come from the preamble). So a class reading `exports.X` got hoisted, severing its closure over the injected `var exports`; `exports` then resolved as an unknown global (warning: *"unknown identifier 'exports' … bare reads lower to 0"*) and `exports.X` lowered to `0`. Free functions and module-level code stay inside the IIFE, which is why they worked.

## Fix
Always add `exports`, `module`, `require` to the IIFE-local set that gates hoisting (`extract_top_level_class_decls`). A class reading any of them now stays inside the IIFE and closes over the injected bindings — same resolution path as free functions / module-level code. Classes that don't touch those bindings still hoist normally.

One file of logic (`hoist_classes.rs`, +16 lines) plus two unit tests (`mod.rs`).

## Test evidence
Minimal `re` repro (class method reads `exports.TAG`):
- Before: `0!`
- After: `hi!` (matches Node)

Extended fixture, all matching Node byte-for-byte:
- constructor `this.v = exports.TAG` → `hi`
- `exports.RE = /x/i; … m(){ return exports.RE.test("X") }` → `true`
- free-function `exports.TAG` read → `hi?` (regression: still works)
- module-level `const TOP = 42` read from a class method → `42` (that class still hoists; regression intact)

Added unit tests: `issue_5251_class_reading_exports_stays_in_iife`, `issue_5251_class_without_exports_still_hoists`. `cargo test --release -p perry -p perry-hir` green (one HTTP integration test flaked under full parallel load — ext-http link race — and passes when run isolated; unrelated to this change).

## ajv before/after (payoff check)
`import Ajv from "ajv"; const a = new Ajv(); const v = a.compile({…}); console.log(v({n:1}), v({}))` with `compilePackages:["*"]`:
- Before: compiled with `unknown identifier 'exports'` warnings; the `(number).test is not a function` sentinel-0 error.
- After: **clean compile + link, no `exports` warnings, the `(number).test` error is gone.** It now hits a *different, later* wall: `TypeError: undefined is not a constructor` at `new Ajv()` — the `Ajv` default-export/constructor binding, a separate issue not addressed here.

## Risks
Low. The change only widens the set of bindings that *keep a class inside the IIFE* (more conservative hoisting). Word-boundary matching (`class_body_references_any`) already excludes `.`-prefixed property accesses, so `this.exports` etc. won't trip it. Worst case: a class that merely *mentions* `exports`/`module`/`require` as a bare identifier stays un-hoisted and is reached via `_cjs.X` — which still works.

## Maintainer note
No version / `CHANGELOG.md` / `Cargo.lock` edits — left for fold-in at merge per CLAUDE.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect hoisting of top-level classes in CommonJS output when they reference injected bindings (`exports`, `module`, `require`), preventing potential runtime errors.

* **Tests**
  * Added regression tests for CommonJS wrapper class hoisting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->