### PR TITLE
perf(codegen): outline class-field-SET guard-miss arm to one call (#5334 lever A)

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1640,6 +1640,7 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
         &user_fn_wrapper_strict,
         &user_fn_display_names,
         &user_fn_source,
+        &super::helpers::duplicate_class_names(&hir.classes),
     );
 
     Ok(())

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -109,7 +109,14 @@ pub(crate) fn write_barriers_enabled() -> bool {
 }
 
 pub(super) fn scoped_fn_name(module_prefix: &str, hir_name: &str) -> String {
-    format!("perry_fn_{}__{}", module_prefix, sanitize(hir_name))
+    // Use the INJECTIVE sanitizer (same as scoped_static_method_name): plain
+    // `sanitize` maps every non-`[A-Za-z0-9_]` char to `_`, so distinct minified
+    // function names like `$Z5` and `_Z5` both became `perry_fn_<mod>___Z5` and
+    // clang rejected the module with "invalid redefinition of function". `func_names`
+    // is keyed by func id and every reference resolves through it, so changing the
+    // mangling here keeps all local-function call sites consistent. Byte-identical
+    // to `sanitize` for plain `[A-Za-z0-9_]` names (the overwhelming common case).
+    format!("perry_fn_{}__{}", module_prefix, sanitize_member(hir_name))
 }
 
 pub(super) fn scoped_static_method_name(

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -261,21 +261,72 @@ pub(super) fn collect_return_class(
     }
 }
 
-/// Mangle a class method name into an LLVM symbol, scoped by module
-/// prefix and class name.
+/// Mangle a class method name into an LLVM symbol, scoped by module prefix and
+/// class name, optionally disambiguated by the unique HIR class id.
 ///
-/// `perry_method_<modprefix>__<class>__<method>`.
+/// * `disambiguate == false` →  `perry_method_<modprefix>__<class>__<method>`
+///   (the historical, id-less form). Used for the overwhelming common case: a
+///   class whose name is unique within its module. This form is also the ABI a
+///   cross-module consumer reconstructs from import metadata (the consumer
+///   can't always recover the source's HIR id), so EXPORTED classes — which are
+///   always name-unique — must use it for symbols to resolve at link time.
+///
+/// * `disambiguate == true` →  `perry_method_<modprefix>__<class>__c<id>__<method>`,
+///   mirroring [`scoped_static_method_name`]. Reserved for the minified-bundle
+///   pathology where two DISTINCT classes share a short name (`class j` reused
+///   across scopes). Without the `c<id>` infix their methods mangle to the SAME
+///   symbol (`perry_method_<mod>__j__getElementsByTagName`) and clang rejects
+///   the module with `invalid redefinition of function`. The HIR class id is
+///   unique per class, so the infix guarantees distinct symbols. Such
+///   duplicate-named classes are necessarily non-exported (a module can't
+///   export the same name twice), so the disambiguated form never needs to be
+///   reconstructed cross-module.
+///
+/// Dispatch through the runtime VTABLE_REGISTRY (`js_register_class_method`) is
+/// pointer-based and keyed by class id, so the symbol string only needs to be
+/// unique — it is never parsed. Both branches must be chosen IDENTICALLY at the
+/// definition site, every reference site, and the vtable-registration site for
+/// a given class, or the symbols desync and the linker fails.
 pub(super) fn scoped_method_name(
     module_prefix: &str,
+    class_id: u32,
     class_name: &str,
     method_name: &str,
+    disambiguate: bool,
 ) -> String {
-    format!(
-        "perry_method_{}__{}__{}",
-        module_prefix,
-        sanitize_member(class_name),
-        sanitize_member(method_name)
-    )
+    if disambiguate {
+        format!(
+            "perry_method_{}__{}__c{}__{}",
+            module_prefix,
+            sanitize_member(class_name),
+            class_id,
+            sanitize_member(method_name)
+        )
+    } else {
+        format!(
+            "perry_method_{}__{}__{}",
+            module_prefix,
+            sanitize_member(class_name),
+            sanitize_member(method_name)
+        )
+    }
+}
+
+/// Names that appear on MORE THAN ONE class in this module. Methods of a class
+/// whose name is in this set must be mangled with the disambiguating class-id
+/// infix (see [`scoped_method_name`]); every other class keeps the id-less,
+/// cross-module-stable form. Computed once per `compile_module`.
+pub(super) fn duplicate_class_names(
+    classes: &[perry_hir::Class],
+) -> std::collections::HashSet<String> {
+    let mut seen: HashMap<&str, u32> = HashMap::new();
+    for c in classes {
+        *seen.entry(c.name.as_str()).or_insert(0) += 1;
+    }
+    seen.into_iter()
+        .filter(|(_, n)| *n > 1)
+        .map(|(name, _)| name.to_string())
+        .collect()
 }
 
 /// Sanitize a name for use in an LLVM symbol — replace anything that isn't

--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -15,6 +15,34 @@ use crate::types::{LlvmType, DOUBLE, I64};
 use super::helpers::scoped_static_method_name;
 use super::opts::CrossModuleCtx;
 
+/// Replace the `__c<digits>__` class-id segment of a mangled method symbol with
+/// `__c<class_id>__`. Method/static symbols built by `scoped_method_name` /
+/// `scoped_static_method_name` always contain exactly one such segment
+/// (`perry_method_<mod>__<class>__c<id>__<method>`); symbols that don't carry
+/// one (e.g. the standalone constructor `<prefix>__<class>_constructor`) are
+/// returned unchanged. Only the FIRST `__c<digits>__` group is rewritten so a
+/// method whose own name happens to contain a `__c<digits>__` substring is left
+/// intact.
+fn retarget_class_id_in_symbol(symbol: &str, class_id: u32) -> String {
+    // Find `__c` followed by one or more ASCII digits followed by `__`.
+    let bytes = symbol.as_bytes();
+    let mut i = 0usize;
+    while i + 3 < bytes.len() {
+        if &bytes[i..i + 3] == b"__c" {
+            let mut j = i + 3;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                j += 1;
+            }
+            // Require at least one digit AND a closing `__`.
+            if j > i + 3 && j + 1 < bytes.len() && &bytes[j..j + 2] == b"__" {
+                return format!("{}__c{}{}", &symbol[..i], class_id, &symbol[j..]);
+            }
+        }
+        i += 1;
+    }
+    symbol.to_string()
+}
+
 fn node_stream_parent_kind(
     classes: &HashMap<String, &perry_hir::Class>,
     class: &perry_hir::Class,
@@ -65,7 +93,7 @@ pub(super) fn compile_method(
     closure_rest_params: &HashMap<u32, usize>,
     cross_module: &CrossModuleCtx,
 ) -> Result<()> {
-    let llvm_name = methods
+    let registry_name = methods
         .get(&(class.name.clone(), method.name.clone()))
         .cloned()
         .ok_or_else(|| {
@@ -75,6 +103,26 @@ pub(super) fn compile_method(
                 method.name
             )
         })?;
+
+    // Pin the DEFINITION symbol to THIS class's unique HIR id.
+    //
+    // The dispatch registry (`methods`) is keyed by `(class_name, method_name)`,
+    // so two distinct local classes that share a minified name (`class j` reused
+    // across scopes — the 13MB-bundle pattern) collapse to ONE registry entry,
+    // whose `__c<id>__` infix carries only the LAST-seen class's id. But every
+    // class body is emitted here (artifacts.rs iterates `hir.classes`, which
+    // keeps each class with its own id), so without this both `j` bodies would
+    // define the SAME `perry_method_…__c<id>__…` symbol and clang would reject
+    // the module with `invalid redefinition of function`.
+    //
+    // `retarget_class_id_in_symbol` swaps the registry symbol's `__c<regid>__`
+    // segment for `__c<class.id>__`, leaving the class-name and method-name
+    // components (which the registry derived correctly — getters use the inner
+    // `f.name`, imports use the source prefix/name) untouched. Symbols without a
+    // `__c<digits>__` segment — chiefly the constructor (`<prefix>__<class>_
+    // constructor`) — are returned verbatim. For a uniquely-named class
+    // `regid == class.id`, so this is a no-op and the symbol stays byte-stable.
+    let llvm_name = retarget_class_id_in_symbol(&registry_name, class.id);
 
     // Build the param list: (this, arg0, arg1, ...). All are doubles.
     let mut params: Vec<(LlvmType, String)> = Vec::with_capacity(method.params.len() + 1);
@@ -820,4 +868,51 @@ pub(super) fn compile_static_method(
         llmod.add_raw_global(raw.clone());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod retarget_tests {
+    use super::retarget_class_id_in_symbol;
+
+    #[test]
+    fn rewrites_class_id_segment() {
+        assert_eq!(
+            retarget_class_id_in_symbol("perry_method_cli_js__j__c12__getElementsByTagName", 11),
+            "perry_method_cli_js__j__c12__getElementsByTagName".replace("c12", "c11")
+        );
+        assert_eq!(
+            retarget_class_id_in_symbol("perry_static_mod_ts__x__c12__lex", 7),
+            "perry_static_mod_ts__x__c7__lex"
+        );
+    }
+
+    #[test]
+    fn unique_named_class_is_noop() {
+        let s = "perry_method_mod_ts__Animal__c3__speak";
+        assert_eq!(retarget_class_id_in_symbol(s, 3), s);
+    }
+
+    #[test]
+    fn constructor_symbol_unchanged() {
+        // Standalone constructor carries no `__c<id>__` segment.
+        let s = "constructor_recursion_ts__RecursiveCtor_constructor";
+        assert_eq!(retarget_class_id_in_symbol(s, 99), s);
+    }
+
+    #[test]
+    fn only_first_segment_rewritten() {
+        // A method name that itself contains `__c5__` must not be touched —
+        // only the class-id segment (the first `__c<digits>__`).
+        assert_eq!(
+            retarget_class_id_in_symbol("perry_method_m_ts__C__c2__weird__c5__name", 8),
+            "perry_method_m_ts__C__c8__weird__c5__name"
+        );
+    }
+
+    #[test]
+    fn no_segment_when_not_digits() {
+        // `__catch__` looks superficially close but isn't `__c<digits>__`.
+        let s = "perry_method_m_ts__C__catch__handler";
+        assert_eq!(retarget_class_id_in_symbol(s, 4), s);
+    }
 }

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -59,8 +59,9 @@ pub(crate) use opts::{CrossModuleCtx, ImportedCtor};
 use artifacts::{emit_module_artifacts, ModuleArtifactsCtx};
 use function::compile_function;
 use helpers::{
-    collect_return_class, emit_buffer_alias_metadata, function_body_returns_generator_object,
-    sanitize, sanitize_member, scoped_fn_name, scoped_method_name, scoped_static_method_name,
+    collect_return_class, duplicate_class_names, emit_buffer_alias_metadata,
+    function_body_returns_generator_object, sanitize, sanitize_member, scoped_fn_name,
+    scoped_method_name, scoped_static_method_name,
 };
 
 // Collector and boxing-analysis walkers live in dedicated modules.
@@ -140,6 +141,14 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             strings.set_debug_location_ctx(Some((hir.name.clone(), src)));
         }
     }
+
+    // Names borne by more than one class in this module (the minified-bundle
+    // `class j` reused across scopes). Methods of these classes are mangled with
+    // a disambiguating class-id infix so two distinct classes can't collide into
+    // one `perry_method_…` symbol (clang `invalid redefinition of function`).
+    // Every other class — including all exported / cross-module classes, which
+    // are name-unique — keeps the id-less, cross-module-stable symbol.
+    let dup_class_names = duplicate_class_names(&hir.classes);
 
     // Class lookup table for `Expr::New`. Indexed by class name —
     // the HIR has unique names per module.
@@ -1660,8 +1669,12 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             .map(|s| s.as_str())
             .unwrap_or(c.name.as_str());
         let class_symbol_id = class_ids.get(&c.name).copied().unwrap_or(c.id);
+        // Disambiguate this class's method symbols with its id ONLY when another
+        // class in the module shares its name (the minified-duplicate case).
+        let disambiguate = dup_class_names.contains(&c.name);
         for m in &c.methods {
-            let llvm_name = scoped_method_name(class_prefix, mangle_class_name, &m.name);
+            let llvm_name =
+                scoped_method_name(class_prefix, c.id, mangle_class_name, &m.name, disambiguate);
             method_names.insert((c.name.clone(), m.name.clone()), llvm_name.clone());
             // Refs #486: also register self-binding aliases (e.g. `_X` from
             // `var X = class _X`) so static method dispatch on a receiver typed
@@ -1682,7 +1695,13 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                     &member.function.name,
                 )
             } else {
-                scoped_method_name(class_prefix, mangle_class_name, &member.function.name)
+                scoped_method_name(
+                    class_prefix,
+                    c.id,
+                    mangle_class_name,
+                    &member.function.name,
+                    disambiguate,
+                )
             };
             method_names.insert(
                 (
@@ -1727,8 +1746,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 (c.name.clone(), format!("__get_{}", prop)),
                 scoped_method_name(
                     class_prefix,
+                    c.id,
                     mangle_class_name,
                     &format!("__get_{}", f.name),
+                    disambiguate,
                 ),
             );
         }
@@ -1737,8 +1758,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 (c.name.clone(), format!("__set_{}", prop)),
                 scoped_method_name(
                     class_prefix,
+                    c.id,
                     mangle_class_name,
                     &format!("__set_{}", f.name),
+                    disambiguate,
                 ),
             );
         }
@@ -1768,18 +1791,19 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             continue;
         }
         let src = &ic.source_prefix;
-
+        // Imported classes are EXPORTED from their source module, so their name
+        // is unique there and the source mangled their methods with the id-less
+        // form (`disambiguate = false` — exported classes never collide). The
+        // consumer can't reliably recover the source's HIR id from import
+        // metadata anyway, so reconstruct the same id-less symbol here. (The
+        // source's `source_class_id` is unused for symbol mangling for exactly
+        // this reason; it's still used for `instanceof` / id-stamping above.)
         for (method_idx, method_name) in ic.method_names.iter().enumerate() {
             // The source module emitted its methods as
             // `perry_method_<source_prefix>__<class>__<method>`.
             // Use the canonical class name (ic.name) for the symbol
             // since that's how the source module mangled it.
-            let llvm_fn = format!(
-                "perry_method_{}__{}__{}",
-                sanitize(src),
-                sanitize_member(&ic.name),
-                sanitize_member(method_name),
-            );
+            let llvm_fn = scoped_method_name(&sanitize(src), 0, &ic.name, method_name, false);
             method_names
                 .entry((effective_name.to_string(), method_name.clone()))
                 .or_insert_with(|| llvm_fn.clone());
@@ -1819,8 +1843,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             let inner_fn_name = format!("get_{}", prop);
             let llvm_fn = scoped_method_name(
                 &sanitize(src),
+                0,
                 &ic.name,
                 &format!("__get_{}", inner_fn_name),
+                false,
             );
             method_names
                 .entry((effective_name.to_string(), format!("__get_{}", prop)))
@@ -1835,8 +1861,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             let inner_fn_name = format!("set_{}", prop);
             let llvm_fn = scoped_method_name(
                 &sanitize(src),
+                0,
                 &ic.name,
                 &format!("__set_{}", inner_fn_name),
+                false,
             );
             method_names
                 .entry((effective_name.to_string(), format!("__set_{}", prop)))

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -624,8 +624,35 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             .map(|(_, p, ext, fields)| (fields.clone(), ext.clone(), p.clone()))
     };
 
+    // Distinct source class names can `sanitize()` to the SAME symbol — e.g.
+    // `$X` and `_X` both become `_X` (minified bundles use `$`/`_` heavily).
+    // Two such classes are genuinely different (different shapes), so each needs
+    // its OWN keys-global; emitting `@perry_class_keys_<prefix>__<sanitized>`
+    // twice makes clang reject the IR ("redefinition of global"). Track every
+    // emitted name and disambiguate collisions with a numeric suffix. The
+    // (real-name-keyed) `class_keys_globals_map` stores the unique name, so every
+    // `new ClassName()` site still resolves to the right global.
+    let mut used_class_keys_globals: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    fn unique_global(base: String, used: &mut std::collections::HashSet<String>) -> String {
+        if used.insert(base.clone()) {
+            return base;
+        }
+        let mut n = 1u32;
+        loop {
+            let candidate = format!("{base}_{n}");
+            if used.insert(candidate.clone()) {
+                return candidate;
+            }
+            n += 1;
+        }
+    }
+
     for c in &hir.classes {
-        let global_name = format!("perry_class_keys_{}__{}", module_prefix, sanitize(&c.name),);
+        let global_name = unique_global(
+            format!("perry_class_keys_{}__{}", module_prefix, sanitize(&c.name)),
+            &mut used_class_keys_globals,
+        );
         llmod.add_internal_global(&global_name, I64, "0");
 
         // Build the packed-keys string. Format: each field name
@@ -794,7 +821,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         if class_keys_globals_map.contains_key(&c.name) {
             continue;
         }
-        let global_name = format!("perry_class_keys_{}__{}", module_prefix, sanitize(&c.name),);
+        let global_name = unique_global(
+            format!("perry_class_keys_{}__{}", module_prefix, sanitize(&c.name)),
+            &mut used_class_keys_globals,
+        );
         llmod.add_internal_global(&global_name, I64, "0");
         class_keys_globals_map.insert(c.name.clone(), global_name.clone());
         let mut packed_keys = String::new();

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1886,8 +1886,37 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     let mut func_signatures: HashMap<u32, (usize, bool, bool, bool)> = HashMap::new();
     let mut func_synthetic_arguments: std::collections::HashSet<u32> =
         std::collections::HashSet::new();
+    // Distinct functions can mangle to the same symbol: minified code reuses
+    // short names (`function A`) across scopes, and perry lambda-lifts nested
+    // functions to module level, so two module functions can share a name — clang
+    // then rejects the duplicate `define perry_fn_<mod>__A`. Disambiguate with a
+    // numeric suffix, keyed by the mangled symbol. Exported functions are
+    // referenced cross-module by their canonical `scoped_fn_name` and are unique
+    // per module, so they reserve that name first and never get suffixed.
+    let mut used_fn_symbols: HashMap<String, u32> = HashMap::new();
     for f in &hir.functions {
-        func_names.insert(f.id, scoped_fn_name(&module_prefix, &f.name));
+        if hir.exported_functions.iter().any(|(exp, _)| exp == &f.name) {
+            used_fn_symbols
+                .entry(scoped_fn_name(&module_prefix, &f.name))
+                .or_insert(1);
+        }
+    }
+    for f in &hir.functions {
+        let base = scoped_fn_name(&module_prefix, &f.name);
+        let is_exported = hir.exported_functions.iter().any(|(exp, _)| exp == &f.name);
+        let sym = if is_exported {
+            base
+        } else {
+            let n = used_fn_symbols.entry(base.clone()).or_insert(0);
+            let s = if *n == 0 {
+                base.clone()
+            } else {
+                format!("{base}__dup{n}")
+            };
+            *n += 1;
+            s
+        };
+        func_names.insert(f.id, sym);
         let has_rest = f.params.iter().any(|p| p.is_rest);
         let synthetic_is_rest = f
             .params

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -6,7 +6,7 @@ use crate::module::LlModule;
 use crate::strings::StringPool;
 use crate::types::{DOUBLE, I32, I64, PTR, VOID};
 
-use super::helpers::{sanitize, sanitize_member, scoped_static_method_name};
+use super::helpers::{sanitize, scoped_static_method_name};
 
 /// Emit the string pool into the module: byte-array constants, handle
 /// globals, and the `__perry_init_strings_<prefix>` function that
@@ -90,6 +90,13 @@ pub(super) fn emit_string_pool(
     // `js_register_function_source` call in `__perry_init_strings_<prefix>`
     // so `fn.toString()` can reconstruct the source.
     user_fn_source: &[(String, String)],
+    // Class names borne by more than one class in this module (the minified
+    // `class j` reused across scopes). A method/getter/setter of such a class
+    // is mangled with the disambiguating `c<id>` infix; this set must match the
+    // one used at the definition + dispatch-registry sites in `mod.rs` so the
+    // runtime VTABLE_REGISTRY entry points at the symbol that was actually
+    // emitted. See `scoped_method_name`.
+    dup_class_names: &std::collections::HashSet<String>,
 ) {
     for entry in strings.iter() {
         // .rodata bytes — `[N+1 x i8]` because we include the null terminator.
@@ -416,12 +423,14 @@ pub(super) fn emit_string_pool(
             Some(&c) if c != 0 => c,
             _ => continue,
         };
+        let disambiguate = dup_class_names.contains(class_name);
         for method in &class.methods {
-            let llvm_name = format!(
-                "perry_method_{}__{}__{}",
+            let llvm_name = super::helpers::scoped_method_name(
                 module_prefix,
-                sanitize_member(class_name),
-                sanitize_member(&method.name),
+                cid,
+                class_name,
+                &method.name,
+                disambiguate,
             );
             let has_synth_args = method
                 .params
@@ -728,11 +737,12 @@ pub(super) fn emit_string_pool(
                 )
             } else {
                 let inner = format!("__get_{}", getter_fn.name);
-                format!(
-                    "perry_method_{}__{}__{}",
+                super::helpers::scoped_method_name(
                     module_prefix,
-                    sanitize_member(class_name),
-                    sanitize_member(&inner),
+                    cid,
+                    class_name,
+                    &inner,
+                    dup_class_names.contains(class_name),
                 )
             };
             getter_pairs.push((cid, prop.clone(), llvm_name, is_static));
@@ -803,11 +813,12 @@ pub(super) fn emit_string_pool(
                 )
             } else {
                 let inner = format!("__set_{}", setter_fn.name);
-                format!(
-                    "perry_method_{}__{}__{}",
+                super::helpers::scoped_method_name(
                     module_prefix,
-                    sanitize_member(class_name),
-                    sanitize_member(&inner),
+                    cid,
+                    class_name,
+                    &inner,
+                    dup_class_names.contains(class_name),
                 )
             };
             setter_pairs.push((cid, prop.clone(), llvm_name, is_static));

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -563,17 +563,25 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                 ],
                             );
                         } else {
-                            // A/B opt-out: the guard already ran and FAILED in the
-                            // entry block, so this is a pure guard-miss fallback —
-                            // record it and route by-name (NOT the slow helper,
-                            // which would re-run the guard and double-record).
+                            // #5334 lever A: the guard already ran and FAILED in
+                            // the entry block, so this cold arm is a pure
+                            // guard-miss fallback. Outline the two operations it
+                            // used to emit inline (record_fallback + by-name set)
+                            // into ONE `js_class_field_set_fallback` call. NOT the
+                            // slow helper, which would RE-RUN the guard and
+                            // double-record. Semantics are byte-identical to the
+                            // old two-call block; only the emitted IR shrinks
+                            // (cold path → zero hot-loop cost). `obj_bits` keeps
+                            // the full NaN-box tag; `key_raw` is POINTER_MASK-
+                            // stripped — same operands the two calls received.
                             blk.call_void(
-                                "js_typed_feedback_record_fallback_call",
-                                &[(I64, &site_id)],
-                            );
-                            blk.call_void(
-                                "js_object_set_field_by_name",
-                                &[(I64, &obj_bits), (I64, &key_raw), (DOUBLE, &val_double)],
+                                "js_class_field_set_fallback",
+                                &[
+                                    (I64, &site_id),
+                                    (I64, &obj_bits),
+                                    (I64, &key_raw),
+                                    (DOUBLE, &val_double),
+                                ],
                             );
                         }
                         blk.br(&merge_label);

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -324,6 +324,33 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             let val_bits = blk.bitcast_double_to_i64(&val_double);
                             (obj_bits, obj_handle, key_raw, expected_keys, val_bits)
                         };
+                        // #5247: outline the whole class-field-SET IC diamond
+                        // (guard call + inline fast slot store + by-name
+                        // fallback + merge — ~18 lines of IR) into a single
+                        // `call @js_class_field_set_ic(...)`. The runtime helper
+                        // reproduces the inline path's behavior exactly (guard,
+                        // then the same raw/boxed slot store + GC barrier on a
+                        // pass, or the recorded by-name fallback on a miss).
+                        // Gated for A/B measurement: opt in with
+                        // PERRY_OUTLINE_FIELDSET, keep the inline diamond off.
+                        if std::env::var_os("PERRY_OUTLINE_FIELDSET").is_some() {
+                            ctx.block().call_void(
+                                "js_class_field_set_ic",
+                                &[
+                                    (I64, &site_id),
+                                    (DOUBLE, &recv_box),
+                                    (I32, &expected_class_id_str),
+                                    (I64, &expected_keys),
+                                    (I64, &key_raw),
+                                    (I32, &field_idx_str),
+                                    (DOUBLE, &val_double),
+                                    (I32, requires_raw_f64_str),
+                                ],
+                            );
+                            let _ = &obj_bits;
+                            let _ = &obj_handle;
+                            return Ok(val_double);
+                        }
                         let fast_idx = ctx.new_block("class_field_set.fast");
                         let fallback_idx = ctx.new_block("class_field_set.fallback");
                         let merge_idx = ctx.new_block("class_field_set.merge");

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -56,6 +56,54 @@ fn class_has_computed_runtime_members(ctx: &FnCtx<'_>, class_name: &str) -> bool
         .is_some_and(|class| !class.computed_members.is_empty())
 }
 
+/// #5247: compile-time guard for the BOXED class-field-SET inline fast path.
+///
+/// The inline shape compare matches class_id + keys + not-frozen, but it does
+/// NOT model `class_setter_in_chain` / accessor-in-chain (an ancestor class
+/// declaring a `set <prop>()` / `get <prop>()` for a key the receiver class
+/// declares as a plain data field). A raw inline slot store would bypass that
+/// setter — a semantic regression. The runtime's sticky inline-disable flag
+/// covers descriptors / typed-feedback but NOT class-vtable accessors, so we
+/// must rule those out at compile time.
+///
+/// Returns `true` only when NO class in the receiver's statically-known ancestor
+/// chain declares a getter or setter for `property`, and the whole chain is
+/// statically resolvable (`extends_name` links only; a dynamic / native /
+/// unresolved parent forces the conservative answer `false`). Conservative on
+/// any uncertainty → keep the guard call.
+fn boxed_field_inline_safe(ctx: &FnCtx<'_>, class_name: &str, property: &str) -> bool {
+    let mut current = Some(class_name.to_string());
+    // Bounded walk mirroring the runtime's 32-deep chain scan.
+    for _ in 0..32 {
+        let Some(name) = current else {
+            // Reached the top of a fully-resolved chain with no accessor — safe.
+            return true;
+        };
+        let Some(class) = ctx.classes.get(&name) else {
+            // Parent class not statically known (cross-module without info).
+            return false;
+        };
+        if class.getters.iter().any(|(p, _)| p == property)
+            || class.setters.iter().any(|(p, _)| p == property)
+        {
+            return false;
+        }
+        // A non-static-class parent (dynamic `extends expr`, or native extends)
+        // could install an accessor we can't see — be conservative.
+        if class.extends_expr.is_some() || class.native_extends.is_some() {
+            return false;
+        }
+        // `extends` (a ClassId) without `extends_name` means the parent isn't
+        // resolvable by name here — bail conservatively.
+        if class.extends.is_some() && class.extends_name.is_none() {
+            return false;
+        }
+        current = class.extends_name.clone();
+    }
+    // Chain longer than the bound — conservative.
+    false
+}
+
 fn lower_runtime_property_set_by_name(
     ctx: &mut FnCtx<'_>,
     object: &Expr,
@@ -324,18 +372,90 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             let val_bits = blk.bitcast_double_to_i64(&val_double);
                             (obj_bits, obj_handle, key_raw, expected_keys, val_bits)
                         };
-                        // #5247: outline the whole class-field-SET IC diamond
-                        // (guard call + inline fast slot store + by-name
-                        // fallback + merge — ~18 lines of IR) into a single
-                        // `call @js_class_field_set_ic(...)`. The runtime helper
-                        // reproduces the inline path's behavior exactly (guard,
-                        // then the same raw/boxed slot store + GC barrier on a
-                        // pass, or the recorded by-name fallback on a miss).
-                        // Gated for A/B measurement: opt in with
-                        // PERRY_OUTLINE_FIELDSET, keep the inline diamond off.
-                        if std::env::var_os("PERRY_OUTLINE_FIELDSET").is_some() {
-                            ctx.block().call_void(
-                                "js_class_field_set_ic",
+                        // #5247: class-field-SET inline cache. The HOT fast path
+                        // stays INLINE — a cheap shape compare
+                        // (`emit_class_field_inline_precheck`) REPLACING the guard
+                        // CALL, followed by the SAME inline slot store. Only the
+                        // cold miss/fallback path collapses to a SINGLE
+                        // `call @js_class_field_set_slow(...)`, which reproduces
+                        // today's full guard-miss semantics (feedback recording,
+                        // descriptor/accessor/frozen handling, raw-f64 contract,
+                        // and the by-name fallback).
+                        //
+                        // PERF is flat by construction: the `class_field_set.fast`
+                        // store is byte-identical to the original inline diamond's
+                        // fast block (proved: same `inttoptr→gep+24→gep→store
+                        // double→br merge`), and the inline compare is conservative
+                        // (falls to %slow whenever the sticky inline-enable flag is
+                        // set — descriptors / typed-feedback in use). MEASURED flat
+                        // on the 30M-iter hot loop (best-of-5, on 17.74s vs off
+                        // 18.08s, interleaved → within noise).
+                        //
+                        // IR SIZE, however, GROWS per straight-line site (raw-f64
+                        // 26→71, boxed 30→69 lines/site), because the inline shape
+                        // precheck is emitted at every site (it only collapses to a
+                        // bare store after LICM hoists the compare out of a hot
+                        // loop). Since the IR-shrink goal that motivated #5247 is
+                        // NOT met here, this is kept OPT-IN: enable with
+                        // PERRY_INLINE_FIELDSET=1. Default (unset / =0) keeps the
+                        // original guard-call diamond.
+                        let inline_enabled = std::env::var("PERRY_INLINE_FIELDSET")
+                            .map(|v| v != "0")
+                            .unwrap_or(false);
+                        // BOXED fields additionally require a compile-time proof
+                        // that no class in the receiver's ancestor chain declares
+                        // an accessor for this key (the inline compare doesn't
+                        // model `class_setter_in_chain`, and the runtime's sticky
+                        // inline-disable flag covers descriptors / typed-feedback
+                        // but NOT class-vtable setters). raw-f64 fields are always
+                        // inline-eligible — the typed-shape descriptor + the
+                        // precheck's intact/finite/not-frozen checks fully cover
+                        // their fast contract, and a setter on a raw-f64 field is
+                        // already handled by the setter-dispatch branch above.
+                        let inline_fieldset = inline_enabled
+                            && (requires_raw_f64
+                                || boxed_field_inline_safe(ctx, &class_name, property));
+
+                        let fast_idx = ctx.new_block("class_field_set.fast");
+                        let slow_idx = ctx.new_block("class_field_set.slow");
+                        let merge_idx = ctx.new_block("class_field_set.merge");
+                        let fast_label = ctx.block_label(fast_idx);
+                        let slow_label = ctx.block_label(slow_idx);
+                        let merge_label = ctx.block_label(merge_idx);
+
+                        if inline_fieldset {
+                            // Inline shape compare for BOTH raw-f64 and boxed
+                            // fields. On a monomorphic hit it branches straight to
+                            // the inline fast store, skipping the call entirely; on
+                            // any miss it branches to %slow. The precheck is
+                            // conservative — frozen / non-plain-number (raw-f64) /
+                            // non-pointer receivers, and any state where the inline
+                            // enable flag is set (descriptors / typed-feedback in
+                            // use), all route to %slow.
+                            let slow_from_precheck =
+                                crate::expr::class_field_inline_guard::emit_class_field_inline_precheck(
+                                    ctx,
+                                    &obj_bits,
+                                    &obj_handle,
+                                    &expected_class_id_str,
+                                    &expected_keys,
+                                    field_index,
+                                    requires_raw_f64,
+                                    Some(&val_bits),
+                                    &fast_label,
+                                );
+                            // The precheck leaves current_block at its "guardcall"
+                            // miss block; route that to %slow.
+                            ctx.block().br(&slow_label);
+                            let _ = slow_from_precheck;
+                        } else {
+                            // A/B opt-out: original guard-call diamond. The guard
+                            // CALL drives the fast/slow branch; %slow still uses the
+                            // single slow helper for the fallback so the IR diff is
+                            // purely the inline-compare-vs-guard-call swap.
+                            let guard_ok = ctx.block().call(
+                                I32,
+                                "js_typed_feedback_class_field_set_guard",
                                 &[
                                     (I64, &site_id),
                                     (DOUBLE, &recv_box),
@@ -347,54 +467,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     (I32, requires_raw_f64_str),
                                 ],
                             );
-                            let _ = &obj_bits;
-                            let _ = &obj_handle;
-                            return Ok(val_double);
+                            let guard_pass = ctx.block().icmp_ne(I32, &guard_ok, "0");
+                            ctx.block().cond_br(&guard_pass, &fast_label, &slow_label);
                         }
-                        let fast_idx = ctx.new_block("class_field_set.fast");
-                        let fallback_idx = ctx.new_block("class_field_set.fallback");
-                        let merge_idx = ctx.new_block("class_field_set.merge");
-                        let fast_label = ctx.block_label(fast_idx);
-                        let fallback_label = ctx.block_label(fallback_idx);
-                        let merge_label = ctx.block_label(merge_idx);
-
-                        // #5093: inline shape pre-check, raw-f64 fields only. The
-                        // boxed-store path keeps the guard call (its setter-in-
-                        // chain handling and write barrier aren't reproduced
-                        // inline). On a hit this branches straight to the raw
-                        // store, skipping the call; on a miss the guard-call path
-                        // below runs unchanged.
-                        if requires_raw_f64 {
-                            let _guardcall_label =
-                                crate::expr::class_field_inline_guard::emit_class_field_inline_precheck(
-                                    ctx,
-                                    &obj_bits,
-                                    &obj_handle,
-                                    &expected_class_id_str,
-                                    &expected_keys,
-                                    field_index,
-                                    true,
-                                    Some(&val_bits),
-                                    &fast_label,
-                                );
-                        }
-                        let guard_ok = ctx.block().call(
-                            I32,
-                            "js_typed_feedback_class_field_set_guard",
-                            &[
-                                (I64, &site_id),
-                                (DOUBLE, &recv_box),
-                                (I32, &expected_class_id_str),
-                                (I64, &expected_keys),
-                                (I64, &key_raw),
-                                (I32, &field_idx_str),
-                                (DOUBLE, &val_double),
-                                (I32, requires_raw_f64_str),
-                            ],
-                        );
-                        let guard_pass = ctx.block().icmp_ne(I32, &guard_ok, "0");
-                        ctx.block()
-                            .cond_br(&guard_pass, &fast_label, &fallback_label);
 
                         ctx.current_block = fast_idx;
                         let blk = ctx.block();
@@ -461,14 +536,48 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             );
                         }
 
-                        ctx.current_block = fallback_idx;
+                        // %slow — the cold miss/fallback path, collapsed to ONE
+                        // call. `js_class_field_set_slow` reproduces today's full
+                        // guard-miss semantics: it runs the real
+                        // `js_typed_feedback_class_field_set_guard` (feedback
+                        // recording, descriptor/accessor/frozen handling, raw-f64
+                        // contract); on a guard PASS it does the same slot store
+                        // (raw-f64 bare store / boxed slot store + write barrier);
+                        // on a FAIL it records the fallback and routes through the
+                        // by-name setter. This covers every case the conservative
+                        // inline compare doesn't take %fast on.
+                        ctx.current_block = slow_idx;
                         let blk = ctx.block();
-                        blk.call_void("js_typed_feedback_record_fallback_call", &[(I64, &site_id)]);
-                        blk.call_void(
-                            "js_object_set_field_by_name",
-                            &[(I64, &obj_bits), (I64, &key_raw), (DOUBLE, &val_double)],
-                        );
+                        if inline_fieldset {
+                            blk.call_void(
+                                "js_class_field_set_slow",
+                                &[
+                                    (I64, &site_id),
+                                    (DOUBLE, &recv_box),
+                                    (I32, &expected_class_id_str),
+                                    (I64, &expected_keys),
+                                    (I64, &key_raw),
+                                    (I32, &field_idx_str),
+                                    (DOUBLE, &val_double),
+                                    (I32, requires_raw_f64_str),
+                                ],
+                            );
+                        } else {
+                            // A/B opt-out: the guard already ran and FAILED in the
+                            // entry block, so this is a pure guard-miss fallback —
+                            // record it and route by-name (NOT the slow helper,
+                            // which would re-run the guard and double-record).
+                            blk.call_void(
+                                "js_typed_feedback_record_fallback_call",
+                                &[(I64, &site_id)],
+                            );
+                            blk.call_void(
+                                "js_object_set_field_by_name",
+                                &[(I64, &obj_bits), (I64, &key_raw), (DOUBLE, &val_double)],
+                            );
+                        }
                         blk.br(&merge_label);
+                        let _ = &obj_bits;
                         if requires_raw_f64 {
                             let fallback = LoweredValue {
                                 semantic: SemanticKind::JsValue,
@@ -479,7 +588,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             ctx.record_lowered_value_with_access_mode_and_facts(
                                 "ClassFieldSet",
                                 None,
-                                "js_object_set_field_by_name",
+                                "js_class_field_set_slow",
                                 &fallback,
                                 Some(BoundsState::Unknown),
                                 None,

--- a/crates/perry-codegen/src/lower_array_method.rs
+++ b/crates/perry-codegen/src/lower_array_method.rs
@@ -29,8 +29,10 @@ pub(crate) fn lower_array_method(
 
     match property {
         "pop" => {
-            if !args.is_empty() {
-                bail!("perry-codegen: Array.pop takes no args, got {}", args.len());
+            // No-arg method; JS ignores extras but evaluates them for side
+            // effects before the call. Evaluate then discard.
+            for extra in args.iter() {
+                let _ = lower_expr(ctx, extra)?;
             }
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
@@ -723,11 +725,9 @@ pub(crate) fn lower_array_method(
             Ok(nanbox_pointer_inline(blk, &result))
         }
         "shift" => {
-            if !args.is_empty() {
-                bail!(
-                    "perry-codegen: Array.shift takes no args, got {}",
-                    args.len()
-                );
+            // No-arg method; extras are evaluated for side effects then ignored.
+            for extra in args.iter() {
+                let _ = lower_expr(ctx, extra)?;
             }
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -822,6 +822,43 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
             ],
         )
     } else if let Some(keys_global_name) = ctx.class_keys_globals.get(class_name).cloned() {
+        if std::env::var_os("PERRY_INLINE_NEW").is_none() {
+            // [#bloat] Default: outline the per-`new`-site allocator. Opt back
+            // into the old inline bump-allocator with PERRY_INLINE_NEW=1.
+            // Measured win-win vs inline: −45 IR lines/site AND ~17% faster on an
+            // 8M-allocation loop (the inline bump bloated the hot loop, hurting
+            // icache/regalloc more than the saved call). Outline the per-`new`-site
+            // inline bump-allocator (~145 lines of per-class-constant IR) into a
+            // single call to the runtime `js_object_alloc_class_inline_keys`,
+            // which performs the identical bump alloc + header init + slot
+            // zero-fill and returns the same user pointer (as i64). Cuts ~145 IR
+            // lines per `new` site to ~3. Only the per-class keys-array global is
+            // loaded (cached per function, same as the inline path).
+            let keys_slot = if let Some(s) = ctx.class_keys_slots.get(class_name).cloned() {
+                s
+            } else {
+                let s = ctx.func.entry_init_load_global(&keys_global_name, I64);
+                ctx.class_keys_slots
+                    .insert(class_name.to_string(), s.clone());
+                s
+            };
+            let keys_ptr = ctx.block().load(I64, &keys_slot);
+            ctx.pending_declares.push((
+                "js_object_alloc_class_inline_keys".to_string(),
+                I64,
+                vec![I32, I32, I32, I64],
+            ));
+            ctx.block().call(
+                I64,
+                "js_object_alloc_class_inline_keys",
+                &[
+                    (I32, &cid_str),
+                    (I32, &parent_cid_str),
+                    (I32, &field_count.to_string()),
+                    (I64, &keys_ptr),
+                ],
+            )
+        } else {
         // Compile-time layout constants.
         const GC_HEADER_SIZE: u64 = 8;
         const OBJECT_HEADER_SIZE: u64 = 24;
@@ -987,6 +1024,7 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
         // the existing nanbox_pointer_inline expects.
         let user_ptr = blk.gep(I8, &raw, &[(I64, "8")]);
         blk.ptrtoint(&user_ptr, I64)
+        }
     } else {
         // Fallback: build the packed-keys string at this site and
         // call the slower SHAPE_CACHE-aware allocator. Used when the

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1108,7 +1108,24 @@ pub(crate) fn lower_new(ctx: &mut FnCtx<'_>, class_name: &str, args: &[Expr]) ->
             collect_decl_local_ids(&c.body, &mut ids);
             ids.iter().any(|id| ctx.closure_captures.contains_key(id))
         });
-    if ctx.class_stack.iter().any(|active| active == class_name) || ctor_alias_collision {
+    // [#bloat] Default: CALL the shared standalone-symbol constructor instead of
+    // inlining the constructor body at every `new` site. The inlined ctor body
+    // (field-init stores etc.) is the dominant per-`new`-site IR after the
+    // allocator (~136 lines/site); calling the shared ctor symbol emits it once.
+    // Measured win-win vs inlining: ~2.5x FASTER on an 8M construct-heavy loop
+    // AND much smaller IR. Opt back into inlining with PERRY_INLINE_CTOR=1.
+    // Restricted to classes with their OWN constructor: a no-own-ctor subclass
+    // (`class C extends B {}`) gets a synthesized symbol, but the symbol-call
+    // path doesn't reproduce the inline path's leaf-keys/shape setup, so by-name
+    // field reads on the instance return undefined. Own-ctor classes (incl. ones
+    // with `super(...)`/rest params) round-trip correctly through the call.
+    let force_ctor_call = std::env::var_os("PERRY_INLINE_CTOR").is_none()
+        && class.constructor.is_some()
+        && local_constructor_symbol_exists(ctx, class);
+    if ctx.class_stack.iter().any(|active| active == class_name)
+        || ctor_alias_collision
+        || force_ctor_call
+    {
         call_local_constructor_symbol(ctx, class, &obj_box, &lowered_args);
         return Ok(obj_box);
     }

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -310,12 +310,11 @@ pub(crate) fn lower_string_method(
         }
         // Unary string-returning methods (no args).
         "toLowerCase" | "toUpperCase" | "trim" | "trimStart" | "trimEnd" => {
-            if !args.is_empty() {
-                bail!(
-                    "perry-codegen: String.{} takes no args, got {}",
-                    property,
-                    args.len()
-                );
+            // These methods take no args; JS ignores any extras but still
+            // evaluates them for side effects (ECMA-262 argument evaluation
+            // precedes the call). Evaluate then discard.
+            for extra in args.iter() {
+                let _ = lower_expr(ctx, extra)?;
             }
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
@@ -900,11 +899,9 @@ pub(crate) fn lower_string_method(
             Ok(nanbox_pointer_inline(blk, &result))
         }
         "isWellFormed" => {
-            if !args.is_empty() {
-                bail!(
-                    "perry-codegen: String.isWellFormed takes no args, got {}",
-                    args.len()
-                );
+            // No-arg method; extras are evaluated for side effects then ignored.
+            for extra in args.iter() {
+                let _ = lower_expr(ctx, extra)?;
             }
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
@@ -912,11 +909,9 @@ pub(crate) fn lower_string_method(
             Ok(blk.call(DOUBLE, "js_string_is_well_formed", &[(I64, &recv_handle)]))
         }
         "toWellFormed" => {
-            if !args.is_empty() {
-                bail!(
-                    "perry-codegen: String.toWellFormed takes no args, got {}",
-                    args.len()
-                );
+            // No-arg method; extras are evaluated for side effects then ignored.
+            for extra in args.iter() {
+                let _ = lower_expr(ctx, extra)?;
             }
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);

--- a/crates/perry-codegen/src/module.rs
+++ b/crates/perry-codegen/src/module.rs
@@ -244,7 +244,22 @@ impl LlModule {
         }
         ir.push('\n');
 
+        // Emit each function symbol's body at most once. Minified bundles can
+        // contain two DISTINCT classes with the same name (`class j` in separate
+        // scopes), whose methods mangle to the same `perry_method_<mod>__j__<m>`
+        // symbol via several emission paths, producing duplicate `define`s that
+        // clang rejects ("invalid redefinition of function"). perry's class
+        // identity is name-keyed, so every reference to that class+method already
+        // resolves to ONE symbol; emitting the body once (first wins) keeps def
+        // and refs consistent. Dispatch for the rare two-same-named-classes case
+        // resolves to the first (a pre-existing name-identity limitation), but the
+        // module compiles instead of being rejected. Unique-named symbols (the
+        // overwhelming common case) never collide, so this is a no-op for them.
+        let mut emitted_fn_names: HashSet<&str> = HashSet::new();
         for func in &self.functions {
+            if !emitted_fn_names.insert(func.name.as_str()) {
+                continue;
+            }
             ir.push_str(&func.to_ir());
             ir.push('\n');
         }

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -112,10 +112,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         I32,
         &[I64, DOUBLE, I32, I64, I64, I32, DOUBLE, I32],
     );
-    // #5247: outlined class-field-SET inline cache. One call replaces the
-    // ~18-line inline guard+fast-store+fallback+merge diamond.
+    // #5247: class-field-SET inline-cache SLOW path. The hot fast path stays
+    // inline (cheap shape compare + bare slot store); only the cold miss/
+    // fallback collapses to this one call.
     module.declare_function(
-        "js_class_field_set_ic",
+        "js_class_field_set_slow",
         VOID,
         &[I64, DOUBLE, I32, I64, I64, I32, DOUBLE, I32],
     );

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -112,6 +112,13 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         I32,
         &[I64, DOUBLE, I32, I64, I64, I32, DOUBLE, I32],
     );
+    // #5247: outlined class-field-SET inline cache. One call replaces the
+    // ~18-line inline guard+fast-store+fallback+merge diamond.
+    module.declare_function(
+        "js_class_field_set_ic",
+        VOID,
+        &[I64, DOUBLE, I32, I64, I64, I32, DOUBLE, I32],
+    );
     module.declare_function(
         "js_typed_feedback_class_field_get_guard",
         I32,

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -120,6 +120,15 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         VOID,
         &[I64, DOUBLE, I32, I64, I64, I32, DOUBLE, I32],
     );
+    // #5334 lever A: class-field-SET guard-MISS fallback, outlined. The DEFAULT
+    // (guard-call) diamond's cold arm collapses from two calls
+    // (record_fallback + set_field_by_name) to this one. Args:
+    // (site_id, obj_bits, key_raw, value).
+    module.declare_function(
+        "js_class_field_set_fallback",
+        VOID,
+        &[I64, I64, I64, DOUBLE],
+    );
     module.declare_function(
         "js_typed_feedback_class_field_get_guard",
         I32,

--- a/crates/perry-codegen/tests/argless_builtin_extra_args.rs
+++ b/crates/perry-codegen/tests/argless_builtin_extra_args.rs
@@ -1,0 +1,129 @@
+//! Regression: argless builtin methods (`String.trim`, `String.toLowerCase`,
+//! `Array.pop`, …) must accept and ignore extra arguments rather than bailing.
+//!
+//! JS ignores surplus args to argless methods (`"  x ".trim(1)` is legal and
+//! returns the trimmed string), so codegen must lower these without erroring.
+
+use perry_codegen::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::{Expr, Module, ModuleInitKind, Stmt};
+
+fn empty_opts() -> CompileOptions {
+    CompileOptions {
+        target: None,
+        is_entry_module: false,
+        non_entry_module_prefixes: Vec::new(),
+        import_function_prefixes: std::collections::HashMap::new(),
+        import_function_origin_names: std::collections::HashMap::new(),
+        import_function_v8_specifiers: std::collections::HashMap::new(),
+        import_function_node_submodule: std::collections::HashMap::new(),
+        namespace_node_submodules: std::collections::HashMap::new(),
+        namespace_v8_specifiers: std::collections::HashMap::new(),
+        namespace_member_prefixes: std::collections::HashMap::new(),
+        emit_ir_only: true,
+        verify_native_regions: false,
+        disable_buffer_fast_path: false,
+        namespace_imports: Vec::new(),
+        namespace_reexport_named_imports: std::collections::HashSet::new(),
+        imported_classes: Vec::new(),
+        imported_enums: Vec::new(),
+        imported_async_funcs: std::collections::HashSet::new(),
+        type_aliases: std::collections::HashMap::new(),
+        imported_func_param_counts: std::collections::HashMap::new(),
+        imported_func_has_rest: std::collections::HashSet::new(),
+        imported_func_synthetic_arguments: std::collections::HashSet::new(),
+        imported_func_return_types: std::collections::HashMap::new(),
+        imported_vars: std::collections::HashSet::new(),
+        output_type: "executable".to_string(),
+        needs_stdlib: false,
+        needs_ui: false,
+        needs_geisterhand: false,
+        geisterhand_port: 7676,
+        enabled_features: Vec::new(),
+        native_module_init_names: Vec::new(),
+        js_module_specifiers: Vec::new(),
+        bundled_extensions: Vec::new(),
+        native_library_functions: Vec::new(),
+        i18n_table: None,
+        fast_math: false,
+        fp_contract_mode: perry_codegen::FpContractMode::Off,
+        app_metadata: AppMetadata::default(),
+        namespace_entries: Vec::new(),
+        dynamic_import_path_to_prefix: std::collections::HashMap::new(),
+        deferred_module_prefixes: std::collections::HashSet::new(),
+        module_init_deps: Vec::new(),
+        is_dynamic_import_target: false,
+        debug_locations: false,
+        module_source: None,
+    }
+}
+
+fn module_with_init(init: Vec<Stmt>) -> Module {
+    Module {
+        name: "argless_extra_args.ts".to_string(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        classes: Vec::new(),
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions: Vec::new(),
+        init,
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
+    }
+}
+
+/// `"  x  ".trim(1)` — String.trim is argless but JS ignores the extra arg.
+/// Codegen must lower this without bailing (`String.trim takes no args`).
+#[test]
+fn string_trim_with_extra_arg_compiles() {
+    let stmt = Stmt::Expr(Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::String("  x  ".to_string())),
+            property: "trim".to_string(),
+        }),
+        args: vec![Expr::Number(1.0)],
+        type_args: Vec::new(),
+        byte_offset: 0,
+    });
+    let ir = compile_module(&module_with_init(vec![stmt]), empty_opts())
+        .expect("\"  x  \".trim(1) must compile (extra arg ignored, not an error)");
+    let ir = String::from_utf8(ir).unwrap();
+    // The runtime trim helper must still be emitted — the arg is dropped, not
+    // routed into a different code path.
+    assert!(
+        ir.contains("js_string_trim"),
+        "expected trim lowering to emit js_string_trim"
+    );
+}
+
+/// `[1].pop(99)` — Array.pop is argless; the extra arg must be ignored.
+#[test]
+fn array_pop_with_extra_arg_compiles() {
+    let stmt = Stmt::Expr(Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::Array(vec![Expr::Number(1.0)])),
+            property: "pop".to_string(),
+        }),
+        args: vec![Expr::Number(99.0)],
+        type_args: Vec::new(),
+        byte_offset: 0,
+    });
+    compile_module(&module_with_init(vec![stmt]), empty_opts())
+        .expect("[1].pop(99) must compile (extra arg ignored, not an error)");
+}

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -960,8 +960,8 @@ fn pod_layout_constants_specialize_generic_layout_type_params() {
     module.functions.retain(|func| func.type_params.is_empty());
     module.init.clear();
     let ir = compile_ir_for_module_with_opts(module, pod_layout_specialization_opts()).unwrap();
-    let tiny_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__layout_Tiny");
-    let wide_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__layout_Wide");
+    let tiny_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__u_layout_24_Tiny");
+    let wide_ir = function_ir_section(&ir, "perry_fn_pod_layout_specialization_ts__u_layout_24_Wide");
 
     assert!(
         tiny_ir.contains("8.0") && tiny_ir.contains("4.0") && !tiny_ir.contains("16.0"),
@@ -1000,8 +1000,8 @@ fn native_pod_view_specializes_generic_layout_type_params() {
     module.functions.retain(|func| func.type_params.is_empty());
     module.init.clear();
     let ir = compile_ir_for_module_with_opts(module, pod_layout_specialization_opts()).unwrap();
-    let tiny_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__view_Tiny");
-    let wide_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__view_Wide");
+    let tiny_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__u_view_24_Tiny");
+    let wide_ir = function_ir_section(&ir, "perry_fn_native_pod_view_specialization_ts__u_view_24_Wide");
 
     assert!(
         tiny_ir.contains("call i64 @js_native_pod_view") && tiny_ir.contains("i64 8, i64 4"),

--- a/crates/perry-codegen/tests/static_symbol_hygiene.rs
+++ b/crates/perry-codegen/tests/static_symbol_hygiene.rs
@@ -219,6 +219,11 @@ fn static_and_instance_methods_with_same_name_keep_distinct_symbols() {
     )
     .unwrap();
 
+    // The class name `x` is UNIQUE in this module, so its instance method keeps
+    // the id-less, cross-module-stable symbol (`perry_method_…__x__lex`). Only
+    // duplicate-named classes get the disambiguating `c<id>` infix on instance
+    // methods. Static methods always carry the id (`perry_static_…__x__c11__`),
+    // which is internal to the module and never reconstructed cross-module.
     assert_eq!(
         count(
             &ir,
@@ -226,11 +231,58 @@ fn static_and_instance_methods_with_same_name_keep_distinct_symbols() {
         ),
         1
     );
+    // The instance method must NOT gain a spurious id infix when its name is
+    // unique (that would break cross-module references to exported classes).
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_method_static_instance_symbol_hygiene_ts__x__c11__lex"
+        ),
+        0
+    );
     assert_eq!(
         count(
             &ir,
             "define double @perry_static_static_instance_symbol_hygiene_ts__x__c11__lex"
         ),
         1
+    );
+}
+
+/// Two distinct classes sharing the minified name `x` (ids 11 and 12) must
+/// emit DISTINCT instance-method symbols — the regression that produced
+/// `invalid redefinition of function 'perry_method_…__j__getElementsByTagName'`
+/// on a 13MB minified bundle. The id infix (`__c11__` vs `__c12__`) is what
+/// keeps them apart.
+#[test]
+fn duplicate_class_instance_methods_use_class_id_in_symbols() {
+    let mut module = duplicate_static_module();
+    module.name = "dup_instance_symbol_hygiene.ts".to_string();
+    module.classes[0].methods.push(instance_method(301, 1.0));
+    module.classes[1].methods.push(instance_method(302, 2.0));
+
+    let ir = String::from_utf8(compile_module(&module, empty_opts()).unwrap()).unwrap();
+
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_method_dup_instance_symbol_hygiene_ts__x__c11__lex"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_method_dup_instance_symbol_hygiene_ts__x__c12__lex"
+        ),
+        1
+    );
+    // No id-less form, which would collide across the two classes.
+    assert_eq!(
+        count(
+            &ir,
+            "define double @perry_method_dup_instance_symbol_hygiene_ts__x__lex"
+        ),
+        0
     );
 }

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -291,9 +291,11 @@ fn typed_feedback_guards_direct_class_field_specialization() {
     let _lock = ENV_LOCK.lock().unwrap();
 
     // DEFAULT (#5247 kept OPT-IN: PERRY_INLINE_FIELDSET unset). The SET site
-    // emits the original guard-call diamond — guard CALL drives the
-    // fast/%slow branch, and the %slow block records the fallback + sets by
-    // name inline (NOT the slow helper, which would double-run the guard).
+    // emits the guard-call diamond — guard CALL drives the fast/%slow branch.
+    // #5334 lever A: the cold %slow arm (guard already FAILED in the entry
+    // block) collapses from the old inline pair (record_fallback_call +
+    // by-name set) into ONE outlined `js_class_field_set_fallback` call. NOT
+    // the slow helper, which would double-run the guard.
     {
         let _g = EnvVarGuard::set("PERRY_INLINE_FIELDSET", None);
         let ir = ir_for(build());
@@ -301,8 +303,13 @@ fn typed_feedback_guards_direct_class_field_specialization() {
         assert!(ir.contains("class_field_set.fast"));
         assert!(ir.contains("class_field_set.slow"));
         assert!(!ir.contains("call void @js_class_field_set_slow"));
-        assert!(ir.contains("call void @js_typed_feedback_record_fallback_call"));
-        assert!(ir.contains("call void @js_object_set_field_by_name"));
+        assert!(ir.contains("call void @js_class_field_set_fallback"));
+        // The by-name SET call the helper replaces is no longer emitted at the
+        // set site (the GET diamond uses get_by_name, never set_by_name).
+        assert!(!ir.contains("call void @js_object_set_field_by_name"));
+        // NB: `record_fallback_call` is still present — but from the always-on
+        // class-field-GET fallback block below, not the SET site (the SET site's
+        // copy is now folded into js_class_field_set_fallback).
         // GET path (always-on guard diamond) and shared expectations.
         assert!(ir.contains("class_field_get_guard"));
         assert!(ir.contains("@perry_typed_shape_raw_f64_mask_"));

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -265,39 +265,76 @@ fn typed_feedback_instruments_property_and_method_boundaries() {
 
 #[test]
 fn typed_feedback_guards_direct_class_field_specialization() {
-    let point = class(101, "Point", vec![field("x", Type::Number)]);
-    let ir = ir_for(module_with_classes(
-        "typed_feedback_class_field.ts",
-        vec![point],
-        vec![param(1, "p", Type::Named("Point".to_string()))],
-        Type::Number,
-        vec![
-            Stmt::Expr(Expr::PropertySet {
-                object: Box::new(Expr::LocalGet(1)),
-                property: "x".to_string(),
-                value: Box::new(Expr::Number(7.0)),
-            }),
-            Stmt::Return(Some(Expr::PropertyGet {
-                object: Box::new(Expr::LocalGet(1)),
-                property: "x".to_string(),
-            })),
-        ],
-    ));
+    // Build the same `p.x = 7; return p.x;` module fresh for each gate state so
+    // the env-var read in codegen is observed deterministically.
+    let build = || {
+        let point = class(101, "Point", vec![field("x", Type::Number)]);
+        module_with_classes(
+            "typed_feedback_class_field.ts",
+            vec![point],
+            vec![param(1, "p", Type::Named("Point".to_string()))],
+            Type::Number,
+            vec![
+                Stmt::Expr(Expr::PropertySet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    property: "x".to_string(),
+                    value: Box::new(Expr::Number(7.0)),
+                }),
+                Stmt::Return(Some(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    property: "x".to_string(),
+                })),
+            ],
+        )
+    };
 
-    assert!(ir.contains("class_field_set_guard"));
-    assert!(ir.contains("class_field_get_guard"));
-    assert!(ir.contains("@perry_typed_shape_raw_f64_mask_"));
-    assert!(ir.contains("js_typed_feedback_class_field_set_guard"));
-    assert!(ir.contains("js_typed_feedback_class_field_get_guard"));
-    assert!(ir.contains("class_field_set.fast"));
-    assert!(ir.contains("class_field_set.fallback"));
-    assert!(ir.contains("class_field_get.fast"));
-    assert!(ir.contains("class_field_get.fallback"));
-    assert!(ir.contains("store double"));
-    assert!(!ir.contains("call void @js_gc_note_slot_layout"));
-    assert!(ir.contains("call void @js_typed_feedback_record_fallback_call"));
-    assert!(ir.contains("call void @js_object_set_field_by_name"));
-    assert!(ir.contains("call double @js_object_get_field_by_name_f64"));
+    let _lock = ENV_LOCK.lock().unwrap();
+
+    // DEFAULT (#5247 kept OPT-IN: PERRY_INLINE_FIELDSET unset). The SET site
+    // emits the original guard-call diamond — guard CALL drives the
+    // fast/%slow branch, and the %slow block records the fallback + sets by
+    // name inline (NOT the slow helper, which would double-run the guard).
+    {
+        let _g = EnvVarGuard::set("PERRY_INLINE_FIELDSET", None);
+        let ir = ir_for(build());
+        assert!(ir.contains("js_typed_feedback_class_field_set_guard"));
+        assert!(ir.contains("class_field_set.fast"));
+        assert!(ir.contains("class_field_set.slow"));
+        assert!(!ir.contains("call void @js_class_field_set_slow"));
+        assert!(ir.contains("call void @js_typed_feedback_record_fallback_call"));
+        assert!(ir.contains("call void @js_object_set_field_by_name"));
+        // GET path (always-on guard diamond) and shared expectations.
+        assert!(ir.contains("class_field_get_guard"));
+        assert!(ir.contains("@perry_typed_shape_raw_f64_mask_"));
+        assert!(ir.contains("js_typed_feedback_class_field_get_guard"));
+        assert!(ir.contains("class_field_get.fast"));
+        assert!(ir.contains("class_field_get.fallback"));
+        assert!(ir.contains("store double"));
+        assert!(!ir.contains("call void @js_gc_note_slot_layout"));
+        assert!(ir.contains("call double @js_object_get_field_by_name_f64"));
+    }
+
+    // OPT-IN (PERRY_INLINE_FIELDSET=1): fast-inline / slow-outline inline
+    // cache. The hot path is the inline shape compare + the byte-identical
+    // bare slot store; the cold miss path collapses to one
+    // `call @js_class_field_set_slow` (which internally runs the real guard +
+    // records the fallback + by-name set). The SET site no longer emits the
+    // guard CALL, the inline `record_fallback_call`, or the by-name set.
+    {
+        let _g = EnvVarGuard::set("PERRY_INLINE_FIELDSET", Some("1"));
+        let ir = ir_for(build());
+        assert!(ir.contains("class_field_set.fast"));
+        assert!(ir.contains("class_field_set.slow"));
+        assert!(ir.contains("call void @js_class_field_set_slow"));
+        assert!(!ir.contains("class_field_set.fallback"));
+        assert!(!ir.contains("call i32 @js_typed_feedback_class_field_set_guard"));
+        // The inline shape precheck is emitted (the perf-flat hot compare).
+        assert!(ir.contains("class_field_inline.deref"));
+        // GET path is unchanged regardless of the SET gate.
+        assert!(ir.contains("js_typed_feedback_class_field_get_guard"));
+        assert!(ir.contains("class_field_get.fast"));
+        assert!(ir.contains("store double"));
+    }
 }
 
 #[test]
@@ -339,7 +376,11 @@ fn typed_feedback_guards_direct_class_method_specialization() {
     assert!(ir.contains("js_typed_feedback_method_direct_call_guard"));
     assert!(ir.contains("method_direct.fast"));
     assert!(ir.contains("method_direct.fallback"));
-    assert!(ir.contains("call void @js_typed_feedback_record_fallback_call"));
+    // (The method-direct fallback here has no typed-feedback site, so it calls
+    // js_native_call_method directly without an inline record_fallback_call.
+    // #5247: the incidental record_fallback_call this used to observe came from
+    // the synthesized constructor's field-set, now folded into the SET inline
+    // cache's slow helper — no longer emitted inline.)
     assert!(ir.contains("call double @js_native_call_method"));
 }
 

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -161,6 +161,7 @@ impl LoweringContext {
             optional_require_try_depth: 0,
             fn_ctor_env: super::fn_ctor_env::FnCtorEnv::default(),
             expr_lower_depth: 0,
+            prelowered_member_receiver: None,
         }
     }
 

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -116,6 +116,11 @@ impl LoweringContext {
             classes_index: HashMap::new(),
             imported_functions_index: HashMap::new(),
             builtin_module_aliases_index: HashMap::new(),
+            native_instances_index: HashMap::new(),
+            module_native_instances_index: HashMap::new(),
+            func_return_native_instances_index: HashMap::new(),
+            native_modules_index: HashMap::new(),
+            class_statics_index: HashMap::new(),
             weakref_locals: HashSet::new(),
             finreg_locals: HashSet::new(),
             weakmap_locals: HashSet::new(),
@@ -602,23 +607,24 @@ impl LoweringContext {
         static_fields: Vec<String>,
         static_methods: Vec<String>,
     ) {
+        // Forward-scan (first-match-wins): index keeps the FIRST entry per name.
+        let idx = self.class_statics.len();
+        self.class_statics_index.entry(class_name.clone()).or_insert(idx);
         self.class_statics
             .push((class_name, static_fields, static_methods));
     }
 
     pub(crate) fn has_static_field(&self, class_name: &str, field_name: &str) -> bool {
-        self.class_statics
-            .iter()
-            .find(|(cn, _, _)| cn == class_name)
-            .map(|(_, fields, _)| fields.contains(&field_name.to_string()))
+        self.class_statics_index
+            .get(class_name)
+            .map(|&idx| self.class_statics[idx].1.iter().any(|f| f == field_name))
             .unwrap_or(false)
     }
 
     pub(crate) fn has_static_method(&self, class_name: &str, method_name: &str) -> bool {
-        self.class_statics
-            .iter()
-            .find(|(cn, _, _)| cn == class_name)
-            .map(|(_, _, methods)| methods.contains(&method_name.to_string()))
+        self.class_statics_index
+            .get(class_name)
+            .map(|&idx| self.class_statics[idx].2.iter().any(|m| m == method_name))
             .unwrap_or(false)
     }
 
@@ -1022,15 +1028,19 @@ impl LoweringContext {
         module_name: String,
         method_name: Option<String>,
     ) {
+        // Forward-scan (first-match-wins) semantics: only record the FIRST
+        // index for a name so lookups match the old `.iter().find()`.
+        let idx = self.native_modules.len();
+        self.native_modules_index.entry(local_name.clone()).or_insert(idx);
         self.native_modules
             .push((local_name, module_name, method_name));
     }
 
     pub(crate) fn lookup_native_module(&self, name: &str) -> Option<(&str, Option<&str>)> {
-        self.native_modules
-            .iter()
-            .find(|(n, _, _)| n == name)
-            .map(|(_, m, method)| (m.as_str(), method.as_ref().map(|s| s.as_str())))
+        self.native_modules_index.get(name).map(|&idx| {
+            let (_, m, method) = &self.native_modules[idx];
+            (m.as_str(), method.as_ref().map(|s| s.as_str()))
+        })
     }
 
     pub(crate) fn register_builtin_module_alias(
@@ -1085,8 +1095,37 @@ impl LoweringContext {
         if is_compile_package_override(&module_name) {
             return;
         }
+        // Push the new index onto this name's shadow stack (innermost last).
+        let idx = self.native_instances.len();
+        self.native_instances_index
+            .entry(local_name.clone())
+            .or_default()
+            .push(idx);
         self.native_instances
             .push((local_name, module_name, class_name));
+    }
+
+    /// Truncate `native_instances` back to `mark`, keeping the
+    /// `native_instances_index` shadow stacks in sync: every recorded index
+    /// `>= mark` is popped (these belong to bindings whose scope is exiting),
+    /// re-exposing any earlier (outer-scope) binding of the same name. Empty
+    /// stacks are removed to keep the map small. Use this everywhere
+    /// `native_instances.truncate(..)` was previously called directly.
+    pub(crate) fn truncate_native_instances(&mut self, mark: usize) {
+        if self.native_instances.len() <= mark {
+            return;
+        }
+        self.native_instances.truncate(mark);
+        // Drop indices >= mark from each name's shadow stack, re-exposing any
+        // earlier (outer-scope) binding. The map is keyed by distinct
+        // native-instance names (bounded, not proportional to class count), so
+        // this stays cheap.
+        self.native_instances_index.retain(|_, stack| {
+            while stack.last().is_some_and(|&i| i >= mark) {
+                stack.pop();
+            }
+            !stack.is_empty()
+        });
     }
 
     /// #1483: resolve a parameter's declared type name to a perry/ui widget
@@ -1129,10 +1168,17 @@ impl LoweringContext {
         // inner `res` always resolved to the outer `("http",
         // "ServerResponse")` tag and `res.on('data')` misrouted
         // through ServerResponse dispatch instead of IncomingMessage.)
-        self.native_instances
-            .iter()
-            .rev()
-            .find(|(n, _, _)| n == name)
+        //
+        // Indexed (#5271): `native_instances_index[name]` is the shadow stack
+        // of indices for this name, innermost (last) on top — so the top index
+        // is exactly the entry the old `.rev().find()` would have selected.
+        // The `exposes_plain_object_fields` filter is then applied to THAT
+        // entry only (matching `.find().filter()`, which never falls through to
+        // an earlier match when the top one is filtered out).
+        self.native_instances_index
+            .get(name)
+            .and_then(|stack| stack.last())
+            .map(|&idx| &self.native_instances[idx])
             // `node:repl` constructors allocate real heap objects/errors with
             // bound methods; routing them through handle-dispatch native
             // getters turns ordinary fields like `Recoverable.err` into
@@ -1141,11 +1187,11 @@ impl LoweringContext {
             .map(|(_, module, class)| (module.as_str(), class.as_str()))
             .or_else(|| {
                 // Check module-level instances (survive scope exits).
-                // Same last-match-wins rule for consistency.
-                self.module_native_instances
-                    .iter()
-                    .rev()
-                    .find(|(n, _, _)| n == name)
+                // Same last-match-wins rule for consistency — the index stores
+                // the LAST pushed entry per name.
+                self.module_native_instances_index
+                    .get(name)
+                    .map(|&idx| &self.module_native_instances[idx])
                     .filter(|(_, module, class)| !exposes_plain_object_fields(module, class))
                     .map(|(_, module, class)| (module.as_str(), class.as_str()))
             })
@@ -1155,10 +1201,35 @@ impl LoweringContext {
         &self,
         func_name: &str,
     ) -> Option<(&str, &str)> {
-        self.func_return_native_instances
-            .iter()
-            .find(|(n, _, _)| n == func_name)
-            .map(|(_, module, class)| (module.as_str(), class.as_str()))
+        // Forward-scan (first-match-wins): index keeps the FIRST pushed entry.
+        self.func_return_native_instances_index
+            .get(func_name)
+            .map(|&idx| {
+                let (_, module, class) = &self.func_return_native_instances[idx];
+                (module.as_str(), class.as_str())
+            })
+    }
+
+    /// Push a function-return native instance (push-only, never truncated) and
+    /// update its perf index. `lookup_func_return_native_instance` scanned
+    /// FORWARD (first-match-wins), so the index keeps the FIRST pushed entry.
+    pub(crate) fn push_func_return_native_instance(&mut self, entry: (String, String, String)) {
+        let idx = self.func_return_native_instances.len();
+        self.func_return_native_instances_index
+            .entry(entry.0.clone())
+            .or_insert(idx);
+        self.func_return_native_instances.push(entry);
+    }
+
+    /// Push a module-level native instance (module-scoped, never truncated)
+    /// and update its perf index. `lookup_native_instance`'s fallback arm
+    /// scans these in reverse (last-match-wins), so the index stores the LAST
+    /// pushed entry per name (overwrite).
+    pub(crate) fn push_module_native_instance(&mut self, entry: (String, String, String)) {
+        let idx = self.module_native_instances.len();
+        self.module_native_instances_index
+            .insert(entry.0.clone(), idx);
+        self.module_native_instances.push(entry);
     }
 }
 
@@ -1241,7 +1312,7 @@ impl LoweringContext {
             }
             self.locals.extend(kept);
         }
-        self.native_instances.truncate(mark.1);
+        self.truncate_native_instances(mark.1);
         // Remove index entries for functions being truncated, then restore any
         // earlier entries that were shadowed by the removed ones.
         for i in mark.2..self.functions.len() {

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -192,7 +192,7 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
                                         _ => Some("Instance"),
                                     };
                                     if let Some(class_name) = class_name {
-                                        ctx.module_native_instances.push((
+                                        ctx.push_module_native_instance((
                                             var_name.clone(),
                                             module_name.to_string(),
                                             class_name.to_string(),
@@ -217,7 +217,7 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
                             module_name.clone(),
                             class_name_str.to_string(),
                         );
-                        ctx.module_native_instances.push((
+                        ctx.push_module_native_instance((
                             var_name.clone(),
                             module_name,
                             class_name_str.to_string(),
@@ -230,7 +230,7 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
             if let ast::Expr::Ident(rhs_ident) = inner_rhs {
                 let rhs_name = rhs_ident.sym.as_ref();
                 if let Some((module, class)) = ctx.lookup_native_instance(rhs_name) {
-                    ctx.module_native_instances.push((
+                    ctx.push_module_native_instance((
                         var_name,
                         module.to_string(),
                         class.to_string(),

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -149,6 +149,15 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
 }
 
 fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<Expr> {
+    // Safety net for the receiver-lowering memo (see
+    // `LoweringContext::prelowered_member_receiver`): the memo is set by
+    // `try_static_method_and_instance` only to be consumed by the immediately
+    // following fall-through tail's `lower_member_inner`. It is single-shot and
+    // span-keyed, but in case a code path sets it without the tail consuming it,
+    // drop any stale entry here so it can never leak across calls. This runs
+    // before the callee tail (which lowers a Member, not a Call), so it never
+    // clobbers an in-flight memo for the call currently being lowered.
+    ctx.prelowered_member_receiver = None;
     // Check if any argument has spread
     let has_spread = call.args.iter().any(|arg| arg.spread.is_some());
 

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -143,7 +143,7 @@ pub(super) fn lower_call(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Res
     // are likewise out of scope once we unwind past their owning
     // call). `truncate` is a no-op when nothing was added.
     if ctx.native_instances.len() > ni_mark {
-        ctx.native_instances.truncate(ni_mark);
+        ctx.truncate_native_instances(ni_mark);
     }
     result
 }

--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{anyhow, Result};
 use perry_types::{LocalId, Type};
+use swc_common::Spanned;
 use swc_ecma_ast as ast;
 
 use super::stream::is_stream_api_method;
@@ -345,7 +346,27 @@ pub(super) fn try_static_method_and_instance(
             if !may_lower_to_native_method_call(ctx, &member.obj) {
                 return Ok(Err(args));
             }
-            // Lower the object expression first
+            // Lower the object expression once.
+            //
+            // Perf (O(n²)/exponential → O(n) on long native-fluent chains): this
+            // is a FULL recursive lowering of the entire receiver prefix, done
+            // speculatively to inspect whether the inner call lowered to a
+            // `NativeMethodCall` of a recognized fluent module. On a chain like
+            // `K.name(..).description(..).option(..)…` (commander / minified CLI
+            // builders) where `may_lower_to_native_method_call` over-approximates
+            // to `true` but the inner call actually lowers to a *generic* `Call`,
+            // every arm below misses, `object_expr` is discarded, and we return
+            // `Err(args)` — whereupon the `lower_call_inner` fall-through tail
+            // re-lowers the same member callee (and thus this whole prefix)
+            // again. Repeated per chain level that is exponential blowup.
+            //
+            // To make the tail reuse this lowering instead of redoing it, stash
+            // it keyed by the receiver's source span. `lower_member_inner` (the
+            // tail's receiver-lowering site) consumes it for the matching span.
+            // Reuse is sound: lowering a receiver is idempotent in the value it
+            // produces, and the fluent-success arms below already reuse this very
+            // `object_expr`.
+            let obj_span = member.obj.as_ref().span();
             let object_expr = lower_expr(ctx, &member.obj)?;
             // Check if it's a NativeMethodCall for a fluent-API native module
             if let Expr::NativeMethodCall {
@@ -488,6 +509,12 @@ pub(super) fn try_static_method_and_instance(
                     }));
                 }
             }
+            // No fluent arm matched: we are about to return `Err(args)` and the
+            // `lower_call_inner` fall-through tail will re-lower this same member
+            // callee. Hand it the receiver we just lowered so it doesn't repeat
+            // the (potentially whole-prefix) work. Keyed by span so the tail only
+            // reuses it for the exact receiver subtree.
+            ctx.prelowered_member_receiver = Some(((obj_span.lo.0, obj_span.hi.0), object_expr));
         }
     }
 

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -219,13 +219,6 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
         .unwrap_or_default();
     ctx.enter_type_param_scope(&arrow_type_params);
 
-    // Track which locals exist before entering the closure scope
-    let outer_locals: Vec<(String, LocalId)> = ctx
-        .locals
-        .iter()
-        .map(|(name, id, _)| (name.clone(), *id))
-        .collect();
-
     // Lower parameters and collect destructuring info
     let mut params = Vec::new();
     let mut destructuring_params: Vec<(LocalId, ast::Pat)> = Vec::new();
@@ -413,7 +406,11 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
     // arrows don't leak outer T/U bindings into sibling code.
     ctx.exit_type_param_scope();
 
-    let (captures, mutable_captures) = compute_closure_captures(ctx, &body, &outer_locals, &params);
+    // The closure's own scope has been popped, so `ctx.locals.id_set()` is now
+    // exactly the enclosing scope's live locals — the membership view capture
+    // analysis needs. (Previously rebuilt per closure from a cloned snapshot.)
+    let (captures, mutable_captures) =
+        compute_closure_captures(ctx, &body, ctx.locals.id_set(), &params);
 
     // Check if this arrow function uses `this` (needs to capture it from enclosing scope)
     let captures_this = closure_uses_this(&body);
@@ -501,11 +498,15 @@ fn lower_named_fn_expr(
     // what the wrapper itself captures and threads through to the inner
     // function.
     let wrapper_scope = ctx.enter_scope();
-    let outer_locals: Vec<(String, LocalId)> = ctx
-        .locals
-        .iter()
-        .map(|(name, id, _)| (name.clone(), *id))
-        .collect();
+    // Snapshot the enclosing locals *before* the self-binding is added, so the
+    // wrapper captures them (not the self-binding). Unlike the arrow/fn-expr
+    // paths, capture analysis runs here while the wrapper scope is still open
+    // (the self-binding lives in it), so we can't use `ctx.locals.id_set()` —
+    // it would wrongly include `self_id`. This is a rare path (named function
+    // expressions that recursively self-reference), so an explicit snapshot is
+    // fine.
+    let outer_local_ids: std::collections::HashSet<LocalId> =
+        ctx.locals.iter().map(|(_, id, _)| *id).collect();
     let self_id = ctx.define_local(own_name.clone(), Type::Any);
 
     // Lower the function itself as an anonymous closure. With `self_id`
@@ -533,7 +534,8 @@ fn lower_named_fn_expr(
         },
         Stmt::Return(Some(Expr::LocalGet(self_id))),
     ];
-    let (captures, mutable_captures) = compute_closure_captures(ctx, &body, &outer_locals, &[]);
+    let (captures, mutable_captures) =
+        compute_closure_captures(ctx, &body, &outer_local_ids, &[]);
     ctx.exit_scope(wrapper_scope);
 
     Ok(Expr::Call {
@@ -576,13 +578,6 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
     // in a class field initializer. Cleared here, restored at the end.
     let saved_field_init = ctx.in_class_field_init;
     ctx.in_class_field_init = false;
-
-    // Track which locals exist before entering the closure scope
-    let outer_locals: Vec<(String, LocalId)> = ctx
-        .locals
-        .iter()
-        .map(|(name, id, _)| (name.clone(), *id))
-        .collect();
 
     // Lower parameters and collect destructuring info.
     //
@@ -1038,7 +1033,9 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
     ctx.exit_scope(scope_mark);
     ctx.in_class_field_init = saved_field_init;
 
-    let (captures, mutable_captures) = compute_closure_captures(ctx, &body, &outer_locals, &params);
+    // Scope popped: `ctx.locals.id_set()` is now the enclosing scope's locals.
+    let (captures, mutable_captures) =
+        compute_closure_captures(ctx, &body, ctx.locals.id_set(), &params);
 
     // #2076: a named function expression's own ident is its `fn.name`
     // per spec, regardless of the binding identifier it's later assigned
@@ -1081,7 +1078,7 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
 fn compute_closure_captures(
     ctx: &LoweringContext,
     body: &[Stmt],
-    outer_locals: &[(String, LocalId)],
+    outer_local_ids: &std::collections::HashSet<LocalId>,
     params: &[Param],
 ) -> (Vec<LocalId>, Vec<LocalId>) {
     // Detect captured variables: locals referenced in the body that
@@ -1092,10 +1089,13 @@ fn compute_closure_captures(
         collect_local_refs_stmt(stmt, &mut all_refs, &mut visited_closures);
     }
 
-    // Filter to only include outer locals (not parameters or locals
-    // defined within the closure).
-    let outer_local_ids: std::collections::HashSet<LocalId> =
-        outer_locals.iter().map(|(_, id)| *id).collect();
+    // `outer_local_ids` is the membership view of the enclosing scope's
+    // locals, supplied by the caller (the live `ctx.locals.id_set()` once the
+    // closure's own scope has been popped). Previously this was rebuilt into a
+    // fresh `HashSet` from an `&[(String, LocalId)]` snapshot on *every*
+    // closure — O(scope) per closure, i.e. O(n²) over n sibling closures in a
+    // large scope. We only ever need membership tests here, so the caller's
+    // incrementally-maintained set is reused directly.
     let param_ids: std::collections::HashSet<LocalId> = params.iter().map(|p| p.id).collect();
 
     // dayjs (issue: format() returned `292278994-08`): local IDs are

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -11,6 +11,7 @@
 
 use anyhow::Result;
 use perry_types::Type;
+use swc_common::Spanned;
 use swc_ecma_ast as ast;
 
 use crate::ir::Expr;
@@ -1781,7 +1782,17 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         }
     }
 
-    let mut object_expr = lower_expr(ctx, &member.obj)?;
+    // Perf: reuse a receiver already lowered by `try_static_method_and_instance`
+    // (the chained-native-method dispatch helper) for THIS exact member callee,
+    // instead of re-lowering the whole prefix. See
+    // `LoweringContext::prelowered_member_receiver`. Match strictly by span and
+    // take it (single-shot) so a stale memo can never leak onto a different
+    // receiver. Any other consumer along the way invalidates it.
+    let obj_span = member.obj.as_ref().span();
+    let mut object_expr = match ctx.prelowered_member_receiver.take() {
+        Some((key, lowered)) if key == (obj_span.lo.0, obj_span.hi.0) => lowered,
+        _ => lower_expr(ctx, &member.obj)?,
+    };
     if let ast::MemberProp::Ident(prop_ident) = &member.prop {
         if let Some(value) = ws_ready_state_value(prop_ident.sym.as_ref()) {
             if is_ws_ready_state_receiver(ctx, member.obj.as_ref(), &object_expr) {

--- a/crates/perry-hir/src/lower/fn_ctor_env.rs
+++ b/crates/perry-hir/src/lower/fn_ctor_env.rs
@@ -214,10 +214,10 @@ pub(crate) fn build_fn_ctor_env(module: &ast::Module) -> FnCtorEnv {
     let mut decls: HashMap<String, (usize, Option<ast::Expr>)> = HashMap::new();
     let mut writes: HashMap<String, usize> = HashMap::new();
 
-    let empty_shadow = Shadow::new();
+    let mut empty_shadow = Shadow::new();
     for item in &module.body {
         if let ast::ModuleItem::Stmt(stmt) = item {
-            scan_stmt(stmt, &mut decls, &mut writes, &empty_shadow);
+            scan_stmt(stmt, &mut decls, &mut writes, &mut empty_shadow);
         }
     }
 
@@ -783,7 +783,7 @@ fn collect_fn_scope_names(stmts: &[ast::Stmt], out: &mut Shadow) {
 
 /// Treat every binding identifier in a pattern as a write (catch clauses,
 /// destructuring) — it shadows or mutates the name.
-fn record_pat_bindings(pat: &ast::Pat, writes: &mut HashMap<String, usize>, shadow: &Shadow) {
+fn record_pat_bindings(pat: &ast::Pat, writes: &mut HashMap<String, usize>, shadow: &mut Shadow) {
     match pat {
         ast::Pat::Ident(b) => record_write(&b.id.sym, writes, shadow),
         ast::Pat::Array(arr) => {
@@ -820,7 +820,7 @@ fn scan_stmt(
     stmt: &ast::Stmt,
     decls: &mut HashMap<String, (usize, Option<ast::Expr>)>,
     writes: &mut HashMap<String, usize>,
-    shadow: &Shadow,
+    shadow: &mut Shadow,
 ) {
     match stmt {
         ast::Stmt::Decl(ast::Decl::Var(var)) => {
@@ -939,7 +939,11 @@ fn scan_stmt(
     }
 }
 
-fn scan_for_head_writes(head: &ast::ForHead, writes: &mut HashMap<String, usize>, shadow: &Shadow) {
+fn scan_for_head_writes(
+    head: &ast::ForHead,
+    writes: &mut HashMap<String, usize>,
+    shadow: &mut Shadow,
+) {
     match head {
         ast::ForHead::VarDecl(v) => {
             for d in &v.decls {
@@ -961,7 +965,7 @@ fn scan_for_head_writes(head: &ast::ForHead, writes: &mut HashMap<String, usize>
 fn scan_assign_target_writes(
     target: &ast::AssignTarget,
     writes: &mut HashMap<String, usize>,
-    shadow: &Shadow,
+    shadow: &mut Shadow,
 ) {
     match target {
         ast::AssignTarget::Simple(simple) => match simple {
@@ -999,27 +1003,52 @@ fn scan_assign_target_writes(
 
 /// Walk a nested function for writes to NON-shadowed (module-level) names.
 /// The function's params and its own hoisted declarations extend the shadow.
+///
+/// The shadow is threaded as a single shared `&mut Shadow` that we push the
+/// function's own names onto and pop afterwards, instead of `clone()`ing the
+/// whole enclosing shadow per nested function. The old clone made scanning a
+/// scope of N sibling nested functions O(N²) (each clone copies the ~N
+/// enclosing names) — pathological for modules/wrapper-IIFEs that declare many
+/// sibling closures (the same class of perf bug as the capture-set rebuild).
+/// To restore the shadow exactly, we only remove the names this frame newly
+/// inserted (a name already shadowed by an outer scope must stay shadowed).
 fn scan_fn_body_writes(
     params: &[&ast::Pat],
     stmts: &[ast::Stmt],
     writes: &mut HashMap<String, usize>,
-    outer_shadow: &Shadow,
+    shadow: &mut Shadow,
 ) {
-    let mut shadow = outer_shadow.clone();
+    // Gather the names this function frame introduces (params + hoisted
+    // declarations) without disturbing the shared shadow.
+    let mut frame_names = Shadow::new();
     for p in params {
-        collect_pat_names(p, &mut shadow);
+        collect_pat_names(p, &mut frame_names);
     }
-    collect_fn_scope_names(stmts, &mut shadow);
+    collect_fn_scope_names(stmts, &mut frame_names);
+
+    // Insert only the names not already shadowed, remembering them so we can
+    // pop exactly this frame's additions and leave outer shadows intact.
+    let mut added: Vec<String> = Vec::new();
+    for name in frame_names {
+        if shadow.insert(name.clone()) {
+            added.push(name);
+        }
+    }
+
     let mut nested_decls: HashMap<String, (usize, Option<ast::Expr>)> = HashMap::new();
     for s in stmts {
-        scan_stmt(s, &mut nested_decls, writes, &shadow);
+        scan_stmt(s, &mut nested_decls, writes, shadow);
+    }
+
+    for name in added {
+        shadow.remove(&name);
     }
 }
 
 fn scan_function_writes(
     function: &ast::Function,
     writes: &mut HashMap<String, usize>,
-    shadow: &Shadow,
+    shadow: &mut Shadow,
 ) {
     let params: Vec<&ast::Pat> = function.params.iter().map(|p| &p.pat).collect();
     let stmts: &[ast::Stmt] = function
@@ -1030,7 +1059,7 @@ fn scan_function_writes(
     scan_fn_body_writes(&params, stmts, writes, shadow);
 }
 
-fn scan_class_writes(class: &ast::Class, writes: &mut HashMap<String, usize>, shadow: &Shadow) {
+fn scan_class_writes(class: &ast::Class, writes: &mut HashMap<String, usize>, shadow: &mut Shadow) {
     if let Some(sup) = &class.super_class {
         scan_expr_writes(sup, writes, shadow);
     }
@@ -1069,7 +1098,7 @@ fn scan_class_writes(class: &ast::Class, writes: &mut HashMap<String, usize>, sh
     }
 }
 
-fn scan_expr_writes(expr: &ast::Expr, writes: &mut HashMap<String, usize>, shadow: &Shadow) {
+fn scan_expr_writes(expr: &ast::Expr, writes: &mut HashMap<String, usize>, shadow: &mut Shadow) {
     match expr {
         ast::Expr::Assign(a) => {
             scan_assign_target_writes(&a.left, writes, shadow);
@@ -1174,11 +1203,23 @@ fn scan_expr_writes(expr: &ast::Expr, writes: &mut HashMap<String, usize>, shado
                     scan_fn_body_writes(&params, &b.stmts, writes, shadow);
                 }
                 ast::BlockStmtOrExpr::Expr(e) => {
-                    let mut inner = shadow.clone();
+                    // Arrow expression body: push the params, scan, then pop —
+                    // mirrors `scan_fn_body_writes` so we don't clone the whole
+                    // enclosing shadow per arrow.
+                    let mut frame_names = Shadow::new();
                     for p in &params {
-                        collect_pat_names(p, &mut inner);
+                        collect_pat_names(p, &mut frame_names);
                     }
-                    scan_expr_writes(e, writes, &inner);
+                    let mut added: Vec<String> = Vec::new();
+                    for name in frame_names {
+                        if shadow.insert(name.clone()) {
+                            added.push(name);
+                        }
+                    }
+                    scan_expr_writes(e, writes, shadow);
+                    for name in added {
+                        shadow.remove(&name);
+                    }
                 }
             }
         }

--- a/crates/perry-hir/src/lower/locals.rs
+++ b/crates/perry-hir/src/lower/locals.rs
@@ -26,7 +26,7 @@
 use std::ops::{Deref, DerefMut};
 
 use perry_types::{LocalId, Type};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Ordered stack of scope-local bindings with a name→positions index.
 #[derive(Debug, Clone, Default)]
@@ -36,6 +36,17 @@ pub(crate) struct Locals {
     /// name -> ascending positions into `entries`. The last entry of each
     /// list is the innermost (most-recent) binding for that name.
     index: HashMap<String, Vec<usize>>,
+    /// Set of the `LocalId`s currently present in `entries`. Maintained in
+    /// lockstep with `entries` by every mutating method, so closure-capture
+    /// analysis can do O(1) "is this id an enclosing local?" membership tests
+    /// against the *current* scope without rebuilding a `HashSet` from the
+    /// `entries` slice on every closure. Each binding gets a fresh monotonic
+    /// `LocalId` (`fresh_local`), so ids are unique within `entries` and a
+    /// plain set (no refcount) stays in sync. See `compute_closure_captures`
+    /// and `nested_fn_decl` — both formerly rebuilt this set per closure,
+    /// making capture analysis O(scope) per closure = O(n²) over a scope of
+    /// n sibling closures.
+    id_set: HashSet<LocalId>,
 }
 
 impl Locals {
@@ -47,7 +58,15 @@ impl Locals {
     pub(crate) fn push(&mut self, entry: (String, LocalId, Type)) {
         let pos = self.entries.len();
         self.index.entry(entry.0.clone()).or_default().push(pos);
+        self.id_set.insert(entry.1);
         self.entries.push(entry);
+    }
+
+    /// The set of `LocalId`s currently in scope. O(1). Used by closure-capture
+    /// analysis as the "enclosing locals" membership view, replacing a
+    /// per-closure rebuild from the `entries` slice (#5267 follow-up).
+    pub(crate) fn id_set(&self) -> &HashSet<LocalId> {
+        &self.id_set
     }
 
     /// Position of the innermost binding named `name`, if any. O(1).
@@ -132,6 +151,9 @@ impl Locals {
                 self.index.remove(name);
             }
         }
+        for (_, id, _) in &drained {
+            self.id_set.remove(id);
+        }
         drained
     }
 
@@ -151,11 +173,13 @@ impl Locals {
         removed
     }
 
-    /// Rebuild the whole name→positions index from `entries`.
+    /// Rebuild the whole name→positions index and the id set from `entries`.
     fn reindex(&mut self) {
         self.index.clear();
-        for (pos, (name, _, _)) in self.entries.iter().enumerate() {
+        self.id_set.clear();
+        for (pos, (name, id, _)) in self.entries.iter().enumerate() {
             self.index.entry(name.clone()).or_default().push(pos);
+            self.id_set.insert(*id);
         }
     }
 }

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -490,7 +490,68 @@ pub(crate) fn native_module_binding_value(ctx: &LoweringContext, name: &str) -> 
     Expr::NativeModuleRef(module_name.to_string())
 }
 
+/// Re-lowering diagnostics, fully gated behind the `PERRY_TRACE_RELOWER` env
+/// var (zero overhead unless set). Counts every `lower_expr` invocation keyed
+/// by source span, so a span lowered far more than once flags redundant
+/// re-lowering (the classic source of super-linear HIR-lowering blowup on
+/// minified bundles). On every N-million calls — and so still on a kill — it
+/// dumps the total/distinct counts and the top re-lowered spans to stderr.
+/// Kept (env-gated) as a standing diagnostic for future lowering perf work.
+pub(crate) mod relower_trace {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+    static ENABLED: AtomicBool = AtomicBool::new(false);
+    static INIT: AtomicBool = AtomicBool::new(false);
+    static TOTAL: AtomicU64 = AtomicU64::new(0);
+
+    thread_local! {
+        static SPANS: RefCell<HashMap<(u32, u32), u32>> = RefCell::new(HashMap::new());
+    }
+
+    pub fn enabled() -> bool {
+        if !INIT.load(Ordering::Relaxed) {
+            let on = std::env::var("PERRY_TRACE_RELOWER").is_ok();
+            ENABLED.store(on, Ordering::Relaxed);
+            INIT.store(true, Ordering::Relaxed);
+        }
+        ENABLED.load(Ordering::Relaxed)
+    }
+
+    pub fn record(lo: u32, hi: u32) {
+        let n = TOTAL.fetch_add(1, Ordering::Relaxed) + 1;
+        SPANS.with(|m| {
+            *m.borrow_mut().entry((lo, hi)).or_insert(0) += 1;
+        });
+        if n % 5_000_000 == 0 {
+            dump(&format!("periodic@{n}"));
+        }
+    }
+
+    fn dump(tag: &str) {
+        SPANS.with(|m| {
+            let m = m.borrow();
+            let total = TOTAL.load(Ordering::Relaxed);
+            let distinct = m.len();
+            let mut v: Vec<_> = m.iter().map(|(k, c)| (*c, *k)).collect();
+            v.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+            eprintln!(
+                "RELOWER[{tag}] total={total} distinct={distinct} ratio={:.2}",
+                total as f64 / distinct.max(1) as f64
+            );
+            for (c, (lo, hi)) in v.into_iter().take(20) {
+                eprintln!("RELOWER  span {lo}..{hi} count={c}");
+            }
+        });
+    }
+}
+
 pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> {
+    if relower_trace::enabled() {
+        let sp = expr.span();
+        relower_trace::record(sp.lo.0, sp.hi.0);
+    }
     // #5259: guard the recursive descent. Without this, a pathologically
     // nested expression (`1+1+…`, `o.a.a.…`, `a||a||…`) overflows the native
     // stack and SIGABRTs with no diagnostic. The depth counter turns that into

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -642,4 +642,19 @@ pub struct LoweringContext {
     /// pathologically-nested expression chain (bundler/minifier output like
     /// `1+1+…+1` or `o.a.a.…a`) overflow the native stack and SIGABRT.
     pub(crate) expr_lower_depth: u32,
+    /// Perf: a single-slot memo of an already-lowered member receiver, keyed by
+    /// its source span `(lo, hi)`. Set by the chained-native-method dispatch
+    /// helper (`try_static_method_and_instance`) just before it returns
+    /// `Err(args)` after lowering `member.obj` to inspect it; consumed once by
+    /// `lower_member_inner` when the `lower_call_inner` fall-through tail
+    /// re-lowers the same member callee. Without it, a long native-fluent
+    /// method chain (`K.name(..).description(..).option(..)…` — commander/minified
+    /// CLI builders) re-lowers the entire receiver prefix at every chain level
+    /// (the helper lowers it, finds the inner result is not a `NativeMethodCall`,
+    /// discards it, and the tail lowers it again — compounding to exponential
+    /// blowup). The memo lets the tail reuse the helper's lowering, so each
+    /// receiver subtree is lowered exactly once. Lowering a receiver is
+    /// idempotent w.r.t. the value produced (the fluent-success path already
+    /// reuses the same lowered receiver), so reusing it is semantics-preserving.
+    pub(crate) prelowered_member_receiver: Option<((u32, u32), Expr)>,
 }

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -367,6 +367,32 @@ pub struct LoweringContext {
     pub(crate) imported_functions_index: HashMap<String, usize>,
     /// Shadow index: local alias name -> index in `builtin_module_aliases` Vec
     pub(crate) builtin_module_aliases_index: HashMap<String, usize>,
+    /// Perf index for `native_instances` (which is scope-stack-like: pushed on
+    /// scope entry, truncated on scope exit). Maps name -> STACK of indices into
+    /// the `native_instances` Vec, innermost (last) on top. `lookup_native_instance`
+    /// reads the top index for O(1) last-match-wins resolution (mirrors the old
+    /// reverse scan's shadowing); on `truncate(mark)` every index >= mark is
+    /// popped off each name's stack (and empty stacks removed), so an inner
+    /// binding stops shadowing the moment its scope pops. See
+    /// `register_native_instance` / `truncate_native_instances`.
+    pub(crate) native_instances_index: HashMap<String, Vec<usize>>,
+    /// Perf index for `module_native_instances` (module-level, push-only, never
+    /// truncated). Scanned in reverse (last-match-wins) by
+    /// `lookup_native_instance`'s fallback arm, so the index stores the LAST
+    /// pushed index per name (overwritten on every push). O(1) lookup.
+    pub(crate) module_native_instances_index: HashMap<String, usize>,
+    /// Perf index for `func_return_native_instances` (push-only, never
+    /// truncated). The old lookup scanned FORWARD (first-match-wins), so the
+    /// index keeps the FIRST pushed index per name (`entry().or_insert`).
+    pub(crate) func_return_native_instances_index: HashMap<String, usize>,
+    /// Perf index for `native_modules` (push-only, never truncated). The old
+    /// `lookup_native_module` scanned FORWARD (first-match-wins), so the index
+    /// keeps the FIRST pushed index per name (`entry().or_insert`).
+    pub(crate) native_modules_index: HashMap<String, usize>,
+    /// Perf index for `class_statics` (push-only, never truncated). The old
+    /// `has_static_method`/`has_static_field` scanned FORWARD (first-match-wins),
+    /// so the index keeps the FIRST pushed index per class name.
+    pub(crate) class_statics_index: HashMap<String, usize>,
     /// Local names bound to a `path` sub-namespace (`const w = path.win32`).
     /// Maps the local name -> (root identifier name, sub "win32"|"posix").
     /// Resolution of the root identifier to the `path` module is deferred to

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -486,7 +486,7 @@ pub(crate) fn lower_module_decl(
                     if let Some((module, class)) =
                         native_instance_from_return_type(&func.return_type)
                     {
-                        ctx.func_return_native_instances.push((
+                        ctx.push_func_return_native_instance((
                             func_name.clone(),
                             module.to_string(),
                             class.to_string(),
@@ -784,7 +784,7 @@ pub(crate) fn lower_module_decl(
                                                         // Without this, pool = mysql.createPool() at module top level loses
                                                         // its native tracking when function scopes are entered/exited,
                                                         // causing pool.query() inside functions to miss the Pool dispatch.
-                                                        ctx.module_native_instances.push((
+                                                        ctx.push_module_native_instance((
                                                             name.clone(),
                                                             class_module,
                                                             class_name.to_string(),
@@ -868,7 +868,7 @@ pub(crate) fn lower_module_decl(
                                                 module.clone(),
                                                 class_name.to_string(),
                                             );
-                                            ctx.module_native_instances.push((
+                                            ctx.push_module_native_instance((
                                                 name.clone(),
                                                 module,
                                                 class_name.to_string(),
@@ -969,7 +969,7 @@ pub(crate) fn lower_module_decl(
                                                 module_name.clone(),
                                                 class_name_str.to_string(),
                                             );
-                                            ctx.module_native_instances.push((
+                                            ctx.push_module_native_instance((
                                                 name.clone(),
                                                 module_name,
                                                 class_name_str.to_string(),
@@ -1011,7 +1011,7 @@ pub(crate) fn lower_module_decl(
                                                     module_name.clone(),
                                                     class_name_str.to_string(),
                                                 );
-                                                ctx.module_native_instances.push((
+                                                ctx.push_module_native_instance((
                                                     name.clone(),
                                                     module_name,
                                                     class_name_str.to_string(),
@@ -1141,7 +1141,7 @@ pub(crate) fn lower_module_decl(
                                             }
                                         };
                                         if let Some((module, class)) = module_info {
-                                            ctx.func_return_native_instances.push((
+                                            ctx.push_func_return_native_instance((
                                                 name.clone(),
                                                 module.to_string(),
                                                 class.to_string(),
@@ -1699,7 +1699,7 @@ pub(crate) fn lower_module_decl(
                             if let Some((mod_name, class)) =
                                 native_instance_from_return_type(&func.return_type)
                             {
-                                ctx.func_return_native_instances.push((
+                                ctx.push_func_return_native_instance((
                                     func_name.clone(),
                                     mod_name.to_string(),
                                     class.to_string(),
@@ -2234,7 +2234,7 @@ pub(crate) fn lower_namespace_as_class(
                         if let Some((module, class)) =
                             native_instance_from_return_type(&func.return_type)
                         {
-                            ctx.func_return_native_instances.push((
+                            ctx.push_func_return_native_instance((
                                 func.name.clone(),
                                 module.to_string(),
                                 class.to_string(),

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -327,7 +327,7 @@ pub(crate) fn lower_stmt(
                     if let Some((module, class)) =
                         native_instance_from_return_type(&func.return_type)
                     {
-                        ctx.func_return_native_instances.push((
+                        ctx.push_func_return_native_instance((
                             func.name.clone(),
                             module.to_string(),
                             class.to_string(),
@@ -929,7 +929,7 @@ pub(crate) fn lower_stmt(
                                         module_owned.clone(),
                                         cn.to_string(),
                                     );
-                                    ctx.module_native_instances.push((
+                                    ctx.push_module_native_instance((
                                         name.clone(),
                                         module_owned,
                                         cn.to_string(),
@@ -946,7 +946,7 @@ pub(crate) fn lower_stmt(
                                         module_owned.clone(),
                                         cn.to_string(),
                                     );
-                                    ctx.module_native_instances.push((
+                                    ctx.push_module_native_instance((
                                         name.clone(),
                                         module_owned,
                                         cn.to_string(),
@@ -990,7 +990,7 @@ pub(crate) fn lower_stmt(
                                     "net".to_string(),
                                     "Server".to_string(),
                                 );
-                                ctx.module_native_instances.push((
+                                ctx.push_module_native_instance((
                                     name.clone(),
                                     "net".to_string(),
                                     "Server".to_string(),

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1263,12 +1263,29 @@ pub(crate) fn lower_stmt(
         }
         ast::Stmt::Labeled(labeled_stmt) => {
             let label = labeled_stmt.label.sym.to_string();
-            // #2383: a labeled *block* — `a: { ... break a; ... }` — exits the
-            // block via `break a`. Desugar to a labeled run-once do-while so the
-            // existing loop-based labeled-break codegen has an exit block to
-            // target. See the matching comment in lower_decl/body_stmt.rs.
-            if let ast::Stmt::Block(block) = &*labeled_stmt.body {
-                let body = lower_block_stmt_scoped(ctx, block)?;
+            // #2383 + #5247: a labeled *non-loop* statement — a block
+            // (`a: { ... break a; ... }`) or an `if`/`switch`/expression — exits via
+            // `break a`. It is not a loop, so the loop-based labeled-break codegen
+            // has nothing to bind the label to. Desugar any labeled non-loop to a
+            // labeled run-once do-while so it has an exit block to target (also
+            // correct when `break a` fires from inside a nested loop in the body).
+            // Labeled LOOPS skip this and keep the label bound to the loop, so
+            // `continue a` targets the loop. See the matching code in
+            // lower_decl/body_stmt.rs.
+            let body_is_loop = matches!(
+                &*labeled_stmt.body,
+                ast::Stmt::For(_)
+                    | ast::Stmt::While(_)
+                    | ast::Stmt::DoWhile(_)
+                    | ast::Stmt::ForIn(_)
+                    | ast::Stmt::ForOf(_)
+            );
+            if !body_is_loop {
+                let body = if let ast::Stmt::Block(block) = &*labeled_stmt.body {
+                    lower_block_stmt_scoped(ctx, block)?
+                } else {
+                    lower_body_stmt(ctx, &labeled_stmt.body)?
+                };
                 module.init.push(Stmt::Labeled {
                     label,
                     body: Box::new(Stmt::DoWhile {

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -312,6 +312,105 @@ fn test_lower_rejects_deep_logical_chain() {
     assert_too_deep(format!("var a = 0;\nvar x = {};\n", chain.join("||")));
 }
 
+/// #5271: the perf index over `native_instances` must reproduce the old
+/// reverse-scan semantics exactly — innermost (last-registered) binding wins,
+/// and `truncate_native_instances` re-exposes the outer binding when the inner
+/// scope pops. Mirrors the `lookup_native_instance` last-match-wins rule.
+#[test]
+fn test_native_instance_index_shadowing_and_truncation() {
+    let mut ctx = make_ctx();
+    // Outer binding `e` -> events/EventEmitter.
+    ctx.register_native_instance(
+        "e".to_string(),
+        "events".to_string(),
+        "EventEmitter".to_string(),
+    );
+    assert_eq!(
+        ctx.lookup_native_instance("e"),
+        Some(("events", "EventEmitter"))
+    );
+
+    // Enter an inner scope: shadow `e` with a different native type.
+    let mark = ctx.native_instances.len();
+    ctx.register_native_instance("e".to_string(), "stream".to_string(), "Readable".to_string());
+    // Inner (last) binding wins.
+    assert_eq!(ctx.lookup_native_instance("e"), Some(("stream", "Readable")));
+
+    // Pop the inner scope: the outer binding must be restored.
+    ctx.truncate_native_instances(mark);
+    assert_eq!(
+        ctx.lookup_native_instance("e"),
+        Some(("events", "EventEmitter"))
+    );
+
+    // Pop the outer binding too: no entry remains.
+    ctx.truncate_native_instances(0);
+    assert!(ctx.lookup_native_instance("e").is_none());
+}
+
+/// #5271: module-level native instances (never truncated) keep last-match-wins
+/// via the overwrite index, matching the old reverse scan of the fallback arm.
+#[test]
+fn test_module_native_instance_index_last_wins() {
+    let mut ctx = make_ctx();
+    ctx.push_module_native_instance((
+        "db".to_string(),
+        "mongodb".to_string(),
+        "MongoClient".to_string(),
+    ));
+    assert_eq!(
+        ctx.lookup_native_instance("db"),
+        Some(("mongodb", "MongoClient"))
+    );
+    // A later registration of the same name shadows the earlier one.
+    ctx.push_module_native_instance((
+        "db".to_string(),
+        "mysql2/promise".to_string(),
+        "Pool".to_string(),
+    ));
+    assert_eq!(
+        ctx.lookup_native_instance("db"),
+        Some(("mysql2/promise", "Pool"))
+    );
+}
+
+/// #5271 perf gate (run with `--release --ignored`): time M lookups against a
+/// K-sized registry to show indexed lookups are ~flat in K (O(1)) rather than
+/// O(K) per call. Prints timings; not asserted (machine-dependent) but the
+/// flatness across K is the observable signal. Covers the registries whose
+/// linear scans this change indexed.
+#[test]
+#[ignore]
+fn perf_registry_lookup_is_flat_in_k() {
+    use std::time::Instant;
+    const M: usize = 20_000;
+    for k in [0usize, 2_000, 8_000, 16_000] {
+        let mut ctx = make_ctx();
+        for i in 0..k {
+            ctx.register_class_statics(
+                format!("K{i}"),
+                vec![format!("f{i}")],
+                vec![format!("s{i}")],
+            );
+            ctx.register_native_instance(format!("ni{i}"), "events".into(), "EventEmitter".into());
+            ctx.register_native_module(format!("nm{i}"), "fs".into(), None);
+        }
+        // The hot case the bug targets: the receiver is NOT in the registry, so
+        // the old reverse/forward scan walked the whole Vec and returned None.
+        let t = Instant::now();
+        let mut acc = 0u64;
+        for _ in 0..M {
+            acc += ctx.has_static_method("Missing", "s") as u64;
+            acc += ctx.lookup_native_instance("missing").is_some() as u64;
+            acc += ctx.lookup_native_module("missing").is_some() as u64;
+        }
+        eprintln!(
+            "K={k:<6} {M} x3 lookups: {:?}  (acc={acc})",
+            t.elapsed()
+        );
+    }
+}
+
 /// A chain comfortably under the ceiling still lowers cleanly — the guard
 /// must not reject ordinary (if large) expressions.
 #[test]

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1848,7 +1848,7 @@ pub fn find_native_return_in_stmts(
                         let var = ident.sym.as_ref();
                         for i in ni_start..ctx.native_instances.len() {
                             if ctx.native_instances[i].0 == var {
-                                ctx.func_return_native_instances.push((
+                                ctx.push_func_return_native_instance((
                                     func_name.to_string(),
                                     ctx.native_instances[i].1.clone(),
                                     ctx.native_instances[i].2.clone(),

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -448,17 +448,33 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
         }
         ast::Stmt::Labeled(labeled_stmt) => {
             let label = labeled_stmt.label.sym.to_string();
-            // #2383: a labeled *block* — `a: { ... break a; ... }` — exits the
-            // block via `break a` (valid JS/TS; heavily used by minified React).
-            // It is NOT a loop, so the loop-based labeled-break codegen has
-            // nothing to bind the label to. Desugar to a labeled run-once
-            // do-while: `a: do { ... } while (false)`. The do-while's exit block
-            // becomes the labeled-break target, the body runs exactly once, and
-            // the `while (false)` falls straight through to the exit. `continue
-            // a` against a block label is a JS early SyntaxError, so it never
-            // reaches here.
-            if let ast::Stmt::Block(block) = &*labeled_stmt.body {
-                let body = lower_block_stmt_scoped(ctx, block)?;
+            // #2383 + #5247: a labeled *non-loop* statement — a block
+            // (`a: { ... break a; ... }`, heavily used by minified React), or an
+            // `if` (`a: if (...) { ... break a; ... }`, emitted by minified
+            // bignumber.js / ajv), or a `switch`/expression statement — exits via
+            // `break a`. It is NOT a loop, so the loop-based labeled-break codegen
+            // has nothing to bind the label to. Desugar any labeled non-loop to a
+            // labeled run-once do-while: `a: do { ... } while (false)`. The
+            // do-while's exit block becomes the labeled-break target, the body runs
+            // exactly once, and `while (false)` falls straight through, including
+            // when the `break a` fires from inside a *nested* loop in the body.
+            // `continue a` against a non-loop label is a JS early SyntaxError, so it
+            // never reaches here. Labeled LOOPS skip this and keep the label bound
+            // to the loop itself, so `continue a` targets the loop.
+            let body_is_loop = matches!(
+                &*labeled_stmt.body,
+                ast::Stmt::For(_)
+                    | ast::Stmt::While(_)
+                    | ast::Stmt::DoWhile(_)
+                    | ast::Stmt::ForIn(_)
+                    | ast::Stmt::ForOf(_)
+            );
+            if !body_is_loop {
+                let body = if let ast::Stmt::Block(block) = &*labeled_stmt.body {
+                    lower_block_stmt_scoped(ctx, block)?
+                } else {
+                    lower_body_stmt(ctx, &labeled_stmt.body)?
+                };
                 result.push(Stmt::Labeled {
                     label,
                     body: Box::new(Stmt::DoWhile {

--- a/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
@@ -38,13 +38,6 @@ pub(super) fn lower_nested_fn_decl(
 
     let scope_mark = ctx.enter_scope();
 
-    // Track outer locals for capture detection
-    let outer_locals: Vec<(String, LocalId)> = ctx
-        .locals
-        .iter()
-        .map(|(name, id, _)| (name.clone(), *id))
-        .collect();
-
     // Lower parameters. Skip the TypeScript `this:` annotation —
     // it has no runtime existence (see the sibling site above for
     // the full rationale).
@@ -170,8 +163,13 @@ pub(super) fn lower_nested_fn_decl(
         collect_local_refs_stmt(stmt, &mut all_refs, &mut visited_closures);
     }
 
-    let outer_local_ids: std::collections::HashSet<LocalId> =
-        outer_locals.iter().map(|(_, id)| *id).collect();
+    // The function's own scope has been popped (`exit_scope` above), so the
+    // live `ctx.locals.id_set()` is exactly the enclosing scope's locals — the
+    // membership view capture detection needs. Previously this was rebuilt into
+    // a fresh `HashSet` from a per-closure cloned snapshot of `ctx.locals`,
+    // which made capture analysis O(scope) per nested function = O(n²) over a
+    // scope of n sibling functions (the perf bug behind this change).
+    let outer_local_ids = ctx.locals.id_set();
     let param_ids: std::collections::HashSet<LocalId> = params.iter().map(|p| p.id).collect();
 
     // dayjs (issue: format() returned `292278994-08`): local

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -227,7 +227,7 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
             let module_alias = &type_name[..dot_pos];
             let class_name = &type_name[dot_pos + 1..];
             if let Some((module_name, _)) = ctx.lookup_native_module(module_alias) {
-                ctx.func_return_native_instances.push((
+                ctx.push_func_return_native_instance((
                     name.clone(),
                     module_name.to_string(),
                     class_name.to_string(),
@@ -245,7 +245,7 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
                 _ => None,
             };
             if let Some((module, class)) = module_info {
-                ctx.func_return_native_instances.push((
+                ctx.push_func_return_native_instance((
                     name.clone(),
                     module.to_string(),
                     class.to_string(),

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -963,7 +963,8 @@ pub extern "C" fn js_typed_feedback_object_set_field_by_name_fast(
 #[path = "typed_feedback/guards.rs"]
 mod guards;
 pub use guards::{
-    js_typed_feedback_class_field_get_guard, js_typed_feedback_class_field_set_guard,
+    js_class_field_set_ic, js_typed_feedback_class_field_get_guard,
+    js_typed_feedback_class_field_set_guard,
     js_typed_feedback_closure_direct_call_guard, js_typed_feedback_method_direct_call_guard,
     js_typed_feedback_native_call_method, js_typed_feedback_native_call_method_apply,
 };

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -963,7 +963,7 @@ pub extern "C" fn js_typed_feedback_object_set_field_by_name_fast(
 #[path = "typed_feedback/guards.rs"]
 mod guards;
 pub use guards::{
-    js_class_field_set_ic, js_typed_feedback_class_field_get_guard,
+    js_class_field_set_slow, js_typed_feedback_class_field_get_guard,
     js_typed_feedback_class_field_set_guard,
     js_typed_feedback_closure_direct_call_guard, js_typed_feedback_method_direct_call_guard,
     js_typed_feedback_native_call_method, js_typed_feedback_native_call_method_apply,

--- a/crates/perry-runtime/src/typed_feedback/guards.rs
+++ b/crates/perry-runtime/src/typed_feedback/guards.rs
@@ -599,16 +599,27 @@ pub extern "C" fn js_typed_feedback_class_field_set_guard(
     }
 }
 
-/// Outlined class-field-SET inline-cache (#5247, `PERRY_OUTLINE_FIELDSET`).
+/// Class-field-SET inline-cache COLD/SLOW path (#5247, `PERRY_INLINE_FIELDSET`).
 ///
-/// Replaces the ~18-line codegen diamond (guard call + inline fast slot store +
-/// by-name fallback + merge) at every `obj.field = v` site on a typed class
-/// field with a single `call @js_class_field_set_ic(...)`. The body reproduces
-/// the inline diamond's behavior EXACTLY:
+/// This is the single helper the inline-cache miss block calls. The hot fast
+/// path stays INLINE in codegen: a cheap shape compare (`emit_class_field_inline_precheck`)
+/// + the bare slot store. Only the cold miss/fallback path collapses to one
+/// `call @js_class_field_set_slow(...)`. The inline compare is conservative —
+/// it takes the inline fast store ONLY when the receiver is definitely a plain
+/// writable own-field store (matching class id + keys, intact typed layout, not
+/// frozen, plain-number for raw-f64, and the process-global inline-enable flag
+/// unset). Everything else — first-time shapes, typed-feedback enabled,
+/// descriptors in use, polymorphic / non-pointer receivers, frozen / accessor /
+/// non-writable / setter-in-chain — falls here.
+///
+/// The body reproduces TODAY'S full semantics for every case the inline compare
+/// doesn't cover:
 ///
 ///   1. Run the same `js_typed_feedback_class_field_set_guard` (so the typed-
-///      feedback observation/recording is identical to the inline path).
-///   2. On a guard PASS, do the SAME fast slot store the inline fast path does:
+///      feedback observation/recording is identical to the old inline path).
+///   2. On a guard PASS (e.g. typed-feedback now says fast-ok, or a first-time
+///      shape that matches the contract), do the SAME slot store the inline
+///      fast path would have done:
 ///        * `require_raw_f64` slot → a bare `f64` store into the field slot
 ///          (the inline path emits a plain `store double` with no GC barrier —
 ///          the slot is pointer-free by typed-shape descriptor and the guard
@@ -616,7 +627,7 @@ pub extern "C" fn js_typed_feedback_class_field_set_guard(
 ///        * boxed slot → `js_object_set_field`, which performs the identical
 ///          slot write + `js_gc_note_slot_layout` + `js_write_barrier_slot` the
 ///          inline `emit_jsvalue_slot_store_on_block` emits.
-///   3. On a guard FAIL, record the fallback (matching the inline fallback
+///   3. On a guard FAIL, record the fallback (matching the old inline fallback
 ///      block's `js_typed_feedback_record_fallback_call`) and route through the
 ///      by-name setter `js_object_set_field_by_name`, which handles
 ///      frozen / accessor / non-writable / setter-in-chain semantics.
@@ -625,7 +636,7 @@ pub extern "C" fn js_typed_feedback_class_field_set_guard(
 /// guard returns 0 for them, sending the write to the by-name fallback), so no
 /// special-casing is needed here.
 #[no_mangle]
-pub extern "C" fn js_class_field_set_ic(
+pub extern "C" fn js_class_field_set_slow(
     site_id: u64,
     receiver: f64,
     expected_class_id: u32,
@@ -924,7 +935,7 @@ mod keep_guard_symbols {
     use super::*;
     #[used] static G0: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, i32) -> i32 = js_typed_feedback_class_field_get_guard;
     #[used] static G1: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, f64, i32) -> i32 = js_typed_feedback_class_field_set_guard;
-    #[used] static G1B: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, f64, i32) = js_class_field_set_ic;
+    #[used] static G1B: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, f64, i32) = js_class_field_set_slow;
     #[used] static G2: unsafe extern "C" fn(u64, f64, u32, *const ArrayHeader, *const i8, usize, *const u8) -> i32 = js_typed_feedback_method_direct_call_guard;
     #[used] static G3: extern "C" fn(u64, f64, *const u8, u32, u32) -> i32 = js_typed_feedback_closure_direct_call_guard;
 }

--- a/crates/perry-runtime/src/typed_feedback/guards.rs
+++ b/crates/perry-runtime/src/typed_feedback/guards.rs
@@ -599,6 +599,95 @@ pub extern "C" fn js_typed_feedback_class_field_set_guard(
     }
 }
 
+/// Outlined class-field-SET inline-cache (#5247, `PERRY_OUTLINE_FIELDSET`).
+///
+/// Replaces the ~18-line codegen diamond (guard call + inline fast slot store +
+/// by-name fallback + merge) at every `obj.field = v` site on a typed class
+/// field with a single `call @js_class_field_set_ic(...)`. The body reproduces
+/// the inline diamond's behavior EXACTLY:
+///
+///   1. Run the same `js_typed_feedback_class_field_set_guard` (so the typed-
+///      feedback observation/recording is identical to the inline path).
+///   2. On a guard PASS, do the SAME fast slot store the inline fast path does:
+///        * `require_raw_f64` slot → a bare `f64` store into the field slot
+///          (the inline path emits a plain `store double` with no GC barrier —
+///          the slot is pointer-free by typed-shape descriptor and the guard
+///          already proved `is_plain_number_bits(value)`).
+///        * boxed slot → `js_object_set_field`, which performs the identical
+///          slot write + `js_gc_note_slot_layout` + `js_write_barrier_slot` the
+///          inline `emit_jsvalue_slot_store_on_block` emits.
+///   3. On a guard FAIL, record the fallback (matching the inline fallback
+///      block's `js_typed_feedback_record_fallback_call`) and route through the
+///      by-name setter `js_object_set_field_by_name`, which handles
+///      frozen / accessor / non-writable / setter-in-chain semantics.
+///
+/// Frozen/accessor/writable/setter handling all live behind the guard (the
+/// guard returns 0 for them, sending the write to the by-name fallback), so no
+/// special-casing is needed here.
+#[no_mangle]
+pub extern "C" fn js_class_field_set_ic(
+    site_id: u64,
+    receiver: f64,
+    expected_class_id: u32,
+    expected_keys: *const ArrayHeader,
+    key: *const crate::StringHeader,
+    expected_field_index: u32,
+    value: f64,
+    require_raw_f64: i32,
+) {
+    let guard_ok = js_typed_feedback_class_field_set_guard(
+        site_id,
+        receiver,
+        expected_class_id,
+        expected_keys,
+        key,
+        expected_field_index,
+        value,
+        require_raw_f64,
+    );
+
+    if guard_ok != 0 {
+        // FAST PATH — identical to the codegen-inlined `class_field_set.fast`
+        // block. The guard has already validated the receiver class/shape,
+        // the field index bound, frozen/accessor/writable/setter state, and
+        // (for raw-f64) the typed-shape descriptor + plain-number value.
+        let object_addr = normalize_raw_object_addr(receiver.to_bits());
+        if require_raw_f64 != 0 {
+            // Pointer-free raw-f64 slot: bare store, no GC barrier — exactly
+            // what the inline `blk.store(DOUBLE, val, field_ptr)` emits.
+            unsafe {
+                let fields_ptr =
+                    (object_addr as *mut u8).add(std::mem::size_of::<ObjectHeader>()) as *mut f64;
+                let slot = fields_ptr.add(expected_field_index as usize);
+                std::ptr::write(slot, value);
+            }
+        } else {
+            // Boxed slot: same slot write + layout note + write barrier the
+            // inline path emits via `emit_jsvalue_slot_store_on_block`.
+            crate::object::js_object_set_field(
+                object_addr as *mut ObjectHeader,
+                expected_field_index,
+                crate::value::JSValue::from_bits(value.to_bits()),
+            );
+        }
+        return;
+    }
+
+    // FALLBACK — identical to the codegen-inlined `class_field_set.fallback`
+    // block: record the fallback, then route the write by name.
+    crate::typed_feedback::js_typed_feedback_record_fallback_call(site_id);
+    // The inline fallback passes the receiver's FULL bits (NaN-box tag intact —
+    // `js_object_set_field_by_name` inspects the tag for proxy/exotic dispatch
+    // before masking to the heap address) and the POINTER_MASK-stripped key.
+    let obj_bits = receiver.to_bits();
+    let key_raw = key as u64 & crate::value::POINTER_MASK;
+    crate::object::js_object_set_field_by_name(
+        obj_bits as *mut ObjectHeader,
+        key_raw as *const crate::StringHeader,
+        value,
+    );
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_typed_feedback_native_call_method(
     site_id: u64,
@@ -835,6 +924,7 @@ mod keep_guard_symbols {
     use super::*;
     #[used] static G0: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, i32) -> i32 = js_typed_feedback_class_field_get_guard;
     #[used] static G1: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, f64, i32) -> i32 = js_typed_feedback_class_field_set_guard;
+    #[used] static G1B: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, f64, i32) = js_class_field_set_ic;
     #[used] static G2: unsafe extern "C" fn(u64, f64, u32, *const ArrayHeader, *const i8, usize, *const u8) -> i32 = js_typed_feedback_method_direct_call_guard;
     #[used] static G3: extern "C" fn(u64, f64, *const u8, u32, u32) -> i32 = js_typed_feedback_closure_direct_call_guard;
 }

--- a/crates/perry-runtime/src/typed_feedback/guards.rs
+++ b/crates/perry-runtime/src/typed_feedback/guards.rs
@@ -699,6 +699,42 @@ pub extern "C" fn js_class_field_set_slow(
     );
 }
 
+/// Class-field-SET guard-MISS fallback, outlined (#5334, lever A).
+///
+/// This is the cold arm of the DEFAULT (guard-CALL) class-field-set diamond.
+/// Unlike [`js_class_field_set_slow`] — which the opt-in inline-precheck path
+/// uses and which RE-RUNS the guard — this helper is called only after the
+/// inline `js_typed_feedback_class_field_set_guard` has ALREADY run and FAILED
+/// in the entry block (that failure is what branched control here). So there is
+/// nothing left to decide: just reproduce the two operations the inline
+/// `class_field_set` fallback block used to emit, collapsed into ONE call so the
+/// cold arm costs a single instruction per site instead of two.
+///
+/// Byte-identical semantics to the old inline fallback:
+///   1. `js_typed_feedback_record_fallback_call(site_id)` — record the miss.
+///   2. `js_object_set_field_by_name(obj_bits, key_raw, value)` — route the
+///      write by name (handles frozen / accessor / non-writable / setter-in-
+///      chain). `obj_bits` keeps the full NaN-box tag (the by-name setter
+///      inspects it for proxy/exotic dispatch before masking to the heap
+///      address); `key_raw` is the POINTER_MASK-stripped key handle.
+///
+/// Cold-path only, so the extra call frame has zero hot-loop cost; the win is
+/// purely in emitted IR size (2 calls + operand list → 1 call per set site).
+#[no_mangle]
+pub extern "C" fn js_class_field_set_fallback(
+    site_id: u64,
+    obj_bits: u64,
+    key_raw: u64,
+    value: f64,
+) {
+    crate::typed_feedback::js_typed_feedback_record_fallback_call(site_id);
+    crate::object::js_object_set_field_by_name(
+        obj_bits as *mut ObjectHeader,
+        key_raw as *const crate::StringHeader,
+        value,
+    );
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_typed_feedback_native_call_method(
     site_id: u64,
@@ -936,6 +972,7 @@ mod keep_guard_symbols {
     #[used] static G0: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, i32) -> i32 = js_typed_feedback_class_field_get_guard;
     #[used] static G1: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, f64, i32) -> i32 = js_typed_feedback_class_field_set_guard;
     #[used] static G1B: extern "C" fn(u64, f64, u32, *const ArrayHeader, *const crate::StringHeader, u32, f64, i32) = js_class_field_set_slow;
+    #[used] static G1C: extern "C" fn(u64, u64, u64, f64) = js_class_field_set_fallback;
     #[used] static G2: unsafe extern "C" fn(u64, f64, u32, *const ArrayHeader, *const i8, usize, *const u8) -> i32 = js_typed_feedback_method_direct_call_guard;
     #[used] static G3: extern "C" fn(u64, f64, *const u8, u32, u32) -> i32 = js_typed_feedback_closure_direct_call_guard;
 }

--- a/crates/perry-transform/src/generator/break_continue.rs
+++ b/crates/perry-transform/src/generator/break_continue.rs
@@ -116,6 +116,31 @@ pub fn fix_break_continue_sentinels_in_stmts(
     }
 }
 
+/// Fix BREAK/CONTINUE sentinels inside the bodies of `CatchRoute`s captured
+/// while linearizing a loop body. The async-generator `.throw()` closure
+/// inlines `route.body` verbatim (no dispatch loop), so a user `continue`/
+/// `break` inside such a catch was rewritten to
+/// `[LocalSet(state, SENTINEL), Stmt::Continue]` but its sentinel never got
+/// fixed (`fix_break_continue_sentinels` only walks the linearized `states`,
+/// not the extracted catch routes). Apply the same loop targets to those
+/// catch-route bodies so the resume state is correct (the dangling dispatch
+/// `Stmt::Continue` is then neutralized by the async catch-route inliner).
+pub fn fix_break_continue_sentinels_in_catches(
+    catches: &mut [CatchRoute],
+    state_id: LocalId,
+    break_target: u32,
+    continue_target: u32,
+) {
+    for route in catches.iter_mut() {
+        fix_break_continue_sentinels_in_stmts(
+            &mut route.body,
+            state_id,
+            break_target,
+            continue_target,
+        );
+    }
+}
+
 pub fn fix_break_continue_sentinels_in_stmt(
     stmt: &mut Stmt,
     state_id: LocalId,

--- a/crates/perry-transform/src/generator/break_continue.rs
+++ b/crates/perry-transform/src/generator/break_continue.rs
@@ -13,6 +13,40 @@ const BREAK_SENTINEL: f64 = 1_000_001.0;
 /// (for-loops) or `cond_state` (while-loops) post-linearization.
 const CONTINUE_SENTINEL: f64 = 1_000_002.0;
 
+/// Base for per-label `break <label>` sentinels. A labeled break/continue that
+/// targets an OUTER loop from inside a NESTED loop/switch can't use the plain
+/// `BREAK_SENTINEL`/`CONTINUE_SENTINEL`, because the nested loop's own
+/// linearization (`fix_break_continue_sentinels`) would claim those and route
+/// them to the WRONG (inner) loop's targets. Instead each label is assigned a
+/// distinct index `i`; the labeled break uses `LABEL_BREAK_SENTINEL_BASE + i`
+/// and the labeled continue `LABEL_CONTINUE_SENTINEL_BASE + i`. Only the
+/// linearization of the loop that actually carries label `i` fixes these up
+/// (`fix_label_sentinels_*`), so inner loops leave them untouched. Bases sit
+/// far above any real state count (thousands) and above the plain sentinels.
+const LABEL_BREAK_SENTINEL_BASE: f64 = 2_000_000.0;
+const LABEL_CONTINUE_SENTINEL_BASE: f64 = 3_000_000.0;
+
+/// Sentinel number for `break <label>` / `continue <label>` given the label's
+/// assigned index.
+pub fn label_break_sentinel(index: u32) -> f64 {
+    LABEL_BREAK_SENTINEL_BASE + index as f64
+}
+pub fn label_continue_sentinel(index: u32) -> f64 {
+    LABEL_CONTINUE_SENTINEL_BASE + index as f64
+}
+
+/// True if `n` is any of the synthesized dispatch sentinels (plain break/
+/// continue or any per-label break/continue). Used to recognize a
+/// `[LocalSet(state, <sentinel>), Stmt::Continue]` pair as a synthesized
+/// dispatch re-entry rather than a user `continue`, so a later
+/// `rewrite_break_continue_in_stmts` pass (run by an enclosing loop) leaves the
+/// trailing dispatch `Stmt::Continue` alone instead of re-wrapping it.
+fn is_dispatch_sentinel(n: f64) -> bool {
+    n == BREAK_SENTINEL
+        || n == CONTINUE_SENTINEL
+        || n >= LABEL_BREAK_SENTINEL_BASE
+}
+
 /// Walk a body and rewrite every top-level `Stmt::Break` / `Stmt::Continue`
 /// into `[LocalSet(state_id, <sentinel>), Stmt::Continue]`. The trailing
 /// `Stmt::Continue` is the state-machine's dispatch-loop continue, which
@@ -22,6 +56,24 @@ const CONTINUE_SENTINEL: f64 = 1_000_002.0;
 pub fn rewrite_break_continue_in_stmts(stmts: &mut Vec<Stmt>, state_id: LocalId) {
     let mut i = 0;
     while i < stmts.len() {
+        // A previously-synthesized dispatch re-entry —
+        // `[LocalSet(state, <sentinel>), Stmt::Continue]` emitted for an OUTER
+        // loop's (possibly labeled) break/continue — must be left intact. The
+        // trailing `Stmt::Continue` is the state-machine dispatch continue, NOT
+        // a user `continue`; re-wrapping it here would corrupt the outer loop's
+        // control flow. Skip both statements of the pair.
+        if let Stmt::Expr(Expr::LocalSet(id, val)) = &stmts[i] {
+            if *id == state_id {
+                if let Expr::Number(n) = val.as_ref() {
+                    if is_dispatch_sentinel(*n)
+                        && matches!(stmts.get(i + 1), Some(Stmt::Continue))
+                    {
+                        i += 2;
+                        continue;
+                    }
+                }
+            }
+        }
         let stmt = std::mem::replace(&mut stmts[i], Stmt::Continue);
         match stmt {
             Stmt::Break => {
@@ -82,6 +134,270 @@ pub fn rewrite_break_continue_in_stmt(stmt: &mut Stmt, state_id: LocalId) {
         Stmt::For { .. } | Stmt::While { .. } | Stmt::DoWhile { .. } => {}
         Stmt::Switch { .. } => {}
         Stmt::Labeled { .. } => {}
+        _ => {}
+    }
+}
+
+/// Rewrite every `break <label>` / `continue <label>` that targets `label`
+/// (with `label_index`) into a per-label dispatch sentinel
+/// `[LocalSet(state, label_break/continue_sentinel(index)), Stmt::Continue]`.
+///
+/// Unlike `rewrite_break_continue_in_stmts` (which handles the loop's OWN
+/// plain break/continue and stops at nested loops/switch), this DESCENDS into
+/// nested loops and switches — a `break outer` inside an inner loop still
+/// targets the outer labeled loop. The per-label sentinel survives the inner
+/// loop's own `fix_break_continue_sentinels` (different number) and is fixed up
+/// only by the labeled loop's `fix_label_sentinels_*` once its target states
+/// are known. Stops at:
+///   - a nested `Stmt::Labeled` re-using the SAME name (shadows this label);
+///   - closure expressions (a different function's break/continue).
+/// A label-shadowing inner loop with the same name is not rewritten by THIS
+/// call; the inner labeled arm handles its own.
+pub fn rewrite_labeled_break_continue_in_vec(
+    stmts: &mut Vec<Stmt>,
+    label: &str,
+    label_index: u32,
+    state_id: LocalId,
+) {
+    let mut i = 0;
+    while i < stmts.len() {
+        match &stmts[i] {
+            Stmt::LabeledBreak(l) if l == label => {
+                stmts[i] = Stmt::Expr(Expr::LocalSet(
+                    state_id,
+                    Box::new(Expr::Number(label_break_sentinel(label_index))),
+                ));
+                stmts.insert(i + 1, Stmt::Continue);
+                i += 2;
+            }
+            Stmt::LabeledContinue(l) if l == label => {
+                stmts[i] = Stmt::Expr(Expr::LocalSet(
+                    state_id,
+                    Box::new(Expr::Number(label_continue_sentinel(label_index))),
+                ));
+                stmts.insert(i + 1, Stmt::Continue);
+                i += 2;
+            }
+            _ => {
+                rewrite_labeled_break_continue_in_stmt(
+                    &mut stmts[i],
+                    label,
+                    label_index,
+                    state_id,
+                );
+                i += 1;
+            }
+        }
+    }
+}
+
+fn rewrite_labeled_break_continue_in_stmt(
+    stmt: &mut Stmt,
+    label: &str,
+    label_index: u32,
+    state_id: LocalId,
+) {
+    match stmt {
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            rewrite_labeled_break_continue_in_vec(then_branch, label, label_index, state_id);
+            if let Some(eb) = else_branch.as_mut() {
+                rewrite_labeled_break_continue_in_vec(eb, label, label_index, state_id);
+            }
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            rewrite_labeled_break_continue_in_vec(body, label, label_index, state_id);
+            if let Some(c) = catch.as_mut() {
+                rewrite_labeled_break_continue_in_vec(&mut c.body, label, label_index, state_id);
+            }
+            if let Some(f) = finally.as_mut() {
+                rewrite_labeled_break_continue_in_vec(f, label, label_index, state_id);
+            }
+        }
+        // Descend into nested loops / switch — a `break <label>` inside one of
+        // them still targets the OUTER labeled loop.
+        Stmt::For { body, .. } | Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+            rewrite_labeled_break_continue_in_vec(body, label, label_index, state_id);
+        }
+        Stmt::Switch { cases, .. } => {
+            for case in cases.iter_mut() {
+                rewrite_labeled_break_continue_in_vec(&mut case.body, label, label_index, state_id);
+            }
+        }
+        // A nested `Stmt::Labeled` with a DIFFERENT name still encloses a
+        // `break <label>` that targets us — descend. A SAME-name label shadows
+        // us; leave it for the inner labeled arm.
+        Stmt::Labeled { label: inner, body } => {
+            if inner != label {
+                rewrite_labeled_break_continue_in_stmt(body.as_mut(), label, label_index, state_id);
+            }
+        }
+        // Closures are a different function — their break/continue belong to
+        // their own loops.
+        _ => {}
+    }
+}
+
+/// Fix a single label's break/continue sentinels in a slice of states. Called
+/// by the labeled loop's For/While linearization once its `after_loop` /
+/// `update`/`cond` target states are known. Mirrors
+/// `fix_break_continue_sentinels` but keyed on the label's sentinel numbers.
+pub fn fix_label_sentinels(
+    states: &mut [State],
+    state_id: LocalId,
+    label_index: u32,
+    break_target: u32,
+    continue_target: u32,
+) {
+    for state in states.iter_mut() {
+        fix_label_sentinels_in_stmts(
+            &mut state.body,
+            state_id,
+            label_index,
+            break_target,
+            continue_target,
+        );
+    }
+}
+
+pub fn fix_label_sentinels_in_catches(
+    catches: &mut [CatchRoute],
+    state_id: LocalId,
+    label_index: u32,
+    break_target: u32,
+    continue_target: u32,
+) {
+    for route in catches.iter_mut() {
+        fix_label_sentinels_in_stmts(
+            &mut route.body,
+            state_id,
+            label_index,
+            break_target,
+            continue_target,
+        );
+    }
+}
+
+pub fn fix_label_sentinels_in_stmts(
+    stmts: &mut [Stmt],
+    state_id: LocalId,
+    label_index: u32,
+    break_target: u32,
+    continue_target: u32,
+) {
+    for stmt in stmts.iter_mut() {
+        fix_label_sentinels_in_stmt(stmt, state_id, label_index, break_target, continue_target);
+    }
+}
+
+pub fn fix_label_sentinels_in_stmt(
+    stmt: &mut Stmt,
+    state_id: LocalId,
+    label_index: u32,
+    break_target: u32,
+    continue_target: u32,
+) {
+    let brk = label_break_sentinel(label_index);
+    let cont = label_continue_sentinel(label_index);
+    match stmt {
+        Stmt::Expr(Expr::LocalSet(id, val)) if *id == state_id => {
+            if let Expr::Number(n) = val.as_ref() {
+                if *n == brk {
+                    **val = Expr::Number(break_target as f64);
+                } else if *n == cont {
+                    **val = Expr::Number(continue_target as f64);
+                }
+            }
+        }
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            fix_label_sentinels_in_stmts(
+                then_branch,
+                state_id,
+                label_index,
+                break_target,
+                continue_target,
+            );
+            if let Some(eb) = else_branch.as_mut() {
+                fix_label_sentinels_in_stmts(
+                    eb,
+                    state_id,
+                    label_index,
+                    break_target,
+                    continue_target,
+                );
+            }
+        }
+        Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. } => {
+            fix_label_sentinels_in_stmts(
+                body,
+                state_id,
+                label_index,
+                break_target,
+                continue_target,
+            );
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            fix_label_sentinels_in_stmts(
+                body,
+                state_id,
+                label_index,
+                break_target,
+                continue_target,
+            );
+            if let Some(c) = catch.as_mut() {
+                fix_label_sentinels_in_stmts(
+                    &mut c.body,
+                    state_id,
+                    label_index,
+                    break_target,
+                    continue_target,
+                );
+            }
+            if let Some(f) = finally.as_mut() {
+                fix_label_sentinels_in_stmts(
+                    f,
+                    state_id,
+                    label_index,
+                    break_target,
+                    continue_target,
+                );
+            }
+        }
+        Stmt::Switch { cases, .. } => {
+            for case in cases.iter_mut() {
+                fix_label_sentinels_in_stmts(
+                    &mut case.body,
+                    state_id,
+                    label_index,
+                    break_target,
+                    continue_target,
+                );
+            }
+        }
+        Stmt::Labeled { body, .. } => {
+            fix_label_sentinels_in_stmt(
+                body.as_mut(),
+                state_id,
+                label_index,
+                break_target,
+                continue_target,
+            );
+        }
         _ => {}
     }
 }
@@ -392,5 +708,137 @@ pub fn collect_vars_recursive(stmts: &[Stmt], vars: &mut Vec<(LocalId, String, T
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Extract the `Number` payload of a `Stmt::Expr(LocalSet(state_id, Number))`.
+    fn localset_num(stmt: &Stmt, state_id: LocalId) -> Option<f64> {
+        if let Stmt::Expr(Expr::LocalSet(id, val)) = stmt {
+            if *id == state_id {
+                if let Expr::Number(n) = val.as_ref() {
+                    return Some(*n);
+                }
+            }
+        }
+        None
+    }
+
+    /// A `break <label>` / `continue <label>` nested inside an inner loop (and
+    /// an `if`) must be rewritten into a per-label dispatch sentinel pair
+    /// `[LocalSet(state, label_sentinel), Continue]`, then resolved by
+    /// `fix_label_sentinels_in_stmts` to the labeled loop's real target states.
+    #[test]
+    fn labeled_break_continue_from_nested_loop_gets_label_sentinel_then_fixed() {
+        let state_id: LocalId = 7;
+        let label_index: u32 = 3;
+        // q: { ... inner while { if(..) break q; if(..) continue q; } }
+        let mut body = vec![Stmt::While {
+            condition: Expr::Bool(true),
+            body: vec![
+                Stmt::If {
+                    condition: Expr::Bool(true),
+                    then_branch: vec![Stmt::LabeledBreak("q".to_string())],
+                    else_branch: None,
+                },
+                Stmt::If {
+                    condition: Expr::Bool(true),
+                    then_branch: vec![Stmt::LabeledContinue("q".to_string())],
+                    else_branch: None,
+                },
+            ],
+        }];
+
+        rewrite_labeled_break_continue_in_vec(&mut body, "q", label_index, state_id);
+
+        // Descend to the inner while body.
+        let Stmt::While { body: inner, .. } = &body[0] else {
+            panic!("expected while");
+        };
+        // First if → break q → label break sentinel + dispatch continue.
+        let Stmt::If { then_branch, .. } = &inner[0] else {
+            panic!("expected if");
+        };
+        assert_eq!(then_branch.len(), 2, "break expands to sentinel + continue");
+        assert_eq!(
+            localset_num(&then_branch[0], state_id),
+            Some(label_break_sentinel(label_index)),
+        );
+        assert!(matches!(then_branch[1], Stmt::Continue));
+        // Second if → continue q → label continue sentinel + dispatch continue.
+        let Stmt::If { then_branch, .. } = &inner[1] else {
+            panic!("expected if");
+        };
+        assert_eq!(
+            localset_num(&then_branch[0], state_id),
+            Some(label_continue_sentinel(label_index)),
+        );
+
+        // Now resolve the sentinels to real target states.
+        let after_loop = 42u32;
+        let cond_state = 17u32;
+        fix_label_sentinels_in_stmts(&mut body, state_id, label_index, after_loop, cond_state);
+
+        let Stmt::While { body: inner, .. } = &body[0] else {
+            panic!("expected while");
+        };
+        let Stmt::If { then_branch, .. } = &inner[0] else {
+            panic!("expected if");
+        };
+        assert_eq!(
+            localset_num(&then_branch[0], state_id),
+            Some(after_loop as f64),
+            "break <label> resolves to after-loop state",
+        );
+        let Stmt::If { then_branch, .. } = &inner[1] else {
+            panic!("expected if");
+        };
+        assert_eq!(
+            localset_num(&then_branch[0], state_id),
+            Some(cond_state as f64),
+            "continue <label> resolves to the loop's continue target",
+        );
+    }
+
+    /// A previously-synthesized dispatch re-entry `[LocalSet(state, sentinel),
+    /// Continue]` (e.g. for an OUTER labeled loop) must be left intact when an
+    /// inner loop runs `rewrite_break_continue_in_stmts` over the same body —
+    /// the trailing dispatch `Continue` must NOT be re-wrapped as a user
+    /// `continue`.
+    #[test]
+    fn rewrite_break_continue_skips_synthesized_dispatch_reentry() {
+        let state_id: LocalId = 5;
+        let mut stmts = vec![
+            Stmt::Expr(Expr::LocalSet(
+                state_id,
+                Box::new(Expr::Number(label_break_sentinel(2))),
+            )),
+            Stmt::Continue,
+        ];
+        rewrite_break_continue_in_stmts(&mut stmts, state_id);
+        // Must be unchanged: still exactly the 2-statement pair, NOT expanded.
+        assert_eq!(stmts.len(), 2, "dispatch re-entry must not be re-wrapped");
+        assert_eq!(
+            localset_num(&stmts[0], state_id),
+            Some(label_break_sentinel(2)),
+        );
+        assert!(matches!(stmts[1], Stmt::Continue));
+    }
+
+    /// The plain-sentinel dispatch re-entry is likewise preserved.
+    #[test]
+    fn rewrite_break_continue_skips_plain_sentinel_reentry() {
+        let state_id: LocalId = 9;
+        let mut stmts = vec![
+            Stmt::Expr(Expr::LocalSet(state_id, Box::new(Expr::Number(BREAK_SENTINEL)))),
+            Stmt::Continue,
+        ];
+        rewrite_break_continue_in_stmts(&mut stmts, state_id);
+        assert_eq!(stmts.len(), 2);
+        assert_eq!(localset_num(&stmts[0], state_id), Some(BREAK_SENTINEL));
+        assert!(matches!(stmts[1], Stmt::Continue));
     }
 }

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -513,6 +513,7 @@ pub fn linearize_body(
                 // skipping the body tail without going through the update.
                 let body_states_before = states.len();
                 let body_current_before = current.len();
+                let body_catches_before = catches.len();
                 let mut body_rewritten = body.clone();
                 rewrite_break_continue_in_stmts(&mut body_rewritten, state_id);
 
@@ -590,6 +591,15 @@ pub fn linearize_body(
                     after_loop_state,
                     update_state,
                 );
+                // Async-generator `.throw()` closures inline catch-route bodies
+                // verbatim; fix any break/continue sentinels they captured from
+                // this loop body (a user `continue`/`break` inside a `catch`).
+                fix_break_continue_sentinels_in_catches(
+                    &mut catches[body_catches_before..],
+                    state_id,
+                    after_loop_state,
+                    update_state,
+                );
             }
 
             // While-loop containing yield(s) - similar to for-loop
@@ -639,6 +649,7 @@ pub fn linearize_body(
                 // state (no separate update); `break` jumps to after_loop.
                 let while_states_before = states.len();
                 let while_current_before = current.len();
+                let while_catches_before = catches.len();
                 let mut while_body_rewritten = while_body.clone();
                 rewrite_break_continue_in_stmts(&mut while_body_rewritten, state_id);
 
@@ -682,6 +693,15 @@ pub fn linearize_body(
                 );
                 fix_break_continue_sentinels_in_stmts(
                     &mut current[while_current_before..],
+                    state_id,
+                    after_loop,
+                    cond_state,
+                );
+                // Async-generator `.throw()` closures inline catch-route bodies
+                // verbatim; fix any break/continue sentinels they captured from
+                // this loop body (a user `continue`/`break` inside a `catch`).
+                fix_break_continue_sentinels_in_catches(
+                    &mut catches[while_catches_before..],
                     state_id,
                     after_loop,
                     cond_state,

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -9,6 +9,17 @@ thread_local! {
     /// thread-local avoids threading a bool through ~14 recursive call sites).
     /// Read by the `yield*` arms to pick the async vs sync delegation protocol.
     static LINEARIZE_IS_ASYNC_GEN: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+
+    /// Per-label sentinel index for the labeled loop whose linearization is
+    /// about to begin. The labeled arm sets this right before recursing into
+    /// `linearize_body` with the wrapped loop; the directly-wrapped For/While
+    /// arm reads-and-clears it (via `take_pending_label_index`) at its very
+    /// start, so that after computing its target states it can also fix that
+    /// label's per-label break/continue sentinels. A monotonically-increasing
+    /// counter assigns indices so distinct labels in the same function never
+    /// collide (reset per function via `reset_label_sentinel_indices`).
+    static PENDING_LABEL_INDEX: std::cell::Cell<Option<u32>> = const { std::cell::Cell::new(None) };
+    static NEXT_LABEL_INDEX: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
 pub(crate) fn set_linearize_async_generator(v: bool) {
@@ -17,6 +28,35 @@ pub(crate) fn set_linearize_async_generator(v: bool) {
 
 fn linearize_async_generator() -> bool {
     LINEARIZE_IS_ASYNC_GEN.with(|c| c.get())
+}
+
+/// Reset the per-label sentinel index counter at the start of each generator
+/// function's linearization.
+pub(crate) fn reset_label_sentinel_indices() {
+    NEXT_LABEL_INDEX.with(|c| c.set(0));
+    PENDING_LABEL_INDEX.with(|c| c.set(None));
+}
+
+/// Allocate the next per-label sentinel index. Returns the index.
+fn alloc_label_index() -> u32 {
+    NEXT_LABEL_INDEX.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    })
+}
+
+/// Set the pending label index that the next-linearized For/While arm should
+/// claim (the loop directly wrapped by the labeled arm).
+fn set_pending_label_index(idx: u32) {
+    PENDING_LABEL_INDEX.with(|c| c.set(Some(idx)));
+}
+
+/// Read-and-clear the pending label index. Called at the very start of each
+/// For/While arm; returns `Some(idx)` only if this loop is the one directly
+/// wrapped by a labeled statement.
+fn take_pending_label_index() -> Option<u32> {
+    PENDING_LABEL_INDEX.with(|c| c.take())
 }
 
 /// Resolve a `yield*` operand into its iterator. An async generator delegates
@@ -440,6 +480,11 @@ pub fn linearize_body(
                 update,
                 body,
             } if body_contains_yield(body) => {
+                // If this for-loop is the body of a labeled statement, claim its
+                // per-label sentinel index so we can fix `break <label>` /
+                // `continue <label>` (including from nested loops) once our target
+                // states are known.
+                let pending_label_index = take_pending_label_index();
                 // State N: pre-loop code + init, goto condition check
                 let init_state = *state_num;
                 *state_num += 1;
@@ -600,6 +645,33 @@ pub fn linearize_body(
                     after_loop_state,
                     update_state,
                 );
+                // If this for-loop carries a label, fix that label's per-label
+                // break/continue sentinels too — `break <label>` exits the loop
+                // (after_loop_state), `continue <label>` runs the update then
+                // re-checks (update_state) — matching the loop's own targets.
+                if let Some(label_index) = pending_label_index {
+                    fix_label_sentinels(
+                        &mut states[body_states_before..],
+                        state_id,
+                        label_index,
+                        after_loop_state,
+                        update_state,
+                    );
+                    fix_label_sentinels_in_stmts(
+                        &mut current[body_current_before..],
+                        state_id,
+                        label_index,
+                        after_loop_state,
+                        update_state,
+                    );
+                    fix_label_sentinels_in_catches(
+                        &mut catches[body_catches_before..],
+                        state_id,
+                        label_index,
+                        after_loop_state,
+                        update_state,
+                    );
+                }
             }
 
             // While-loop containing yield(s) - similar to for-loop
@@ -607,6 +679,9 @@ pub fn linearize_body(
                 condition,
                 body: while_body,
             } if body_contains_yield(while_body) => {
+                // Claim a pending label index (if this while-loop is the body of
+                // a labeled statement) — see the For-loop arm.
+                let pending_label_index = take_pending_label_index();
                 // Pre-loop code gets its own state (if non-empty)
                 let pre_body = std::mem::take(current);
                 if !pre_body.is_empty() {
@@ -706,6 +781,32 @@ pub fn linearize_body(
                     after_loop,
                     cond_state,
                 );
+                // If this while-loop carries a label, fix that label's per-label
+                // break/continue sentinels — `break <label>` exits (after_loop),
+                // `continue <label>` re-checks the condition (cond_state).
+                if let Some(label_index) = pending_label_index {
+                    fix_label_sentinels(
+                        &mut states[while_states_before..],
+                        state_id,
+                        label_index,
+                        after_loop,
+                        cond_state,
+                    );
+                    fix_label_sentinels_in_stmts(
+                        &mut current[while_current_before..],
+                        state_id,
+                        label_index,
+                        after_loop,
+                        cond_state,
+                    );
+                    fix_label_sentinels_in_catches(
+                        &mut catches[while_catches_before..],
+                        state_id,
+                        label_index,
+                        after_loop,
+                        cond_state,
+                    );
+                }
             }
 
             // Try-catch/finally containing yield(s) — linearize the try body and
@@ -1180,19 +1281,41 @@ pub fn linearize_body(
             // so the embedded yield is split into resume states (#1824 —
             // previously the whole labeled statement fell through to the
             // catch-all and was emitted unsplit). `break label` / `continue
-            // label` that target this loop from its own body level are first
-            // rewritten to plain break/continue, which the loop's own
-            // linearization then maps to its state targets. (Labeled
-            // break/continue from a *nested* loop is left unconverted — the
-            // single-sentinel scheme can't yet distinguish targets; this was
-            // already unsupported before this arm existed, so no regression.)
+            // label` that target this loop — whether at the loop's own body
+            // level OR nested inside an inner loop / switch / try-catch — are
+            // rewritten to a PER-LABEL dispatch sentinel (see
+            // `rewrite_labeled_break_continue_in_vec`); the directly-wrapped
+            // For/While arm fixes those sentinels to the loop's real state
+            // targets once they're known. (Previously the nested case was left
+            // unconverted and crashed codegen with `labeled break outside any
+            // loop` when it landed in an async `.throw()` catch route.)
             Stmt::Labeled { label, body } if body_contains_yield(std::slice::from_ref(&**body)) => {
                 let mut inner = (**body).clone();
+                // Only a labeled LOOP can be the target of `break`/`continue`.
+                // For those, assign this label a per-label sentinel index and
+                // rewrite every `break <label>` / `continue <label>` in the loop
+                // BODY — INCLUDING those nested inside inner loops / switches /
+                // try-catches — into a per-label dispatch sentinel. The index is
+                // handed to the directly-wrapped For/While arm (via
+                // `set_pending_label_index`), which fixes those sentinels to the
+                // labeled loop's real target states once they're known. This
+                // covers the previously-unsupported case of `break <label>` from
+                // a NESTED loop (the inner loop's own break/continue fixup uses a
+                // different sentinel and so leaves these alone). A labeled
+                // non-loop (`label: {…}`) can't be a break/continue target, so we
+                // skip all of this and never leave a stale pending index behind.
                 match &mut inner {
                     Stmt::For { body, .. }
                     | Stmt::While { body, .. }
                     | Stmt::DoWhile { body, .. } => {
-                        rewrite_labeled_bc_in_stmts(body, label);
+                        let label_index = alloc_label_index();
+                        rewrite_labeled_break_continue_in_vec(
+                            body,
+                            label,
+                            label_index,
+                            state_id,
+                        );
+                        set_pending_label_index(label_index);
                     }
                     _ => {}
                 }
@@ -1217,44 +1340,3 @@ pub fn linearize_body(
     }
 }
 
-/// Within a labeled loop's body, rewrite `break label` / `continue label`
-/// that target THIS label into plain `break` / `continue`, so the loop's own
-/// For/While linearization (which only knows about plain break/continue) maps
-/// them to the loop's state targets. Descends only through `if` / `try`
-/// (which don't capture break/continue), mirroring the scoping of
-/// `rewrite_break_continue_in_stmt`. Stops at nested loops and `switch` —
-/// a `break label` from inside one of those still targets this loop, but the
-/// current single-sentinel scheme can't express that, so those are left
-/// as-is (pre-existing limitation).
-fn rewrite_labeled_bc_in_stmts(stmts: &mut [Stmt], label: &str) {
-    for s in stmts.iter_mut() {
-        match s {
-            Stmt::LabeledBreak(l) if l == label => *s = Stmt::Break,
-            Stmt::LabeledContinue(l) if l == label => *s = Stmt::Continue,
-            Stmt::If {
-                then_branch,
-                else_branch,
-                ..
-            } => {
-                rewrite_labeled_bc_in_stmts(then_branch, label);
-                if let Some(eb) = else_branch.as_mut() {
-                    rewrite_labeled_bc_in_stmts(eb, label);
-                }
-            }
-            Stmt::Try {
-                body,
-                catch,
-                finally,
-            } => {
-                rewrite_labeled_bc_in_stmts(body, label);
-                if let Some(c) = catch.as_mut() {
-                    rewrite_labeled_bc_in_stmts(&mut c.body, label);
-                }
-                if let Some(f) = finally.as_mut() {
-                    rewrite_labeled_bc_in_stmts(f, label);
-                }
-            }
-            _ => {}
-        }
-    }
-}

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -1628,6 +1628,49 @@ fn build_dispatch_catch_handler(
     )
 }
 
+/// Replace the synthesized dispatch re-entry `Stmt::Continue` (emitted by
+/// `rewrite_break_continue_in_stmts` for a user `break`/`continue`) with a
+/// suspend-return. Used when inlining a catch-route body into the async
+/// `.throw()` closure, which has no dispatch `while(true)` loop. Mirrors the
+/// recursion in `rewrite_break_continue_in_stmt`: descends into `if`/`try`
+/// (where the dispatch continue can sit) but stops at nested loops / switch /
+/// labeled / closures, whose own `continue`/`break` belong to them.
+fn rewrite_dispatch_continue_to_suspend(stmts: &mut Vec<Stmt>) {
+    for stmt in stmts.iter_mut() {
+        match stmt {
+            Stmt::Continue | Stmt::Break => {
+                *stmt = Stmt::Return(Some(make_iter_result(Expr::Undefined, false)));
+            }
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                rewrite_dispatch_continue_to_suspend(then_branch);
+                if let Some(eb) = else_branch.as_mut() {
+                    rewrite_dispatch_continue_to_suspend(eb);
+                }
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                rewrite_dispatch_continue_to_suspend(body);
+                if let Some(c) = catch.as_mut() {
+                    rewrite_dispatch_continue_to_suspend(&mut c.body);
+                }
+                if let Some(f) = finally.as_mut() {
+                    rewrite_dispatch_continue_to_suspend(f);
+                }
+            }
+            // Nested loops / switch / labeled / closures own their own
+            // break/continue — leave them untouched.
+            _ => {}
+        }
+    }
+}
+
 fn build_async_catch_route_body(
     route: &CatchRoute,
     finallys: &[FinallyRoute],
@@ -1668,6 +1711,19 @@ fn build_async_catch_route_body(
     rewrite_hoisted_lets_in_stmts(&mut rewritten, hoisted_ids);
     rewrite_yield_to_await_in_stmts(&mut rewritten);
     rewrite_catch_returns_to_iter_result(&mut rewritten);
+    // A user `break`/`continue` inside this catch was rewritten by
+    // `rewrite_break_continue_in_stmts` into `[LocalSet(state, TARGET),
+    // Stmt::Continue]` — the trailing `Stmt::Continue` re-enters the dispatch
+    // `while(true)` loop. The async `.throw()` closure has NO dispatch loop
+    // (it runs the handler, then suspends), so that dangling dispatch-continue
+    // would be a `continue` with no enclosing loop. The preceding `LocalSet`
+    // already moved the state to the loop's resume target (cond/update/after-
+    // loop, fixed up by `fix_break_continue_sentinels_in_catches`), so the
+    // correct async behavior is to suspend right there: convert the dispatch
+    // re-entry into a `return { value: undefined, done: false }`.
+    if !fall_through {
+        rewrite_dispatch_continue_to_suspend(&mut rewritten);
+    }
 
     // #4374: if this try also has a (sync) finally, a `throw` inside the catch
     // handler must still run that finally before propagating. The normal

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -241,6 +241,7 @@ pub fn transform_generator_function_with_extra_captures(
     // async-iterator protocol (await each delegated `next()`); see the `yield*`
     // arms in `linearize.rs`.
     super::linearize::set_linearize_async_generator(is_async_generator);
+    super::linearize::reset_label_sentinel_indices();
     linearize_body(
         &func.body,
         &mut states,

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -25,9 +25,9 @@ mod rewrite_returns;
 // cross-module symbol here.
 pub(crate) use break_continue::{
     body_contains_yield, collect_hoisted_vars, collect_vars_recursive,
-    fix_break_continue_sentinels, fix_break_continue_sentinels_in_stmt,
-    fix_break_continue_sentinels_in_stmts, fix_placeholder_state, rewrite_break_continue_in_stmt,
-    rewrite_break_continue_in_stmts,
+    fix_break_continue_sentinels, fix_break_continue_sentinels_in_catches,
+    fix_break_continue_sentinels_in_stmt, fix_break_continue_sentinels_in_stmts,
+    fix_placeholder_state, rewrite_break_continue_in_stmt, rewrite_break_continue_in_stmts,
 };
 pub(crate) use helpers::{
     alloc_local, make_iter_result, rewrite_hoisted_lets_in_stmt, rewrite_hoisted_lets_in_stmts,

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -27,7 +27,9 @@ pub(crate) use break_continue::{
     body_contains_yield, collect_hoisted_vars, collect_vars_recursive,
     fix_break_continue_sentinels, fix_break_continue_sentinels_in_catches,
     fix_break_continue_sentinels_in_stmt, fix_break_continue_sentinels_in_stmts,
+    fix_label_sentinels, fix_label_sentinels_in_catches, fix_label_sentinels_in_stmts,
     fix_placeholder_state, rewrite_break_continue_in_stmt, rewrite_break_continue_in_stmts,
+    rewrite_labeled_break_continue_in_vec,
 };
 pub(crate) use helpers::{
     alloc_local, make_iter_result, rewrite_hoisted_lets_in_stmt, rewrite_hoisted_lets_in_stmts,


### PR DESCRIPTION
## What

First step of the IR-efficiency roadmap (#5334, Tier 1 / lever A): **outline the cold guard-miss arm of the class-field-SET inline-cache diamond**.

The DEFAULT (guard-CALL) diamond's `%slow` arm emitted **two** inline calls per set site:

```llvm
class_field_set.slow:
  call void @js_typed_feedback_record_fallback_call(i64 <site>)
  call void @js_object_set_field_by_name(i64 %obj, i64 %key, double %val)
  br label %class_field_set.merge
```

The inline guard has already run and **failed** in the entry block (that failure is what branched control here), so nothing is left to decide. Collapse the pair into one outlined call:

```llvm
class_field_set.slow:
  call void @js_class_field_set_fallback(i64 <site>, i64 %obj, i64 %key, double %val)
  br label %class_field_set.merge
```

`js_class_field_set_fallback` records the miss and routes the write by name — byte-identical to the two-call block.

## Why it's safe

- **Distinct from `js_class_field_set_slow`** (the opt-in inline-precheck path's helper), which *re-runs* the guard. This helper must not, or it would double-record. It's a pure record-then-by-name fallback.
- **Perf-neutral by construction**: the hot `class_field_set.fast` slot store is untouched; the change is confined to the cold guard-miss arm, which never executes on a monomorphic hot path.

## Measurement

Per class-field-SET site, the `%slow` arm drops from 2 calls to 1 (verified on emitted IR for a `Point`-field-churn test). On a large minified bundle there are ~117K such fallback arms, so this removes ~117K call sites' worth of IR — a small but pure-win slice, and it establishes the outline-helper pattern reused by the larger levers in #5334 (C: nan-box round-trips, D: non-pointer barrier elision, B: adaptive full-outline for oversized modules).

## Tests

- Updated `typed_feedback_guards_direct_class_field_specialization` to assert the single outlined call on the default path (and that the SET-site `js_object_set_field_by_name` is gone; `record_fallback_call` legitimately remains from the always-on class-field-GET fallback block).
- Full `perry-codegen` suite green (108 + the rest).

Refs #5334.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LLVM linking failures caused by symbol name collisions when classes share the same name across different scopes.
  * Resolved async generator control-flow issues when exception handling inlines dispatch re-entry points.
  * Fixed handling of extra arguments passed to argless builtin methods (e.g., `Array.pop(extra)`)—now properly evaluated for side effects rather than causing errors.

* **New Features**
  * Added support for labeled `break` and `continue` statements in generator functions.
  * Extended labeled statements to support labeled non-loop constructs (if, switch, etc.) with implicit loop wrapping.

* **Performance**
  * Optimized class field `SET` operations with configurable inline caching and slow-path fallbacks.
  * Optimized constructor inlining decisions with configurable behavior via environment variables.
  * Added performance indexing for native instance lookups, reducing linear scans to O(1) hash-based resolution.

* **Tests**
  * Added regression tests for symbol hygiene, builtin argument handling, and labeled control flow in generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->