### PR TITLE
test(regex): pin @colors char-class escape; winston regex SyntaxError was build-skew, not a source bug

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -2071,4 +2071,48 @@ mod tests {
         let re = js_regexp_new(make_string(pat), flags);
         assert!(!re.is_null(), "ID_Start-shaped pattern failed to construct");
     }
+
+    /// `@colors/colors` (a winston dep) builds the escape regex
+    /// `escapeStringRegexp = s => s.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')`
+    /// and then `new RegExp(escapeStringRegexp(ansiStyles[k].close), 'g')` where
+    /// `close` is e.g. `"\x1b[0m"`. Node escapes the literal `[` to `\[`, giving
+    /// the valid pattern `\x1b\[0m`. Perry must do the same: the char-class
+    /// `[|\\{}()[\]^$+*?.]` contains a *literal* `[` (legal in a JS class but not
+    /// in the Rust `regex` crate) and an escaped `\]`. If the class compiles
+    /// empty or the `[` isn't a member, `escapeStringRegexp` returns its input
+    /// unchanged, the bare `[0m` reaches `new RegExp`, and you get
+    /// `SyntaxError: Invalid regular expression: /[0m/`. This pins the whole
+    /// build + match + `$&`-expand path against that regression.
+    #[test]
+    fn colors_escape_string_regexp_char_class() {
+        let pat = r"[|\\{}()[\]^$+*?.]";
+        // Source is preserved verbatim (no empty `(?:)`).
+        let re = js_regexp_new(make_string(pat), make_string("g"));
+        assert!(
+            !re.is_null(),
+            "@colors char-class pattern failed to construct"
+        );
+        let src = js_regexp_get_source(re);
+        assert_eq!(string_as_str(src), pat, "source must round-trip the class");
+
+        // The literal `[` is a member of the class.
+        assert!(
+            js_regexp_test(re, make_string("[")) != 0,
+            "`[` must match the class"
+        );
+
+        // `escapeStringRegexp("\x1b[0m")` → `"\x1b\\[0m"` (only `[` is escaped;
+        // ESC and the digits/`m` are not operators). `$&` → the matched char.
+        let out = js_string_replace_regex_named(make_string("\u{1b}[0m"), re, make_string(r"\$&"));
+        assert_eq!(
+            string_as_str(out),
+            "\u{1b}\\[0m",
+            "the `[` must be escaped so `new RegExp(out)` is valid"
+        );
+
+        // And the escaped output is itself a constructible pattern (what
+        // @colors then feeds to `new RegExp(..., 'g')`).
+        let re2 = js_regexp_new(out, make_string("g"));
+        assert!(!re2.is_null(), "escaped output `\\x1b\\[0m` must construct");
+    }
 }


### PR DESCRIPTION
## Summary

Investigated the winston `compilePackages` failure
`SyntaxError: Invalid regular expression: /[0m/: invalid pattern`.

**Root chain (confirmed):** winston → `@colors/colors`. `colors.js:101` does
`new RegExp(escapeStringRegexp(close), 'g')` where `close` is `'[' + val[1] + 'm'`
(e.g. `\x1b[0m`), and `escapeStringRegexp` (`colors.js:78`) is
`s => s.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')` (the module-level
`matchOperatorsRe`). Node escapes the literal `[` → `\[` (valid pattern
`\x1b\[0m`); the symptom was that perry returned the input *unescaped* so the
bare `[0m` reached `new RegExp` → unterminated char class → the thrown error.

## Real root cause — it is NOT a regex/codegen source bug

The SyntaxError is a **stale-ext-lib LINK SKEW artifact** (the
`project_autoopt_ffi_symbol_link_break` class), not a perry source bug.

The corpus links the prebuilt `libperry_ext_{http,events,zlib}.a`, each of which
statically embeds its own copy of `perry_runtime`. When `perry-runtime` /
`perry-stdlib` are rebuilt (per CLAUDE.md's documented
`-p perry-runtime -p perry-stdlib` command) **without** rebuilding those ext
libs, the corpus binary links a `perry_runtime` copy that is out of sync with
the freshly built `libperry_runtime.a` / `libperry_stdlib.a`. The linker then
resolves `js_string_replace_regex` / the string-method dispatch from the *stale*
archive, which silently fails to escape (returns the input unchanged). The
regex literal itself was always built correctly (verified at runtime:
`pattern="[|\\\\{}()[\\]^$+*?.]" flags="g"`, `pat_is_regex=true`, the dispatcher
reached the regex branch).

Rebuilding the three ext libs *coherently* with runtime/stdlib makes the
SyntaxError vanish on pristine source. Double-compile is deterministic.

### How it was localized
Step-by-step runtime probes (all reverted) through:
`js_regexp_new` (pattern/flags correct) → `js_typed_feedback_native_call_method`
→ `js_native_call_method` "replace" arm → regex-detection → `js_string_replace_regex`.
The replace path produced `in="\u{1b}[0m"` → `out="\u{1b}\\[0m"` (correct escaping)
**once the ext libs were rebuilt**. The earlier `(?:)` / unescaped-output
observations only appeared with skewed ext libs.

## The change

A Rust regression test, `colors_escape_string_regexp_char_class`, that pins the
whole build + match + `$&`-expand path against the @colors pattern:

- `js_regexp_new("[|\\{}()[\]^$+*?.]", "g")` constructs (no empty `(?:)`),
- `.source` round-trips the class verbatim,
- the literal `[` matches the class,
- `"\x1b[0m".replace(re, "\\$&")` === `"\x1b\\[0m"` (only `[` escaped),
- the escaped output is itself constructible (`new RegExp(out, 'g')`).

It passes on pristine source — proof the regex engine handles the class.

## Before / after

- **Before** (skewed ext libs): `SyntaxError: Invalid regular expression: /[0m/: invalid pattern`
- **After** (coherent rebuild of perry + perry-runtime + perry-stdlib +
  perry-ext-{http,events,zlib}): SyntaxError GONE. winston advances to a new,
  separate wall: `TypeError: Cannot read properties of undefined (reading 'length')`
  during winston module init (not chased — out of scope).
- `.source` before/after: always `[|\\{}()[\]^$+*?.]` at runtime; the corruption
  was in the linked replace helper, not the literal.

## Corpus

`secret-tests/corpus` (PERRY_NO_AUTO_OPTIMIZE=1, sequential): **54/59 (91%)**,
no regressions. Remaining fails: bluebird/pino/winston (`convert/read-undefined`),
execa (`link/undefined-symbol`), semver (`Invalid comparator`). winston stays at
the 54 count (its next wall is a distinct bug).

## Notes / honesty

- No `[workspace.package] version`, `Current Version`, `CHANGELOG.md`, or
  `Cargo.lock` edits (maintainer folds at merge).
- The actionable perry-side takeaway is build hygiene: a coherent rebuild
  (`cargo build --release` of the whole workspace, or explicitly including the
  ext crates) avoids the skew; the documented partial rebuild command can leave
  ext libs stale and produce silently-wrong behavior in compilePackages binaries.
  That is a CI/harness concern beyond this PR's scope; the regression test guards
  the regex behavior itself.
- `cargo fmt --check`, `check_file_size.sh`, `gc_store_site_inventory.py`,
  `addr_class_inventory.py` all clean. `regex.rs` is pre-existing allowlisted
  (RegExp runtime trunk, already >2000 LOC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify correct handling of regular expressions with character classes and escape sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->