### PR TITLE
feat(plugin): add unregister/off methods for hooks, tools, services, routes, events

### DIFF
--- a/crates/perry-codegen/src/lower_call/ui_tables.rs
+++ b/crates/perry-codegen/src/lower_call/ui_tables.rs
@@ -284,6 +284,47 @@ static PERRY_PLUGIN_INSTANCE_TABLE: &[UiSig] = &[
         args: &[UiArgKind::F64, UiArgKind::F64],
         ret: UiReturnKind::F64,
     },
+    // api.unregisterHook(hookName, handler) -> undefined
+    // Removes the single entry whose closure bits match `handler`. The
+    // caller must be the same plugin that registered the hook; otherwise
+    // the call is a silent no-op.
+    UiSig {
+        method: "unregisterHook",
+        runtime: "perry_plugin_unregister_hook",
+        args: &[UiArgKind::F64, UiArgKind::Closure],
+        ret: UiReturnKind::F64,
+    },
+    // api.unregisterTool(name) -> undefined
+    UiSig {
+        method: "unregisterTool",
+        runtime: "perry_plugin_unregister_tool",
+        args: &[UiArgKind::F64],
+        ret: UiReturnKind::F64,
+    },
+    // api.unregisterService(name) -> undefined
+    // The service's `stopFn` is invoked before the entry is removed,
+    // matching the lifecycle contract of `registerService`.
+    UiSig {
+        method: "unregisterService",
+        runtime: "perry_plugin_unregister_service",
+        args: &[UiArgKind::F64],
+        ret: UiReturnKind::F64,
+    },
+    // api.unregisterRoute(path) -> undefined
+    UiSig {
+        method: "unregisterRoute",
+        runtime: "perry_plugin_unregister_route",
+        args: &[UiArgKind::F64],
+        ret: UiReturnKind::F64,
+    },
+    // api.off(event, handler) -> undefined
+    // Removes the single event-bus subscription whose closure bits match.
+    UiSig {
+        method: "off",
+        runtime: "perry_plugin_off",
+        args: &[UiArgKind::F64, UiArgKind::Closure],
+        ret: UiReturnKind::F64,
+    },
 ];
 
 pub fn perry_plugin_table_lookup(method: &str) -> Option<&'static UiSig> {

--- a/crates/perry-runtime/src/gc/tests/helper_stores.rs
+++ b/crates/perry-runtime/src/gc/tests/helper_stores.rs
@@ -211,6 +211,9 @@ fn regex_global_result_array_preserves_young_match_strings() {
 #[test]
 fn plugin_and_promise_field_population_helpers_preserve_young_children() {
     let _guard = CopyingNurseryTestGuard::new(0);
+    let _plugin_registry_guard = crate::plugin::PLUGIN_REGISTRY_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let _env_guard = EnvVarGuard::set("PERRY_GC_VERIFY_EVACUATION", "1");
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
 

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
@@ -855,6 +855,7 @@ static RUNTIME_CALLBACK_ROOT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex:
 
 struct RuntimeCallbackRootGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
+    _plugin_lock: std::sync::MutexGuard<'static, ()>,
 }
 
 impl RuntimeCallbackRootGuard {
@@ -862,8 +863,14 @@ impl RuntimeCallbackRootGuard {
         let lock = RUNTIME_CALLBACK_ROOT_TEST_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let plugin_lock = crate::plugin::PLUGIN_REGISTRY_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         clear_runtime_callback_roots_for_test();
-        Self { _lock: lock }
+        Self {
+            _lock: lock,
+            _plugin_lock: plugin_lock,
+        }
     }
 }
 

--- a/crates/perry-runtime/src/gc/tests/support.rs
+++ b/crates/perry-runtime/src/gc/tests/support.rs
@@ -332,7 +332,12 @@ fn reset_copying_nursery_runtime_test_state() {
     crate::geisterhand_registry::test_clear_geisterhand_roots();
     crate::ui_text_registry::test_clear_ui_text_registry_roots();
     #[cfg(feature = "full")]
-    crate::plugin::test_clear_plugin_roots();
+    {
+        let _plugin_registry_guard = crate::plugin::PLUGIN_REGISTRY_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        crate::plugin::test_clear_plugin_roots();
+    }
 }
 
 impl CopyingNurseryTestGuard {

--- a/crates/perry-runtime/src/plugin.rs
+++ b/crates/perry-runtime/src/plugin.rs
@@ -473,6 +473,92 @@ pub extern "C" fn perry_plugin_emit(api_handle: i64, event: f64, data: f64) -> f
     perry_plugin_emit_event(event, data)
 }
 
+/// Unregister a previously-registered hook handler. Removes the entry whose
+/// closure bits match `handler` (closure-identity match). No-op if the
+/// caller is not the registering plugin or no such entry exists.
+#[no_mangle]
+pub extern "C" fn perry_plugin_unregister_hook(
+    api_handle: i64,
+    hook_name: f64,
+    handler: f64,
+) -> f64 {
+    let name = unsafe { extract_string(hook_name) };
+    let target_bits = handler.to_bits();
+    let mut reg = REGISTRY.lock().unwrap();
+    if let Some(plugin_id) = reg.plugin_id_for_handle(api_handle) {
+        if let Some(hooks) = reg.hooks.get_mut(&name) {
+            hooks.retain(|h| !(h.plugin_id == plugin_id && h.handler_closure == target_bits));
+        }
+        reg.hooks.retain(|_, v| !v.is_empty());
+    }
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+/// Unregister a tool by name. No-op if the caller didn't register it.
+#[no_mangle]
+pub extern "C" fn perry_plugin_unregister_tool(api_handle: i64, name: f64) -> f64 {
+    let tool_name = unsafe { extract_string(name) };
+    let mut reg = REGISTRY.lock().unwrap();
+    if let Some(plugin_id) = reg.plugin_id_for_handle(api_handle) {
+        reg.tools.retain(|t| !(t.plugin_id == plugin_id && t.name == tool_name));
+    }
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+/// Unregister a service by name. The service's `stopFn` is invoked before
+/// the entry is removed (matches the lifecycle contract of `registerService`).
+#[no_mangle]
+pub extern "C" fn perry_plugin_unregister_service(api_handle: i64, name: f64) -> f64 {
+    let svc_name = unsafe { extract_string(name) };
+    let mut reg = REGISTRY.lock().unwrap();
+    if let Some(plugin_id) = reg.plugin_id_for_handle(api_handle) {
+        if let Some(idx) = reg
+            .services
+            .iter()
+            .position(|s| s.plugin_id == plugin_id && s.name == svc_name)
+        {
+            let svc = reg.services.remove(idx);
+            let ptr_mask: u64 = 0x0000_FFFF_FFFF_FFFF;
+            let stop_ptr = (svc.stop_fn & ptr_mask) as *const crate::closure::ClosureHeader;
+            if !stop_ptr.is_null() {
+                drop(reg);
+                unsafe {
+                    crate::closure::js_closure_call0(stop_ptr);
+                }
+            }
+        }
+    }
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+/// Unregister a route by path. No-op if the caller didn't register it.
+#[no_mangle]
+pub extern "C" fn perry_plugin_unregister_route(api_handle: i64, path: f64) -> f64 {
+    let route_path = unsafe { extract_string(path) };
+    let mut reg = REGISTRY.lock().unwrap();
+    if let Some(plugin_id) = reg.plugin_id_for_handle(api_handle) {
+        reg.routes
+            .retain(|r| !(r.plugin_id == plugin_id && r.path == route_path));
+    }
+    f64::from_bits(JSValue::undefined().bits())
+}
+
+/// Unsubscribe a previously-registered event handler. Removes the entry
+/// whose closure bits match `handler`. No-op otherwise.
+#[no_mangle]
+pub extern "C" fn perry_plugin_off(api_handle: i64, event: f64, handler: f64) -> f64 {
+    let event_name = unsafe { extract_string(event) };
+    let target_bits = handler.to_bits();
+    let mut reg = REGISTRY.lock().unwrap();
+    if let Some(plugin_id) = reg.plugin_id_for_handle(api_handle) {
+        if let Some(handlers) = reg.events.get_mut(&event_name) {
+            handlers.retain(|e| !(e.plugin_id == plugin_id && e.handler_closure == target_bits));
+        }
+        reg.events.retain(|_, v| !v.is_empty());
+    }
+    f64::from_bits(JSValue::undefined().bits())
+}
+
 // ============================================================================
 // Host-side functions — called by the host application
 // ============================================================================

--- a/crates/perry-runtime/src/plugin.rs
+++ b/crates/perry-runtime/src/plugin.rs
@@ -490,7 +490,12 @@ pub extern "C" fn perry_plugin_unregister_hook(
     let mut reg = REGISTRY.lock().unwrap();
     if let Some(plugin_id) = reg.plugin_id_for_handle(api_handle) {
         if let Some(hooks) = reg.hooks.get_mut(&name) {
-            hooks.retain(|h| !(h.plugin_id == plugin_id && h.handler_closure == target_bits));
+            if let Some(pos) = hooks
+                .iter()
+                .position(|h| h.plugin_id == plugin_id && h.handler_closure == target_bits)
+            {
+                hooks.remove(pos);
+            }
         }
         reg.hooks.retain(|_, v| !v.is_empty());
     }
@@ -521,13 +526,23 @@ pub extern "C" fn perry_plugin_unregister_service(api_handle: i64, name: f64) ->
             .iter()
             .position(|s| s.plugin_id == plugin_id && s.name == svc_name)
         {
-            let svc = reg.services.remove(idx);
             let ptr_mask: u64 = 0x0000_FFFF_FFFF_FFFF;
-            let stop_ptr = (svc.stop_fn & ptr_mask) as *const crate::closure::ClosureHeader;
-            if !stop_ptr.is_null() {
+            let stop_bits = reg.services[idx].stop_fn;
+            let stop_ptr = (stop_bits & ptr_mask) as *const crate::closure::ClosureHeader;
+            if stop_ptr.is_null() {
+                reg.services.remove(idx);
+            } else {
                 drop(reg);
                 unsafe {
                     crate::closure::js_closure_call0(stop_ptr);
+                }
+                let mut reg = REGISTRY.lock().unwrap();
+                if let Some(idx2) = reg
+                    .services
+                    .iter()
+                    .position(|s| s.plugin_id == plugin_id && s.name == svc_name)
+                {
+                    reg.services.remove(idx2);
                 }
             }
         }
@@ -556,7 +571,12 @@ pub extern "C" fn perry_plugin_off(api_handle: i64, event: f64, handler: f64) ->
     let mut reg = REGISTRY.lock().unwrap();
     if let Some(plugin_id) = reg.plugin_id_for_handle(api_handle) {
         if let Some(handlers) = reg.events.get_mut(&event_name) {
-            handlers.retain(|e| !(e.plugin_id == plugin_id && e.handler_closure == target_bits));
+            if let Some(pos) = handlers
+                .iter()
+                .position(|e| e.plugin_id == plugin_id && e.handler_closure == target_bits)
+            {
+                handlers.remove(pos);
+            }
         }
         reg.events.retain(|_, v| !v.is_empty());
     }

--- a/crates/perry-runtime/src/plugin.rs
+++ b/crates/perry-runtime/src/plugin.rs
@@ -164,6 +164,9 @@ lazy_static! {
     static ref REGISTRY: Mutex<PluginRegistry> = Mutex::new(PluginRegistry::new());
 }
 
+#[cfg(test)]
+pub(crate) static PLUGIN_REGISTRY_TEST_LOCK: Mutex<()> = Mutex::new(());
+
 /// GC root scanner for closures and JS values held by the process-wide
 /// plugin registry. These slots live outside the managed heap, so copied-minor
 /// GC must see and rewrite them explicitly.
@@ -500,7 +503,8 @@ pub extern "C" fn perry_plugin_unregister_tool(api_handle: i64, name: f64) -> f6
     let tool_name = unsafe { extract_string(name) };
     let mut reg = REGISTRY.lock().unwrap();
     if let Some(plugin_id) = reg.plugin_id_for_handle(api_handle) {
-        reg.tools.retain(|t| !(t.plugin_id == plugin_id && t.name == tool_name));
+        reg.tools
+            .retain(|t| !(t.plugin_id == plugin_id && t.name == tool_name));
     }
     f64::from_bits(JSValue::undefined().bits())
 }
@@ -1084,4 +1088,280 @@ pub(crate) fn test_plugin_roots_snapshot() -> (u64, u64, u64, u64, u64, u64, u64
             .unwrap_or(0),
         reg.config.get("config").copied().unwrap_or(0),
     )
+}
+
+// ============================================================================
+// Unit tests — exercise the 5 selective-cleanup FFI functions added for
+// issue #5270 (PluginApi.unregister* / off).
+//
+// Each test seeds a small PluginRegistry directly (bypassing dlopen +
+// plugin_activate), then calls the unregister FFI with synthetic NaN-boxed
+// args. The assertions read the registry state back to confirm the targeted
+// row was removed without disturbing unrelated entries.
+// ============================================================================
+
+#[cfg(test)]
+mod unregister_tests {
+    use super::*;
+
+    /// Allocate a fresh api_handle in the test registry bound to plugin_id 1.
+    /// Mirrors what `perry_plugin_load` does for a real plugin: increments
+    /// `next_api_handle` and inserts the binding so `plugin_id_for_handle`
+    /// resolves. The handle is owned by no real shared library so there's
+    /// no dlclose on drop — `test_clear_plugin_roots` reclaims everything
+    /// at the end of the test.
+    fn fresh_api_handle() -> i64 {
+        let mut reg = REGISTRY.lock().unwrap();
+        reg.alloc_api_handle(1)
+    }
+
+    /// Seed the registry with the canonical 6-entry fixture (one of each
+    /// registration type) so each unregister test has well-defined state.
+    /// Closure bits are arbitrary f64-bit patterns; identity compare uses
+    /// `to_bits()`, so values just need to be distinct across entries.
+    fn seed() {
+        let mut reg = REGISTRY.lock().unwrap();
+        *reg = PluginRegistry::new();
+        // Reset the active_api_handles by reconstructing the registry, then
+        // re-allocate the test's preferred handle (1) below.
+        reg.hooks.insert(
+            "beforeSave".to_string(),
+            vec![
+                HookRegistration {
+                    plugin_id: 1,
+                    handler_closure: 0xAAAA_0001_0001_u64,
+                    priority: 10,
+                    mode: HOOK_MODE_FILTER,
+                },
+                HookRegistration {
+                    plugin_id: 1,
+                    handler_closure: 0xAAAA_0001_0002_u64,
+                    priority: 20,
+                    mode: HOOK_MODE_ACTION,
+                },
+            ],
+        );
+        reg.tools.push(ToolRegistration {
+            plugin_id: 1,
+            name: "formatCode".to_string(),
+            description: "format".to_string(),
+            handler_closure: 0xBBBB_0001_0001_u64,
+        });
+        reg.tools.push(ToolRegistration {
+            plugin_id: 2,
+            name: "otherPluginTool".to_string(),
+            description: "owned by plugin 2".to_string(),
+            handler_closure: 0xBBBB_0002_0001_u64,
+        });
+        reg.services.push(ServiceRegistration {
+            plugin_id: 1,
+            name: "worker".to_string(),
+            start_fn: 0xCCCC_0001_0001_u64,
+            stop_fn: 0xCCCC_0001_0002_u64,
+        });
+        reg.routes.push(RouteRegistration {
+            plugin_id: 1,
+            path: "/api/foo".to_string(),
+            handler_closure: 0xDDDD_0001_0001_u64,
+        });
+        reg.events.insert(
+            "dataUpdated".to_string(),
+            vec![EventRegistration {
+                plugin_id: 1,
+                handler_closure: 0xEEEE_0001_0001_u64,
+            }],
+        );
+        reg.active_api_handles.insert(1, 1);
+        reg.next_api_handle = 2;
+    }
+
+    fn teardown() {
+        *REGISTRY.lock().unwrap() = PluginRegistry::new();
+    }
+
+    fn lock_tests() -> std::sync::MutexGuard<'static, ()> {
+        PLUGIN_REGISTRY_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[test]
+    fn unregister_hook_removes_only_matching_entry() {
+        let _test_guard = lock_tests();
+        seed();
+        let handle = fresh_api_handle();
+        let hook_name = unsafe { make_nanboxed_string("beforeSave") };
+        let target_handler = f64::from_bits(0xAAAA_0001_0001_u64);
+        let _ = unsafe { perry_plugin_unregister_hook(handle, hook_name, target_handler) };
+
+        let reg = REGISTRY.lock().unwrap();
+        let hooks = reg
+            .hooks
+            .get("beforeSave")
+            .expect("beforeSave still present");
+        assert_eq!(hooks.len(), 1, "one matching handler should remain");
+        assert_eq!(hooks[0].handler_closure, 0xAAAA_0001_0002_u64);
+        drop(reg);
+
+        // Second call with the remaining handler — bucket should now be empty
+        // and the parent map entry pruned.
+        let other_handler = f64::from_bits(0xAAAA_0001_0002_u64);
+        let _ = unsafe { perry_plugin_unregister_hook(handle, hook_name, other_handler) };
+        let reg = REGISTRY.lock().unwrap();
+        assert!(
+            reg.hooks.get("beforeSave").is_none(),
+            "empty hook bucket should be removed"
+        );
+        drop(reg);
+        teardown();
+    }
+
+    #[test]
+    fn unregister_hook_with_wrong_bits_is_noop() {
+        let _test_guard = lock_tests();
+        seed();
+        let handle = fresh_api_handle();
+        let hook_name = unsafe { make_nanboxed_string("beforeSave") };
+        let bogus_handler = f64::from_bits(0xDEAD_BEEF_DEAD_BEEF_u64);
+
+        let _ = unsafe { perry_plugin_unregister_hook(handle, hook_name, bogus_handler) };
+
+        let reg = REGISTRY.lock().unwrap();
+        let hooks = reg.hooks.get("beforeSave").unwrap();
+        assert_eq!(hooks.len(), 2, "no matching bits → both handlers stay");
+        drop(reg);
+        teardown();
+    }
+
+    #[test]
+    fn unregister_hook_from_other_plugin_is_noop() {
+        let _test_guard = lock_tests();
+        seed();
+        // Forge an api_handle bound to plugin 2 (the owner of otherPluginTool).
+        // Plugin 2 shouldn't be able to remove plugin 1's hooks.
+        let mut reg = REGISTRY.lock().unwrap();
+        let handle_2 = reg.alloc_api_handle(2);
+        drop(reg);
+
+        let hook_name = unsafe { make_nanboxed_string("beforeSave") };
+        let target = f64::from_bits(0xAAAA_0001_0001_u64);
+        let _ = unsafe { perry_plugin_unregister_hook(handle_2, hook_name, target) };
+
+        let reg = REGISTRY.lock().unwrap();
+        assert_eq!(reg.hooks.get("beforeSave").unwrap().len(), 2);
+        drop(reg);
+        teardown();
+    }
+
+    #[test]
+    fn unregister_tool_removes_only_matching_row() {
+        let _test_guard = lock_tests();
+        seed();
+        let handle = fresh_api_handle();
+        let name = unsafe { make_nanboxed_string("formatCode") };
+        let _ = unsafe { perry_plugin_unregister_tool(handle, name) };
+
+        let reg = REGISTRY.lock().unwrap();
+        assert_eq!(reg.tools.len(), 1, "only the matching tool is removed");
+        assert_eq!(reg.tools[0].name, "otherPluginTool");
+        drop(reg);
+        teardown();
+    }
+
+    #[test]
+    fn unregister_tool_unknown_name_is_noop() {
+        let _test_guard = lock_tests();
+        seed();
+        let handle = fresh_api_handle();
+        let bogus = unsafe { make_nanboxed_string("doesNotExist") };
+        let _ = unsafe { perry_plugin_unregister_tool(handle, bogus) };
+
+        let reg = REGISTRY.lock().unwrap();
+        assert_eq!(reg.tools.len(), 2);
+        drop(reg);
+        teardown();
+    }
+
+    #[test]
+    fn unregister_route_removes_matching_path() {
+        let _test_guard = lock_tests();
+        seed();
+        let handle = fresh_api_handle();
+        let path = unsafe { make_nanboxed_string("/api/foo") };
+        let _ = unsafe { perry_plugin_unregister_route(handle, path) };
+
+        let reg = REGISTRY.lock().unwrap();
+        assert_eq!(reg.routes.len(), 0);
+        drop(reg);
+        teardown();
+    }
+
+    #[test]
+    fn unregister_service_removes_matching_row() {
+        let _test_guard = lock_tests();
+        seed();
+        let handle = fresh_api_handle();
+        let name = unsafe { make_nanboxed_string("worker") };
+        // `stop_fn` is a closure pointer stored as bits — calling
+        // `js_closure_call0` on it would dereference arbitrary memory. The
+        // null-pointer guard inside unregister_service checks the masked pointer,
+        // so stubbing stop_fn to zero exercises the removal path without crashing.
+        {
+            let mut reg = REGISTRY.lock().unwrap();
+            for svc in reg.services.iter_mut() {
+                svc.stop_fn = 0;
+            }
+        }
+        let _ = unsafe { perry_plugin_unregister_service(handle, name) };
+
+        let reg = REGISTRY.lock().unwrap();
+        assert_eq!(reg.services.len(), 0, "worker service removed");
+        drop(reg);
+        teardown();
+    }
+
+    #[test]
+    fn unregister_off_removes_matching_event_handler() {
+        let _test_guard = lock_tests();
+        seed();
+        let handle = fresh_api_handle();
+        let event = unsafe { make_nanboxed_string("dataUpdated") };
+        let handler = f64::from_bits(0xEEEE_0001_0001_u64);
+        let _ = unsafe { perry_plugin_off(handle, event, handler) };
+
+        let reg = REGISTRY.lock().unwrap();
+        assert!(
+            reg.events.get("dataUpdated").is_none(),
+            "empty event bucket should be removed"
+        );
+        drop(reg);
+        teardown();
+    }
+
+    #[test]
+    fn unregister_with_unknown_api_handle_is_noop() {
+        let _test_guard = lock_tests();
+        seed();
+        // An api_handle that was never allocated returns None from
+        // plugin_id_for_handle → every unregister path's body is skipped.
+        let ghost_handle: i64 = 9999;
+        let hook_name = unsafe { make_nanboxed_string("beforeSave") };
+        let _ = unsafe { perry_plugin_unregister_hook(ghost_handle, hook_name, 0.0) };
+        let name = unsafe { make_nanboxed_string("formatCode") };
+        let _ = unsafe { perry_plugin_unregister_tool(ghost_handle, name) };
+        let path = unsafe { make_nanboxed_string("/api/foo") };
+        let _ = unsafe { perry_plugin_unregister_route(ghost_handle, path) };
+        let _ = unsafe { perry_plugin_unregister_service(ghost_handle, name) };
+        let event = unsafe { make_nanboxed_string("dataUpdated") };
+        let _ = unsafe { perry_plugin_off(ghost_handle, event, 0.0) };
+
+        let reg = REGISTRY.lock().unwrap();
+        assert_eq!(reg.hooks.get("beforeSave").unwrap().len(), 2);
+        assert_eq!(reg.tools.len(), 2);
+        assert_eq!(reg.routes.len(), 1);
+        assert_eq!(reg.services.len(), 1);
+        assert_eq!(reg.events.get("dataUpdated").unwrap().len(), 1);
+        drop(reg);
+        teardown();
+    }
 }

--- a/docs/examples/plugins/plugin_snippets.ts
+++ b/docs/examples/plugins/plugin_snippets.ts
@@ -109,6 +109,59 @@ function registerWorker(api: PluginApi) {
 }
 // ANCHOR_END: register-service
 
+// ANCHOR: unregister-hooks
+// Selective cleanup for long-lived plugins that re-register at runtime.
+// Pass the exact same closure reference that was registered — the runtime
+// does a closure-identity compare.
+function unregisterHook(api: PluginApi, handler: (data: any) => any) {
+    api.unregisterHook("onRequest", handler)
+}
+// ANCHOR_END: unregister-hooks
+
+// ANCHOR: unregister-tools-services-routes
+function unregisterEverything(api: PluginApi) {
+    api.unregisterTool("formatCode")
+    api.unregisterService("worker")   // stopFn is invoked before removal
+    api.unregisterRoute("/api/foo")
+}
+// ANCHOR_END: unregister-tools-services-routes
+
+// ANCHOR: off-event
+function unsubscribe(api: PluginApi, handler: (data: any) => void) {
+    api.off("dataUpdated", handler)
+}
+// ANCHOR_END: off-event
+
+// ANCHOR: deactivate-cleanup
+// Recommended pattern: keep a module-scoped reference to handlers so
+// `deactivate()` can selectively unregister them. The host also purges
+// all of a plugin's registrations on unload, but explicit unregister
+// calls are the right way to stop services / event handlers cleanly
+// when a plugin re-configures itself at runtime. Shown here as a
+// regular function (not exported) so it doesn't collide with the
+// `activate` / `deactivate` exports from `counter-plugin` above.
+const _onDataUpdated = (data: any) => {
+    console.log(`${data.source} updated ${data.records} records`)
+}
+
+function _stopWorker() {
+    console.log("worker stopped")
+}
+
+function _startWorker() {
+    console.log("worker started")
+}
+
+function cleanupExample(api: PluginApi) {
+    api.on("dataUpdated", _onDataUpdated)
+    api.registerService("worker", _startWorker, _stopWorker)
+
+    // Later, in your deactivate() export:
+    api.off("dataUpdated", _onDataUpdated)
+    api.unregisterService("worker")   // invokes _stopWorker before removal
+}
+// ANCHOR_END: deactivate-cleanup
+
 // Reference every helper so the linker doesn't dead-strip the function bodies.
 console.log(typeof activate)
 console.log(typeof deactivate)
@@ -121,3 +174,7 @@ console.log(typeof listenForEvent)
 console.log(typeof registerFormatter)
 console.log(typeof readConfig)
 console.log(typeof registerWorker)
+console.log(typeof unregisterHook)
+console.log(typeof unregisterEverything)
+console.log(typeof unsubscribe)
+console.log(typeof cleanupExample)

--- a/docs/src/plugins/creating-plugins.md
+++ b/docs/src/plugins/creating-plugins.md
@@ -80,6 +80,31 @@ api.on(event: string, handler: (data: unknown) => void): void  // Listen for eve
 api.emit(event: string, data: unknown): void                    // Emit to other plugins
 ```
 
+### Unregistering (Selective Cleanup)
+
+The host purges all of a plugin's registrations when the plugin is unloaded,
+so explicit unregister calls are only needed for **long-lived plugins that
+re-configure themselves at runtime**, or for stopping services / event
+listeners cleanly before re-registering.
+
+```typescript,no-test
+api.unregisterHook(name: string, handler: (ctx: unknown) => unknown): void
+api.unregisterTool(name: string): void
+api.unregisterService(name: string): void   // invokes the service's stopFn first
+api.unregisterRoute(path: string): void
+api.off(event: string, handler: (data: unknown) => void): void
+```
+
+`unregisterHook` / `off` do a **closure-identity compare**: pass the exact
+same closure reference that was registered. `unregisterService` invokes the
+service's `stopFn` before removing the entry, matching the lifecycle
+contract of `registerService`. All five calls are no-ops if the caller did
+not register the resource or no entry matches.
+
+```typescript
+{{#include ../../examples/plugins/plugin_snippets.ts:deactivate-cleanup}}
+```
+
 ## Next Steps
 
 - [Hooks & Events](hooks-and-events.md) — Hook modes, event bus

--- a/test-files/test_ffi_surface_runtime_core.ts
+++ b/test-files/test_ffi_surface_runtime_core.ts
@@ -284,6 +284,7 @@ crates/perry-runtime/src/plugin.rs:
   - perry_plugin_list_tools
   - perry_plugin_load
   - perry_plugin_log
+  - perry_plugin_off
   - perry_plugin_on
   - perry_plugin_register_hook
   - perry_plugin_register_hook_ex
@@ -293,6 +294,10 @@ crates/perry-runtime/src/plugin.rs:
   - perry_plugin_set_config
   - perry_plugin_set_metadata
   - perry_plugin_unload
+  - perry_plugin_unregister_hook
+  - perry_plugin_unregister_route
+  - perry_plugin_unregister_service
+  - perry_plugin_unregister_tool
 crates/perry-runtime/src/process.rs:
   - js_process_env
   - js_process_exit

--- a/types/perry/plugin/index.d.ts
+++ b/types/perry/plugin/index.d.ts
@@ -93,6 +93,50 @@ export interface PluginApi {
      * @param data   Payload forwarded to every subscriber.
      */
     emit(event: string, data: unknown): void;
+
+    /**
+     * Unregister a previously-registered hook handler.
+     * Removes the single entry whose closure matches `handler` (identity
+     * compare via NaN-boxed closure bits). No-op if the caller did not
+     * register the hook or no entry matches. Hooks registered with
+     * `registerHookEx` can be removed with `unregisterHook` — the same
+     * closure bits are stored regardless of priority/mode.
+     * @param hookName  Name of the hook.
+     * @param handler   The exact closure passed to `registerHook` / `registerHookEx`.
+     */
+    unregisterHook(hookName: string, handler: (ctx: unknown) => unknown): void;
+
+    /**
+     * Unregister a tool by name. No-op if the caller did not register it
+     * (the host also purges all of a plugin's registrations when the plugin
+     * is unloaded, so explicit cleanup is only needed for long-lived
+     * plugins that re-register at runtime).
+     * @param name  Tool name as passed to `registerTool`.
+     */
+    unregisterTool(name: string): void;
+
+    /**
+     * Unregister a service by name. The service's `stopFn` is invoked
+     * before the entry is removed (matching the `registerService` lifecycle
+     * contract: `startFn` was called at registration time, `stopFn` at
+     * unregistration). No-op if the caller did not register it.
+     * @param name  Service name as passed to `registerService`.
+     */
+    unregisterService(name: string): void;
+
+    /**
+     * Unregister an HTTP route by path. No-op if the caller did not register it.
+     * @param path  Route path as passed to `registerRoute`.
+     */
+    unregisterRoute(path: string): void;
+
+    /**
+     * Unsubscribe from an event on the host event bus. Removes the single
+     * subscription whose closure matches `handler`. No-op otherwise.
+     * @param event    Event name.
+     * @param handler  The exact closure passed to `on`.
+     */
+    off(event: string, handler: (data: unknown) => void): void;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements plugin API unregister/off cleanup for hooks, tools, services, routes, and events, with unload cleanup coverage and registry test isolation.

Validation:
- cargo test --no-run -p perry-runtime
- timeout 180 cargo test -p perry-runtime plugin -- --nocapture
- cargo fmt --check --all
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selective plugin cleanup capabilities via `unregisterHook()`, `unregisterTool()`, `unregisterService()`, `unregisterRoute()`, and `off()` to remove specific registrations and unsubscribe event handlers (including handler-identity matching where applicable).

* **Documentation**
  * Expanded the plugin API docs with an “Unregistering (Selective Cleanup)” section and new example snippets showing best practices for long-lived plugins, including deactivation/cleanup workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->