### PR TITLE
test(arkts): fix harmonyos-smoke compile — byte_offset drift after #5250

### DIFF
--- a/crates/perry-codegen-arkts/src/tests.rs
+++ b/crates/perry-codegen-arkts/src/tests.rs
@@ -960,6 +960,7 @@ fn state_method_call(state_id: u32, method: &str, args: Vec<Expr>) -> Expr {
         }),
         args,
         type_args: vec![],
+        byte_offset: 0,
     }
 }
 
@@ -2531,6 +2532,7 @@ fn issue_410_serialize_condition_fallback_has_no_block_comment_close() {
         callee: Box::new(Expr::LocalGet(99)),
         args: vec![],
         type_args: vec![],
+        byte_offset: 0,
     };
     let s = serialize_condition(&unrecognized, &bindings, &consts);
     assert!(
@@ -2762,6 +2764,7 @@ fn issue_410_conditional_modifier_chain_has_no_nested_block_comments() {
             callee: Box::new(Expr::LocalGet(999)),
             args: vec![],
             type_args: vec![],
+            byte_offset: 0,
         },
     ));
     m.init.push(let_widget(

--- a/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
+++ b/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
@@ -149,6 +149,7 @@ fn full_phase2_app_emits_canonical_arkui() {
         }),
         args: vec![],
         type_args: vec![],
+        byte_offset: 0,
     };
 
     // --- Phase 2 v6 + v5: Button with state.set + inline style ---
@@ -160,6 +161,7 @@ fn full_phase2_app_emits_canonical_arkui() {
         }),
         args: vec![Expr::Number(1.0)],
         type_args: vec![],
+        byte_offset: 0,
     })];
     let inc_button = nmc(
         "Button",
@@ -523,6 +525,7 @@ fn minimal_counter_app_emits_clean_page() {
                 }),
                 args: vec![],
                 type_args: vec![],
+                byte_offset: 0,
             },
             nmc(
                 "Button",


### PR DESCRIPTION
## Why harmonyos-smoke is red

The `harmonyos-smoke` job fails at step 5 (`cargo test -p perry-codegen-arkts --lib`) with:

```
error[E0063]: missing field `byte_offset` in initializer of `perry_hir::Expr`
  crates/perry-codegen-arkts/src/tests.rs:956, :2531, :2763
  crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs:145, :156, :521
```

#5250 added `Expr::Call.byte_offset` (call-site source locations for diagnostics) but missed the 6 `Expr::Call { .. }` literals in `perry-codegen-arkts`'s tests. Because `perry-codegen-arkts` is **not** built by the gating `cargo-test` job — only by `harmonyos-smoke`, which is `continue-on-error: true` (informational, "must not block package publish") — this E0063 has sat red on `main`, and on every open PR, without failing any required check. Same class as the #5266 cheerio fix (which patched the `perry-hir` integration test the same merge missed).

## Fix

Add `byte_offset: 0` to the 6 `Expr::Call` initializers (3 in `src/tests.rs`, 3 in `tests/phase2_full_app_smoke.rs`). The HarmonyOS/ArkTS codegen target is real, so the smoke test is worth keeping green rather than deleting — it was only bit-rotting because it's non-gating.

## Verification

Exactly the two commands `harmonyos-smoke` runs:
- `cargo test -p perry-codegen-arkts --release --lib` → **111 passed, 0 failed**
- `cargo test -p perry-codegen-arkts --release --test phase2_full_app_smoke` → **2 passed, 0 failed**

fmt clean; file-size / GC store-site / addr-class gates pass. No `version` / `CHANGELOG.md` / `Cargo.lock` edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test fixtures with required fields to maintain compatibility with test infrastructure.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->