### PR TITLE
fix(cjs): semver read-undefined (COMPARATOR) — internal require()s mis-forwarded as re-exports

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/extract_exports.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_exports.rs
@@ -34,6 +34,65 @@ pub fn extract_single_module_exports_assignment(source: &str) -> Option<String> 
     found
 }
 
+/// Return the set of specs `SPEC` for which this module is a *trivial
+/// re-export wrapper* — i.e. it contains a `module.exports = require('SPEC')`
+/// (or bare `exports = require('SPEC')`) assignment, optionally inside a
+/// conditional (`if (...) module.exports = require('SPEC')`). Such a module
+/// has no exports of its own; its public surface IS the target's, so the
+/// wrap layer must forward the target's named exports.
+///
+/// Crucially, a module that merely `require()`s a sibling for its OWN use
+/// (`const { t } = require('./re')`, then defines a class) is NOT a
+/// re-export wrapper of `./re` and must NOT inherit `./re`'s export names —
+/// doing so emits a spurious `export const t = _cjs.t;` that both shadows
+/// the module's own `t` binding and resolves to `undefined` (the target's
+/// names aren't on THIS module's `exports`). This is the semver
+/// `Cannot read properties of undefined (reading 'COMPARATOR')` root:
+/// `classes/comparator.js` requires `../internal/re` for `re`/`t`, and the
+/// old unconditional recursion forwarded re.js's `t`/`re`/`src`/`safeRe`
+/// names as undefined module-scope consts.
+pub fn module_reexport_specs(source: &str) -> Vec<String> {
+    // `module.exports = require('SPEC')` or `exports = require('SPEC')`.
+    // Allow leading whitespace (conditional bodies are indented) and an
+    // optional one-line `if (...)` / `else` prefix on the same line. The
+    // RHS must be EXACTLY a `require(...)` call (no member access /
+    // additional operators), so `module.exports = require('x').foo` or
+    // `module.exports = { ...require('x') }` are excluded — those are not
+    // pure re-exports.
+    // The require(...) call must be the ENTIRE right-hand side. The regex
+    // matches `(?:module.)?exports = require('SPEC')` with an optional
+    // trailing `;`; the capture group 0's end is then checked to ensure the
+    // next non-whitespace byte is a statement boundary (`;`, `}`, newline, or
+    // end of source) — so `module.exports = require('x').foo` and
+    // `module.exports = { ...require('x') }` are rejected (a `.` / `}` from a
+    // surrounding object would follow without an intervening boundary). The
+    // `regex` crate has no lookahead, hence the post-match boundary probe.
+    let re = regex::Regex::new(
+        r#"(?m)(?:^|[;{}]|\belse\b|\)\s*)\s*(?:module\.)?exports\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)\s*;?"#,
+    )
+    .unwrap();
+    let bytes = source.as_bytes();
+    let mut specs: Vec<String> = Vec::new();
+    for cap in re.captures_iter(source) {
+        let Some(spec) = cap.get(1) else { continue };
+        let whole = cap.get(0).unwrap();
+        // Probe the first non-whitespace byte after the match.
+        let mut e = whole.end();
+        while e < bytes.len() && (bytes[e] == b' ' || bytes[e] == b'\t') {
+            e += 1;
+        }
+        let boundary = e >= bytes.len() || matches!(bytes[e], b';' | b'}' | b'\n' | b'\r');
+        if !boundary {
+            continue;
+        }
+        let s = spec.as_str().to_string();
+        if !specs.contains(&s) {
+            specs.push(s);
+        }
+    }
+    specs
+}
+
 /// Issue #665 follow-up: detect `(?:module\.)?exports\.NAME = require('SPEC')`
 /// patterns and return `(name, spec)` pairs. Order is preserved and duplicates
 /// (same NAME) are dropped on the first occurrence. If the same NAME also

--- a/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
@@ -432,6 +432,149 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
 /// We accept the same anchor rule as the class scan: declarations at the
 /// start of a line (after only whitespace), brace-depth-aware so we
 /// ignore decls inside functions / classes / object literals.
+/// Walk a brace/bracket-balanced binding pattern starting at `start`
+/// (which must point at the opening `{` or `[`) and push every bound
+/// identifier into `names`. Returns the byte index just past the
+/// matching closing delimiter.
+///
+/// Object patterns bind the *target* of each `key: target` pair (the
+/// shorthand `key` when no `: target` is present); array patterns bind
+/// each element. Defaults (`= expr`) and computed/literal keys are
+/// skipped over so they don't contribute spurious names, and a rest
+/// element (`...rest`) binds `rest`. Nested patterns recurse. This is a
+/// conservative textual walk (no SWC parse) matching the rest of the
+/// cjs_wrap layer; over-collecting a name is harmless here (it only
+/// makes the #2310 hoist guard *more* conservative), so the goal is to
+/// never MISS a real binding.
+fn collect_pattern_binding_names(bytes: &[u8], start: usize, names: &mut Vec<String>) -> usize {
+    let open = bytes[start];
+    let (close, is_object) = if open == b'{' {
+        (b'}', true)
+    } else {
+        (b']', false)
+    };
+    let mut i = start + 1;
+    // In an object pattern, after a `:` the following identifier is the
+    // binding target (not a key); track that so `{ key: target }` records
+    // `target`, while a bare `{ key }` records `key`.
+    let mut after_colon = false;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' | b'[' => {
+                i = collect_pattern_binding_names(bytes, i, names);
+                after_colon = false;
+                continue;
+            }
+            c if c == close => {
+                i += 1;
+                break;
+            }
+            // Skip string / template keys.
+            b'"' | b'\'' => {
+                let q = bytes[i];
+                i += 1;
+                while i < bytes.len() && bytes[i] != q {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                }
+                i += 1;
+            }
+            b'`' => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'`' {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                }
+                i += 1;
+            }
+            // A default initializer (`= expr`) — skip to the next top-level
+            // comma or the pattern's closing delimiter, brace/paren aware so
+            // a default object/array/call doesn't confuse the element split.
+            b'=' if i + 1 >= bytes.len() || bytes[i + 1] != b'=' => {
+                i += 1;
+                let mut inner: i32 = 0;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'(' | b'[' | b'{' => inner += 1,
+                        b')' | b']' | b'}' if inner > 0 => inner -= 1,
+                        c if c == close && inner == 0 => break,
+                        b',' if inner == 0 => break,
+                        b'"' | b'\'' => {
+                            let q = bytes[i];
+                            i += 1;
+                            while i < bytes.len() && bytes[i] != q {
+                                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                                    i += 2;
+                                    continue;
+                                }
+                                i += 1;
+                            }
+                        }
+                        _ => {}
+                    }
+                    i += 1;
+                }
+                after_colon = false;
+            }
+            b':' => {
+                after_colon = true;
+                i += 1;
+            }
+            b',' => {
+                after_colon = false;
+                i += 1;
+            }
+            // A computed object key `[expr]:` — skip the bracketed expression
+            // (only meaningful in object patterns; array patterns never hit
+            // this because their `[` is consumed by the nested-pattern arm).
+            b'[' => {
+                // Unreachable in practice (handled above), kept for clarity.
+                i += 1;
+            }
+            c if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' || c == b'.' => {
+                // Identifier (or `...rest` after the dots). Read it.
+                let name_start = i;
+                while i < bytes.len()
+                    && (bytes[i].is_ascii_alphanumeric()
+                        || bytes[i] == b'_'
+                        || bytes[i] == b'$'
+                        || bytes[i] == b'.')
+                {
+                    i += 1;
+                }
+                let raw = std::str::from_utf8(&bytes[name_start..i]).unwrap_or("");
+                // Strip a leading `...` (rest element).
+                let ident = raw.trim_start_matches('.');
+                // In an object pattern, a bare identifier followed (after
+                // whitespace) by `:` is a KEY, not a binding — defer to the
+                // post-colon identifier. Peek ahead past whitespace.
+                let mut j = i;
+                while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
+                    j += 1;
+                }
+                let is_key = is_object && !after_colon && j < bytes.len() && bytes[j] == b':';
+                if !is_key && !ident.is_empty() && !ident.contains('.') {
+                    let n = ident.to_string();
+                    if !names.contains(&n) {
+                        names.push(n);
+                    }
+                }
+                after_colon = false;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    i
+}
+
 fn collect_top_level_let_const_var_names(source: &str) -> Vec<String> {
     let bytes = source.as_bytes();
     let mut names: Vec<String> = Vec::new();
@@ -526,18 +669,32 @@ fn collect_top_level_let_const_var_names(source: &str) -> Vec<String> {
             while q < bytes.len() && (bytes[q] == b' ' || bytes[q] == b'\t') {
                 q += 1;
             }
-            let name_start = q;
-            while q < bytes.len()
-                && (bytes[q].is_ascii_alphanumeric() || bytes[q] == b'_' || bytes[q] == b'$')
-            {
-                q += 1;
-            }
-            if q > name_start {
-                let n = std::str::from_utf8(&bytes[name_start..q])
-                    .unwrap_or("")
-                    .to_string();
-                if !n.is_empty() && !names.contains(&n) {
-                    names.push(n);
+            // Issue: a destructuring declarator (`const { tbl } = require(...)`,
+            // `const [a, b] = ...`) binds names INSIDE a `{…}`/`[…]` pattern,
+            // not as a bare identifier. The plain identifier scan below skips
+            // straight past the `{`/`[` and captures nothing, so a class whose
+            // body references `tbl` looks free of IIFE-locals → gets hoisted →
+            // severs its closure over `tbl` → `tbl` resolves to the `_cjs.tbl`
+            // export read-back, which is `undefined` (semver's `const { t } =
+            // require('./re')` read from a class method is exactly this). Walk
+            // the brace/bracket-balanced pattern and collect every bound name.
+            if q < bytes.len() && (bytes[q] == b'{' || bytes[q] == b'[') {
+                let pat_end = collect_pattern_binding_names(bytes, q, &mut names);
+                q = pat_end;
+            } else {
+                let name_start = q;
+                while q < bytes.len()
+                    && (bytes[q].is_ascii_alphanumeric() || bytes[q] == b'_' || bytes[q] == b'$')
+                {
+                    q += 1;
+                }
+                if q > name_start {
+                    let n = std::str::from_utf8(&bytes[name_start..q])
+                        .unwrap_or("")
+                        .to_string();
+                    if !n.is_empty() && !names.contains(&n) {
+                        names.push(n);
+                    }
                 }
             }
             // Skip ahead past an `=` initializer (brace/paren/bracket-aware so a

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -47,6 +47,7 @@ pub(self) use detect::is_js_reserved_word;
 pub(self) use extract_exports::{
     extract_exports_from_source, extract_named_exports_from_require,
     extract_object_literal_exports_from_require, extract_single_module_exports_assignment,
+    module_reexport_specs,
 };
 pub(self) use extract_requires::{
     extract_export_star_specs, extract_require_aliases_with_ranges, extract_require_specifiers,
@@ -67,6 +68,7 @@ mod tests {
     use super::extract_exports::{
         extract_exports_from_source, extract_named_exports_from_require,
         extract_object_literal_exports_from_require, extract_single_module_exports_assignment,
+        module_reexport_specs,
     };
     use super::extract_requires::{
         extract_require_aliases_with_ranges, extract_require_specifiers,
@@ -1512,5 +1514,94 @@ module.exports = SafeBuffer;"#;
             "self-contained class must still hoist above the IIFE; got:\n{}",
             wrapped
         );
+    }
+
+    /// `module_reexport_specs` recognizes the trivial re-export wrapper
+    /// shape (`module.exports = require('./X')`, incl. conditional / bare
+    /// `exports =`) and ONLY that shape — a module that requires a sibling
+    /// for its own use must not be treated as a re-export of it.
+    #[test]
+    fn module_reexport_specs_only_for_true_reexports() {
+        // Trivial re-export wrappers.
+        assert_eq!(
+            module_reexport_specs("module.exports = require('./lib/index');"),
+            vec!["./lib/index".to_string()]
+        );
+        assert_eq!(
+            module_reexport_specs(
+                "if (process.env.NODE_ENV === 'production') { module.exports = require('./prod'); } else { module.exports = require('./dev'); }"
+            ),
+            vec!["./prod".to_string(), "./dev".to_string()]
+        );
+        assert_eq!(
+            module_reexport_specs("exports = require('./x');"),
+            vec!["./x".to_string()]
+        );
+
+        // NOT re-export wrappers — semver's comparator.js shape: require a
+        // sibling for internal use, then export a class. Forwarding ./re's
+        // names here is exactly the `reading 'COMPARATOR'` bug.
+        assert!(module_reexport_specs(
+            "const { safeRe: re, t } = require('../internal/re');\nclass Comparator { parse() { return re[t.COMPARATOR]; } }\nmodule.exports = Comparator;"
+        )
+        .is_empty());
+        // Member access / object-spread on the require result are not pure
+        // re-exports either.
+        assert!(module_reexport_specs("module.exports = require('./x').foo;").is_empty());
+        assert!(module_reexport_specs("module.exports = { ...require('./x') };").is_empty());
+    }
+
+    /// Regression for the semver `Cannot read properties of undefined
+    /// (reading 'COMPARATOR')` root: a module that requires a sibling for
+    /// internal use (NOT a re-export wrapper) must not get the sibling's
+    /// export names forwarded as spurious `export const X = _cjs.X;`
+    /// declarations. Those both shadow the module's own destructured
+    /// bindings and resolve to `undefined`.
+    #[test]
+    fn internal_require_does_not_forward_sibling_exports() {
+        let dir =
+            std::env::temp_dir().join(format!("perry_cjs_reexport_test_{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        // The required sibling exposes a `t` table (semver internal/re.js shape).
+        fs::write(
+            dir.join("re.js"),
+            "module.exports = { t: { COMPARATOR: 0 } };",
+        )
+        .unwrap();
+        let consumer = "const { t } = require('./re');\nclass Comparator { constructor() { this.r = t.COMPARATOR; } }\nmodule.exports = Comparator;\n";
+        let wrapped = wrap_commonjs(consumer, &dir.join("comparator.js"));
+        assert!(
+            !wrapped.contains("export const t = _cjs.t;"),
+            "internal require('./re') must NOT forward re.js's `t` export, got:\n{}",
+            wrapped
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `collect_top_level_let_const_var_names` (via the #2310 hoist guard)
+    /// must recognize destructured top-level bindings so a class closing
+    /// over them is not hoisted out of the IIFE (which would sever the
+    /// closure). Indirectly asserted through the wrap: a class referencing
+    /// a destructured IIFE-local stays inside the IIFE.
+    #[test]
+    fn destructured_iife_local_keeps_class_in_iife() {
+        // `module.exports = { C }` (object aggregator, not a single-class
+        // default) so the flat-emit path is NOT taken — exercising the
+        // hoist-guard path specifically.
+        let src = "const { tbl } = require('./re');\n\
+                   class C { method() { return tbl.X; } }\n\
+                   module.exports = { C };\n";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/cmp.js"));
+        // The class must NOT be hoisted above the IIFE — it closes over the
+        // destructured `tbl`.
+        if let Some(iife_open) = wrapped.find("const _cjs = (function()") {
+            if let Some(class_pos) = wrapped.find("class C ") {
+                assert!(
+                    class_pos > iife_open,
+                    "class closing over destructured IIFE-local `tbl` must stay inside the IIFE; got:\n{}",
+                    wrapped
+                );
+            }
+        }
     }
 }

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -316,8 +316,26 @@ pub(in crate::commands::compile) fn wrap_commonjs_for_target(
     // react/index.js — which has zero `exports.X =` patterns of its own —
     // produces zero named exports and downstream `import { useState } from
     // "react"` link-fails.
+    //
+    // CRUCIAL: only specs THIS module actually re-exports
+    // (`module.exports = require('SPEC')`) qualify. A module that merely
+    // `require()`s a sibling for its own internal use — e.g. semver's
+    // `classes/comparator.js` doing `const { safeRe: re, t } =
+    // require('../internal/re')` and then defining a class that reads
+    // `re[t.COMPARATOR]` — is NOT a re-export wrapper of `../internal/re`.
+    // Forwarding the target's names here emitted spurious module-scope
+    // `export const t = _cjs.t;` (and `re`, `src`, `safeRe`) declarations
+    // that (a) shadowed the module's own same-named bindings and (b)
+    // resolved to `undefined` because those names are not on THIS module's
+    // `exports` — the `Cannot read properties of undefined (reading
+    // 'COMPARATOR')` root for semver/pino/bluebird.
+    let reexport_specs = module_reexport_specs(source);
     for spec in &require_specs {
         if !spec.starts_with("./") && !spec.starts_with("../") {
+            continue;
+        }
+        // Only forward exports of specs this module genuinely re-exports.
+        if !reexport_specs.iter().any(|s| s == spec) {
             continue;
         }
         // #4872: specs re-exported via `__exportStar` surface through the


### PR DESCRIPTION
## Context

From the native-npm corpus (`compilePackages: ["*"]`), the **read-undefined** cluster was the top remaining pattern (3 pkgs: semver, pino, bluebird — all `Cannot read properties of undefined`). This PR roots and fixes **semver**, plus a related hoist-guard correctness gap. **pino and bluebird have distinct roots and are NOT fixed here** (see Honest scope).

## Roots & fixes (both CJS-interop, in `cjs_wrap`)

1. **semver `Cannot read properties of undefined (reading 'COMPARATOR')`.** `semver/classes/comparator.js` does `const { safeRe: re, t } = require('../internal/re')` — a require for *internal use*, then `module.exports = Comparator`. Perry mis-classified this as a trivial re-export wrapper and forwarded `../internal/re`'s export names as spurious `export const t = _cjs.t;` declarations, which **shadowed the module's own destructured `t`** and resolved to `undefined` → `t.COMPARATOR` threw. New `module_reexport_specs` recognizes **only** true re-export shapes (`module.exports = require('./X')`, incl. conditional and bare `exports =`) and explicitly rejects member-access (`require('./x').foo`), object-spread (`{ ...require('./x') }`), and internal requires.

2. **Destructured-binding hoist guard.** `collect_pattern_binding_names` walks object/array binding patterns (defaults, rest `...`, nesting, computed/string keys) so the #2310 class-hoist guard recognizes top-level destructured bindings — keeping a class that closes over them inside the cjs_wrap IIFE instead of hoisting it out (which severs the closure → undefined reads). Conservative textual walk consistent with the rest of the layer (over-collecting only makes the guard more conservative).

## Verification

- `cargo test -p perry cjs_wrap` → **86 passed**, incl. 3 new regression tests (`module_reexport_specs_only_for_true_reexports`, `internal_require_does_not_forward_sibling_exports`, `destructured_iife_local_keeps_class_in_iife`).
- **semver (corpus):** `COMPARATOR` error **gone** — advances to a separate downstream wall (`TypeError: Invalid comparator: >=0.0.0-0`), i.e. the read-undefined is resolved.
- **Full corpus: no regressions** — 53/59, all previously-passing packages still pass.
- fmt clean; file-size / GC store-site / addr-class gates pass.
- Full `cargo test -p perry`: green except `require_native_builtin_lowers_like_namespace_import`, which **fails identically on clean main** (`inline-platform` is a macOS-local artifact: `process.platform` ≠ the test's hardcoded Linux value; green on CI). Not introduced by this PR.

## Honest scope

Fixes **semver** + a real hoist-guard correctness gap. **bluebird** (`reading 'prototype'`) and **pino** (`reading 'get'`) still fail with the same bucket but have **different roots** — the investigating agent didn't reach them. They remain open for a follow-up.

No `version` / `CHANGELOG.md` / `Cargo.lock` edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved detection of CommonJS re-export wrapper modules for more accurate export forwarding.

* **Bug Fixes**
  * Fixed spurious exports from internally required modules that were not genuinely re-exported.
  * Corrected handling of destructured bindings to prevent hoisting issues in class definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->