### PR TITLE
test(262): un-skip eval/intl402/property-escapes — make parity honest (#5300)

### DIFF
--- a/scripts/test262_subset.py
+++ b/scripts/test262_subset.py
@@ -97,19 +97,24 @@ PREAMBLE = TEST262_DIR / "preamble.js"
 SELF_VALIDATE_FEATURES_FILE = TEST262_DIR / "self-validate-features.txt"
 
 # Default subtrees to walk (relative to <root>/test). Language + builtins are
-# the cleanest TS-subset denominator; intl402/staging are out of scope.
-DEFAULT_DIRS = ("language", "built-ins")
+# intl402 is now measured (Perry has substantial Intl: ~78% — the old "no ICU"
+# assumption was stale). staging (TC39 proposals) stays out of scope.
+DEFAULT_DIRS = ("language", "built-ins", "intl402")
 
 # Subtrees skipped wholesale — out of scope for Perry's TS subset regardless of
 # feature tags (some cases in these dirs carry no `features:`).
+#
+# History: `eval`, `intl402`, and `RegExp/property-escapes` USED to be skipped
+# here as "AOT can't eval" / "no ICU" / "Rust regex crate gap". Those are all
+# stale — Perry measures eval-code ~94%, intl402 ~78%, property-escapes ~87%, so
+# they are no longer skipped (the eval cases run with PERRY_ALLOW_EVAL=1, set in
+# the compile env below). `RegExp/lookbehind` was vestigial (no such subdir).
+# Only genuinely-out-of-scope `staging` (proposals) remains.
+# NB: Temporal is judged in self-validating mode (#4792) — the Node oracle lacks
+# it; under intl402/ the Temporal locale-format cases are now measured too.
 _PATH_SKIP = re.compile(
     r"(?:^|/)(?:"
-    r"intl402|staging|"
-    r"eval|"  # dynamic eval — Perry is AOT
-    # NB: Temporal is intentionally NOT skipped — Perry implements it but the
-    # Node oracle does not, so it is judged in self-validating mode (#4792).
-    # (Temporal under intl402/ stays out: intl402 is skipped wholesale above.)
-    r"RegExp/(?:lookbehind|property-escapes)"  # Rust regex crate gaps
+    r"staging"
     r")(?:/|$)"
 )
 # NB: Atomics/SharedArrayBuffer are now in scope (#4794). The agent-based cases
@@ -464,7 +469,7 @@ def main() -> int:
             # 2) Perry compile (permissive — unimplemented surfaces as a gap).
             out_bin = workdir / "case.out"
             c_env = dict(base_env, PERRY_ALLOW_UNIMPLEMENTED="1",
-                         PERRY_NO_AUTO_OPTIMIZE="1")
+                         PERRY_NO_AUTO_OPTIMIZE="1", PERRY_ALLOW_EVAL="1")
             c_exit, c_out = run(
                 [str(args.perry_bin), "compile", str(staged), "-o",
                  str(out_bin)], c_env, args.timeout, cwd=str(workdir))

--- a/test-compat/test262/features-applicable.txt
+++ b/test-compat/test262/features-applicable.txt
@@ -63,12 +63,36 @@ Proxy
 SharedArrayBuffer
 Atomics
 
+# --- Intl / ECMA-402 (#5298) — measured ~78%; the old "no ICU" was stale ---
+Intl.DateTimeFormat-datetimestyle
+Intl.DateTimeFormat-dayPeriod
+Intl.DateTimeFormat-extend-timezonename
+Intl.DateTimeFormat-formatRange
+Intl.DateTimeFormat-fractionalSecondDigits
+Intl.DisplayNames
+Intl.DisplayNames-v2
+Intl.DurationFormat
+Intl.Era-monthcode
+Intl.ListFormat
+Intl.Locale
+Intl.Locale-info
+Intl.NumberFormat-unified
+Intl.NumberFormat-v3
+Intl.RelativeTimeFormat
+Intl.Segmenter
+intl-normative-optional
+
+# --- regexp (#5300) — \p{} property escapes measured ~87% ---
+regexp-unicode-property-escapes
+
+# --- eval (#5300) — measured ~94%; runs with PERRY_ALLOW_EVAL=1 (not "AOT can't") ---
+eval
+
 # --- explicit non-targets (commented for visibility) ---
-# eval                         — Perry is AOT
 # Function-prototype-toString  — Perry does not retain source text
-# Intl                         — out of scope (no ICU)
 # top-level-await              — partial; semantics depend on loader
-# regexp-lookbehind            — Rust regex crate lacks lookbehind
+# regexp-lookbehind            — vestigial (no such test262 subdir); lookbehind cases run inline
+# regexp-v-flag                — RegExp `v` flag not yet measured
 # resizable-arraybuffer        — not implemented
 # Temporal                     — implemented, but scored via self-validate-features.txt
 #                                (the Node oracle lacks Temporal; see #4792)


### PR DESCRIPTION
Closes #5300.

The test262 headline (~95.2%) was parity over a **curated subset** — three skip layers hid categories Perry handles well. This removes the stale ones so the number reflects reality.

## Changes
- **`_PATH_SKIP`**: dropped `eval`, `intl402`, `RegExp/(?:lookbehind|property-escapes)`. Kept `staging` (genuine proposals) + flag-skips.
- **`DEFAULT_DIRS`**: added `intl402`.
- **compile env**: `PERRY_ALLOW_EVAL=1` so eval-tagged cases run instead of compile-failing.
- **`features-applicable.txt`**: added the `Intl.*` feature tags + `regexp-unicode-property-escapes`; moved eval/Intl/regexp out of the 'non-targets' comment block.

## Measured reality (node v26 oracle) — why these are no longer 'out of scope'
| category | parity |
|---|---|
| eval (eval-code) | **94%** |
| intl402 (Intl/ECMA-402) | **78%** |
| RegExp/property-escapes | **87%** |

## Effect
The default sweep now measures these. The headline drops from ~95.2% (curated) to **~92% (honest, all-runnable ≈ 91.8%)** — not a regression, just no longer hiding real coverage *and* real gaps. Verified end-to-end: property-escapes scores 508/585=86.8% via the default allowlist (no `--all-features`).

## Follow-up gap tickets
#5297 annexB/language (50% — Annex B B.3.3), #5298 intl402 (549 fails), #5299 staging (55%). Tooling-only; no version/CHANGELOG bump (maintainer folds in).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded Test262 test coverage to include internationalization (Intl/ECMA-402) features, enabling broader standards validation
  * Added support for testing eval, RegExp lookbehind, and RegExp property escapes
  * Enhanced test environment to properly handle dynamic code evaluation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->