### PR TITLE
fix(runtime): %TypedArray%.prototype[@@toStringTag] accessor (#5268)

### DIFF
--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -169,9 +169,14 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                 .unwrap_or(PropertyAttrs::new(true, true, true));
             if let Some((get, set)) = crate::symbol::symbol_accessor_descriptor_bits(owner, sym_key)
             {
+                // A getter-only (or setter-only) accessor stores the absent half
+                // as `0`; render it as `undefined` so the descriptor matches Node
+                // (`{ get, set: undefined, … }`), mirroring the exotic-expando
+                // accessor path below.
+                let undef = crate::value::TAG_UNDEFINED;
                 return build_accessor_descriptor(
-                    f64::from_bits(get),
-                    f64::from_bits(set),
+                    f64::from_bits(if get == 0 { undef } else { get }),
+                    f64::from_bits(if set == 0 { undef } else { set }),
                     attrs.enumerable(),
                     attrs.configurable(),
                 );

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2365,6 +2365,65 @@ fn install_function_has_instance_symbol(proto_obj: *mut ObjectHeader) {
     }
 }
 
+/// `%TypedArray%.prototype[@@toStringTag]` getter (#5268). Per ES2024
+/// 23.2.3.38 this accessor's getter returns the receiver's
+/// `[[TypedArrayName]]` ("Int8Array", …) when `this` is a typed array, and
+/// `undefined` for any other receiver — it never throws. safe-stable-stringify
+/// (pulled in transitively by pino) reads
+/// `Object.getOwnPropertyDescriptor(%TypedArray%.prototype,
+/// Symbol.toStringTag).get` and `.call`s it to brand-check typed arrays;
+/// pre-fix the descriptor was `undefined`, so `.get` threw
+/// `Cannot read properties of undefined (reading 'get')`.
+extern "C" fn typed_array_to_string_tag_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    match typed_array_receiver() {
+        Some((_, kind)) => {
+            let name = crate::typedarray::name_for_kind(kind);
+            let s = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            f64::from_bits(crate::value::js_nanbox_string(s as i64).to_bits())
+        }
+        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    }
+}
+
+/// Install the non-enumerable, configurable `%TypedArray%.prototype
+/// [@@toStringTag]` accessor (getter only) on the shared intrinsic prototype.
+/// Stored in the symbol side table (like `@@iterator`), so it adds no inline
+/// fields — sidestepping the field-count overflow noted alongside the data
+/// methods above. #5268.
+fn install_typed_array_to_string_tag_symbol(proto_obj: *mut ObjectHeader) {
+    if proto_obj.is_null() {
+        return;
+    }
+    unsafe {
+        let func_ptr = typed_array_to_string_tag_getter_thunk as *const u8;
+        crate::closure::js_register_closure_arity(func_ptr, 0);
+        let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+        if closure.is_null() {
+            return;
+        }
+        super::native_module::set_bound_native_closure_name(closure, "get [Symbol.toStringTag]");
+        super::native_module::set_builtin_closure_length(closure as usize, 0);
+        let sym = crate::symbol::well_known_symbol("toStringTag");
+        if sym.is_null() {
+            return;
+        }
+        let proto_f64 = f64::from_bits(crate::value::js_nanbox_pointer(proto_obj as i64).to_bits());
+        let sym_f64 = f64::from_bits(crate::value::JSValue::pointer(sym as *const u8).bits());
+        let get_bits = crate::value::js_nanbox_pointer(closure as i64).to_bits();
+        crate::symbol::set_symbol_accessor_property(proto_f64, sym_f64, get_bits, 0);
+        let owner = crate::symbol::obj_key_from_f64(proto_f64);
+        let sym_key = crate::symbol::sym_key_from_f64(sym_f64);
+        // Node: `{ enumerable: false, configurable: true }`.
+        crate::symbol::set_symbol_property_attrs(
+            owner,
+            sym_key,
+            super::PropertyAttrs::new(false, false, true),
+        );
+    }
+}
+
 fn install_typed_array_iterator_symbol(proto_obj: *mut ObjectHeader) {
     if proto_obj.is_null() {
         return;
@@ -2456,6 +2515,7 @@ fn ensure_typed_array_intrinsic() -> (*mut crate::closure::ClosureHeader, *mut O
     // "length")` to keep working.
     install_typed_array_proto_accessors(proto);
     install_typed_array_iterator_symbol(proto);
+    install_typed_array_to_string_tag_symbol(proto);
     // The per-kind prototypes (`Int8Array.prototype`, …) inherit ALL of their
     // methods from this shared `%TypedArray%.prototype` (their `[[Prototype]]`),
     // so `Int8Array.prototype.hasOwnProperty("map") === false` and

--- a/crates/perry/tests/issue_5268_typed_array_to_string_tag_descriptor.rs
+++ b/crates/perry/tests/issue_5268_typed_array_to_string_tag_descriptor.rs
@@ -1,0 +1,107 @@
+//! Regression test for #5268 (pino follow-up wall): reading
+//! `Object.getOwnPropertyDescriptor(%TypedArray%.prototype, Symbol.toStringTag)`
+//! must return an accessor descriptor whose `.get` is a callable getter — not
+//! `undefined`.
+//!
+//! After PR #5269 removed the `Object prototype may only be an Object or null:
+//! undefined` throw for graceful-fs / fs-extra / pino, pino's next wall was a
+//! `TypeError: Cannot read properties of undefined (reading 'get')` raised by
+//! its transitive dependency `safe-stable-stringify`, which does:
+//!
+//! ```js
+//! const typedArrayPrototypeGetSymbolToStringTag =
+//!   Object.getOwnPropertyDescriptor(
+//!     Object.getPrototypeOf(Object.getPrototypeOf(new Int8Array())),
+//!     Symbol.toStringTag
+//!   ).get
+//! ```
+//!
+//! Perry returned `undefined` for that descriptor (no `@@toStringTag` accessor
+//! existed on the shared `%TypedArray%.prototype`), so `.get` threw. The fix
+//! installs the spec accessor (ES2024 23.2.3.38): a non-enumerable, configurable
+//! getter that returns the receiver's `[[TypedArrayName]]` ("Int8Array", …) for
+//! a typed-array receiver and `undefined` for any other receiver (no throw).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: 'TypeError: Cannot read properties of \
+         undefined (reading 'get')')\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn typed_array_proto_to_string_tag_accessor_descriptor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+// safe-stable-stringify's exact shape: grab the %TypedArray%.prototype
+// @@toStringTag getter off the descriptor and brand-check with it.
+const taProto = Object.getPrototypeOf(Object.getPrototypeOf(new Int8Array()));
+const desc = Object.getOwnPropertyDescriptor(taProto, Symbol.toStringTag);
+
+console.log("desc_is_object:", typeof desc === "object" && desc !== null);
+console.log("get_is_function:", typeof (desc as any).get === "function");
+console.log("set_is_undefined:", (desc as any).set === undefined);
+console.log("enumerable:", (desc as any).enumerable);
+console.log("configurable:", (desc as any).configurable);
+
+const getter = (desc as any).get as Function;
+// Returns the [[TypedArrayName]] for a typed-array receiver.
+console.log("tag_int8:", getter.call(new Int8Array()));
+console.log("tag_f64:", getter.call(new Float64Array()));
+// Returns undefined (does NOT throw) for a non-typed-array receiver.
+console.log("tag_plain:", getter.call({}));
+
+// Object.prototype.toString still tags typed arrays correctly.
+console.log("tostring:", Object.prototype.toString.call(new Uint8Array()));
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "desc_is_object: true\n\
+         get_is_function: true\n\
+         set_is_undefined: true\n\
+         enumerable: false\n\
+         configurable: true\n\
+         tag_int8: Int8Array\n\
+         tag_f64: Float64Array\n\
+         tag_plain: undefined\n\
+         tostring: [object Uint8Array]\n"
+    );
+}

--- a/test-files/test_issue_5268_typed_array_to_string_tag_descriptor.ts
+++ b/test-files/test_issue_5268_typed_array_to_string_tag_descriptor.ts
@@ -1,0 +1,35 @@
+// #5268 (pino follow-up wall): `%TypedArray%.prototype[Symbol.toStringTag]`
+// must be an accessor whose `.get` is callable — not an absent (`undefined`)
+// descriptor.
+//
+// After #5269 cleared the `Object prototype may only be an Object or null:
+// undefined` throw, pino's next wall came from `safe-stable-stringify`:
+//
+//   const typedArrayPrototypeGetSymbolToStringTag =
+//     Object.getOwnPropertyDescriptor(
+//       Object.getPrototypeOf(Object.getPrototypeOf(new Int8Array())),
+//       Symbol.toStringTag
+//     ).get
+//
+// Perry returned `undefined` for that descriptor, so `.get` threw
+// `TypeError: Cannot read properties of undefined (reading 'get')`. The fix
+// installs the spec accessor (ES2024 23.2.3.38) on the shared
+// `%TypedArray%.prototype`: a non-enumerable, configurable getter that returns
+// the receiver's `[[TypedArrayName]]` for a typed-array receiver and
+// `undefined` (no throw) for anything else.
+
+const taProto = Object.getPrototypeOf(Object.getPrototypeOf(new Int8Array()));
+const desc = Object.getOwnPropertyDescriptor(taProto, Symbol.toStringTag);
+
+console.log("desc is object:", typeof desc === "object" && desc !== null);
+console.log("get is function:", typeof (desc as any).get === "function");
+console.log("set is undefined:", (desc as any).set === undefined);
+console.log("enumerable:", (desc as any).enumerable);
+console.log("configurable:", (desc as any).configurable);
+
+const getter = (desc as any).get as Function;
+console.log("tag for Int8Array:", getter.call(new Int8Array()));
+console.log("tag for Float64Array:", getter.call(new Float64Array()));
+console.log("tag for plain object:", getter.call({}));
+
+console.log("Object.prototype.toString:", Object.prototype.toString.call(new Uint8Array()));


### PR DESCRIPTION
## #5268 — pino follow-up wall: `Cannot read properties of undefined (reading 'get')`

### Background
PR #5269 (merged) cleared the titular `TypeError: Object prototype may only be an Object or null: undefined` throw for the three corpus packages. With that fix in place on `main` today:

| package | status |
|---|---|
| graceful-fs | ✅ loads, `readFileSync`/`ReadStream` resolve |
| fs-extra | ✅ loads (benign `fs.realpath.native` warning) |
| pino | proto-throw gone; **next wall** → `TypeError: Cannot read properties of undefined (reading 'get')` |

#5269 explicitly scoped pino's next wall as out of scope ("unrelated, not fixed here"). This PR fixes that wall.

### Traced root cause
The `.get` throw comes from pino's transitive dependency **safe-stable-stringify** (`index.js:53`):

```js
const typedArrayPrototypeGetSymbolToStringTag =
  Object.getOwnPropertyDescriptor(
    Object.getPrototypeOf(Object.getPrototypeOf(new Int8Array())),
    Symbol.toStringTag
  ).get
```

`Object.getPrototypeOf(Object.getPrototypeOf(new Int8Array()))` is the shared `%TypedArray%.prototype`. Perry never installed a `@@toStringTag` accessor there, so `Object.getOwnPropertyDescriptor(..., Symbol.toStringTag)` returned `undefined`, and `.get` on `undefined` threw.

### Fix
Install the spec accessor (ES2024 23.2.3.38) on the intrinsic `%TypedArray%.prototype`:
- a **non-enumerable, configurable** accessor (getter only)
- the getter returns the receiver's `[[TypedArrayName]]` (`"Int8Array"`, …) for a typed-array receiver and **`undefined` (no throw)** for any other receiver — matching V8's `get [Symbol.toStringTag]`.

It is stored in the symbol side table (like the existing `@@iterator`), so it adds **no inline fields** — sidestepping the field-count overflow that the code comments warn about for the intrinsic's data methods.

Also fixed the symbol-keyed `getOwnPropertyDescriptor` path to render an absent `get`/`set` (stored as `0`) as `undefined`, so getter-only symbol accessors report `{ get, set: undefined, … }` like Node — mirroring the existing exotic-expando accessor path right below it.

### Before / after (vs `node`)
```
Object.getOwnPropertyDescriptor(%TypedArray%.prototype, Symbol.toStringTag)
  before: undefined
  after:  { get: [Function: get [Symbol.toStringTag]], set: undefined,
            enumerable: false, configurable: true }   // identical to Node
get.call(new Int8Array()) → "Int8Array"   get.call({}) → undefined   // identical to Node
```
Running the real pino driver (`compilePackages: ["pino", …]`) now gets **past** this wall (next wall is a separate, generic `Cannot convert undefined or null to object` — out of scope here, same way #5269 scoped this one).

### Files
- `crates/perry-runtime/src/object/global_this.rs` — getter thunk + installer, wired into `ensure_typed_array_intrinsic`.
- `crates/perry-runtime/src/object/descriptors.rs` — render absent `get`/`set` as `undefined` in the symbol descriptor path.

### Tests
- New `crates/perry/tests/issue_5268_typed_array_to_string_tag_descriptor.rs` (compile + run) — passes.
- New `test-files/test_issue_5268_typed_array_to_string_tag_descriptor.ts`.
- Existing `issue_5268_native_ctor_prototype_undefined` (from #5269): still passes.
- `cargo test -p perry-runtime --lib` typed-array / symbol / descriptor subsets: pass; no regressions.

### Risk
Low. Adds one accessor to a single intrinsic via the side table (no layout change), and tightens the symbol-descriptor rendering toward Node parity (an absent half was previously rendered as the bogus number `0`). `Object.prototype.toString.call(typedArray)` continues to print `[object Int8Array]`.

### Note for maintainer
No `Cargo.toml` version / `CLAUDE.md` / `CHANGELOG.md` / `Cargo.lock` edits — per request, leaving the version bump + changelog for fold-in at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxsCYpFFV8aQqZeYswF5gU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxsCYpFFV8aQqZeYswF5gU)_