### PR TITLE
fix(resolve): honor the 'node' exports condition above 'default' (execa link)

### DIFF
--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -669,11 +669,22 @@ fn resolve_exports_with_conditions(
 }
 
 /// Resolve exports field from package.json for executable module entries.
+///
+/// `node` is ranked ABOVE `default` (and above `import`/`module`) because perry
+/// compiles a Node target: a package whose `exports` offers a `{ node, default }`
+/// conditional pair ships its full Node API under `node` and a reduced
+/// browser/edge build under `default`. Picking `default` drops Node-only
+/// exports — e.g. `unicorn-magic` exposes `toPath`/`traversePathUp` only in its
+/// `node` entry (`./node.js`); resolving `./default.js` left them undefined, so
+/// `npm-run-path` (→ execa) failed to LINK (`undefined symbol
+/// perry_fn_…unicorn_magic…__toPath`). Matches the `resolve_subpath_import`
+/// condition order (chalk's `#supports-color` `{ node, default }`); the two
+/// resolvers must agree.
 pub(super) fn resolve_exports(exports: &serde_json::Value, subpath: &str) -> Option<String> {
     resolve_exports_with_conditions(
         exports,
         subpath,
-        &["perry", "import", "module", "default", "require", "node"],
+        &["perry", "node", "import", "module", "default", "require"],
     )
 }
 

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -729,7 +729,15 @@ pub(super) fn resolve_exports_candidates(
     exports: &serde_json::Value,
     subpath: &str,
 ) -> Vec<String> {
-    const CONDITIONS: &[&str] = &["perry", "import", "module", "default", "require", "node"];
+    // `node` ranked above `default` (perry compiles a Node target): a
+    // `{ node, default }` conditional pair must resolve the Node build, not the
+    // reduced browser/edge `default`. Candidates are collected in this order
+    // and the caller picks the first that exists on disk, so listing `node`
+    // first makes the Node entry win. (unicorn-magic exposes toPath/
+    // traversePathUp only in `./node.js`; resolving `./default.js` left them
+    // undefined → npm-run-path → execa LINK failure.) Mirrors `resolve_exports`
+    // / `resolve_subpath_import`.
+    const CONDITIONS: &[&str] = &["perry", "node", "import", "module", "default", "require"];
     fn collect(value: &serde_json::Value, subpath: &str, out: &mut Vec<String>) {
         match value {
             serde_json::Value::String(s) => {


### PR DESCRIPTION
## Problem

Native-compiling **execa** failed to LINK: `Undefined symbols … perry_fn_…unicorn_magic_default_js__toPath / __traversePathUp`, referenced from `npm-run-path`.

`npm-run-path` does `import {toPath, traversePathUp} from 'unicorn-magic'`. `unicorn-magic`'s `exports` is a `{ node, default }` conditional pair:
```json
{ "node": { "import": "./node.js" }, "default": { "import": "./default.js" } }
```
`./node.js` defines `toPath`/`traversePathUp`; `./default.js` (browser/edge) only has `delay`. perry's resolver ranked the `default` condition **above** `node`, so it resolved `./default.js` → those exports were never emitted → undefined symbols at link.

## Fix

perry compiles a **Node** target, so the `node` condition must outrank `default` (and the browser-ish `default` is the fallback). Two resolver condition-lists needed reordering to `["perry", "node", "import", "module", "default", "require"]`:
- `resolve_exports`
- **`resolve_exports_candidates`** — the one actually used for bare-package main-entry resolution (it collects candidates in condition order and the caller picks the first that exists on disk).

This matches the already-correct `resolve_subpath_import` order (chalk's `#supports-color` `{ node, default }`); all three resolvers now agree.

## Verification

- **execa now LINKS** (was: undefined symbol). It advances to a separate, unrelated read-undefined wall (`reading 'prototype'`, shared with bluebird — not chased here).
- **Full corpus: 55/59, no regressions.** Controls `zod`/`yargs`/`chalk` (which rely on exports/imports-map resolution) still green.
- fmt clean; file-size / GC store-site / addr-class gates pass. No `version`/`CHANGELOG`/`Cargo.lock` edits.

(Note: corpus harness `run.py` was also fixed separately — it must compile with `--no-cache` and detect success by returncode+binary-exists, not the "Wrote executable" stdout string, or it mis-measures.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module resolution by adjusting the priority of export conditions, ensuring the Node environment condition is now evaluated before the default condition in package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->