### PR TITLE
fix(codegen): injective function-symbol names (distinct names that sanitize alike)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v0.5.1177 — fix(codegen): injective function-symbol names (distinct names that sanitize alike)
+
+Two distinct module-level functions could mangle to the same LLVM symbol, so
+clang rejected the module with "invalid redefinition of function". Two root
+causes, both fixed:
+
+- `scoped_fn_name` used the lossy `sanitize` (every non-`[A-Za-z0-9_]` byte →
+  `_`), so minified names like `$Z5` and `_Z5` both became
+  `perry_fn_<mod>___Z5`. Switched to the injective `sanitize_member` (the same
+  mangler `scoped_static_method_name` already uses); byte-identical for the
+  common `[A-Za-z0-9_]` case. `func_names` is keyed by func id and every call
+  site resolves through it, so changing the mangling stays consistent.
+- Minified code reuses short names (`function A`) across scopes, and perry
+  lambda-lifts nested functions to module level, so two module functions can
+  legitimately share a name. `compile_module` now disambiguates collisions
+  with a `__dupN` suffix keyed by the mangled symbol. Exported functions are
+  referenced cross-module by their canonical `scoped_fn_name`, so they reserve
+  their name first and never get suffixed.
+
+Sibling fix to the per-class class-keys-global disambiguation (5ac457967).
+
 ## v0.5.1176 — fix(runtime): loose equality (`==`) now treats SSO short strings as strings
 
 `js_jsvalue_loose_equals` (the helper behind `assert.equal`/`assert.deepEqual`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1176
+**Current Version:** 0.5.1177
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "base64",
@@ -5340,14 +5340,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "cc",
  "libc",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "log",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "base64",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1176"
+version = "0.5.1177"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "clap",
@@ -5497,14 +5497,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5603,14 +5603,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "bytes",
  "h2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "bson",
  "futures-util",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "image",
@@ -5799,14 +5799,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "brotli",
  "flate2",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "base64",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6017,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6035,14 +6035,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "itoa",
@@ -6059,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6092,7 +6092,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "block2",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "block2",
@@ -6123,7 +6123,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1176"
+version = "0.5.1177"
 
 [[package]]
 name = "perry-ui-test"
@@ -6131,11 +6131,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1176"
+version = "0.5.1177"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "block2",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "block2",
@@ -6167,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "block2",
  "libc",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "libc",
@@ -6197,14 +6197,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1176"
+version = "0.5.1177"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1176"
+version = "0.5.1177"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -109,7 +109,14 @@ pub(crate) fn write_barriers_enabled() -> bool {
 }
 
 pub(super) fn scoped_fn_name(module_prefix: &str, hir_name: &str) -> String {
-    format!("perry_fn_{}__{}", module_prefix, sanitize(hir_name))
+    // Use the INJECTIVE sanitizer (same as scoped_static_method_name): plain
+    // `sanitize` maps every non-`[A-Za-z0-9_]` char to `_`, so distinct minified
+    // function names like `$Z5` and `_Z5` both became `perry_fn_<mod>___Z5` and
+    // clang rejected the module with "invalid redefinition of function". `func_names`
+    // is keyed by func id and every reference resolves through it, so changing the
+    // mangling here keeps all local-function call sites consistent. Byte-identical
+    // to `sanitize` for plain `[A-Za-z0-9_]` names (the overwhelming common case).
+    format!("perry_fn_{}__{}", module_prefix, sanitize_member(hir_name))
 }
 
 pub(super) fn scoped_static_method_name(

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1937,8 +1937,37 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     let mut func_signatures: HashMap<u32, (usize, bool, bool, bool)> = HashMap::new();
     let mut func_synthetic_arguments: std::collections::HashSet<u32> =
         std::collections::HashSet::new();
+    // Distinct functions can mangle to the same symbol: minified code reuses
+    // short names (`function A`) across scopes, and perry lambda-lifts nested
+    // functions to module level, so two module functions can share a name — clang
+    // then rejects the duplicate `define perry_fn_<mod>__A`. Disambiguate with a
+    // numeric suffix, keyed by the mangled symbol. Exported functions are
+    // referenced cross-module by their canonical `scoped_fn_name` and are unique
+    // per module, so they reserve that name first and never get suffixed.
+    let mut used_fn_symbols: HashMap<String, u32> = HashMap::new();
     for f in &hir.functions {
-        func_names.insert(f.id, scoped_fn_name(&module_prefix, &f.name));
+        if hir.exported_functions.iter().any(|(exp, _)| exp == &f.name) {
+            used_fn_symbols
+                .entry(scoped_fn_name(&module_prefix, &f.name))
+                .or_insert(1);
+        }
+    }
+    for f in &hir.functions {
+        let base = scoped_fn_name(&module_prefix, &f.name);
+        let is_exported = hir.exported_functions.iter().any(|(exp, _)| exp == &f.name);
+        let sym = if is_exported {
+            base
+        } else {
+            let n = used_fn_symbols.entry(base.clone()).or_insert(0);
+            let s = if *n == 0 {
+                base.clone()
+            } else {
+                format!("{base}__dup{n}")
+            };
+            *n += 1;
+            s
+        };
+        func_names.insert(f.id, sym);
         let has_rest = f.params.iter().any(|p| p.is_rest);
         let synthetic_is_rest = f
             .params

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -960,8 +960,14 @@ fn pod_layout_constants_specialize_generic_layout_type_params() {
     module.functions.retain(|func| func.type_params.is_empty());
     module.init.clear();
     let ir = compile_ir_for_module_with_opts(module, pod_layout_specialization_opts()).unwrap();
-    let tiny_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__u_layout_24_Tiny");
-    let wide_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__u_layout_24_Wide");
+    let tiny_ir = function_ir_section(
+        &ir,
+        "perry_fn_pod_layout_specialization_ts__u_layout_24_Tiny",
+    );
+    let wide_ir = function_ir_section(
+        &ir,
+        "perry_fn_pod_layout_specialization_ts__u_layout_24_Wide",
+    );
 
     assert!(
         tiny_ir.contains("8.0") && tiny_ir.contains("4.0") && !tiny_ir.contains("16.0"),
@@ -1000,8 +1006,14 @@ fn native_pod_view_specializes_generic_layout_type_params() {
     module.functions.retain(|func| func.type_params.is_empty());
     module.init.clear();
     let ir = compile_ir_for_module_with_opts(module, pod_layout_specialization_opts()).unwrap();
-    let tiny_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__u_view_24_Tiny");
-    let wide_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__u_view_24_Wide");
+    let tiny_ir = function_ir_section(
+        &ir,
+        "perry_fn_native_pod_view_specialization_ts__u_view_24_Tiny",
+    );
+    let wide_ir = function_ir_section(
+        &ir,
+        "perry_fn_native_pod_view_specialization_ts__u_view_24_Wide",
+    );
 
     assert!(
         tiny_ir.contains("call i64 @js_native_pod_view") && tiny_ir.contains("i64 8, i64 4"),

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -960,8 +960,8 @@ fn pod_layout_constants_specialize_generic_layout_type_params() {
     module.functions.retain(|func| func.type_params.is_empty());
     module.init.clear();
     let ir = compile_ir_for_module_with_opts(module, pod_layout_specialization_opts()).unwrap();
-    let tiny_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__layout_Tiny");
-    let wide_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__layout_Wide");
+    let tiny_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__u_layout_24_Tiny");
+    let wide_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__u_layout_24_Wide");
 
     assert!(
         tiny_ir.contains("8.0") && tiny_ir.contains("4.0") && !tiny_ir.contains("16.0"),
@@ -1000,8 +1000,8 @@ fn native_pod_view_specializes_generic_layout_type_params() {
     module.functions.retain(|func| func.type_params.is_empty());
     module.init.clear();
     let ir = compile_ir_for_module_with_opts(module, pod_layout_specialization_opts()).unwrap();
-    let tiny_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__view_Tiny");
-    let wide_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__view_Wide");
+    let tiny_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__u_view_24_Tiny");
+    let wide_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__u_view_24_Wide");
 
     assert!(
         tiny_ir.contains("call i64 @js_native_pod_view") && tiny_ir.contains("i64 8, i64 4"),


### PR DESCRIPTION
## What
`scoped_fn_name` mangled `perry_fn_<mod>__<sanitize(name)>` using the **non-injective** `sanitize` (every non-`[A-Za-z0-9_]` char → `_`). So distinct minified function names like `$Z5` and `_Z5` both became `perry_fn_<mod>___Z5`, and clang rejected the module:

```
error: invalid redefinition of function 'perry_fn_cli_js___Z5'
```

Same root cause as the class-keys global collision (#5290), for function symbols. Surfaced compiling a large minified bundle once the class-keys collision was fixed.

## Fix
Use the **injective** `sanitize_member` (already used by `scoped_static_method_name`) — byte-identical for plain `[A-Za-z0-9_]` names (the overwhelming common case), and escapes others as `u_…_<hex>_…`. All local-function references resolve through the id-keyed `func_names` map (built from `scoped_fn_name`), so definitions and references stay consistent automatically.

Updated the two pod-layout specialization tests that hardcoded the old `$`→`_` mangling (`layout$Tiny` → `u_layout_24_Tiny`).

## Tests
`cargo test -p perry-codegen --tests` green. `function $Z5(){return 1}` + `function _Z5(){return 2}` previously aborted with clang "invalid redefinition"; now compiles and runs (`1 2`, matches Node).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLVM function symbol mangling by making the generated local/function portion injective to avoid collisions from minified or special-character identifiers.
  * Disambiguate per-module LLVM symbols: exported functions keep stable canonical names, while internal duplicates receive deterministic `__dupN` suffixes to keep references aligned.

* **Tests**
  * Updated native regression IR symbol expectations for pod-layout and native pod view Tiny/Wide specializations.

* **Documentation / Chores**
  * Added a changelog entry for `v0.5.1177` and bumped project version metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->