### PR TITLE
ci: move sccache off the GHA backend onto a persisted disk cache (fix cargo-test timeouts)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,20 @@ jobs:
     timeout-minutes: 30
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: "2G"
+      # sccache on a LOCAL DISK cache, persisted as a single tarball via
+      # actions/cache (see the "Cache sccache objects" step) — NOT the GitHub
+      # Actions cache backend (SCCACHE_GHA_ENABLED). The GHA backend stores one
+      # cache object per compilation unit; GitHub's cache service throttled /
+      # LRU-evicted the thousands of tiny entries, so a full build wrote ~3.3k
+      # objects (≈35 min of write time) yet the next run got ~0% Rust hits
+      # (measured: 3 hits / 3209 misses, 613 write errors) — i.e. every run
+      # recompiled the dependency graph cold. A single tarball'd disk cache
+      # restores in one step and gives real cross-run hit rates. Note
+      # SCCACHE_CACHE_SIZE is honoured by the disk backend (it was a silent
+      # no-op under the GHA backend, which is why the old "2G" never mattered).
+      SCCACHE_GHA_ENABLED: "false"
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      SCCACHE_CACHE_SIZE: "12G"
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
@@ -121,8 +133,22 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Start sccache
+      - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+
+      # Persist the sccache disk cache across runs. The github.job +
+      # github.run_id key makes every run (including PRs) save its own fresh
+      # entry — distinct per job so the three sccache jobs don't collide on
+      # save — while the shared prefix restore-keys pull the most recent prior
+      # cache from ANY of them. The object cache therefore warms continuously
+      # and cross-pollinates instead of starting cold each run.
+      - name: Cache sccache objects
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.sccache
+          key: sccache-${{ runner.os }}-perry-${{ github.job }}-${{ github.run_id }}
+          restore-keys: |
+            sccache-${{ runner.os }}-perry-
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -175,13 +201,17 @@ jobs:
     # don't exercise any platform behavior; they're pure logic +
     # codegen.
     runs-on: ubuntu-latest
-    # Was unbounded (the workflow default of 360 min). This gate legitimately
-    # runs ~45-50 min (per-package serial build+prune loop below, plus the big
-    # stdlib links), and a cold sccache run can be a bit slower — so the bound
-    # is set well ABOVE the real runtime: it exists only to cut a true hang
-    # (e.g. a flaky link SIGBUS retry storm) at ~2 h instead of 6 h, never to
-    # fail a normal slow run.
-    timeout-minutes: 120
+    # The per-package serial build+prune loop below (plus the big stdlib links)
+    # takes ~50-60 min with a WARM sccache disk cache. A fully cold cache
+    # (recompiling the whole dependency graph) measured ~90-103 min, and PRs
+    # that invalidate perry-runtime/perry-codegen previously exceeded the old
+    # 120-min bound entirely. The bound is 180 to (a) leave headroom while the
+    # disk cache warms after the sccache-backend fix, and (b) still cut a true
+    # hang (e.g. a flaky link SIGBUS retry storm). Once warm hit rates are
+    # confirmed in CI this can come back down. NOTE: the old "~45-50 min" figure
+    # predated the sccache GHA-backend rot — it was never accurate once that
+    # cache stopped delivering Rust hits.
+    timeout-minutes: 180
     # sccache (compiler-level cache, shared across ALL branches/jobs via the
     # GitHub Actions cache backend) on top of Swatinem/rust-cache (target/ +
     # registry). rust-cache only writes on main (save-if below), so PRs can't
@@ -193,8 +223,20 @@ jobs:
     # loop below).
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: "2G"
+      # sccache on a LOCAL DISK cache, persisted as a single tarball via
+      # actions/cache (see the "Cache sccache objects" step) — NOT the GitHub
+      # Actions cache backend (SCCACHE_GHA_ENABLED). The GHA backend stores one
+      # cache object per compilation unit; GitHub's cache service throttled /
+      # LRU-evicted the thousands of tiny entries, so a full build wrote ~3.3k
+      # objects (≈35 min of write time) yet the next run got ~0% Rust hits
+      # (measured: 3 hits / 3209 misses, 613 write errors) — i.e. every run
+      # recompiled the dependency graph cold. A single tarball'd disk cache
+      # restores in one step and gives real cross-run hit rates. Note
+      # SCCACHE_CACHE_SIZE is honoured by the disk backend (it was a silent
+      # no-op under the GHA backend, which is why the old "2G" never mattered).
+      SCCACHE_GHA_ENABLED: "false"
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      SCCACHE_CACHE_SIZE: "12G"
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
@@ -202,8 +244,22 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Start sccache
+      - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+
+      # Persist the sccache disk cache across runs. The github.job +
+      # github.run_id key makes every run (including PRs) save its own fresh
+      # entry — distinct per job so the three sccache jobs don't collide on
+      # save — while the shared prefix restore-keys pull the most recent prior
+      # cache from ANY of them. The object cache therefore warms continuously
+      # and cross-pollinates instead of starting cold each run.
+      - name: Cache sccache objects
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.sccache
+          key: sccache-${{ runner.os }}-perry-${{ github.job }}-${{ github.run_id }}
+          restore-keys: |
+            sccache-${{ runner.os }}-perry-
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -348,8 +404,20 @@ jobs:
     timeout-minutes: 45
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: "2G"
+      # sccache on a LOCAL DISK cache, persisted as a single tarball via
+      # actions/cache (see the "Cache sccache objects" step) — NOT the GitHub
+      # Actions cache backend (SCCACHE_GHA_ENABLED). The GHA backend stores one
+      # cache object per compilation unit; GitHub's cache service throttled /
+      # LRU-evicted the thousands of tiny entries, so a full build wrote ~3.3k
+      # objects (≈35 min of write time) yet the next run got ~0% Rust hits
+      # (measured: 3 hits / 3209 misses, 613 write errors) — i.e. every run
+      # recompiled the dependency graph cold. A single tarball'd disk cache
+      # restores in one step and gives real cross-run hit rates. Note
+      # SCCACHE_CACHE_SIZE is honoured by the disk backend (it was a silent
+      # no-op under the GHA backend, which is why the old "2G" never mattered).
+      SCCACHE_GHA_ENABLED: "false"
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      SCCACHE_CACHE_SIZE: "12G"
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
@@ -357,8 +425,22 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Start sccache
+      - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+
+      # Persist the sccache disk cache across runs. The github.job +
+      # github.run_id key makes every run (including PRs) save its own fresh
+      # entry — distinct per job so the three sccache jobs don't collide on
+      # save — while the shared prefix restore-keys pull the most recent prior
+      # cache from ANY of them. The object cache therefore warms continuously
+      # and cross-pollinates instead of starting cold each run.
+      - name: Cache sccache objects
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.sccache
+          key: sccache-${{ runner.os }}-perry-${{ github.job }}-${{ github.run_id }}
+          restore-keys: |
+            sccache-${{ runner.os }}-perry-
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## v0.5.1179 — ci: move sccache off the GHA backend onto a persisted disk cache (fix cargo-test timeouts)
+
+The `cargo-test` gate was timing out at its 120-min cap on PRs that touch
+`perry-runtime`/`perry-codegen`, and even successful runs were taking 90-103 min
+(not the "~45-50 min" the stale comment claimed). Root cause: sccache was using
+the GitHub Actions cache backend (`SCCACHE_GHA_ENABLED=true`), which stores one
+cache object per compilation unit. GitHub's cache service throttled and
+LRU-evicted the thousands of tiny entries, so a full build wrote ~3.3k objects
+(≈35 min of write time) yet the next run got essentially **zero** Rust cache
+hits (measured on a timed-out run: 3 hits / 3209 misses, 613 write errors). Every
+run effectively recompiled the whole dependency graph cold. `SCCACHE_CACHE_SIZE`
+was a silent no-op under the GHA backend, so the old `2G` never mattered.
+
+Changes (all three sccache jobs — `cargo-test`, `api-docs-drift`,
+`compiler-output-regression` — which compile overlapping crate graphs):
+
+- Switch sccache to a **local disk cache** (`SCCACHE_DIR`, `SCCACHE_GHA_ENABLED=false`,
+  `SCCACHE_CACHE_SIZE=12G`) persisted as a single tarball via `actions/cache@v4`.
+  The cache key is `sccache-<os>-perry-<job>-<run_id>` with a shared
+  `sccache-<os>-perry-` restore-keys prefix, so every run (PRs included) saves
+  its own entry while restoring the most recent one from any of the three jobs —
+  the object cache warms continuously and cross-pollinates instead of starting
+  cold each run.
+- Raise the `cargo-test` `timeout-minutes` 120 → 180 as headroom while the disk
+  cache warms (cold runs are ~90-103 min); can be lowered once warm hit rates are
+  confirmed.
+
+No production code changes.
+
 ## v0.5.1178 — perf(codegen): outline per-new-site inline allocator (smaller IR + faster)
 
 `new ClassName(...)` previously emitted the full object-allocation prologue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1178
+**Current Version:** 0.5.1179
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "base64",
@@ -5340,14 +5340,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "cc",
  "libc",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "log",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "base64",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1178"
+version = "0.5.1179"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "clap",
@@ -5497,14 +5497,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5603,14 +5603,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "bytes",
  "h2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "bson",
  "futures-util",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "image",
@@ -5799,14 +5799,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "brotli",
  "flate2",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "base64",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6017,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6035,14 +6035,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "itoa",
@@ -6059,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6092,7 +6092,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "block2",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "block2",
@@ -6123,7 +6123,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1178"
+version = "0.5.1179"
 
 [[package]]
 name = "perry-ui-test"
@@ -6131,11 +6131,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1178"
+version = "0.5.1179"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "block2",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "block2",
@@ -6167,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "block2",
  "libc",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "libc",
@@ -6197,14 +6197,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1178"
+version = "0.5.1179"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1178"
+version = "0.5.1179"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
## Problem

The `cargo-test` required gate has been timing out at its 120-min cap on PRs that touch `perry-runtime`/`perry-codegen` (e.g. #5294, killed at package **48 of 76**), and even **successful** runs were taking **90-103 min** — not the "~45-50 min" the stale comment claimed.

Root cause, from the sccache stats on a timed-out run:

| metric | value |
|--------|-------|
| Rust cache hits | **3** |
| Rust cache misses | **3209** (0.09% hit rate) |
| cache write errors | **613** |
| cache write time | ~35 min |
| `SCCACHE_CACHE_SIZE` | `2G` |

sccache was using the **GitHub Actions cache backend** (`SCCACHE_GHA_ENABLED=true`), which stores one cache object per compilation unit. GitHub's cache service throttles and LRU-evicts the thousands of tiny entries, so a full build wrote ~3.3k objects (≈35 min) yet the next run got essentially **zero** Rust hits — every run recompiled the whole dependency graph cold. `SCCACHE_CACHE_SIZE` is a silent no-op under the GHA backend, so the old `2G` never mattered.

## Fix

Switch all three sccache jobs (`cargo-test`, `api-docs-drift`, `compiler-output-regression` — they compile overlapping crate graphs) to a **local disk cache** persisted as a single tarball via `actions/cache@v4`:

- `SCCACHE_GHA_ENABLED=false`, `SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache`, `SCCACHE_CACHE_SIZE=12G` (now actually honoured by the disk backend).
- Cache key `sccache-<os>-perry-<job>-<run_id>` with a shared `sccache-<os>-perry-` **restore-keys** prefix — every run (PRs included) saves its own entry while restoring the most recent one from any of the three jobs, so the object cache warms continuously and cross-pollinates instead of starting cold.
- Bump `cargo-test` `timeout-minutes` 120 → 180 as headroom while the cache warms (cold runs are ~90-103 min); can be lowered once warm hit rates are confirmed in CI.

A single tarball restores in one step and gives real cross-run hit rates, versus thousands of tiny GHA-API objects that never survived.

## Validation

No production code changes. This PR's own `cargo-test` run starts with a cold disk cache (~90-103 min, under the new 180 cap) and will **populate** the cache; subsequent runs should show high sccache Rust hit rates and drop toward ~50-60 min. Worth watching the sccache "Post" stats over the next few main-branch runs to confirm before lowering the timeout.

> Note: an S3/R2 sccache backend would be even more robust but needs repo secrets — this disk-cache approach is secret-free and is the standard sccache-on-GHA-without-S3 pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 0.5.1179
  * Enhanced continuous integration caching infrastructure for improved build performance and reduced redundant compilation across test jobs
  * Extended build timeout allowance to optimize cache initialization and ensure reliable test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->