### PR TITLE
Use i32 guards for trusted numeric array gets

### DIFF
--- a/PERF_RUN_LOG.md
+++ b/PERF_RUN_LOG.md
@@ -367,3 +367,72 @@
   - `benchmarks/baseline.json` is stale for this Linux environment; compare was run with `--warn-only`, and the before/after comparison above uses the captured local fifth-cycle baseline.
   - This follow-up is intended as a stacked draft PR on top of the i32 array index lowering PR.
 - PR: https://github.com/PerryTS/perry/pull/5312
+
+## 2026-06-17 - Use i32 numeric array get guards for trusted integer indices
+
+- Start revision: `f8454f6bb`
+- Branch: `codex/perry-i32-numeric-get-guard`
+- Worker assignment: single Codex pass in this worktree
+- Benchmark environment: Linux `/usr/bin/time` and `perf stat`; local `node` cannot execute `.ts` benchmark inputs, so Node columns and correctness comparisons were skipped by the harness
+- Baseline commands:
+  - `target/release/perry compile --no-cache benchmarks/suite/16_matrix_multiply.ts -o /tmp/perry-matrix-invariant-hoist-baseline --trace llvm --quiet`
+  - `for i in 1 2 3 4 5; do /usr/bin/time -f "matrix baseline sample=$i wall=%e rss_kb=%M" /tmp/perry-matrix-invariant-hoist-baseline; done`
+  - `PERRY_TYPED_FEEDBACK_TRACE=/tmp/perry-matrix-invariant-hoist-baseline-trace.json /usr/bin/time -f "matrix baseline trace wall=%e rss_kb=%M" /tmp/perry-matrix-invariant-hoist-baseline && jq '[.sites[] | select(.kind=="array_element") | {site_id, operation, guard_name, observed_count, guard_passes, guard_failures, fallback_calls}]' /tmp/perry-matrix-invariant-hoist-baseline-trace.json`
+  - `perf stat -e cycles,instructions,branches,branch-misses /tmp/perry-matrix-invariant-hoist-baseline`
+  - `perf record -F 999 -g --call-graph fp -o /tmp/perry-matrix-invariant-hoist-baseline.perf /tmp/perry-matrix-invariant-hoist-baseline`
+- Baseline results:
+  - direct matrix binary samples: 391ms, 406ms, 385ms, 397ms, 407ms; checksum always `41079519680`
+  - trace run: `matrix_multiply:394`, wall 0.42s, RSS 31528KB
+  - hot get trace sites `3181980809628221440` and `3181980809628221441`: 16,777,216 observations/passes each, 0 failures, 0 fallback calls
+  - final checksum get trace site `3181980809628221446`: 65,536 observations/passes, 0 failures, 0 fallback calls
+  - direct matrix `perf stat`: 1,462,371,864 cycles, 7,017,654,871 instructions, 1,568,480,811 branches, 253,622 branch-misses, 0.4253s elapsed
+  - `perf report` showed roughly 48.7% and 45.6% at the two generated hot get fast-path load/address-mask regions
+  - `benchmarks/quick.sh` from the previous cycle: matrix_multiply 390ms/30MB
+- Selected gap and evidence:
+  - After invariant-read hoisting, `16_matrix_multiply.ts` had two fully hot numeric array index-get sites in the innermost multiply loop.
+  - LLVM IR still emitted `sitofp i32` for each trusted computed get index before calling `js_typed_feedback_numeric_array_index_get_guard`, even though codegen had already proven and lowered the index as i32.
+  - The runtime guard then rechecked the boxed index bits with `is_plain_number_bits(index_value)`, adding avoidable work on every hot get.
+- Change:
+  - Added `js_typed_feedback_numeric_array_index_get_guard_i32(site_id, receiver, index, require_in_bounds)` for codegen paths that already have a trusted i32 index.
+  - The new guard preserves numeric-layout, bounds, observation, pass/fail, and fallback accounting, but skips the boxed-index argument and plain-number bit check.
+  - Changed computed numeric array gets and bounded-index numeric gets to call the trusted-i32 guard when the index is already lowered as i32.
+  - Moved the i32-to-double boxing for trusted-i32 gets into the fallback block only, so the hot fast path does not materialize the boxed index.
+  - Reused the trusted-i32 helper from the invariant numeric array read hoist prebody.
+- Post-change benchmark commands:
+  - `cargo build --release`
+  - `target/release/perry compile --no-cache benchmarks/suite/16_matrix_multiply.ts -o /tmp/perry-matrix-i32-get-guard --trace llvm --quiet`
+  - `rg -n "numeric_array_index_get_guard_i32|numeric_array_index_get_guard\\(|sitofp i32" .perry-trace/llvm/_16_matrix_multiply_ts.ll`
+  - `for i in 1 2 3 4 5; do /usr/bin/time -f "matrix i32-guard sample=$i wall=%e rss_kb=%M" /tmp/perry-matrix-i32-get-guard; done`
+  - `PERRY_TYPED_FEEDBACK_TRACE=/tmp/perry-matrix-i32-get-guard-trace.json /usr/bin/time -f "matrix i32-guard trace wall=%e rss_kb=%M" /tmp/perry-matrix-i32-get-guard && jq '[.sites[] | select(.kind=="array_element") | {site_id, operation, guard_name, observed_count, guard_passes, guard_failures, fallback_calls}]' /tmp/perry-matrix-i32-get-guard-trace.json`
+  - `perf stat -e cycles,instructions,branches,branch-misses /tmp/perry-matrix-i32-get-guard`
+  - `benchmarks/quick.sh`
+  - `benchmarks/compare.sh --quick --runs 3 --warn-only --json-out /tmp/perry-compare-i32-get-guard.json`
+- Post-change results:
+  - LLVM IR uses `js_typed_feedback_numeric_array_index_get_guard_i32` for the two hot matrix get sites and the final checksum get site; the remaining get-index `sitofp` instructions are in fallback blocks.
+  - direct matrix binary samples: 378ms, 381ms, 385ms, 365ms, 376ms; checksum always `41079519680`
+  - trace run: `matrix_multiply:384`, wall 0.41s, RSS 31436KB
+  - hot get trace sites `3181980809628221440` and `3181980809628221441`: 16,777,216 observations/passes each, 0 failures, 0 fallback calls
+  - final checksum get trace site `3181980809628221446`: 65,536 observations/passes, 0 failures, 0 fallback calls
+  - direct matrix `perf stat`: 1,372,519,931 cycles, 6,614,211,059 instructions, 1,434,035,989 branches, 244,367 branch-misses, 0.4080s elapsed
+  - quick: fibonacci 262ms/18MB, math_intensive 61ms/18MB, nested_loops 118ms/22MB, factorial 93ms/18MB, matrix_multiply 368ms/30MB
+  - compare quick medians: loop_overhead 78ms/18828KB, fibonacci 246ms/18944KB, math_intensive 56ms/18904KB, nested_loops 120ms/23176KB, factorial 85ms/18904KB
+- Measured impact:
+  - `16_matrix_multiply` direct binary: 397ms -> 378ms median, 4.8% faster
+  - `16_matrix_multiply` quick: 390ms -> 368ms, 5.6% faster
+  - Direct matrix binary cycles: 1.462B -> 1.373B, 6.1% fewer
+  - Direct matrix binary instructions: 7.018B -> 6.614B, 5.8% fewer
+  - Direct matrix binary branches: 1.568B -> 1.434B, 8.6% fewer
+- Verification:
+  - `cargo fmt --check`
+  - `git diff --check`
+  - `cargo test -p perry-runtime typed_feedback_numeric_array_get_guard_i32_requires_numeric_layout`
+  - `cargo test -p perry-codegen --test typed_feedback`
+  - `cargo test -p perry-codegen --test typed_shape_descriptors`
+  - `PERRY_BIN=target/release/perry python3 tests/test_typed_feedback_runtime_evidence.py`
+  - `tests/test_benchmark_output_verifier.sh`
+  - `cargo build --release`
+  - Final typed-feedback trace confirmed unchanged get observation/pass totals and zero fallback calls.
+- Notes:
+  - `benchmarks/baseline.json` is stale for this Linux environment; compare was run with `--warn-only`, and the matrix before/after comparison above uses the captured local sixth-cycle baseline.
+  - This is a deliberately narrow runtime ABI and codegen change: only paths with an already trusted i32 index use the new guard, and fallback boxing remains available for correctness.
+- PR: https://github.com/PerryTS/perry/pull/5313

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -195,6 +195,47 @@ pub(crate) fn lower_guarded_array_index_get(
     require_numeric_layout: bool,
     skipped_fast_pass_count: Option<&str>,
 ) -> Result<String> {
+    lower_guarded_array_index_get_impl(
+        ctx,
+        arr_box,
+        Some(idx_box),
+        idx_i32,
+        block_prefix,
+        require_numeric_layout,
+        skipped_fast_pass_count,
+        false,
+    )
+}
+
+pub(crate) fn lower_guarded_array_index_get_trusted_i32(
+    ctx: &mut FnCtx<'_>,
+    arr_box: &str,
+    idx_i32: &str,
+    block_prefix: &str,
+    skipped_fast_pass_count: Option<&str>,
+) -> Result<String> {
+    lower_guarded_array_index_get_impl(
+        ctx,
+        arr_box,
+        None,
+        idx_i32,
+        block_prefix,
+        true,
+        skipped_fast_pass_count,
+        true,
+    )
+}
+
+fn lower_guarded_array_index_get_impl(
+    ctx: &mut FnCtx<'_>,
+    arr_box: &str,
+    idx_box: Option<&str>,
+    idx_i32: &str,
+    block_prefix: &str,
+    require_numeric_layout: bool,
+    skipped_fast_pass_count: Option<&str>,
+    trusted_i32_index: bool,
+) -> Result<String> {
     let contract = if require_numeric_layout {
         TypedFeedbackContract::numeric_array_get_index()
     } else {
@@ -215,34 +256,58 @@ pub(crate) fn lower_guarded_array_index_get(
 
     let guard_ok = {
         let blk = ctx.block();
-        let guard_fn = if require_numeric_layout {
-            "js_typed_feedback_numeric_array_index_get_guard"
+        let use_i32_numeric_guard = require_numeric_layout && trusted_i32_index;
+        let guard_i32 = if use_i32_numeric_guard {
+            blk.call(
+                I32,
+                "js_typed_feedback_numeric_array_index_get_guard_i32",
+                &[
+                    (I64, &feedback_site_id),
+                    (DOUBLE, arr_box),
+                    (I32, idx_i32),
+                    (I32, "1"),
+                ],
+            )
         } else {
-            "js_typed_feedback_plain_array_index_get_guard"
+            let guard_fn = if require_numeric_layout {
+                "js_typed_feedback_numeric_array_index_get_guard"
+            } else {
+                "js_typed_feedback_plain_array_index_get_guard"
+            };
+            let idx_box =
+                idx_box.expect("non-i32 array index guard path requires a boxed index value");
+            blk.call(
+                I32,
+                guard_fn,
+                &[
+                    (I64, &feedback_site_id),
+                    (DOUBLE, arr_box),
+                    (DOUBLE, idx_box),
+                    (I32, idx_i32),
+                    (I32, "1"),
+                ],
+            )
         };
-        let guard_i32 = blk.call(
-            I32,
-            guard_fn,
-            &[
-                (I64, &feedback_site_id),
-                (DOUBLE, arr_box),
-                (DOUBLE, idx_box),
-                (I32, idx_i32),
-                (I32, "1"),
-            ],
-        );
         blk.icmp_ne(I32, &guard_i32, "0")
     };
     ctx.block().cond_br(&guard_ok, &fast_label, &fallback_label);
 
     ctx.current_block = fallback_idx;
+    let fallback_idx_box;
+    let fallback_idx_ref = match idx_box {
+        Some(idx_box) => idx_box,
+        None => {
+            fallback_idx_box = ctx.block().sitofp(I32, idx_i32, DOUBLE);
+            &fallback_idx_box
+        }
+    };
     let fallback_val = ctx.block().call(
         DOUBLE,
         "js_typed_feedback_array_index_get_fallback_boxed",
         &[
             (I64, &feedback_site_id),
             (DOUBLE, arr_box),
-            (DOUBLE, idx_box),
+            (DOUBLE, fallback_idx_ref),
         ],
     );
     let fallback_end_label = ctx.block().label.clone();
@@ -850,15 +915,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             ctx.block().fptosi(DOUBLE, &idx_double, I32)
                         };
                         if require_numeric_layout {
-                            let idx_double = ctx.block().sitofp(I32, &idx_i32, DOUBLE);
-                            return lower_guarded_array_index_get(
-                                ctx,
-                                &arr_box,
-                                &idx_double,
-                                &idx_i32,
-                                "bidx.num",
-                                true,
-                                None,
+                            return lower_guarded_array_index_get_trusted_i32(
+                                ctx, &arr_box, &idx_i32, "bidx.num", None,
                             );
                         }
                         return lower_bounded_array_index_get(ctx, &arr_box, &idx_i32);
@@ -881,6 +939,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     ctx.integer_returning_functions,
                     ctx.i32_identity_functions,
                 );
+                if use_i32_index && require_numeric_layout {
+                    let idx_i32 = lower_expr_as_i32(ctx, index)?;
+                    return lower_guarded_array_index_get_trusted_i32(
+                        ctx, &arr_box, &idx_i32, "arr", None,
+                    );
+                }
                 let (idx_double, idx_i32) = if use_i32_index {
                     let idx_i32 = lower_expr_as_i32(ctx, index)?;
                     let idx_double = ctx.block().sitofp(I32, &idx_i32, DOUBLE);

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -93,7 +93,7 @@ pub(crate) use i32_fast_path::{
     try_flat_const_2d_int, try_lower_flat_const_index_get,
 };
 pub(crate) use index::lower_index_set_fast;
-pub(crate) use index_get::lower_guarded_array_index_get;
+pub(crate) use index_get::lower_guarded_array_index_get_trusted_i32;
 pub(crate) use nanbox_inline::{
     i32_bool_to_nanbox, nanbox_bigint_inline, nanbox_pointer_inline, nanbox_pointer_inline_pub,
     nanbox_string_inline,

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -88,6 +88,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         &[I64, I64],
     );
     module.declare_function(
+        "js_typed_feedback_numeric_array_index_get_guard_i32",
+        I32,
+        &[I64, DOUBLE, I32, I32],
+    );
+    module.declare_function(
         "js_typed_feedback_observe_property_get",
         VOID,
         &[I64, I64, I64],

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 use crate::expr::{
-    expr_has_numeric_pointer_free_array_layout, lower_guarded_array_index_get,
+    expr_has_numeric_pointer_free_array_layout, lower_guarded_array_index_get_trusted_i32,
     nanbox_pointer_inline, BoundedIndexPair, IntRangeFact,
 };
 use crate::loop_purity::body_needs_asm_barrier;
@@ -893,8 +893,6 @@ fn emit_invariant_numeric_array_index_get_hoist(
             let idx_double = lower_expr(ctx, &idx_expr)?;
             ctx.block().fptosi(DOUBLE, &idx_double, I32)
         };
-    let idx_double = ctx.block().sitofp(I32, &idx_i32, DOUBLE);
-
     let inner_counter_slot = ctx
         .i32_counter_slots
         .get(&hoist.inner_counter_local_id)
@@ -906,13 +904,11 @@ fn emit_invariant_numeric_array_index_get_hoist(
     let skipped_i32 = ctx.block().sub(I32, &remaining_i32, "1");
     let skipped_i64 = ctx.block().zext(I32, &skipped_i32, I64);
 
-    lower_guarded_array_index_get(
+    lower_guarded_array_index_get_trusted_i32(
         ctx,
         &arr_box,
-        &idx_double,
         &idx_i32,
         "hoist.num",
-        true,
         Some(&skipped_i64),
     )
 }

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -591,7 +591,7 @@ fn typed_feedback_guards_computed_numeric_array_index_uses_i32_loop_bound() {
         }],
     ));
 
-    assert!(ir.contains("call i32 @js_typed_feedback_numeric_array_index_get_guard"));
+    assert!(ir.contains("call i32 @js_typed_feedback_numeric_array_index_get_guard_i32"));
     assert!(ir.contains("call double @js_typed_feedback_array_index_get_fallback_boxed"));
     assert!(ir.contains("mul i32"), "{ir}");
     assert!(ir.contains("add i32"), "{ir}");
@@ -688,7 +688,7 @@ fn typed_feedback_hoists_invariant_numeric_array_get_out_of_inner_loop() {
         ir.contains("call void @js_typed_feedback_record_array_guard_fast_passes"),
         "{ir}"
     );
-    assert!(ir.contains("call i32 @js_typed_feedback_numeric_array_index_get_guard"));
+    assert!(ir.contains("call i32 @js_typed_feedback_numeric_array_index_get_guard_i32"));
 }
 
 #[test]

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1523,6 +1523,55 @@ pub extern "C" fn js_typed_feedback_numeric_array_index_get_guard(
 }
 
 #[no_mangle]
+pub extern "C" fn js_typed_feedback_numeric_array_index_get_guard_i32(
+    site_id: u64,
+    receiver: f64,
+    index: i32,
+    require_in_bounds: i32,
+) -> i32 {
+    let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    let require_in_bounds = require_in_bounds != 0;
+    if site_id != 0 && index >= 0 {
+        if let Some(observation) =
+            numeric_array_fast_observation(raw_addr, index as u32, require_in_bounds, None)
+        {
+            if array_guard_fast_pass(site_id, &observation, true) {
+                return 1;
+            }
+        }
+    }
+    let observed_index = if index >= 0 { index as u32 } else { u32::MAX };
+    let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(observed_index));
+    let observation = Observation {
+        source: ObservationSource::Array,
+        object_addr: 0,
+        shape_addr: 0,
+        key_hash: 0,
+        class_id,
+        heap_type,
+        aux,
+        value_tag: element_kind,
+    };
+    let contract_valid = index >= 0
+        && numeric_array_index_guard(
+            raw_addr as *const ArrayHeader,
+            index as u32,
+            require_in_bounds,
+        );
+    let pass = guard_observe(
+        site_id,
+        TypedFeedbackSiteKind::ArrayElement,
+        observation,
+        contract_valid,
+    );
+    if pass {
+        1
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn js_typed_feedback_array_index_get_fallback_boxed(
     site_id: u64,
     receiver: f64,

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -506,6 +506,33 @@ fn typed_feedback_numeric_array_get_guard_requires_numeric_layout() {
 }
 
 #[test]
+fn typed_feedback_numeric_array_get_guard_i32_requires_numeric_layout() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(27, TypedFeedbackSiteKind::ArrayElement, "arr[i]");
+
+    let values = [1.0, 2.0];
+    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    let first = js_typed_feedback_numeric_array_index_get_guard_i32(27, arr_box, 0, 1);
+    assert_eq!(first, 1);
+
+    let payload = crate::string::js_string_from_bytes(b"downgraded".as_ptr(), 10);
+    let payload_value = crate::value::js_nanbox_string(payload as i64);
+    crate::array::js_array_set_f64(arr, 0, payload_value);
+    assert_eq!(crate::array::js_array_is_numeric_f64_layout(arr), 0);
+
+    let second = js_typed_feedback_numeric_array_index_get_guard_i32(27, arr_box, 0, 1);
+    assert_eq!(second, 0);
+
+    let site = &typed_feedback_snapshot().sites[0];
+    assert_eq!(site.guard_passes, 1);
+    assert_eq!(site.guard_failures, 1);
+    assert_eq!(site.fallback_calls, 0);
+}
+
+#[test]
 fn typed_feedback_numeric_array_guard_fast_path_preserves_snapshot_counts() {
     let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
     reset_typed_feedback_for_tests();

--- a/crates/perry-runtime/src/typed_feedback/trace.rs
+++ b/crates/perry-runtime/src/typed_feedback/trace.rs
@@ -392,4 +392,5 @@ mod keep_typed_feedback {
     #[used] static K22: extern "C" fn(u64, f64) -> f64 = js_typed_feedback_observe_helper_return;
     #[cfg(feature = "diagnostics")]
     #[used] static K23: extern "C" fn() = js_typed_feedback_maybe_dump_trace;
+    #[used] static K24: extern "C" fn(u64, f64, i32, i32) -> i32 = js_typed_feedback_numeric_array_index_get_guard_i32;
 }


### PR DESCRIPTION
## Summary
- add an i32-only numeric array index-get guard for codegen paths with an already trusted i32 index
- lower trusted computed numeric gets without hot-path index boxing; fallback blocks still box for the generic fallback call
- reuse the trusted-i32 guard from the invariant numeric array read hoist path

## Benchmark Evidence
Baseline: parent commit f8454f6bb (`codex/perry-invariant-array-read-hoist`).

Matrix direct samples (`16_matrix_multiply.ts`, release generated binary):
- before: 391ms, 406ms, 385ms, 397ms, 407ms; median 397ms
- after: 378ms, 381ms, 385ms, 365ms, 376ms; median 378ms
- checksum stayed `41079519680`

Matrix perf stat:
- cycles: 1,462,371,864 -> 1,372,519,931 (6.1% fewer)
- instructions: 7,017,654,871 -> 6,614,211,059 (5.8% fewer)
- branches: 1,568,480,811 -> 1,434,035,989 (8.6% fewer)
- elapsed: 0.4253s -> 0.4080s

Typed-feedback trace stayed equivalent for the two hot matrix get sites: 16,777,216 observations/passes each, 0 failures, 0 fallback calls. LLVM trace confirms the hot get sites now call `js_typed_feedback_numeric_array_index_get_guard_i32`, with `sitofp` only in fallback blocks.

`benchmarks/quick.sh` snapshot:
- fibonacci 262ms/18MB
- math_intensive 61ms/18MB
- nested_loops 118ms/22MB
- factorial 93ms/18MB
- matrix_multiply 368ms/30MB

`benchmarks/compare.sh --quick --runs 3 --warn-only --json-out /tmp/perry-compare-i32-get-guard.json` completed. The repo baseline JSON is stale for this Linux environment, so its regression labels are not used as the decision signal.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p perry-runtime typed_feedback_numeric_array_get_guard_i32_requires_numeric_layout`
- `cargo test -p perry-codegen --test typed_feedback`
- `cargo test -p perry-codegen --test typed_shape_descriptors`
- `PERRY_BIN=target/release/perry python3 tests/test_typed_feedback_runtime_evidence.py`
- `tests/test_benchmark_output_verifier.sh`
- `cargo build --release`
