### PR TITLE
test(hir): fix cheerio_call_rewrite compile on main (missing byte_offset after #5250)

### DIFF
--- a/crates/perry-hir/tests/cheerio_call_rewrite.rs
+++ b/crates/perry-hir/tests/cheerio_call_rewrite.rs
@@ -120,7 +120,7 @@ fn non_native_fluent_chains_are_walked_linearly() {
                 return_type: Type::Any,
             }],
             type_args: Vec::new(),
-        byte_offset: 0,
+            byte_offset: 0,
         };
     }
 

--- a/crates/perry-hir/tests/cheerio_call_rewrite.rs
+++ b/crates/perry-hir/tests/cheerio_call_rewrite.rs
@@ -105,6 +105,7 @@ fn non_native_fluent_chains_are_walked_linearly() {
             return_type: Type::Any,
         }],
         type_args: Vec::new(),
+        byte_offset: 0,
     };
 
     for i in 0..32 {
@@ -119,6 +120,7 @@ fn non_native_fluent_chains_are_walked_linearly() {
                 return_type: Type::Any,
             }],
             type_args: Vec::new(),
+        byte_offset: 0,
         };
     }
 
@@ -129,6 +131,7 @@ fn non_native_fluent_chains_are_walked_linearly() {
         }),
         args: Vec::new(),
         type_args: Vec::new(),
+        byte_offset: 0,
     };
 
     let mut module = Module::new("non-native-fluent-chain");


### PR DESCRIPTION
#5250 added `Expr::Call.byte_offset` but missed updating `crates/perry-hir/tests/cheerio_call_rewrite.rs`, so `cargo test -p perry-hir` fails to compile on `main` (`error[E0063]: missing field byte_offset` ×3). This adds `byte_offset: 0` to the 3 `Expr::Call` constructions. Test compiles + passes. No src changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated internal test fixtures for expression call rewrites to include an additional `byte_offset` field.
  * Minor fixture structure improvements; no changes to test assertions or execution logic.

* **User Impact**
  * No user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->