### PR TITLE
fix(cjs-wrap): function-nested class named export lost (ajv 'undefined is not a constructor')

### DIFF
--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -344,6 +344,34 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     }
                 }
                 ctx.pending_classes.push(class);
+                // #5251 follow-up — a function-nested `class X { … }` whose
+                // name collides with an OUTER same-named local must SHADOW
+                // that local within this scope, exactly as a nested
+                // `function X(){}` does (see `lower_nested_fn_decl`, which
+                // `define_local`s the function name + emits a `Stmt::Let`).
+                // Without a scope-local binding, a later in-scope reference to
+                // `X` (e.g. the cjs_wrap `exports.X = X` that records the
+                // module's named export) falls through `lookup_local` to the
+                // enclosing module-scope `const X = _cjs.X` re-export binding —
+                // a circular self-read that resolves to `undefined`. That is
+                // the class-vs-function export asymmetry that left
+                // `require('./code').Name` undefined for ajv's `codegen/code.js`
+                // (`class Name`) while an identically-shaped `function Name`
+                // exported fine. Bind the name to a `ClassRef` value (the same
+                // shape `var C = class {…}` lowers to, recorded by codegen in
+                // `local_class_aliases`) so the in-scope read resolves to the
+                // class. Gated on a pre-existing outer binding so working
+                // packages (no collision) are byte-for-byte unaffected.
+                if ctx.lookup_local(&class_name).is_some() {
+                    let class_local = ctx.define_local(class_name.clone(), Type::Any);
+                    result.push(Stmt::Let {
+                        id: class_local,
+                        name: class_name.clone(),
+                        ty: Type::Any,
+                        init: Some(Expr::ClassRef(class_name.clone())),
+                        mutable: false,
+                    });
+                }
             } else {
                 // Duplicate same-named class: still evaluate its computed
                 // member keys for their spec-mandated side effects. See

--- a/tests/test_cjs_nested_class_named_export.sh
+++ b/tests/test_cjs_nested_class_named_export.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Regression (fix/ajv-not-constructor): a compiled CJS package whose class is
+# kept inside the cjs_wrap IIFE (#5251 hoist guard — the class body references
+# the injected `exports`) must still surface its `exports.X = X` named export to
+# `require('./code').X`. The HIR lowering for a function-nested `class X {}` now
+# defines a scope-local binding shadowing the outer same-named re-export const,
+# matching how a nested `function X(){}` already behaves.
+#
+# Pre-fix: `require('./code').Name` was `undefined` (the in-IIFE `exports.Name =
+# Name` resolved `Name` to the circular module-scope `const Name = _cjs.Name`),
+# so ajv's `new code_1.Name(...)` threw "undefined is not a constructor".
+# The function variant in the identical shape always worked — this guards both.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+if ! command -v cc >/dev/null 2>&1; then
+  echo "SKIP: cc not available"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+PKG="$TMPDIR/node_modules/pk"
+mkdir -p "$PKG"
+
+# code.js — the kept-in-IIFE shape: `class Name` whose ctor reads the injected
+# `exports`, then `exports.Name = Name`. The #5251 guard keeps the class inside
+# the IIFE; the named export must still reach the module's external exports.
+cat > "$PKG/code.js" << 'EOF'
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Name = void 0;
+exports.IDENTIFIER = /^[a-z]+$/i;
+class Name { constructor(s){ if(!exports.IDENTIFIER.test(s)) throw new Error("bad"); this.str = s; } }
+exports.Name = Name;
+EOF
+
+# func.js — the FUNCTION variant of the identical shape (the asymmetry to guard
+# against re-breaking): a function kept in the IIFE exported the same way.
+cat > "$PKG/func.js" << 'EOF'
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Make = void 0;
+exports.PREFIX = "v";
+function Make(s){ this.tag = exports.PREFIX + s; }
+exports.Make = Make;
+EOF
+
+# scope.js — cross-module consumer that constructs the kept-in-IIFE class at
+# module-init time (mirrors ajv's scope.js `new code_1.Name("const")`).
+cat > "$PKG/scope.js" << 'EOF'
+"use strict";
+const code_1 = require("./code");
+const func_1 = require("./func");
+exports.varKinds = { const: new code_1.Name("const") };
+exports.made = new func_1.Make("x");
+EOF
+
+cat > "$PKG/index.js" << 'EOF'
+"use strict";
+const code_1 = require("./code");
+const func_1 = require("./func");
+const scope_1 = require("./scope");
+module.exports = function(){
+  return "Name=" + typeof code_1.Name
+    + " Make=" + typeof func_1.Make
+    + " kind=" + String(scope_1.varKinds.const)
+    + " made=" + scope_1.made.tag;
+};
+EOF
+
+cat > "$PKG/package.json" << 'EOF'
+{ "name":"pk","version":"1.0.0","main":"index.js" }
+EOF
+
+cat > "$TMPDIR/package.json" << 'EOF'
+{ "type":"module","private":true,"perry":{"compilePackages":["*"],"allow":{"compilePackages":["*"]}} }
+EOF
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+import pk from "pk";
+console.log(pk());
+EOF
+
+cd "$TMPDIR"
+COMPILE_OUTPUT=$(PERRY_NO_AUTO_OPTIMIZE=1 "$PERRY" main.ts -o test_bin --no-cache 2>&1) || {
+  echo "FAIL: compile error"
+  echo "$COMPILE_OUTPUT" | tail -20
+  exit 1
+}
+
+RUN_OUTPUT=$(./test_bin 2>&1)
+# Matches `node main.ts`: the class & function both export as functions, and the
+# cross-module `new code_1.Name(...)` / `new func_1.Make(...)` succeed.
+EXPECTED="Name=function Make=function kind=[object Object] made=vx"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: kept-in-IIFE class named export not visible on require()"
+echo "Expected: $EXPECTED"
+echo "Got:      $RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Root

In a compiled CJS package (\`perry.compilePackages\`), a **function-nested \`class X {}\`** whose name collides with an outer same-named local **failed to shadow that local**, so an in-scope read of \`X\` resolved to the wrong binding.

Concretely: the #5251 hoist guard correctly keeps a class inside the wrapping IIFE when its body references the injected \`exports\`/\`module\`/\`require\` (ajv's \`codegen/code.js\`: \`class Name { constructor(s){ if(!exports.IDENTIFIER.test(s)) ... } }\`). The cjs_wrap then emits a module-scope re-export binding \`export const Name = _cjs.Name;\` (= local \`Name\`). When the IIFE body runs \`exports.Name = Name\` (recording the module's named export), the identifier \`Name\` was resolved via \`lookup_local\` — which walked past the (absent) in-IIFE binding up to that module-scope \`const Name = _cjs.Name\`. That is a **circular self-read** → \`undefined\`. So \`require('./code').Name\` was \`undefined\`, and ajv's \`scope.js\` \`new code_1.Name(...)\` threw **\`TypeError: undefined is not a constructor\`** (at \`compile/codegen/scope.js:17\`).

**Class-vs-function asymmetry:** a nested \`function X(){}\` already \`define_local\`s its name (\`lower_nested_fn_decl\`) and shadows the outer const, so the identical shape exported fine. A nested \`class X {}\` only registered into the global class table and created **no scope-local binding** — the gap.

## Fix

\`crates/perry-hir/src/lower_decl/body_stmt.rs\` — when lowering a function-nested class whose name has a pre-existing outer local, define a scope-local binding and emit \`Stmt::Let { name, init: ClassRef(name) }\` (the same shape \`var C = class {…}\` lowers to, already recorded by codegen in \`local_class_aliases\`). This shadows the outer re-export const, mirroring the function path. Gated on a pre-existing outer binding so packages without a collision are byte-for-byte unaffected.

## Minimal repro (before/after)

CJS package \`pk\` with \`code.js\` (\`class Name\`; \`exports.Name = Name\`), \`scope.js\` (\`new require('./code').Name(...)\`), \`index.js\` (re-exports), consumed by \`import pk from "pk"\`:
- **node:**  \`Name=function kind=[object Object]\`
- **perry before:** \`TypeError: undefined is not a constructor\`
- **perry after:** \`Name=function kind=[object Object]\` ✅ (== node)

Swapping \`class Name\` → \`function Name\` made perry succeed pre-fix (the asymmetry). A new regression test \`tests/test_cjs_nested_class_named_export.sh\` exercises both the class case (the bug) and the function case (the guard) end-to-end.

## ajv (before/after)

- **before:** \`TypeError: undefined is not a constructor\` (codegen/scope.js)
- **after:** advances past it; next wall is \`ReferenceError: Assign is not defined\` (separate, not chased)

## Validation

- perry-hir: 160+ tests pass; cjs_wrap unit suite: 87 pass.
- Lint gates: \`cargo fmt --check\`, \`check_file_size.sh\`, \`gc_store_site_inventory.py\`, \`addr_class_inventory.py\` all pass.
- secret-tests corpus: **53/59 OK (89%)** — identical pass set to baseline, zero regressions (ajv's error category advanced from \`not-a-constructor\` → \`not-defined\`).

## Note for maintainer

Per contributor convention, this PR does **not** touch \`[workspace.package] version\` (Cargo.toml), the \`Current Version:\` line (CLAUDE.md), \`CHANGELOG.md\`, or \`Cargo.lock\` — please fold the version bump + changelog entry at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable scoping behavior for nested class declarations that share a name with an outer binding, ensuring correct identifier resolution and proper class accessibility within nested scopes.

* **Tests**
  * Added regression test to verify proper CommonJS named-export visibility for nested class declarations and their correct instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->