### PR TITLE
fix(runtime): %TypedArray%.prototype[@@toStringTag] accessor (pino root)

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -680,6 +680,21 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ))
         }
         Expr::Uint8ArrayGet { array, index } => {
+            // A symbol-keyed read (`u8[Symbol.toStringTag]`,
+            // `u8[Symbol.iterator]`) must resolve through the symbol-property
+            // path, which exposes the `%TypedArray%.prototype` symbol accessors
+            // (`@@toStringTag` — used by `safe-stable-stringify` — and
+            // `@@iterator`). The dynamic-index helper below stringifies the key
+            // and would miss them.
+            if matches!(index.as_ref(), Expr::SymbolFor(_)) {
+                let a = lower_expr(ctx, array)?;
+                let key = lower_expr(ctx, index)?;
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_object_get_symbol_property",
+                    &[(DOUBLE, &a), (DOUBLE, &key)],
+                ));
+            }
             if !is_numeric_expr(ctx, index) {
                 let a = lower_expr(ctx, array)?;
                 let key = lower_expr(ctx, index)?;

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -562,6 +562,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 ));
             }
             if is_width_tracked_typed_array_receiver(ctx, object) {
+                // A symbol-keyed read on a typed array (`ta[Symbol.toStringTag]`,
+                // `ta[Symbol.iterator]`) must NOT take the dynamic-index helper
+                // below — it stringifies the key and reads an ordinary [[Get]],
+                // missing the `%TypedArray%.prototype` symbol accessors. Route
+                // symbol keys to the symbol-property resolver (mirrors the array
+                // path), which exposes `@@toStringTag` (`safe-stable-stringify`)
+                // and `@@iterator`.
+                if matches!(index.as_ref(), Expr::SymbolFor(_)) {
+                    let obj_box = lower_expr(ctx, object)?;
+                    let key_box = lower_expr(ctx, index)?;
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_object_get_symbol_property",
+                        &[(DOUBLE, &obj_box), (DOUBLE, &key_box)],
+                    ));
+                }
                 // #2063: a key that isn't provably a number — a method-name
                 // string (`ta["copyWithin"]`, `ta[m]` where m iterates method
                 // names), a numeric string (`ta["2"]`), or any non-numeric /

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -169,9 +169,13 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                 .unwrap_or(PropertyAttrs::new(true, true, true));
             if let Some((get, set)) = crate::symbol::symbol_accessor_descriptor_bits(owner, sym_key)
             {
+                // A `0` get/set means "absent half" — surface it as `undefined`
+                // (not the number `0`) so a get-only accessor reflects
+                // `{ get, set: undefined }`.
+                let undef = crate::value::TAG_UNDEFINED;
                 return build_accessor_descriptor(
-                    f64::from_bits(get),
-                    f64::from_bits(set),
+                    f64::from_bits(if get == 0 { undef } else { get }),
+                    f64::from_bits(if set == 0 { undef } else { set }),
                     attrs.enumerable(),
                     attrs.configurable(),
                 );

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -2295,6 +2295,60 @@ extern "C" fn typed_array_buffer_getter_thunk(
     }
 }
 
+/// `%TypedArray%.prototype [ @@toStringTag ]` getter (ES2024 23.2.3.38). When
+/// `this` is a TypedArray it returns the constructor name (`"Int8Array"`,
+/// `"Uint8Array"`, …); for any other receiver it returns `undefined` (NO
+/// throw — the spec getter is `undefined`-tolerant). `safe-stable-stringify`
+/// (a pino dependency) detects typed arrays via
+/// `getOwnPropertyDescriptor(%TypedArray%.prototype, Symbol.toStringTag).get`
+/// then `desc.get.call(value)`, so a missing accessor previously threw
+/// `Cannot read properties of undefined (reading 'get')`.
+extern "C" fn typed_array_to_string_tag_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    match crate::object::typed_array_to_string_tag_name(this) {
+        Some(name) => {
+            let s = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            f64::from_bits(crate::js_nanbox_string(s as i64).to_bits())
+        }
+        None => f64::from_bits(crate::value::TAG_UNDEFINED),
+    }
+}
+
+/// Install the `%TypedArray%.prototype [ @@toStringTag ]` accessor (get-only,
+/// `{ enumerable: false, configurable: true }`) on the intrinsic prototype so
+/// `Object.getOwnPropertyDescriptor(%TypedArray%.prototype, Symbol.toStringTag)`
+/// reflects a real accessor descriptor with a callable `.get`. The getter's
+/// `this`-based result drives `safe-stable-stringify`'s typed-array detection.
+fn install_typed_array_to_string_tag(proto_obj: *mut ObjectHeader) {
+    if proto_obj.is_null() {
+        return;
+    }
+    let sym = crate::symbol::well_known_symbol("toStringTag");
+    if sym.is_null() {
+        return;
+    }
+    unsafe {
+        let f = typed_array_to_string_tag_getter_thunk as *const u8;
+        crate::closure::js_register_closure_arity(f, 0);
+        let c = crate::closure::js_closure_alloc(f, 0);
+        if c.is_null() {
+            return;
+        }
+        super::native_module::set_bound_native_closure_name(c, "get [Symbol.toStringTag]");
+        let get_bits = crate::value::js_nanbox_pointer(c as i64).to_bits();
+        let proto_value = crate::value::js_nanbox_pointer(proto_obj as i64);
+        let sym_value = f64::from_bits(crate::value::JSValue::pointer(sym as *const u8).bits());
+        crate::symbol::set_symbol_accessor_property(proto_value, sym_value, get_bits, 0);
+        crate::symbol::set_symbol_property_attrs(
+            proto_obj as usize,
+            sym as usize,
+            super::PropertyAttrs::new(false, false, true),
+        );
+    }
+}
+
 /// Install the four `%TypedArray%.prototype` accessor descriptors
 /// (`length`, `byteLength`, `byteOffset`, `buffer`) on a typed-array
 /// constructor's prototype object so `Object.getOwnPropertyDescriptor`
@@ -2456,6 +2510,7 @@ fn ensure_typed_array_intrinsic() -> (*mut crate::closure::ClosureHeader, *mut O
     // "length")` to keep working.
     install_typed_array_proto_accessors(proto);
     install_typed_array_iterator_symbol(proto);
+    install_typed_array_to_string_tag(proto);
     // The per-kind prototypes (`Int8Array.prototype`, …) inherit ALL of their
     // methods from this shared `%TypedArray%.prototype` (their `[[Prototype]]`),
     // so `Int8Array.prototype.hasOwnProperty("map") === false` and

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -2016,6 +2016,45 @@ unsafe fn object_to_string_tag_property(value: f64) -> Option<String> {
     string_value_to_owned(tag_value)
 }
 
+/// The `%TypedArray%.prototype [ @@toStringTag ]` value for `value` if it is a
+/// TypedArray (the constructor name, e.g. `"Int8Array"` / `"Uint8Array"`),
+/// else `None`. Covers both the raw-pointer typed-array representation and
+/// Perry's buffer-backed `Uint8Array`/`Uint8ClampedArray` (Node's `Buffer` is
+/// a `Uint8Array`, so it too reports `"Uint8Array"`). `ArrayBuffer` /
+/// `SharedArrayBuffer` / `DataView` / `CryptoKey` are NOT typed arrays and
+/// return `None` (their `@@toStringTag` getter yields `undefined`). Shared by
+/// `js_object_to_string`'s typed-array brand arm and the public
+/// `%TypedArray%.prototype[@@toStringTag]` accessor getter.
+pub(crate) fn typed_array_to_string_tag_name(value: f64) -> Option<&'static str> {
+    use crate::value::JSValue;
+    let bits = value.to_bits();
+    let jsv = JSValue::from_bits(bits);
+    let raw_addr = if jsv.is_pointer() {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if bits > 0x1000 && (bits >> 48) == 0 {
+        bits as usize
+    } else {
+        return None;
+    };
+    if raw_addr < 0x1000 {
+        return None;
+    }
+    if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw_addr) {
+        return Some(crate::typedarray::name_for_kind(kind));
+    }
+    // Buffer-backed `Uint8Array` (and Node `Buffer`) — registered as a buffer
+    // but still a TypedArray. Exclude the non-TypedArray buffer flavours.
+    if crate::buffer::is_registered_buffer(raw_addr)
+        && crate::buffer::crypto_key_meta(raw_addr).is_none()
+        && !crate::buffer::is_array_buffer(raw_addr)
+        && !crate::buffer::is_shared_array_buffer(raw_addr)
+        && !crate::buffer::is_data_view(raw_addr)
+    {
+        return Some("Uint8Array");
+    }
+    None
+}
+
 /// `Object.prototype.toString.call(x)` — returns `[object <tag>]` where
 /// `<tag>` is read from the value's class-level `Symbol.toStringTag` getter
 /// if registered, otherwise `Object` (matching Node for plain objects).

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -1953,6 +1953,26 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
+    // `(new Int8Array())[Symbol.toStringTag]` → `"Int8Array"` (and Node
+    // `Buffer`/`Uint8Array` → `"Uint8Array"`). The accessor lives on the
+    // `%TypedArray%.prototype` intrinsic, not the instance, so the OWN-accessor
+    // lookup above missed it; resolve the constructor name directly off the
+    // receiver here (the intrinsic getter does the same via its `this`). Covers
+    // both the raw-pointer typed-array form and Perry's buffer-backed
+    // `Uint8Array`. `safe-stable-stringify` (a pino dep) relies on this.
+    if raw_addr >= 0x1000 {
+        let tag_wk = well_known_symbol("toStringTag");
+        if !tag_wk.is_null() {
+            let tag_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(tag_wk as *const u8).bits());
+            if sym_key_from_f64(sym_f64) == sym_key_from_f64(tag_f64) {
+                if let Some(name) = crate::object::typed_array_to_string_tag_name(obj_f64) {
+                    let s = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                    return f64::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+                }
+            }
+        }
+    }
     // #321: arrays expose `Symbol.iterator`. perry has no standalone array
     // iterator object (for-of is special-cased), but `arr[Symbol.iterator]`
     // must resolve to a callable so `Symbol.iterator in arr` is true

--- a/test-files/test_gap_typedarray_tostringtag.ts
+++ b/test-files/test_gap_typedarray_tostringtag.ts
@@ -1,0 +1,40 @@
+// %TypedArray%.prototype[@@toStringTag] accessor.
+//
+// Per ES2024 23.2.3.38, `%TypedArray%.prototype` has a get-only
+// `[Symbol.toStringTag]` accessor whose getter returns the typed array's
+// constructor name (e.g. "Int8Array") when `this` is a TypedArray, else
+// `undefined`. It is `{ enumerable: false, configurable: true, set: undefined }`.
+//
+// `safe-stable-stringify` (a pino dependency) detects typed arrays via
+//   getOwnPropertyDescriptor(%TypedArray%.prototype, Symbol.toStringTag).get
+// then `desc.get.call(value)`, so a missing accessor threw
+// `Cannot read properties of undefined (reading 'get')`.
+
+const proto = Object.getPrototypeOf(Object.getPrototypeOf(new Int8Array()));
+const d = Object.getOwnPropertyDescriptor(proto, Symbol.toStringTag)!;
+
+// 1. The descriptor is a real accessor.
+console.log("desc:", typeof d, typeof d.get);
+console.log("attrs:", d.enumerable, d.configurable, d.set);
+
+// 2. Per-kind tag via the public symbol — inline and through a variable.
+console.log("Int8:", new Int8Array()[Symbol.toStringTag]);
+const u8 = new Uint8Array(3);
+console.log("Uint8:", u8[Symbol.toStringTag]);
+console.log("Uint8Clamped:", new Uint8ClampedArray(2)[Symbol.toStringTag]);
+console.log("Int16:", new Int16Array()[Symbol.toStringTag]);
+console.log("Uint16:", new Uint16Array()[Symbol.toStringTag]);
+console.log("Int32:", new Int32Array()[Symbol.toStringTag]);
+console.log("Uint32:", new Uint32Array()[Symbol.toStringTag]);
+console.log("Float32:", new Float32Array()[Symbol.toStringTag]);
+console.log("Float64:", new Float64Array()[Symbol.toStringTag]);
+
+// 3. `desc.get.call(...)` — the safe-stable-stringify detection idiom.
+console.log("get.call(Int8):", d.get!.call(new Int8Array()));
+console.log("get.call(Uint8):", d.get!.call(u8));
+console.log("get.call({}):", d.get!.call({}));
+
+// 4. No regression to the brand-check `Object.prototype.toString`.
+console.log("toString(Int8):", Object.prototype.toString.call(new Int8Array()));
+console.log("toString(Uint8):", Object.prototype.toString.call(u8));
+console.log("String:", String(new Int8Array(2)));


### PR DESCRIPTION
## pino — root fixed: `%TypedArray%.prototype[@@toStringTag]` accessor

### Root cause
pino's dep `safe-stable-stringify/index.js:61` detects typed arrays via:
```js
Object.getOwnPropertyDescriptor(
  Object.getPrototypeOf(Object.getPrototypeOf(new Int8Array())),
  Symbol.toStringTag
).get
```
Perry's `%TypedArray%.prototype` was missing the spec `[Symbol.toStringTag]`
accessor (ES2024 23.2.3.38), so `getOwnPropertyDescriptor` returned `undefined`
and `.get` threw `Cannot read properties of undefined (reading 'get')`.
(`Object.prototype.toString.call(ta)` already produced `[object Int8Array]` via a
separate internal-tag path — only the *public* accessor was absent.)

### Fix
1. **Install** a get-only `@@toStringTag` accessor on the `%TypedArray%`
   intrinsic proto (`enumerable:false, configurable:true, set:undefined`). The
   getter returns the constructor name for a TypedArray receiver, `undefined`
   otherwise. (`object/global_this.rs`)
2. **Shared helper** `typed_array_to_string_tag_name` resolves the name for both
   the raw-pointer typed-array representation and Perry's buffer-backed
   `Uint8Array` (Node `Buffer` is a `Uint8Array`, so it too reports
   `"Uint8Array"`); excludes `ArrayBuffer`/`SharedArrayBuffer`/`DataView`/
   `CryptoKey`. (`object/mod.rs`)
3. **Property read** path resolves `@@toStringTag` off the receiver in
   `js_object_get_symbol_property`. (`symbol.rs`)
4. **Codegen**: symbol-keyed typed-array index reads (`Uint8ArrayGet` and the
   width-tracked `IndexGet` path) were taking the dynamic numeric-index helper,
   which stringifies the key and misses the proto symbol accessors. Route
   `SymbolFor` keys through `js_object_get_symbol_property`.
   (`expr/arrays_finds.rs`, `expr/index_get.rs`)
5. **Descriptor read**: surface an absent symbol-accessor `get`/`set` half as
   `undefined` instead of the number `0`. (`object/descriptors.rs`)

### Verification (vs `node --experimental-strip-types`)
Minimal repro now byte-identical to node:
```
desc: object function
attrs: false true undefined
Int8: Int8Array   Uint8: Uint8Array   Float64: Float64Array   (all kinds)
get.call(Int8): Int8Array   get.call({}): undefined
toString(Int8): [object Int8Array]   String: 0,0
```
- pino driver: the `reading 'get'` error is **gone**.
- New gap test `test-files/test_gap_typedarray_tostringtag.ts` diffs identical to node.
- `perry-runtime` symbol/typed_array/descriptor unit tests green.

### Before / after + next wall
- pino **before**: `TypeError: Cannot read properties of undefined (reading 'get')`
- pino **after**: progresses past that; **next wall** is a *separate*
  `TypeError: Cannot convert undefined or null to object` at
  `safe-stable-stringify/index.js:272` (an `Object.keys`-style call on an
  undefined value — distinct from the accessor bug; not chased).

### Corpus (`secret-tests/corpus`, `PERRY_NO_AUTO_OPTIMIZE=1`)
- **53/59 before → 53/59 after — no regressions.** Same failing set
  (bluebird, pino, semver, winston, ajv, execa). pino's *failure mode advanced*
  (root fixed) but it isn't fully green yet, so the count is unchanged.

### bluebird (secondary) — characterized, not fixed
Still fails `TypeError: Cannot read properties of undefined (reading 'prototype')`,
`--debug-symbols` points at `bluebird/js/release/promise.js:381` but that line is
`_promiseAt` (no `.prototype` read) — confirming the CJS-wrap line skew noted in
the task. The real undefined `.prototype` read is on some
`require('./submodule')(Promise)` result coming back undefined. Left characterized;
fixing it is a separate, deeper investigation. Per the task, shipping pino's root
fix alone is acceptable.

### Metadata note (for maintainer)
Per task constraints this PR does **not** touch `Cargo.toml` version, the
`CLAUDE.md` Current Version line, `CHANGELOG.md`, or `Cargo.lock` — please fold
the version bump + changelog entry in at merge.
