### PR TITLE
fix(cjs-wrap): don't adopt a require alias that collides with a named export (pino)

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -498,6 +498,59 @@ module.exports = inner;
     }
 
     #[test]
+    fn wrap_does_not_adopt_alias_that_collides_with_named_export() {
+        // Regression: pino.js does `const symbols = require('./lib/symbols')`
+        // AND `module.exports.symbols = symbols`. Adopting the `symbols` alias
+        // as the import local (`import symbols from './lib/symbols';`) collided
+        // with the module-scope `export const symbols = _cjs.symbols;` the wrap
+        // emits for the named export. HIR bound the IIFE-body reference
+        // `const { ... } = symbols` to the `export const` (value `_cjs.symbols`,
+        // `undefined` until the IIFE returns), so the top-level destructure
+        // threw `Cannot convert undefined or null to object` (pino.js:23).
+        //
+        // The fix refuses to adopt an alias whose name is also a plain named
+        // export: the spec stays on `_req_N`, the body's `const symbols =
+        // require(...)` survives as an IIFE-local, and the module-scope
+        // `export const symbols` no longer collides.
+        let src = "const symbols = require('./lib/symbols');\n\
+                   const { aSym, bSym } = symbols;\n\
+                   function build() { return [aSym, bSym]; }\n\
+                   module.exports = build;\n\
+                   module.exports.symbols = symbols;";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/pkg/index.js"));
+        // Alias NOT adopted — import keeps the `_req_N` placeholder name...
+        assert!(
+            wrapped.contains("import _req_0 from './lib/symbols';"),
+            "expected non-adopted _req_0 import (no `import symbols`), got:\n{}",
+            wrapped
+        );
+        assert!(
+            !wrapped.contains("import symbols from './lib/symbols';"),
+            "must NOT adopt the colliding `symbols` alias as the import local, got:\n{}",
+            wrapped
+        );
+        // ...the require dispatches through it...
+        assert!(
+            wrapped.contains("if (specifier === './lib/symbols') return _req_0;"),
+            "expected require dispatch through _req_0, got:\n{}",
+            wrapped
+        );
+        // ...the original `const symbols = require(...)` survives in the IIFE
+        // body (NOT blanked) so the destructure reads the real value...
+        assert!(
+            wrapped.contains("const symbols = require('./lib/symbols');"),
+            "expected the alias declaration to survive as an IIFE-local, got:\n{}",
+            wrapped
+        );
+        // ...and the named export still surfaces.
+        assert!(
+            wrapped.contains("export const symbols = _cjs.symbols;"),
+            "expected the named export to be preserved, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
     fn identifier_is_reassigned_distinguishes_declaration_from_write() {
         use super::extract_requires::identifier_is_reassigned;
         // Pure read-only alias: declaration + member reads only.

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -114,6 +114,46 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
     // name. The first alias for each spec wins; subsequent aliases of the
     // same spec keep their `const X = <chosen>;` form (handled below).
     let raw_aliases = extract_require_aliases_with_ranges(source);
+
+    // Names this module will declare at MODULE scope as `export const X =
+    // _cjs.X;` (the `named_export_decls` set computed below). Adopting an
+    // alias whose name matches one of these is a self-collision: the wrap
+    // would emit BOTH `import X from '<spec>';` (the adopted alias import) and
+    // `export const X = _cjs.X;` — two module-scope bindings named `X`. HIR's
+    // resolver then binds the IIFE-body reference `X` (e.g. `const { ... } =
+    // X`) to the `export const`, whose value `_cjs.X` is `undefined` until the
+    // IIFE returns. This is the pino `const symbols = require('./lib/symbols')`
+    // + `module.exports.symbols = symbols` shape: the top-level
+    // `const { ...30 syms... } = symbols` destructure read `undefined` and
+    // threw `Cannot convert undefined or null to object` (pino.js:23).
+    //
+    // Refusing adoption keeps the spec on `_req_N`, so the original body line
+    // `const X = require('<spec>')` is NOT blanked, runs inside the IIFE, and
+    // binds an IIFE-LOCAL `X = _req_N` — distinct from the module-scope
+    // `export const X`. The body's `X` references resolve to the local; the
+    // export still surfaces the value. This mirrors how a destructured
+    // `const { ... } = require('<spec>')` spec (levels/constants/tools) already
+    // keeps `_req_N` and works. The collision set deliberately excludes
+    // re-export-via-require names (those become `export { _req_N as X };`, no
+    // module-scope `const X`) and hoisted-class names (already blocked below),
+    // so class-identity adoption (#665) is unaffected.
+    let export_const_collision_names: std::collections::HashSet<String> = {
+        let plain_exports = extract_exports_from_source(source);
+        let mut reexport_names: std::collections::HashSet<String> =
+            extract_named_exports_from_require(source)
+                .into_iter()
+                .map(|(n, _)| n)
+                .collect();
+        for (name, _) in extract_object_literal_exports_from_require(source) {
+            reexport_names.insert(name);
+        }
+        plain_exports
+            .into_iter()
+            .filter(|n| !reexport_names.contains(n))
+            .filter(|n| !hoisted_class_names.contains(n))
+            .collect()
+    };
+
     let alias_is_safe = |alias: &str| -> bool {
         if alias.starts_with("_req_") {
             return false;
@@ -122,6 +162,11 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
             return false;
         }
         if hoisted_class_names.iter().any(|c| c == alias) {
+            return false;
+        }
+        // Self-collision with a module-scope `export const <alias> = _cjs.<alias>;`
+        // (see `export_const_collision_names` above) — keep the spec on `_req_N`.
+        if export_const_collision_names.contains(alias) {
             return false;
         }
         // #5006: a reassigned alias (`s = s.filter(...)`) must stay a real


### PR DESCRIPTION
## Shared root (the one fixed here)

When a compiled CJS package does **both** \`const X = require('./Y')\` **and**
\`module.exports.X = X\`, the CJS→ESM wrap (\`crates/perry/src/commands/compile/cjs_wrap/wrap.rs\`)
emitted **two module-scope bindings named \`X\`**:

- \`import X from './Y';\` — the adopted-alias import (Issue #665 machinery, to
  propagate class identity)
- \`export const X = _cjs.X;\` — the named-export declaration

These collide. Perry's HIR resolver binds the IIFE-body reference \`X\` to the
\`export const X = _cjs.X;\`, whose value is **\`undefined\` until the IIFE
returns** (\`_cjs\` is the IIFE result). The original \`const X = require(...)\`
body line had also been *blanked* (adopted aliases are stripped so they don't
shadow the import), so there is no IIFE-local \`X\` to fall back to.

This is exactly the **pino** shape:

```js
const symbols = require('./lib/symbols')   // adopted alias
const { ...30 syms... } = symbols          // pino.js:23 — reads `undefined`
module.exports.symbols = symbols           // → `export const symbols = _cjs.symbols`
```

→ \`TypeError: Cannot convert undefined or null to object\` at pino.js:23.

### The fix

Refuse to adopt a require-alias whose name is also a **plain named export**
(\`exports.X = ... \` / \`module.exports.X = ...\`) of the module. The spec stays
on its \`_req_N\` import local, so:

- the body's \`const X = require('./Y')\` is **not** blanked — it runs inside the
  IIFE and binds a function-scoped local \`X = _req_N\`;
- the module-scope \`export const X = _cjs.X;\` no longer collides;
- the IIFE-body \`X\` references resolve to the local (the real value).

The collision set deliberately **excludes** re-export-via-require names (those
become \`export { _req_N as X };\`, which carries no \`const X\`) and hoisted-class
names (already blocked), so the #665 class-identity adoption path is unchanged.

## Which of the 3 this fixes

| package | before | after |
|---|---|---|
| **pino** | \`TypeError: Cannot convert undefined or null to object\` (pino.js:23) | **runs — \`pino object\`, exit 0** |
| winston | \`Cannot read properties of undefined (reading 'length')\` | unchanged (different root, see below) |
| bluebird | \`Cannot read properties of undefined (reading 'prototype')\` | unchanged (different root, see below) |

The three share a *symptom* (a module-level entity reads undefined) but have
**three distinct roots**. Only pino's was the alias/export collision.

### winston — prototype accessor on a stream subclass (NOT fixed)
\`logger.js\` defines \`transports\` as a **getter on the prototype** via
\`Object.defineProperty(Logger.prototype, 'transports', { get(){...} })\`, where
\`class Logger extends Transform\` (node stream). Reading \`this.transports\` on an
instance does not resolve the prototype getter, so it returns \`undefined\` and
\`.length\` throws. This is a prototype-accessor-resolution issue on a
native-stream subclass — unrelated to the wrap.

### bluebird — forward-referenced function declaration in a factory IIFE (NOT fixed)
\`promise.js\` is \`module.exports = function(){ ... }\`. Inside that factory,
\`var tryConvertToPromise = require("./thenables")(Promise, INTERNAL)\` (line 67)
references \`Promise\` **before** its \`function Promise(executor){}\` declaration
(line 94). JS hoists function declarations; Perry's codegen does not hoist a
later \`function foo\` forward-referenced earlier in the same scope, so \`Promise\`
is \`undefined\` and a downstream \`.prototype\` read throws. This is a
function-hoisting codegen gap inside a CJS factory closure.

## Corpus status

Corrected corpus harness (the bundled \`run.py\` mis-gates on a \"Wrote
executable\" string that perry omits when stdout is a captured pipe — validated
instead by returncode + binary-exists + run):

- **before:** pino failing → **55/59 OK** after (pino moved fail→pass; no
  regressions).
- remaining failures are pre-existing and unrelated: \`winston\` / \`bluebird\`
  (above), \`execa\` (link: \`unicorn-magic\` named exports not emitted),
  \`semver\` (\`Invalid comparator\` regex).

## Tests
- New unit regression \`wrap_does_not_adopt_alias_that_collides_with_named_export\`
  in \`cjs_wrap/mod.rs\` (89 cjs_wrap tests pass).
- Lint gates clean: \`check_file_size.sh\`, \`gc_store_site_inventory.py\`,
  \`addr_class_inventory.py\`; \`cargo fmt --all --check\` clean.

## Version / CHANGELOG
Per CLAUDE.md, the maintainer folds in the version bump + CHANGELOG entry at
merge time — this branch intentionally does **not** touch \`Cargo.toml\`,
\`Cargo.lock\`, \`CLAUDE.md\`, or \`CHANGELOG.md\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of CommonJS modules where variable names could create naming conflicts during module conversion.

* **Tests**
  * Added regression test to ensure proper handling of variable naming edge cases in module conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->