### PR TITLE
test262: honor explicit --dir for path-skipped subtrees (#5299)

### DIFF
--- a/scripts/test262_subset.py
+++ b/scripts/test262_subset.py
@@ -68,6 +68,7 @@ Usage
     scripts/test262_subset.py --root vendor/test262 --dir language/expressions
     scripts/test262_subset.py --root vendor/test262 --max 500
     scripts/test262_subset.py --root vendor/test262 --all-features
+    scripts/test262_subset.py --root vendor/test262 --dir staging   # TC39 proposals (#5299)
 
 See test-compat/test262/README.md.
 """
@@ -109,7 +110,9 @@ DEFAULT_DIRS = ("language", "built-ins", "intl402")
 # stale — Perry measures eval-code ~94%, intl402 ~78%, property-escapes ~87%, so
 # they are no longer skipped (the eval cases run with PERRY_ALLOW_EVAL=1, set in
 # the compile env below). `RegExp/lookbehind` was vestigial (no such subdir).
-# Only genuinely-out-of-scope `staging` (proposals) remains.
+# Only genuinely-out-of-scope `staging` (proposals) remains skipped by default;
+# pass `--dir staging` to measure it anyway (the guard is bypassed for any
+# subtree the user names explicitly — see `discover`, #5299).
 # NB: Temporal is judged in self-validating mode (#4792) — the Node oracle lacks
 # it; under intl402/ the Temporal locale-format cases are now measured too.
 _PATH_SKIP = re.compile(
@@ -265,11 +268,17 @@ def discover(root: Path, dirs: list[str], applicable: set[str],
         base = test_root / d
         if not base.is_dir():
             continue
+        # `_PATH_SKIP` guards the *default* wholesale walk (it keeps `staging`
+        # out of the headline parity number). When the user deliberately names
+        # a normally-skipped subtree — `--dir staging` (#5299) — honor it: the
+        # whole point of the request is to measure that subtree, so don't let
+        # the same-named guard filter every case back out.
+        dir_opt_in = bool(_PATH_SKIP.search(d.strip("/") + "/"))
         for path in sorted(base.rglob("*.js")):
             rel = path.relative_to(test_root).as_posix()
             if path.name.endswith("_FIXTURE.js") or "_FIXTURE" in path.name:
                 continue
-            if _PATH_SKIP.search(rel):
+            if not dir_opt_in and _PATH_SKIP.search(rel):
                 continue
             try:
                 src = path.read_text(encoding="utf-8", errors="replace")

--- a/test-compat/test262/README.md
+++ b/test-compat/test262/README.md
@@ -30,6 +30,11 @@ a case unless:
 Pass `--all-features` to ignore the feature allow-list and run every
 discovered case (useful for measuring the raw denominator).
 
+`staging` (TC39 proposals) is the one subtree skipped wholesale by default,
+but naming it explicitly bypasses that guard so you can measure it on demand
+(#5299): `scripts/test262_subset.py --dir staging`. Any subtree the user
+names with `--dir` is honoured even if it would otherwise be path-skipped.
+
 ### Self-validating features (oracle can't run them) — #4792
 
 Some features Perry implements aren't in the Node oracle at all — `Temporal`


### PR DESCRIPTION
## What

Makes `scripts/test262_subset.py --dir staging` — the measurement command cited in #5299 — actually measure the `staging` subtree instead of silently measuring nothing.

## Why

`staging` is matched by `_PATH_SKIP`, and `discover()` applies that pattern to **every** discovered case regardless of whether the user explicitly requested the subtree. So `--dir staging` walked `test/staging/**`, then filtered every case back out — the headline-parity guard was swallowing a deliberate request. The 55%-staging number in #5299 was thus not reproducible via the documented command.

## Change

- In `discover()`, compute `dir_opt_in` per requested dir: if the dir the user named with `--dir` itself matches `_PATH_SKIP`, bypass the per-case skip for cases under it.
- The default sweep (`language`, `built-ins`, `intl402`) is unchanged — `staging` stays out of the headline parity number. Only an explicit `--dir staging` (or `--dir staging/sm`, etc.) opts in.
- Docstring + `test-compat/test262/README.md` updated to document the override.

This unblocks the triage pass requested in #5299 (bucketing the ~619/1,127 staging proposals) by making the measurement reproducible. No runtime/codegen behavior changes.

## Testing

- `python3 -m py_compile scripts/test262_subset.py` passes.
- Verified `dir_opt_in` is `True` for `staging` / `staging/sm` and `False` for `language` / `built-ins` / `intl402`.
- No vendored `vendor/test262` checkout in this environment, so the full staging sweep was not run here.

Per maintainer convention, this PR intentionally omits the version bump and CHANGELOG entry.

Refs #5299 (unblocks the triage; does not itself complete it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the staging subtree is excluded from default test runs but can be explicitly included via command-line option.

* **Features**
  * Added support for explicitly opt-ing into previously excluded test subtrees when specified in test execution commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->