### PR TITLE
fix(transform): async-generator break/continue in catch no longer drops the dispatch loop

### DIFF
--- a/crates/perry-transform/src/generator/break_continue.rs
+++ b/crates/perry-transform/src/generator/break_continue.rs
@@ -116,6 +116,31 @@ pub fn fix_break_continue_sentinels_in_stmts(
     }
 }
 
+/// Fix BREAK/CONTINUE sentinels inside the bodies of `CatchRoute`s captured
+/// while linearizing a loop body. The async-generator `.throw()` closure
+/// inlines `route.body` verbatim (no dispatch loop), so a user `continue`/
+/// `break` inside such a catch was rewritten to
+/// `[LocalSet(state, SENTINEL), Stmt::Continue]` but its sentinel never got
+/// fixed (`fix_break_continue_sentinels` only walks the linearized `states`,
+/// not the extracted catch routes). Apply the same loop targets to those
+/// catch-route bodies so the resume state is correct (the dangling dispatch
+/// `Stmt::Continue` is then neutralized by the async catch-route inliner).
+pub fn fix_break_continue_sentinels_in_catches(
+    catches: &mut [CatchRoute],
+    state_id: LocalId,
+    break_target: u32,
+    continue_target: u32,
+) {
+    for route in catches.iter_mut() {
+        fix_break_continue_sentinels_in_stmts(
+            &mut route.body,
+            state_id,
+            break_target,
+            continue_target,
+        );
+    }
+}
+
 pub fn fix_break_continue_sentinels_in_stmt(
     stmt: &mut Stmt,
     state_id: LocalId,

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -513,6 +513,7 @@ pub fn linearize_body(
                 // skipping the body tail without going through the update.
                 let body_states_before = states.len();
                 let body_current_before = current.len();
+                let body_catches_before = catches.len();
                 let mut body_rewritten = body.clone();
                 rewrite_break_continue_in_stmts(&mut body_rewritten, state_id);
 
@@ -590,6 +591,15 @@ pub fn linearize_body(
                     after_loop_state,
                     update_state,
                 );
+                // Async-generator `.throw()` closures inline catch-route bodies
+                // verbatim; fix any break/continue sentinels they captured from
+                // this loop body (a user `continue`/`break` inside a `catch`).
+                fix_break_continue_sentinels_in_catches(
+                    &mut catches[body_catches_before..],
+                    state_id,
+                    after_loop_state,
+                    update_state,
+                );
             }
 
             // While-loop containing yield(s) - similar to for-loop
@@ -639,6 +649,7 @@ pub fn linearize_body(
                 // state (no separate update); `break` jumps to after_loop.
                 let while_states_before = states.len();
                 let while_current_before = current.len();
+                let while_catches_before = catches.len();
                 let mut while_body_rewritten = while_body.clone();
                 rewrite_break_continue_in_stmts(&mut while_body_rewritten, state_id);
 
@@ -682,6 +693,15 @@ pub fn linearize_body(
                 );
                 fix_break_continue_sentinels_in_stmts(
                     &mut current[while_current_before..],
+                    state_id,
+                    after_loop,
+                    cond_state,
+                );
+                // Async-generator `.throw()` closures inline catch-route bodies
+                // verbatim; fix any break/continue sentinels they captured from
+                // this loop body (a user `continue`/`break` inside a `catch`).
+                fix_break_continue_sentinels_in_catches(
+                    &mut catches[while_catches_before..],
                     state_id,
                     after_loop,
                     cond_state,

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -1628,6 +1628,49 @@ fn build_dispatch_catch_handler(
     )
 }
 
+/// Replace the synthesized dispatch re-entry `Stmt::Continue` (emitted by
+/// `rewrite_break_continue_in_stmts` for a user `break`/`continue`) with a
+/// suspend-return. Used when inlining a catch-route body into the async
+/// `.throw()` closure, which has no dispatch `while(true)` loop. Mirrors the
+/// recursion in `rewrite_break_continue_in_stmt`: descends into `if`/`try`
+/// (where the dispatch continue can sit) but stops at nested loops / switch /
+/// labeled / closures, whose own `continue`/`break` belong to them.
+fn rewrite_dispatch_continue_to_suspend(stmts: &mut Vec<Stmt>) {
+    for stmt in stmts.iter_mut() {
+        match stmt {
+            Stmt::Continue | Stmt::Break => {
+                *stmt = Stmt::Return(Some(make_iter_result(Expr::Undefined, false)));
+            }
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                rewrite_dispatch_continue_to_suspend(then_branch);
+                if let Some(eb) = else_branch.as_mut() {
+                    rewrite_dispatch_continue_to_suspend(eb);
+                }
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                rewrite_dispatch_continue_to_suspend(body);
+                if let Some(c) = catch.as_mut() {
+                    rewrite_dispatch_continue_to_suspend(&mut c.body);
+                }
+                if let Some(f) = finally.as_mut() {
+                    rewrite_dispatch_continue_to_suspend(f);
+                }
+            }
+            // Nested loops / switch / labeled / closures own their own
+            // break/continue — leave them untouched.
+            _ => {}
+        }
+    }
+}
+
 fn build_async_catch_route_body(
     route: &CatchRoute,
     finallys: &[FinallyRoute],
@@ -1668,6 +1711,19 @@ fn build_async_catch_route_body(
     rewrite_hoisted_lets_in_stmts(&mut rewritten, hoisted_ids);
     rewrite_yield_to_await_in_stmts(&mut rewritten);
     rewrite_catch_returns_to_iter_result(&mut rewritten);
+    // A user `break`/`continue` inside this catch was rewritten by
+    // `rewrite_break_continue_in_stmts` into `[LocalSet(state, TARGET),
+    // Stmt::Continue]` — the trailing `Stmt::Continue` re-enters the dispatch
+    // `while(true)` loop. The async `.throw()` closure has NO dispatch loop
+    // (it runs the handler, then suspends), so that dangling dispatch-continue
+    // would be a `continue` with no enclosing loop. The preceding `LocalSet`
+    // already moved the state to the loop's resume target (cond/update/after-
+    // loop, fixed up by `fix_break_continue_sentinels_in_catches`), so the
+    // correct async behavior is to suspend right there: convert the dispatch
+    // re-entry into a `return { value: undefined, done: false }`.
+    if !fall_through {
+        rewrite_dispatch_continue_to_suspend(&mut rewritten);
+    }
 
     // #4374: if this try also has a (sync) finally, a `throw` inside the catch
     // handler must still run that finally before propagating. The normal

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -25,9 +25,9 @@ mod rewrite_returns;
 // cross-module symbol here.
 pub(crate) use break_continue::{
     body_contains_yield, collect_hoisted_vars, collect_vars_recursive,
-    fix_break_continue_sentinels, fix_break_continue_sentinels_in_stmt,
-    fix_break_continue_sentinels_in_stmts, fix_placeholder_state, rewrite_break_continue_in_stmt,
-    rewrite_break_continue_in_stmts,
+    fix_break_continue_sentinels, fix_break_continue_sentinels_in_catches,
+    fix_break_continue_sentinels_in_stmt, fix_break_continue_sentinels_in_stmts,
+    fix_placeholder_state, rewrite_break_continue_in_stmt, rewrite_break_continue_in_stmts,
 };
 pub(crate) use helpers::{
     alloc_local, make_iter_result, rewrite_hoisted_lets_in_stmt, rewrite_hoisted_lets_in_stmts,


### PR DESCRIPTION
## What
For a real `async function*`, a user `break`/`continue` inside a `catch` (e.g. `while(k){ try{ ...yield... } catch(e){ continue } }`) was lowered into the separate `__async_throw` catch-route closure, which has no dispatch loop — so the synthesized dispatch `continue` became a `continue` with no enclosing loop (codegen: `continue statement outside any loop`), and its `CONTINUE_SENTINEL` resume-state was never fixed up.

Fix: (1) `fix_break_continue_sentinels_in_catches` resolves break/continue sentinels inside extracted `CatchRoute` bodies to the loop's real cond/update/after-loop state; (2) `rewrite_dispatch_continue_to_suspend` converts the now-dangling dispatch re-entry in the async catch route into a suspend `return {value: undefined, done: false}` — correct async-generator semantics (the next `.next()` dispatches at the already-set resume state).

## Why
Surfaced compiling a large real-world minified bundle (its async-generator main loop); also fixes async generators with `continue`/`break` in a `catch` generally. Verified: a `continue`-in-try loop yields `1,3,5` (evens skipped) matching Node.

## Tests
`cargo test -p perry-transform --tests` green (incl. plain break/continue async-gen still `1,3,5,7`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed break/continue sentinel rewriting for catch routes generated from loop bodies in async generators, ensuring control flow targets are correctly updated after loop linearization.
  * Improved handling of synthesized dispatch re-entry continue statements so they correctly complete suspensions (returning the appropriate iterator result) rather than producing invalid continues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->