### PR TITLE
[codex] Allow numeric array guards for overallocated capacity

### DIFF
--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -793,7 +793,7 @@ pub(crate) unsafe fn array_numeric_raw_f64_push_inbounds(
     }
     let length = (*arr).length;
     let capacity = (*arr).capacity;
-    if length >= capacity || length > 16_000_000 || capacity > 16_000_000 {
+    if length >= capacity || length > 16_000_000 {
         return false;
     }
 

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -707,6 +707,25 @@ fn test_numeric_array_layout_query_recovers_dense_numeric_metadata() {
 }
 
 #[test]
+fn test_numeric_array_layout_allows_overallocated_capacity_below_live_limit() {
+    let mut arr = js_array_alloc(0);
+    arr = js_array_push_f64(arr, 1.0);
+
+    unsafe {
+        // Model a large dense array whose capacity rounded up past the
+        // 16M live-slot scan limit while its actual length stayed below it.
+        (*arr).capacity = 16_777_216;
+    }
+
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 1);
+    assert_eq!(js_array_numeric_get_f64_unboxed(arr, 0), 1.0);
+
+    let arr = js_array_numeric_push_f64_unboxed(arr, 2.0);
+    assert_eq!(js_array_length(arr), 2);
+    assert_eq!(js_array_numeric_get_f64_unboxed(arr, 1), 2.0);
+}
+
+#[test]
 fn test_array_get_f64_large_dense_array_preserves_values() {
     let arr = js_array_alloc_with_length(100_001);
     js_array_set_f64(arr, 100_000, 42.0);

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1184,7 +1184,7 @@ fn plain_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bound
         let arr = raw_addr as *const ArrayHeader;
         let len = (*arr).length;
         let cap = (*arr).capacity;
-        if len > 16_000_000 || cap > 16_000_000 || len > cap {
+        if len > 16_000_000 || len > cap {
             return false;
         }
         !require_in_bounds || index < len
@@ -1212,7 +1212,7 @@ fn numeric_array_fast_observation(
         let arr = raw_addr as *const ArrayHeader;
         let len = (*arr).length;
         let cap = (*arr).capacity;
-        if len > 16_000_000 || cap > 16_000_000 || len > cap {
+        if len > 16_000_000 || len > cap {
             return None;
         }
         let in_bounds = index < len;
@@ -1265,7 +1265,6 @@ fn numeric_array_push_guard(arr: *const ArrayHeader, value: f64) -> bool {
         let len = (*arr).length;
         let cap = (*arr).capacity;
         len <= 16_000_000
-            && cap <= 16_000_000
             && len < cap
             && is_numeric_value_bits(value.to_bits())
             && crate::array::js_array_is_numeric_f64_layout(arr) != 0

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -672,6 +672,37 @@ fn typed_feedback_numeric_array_set_guard_requires_numeric_value_and_layout() {
 }
 
 #[test]
+fn typed_feedback_numeric_array_guards_allow_overallocated_capacity_below_live_limit() {
+    let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
+    reset_typed_feedback_for_tests();
+    register(67, TypedFeedbackSiteKind::ArrayElement, "arr[i]");
+    register(68, TypedFeedbackSiteKind::ArrayElement, "arr[i]=");
+    register(69, TypedFeedbackSiteKind::ArrayElement, "arr.push");
+
+    let mut arr = crate::array::js_array_alloc(0);
+    arr = crate::array::js_array_push_f64(arr, 1.0);
+    unsafe {
+        // Models a dense numeric array grown to 10M elements: doubling can
+        // leave capacity above 16M while the live length remains below it.
+        (*arr).capacity = 16_777_216;
+    }
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    assert_eq!(
+        js_typed_feedback_numeric_array_index_get_guard_i32(67, arr_box, 0, 1),
+        1
+    );
+    assert_eq!(
+        js_typed_feedback_numeric_array_index_set_guard(68, arr_box, 0, 2.0, 1),
+        1
+    );
+    assert_eq!(
+        js_typed_feedback_numeric_array_push_guard(69, arr_box, 3.0),
+        1
+    );
+}
+
+#[test]
 fn typed_feedback_numeric_array_push_guard_requires_room_numeric_value_and_layout() {
     let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
     reset_typed_feedback_for_tests();


### PR DESCRIPTION
## Summary

Relax numeric-array fast-path guards so they reject arrays by live length, not rounded allocation capacity. Large dense numeric arrays can have `length < 16_000_000` while growth has rounded `capacity` to `16_777_216`; those arrays are still safe for pointer-free layout scans because the GC/layout paths scan live slots only.

This updates:
- raw f64 numeric push inbounds guard
- typed-feedback plain/numeric index guards
- typed-feedback numeric push guard
- regression tests for overallocated capacity on layout, get/set guard, and push guard

## Root Cause

`03_array_write` and `04_array_read` build 10M-element numeric arrays. Growth doubles capacity from `8,388,608` to `16,777,216`, then the previous `cap > 16_000_000` check rejected numeric layout/typed-feedback guards even though live length stayed under the scan limit. That made the preguarded timed loops take the fallback path for every iteration.

Baseline trace evidence from cycle 12:
- `03_array_write` timed set site: `guard_passes=0`, `guard_failures=1`, `fallback_calls=10000000`
- `04_array_read` timed get site: `guard_passes=0`, `guard_failures=1`, `fallback_calls=10000000`

Optimized trace evidence from this branch:
- `03_array_write` timed set site: `guard_passes=10000000`, `guard_failures=0`, `fallback_calls=0`
- `04_array_read` timed get site: `guard_passes=10000000`, `guard_failures=0`, `fallback_calls=0`

## Benchmark Evidence

Baseline compiler: cycle 12 release compiler at `39f5d82b`
Optimized compiler: this branch release compiler at `282687e55`

21 paired alternating runs:

`benchmarks/suite/03_array_write.ts`
- baseline mean `779.38ms`, median `733.00ms`, min/max `706.00ms` / `999.00ms`
- optimized mean `2.86ms`, median `3.00ms`, min/max `2.00ms` / `3.00ms`
- mean speedup `99.63%`, median speedup `99.59%`
- output check: `checksum:9999999`

`benchmarks/suite/04_array_read.ts`
- baseline mean `550.05ms`, median `549.00ms`, min/max `545.00ms` / `563.00ms`
- optimized mean `5.76ms`, median `6.00ms`, min/max `5.00ms` / `6.00ms`
- mean speedup `98.95%`, median speedup `98.91%`
- output check: `sum:49999995000000`

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p perry-runtime overallocated_capacity -- --nocapture` - 2 passed
- `cargo test -p perry-runtime typed_feedback_numeric_array -- --nocapture` - 8 passed
- `cargo test -p perry-runtime test_numeric_array_layout -- --nocapture` - 11 passed
- `cargo build --release -p perry`
- Compiled `03_array_write.ts` and `04_array_read.ts` with `--trace llvm`
- Ran optimized binaries with `PERRY_TYPED_FEEDBACK_TRACE` and verified no timed-loop fallbacks
