### PR TITLE
fix(cjs-wrap): chain-aware class hoist — keep a class in the IIFE when its extends-parent is kept (ajv)

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
@@ -220,9 +220,30 @@ pub fn rewrite_module_exports_class_expression(source: &str) -> Option<String> {
 /// already a duplicate of a previously-seen class (defensive).
 pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, String) {
     let bytes = source.as_bytes();
-    let mut hoisted_blocks: Vec<&str> = Vec::new();
-    let mut hoisted_names: Vec<String> = Vec::new();
-    let mut elided: Vec<(usize, usize)> = Vec::new();
+
+    // A top-level `class` candidate discovered by the brace-balanced scan.
+    // We collect every candidate first, then decide hoist-vs-keep in a
+    // chain-aware fixpoint pass below — deciding per class independently
+    // (the original single forward pass) splits an inheritance chain across
+    // the IIFE boundary: a parent KEPT inside the IIFE (because it refs an
+    // IIFE-local) becomes invisible to a child HOISTED to top level, so the
+    // child's `extends <Parent>` throws `ReferenceError: <Parent> is not
+    // defined` (ajv `class AssignOp extends Assign` / `new Assign(...)`).
+    struct ClassCand<'a> {
+        name: String,
+        block_text: &'a str,
+        // `extends <Parent>` parent identifier (first ident after `extends`),
+        // if this class extends a bare same-module name (not a member access
+        // like `_x.default` — those resolve via a different path).
+        extends_parent: Option<String>,
+        line_start: usize,
+        end: usize,
+        // True iff the class body / extends-head textually references an
+        // IIFE-local binding (#2310 / #5251). Such a class genuinely cannot
+        // be hoisted out of the IIFE.
+        references_iife_local: bool,
+    }
+    let mut candidates: Vec<ClassCand> = Vec::new();
 
     // Issue #2310 — collect the names of top-level `let`/`const`/`var`
     // declarations in this CJS source so we can REFUSE to hoist a class
@@ -383,10 +404,16 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
                         let references_iife_local =
                             class_body_references_any(body_text, &iife_locals)
                                 || class_body_references_any(extends_head, &iife_locals);
-                        if !hoisted_names.contains(&class_name) && !references_iife_local {
-                            hoisted_blocks.push(block_text);
-                            hoisted_names.push(class_name);
-                            elided.push((line_start, r));
+                        let extends_parent = parse_extends_parent(extends_head);
+                        if !candidates.iter().any(|c| c.name == class_name) {
+                            candidates.push(ClassCand {
+                                name: class_name,
+                                block_text,
+                                extends_parent,
+                                line_start,
+                                end: r,
+                                references_iife_local,
+                            });
                         }
                         i = r;
                         continue;
@@ -399,6 +426,55 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
             i += 1;
         }
         i += 1;
+    }
+
+    // Chain-aware keep decision. Start by keeping every class that directly
+    // references an IIFE-local; then iterate to a fixpoint, additionally
+    // keeping any class whose `extends` parent is a same-module sibling that
+    // is itself kept. A kept parent cannot be hoisted (it's an IIFE-local),
+    // so a hoisted child would lose visibility of it — keep the child too.
+    // Parents resolved via member access / require alias are handled by the
+    // #2310/#5251 textual checks already and are not in `candidates`, so they
+    // never force-keep here.
+    let cand_names: std::collections::HashSet<&str> =
+        candidates.iter().map(|c| c.name.as_str()).collect();
+    let mut kept: Vec<bool> = candidates.iter().map(|c| c.references_iife_local).collect();
+    loop {
+        let mut changed = false;
+        for idx in 0..candidates.len() {
+            if kept[idx] {
+                continue;
+            }
+            if let Some(parent) = &candidates[idx].extends_parent {
+                // Only same-module sibling parents matter.
+                if cand_names.contains(parent.as_str()) {
+                    let parent_kept = candidates
+                        .iter()
+                        .position(|c| &c.name == parent)
+                        .map(|pidx| kept[pidx])
+                        .unwrap_or(false);
+                    if parent_kept {
+                        kept[idx] = true;
+                        changed = true;
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    let mut hoisted_blocks: Vec<&str> = Vec::new();
+    let mut hoisted_names: Vec<String> = Vec::new();
+    let mut elided: Vec<(usize, usize)> = Vec::new();
+    for (idx, cand) in candidates.iter().enumerate() {
+        if kept[idx] {
+            continue;
+        }
+        hoisted_blocks.push(cand.block_text);
+        hoisted_names.push(cand.name.clone());
+        elided.push((cand.line_start, cand.end));
     }
 
     let mut out_source = source.to_string();
@@ -895,6 +971,42 @@ pub fn source_has_top_level_return(source: &str) -> bool {
         i += 1;
     }
     false
+}
+
+/// Parse the `extends` parent identifier out of a class head's extends-clause
+/// text (the slice between the class name and the body's opening `{`, e.g.
+/// ` extends Assign `). Returns the bare parent identifier ONLY when the
+/// extends target is a simple same-module name — `Some("Assign")`. Returns
+/// `None` for an absent `extends`, or for a member-access / call-expression
+/// parent (`extends _code.default`, `extends mixin(Base)`) since those
+/// resolve via the require-alias path, not as a sibling top-level class.
+fn parse_extends_parent(extends_head: &str) -> Option<String> {
+    let trimmed = extends_head.trim_start();
+    let rest = trimmed.strip_prefix("extends")?;
+    // `extends` must be followed by whitespace (not `extendsX`).
+    let after = rest.strip_prefix(|c: char| c.is_ascii_whitespace())?;
+    let after = after.trim_start();
+    let bytes = after.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c.is_ascii_alphanumeric() || c == b'_' || c == b'$' {
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    if i == 0 {
+        return None;
+    }
+    let ident = &after[..i];
+    // Anything after the identifier other than whitespace (`.`, `(`, `<`)
+    // means it's a member access / call / generic — not a bare sibling.
+    let tail = after[i..].trim_start();
+    if !tail.is_empty() {
+        return None;
+    }
+    Some(ident.to_string())
 }
 
 /// Issue #2310 — true if `class_body` contains any of the given names as a

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -73,7 +73,9 @@ mod tests {
     use super::extract_requires::{
         extract_require_aliases_with_ranges, extract_require_specifiers,
     };
-    use super::hoist_classes::{source_has_top_level_return, top_level_class_names};
+    use super::hoist_classes::{
+        extract_top_level_class_decls, source_has_top_level_return, top_level_class_names,
+    };
     use super::wrap::{wrap_commonjs, wrap_commonjs_for_target, wrap_commonjs_with_body_offset};
     use std::fs;
     use std::path::PathBuf;
@@ -1631,5 +1633,39 @@ module.exports = SafeBuffer;"#;
                 );
             }
         }
+    }
+
+    /// Chain-aware hoist: a class that does NOT itself reference an IIFE-local
+    /// but `extends` a sibling class that IS kept in the IIFE must ALSO stay in
+    /// the IIFE — hoisting only the child out would leave its `extends <Parent>`
+    /// unable to see the IIFE-local parent (ajv `codegen/index.js`'s
+    /// `class AssignOp extends Assign` where `Assign` refs `code_1`). Asserts
+    /// `extract_top_level_class_decls` hoists NEITHER class.
+    #[test]
+    fn hoist_keeps_inheritance_chain_with_iife_local_parent_together() {
+        let src = "const code_1 = require('./code');\n\
+                   class Node { kind() { return code_1.tag; } }\n\
+                   class Assign extends Node { render() { return code_1.name; } }\n\
+                   class AssignOp extends Assign {}\n\
+                   module.exports = { AssignOp };\n";
+        let (_blocks, hoisted_names, _rest) = extract_top_level_class_decls(src);
+        // `Node`/`Assign` ref `code_1` (kept); `AssignOp` extends the kept
+        // `Assign` so it must be kept too — none should be hoisted.
+        assert!(
+            hoisted_names.is_empty(),
+            "no class should be hoisted (chain anchored to IIFE-local `code_1`); hoisted: {:?}",
+            hoisted_names
+        );
+        // Control: a self-contained class with no IIFE-local refs and no kept
+        // parent IS still hoistable.
+        let src2 = "const code_1 = require('./code');\n\
+                    class Plain {}\n\
+                    module.exports = { Plain };\n";
+        let (_b2, hoisted2, _r2) = extract_top_level_class_decls(src2);
+        assert!(
+            hoisted2.contains(&"Plain".to_string()),
+            "a class with no IIFE-local ref and no kept parent should still hoist; hoisted: {:?}",
+            hoisted2
+        );
     }
 }


### PR DESCRIPTION
## Problem

Compiling **ajv** natively (`perry.compilePackages`) threw `ReferenceError: Assign is not defined` at `ajv/dist/compile/codegen/index.js` (`class AssignOp extends Assign` / `new Assign(...)`).

## Root cause

`cjs_wrap`'s `extract_top_level_class_decls` decided hoist-vs-keep **per class**: a top-level class is kept inside the wrapping IIFE iff its body/`extends`-head textually references an IIFE-local (the #2310/#5251 set — top-level `let`/`const`/`var` names such as a `const code_1 = require("./code")` alias, plus the injected `exports`/`module`/`require`). ajv's node-class chain has **mixed** references:

- `class Node { … }` — no IIFE-local ref → **hoisted** out (above the IIFE)
- `class Assign extends Node { … code_1.Name … }` — refs `code_1` → **kept** in the IIFE
- `class AssignOp extends Assign { … }` — no ref → **hoisted** out

A class hoisted to top level whose `extends` parent is **kept inside the IIFE** can't see the parent (it's an IIFE-local) → `ReferenceError: Assign is not defined`. The per-class decision split an inheritance chain across the IIFE boundary.

## Fix

Make the keep decision **chain-aware** (`hoist_classes.rs`): collect all top-level class candidates, seed `kept` with the classes that directly reference an IIFE-local, then **iterate to a fixpoint**, additionally keeping any class whose `extends` parent is a same-module sibling that is itself kept. A kept parent genuinely cannot be hoisted (it references an IIFE-local), so its children must stay with it. New `parse_extends_parent` extracts the bare sibling parent identifier — returns `None` for member-access / call / generic parents (`extends _x.default`, `extends mixin(Base)`), which resolve via the require-alias path and are not force-kept. Kept classes stay at their original source position (existing elide-to-blank-lines behavior preserves declaration order / TDZ).

## Verification

- Minimal repro (3-class chain, hoisted children `extends` a kept-in-IIFE parent) → perry == `node --experimental-strip-types`.
- **ajv**: `Assign is not defined` **gone** → ajv now imports/runs. **Corpus 53 → 54/59 (91%), no regressions** (other 5 unchanged: bluebird/pino/semver/winston/execa).
- New unit regression test `hoist_keeps_inheritance_chain_with_iife_local_parent_together` (+ a control that a no-ref/no-kept-parent class still hoists). `cargo test -p perry cjs_wrap` → 88 passed.
- fmt clean; file-size / GC store-site / addr-class gates pass.

No `[workspace.package] version` / `CHANGELOG.md` / `Cargo.lock` edits (maintainer folds at merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class inheritance chain handling during code compilation to ensure related classes remain properly connected and grouped during transformation, preventing inheritance relationships from being incorrectly separated.

* **Tests**
  * Added test coverage for inheritance chain preservation during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->