### PR TITLE
fix(runtime): native ctor-class exports expose a real .prototype (#5268)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -2964,18 +2964,28 @@ pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Opt
     // `'prototype' in C.prototype.m === false`). (Test262 definition method/accessor
     // prop-desc.)
     //
-    // #4973 / #3527 exception: bound NATIVE-MODULE *class* exports
-    // (`http.Server`, `http.IncomingMessage`, `http.ServerResponse`, …) are
+    // #4973 / #3527 / #5268 exception: bound NATIVE-MODULE *class* exports
+    // (`http.Server`, `fs.ReadStream`, `events.EventEmitter`, …) are
     // constructors in Node, and the util.inherits / `Object.create(Ctor.
-    // prototype)` subclass pattern reads their `.prototype` as a
-    // setPrototypeOf / Object.create operand. Returning None here made that
-    // read `undefined`, and `Object.create(undefined)` /
-    // `Object.setPrototypeOf(x, undefined)` then threw "Object prototype may
-    // only be an Object or null" — the exact blocker hit at Express init
-    // (`express/lib/request.js`: `Object.create(http.IncomingMessage.
-    // prototype)`). These exports are cached singleton closures
-    // (NATIVE_CALLABLE_EXPORTS), so the synthetic-class path below gives them
-    // a stable prototype object.
+    // prototype)` / `Object.setPrototypeOf(x, Ctor.prototype)` subclass
+    // pattern reads their `.prototype` as a setPrototypeOf / Object.create
+    // operand. Returning None here made that read `undefined`, and
+    // `Object.create(undefined)` / `Object.setPrototypeOf(x, undefined)` then
+    // threw "Object prototype may only be an Object or null" — the blocker hit
+    // at Express init (`express/lib/request.js`:
+    // `Object.create(http.IncomingMessage.prototype)`), graceful-fs's
+    // `ReadStream.prototype = Object.create(fs$ReadStream.prototype)`, and
+    // pino's `Object.setPrototypeOf(prototype, EventEmitter.prototype)`.
+    //
+    // A bound-native export is a constructor class when its method name uses
+    // Node's constructor-cased convention (a leading uppercase ASCII letter,
+    // e.g. `ReadStream`/`EventEmitter`/`Server`) AND it isn't explicitly
+    // marked non-constructable (built-in prototype methods like
+    // `String.prototype.charAt` carry that flag). Such exports are cached
+    // singleton closures (NATIVE_CALLABLE_EXPORTS), so the synthetic-class
+    // path below gives them a stable `.prototype` object. Non-constructor
+    // bound methods (`fs.readFile`, `path.join`, …) keep `prototype ===
+    // undefined`, matching Node's built-in non-constructor functions.
     {
         let jv = crate::value::JSValue::from_bits(func_value.to_bits());
         if jv.is_pointer() {
@@ -2984,24 +2994,17 @@ pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Opt
                 && is_valid_obj_ptr(cptr as *const u8)
                 && crate::closure::closure_is_bound_method(cptr)
             {
+                if super::native_module::builtin_closure_is_non_constructable_value(func_value) {
+                    return None;
+                }
                 let is_native_class_export = unsafe {
                     super::native_module::bound_native_callable_module_and_method(func_value)
                 }
-                .map(|(module, method)| {
-                    matches!(
-                        (module.as_str(), method.as_str()),
-                        // Shared http/https constructor classes.
-                        ("http" | "https", "Server" | "Agent")
-                            // http-only request/response constructor classes
-                            // that userland subclasses (Express, util.inherits).
-                            | (
-                                "http",
-                                "IncomingMessage"
-                                    | "ServerResponse"
-                                    | "OutgoingMessage"
-                                    | "ClientRequest"
-                            )
-                    )
+                .map(|(_module, method)| {
+                    method
+                        .as_bytes()
+                        .first()
+                        .is_some_and(|b| b.is_ascii_uppercase())
                 })
                 .unwrap_or(false);
                 if !is_native_class_export {

--- a/crates/perry/tests/issue_5268_native_ctor_prototype_undefined.rs
+++ b/crates/perry/tests/issue_5268_native_ctor_prototype_undefined.rs
@@ -1,0 +1,109 @@
+//! Regression test for #5268: native-module constructor *class* exports must
+//! expose a real `.prototype` object so the userland subclass idioms used by
+//! graceful-fs / fs-extra / pino don't throw
+//! `TypeError: Object prototype may only be an Object or null: undefined`.
+//!
+//! graceful-fs `graceful-fs.js`:
+//! ```js
+//! var fs$ReadStream = fs.ReadStream
+//! if (fs$ReadStream) {
+//!   ReadStream.prototype = Object.create(fs$ReadStream.prototype) // throws pre-fix
+//! }
+//! ```
+//! pino `lib/proto.js`:
+//! ```js
+//! const { EventEmitter } = require('node:events')
+//! Object.setPrototypeOf(prototype, EventEmitter.prototype) // throws pre-fix
+//! ```
+//!
+//! Pre-fix, `fs.ReadStream`/`fs.WriteStream`/`events.EventEmitter` were truthy
+//! callable closures (bound-native exports) whose `.prototype` resolved to
+//! `undefined`: `ordinary_function_prototype_value_for_read`
+//! (crates/perry-runtime/src/object/class_registry.rs) returned `None` for
+//! every bound-native export except a hardcoded http/https whitelist. Reading
+//! `Object.create(undefined)` / `Object.setPrototypeOf(x, undefined)` then hit
+//! the spec TypeError. Fix: recognize constructor-cased bound-native exports
+//! (leading uppercase, not flagged non-constructable) and let the
+//! synthetic-class path materialize a stable `.prototype` object — while
+//! keeping non-constructor exports (`fs.readFile`, …) at `prototype ===
+//! undefined`, matching Node's built-in non-constructor functions.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: 'TypeError: Object prototype may \
+         only be an Object or null: undefined')\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn native_ctor_class_exports_expose_real_prototype() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import * as fs from "node:fs";
+import { EventEmitter } from "node:events";
+
+// Native constructor classes expose an object .prototype (not undefined).
+const rsProto = (fs as any).ReadStream.prototype;
+const wsProto = (fs as any).WriteStream.prototype;
+const eeProto = (EventEmitter as any).prototype;
+console.log("rs:", typeof rsProto === "object" && rsProto !== null);
+console.log("ws:", typeof wsProto === "object" && wsProto !== null);
+console.log("ee:", typeof eeProto === "object" && eeProto !== null);
+
+// graceful-fs's ReadStream pattern: Object.create(Ctor.prototype).
+const sub = Object.create((fs as any).ReadStream.prototype);
+console.log("create:", typeof sub === "object" && sub !== null);
+console.log("chain:", Object.getPrototypeOf(sub) === (fs as any).ReadStream.prototype);
+
+// pino's proto.js pattern: setPrototypeOf(prototype, EventEmitter.prototype).
+const prototype: any = { child() { return null; } };
+Object.setPrototypeOf(prototype, (EventEmitter as any).prototype);
+console.log("setproto:", true);
+
+// Non-constructor native exports keep prototype === undefined (no spurious
+// synthesis), matching Node's built-in non-constructor functions.
+console.log("nonctor:", (fs as any).readFile.prototype === undefined);
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "rs: true\nws: true\nee: true\ncreate: true\nchain: true\nsetproto: true\nnonctor: true\n"
+    );
+}

--- a/test-files/test_issue_5268_native_ctor_prototype_undefined.ts
+++ b/test-files/test_issue_5268_native_ctor_prototype_undefined.ts
@@ -1,0 +1,47 @@
+// #5268: native-module constructor *class* exports must expose a real
+// `.prototype` object so the userland subclass idioms
+//
+//     ReadStream.prototype = Object.create(fs$ReadStream.prototype)  // graceful-fs
+//     Object.setPrototypeOf(prototype, EventEmitter.prototype)        // pino
+//
+// don't throw "Object prototype may only be an Object or null: undefined".
+//
+// Pre-fix, `fs.ReadStream`/`fs.WriteStream`/`events.EventEmitter` were
+// truthy callable closures (bound-native exports) whose `.prototype`
+// read resolved to `undefined`: `ordinary_function_prototype_value_for_read`
+// short-circuited to `None` for every bound-native export except a
+// hardcoded http/https whitelist. graceful-fs guards on truthiness of
+// `fs$ReadStream` (truthy) then calls `Object.create(fs$ReadStream.prototype)`
+// → `Object.create(undefined)` → throw. The fix recognizes constructor-cased
+// bound-native exports (leading uppercase, not flagged non-constructable) and
+// lets the synthetic-class path materialize a stable `.prototype` object.
+
+import * as fs from "node:fs";
+import { EventEmitter } from "node:events";
+
+// 1. Native constructor classes expose an object `.prototype` (not undefined).
+const rsProto = (fs as any).ReadStream.prototype;
+const wsProto = (fs as any).WriteStream.prototype;
+const eeProto = (EventEmitter as any).prototype;
+console.log("fs.ReadStream.prototype is object:", typeof rsProto === "object" && rsProto !== null);
+console.log("fs.WriteStream.prototype is object:", typeof wsProto === "object" && wsProto !== null);
+console.log("EventEmitter.prototype is object:", typeof eeProto === "object" && eeProto !== null);
+
+// 2. graceful-fs's clone() ReadStream pattern: `Object.create(Ctor.prototype)`
+//    must not throw and must yield an object whose proto is Ctor.prototype.
+const sub = Object.create((fs as any).ReadStream.prototype);
+console.log("Object.create(ReadStream.prototype) ok:", typeof sub === "object" && sub !== null);
+console.log(
+  "subclass proto chains to ReadStream.prototype:",
+  Object.getPrototypeOf(sub) === (fs as any).ReadStream.prototype,
+);
+
+// 3. pino's proto.js pattern: `Object.setPrototypeOf(prototype, EventEmitter.prototype)`
+//    must not throw on the (now real) EventEmitter.prototype operand.
+const prototype: any = { child() { return null; } };
+Object.setPrototypeOf(prototype, (EventEmitter as any).prototype);
+console.log("setPrototypeOf(obj, EventEmitter.prototype) ok:", true);
+
+// 4. Non-constructor native exports keep `prototype === undefined`, matching
+//    Node's built-in non-constructor functions (no spurious synthesis).
+console.log("fs.readFile.prototype is undefined:", (fs as any).readFile.prototype === undefined);

--- a/test-files/test_issue_pino_prototype_undefined.ts
+++ b/test-files/test_issue_pino_prototype_undefined.ts
@@ -75,9 +75,9 @@ const eeKind = typeof (EventEmitter as any);
 console.log("ee_truthy:", eeKind !== "undefined");
 
 // 2. Reading `.prototype` on the destructured EventEmitter must not
-//    throw. Returning `undefined` here is acceptable (Perry doesn't
-//    materialize a real EventEmitter.prototype object yet); the
-//    contract is just "doesn't trip the TypeError".
+//    throw. As of #5268 Perry materializes a real EventEmitter.prototype
+//    object (constructor-cased bound-native exports get a synthesized
+//    `.prototype`); the contract is just "doesn't trip the TypeError".
 const proto = (EventEmitter as any).prototype;
 console.log("proto_read_ok:", proto !== "__threw__");
 


### PR DESCRIPTION
## #5268 — `Object prototype may only be an Object or null: undefined` (corpus top pattern: graceful-fs, fs-extra, pino)

### Traced root cause
Native-module constructor **class** exports (`fs.ReadStream`, `fs.WriteStream`, `events.EventEmitter`, …) are truthy callable closures (bound-native exports) whose `.prototype` resolved to **`undefined`**.

`ordinary_function_prototype_value_for_read` (`crates/perry-runtime/src/object/class_registry.rs`) short-circuited to `None` for **every** bound-native export except a hardcoded `http`/`https` whitelist (added for #3527/#4973). For everything else, `.prototype` read back `undefined`.

The three packages all guard on truthiness then read `.prototype`:
- **graceful-fs** `graceful-fs.js:242`: `var fs$ReadStream = fs.ReadStream; if (fs$ReadStream) { ReadStream.prototype = Object.create(fs$ReadStream.prototype) }` → `Object.create(undefined)`.
- **fs-extra**: re-exports graceful-fs → same throw.
- **pino** `lib/proto.js:77`: `Object.setPrototypeOf(prototype, EventEmitter.prototype)` → `Object.setPrototypeOf(x, undefined)`.

Each fed `undefined` into the proto-validation throw site.

### How it was traced
Temporary `eprintln!` + backtrace at the three throw sites (`object_ops.rs` setPrototypeOf, `descriptors.rs` Object.create, `proxy/prototype.rs` Reflect). Running the real corpus drivers showed:
- graceful-fs/fs-extra → `js_object_create_with_props` with `proto = undefined` (and props `undefined`).
- pino → `js_object_set_prototype_of` with `proto = undefined`, receiver a real object.

Reduced to `fs.ReadStream.prototype === undefined` / `EventEmitter.prototype === undefined`, then localized to the bound-native whitelist gate. All tracing removed before commit.

### Fix
Replace the http/https whitelist with a principled rule: a bound-native export is a **constructor class** when its method name uses Node's constructor-cased convention (leading uppercase ASCII letter, e.g. `ReadStream`/`EventEmitter`/`Server`) **and** it isn't flagged non-constructable (built-in prototype methods like `String.prototype.charAt` carry that flag). Such exports flow through the existing synthetic-class path (`ensure_function_prototype_object`), which materializes a stable `.prototype` object. Non-constructor bound methods (`fs.readFile`, `path.join`, …) keep `prototype === undefined`, matching Node's built-in non-constructor functions.

One file changed: `crates/perry-runtime/src/object/class_registry.rs`.

### Tests
- New `crates/perry/tests/issue_5268_native_ctor_prototype_undefined.rs` (compile+run) — passes.
- New `test-files/test_issue_5268_native_ctor_prototype_undefined.ts`.
- Updated stale comment in `test-files/test_issue_pino_prototype_undefined.ts` (it claimed `EventEmitter.prototype` stays undefined; now it's a real object — the test's lenient assertions still pass).
- `cargo test -p perry-runtime --lib -- --test-threads=1`: **1044 passed, 0 failed**. (Parallel runs surface a nondeterministic set of pre-existing shared-global-side-table flakes — `url path_to_file_url`, `closure dynamic_props tests_1802`, etc. — independent of this change; verified by stashing the fix and observing a *different* failing set on clean baseline parallel runs.)
- `issue_4908_subclass_native_member_base`, `issue_5257_require_adopt_no_default_namespace`, existing `test_gap_3527_http_ctor_prototype` + `test_issue_pino_prototype_undefined`: pass.

### 3-package before/after (real corpus, `PERRY_NO_AUTO_OPTIMIZE=1`)
| driver | before | after |
|---|---|---|
| `graceful_fs_.ts` | throws `Object prototype … : undefined` | prints `graceful-fs object` ✅ |
| `fs_extra_.ts` | throws `Object prototype … : undefined` | prints `fs-extra object` ✅ (benign `fs.realpath.native` warning) |
| `pino_.ts` | throws `Object prototype … : undefined` | throw gone; next wall: `TypeError: Cannot read properties of undefined (reading 'get')` (unrelated, not fixed here) |

### Risks
Low. The change widens which bound-native exports get a synthesized `.prototype` from a 6-name whitelist to "constructor-cased, constructable". This only affects `.prototype` *reads* on native exports (no behavior change for user closures, declared classes, or http/https which remain covered). Non-constructable exports are now explicitly excluded earlier, so built-in prototype methods are unaffected.

### Note for maintainer
No `Cargo.toml` version / `CLAUDE.md` / `CHANGELOG.md` / `Cargo.lock` edits (per workflow — fold in at merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed native-module constructor exports to properly expose `.prototype` objects at runtime, enabling valid inheritance patterns and prototype chain manipulation operations that previously failed with undefined values.

* **Tests**
  * Added comprehensive regression test coverage to verify native-module constructors consistently expose valid prototype objects for proper subclassing and object prototype manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->