### PR TITLE
fix(codegen): unique class-keys global per class (distinct names that sanitize alike)

### DIFF
--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -675,8 +675,35 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             .map(|(_, p, ext, fields)| (fields.clone(), ext.clone(), p.clone()))
     };
 
+    // Distinct source class names can `sanitize()` to the SAME symbol — e.g.
+    // `$X` and `_X` both become `_X` (minified bundles use `$`/`_` heavily).
+    // Two such classes are genuinely different (different shapes), so each needs
+    // its OWN keys-global; emitting `@perry_class_keys_<prefix>__<sanitized>`
+    // twice makes clang reject the IR ("redefinition of global"). Track every
+    // emitted name and disambiguate collisions with a numeric suffix. The
+    // (real-name-keyed) `class_keys_globals_map` stores the unique name, so every
+    // `new ClassName()` site still resolves to the right global.
+    let mut used_class_keys_globals: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    fn unique_global(base: String, used: &mut std::collections::HashSet<String>) -> String {
+        if used.insert(base.clone()) {
+            return base;
+        }
+        let mut n = 1u32;
+        loop {
+            let candidate = format!("{base}_{n}");
+            if used.insert(candidate.clone()) {
+                return candidate;
+            }
+            n += 1;
+        }
+    }
+
     for c in &hir.classes {
-        let global_name = format!("perry_class_keys_{}__{}", module_prefix, sanitize(&c.name),);
+        let global_name = unique_global(
+            format!("perry_class_keys_{}__{}", module_prefix, sanitize(&c.name)),
+            &mut used_class_keys_globals,
+        );
         llmod.add_internal_global(&global_name, I64, "0");
 
         // Build the packed-keys string. Format: each field name
@@ -845,7 +872,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         if class_keys_globals_map.contains_key(&c.name) {
             continue;
         }
-        let global_name = format!("perry_class_keys_{}__{}", module_prefix, sanitize(&c.name),);
+        let global_name = unique_global(
+            format!("perry_class_keys_{}__{}", module_prefix, sanitize(&c.name)),
+            &mut used_class_keys_globals,
+        );
         llmod.add_internal_global(&global_name, I64, "0");
         class_keys_globals_map.insert(c.name.clone(), global_name.clone());
         let mut packed_keys = String::new();


### PR DESCRIPTION
## What
Distinct source class names can `sanitize()` to the same LLVM symbol — e.g. `$X` and `_X` both become `_X` (minified bundles use `$`/`_` heavily in identifiers). Two such classes are genuinely different (different shapes/layouts), so each needs its own keys-global; but codegen emitted `@perry_class_keys_<modprefix>__<sanitized>` for both, and clang rejected the IR:

```
error: redefinition of global '@perry_class_keys_cli_js___Q7'
```

The existing dedup guard only compared the *real* class name (so `$X` ≠ `_X` both passed), not the sanitized symbol.

## Fix
Track every emitted class-keys global name in a shared set and disambiguate collisions with a numeric suffix, in **both** the local-class and imported-stub generation loops (`codegen/mod.rs`). The real-name-keyed `class_keys_globals_map` stores the unique name, so every `new ClassName()` load/store site still resolves to the correct global.

## Why
Surfaced compiling a large real-world minified bundle — multiple distinct classes named `$Q7` / `_Q7` etc. in one module collided.

## Verification
Minimal repro `class $X{m(){return 1}}` + `class _X{n(){return 2}}` previously aborted with `redefinition of global`; now compiles **and runs matching Node** (`1 2`), confirming the two classes keep distinct keys-globals/shapes rather than sharing one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where certain class definitions could generate identical internal symbol names, causing build failures in edge cases.
* Ensured generated class key globals are collision-resistant by automatically choosing unique names when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->